### PR TITLE
fix(chat): correct tempfile.mkstemp argument order (#1051)

### DIFF
--- a/autobot-backend/chat_history/file_io.py
+++ b/autobot-backend/chat_history/file_io.py
@@ -91,7 +91,7 @@ class FileIOMixin:
         # Create temporary file in same directory (required for atomic rename)
         # Issue #718: Use dedicated executor to avoid blocking on saturated pool
         fd, temp_path = await self._run_in_io_executor(
-            tempfile.mkstemp, dir_path, ".tmp_chat_", ".json"
+            tempfile.mkstemp, ".json", ".tmp_chat_", dir_path
         )
 
         try:


### PR DESCRIPTION
## Summary
- Fixed `tempfile.mkstemp` positional argument order in `_atomic_write()` — `dir_path` was passed as `suffix` and `".json"` as `dir`, producing invalid temp paths like `.json/.tmp_chat_tz4734d9data/chats`
- Corrected to `mkstemp(suffix=".json", prefix=".tmp_chat_", dir=dir_path)`

## Test Plan
- [x] Verified correct temp path generation with Python test
- [x] Linting passes (`ruff check`)
- [x] All pre-commit hooks pass

Closes #1051

🤖 Generated with Claude Code