### PR TITLE
feat(secrets): system secrets management (#1417)

### DIFF
--- a/autobot-slm-backend/api/__init__.py
+++ b/autobot-slm-backend/api/__init__.py
@@ -30,6 +30,7 @@ from .monitoring import router as monitoring_router
 from .nodes import router as nodes_router
 from .npu import router as npu_router
 from .orchestration import router as orchestration_router
+from .secrets import router as secrets_router
 from .security import router as security_router
 from .services import fleet_router as fleet_services_router
 from .services import router as services_router
@@ -83,6 +84,7 @@ __all__ = [
     "autobot_users_router",
     "autobot_teams_router",
     "sso_router",
+    "secrets_router",
     "setup_wizard_router",
     "sso_auth_router",
 ]

--- a/autobot-slm-backend/api/secrets.py
+++ b/autobot-slm-backend/api/secrets.py
@@ -1,0 +1,153 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+System Secrets API Routes (#1417)
+
+Encrypted storage for internal system tokens (HF_TOKEN, API keys, etc.).
+Admin-only — secrets are not exposed to end users.
+"""
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from models.database import SystemSecret
+from models.schemas import SecretCreate, SecretResponse, SecretUpdate
+from services.auth import require_admin
+from services.database import get_db
+from services.encryption import decrypt_data, encrypt_data
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing_extensions import Annotated
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/secrets", tags=["secrets"])
+
+
+@router.get("", response_model=List[SecretResponse])
+async def list_secrets(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[dict, Depends(require_admin)],
+) -> List[SecretResponse]:
+    """List all system secrets (values never returned)."""
+    result = await db.execute(select(SystemSecret).order_by(SystemSecret.key))
+    return [SecretResponse.model_validate(s) for s in result.scalars().all()]
+
+
+@router.post(
+    "",
+    response_model=SecretResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_secret(
+    data: SecretCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[dict, Depends(require_admin)],
+) -> SecretResponse:
+    """Create a new system secret (admin only)."""
+    existing = await db.execute(
+        select(SystemSecret).where(SystemSecret.key == data.key)
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Secret '{data.key}' already exists",
+        )
+
+    secret = SystemSecret(
+        key=data.key,
+        encrypted_value=encrypt_data(data.value),
+        category=data.category,
+        description=data.description,
+    )
+    db.add(secret)
+    await db.commit()
+    await db.refresh(secret)
+
+    logger.info("System secret created: %s [%s]", data.key, data.category)
+    return SecretResponse.model_validate(secret)
+
+
+@router.get("/{key}", response_model=SecretResponse)
+async def get_secret(
+    key: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[dict, Depends(require_admin)],
+) -> SecretResponse:
+    """Get a system secret metadata (value never returned)."""
+    result = await db.execute(select(SystemSecret).where(SystemSecret.key == key))
+    secret = result.scalar_one_or_none()
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Secret not found",
+        )
+    return SecretResponse.model_validate(secret)
+
+
+@router.get("/{key}/value")
+async def get_secret_value(
+    key: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[dict, Depends(require_admin)],
+) -> dict:
+    """Get a decrypted secret value (admin only, for fleet provisioning)."""
+    result = await db.execute(select(SystemSecret).where(SystemSecret.key == key))
+    secret = result.scalar_one_or_none()
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Secret not found",
+        )
+    return {"key": secret.key, "value": decrypt_data(secret.encrypted_value)}
+
+
+@router.put("/{key}", response_model=SecretResponse)
+async def update_secret(
+    key: str,
+    data: SecretUpdate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[dict, Depends(require_admin)],
+) -> SecretResponse:
+    """Update a system secret (admin only)."""
+    result = await db.execute(select(SystemSecret).where(SystemSecret.key == key))
+    secret = result.scalar_one_or_none()
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Secret not found",
+        )
+
+    if data.value is not None:
+        secret.encrypted_value = encrypt_data(data.value)
+    if data.category is not None:
+        secret.category = data.category
+    if data.description is not None:
+        secret.description = data.description
+
+    await db.commit()
+    await db.refresh(secret)
+
+    logger.info("System secret updated: %s", key)
+    return SecretResponse.model_validate(secret)
+
+
+@router.delete("/{key}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_secret(
+    key: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    _: Annotated[dict, Depends(require_admin)],
+) -> None:
+    """Delete a system secret (admin only)."""
+    result = await db.execute(select(SystemSecret).where(SystemSecret.key == key))
+    secret = result.scalar_one_or_none()
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Secret not found",
+        )
+
+    await db.delete(secret)
+    await db.commit()
+    logger.info("System secret deleted: %s", key)

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -39,6 +39,7 @@ from api import (
     nodes_router,
     npu_router,
     orchestration_router,
+    secrets_router,
     security_router,
     services_router,
     settings_router,
@@ -57,6 +58,7 @@ from api.code_source import router as code_source_router
 from api.performance import router as performance_router
 from api.personality_proxy import router as personality_proxy_router
 from api.roles import router as roles_router
+from config import settings
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from services.a2a_card_fetcher import start_card_refresh_task
@@ -64,8 +66,6 @@ from services.database import db_service
 from services.git_tracker import start_version_checker
 from services.reconciler import reconciler_service
 from services.schedule_executor import start_schedule_executor, stop_schedule_executor
-
-from config import settings
 
 logging.basicConfig(
     level=logging.DEBUG if settings.debug else logging.INFO,
@@ -283,6 +283,7 @@ app.include_router(node_vnc_router, prefix="/api")
 app.include_router(vnc_router, prefix="/api")
 app.include_router(node_tls_router, prefix="/api")
 app.include_router(tls_router, prefix="/api")
+app.include_router(secrets_router, prefix="/api")
 app.include_router(security_router, prefix="/api")
 app.include_router(code_sync_router, prefix="/api")
 app.include_router(roles_router, prefix="/api")

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -582,6 +582,32 @@ class BlueGreenDeployment(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 
+class SecretCategory(str, enum.Enum):
+    """System secret category enumeration (#1417)."""
+
+    SYSTEM = "system"
+    API_TOKEN = "api_token"
+    SERVICE = "service"
+
+
+class SystemSecret(Base):
+    """Encrypted system secret for fleet-wide configuration (#1417).
+
+    Stores sensitive tokens (HF_TOKEN, API keys, etc.) encrypted at rest.
+    These are internal AutoBot system secrets, not shared with end users.
+    """
+
+    __tablename__ = "system_secrets"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    key = Column(String(128), unique=True, nullable=False, index=True)
+    encrypted_value = Column(Text, nullable=False)
+    category = Column(String(32), default=SecretCategory.SYSTEM.value)
+    description = Column(String(255), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
 class CredentialType(str, enum.Enum):
     """Credential type enumeration."""
 

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -322,6 +322,41 @@ class SettingResponse(BaseModel):
 
 
 # =============================================================================
+# System Secrets Schemas (#1417)
+# =============================================================================
+
+
+class SecretCreate(BaseModel):
+    """Create a system secret."""
+
+    key: str = Field(..., min_length=1, max_length=128)
+    value: str = Field(..., min_length=1)
+    category: str = "system"
+    description: Optional[str] = None
+
+
+class SecretUpdate(BaseModel):
+    """Update a system secret."""
+
+    value: Optional[str] = None
+    category: Optional[str] = None
+    description: Optional[str] = None
+
+
+class SecretResponse(BaseModel):
+    """System secret response (value masked)."""
+
+    id: int
+    key: str
+    category: str
+    description: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+# =============================================================================
 # Role Schemas
 # =============================================================================
 

--- a/autobot-slm-frontend/src/composables/useSecretsApi.ts
+++ b/autobot-slm-frontend/src/composables/useSecretsApi.ts
@@ -1,0 +1,97 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * System Secrets API Composable (#1417)
+ *
+ * Provides REST API integration for encrypted system secrets
+ * management via the SLM backend. Admin-only.
+ */
+
+import axios, { type AxiosInstance } from 'axios'
+import { useAuthStore } from '@/stores/auth'
+
+const SLM_API_BASE = '/api'
+
+export interface SecretCreate {
+  key: string
+  value: string
+  category?: string
+  description?: string
+}
+
+export interface SecretUpdate {
+  value?: string
+  category?: string
+  description?: string
+}
+
+export interface SecretResponse {
+  id: number
+  key: string
+  category: string
+  description: string | null
+  created_at: string
+  updated_at: string
+}
+
+export function useSecretsApi() {
+  const authStore = useAuthStore()
+
+  const client: AxiosInstance = axios.create({
+    baseURL: SLM_API_BASE,
+    headers: { 'Content-Type': 'application/json' },
+    timeout: 30000,
+  })
+
+  client.interceptors.request.use((config) => {
+    const token = authStore.token
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
+    return config
+  })
+
+  client.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      if (error.response?.status === 401) {
+        authStore.logout()
+      }
+      return Promise.reject(error)
+    }
+  )
+
+  async function listSecrets(): Promise<SecretResponse[]> {
+    const response = await client.get<SecretResponse[]>('/secrets')
+    return response.data
+  }
+
+  async function createSecret(data: SecretCreate): Promise<SecretResponse> {
+    const response = await client.post<SecretResponse>('/secrets', data)
+    return response.data
+  }
+
+  async function updateSecret(
+    key: string,
+    data: SecretUpdate
+  ): Promise<SecretResponse> {
+    const response = await client.put<SecretResponse>(
+      `/secrets/${encodeURIComponent(key)}`,
+      data
+    )
+    return response.data
+  }
+
+  async function deleteSecret(key: string): Promise<void> {
+    await client.delete(`/secrets/${encodeURIComponent(key)}`)
+  }
+
+  return {
+    listSecrets,
+    createSecret,
+    updateSecret,
+    deleteSecret,
+  }
+}

--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -209,6 +209,13 @@ const router = createRouter({
           meta: { title: 'Personality', parent: 'settings', admin: true }
         },
         {
+          // Issue #1417: System Secrets Management
+          path: 'admin/secrets',
+          name: 'settings-admin-secrets',
+          component: () => import('@/views/settings/admin/SecretsSettings.vue'),
+          meta: { title: 'System Secrets', parent: 'settings', admin: true }
+        },
+        {
           path: 'admin/log-forwarding',
           name: 'settings-admin-log-forwarding',
           component: () => import('@/views/settings/admin/LogForwardingSettings.vue'),

--- a/autobot-slm-frontend/src/views/SettingsView.vue
+++ b/autobot-slm-frontend/src/views/SettingsView.vue
@@ -38,6 +38,7 @@ const tabs = [
   { id: 'cache', name: 'Cache', path: '/settings/admin/cache', icon: 'M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4' },
   { id: 'prompts', name: 'Prompts', path: '/settings/admin/prompts', icon: 'M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z' },
   { id: 'personality', name: 'Personality', path: '/settings/admin/personality', icon: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z' },
+  { id: 'secrets', name: 'Secrets', path: '/settings/admin/secrets', icon: 'M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z' },
   { id: 'log-forwarding', name: 'Log Forwarding', path: '/settings/admin/log-forwarding', icon: 'M12 19l9 2-9-18-9 18 9-2zm0 0v-8' },
   // Issue: NPU Workers consolidated to Fleet Overview /fleet/npu (Worker Registry sub-tab)
 ]

--- a/autobot-slm-frontend/src/views/settings/admin/SecretsSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/SecretsSettings.vue
@@ -1,0 +1,384 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+<script setup lang="ts">
+/**
+ * SecretsSettings - System Secrets Management (#1417)
+ *
+ * Admin-only page for managing encrypted system tokens
+ * (HF_TOKEN, API keys, service credentials).
+ * Values are stored encrypted at rest and never displayed.
+ */
+
+import { ref, onMounted } from 'vue'
+import {
+  useSecretsApi,
+  type SecretResponse,
+  type SecretCreate,
+} from '@/composables/useSecretsApi'
+
+const api = useSecretsApi()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const success = ref<string | null>(null)
+const secrets = ref<SecretResponse[]>([])
+
+const showAddForm = ref(false)
+const saving = ref(false)
+const newSecret = ref<SecretCreate>({
+  key: '',
+  value: '',
+  category: 'system',
+  description: '',
+})
+
+const editingKey = ref<string | null>(null)
+const editValue = ref('')
+
+const categories = [
+  { value: 'system', label: 'System' },
+  { value: 'api_token', label: 'API Token' },
+  { value: 'service', label: 'Service' },
+]
+
+async function fetchSecrets(): Promise<void> {
+  loading.value = true
+  error.value = null
+  try {
+    secrets.value = await api.listSecrets()
+  } catch (e: unknown) {
+    const err = e as { response?: { data?: { detail?: string } } }
+    error.value =
+      err.response?.data?.detail || 'Failed to load secrets'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function addSecret(): Promise<void> {
+  if (!newSecret.value.key || !newSecret.value.value) return
+  saving.value = true
+  error.value = null
+  try {
+    await api.createSecret(newSecret.value)
+    success.value = `Secret "${newSecret.value.key}" created`
+    newSecret.value = { key: '', value: '', category: 'system', description: '' }
+    showAddForm.value = false
+    await fetchSecrets()
+    setTimeout(() => { success.value = null }, 3000)
+  } catch (e: unknown) {
+    const err = e as { response?: { data?: { detail?: string } } }
+    error.value =
+      err.response?.data?.detail || 'Failed to create secret'
+  } finally {
+    saving.value = false
+  }
+}
+
+async function updateSecretValue(key: string): Promise<void> {
+  if (!editValue.value) return
+  saving.value = true
+  error.value = null
+  try {
+    await api.updateSecret(key, { value: editValue.value })
+    success.value = `Secret "${key}" updated`
+    editingKey.value = null
+    editValue.value = ''
+    await fetchSecrets()
+    setTimeout(() => { success.value = null }, 3000)
+  } catch (e: unknown) {
+    const err = e as { response?: { data?: { detail?: string } } }
+    error.value =
+      err.response?.data?.detail || 'Failed to update secret'
+  } finally {
+    saving.value = false
+  }
+}
+
+async function removeSecret(key: string): Promise<void> {
+  if (!confirm(`Delete secret "${key}"? This cannot be undone.`)) return
+  error.value = null
+  try {
+    await api.deleteSecret(key)
+    success.value = `Secret "${key}" deleted`
+    await fetchSecrets()
+    setTimeout(() => { success.value = null }, 3000)
+  } catch (e: unknown) {
+    const err = e as { response?: { data?: { detail?: string } } }
+    error.value =
+      err.response?.data?.detail || 'Failed to delete secret'
+  }
+}
+
+function startEdit(key: string): void {
+  editingKey.value = key
+  editValue.value = ''
+}
+
+function cancelEdit(): void {
+  editingKey.value = null
+  editValue.value = ''
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString()
+}
+
+function categoryLabel(value: string): string {
+  return categories.find((c) => c.value === value)?.label || value
+}
+
+onMounted(fetchSecrets)
+</script>
+
+<template>
+  <div class="p-6 space-y-6">
+    <!-- Messages -->
+    <div
+      v-if="error"
+      class="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 flex items-center gap-3"
+    >
+      <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+      {{ error }}
+      <button class="ml-auto text-red-500 hover:text-red-700" @click="error = null">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <div
+      v-if="success"
+      class="p-4 bg-green-50 border border-green-200 rounded-lg text-green-700 flex items-center gap-3"
+    >
+      <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+      {{ success }}
+    </div>
+
+    <!-- Header -->
+    <div class="flex items-center justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-gray-900">System Secrets</h2>
+        <p class="text-sm text-gray-500 mt-1">
+          Encrypted tokens and credentials for AutoBot infrastructure. Values are never displayed.
+        </p>
+      </div>
+      <button
+        class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+        @click="showAddForm = !showAddForm"
+      >
+        {{ showAddForm ? 'Cancel' : 'Add Secret' }}
+      </button>
+    </div>
+
+    <!-- Add Secret Form -->
+    <div v-if="showAddForm" class="bg-gray-50 border border-gray-200 rounded-lg p-5 space-y-4">
+      <h3 class="font-medium text-gray-900">New Secret</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Key</label>
+          <input
+            v-model="newSecret.key"
+            type="text"
+            placeholder="e.g. HF_TOKEN"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 text-sm"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Category</label>
+          <select
+            v-model="newSecret.category"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 text-sm"
+          >
+            <option v-for="cat in categories" :key="cat.value" :value="cat.value">
+              {{ cat.label }}
+            </option>
+          </select>
+        </div>
+        <div class="md:col-span-2">
+          <label class="block text-sm font-medium text-gray-700 mb-1">Value</label>
+          <input
+            v-model="newSecret.value"
+            type="password"
+            placeholder="Secret value (will be encrypted)"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 text-sm font-mono"
+          />
+        </div>
+        <div class="md:col-span-2">
+          <label class="block text-sm font-medium text-gray-700 mb-1">Description</label>
+          <input
+            v-model="newSecret.description"
+            type="text"
+            placeholder="Optional description"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 text-sm"
+          />
+        </div>
+      </div>
+      <div class="flex justify-end">
+        <button
+          :disabled="!newSecret.key || !newSecret.value || saving"
+          class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
+          @click="addSecret"
+        >
+          {{ saving ? 'Saving...' : 'Create Secret' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-12">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+    </div>
+
+    <!-- Empty State -->
+    <div
+      v-else-if="secrets.length === 0"
+      class="text-center py-12 bg-gray-50 rounded-lg border border-gray-200"
+    >
+      <svg
+        class="mx-auto h-12 w-12 text-gray-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+        />
+      </svg>
+      <h3 class="mt-2 text-sm font-medium text-gray-900">No secrets configured</h3>
+      <p class="mt-1 text-sm text-gray-500">Add system tokens like HF_TOKEN to get started.</p>
+    </div>
+
+    <!-- Secrets Table -->
+    <div v-else class="bg-white border border-gray-200 rounded-lg overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Key
+            </th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Category
+            </th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Description
+            </th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Updated
+            </th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+          <tr v-for="secret in secrets" :key="secret.id">
+            <td class="px-6 py-4 whitespace-nowrap">
+              <span class="text-sm font-mono font-medium text-gray-900">{{ secret.key }}</span>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap">
+              <span
+                class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+                :class="{
+                  'bg-blue-100 text-blue-800': secret.category === 'system',
+                  'bg-purple-100 text-purple-800': secret.category === 'api_token',
+                  'bg-green-100 text-green-800': secret.category === 'service',
+                }"
+              >
+                {{ categoryLabel(secret.category) }}
+              </span>
+            </td>
+            <td class="px-6 py-4 text-sm text-gray-500">
+              {{ secret.description || '-' }}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              {{ formatDate(secret.updated_at) }}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
+              <template v-if="editingKey === secret.key">
+                <div class="flex items-center gap-2 justify-end">
+                  <input
+                    v-model="editValue"
+                    type="password"
+                    placeholder="New value"
+                    class="w-48 px-2 py-1 border border-gray-300 rounded text-sm font-mono"
+                  />
+                  <button
+                    :disabled="!editValue || saving"
+                    class="text-green-600 hover:text-green-800 disabled:opacity-50"
+                    @click="updateSecretValue(secret.key)"
+                  >
+                    Save
+                  </button>
+                  <button class="text-gray-500 hover:text-gray-700" @click="cancelEdit">
+                    Cancel
+                  </button>
+                </div>
+              </template>
+              <template v-else>
+                <button
+                  class="text-blue-600 hover:text-blue-800 mr-3"
+                  @click="startEdit(secret.key)"
+                >
+                  Update
+                </button>
+                <button
+                  class="text-red-600 hover:text-red-800"
+                  @click="removeSecret(secret.key)"
+                >
+                  Delete
+                </button>
+              </template>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Info Box -->
+    <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
+      <div class="flex gap-3">
+        <svg
+          class="w-5 h-5 text-blue-500 flex-shrink-0 mt-0.5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <div class="text-sm text-blue-800">
+          <p class="font-medium">About System Secrets</p>
+          <p class="mt-1">
+            Secrets are encrypted with AES-256-GCM before storage. Values are never displayed
+            after creation. Use these for internal AutoBot infrastructure tokens
+            (e.g. HuggingFace, external APIs) that fleet nodes need but end users should not see.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Add `SystemSecret` model with AES-256-GCM encrypted value storage
- Add admin-only CRUD API at `/api/secrets` (values never returned in list/get responses)
- Add `/api/secrets/{key}/value` endpoint for fleet provisioning (admin-only decryption)
- Add `SecretsSettings.vue` admin page in Settings > Secrets with create/update/delete UI
- Add `useSecretsApi` composable for frontend API integration
- Three secret categories: System, API Token, Service

## Architecture
- Values encrypted at rest using existing `services/encryption.py` (AES-256-GCM + PBKDF2)
- Secret values are **never** returned in list/detail responses — only metadata
- Decrypted values only accessible via explicit `/value` endpoint
- Admin-only access enforced on all endpoints

## Test Plan
- [ ] Create secret via admin UI at `/settings/admin/secrets`
- [ ] Verify secret appears in list (value not shown)
- [ ] Update secret value
- [ ] Delete secret
- [ ] Verify non-admin users cannot access `/api/secrets`

Closes #1417