### PR TITLE
fix(ansible): deploy gaps — SLM migrations, shared ownership, NPU health, drift CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -102,10 +102,18 @@ jobs:
           echo "⚠️ Security issues detected - review bandit output"
         }
 
+    - name: Check Ansible agent code drift (#1629)
+      run: |
+        bash pipeline-scripts/detect-agent-code-drift.sh || {
+          echo "Ansible slm_agent role has drifted from canonical source"
+          echo "See Issue #1629 for details"
+          exit 1
+        }
+
     - name: Code quality summary
       if: always()
       run: |
-        echo "📊 Code Quality Check Complete"
+        echo "Code Quality Check Complete"
         echo ""
         echo "Note: Checks are in warn-only mode while Issue #173 is being addressed."
         echo "Once violations are fixed, strict enforcement will be enabled."

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -232,6 +232,29 @@
         - autobot-shared
       tags: [slm]
 
+    # --- SLM custom migrations (#1630) ---
+    - name: "[PLAY 1] SLM | Run database migrations (#1630)"
+      command:
+        cmd: >-
+          /opt/autobot/autobot-slm-backend/venv/bin/python
+          -m migrations.runner
+        chdir: /opt/autobot/autobot-slm-backend
+      become: true
+      become_user: autobot
+      environment:
+        PYTHONPATH: /opt/autobot/autobot-slm-backend
+      register: slm_migration_result
+      failed_when: false
+      tags: [slm, slm-backend, migrate]
+
+    - name: "[PLAY 1] SLM | Warn if migration failed (#1630)"
+      debug:
+        msg: "WARNING: SLM migration failed: {{ slm_migration_result.stderr | default('') }}"
+      when:
+        - slm_migration_result is defined
+        - slm_migration_result.rc | default(0) != 0
+      tags: [slm, slm-backend, migrate]
+
     # --- Dependency install (#1603) ---
     - name: "[PLAY 1] SLM | Install Python dependencies"
       command:
@@ -392,6 +415,16 @@
       when: "'01-Backend' in inventory_hostname"
       changed_when: true
       tags: [backend]
+
+    - name: "[PLAY 2] Backend | Fix shared ownership (#1632)"
+      file:
+        path: /opt/autobot/autobot-shared
+        owner: autobot
+        group: autobot
+        recurse: true
+      become: true
+      when: "'01-Backend' in inventory_hostname"
+      tags: [backend, shared]
 
     - name: "[PLAY 2] Backend | Remove legacy backend symlink"
       file:
@@ -566,12 +599,28 @@
       failed_when: false
       tags: [npu, npu-worker, restart]
 
-    - name: "[PLAY 2] NPU | Wait for service to stabilize"
-      pause:
-        seconds: 10
+    - name: "[PLAY 2] NPU | Wait for service to stabilize (#1633)"
+      command: systemctl is-active autobot-npu-worker
+      become: true
+      register: npu_status
+      retries: 6
+      delay: 5
+      until: npu_status.rc == 0
       when: >-
         '03-NPU' in inventory_hostname or
         'npu-worker' in inventory_hostname
+      failed_when: false
+      tags: [npu, npu-worker, restart]
+
+    - name: "[PLAY 2] NPU | Warn if service not active (#1633)"
+      debug:
+        msg: "WARNING: autobot-npu-worker not active after restart: {{ npu_status.stdout | default('unknown') }}"
+      when:
+        - >-
+          '03-NPU' in inventory_hostname or
+          'npu-worker' in inventory_hostname
+        - npu_status is defined
+        - npu_status.rc | default(0) != 0
       tags: [npu, npu-worker, restart]
 
     # ----- Browser Worker (172.16.168.25) -----

--- a/pipeline-scripts/detect-agent-code-drift.sh
+++ b/pipeline-scripts/detect-agent-code-drift.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Detect drift between canonical SLM agent code and Ansible role copy.
+# Used by: .github/workflows/code-quality.yml
+# Reference: Issue #1629
+#
+# The SLM agent code lives in two places:
+#   - autobot-slm-backend/slm/agent/        (canonical, actively developed)
+#   - autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/  (Ansible copy)
+#
+# They MUST stay identical. This script fails if they diverge.
+
+set -euo pipefail
+
+CANONICAL="autobot-slm-backend/slm/agent"
+ANSIBLE_COPY="autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent"
+
+if [ ! -d "$CANONICAL" ]; then
+    echo "ERROR: Canonical agent directory not found: $CANONICAL"
+    exit 1
+fi
+
+if [ ! -d "$ANSIBLE_COPY" ]; then
+    echo "ERROR: Ansible agent copy not found: $ANSIBLE_COPY"
+    exit 1
+fi
+
+# Compare, excluding __pycache__ and test files
+DIFF_OUTPUT=$(diff -r "$CANONICAL" "$ANSIBLE_COPY" \
+    --exclude='__pycache__' \
+    --exclude='*_test.py' \
+    --exclude='*.pyc' \
+    2>&1) || true
+
+if [ -n "$DIFF_OUTPUT" ]; then
+    echo "DRIFT DETECTED between canonical agent and Ansible copy (#1629)"
+    echo ""
+    echo "$DIFF_OUTPUT"
+    echo ""
+    echo "Fix: copy canonical files to Ansible role:"
+    echo "  cp autobot-slm-backend/slm/agent/*.py \\"
+    echo "     autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/"
+    exit 1
+fi
+
+echo "Agent code in sync: canonical == Ansible copy"
+exit 0


### PR DESCRIPTION
## Summary

Fixes 4 deploy-related gaps discovered during code-sync implementation (#1603–#1624):

- **#1630**: Add explicit SLM custom migration step (`python3 -m migrations.runner`) in Play 1 before service restart, matching Backend's Alembic pattern from #1608
- **#1632**: Add `autobot-shared` ownership fix for Backend (.20) — was left root-owned after `unarchive` with `become: true`
- **#1633**: Replace NPU `pause: 10` with `systemctl is-active` health check (6 retries × 5s), consistent with Backend/Frontend/Browser verification
- **#1629**: Add CI drift detection script (`pipeline-scripts/detect-agent-code-drift.sh`) and `code-quality.yml` step to fail if Ansible `slm_agent` role diverges from canonical source

## Test Plan

- [x] Ansible syntax check passes: `ansible-playbook playbooks/update-all-nodes.yml --syntax-check`
- [x] Drift detection script passes locally: `bash pipeline-scripts/detect-agent-code-drift.sh`
- [ ] Deploy to staging and verify SLM migration step runs before restart
- [ ] Verify `autobot-shared` is autobot-owned on .20 after deploy
- [ ] Verify NPU health check detects failed service

Closes #1630, closes #1632, closes #1633, closes #1629