### PR TITLE
feat(ansible): Install netcat on all VMs for network diagnostics (#703)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-base.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-base.yml
@@ -68,7 +68,8 @@
 
           # Network tools
           - net-tools
-          - netcat
+          - netcat-openbsd
+          - iputils-ping
           - dnsutils
           - traceroute
           - nmap

--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -26,6 +26,10 @@
       - ca-certificates
       - gnupg
       - lsb-release
+      # Network diagnostics (#703)
+      - netcat-openbsd
+      - iputils-ping
+      - dnsutils
     state: present
   become: yes
   tags: ['common', 'packages']

--- a/autobot-slm-backend/ansible/roles/common/vars/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/vars/main.yml
@@ -16,6 +16,10 @@ common_packages:
   - ca-certificates
   - gnupg
   - lsb-release
+  # Network diagnostics (#703)
+  - netcat-openbsd
+  - iputils-ping
+  - dnsutils
 
 autobot_user: autobot
 autobot_home: /home/autobot

--- a/autobot-slm-backend/ansible/site.yml
+++ b/autobot-slm-backend/ansible/site.yml
@@ -22,6 +22,10 @@
           - vim
           - unzip
           - software-properties-common
+          # Network diagnostics (#703)
+          - netcat-openbsd
+          - iputils-ping
+          - dnsutils
         state: present
       tags: ['system', 'packages']
 


### PR DESCRIPTION
## Summary
- Add `netcat-openbsd`, `iputils-ping`, and `dnsutils` to base VM provisioning
- Updated 4 Ansible files to ensure consistent network diagnostic tooling across all VMs
- Fixes missing `nc` on AI Stack (172.16.168.24) and Browser (172.16.168.25) VMs

## Files Changed
- `autobot-slm-backend/ansible/roles/common/vars/main.yml` - Added packages to `common_packages` variable
- `autobot-slm-backend/ansible/roles/common/tasks/main.yml` - Added packages to "Install base packages" task
- `autobot-slm-backend/ansible/playbooks/deploy-base.yml` - Changed `netcat` to `netcat-openbsd`, added `iputils-ping`
- `autobot-slm-backend/ansible/site.yml` - Added packages to pre_tasks common packages

## Test plan
- [ ] Run `ansible-playbook playbooks/deploy-base.yml --tags packages --check` for dry-run validation
- [ ] Verify on AI Stack VM: `ssh autobot@172.16.168.24 'nc -zv 192.168.168.49 514'`
- [ ] Verify on Browser VM: `ssh autobot@172.16.168.25 'nc -zv 192.168.168.49 514'`
- [ ] Confirm `which nc` on all 6 hosts

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)