### PR TITLE
build(deps): safe dependency bumps (cherry-picked from #1388)

### DIFF
--- a/autobot-infrastructure/shared/config/requirements-ci.txt
+++ b/autobot-infrastructure/shared/config/requirements-ci.txt
@@ -5,7 +5,7 @@ starlette>=0.49.1                 # SECURITY UPDATE - CVE fix (GHSA-7f5h-v6xp-fc
 python-multipart>=0.0.9           # Required for FastAPI form data handling
 uvicorn>=0.30.0
 requests==2.32.4
-aiohttp==3.12.15
+aiohttp==3.13.3
 aiofiles>=23.0.0
 aiosqlite>=0.17.0
 beautifulsoup4>=4.12.0

--- a/autobot-infrastructure/shared/config/requirements.txt
+++ b/autobot-infrastructure/shared/config/requirements.txt
@@ -4,7 +4,7 @@ starlette>=0.49.1                 # SECURITY UPDATE - CVE fix (GHSA-7f5h-v6xp-fc
 python-multipart>=0.0.9           # Required for FastAPI form data handling
 uvicorn>=0.30.0
 requests==2.32.4
-aiohttp==3.12.15
+aiohttp==3.13.3
 aiofiles>=23.0.0
 aiosqlite>=0.17.0
 beautifulsoup4>=4.12.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,10 +10,10 @@
 # ===== CORE FRAMEWORK =====
 fastapi==0.115.9
 starlette==0.45.3
-python-multipart==0.0.20
+python-multipart==0.0.22
 uvicorn==0.35.0
 requests==2.32.4
-aiohttp==3.12.15
+aiohttp==3.13.3
 aiofiles==24.1.0
 aiosqlite==0.21.0
 beautifulsoup4==4.13.4
@@ -43,9 +43,9 @@ playwright==1.54.0
 
 # ===== DOCUMENT PROCESSING =====
 python-docx==1.1.2
-pypdf==6.0.0
+pypdf==6.7.5
 markdown==3.8.2
-nltk==3.9.1
+nltk==3.9.3
 
 # ===== GUI & AUTOMATION =====
 pyautogui==0.9.54
@@ -60,7 +60,7 @@ markdownify==1.2.0
 langchain==0.3.26
 langchain-community==0.3.27
 langchain-core==0.3.68
-langchain-text-splitters==0.3.8
+langchain-text-splitters==0.3.9
 langsmith==0.4.5
 llama-index-core==0.12.52
 llama-index-llms-ollama==0.6.2


### PR DESCRIPTION
## Summary
- Cherry-picked only the **low-risk** updates from Dependabot PR #1388
- aiohttp 3.12.15 → 3.13.3
- pypdf 6.0.0 → 6.7.5
- nltk 3.9.1 → 3.9.3
- python-multipart 0.0.20 → 0.0.22
- langchain-text-splitters 0.3.8 → 0.3.9

## Excluded (risky)
- langchain-core 0.3 → 1.2 (major version, breaking API changes)
- protobuf upper bound <5 → <8 (contradicts documented constraint)
- llama-index-core 0.12 → 0.13 (known for breaking changes)
- pillow 11 → 12, starlette 0.45 → 0.49, cryptography 45 → 46, torch upper bound loosening

See review on #1388 for full analysis.

## Test plan
- [ ] CI pipeline passes with updated versions
- [ ] No import errors or runtime failures from bumped packages