### PR TITLE
feat(i18n): wire TranslationAgent to chat tool shortcuts (#1328)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -2051,6 +2051,97 @@ async def get_enhanced_chat_capabilities(
                 "enhanced_chat": True,
                 "ai_stack_integration": False,
                 "knowledge_base_integration": True,
-                "error": "Partial capabilities due to AI Stack unavailability",
+                "error": ("Partial capabilities due to" " AI Stack unavailability"),
             }
         )
+
+
+# ====================================================================
+# Issue #1328: Translation Shortcut Endpoint
+# ====================================================================
+
+
+class TranslateRequest(BaseModel):
+    """Request model for direct translation."""
+
+    text: str = Field(
+        ...,
+        min_length=1,
+        max_length=50000,
+        description="Text to translate",
+    )
+    target_language: str = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="Target language name",
+    )
+    source_language: Optional[str] = Field(
+        None,
+        description="Source language (auto-detect if omitted)",
+    )
+
+
+class DetectLanguageRequest(BaseModel):
+    """Request model for language detection."""
+
+    text: str = Field(
+        ...,
+        min_length=1,
+        max_length=50000,
+        description="Text to detect language of",
+    )
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="translate_text",
+    error_code_prefix="TRANSLATE",
+)
+@router.post("/translate")
+async def translate_text(
+    body: TranslateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Translate text via TranslationAgent (#1328)."""
+    from agents.base_agent import AgentRequest
+    from agents.translation_agent import get_translation_agent
+
+    agent = get_translation_agent()
+    req = AgentRequest(
+        request_id=str(uuid4()),
+        agent_type="translation",
+        action="translate",
+        payload={
+            "text": body.text,
+            "target_language": body.target_language,
+            "source_language": (body.source_language or "auto-detect"),
+        },
+    )
+    result = await agent.handle_translate(req)
+    return JSONResponse(content=result)
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="detect_language",
+    error_code_prefix="TRANSLATE",
+)
+@router.post("/detect-language")
+async def detect_language(
+    body: DetectLanguageRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Detect language via TranslationAgent (#1328)."""
+    from agents.base_agent import AgentRequest
+    from agents.translation_agent import get_translation_agent
+
+    agent = get_translation_agent()
+    req = AgentRequest(
+        request_id=str(uuid4()),
+        agent_type="translation",
+        action="detect_language",
+        payload={"text": body.text},
+    )
+    result = await agent.handle_detect_language(req)
+    return JSONResponse(content=result)

--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -269,6 +269,14 @@
       </div>
     </div>
 
+    <!-- Issue #1328: Translation Shortcut Panel -->
+    <TranslationShortcutPanel
+      v-if="showTranslatePanel"
+      :initial-text="messageText"
+      @close="showTranslatePanel = false"
+      @translation-result="handleTranslationResult"
+    />
+
     <!-- Vision Analysis Modal (#1242) -->
     <VisionAnalysisModal
       v-if="showVisionModal"
@@ -288,6 +296,7 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner.vue'
 import ProgressBar from '@/components/ui/ProgressBar.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import VisionAnalysisModal from './VisionAnalysisModal.vue'
+import TranslationShortcutPanel from './TranslationShortcutPanel.vue'
 import { formatFileSize } from '@/utils/formatHelpers'
 import { getFileIconByMimeType } from '@/utils/iconMappings'
 import { createLogger } from '@/utils/debugUtils'
@@ -322,6 +331,7 @@ const isVoiceRecording = ref(false)
 const isSending = ref(false)
 const showEmojiPicker = ref(false)
 const showVisionModal = ref(false)
+const showTranslatePanel = ref(false)
 const showQuickActions = ref(true)
 
 // Issue #249: Knowledge-Enhanced Chat (RAG) toggle
@@ -684,21 +694,41 @@ const insertEmoji = (emoji: typeof commonEmojis[0]) => {
   showEmojiPicker.value = false
 }
 
-const useQuickAction = (action: typeof quickActions[0]) => {
-  const actionTexts = {
-    help: 'Can you help me with ',
-    summarize: 'Please summarize our conversation',
-    translate: 'Please translate the following text: ',
-    explain: 'Can you explain '
+const useQuickAction = (action: { id: string; label: string; icon: string; description: string }) => {
+  // Issue #1328: Translate opens the translation panel
+  if (action.id === 'translate') {
+    showTranslatePanel.value = !showTranslatePanel.value
+    return
   }
 
-  const text = actionTexts[action.id as keyof typeof actionTexts] || ''
+  const actionTexts: Record<string, string> = {
+    help: 'Can you help me with ',
+    summarize: 'Please summarize our conversation',
+    explain: 'Can you explain ',
+  }
+
+  const text = actionTexts[action.id] || ''
   messageText.value = text
 
   nextTick(() => {
     messageInput.value?.focus()
     const textarea = messageInput.value!
     textarea.setSelectionRange(text.length, text.length)
+  })
+}
+
+// Issue #1328: Handle translation result — display in chat
+const handleTranslationResult = (payload: {
+  originalText: string
+  translatedText: string
+  targetLanguage: string
+}) => {
+  showTranslatePanel.value = false
+  store.addMessage({
+    content: `**${payload.targetLanguage}:**\n${payload.translatedText}`,
+    sender: 'assistant',
+    status: 'sent',
+    type: 'message',
   })
 }
 

--- a/autobot-frontend/src/components/chat/TranslationShortcutPanel.vue
+++ b/autobot-frontend/src/components/chat/TranslationShortcutPanel.vue
@@ -1,0 +1,267 @@
+<template>
+  <div class="translation-panel">
+    <div class="translation-panel-header">
+      <h4 class="panel-title">
+        <i class="fas fa-language" aria-hidden="true"></i>
+        {{ $t('chat.translate.title') }}
+      </h4>
+      <BaseButton
+        variant="ghost"
+        size="xs"
+        @click="$emit('close')"
+        :aria-label="$t('chat.translate.close')"
+      >
+        <i class="fas fa-times" aria-hidden="true"></i>
+      </BaseButton>
+    </div>
+
+    <div class="translation-panel-body">
+      <!-- Language Selection -->
+      <div class="language-row">
+        <label for="target-language" class="language-label">
+          {{ $t('chat.translate.targetLanguage') }}
+        </label>
+        <select
+          id="target-language"
+          v-model="targetLanguage"
+          class="language-select"
+        >
+          <option
+            v-for="lang in languages"
+            :key="lang.code"
+            :value="lang.name"
+          >
+            {{ lang.name }}
+          </option>
+        </select>
+      </div>
+
+      <!-- Text Input -->
+      <div class="text-row">
+        <label for="translate-text" class="sr-only">
+          {{ $t('chat.translate.textToTranslate') }}
+        </label>
+        <textarea
+          id="translate-text"
+          v-model="textToTranslate"
+          class="translate-textarea"
+          :placeholder="$t('chat.translate.placeholder')"
+          rows="3"
+        ></textarea>
+      </div>
+
+      <!-- Action Buttons -->
+      <div class="action-row">
+        <BaseButton
+          variant="ghost"
+          size="sm"
+          @click="detectLanguage"
+          :disabled="!textToTranslate.trim() || isLoading"
+          class="detect-btn"
+        >
+          <i class="fas fa-search" aria-hidden="true"></i>
+          {{ $t('chat.translate.detectLanguage') }}
+        </BaseButton>
+        <BaseButton
+          variant="primary"
+          size="sm"
+          @click="translateText"
+          :disabled="!canTranslate"
+          :loading="isLoading"
+        >
+          <i class="fas fa-language" aria-hidden="true"></i>
+          {{ $t('chat.translate.translate') }}
+        </BaseButton>
+      </div>
+
+      <!-- Result Display -->
+      <div v-if="detectedLanguage" class="result-info">
+        <i class="fas fa-info-circle" aria-hidden="true"></i>
+        {{ $t('chat.translate.detectedAs', { language: detectedLanguage }) }}
+      </div>
+
+      <div v-if="translationError" class="result-error">
+        <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+        {{ translationError }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Issue #1328: Translation shortcut panel with language picker
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import BaseButton from '@/components/base/BaseButton.vue'
+import apiClient from '@/utils/ApiClient'
+import { createLogger } from '@/utils/debugUtils'
+
+const { t } = useI18n()
+const logger = createLogger('TranslationShortcutPanel')
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'translation-result', payload: {
+    originalText: string
+    translatedText: string
+    targetLanguage: string
+    sourceLanguage?: string
+  }): void
+}>()
+
+const props = defineProps<{
+  initialText?: string
+}>()
+
+// State
+const textToTranslate = ref(props.initialText || '')
+const targetLanguage = ref('Latvian')
+const isLoading = ref(false)
+const detectedLanguage = ref('')
+const translationError = ref('')
+
+// Supported languages — Latvian first as default (#1328)
+const languages = [
+  { code: 'lv', name: 'Latvian' },
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+  { code: 'it', name: 'Italian' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'ru', name: 'Russian' },
+  { code: 'zh', name: 'Chinese' },
+  { code: 'ja', name: 'Japanese' },
+  { code: 'ko', name: 'Korean' },
+  { code: 'ar', name: 'Arabic' },
+  { code: 'hi', name: 'Hindi' },
+  { code: 'nl', name: 'Dutch' },
+  { code: 'pl', name: 'Polish' },
+  { code: 'sv', name: 'Swedish' },
+  { code: 'tr', name: 'Turkish' },
+  { code: 'uk', name: 'Ukrainian' },
+  { code: 'lt', name: 'Lithuanian' },
+  { code: 'et', name: 'Estonian' },
+]
+
+const canTranslate = computed(() => {
+  return textToTranslate.value.trim().length > 0
+    && targetLanguage.value.length > 0
+    && !isLoading.value
+})
+
+const translateText = async () => {
+  if (!canTranslate.value) return
+
+  isLoading.value = true
+  translationError.value = ''
+
+  try {
+    const result = await apiClient.post('/api/translate', {
+      text: textToTranslate.value.trim(),
+      target_language: targetLanguage.value,
+    })
+
+    if (result.status === 'success') {
+      emit('translation-result', {
+        originalText: textToTranslate.value.trim(),
+        translatedText: result.response,
+        targetLanguage: targetLanguage.value,
+      })
+    } else {
+      translationError.value = result.response || t('chat.translate.error')
+    }
+  } catch (error) {
+    logger.error('Translation failed:', error)
+    translationError.value = t('chat.translate.error')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const detectLanguage = async () => {
+  if (!textToTranslate.value.trim()) return
+
+  isLoading.value = true
+  detectedLanguage.value = ''
+  translationError.value = ''
+
+  try {
+    const result = await apiClient.post('/api/detect-language', {
+      text: textToTranslate.value.trim(),
+    })
+
+    if (result.status === 'success') {
+      detectedLanguage.value = result.response
+    } else {
+      translationError.value = result.response || t('chat.translate.error')
+    }
+  } catch (error) {
+    logger.error('Language detection failed:', error)
+    translationError.value = t('chat.translate.error')
+  } finally {
+    isLoading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.translation-panel {
+  @apply border border-autobot-border rounded-lg bg-autobot-bg-card
+    shadow-lg mb-3;
+}
+
+.translation-panel-header {
+  @apply flex items-center justify-between px-3 py-2
+    border-b border-autobot-border;
+}
+
+.panel-title {
+  @apply text-sm font-medium text-autobot-text-primary flex items-center
+    gap-2;
+}
+
+.translation-panel-body {
+  @apply p-3 space-y-3;
+}
+
+.language-row {
+  @apply flex items-center gap-2;
+}
+
+.language-label {
+  @apply text-xs font-medium text-autobot-text-secondary whitespace-nowrap;
+}
+
+.language-select {
+  @apply flex-1 text-sm border border-autobot-border rounded px-2 py-1.5
+    bg-autobot-bg-tertiary text-autobot-text-primary;
+}
+
+.translate-textarea {
+  @apply w-full text-sm border border-autobot-border rounded px-3 py-2
+    bg-autobot-bg-tertiary text-autobot-text-primary resize-none;
+}
+
+.translate-textarea:focus {
+  @apply border-autobot-primary ring-1 ring-autobot-primary outline-none;
+}
+
+.action-row {
+  @apply flex items-center justify-between gap-2;
+}
+
+.detect-btn {
+  @apply text-xs;
+}
+
+.result-info {
+  @apply text-xs text-autobot-text-secondary flex items-center gap-1
+    bg-blue-50 px-2 py-1.5 rounded;
+}
+
+.result-error {
+  @apply text-xs text-red-600 flex items-center gap-1
+    bg-red-50 px-2 py-1.5 rounded;
+}
+</style>

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -227,6 +227,17 @@
       "aiResponding": "AI is responding...",
       "typeMessage": "Type a message..."
     },
+    "translate": {
+      "title": "Translate Text",
+      "close": "Close translation panel",
+      "targetLanguage": "To:",
+      "textToTranslate": "Text to translate",
+      "placeholder": "Enter or paste text to translate...",
+      "detectLanguage": "Detect Language",
+      "translate": "Translate",
+      "detectedAs": "Detected: {language}",
+      "error": "Translation failed. Please try again."
+    },
     "messages": {
       "conversation": "Conversation messages",
       "aiAssistant": "AI Assistant",


### PR DESCRIPTION
## Summary
- Add /api/translate and /api/detect-language backend endpoints that invoke TranslationAgent directly
- Create TranslationShortcutPanel.vue with language picker dropdown (Latvian default, 20 languages)
- Wire translate quick action in ChatInput.vue to open the panel instead of prefilling text
- Add i18n keys for translation UI strings

## Test Plan
- [ ] Click Translate quick action - panel opens with Latvian selected
- [ ] Enter text and click Translate - result appears in chat
- [ ] Click Detect Language - detected language shown
- [ ] Panel closes on X button or after successful translation
- [ ] Auto-routing still works for natural language

Closes #1328