### PR TITLE
build(deps): remaining security bumps from #1388

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -1,7 +1,7 @@
 -e ../autobot-shared
 
 # Core
-fastapi>=0.100.0
+fastapi>=0.125.0                # SECURITY UPDATE - requires starlette >=0.52.1
 uvicorn>=0.23.0
 python-dotenv>=1.0.0
 aiofiles>=23.0.0
@@ -36,7 +36,7 @@ llama-index-embeddings-ollama>=0.1.0,<0.2.0  # Ollama embeddings (older API)
 llama-index-vector-stores-chroma>=0.1.0,<0.2.0  # ChromaDB vector store (older API)
 # LangChain 1.x ecosystem — pinned to 0.3.x minor to prevent drift (#1047)
 langchain>=0.3.0,<0.4.0               # Issue #1043: Upgraded for LangGraph compatibility
-langchain-core>=0.3.0,<0.4.0          # Issue #1043: Core abstractions for LangGraph
+langchain-core>=0.3.81,<0.4.0         # Issue #1043 + SECURITY UPDATE (injection + SSRF)
 langchain-community>=0.3.0,<0.4.0     # Issue #1043: Community integrations
 langchain-ollama>=0.3.0,<0.4.0        # Issue #1047: ChatOllama for QA chain (replaces legacy Ollama)
 langgraph>=1.0.0,<2.0.0               # Issue #1043: StateGraph for chat orchestration
@@ -49,9 +49,9 @@ PyYAML>=6.0            # SKILL.md frontmatter parsing (Phase 3 sync engine)
 praw>=7.7.0             # Reddit OAuth API for CommunityGrowthSkill
 
 # Media processing pipelines (Issue #932)
-aiohttp>=3.9.0          # Async HTTP client for link pipeline
+aiohttp>=3.13.3         # Async HTTP client - SECURITY UPDATE (7 CVE fixes)
 beautifulsoup4>=4.12.0  # HTML parsing for link pipeline
-Pillow>=10.0.0          # Image loading and EXIF extraction for image pipeline
+Pillow>=12.1.1          # Image processing - SECURITY UPDATE (OOB write fix)
 # Optional (install separately for full media support):
 # opencv-python>=4.8.0   # Frame extraction for video pipeline
 # transformers>=4.30.0   # Whisper transcription for audio pipeline

--- a/autobot-slm-backend/ansible/roles/dependency_patching/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/dependency_patching/defaults/main.yml
@@ -37,13 +37,24 @@ pip_extra_args: "--no-cache-dir"
 # Packages to update (CVE fixes from Issue #544)
 # Format: package_name: minimum_version
 python_security_updates:
+  # Critical
+  langchain-core: "0.3.81"        # Serialization injection + template injection + SSRF
+  nltk: "3.9.3"                   # Zip slip vulnerability
+  # High
+  starlette: "0.52.1"             # O(n^2) DoS via Range header
+  fastapi: "0.135.1"              # Requires starlette >=0.46.0
+  aiohttp: "3.13.3"               # Zip bomb + DoS + payload + chunked
+  python-multipart: "0.0.22"      # Arbitrary file write
+  cryptography: "46.0.5"          # Subgroup attack on SECT curves
+  pillow: "12.1.1"                # OOB write loading PSD images
+  protobuf: "5.29.6"              # JSON recursion depth bypass
+  # Medium (pypdf - 10 CVEs)
+  pypdf: "6.7.5"                  # Infinite loops, RAM exhaustion, malformed streams
+  # Carried forward from prior patches
   filelock: "3.20.1"
   keras: "3.12.0"
-  langchain-core: "0.3.81"
   markdownify: "0.14.1"
   marshmallow: "3.26.2"
-  pypdf: "6.4.0"
-  starlette: "0.49.1"
   urllib3: "2.6.0"
   werkzeug: "3.1.4"
   requests: "2.32.4"

--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -10,7 +10,7 @@
 prometheus-client>=0.20.0
 
 # Web framework
-fastapi>=0.109.0
+fastapi>=0.125.0                # SECURITY UPDATE - requires starlette >=0.52.1
 uvicorn[standard]>=0.27.0
 
 # Database - PostgreSQL (Issue #786)
@@ -27,7 +27,7 @@ typing_extensions>=4.0.0  # For Python 3.8 compatibility
 python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
 bcrypt>=4.0.0,<5.0.0  # bcrypt 5.0.0 incompatible with passlib
-python-multipart>=0.0.6
+python-multipart>=0.0.22          # SECURITY UPDATE - arbitrary file write fix
 
 # Async utilities
 aiofiles>=23.2.0

--- a/autobot-tts-worker/requirements.txt
+++ b/autobot-tts-worker/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.100.0
+fastapi>=0.125.0                # SECURITY UPDATE - requires starlette >=0.52.1
 uvicorn[standard]>=0.20.0
 transformers>=4.40.0
 torch>=2.0.0
@@ -6,4 +6,4 @@ soundfile>=0.12.0
 numpy>=1.24.0
 huggingface_hub>=0.20.0
 aiofiles>=23.0.0
-python-multipart>=0.0.6
+python-multipart>=0.0.22          # SECURITY UPDATE - arbitrary file write fix

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ tenacity>=8.5.0
 # Async SSH for PKI certificate distribution (Issue #166)
 asyncssh>=2.22.0
 
-# TensorFlow compatibility - protobuf 4.x required for TensorFlow 2.19.1
-# Protobuf 5.x/6.x causes MessageFactory.GetPrototype AttributeError
-protobuf>=4.23.0,<5.0.0
+# TensorFlow 2.19.1 supports protobuf <6.0.0dev (verified from PyPI metadata)
+# Bumped to 5.29.6+ for JSON recursion depth bypass fix
+protobuf>=5.29.6,<6.0.0
 
 # vLLM - High-performance LLM inference with prefix caching
 # Provides 3-4x throughput improvement with 98.7% cache efficiency
@@ -18,7 +18,7 @@ vllm>=0.6.0
 
 # Document parsing libraries for knowledge base
 # Supports PDF, Word, Excel, PowerPoint, OpenDocument formats
-pypdf>=6.4.0              # PDF parsing - SECURITY UPDATE (4 CVE fixes)
+pypdf>=6.7.5              # PDF parsing - SECURITY UPDATE (13 CVE fixes)
 python-docx>=1.1.2        # Microsoft Word (.docx)
 openpyxl>=3.1.5           # Microsoft Excel (.xlsx)
 python-pptx>=1.0.2        # Microsoft PowerPoint (.pptx)


### PR DESCRIPTION
## Summary
- Bumps minimum versions for Dependabot-flagged packages in component-level requirements files (`autobot-backend/`, `autobot-slm-backend/`, `autobot-tts-worker/`, root `requirements.txt`)
- Updates Ansible `dependency_patching` role defaults with all 18 packages for fleet-wide rolling updates
- Complements the CI-pinned bumps already merged in #1393

## Packages bumped
| Package | Old minimum | New minimum | Severity |
|---------|------------|------------|----------|
| fastapi | >=0.100.0 | >=0.125.0 | High (starlette coupling) |
| python-multipart | >=0.0.6 | >=0.0.22 | High (arbitrary file write) |
| aiohttp | >=3.9.0 | >=3.13.3 | High (7 CVEs) |
| langchain-core | >=0.3.0 | >=0.3.81 | Critical (injection + SSRF) |
| Pillow | >=10.0.0 | >=12.1.1 | High (OOB write) |
| pypdf | >=6.4.0 | >=6.7.5 | Medium (13 CVEs) |
| protobuf | >=4.23.0,<5.0.0 | >=5.29.6,<6.0.0 | High (recursion bypass) |
| cryptography | (added to Ansible) | 46.0.5 | High |
| nltk | (added to Ansible) | 3.9.3 | Critical (zip slip) |

## Test plan
- [ ] CI pipeline passes with new minimum versions
- [ ] `pip check` shows no new conflicts
- [ ] Verify Ansible `patch-dependencies.yml` templates correctly with updated defaults

Resolves #1388