### PR TITLE
feat(templates): community template descriptions, secrets metadata, and UI (#1415)

### DIFF
--- a/autobot-backend/api/templates.py
+++ b/autobot-backend/api/templates.py
@@ -147,6 +147,37 @@ async def list_workflow_templates(
 
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
+    operation="get_secrets_usage",
+    error_code_prefix="TEMPLATES",
+)
+@router.get("/templates/secrets-usage")
+async def get_secrets_usage():
+    """Map secret keys to the templates that require them (#1415)."""
+    try:
+        all_templates = workflow_template_manager.list_templates()
+        usage_map: Dict[str, list] = {}
+        for template in all_templates:
+            for secret_key, meta in (template.required_secrets or {}).items():
+                if secret_key not in usage_map:
+                    usage_map[secret_key] = []
+                usage_map[secret_key].append(
+                    {
+                        "template_id": template.id,
+                        "template_name": template.name,
+                        "required": meta.get("required", True),
+                        "scope": meta.get("scope", ""),
+                    }
+                )
+        return {"success": True, "secrets_usage": usage_map}
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to get secrets usage: {str(e)}",
+        )
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
     operation="search_templates",
     error_code_prefix="TEMPLATES",
 )

--- a/autobot-backend/workflow_templates/community.py
+++ b/autobot-backend/workflow_templates/community.py
@@ -6,6 +6,7 @@ Community Growth Workflow Templates
 
 Issue #1161: Autonomous community outreach templates for Reddit, Twitter,
 Discord, and GitHub — each with a human-approval gate before posting.
+Issue #1415: User-friendly step descriptions and required_secrets metadata.
 """
 
 from typing import Dict, List
@@ -22,7 +23,11 @@ def _build_reddit_monitor_gather_steps() -> List[WorkflowStep]:
             id="reddit_search",
             agent_type="community_growth",
             action="reddit_search",
-            description="Community_Growth: Search subreddits for keyword matches",
+            description=(
+                "Search target subreddits for posts matching your keywords. "
+                "Uses Reddit API (read-only, app credentials only) to find "
+                "relevant discussions, filtering by minimum score."
+            ),
             inputs={
                 "subreddits": "{subreddits}",
                 "keywords": "{keywords}",
@@ -35,7 +40,11 @@ def _build_reddit_monitor_gather_steps() -> List[WorkflowStep]:
             id="draft_replies",
             agent_type="community_growth",
             action="llm_draft_content",
-            description="Community_Growth: Draft replies for matching posts",
+            description=(
+                "AutoBot sends each matching post to the local LLM (Ollama) "
+                "and drafts a helpful, contextual reply for every result. "
+                "Replies mention the AutoBot project where relevant."
+            ),
             dependencies=["reddit_search"],
             inputs={
                 "format": "reddit_reply",
@@ -57,7 +66,9 @@ def _build_reddit_monitor_post_steps() -> List[WorkflowStep]:
             agent_type="orchestrator",
             action="human_review",
             description=(
-                "Orchestrator: Review drafted replies before posting (requires your approval)"
+                "All drafted replies are presented for your review. "
+                "You can edit, approve, or reject each reply before "
+                "anything is posted. Nothing goes live without your OK."
             ),
             requires_approval=True,
             dependencies=["draft_replies"],
@@ -67,7 +78,12 @@ def _build_reddit_monitor_post_steps() -> List[WorkflowStep]:
             id="reddit_reply",
             agent_type="community_growth",
             action="reddit_reply",
-            description="Community_Growth: Post approved replies to Reddit",
+            description=(
+                "Post the approved replies to their respective Reddit "
+                "threads. Requires full Reddit OAuth credentials "
+                "(username + password). Only replies you approved in "
+                "the previous step are posted."
+            ),
             dependencies=["review_drafts"],
             inputs={"dry_run": False},
             expected_duration_ms=20000,
@@ -101,6 +117,28 @@ def create_reddit_monitor_reply_template() -> WorkflowTemplate:
         tags=["community", "reddit", "outreach", "monitor", "reply"],
         variables=_get_reddit_monitor_variables(),
         steps=steps,
+        required_secrets={
+            "REDDIT_CLIENT_ID": {
+                "description": "Reddit OAuth app client ID",
+                "required": True,
+                "scope": "read",
+            },
+            "REDDIT_CLIENT_SECRET": {
+                "description": "Reddit OAuth app client secret",
+                "required": True,
+                "scope": "read",
+            },
+            "REDDIT_USERNAME": {
+                "description": "Reddit account username (required for posting)",
+                "required": True,
+                "scope": "write",
+            },
+            "REDDIT_PASSWORD": {
+                "description": "Reddit account password (required for posting)",
+                "required": True,
+                "scope": "write",
+            },
+        },
     )
 
 
@@ -111,7 +149,12 @@ def _build_blast_fetch_draft_steps() -> List[WorkflowStep]:
             id="fetch_release",
             agent_type="community_growth",
             action="github_get_releases",
-            description="Community_Growth: Fetch latest GitHub release notes",
+            description=(
+                "Fetch the latest release from the GitHub repository, "
+                "including tag name, release notes, and highlights. "
+                "Uses GitHub API (public repos need no token; private "
+                "repos require a GITHUB_TOKEN)."
+            ),
             inputs={"repo": "{repo}", "limit": 1},
             expected_duration_ms=10000,
         ),
@@ -119,7 +162,12 @@ def _build_blast_fetch_draft_steps() -> List[WorkflowStep]:
             id="draft_content",
             agent_type="community_growth",
             action="llm_draft_content",
-            description="Community_Growth: Draft announcements for all channels",
+            description=(
+                "AutoBot sends the release notes to the local LLM and "
+                "drafts three separate announcements: a Reddit post, a "
+                "tweet (<=280 chars), and a Discord message — each "
+                "tailored for its platform."
+            ),
             dependencies=["fetch_release"],
             inputs={
                 "format": "all_channels",
@@ -141,8 +189,10 @@ def _build_blast_review_step() -> List[WorkflowStep]:
             agent_type="orchestrator",
             action="human_review",
             description=(
-                "Orchestrator: Review release content for Reddit, Twitter, and Discord "
-                "(requires your approval)"
+                "All three drafted announcements (Reddit, Twitter, "
+                "Discord) are presented for your review. Edit wording, "
+                "approve or reject each one individually. Nothing is "
+                "posted without your approval."
             ),
             requires_approval=True,
             dependencies=["draft_content"],
@@ -158,7 +208,11 @@ def _build_blast_posting_steps() -> List[WorkflowStep]:
             id="reddit_post",
             agent_type="community_growth",
             action="reddit_post",
-            description="Community_Growth: Post release announcement to Reddit",
+            description=(
+                "Submit the approved announcement as a new post to "
+                "the target subreddit. Requires full Reddit OAuth "
+                "credentials."
+            ),
             dependencies=["review_content"],
             inputs={"subreddit": "{target_subreddits}", "dry_run": False},
             expected_duration_ms=15000,
@@ -167,7 +221,10 @@ def _build_blast_posting_steps() -> List[WorkflowStep]:
             id="twitter_post",
             agent_type="community_growth",
             action="twitter_post",
-            description="Community_Growth: Post release announcement to Twitter",
+            description=(
+                "Publish the approved tweet via Twitter API v2. "
+                "Requires a TWITTER_BEARER_TOKEN with write access."
+            ),
             dependencies=["review_content"],
             inputs={"dry_run": False},
             expected_duration_ms=10000,
@@ -176,7 +233,11 @@ def _build_blast_posting_steps() -> List[WorkflowStep]:
             id="discord_notify",
             agent_type="community_growth",
             action="discord_notify",
-            description="Community_Growth: Post release announcement to Discord",
+            description=(
+                "Send the approved announcement to the configured "
+                "Discord channel via webhook. Requires a "
+                "DISCORD_WEBHOOK_URL."
+            ),
             dependencies=["review_content"],
             inputs={"dry_run": False},
             expected_duration_ms=5000,
@@ -214,6 +275,43 @@ def create_release_announcement_blast_template() -> WorkflowTemplate:
         tags=["community", "release", "reddit", "twitter", "discord", "announcement"],
         variables=_get_blast_variables(),
         steps=steps,
+        required_secrets={
+            "GITHUB_TOKEN": {
+                "description": "GitHub token (only needed for private repos)",
+                "required": False,
+                "scope": "read",
+            },
+            "REDDIT_CLIENT_ID": {
+                "description": "Reddit OAuth app client ID",
+                "required": True,
+                "scope": "write",
+            },
+            "REDDIT_CLIENT_SECRET": {
+                "description": "Reddit OAuth app client secret",
+                "required": True,
+                "scope": "write",
+            },
+            "REDDIT_USERNAME": {
+                "description": "Reddit account username",
+                "required": True,
+                "scope": "write",
+            },
+            "REDDIT_PASSWORD": {
+                "description": "Reddit account password",
+                "required": True,
+                "scope": "write",
+            },
+            "TWITTER_BEARER_TOKEN": {
+                "description": "Twitter API v2 bearer token with write access",
+                "required": True,
+                "scope": "write",
+            },
+            "DISCORD_WEBHOOK_URL": {
+                "description": "Discord channel webhook URL",
+                "required": True,
+                "scope": "write",
+            },
+        },
     )
 
 
@@ -224,7 +322,11 @@ def _build_digest_gather_steps() -> List[WorkflowStep]:
             id="fetch_releases",
             agent_type="community_growth",
             action="github_get_releases",
-            description="Community_Growth: Fetch recent GitHub releases",
+            description=(
+                "Fetch the 5 most recent releases from the GitHub "
+                "repository. Runs in parallel with the Reddit search "
+                "step. Public repos need no token."
+            ),
             inputs={"repo": "{repo}", "limit": 5},
             expected_duration_ms=10000,
         ),
@@ -232,7 +334,11 @@ def _build_digest_gather_steps() -> List[WorkflowStep]:
             id="search_mentions",
             agent_type="community_growth",
             action="reddit_search",
-            description="Community_Growth: Search Reddit for AutoBot mentions",
+            description=(
+                "Search target subreddits for mentions of AutoBot and "
+                "mrveiss. Runs in parallel with the GitHub releases "
+                "fetch. Uses read-only Reddit app credentials."
+            ),
             inputs={
                 "subreddits": "{target_subreddits}",
                 "keywords": ["autobot", "mrveiss"],
@@ -251,7 +357,12 @@ def _build_digest_draft_review_post_steps() -> List[WorkflowStep]:
             id="draft_digest",
             agent_type="community_growth",
             action="llm_draft_content",
-            description="Community_Growth: Draft community digest post",
+            description=(
+                "AutoBot combines the GitHub releases and Reddit "
+                "mentions, then sends them to the local LLM to draft "
+                "a community digest post summarising activity over "
+                "the lookback period."
+            ),
             dependencies=["fetch_releases", "search_mentions"],
             inputs={
                 "format": "reddit_post",
@@ -267,8 +378,9 @@ def _build_digest_draft_review_post_steps() -> List[WorkflowStep]:
             agent_type="orchestrator",
             action="human_review",
             description=(
-                "Orchestrator: Review community digest before publishing "
-                "(requires your approval)"
+                "The drafted digest is presented for your review. "
+                "Edit, approve, or reject before it goes live. "
+                "Nothing is posted without your approval."
             ),
             requires_approval=True,
             dependencies=["draft_digest"],
@@ -278,7 +390,11 @@ def _build_digest_draft_review_post_steps() -> List[WorkflowStep]:
             id="post_digest",
             agent_type="community_growth",
             action="reddit_post",
-            description="Community_Growth: Post community digest to Reddit",
+            description=(
+                "Submit the approved digest as a new post to the "
+                "target subreddit. Requires full Reddit OAuth "
+                "credentials."
+            ),
             dependencies=["review_digest"],
             inputs={"subreddit": "{target_subreddits}", "dry_run": False},
             expected_duration_ms=15000,
@@ -312,6 +428,33 @@ def create_community_digest_post_template() -> WorkflowTemplate:
         tags=["community", "digest", "reddit", "github", "releases", "weekly"],
         variables=_get_digest_variables(),
         steps=steps,
+        required_secrets={
+            "GITHUB_TOKEN": {
+                "description": "GitHub token (only needed for private repos)",
+                "required": False,
+                "scope": "read",
+            },
+            "REDDIT_CLIENT_ID": {
+                "description": "Reddit OAuth app client ID",
+                "required": True,
+                "scope": "read+write",
+            },
+            "REDDIT_CLIENT_SECRET": {
+                "description": "Reddit OAuth app client secret",
+                "required": True,
+                "scope": "read+write",
+            },
+            "REDDIT_USERNAME": {
+                "description": "Reddit account username (required for posting)",
+                "required": True,
+                "scope": "write",
+            },
+            "REDDIT_PASSWORD": {
+                "description": "Reddit account password (required for posting)",
+                "required": True,
+                "scope": "write",
+            },
+        },
     )
 
 

--- a/autobot-backend/workflow_templates/types.py
+++ b/autobot-backend/workflow_templates/types.py
@@ -74,11 +74,14 @@ class WorkflowTemplate:
     agents_involved: List[str]
     tags: List[str]
     variables: Dict[str, str] = None
+    required_secrets: Dict[str, Dict[str, Any]] = None
 
     def __post_init__(self):
         """Initialize default value for variables field."""
         if self.variables is None:
             self.variables = {}
+        if self.required_secrets is None:
+            self.required_secrets = {}
 
     def to_summary_dict(self) -> Dict[str, Any]:
         """Convert template to summary dict for caching."""
@@ -94,6 +97,7 @@ class WorkflowTemplate:
             "step_count": len(self.steps),
             "approval_steps": sum(1 for step in self.steps if step.requires_approval),
             "variables": self.variables,
+            "required_secrets": self.required_secrets,
         }
 
     def to_detail_dict(self) -> Dict[str, Any]:
@@ -108,5 +112,6 @@ class WorkflowTemplate:
             "agents_involved": self.agents_involved,
             "tags": self.tags,
             "variables": self.variables,
+            "required_secrets": self.required_secrets,
             "steps": [step.to_dict() for step in self.steps],
         }

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -212,6 +212,14 @@
               <span v-for="tag in secret.tags.slice(0, 3)" :key="tag" class="tag">{{ tag }}</span>
               <span v-if="secret.tags.length > 3" class="tag more">+{{ secret.tags.length - 3 }}</span>
             </div>
+
+            <!-- Workflow usage (#1415) -->
+            <div class="card-workflow-usage" v-if="getWorkflowUsage(secret).length">
+              <span class="usage-label"><i class="fas fa-project-diagram"></i> Used by:</span>
+              <span v-for="usage in getWorkflowUsage(secret)" :key="usage.template_id" class="usage-tag">
+                {{ usage.template_name }}
+              </span>
+            </div>
           </div>
 
           <!-- Card Actions -->
@@ -832,6 +840,7 @@ const credentialTemplates = computed(() => [
 const secrets = ref<any[]>([]);
 const stats = ref<any>(null);
 const loading = ref(false);
+const workflowUsage = ref<Record<string, any[]>>({});
 const saving = ref(false);
 const deleting = ref(false);
 const transferring = ref(false);
@@ -2045,6 +2054,30 @@ watch(selectedScope, () => {
 
 .tag.more {
   color: var(--color-primary);
+}
+
+.card-workflow-usage {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.usage-label {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.usage-tag {
+  font-size: 11px;
+  padding: 2px 8px;
+  background: var(--color-primary-bg);
+  color: var(--color-primary);
+  border-radius: 10px;
 }
 
 .card-actions {

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
@@ -69,6 +69,21 @@
             </div>
           </div>
 
+          <!-- Required Credentials (#1415) -->
+          <div v-if="(previewTemplate as any).required_secrets && Object.keys((previewTemplate as any).required_secrets).length" class="preview-secrets">
+            <h4>Required Credentials</h4>
+            <div class="secret-items">
+              <div v-for="(meta, key) in (previewTemplate as any).required_secrets" :key="key" class="secret-item">
+                <i class="fas fa-key"></i>
+                <div class="secret-info">
+                  <span class="secret-name">{{ key }}</span>
+                  <span class="secret-desc">{{ meta.description }}</span>
+                </div>
+                <span class="secret-scope" :class="meta.scope">{{ meta.scope }}</span>
+              </div>
+            </div>
+          </div>
+
           <h4>{{ $t('workflow.templates.steps') }}</h4>
           <div class="preview-steps">
             <div v-for="(step, i) in getTemplateSteps(previewTemplate)" :key="i" class="preview-step">
@@ -291,6 +306,18 @@ const getCategoryClass = (cat: string) => ({
   community: cat === 'Community' || cat === 'community'
 })
 
+// Open preview - fetch full detail if steps are missing (#1415)
+const openPreview = async (template: AnyTemplate) => {
+  if (!('steps' in template) || !Array.isArray((template as any).steps)) {
+    const detail = await fetchTemplateDetail(template.id)
+    if (detail) {
+      previewTemplate.value = detail
+      return
+    }
+  }
+  previewTemplate.value = template
+}
+
 // Retry loading on error
 const retryLoad = async () => {
   await Promise.all([fetchTemplates(), fetchCategories()])
@@ -358,6 +385,17 @@ onMounted(async () => {
 .preview-agents { margin-bottom: 20px; }
 .agent-tags { display: flex; flex-wrap: wrap; gap: 6px; }
 .agent-tag { padding: 4px 10px; background: var(--color-primary-bg); color: var(--color-primary); border-radius: 12px; font-size: 12px; }
+
+.preview-secrets { margin-bottom: 20px; }
+.secret-items { display: flex; flex-direction: column; gap: 8px; }
+.secret-item { display: flex; align-items: center; gap: 10px; padding: 8px 12px; background: var(--bg-tertiary); border-radius: 8px; font-size: 13px; }
+.secret-item i { color: var(--text-tertiary); font-size: 12px; }
+.secret-info { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.secret-name { font-weight: 600; color: var(--text-primary); font-size: 12px; }
+.secret-desc { color: var(--text-tertiary); font-size: 11px; }
+.secret-scope { padding: 2px 6px; border-radius: 8px; font-size: 10px; background: var(--bg-secondary); color: var(--text-tertiary); }
+.secret-scope.write { background: var(--color-warning-bg); color: var(--color-warning); }
+.secret-scope.read { background: var(--color-success-bg); color: var(--color-success); }
 
 .preview-steps { display: flex; flex-direction: column; gap: 12px; }
 .preview-step { display: flex; gap: 12px; padding: 12px; background: var(--bg-tertiary); border-radius: 8px; }

--- a/autobot-frontend/src/types/workflowTemplates.ts
+++ b/autobot-frontend/src/types/workflowTemplates.ts
@@ -7,7 +7,7 @@
  * Issue #778 - Workflow Templates Enhancement
  */
 
-export type TemplateCategory = 'security' | 'research' | 'development' | 'system_admin' | 'analysis'
+export type TemplateCategory = 'security' | 'research' | 'development' | 'system_admin' | 'analysis' | 'community'
 export type TaskComplexity = 'simple' | 'moderate' | 'complex' | 'research' | 'security_scan' | 'install'
 export type RiskLevel = 'low' | 'medium' | 'high' | 'critical'
 
@@ -21,6 +21,12 @@ export interface TemplateStep {
   agent_type?: string
 }
 
+export interface SecretRequirement {
+  description: string
+  required: boolean
+  scope: string
+}
+
 export interface WorkflowTemplateSummary {
   id: string
   name: string
@@ -31,6 +37,9 @@ export interface WorkflowTemplateSummary {
   agents_involved: string[]
   tags: string[]
   icon?: string
+  step_count?: number
+  approval_steps?: number
+  required_secrets?: Record<string, SecretRequirement>
 }
 
 export interface WorkflowTemplateDetail extends WorkflowTemplateSummary {


### PR DESCRIPTION
## Summary
- **Community template descriptions**: Rewrote all 15 step descriptions across 3 community templates (Reddit Monitor & Reply, Community Digest Post, Release Announcement Blast) from technical `Community_Growth:` prefixes to user-friendly explanations of what AutoBot does at each step
- **Required secrets metadata**: Added `required_secrets` field to `WorkflowTemplate` dataclass and populated it for all 3 community templates (Reddit OAuth, Twitter, Discord webhooks, GitHub tokens)
- **Secrets usage API**: New `GET /api/templates/templates/secrets-usage` endpoint that maps credential keys to the templates that require them (impact analysis)
- **Gallery UI**: Added community category icon/color, step count from API summary data, and `openPreview()` that fetches full template detail for the preview panel
- **TypeScript types**: Added `SecretRequirement` interface, `community` category, `step_count`/`approval_steps`/`required_secrets` to `WorkflowTemplateSummary`

## Changed Files
- `autobot-backend/workflow_templates/types.py` — `required_secrets` field on `WorkflowTemplate`
- `autobot-backend/workflow_templates/community.py` — All 3 template definitions rewritten
- `autobot-backend/api/templates.py` — New `/templates/secrets-usage` endpoint
- `autobot-frontend/src/types/workflowTemplates.ts` — New types
- `autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue` — UI enhancements

## Test plan
- [ ] Verify community templates show user-friendly descriptions in gallery preview
- [ ] Verify community icon and green color appear in template cards
- [ ] Verify step counts display correctly from API summary
- [ ] Verify preview panel shows required credentials section
- [ ] Verify `/api/templates/templates/secrets-usage` returns correct usage map
- [ ] Verify SecretsManager shows "Used by" badges for credentials linked to templates

Closes #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)