### PR TITLE
fix: Update path_constants.py for post-reorganization directories (#795)

### DIFF
--- a/autobot-user-backend/constants/path_constants.py
+++ b/autobot-user-backend/constants/path_constants.py
@@ -17,25 +17,28 @@ class PathConstants:
     # Project root - dynamically determined
     PROJECT_ROOT: Path = Path(__file__).parent.parent.parent
 
-    # Core directories
-    CONFIG_DIR: Path = PROJECT_ROOT / "config"
+    # Backend resources (#793)
+    PROMPTS_DIR: Path = PROJECT_ROOT / "autobot-user-backend" / "resources" / "prompts"
+
+    # Core directories (updated for #781 reorganization)
+    CONFIG_DIR: Path = PROJECT_ROOT / "infrastructure" / "shared" / "config"
     DATA_DIR: Path = PROJECT_ROOT / "data"
     LOGS_DIR: Path = PROJECT_ROOT / "logs"
     DOCS_DIR: Path = PROJECT_ROOT / "docs"
-    SRC_DIR: Path = PROJECT_ROOT / "src"
-    TESTS_DIR: Path = PROJECT_ROOT / "tests"
-    BACKEND_DIR: Path = PROJECT_ROOT / "backend"
-    DATABASE_DIR: Path = PROJECT_ROOT / "database"
-    FRONTEND_DIR: Path = PROJECT_ROOT / "autobot-vue"
+    SRC_DIR: Path = PROJECT_ROOT / "autobot-user-backend"
+    TESTS_DIR: Path = PROJECT_ROOT / "autobot-user-backend"
+    BACKEND_DIR: Path = PROJECT_ROOT / "autobot-user-backend"
+    DATABASE_DIR: Path = PROJECT_ROOT / "autobot-user-backend" / "database"
+    FRONTEND_DIR: Path = PROJECT_ROOT / "autobot-user-frontend"
     SCRIPTS_DIR: Path = PROJECT_ROOT / "scripts"
     UTILITIES_DIR: Path = SCRIPTS_DIR / "utilities"
-    ANALYSIS_DIR: Path = PROJECT_ROOT / "analysis"
-    REPORTS_DIR: Path = PROJECT_ROOT / "reports"
+    ANALYSIS_DIR: Path = PROJECT_ROOT / "infrastructure" / "shared" / "analysis"
+    REPORTS_DIR: Path = PROJECT_ROOT / "data" / "reports"
     REFACTORING_REPORTS_DIR: Path = REPORTS_DIR / "refactoring"
-    MCP_TOOLS_DIR: Path = PROJECT_ROOT / "mcp-tools"
+    MCP_TOOLS_DIR: Path = PROJECT_ROOT / "infrastructure" / "shared" / "mcp"
     TEMP_DIR: Path = PROJECT_ROOT / "temp"
-    ARCHIVE_DIR: Path = PROJECT_ROOT / "archive"
-    ANSIBLE_DIR: Path = PROJECT_ROOT / "ansible"
+    ARCHIVE_DIR: Path = PROJECT_ROOT / "docs" / "archives"
+    ANSIBLE_DIR: Path = PROJECT_ROOT / "autobot-slm-backend" / "ansible"
     ANSIBLE_PLAYBOOKS_DIR: Path = ANSIBLE_DIR / "playbooks"
 
     # Configuration subdirectories


### PR DESCRIPTION
## Summary
- Updates 9 path constants in `path_constants.py` that pointed to directories removed/moved during the #781 folder reorganization
- All constants now resolve to existing directories verified at runtime
- `error_messages.yaml`, `config.yaml`, and database schema paths all load correctly

## Changes
| Constant | Old Path | New Path |
|----------|----------|----------|
| `CONFIG_DIR` | `config/` | `infrastructure/shared/config/` |
| `SRC_DIR` | `src/` | `autobot-user-backend/` |
| `TESTS_DIR` | `tests/` | `autobot-user-backend/` |
| `BACKEND_DIR` | `backend/` | `autobot-user-backend/` |
| `DATABASE_DIR` | `database/` | `autobot-user-backend/database/` |
| `FRONTEND_DIR` | `autobot-vue/` | `autobot-user-frontend/` |
| `ANALYSIS_DIR` | `analysis/` | `infrastructure/shared/analysis/` |
| `REPORTS_DIR` | `reports/` | `data/reports/` |
| `MCP_TOOLS_DIR` | `mcp-tools/` | `infrastructure/shared/mcp/` |
| `ARCHIVE_DIR` | `archive/` | `docs/archives/` |
| `ANSIBLE_DIR` | `ansible/` | `autobot-slm-backend/ansible/` |

## Test plan
- [x] All 18 path constants verified to resolve to existing directories
- [x] `ErrorCatalog.load_catalog()` returns `True` (loads `error_messages.yaml`)
- [x] `config.yaml` accessible via `PATH.CONFIG_DIR`
- [x] Database schemas findable via `PATH.DATABASE_DIR / "schemas"`
- [ ] Full integration test on deployed VM

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)