### PR TITLE
refactor(knowledge): architecture improvements for ECL pipeline (#1074)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/llm_utils.py
@@ -1,0 +1,69 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Shared LLM utilities for ECL pipeline cognifiers.
+
+Issue #1074: Extract duplicated parse/build helpers from cognifiers (ARCH-3/4).
+"""
+
+import json
+import logging
+from typing import Any, Dict, List
+
+from backend.knowledge.pipeline.models.entity import Entity
+
+logger = logging.getLogger(__name__)
+
+
+def parse_llm_json_response(
+    content: str,
+    *,
+    fallback_dict: bool = False,
+) -> List[Dict[str, Any]] | Dict[str, Any]:
+    """Parse LLM response as JSON, handling markdown code fences.
+
+    Args:
+        content: Raw LLM response text.
+        fallback_dict: If True, return a dict fallback on parse failure
+                       (used by summarizer). Otherwise return empty list.
+
+    Returns:
+        Parsed JSON (list or dict depending on LLM output).
+    """
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        if "```json" in content:
+            json_str = content.split("```json")[1].split("```")[0].strip()
+            return json.loads(json_str)
+        if "```" in content:
+            json_str = content.split("```")[1].split("```")[0].strip()
+            return json.loads(json_str)
+        logger.warning("Could not parse LLM response as JSON")
+        if fallback_dict:
+            return {"summary": content, "key_topics": [], "key_entities": []}
+        return []
+
+
+def build_entity_map(
+    entities: List[Entity],
+    *,
+    include_canonical: bool = True,
+) -> Dict[str, Entity]:
+    """Build name-to-entity lookup mapping.
+
+    Args:
+        entities: Entity list to index.
+        include_canonical: Also index by canonical_name (relationship
+                          extractor needs this; summarizer does not).
+
+    Returns:
+        Mapping of lowercase name -> Entity.
+    """
+    entity_map: Dict[str, Entity] = {}
+    for entity in entities:
+        entity_map[entity.name.lower()] = entity
+        if include_canonical:
+            entity_map[entity.canonical_name] = entity
+    return entity_map

--- a/autobot-backend/knowledge/pipeline/config.py
+++ b/autobot-backend/knowledge/pipeline/config.py
@@ -7,6 +7,7 @@ Pipeline Configuration - Default pipeline configurations.
 Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
 """
 
+import copy
 import logging
 import re
 from typing import Any, Dict
@@ -59,7 +60,7 @@ def load_pipeline_config(config_dict: Dict[str, Any]) -> Dict[str, Any]:
 
 def _validate_stage_config(stage_config: list, stage_name: str) -> None:
     """
-    Validate stage configuration. Helper for load_pipeline_config (Issue #665).
+    Validate stage configuration. Helper for load_pipeline_config (#665).
 
     Args:
         stage_config: List of task configurations
@@ -87,6 +88,6 @@ def get_default_config() -> Dict[str, Any]:
     Get the default knowledge enrichment pipeline configuration.
 
     Returns:
-        Default pipeline configuration dict
+        Default pipeline configuration dict (deep copy)
     """
-    return DEFAULT_KNOWLEDGE_PIPELINE.copy()
+    return copy.deepcopy(DEFAULT_KNOWLEDGE_PIPELINE)

--- a/autobot-backend/knowledge/pipeline/models/relationship.py
+++ b/autobot-backend/knowledge/pipeline/models/relationship.py
@@ -7,11 +7,11 @@ Relationship Model - Entity relationship representation for ECL pipeline.
 Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Literal
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 RelationType = Literal[
     "CAUSES",
@@ -40,6 +40,11 @@ RelationType = Literal[
 ]
 
 
+def _utcnow() -> datetime:
+    """Return timezone-aware UTC now (replaces deprecated datetime.utcnow)."""
+    return datetime.now(timezone.utc)
+
+
 class Relationship(BaseModel):
     """
     Represents a directed relationship between two entities.
@@ -47,6 +52,10 @@ class Relationship(BaseModel):
     Relationships capture semantic connections extracted from text,
     with optional bidirectionality for symmetric relations.
     """
+
+    model_config = ConfigDict(
+        json_encoders={datetime: lambda v: v.isoformat(), UUID: str},
+    )
 
     id: UUID = Field(default_factory=uuid4, description="Unique relationship ID")
     source_entity_id: UUID = Field(
@@ -72,16 +81,8 @@ class Relationship(BaseModel):
         default_factory=list, description="Chunks where relationship was found"
     )
     created_at: datetime = Field(
-        default_factory=datetime.utcnow, description="Relationship creation timestamp"
+        default_factory=_utcnow, description="Relationship creation timestamp"
     )
     updated_at: datetime = Field(
-        default_factory=datetime.utcnow, description="Last update timestamp"
+        default_factory=_utcnow, description="Last update timestamp"
     )
-
-    class Config:
-        """Pydantic model configuration."""
-
-        json_encoders = {
-            datetime: lambda v: v.isoformat(),
-            UUID: lambda v: str(v),
-        }

--- a/autobot-backend/knowledge/pipeline/registry.py
+++ b/autobot-backend/knowledge/pipeline/registry.py
@@ -7,7 +7,10 @@ Task Registry for ECL Knowledge Pipeline.
 Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
 """
 
+import logging
 from typing import Any, Callable, Dict, Type
+
+logger = logging.getLogger(__name__)
 
 
 class TaskRegistry:
@@ -30,6 +33,13 @@ class TaskRegistry:
         """
 
         def decorator(extractor_class: Type[Any]) -> Type[Any]:
+            if name in cls._extractors:
+                logger.warning(
+                    "Overwriting extractor '%s' (%s -> %s)",
+                    name,
+                    cls._extractors[name].__name__,
+                    extractor_class.__name__,
+                )
             cls._extractors[name] = extractor_class
             return extractor_class
 
@@ -48,6 +58,13 @@ class TaskRegistry:
         """
 
         def decorator(cognifier_class: Type[Any]) -> Type[Any]:
+            if name in cls._cognifiers:
+                logger.warning(
+                    "Overwriting cognifier '%s' (%s -> %s)",
+                    name,
+                    cls._cognifiers[name].__name__,
+                    cognifier_class.__name__,
+                )
             cls._cognifiers[name] = cognifier_class
             return cognifier_class
 
@@ -66,6 +83,13 @@ class TaskRegistry:
         """
 
         def decorator(loader_class: Type[Any]) -> Type[Any]:
+            if name in cls._loaders:
+                logger.warning(
+                    "Overwriting loader '%s' (%s -> %s)",
+                    name,
+                    cls._loaders[name].__name__,
+                    loader_class.__name__,
+                )
             cls._loaders[name] = loader_class
             return loader_class
 


### PR DESCRIPTION
## Summary
- **ARCH-3/4**: Extract shared `parse_llm_json_response()` and `build_entity_map()` into `cognifiers/llm_utils.py`, removing duplication from 4 cognifiers
- **ARCH-2**: Add duplicate registration warning to `TaskRegistry` (logs when extractor/cognifier/loader is overwritten)
- **ARCH-5**: Use `copy.deepcopy()` for default pipeline config (prevents shared mutable state)
- **ARCH-1**: Switch to async Redis client in `redis_graph_loader`, `knowledge_graph_routes`, and `temporal_search` (fixes sync calls blocking the event loop)
- Migrate 5 models to Pydantic v2 `ConfigDict` and replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`
- Fix f-string logging anti-pattern in `redis_graph_loader`

Closes #1074

## Files Changed (15)
- `cognifiers/llm_utils.py` (NEW) — shared LLM response parsing utilities
- `entity_extractor.py`, `relationship_extractor.py`, `event_extractor.py`, `summarizer.py` — use shared utils
- `registry.py` — duplicate registration warning
- `config.py` — deepcopy default config
- `redis_graph_loader.py`, `knowledge_graph_routes.py`, `temporal_search.py` — async Redis
- `entity.py`, `relationship.py`, `event.py`, `chunk.py`, `summary.py` — Pydantic v2 + tz-aware datetime

## Test plan
- [ ] Verify ruff check passes on all 15 files
- [ ] Verify pre-commit hooks pass
- [ ] Verify no merge conflicts with Dev_new_gui

🤖 Generated with [Claude Code](https://claude.com/claude-code)