### PR TITLE
fix(slm): code_status reflects service health (#1605)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
-from config import settings
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import FileResponse
 from models.database import (
@@ -56,6 +55,8 @@ from services.sync_orchestrator import get_sync_orchestrator
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
+
+from config import settings
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/code-sync", tags=["code-sync"])
@@ -135,8 +136,16 @@ async def get_sync_status(
     total_result = await db.execute(select(func.count(Node.id)))
     total_nodes = total_result.scalar() or 0
 
+    # Issue #1605: count outdated + service-failed as needing attention
     outdated_result = await db.execute(
-        select(func.count(Node.id)).where(Node.code_status == CodeStatus.OUTDATED.value)
+        select(func.count(Node.id)).where(
+            Node.code_status.in_(
+                [
+                    CodeStatus.OUTDATED.value,
+                    CodeStatus.CODE_CURRENT_SERVICE_FAILED.value,
+                ]
+            )
+        )
     )
     outdated_nodes = outdated_result.scalar() or 0
 
@@ -225,10 +234,18 @@ async def get_pending_nodes(
     latest_setting = setting_result.scalar_one_or_none()
     latest_version = latest_setting.value if latest_setting else None
 
-    # Get outdated nodes
+    # Get nodes needing attention: outdated or code-current-but-service-failed
+    # Issue #1605: include service-failed nodes so operators see them
     result = await db.execute(
         select(Node)
-        .where(Node.code_status == CodeStatus.OUTDATED.value)
+        .where(
+            Node.code_status.in_(
+                [
+                    CodeStatus.OUTDATED.value,
+                    CodeStatus.CODE_CURRENT_SERVICE_FAILED.value,
+                ]
+            )
+        )
         .order_by(Node.hostname)
     )
     nodes = result.scalars().all()

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -1417,11 +1417,15 @@ async def replace_node(
     return NodeResponse.model_validate(new_node)
 
 
-async def _update_heartbeat_code_status(db: AsyncSession, node: Node) -> str | None:
+async def _update_heartbeat_code_status(
+    db: AsyncSession, node: Node, extra_data: dict | None = None
+) -> str | None:
     """Query latest commit setting and update node.code_status.
 
     Returns the latest_version string or None.
     Helper for node_heartbeat (Issue #1102).
+    Issue #1605: Also checks service health — code_current_service_failed
+    when commit matches but autobot services are failed/crash-looping.
     """
     latest_result = await db.execute(
         select(Setting).where(Setting.key == "slm_agent_latest_commit")
@@ -1433,13 +1437,33 @@ async def _update_heartbeat_code_status(db: AsyncSession, node: Node) -> str | N
     # Do NOT use heartbeat.code_version — agents report stale values (Issue #889).
     if latest_version:
         if node.code_version == latest_version:
-            node.code_status = CodeStatus.UP_TO_DATE.value
+            # Issue #1605: check if autobot services are actually healthy
+            if _has_failed_autobot_service(extra_data):
+                node.code_status = CodeStatus.CODE_CURRENT_SERVICE_FAILED.value
+            else:
+                node.code_status = CodeStatus.UP_TO_DATE.value
         elif node.code_version:
             node.code_status = CodeStatus.OUTDATED.value
         else:
             node.code_status = CodeStatus.UNKNOWN.value
 
     return latest_version
+
+
+def _has_failed_autobot_service(extra_data: dict | None) -> bool:
+    """Check if any autobot-* service is failed or crash-looping.
+
+    Issue #1605: Prevents code_status=up_to_date when service is broken.
+    """
+    if not extra_data:
+        return False
+    for svc in extra_data.get("discovered_services", []):
+        name = svc.get("name", "")
+        if not name.startswith("autobot"):
+            continue
+        if svc.get("status") in ("failed", "crash-loop"):
+            return True
+    return False
 
 
 async def _apply_heartbeat_reports(
@@ -1498,7 +1522,9 @@ async def node_heartbeat(
 
         await _apply_heartbeat_reports(db, node_id, heartbeat, node)
 
-        latest_version = await _update_heartbeat_code_status(db, node)
+        latest_version = await _update_heartbeat_code_status(
+            db, node, heartbeat.extra_data
+        )
         await db.commit()
         await db.refresh(node)
 

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -69,6 +69,7 @@ class CodeStatus(str, enum.Enum):
 
     UP_TO_DATE = "up_to_date"
     OUTDATED = "outdated"
+    CODE_CURRENT_SERVICE_FAILED = "code_current_service_failed"  # #1605
     UNKNOWN = "unknown"
 
 


### PR DESCRIPTION
## Summary
- Add `CODE_CURRENT_SERVICE_FAILED` to `CodeStatus` enum — code matches expected commit but autobot service is failed/crash-looping
- `_update_heartbeat_code_status()` now checks `discovered_services` from heartbeat extra_data for failed autobot services
- Pending-nodes and status count endpoints include `code_current_service_failed` nodes alongside `outdated`
- Fleet sync trigger still targets only `OUTDATED` — re-syncing code won't fix a service failure

## Changed Files
- `models/database.py` — new `CODE_CURRENT_SERVICE_FAILED` enum value
- `api/nodes.py` — `_update_heartbeat_code_status()` + `_has_failed_autobot_service()` helper
- `api/code_sync.py` — pending-nodes and count queries include service-failed status

## Test Plan
- [ ] Deploy to .19 SLM server
- [ ] Verify a healthy node reports `code_status: up_to_date`
- [ ] Stop an autobot service on a node → verify heartbeat sets `code_status: code_current_service_failed`
- [ ] Verify pending-nodes API includes the service-failed node
- [ ] Verify fleet sync does NOT attempt to re-sync code to service-failed nodes
- [ ] Restart the service → verify status returns to `up_to_date`

Closes #1605