### PR TITLE
fix(backend): remove duplicate orchestration router registration (#1060)

### DIFF
--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -170,8 +170,7 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["feedback", "learning-loop"],
         "feedback",
     ),
-    # Orchestration and caching
-    ("backend.api.orchestration", "/orchestration", ["orchestration"], "orchestration"),
+    # Caching
     (
         "backend.api.cache_management",
         "/cache-management",

--- a/autobot-backend/llm_self_awareness.py
+++ b/autobot-backend/llm_self_awareness.py
@@ -412,7 +412,7 @@ class LLMSelfAwareness:
             },
             "workflow_management": {
                 "description": "Multi-agent workflow orchestration",
-                "endpoints": ["/api/workflow", "/api/orchestration"],
+                "endpoints": ["/api/workflow", "/api/orchestrator"],
                 "features": ["task_planning", "agent_coordination", "approval_flows"],
             },
             "monitoring": {

--- a/autobot-backend/middleware/service_auth_enforcement.py
+++ b/autobot-backend/middleware/service_auth_enforcement.py
@@ -15,9 +15,10 @@ from collections import defaultdict
 from typing import Dict, List
 
 import structlog
-from backend.security.service_auth import validate_service_auth
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
+
+from backend.security.service_auth import validate_service_auth
 
 logger = structlog.get_logger()
 
@@ -83,7 +84,7 @@ EXEMPT_PATHS: List[str] = [
     # Infrastructure monitoring (visible to users)
     "/api/infrastructure",
     # Additional user-facing endpoints
-    "/api/orchestration",
+    "/api/orchestrator",
     "/api/workflow",
     "/api/embeddings",
     "/api/voice",


### PR DESCRIPTION
## Summary
- Removed duplicate `backend.api.orchestration` registration in `feature_routers.py` (was mounted at both `/orchestrator` and `/orchestration`)
- Kept `/orchestrator` prefix (used by 11 frontend call sites in `useWorkflowBuilder.ts`)
- Updated `/api/orchestration` → `/api/orchestrator` in `service_auth_enforcement.py` (public paths list) and `llm_self_awareness.py` (capability endpoints)

## Root Cause
The module was registered twice during the Issue #281 refactoring — once at line 36 (`/orchestrator`) and again at line 174 (`/orchestration`). Both loaded the same module, creating duplicate FastAPI routes.

## Test Plan
- [ ] Verify `/api/orchestrator/status` responds correctly
- [ ] Verify `/api/orchestration/status` no longer exists (404)
- [ ] Verify frontend workflow builder still functions

Closes #1060

🤖 Generated with Claude Code