### PR TITLE
fix(backend): resolve startup warnings for optional routers and pydantic v2

### DIFF
--- a/autobot-backend/models/npu_models.py
+++ b/autobot-backend/models/npu_models.py
@@ -11,9 +11,10 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 
+from pydantic import BaseModel, Field, validator
+
 from backend.constants.network_constants import NetworkConstants
 from backend.constants.threshold_constants import CategoryDefaults
-from pydantic import BaseModel, Field, validator
 
 # Issue #380: Module-level tuple for URL scheme validation
 _VALID_URL_SCHEMES = ("http://", "https://")
@@ -84,7 +85,7 @@ class NPUWorkerConfig(BaseModel):
         return v
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "id": "npu-worker-1",
                 "name": "Primary NPU Worker",
@@ -126,7 +127,7 @@ class NPUWorkerStatus(BaseModel):
     )
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "id": "npu-worker-1",
                 "status": "online",
@@ -162,7 +163,7 @@ class NPUWorkerMetrics(BaseModel):
     )
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "id": "npu-worker-1",
                 "avg_response_time_ms": 245.8,
@@ -203,7 +204,7 @@ class LoadBalancingConfig(BaseModel):
     )
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "strategy": "least-loaded",
                 "health_check_interval": 30,
@@ -261,7 +262,7 @@ class NPUWorkerDetails(BaseModel):
         }
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "config": {
                     "id": "npu-worker-1",
@@ -328,7 +329,7 @@ class WorkerHeartbeat(BaseModel):
     )
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "worker_id": "windows_npu_worker_abc123",
                 "status": "online",
@@ -362,7 +363,7 @@ class WorkerTestResult(BaseModel):
     )
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "worker_id": "npu-worker-1",
                 "success": True,

--- a/autobot-backend/npu_integration.py
+++ b/autobot-backend/npu_integration.py
@@ -22,11 +22,10 @@ import yaml
 if TYPE_CHECKING:
     from backend.utils.service_client import ServiceHTTPClient
 
-from backend.constants.threshold_constants import LLMDefaults, TimingConstants
+from utils.service_registry import get_service_url
 
 from autobot_shared.http_client import HTTPClientManager, get_http_client
-
-from .utils.service_registry import get_service_url
+from backend.constants.threshold_constants import LLMDefaults, TimingConstants
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/routers/feedback.py
+++ b/autobot-backend/routers/feedback.py
@@ -13,15 +13,30 @@ from typing import Dict, List, Optional
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from backend.services.feedback_tracker import FeedbackTracker
-from backend.services.incremental_trainer import IncrementalTrainer
-
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["feedback"])
 
-# Initialize services
-feedback_tracker = FeedbackTracker()
+# Lazy service initialization — FeedbackTracker accesses config.database,
+# IncrementalTrainer chains to torchmetrics. Both deferred to avoid import crash.
+_feedback_tracker = None
+
+
+def _get_feedback_tracker():
+    """Get or create FeedbackTracker instance on first use."""
+    global _feedback_tracker
+    if _feedback_tracker is None:
+        from backend.services.feedback_tracker import FeedbackTracker
+
+        _feedback_tracker = FeedbackTracker()
+    return _feedback_tracker
+
+
+def _get_incremental_trainer():
+    """Lazy import IncrementalTrainer to avoid torchmetrics at module load."""
+    from backend.services.incremental_trainer import IncrementalTrainer
+
+    return IncrementalTrainer()
 
 
 # =============================================================================
@@ -114,7 +129,7 @@ async def record_feedback(request: FeedbackRequest):
         )
 
     try:
-        feedback = feedback_tracker.record_feedback(
+        feedback = _get_feedback_tracker().record_feedback(
             context=request.context,
             suggestion=request.suggestion,
             action=request.action,
@@ -155,7 +170,7 @@ async def get_acceptance_metrics(
     - **time_window_days**: Time window for metrics (1-90 days)
     """
     try:
-        metrics = feedback_tracker.get_acceptance_metrics(
+        metrics = _get_feedback_tracker().get_acceptance_metrics(
             language=language,
             pattern_type=pattern_type,
             time_window_days=time_window_days,
@@ -189,7 +204,7 @@ async def get_recent_feedback(
         )
 
     try:
-        events = feedback_tracker.get_recent_feedback(limit=limit, action=action)
+        events = _get_feedback_tracker().get_recent_feedback(limit=limit, action=action)
 
         return {
             "events": events,
@@ -228,13 +243,13 @@ async def trigger_retraining(
         try:
             if request.mode == "incremental":
                 logger.info("Starting incremental training...")
-                trainer = IncrementalTrainer()
+                trainer = _get_incremental_trainer()
                 result = trainer.update_from_feedback(time_window_hours=24)
                 logger.info(f"Incremental training result: {result}")
 
             else:  # full retrain
                 logger.info("Starting full retraining...")
-                trainer = IncrementalTrainer()
+                trainer = _get_incremental_trainer()
                 result = trainer.trigger_full_retrain(
                     language=request.language, num_epochs=request.num_epochs
                 )
@@ -242,7 +257,7 @@ async def trigger_retraining(
 
                 # Mark retrain as completed
                 if result["status"] == "success":
-                    feedback_tracker.mark_retrain_completed()
+                    _get_feedback_tracker().mark_retrain_completed()
 
         except Exception as e:
             logger.error(f"Training failed: {e}", exc_info=True)
@@ -271,8 +286,10 @@ async def get_feedback_statistics():
     """
     try:
         # Get 7-day and 30-day metrics
-        metrics_7d = feedback_tracker.get_acceptance_metrics(time_window_days=7)
-        metrics_30d = feedback_tracker.get_acceptance_metrics(time_window_days=30)
+        metrics_7d = _get_feedback_tracker().get_acceptance_metrics(time_window_days=7)
+        metrics_30d = _get_feedback_tracker().get_acceptance_metrics(
+            time_window_days=30
+        )
 
         return {
             "last_7_days": {


### PR DESCRIPTION
## Summary
- Fix 5 backend startup warnings that logged on every boot (#1046)
- **npu_workers cascade**: `npu_integration.py` used relative import (`from .utils`) in a root-level module — fixed to bare import
- **code_completion router**: `config.database` accessed at module level but attribute doesn't exist — deferred to lazy `_get_db_session()`
- **model_management router**: Import chain `CompletionTrainer → evaluator → torchmetrics` failed — lazy-loaded torch/trainer; deferred `config.database`
- **feedback router**: Same torchmetrics chain via `IncrementalTrainer` + `FeedbackTracker()` hitting `config.database` — both lazy-loaded
- **npu_models.py**: Renamed `schema_extra` → `json_schema_extra` in 7 Pydantic models for v2 compatibility

## Discovered Issues (created separately)
- #1051: Chat atomic write path creates invalid `.json/.tmp_chat_*` directory
- #1052: Feature flags enforcement mode warning spams logs on every request

## Test Plan
- [x] `ruff check` passes on all 5 files
- [x] All pre-commit hooks pass (black, isort, flake8, bandit, function length)
- [ ] Backend starts without the 4 startup warnings
- [ ] Optional routers still degrade gracefully when dependencies missing

Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)