### PR TITLE
fix(deploy): install pip/npm deps during code-sync (#1603)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -14,6 +14,7 @@
 #
 # Tags:
 #   restart              - all service restart tasks (skip for code-only deploys)
+#   deps                 - pip install / npm ci tasks (skip for code-only deploys) (#1603)
 #   backend              - autobot-backend deploy + restart tasks
 #   frontend             - autobot-frontend deploy + build + nginx restart tasks
 #   npu, npu-worker      - NPU worker deploy + restart tasks
@@ -113,6 +114,44 @@
       debug:
         msg: "7 deploy archives created from {{ deploy_ref }} ({{ deploy_info.stdout }})"
 
+    # --- Dependency change detection (#1603) ---
+    - name: "[PRE-FLIGHT] Get previous commit (before pull)"
+      command: >-
+        git -C {{ git_repo_root }} rev-parse HEAD~1
+      register: prev_commit
+      changed_when: false
+      failed_when: false
+
+    - name: "[PRE-FLIGHT] Check if Python deps changed"
+      shell: >-
+        git -C {{ git_repo_root }} diff --name-only
+        {{ prev_commit.stdout | default('HEAD') }} HEAD
+        -- '*/requirements.txt' 'autobot-shared/setup.py' 'autobot-shared/pyproject.toml'
+      register: python_deps_diff
+      changed_when: false
+      failed_when: false
+
+    - name: "[PRE-FLIGHT] Check if Node.js deps changed"
+      shell: >-
+        git -C {{ git_repo_root }} diff --name-only
+        {{ prev_commit.stdout | default('HEAD') }} HEAD
+        -- '*/package.json' '*/package-lock.json'
+      register: node_deps_diff
+      changed_when: false
+      failed_when: false
+
+    - name: "[PRE-FLIGHT] Set dependency change flags"
+      set_fact:
+        python_deps_changed: "{{ python_deps_diff.stdout | default('') | length > 0 }}"
+        node_deps_changed: "{{ node_deps_diff.stdout | default('') | length > 0 }}"
+
+    - name: "[PRE-FLIGHT] Display dependency change status"
+      debug:
+        msg:
+          - "  Python deps changed: {{ python_deps_changed }}"
+          - "  Node.js deps changed: {{ node_deps_changed }}"
+          - "  Changed files: {{ (python_deps_diff.stdout_lines | default([])) + (node_deps_diff.stdout_lines | default([])) }}"
+
     - name: "[PRE-FLIGHT] Get full commit hash"
       command: git -C {{ git_repo_root }} log -1 --format='%H'
       register: deploy_commit_full
@@ -192,6 +231,28 @@
         - autobot-slm-frontend
         - autobot-shared
       tags: [slm]
+
+    # --- Dependency install (#1603) ---
+    - name: "[PLAY 1] SLM | Install Python dependencies"
+      command:
+        cmd: /opt/autobot/autobot-slm-backend/venv/bin/pip install
+             -r /opt/autobot/autobot-slm-backend/requirements.txt
+             --quiet
+      become: true
+      become_user: autobot
+      when: hostvars['localhost']['python_deps_changed'] | bool
+      register: slm_pip_install
+      tags: [slm, slm-backend, deps]
+
+    - name: "[PLAY 1] SLM | Install Node.js dependencies"
+      command:
+        cmd: npm ci --ignore-scripts
+        chdir: /opt/autobot/autobot-slm-frontend
+      become: true
+      become_user: autobot
+      when: hostvars['localhost']['node_deps_changed'] | bool
+      register: slm_npm_install
+      tags: [slm, slm-frontend, deps]
 
     - name: "[PLAY 1] SLM | Rebuild frontend production build"
       command:
@@ -340,6 +401,19 @@
       when: "'01-Backend' in inventory_hostname"
       tags: [backend]
 
+    - name: "[PLAY 2] Backend | Install Python dependencies"
+      command:
+        cmd: /opt/autobot/autobot-backend/venv/bin/pip install
+             -r /opt/autobot/autobot-backend/requirements.txt
+             --quiet
+      become: true
+      become_user: autobot
+      when:
+        - "'01-Backend' in inventory_hostname"
+        - hostvars['localhost']['python_deps_changed'] | bool
+      register: backend_pip_install
+      tags: [backend, deps]
+
     - name: "[PLAY 2] Backend | Restart service"
       systemd:
         name: autobot-backend
@@ -380,6 +454,18 @@
       become: true
       when: "'02-Frontend' in inventory_hostname"
       tags: [frontend]
+
+    - name: "[PLAY 2] Frontend | Install Node.js dependencies"
+      command:
+        cmd: npm ci --ignore-scripts
+        chdir: /opt/autobot/autobot-frontend
+      become: true
+      become_user: autobot
+      when:
+        - "'02-Frontend' in inventory_hostname"
+        - hostvars['localhost']['node_deps_changed'] | bool
+      register: frontend_npm_install
+      tags: [frontend, deps]
 
     - name: "[PLAY 2] Frontend | Rebuild production dist"
       command:
@@ -432,6 +518,21 @@
         'npu-worker' in inventory_hostname
       tags: [npu, npu-worker]
 
+    - name: "[PLAY 2] NPU | Install Python dependencies"
+      command:
+        cmd: /opt/autobot/autobot-npu-worker/venv/bin/pip install
+             -r /opt/autobot/autobot-npu-worker/requirements.txt
+             --quiet
+      become: true
+      become_user: autobot
+      when:
+        - >-
+          '03-NPU' in inventory_hostname or
+          'npu-worker' in inventory_hostname
+        - hostvars['localhost']['python_deps_changed'] | bool
+      register: npu_pip_install
+      tags: [npu, npu-worker, deps]
+
     - name: "[PLAY 2] NPU | Restart service"
       systemd:
         name: autobot-npu-worker
@@ -473,6 +574,22 @@
         '05-Browser' in inventory_hostname or
         'browser-automation' in inventory_hostname
       tags: [browser, browser-worker]
+
+    - name: "[PLAY 2] Browser | Install Python dependencies"
+      command:
+        cmd: /opt/autobot/autobot-browser-worker/venv/bin/pip install
+             -r /opt/autobot/autobot-browser-worker/requirements.txt
+             --quiet
+      become: true
+      become_user: autobot
+      when:
+        - >-
+          '05-Browser' in inventory_hostname or
+          'browser-automation' in inventory_hostname
+        - hostvars['localhost']['python_deps_changed'] | bool
+      register: browser_pip_install
+      failed_when: false
+      tags: [browser, browser-worker, deps]
 
     - name: "[PLAY 2] Browser | Restart service"
       systemd:

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
-from config import settings
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse
 from models.database import (
@@ -56,6 +55,8 @@ from services.sync_orchestrator import get_sync_orchestrator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
+
+from config import settings
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/code-sync", tags=["code-sync"])
@@ -367,6 +368,40 @@ async def _restart_slm_service(service: str) -> None:
         logger.warning("Failed to restart %s: %s", service, exc)
 
 
+async def _install_slm_pip_dependencies() -> None:
+    """Install Python dependencies from requirements.txt into the SLM venv.
+
+    Runs unconditionally after rsync — pip is fast when nothing changed (#1603).
+    """
+    req_path = "/opt/autobot/autobot-slm-backend/requirements.txt"
+    pip_bin = "/opt/autobot/autobot-slm-backend/venv/bin/pip"
+
+    if not Path(req_path).exists():
+        logger.debug("No requirements.txt at %s — skipping pip install", req_path)
+        return
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            pip_bin,
+            "install",
+            "-r",
+            req_path,
+            "--quiet",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300.0)
+        if proc.returncode == 0:
+            logger.info("SLM pip install completed successfully")
+        else:
+            output = stdout.decode(errors="replace")[:500] if stdout else ""
+            logger.error("SLM pip install failed (rc=%d): %s", proc.returncode, output)
+    except asyncio.TimeoutError:
+        logger.error("SLM pip install timed out after 300s")
+    except Exception as exc:
+        logger.error("SLM pip install error: %s", exc)
+
+
 async def _fetch_code_source_connection_info(
     db_service,
 ) -> Optional[Tuple[str, str, str]]:
@@ -493,6 +528,9 @@ async def _sync_slm_from_code_source(node_id: str) -> None:
     if not all_ok:
         logger.error("SLM self-sync had failures; services NOT restarted")
         return
+
+    # --- Phase 2b: install Python dependencies if requirements.txt changed (#1603) ---
+    await _install_slm_pip_dependencies()
 
     # --- Phase 3: mark up-to-date in DB before restarting (#1209) ---
     await _mark_slm_node_up_to_date(db_service, node_id)


### PR DESCRIPTION
## Summary

- Add dependency change detection to `update-all-nodes.yml` (Play 0): diffs `requirements.txt` / `package.json` between old and new commit
- Add `pip install -r requirements.txt` tasks for SLM (.19), Backend (.20), NPU (.22), Browser (.25) — only when Python deps changed
- Add `npm ci` tasks for SLM Frontend (.19) and User Frontend (.21) — only when Node deps changed  
- Add `_install_slm_pip_dependencies()` to the SLM self-sync fire-and-forget path in `code_sync.py`
- New `deps` tag allows `--skip-tags deps` for code-only deploys

## Context

PR #1590 (`python-jose` → `PyJWT`) broke the SLM backend on .19 because code was synced but `PyJWT` was never installed. The backend crash-looped 128+ times before manual discovery.

## Test Plan

- [ ] Deploy with a `requirements.txt` change — verify `pip install` runs on affected nodes
- [ ] Deploy without dependency changes — verify `pip install` is skipped (conditional on diff)
- [ ] Test `--skip-tags deps` to confirm dependency install can be bypassed
- [ ] Trigger SLM self-sync via UI — verify pip install runs before restart
- [ ] Deploy with `package.json` change — verify `npm ci` runs on frontend nodes

Closes #1603