### PR TITLE
fix(approval): add auth, input validation, and security hardening (#1402)

### DIFF
--- a/autobot-backend/api/approval_gates.py
+++ b/autobot-backend/api/approval_gates.py
@@ -9,10 +9,13 @@ CRUD and lifecycle endpoints for human-in-the-loop approval gates.
 
 import logging
 import uuid
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from api.user_management.dependencies import get_db_session
-from fastapi import APIRouter, Depends, HTTPException, status
+from auth_middleware import get_current_user
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from models.approval import ApprovalStatus, ApprovalType
 from pydantic import BaseModel, Field
 from services.approval_gate_service import ApprovalGateService
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,11 +27,19 @@ router = APIRouter()
 # -- Request / Response schemas ----------------------------------------
 
 
+class AuthorTypeEnum(str, Enum):
+    """Valid author types for comments."""
+
+    HUMAN = "human"
+    AGENT = "agent"
+    SYSTEM = "system"
+
+
 class CreateApprovalRequest(BaseModel):
     """Request body for creating an approval gate."""
 
     title: str
-    approval_type: str
+    approval_type: ApprovalType
     description: Optional[str] = None
     requested_by_agent: Optional[str] = None
     workflow_id: Optional[str] = None
@@ -40,7 +51,6 @@ class CreateApprovalRequest(BaseModel):
 class TransitionRequest(BaseModel):
     """Request body for approve / reject / request-revision."""
 
-    decided_by: str
     comment: Optional[str] = None
 
 
@@ -54,9 +64,8 @@ class ResubmitRequest(BaseModel):
 class AddCommentRequest(BaseModel):
     """Request body for adding a comment."""
 
-    author: str
     body: str
-    author_type: str = "human"
+    author_type: AuthorTypeEnum = AuthorTypeEnum.HUMAN
 
 
 class LinkTaskRequest(BaseModel):
@@ -172,13 +181,14 @@ def _to_response(approval) -> ApprovalResponse:
 )
 async def create_approval(
     body: CreateApprovalRequest,
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """Create a new approval gate request (#1402)."""
     svc = ApprovalGateService(session)
     approval = await svc.create_approval(
         title=body.title,
-        approval_type=body.approval_type,
+        approval_type=body.approval_type.value,
         description=body.description,
         requested_by_agent=body.requested_by_agent,
         workflow_id=body.workflow_id,
@@ -194,19 +204,20 @@ async def create_approval(
     response_model=List[ApprovalResponse],
 )
 async def list_approvals(
-    status_filter: Optional[str] = None,
-    approval_type: Optional[str] = None,
+    status_filter: Optional[ApprovalStatus] = None,
+    approval_type: Optional[ApprovalType] = None,
     workflow_id: Optional[str] = None,
     agent_id: Optional[str] = None,
-    limit: int = 50,
-    offset: int = 0,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """List approval gates with optional filters (#1402)."""
     svc = ApprovalGateService(session)
     approvals = await svc.list_approvals(
-        status=status_filter,
-        approval_type=approval_type,
+        status=status_filter.value if status_filter else None,
+        approval_type=approval_type.value if approval_type else None,
         workflow_id=workflow_id,
         agent_id=agent_id,
         limit=limit,
@@ -221,6 +232,7 @@ async def list_approvals(
 )
 async def get_approval(
     approval_id: uuid.UUID,
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """Get a single approval gate by ID (#1402)."""
@@ -241,14 +253,16 @@ async def get_approval(
 async def approve(
     approval_id: uuid.UUID,
     body: TransitionRequest,
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """Approve a pending approval gate (#1402)."""
     svc = ApprovalGateService(session)
+    username = current_user.get("username", "unknown")
     try:
         approval = await svc.approve(
             approval_id,
-            body.decided_by,
+            username,
             body.comment,
         )
     except ValueError as e:
@@ -266,14 +280,16 @@ async def approve(
 async def reject(
     approval_id: uuid.UUID,
     body: TransitionRequest,
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """Reject a pending approval gate (#1402)."""
     svc = ApprovalGateService(session)
+    username = current_user.get("username", "unknown")
     try:
         approval = await svc.reject(
             approval_id,
-            body.decided_by,
+            username,
             body.comment,
         )
     except ValueError as e:
@@ -291,14 +307,16 @@ async def reject(
 async def request_revision(
     approval_id: uuid.UUID,
     body: TransitionRequest,
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """Request revision on a pending approval gate (#1402)."""
     svc = ApprovalGateService(session)
+    username = current_user.get("username", "unknown")
     try:
         approval = await svc.request_revision(
             approval_id,
-            body.decided_by,
+            username,
             body.comment,
         )
     except ValueError as e:
@@ -316,6 +334,7 @@ async def request_revision(
 async def resubmit(
     approval_id: uuid.UUID,
     body: ResubmitRequest,
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """Resubmit an approval after revision request (#1402)."""
@@ -342,16 +361,18 @@ async def resubmit(
 async def add_comment(
     approval_id: uuid.UUID,
     body: AddCommentRequest,
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """Add a comment to an approval gate (#1402)."""
     svc = ApprovalGateService(session)
+    username = current_user.get("username", "unknown")
     try:
         comment = await svc.add_comment(
             approval_id,
-            body.author,
+            username,
             body.body,
-            body.author_type,
+            body.author_type.value,
         )
     except ValueError as e:
         raise HTTPException(
@@ -376,6 +397,7 @@ async def add_comment(
 async def link_task(
     approval_id: uuid.UUID,
     body: LinkTaskRequest,
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """Link a task/issue to an approval gate (#1402)."""
@@ -406,6 +428,7 @@ async def link_task(
 async def unlink_task(
     approval_id: uuid.UUID,
     task_id: str,
+    current_user: dict = Depends(get_current_user),
     session: AsyncSession = Depends(get_db_session),
 ):
     """Unlink a task from an approval gate (#1402)."""

--- a/autobot-backend/services/approval_gate_service.py
+++ b/autobot-backend/services/approval_gate_service.py
@@ -11,7 +11,7 @@ notifications for pending approvals.
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Dict, List, Optional
 
 from models.approval import Approval, ApprovalComment, ApprovalStatus, TaskApprovalLink
@@ -20,6 +20,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 logger = logging.getLogger(__name__)
+
+# Valid state transitions: source -> {allowed targets}
+_VALID_TRANSITIONS = {
+    ApprovalStatus.PENDING.value: {
+        ApprovalStatus.APPROVED.value,
+        ApprovalStatus.REJECTED.value,
+        ApprovalStatus.REVISION_REQUESTED.value,
+    },
+    ApprovalStatus.REVISION_REQUESTED.value: {
+        ApprovalStatus.APPROVED.value,
+        ApprovalStatus.REJECTED.value,
+    },
+}
 
 
 class ApprovalGateService:
@@ -270,8 +283,15 @@ class ApprovalGateService:
         self,
         approval_id: uuid.UUID,
     ) -> Approval:
-        """Load approval or raise ValueError."""
-        stmt = select(Approval).where(Approval.id == approval_id)
+        """Load approval with relationships or raise ValueError."""
+        stmt = (
+            select(Approval)
+            .options(
+                selectinload(Approval.comments),
+                selectinload(Approval.task_links),
+            )
+            .where(Approval.id == approval_id)
+        )
         result = await self.session.execute(stmt)
         approval = result.scalar_one_or_none()
         if approval is None:
@@ -288,17 +308,15 @@ class ApprovalGateService:
         """Perform a status transition with validation."""
         approval = await self._get_or_raise(approval_id)
 
-        if approval.status not in (
-            ApprovalStatus.PENDING.value,
-            ApprovalStatus.REVISION_REQUESTED.value,
-        ):
+        allowed = _VALID_TRANSITIONS.get(approval.status, set())
+        if new_status.value not in allowed:
             raise ValueError(
                 f"Cannot transition from {approval.status} " f"to {new_status.value}"
             )
 
         approval.status = new_status.value
         approval.decided_by_user = decided_by
-        approval.decided_at = datetime.utcnow()
+        approval.decided_at = datetime.now(UTC)
 
         if comment:
             c = ApprovalComment(

--- a/autobot-frontend/src/components/workflow/ApprovalGatePanel.vue
+++ b/autobot-frontend/src/components/workflow/ApprovalGatePanel.vue
@@ -213,8 +213,6 @@ const typeFilter = ref('')
 const activeCommentId = ref<string | null>(null)
 const commentText = ref('')
 
-const currentUser = 'web_user'
-
 async function refresh() {
   await fetchApprovals({
     status: statusFilter.value || undefined,
@@ -223,17 +221,17 @@ async function refresh() {
 }
 
 async function handleApprove(id: string) {
-  await doApprove(id, currentUser)
+  await doApprove(id)
   await refresh()
 }
 
 async function handleReject(id: string) {
-  await doReject(id, currentUser)
+  await doReject(id)
   await refresh()
 }
 
 async function handleRequestRevision(id: string) {
-  await doRequestRevision(id, currentUser)
+  await doRequestRevision(id)
   await refresh()
 }
 
@@ -249,7 +247,7 @@ function cancelComment() {
 
 async function submitComment(approvalId: string) {
   if (!commentText.value.trim()) return
-  await doAddComment(approvalId, currentUser, commentText.value)
+  await doAddComment(approvalId, commentText.value)
   cancelComment()
   await refresh()
 }

--- a/autobot-frontend/src/composables/useApprovalGates.ts
+++ b/autobot-frontend/src/composables/useApprovalGates.ts
@@ -172,13 +172,12 @@ export function useApprovalGates() {
 
   async function approve(
     id: string,
-    decidedBy: string,
     comment?: string
   ): Promise<Approval | null> {
     try {
       const result = await apiPost<Approval>(
         `/api/approval-gates/${id}/approve`,
-        { decided_by: decidedBy, comment }
+        { comment }
       )
       _updateLocal(result)
       return result
@@ -191,13 +190,12 @@ export function useApprovalGates() {
 
   async function reject(
     id: string,
-    decidedBy: string,
     comment?: string
   ): Promise<Approval | null> {
     try {
       const result = await apiPost<Approval>(
         `/api/approval-gates/${id}/reject`,
-        { decided_by: decidedBy, comment }
+        { comment }
       )
       _updateLocal(result)
       return result
@@ -210,13 +208,12 @@ export function useApprovalGates() {
 
   async function requestRevision(
     id: string,
-    decidedBy: string,
     comment?: string
   ): Promise<Approval | null> {
     try {
       const result = await apiPost<Approval>(
         `/api/approval-gates/${id}/request-revision`,
-        { decided_by: decidedBy, comment }
+        { comment }
       )
       _updateLocal(result)
       return result
@@ -250,14 +247,13 @@ export function useApprovalGates() {
 
   async function addComment(
     approvalId: string,
-    author: string,
     body: string,
     authorType = 'human'
   ): Promise<ApprovalComment | null> {
     try {
       return await apiPost<ApprovalComment>(
         `/api/approval-gates/${approvalId}/comments`,
-        { author, body, author_type: authorType }
+        { body, author_type: authorType }
       )
     } catch (e) {
       logger.error('Failed to add comment:', e)


### PR DESCRIPTION
## Summary
- Add `get_current_user` auth dependency to all approval gate endpoints (prevents unauthenticated access)
- Remove client-supplied `decided_by`/`author` fields — derive identity from JWT token (prevents identity spoofing)
- Add Pydantic enum validation for `approval_type` and `author_type`, pagination bounds via `Query(ge=, le=)`
- Replace deprecated `datetime.utcnow()` with `datetime.now(UTC)` (Python 3.12)
- Add explicit state transition map (`_VALID_TRANSITIONS`) instead of ad-hoc status checks
- Add `selectinload()` for relationships to prevent MissingGreenlet in async context
- Update frontend composable and component to match new API contract (no client-side user params)

## Context
Security fixes identified during code review of PR #1437 (approval gates feature). Cherry-picked from `feat/1402-approval-gates` commit `f5fe6906`.

Closes #1402

## Test plan
- [ ] Verify all approval endpoints require valid JWT (401 without token)
- [ ] Verify `decided_by` is derived from token, not request body
- [ ] Verify invalid `approval_type` values are rejected with 422
- [ ] Verify state transitions follow `_VALID_TRANSITIONS` map
- [ ] Verify frontend approve/reject/comment flows still work without passing user

🤖 Generated with [Claude Code](https://claude.com/claude-code)