### PR TITLE
feat(slm): detect crash-looping services and degrade node status (#1604)

### DIFF
--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -248,6 +248,7 @@ class ServiceStatus(str, enum.Enum):
     RUNNING = "running"
     STOPPED = "stopped"
     FAILED = "failed"
+    CRASH_LOOP = "crash-loop"  # Issue #1604: activating/auto-restart
     UNKNOWN = "unknown"
 
 

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -16,7 +16,6 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
-from config import settings
 from models.database import (
     Deployment,
     DeploymentStatus,
@@ -33,6 +32,8 @@ from models.database import (
 from services.service_categorizer import categorize_service
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -1233,7 +1234,7 @@ class ReconcilerService:
 
         old_status = node.status
         new_status = self._calculate_node_status(
-            cpu_percent, memory_percent, disk_percent
+            cpu_percent, memory_percent, disk_percent, extra_data
         )
 
         await self._handle_node_status_change(
@@ -1402,15 +1403,35 @@ class ReconcilerService:
         # Note: commit happens in the calling method (update_node_heartbeat)
 
     def _calculate_node_status(
-        self, cpu_percent: float, memory_percent: float, disk_percent: float
+        self,
+        cpu_percent: float,
+        memory_percent: float,
+        disk_percent: float,
+        extra_data: Optional[dict] = None,
     ) -> str:
-        """Calculate node status based on health metrics."""
+        """Calculate node status based on health metrics and services.
+
+        Issue #1604: Also degrade if any autobot service is crash-looping.
+        """
         if cpu_percent > 95 or memory_percent > 95 or disk_percent > 95:
             return NodeStatus.ERROR.value
-        elif cpu_percent > 80 or memory_percent > 80 or disk_percent > 80:
+
+        # Issue #1604: Check for crash-looping services
+        if extra_data:
+            for svc in extra_data.get("discovered_services", []):
+                svc_name = svc.get("name", "")
+                if not svc_name.startswith("autobot"):
+                    continue
+                if svc.get("status") == "crash-loop":
+                    return NodeStatus.DEGRADED.value
+                n_restarts = svc.get("n_restarts", 0)
+                if n_restarts > 3:
+                    return NodeStatus.DEGRADED.value
+
+        if cpu_percent > 80 or memory_percent > 80 or disk_percent > 80:
             return NodeStatus.DEGRADED.value
-        else:
-            return NodeStatus.ONLINE.value
+
+        return NodeStatus.ONLINE.value
 
     # ------------------------------------------------------------------
     # Manifest-driven background tasks (Issue #926 Phase 3)

--- a/autobot-slm-backend/slm/agent/health_collector.py
+++ b/autobot-slm-backend/slm/agent/health_collector.py
@@ -140,8 +140,9 @@ class HealthCollector:
                         service_info.update(
                             self._get_service_details(service_info["name"])
                         )
-                    elif service_info["status"] == "failed":
+                    elif service_info["status"] in ("failed", "crash-loop"):
                         # Issue #1019: Capture error context for failed services
+                        # Issue #1604: Also capture for crash-looping services
                         service_info.update(
                             self._get_service_details(service_info["name"])
                         )
@@ -213,6 +214,8 @@ class HealthCollector:
             return "running"
         elif active_state == "failed" or sub_state == "failed":
             return "failed"
+        elif active_state == "activating" and sub_state == "auto-restart":
+            return "crash-loop"  # Issue #1604
         elif active_state == "inactive":
             return "stopped"
         return "unknown"
@@ -228,7 +231,8 @@ class HealthCollector:
                         "systemctl",
                         "show",
                         service_name,
-                        "--property=MainPID,MemoryCurrent,Description,UnitFileState",
+                        "--property=MainPID,MemoryCurrent,Description,"
+                        "UnitFileState,NRestarts",
                     ],
                     capture_output=True,
                     text=True,
@@ -248,6 +252,8 @@ class HealthCollector:
                             details["description"] = value[:500]
                         elif key == "UnitFileState":
                             details["enabled"] = value == "enabled"
+                        elif key == "NRestarts" and value.isdigit():
+                            details["n_restarts"] = int(value)
 
         except Exception as e:
             logger.debug("Could not get details for %s: %s", service_name, e)


### PR DESCRIPTION
## Summary
- Add `NRestarts` and crash-loop detection to `HealthCollector` agent
- Add `CRASH_LOOP` enum value to `ServiceStatus` model
- Update `reconciler._calculate_node_status()` to degrade node status when autobot services are crash-looping or have >3 restarts
- Capture journalctl error context for crash-looping services (same as failed)

## Changed Files
- `slm/agent/health_collector.py` — NRestarts property, crash-loop status mapping, error context for crash-loop
- `models/database.py` — CRASH_LOOP enum
- `services/reconciler.py` — crash-loop aware status calculation

## Test Plan
- [ ] Deploy to .19 SLM server
- [ ] Simulate a crash-looping service (`systemctl restart` in rapid succession)
- [ ] Verify heartbeat reports `crash-loop` status with `n_restarts` count
- [ ] Verify node status degrades to DEGRADED in SLM dashboard
- [ ] Verify error_message field populated for crash-looping services

Closes #1604