### PR TITLE
fix(frontend): correct knowledge index endpoint in CodebaseAnalytics (#1421)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -4086,10 +4086,10 @@ async function addToKnowledgeBase() {
   knowledgeBaseAdding.value = true
   try {
     const backendUrl = await appConfig.getServiceUrl('backend')
-    const response = await fetchWithAuth(`${backendUrl}/api/knowledge/index`, {
+    const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/index`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ path: rootPath.value })
+      body: JSON.stringify({ root_path: rootPath.value })
     })
     if (!response.ok) {
       const text = await response.text()


### PR DESCRIPTION
## Summary
- Fixed `addToKnowledgeBase()` in CodebaseAnalytics.vue calling non-existent `POST /api/knowledge/index`
- Updated to call existing `POST /api/analytics/codebase/index` with `root_path` field matching `IndexCodebaseRequest`
- Confirmed `GET /api/debt/summary` and `GET /api/monitoring/status` already exist (issue description was partially incorrect)

## Test Plan
- [ ] Verify "Add to Knowledge Base" button in CodebaseAnalytics triggers indexing via `/api/analytics/codebase/index`
- [ ] Verify debt summary and monitoring status cards still load correctly

Closes #1421