### PR TITLE
feat(i18n): prompt language injection for all agents (#1327)

### DIFF
--- a/autobot-backend/agents/audio_processing_agent.py
+++ b/autobot-backend/agents/audio_processing_agent.py
@@ -104,7 +104,7 @@ class AudioProcessingAgent(StandardizedAgent):
         try:
             logger.info("Audio Processing Agent processing: %s...", request_text[:50])
             messages = [
-                {"role": "system", "content": self._get_system_prompt()},
+                {"role": "system", "content": self._get_localized_system_prompt()},
                 {"role": "user", "content": request_text},
             ]
             response = await self.llm_interface.chat_completion(

--- a/autobot-backend/agents/chat_agent.py
+++ b/autobot-backend/agents/chat_agent.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 
 from constants.threshold_constants import LLMDefaults
 from llm_interface import LLMInterface
+from prompt_manager import get_language_instruction, resolve_language
 
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
@@ -140,8 +141,11 @@ class ChatAgent(StandardizedAgent):
         try:
             logger.info("Chat Agent processing message: %s...", message[:50])
 
-            # Prepare chat-optimized system prompt
-            system_prompt = self._get_chat_system_prompt()
+            # Prepare chat-optimized system prompt with language (#1327)
+            lang_code = resolve_language()
+            system_prompt = self._get_chat_system_prompt() + get_language_instruction(
+                lang_code
+            )
 
             # Build conversation context
             messages = [{"role": "system", "content": system_prompt}]

--- a/autobot-backend/agents/code_generation_agent.py
+++ b/autobot-backend/agents/code_generation_agent.py
@@ -97,7 +97,7 @@ class CodeGenerationAgent(StandardizedAgent):
         try:
             logger.info("Code Generation Agent processing: %s...", request_text[:50])
             messages = [
-                {"role": "system", "content": self._get_system_prompt()},
+                {"role": "system", "content": self._get_localized_system_prompt()},
                 {"role": "user", "content": request_text},
             ]
             response = await self.llm_interface.chat_completion(

--- a/autobot-backend/agents/data_analysis_agent.py
+++ b/autobot-backend/agents/data_analysis_agent.py
@@ -96,7 +96,7 @@ class DataAnalysisAgent(StandardizedAgent):
         try:
             logger.info("Data Analysis Agent processing: %s...", request_text[:50])
             messages = [
-                {"role": "system", "content": self._get_system_prompt()},
+                {"role": "system", "content": self._get_localized_system_prompt()},
                 {"role": "user", "content": request_text},
             ]
             response = await self.llm_interface.chat_completion(

--- a/autobot-backend/agents/image_analysis_agent.py
+++ b/autobot-backend/agents/image_analysis_agent.py
@@ -115,7 +115,7 @@ class ImageAnalysisAgent(StandardizedAgent):
         try:
             logger.info("Image Analysis Agent processing: %s...", request_text[:50])
             messages = [
-                {"role": "system", "content": self._get_system_prompt()},
+                {"role": "system", "content": self._get_localized_system_prompt()},
                 {"role": "user", "content": request_text},
             ]
             response = await self.llm_interface.chat_completion(

--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -103,7 +103,7 @@ class SentimentAnalysisAgent(StandardizedAgent):
         try:
             logger.info("Sentiment Analysis Agent processing: %s...", request_text[:50])
             messages = [
-                {"role": "system", "content": self._get_system_prompt()},
+                {"role": "system", "content": self._get_localized_system_prompt()},
                 {"role": "user", "content": request_text},
             ]
             response = await self.llm_interface.chat_completion(

--- a/autobot-backend/agents/standardized_agent.py
+++ b/autobot-backend/agents/standardized_agent.py
@@ -19,6 +19,8 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
+from prompt_manager import get_language_instruction, resolve_language
+
 from .base_agent import AgentRequest, AgentResponse, BaseAgent, DeploymentMode
 
 
@@ -131,6 +133,17 @@ class StandardizedAgent(BaseAgent):
             )
 
         return None, handler_config, handler_method
+
+    def _get_localized_system_prompt(self, language=None):
+        """Get system prompt with language instruction appended.
+
+        Issue #1327: Wraps _get_system_prompt() with language injection.
+        Resolves language from request param > personality > 'en'.
+        English adds no extra instruction.
+        """
+        base = self._get_system_prompt()
+        lang_code = resolve_language(language)
+        return base + get_language_instruction(lang_code)
 
     def _build_success_response(
         self, request: AgentRequest, result: Any, processing_time: float

--- a/autobot-backend/agents/summarization_agent.py
+++ b/autobot-backend/agents/summarization_agent.py
@@ -100,7 +100,7 @@ class SummarizationAgent(StandardizedAgent):
         try:
             logger.info("Summarization Agent processing: %s...", request_text[:50])
             messages = [
-                {"role": "system", "content": self._get_system_prompt()},
+                {"role": "system", "content": self._get_localized_system_prompt()},
                 {"role": "user", "content": request_text},
             ]
             response = await self.llm_interface.chat_completion(

--- a/autobot-backend/agents/translation_agent.py
+++ b/autobot-backend/agents/translation_agent.py
@@ -102,7 +102,7 @@ class TranslationAgent(StandardizedAgent):
         try:
             logger.info("Translation Agent processing: %s...", request_text[:50])
             messages = [
-                {"role": "system", "content": self._get_system_prompt()},
+                {"role": "system", "content": self._get_localized_system_prompt()},
                 {"role": "user", "content": request_text},
             ]
             response = await self.llm_interface.chat_completion(

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List
 from async_chat_workflow import WorkflowMessage
 from constants.model_constants import ModelConstants
 from dependencies import global_config_manager
-from prompt_manager import get_prompt
+from prompt_manager import get_language_instruction, get_prompt, resolve_language
 
 from autobot_shared.http_client import get_http_client
 
@@ -143,39 +143,18 @@ class LLMHandlerMixin:
             return ""
 
     def _resolve_language(self, request_language=None):
-        """Resolve response language from request, personality, or default.
+        """Resolve response language. Delegates to prompt_manager.
 
-        Issue #1325: Priority order:
-        1. Per-message language param (highest)
-        2. Personality profile language_code
-        3. Default: 'en'
+        Issue #1327: Moved to shared utility in prompt_manager.
         """
-        if request_language:
-            return request_language
-        try:
-            from services.personality_service import get_personality_manager
-
-            profile = get_personality_manager().get_active_profile()
-            if profile and profile.language_code:
-                return profile.language_code
-        except Exception:
-            pass
-        return "en"
+        return resolve_language(request_language)
 
     def _get_language_instruction(self, language_code):
-        """Build a language instruction for the system prompt.
+        """Build language instruction. Delegates to prompt_manager.
 
-        Issue #1325: Returns empty string for English (default).
+        Issue #1327: Moved to shared utility in prompt_manager.
         """
-        if not language_code or language_code == "en":
-            return ""
-        from services.personality_service import SUPPORTED_LANGUAGES
-
-        lang_name = SUPPORTED_LANGUAGES.get(language_code, language_code)
-        return (
-            f"\n\n**Response Language:** Always respond in "
-            f"{lang_name} ({language_code})."
-        )
+        return get_language_instruction(language_code)
 
     def _get_system_prompt(self, language=None) -> str:
         """Get system prompt with optional personality preamble.

--- a/autobot-backend/conversation.py
+++ b/autobot-backend/conversation.py
@@ -17,7 +17,6 @@ from agents import get_kb_librarian
 from agents.classification_agent import ClassificationAgent, ClassificationResult
 from agents.llm_failsafe_agent import get_robust_llm_response
 from autobot_types import TaskComplexity
-from config import config as global_config_manager
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import TimingConstants
 from research_browser_manager import research_browser_manager
@@ -28,6 +27,8 @@ from source_attribution import (
     source_manager,
     track_source,
 )
+
+from config import config as global_config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -452,8 +453,13 @@ class Conversation:
         return "\n".join(research_lines)
 
     def _get_system_prompt(self) -> str:
-        """Get the system prompt for response generation."""
-        return (
+        """Get the system prompt for response generation.
+
+        Issue #1327: Appends language instruction when non-English.
+        """
+        from prompt_manager import get_language_instruction, resolve_language
+
+        base = (
             "You are AutoBot, an intelligent AI assistant. You have access to a "
             "knowledge base and can conduct external research.\n\n"
             "IMPORTANT INSTRUCTIONS:\n"
@@ -466,6 +472,8 @@ class Conversation:
             "5. Be conversational but accurate\n"
             "6. If you don't know something and it's not in KB or research, say so clearly"
         )
+        lang_code = resolve_language()
+        return base + get_language_instruction(lang_code)
 
     def _build_user_prompt(
         self, user_message: str, kb_context: str, research_context: str

--- a/autobot-backend/prompt_manager.py
+++ b/autobot-backend/prompt_manager.py
@@ -646,3 +646,59 @@ def reload_prompts() -> None:
     Convenience function to reload all prompts.
     """
     prompt_manager.reload()
+
+
+# Issue #1327: Supported languages for prompt language injection.
+# Canonical copy lives in personality_service.SUPPORTED_LANGUAGES;
+# duplicated here to avoid circular-import issues at call time.
+SUPPORTED_LANGUAGES = {
+    "en": "English",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "pt": "Portuguese",
+    "zh": "Chinese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "ar": "Arabic",
+    "ru": "Russian",
+    "it": "Italian",
+    "nl": "Dutch",
+    "hi": "Hindi",
+}
+
+
+def resolve_language(request_language=None):
+    """Resolve response language from request, personality, or default.
+
+    Issue #1327: Shared utility for all agents and handlers.
+    Priority: request param > personality profile > 'en'.
+    """
+    if request_language:
+        return request_language
+    try:
+        from services.personality_service import get_personality_manager
+
+        profile = get_personality_manager().get_active_profile()
+        if profile and profile.language_code:
+            return profile.language_code
+    except Exception:
+        pass
+    return "en"
+
+
+def get_language_instruction(language_code):
+    """Build a language instruction block for system prompts.
+
+    Issue #1327: Returns empty string for English (default),
+    so no noise is added when language is not explicitly set.
+    """
+    if not language_code or language_code == "en":
+        return ""
+    lang_name = SUPPORTED_LANGUAGES.get(language_code, language_code)
+    return (
+        f"\n\n**Language Requirement:** You MUST respond in "
+        f"{lang_name} ({language_code}). "
+        f"All your responses, explanations, and generated "
+        f"content must be in {lang_name}."
+    )


### PR DESCRIPTION
## Summary
- Extract `resolve_language()` and `get_language_instruction()` to `prompt_manager.py` as shared utilities
- Add `_get_localized_system_prompt()` to `StandardizedAgent` base class — inherited by 7 agent subclasses
- Wire language injection into `ChatAgent`, `Conversation` handler, and `LLMHandlerMixin`
- English (default) adds no extra instruction; non-English appends a Language Requirement block
- Resolution priority: per-request param > personality profile > 'en'

## Test Plan
- [ ] Set personality language to "es" → all agents respond in Spanish
- [ ] Default (no language set) → no extra instruction in prompt (no noise)
- [ ] Per-request language override works across agent types
- [ ] Verify English default adds no Language Requirement block

Closes #1327