### PR TITLE
chore(ci): auto-close issues for PRs merged to Dev_new_gui

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,80 @@
+# Auto-close issues referenced in PRs merged to non-default branches
+#
+# GitHub's built-in auto-close keywords (Closes #NNN, Fixes #NNN) only
+# trigger when merging to the default branch (main). Since AutoBot PRs
+# target Dev_new_gui, this workflow fills the gap.
+#
+# See: https://github.com/mrveiss/AutoBot-AI/issues/1601
+
+name: Auto-close referenced issues
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [Dev_new_gui]
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: self-hosted
+    permissions:
+      issues: write
+
+    steps:
+      - name: Close referenced issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body || '';
+            const prNumber = context.payload.pull_request.number;
+
+            // Match GitHub auto-close keywords:
+            // close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const issueNumbers = new Set();
+            let match;
+
+            while ((match = pattern.exec(prBody)) !== null) {
+              issueNumbers.add(parseInt(match[1], 10));
+            }
+
+            if (issueNumbers.size === 0) {
+              console.log('No issue references found in PR body.');
+              return;
+            }
+
+            console.log(`Found issue references: ${[...issueNumbers].join(', ')}`);
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                const issue = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                });
+
+                if (issue.data.state === 'closed') {
+                  console.log(`Issue #${issueNumber} is already closed.`);
+                  continue;
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `Closed by #${prNumber} (merged to Dev_new_gui).`,
+                });
+
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+
+                console.log(`Closed issue #${issueNumber}.`);
+              } catch (error) {
+                console.log(`Failed to close issue #${issueNumber}: ${error.message}`);
+              }
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,6 +430,7 @@ Dispatched subagents cannot autonomously acquire Bash tool permission. This mean
 **Always close the issue after implementation:**
 - Run `gh issue close <number>` and verify with `gh issue view <number>`
 - Add closing comment summarizing what was done
+- **Auto-close limitation:** GitHub's `Closes #NNN` keywords only work for the default branch (`main`). PRs targeting `Dev_new_gui` will NOT auto-close issues. The `auto-close-issues.yml` workflow handles this, but always verify with `gh issue view` after merge.
 
 **PR Workflow — Review Mode** (PR link only): read `gh pr view/diff`, do NOT switch branches or change code.
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-close-issues.yml` — a GitHub Action that parses PR descriptions for auto-close keywords (`Closes #NNN`, `Fixes #NNN`, `Resolves #NNN`) and closes referenced issues when PRs merge to `Dev_new_gui`
- Documents the limitation in `CLAUDE.md` GitHub Workflow section
- Also closed 3 orphaned issues (#1578, #1580, #1597) that were already merged but never auto-closed

Closes #1601

## Why

GitHub's built-in auto-close keywords only trigger for the **default branch** (`main`). Since all AutoBot PRs target `Dev_new_gui`, issues were accumulating as open despite their PRs being merged.

## Test plan

- [ ] Verify workflow YAML is valid (`check yaml` pre-commit passed)
- [ ] Merge this PR to Dev_new_gui and confirm #1601 is auto-closed by the new workflow
- [ ] Future PRs with `Closes #NNN` targeting Dev_new_gui should auto-close issues