### PR TITLE
build(deps): bump cryptography 46.0.5 and pillow 12.1.1

### DIFF
--- a/autobot-infrastructure/shared/config/requirements.txt
+++ b/autobot-infrastructure/shared/config/requirements.txt
@@ -72,7 +72,7 @@ scipy>=1.11.0                    # Scientific computing for audio processing
 # ===== GUI & AUTOMATION =====
 pyautogui==0.9.54
 mouseinfo==0.1.3
-pillow>=10.0.0
+pillow>=12.1.1
 numpy>=1.21.0,<1.25.0
 opencv-python>=4.8.0             # Computer vision for GUI automation
 pygetwindow>=0.0.9               # Window management
@@ -97,7 +97,7 @@ llama-index-readers-file>=0.5.6   # File readers for RAG - Pin to v0.5.6+ for py
 pre-commit>=3.6.0
 detect-secrets>=1.4.0
 pycryptodome>=3.19.0              # Encryption for secure agent communication
-cryptography>=45.0.6             # Additional crypto support - SECURITY UPDATE
+cryptography>=46.0.5             # Additional crypto support - SECURITY UPDATE
 pyjwt>=2.8.0                     # JWT token authentication
 bcrypt>=4.0.0                    # Password hashing
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -50,7 +50,7 @@ nltk==3.9.3
 # ===== GUI & AUTOMATION =====
 pyautogui==0.9.54
 mouseinfo==0.1.3
-pillow==11.3.0
+pillow==12.1.1
 numpy==1.26.4
 opencv-python==4.11.0.86
 pygetwindow==0.0.9
@@ -73,7 +73,7 @@ llama-index-vector-stores-redis==0.5.2
 pre-commit==4.2.0
 detect-secrets==1.5.0
 pycryptodome==3.23.0
-cryptography==45.0.4
+cryptography==46.0.5
 
 # ===== MONITORING =====
 prometheus-client==0.20.0


### PR DESCRIPTION
## Summary
- Bumps cryptography from 45.0.4 to 46.0.5
- Bumps pillow from 11.3.0 to 12.1.1 (CI pin) / >=12.1.1 (infrastructure floor)

Safe subset cherry-picked from Dependabot PR #1435 (closed due to breaking langchain-core 0.3->1.2, starlette/FastAPI mismatch, and llama-index-core incompatibility).

## Test plan
- [ ] CI passes
- [ ] Backend starts successfully
- [ ] Image processing features work (pillow)
- [ ] TLS/crypto operations work (cryptography)