### PR TITLE
feat(voice): STT multilingual + Whisper airgapped fallback (#1329)

### DIFF
--- a/autobot-backend/api/voice.py
+++ b/autobot-backend/api/voice.py
@@ -228,20 +228,35 @@ _MIME_TO_SUFFIX = {
 }
 
 
-def _whisper_sync(pipe, audio_bytes: bytes, suffix: str) -> dict:
-    """Blocking Whisper inference — call via asyncio.to_thread (#1030)."""
+def _whisper_sync(pipe, audio_bytes: bytes, suffix: str, language: str = "") -> dict:
+    """Blocking Whisper inference — call via asyncio.to_thread (#1030).
+
+    Args:
+        language: BCP-47 language hint (e.g. "en", "de"). Empty = auto-detect.
+    """
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
         tmp.write(audio_bytes)
         tmp_path = tmp.name
 
     try:
-        output = pipe(tmp_path, return_timestamps=False)
+        generate_kwargs = {}
+        if language:
+            generate_kwargs["language"] = language
+        output = pipe(
+            tmp_path,
+            return_timestamps=False,
+            generate_kwargs=generate_kwargs or None,
+        )
         text = output.get("text", "").strip() if isinstance(output, dict) else ""
-        language = (
+        detected_lang = (
             output.get("language", "unknown") if isinstance(output, dict) else "unknown"
         )
         confidence = 0.9 if text else 0.0
-        return {"text": text, "language": language, "confidence": confidence}
+        return {
+            "text": text,
+            "language": detected_lang,
+            "confidence": confidence,
+        }
     except Exception as exc:
         logger.warning("Whisper transcription failed: %s", exc)
         return {"text": "", "language": "unknown", "confidence": 0.0}
@@ -252,7 +267,9 @@ def _whisper_sync(pipe, audio_bytes: bytes, suffix: str) -> dict:
             pass
 
 
-async def _transcribe_with_whisper(audio_bytes: bytes, content_type: str) -> dict:
+async def _transcribe_with_whisper(
+    audio_bytes: bytes, content_type: str, language: str = ""
+) -> dict:
     """Run Whisper transcription in a background thread (#1030)."""
     from media.audio.pipeline import _get_whisper_pipeline
 
@@ -262,7 +279,7 @@ async def _transcribe_with_whisper(audio_bytes: bytes, content_type: str) -> dic
 
     ct = content_type.split(";")[0].strip()
     suffix = _MIME_TO_SUFFIX.get(ct, ".wav")
-    return await asyncio.to_thread(_whisper_sync, pipe, audio_bytes, suffix)
+    return await asyncio.to_thread(_whisper_sync, pipe, audio_bytes, suffix, language)
 
 
 @with_error_handling(
@@ -274,8 +291,13 @@ async def _transcribe_with_whisper(audio_bytes: bytes, content_type: str) -> dic
 async def voice_transcribe_api(
     request: Request,
     audio: UploadFile = File(...),
+    language: str = Form(""),
 ):
-    """Transcribe audio blob to text via Whisper (#1030)."""
+    """Transcribe audio blob to text via Whisper (#1030, #1329).
+
+    Args:
+        language: BCP-47 language hint (e.g. "en", "de"). Empty = auto-detect.
+    """
     security_layer = request.app.state.security_layer
     if not security_layer.check_permission("user", "allow_voice_listen"):
         return JSONResponse(
@@ -291,7 +313,7 @@ async def voice_transcribe_api(
         )
 
     result = await _transcribe_with_whisper(
-        audio_bytes, audio.content_type or "audio/webm"
+        audio_bytes, audio.content_type or "audio/webm", language
     )
     security_layer.audit_log(
         "voice_transcribe",

--- a/autobot-backend/voice_processing/speech_recognition.py
+++ b/autobot-backend/voice_processing/speech_recognition.py
@@ -63,7 +63,9 @@ class SpeechRecognitionEngine:
         except ImportError:
             logger.warning("Language detection not available")
 
-    async def _run_parallel_analysis(self, audio_input: AudioInput) -> tuple:
+    async def _run_parallel_analysis(
+        self, audio_input: AudioInput, language: str = "en"
+    ) -> tuple:
         """Issue #665: Extracted from transcribe_audio to reduce function length.
 
         Run audio analysis operations in parallel for better performance.
@@ -73,7 +75,7 @@ class SpeechRecognitionEngine:
             return await asyncio.gather(
                 self._analyze_audio_quality(audio_input),
                 self._calculate_noise_level(audio_input),
-                self._perform_speech_recognition(audio_input),
+                self._perform_speech_recognition(audio_input, language),
                 self._detect_speech_segments(audio_input),
             )
         # Run parallel operations without speech recognition
@@ -122,9 +124,13 @@ class SpeechRecognitionEngine:
         )
 
     async def transcribe_audio(
-        self, audio_input: AudioInput
+        self, audio_input: AudioInput, language: str = "en"
     ) -> SpeechRecognitionResult:
-        """Transcribe audio to text using speech recognition"""
+        """Transcribe audio to text using speech recognition.
+
+        Args:
+            language: BCP-47 language code (e.g. "en", "de"). Defaults to "en".
+        """
 
         async with task_tracker.track_task(
             "Speech Recognition",
@@ -135,6 +141,7 @@ class SpeechRecognitionEngine:
                 "audio_id": audio_input.audio_id,
                 "duration": audio_input.duration,
                 "sample_rate": audio_input.sample_rate,
+                "language": language,
             },
         ) as task_context:
             start_time = time.time()
@@ -145,7 +152,7 @@ class SpeechRecognitionEngine:
                     noise_level,
                     transcription_result,
                     speech_segments,
-                ) = await self._run_parallel_analysis(audio_input)
+                ) = await self._run_parallel_analysis(audio_input, language)
                 processing_time = time.time() - start_time
 
                 result = self._build_recognition_result(
@@ -215,11 +222,15 @@ class SpeechRecognitionEngine:
             logger.debug("Noise level calculation failed: %s", e)
             return 0.5
 
-    def _try_google_recognition(self, audio_data) -> List[Dict[str, Any]]:
+    def _try_google_recognition(
+        self, audio_data, language: str = "en"
+    ) -> List[Dict[str, Any]]:
         """Try Google speech recognition (Issue #298 - extracted helper)."""
         results = []
         try:
-            result = self.recognizer.recognize_google(audio_data, show_all=True)
+            result = self.recognizer.recognize_google(
+                audio_data, language=language, show_all=True
+            )
             if not result or "alternative" not in result:
                 return results
             for alt in result["alternative"]:
@@ -250,9 +261,9 @@ class SpeechRecognitionEngine:
             return []
 
     async def _perform_speech_recognition(
-        self, audio_input: AudioInput
+        self, audio_input: AudioInput, language: str = "en"
     ) -> Dict[str, Any]:
-        """Perform actual speech recognition"""
+        """Perform actual speech recognition (#1329: language passthrough)."""
         empty_result = {
             "transcription": "",
             "confidence": 0.0,
@@ -268,7 +279,7 @@ class SpeechRecognitionEngine:
             audio_data = self._convert_to_audio_data(audio_input)
 
             # Try recognition engines (Issue #298 - uses helpers)
-            transcription_results = self._try_google_recognition(audio_data)
+            transcription_results = self._try_google_recognition(audio_data, language)
 
             if not transcription_results:
                 transcription_results = self._try_sphinx_recognition(audio_data)
@@ -282,7 +293,7 @@ class SpeechRecognitionEngine:
                 "transcription": best_result["text"],
                 "confidence": best_result["confidence"],
                 "alternatives": transcription_results[1:],
-                "language": "en",
+                "language": language,
             }
 
         except Exception as e:

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -15,6 +15,7 @@ import { useVoiceOutput } from '@/composables/useVoiceOutput'
 import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
 import { useChatController } from '@/models/controllers'
 import { useChatStore } from '@/stores/useChatStore'
+import { useUserStore } from '@/stores/useUserStore'
 import { getBackendWsUrl } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
@@ -63,6 +64,9 @@ let _vadNode: AudioWorkletNode | null = null
 let _micStream: MediaStream | null = null
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _sileroVad: any = null
+let _whisperFallback = false // #1329: true when browser STT unavailable (airgapped)
+let _fallbackRecorder: MediaRecorder | null = null
+let _fallbackStream: MediaStream | null = null
 
 // Issue #1371: Cooldown timer to prevent TTS echo from triggering VAD
 let _ttsCooldownTimer: ReturnType<typeof setTimeout> | null = null
@@ -266,11 +270,111 @@ function _handleBargeIn(): void {
   _startListeningInternal()
 }
 
+// ─── Language helper (#1329) ─────────────────────────────
+
+/** Map short language codes to BCP-47 tags for browser SpeechRecognition. */
+const _LANG_TO_BCP47: Record<string, string> = {
+  en: 'en-US', de: 'de-DE', fr: 'fr-FR', es: 'es-ES',
+  it: 'it-IT', pt: 'pt-BR', nl: 'nl-NL', ru: 'ru-RU',
+  ja: 'ja-JP', ko: 'ko-KR', zh: 'zh-CN', ar: 'ar-SA',
+  hi: 'hi-IN', pl: 'pl-PL', cs: 'cs-CZ', sv: 'sv-SE',
+  da: 'da-DK', fi: 'fi-FI', nb: 'nb-NO', lv: 'lv-LV',
+  lt: 'lt-LT', et: 'et-EE', uk: 'uk-UA', tr: 'tr-TR',
+}
+
+function _getSttLanguage(): string {
+  const store = useUserStore()
+  const lang = store.preferences.language || 'en'
+  return _LANG_TO_BCP47[lang] || lang
+}
+
+function _getShortLanguage(): string {
+  const store = useUserStore()
+  return store.preferences.language || 'en'
+}
+
+// ─── Whisper fallback for airgapped mode (#1329) ────────
+
+async function _startWhisperFallback(): Promise<void> {
+  if (state.value === 'listening') return
+  if (!isActive.value) return
+
+  if (!micAccessAvailable.value) {
+    errorMessage.value = _getMicContextError('walkie-talkie')
+    return
+  }
+
+  try {
+    _fallbackStream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    _fallbackRecorder = new MediaRecorder(_fallbackStream, {
+      mimeType: MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+        ? 'audio/webm;codecs=opus'
+        : 'audio/webm',
+    })
+    const chunks: Blob[] = []
+
+    _fallbackRecorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunks.push(e.data)
+    }
+
+    _fallbackRecorder.onstop = () => {
+      const blob = new Blob(chunks, { type: 'audio/webm' })
+      _fallbackStream?.getTracks().forEach((t) => t.stop())
+      _fallbackStream = null
+      if (!isActive.value || blob.size === 0) {
+        state.value = 'idle'
+        return
+      }
+      state.value = 'processing'
+      _transcribeAudioWithLanguage(blob)
+        .then((text) => {
+          if (text) {
+            _dispatchTranscript(text)
+          } else {
+            state.value = 'idle'
+          }
+        })
+        .catch((err) => {
+          logger.error('Whisper fallback transcription error:', err)
+          errorMessage.value = 'Transcription failed. Try again.'
+          state.value = 'idle'
+        })
+    }
+
+    _fallbackRecorder.start()
+    state.value = 'listening'
+    currentTranscript.value = ''
+    logger.debug('Whisper fallback recording started')
+  } catch (e) {
+    const err = e instanceof Error ? e : new Error(String(e))
+    logger.error('Whisper fallback mic init failed:', err)
+    if (err.name === 'NotAllowedError' || err.name === 'NotFoundError') {
+      errorMessage.value = _getMicContextError('walkie-talkie')
+    } else {
+      errorMessage.value = `Mic init failed: ${err.message || 'unknown error'}`
+    }
+    state.value = 'idle'
+  }
+}
+
+function _stopWhisperFallback(): void {
+  if (_fallbackRecorder && _fallbackRecorder.state !== 'inactive') {
+    _fallbackRecorder.stop()
+  }
+  _fallbackRecorder = null
+}
+
 // ─── STT helper (shared across modes) ───────────────────
 
 function _startListeningInternal(): void {
   if (state.value === 'listening') return
   if (!isActive.value) return
+
+  // #1329: If browser STT failed previously (airgapped), use Whisper fallback
+  if (_whisperFallback) {
+    _startWhisperFallback()
+    return
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const w = window as any
@@ -283,7 +387,7 @@ function _startListeningInternal(): void {
   _recognition = new Ctor()
   _recognition.continuous = mode.value === 'full-duplex'
   _recognition.interimResults = true
-  _recognition.lang = 'en-US'
+  _recognition.lang = _getSttLanguage()
 
   _recognition.onstart = () => {
     state.value = 'listening'
@@ -347,6 +451,12 @@ function _startListeningInternal(): void {
     if (event.error === 'not-allowed') {
       errorMessage.value =
         'Microphone access denied. Allow mic in browser settings.'
+    } else if (event.error === 'network') {
+      // #1329: Browser STT needs internet — fall back to local Whisper
+      logger.warn('Browser STT network error — switching to Whisper fallback')
+      _whisperFallback = true
+      _startWhisperFallback()
+      return
     } else if (event.error === 'no-speech') {
       if (mode.value === 'full-duplex' && isActive.value) {
         state.value = 'idle'
@@ -367,6 +477,7 @@ function _stopRecognition(): void {
     try { _recognition.abort() } catch { /* ignore */ }
     _recognition = null
   }
+  _stopWhisperFallback()
   currentTranscript.value = ''
 }
 
@@ -490,10 +601,15 @@ function _float32ToWav(samples: Float32Array, sr: number): Blob {
   return new Blob([buf], { type: 'audio/wav' })
 }
 
-/** POST audio blob to /api/voice/transcribe → { text, confidence }. */
-async function _transcribeAudio(blob: Blob): Promise<string> {
+/** POST audio blob to /api/voice/transcribe → { text, confidence } (#1329). */
+async function _transcribeAudioWithLanguage(
+  blob: Blob,
+  filename = 'speech.wav',
+): Promise<string> {
   const form = new FormData()
-  form.append('audio', blob, 'speech.wav')
+  form.append('audio', blob, filename)
+  const lang = _getShortLanguage()
+  if (lang) form.append('language', lang)
   const res = await fetchWithAuth('/api/voice/transcribe', {
     method: 'POST',
     body: form,
@@ -504,6 +620,11 @@ async function _transcribeAudio(blob: Blob): Promise<string> {
   }
   const data = await res.json()
   return (data.text ?? '').trim()
+}
+
+/** POST audio blob to /api/voice/transcribe → { text, confidence }. */
+async function _transcribeAudio(blob: Blob): Promise<string> {
+  return _transcribeAudioWithLanguage(blob, 'speech.wav')
 }
 
 /** Start Silero VAD for hands-free speech detection (#1030). */
@@ -662,6 +783,8 @@ export function useVoiceConversation() {
     if (mode.value === 'hands-free') {
       _stopHandsFree()
       state.value = 'idle'
+    } else if (_fallbackRecorder && _fallbackRecorder.state !== 'inactive') {
+      _stopWhisperFallback()
     } else if (_recognition) {
       _recognition.stop()
     }


### PR DESCRIPTION
## Summary
- Accept `language` parameter in `/api/voice/transcribe` — passed to Whisper via `generate_kwargs` for language-hinted transcription
- Thread `language` param through `SpeechRecognitionEngine` → Google STT `recognize_google(language=...)` — removes hardcoded `"en"`
- Frontend reads user language preference from `useUserStore`, maps to BCP-47 tag for browser `SpeechRecognition.lang`
- **Whisper airgapped fallback:** When browser STT fires `network` error (no internet), auto-switches to `MediaRecorder` → POST audio to backend Whisper. Sticky for session, seamless across walkie-talkie and full-duplex modes.

## Files Changed
- `autobot-backend/api/voice.py` — language param in `_whisper_sync`, `_transcribe_with_whisper`, `/transcribe` endpoint
- `autobot-backend/voice_processing/speech_recognition.py` — language passthrough to Google STT, remove hardcoded `"en"`
- `autobot-frontend/src/composables/useVoiceConversation.ts` — language wiring, BCP-47 mapping, Whisper fallback flow

## Test Plan
- [ ] Walkie-talkie mode: set language to non-English (e.g. German), speak → verify correct transcription
- [ ] Hands-free mode: verify language param sent in `/api/voice/transcribe` POST
- [ ] Airgapped: disconnect internet, use walkie-talkie → verify auto-fallback to Whisper after `network` error
- [ ] English default: no language set → verify English recognition still works
- [ ] Full-duplex mode: verify language preference applied to browser STT

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)