### PR TITLE
feat(voice): TTS voice-per-language mapping in personality profiles (#1333)

### DIFF
--- a/autobot-backend/api/personality.py
+++ b/autobot-backend/api/personality.py
@@ -50,6 +50,7 @@ class ProfileDetail(BaseModel):
     created_at: str
     updated_at: str
     voice_id: str = ""
+    voice_ids: Dict[str, str] = {}
     language_code: str = "en"
 
 
@@ -62,6 +63,7 @@ class ProfileCreate(BaseModel):
     off_limits: List[str] = []
     custom_notes: str = ""
     voice_id: str = ""
+    voice_ids: Dict[str, str] = {}
     language_code: str = "en"
 
     @field_validator("tone")
@@ -90,6 +92,7 @@ class ProfileUpdate(BaseModel):
     off_limits: Optional[List[str]] = None
     custom_notes: Optional[str] = None
     voice_id: Optional[str] = None
+    voice_ids: Optional[Dict[str, str]] = None
     language_code: Optional[str] = None
 
     @field_validator("tone")
@@ -134,6 +137,7 @@ def _profile_to_detail(p) -> ProfileDetail:
         off_limits=p.off_limits,
         custom_notes=p.custom_notes,
         voice_id=p.voice_id,  # (#1135)
+        voice_ids=p.voice_ids,  # (#1333)
         language_code=p.language_code,  # (#1324)
         is_system=p.is_system,
         created_by=p.created_by,

--- a/autobot-backend/resources/personalities/default.json
+++ b/autobot-backend/resources/personalities/default.json
@@ -23,6 +23,7 @@
   ],
   "custom_notes": "",
   "voice_id": "",
+  "voice_ids": {},
   "language_code": "en",
   "is_system": true,
   "created_by": "system",

--- a/autobot-backend/services/personality_service.py
+++ b/autobot-backend/services/personality_service.py
@@ -75,6 +75,9 @@ class PersonalityProfile:
     off_limits: List[str] = field(default_factory=list)
     custom_notes: str = ""
     voice_id: str = ""  # Pocket TTS voice override (#1135)
+    voice_ids: Dict[str, str] = field(
+        default_factory=dict
+    )  # Per-language voices (#1333)
     language_code: str = "en"  # Response language (#1324)
     is_system: bool = False
     created_by: str = "system"
@@ -243,6 +246,7 @@ class PersonalityManager:
             off_limits=list(kwargs.get("off_limits", [])),
             custom_notes=kwargs.get("custom_notes", ""),
             voice_id=kwargs.get("voice_id", ""),
+            voice_ids=dict(kwargs.get("voice_ids", {})),
             language_code=kwargs.get("language_code", "en"),
             is_system=False,
             created_by=created_by,
@@ -273,6 +277,7 @@ class PersonalityManager:
             "off_limits",
             "custom_notes",
             "voice_id",
+            "voice_ids",
             "language_code",
         }
         for key, val in updates.items():

--- a/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
@@ -61,10 +61,17 @@ VoiceSettingsPanel.vue - Voice profile selection and management (#1054)
       <i class="fas fa-spinner fa-spin"></i> {{ $t('voice.loadingVoices') }}
     </div>
 
-    <div v-if="personalityVoiceId" class="personality-voice-hint">
+    <div v-if="personalityVoiceId || hasLanguageVoices" class="personality-voice-hint">
       <i class="fas fa-user-circle"></i>
-      {{ $t('voice.personalityOverride') }}
-      <strong>{{ voices.find(v => v.id === personalityVoiceId)?.name ?? personalityVoiceId }}</strong>
+      <div class="personality-voice-details">
+        <div v-if="personalityVoiceId">
+          {{ $t('voice.personalityOverride') }}
+          <strong>{{ voices.find(v => v.id === personalityVoiceId)?.name ?? personalityVoiceId }}</strong>
+        </div>
+        <div v-if="hasLanguageVoices">
+          {{ $t('voice.languageVoicesActive', { count: Object.keys(personalityVoiceIds).length }) }}
+        </div>
+      </div>
     </div>
 
     <div v-if="error" class="error-msg">{{ error }}</div>
@@ -131,7 +138,7 @@ VoiceSettingsPanel.vue - Voice profile selection and management (#1054)
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
 import { createLogger } from '@/utils/debugUtils'
@@ -144,6 +151,7 @@ const {
   selectedVoiceId,
   effectiveVoiceId,
   personalityVoiceId,
+  personalityVoiceIds,
   loading,
   error,
   fetchVoices,
@@ -152,6 +160,10 @@ const {
   deleteVoice,
   fetchPersonalityVoice,
 } = useVoiceProfiles()
+
+const hasLanguageVoices = computed(() =>
+  Object.keys(personalityVoiceIds.value).length > 0
+)
 
 const showAddDialog = ref(false)
 const newVoiceName = ref('')
@@ -461,6 +473,12 @@ async function handleDelete(voiceId: string, name: string) {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs, 6px);
+}
+
+.personality-voice-details {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .personality-voice-hint strong {

--- a/autobot-frontend/src/composables/useVoiceProfiles.ts
+++ b/autobot-frontend/src/composables/useVoiceProfiles.ts
@@ -31,9 +31,19 @@ const loading = ref(false)
 const error = ref<string | null>(null)
 // Personality-assigned voice — overrides user selection when set (#1135)
 const personalityVoiceId = ref<string>('')
-const effectiveVoiceId = computed<string>(() =>
-  personalityVoiceId.value || selectedVoiceId.value
-)
+// Per-language voice map from personality profile (#1333)
+const personalityVoiceIds = ref<Record<string, string>>({})
+const effectiveVoiceId = computed<string>(() => {
+  // Voice resolution order (#1333):
+  // 1. voice_ids[current_language] (language-specific)
+  // 2. voice_id (profile default, backward compatible)
+  // 3. User-selected voice (selectedVoiceId)
+  const lang = localStorage.getItem('autobot-language') || 'en'
+  const langVoice = personalityVoiceIds.value[lang]
+  if (langVoice) return langVoice
+  if (personalityVoiceId.value) return personalityVoiceId.value
+  return selectedVoiceId.value
+})
 
 export function useVoiceProfiles() {
   async function fetchVoices(): Promise<void> {
@@ -128,11 +138,14 @@ export function useVoiceProfiles() {
       if (res.ok) {
         const profile = await res.json()
         personalityVoiceId.value = profile?.voice_id ?? ''
+        personalityVoiceIds.value = profile?.voice_ids ?? {}
       } else {
         personalityVoiceId.value = ''
+        personalityVoiceIds.value = {}
       }
     } catch {
       personalityVoiceId.value = ''
+      personalityVoiceIds.value = {}
     }
   }
 
@@ -140,6 +153,7 @@ export function useVoiceProfiles() {
     voices,
     selectedVoiceId,
     personalityVoiceId,
+    personalityVoiceIds,
     effectiveVoiceId,
     loading,
     error,

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -597,7 +597,8 @@
     "stop": "Stop",
     "record": "Record",
     "creating": "Creating...",
-    "confirmDeleteVoice": "Delete voice \"{name}\"?"
+    "confirmDeleteVoice": "Delete voice \"{name}\"?",
+    "languageVoicesActive": "{count} language-specific voice(s) configured"
   },
   "analytics": {
     "title": "Analytics",

--- a/autobot-slm-frontend/src/composables/usePersonality.ts
+++ b/autobot-slm-frontend/src/composables/usePersonality.ts
@@ -39,6 +39,7 @@ export interface PersonalityProfile {
   off_limits: string[]
   custom_notes: string
   voice_id: string
+  voice_ids: Record<string, string>
   is_system: boolean
   created_by: string
   created_at: string
@@ -54,6 +55,7 @@ export interface ProfileCreate {
   off_limits?: string[]
   custom_notes?: string
   voice_id?: string
+  voice_ids?: Record<string, string>
 }
 
 export interface ProfileUpdate {
@@ -65,6 +67,7 @@ export interface ProfileUpdate {
   off_limits?: string[]
   custom_notes?: string
   voice_id?: string
+  voice_ids?: Record<string, string>
 }
 
 export const TONE_OPTIONS = [


### PR DESCRIPTION
## Summary

Extends personality profiles to map languages to specific TTS voices, so voice output sounds natural in each language.

- Add `voice_ids: Dict[str, str]` field to `PersonalityProfile` (e.g., `{"en": "voice_en_01", "es": "voice_es_01"}`)
- Voice resolution order: `voice_ids[language]` > `voice_id` > user selection
- Update personality API schemas to accept/return `voice_ids`
- Update `useVoiceProfiles` composable with language-aware voice resolution
- Update `VoiceSettingsPanel` to display per-language voice configuration status
- Add `voice_ids` types to SLM frontend

## Voice Resolution Order

```
1. voice_ids[current_language]  (language-specific from personality)
2. voice_id                      (profile default, backward compatible)
3. selectedVoiceId               (user's manual selection)
```

## Files Changed

| File | Change |
|------|--------|
| `personality_service.py` | Add `voice_ids` field, update create/update |
| `api/personality.py` | Add to API schemas |
| `default.json` | Add empty `voice_ids` |
| `useVoiceProfiles.ts` | Language-aware `effectiveVoiceId` |
| `VoiceSettingsPanel.vue` | Display per-language voice info |
| `en.json` | Add `languageVoicesActive` key |
| SLM `usePersonality.ts` | Add types |

## Test Plan

- [ ] Existing profiles with only `voice_id` still work (backward compatible)
- [ ] Setting `voice_ids: {"es": "voice_es"}` uses Spanish voice for Spanish language
- [ ] Falls back to `voice_id` when no language-specific voice configured
- [ ] UI shows language voice count when configured

Closes #1333

🤖 Generated with [Claude Code](https://claude.com/claude-code)