### PR TITLE
fix(hooks): worktree branch guard prevents stash corruption (#1654)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,19 @@ repos:
         exclude: (code_analysis/|_test\.py|\.e2e_test\.py|\.integration_test\.py|\.performance_test\.py|conftest\.py)$
         additional_dependencies: ["bandit[toml]"]
 
+  # Block commits when branch is shared with a worktree (Issue #1654)
+  # Must run BEFORE the stash/restore cycle to prevent branch corruption.
+  - repo: local
+    hooks:
+      - id: worktree-branch-guard
+        name: Worktree Branch Guard (Issue #1654)
+        entry: autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+        description: "Blocks commits when current branch is also checked out in another worktree"
+
   # Hardcoded value detection (Issue #694)
   - repo: local
     hooks:

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-worktree-branch-guard
@@ -1,0 +1,93 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Pre-commit Hook: Block Commits on Branches Shared with Worktrees
+# =================================================================
+#
+# Runs at the pre-commit stage (BEFORE the stash/restore cycle).
+# Blocks the commit when the current branch is also checked out in
+# another git worktree, because pre-commit's stash push/pop cycle
+# corrupts the branch state in this scenario:
+#
+#   1. pre-commit runs `git stash push --include-untracked`
+#   2. The stash interacts with the worktree's branch ref
+#   3. On `git stash pop`, the active branch silently switches
+#   4. The commit lands on the correct SHA but the local branch
+#      ref is orphaned — recoverable only via `git reflog`
+#
+# Fix: either remove the conflicting worktree first, or work
+# inside the worktree itself (not the main working directory).
+#
+# Issue: #1654 - pre-commit stash pop can switch active branch
+# Related: #1503 - pre-commit stash/restore stages untracked files
+
+set -uo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+main() {
+    current_branch=$(git branch --show-current 2>/dev/null)
+
+    # Detached HEAD or no branch — nothing to guard
+    if [[ -z "$current_branch" ]]; then
+        exit 0
+    fi
+
+    # Check if any other worktree has this branch checked out
+    conflict=""
+    while IFS= read -r line; do
+        # git worktree list --porcelain outputs:
+        #   worktree /path/to/worktree
+        #   HEAD <sha>
+        #   branch refs/heads/<branch>
+        #   (blank line)
+        if [[ "$line" == worktree\ * ]]; then
+            wt_path="${line#worktree }"
+        fi
+        if [[ "$line" == branch\ * ]]; then
+            wt_branch="${line#branch refs/heads/}"
+            # Skip the main working directory (current worktree)
+            main_wt=$(git rev-parse --show-toplevel 2>/dev/null)
+            if [[ "$wt_branch" == "$current_branch" && "$wt_path" != "$main_wt" ]]; then
+                conflict="$wt_path"
+                break
+            fi
+        fi
+    done < <(git worktree list --porcelain 2>/dev/null)
+
+    if [[ -z "$conflict" ]]; then
+        exit 0
+    fi
+
+    echo ""
+    echo -e "${BOLD}${RED}BLOCKED: branch also checked out in worktree (Issue #1654)${NC}"
+    echo -e "${CYAN}──────────────────────────────────────────────────────${NC}"
+    echo ""
+    echo -e "  Branch:    ${BOLD}${current_branch}${NC}"
+    echo -e "  Worktree:  ${conflict}"
+    echo ""
+    echo "  pre-commit's stash push/pop cycle will corrupt the branch"
+    echo "  state when the same branch is checked out in two places."
+    echo ""
+    echo -e "  ${YELLOW}Fix options:${NC}"
+    echo "    1. Remove the worktree first:"
+    echo "       git worktree remove ${conflict}"
+    echo ""
+    echo "    2. Work inside the worktree instead:"
+    echo "       cd ${conflict}"
+    echo ""
+    echo "    3. Checkout a different branch in the main directory:"
+    echo "       git checkout Dev_new_gui"
+    echo -e "${CYAN}──────────────────────────────────────────────────────${NC}"
+    echo ""
+
+    exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- New pre-commit hook `worktree-branch-guard` blocks commits when the current branch is also checked out in another git worktree
- Prevents pre-commit's `git stash push/pop` cycle from corrupting branch state (silent branch switch, orphaned commits)
- Registered as the first local hook in `.pre-commit-config.yaml` so it runs before any stash operation

## Root Cause
When pre-commit runs `git stash push --include-untracked` and the same branch is checked out in both the main working directory and a worktree, the stash pop can silently switch the active branch and orphan the commit (recoverable only via `git reflog`).

## Test Plan
- [x] Hook passes when branch is NOT in another worktree
- [x] Hook detects conflict when branch IS in another worktree
- [x] Detached HEAD case handled (skip check)
- [x] Pre-commit hooks pass with new hook registered

Closes #1654