### PR TITLE
refactor(ansible): Remove hardcoded IPs from playbooks and roles (#799)

### DIFF
--- a/autobot-slm-backend/ansible/enable-tls.yml
+++ b/autobot-slm-backend/ansible/enable-tls.yml
@@ -79,7 +79,7 @@
       ansible.builtin.lineinfile:
         path: /opt/autobot/autobot-vue/.env.local
         regexp: '^VITE_API_BASE_URL='
-        line: "VITE_API_BASE_URL=https://172.16.168.20:8443"
+        line: "VITE_API_BASE_URL=https://{{ backend_host }}:8443"
         create: true
         mode: "0644"
         owner: autobot
@@ -225,9 +225,9 @@
           ============================================
 
           Services configured for TLS:
-            - Frontend: https://172.16.168.21:443
-            - Backend:  https://172.16.168.20:8443
-            - Redis:    redis://172.16.168.23:6380 (TLS)
+            - Frontend: https://{{ frontend_host }}:443
+            - Backend:  https://{{ backend_host }}:8443
+            - Redis:    redis://{{ redis_host }}:6380 (TLS)
 
           Update your SSOT config (.env) with:
             AUTOBOT_FRONTEND_TLS_ENABLED=true
@@ -235,7 +235,7 @@
             AUTOBOT_REDIS_TLS_ENABLED=true
 
           Verify with:
-            curl -k https://172.16.168.21:443
-            curl -k https://172.16.168.20:8443/api/health
-            redis-cli -h 172.16.168.23 -p 6380 --tls ping
+            curl -k https://{{ frontend_host }}:443
+            curl -k https://{{ backend_host }}:8443/api/health
+            redis-cli -h {{ redis_host }} -p 6380 --tls ping
           ============================================

--- a/autobot-slm-backend/ansible/health-check.yml
+++ b/autobot-slm-backend/ansible/health-check.yml
@@ -11,10 +11,10 @@
 
   vars:
     # TLS settings from environment
+    # redis_host and redis_port come from inventory (production.yml all.vars)
+    # Override via: ansible-playbook health-check.yml -e "redis_host=x.x.x.x"
     redis_tls_enabled: "{{ lookup('env', 'AUTOBOT_REDIS_TLS_ENABLED') | default('false', true) | lower == 'true' }}"
     redis_tls_port: "{{ lookup('env', 'AUTOBOT_REDIS_TLS_PORT') | default(6380, true) }}"
-    redis_port: "{{ lookup('env', 'AUTOBOT_REDIS_PORT') | default(6379, true) }}"
-    redis_host: "{{ lookup('env', 'AUTOBOT_REDIS_HOST') | default('172.16.168.23', true) }}"
     tls_cert_dir: "{{ lookup('env', 'AUTOBOT_TLS_REMOTE_CERT_DIR') | default('/etc/autobot/certs', true) }}"
 
     # Services to check

--- a/autobot-slm-backend/ansible/inventory/production.yml
+++ b/autobot-slm-backend/ansible/inventory/production.yml
@@ -27,15 +27,21 @@ all:
     autobot_environment: "production"
     autobot_version: "2.0.0"
 
-    # Service discovery endpoints - UPDATED FOR PROVIDED VMs
-    redis_host: "172.16.168.23"      # Database VM
-    redis_port: 6379
-    backend_host: "172.16.168.20"    # Backend WSL
+    # Service discovery endpoints - derived from inventory hosts (Issue #799)
+    slm_host: "{{ hostvars['autobot-slm']['ansible_host'] }}"
+    slm_port: 8000
+    backend_host: "{{ hostvars['autobot-host']['network_address'] }}"
     backend_port: 8001
-    ai_stack_host: "172.16.168.24"   # AI Stack VM
+    frontend_host: "{{ hostvars['autobot-frontend']['ansible_host'] }}"
+    frontend_port: 5173
+    redis_host: "{{ hostvars['autobot-database']['ansible_host'] }}"
+    redis_port: 6379
+    ai_stack_host: "{{ hostvars['autobot-aiml']['ansible_host'] }}"
     ai_stack_port: 8080
-    npu_worker_host: "172.16.168.22" # NPU Worker VM (dedicated)
+    npu_worker_host: "{{ hostvars['autobot-npu']['ansible_host'] }}"
     npu_worker_port: 8081
+    browser_host: "{{ hostvars['autobot-browser']['ansible_host'] }}"
+    browser_port: 3000
 
   children:
     frontend:
@@ -70,6 +76,7 @@ all:
           ansible_become: no           # Issue #700: Disable become for local host by default
           # Enable become when needed with: --extra-vars "ansible_become=yes"
           # Or use: --ask-become-pass for operations requiring sudo
+          network_address: 172.16.168.20  # Reachable from other VMs (ansible_host is 127.0.0.1 for local)
           vm_id: "autobot-wsl-machine"
           vm_role: "wsl-host"
           vm_hostname: "autobot-host"

--- a/autobot-slm-backend/ansible/playbooks/deploy-development-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-development-services.yml
@@ -56,14 +56,14 @@
         content: |
           # Development Environment Variables
           NODE_ENV=development
-          VITE_BACKEND_HOST=172.16.168.20
-          VITE_BACKEND_PORT=8001
-          VITE_WS_HOST=172.16.168.20
-          VITE_WS_PORT=8001
-          VITE_REDIS_HOST=172.16.168.23
-          VITE_AI_STACK_HOST=172.16.168.24
-          VITE_BROWSER_HOST=172.16.168.25
-          VITE_NPU_WORKER_HOST=172.16.168.22
+          VITE_BACKEND_HOST={{ backend_host }}
+          VITE_BACKEND_PORT={{ backend_port }}
+          VITE_WS_HOST={{ backend_host }}
+          VITE_WS_PORT={{ backend_port }}
+          VITE_REDIS_HOST={{ redis_host }}
+          VITE_AI_STACK_HOST={{ ai_stack_host }}
+          VITE_BROWSER_HOST={{ browser_host }}
+          VITE_NPU_WORKER_HOST={{ npu_worker_host }}
           DEBUG_PROXY=false
           LOG_LEVEL=info
         dest: /opt/autobot/config/frontend-dev.env
@@ -121,14 +121,14 @@
 
     - name: Wait for frontend to be ready
       wait_for:
-        host: 172.16.168.21
-        port: 5173
+        host: "{{ frontend_host }}"
+        port: "{{ frontend_port }}"
         delay: 10
         timeout: 60
 
     - name: Test frontend development server
       uri:
-        url: "http://172.16.168.21:5173"
+        url: "http://{{ frontend_host }}:{{ frontend_port }}"
         method: GET
         status_code: 200
         timeout: 30
@@ -138,7 +138,7 @@
       debug:
         msg: |
           Frontend Development Server Status:
-          - URL: http://172.16.168.21:5173
+          - URL: http://{{ frontend_host }}:{{ frontend_port }}
           - Status: {{ frontend_test.status }}
           - Service: autobot-frontend-dev
           - Mode: Development (hot reload enabled)
@@ -162,7 +162,7 @@
         marker: "# {mark} DEVELOPMENT MODE FRONTEND MANAGEMENT"
         block: |
           start_frontend_dev() {
-              echo "🌐 Starting Frontend Development Server on VM 172.16.168.21..."
+              echo "🌐 Starting Frontend Development Server on VM {{ frontend_host }}..."
 
               # Start development frontend service via Ansible
               ansible frontend -i ansible/inventory/production.yml -m systemd -a "name=autobot-frontend-dev state=restarted enabled=yes" -b
@@ -172,8 +172,8 @@
               sleep 10
 
               # Test frontend availability
-              if curl -s -o /dev/null -w "%{http_code}" http://172.16.168.21:5173 | grep -q "200"; then
-                  echo "✅ Frontend development server ready at http://172.16.168.21:5173"
+              if curl -s -o /dev/null -w "%{http_code}" http://{{ frontend_host }}:{{ frontend_port }} | grep -q "200"; then
+                  echo "✅ Frontend development server ready at http://{{ frontend_host }}:{{ frontend_port }}"
               else
                   echo "⚠️  Frontend development server may not be fully ready yet"
                   echo "   Check status with: ansible frontend -i ansible/inventory/production.yml -m shell -a 'systemctl status autobot-frontend-dev'"
@@ -202,13 +202,13 @@
           🚀 Development Environment Ready!
 
           Frontend Development Server:
-          - URL: http://172.16.168.21:5173
+          - URL: http://{{ frontend_host }}:{{ frontend_port }}
           - Service: autobot-frontend-dev (systemd)
           - Hot reload: Enabled
           - Source: /opt/autobot/src/autobot-vue
 
           Backend:
-          - URL: http://172.16.168.20:8001
+          - URL: http://{{ backend_host }}:{{ backend_port }}
           - Service: Runs via run_autobot.sh --dev
 
           Usage:

--- a/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
@@ -200,7 +200,7 @@
                 - frontend_logs:/var/log/nginx
               environment:
                 - NODE_ENV=production
-                - VITE_BACKEND_HOST={{ hostvars['autobot-backend']['ansible_host'] | default('172.16.168.1') }}
+                - VITE_BACKEND_HOST={{ backend_host }}
                 - VITE_BACKEND_PORT=8001
                 - VITE_REDIS_HOST={{ hostvars['autobot-database']['ansible_host'] }}
                 - VITE_AI_STACK_HOST={{ hostvars['autobot-aiml']['ansible_host'] }}

--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -223,12 +223,12 @@
         npm run build
       become_user: autobot-service
       environment:
-        VITE_BACKEND_HOST: "172.16.168.20"  # WSL Host IP
-        VITE_BACKEND_PORT: "8001"
-        VITE_REDIS_HOST: "172.16.168.23"
-        VITE_AI_STACK_HOST: "172.16.168.24"
-        VITE_BROWSER_HOST: "172.16.168.25"
-        VITE_NPU_WORKER_HOST: "172.16.168.22"
+        VITE_BACKEND_HOST: "{{ backend_host }}"
+        VITE_BACKEND_PORT: "{{ backend_port }}"
+        VITE_REDIS_HOST: "{{ redis_host }}"
+        VITE_AI_STACK_HOST: "{{ ai_stack_host }}"
+        VITE_BROWSER_HOST: "{{ browser_host }}"
+        VITE_NPU_WORKER_HOST: "{{ npu_worker_host }}"
 
     - name: Configure Nginx for frontend
       copy:
@@ -248,7 +248,7 @@
 
               # Proxy API requests to backend VM
               location /api/ {
-                  proxy_pass http://172.16.168.20:8001/api/;
+                  proxy_pass http://{{ backend_host }}:{{ backend_port }}/api/;
                   proxy_http_version 1.1;
                   proxy_set_header Upgrade $http_upgrade;
                   proxy_set_header Connection 'upgrade';
@@ -262,7 +262,7 @@
 
               # WebSocket proxy for real-time features
               location /ws/ {
-                  proxy_pass http://172.16.168.20:8001/ws/;
+                  proxy_pass http://{{ backend_host }}:{{ backend_port }}/ws/;
                   proxy_http_version 1.1;
                   proxy_set_header Upgrade $http_upgrade;
                   proxy_set_header Connection "Upgrade";
@@ -572,7 +572,7 @@
           ExecStart=/opt/autobot/venv/bin/python -m docker.ai-stack.ai_server
           Environment="AI_SERVER_HOST=0.0.0.0"
           Environment="AI_SERVER_PORT=8080"
-          Environment="REDIS_HOST=172.16.168.23"
+          Environment="REDIS_HOST={{ redis_host }}"
           Environment="REDIS_PORT=6379"
           Environment="REDIS_PASSWORD={{ autobot_redis_password | default(lookup('env', 'AUTOBOT_REDIS_PASSWORD')) }}"
           Environment="OLLAMA_HOST=http://localhost:11434"
@@ -597,7 +597,7 @@
           ExecStart=/opt/autobot/venv/bin/python -m docker.npu-worker.npu_worker
           Environment="NPU_SERVER_HOST=0.0.0.0"
           Environment="NPU_SERVER_PORT=8081"
-          Environment="REDIS_HOST=172.16.168.23"
+          Environment="REDIS_HOST={{ redis_host }}"
           Environment="REDIS_PORT=6379"
           Environment="REDIS_PASSWORD={{ autobot_redis_password | default(lookup('env', 'AUTOBOT_REDIS_PASSWORD')) }}"
           Environment="DEVICE=CPU"
@@ -687,7 +687,7 @@
           ExecStart=/usr/bin/node playwright-server.js
           Environment="DISPLAY=:99"
           Environment="PLAYWRIGHT_SERVER_PORT=3000"
-          Environment="REDIS_HOST=172.16.168.23"
+          Environment="REDIS_HOST={{ redis_host }}"
           Environment="REDIS_PORT=6379"
           Environment="REDIS_PASSWORD={{ autobot_redis_password | default(lookup('env', 'AUTOBOT_REDIS_PASSWORD')) }}"
           Restart=always

--- a/autobot-slm-backend/ansible/playbooks/deploy-user-management-db.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-user-management-db.yml
@@ -6,8 +6,8 @@
 # Issue: #786 - Ansible playbooks for user management database setup
 #
 # This playbook sets up PostgreSQL databases for user management:
-# - SLM Server (172.16.168.19): slm, slm_users databases
-# - Redis VM (172.16.168.23): autobot_users database
+# - SLM Server: slm, slm_users databases
+# - Database VM: autobot_users database
 #
 # Usage:
 #   ansible-playbook -i slm-server/ansible/inventory.yml ansible/playbooks/deploy-user-management-db.yml
@@ -18,7 +18,7 @@
 # =============================================================================
 # Phase 1: SLM Server PostgreSQL Setup
 # =============================================================================
-- name: "Deploy PostgreSQL on SLM Server (172.16.168.19)"
+- name: "Deploy PostgreSQL on SLM Server"
   hosts: slm
   become: true
   gather_facts: true
@@ -68,7 +68,7 @@
 # =============================================================================
 # Phase 2: Redis VM PostgreSQL Setup
 # =============================================================================
-- name: "Deploy PostgreSQL on Redis VM (172.16.168.23)"
+- name: "Deploy PostgreSQL on Database VM"
   hosts: redis
   become: true
   gather_facts: true
@@ -83,10 +83,10 @@
     pg_hba_remote_access:
       - database: autobot_users
         user: autobot_app
-        address: "172.16.168.19/32"
+        address: "{{ slm_host }}/32"
       - database: autobot_users
         user: autobot_app
-        address: "172.16.168.20/32"
+        address: "{{ backend_host }}/32"
 
   pre_tasks:
     - name: Display Redis VM database deployment info
@@ -98,7 +98,7 @@
           - "Host: {{ inventory_hostname }} ({{ ansible_host }})"
           - "User: {{ db_user }}"
           - "Databases: {{ databases | join(', ') }}"
-          - "Remote access from: SLM (172.16.168.19), Main (172.16.168.20)"
+          - "Remote access from: SLM ({{ slm_host }}), Main ({{ backend_host }})"
 
   roles:
     - role: postgresql
@@ -114,8 +114,8 @@
         src: "{{ item }}"
         proto: tcp
       loop:
-        - "172.16.168.19"
-        - "172.16.168.20"
+        - "{{ slm_host }}"
+        - "{{ backend_host }}"
 
     - name: Verify autobot_users database is accessible
       community.postgresql.postgresql_ping:
@@ -141,7 +141,7 @@
   gather_facts: false
 
   vars:
-    autobot_db_host: "172.16.168.23"
+    autobot_db_host: "{{ redis_host }}"
     autobot_db_user: "autobot_app"
 
   tasks:
@@ -178,12 +178,12 @@
           - "User Management Database Setup Complete"
           - "======================================"
           - ""
-          - "SLM Server (172.16.168.19):"
+          - "SLM Server ({{ slm_host }}):"
           - "  - Database: slm (operational data)"
           - "  - Database: slm_users (admin accounts)"
           - "  - Credentials: /etc/autobot/db-credentials.env"
           - ""
-          - "Redis VM (172.16.168.23):"
+          - "Database VM ({{ redis_host }}):"
           - "  - Database: autobot_users (app users)"
           - "  - Credentials: /etc/autobot/db-credentials.env"
           - "  - Remote access: SLM, Main Backend"

--- a/autobot-slm-backend/ansible/playbooks/enroll-local.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-local.yml
@@ -18,7 +18,7 @@
     slm_agent_dir: /opt/slm-agent
     slm_data_dir: /var/lib/slm-agent
     slm_node_id: "{{ lookup('env', 'SLM_NODE_ID') | default('01-Code-Source', true) }}"
-    slm_admin_url: "{{ lookup('env', 'SLM_ADMIN_URL') | default('http://172.16.168.19:8000', true) }}"
+    slm_admin_url: "{{ lookup('env', 'SLM_ADMIN_URL') | default('http://' ~ (slm_host | default('127.0.0.1')) ~ ':' ~ (slm_port | default(8000)), true) }}"
     # SLM server's public key - will be fetched dynamically
     slm_server_pubkey: "{{ lookup('env', 'SLM_PUBKEY') | default('', true) }}"
     # Emergency admin user - fallback access when SSH keys fail

--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -307,7 +307,7 @@
                 content: |
                   SLM_CODE_SOURCE=true
                   SLM_NOTIFY_PORT=8000
-                  SLM_ADMIN_URL={{ slm_admin_url | default('http://172.16.168.19:8000') }}
+                  SLM_ADMIN_URL={{ slm_admin_url | default('http://' ~ (slm_host | default('127.0.0.1')) ~ ':' ~ (slm_port | default(8000))) }}
                 dest: /etc/slm-agent/environment
                 mode: '0644'
               notify: restart slm-agent

--- a/autobot-slm-backend/ansible/playbooks/setup-vm-names-and-lvm.yml
+++ b/autobot-slm-backend/ansible/playbooks/setup-vm-names-and-lvm.yml
@@ -41,12 +41,12 @@
       blockinfile:
         path: /etc/hosts
         block: |
-          # AutoBot VM Infrastructure
-          172.16.168.21  autobot-frontend.autobot.internal  autobot-frontend
-          172.16.168.22  autobot-backend.autobot.internal   autobot-backend
-          172.16.168.23  autobot-database.autobot.internal  autobot-database
-          172.16.168.24  autobot-aiml.autobot.internal      autobot-aiml
-          172.16.168.25  autobot-browser.autobot.internal   autobot-browser
+          # AutoBot VM Infrastructure (generated from inventory)
+          {% for host in groups['all'] %}
+          {% if hostvars[host]['ansible_host'] is defined and hostvars[host]['ansible_host'] != '127.0.0.1' %}
+          {{ hostvars[host].get('network_address', hostvars[host]['ansible_host']) }}  {{ hostvars[host].get('vm_hostname', host) }}.{{ autobot_domain | default('autobot.internal') }}  {{ hostvars[host].get('vm_hostname', host) }}
+          {% endif %}
+          {% endfor %}
         marker: "# {mark} AUTOBOT VM BLOCK"
         backup: yes
 

--- a/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
@@ -19,6 +19,6 @@ chromadb_host: "0.0.0.0"
 chromadb_port: 8000
 
 # Redis connection
-ai_redis_host: "172.16.168.23"
+ai_redis_host: "{{ redis_host | default('127.0.0.1') }}"
 ai_redis_port: 6379
 ai_redis_password: ""

--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -20,7 +20,7 @@ backend_port: 8001
 backend_workers: 4
 
 # Redis connection
-backend_redis_host: "172.16.168.23"
+backend_redis_host: "{{ redis_host | default('127.0.0.1') }}"
 backend_redis_port: 6379
 backend_redis_password: ""
 

--- a/autobot-slm-backend/ansible/roles/frontend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/defaults/main.yml
@@ -22,7 +22,7 @@ frontend_host: "0.0.0.0"
 frontend_port: 5173
 
 # Backend connection
-frontend_backend_url: "http://172.16.168.20:8001"
+frontend_backend_url: "http://{{ backend_host | default('127.0.0.1') }}:{{ backend_port | default(8001) }}"
 
 # TLS Configuration (Issue #164)
 frontend_tls_enabled: false

--- a/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
@@ -43,8 +43,9 @@ grafana_data_dir: "/var/lib/grafana"
 
 # Targets to scrape (can be populated dynamically)
 prometheus_targets: []
-#  - "172.16.168.20:9100"
-#  - "172.16.168.21:9100"
+# Populate dynamically from inventory, e.g.:
+#  - "{{ hostvars['autobot-host']['network_address'] }}:9100"
+#  - "{{ hostvars['autobot-frontend']['ansible_host'] }}:9100"
 
 # SLM integration
 slm_api_url: "http://localhost:8000"

--- a/autobot-slm-backend/ansible/roles/npu-worker/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/defaults/main.yml
@@ -18,6 +18,6 @@ npu_host: "0.0.0.0"
 npu_port: 8081
 
 # Redis connection
-npu_redis_host: "172.16.168.23"
+npu_redis_host: "{{ redis_host | default('127.0.0.1') }}"
 npu_redis_port: 6379
 npu_redis_password: ""

--- a/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/defaults/main.yml
@@ -28,7 +28,7 @@ redis_tls_cert_dir: "{{ lookup('env', 'AUTOBOT_TLS_REMOTE_CERT_DIR') | default('
 redis_tls_source: "{{ lookup('env', 'AUTOBOT_TLS_SOURCE') | default('local', true) }}"
 
 # SLM API configuration (for redis_tls_source='slm-api')
-slm_api_url: "{{ lookup('env', 'SLM_API_URL') | default('http://172.16.168.19:8000', true) }}"
+slm_api_url: "{{ lookup('env', 'SLM_API_URL') | default('http://' ~ (slm_host | default('127.0.0.1')) ~ ':' ~ (slm_port | default(8000)), true) }}"
 slm_api_token: "{{ lookup('env', 'SLM_API_TOKEN') | default('', true) }}"
 redis_tls_credential_id: "{{ lookup('env', 'REDIS_TLS_CREDENTIAL_ID') | default('', true) }}"
 

--- a/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
@@ -6,7 +6,7 @@
 # Override these in inventory or playbook variables
 
 # Admin connectivity
-slm_admin_url: "http://172.16.168.19:8000"
+slm_admin_url: "http://{{ slm_host | default('127.0.0.1') }}:{{ slm_port | default(8000) }}"
 slm_heartbeat_interval: 30
 
 # Agent user/group (should match common role's autobot user)


### PR DESCRIPTION
## Summary

Closes #799

- Replace **57 hardcoded `172.16.168.x` IPs** across **17 Ansible files** with inventory-derived variables
- IPs now exist ONLY in inventory files (`ansible_host` per host) and are referenced via `hostvars` lookups
- Add `network_address` field to backend host (which uses `ansible_host: 127.0.0.1` for local connection but needs `172.16.168.20` for remote access)
- Replace static `/etc/hosts` block with Jinja2 loop that generates entries from inventory dynamically

## Files Changed (17)

**Inventory:**
- `inventory/production.yml` — hostvars-based service discovery, `network_address` for backend

**Playbooks (10):**
- `deploy-native-services.yml` — VITE_* env vars, nginx proxy_pass, systemd REDIS_HOST
- `deploy-development-services.yml` — env file, wait_for, URI test, display messages, run_autobot.sh
- `deploy-user-management-db.yml` — pg_hba addresses, firewall rules, db_host, display messages
- `setup-vm-names-and-lvm.yml` — /etc/hosts block → Jinja2 inventory loop
- `enable-tls.yml` — VITE_API_BASE_URL, TLS summary URLs
- `enroll-node.yml` — SLM_ADMIN_URL default
- `enroll-local.yml` — slm_admin_url default
- `deploy-hybrid-docker.yml` — backend host reference
- `health-check.yml` — remove redis_host/redis_port variable shadowing

**Role Defaults (7):**
- `frontend/defaults/main.yml` — `frontend_backend_url`
- `backend/defaults/main.yml` — `backend_redis_host`
- `npu-worker/defaults/main.yml` — `npu_redis_host`
- `ai-stack/defaults/main.yml` — `ai_redis_host`
- `slm_agent/defaults/main.yml` — `slm_admin_url`
- `redis/defaults/main.yml` — `slm_api_url`
- `monitoring/defaults/main.yml` — commented prometheus_targets examples

## Verification

```bash
# Zero hardcoded IPs outside inventory
grep -r '172\.16\.168\.' --include='*.yml' autobot-slm-backend/ansible/ | grep -v inventory/ | wc -l
# Returns: 0
```

## Test plan

- [ ] Verify `ansible-playbook --syntax-check` passes for all playbooks with production inventory
- [ ] Deploy to staging and verify service discovery resolves correctly
- [ ] Verify `/etc/hosts` generation on fresh VM produces correct entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)