### PR TITLE
fix(slm): widen code_status column to VARCHAR(50) (#1622)

### DIFF
--- a/autobot-slm-backend/migrations/runner.py
+++ b/autobot-slm-backend/migrations/runner.py
@@ -46,6 +46,7 @@ MIGRATIONS = [
     "add_external_agents",
     "fix_services_memory_bytes_bigint",
     "add_role_metadata_fields",
+    "widen_code_status_column",
 ]
 
 

--- a/autobot-slm-backend/migrations/widen_code_status_column.py
+++ b/autobot-slm-backend/migrations/widen_code_status_column.py
@@ -1,0 +1,33 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Migration: Widen code_status column from VARCHAR(20) to VARCHAR(50).
+
+The CODE_CURRENT_SERVICE_FAILED enum value (#1605) is 27 chars,
+exceeding the original VARCHAR(20) constraint.
+Related to Issue #1622.
+"""
+
+import logging
+
+from migrations.utils import get_connection, table_exists
+
+logger = logging.getLogger(__name__)
+
+
+def migrate(db_url: str) -> None:
+    """Widen code_status column to VARCHAR(50) (#1622)."""
+    conn = get_connection(db_url)
+    cursor = conn.cursor()
+
+    if not table_exists(cursor, "nodes"):
+        logger.error("nodes table does not exist.")
+        conn.close()
+        return
+
+    cursor.execute("ALTER TABLE nodes ALTER COLUMN code_status TYPE VARCHAR(50)")
+
+    conn.commit()
+    conn.close()
+    logger.info("Widened code_status column to VARCHAR(50)")

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -118,7 +118,7 @@ class Node(Base):
 
     # Code version tracking (Issue #741)
     code_version = Column(String(64), nullable=True)
-    code_status = Column(String(20), default=CodeStatus.UNKNOWN.value)
+    code_status = Column(String(50), default=CodeStatus.UNKNOWN.value)  # #1622
 
     # Role-based tracking (Issue #779)
     detected_roles = Column(JSON, default=list)


### PR DESCRIPTION
## Summary
- Widen `nodes.code_status` from `VARCHAR(20)` to `VARCHAR(50)` in model and migration
- `CODE_CURRENT_SERVICE_FAILED` (#1605) is 27 chars, exceeding the original constraint
- SQLite silently ignores but PostgreSQL would truncate/error

## Changed Files
- `models/database.py` — `String(50)` for code_status column
- `migrations/widen_code_status_column.py` — new migration: ALTER COLUMN TYPE
- `migrations/runner.py` — register new migration

## Test Plan
- [ ] Run migration runner on .19: `python3 -m migrations.runner`
- [ ] Verify column type widened: `\d nodes` in psql
- [ ] Set a node's code_status to `code_current_service_failed` — verify no truncation

Closes #1622