### PR TITLE
feat(compliance): add pre-commit hook for direct Redis connections (#1086)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,6 +108,18 @@ repos:
         stages: [pre-commit]
         description: "Blocks commits with functions >65 lines, warns for 51-65 lines"
 
+  # No direct redis.Redis() in production code (Issue #1086)
+  - repo: local
+    hooks:
+      - id: no-direct-redis
+        name: No Direct Redis Connections in Production Code (Issue #1086)
+        entry: autobot-infrastructure/shared/scripts/hooks/pre-commit-no-direct-redis
+        language: script
+        types: [python]
+        pass_filenames: false
+        stages: [pre-commit]
+        description: "Blocks commits with direct redis.Redis() — use get_redis_client() instead"
+
   # No print()/console.* in production code (Issue #1082)
   - repo: local
     hooks:

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-direct-redis
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-direct-redis
@@ -1,0 +1,116 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Pre-commit Hook: No Direct Redis Connections in Production Code
+# ==============================================================
+#
+# Blocks commits containing:
+# - Direct redis.Redis() instantiation in production code
+# - Direct aioredis.Redis() instantiation in production code
+#
+# Intentional exceptions:
+# - autobot-shared/redis_client.py (the canonical client definition)
+# - autobot-infrastructure/ (standalone scripts that can't import autobot_shared)
+# - Test files (*_test.py, *.integration_test.py, etc.)
+# - Lines with "# noqa: redis" comments
+#
+# Issue: #1086 - Pre-commit check to flag redis.Redis() in new code
+#
+# Install: pre-commit install (uses .pre-commit-config.yaml)
+
+set -uo pipefail
+
+# Colors (matching existing hooks pattern)
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+VIOLATIONS=0
+
+# Get staged Python files (production code only)
+get_staged_python_files() {
+    git diff --cached --name-only --diff-filter=ACM 2>/dev/null | \
+        grep -E '\.py$' | \
+        grep -v -E '(__pycache__|node_modules|\.venv|venv|archive|temp)' | \
+        grep -v -E '(_test\.py$|\.e2e_test\.py$|\.integration_test\.py$|\.performance_test\.py$)' | \
+        grep -v -E '(conftest\.py$|test_.*\.py$)' | \
+        grep -v -E '^autobot-infrastructure/' | \
+        grep -v -E '^autobot-shared/redis_client\.py$' || true
+}
+
+# Check a Python file for direct redis.Redis() calls
+check_direct_redis() {
+    local file="$1"
+    local line_num=0
+
+    while IFS= read -r line; do
+        ((line_num++))
+
+        # Skip empty lines
+        [[ -z "$line" ]] && continue
+
+        # Skip comments
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+        # Skip noqa exemption
+        echo "$line" | grep -q 'noqa: redis' && continue
+
+        # Match redis.Redis( or aioredis.Redis( — direct instantiation
+        if echo "$line" | grep -qE '(^|[[:space:]])((aio)?redis)\.Redis\s*\('; then
+            echo -e "  ${RED}VIOLATION${NC} ${file}:${line_num}"
+            echo "    ${line:0:100}"
+            ((VIOLATIONS++))
+        fi
+    done < "$file"
+}
+
+main() {
+    echo -e "${BOLD}${CYAN}Pre-commit: No Direct Redis Connections in Production Code${NC}"
+    echo "Issue #1086 - Redis Client Standard Enforcement"
+    echo "================================================"
+    echo ""
+
+    local py_files
+    py_files=$(get_staged_python_files)
+
+    if [[ -z "$py_files" ]]; then
+        echo -e "${GREEN}No production Python files staged for commit.${NC}"
+        exit 0
+    fi
+
+    local py_count
+    py_count=$(echo "$py_files" | wc -l)
+    echo -e "Scanning ${BOLD}${py_count}${NC} Python file(s) for direct redis.Redis() usage..."
+    echo ""
+
+    for file in $py_files; do
+        [[ -f "$file" ]] && check_direct_redis "$file"
+    done
+
+    echo ""
+    echo "================================================"
+
+    if [[ $VIOLATIONS -gt 0 ]]; then
+        echo -e "${RED}COMMIT BLOCKED: $VIOLATIONS direct Redis connection(s) found${NC}"
+        echo ""
+        echo "Quick fix:"
+        echo "  from autobot_shared.redis_client import get_redis_client"
+        echo "  redis_client = get_redis_client(async_client=False, database=\"main\")"
+        echo ""
+        echo "Available databases: main, knowledge, prompts, analytics"
+        echo ""
+        echo "Exempt a line (standalone scripts only): add '# noqa: redis'"
+        echo ""
+        exit 1
+    else
+        echo -e "${GREEN}No direct Redis connection violations found!${NC}"
+        exit 0
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add `pre-commit-no-direct-redis` hook that blocks `redis.Redis()` direct instantiation in production code
- Register hook in `.pre-commit-config.yaml` with appropriate exclusions
- Completes the third and final acceptance criterion for issue #1086

## Hook behavior
- Scans staged Python files in production components (`autobot-backend/`, `autobot-shared/`, `autobot-slm-backend/`, `autobot-npu-worker/`, `autobot-browser-worker/`)
- Excludes `autobot-infrastructure/` (standalone scripts legitimately cannot import `autobot_shared`)
- Excludes `autobot-shared/redis_client.py` (the canonical definition itself)
- Excludes test files (`*_test.py`, `conftest.py`, etc.)
- Supports `# noqa: redis` comment for approved exceptions
- On failure: shows violation location and suggests `get_redis_client()` with database guidance

## Test Plan
- [x] Hook blocks `redis.Redis(` in production files (exit code 1)
- [x] Hook passes with `# noqa: redis` exemption (exit code 0)
- [x] Hook skips when no production Python files are staged (exit code 0)
- [x] Infrastructure scripts correctly excluded
- [x] Pre-commit hooks run cleanly on commit

Closes #1086

🤖 Generated with Claude Code