### PR TITLE
fix(slm): route WebSocket through nginx with SSL support (#1048)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -37,6 +37,9 @@ SERVICE_AUTH_CIRCUIT_BREAKER_PERCENTAGE={{ service_auth_circuit_breaker_percenta
 SERVICE_AUTH_RATE_LIMIT_WINDOW={{ service_auth_rate_limit_window | default(300) }}
 SERVICE_AUTH_RATE_LIMIT_MAX_FAILURES={{ service_auth_rate_limit_max_failures | default(10) }}
 
+# SLM connection (Issue #1048: route through nginx, not direct port)
+AUTOBOT_SLM_TLS_ENABLED=true
+
 # ChromaDB (remote on AI Stack VM)
 AUTOBOT_CHROMADB_HOST={{ backend_chromadb_host | default(ai_stack_host | default('172.16.168.24')) }}
 AUTOBOT_CHROMADB_PORT={{ backend_chromadb_port | default('8000') }}


### PR DESCRIPTION
## Summary
- Add `_create_permissive_ssl_context()` to `slm_client.py` for self-signed cert support
- Update aiohttp HTTP session to use SSL-aware connector for HTTPS connections to SLM
- Update websockets connection to pass SSL context for `wss://` URLs
- Add `AUTOBOT_SLM_TLS_ENABLED=true` to Ansible backend env template

## Root Cause
SLM backend on .19 binds to `127.0.0.1:8000` (localhost only). Backend on .20 was connecting directly to `ws://172.16.168.19:8000/api/ws/events`, bypassing nginx. With `slm_tls_enabled=True` (already default in ssot_config), connections now route through nginx at `wss://172.16.168.19/api/ws/events`.

## Test Plan
- [ ] Verify backend starts without SLM connection errors in logs
- [ ] Confirm WebSocket connects via `wss://` through nginx
- [ ] Verify HTTP API calls to SLM work through HTTPS

Closes #1048

🤖 Generated with Claude Code