### PR TITLE
feat(analytics): shared getCssVar composable + wire uniqueEndpoints (#1602)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -1139,6 +1139,7 @@ interface CommunicationPatternsData {
   websocket_connections: number
   api_call_frequency: number
   data_transfer_rate: number
+  unique_endpoints: number  // Issue #1602: was extracted but never displayed
 }
 
 interface CodeQualityData {
@@ -3756,7 +3757,8 @@ const loadCommunicationPatterns = async () => {
     communicationPatterns.value = {
       websocket_connections: wsConnections,
       api_call_frequency: apiFrequency,
-      data_transfer_rate: estimatedDataRate
+      data_transfer_rate: estimatedDataRate,
+      unique_endpoints: uniqueEndpoints  // Issue #1602: wire previously unused value
     }
   } catch (error: unknown) {
     logger.error('loadCommunicationPatterns failed:', error)
@@ -3895,15 +3897,8 @@ const getPriorityClass = (severity: string | undefined): string => {
   }
 }
 
-/**
- * Helper to get CSS variable value at runtime.
- * Used for JavaScript color values (charts, Cytoscape, D3, etc.)
- * Falls back to provided default for SSR/testing safety.
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
+// Issue #1602: getCssVar moved to shared composable
+import { getCssVar } from '@/composables/useCssVars'
 
 const getSeverityColor = (severity: string | undefined): string => {
   switch (severity?.toLowerCase()) {

--- a/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
@@ -68,6 +68,10 @@
             <div class="pattern-label">{{ $t('analytics.codebase.communication.dataTransferRate') }}</div>
             <div class="pattern-value">{{ communicationPatterns.data_transfer_rate || 0 }} KB/s</div>
           </div>
+          <div class="pattern-item">
+            <div class="pattern-label">{{ $t('analytics.codebase.communication.uniqueEndpoints') }}</div>
+            <div class="pattern-value">{{ communicationPatterns.unique_endpoints || 0 }}</div>
+          </div>
         </div>
         <EmptyState
           v-else
@@ -173,6 +177,7 @@ interface CommunicationPatternsData {
   websocket_connections: number
   api_call_frequency: number
   data_transfer_rate: number
+  unique_endpoints: number
 }
 
 interface CodeQualityData {

--- a/autobot-frontend/src/composables/useCssVars.ts
+++ b/autobot-frontend/src/composables/useCssVars.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared CSS variable accessor for JavaScript-side color/font values.
+ * Issue #704: CSS-to-JS bridge used by charts, Cytoscape, D3, etc.
+ * Issue #1602: Extracted from 23 component-local duplicates.
+ *
+ * @param name - CSS custom property name (e.g., '--chart-blue')
+ * @param fallback - Default value for SSR/testing or missing property
+ * @returns The resolved CSS variable value or fallback
+ */
+export function getCssVar(name: string, fallback: string): string {
+  if (typeof document === 'undefined') return fallback
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
+}

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -720,6 +720,7 @@
         "websocketConnections": "WebSocket Connections",
         "apiCallFrequency": "API Call Frequency",
         "dataTransferRate": "Data Transfer Rate",
+        "uniqueEndpoints": "Unique Endpoints",
         "noData": "No communication data available."
       },
       "quality": {


### PR DESCRIPTION
## Summary

Resolves #1602 — Previously flagged as "dead code", these were actually unfinished features that needed proper implementation.

### Changes

1. **Shared `useCssVars.ts` composable** — Extracted `getCssVar()` from 23 component-local duplicates into a single shared utility (`src/composables/useCssVars.ts`). CodebaseAnalytics.vue now imports from shared. Other 22 components can be migrated in a follow-up.

2. **Wire `uniqueEndpoints` display** — The `unique_endpoints` value was extracted from the `/api/analytics/communication/patterns` API response but never stored or displayed. Now:
   - Added to `CommunicationPatternsData` interface (both parent and panel)
   - Passed through `communicationPatterns.value`
   - Displayed in `CodebaseOverviewPanel.vue` communication metrics
   - Added i18n key `analytics.codebase.communication.uniqueEndpoints`

## Test plan

- [ ] Verify Communication Patterns section shows 4 metrics (WS connections, API frequency, data rate, unique endpoints)
- [ ] Verify unique endpoints count matches backend API response
- [ ] Verify getCssVar still resolves CSS variables correctly in charts/visualizations