### PR TITLE
fix(config): use SSOT URL properties in voice tests (#1618)

### DIFF
--- a/autobot-backend/api/voice_integration_test.py
+++ b/autobot-backend/api/voice_integration_test.py
@@ -22,8 +22,8 @@ from autobot_shared.ssot_config import config
 # ------------------------------------------------------------------ #
 # Config (#1618: use SSOT — no hardcoded IPs)                         #
 # ------------------------------------------------------------------ #
-BACKEND_URL = f"http://{config.vm.main}:{config.port.backend}"
-TTS_WORKER_URL = f"http://{config.vm.tts}:{config.port.tts}"
+BACKEND_URL = config.backend_url
+TTS_WORKER_URL = config.tts_worker_url
 LATENCY_BUDGET_SEC = 5.0  # STT → TTS round-trip target
 
 


### PR DESCRIPTION
## Summary
- Replace manual f-string URL construction with SSOT property accessors in `voice_integration_test.py`
- `config.backend_url` handles HTTP/HTTPS based on TLS config (f-string always used HTTP)
- `config.tts_worker_url` resolves host+port from SSOT config

## Context
The initial fix (commit `8f55a4f36`, already on Dev_new_gui) replaced hardcoded IPs with SSOT config fields. This PR improves it further by using the property-based URL accessors which handle protocol selection correctly.

## Test Plan
- [x] Linting passes (`flake8 --max-line-length=100`)
- [x] No remaining hardcoded `.22:8082` references in backend
- [ ] Voice integration tests pass against TTS worker on .24

Closes #1618