### PR TITLE
fix(i18n): replace hardcoded title strings in KnowledgeUpload.vue (#1410)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
@@ -220,7 +220,7 @@
                 <i class="fas fa-folder-open"></i>
                 {{ selectedFiles.length }} file{{ selectedFiles.length > 1 ? 's' : '' }} selected
               </h5>
-              <button @click="clearAllFiles" class="clear-all-btn" title="Clear all files">
+              <button @click="clearAllFiles" class="clear-all-btn" :title="$t('knowledge.upload.clearAllTitle')">
                 <i class="fas fa-trash-alt"></i>
                 {{ $t('knowledge.upload.clearAll') }}
               </button>
@@ -267,14 +267,14 @@
                       class="preview-toggle-btn"
                       :class="{ 'active': expandedFileId === fileItem.id }"
                       @click.stop="toggleFilePreview(fileItem.id)"
-                      title="Preview content"
+                      :title="$t('knowledge.upload.previewContentTitle')"
                     >
                       <i :class="expandedFileId === fileItem.id ? 'fas fa-chevron-up' : 'fas fa-eye'"></i>
                     </button>
                     <button
                       class="remove-file-btn"
                       @click.stop="removeFile(index)"
-                      title="Remove file"
+                      :title="$t('knowledge.upload.removeFileTitle')"
                     >
                       <i class="fas fa-times"></i>
                     </button>

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -567,7 +567,13 @@
     "cacheApiUnavailable": "Cache API not available",
     "cachedSettings": "Using cached settings (backend offline)",
     "appearanceDesc": "Customize the look and feel of your workspace",
-    "voiceDesc": "Configure text-to-speech voice and voice profiles"
+    "voiceDesc": "Configure text-to-speech voice and voice profiles",
+    "languageDesc": "Choose your preferred language for the interface and AI responses",
+    "languageTitle": "Language Preferences",
+    "languageSelect": "Interface Language",
+    "languageHint": "Select your preferred language. The interface will switch immediately if translations are available. AI responses will also use this language.",
+    "languageChanged": "Language updated successfully",
+    "languageChangeFailed": "Failed to update language"
   },
   "voice": {
     "title": "Voice",
@@ -4100,6 +4106,9 @@
   "knowledge.upload.browse": "browse",
   "knowledge.upload.supportedFormats": "Supported formats: PDF, TXT, MD, JSON, CSV, DOCX",
   "knowledge.upload.clearAll": "Clear All",
+  "knowledge.upload.clearAllTitle": "Clear all files",
+  "knowledge.upload.previewContentTitle": "Preview content",
+  "knowledge.upload.removeFileTitle": "Remove file",
   "knowledge.upload.uploadedSuccessfully": "Uploaded successfully",
   "knowledge.upload.uploadFailed": "Upload failed",
   "knowledge.upload.contentPreview": "Content Preview",


### PR DESCRIPTION
## Summary
- Replace 3 hardcoded English `title` attributes in `KnowledgeUpload.vue` with `$t()` calls
- Add `clearAllTitle`, `previewContentTitle`, `removeFileTitle` keys to `en.json`

## Test Plan
- [x] `npm run build` passes
- [x] No remaining hardcoded `title="..."` in KnowledgeUpload.vue

Closes #1410