### PR TITLE
security(deps): replace python-jose with PyJWT (#1575)

### DIFF
--- a/autobot-infrastructure/shared/scripts/install-slm.sh
+++ b/autobot-infrastructure/shared/scripts/install-slm.sh
@@ -385,7 +385,7 @@ setup_slm_backend() {
             aiosqlite \
             pydantic \
             pydantic-settings \
-            python-jose[cryptography] \
+            PyJWT[crypto] \
             passlib[bcrypt] \
             aiofiles \
             ansible-runner \

--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -24,7 +24,7 @@ pydantic-settings>=2.1.0
 typing_extensions>=4.0.0  # For Python 3.8 compatibility
 
 # Authentication
-python-jose[cryptography]>=3.3.0
+PyJWT[crypto]>=2.8.0
 passlib[bcrypt]>=1.7.4
 bcrypt>=4.0.0,<5.0.0  # bcrypt 5.0.0 incompatible with passlib
 python-multipart>=0.0.22          # SECURITY UPDATE - arbitrary file write fix

--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -11,16 +11,16 @@ import logging
 from datetime import datetime, timedelta
 from typing import Optional
 
+import jwt
+from config import settings
 from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
+from jwt.exceptions import InvalidTokenError
 from models.database import User
 from models.schemas import TokenResponse, UserCreate, UserResponse
 from passlib.context import CryptContext
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class AuthService:
                 token, settings.secret_key, algorithms=[self.algorithm]
             )
             return payload
-        except JWTError as e:
+        except InvalidTokenError as e:
             logger.warning("JWT decode error: %s", e)
             return None
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -70,7 +70,7 @@ Key packages:
 - asyncpg (0.29+)
 - redis (5.0+)
 - pydantic (2.5+)
-- python-jose[cryptography]
+- PyJWT[crypto]
 - passlib[bcrypt]
 - python-multipart
 - aiohttp
@@ -329,7 +329,7 @@ python3 -m playwright install webkit
 # See autobot-shared/requirements.txt
 redis>=5.0.0
 pydantic>=2.5.0
-python-jose[cryptography]>=3.3.0
+PyJWT[crypto]>=2.8.0
 passlib[bcrypt]>=1.7.4
 ```
 
@@ -361,7 +361,7 @@ sqlalchemy>=2.0.0
 asyncpg>=0.29.0
 redis>=5.0.0
 pydantic>=2.5.0
-python-jose[cryptography]>=3.3.0
+PyJWT[crypto]>=2.8.0
 passlib[bcrypt]>=1.7.4
 python-multipart>=0.0.6
 aiohttp>=3.9.0


### PR DESCRIPTION
## Summary

- Replaces `python-jose[cryptography]` with `PyJWT[crypto]` to eliminate the `python-ecdsa` transitive dependency which has a Minerva timing attack vulnerability (Dependabot alert #276, no upstream patch)
- Updates SLM backend auth service: `from jose import JWTError, jwt` → `import jwt` + `InvalidTokenError`
- Updates install script and dependency documentation

## Files Changed

| File | Change |
|------|--------|
| `autobot-slm-backend/requirements.txt` | `python-jose[cryptography]>=3.3.0` → `PyJWT[crypto]>=2.8.0` |
| `autobot-slm-backend/services/auth.py` | Import swap + exception class rename |
| `autobot-infrastructure/shared/scripts/install-slm.sh` | Updated pip install list |
| `docs/DEPENDENCIES.md` | Updated all references |

## API Compatibility

PyJWT and python-jose share the same `jwt.encode()` / `jwt.decode()` API surface. The only change is the exception class: `JWTError` → `InvalidTokenError` (from `jwt.exceptions`).

## Test Plan

- [ ] Verify SLM backend starts successfully on .19
- [ ] Verify JWT login: `curl -X POST https://<slm>/api/auth/login -d '{"username":"admin","password":"..."}' | jq .access_token`
- [ ] Verify token-protected endpoints work with the returned token
- [ ] Verify invalid/expired tokens are properly rejected

Closes #1575