### PR TITLE
fix(deploy): run Alembic migrations during code-sync (#1608)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -414,6 +414,28 @@
       register: backend_pip_install
       tags: [backend, deps]
 
+    - name: "[PLAY 2] Backend | Run Alembic migrations (#1608)"
+      command:
+        cmd: /opt/autobot/autobot-backend/venv/bin/python -m alembic upgrade head
+        chdir: /opt/autobot/autobot-backend
+      become: true
+      become_user: autobot
+      environment:
+        PYTHONPATH: /opt/autobot/autobot-backend
+      when: "'01-Backend' in inventory_hostname"
+      register: backend_migration_result
+      failed_when: false
+      tags: [backend, migrate]
+
+    - name: "[PLAY 2] Backend | Warn if migration failed (#1608)"
+      debug:
+        msg: "WARNING: Alembic migration failed: {{ backend_migration_result.stderr | default('') }}"
+      when:
+        - "'01-Backend' in inventory_hostname"
+        - backend_migration_result is defined
+        - backend_migration_result.rc | default(0) != 0
+      tags: [backend, migrate]
+
     - name: "[PLAY 2] Backend | Restart service"
       systemd:
         name: autobot-backend


### PR DESCRIPTION
## Summary
- Add `alembic upgrade head` step to `update-all-nodes.yml` Play 2 for user backend (.20)
- Runs between pip install and service restart
- Uses venv python with PYTHONPATH set (matches `setup-user-backend.yml` pattern)
- Non-fatal (`failed_when: false`) with warning — avoids blocking deploys for already-applied migrations

## Root Cause
The code-sync workflow deploys code and restarts services but never runs DB migrations. Any PR adding an Alembic migration would break the user backend at runtime (code references columns that don't exist yet).

## Changed Files
- `ansible/playbooks/update-all-nodes.yml` — new migration task + warning task

## Test Plan
- [ ] Run `ansible-playbook update-all-nodes.yml --tags backend,migrate` on .20
- [ ] Verify `alembic upgrade head` executes successfully
- [ ] Verify migration warning task only fires when migration fails
- [ ] Verify backend starts successfully after migration + restart
- [ ] Verify `alembic current` shows HEAD revision after deploy

Closes #1608