### PR TITLE
feat(slm-frontend): accessibility audit and WCAG improvements (#754)

### DIFF
--- a/autobot-slm-frontend/src/App.vue
+++ b/autobot-slm-frontend/src/App.vue
@@ -7,20 +7,24 @@
  * Main App Component
  *
  * Issue #741: Added UpdateNotification for code sync alerts.
+ * Issue #754: Added SkipLink, ARIA landmarks, high contrast init.
  */
 
 import { onMounted, watch, computed } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 import Sidebar from '@/components/common/Sidebar.vue'
+import SkipLink from '@/components/common/SkipLink.vue'
 import UpdateNotification from '@/components/UpdateNotification.vue'
 import { useFleetStore } from '@/stores/fleet'
 import { useAuthStore } from '@/stores/auth'
 import { useSlmWebSocket } from '@/composables/useSlmWebSocket'
+import { useHighContrast } from '@/composables/useAccessibility'
 
 const route = useRoute()
 const fleetStore = useFleetStore()
 const authStore = useAuthStore()
 const ws = useSlmWebSocket()
+const highContrast = useHighContrast()
 
 const isLoginPage = computed(() => route.name === 'login')
 
@@ -55,6 +59,9 @@ async function initializeApp(): Promise<void> {
 }
 
 onMounted(async () => {
+  // Issue #754: Initialize high contrast preference from localStorage
+  highContrast.init()
+
   if (authStore.isAuthenticated) {
     await initializeApp()
   }
@@ -62,6 +69,9 @@ onMounted(async () => {
 </script>
 
 <template>
+  <!-- Issue #754: Skip link for keyboard navigation -->
+  <SkipLink />
+
   <!-- Login page - no sidebar -->
   <template v-if="isLoginPage">
     <RouterView />
@@ -74,7 +84,12 @@ onMounted(async () => {
       <div class="flex-1 flex flex-col overflow-hidden">
         <!-- Issue #741: Top-bar notification for code updates -->
         <UpdateNotification />
-        <main class="flex-1 overflow-auto">
+        <main
+          id="main-content"
+          class="flex-1 overflow-auto"
+          role="main"
+          aria-label="Main content"
+        >
           <RouterView />
         </main>
       </div>

--- a/autobot-slm-frontend/src/assets/styles/main.css
+++ b/autobot-slm-frontend/src/assets/styles/main.css
@@ -6,6 +6,147 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ─── Accessibility: CSS Custom Properties (Issue #754) ──────── */
+
+:root {
+  --a11y-focus-ring: #0284c7;
+  --a11y-focus-width: 2px;
+  --a11y-bg: #ffffff;
+  --a11y-bg-surface: #f9fafb;
+  --a11y-bg-muted: #f3f4f6;
+  --a11y-text: #111827;
+  --a11y-text-muted: #6b7280;
+  --a11y-border: #d1d5db;
+  --a11y-sidebar-bg: #111827;
+  --a11y-sidebar-text: #f3f4f6;
+  --a11y-sidebar-active: #0284c7;
+}
+
+/* ─── High Contrast Mode (Issue #754) ────────────────────────── */
+
+:root[data-theme="high-contrast"] {
+  --a11y-focus-ring: #facc15;
+  --a11y-focus-width: 3px;
+  --a11y-bg: #000000;
+  --a11y-bg-surface: #1a1a1a;
+  --a11y-bg-muted: #262626;
+  --a11y-text: #ffffff;
+  --a11y-text-muted: #d4d4d4;
+  --a11y-border: #737373;
+  --a11y-sidebar-bg: #000000;
+  --a11y-sidebar-text: #ffffff;
+  --a11y-sidebar-active: #facc15;
+}
+
+:root[data-theme="high-contrast"] body {
+  background-color: var(--a11y-bg);
+  color: var(--a11y-text);
+}
+
+:root[data-theme="high-contrast"] .card {
+  background-color: var(--a11y-bg-surface);
+  border-color: var(--a11y-border);
+  color: var(--a11y-text);
+}
+
+:root[data-theme="high-contrast"] .bg-gray-100,
+:root[data-theme="high-contrast"] .bg-gray-50 {
+  background-color: var(--a11y-bg-muted) !important;
+}
+
+:root[data-theme="high-contrast"] .bg-gray-900 {
+  background-color: var(--a11y-sidebar-bg) !important;
+}
+
+:root[data-theme="high-contrast"] .bg-white {
+  background-color: var(--a11y-bg-surface) !important;
+}
+
+:root[data-theme="high-contrast"] .text-gray-900,
+:root[data-theme="high-contrast"] .text-gray-800,
+:root[data-theme="high-contrast"] .text-gray-700 {
+  color: var(--a11y-text) !important;
+}
+
+:root[data-theme="high-contrast"] .text-gray-600,
+:root[data-theme="high-contrast"] .text-gray-500,
+:root[data-theme="high-contrast"] .text-gray-400 {
+  color: var(--a11y-text-muted) !important;
+}
+
+:root[data-theme="high-contrast"] .border-gray-200,
+:root[data-theme="high-contrast"] .border-gray-300,
+:root[data-theme="high-contrast"] .border-gray-100 {
+  border-color: var(--a11y-border) !important;
+}
+
+:root[data-theme="high-contrast"] .btn-primary {
+  background-color: #facc15 !important;
+  color: #000000 !important;
+}
+
+:root[data-theme="high-contrast"] .btn-primary:hover {
+  background-color: #eab308 !important;
+}
+
+:root[data-theme="high-contrast"] .btn-secondary {
+  background-color: #404040 !important;
+  color: #ffffff !important;
+  border: 1px solid #737373;
+}
+
+:root[data-theme="high-contrast"] .input {
+  background-color: var(--a11y-bg-surface);
+  border-color: var(--a11y-border);
+  color: var(--a11y-text);
+}
+
+:root[data-theme="high-contrast"] select {
+  background-color: var(--a11y-bg-surface);
+  border-color: var(--a11y-border);
+  color: var(--a11y-text);
+}
+
+:root[data-theme="high-contrast"] table thead {
+  background-color: var(--a11y-bg-muted) !important;
+}
+
+:root[data-theme="high-contrast"] table th,
+:root[data-theme="high-contrast"] table td {
+  color: var(--a11y-text) !important;
+  border-color: var(--a11y-border) !important;
+}
+
+
+/* ─── Global Focus Indicators (Issue #754) ───────────────────── */
+
+*:focus-visible {
+  outline: var(--a11y-focus-width) solid var(--a11y-focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Remove default focus ring for mouse users but keep for keyboard */
+*:focus:not(:focus-visible) {
+  outline: none;
+}
+
+
+/* ─── Screen Reader Only Utility (Issue #754) ────────────────── */
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+
 @layer base {
   body {
     @apply text-gray-900 antialiased;

--- a/autobot-slm-frontend/src/components/AddNodeModal.vue
+++ b/autobot-slm-frontend/src/components/AddNodeModal.vue
@@ -12,10 +12,14 @@
         v-if="visible"
         class="fixed inset-0 z-50 overflow-y-auto"
         @click.self="handleOverlayClick"
+        @keydown.escape="handleClose"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-node-modal-title"
       >
         <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
           <!-- Background overlay -->
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+          <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
           <!-- Modal panel -->
           <div
@@ -24,22 +28,23 @@
           >
             <!-- Header -->
             <div class="flex items-center justify-between border-b border-gray-200 px-6 py-4">
-              <h3 class="text-lg font-semibold text-gray-900">{{ modalTitle }}</h3>
+              <h3 id="add-node-modal-title" class="text-lg font-semibold text-gray-900">{{ modalTitle }}</h3>
               <button
                 @click="handleClose"
                 :disabled="isSubmitting"
                 class="rounded-md text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50"
+                aria-label="Close dialog"
               >
-                <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
             </div>
 
             <!-- Replace Mode Warning -->
-            <div v-if="isReplaceMode" class="mx-6 mt-4 p-3 bg-yellow-100 border border-yellow-300 rounded-lg">
+            <div v-if="isReplaceMode" class="mx-6 mt-4 p-3 bg-yellow-100 border border-yellow-300 rounded-lg" role="alert">
               <div class="flex items-start gap-3">
-                <svg class="h-5 w-5 text-yellow-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-yellow-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
                 <div>
@@ -57,19 +62,20 @@
               <form @submit.prevent="handleSubmit" class="space-y-6">
 
                 <!-- Connection Information Section -->
-                <div class="space-y-4">
-                  <h4 class="flex items-center gap-2 text-sm font-semibold text-gray-700 border-b border-gray-100 pb-2">
-                    <svg class="h-4 w-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <fieldset class="space-y-4">
+                  <legend class="flex items-center gap-2 text-sm font-semibold text-gray-700 border-b border-gray-100 pb-2">
+                    <svg class="h-4 w-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
                     </svg>
                     Connection Information
-                  </h4>
+                  </legend>
 
                   <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                     <!-- Hostname -->
                     <div class="sm:col-span-1">
                       <label for="hostname" class="block text-sm font-medium text-gray-700 mb-1">
-                        Hostname <span class="text-danger-500">*</span>
+                        Hostname <span class="text-danger-500" aria-hidden="true">*</span>
+                        <span class="sr-only">(required)</span>
                       </label>
                       <input
                         v-model="formData.hostname"
@@ -77,15 +83,19 @@
                         id="hostname"
                         :class="['input', { 'border-danger-500 focus:ring-danger-500 focus:border-danger-500': errors.hostname }]"
                         placeholder="e.g., npu-worker-02"
+                        aria-required="true"
+                        :aria-invalid="!!errors.hostname"
+                        :aria-describedby="errors.hostname ? 'hostname-error' : undefined"
                         @blur="validateField('hostname')"
                       />
-                      <p v-if="errors.hostname" class="mt-1 text-xs text-danger-500">{{ errors.hostname }}</p>
+                      <p v-if="errors.hostname" id="hostname-error" class="mt-1 text-xs text-danger-500" role="alert">{{ errors.hostname }}</p>
                     </div>
 
                     <!-- IP Address -->
                     <div class="sm:col-span-1">
                       <label for="ip_address" class="block text-sm font-medium text-gray-700 mb-1">
-                        IP Address <span class="text-danger-500">*</span>
+                        IP Address <span class="text-danger-500" aria-hidden="true">*</span>
+                        <span class="sr-only">(required)</span>
                       </label>
                       <input
                         v-model="formData.ip_address"
@@ -93,9 +103,12 @@
                         id="ip_address"
                         :class="['input', { 'border-danger-500 focus:ring-danger-500 focus:border-danger-500': errors.ip_address }]"
                         placeholder="e.g., 172.16.168.26"
+                        aria-required="true"
+                        :aria-invalid="!!errors.ip_address"
+                        :aria-describedby="errors.ip_address ? 'ip-error' : undefined"
                         @blur="validateField('ip_address')"
                       />
-                      <p v-if="errors.ip_address" class="mt-1 text-xs text-danger-500">{{ errors.ip_address }}</p>
+                      <p v-if="errors.ip_address" id="ip-error" class="mt-1 text-xs text-danger-500" role="alert">{{ errors.ip_address }}</p>
                     </div>
 
                     <!-- SSH Port -->
@@ -114,19 +127,19 @@
                       />
                     </div>
                   </div>
-                </div>
+                </fieldset>
 
                 <!-- Authentication Method Section -->
-                <div class="space-y-4">
-                  <h4 class="flex items-center gap-2 text-sm font-semibold text-gray-700 border-b border-gray-100 pb-2">
-                    <svg class="h-4 w-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <fieldset class="space-y-4">
+                  <legend class="flex items-center gap-2 text-sm font-semibold text-gray-700 border-b border-gray-100 pb-2">
+                    <svg class="h-4 w-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
                     </svg>
                     Authentication Method
-                  </h4>
+                  </legend>
 
                   <!-- Auth Method Selection -->
-                  <div class="flex gap-4">
+                  <div class="flex gap-4" role="radiogroup" aria-label="Authentication method">
                     <label
                       :class="[
                         'flex-1 flex items-center gap-3 p-4 border-2 rounded-lg cursor-pointer transition-all',
@@ -141,7 +154,7 @@
                         value="password"
                         class="sr-only"
                       />
-                      <div class="flex items-center justify-center w-10 h-10 bg-primary-100 rounded-lg">
+                      <div class="flex items-center justify-center w-10 h-10 bg-primary-100 rounded-lg" aria-hidden="true">
                         <svg class="h-5 w-5 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                         </svg>
@@ -166,7 +179,7 @@
                         value="pki"
                         class="sr-only"
                       />
-                      <div class="flex items-center justify-center w-10 h-10 bg-primary-100 rounded-lg">
+                      <div class="flex items-center justify-center w-10 h-10 bg-primary-100 rounded-lg" aria-hidden="true">
                         <svg class="h-5 w-5 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
                         </svg>
@@ -184,7 +197,8 @@
                       <!-- SSH User -->
                       <div>
                         <label for="ssh_user" class="block text-sm font-medium text-gray-700 mb-1">
-                          Username <span class="text-danger-500">*</span>
+                          Username <span class="text-danger-500" aria-hidden="true">*</span>
+                          <span class="sr-only">(required)</span>
                         </label>
                         <input
                           v-model="formData.ssh_user"
@@ -192,6 +206,7 @@
                           id="ssh_user"
                           class="input"
                           placeholder="autobot"
+                          aria-required="true"
                         />
                       </div>
 
@@ -199,7 +214,8 @@
                       <div>
                         <label for="ssh_password" class="block text-sm font-medium text-gray-700 mb-1">
                           Password
-                          <span v-if="!isEditMode || needsCredentialsForEdit" class="text-danger-500">*</span>
+                          <span v-if="!isEditMode || needsCredentialsForEdit" class="text-danger-500" aria-hidden="true">*</span>
+                          <span v-if="!isEditMode || needsCredentialsForEdit" class="sr-only">(required)</span>
                           <span v-else class="text-gray-400 text-xs ml-1">(optional)</span>
                         </label>
                         <div class="relative">
@@ -209,23 +225,28 @@
                             id="ssh_password"
                             :class="['input pr-10', { 'border-danger-500 focus:ring-danger-500 focus:border-danger-500': errors.ssh_password }]"
                             :placeholder="isEditMode && !needsCredentialsForEdit ? 'Leave empty for basic edit' : 'Enter password'"
+                            :aria-required="!isEditMode || needsCredentialsForEdit ? 'true' : undefined"
+                            :aria-invalid="!!errors.ssh_password"
+                            :aria-describedby="errors.ssh_password ? 'password-error' : undefined"
                             @blur="validateField('ssh_password')"
                           />
                           <button
                             type="button"
                             @click="showPassword = !showPassword"
                             class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+                            :aria-label="showPassword ? 'Hide password' : 'Show password'"
+                            :aria-pressed="showPassword"
                           >
-                            <svg v-if="!showPassword" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <svg v-if="!showPassword" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                             </svg>
-                            <svg v-else class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <svg v-else class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
                             </svg>
                           </button>
                         </div>
-                        <p v-if="errors.ssh_password" class="mt-1 text-xs text-danger-500">{{ errors.ssh_password }}</p>
+                        <p v-if="errors.ssh_password" id="password-error" class="mt-1 text-xs text-danger-500" role="alert">{{ errors.ssh_password }}</p>
                       </div>
                     </div>
 
@@ -245,7 +266,8 @@
                     <!-- SSH User -->
                     <div>
                       <label for="ssh_user_pki" class="block text-sm font-medium text-gray-700 mb-1">
-                        Username <span class="text-danger-500">*</span>
+                        Username <span class="text-danger-500" aria-hidden="true">*</span>
+                        <span class="sr-only">(required)</span>
                       </label>
                       <input
                         v-model="formData.ssh_user"
@@ -253,13 +275,14 @@
                         id="ssh_user_pki"
                         class="input"
                         placeholder="autobot"
+                        aria-required="true"
                       />
                     </div>
 
                     <!-- Key Source Selection -->
                     <div>
                       <label class="block text-sm font-medium text-gray-700 mb-2">SSH Key Source</label>
-                      <div class="space-y-2">
+                      <div class="space-y-2" role="radiogroup" aria-label="SSH key source">
                         <label
                           v-for="option in keySourceOptions"
                           :key="option.value"
@@ -306,23 +329,25 @@
                         rows="5"
                         :class="['input font-mono text-xs', { 'border-danger-500 focus:ring-danger-500 focus:border-danger-500': errors.ssh_key }]"
                         placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;...&#10;-----END OPENSSH PRIVATE KEY-----"
+                        :aria-invalid="!!errors.ssh_key"
+                        :aria-describedby="errors.ssh_key ? 'ssh-key-error' : undefined"
                         @blur="validateField('ssh_key')"
                       ></textarea>
-                      <p v-if="errors.ssh_key" class="mt-1 text-xs text-danger-500">{{ errors.ssh_key }}</p>
+                      <p v-if="errors.ssh_key" id="ssh-key-error" class="mt-1 text-xs text-danger-500" role="alert">{{ errors.ssh_key }}</p>
                     </div>
                   </div>
-                </div>
+                </fieldset>
 
                 <!-- Role Assignment Section -->
-                <div class="space-y-4">
-                  <h4 class="flex items-center gap-2 text-sm font-semibold text-gray-700 border-b border-gray-100 pb-2">
-                    <svg class="h-4 w-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <fieldset class="space-y-4">
+                  <legend class="flex items-center gap-2 text-sm font-semibold text-gray-700 border-b border-gray-100 pb-2">
+                    <svg class="h-4 w-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
                     </svg>
                     Role Assignment
-                  </h4>
+                  </legend>
 
-                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-3" role="group" aria-label="Available roles">
                     <label
                       v-for="role in availableRoles"
                       :key="role.id"
@@ -338,6 +363,7 @@
                         :value="role.id"
                         v-model="formData.roles"
                         class="mt-0.5 w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                        :aria-label="`${role.name}: ${role.description}`"
                       />
                       <div>
                         <p class="font-medium text-gray-900 text-sm">{{ role.name }}</p>
@@ -345,30 +371,30 @@
                       </div>
                     </label>
                   </div>
-                  <p v-if="errors.roles" class="text-xs text-danger-500">{{ errors.roles }}</p>
+                  <p v-if="errors.roles" class="text-xs text-danger-500" role="alert">{{ errors.roles }}</p>
 
                   <!-- Selected Roles Details -->
-                  <div v-if="selectedRolesDetails.length > 0" class="p-3 bg-gray-50 rounded-lg">
+                  <div v-if="selectedRolesDetails.length > 0" class="p-3 bg-gray-50 rounded-lg" role="status">
                     <p class="text-xs font-medium text-gray-600 mb-2">Selected roles will configure:</p>
                     <div class="space-y-1">
                       <div v-for="role in selectedRolesDetails" :key="role.id" class="flex items-center gap-2 text-xs">
-                        <span class="w-2 h-2 bg-primary-500 rounded-full"></span>
+                        <span class="w-2 h-2 bg-primary-500 rounded-full" aria-hidden="true"></span>
                         <span class="text-gray-700">{{ role.name }}: {{ role.services?.join(', ') || 'No services' }}</span>
                         <span v-if="role.default_port" class="text-gray-500">(Port {{ role.default_port }})</span>
                       </div>
                     </div>
                   </div>
-                </div>
+                </fieldset>
 
                 <!-- Enrollment Options Section -->
-                <div class="space-y-4">
-                  <h4 class="flex items-center gap-2 text-sm font-semibold text-gray-700 border-b border-gray-100 pb-2">
-                    <svg class="h-4 w-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <fieldset class="space-y-4">
+                  <legend class="flex items-center gap-2 text-sm font-semibold text-gray-700 border-b border-gray-100 pb-2">
+                    <svg class="h-4 w-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                     </svg>
                     {{ isEditMode ? 'Update Options' : 'Enrollment Options' }}
-                  </h4>
+                  </legend>
 
                   <!-- Add/Replace Mode Options -->
                   <div v-if="!isEditMode" class="space-y-3">
@@ -421,8 +447,8 @@
                   <!-- Edit Mode Options -->
                   <div v-if="isEditMode" class="space-y-3">
                     <!-- Info: PKI auth - no password ever needed -->
-                    <div v-if="formData.auth_method === 'pki'" class="flex items-start gap-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-                      <svg class="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <div v-if="formData.auth_method === 'pki'" class="flex items-start gap-3 p-3 bg-blue-50 border border-blue-200 rounded-lg" role="status">
+                      <svg class="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
                       </svg>
                       <p class="text-sm text-blue-700">
@@ -430,8 +456,8 @@
                       </p>
                     </div>
                     <!-- Info: Password auth - credentials optional for basic edits -->
-                    <div v-else-if="!needsCredentialsForEdit" class="flex items-start gap-3 p-3 bg-green-50 border border-green-200 rounded-lg">
-                      <svg class="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <div v-else-if="!needsCredentialsForEdit" class="flex items-start gap-3 p-3 bg-green-50 border border-green-200 rounded-lg" role="status">
+                      <svg class="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                       </svg>
                       <p class="text-sm text-green-700">
@@ -439,8 +465,8 @@
                       </p>
                     </div>
                     <!-- Info: Password auth with SSH ops - password required -->
-                    <div v-else class="flex items-start gap-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-                      <svg class="h-5 w-5 text-amber-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <div v-else class="flex items-start gap-3 p-3 bg-amber-50 border border-amber-200 rounded-lg" role="alert">
+                      <svg class="h-5 w-5 text-amber-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                       </svg>
                       <p class="text-sm text-amber-700">
@@ -478,15 +504,15 @@
                   </div>
 
                   <!-- PKI Migration Notice -->
-                  <div v-if="isEditMode && formData.auth_method === 'password' && formData.ssh_password" class="flex items-start gap-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-                    <svg class="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <div v-if="isEditMode && formData.auth_method === 'password' && formData.ssh_password" class="flex items-start gap-3 p-3 bg-blue-50 border border-blue-200 rounded-lg" role="status">
+                    <svg class="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                     <p class="text-sm text-blue-700">
                       Password will be used to establish connection and deploy PKI certificates.
                     </p>
                   </div>
-                </div>
+                </fieldset>
 
                 <!-- Replace Confirmation (for replace mode) -->
                 <div v-if="isReplaceMode" class="space-y-3">
@@ -513,7 +539,7 @@
                   testResult.success
                     ? 'bg-green-50 border-green-200'
                     : 'bg-red-50 border-red-200'
-                ]">
+                ]" :role="testResult.success ? 'status' : 'alert'">
                   <svg
                     :class="[
                       'h-5 w-5 mt-0.5 flex-shrink-0',
@@ -522,6 +548,7 @@
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
+                    aria-hidden="true"
                   >
                     <path
                       v-if="testResult.success"
@@ -552,6 +579,7 @@
                 <div
                   v-if="error"
                   class="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm"
+                  role="alert"
                 >
                   {{ error }}
                 </div>
@@ -560,6 +588,7 @@
                 <div
                   v-if="success"
                   class="p-3 bg-green-50 border border-green-200 rounded-lg text-green-700 text-sm"
+                  role="status"
                 >
                   {{ success }}
                 </div>
@@ -584,11 +613,11 @@
                   :disabled="!canTest || isTesting"
                   class="btn btn-secondary flex items-center gap-2"
                 >
-                  <svg v-if="isTesting" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+                  <svg v-if="isTesting" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                   </svg>
-                  <svg v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
                   </svg>
                   {{ isTesting ? 'Testing...' : 'Test Connection' }}
@@ -603,14 +632,14 @@
                     isReplaceMode ? 'btn-danger' : 'btn-primary'
                   ]"
                 >
-                  <svg v-if="isSubmitting" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+                  <svg v-if="isSubmitting" class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                   </svg>
-                  <svg v-else-if="isEditMode" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg v-else-if="isEditMode" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4" />
                   </svg>
-                  <svg v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
                   </svg>
                   {{ submitButtonText }}
@@ -628,6 +657,19 @@
 // AutoBot - AI-Powered Automation Platform
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
+
+/**
+ * AddNodeModal - Modal for adding, editing, or replacing fleet nodes.
+ *
+ * Issue #754: Added role="dialog", aria-modal, aria-labelledby,
+ * @keydown.escape, aria-hidden on decorative elements,
+ * aria-label/aria-pressed on password toggle, aria-required/aria-invalid
+ * on required fields, aria-describedby linking errors to inputs,
+ * role="alert" on error messages, role="status" on info/success,
+ * role="radiogroup" on auth method and key source, fieldset/legend
+ * on form sections, role="group" on role checkboxes,
+ * sr-only text for required indicators.
+ */
 
 import { ref, computed, watch, onMounted } from 'vue'
 import { useSlmApi } from '@/composables/useSlmApi'
@@ -1128,3 +1170,18 @@ function handleClose() {
   emit('close')
 }
 </script>
+
+<style scoped>
+/* Screen reader only utility (Issue #754) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+</style>

--- a/autobot-slm-frontend/src/components/DeploymentLogViewer.vue
+++ b/autobot-slm-frontend/src/components/DeploymentLogViewer.vue
@@ -3,6 +3,15 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
+/**
+ * DeploymentLogViewer - Real-time deployment log viewer with WebSocket.
+ *
+ * Issue #754: Added role="dialog", aria-modal, aria-labelledby,
+ * role="progressbar" with aria-valuenow, role="log" on log container,
+ * role="status" on connection indicator, role="alert" on error,
+ * accessible labels on close buttons.
+ */
+
 import { ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -226,18 +235,23 @@ onUnmounted(() => {
     v-if="visible"
     class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
     @click.self="emit('close')"
+    @keydown.escape="emit('close')"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="deployment-log-title"
   >
     <div class="bg-gray-900 rounded-lg shadow-xl w-full max-w-4xl mx-4 max-h-[80vh] flex flex-col">
       <!-- Header -->
       <div class="flex items-center justify-between px-4 py-3 border-b border-gray-700">
         <div class="flex items-center gap-3">
-          <h3 class="text-lg font-semibold text-white">Deployment Log</h3>
+          <h3 id="deployment-log-title" class="text-lg font-semibold text-white">Deployment Log</h3>
           <span class="text-sm text-gray-400">{{ deploymentId }}</span>
           <span
             :class="[
               'px-2 py-0.5 text-xs font-medium rounded-full',
               getStatusBadgeClass(status),
             ]"
+            role="status"
           >
             {{ status }}
           </span>
@@ -245,8 +259,9 @@ onUnmounted(() => {
         <button
           @click="emit('close')"
           class="text-gray-400 hover:text-white transition-colors"
+          aria-label="Close deployment log"
         >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -260,13 +275,20 @@ onUnmounted(() => {
       <!-- Progress Bar -->
       <div v-if="progress > 0" class="px-4 py-2 border-b border-gray-700">
         <div class="flex items-center gap-3">
-          <div class="flex-1 bg-gray-700 rounded-full h-2">
+          <div
+            class="flex-1 bg-gray-700 rounded-full h-2"
+            role="progressbar"
+            :aria-valuenow="progress"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :aria-label="`Deployment progress: ${progress}%`"
+          >
             <div
               class="bg-blue-500 h-2 rounded-full transition-all duration-300"
               :style="{ width: `${progress}%` }"
             />
           </div>
-          <span class="text-sm text-gray-400 w-12 text-right">{{ progress }}%</span>
+          <span class="text-sm text-gray-400 w-12 text-right" aria-hidden="true">{{ progress }}%</span>
         </div>
       </div>
 
@@ -274,6 +296,9 @@ onUnmounted(() => {
       <div
         ref="logContainer"
         class="flex-1 overflow-y-auto p-4 font-mono text-sm bg-gray-950"
+        role="log"
+        aria-label="Deployment log output"
+        aria-live="polite"
       >
         <div
           v-for="(log, index) in logs"
@@ -292,9 +317,10 @@ onUnmounted(() => {
       <div
         v-if="error"
         class="px-4 py-3 bg-red-900 border-t border-red-700 text-red-200"
+        role="alert"
       >
         <div class="flex items-center gap-2">
-          <svg class="w-5 h-5 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+          <svg class="w-5 h-5 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
             <path
               fill-rule="evenodd"
               d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
@@ -307,12 +333,13 @@ onUnmounted(() => {
 
       <!-- Footer -->
       <div class="flex items-center justify-between px-4 py-3 border-t border-gray-700">
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2" role="status" :aria-label="isConnected ? 'WebSocket connected' : 'WebSocket disconnected'">
           <span
             :class="[
               'w-2 h-2 rounded-full',
               isConnected ? 'bg-green-500' : 'bg-red-500',
             ]"
+            aria-hidden="true"
           />
           <span class="text-sm text-gray-400">
             {{ isConnected ? 'Connected' : 'Disconnected' }}

--- a/autobot-slm-frontend/src/components/RoleManagementModal.vue
+++ b/autobot-slm-frontend/src/components/RoleManagementModal.vue
@@ -7,6 +7,10 @@
  * Role Management Modal (Issue #779)
  *
  * Allows viewing and managing roles for a node.
+ *
+ * Issue #754: Added role="dialog", aria-modal, aria-labelledby,
+ * keyboard escape handling, accessible labels on buttons,
+ * scope attributes on table headers, role="status" on sync message.
  */
 
 import { ref, computed, onMounted } from 'vue'
@@ -109,21 +113,30 @@ function formatDate(dateStr: string | null): string {
 </script>
 
 <template>
-  <div class="modal-overlay" @click.self="emit('close')">
+  <div
+    class="modal-overlay"
+    @click.self="emit('close')"
+    @keydown.escape="emit('close')"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="role-mgmt-title"
+  >
     <div class="modal-content">
       <div class="modal-header">
-        <h3>Role Management</h3>
+        <h3 id="role-mgmt-title">Role Management</h3>
         <span class="hostname">{{ hostname }}</span>
-        <button class="close-btn" @click="emit('close')">×</button>
+        <button class="close-btn" @click="emit('close')" aria-label="Close role management">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
 
-      <div v-if="isLoading" class="loading">
+      <div v-if="isLoading" class="loading" role="status">
         Loading role information...
       </div>
 
       <div v-else class="modal-body">
         <!-- Detected Roles Section -->
-        <section class="section">
+        <section class="section" aria-label="Auto-detected roles">
           <h4>Auto-Detected Roles</h4>
           <div v-if="detectedRolesList.length === 0" class="empty-message">
             No roles auto-detected on this node.
@@ -141,16 +154,16 @@ function formatDate(dateStr: string | null): string {
         </section>
 
         <!-- All Role Statuses -->
-        <section class="section">
+        <section class="section" aria-label="Role status table">
           <h4>Role Status</h4>
           <table class="role-table" v-if="allNodeRoles.length > 0">
             <thead>
               <tr>
-                <th>Role</th>
-                <th>Status</th>
-                <th>Version</th>
-                <th>Last Synced</th>
-                <th>Actions</th>
+                <th scope="col">Role</th>
+                <th scope="col">Status</th>
+                <th scope="col">Version</th>
+                <th scope="col">Last Synced</th>
+                <th scope="col">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -173,6 +186,7 @@ function formatDate(dateStr: string | null): string {
                     class="btn btn-sm btn-primary"
                     :disabled="isSyncing"
                     @click="handleSyncRole(role.role_name)"
+                    :aria-label="`Sync ${role.role_name}`"
                   >
                     Sync
                   </button>
@@ -181,6 +195,7 @@ function formatDate(dateStr: string | null): string {
                     class="btn btn-sm btn-danger"
                     :disabled="isSaving"
                     @click="handleRemoveRole(role.role_name)"
+                    :aria-label="`Remove ${role.role_name}`"
                   >
                     Remove
                   </button>
@@ -194,10 +209,11 @@ function formatDate(dateStr: string | null): string {
         </section>
 
         <!-- Assign Role Section -->
-        <section class="section">
+        <section class="section" aria-label="Assign role">
           <h4>Assign Role Manually</h4>
           <div class="assign-form">
-            <select v-model="selectedRole" class="role-select">
+            <label for="role-select" class="sr-only">Select a role to assign</label>
+            <select id="role-select" v-model="selectedRole" class="role-select">
               <option value="">Select a role...</option>
               <option
                 v-for="role in availableRoles"
@@ -218,7 +234,7 @@ function formatDate(dateStr: string | null): string {
         </section>
 
         <!-- Listening Ports -->
-        <section class="section" v-if="nodeRoles?.listening_ports?.length">
+        <section class="section" v-if="nodeRoles?.listening_ports?.length" aria-label="Listening ports">
           <h4>Listening Ports</h4>
           <div class="port-list">
             <span
@@ -233,7 +249,7 @@ function formatDate(dateStr: string | null): string {
         </section>
 
         <!-- Sync Message -->
-        <div v-if="syncMessage" class="sync-message">
+        <div v-if="syncMessage" class="sync-message" role="status">
           {{ syncMessage }}
         </div>
       </div>
@@ -484,5 +500,18 @@ function formatDate(dateStr: string | null): string {
 .btn-danger {
   background: var(--danger-color, #ef4444);
   color: white;
+}
+
+/* Screen reader only utility (Issue #754) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }
 </style>

--- a/autobot-slm-frontend/src/components/UpdateNotification.vue
+++ b/autobot-slm-frontend/src/components/UpdateNotification.vue
@@ -8,6 +8,9 @@
  *
  * Top-bar notification banner that appears when nodes need code updates.
  * Provides quick access to the Code Sync page and can be dismissed.
+ *
+ * Issue #754: Added role="alert", aria-live, accessible labels
+ * on dismiss button, aria-hidden on decorative icons.
  */
 
 import { ref, computed, onMounted } from 'vue'
@@ -68,11 +71,13 @@ function goToCodeSync(): void {
     <div
       v-if="shouldShow"
       class="update-notification"
+      role="alert"
+      aria-live="polite"
     >
       <div class="flex items-center justify-between gap-4">
         <div class="flex items-center gap-3">
           <!-- Warning icon -->
-          <div class="flex-shrink-0">
+          <div class="flex-shrink-0" aria-hidden="true">
             <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 stroke-linecap="round"
@@ -105,9 +110,9 @@ function goToCodeSync(): void {
           <button
             @click="dismiss"
             class="p-1.5 text-amber-600 hover:text-amber-800 hover:bg-amber-200 rounded-md transition-colors"
-            title="Dismiss"
+            aria-label="Dismiss update notification"
           >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>

--- a/autobot-slm-frontend/src/components/common/SkipLink.vue
+++ b/autobot-slm-frontend/src/components/common/SkipLink.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * SkipLink - Accessible skip navigation link.
+ *
+ * Provides a visually hidden link that becomes visible on focus,
+ * allowing keyboard users to skip past navigation to main content.
+ *
+ * Issue #754: Accessibility audit and improvements.
+ */
+
+withDefaults(defineProps<{
+  /** CSS selector or id of the target element to skip to. */
+  target?: string
+  /** Link text shown when focused. */
+  label?: string
+}>(), {
+  target: '#main-content',
+  label: 'Skip to main content',
+})
+
+function handleClick(event: MouseEvent, target: string): void {
+  event.preventDefault()
+  const el = document.querySelector(target)
+  if (el instanceof HTMLElement) {
+    el.setAttribute('tabindex', '-1')
+    el.focus()
+    el.removeAttribute('tabindex')
+  }
+}
+</script>
+
+<template>
+  <a
+    :href="target"
+    class="skip-link"
+    @click="handleClick($event, target)"
+  >
+    {{ label }}
+  </a>
+</template>
+
+<style scoped>
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  padding: 0.75rem 1.5rem;
+  background: var(--a11y-bg, #0284c7);
+  color: var(--a11y-text, #ffffff);
+  font-weight: 600;
+  font-size: 0.875rem;
+  border-radius: 0 0 0.5rem 0.5rem;
+  text-decoration: none;
+  transition: top 0.15s ease-in-out;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 2px solid var(--a11y-focus-ring, #38bdf8);
+  outline-offset: 2px;
+}
+</style>

--- a/autobot-slm-frontend/src/components/fleet/FleetSummary.vue
+++ b/autobot-slm-frontend/src/components/fleet/FleetSummary.vue
@@ -3,6 +3,12 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
+/**
+ * FleetSummary - Fleet health statistics cards.
+ *
+ * Issue #754: Added ARIA roles, region landmark, descriptive labels.
+ */
+
 import { computed } from 'vue'
 import { useFleetStore } from '@/stores/fleet'
 
@@ -49,14 +55,19 @@ const stats = computed(() => [
 </script>
 
 <template>
-  <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
+  <div
+    class="grid grid-cols-2 md:grid-cols-5 gap-4"
+    role="region"
+    aria-label="Fleet health summary"
+  >
     <div
       v-for="stat in stats"
       :key="stat.label"
       class="card p-4"
+      :aria-label="`${stat.label}: ${stat.value}`"
     >
       <div class="flex items-center gap-3">
-        <div :class="['p-2 rounded-lg', stat.bgColor]">
+        <div :class="['p-2 rounded-lg', stat.bgColor]" aria-hidden="true">
           <!-- Server icon -->
           <svg v-if="stat.icon === 'server'" :class="['w-5 h-5', stat.color]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />

--- a/autobot-slm-frontend/src/components/fleet/NodeCard.vue
+++ b/autobot-slm-frontend/src/components/fleet/NodeCard.vue
@@ -3,6 +3,13 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
+/**
+ * NodeCard - Fleet node summary card.
+ *
+ * Issue #754: Added ARIA labels for icon-only buttons, role="listitem",
+ * progress bar accessibility, dropdown menu roles, status labels.
+ */
+
 import { ref, computed } from 'vue'
 import type { SLMNode } from '@/types/slm'
 import { useFleetStore } from '@/stores/fleet'
@@ -83,6 +90,17 @@ function closeMenu(): void {
   showMenu.value = false
 }
 
+/**
+ * Handle keyboard events for dropdown menu items.
+ *
+ * Helper for NodeCard keyboard navigation (Issue #754).
+ */
+function handleMenuKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    showMenu.value = false
+  }
+}
+
 // Update indicators (#682)
 const updateSummary = computed(() => {
   return fleetStore.getNodeUpdateSummary(props.node.node_id)
@@ -94,11 +112,20 @@ const hasUpdates = computed(() => {
 </script>
 
 <template>
-  <div class="card p-4 hover:shadow-md transition-shadow relative" @mouseleave="closeMenu">
+  <div
+    class="card p-4 hover:shadow-md transition-shadow relative"
+    role="listitem"
+    :aria-label="`Node ${node.hostname}, status: ${statusText}`"
+    @mouseleave="closeMenu"
+  >
     <!-- Header -->
     <div class="flex items-start justify-between mb-3">
       <div class="flex items-center gap-2 min-w-0 flex-1">
-        <div :class="['w-3 h-3 rounded-full flex-shrink-0', statusClass]"></div>
+        <div
+          :class="['w-3 h-3 rounded-full flex-shrink-0', statusClass]"
+          role="img"
+          :aria-label="`Status: ${statusText}`"
+        ></div>
         <span class="font-medium text-gray-900 truncate">{{ node.hostname }}</span>
       </div>
       <div class="flex items-center gap-2">
@@ -108,9 +135,11 @@ const hasUpdates = computed(() => {
           <button
             @click.stop="toggleMenu"
             class="p-1 text-gray-400 hover:text-gray-600 transition-colors rounded hover:bg-gray-100"
-            title="Actions"
+            :aria-label="`Actions for ${node.hostname}`"
+            :aria-expanded="showMenu"
+            aria-haspopup="true"
           >
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
             </svg>
           </button>
@@ -118,78 +147,55 @@ const hasUpdates = computed(() => {
           <div
             v-if="showMenu"
             class="absolute right-0 top-full mt-1 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50"
+            role="menu"
+            :aria-label="`Actions for ${node.hostname}`"
+            @keydown="handleMenuKeydown"
           >
-            <button
-              @click="handleAction('edit')"
-              class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <button @click="handleAction('edit')" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
               </svg>
               Edit Node
             </button>
-            <button
-              @click="handleAction('roles')"
-              class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <button @click="handleAction('roles')" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
               </svg>
               Manage Roles
             </button>
-            <button
-              v-if="canEnroll"
-              @click="handleAction('enroll')"
-              :disabled="isEnrolling"
-              class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2 disabled:opacity-50"
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <button v-if="canEnroll" @click="handleAction('enroll')" :disabled="isEnrolling" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2 disabled:opacity-50">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               {{ isEnrolling ? 'Enrolling...' : 'Enroll Node' }}
             </button>
-            <button
-              @click="handleAction('test')"
-              class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <button @click="handleAction('test')" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0" />
               </svg>
               Test Connection
             </button>
-            <button
-              @click="handleAction('certificate')"
-              class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <button @click="handleAction('certificate')" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
               </svg>
               Certificate
             </button>
-            <button
-              @click="handleAction('events')"
-              class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <button @click="handleAction('events')" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               View Events
             </button>
-            <button
-              @click="handleAction('services')"
-              class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2"
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <button @click="handleAction('services')" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
               </svg>
               Services
             </button>
-            <hr class="my-1 border-gray-200" />
-            <button
-              @click="handleAction('delete')"
-              class="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 flex items-center gap-2"
-            >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <hr class="my-1 border-gray-200" role="separator" />
+            <button @click="handleAction('delete')" role="menuitem" class="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 flex items-center gap-2">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
               </svg>
               Delete Node
@@ -205,7 +211,6 @@ const hasUpdates = computed(() => {
         {{ node.ip_address }}
         <span v-if="node.ssh_port && node.ssh_port !== 22" class="text-gray-400">:{{ node.ssh_port }}</span>
       </div>
-      <!-- Auth Method Badge (#722) -->
       <span
         :class="['px-2 py-0.5 text-xs font-medium rounded', authMethodBadge.class]"
         :title="`Authentication: ${authMethodBadge.label}`"
@@ -214,12 +219,14 @@ const hasUpdates = computed(() => {
       </span>
     </div>
 
-    <!-- Enrolling Transition Indicator (#722) -->
+    <!-- Enrolling Transition Indicator -->
     <div
       v-if="isEnrolling"
       class="flex items-center gap-2 px-2 py-1.5 mb-3 bg-blue-50 border border-blue-200 rounded text-xs text-blue-700"
+      role="status"
+      aria-label="Node is being enrolled"
     >
-      <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+      <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
       </svg>
@@ -227,7 +234,7 @@ const hasUpdates = computed(() => {
     </div>
 
     <!-- Roles -->
-    <div class="flex flex-wrap gap-1 mb-3">
+    <div class="flex flex-wrap gap-1 mb-3" aria-label="Assigned roles">
       <span
         v-for="role in node.roles"
         :key="role"
@@ -244,36 +251,28 @@ const hasUpdates = computed(() => {
     <div v-if="hasUpdates" class="flex items-center gap-2 mb-3">
       <button
         @click="handleAction('updates')"
+        :aria-label="`${updateSummary?.total_updates} updates available for ${node.hostname}`"
         class="flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-md bg-amber-50 border border-amber-200 text-amber-700 hover:bg-amber-100 transition-colors w-full"
       >
-        <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
         </svg>
         <span v-if="updateSummary?.system_updates" class="whitespace-nowrap">
           {{ updateSummary.system_updates }} pkg{{ updateSummary.system_updates !== 1 ? 's' : '' }}
         </span>
-        <span
-          v-if="updateSummary?.system_updates && updateSummary?.code_update_available"
-          class="text-amber-400"
-        >+</span>
-        <span v-if="updateSummary?.code_update_available" class="whitespace-nowrap">
-          code
-        </span>
+        <span v-if="updateSummary?.system_updates && updateSummary?.code_update_available" class="text-amber-400" aria-hidden="true">+</span>
+        <span v-if="updateSummary?.code_update_available" class="whitespace-nowrap">code</span>
       </button>
     </div>
 
-    <!-- Health Metrics -->
-    <div v-if="node.health" class="space-y-2 mb-3">
+    <!-- Health Metrics (Issue #754: progressbar roles) -->
+    <div v-if="node.health" class="space-y-2 mb-3" aria-label="Health metrics">
       <!-- CPU -->
       <div class="flex items-center gap-2 text-xs">
-        <span class="w-12 text-gray-500">CPU</span>
-        <div class="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
+        <span class="w-12 text-gray-500" id="cpu-label">CPU</span>
+        <div class="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden" role="progressbar" :aria-valuenow="node.health.cpu_percent" aria-valuemin="0" aria-valuemax="100" aria-labelledby="cpu-label">
           <div
-            :class="[
-              'h-full rounded-full transition-all',
-              node.health.cpu_percent > 80 ? 'bg-red-500' :
-              node.health.cpu_percent > 60 ? 'bg-yellow-500' : 'bg-green-500'
-            ]"
+            :class="['h-full rounded-full transition-all', node.health.cpu_percent > 80 ? 'bg-red-500' : node.health.cpu_percent > 60 ? 'bg-yellow-500' : 'bg-green-500']"
             :style="{ width: `${node.health.cpu_percent}%` }"
           ></div>
         </div>
@@ -282,14 +281,10 @@ const hasUpdates = computed(() => {
 
       <!-- Memory -->
       <div class="flex items-center gap-2 text-xs">
-        <span class="w-12 text-gray-500">MEM</span>
-        <div class="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
+        <span class="w-12 text-gray-500" id="mem-label">MEM</span>
+        <div class="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden" role="progressbar" :aria-valuenow="node.health.memory_percent" aria-valuemin="0" aria-valuemax="100" aria-labelledby="mem-label">
           <div
-            :class="[
-              'h-full rounded-full transition-all',
-              node.health.memory_percent > 80 ? 'bg-red-500' :
-              node.health.memory_percent > 60 ? 'bg-yellow-500' : 'bg-green-500'
-            ]"
+            :class="['h-full rounded-full transition-all', node.health.memory_percent > 80 ? 'bg-red-500' : node.health.memory_percent > 60 ? 'bg-yellow-500' : 'bg-green-500']"
             :style="{ width: `${node.health.memory_percent}%` }"
           ></div>
         </div>
@@ -298,14 +293,10 @@ const hasUpdates = computed(() => {
 
       <!-- Disk -->
       <div class="flex items-center gap-2 text-xs">
-        <span class="w-12 text-gray-500">DISK</span>
-        <div class="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
+        <span class="w-12 text-gray-500" id="disk-label">DISK</span>
+        <div class="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden" role="progressbar" :aria-valuenow="node.health.disk_percent" aria-valuemin="0" aria-valuemax="100" aria-labelledby="disk-label">
           <div
-            :class="[
-              'h-full rounded-full transition-all',
-              node.health.disk_percent > 80 ? 'bg-red-500' :
-              node.health.disk_percent > 60 ? 'bg-yellow-500' : 'bg-green-500'
-            ]"
+            :class="['h-full rounded-full transition-all', node.health.disk_percent > 80 ? 'bg-red-500' : node.health.disk_percent > 60 ? 'bg-yellow-500' : 'bg-green-500']"
             :style="{ width: `${node.health.disk_percent}%` }"
           ></div>
         </div>
@@ -325,9 +316,9 @@ const hasUpdates = computed(() => {
         <button
           @click="handleAction('view')"
           class="p-1.5 text-gray-400 hover:text-primary-600 hover:bg-primary-50 transition-colors rounded"
-          title="View details"
+          :aria-label="`View details for ${node.hostname}`"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
           </svg>
@@ -335,9 +326,9 @@ const hasUpdates = computed(() => {
         <button
           @click="handleAction('restart')"
           class="p-1.5 text-gray-400 hover:text-yellow-600 hover:bg-yellow-50 transition-colors rounded"
-          title="Restart services"
+          :aria-label="`Restart ${node.hostname}`"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
           </svg>
         </button>

--- a/autobot-slm-frontend/src/composables/useAccessibility.ts
+++ b/autobot-slm-frontend/src/composables/useAccessibility.ts
@@ -1,0 +1,305 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Accessibility composables for WCAG 2.1 AA compliance.
+ *
+ * Provides:
+ * - useFocusTrap: traps focus within modals/dialogs
+ * - useKeyboardNav: arrow key navigation for lists/grids
+ * - useHighContrast: high contrast mode toggle with localStorage
+ * - useAnnounce: screen reader announcements via aria-live
+ *
+ * Issue #754: Accessibility audit and improvements.
+ */
+
+import { ref, onMounted, onUnmounted, watch, type Ref } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('Accessibility')
+
+// ─── High Contrast Mode ───────────────────────────────────────
+
+const CONTRAST_STORAGE_KEY = 'autobot-high-contrast'
+
+/** Shared reactive state for high contrast mode across all consumers. */
+const highContrastEnabled = ref(false)
+
+/**
+ * Apply or remove the high-contrast data attribute on the root element.
+ *
+ * Helper for useHighContrast (Issue #754).
+ */
+function applyHighContrast(enabled: boolean): void {
+  if (enabled) {
+    document.documentElement.setAttribute('data-theme', 'high-contrast')
+  } else {
+    document.documentElement.removeAttribute('data-theme')
+  }
+}
+
+/**
+ * High contrast mode composable with localStorage persistence.
+ *
+ * Issue #754: Accessibility audit and improvements.
+ */
+export function useHighContrast() {
+  function toggle(): void {
+    highContrastEnabled.value = !highContrastEnabled.value
+    localStorage.setItem(CONTRAST_STORAGE_KEY, String(highContrastEnabled.value))
+    applyHighContrast(highContrastEnabled.value)
+    logger.info('High contrast mode:', highContrastEnabled.value ? 'enabled' : 'disabled')
+  }
+
+  function init(): void {
+    const stored = localStorage.getItem(CONTRAST_STORAGE_KEY)
+    if (stored === 'true') {
+      highContrastEnabled.value = true
+      applyHighContrast(true)
+    }
+  }
+
+  return {
+    enabled: highContrastEnabled,
+    toggle,
+    init,
+  }
+}
+
+
+// ─── Focus Trap ───────────────────────────────────────────────
+
+/**
+ * Trap focus within a container element (for modals/dialogs).
+ *
+ * Issue #754: Accessibility audit and improvements.
+ */
+export function useFocusTrap(containerRef: Ref<HTMLElement | null>) {
+  let previousFocus: HTMLElement | null = null
+
+  const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(', ')
+
+  function getFocusableElements(): HTMLElement[] {
+    if (!containerRef.value) return []
+    return Array.from(containerRef.value.querySelectorAll(FOCUSABLE_SELECTOR))
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (event.key !== 'Tab') return
+
+    const focusable = getFocusableElements()
+    if (focusable.length === 0) return
+
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  function activate(): void {
+    previousFocus = document.activeElement as HTMLElement
+    document.addEventListener('keydown', handleKeyDown)
+
+    // Focus first focusable element in the container
+    const focusable = getFocusableElements()
+    if (focusable.length > 0) {
+      focusable[0].focus()
+    }
+  }
+
+  function deactivate(): void {
+    document.removeEventListener('keydown', handleKeyDown)
+    if (previousFocus) {
+      previousFocus.focus()
+      previousFocus = null
+    }
+  }
+
+  // Auto-activate/deactivate based on container visibility
+  watch(containerRef, (el) => {
+    if (el) {
+      activate()
+    } else {
+      deactivate()
+    }
+  })
+
+  onUnmounted(() => {
+    deactivate()
+  })
+
+  return { activate, deactivate }
+}
+
+
+// ─── Keyboard Navigation ──────────────────────────────────────
+
+interface KeyboardNavOptions {
+  /** Orientation: 'vertical' for up/down, 'horizontal' for left/right, 'grid' for both. */
+  orientation?: 'vertical' | 'horizontal' | 'grid'
+  /** Number of columns for grid orientation. */
+  columns?: number
+  /** Whether navigation wraps at boundaries. */
+  wrap?: boolean
+  /** Callback when an item is activated (Enter/Space). */
+  onActivate?: (index: number) => void
+}
+
+/**
+ * Arrow key navigation for lists, grids, and tab panels.
+ *
+ * Issue #754: Accessibility audit and improvements.
+ */
+export function useKeyboardNav(
+  items: Ref<HTMLElement[]>,
+  options: KeyboardNavOptions = {}
+) {
+  const {
+    orientation = 'vertical',
+    columns = 1,
+    wrap = true,
+    onActivate,
+  } = options
+
+  const activeIndex = ref(0)
+
+  function moveFocus(newIndex: number): void {
+    const count = items.value.length
+    if (count === 0) return
+
+    let idx = newIndex
+    if (wrap) {
+      idx = ((idx % count) + count) % count
+    } else {
+      idx = Math.max(0, Math.min(count - 1, idx))
+    }
+
+    activeIndex.value = idx
+    items.value[idx]?.focus()
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    const count = items.value.length
+    if (count === 0) return
+
+    let handled = false
+
+    switch (event.key) {
+      case 'ArrowDown':
+        if (orientation === 'vertical' || orientation === 'grid') {
+          moveFocus(activeIndex.value + (orientation === 'grid' ? columns : 1))
+          handled = true
+        }
+        break
+      case 'ArrowUp':
+        if (orientation === 'vertical' || orientation === 'grid') {
+          moveFocus(activeIndex.value - (orientation === 'grid' ? columns : 1))
+          handled = true
+        }
+        break
+      case 'ArrowRight':
+        if (orientation === 'horizontal' || orientation === 'grid') {
+          moveFocus(activeIndex.value + 1)
+          handled = true
+        }
+        break
+      case 'ArrowLeft':
+        if (orientation === 'horizontal' || orientation === 'grid') {
+          moveFocus(activeIndex.value - 1)
+          handled = true
+        }
+        break
+      case 'Home':
+        moveFocus(0)
+        handled = true
+        break
+      case 'End':
+        moveFocus(count - 1)
+        handled = true
+        break
+      case 'Enter':
+      case ' ':
+        if (onActivate) {
+          onActivate(activeIndex.value)
+          handled = true
+        }
+        break
+    }
+
+    if (handled) {
+      event.preventDefault()
+    }
+  }
+
+  return {
+    activeIndex,
+    handleKeyDown,
+    moveFocus,
+  }
+}
+
+
+// ─── Screen Reader Announcements ──────────────────────────────
+
+/**
+ * Announce messages to screen readers via an aria-live region.
+ *
+ * Issue #754: Accessibility audit and improvements.
+ */
+export function useAnnounce() {
+  let liveRegion: HTMLElement | null = null
+
+  function ensureLiveRegion(): HTMLElement {
+    if (liveRegion) return liveRegion
+
+    const existing = document.getElementById('a11y-live-region')
+    if (existing) {
+      liveRegion = existing
+      return liveRegion
+    }
+
+    liveRegion = document.createElement('div')
+    liveRegion.id = 'a11y-live-region'
+    liveRegion.setAttribute('aria-live', 'polite')
+    liveRegion.setAttribute('aria-atomic', 'true')
+    liveRegion.setAttribute('role', 'status')
+    liveRegion.className = 'sr-only'
+    document.body.appendChild(liveRegion)
+    return liveRegion
+  }
+
+  /**
+   * Announce a message to screen readers.
+   *
+   * Helper for useAnnounce (Issue #754).
+   */
+  function announce(message: string, priority: 'polite' | 'assertive' = 'polite'): void {
+    const region = ensureLiveRegion()
+    region.setAttribute('aria-live', priority)
+    // Clear then set to ensure re-announcement
+    region.textContent = ''
+    requestAnimationFrame(() => {
+      region.textContent = message
+    })
+  }
+
+  onMounted(() => {
+    ensureLiveRegion()
+  })
+
+  return { announce }
+}

--- a/autobot-slm-frontend/src/views/LoginView.vue
+++ b/autobot-slm-frontend/src/views/LoginView.vue
@@ -3,6 +3,13 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
+/**
+ * LoginView - Authentication page
+ *
+ * Issue #754: Added ARIA labels, roles, aria-live for errors,
+ * accessible password toggle, and MFA form accessibility.
+ */
+
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
@@ -70,11 +77,18 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4">
+  <div
+    class="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center p-4"
+    role="main"
+    aria-label="Login page"
+  >
     <div class="w-full max-w-md">
       <!-- Logo/Header -->
       <div class="text-center mb-8">
-        <div class="inline-flex items-center justify-center w-16 h-16 rounded-xl bg-gradient-to-br from-primary-500 to-primary-600 shadow-lg mb-4">
+        <div
+          class="inline-flex items-center justify-center w-16 h-16 rounded-xl bg-gradient-to-br from-primary-500 to-primary-600 shadow-lg mb-4"
+          aria-hidden="true"
+        >
           <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
           </svg>
@@ -86,14 +100,19 @@ onMounted(async () => {
       <!-- Login Form -->
       <div class="bg-white rounded-2xl shadow-xl p-8">
         <!-- Standard Login Form -->
-        <form v-if="!authStore.mfaPending" @submit.prevent="handleLogin" class="space-y-6">
+        <form
+          v-if="!authStore.mfaPending"
+          @submit.prevent="handleLogin"
+          class="space-y-6"
+          aria-label="Sign in form"
+        >
           <!-- Username -->
           <div>
             <label for="username" class="block text-sm font-medium text-gray-700 mb-1">
               Username
             </label>
             <div class="relative">
-              <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none" aria-hidden="true">
                 <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                 </svg>
@@ -104,6 +123,7 @@ onMounted(async () => {
                 type="text"
                 required
                 autocomplete="username"
+                aria-required="true"
                 class="block w-full pl-10 pr-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-colors"
                 placeholder="Enter your username"
               />
@@ -116,7 +136,7 @@ onMounted(async () => {
               Password
             </label>
             <div class="relative">
-              <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none" aria-hidden="true">
                 <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                 </svg>
@@ -127,6 +147,7 @@ onMounted(async () => {
                 :type="showPassword ? 'text' : 'password'"
                 required
                 autocomplete="current-password"
+                aria-required="true"
                 class="block w-full pl-10 pr-10 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-colors"
                 placeholder="Enter your password"
               />
@@ -134,11 +155,13 @@ onMounted(async () => {
                 type="button"
                 @click="showPassword = !showPassword"
                 class="absolute inset-y-0 right-0 pr-3 flex items-center"
+                :aria-label="showPassword ? 'Hide password' : 'Show password'"
+                :aria-pressed="showPassword"
               >
-                <svg v-if="showPassword" class="h-5 w-5 text-gray-400 hover:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg v-if="showPassword" class="h-5 w-5 text-gray-400 hover:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
                 </svg>
-                <svg v-else class="h-5 w-5 text-gray-400 hover:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg v-else class="h-5 w-5 text-gray-400 hover:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                 </svg>
@@ -147,9 +170,9 @@ onMounted(async () => {
           </div>
 
           <!-- Error Message -->
-          <div v-if="authStore.error" class="bg-red-50 border border-red-200 rounded-lg p-3">
+          <div v-if="authStore.error" class="bg-red-50 border border-red-200 rounded-lg p-3" role="alert">
             <div class="flex items-center gap-2 text-red-700">
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <span class="text-sm">{{ authStore.error }}</span>
@@ -162,7 +185,7 @@ onMounted(async () => {
             :disabled="authStore.loading"
             class="w-full flex items-center justify-center gap-2 py-2.5 px-4 bg-gradient-to-r from-primary-600 to-primary-700 text-white font-medium rounded-lg hover:from-primary-700 hover:to-primary-800 focus:ring-4 focus:ring-primary-300 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <svg v-if="authStore.loading" class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24">
+            <svg v-if="authStore.loading" class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
               <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
             </svg>
@@ -171,9 +194,9 @@ onMounted(async () => {
         </form>
 
         <!-- MFA Verification Form -->
-        <div v-else class="space-y-6">
+        <div v-else class="space-y-6" role="form" aria-label="Two-factor authentication">
           <div class="text-center mb-4">
-            <svg class="w-12 h-12 text-primary-600 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-12 h-12 text-primary-600 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
             </svg>
             <h2 class="text-lg font-semibold text-gray-900">Two-Factor Authentication</h2>
@@ -181,28 +204,45 @@ onMounted(async () => {
           </div>
 
           <div>
-            <input v-model="mfaCode" type="text" inputmode="numeric" maxlength="8" autocomplete="one-time-code"
+            <label for="mfa-code" class="sr-only">Authentication code</label>
+            <input
+              id="mfa-code"
+              v-model="mfaCode"
+              type="text"
+              inputmode="numeric"
+              maxlength="8"
+              autocomplete="one-time-code"
+              aria-label="6-digit authentication code"
               class="block w-full text-center text-2xl tracking-widest py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-              placeholder="000000" @keyup.enter="handleMFAVerify" />
+              placeholder="000000"
+              @keyup.enter="handleMFAVerify"
+            />
           </div>
 
-          <div v-if="authStore.error" class="bg-red-50 border border-red-200 rounded-lg p-3">
+          <div v-if="authStore.error" class="bg-red-50 border border-red-200 rounded-lg p-3" role="alert">
             <span class="text-sm text-red-700">{{ authStore.error }}</span>
           </div>
 
-          <button @click="handleMFAVerify" :disabled="authStore.loading || mfaCode.length < 6"
-            class="w-full py-2.5 px-4 bg-gradient-to-r from-primary-600 to-primary-700 text-white font-medium rounded-lg hover:from-primary-700 hover:to-primary-800 disabled:opacity-50">
+          <button
+            @click="handleMFAVerify"
+            :disabled="authStore.loading || mfaCode.length < 6"
+            class="w-full py-2.5 px-4 bg-gradient-to-r from-primary-600 to-primary-700 text-white font-medium rounded-lg hover:from-primary-700 hover:to-primary-800 disabled:opacity-50"
+          >
             {{ authStore.loading ? 'Verifying...' : 'Verify' }}
           </button>
 
-          <button @click="cancelMFA" type="button" class="w-full py-2 text-sm text-gray-500 hover:text-gray-700">
+          <button
+            @click="cancelMFA"
+            type="button"
+            class="w-full py-2 text-sm text-gray-500 hover:text-gray-700"
+          >
             Back to login
           </button>
         </div>
 
         <!-- SSO Login Options -->
         <div v-if="ssoProviders.length > 0 && !authStore.mfaPending" class="mt-6">
-          <div class="relative my-6">
+          <div class="relative my-6" aria-hidden="true">
             <div class="absolute inset-0 flex items-center">
               <div class="w-full border-t border-gray-300"></div>
             </div>
@@ -211,7 +251,7 @@ onMounted(async () => {
             </div>
           </div>
 
-          <div class="space-y-3">
+          <div class="space-y-3" role="group" aria-label="Single sign-on providers">
             <button
               v-for="provider in ssoProviders"
               :key="provider.id"
@@ -219,15 +259,16 @@ onMounted(async () => {
               :disabled="ssoLoading"
               type="button"
               class="w-full flex items-center justify-center gap-3 px-4 py-2.5 bg-gray-50 border border-gray-300 rounded-lg hover:bg-gray-100 text-gray-700 transition-colors disabled:opacity-50"
+              :aria-label="`Sign in with ${provider.name}`"
             >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
               </svg>
               <span class="text-sm font-medium">{{ provider.name }}</span>
             </button>
           </div>
 
-          <p v-if="ssoError" class="mt-3 text-sm text-red-500 text-center">{{ ssoError }}</p>
+          <p v-if="ssoError" class="mt-3 text-sm text-red-500 text-center" role="alert">{{ ssoError }}</p>
         </div>
 
         <!-- Footer -->

--- a/autobot-slm-frontend/src/views/MonitoringView.vue
+++ b/autobot-slm-frontend/src/views/MonitoringView.vue
@@ -8,6 +8,9 @@
  *
  * Provides navigation tabs for monitoring sub-routes and displays
  * the active sub-view via router-view.
+ *
+ * Issue #754: Added ARIA tablist/tab roles, aria-selected,
+ * status indicators, accessible labels.
  */
 
 import { computed } from 'vue'
@@ -68,9 +71,10 @@ function getStatusColor(status: string): string {
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-4">
           <h1 class="text-2xl font-bold text-gray-900">Monitoring</h1>
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2" role="status" :aria-label="`System health: ${systemHealth}`">
             <span
               :class="['w-2.5 h-2.5 rounded-full', getStatusColor(systemHealth)]"
+              aria-hidden="true"
             ></span>
             <span class="text-sm text-gray-600 capitalize">{{ systemHealth }}</span>
           </div>
@@ -79,13 +83,13 @@ function getStatusColor(status: string): string {
         <!-- Quick Stats -->
         <div class="flex items-center gap-4 text-sm">
           <div class="flex items-center gap-2 text-gray-600">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
             </svg>
             <span>{{ fleetStore.nodeList.length }} Nodes</span>
           </div>
-          <div v-if="hasCriticalAlerts" class="flex items-center gap-2 text-danger-600">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div v-if="hasCriticalAlerts" class="flex items-center gap-2 text-danger-600" role="alert">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
             <span>{{ activeAlertCount }} Alert{{ activeAlertCount !== 1 ? 's' : '' }}</span>
@@ -94,11 +98,18 @@ function getStatusColor(status: string): string {
       </div>
 
       <!-- Tab Navigation -->
-      <div class="flex gap-1 mt-4 -mb-4 overflow-x-auto">
+      <div
+        class="flex gap-1 mt-4 -mb-4 overflow-x-auto"
+        role="tablist"
+        aria-label="Monitoring sections"
+      >
         <button
           v-for="tab in tabs"
           :key="tab.id"
           @click="navigateTo(tab.path)"
+          role="tab"
+          :aria-selected="activeTab === tab.id"
+          :aria-current="activeTab === tab.id ? 'page' : undefined"
           :class="[
             'px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors flex items-center gap-2 whitespace-nowrap',
             activeTab === tab.id
@@ -106,13 +117,14 @@ function getStatusColor(status: string): string {
               : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
           ]"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="tab.icon" />
           </svg>
           {{ tab.name }}
           <span
             v-if="tab.id === 'alerts' && activeAlertCount > 0"
             class="px-1.5 py-0.5 text-xs font-bold bg-danger-500 text-white rounded-full"
+            :aria-label="`${activeAlertCount} active alerts`"
           >
             {{ activeAlertCount }}
           </span>

--- a/autobot-slm-frontend/src/views/PerformanceView.vue
+++ b/autobot-slm-frontend/src/views/PerformanceView.vue
@@ -9,6 +9,9 @@
  * Provides navigation tabs for performance sub-routes and displays
  * the active sub-view via router-view.
  * Issue #752 - Comprehensive performance monitoring.
+ *
+ * Issue #754: Added ARIA tablist/tab roles, aria-selected,
+ * accessible status indicators and labels.
  */
 
 import { computed } from 'vue'
@@ -86,7 +89,7 @@ function navigateTo(path: string): void {
         </div>
 
         <!-- Quick Stats Bar -->
-        <div class="flex items-center gap-6 text-sm">
+        <div class="flex items-center gap-6 text-sm" role="status" aria-label="Performance summary">
           <div class="flex items-center gap-2 text-gray-600">
             <span class="text-gray-400">Avg Latency:</span>
             <span class="font-semibold">{{ avgLatency.toFixed(1) }}ms</span>
@@ -112,13 +115,14 @@ function navigateTo(path: string): void {
             @click="fetchOverview"
             :disabled="loading"
             class="p-1.5 text-gray-400 hover:text-gray-600 rounded transition-colors"
-            title="Refresh"
+            aria-label="Refresh performance data"
           >
             <svg
               :class="['w-4 h-4', loading ? 'animate-spin' : '']"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path
                 stroke-linecap="round"
@@ -132,11 +136,18 @@ function navigateTo(path: string): void {
       </div>
 
       <!-- Tab Navigation -->
-      <div class="flex gap-1 mt-4 -mb-4 overflow-x-auto">
+      <div
+        class="flex gap-1 mt-4 -mb-4 overflow-x-auto"
+        role="tablist"
+        aria-label="Performance sections"
+      >
         <button
           v-for="tab in tabs"
           :key="tab.id"
           @click="navigateTo(tab.path)"
+          role="tab"
+          :aria-selected="activeTab === tab.id"
+          :aria-current="activeTab === tab.id ? 'page' : undefined"
           :class="[
             'px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors',
             'flex items-center gap-2 whitespace-nowrap',
@@ -145,7 +156,7 @@ function navigateTo(path: string): void {
               : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
           ]"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="tab.icon" />
           </svg>
           {{ tab.name }}

--- a/autobot-slm-frontend/src/views/SecurityView.vue
+++ b/autobot-slm-frontend/src/views/SecurityView.vue
@@ -3,6 +3,17 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
+/**
+ * SecurityView - Security analytics and policy management
+ *
+ * Issue #754: Added role="tablist"/role="tab"/aria-selected on tab nav,
+ * role="alert" on error messages, role="status" on loading,
+ * scope="col" on all table headers, role="img" with aria-label on
+ * severity dots, aria-label on filter selects, role="dialog" with
+ * aria-modal/aria-labelledby on upload modal, @keydown.escape on modal,
+ * aria-hidden on decorative icons, accessible button labels.
+ */
+
 import { ref, onMounted, computed } from 'vue'
 import { useSlmApi } from '@/composables/useSlmApi'
 import { createLogger } from '@/utils/debugUtils'
@@ -543,17 +554,20 @@ const scoreColor = computed(() => {
     </div>
 
     <!-- Error Alert -->
-    <div v-if="error" class="mb-4 p-4 bg-error-50 border border-error-200 rounded-lg">
+    <div v-if="error" class="mb-4 p-4 bg-error-50 border border-error-200 rounded-lg" role="alert">
       <p class="text-error-700">{{ error }}</p>
     </div>
 
     <!-- Tab Navigation -->
     <div class="border-b border-gray-200 mb-6">
-      <nav class="flex gap-4">
+      <nav class="flex gap-4" role="tablist" aria-label="Security sections">
         <button
           v-for="tab in tabs"
           :key="tab.id"
           @click="onTabChange(tab.id)"
+          role="tab"
+          :aria-selected="activeTab === tab.id"
+          :aria-current="activeTab === tab.id ? 'page' : undefined"
           :class="[
             'px-1 py-3 text-sm font-medium border-b-2 transition-colors',
             activeTab === tab.id
@@ -567,12 +581,12 @@ const scoreColor = computed(() => {
     </div>
 
     <!-- Loading -->
-    <div v-if="loading" class="flex justify-center py-12">
-      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+    <div v-if="loading" class="flex justify-center py-12" role="status" aria-label="Loading security data">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600" aria-hidden="true"></div>
     </div>
 
     <!-- Security Overview -->
-    <div v-else-if="activeTab === 'overview'">
+    <div v-else-if="activeTab === 'overview'" role="tabpanel" aria-label="Security Overview">
       <template v-if="overview">
         <!-- Security Score -->
         <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
@@ -615,7 +629,11 @@ const scoreColor = computed(() => {
               class="px-6 py-4 flex items-center justify-between"
             >
               <div class="flex items-center gap-3">
-                <div :class="['w-2 h-2 rounded-full', severityColors[event.severity] || 'bg-gray-500']"></div>
+                <div
+                  :class="['w-2 h-2 rounded-full', severityColors[event.severity] || 'bg-gray-500']"
+                  role="img"
+                  :aria-label="`${event.severity} severity`"
+                ></div>
                 <div>
                   <div class="text-sm font-medium text-gray-900">{{ event.title }}</div>
                   <div class="text-xs text-gray-500">
@@ -632,7 +650,7 @@ const scoreColor = computed(() => {
     </div>
 
     <!-- TLS Settings (Issue #164) -->
-    <div v-else-if="activeTab === 'tls-settings'">
+    <div v-else-if="activeTab === 'tls-settings'" role="tabpanel" aria-label="TLS Settings">
       <!-- Header -->
       <div class="mb-6">
         <h2 class="text-lg font-semibold text-gray-900">TLS/HTTPS Configuration</h2>
@@ -642,12 +660,16 @@ const scoreColor = computed(() => {
       </div>
 
       <!-- Result Alert -->
-      <div v-if="tlsEnableResult" :class="['mb-6 p-4 rounded-lg border', tlsEnableResult.success ? 'bg-success-50 border-success-200' : 'bg-error-50 border-error-200']">
+      <div
+        v-if="tlsEnableResult"
+        :class="['mb-6 p-4 rounded-lg border', tlsEnableResult.success ? 'bg-success-50 border-success-200' : 'bg-error-50 border-error-200']"
+        :role="tlsEnableResult.success ? 'status' : 'alert'"
+      >
         <div class="flex items-start gap-3">
-          <svg v-if="tlsEnableResult.success" class="w-5 h-5 text-success-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg v-if="tlsEnableResult.success" class="w-5 h-5 text-success-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
-          <svg v-else class="w-5 h-5 text-error-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg v-else class="w-5 h-5 text-error-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <div>
@@ -659,8 +681,8 @@ const scoreColor = computed(() => {
               <pre class="mt-2 text-xs bg-white p-3 rounded border overflow-x-auto max-h-48">{{ tlsEnableResult.details }}</pre>
             </details>
           </div>
-          <button @click="tlsEnableResult = null" class="ml-auto text-gray-400 hover:text-gray-600">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <button @click="tlsEnableResult = null" class="ml-auto text-gray-400 hover:text-gray-600" aria-label="Dismiss TLS result">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -673,7 +695,7 @@ const scoreColor = computed(() => {
           <h3 class="text-base font-semibold">Select Services to Enable TLS</h3>
         </div>
         <div class="p-6">
-          <div class="space-y-4">
+          <div class="space-y-4" role="group" aria-label="TLS service selection">
             <div
               v-for="service in tlsServices"
               :key="service.name"
@@ -686,6 +708,7 @@ const scoreColor = computed(() => {
                   type="checkbox"
                   :checked="selectedTlsServices.includes(service.name)"
                   class="h-5 w-5 text-primary-600 rounded border-gray-300 focus:ring-primary-500"
+                  :aria-label="`Enable TLS for ${service.displayName}`"
                   @click.stop
                   @change="toggleTlsService(service.name)"
                 />
@@ -744,11 +767,11 @@ const scoreColor = computed(() => {
               : 'bg-primary-600 hover:bg-primary-700'
           ]"
         >
-          <svg v-if="tlsEnabling" class="animate-spin h-5 w-5" fill="none" viewBox="0 0 24 24">
+          <svg v-if="tlsEnabling" class="animate-spin h-5 w-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
           </svg>
-          <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
           </svg>
           {{ tlsEnabling ? 'Enabling TLS...' : `Enable TLS on ${selectedTlsServices.length} Service${selectedTlsServices.length !== 1 ? 's' : ''}` }}
@@ -758,7 +781,7 @@ const scoreColor = computed(() => {
       <!-- Help Section -->
       <div class="mt-8 p-4 bg-blue-50 rounded-lg border border-blue-200">
         <div class="flex items-start gap-3">
-          <svg class="w-5 h-5 text-blue-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-5 h-5 text-blue-600 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <div class="text-sm text-blue-800">
@@ -777,7 +800,7 @@ const scoreColor = computed(() => {
     </div>
 
     <!-- TLS Certificates (Issue #725) -->
-    <div v-else-if="activeTab === 'certificates'">
+    <div v-else-if="activeTab === 'certificates'" role="tabpanel" aria-label="TLS Certificates">
       <!-- Summary Cards -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <div class="card p-4">
@@ -824,12 +847,12 @@ const scoreColor = computed(() => {
         <table v-else class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Node</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Common Name</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Expiry</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Node</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Common Name</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Expiry</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
@@ -870,7 +893,7 @@ const scoreColor = computed(() => {
                     @click="renewTlsCertificate(endpoint.credential_id)"
                     :disabled="renewingCredentialId === endpoint.credential_id"
                     class="px-2 py-1 rounded text-xs bg-blue-100 hover:bg-blue-200 text-blue-700 disabled:opacity-50"
-                    title="Renew certificate (same keys)"
+                    :aria-label="`Renew certificate for ${endpoint.hostname}`"
                   >
                     {{ renewingCredentialId === endpoint.credential_id ? '...' : 'Renew' }}
                   </button>
@@ -878,7 +901,7 @@ const scoreColor = computed(() => {
                     @click="rotateTlsCertificate(endpoint.credential_id)"
                     :disabled="rotatingCredentialId === endpoint.credential_id"
                     class="px-2 py-1 rounded text-xs bg-purple-100 hover:bg-purple-200 text-purple-700 disabled:opacity-50"
-                    title="Rotate certificate (new keys)"
+                    :aria-label="`Rotate certificate for ${endpoint.hostname}`"
                   >
                     {{ rotatingCredentialId === endpoint.credential_id ? '...' : 'Rotate' }}
                   </button>
@@ -890,12 +913,14 @@ const scoreColor = computed(() => {
                         ? 'bg-gray-100 hover:bg-gray-200 text-gray-700'
                         : 'bg-success-100 hover:bg-success-200 text-success-700'
                     ]"
+                    :aria-label="`${endpoint.is_active ? 'Disable' : 'Enable'} certificate for ${endpoint.hostname}`"
                   >
                     {{ endpoint.is_active ? 'Disable' : 'Enable' }}
                   </button>
                   <button
                     @click="deleteTlsCertificate(endpoint.credential_id)"
                     class="px-2 py-1 rounded text-xs bg-error-100 hover:bg-error-200 text-error-700"
+                    :aria-label="`Delete certificate for ${endpoint.hostname}`"
                   >
                     Delete
                   </button>
@@ -908,10 +933,12 @@ const scoreColor = computed(() => {
     </div>
 
     <!-- Audit Logs -->
-    <div v-else-if="activeTab === 'audit'">
+    <div v-else-if="activeTab === 'audit'" role="tabpanel" aria-label="Audit Logs">
       <!-- Filters -->
       <div class="mb-4 flex gap-4">
+        <label for="audit-category-filter" class="sr-only">Filter by category</label>
         <select
+          id="audit-category-filter"
           v-model="auditCategoryFilter"
           @change="fetchAuditLogs()"
           class="rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 text-sm"
@@ -935,12 +962,12 @@ const scoreColor = computed(() => {
         <table v-else class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Time</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">User</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Category</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Action</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Resource</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Time</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">User</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Category</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Action</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Resource</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
@@ -975,14 +1002,14 @@ const scoreColor = computed(() => {
             </tr>
           </tbody>
         </table>
-        <div v-if="auditLogsTotal > perPage" class="px-6 py-4 border-t border-gray-200 text-sm text-gray-500">
+        <div v-if="auditLogsTotal > perPage" class="px-6 py-4 border-t border-gray-200 text-sm text-gray-500" role="status">
           Showing {{ auditLogs.length }} of {{ auditLogsTotal }} logs
         </div>
       </div>
     </div>
 
     <!-- Threat Detection -->
-    <div v-else-if="activeTab === 'threats'">
+    <div v-else-if="activeTab === 'threats'" role="tabpanel" aria-label="Threat Detection">
       <!-- Summary Cards -->
       <div v-if="threatSummary" class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
         <div class="card p-4">
@@ -1009,7 +1036,9 @@ const scoreColor = computed(() => {
 
       <!-- Filters -->
       <div class="mb-4 flex gap-4">
+        <label for="event-severity-filter" class="sr-only">Filter by severity</label>
         <select
+          id="event-severity-filter"
           v-model="eventSeverityFilter"
           @change="fetchSecurityEvents()"
           class="rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 text-sm"
@@ -1035,7 +1064,11 @@ const scoreColor = computed(() => {
           >
             <div class="flex items-start justify-between">
               <div class="flex items-start gap-3">
-                <div :class="['w-3 h-3 mt-1 rounded-full', severityColors[event.severity]]"></div>
+                <div
+                  :class="['w-3 h-3 mt-1 rounded-full', severityColors[event.severity]]"
+                  role="img"
+                  :aria-label="`${event.severity} severity`"
+                ></div>
                 <div>
                   <div class="font-medium text-gray-900">{{ event.title }}</div>
                   <div class="text-sm text-gray-500 mt-1">{{ event.description || 'No description' }}</div>
@@ -1064,12 +1097,14 @@ const scoreColor = computed(() => {
                     v-if="!event.is_acknowledged"
                     @click="acknowledgeEvent(event.event_id)"
                     class="px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 rounded"
+                    :aria-label="`Acknowledge event: ${event.title}`"
                   >
                     Ack
                   </button>
                   <button
                     @click="resolveEvent(event.event_id)"
                     class="px-2 py-1 text-xs bg-success-100 hover:bg-success-200 text-success-700 rounded"
+                    :aria-label="`Resolve event: ${event.title}`"
                   >
                     Resolve
                   </button>
@@ -1078,14 +1113,14 @@ const scoreColor = computed(() => {
             </div>
           </div>
         </div>
-        <div v-if="eventsTotal > perPage" class="px-6 py-4 border-t border-gray-200 text-sm text-gray-500">
+        <div v-if="eventsTotal > perPage" class="px-6 py-4 border-t border-gray-200 text-sm text-gray-500" role="status">
           Showing {{ securityEvents.length }} of {{ eventsTotal }} events
         </div>
       </div>
     </div>
 
     <!-- Security Policies -->
-    <div v-else-if="activeTab === 'policies'">
+    <div v-else-if="activeTab === 'policies'" role="tabpanel" aria-label="Security Policies">
       <!-- Policies List -->
       <div class="card">
         <div v-if="policies.length === 0" class="p-6 text-center text-gray-500">
@@ -1132,6 +1167,7 @@ const scoreColor = computed(() => {
                       ? 'bg-error-100 hover:bg-error-200 text-error-700'
                       : 'bg-success-100 hover:bg-success-200 text-success-700'
                   ]"
+                  :aria-label="`${policy.is_enforced ? 'Disable' : 'Enable'} policy: ${policy.name}`"
                 >
                   {{ policy.is_enforced ? 'Disable' : 'Enable' }}
                 </button>
@@ -1139,7 +1175,7 @@ const scoreColor = computed(() => {
             </div>
           </div>
         </div>
-        <div v-if="policiesTotal > perPage" class="px-6 py-4 border-t border-gray-200 text-sm text-gray-500">
+        <div v-if="policiesTotal > perPage" class="px-6 py-4 border-t border-gray-200 text-sm text-gray-500" role="status">
           Showing {{ policies.length }} of {{ policiesTotal }} policies
         </div>
       </div>
@@ -1152,16 +1188,30 @@ const scoreColor = computed(() => {
           v-if="showUploadModal"
           class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
           @click.self="showUploadModal = false"
+          @keydown.escape="showUploadModal = false"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="upload-cert-title"
         >
           <div class="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
-            <div class="px-6 py-4 border-b border-gray-200">
-              <h3 class="text-lg font-semibold text-gray-900">Upload TLS Certificate</h3>
+            <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+              <h3 id="upload-cert-title" class="text-lg font-semibold text-gray-900">Upload TLS Certificate</h3>
+              <button
+                @click="showUploadModal = false"
+                class="text-gray-400 hover:text-gray-600"
+                aria-label="Close upload dialog"
+              >
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
             </div>
 
             <div class="p-6 space-y-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Node ID</label>
+                <label for="cert-node-id" class="block text-sm font-medium text-gray-700 mb-1">Node ID</label>
                 <input
+                  id="cert-node-id"
                   v-model="selectedNodeId"
                   type="text"
                   placeholder="Enter node ID"
@@ -1170,8 +1220,9 @@ const scoreColor = computed(() => {
               </div>
 
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Certificate Name (optional)</label>
+                <label for="cert-name" class="block text-sm font-medium text-gray-700 mb-1">Certificate Name (optional)</label>
                 <input
+                  id="cert-name"
                   v-model="uploadForm.name"
                   type="text"
                   placeholder="e.g., redis-server, api-client"
@@ -1180,8 +1231,9 @@ const scoreColor = computed(() => {
               </div>
 
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">CA Certificate (PEM)</label>
+                <label for="cert-ca" class="block text-sm font-medium text-gray-700 mb-1">CA Certificate (PEM)</label>
                 <textarea
+                  id="cert-ca"
                   v-model="uploadForm.ca_cert"
                   rows="4"
                   placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
@@ -1190,8 +1242,9 @@ const scoreColor = computed(() => {
               </div>
 
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Server Certificate (PEM)</label>
+                <label for="cert-server" class="block text-sm font-medium text-gray-700 mb-1">Server Certificate (PEM)</label>
                 <textarea
+                  id="cert-server"
                   v-model="uploadForm.server_cert"
                   rows="4"
                   placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
@@ -1200,8 +1253,9 @@ const scoreColor = computed(() => {
               </div>
 
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Private Key (PEM)</label>
+                <label for="cert-key" class="block text-sm font-medium text-gray-700 mb-1">Private Key (PEM)</label>
                 <textarea
+                  id="cert-key"
                   v-model="uploadForm.server_key"
                   rows="4"
                   placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----"
@@ -1231,3 +1285,18 @@ const scoreColor = computed(() => {
     </Teleport>
   </div>
 </template>
+
+<style scoped>
+/* Screen reader only utility (Issue #754) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+</style>

--- a/autobot-slm-frontend/src/views/SettingsView.vue
+++ b/autobot-slm-frontend/src/views/SettingsView.vue
@@ -8,6 +8,9 @@
  *
  * Provides navigation tabs for settings sub-routes and displays
  * the active sub-view via router-view.
+ *
+ * Issue #754: Added ARIA tablist/tab roles, aria-selected,
+ * aria-current, accessible error/success messages.
  */
 
 import { computed, ref, onMounted } from 'vue'
@@ -80,11 +83,18 @@ onMounted(() => {
       </div>
 
       <!-- Tab Navigation -->
-      <div class="flex gap-1 mt-4 -mb-4 overflow-x-auto">
+      <div
+        class="flex gap-1 mt-4 -mb-4 overflow-x-auto"
+        role="tablist"
+        aria-label="Settings sections"
+      >
         <button
           v-for="tab in tabs"
           :key="tab.id"
           @click="navigateTo(tab.path)"
+          role="tab"
+          :aria-selected="activeTab === tab.id"
+          :aria-current="activeTab === tab.id ? 'page' : undefined"
           :class="[
             'px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors flex items-center gap-2 whitespace-nowrap',
             activeTab === tab.id
@@ -92,7 +102,7 @@ onMounted(() => {
               : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
           ]"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="tab.icon" />
           </svg>
           {{ tab.name }}
@@ -101,10 +111,10 @@ onMounted(() => {
     </div>
 
     <!-- Messages -->
-    <div v-if="error" class="mx-6 mt-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+    <div v-if="error" class="mx-6 mt-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700" role="alert">
       {{ error }}
     </div>
-    <div v-if="success" class="mx-6 mt-4 p-4 bg-green-50 border border-green-200 rounded-lg text-green-700">
+    <div v-if="success" class="mx-6 mt-4 p-4 bg-green-50 border border-green-200 rounded-lg text-green-700" role="status">
       {{ success }}
     </div>
 

--- a/autobot-slm-frontend/src/views/ToolsView.vue
+++ b/autobot-slm-frontend/src/views/ToolsView.vue
@@ -8,6 +8,11 @@
  *
  * Provides diagnostic and management tools for fleet operations.
  * Integrated into SLM as per Issue #729.
+ *
+ * Issue #754: Added aria-hidden on decorative icons, aria-label on
+ * tool buttons, for/id on form labels, role="alert" on errors,
+ * role="region" on output, aria-label on close button,
+ * accessible labels on action buttons.
  */
 
 import { ref, computed, onMounted, onUnmounted } from 'vue'
@@ -333,19 +338,21 @@ onMounted(async () => {
     <!-- Content (no header - parent ToolsLayout provides it) -->
     <div class="flex-1 overflow-auto p-6">
       <!-- Info Banner -->
-      <div class="mb-6 flex items-center gap-2 text-sm text-gray-600 bg-white rounded-lg p-3 border border-gray-200">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div class="mb-6 flex items-center gap-2 text-sm text-gray-600 bg-white rounded-lg p-3 border border-gray-200" role="status">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />
         </svg>
         <span>{{ nodes.length }} nodes available for fleet operations</span>
       </div>
       <!-- Tools Grid -->
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6" role="group" aria-label="Available tools">
         <button
           v-for="tool in tools"
           :key="tool.id"
           @click="selectTool(tool.id)"
           :disabled="!tool.available"
+          :aria-label="`${tool.name}: ${tool.description}`"
+          :aria-pressed="activeTool === tool.id"
           :class="[
             'bg-white rounded-lg shadow-sm border border-gray-200 p-6 text-left transition-all',
             tool.available
@@ -355,7 +362,7 @@ onMounted(async () => {
           ]"
         >
           <div class="flex items-start gap-4">
-            <div class="p-3 bg-primary-100 rounded-lg">
+            <div class="p-3 bg-primary-100 rounded-lg" aria-hidden="true">
               <!-- Network icon -->
               <svg v-if="tool.icon === 'network'" class="w-6 h-6 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
@@ -390,7 +397,7 @@ onMounted(async () => {
       </div>
 
       <!-- Tool Interface Panel -->
-      <div v-if="activeTool" class="bg-white rounded-lg shadow-sm border border-gray-200">
+      <div v-if="activeTool" class="bg-white rounded-lg shadow-sm border border-gray-200" role="region" :aria-label="tools.find(t => t.id === activeTool)?.name || 'Tool panel'">
         <!-- Panel Header -->
         <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <h2 class="text-lg font-semibold text-gray-900">
@@ -399,8 +406,9 @@ onMounted(async () => {
           <button
             @click="closeTool"
             class="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            aria-label="Close tool panel"
           >
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -411,8 +419,9 @@ onMounted(async () => {
           <!-- Network Test Tool -->
           <div v-if="activeTool === 'network-test'" class="space-y-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
+              <label for="net-test-node" class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
               <select
+                id="net-test-node"
                 v-model="selectedNode"
                 class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               >
@@ -427,7 +436,7 @@ onMounted(async () => {
               :disabled="loading || !selectedNode"
               class="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 flex items-center gap-2"
             >
-              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
@@ -438,8 +447,9 @@ onMounted(async () => {
           <!-- Health Check Tool -->
           <div v-else-if="activeTool === 'health-check'" class="space-y-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
+              <label for="health-check-node" class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
               <select
+                id="health-check-node"
                 v-model="selectedNode"
                 class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               >
@@ -454,7 +464,7 @@ onMounted(async () => {
               :disabled="loading || !selectedNode"
               class="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 flex items-center gap-2"
             >
-              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
@@ -466,8 +476,9 @@ onMounted(async () => {
           <div v-else-if="activeTool === 'service-restart'" class="space-y-4">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
+                <label for="svc-mgr-node" class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
                 <select
+                  id="svc-mgr-node"
                   v-model="selectedNode"
                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 >
@@ -478,20 +489,22 @@ onMounted(async () => {
                 </select>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2">Service Name</label>
+                <label for="svc-mgr-service" class="block text-sm font-medium text-gray-700 mb-2">Service Name</label>
                 <input
                   type="text"
+                  id="svc-mgr-service"
                   v-model="selectedService"
                   placeholder="e.g., autobot-agent, redis, nginx"
                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 />
               </div>
             </div>
-            <div class="flex gap-2">
+            <div class="flex gap-2" role="group" aria-label="Service actions">
               <button
                 @click="serviceAction('start')"
                 :disabled="loading || !selectedNode || !selectedService"
                 class="px-4 py-2 bg-success-600 text-white rounded-lg hover:bg-success-700 transition-colors disabled:opacity-50"
+                :aria-label="`Start ${selectedService || 'service'}`"
               >
                 Start
               </button>
@@ -499,6 +512,7 @@ onMounted(async () => {
                 @click="serviceAction('stop')"
                 :disabled="loading || !selectedNode || !selectedService"
                 class="px-4 py-2 bg-danger-600 text-white rounded-lg hover:bg-danger-700 transition-colors disabled:opacity-50"
+                :aria-label="`Stop ${selectedService || 'service'}`"
               >
                 Stop
               </button>
@@ -506,6 +520,7 @@ onMounted(async () => {
                 @click="serviceAction('restart')"
                 :disabled="loading || !selectedNode || !selectedService"
                 class="px-4 py-2 bg-warning-600 text-white rounded-lg hover:bg-warning-700 transition-colors disabled:opacity-50"
+                :aria-label="`Restart ${selectedService || 'service'}`"
               >
                 Restart
               </button>
@@ -516,8 +531,9 @@ onMounted(async () => {
           <div v-else-if="activeTool === 'log-viewer'" class="space-y-4">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
+                <label for="log-viewer-node" class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
                 <select
+                  id="log-viewer-node"
                   v-model="selectedNode"
                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 >
@@ -528,17 +544,19 @@ onMounted(async () => {
                 </select>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2">Service Name</label>
+                <label for="log-viewer-service" class="block text-sm font-medium text-gray-700 mb-2">Service Name</label>
                 <input
                   type="text"
+                  id="log-viewer-service"
                   v-model="selectedService"
                   placeholder="e.g., autobot-agent"
                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2">Lines</label>
+                <label for="log-viewer-lines" class="block text-sm font-medium text-gray-700 mb-2">Lines</label>
                 <select
+                  id="log-viewer-lines"
                   v-model="logLines"
                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 >
@@ -554,7 +572,7 @@ onMounted(async () => {
               :disabled="loading || !selectedNode || !selectedService"
               class="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 flex items-center gap-2"
             >
-              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
@@ -565,9 +583,10 @@ onMounted(async () => {
           <!-- Redis CLI Tool -->
           <div v-else-if="activeTool === 'redis-cli'" class="space-y-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-2">Redis Command</label>
+              <label for="redis-command" class="block text-sm font-medium text-gray-700 mb-2">Redis Command</label>
               <input
                 type="text"
+                id="redis-command"
                 v-model="redisCommand"
                 placeholder="e.g., PING, INFO, KEYS *"
                 class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 font-mono"
@@ -581,7 +600,7 @@ onMounted(async () => {
               :disabled="loading || !redisCommand"
               class="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 flex items-center gap-2"
             >
-              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
@@ -593,8 +612,9 @@ onMounted(async () => {
           <div v-else-if="activeTool === 'ansible-runner'" class="space-y-4">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
+                <label for="ansible-node" class="block text-sm font-medium text-gray-700 mb-2">Select Node</label>
                 <select
+                  id="ansible-node"
                   v-model="selectedNode"
                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
                 >
@@ -605,9 +625,10 @@ onMounted(async () => {
                 </select>
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-2">Command</label>
+                <label for="ansible-command" class="block text-sm font-medium text-gray-700 mb-2">Command</label>
                 <input
                   type="text"
+                  id="ansible-command"
                   v-model="ansibleCommand"
                   placeholder="e.g., uptime, df -h, free -m"
                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 font-mono"
@@ -622,7 +643,7 @@ onMounted(async () => {
               :disabled="loading || !selectedNode || !ansibleCommand"
               class="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 flex items-center gap-2"
             >
-              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+              <svg v-if="loading" class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
@@ -631,14 +652,14 @@ onMounted(async () => {
           </div>
 
           <!-- Error Message -->
-          <div v-if="error" class="mt-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+          <div v-if="error" class="mt-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700" role="alert">
             {{ error }}
           </div>
 
           <!-- Result Output -->
-          <div v-if="result" class="mt-4">
-            <label class="block text-sm font-medium text-gray-700 mb-2">Output</label>
-            <pre class="p-4 bg-gray-900 text-gray-100 rounded-lg overflow-auto max-h-96 text-sm font-mono whitespace-pre-wrap">{{ result }}</pre>
+          <div v-if="result" class="mt-4" role="region" aria-label="Command output">
+            <label for="tool-output" class="block text-sm font-medium text-gray-700 mb-2">Output</label>
+            <pre id="tool-output" class="p-4 bg-gray-900 text-gray-100 rounded-lg overflow-auto max-h-96 text-sm font-mono whitespace-pre-wrap" role="log">{{ result }}</pre>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Comprehensive WCAG 2.1 AA accessibility audit across all 75 SLM frontend Vue components
- Updated 17 high-impact files with proper ARIA roles, keyboard navigation, and screen reader support (+1,305/-436 lines)
- Created reusable accessibility infrastructure: `useAccessibility.ts` composable and `SkipLink.vue` component

## Changes

### New Files
- **`useAccessibility.ts`** - 4 composables: `useHighContrast()` (data-theme toggle + localStorage), `useFocusTrap()` (Tab/Shift+Tab containment), `useKeyboardNav()` (Arrow/Home/End/Enter for lists/grids), `useAnnounce()` (aria-live region for screen readers)
- **`SkipLink.vue`** - "Skip to main content" link, hidden until focused via keyboard

### Global Infrastructure (`main.css`)
- CSS custom properties for theming
- `:root[data-theme="high-contrast"]` overrides (increased contrast ratios, stronger borders, visible focus rings)
- `*:focus-visible` keyboard-only focus indicators
- `.sr-only` screen-reader-only utility class

### Component-by-Component ARIA Fixes (17 files)

| Component | Key Improvements |
|-----------|-----------------|
| App.vue | SkipLink, `id="main-content"`, `role="main"` |
| Sidebar.vue | `role="complementary"/"menubar"`, keyboard nav, high contrast toggle, `aria-current="page"` |
| LoginView.vue | ARIA on forms/alerts/MFA, `aria-pressed` on password toggle |
| FleetOverview.vue | `tablist/tab/tabpanel`, dialog roles on modals, extracted helper function |
| NodeCard.vue | `listitem`, `menu/menuitem`, `progressbar` with `aria-valuenow` |
| FleetSummary.vue | `region` role, stat `aria-labels` |
| SecurityView.vue | `tablist/tab/tabpanel`, `scope="col"` on tables, `role="dialog"` on upload modal, `role="img"` on severity dots, `aria-label` on filters |
| SettingsView.vue | `tablist/tab`, `aria-selected`, `role="alert"`/`"status"` on messages |
| MonitoringView.vue | `tablist/tab`, health status indicator, alert section roles |
| PerformanceView.vue | `tablist/tab`, performance summary status, refresh button label |
| ToolsView.vue | `aria-label` on tool buttons, `for/id` on form labels, `role="alert"` on errors, `role="log"` on output |
| AddNodeModal.vue | `role="dialog"/aria-modal`, `fieldset/legend`, `aria-required/aria-invalid`, `aria-describedby` on error links, `role="radiogroup"`, password toggle `aria-pressed` |
| DeploymentLogViewer.vue | `role="dialog"`, `role="progressbar"` with valuenow/min/max, `role="log"` with `aria-live`, `role="alert"` on errors |
| RoleManagementModal.vue | `role="dialog"`, `scope="col"` on table headers, `sr-only` labels on select |
| ScheduleModal.vue | `role="dialog"`, `for/id` on fields, `role="group"` on presets, `aria-pressed` on buttons |
| UpdateNotification.vue | `role="alert"`, `aria-live="polite"`, `aria-hidden` on decorative icons |

## ARIA Patterns Applied Consistently

- **Tab navigation**: `role="tablist"` container + `role="tab"` buttons with `:aria-selected` and `:aria-current`
- **Modal dialogs**: `role="dialog"` + `aria-modal="true"` + `aria-labelledby` + `@keydown.escape`
- **Forms**: `for/id` label-input pairs, `aria-required`, `aria-invalid`, `aria-describedby` for error messages
- **Decorative elements**: `aria-hidden="true"` on all SVG icons, status dots, spinner animations
- **Dynamic content**: `role="alert"` on errors, `role="status"` on success/info, `aria-live="polite"` on live regions
- **Progress indicators**: `role="progressbar"` with `aria-valuenow/min/max`

## Test plan

- [ ] Verify skip link appears on Tab press from page top and navigates to main content
- [ ] Verify high contrast mode toggles from sidebar and persists across page reload
- [ ] Verify all modal dialogs close on Escape key press
- [ ] Verify tab navigation buttons show correct `aria-selected` state
- [ ] Test with screen reader (NVDA/VoiceOver) on login, fleet overview, security, and tools pages
- [ ] Verify form validation errors are announced by screen reader via `aria-describedby`
- [ ] Verify all interactive elements are keyboard-reachable (no focus traps outside modals)

Closes #754

Generated with [Claude Code](https://claude.com/claude-code)