### PR TITLE
fix(codebase-analytics): run indexing in subprocess to prevent ChromaDB SIGSEGV (#1180)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/indexing.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/indexing.py
@@ -38,9 +38,9 @@ from ..scanner import (
     _current_indexing_task_id,
     _index_queue,
     _load_task_from_redis,
+    _run_indexing_subprocess,
     _tasks_lock,
     _tasks_sync_lock,
-    do_indexing_with_progress,
     indexing_tasks,
 )
 
@@ -139,7 +139,7 @@ def _start_next_queued_job() -> None:
     next_task_id = str(uuid.uuid4())
     _current_indexing_task_id = next_task_id
     task = asyncio.get_event_loop().create_task(
-        do_indexing_with_progress(next_task_id, next_path)
+        _run_indexing_subprocess(next_task_id, next_path)
     )
     _active_tasks[next_task_id] = task
     task.add_done_callback(_create_cleanup_callback(next_task_id))
@@ -196,7 +196,7 @@ async def index_codebase(request: Optional[IndexCodebaseRequest] = None):
         _current_indexing_task_id = task_id
 
         logger.info("🔄 About to create_task")
-        task = asyncio.create_task(do_indexing_with_progress(task_id, root_path))
+        task = asyncio.create_task(_run_indexing_subprocess(task_id, root_path))
         logger.info("✅ Task created: %s", task)
         _active_tasks[task_id] = task
         logger.info("💾 Task stored in _active_tasks")

--- a/autobot-backend/api/codebase_analytics/indexing_worker.py
+++ b/autobot-backend/api/codebase_analytics/indexing_worker.py
@@ -1,0 +1,51 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Subprocess entry point for isolated codebase indexing (#1180).
+
+Runs do_indexing_with_progress in a separate process so its ChromaDB
+PersistentClient does not conflict with the KB's concurrent PersistentClient.
+If this process crashes (SIGSEGV in chromadb_rust_bindings), the parent
+uvicorn worker that launched it is unaffected.
+
+Usage (internal — called by _run_indexing_subprocess):
+    python indexing_worker.py <task_id> <root_path>
+"""
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+# Set up sys.path before importing project modules.
+# Required because subprocess env may not have PYTHONPATH set identically.
+_BACKEND_ROOT = Path(__file__).parent.parent.parent  # .../autobot-backend/
+_SHARED_ROOT = _BACKEND_ROOT.parent / "autobot-shared"
+for _p in [str(_BACKEND_ROOT.parent), str(_SHARED_ROOT), str(_BACKEND_ROOT)]:
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from api.codebase_analytics.scanner import do_indexing_with_progress  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Entry point: parse CLI args and run indexing task."""
+    if len(sys.argv) < 3:
+        logger.error("Usage: indexing_worker.py <task_id> <root_path>")
+        sys.exit(1)
+
+    task_id = sys.argv[1]
+    root_path = sys.argv[2]
+
+    logger.info("[Worker] Starting indexing task=%s path=%s", task_id, root_path)
+    asyncio.run(do_indexing_with_progress(task_id, root_path))
+    logger.info("[Worker] Indexing task=%s finished", task_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `api/codebase_analytics/indexing_worker.py` — subprocess entry point that sets up sys.path and calls `asyncio.run(do_indexing_with_progress(task_id, root_path))`
- Add `_run_indexing_subprocess()` + `_handle_subprocess_crash()` to `scanner.py`
- Update `endpoints/indexing.py` — replace `do_indexing_with_progress` with `_run_indexing_subprocess` at both call sites (`index_codebase` + `_start_next_queued_job`)

## Root Cause
Two concurrent `chromadb.PersistentClient` instances in the same uvicorn worker — KB at `autobot-backend/data/chromadb` and analytics at `data/chromadb` — trigger a null pointer dereference in the embedded Rust/tokio runtime at a consistent offset (`0x1b8460e`), killing the worker process ~100-140s into indexing.

## Fix
Run `do_indexing_with_progress` in an isolated subprocess via `asyncio.create_subprocess_exec`. The subprocess gets its own process memory with only the analytics `PersistentClient` — no in-process conflict with the KB client. If the subprocess SIGSEGV-crashes, the parent uvicorn worker is unaffected. `_handle_subprocess_crash` detects non-zero exit and marks the task failed in Redis so polling clients get a clear error state.

Integrates with the #1179 Redis state fix: initial `running` state is written to Redis before subprocess launch so status polls never return `not_found` during startup latency.

## Test Plan
- [ ] `POST /api/analytics/codebase/index` returns `task_id`
- [ ] `GET /api/analytics/codebase/index/status/{task_id}` returns `running` (never `not_found`)
- [ ] Indexing runs to completion — no SIGSEGV in `dmesg` during/after indexing
- [ ] On subprocess crash: status endpoint returns `failed` with descriptive error message

Closes #1180