### PR TITLE
fix(slm): Fleet tools Deep Health Check + Redis CLI + Command Runner (#1062, #1063)

### DIFF
--- a/autobot-slm-frontend/src/components/fleet/FleetToolsTab.vue
+++ b/autobot-slm-frontend/src/components/fleet/FleetToolsTab.vue
@@ -126,7 +126,7 @@ async function runRedisCommand(): Promise<void> {
     }
 
     // Execute via SSH
-    const response = await fetch(`/api/nodes/${targetNode.node_id}/execute`, {
+    const response = await fetch(`/api/nodes/${targetNode.node_id}/exec`, {
       method: 'POST',
       headers: {
         ...authStore.getAuthHeaders(),
@@ -162,7 +162,7 @@ async function runShellCommand(): Promise<void> {
   result.value = null
 
   try {
-    const response = await fetch(`/api/nodes/${selectedNode.value}/execute`, {
+    const response = await fetch(`/api/nodes/${selectedNode.value}/exec`, {
       method: 'POST',
       headers: {
         ...authStore.getAuthHeaders(),

--- a/autobot-slm-frontend/src/views/ToolsView.vue
+++ b/autobot-slm-frontend/src/views/ToolsView.vue
@@ -261,7 +261,7 @@ async function runRedisCommand(): Promise<void> {
     }
 
     // Execute via ansible ad-hoc
-    const response = await fetch(`/api/nodes/${targetNode.node_id}/execute`, {
+    const response = await fetch(`/api/nodes/${targetNode.node_id}/exec`, {
       method: 'POST',
       headers: {
         ...authStore.getAuthHeaders(),
@@ -297,7 +297,7 @@ async function runAnsibleCommand(): Promise<void> {
   result.value = null
 
   try {
-    const response = await fetch(`/api/nodes/${selectedNode.value}/execute`, {
+    const response = await fetch(`/api/nodes/${selectedNode.value}/exec`, {
       method: 'POST',
       headers: {
         ...authStore.getAuthHeaders(),


### PR DESCRIPTION
## Summary
- **#1062**: Add missing `GET /api/nodes/{node_id}/health` endpoint — Deep Health Check was returning 404 because the endpoint never existed in the SLM backend
- **#1063**: Fix Redis CLI and Command Runner path mismatch — frontend called `/execute` but backend has `/exec`

## Changes
- `autobot-slm-backend/api/nodes.py`: Add `NodeHealthResponse` model and `get_node_health` endpoint returning CPU, memory, disk, heartbeat, and services from DB
- `autobot-slm-frontend/src/views/ToolsView.vue`: Fix `/execute` → `/exec` for Redis CLI and Ansible Ad-Hoc tools
- `autobot-slm-frontend/src/components/fleet/FleetToolsTab.vue`: Fix `/execute` → `/exec` for Redis CLI and Command Runner tools

## Test plan
- [x] Deep Health Check: `GET /api/nodes/00-SLM-Manager/health` returns HTTP 200 with valid health data
- [x] Redis CLI: `POST /api/nodes/04-Databases/exec` with `redis-cli PING` returns PONG
- [x] Command Runner: `POST /api/nodes/00-SLM-Manager/exec` with `uptime` returns output
- [x] All previously working tools (Network Test, Service Logs, Service Manager) still work
- [x] Backend linting passes (`ruff check`)
- [x] Pre-commit hooks pass

Closes #1062, closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)