### PR TITLE
feat(config): model-to-endpoint routing for CPU/GPU Ollama nodes (#1070)

### DIFF
--- a/autobot-backend/config/config.yaml
+++ b/autobot-backend/config/config.yaml
@@ -10,6 +10,13 @@ backend:
   llm:
     ollama:
       endpoint: http://127.0.0.1:11434
+      # GPU endpoint for model-to-endpoint routing (#1070)
+      # When set, models in gpu_models are routed here instead of the default endpoint.
+      # gpu_endpoint: http://172.16.168.20:11434
+      # gpu_models:
+      #   - "mistral:7b-instruct"
+      #   - "deepseek-r1:14b"
+      #   - "codellama:13b"
 
 # Infrastructure host overrides
 # Fallback path for _get_ollama_endpoint_fallback() via get_host("ollama")

--- a/autobot-backend/config/service_config.py
+++ b/autobot-backend/config/service_config.py
@@ -202,6 +202,16 @@ class ServiceConfigMixin:
             f"http://{NetworkConstants.LOCALHOST_NAME}:{NetworkConstants.OLLAMA_PORT}"
         )
 
+    def get_ollama_url_for_model(self, model_name: str) -> str:
+        """Get Ollama URL routed by model name (#1070).
+
+        Delegates to ModelConfigMixin.get_ollama_endpoint_for_model
+        which checks gpu_endpoint/gpu_models in config.yaml.
+        Falls back to get_ollama_url() if GPU routing is not
+        configured or the model is not a GPU model.
+        """
+        return self.get_ollama_endpoint_for_model(model_name)
+
     def get_redis_url(self) -> str:
         """Get the Redis service URL from configuration (backward compatibility)"""
         env_url = os.getenv("AUTOBOT_REDIS_URL")


### PR DESCRIPTION
## Summary
- Add GPU/CPU Ollama endpoint routing based on model name
- GPU models (e.g. `mistral:7b-instruct`) route to `AUTOBOT_OLLAMA_GPU_ENDPOINT`
- CPU/default models route to `AUTOBOT_OLLAMA_ENDPOINT` (backward compatible)
- Configurable via env vars (`AUTOBOT_OLLAMA_GPU_ENDPOINT`, `AUTOBOT_OLLAMA_GPU_MODELS`) or `config.yaml` (`gpu_endpoint`, `gpu_models`)

## Files Changed
- `autobot-shared/ssot_config.py` — GPU endpoint/models fields + routing method on `LLMConfig`
- `autobot-backend/config/config.yaml` — Documented GPU routing config options
- `autobot-backend/config/model_config.py` — `get_ollama_endpoint_for_model()` on `ModelConfigMixin`
- `autobot-backend/config/service_config.py` — `get_ollama_url_for_model()` convenience wrapper
- `autobot-backend/chat_workflow/llm_handler.py` — Resolve model before endpoint; use model-aware routing

## Configuration
```bash
# .env
AUTOBOT_OLLAMA_GPU_ENDPOINT=http://172.16.168.20:11434
AUTOBOT_OLLAMA_GPU_MODELS=mistral:7b-instruct,deepseek-r1:14b,codellama:13b
```

Or in `config.yaml`:
```yaml
backend:
  llm:
    ollama:
      endpoint: http://172.16.168.26:11434  # CPU default
      gpu_endpoint: http://172.16.168.20:11434
      gpu_models:
        - "mistral:7b-instruct"
        - "deepseek-r1:14b"
```

## Test Plan
- [ ] Verify backward compatibility: no GPU config → single endpoint works as before
- [ ] Set GPU env vars → GPU model requests route to GPU endpoint
- [ ] Non-GPU model requests still route to default endpoint
- [ ] Config reload picks up new GPU endpoint/models

Closes #1070

🤖 Generated with Claude Code