### PR TITLE
fix(slm): fix frontend ownership before npm build in self-sync (#1624)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -369,9 +369,22 @@ async def _build_slm_frontend() -> None:
 
     Issue #1607: The Ansible path builds the frontend; the self-sync
     path was missing this step, serving stale dist/ files.
+    Issue #1624: Fix ownership before build — Ansible deploys as root.
     """
     frontend_dir = "/opt/autobot/autobot-slm-frontend"
     try:
+        # Fix ownership — Ansible may have created root-owned files (#1624)
+        proc = await asyncio.create_subprocess_exec(
+            "sudo",
+            "chown",
+            "-R",
+            "autobot:autobot",
+            frontend_dir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=30.0)
+
         # npm ci — install exact lockfile deps
         proc = await asyncio.create_subprocess_exec(
             "npm",


### PR DESCRIPTION
## Summary
- Add `sudo chown -R autobot:autobot` for SLM frontend dir before `npm ci`
- Prevents permission errors when Ansible previously deployed root-owned files

## Root Cause
Ansible deploys with `become: true` (root), creating root-owned `node_modules/` and `dist/`. The self-sync path runs as the `autobot` service user, so `npm ci` fails trying to modify root-owned files.

## Changed Files
- `api/code_sync.py` — ownership fix step in `_build_slm_frontend()`

## Test Plan
- [ ] Create root-owned file in `/opt/autobot/autobot-slm-frontend/node_modules/`
- [ ] Trigger SLM self-sync via code-sync UI
- [ ] Verify chown runs before npm ci (check logs)
- [ ] Verify frontend build succeeds

Closes #1624