### PR TITLE
chore(docs): document subagent Bash permission constraints (#1580)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,6 +409,13 @@ Each session stays in its issue scope. If Session A discovers a bug in Session B
 - Analysis: `code-skeptic`, `systems-architect`, `performance-engineer`, `security-auditor`, `ai-ml-engineer`
 - Planning: `project-task-planner`, `project-manager`
 
+**Subagent Bash Permission Constraint:**
+Dispatched subagents cannot autonomously acquire Bash tool permission. This means:
+- Bulk operations requiring Python scripts (e.g., i18n batch translation) must run in the main session
+- Git operations (commit, push, PR creation) from subagents require pre-authorized Bash access
+- Workaround: run batch file-manipulation and git work directly in the main session, not via subagents
+- JSON validation, file writes via MCP tools still work — only shell execution is blocked
+
 ### GitHub Workflow
 
 **Commit format:** `<type>(scope): <description> (#issue-number)`


### PR DESCRIPTION
## Summary
- Documents that dispatched subagents cannot autonomously acquire Bash tool permission
- Notes that bulk i18n/translation and git operations must run in the main session
- Added concise subsection under Agent Delegation in CLAUDE.md

Closes #1580

## Test plan
- [x] CLAUDE.md updated with subagent constraint documentation
- [x] Section placed logically under Agent Delegation guidance
- [x] Pre-commit hooks pass