### PR TITLE
fix(security): add missing await on async factory calls (#1053)

### DIFF
--- a/autobot-backend/api/security.py
+++ b/autobot-backend/api/security.py
@@ -277,7 +277,7 @@ async def get_threat_intel_status(request: Request):
     their rate limit status, and cache statistics.
     """
     try:
-        threat_service = get_threat_intelligence_service()
+        threat_service = await get_threat_intelligence_service()
         status = await threat_service.get_service_status()
 
         return ThreatIntelStatusResponse(
@@ -305,7 +305,7 @@ async def check_url_reputation(request: Request, url_request: URLCheckRequest):
     aggregated threat score. Results are cached for 2 hours.
     """
     try:
-        threat_service = get_threat_intelligence_service()
+        threat_service = await get_threat_intelligence_service()
 
         if not threat_service.is_any_service_configured:
             return URLCheckResponse(
@@ -349,8 +349,8 @@ async def get_domain_security_stats(request: Request):
     threat intelligence integration status, and recent activity.
     """
     try:
-        domain_manager = get_domain_security_manager()
-        threat_service = get_threat_intelligence_service()
+        domain_manager = await get_domain_security_manager()
+        threat_service = await get_threat_intelligence_service()
 
         # Get threat intel status
         threat_status = await threat_service.get_service_status()


### PR DESCRIPTION
## Summary
- Added missing `await` to 4 calls to async singleton factory functions in `security.py`
- `get_threat_intelligence_service()` and `get_domain_security_manager()` are `async def` — without `await`, callers received coroutine objects instead of service instances
- Fixes 3 endpoints: `GET /threat-intel/status`, `POST /threat-intel/check-url`, `GET /domain-security/stats`

## Investigation
- Full codebase scan confirmed no other files have this pattern — all other callers of these factories already use `await` correctly
- The issue stated 3 missing awaits; actual count is 4 (line 308 in `check_url_reputation` was also affected)

## Test Plan
- [ ] `GET /api/security/threat-intel/status` returns 200 (was 500)
- [ ] `POST /api/security/threat-intel/check-url` returns expected response (was 500)
- [ ] `GET /api/security/domain-security/stats` returns 200 (was 500)
- [ ] No regressions on other security endpoints

Closes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)