### PR TITLE
fix(compliance): move E402 module-level imports to top (#1117)

### DIFF
--- a/autobot-backend/conversation_file_manager.py
+++ b/autobot-backend/conversation_file_manager.py
@@ -29,8 +29,13 @@ from typing import Any, Dict, List, Optional
 import aiofiles
 import aiosqlite
 import redis.asyncio as async_redis
-
 from backend.constants.threshold_constants import TimingConstants
+from config import unified_config_manager
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from autobot_shared.redis_client import get_redis_client as get_redis_manager
 
 # Module-level project root constant (Issue #380 - avoid repeated Path computation)
 _PROJECT_ROOT = Path(__file__).parent.parent
@@ -86,13 +91,6 @@ class FileInfo:
             self.uploaded_by,
         )
 
-
-from config import unified_config_manager
-from redis.exceptions import ConnectionError as RedisConnectionError
-from redis.exceptions import RedisError
-from redis.exceptions import TimeoutError as RedisTimeoutError
-
-from autobot_shared.redis_client import get_redis_client as get_redis_manager
 
 logger = logging.getLogger(__name__)
 
@@ -1364,10 +1362,8 @@ class ConversationFileManager:
 
 
 # Global instance (singleton pattern, thread-safe)
-import asyncio as _asyncio
-
 _conversation_file_manager_instance: Optional[ConversationFileManager] = None
-_conversation_file_manager_lock = _asyncio.Lock()
+_conversation_file_manager_lock = asyncio.Lock()
 
 
 async def get_conversation_file_manager() -> ConversationFileManager:

--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -8,13 +8,10 @@ import os
 from typing import Any, Dict, List, Optional
 
 import yaml
-
-logger = logging.getLogger(__name__)
-
-# Import the centralized ConfigManager
+from backend.constants.network_constants import NetworkConstants
 from config import config as global_config_manager
 
-from backend.constants.network_constants import NetworkConstants
+logger = logging.getLogger(__name__)
 
 # Performance optimization: O(1) lookup for boolean string values (Issue #326)
 BOOLEAN_TRUE_VALUES = {"true", "1", "yes"}


### PR DESCRIPTION
## Summary

Fix E402 violations (module-level imports not at top) in two files.

### `conversation_file_manager.py`
- Moved 5 imports (`config`, `redis.exceptions` ×3, `autobot_shared.redis_client`) from after the `FileInfo` dataclass definition (~line 90) to the top imports block
- Removed redundant `import asyncio as _asyncio` (~line 1367) — `asyncio` was already imported at line 16; replaced `_asyncio.Lock()` with `asyncio.Lock()`

### `security_layer.py`
- Moved 2 imports (`backend.constants.network_constants`, `config`) from after the `logger` assignment to before it, joining the top-level imports block

## Test Plan
- [x] Both files parse cleanly (`ast.parse`)
- [x] All imports now at top — no E402 violations remain
- [x] `isort`, `flake8`, `black`, `bandit` all pass
- [x] No runtime behaviour changed (imports moved, not altered)

Closes #1117

🤖 Generated with Claude Code