### PR TITLE
fix(tts): normalize audio to 90% peak for consistent volume (#1394)

### DIFF
--- a/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
+++ b/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
@@ -37,8 +37,14 @@ MODELS_DIR = Path(os.getenv("TTS_MODELS_DIR", "{{ tts_models_dir }}"))
 
 # Built-in Pocket TTS voices
 BUILTIN_VOICES = [
-    "alba", "marius", "javert", "jean",
-    "fantine", "cosette", "eponine", "azelma",
+    "alba",
+    "marius",
+    "javert",
+    "jean",
+    "fantine",
+    "cosette",
+    "eponine",
+    "azelma",
 ]
 DEFAULT_VOICE = "alba"
 
@@ -55,6 +61,7 @@ def _load_model():
     global _model
     try:
         from pocket_tts import TTSModel
+
         MODELS_DIR.mkdir(parents=True, exist_ok=True)
         VOICES_DIR.mkdir(parents=True, exist_ok=True)
         _model = TTSModel.load_model()
@@ -101,24 +108,21 @@ def _load_metadata() -> dict:
 def _save_metadata(meta: dict) -> None:
     """Save voice profiles metadata."""
     path = _get_metadata_path()
-    path.write_text(
-        json.dumps(meta, indent=2), encoding="utf-8"
-    )
+    path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
 
 
 def _to_wav_bytes(audio_tensor, sample_rate: int) -> bytes:
-    """Convert torch audio tensor to 16-bit WAV bytes."""
+    """Convert torch audio tensor to normalized 16-bit WAV bytes."""
     import soundfile as sf
+
     audio_np = audio_tensor.numpy().astype(np.float32)
     if audio_np.ndim > 1:
         audio_np = audio_np.squeeze()
     peak = max(abs(audio_np.max()), abs(audio_np.min()), 1e-8)
-    if peak > 1.0:
-        audio_np = audio_np / peak
+    # Normalize to 90% peak to ensure consistent audible volume (#1394)
+    audio_np = audio_np * (0.9 / peak)
     buf = io.BytesIO()
-    sf.write(
-        buf, audio_np, sample_rate, format="WAV", subtype="PCM_16"
-    )
+    sf.write(buf, audio_np, sample_rate, format="WAV", subtype="PCM_16")
     buf.seek(0)
     return buf.read()
 
@@ -133,6 +137,7 @@ def _run_synthesis(text: str, voice_id: str) -> bytes:
 def _run_create_voice(name: str, audio_path: str) -> str:
     """Extract voice embedding and save as .safetensors."""
     from pocket_tts import export_model_state
+
     vid = str(uuid.uuid4())[:8]
     voice_state = _model.get_state_for_audio_prompt(audio_path)
     sf_path = VOICES_DIR / f"{vid}.safetensors"
@@ -183,27 +188,19 @@ async def synthesize(
 ) -> StreamingResponse:
     """Synthesize speech from text. Returns audio/wav."""
     if not _model_loaded:
-        raise HTTPException(
-            503, detail=f"Model not ready: {_model_error}"
-        )
+        raise HTTPException(503, detail=f"Model not ready: {_model_error}")
     loop = asyncio.get_event_loop()
     try:
-        wav = await loop.run_in_executor(
-            None, _run_synthesis, text, voice_id
-        )
+        wav = await loop.run_in_executor(None, _run_synthesis, text, voice_id)
     except ValueError as e:
         raise HTTPException(404, detail=str(e)) from e
     except Exception as e:
         logger.error("Synthesis error: %s", e)
-        raise HTTPException(
-            500, detail=f"Synthesis failed: {e}"
-        ) from e
+        raise HTTPException(500, detail=f"Synthesis failed: {e}") from e
     return StreamingResponse(
         io.BytesIO(wav),
         media_type="audio/wav",
-        headers={
-            "Content-Disposition": "attachment; filename=speech.wav"
-        },
+        headers={"Content-Disposition": "attachment; filename=speech.wav"},
     )
 
 
@@ -212,17 +209,17 @@ async def list_voices() -> JSONResponse:
     """List all available voice profiles."""
     voices = []
     for name in BUILTIN_VOICES:
-        voices.append(
-            {"id": name, "name": name, "builtin": True}
-        )
+        voices.append({"id": name, "name": name, "builtin": True})
     meta = _load_metadata()
     for vid, info in meta.get("voices", {}).items():
-        voices.append({
-            "id": vid,
-            "name": info.get("name", vid),
-            "builtin": False,
-            "created": info.get("created", ""),
-        })
+        voices.append(
+            {
+                "id": vid,
+                "name": info.get("name", vid),
+                "builtin": False,
+                "created": info.get("created", ""),
+            }
+        )
     return JSONResponse(voices)
 
 
@@ -233,27 +230,20 @@ async def create_voice(
 ) -> JSONResponse:
     """Create voice profile from reference audio."""
     if not _model_loaded:
-        raise HTTPException(
-            503, detail=f"Model not ready: {_model_error}"
-        )
+        raise HTTPException(503, detail=f"Model not ready: {_model_error}")
     import tempfile
+
     audio_bytes = await audio.read()
     suffix = Path(audio.filename or "ref.wav").suffix or ".wav"
-    with tempfile.NamedTemporaryFile(
-        suffix=suffix, delete=False
-    ) as tmp:
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
         tmp.write(audio_bytes)
         tmp_path = tmp.name
     loop = asyncio.get_event_loop()
     try:
-        vid = await loop.run_in_executor(
-            None, _run_create_voice, name, tmp_path
-        )
+        vid = await loop.run_in_executor(None, _run_create_voice, name, tmp_path)
     except Exception as e:
         logger.error("Voice creation error: %s", e)
-        raise HTTPException(
-            500, detail=f"Voice creation failed: {e}"
-        ) from e
+        raise HTTPException(500, detail=f"Voice creation failed: {e}") from e
     finally:
         os.unlink(tmp_path)
     return JSONResponse({"id": vid, "name": name})
@@ -263,14 +253,10 @@ async def create_voice(
 async def delete_voice(voice_id: str) -> JSONResponse:
     """Delete a custom voice profile."""
     if voice_id in BUILTIN_VOICES:
-        raise HTTPException(
-            400, detail="Cannot delete built-in voice"
-        )
+        raise HTTPException(400, detail="Cannot delete built-in voice")
     meta = _load_metadata()
     if voice_id not in meta.get("voices", {}):
-        raise HTTPException(
-            404, detail=f"Voice not found: {voice_id}"
-        )
+        raise HTTPException(404, detail=f"Voice not found: {voice_id}")
     sf_path = VOICES_DIR / f"{voice_id}.safetensors"
     if sf_path.exists():
         sf_path.unlink()
@@ -288,8 +274,10 @@ async def root() -> dict:
         "version": "2.0.0",
         "engine": "pocket-tts",
         "endpoints": [
-            "/health", "/tts/synthesize",
-            "/voices", "/voices/create",
+            "/health",
+            "/tts/synthesize",
+            "/voices",
+            "/voices/create",
         ],
     }
 
@@ -303,8 +291,11 @@ def main() -> None:
     logger.info("Models dir: %s", MODELS_DIR)
     logger.info("=" * 60)
     uvicorn.run(
-        app, host=TTS_HOST, port=TTS_PORT,
-        log_level="info", access_log=True,
+        app,
+        host=TTS_HOST,
+        port=TTS_PORT,
+        log_level="info",
+        access_log=True,
     )
 
 


### PR DESCRIPTION
## Summary
- Fix low volume TTS output by normalizing audio to 90% peak level
- The `_to_wav_bytes` function only clipped audio down (when peak > 1.0) but never boosted quiet output
- Pocket TTS model outputs at ~53% peak / ~9% RMS — now normalized to 90% peak / ~15% RMS
- Includes black auto-formatting of the TTS worker Ansible template

## Root Cause
```python
# BEFORE (broken): only normalizes down, never up
if peak > 1.0:
    audio_np = audio_np / peak

# AFTER (fixed): always normalize to target level
audio_np = audio_np * (0.9 / peak)
```

## Verification
Tested on .24 TTS worker:
- **Before**: Peak 53.5%, RMS 9.2% (barely audible)
- **After**: Peak 90.0%, RMS 15.3% (clearly audible)

## Related
- Voice cloning (custom voices) blocked by missing HF token — tracked in #1411

Closes #1394