### PR TITLE
feat(voice): language awareness in voice conversation pipeline (#1334)

### DIFF
--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -43,6 +43,15 @@
                 <option value="full-duplex">{{ $t('chat.voice.fullDuplex') }}</option>
               </select>
 
+              <!-- Language indicator (#1334) -->
+              <div
+                class="voice-overlay__lang-badge"
+                :title="$t('chat.voice.languageLabel')"
+              >
+                <i class="fas fa-globe"></i>
+                {{ voiceConversation.currentLanguage.value.toUpperCase() }}
+              </div>
+
               <!-- WS connection indicator (full-duplex only) -->
               <div
                 v-if="voiceConversation.mode.value === 'full-duplex'"
@@ -430,6 +439,26 @@ onBeforeUnmount(() => {
 
 .voice-overlay__mode-select option:disabled {
   color: rgba(148, 163, 184, 0.4);
+}
+
+/* Language badge (#1334) */
+.voice-overlay__lang-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.375rem;
+  background: rgba(37, 99, 235, 0.1);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  color: #93c5fd;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.voice-overlay__lang-badge i {
+  font-size: 0.625rem;
+  opacity: 0.7;
 }
 
 /* WS connection indicator (full-duplex) */

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -26,6 +26,15 @@
           <option value="full-duplex">{{ $t('chat.voice.fullDuplex') }}</option>
         </select>
 
+        <!-- Language indicator (#1334) -->
+        <div
+          class="voice-panel__lang-badge"
+          :title="$t('chat.voice.languageLabel')"
+        >
+          <i class="fas fa-globe"></i>
+          {{ voiceConversation.currentLanguage.value.toUpperCase() }}
+        </div>
+
         <!-- WS indicator (full-duplex) -->
         <div
           v-if="voiceConversation.mode.value === 'full-duplex'"
@@ -283,6 +292,25 @@ onBeforeUnmount(() => {
   color: var(--text-secondary, #94a3b8);
   font-size: 0.6875rem;
   cursor: pointer;
+}
+
+.voice-panel__lang-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.25rem;
+  background: rgba(37, 99, 235, 0.1);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  color: #93c5fd;
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.voice-panel__lang-badge i {
+  font-size: 0.5625rem;
+  opacity: 0.7;
 }
 
 .voice-panel__ws-dot {

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -15,7 +15,7 @@ import { useVoiceOutput } from '@/composables/useVoiceOutput'
 import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
 import { useChatController } from '@/models/controllers'
 import { useChatStore } from '@/stores/useChatStore'
-import { useUserStore } from '@/stores/useUserStore'
+import { usePreferences } from '@/composables/usePreferences'
 import { getBackendWsUrl } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
@@ -270,7 +270,7 @@ function _handleBargeIn(): void {
   _startListeningInternal()
 }
 
-// ─── Language helper (#1329) ─────────────────────────────
+// ─── Language helper (#1329, #1334) ──────────────────────
 
 /** Map short language codes to BCP-47 tags for browser SpeechRecognition. */
 const _LANG_TO_BCP47: Record<string, string> = {
@@ -282,15 +282,21 @@ const _LANG_TO_BCP47: Record<string, string> = {
   lt: 'lt-LT', et: 'et-EE', uk: 'uk-UA', tr: 'tr-TR',
 }
 
+/** Current language code exposed for UI indicators (#1334). */
+const currentLanguage = ref('en')
+
 function _getSttLanguage(): string {
-  const store = useUserStore()
-  const lang = store.preferences.language || 'en'
+  const { language } = usePreferences()
+  const lang = language.value || 'en'
+  currentLanguage.value = lang
   return _LANG_TO_BCP47[lang] || lang
 }
 
 function _getShortLanguage(): string {
-  const store = useUserStore()
-  return store.preferences.language || 'en'
+  const { language } = usePreferences()
+  const lang = language.value || 'en'
+  currentLanguage.value = lang
+  return lang
 }
 
 // ─── Whisper fallback for airgapped mode (#1329) ────────
@@ -515,7 +521,11 @@ function _dispatchTranscript(text: string): void {
     timestamp: Date.now(),
   })
 
-  controller.sendMessage(text, { use_knowledge: false }).then(() => {
+  const lang = _getShortLanguage()
+  controller.sendMessage(text, {
+    use_knowledge: false,
+    language: lang,
+  }).then(() => {
     const session = store.sessions.find(
       (s) => s.id === store.currentSessionId,
     )
@@ -740,6 +750,7 @@ export function useVoiceConversation() {
     state.value = 'idle'
     bubbles.value = []
     errorMessage.value = ''
+    currentLanguage.value = _getShortLanguage()
     unlockAudio()
 
     if (mode.value === 'full-duplex') {
@@ -838,6 +849,17 @@ export function useVoiceConversation() {
     }
   })
 
+  // #1334: Update STT language when preference changes mid-conversation
+  const { language: prefLanguage } = usePreferences()
+  watch(prefLanguage, (newLang) => {
+    currentLanguage.value = newLang || 'en'
+    if (_recognition && state.value === 'listening') {
+      const bcp47 = _LANG_TO_BCP47[newLang] || newLang
+      _recognition.lang = bcp47
+    }
+    logger.debug('Language preference changed:', newLang)
+  })
+
   function cleanup(): void {
     deactivate()
   }
@@ -846,6 +868,7 @@ export function useVoiceConversation() {
     state,
     mode,
     currentTranscript,
+    currentLanguage,
     bubbles,
     isActive,
     errorMessage,

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -12,6 +12,7 @@ import { ref } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
+import { usePreferences } from '@/composables/usePreferences'
 import { getBackendWsUrl } from '@/config/ssot-config'
 
 const logger = createLogger('useVoiceOutput')
@@ -211,7 +212,8 @@ export function useVoiceOutput() {
 
     try {
       const { effectiveVoiceId } = useVoiceProfiles()
-      const language = localStorage.getItem('autobot-language') || ''
+      const { language: prefLang } = usePreferences()
+      const language = prefLang.value || ''
       const formData = new FormData()
       formData.append('text', text)
       if (effectiveVoiceId.value) {
@@ -254,7 +256,8 @@ export function useVoiceOutput() {
     try {
       const ws = await _connectTtsWs()
       const { effectiveVoiceId } = useVoiceProfiles()
-      const language = localStorage.getItem('autobot-language') || ''
+      const { language: prefLang } = usePreferences()
+      const language = prefLang.value || ''
       ws.send(JSON.stringify({
         type: 'speak_sentence',
         text: text.trim(),

--- a/autobot-frontend/src/composables/useVoiceProfiles.ts
+++ b/autobot-frontend/src/composables/useVoiceProfiles.ts
@@ -9,6 +9,7 @@
 
 import { ref, computed } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { usePreferences } from '@/composables/usePreferences'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useVoiceProfiles')
@@ -38,7 +39,8 @@ const effectiveVoiceId = computed<string>(() => {
   // 1. voice_ids[current_language] (language-specific)
   // 2. voice_id (profile default, backward compatible)
   // 3. User-selected voice (selectedVoiceId)
-  const lang = localStorage.getItem('autobot-language') || 'en'
+  const { language } = usePreferences()
+  const lang = language.value || 'en'
   const langVoice = personalityVoiceIds.value[lang]
   if (langVoice) return langVoice
   if (personalityVoiceId.value) return personalityVoiceId.value

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -508,6 +508,7 @@
       "fullDuplex": "Full-duplex",
       "connected": "Connected",
       "disconnected": "Disconnected",
+      "languageLabel": "Voice language",
       "closeVoiceChat": "Close voice chat",
       "closeVoicePanel": "Close voice panel",
       "tapMicToStart": "Tap the mic to start a conversation",


### PR DESCRIPTION
## Summary
- Use `usePreferences()` composable for language across all voice composables (`useVoiceConversation`, `useVoiceOutput`, `useVoiceProfiles`) instead of raw `localStorage.getItem('autobot-language')`
- Pass language parameter to chat API when dispatching voice transcripts
- Expose reactive `currentLanguage` ref and watch for mid-conversation language changes (updates STT on the fly)
- Add language indicator badge (globe icon + language code) to both `VoiceConversationOverlay` and `VoiceConversationPanel` headers

## Test Plan
- [ ] Start a voice conversation — language badge shows current language code (e.g. EN)
- [ ] Change language in Settings — badge updates, next voice interaction uses new language
- [ ] Test STT in non-English language (e.g. German) — transcription works correctly
- [ ] Test TTS in non-English language — response is spoken in correct language
- [ ] Verify English still works identically (no regressions)
- [ ] Verify both overlay (modal) and side panel display the language badge

Closes #1334

🤖 Generated with [Claude Code](https://claude.com/claude-code)