### PR TITLE
refactor(frontend): shared CSS utils composable (#1606, #1647)

### DIFF
--- a/autobot-frontend/src/components/analytics/BugPredictionDashboard.vue
+++ b/autobot-frontend/src/components/analytics/BugPredictionDashboard.vue
@@ -387,17 +387,10 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { createLogger } from '@/utils/debugUtils';
 import { formatTimeAgo } from '@/utils/formatHelpers';
+import { getCssVar } from '@/composables/useCssVars'
 
 // Create scoped logger for BugPredictionDashboard
 const logger = createLogger('BugPredictionDashboard');
-
-/**
- * Helper function to get CSS custom property value
- * Issue #704: Added for dynamic color access in JavaScript
- */
-function getCssVar(varName: string): string {
-  return getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
-}
 
 // Types
 interface RiskFile {

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -421,14 +421,11 @@
 import { ref, computed, onMounted, onUnmounted, watch, reactive } from 'vue';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { createLogger } from '@/utils/debugUtils';
+import { getCssVar } from '@/composables/useCssVars'
 
 const logger = createLogger('CodeQualityDashboard');
 
 // Helper to get CSS variable value for JavaScript usage (SVG, charts, etc.)
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback;
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
-}
 
 // Reactive chart colors that read from CSS variables
 const chartColors = reactive({

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -3897,17 +3897,8 @@ const getPriorityClass = (severity: string | undefined): string => {
   }
 }
 
-// Issue #1602: getCssVar moved to shared composable
-import { getCssVar } from '@/composables/useCssVars'
-
-const getSeverityColor = (severity: string | undefined): string => {
-  switch (severity?.toLowerCase()) {
-    case 'critical': return getCssVar('--color-error-hover', '#dc2626')
-    case 'high': return getCssVar('--chart-orange', '#ea580c')
-    case 'medium': return getCssVar('--color-warning-hover', '#d97706')
-    default: return getCssVar('--color-success-hover', '#059669')
-  }
-}
+// Issue #1602/#1606: getCssVar + getSeverityColor moved to shared composable
+import { getCssVar, getSeverityColor } from '@/composables/useCssVars'
 
 const formatProblemType = (type: string | undefined): string => {
   return type?.replace(/_/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase()) || 'Unknown'

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -436,6 +436,7 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { createLogger } from '@/utils/debugUtils';
+import { getCssVar } from '@/composables/useCssVars'
 
 // Create scoped logger for TechnicalDebtDashboard
 const logger = createLogger('TechnicalDebtDashboard');
@@ -509,14 +510,6 @@ const sortField = ref('roi_score');
 const sortDirection = ref<'asc' | 'desc'>('desc');
 const currentPage = ref(1);
 const itemsPerPage = 10;
-
-/**
- * Issue #704: Helper to read CSS custom properties from design tokens
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 /**
  * Issue #704: Category colors using design tokens

--- a/autobot-frontend/src/components/charts/DependencyTreemap.vue
+++ b/autobot-frontend/src/components/charts/DependencyTreemap.vue
@@ -23,17 +23,9 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseChart from './BaseChart.vue'
 import type { ApexOptions } from 'apexcharts'
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
-
-/**
- * Get CSS variable value from the document
- * Issue #704: Use design tokens for theming
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 interface DependencyData {
   package: string

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -345,6 +345,7 @@ import cytoscape, { type Core, type NodeSingular } from 'cytoscape'
 import fcose from 'cytoscape-fcose'
 // Issue #711: Virtual scrolling for large orphaned function lists
 import { useVirtualScrollSimple } from '@/composables/useVirtualScroll'
+import { getCssVar } from '@/composables/useCssVars'
 
 // Register fcose layout
 cytoscape.use(fcose)
@@ -641,15 +642,6 @@ function initCytoscape() {
   cy.on('zoom', () => {
     zoomLevel.value = cy?.zoom() || 1
   })
-}
-
-/**
- * Gets a CSS variable value from the document root
- * Issue #704: Use design tokens for theming
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
 }
 
 /**

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -216,6 +216,7 @@ import { useI18n } from 'vue-i18n'
 import cytoscape, { type Core, type NodeSingular } from 'cytoscape'
 // @ts-expect-error - cytoscape-fcose has no type declarations
 import fcose from 'cytoscape-fcose'
+import { getCssVar } from '@/composables/useCssVars'
 
 // Register fcose layout
 cytoscape.use(fcose)
@@ -455,15 +456,6 @@ function initCytoscape() {
   cy.on('zoom', () => {
     zoomLevel.value = cy?.zoom() || 1
   })
-}
-
-/**
- * Get CSS variable value from the document
- * Issue #704: Use design tokens for theming
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
 }
 
 function getCytoscapeStyles(): cytoscape.StylesheetStyle[] {

--- a/autobot-frontend/src/components/charts/ModuleImportsChart.vue
+++ b/autobot-frontend/src/components/charts/ModuleImportsChart.vue
@@ -23,17 +23,9 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseChart from './BaseChart.vue'
 import type { ApexOptions } from 'apexcharts'
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
-
-/**
- * Get CSS variable value from the document
- * Issue #704: Use design tokens for theming
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 interface ModuleData {
   path: string

--- a/autobot-frontend/src/components/charts/ProblemTypesChart.vue
+++ b/autobot-frontend/src/components/charts/ProblemTypesChart.vue
@@ -23,6 +23,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseChart from './BaseChart.vue'
 import type { ApexOptions } from 'apexcharts'
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
 
@@ -91,15 +92,6 @@ const chartOptions = computed<ApexOptions>(() => ({
     }
   ]
 }))
-
-/**
- * Get CSS variable value from the document
- * Issue #704: Use design tokens for theming
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 // Get colors based on problem types
 // Issue #704: Using design tokens with fallbacks for SSR compatibility

--- a/autobot-frontend/src/components/charts/RaceConditionsDonut.vue
+++ b/autobot-frontend/src/components/charts/RaceConditionsDonut.vue
@@ -23,17 +23,9 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseChart from './BaseChart.vue'
 import type { ApexOptions } from 'apexcharts'
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
-
-/**
- * Get CSS variable value from the document
- * Issue #704: Use design tokens for theming
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 interface RaceConditionData {
   category?: string

--- a/autobot-frontend/src/components/charts/SeverityBarChart.vue
+++ b/autobot-frontend/src/components/charts/SeverityBarChart.vue
@@ -22,18 +22,10 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseChart from './BaseChart.vue'
+import { getCssVar, getSeverityColors } from '@/composables/useCssVars'
 import type { ApexOptions } from 'apexcharts'
 
 const { t } = useI18n()
-
-/**
- * Get CSS variable value from the document
- * Issue #704: Use design tokens for theming
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 interface SeverityData {
   severity?: string
@@ -120,27 +112,6 @@ const chartOptions = computed<ApexOptions>(() => ({
   }
 }))
 
-// Get colors based on severity
-// Issue #704: Using design tokens with fallbacks for SSR compatibility
-function getSeverityColors(severities: string[]): string[] {
-  const severityColors: Record<string, string> = {
-    critical: getCssVar('--color-error-hover', '#dc2626'),
-    high: getCssVar('--color-error', '#ef4444'),
-    error: getCssVar('--color-error', '#ef4444'),
-    medium: getCssVar('--color-warning', '#f59e0b'),
-    warning: getCssVar('--color-warning', '#f59e0b'),
-    low: getCssVar('--color-info', '#3b82f6'),
-    info: getCssVar('--color-info', '#3b82f6'),
-    hint: getCssVar('--color-success', '#10b981'),
-    suggestion: getCssVar('--color-success', '#10b981'),
-    trivial: getCssVar('--text-tertiary', '#64748b')
-  }
-
-  return severities.map((severity) => {
-    const key = severity.toLowerCase()
-    return severityColors[key] || getCssVar('--chart-indigo', '#6366f1')
-  })
-}
 
 // Format severity label for display
 function formatSeverityLabel(severity: string): string {

--- a/autobot-frontend/src/components/charts/TopFilesChart.vue
+++ b/autobot-frontend/src/components/charts/TopFilesChart.vue
@@ -23,17 +23,9 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseChart from './BaseChart.vue'
 import type { ApexOptions } from 'apexcharts'
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
-
-/**
- * Get CSS variable value from the document
- * Issue #704: Use design tokens for theming
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 interface FileData {
   file?: string

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -352,6 +352,7 @@ import fcose from 'cytoscape-fcose'
 import apiClient from '@/utils/ApiClient'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
+import { getCssVar } from '@/composables/useCssVars'
 import MemoryOrphanManager from '@/components/knowledge/MemoryOrphanManager.vue'
 
 // Register fcose layout
@@ -501,18 +502,6 @@ const relationCount = computed(() => graphEdges.value.length)
 // ============================================================================
 // Node Colors & Icons
 // ============================================================================
-
-/**
- * Gets a CSS variable value from the document root
- * Issue #704: Use design tokens for theming
- * @param name - CSS variable name (e.g., '--chart-blue')
- * @param fallback - Fallback value if variable is not defined
- * @returns The CSS variable value or fallback
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 /**
  * Returns the color associated with an entity type for graph visualization

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -796,20 +796,10 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import EmptyState from '@/components/ui/EmptyState.vue';
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
 import BaseModal from '@/components/ui/BaseModal.vue';
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n();
 const logger = createLogger('SecretsManager');
-
-/**
- * Helper to get CSS custom property value at runtime.
- * Used for dynamic styles that need design token colors (e.g., inline styles).
- * @param name - CSS custom property name (e.g., '--color-primary')
- * @param fallback - Fallback value for SSR/testing
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback;
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
-}
 
 // Credential type categories with icons and colors (using design tokens)
 const credentialCategories = computed(() => [

--- a/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.vue
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.vue
@@ -210,17 +210,10 @@ import { ref, onMounted, reactive } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import apiClient from '@/utils/ApiClient'
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
 const logger = createLogger('ThreatIntelligenceDashboard')
-
-/**
- * Helper to get CSS custom property value from the document root.
- * Used for dynamic color access in JavaScript when needed.
- */
-function getCssVar(varName: string): string {
-  return getComputedStyle(document.documentElement).getPropertyValue(varName).trim()
-}
 
 // State
 const loading = ref(false)

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
@@ -183,17 +183,10 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
 const logger = createLogger('AgentActivityVisualization')
-
-/**
- * Helper to retrieve CSS custom property values from design tokens.
- * Issue #704: Design token migration helper
- */
-function getCssVar(varName: string): string {
-  return getComputedStyle(document.documentElement).getPropertyValue(varName).trim()
-}
 
 // Types
 interface Agent {

--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
@@ -120,13 +120,6 @@ const chartRef = ref<InstanceType<typeof VueApexCharts> | null>(null)
 // Data
 const heatmapData = ref<Array<{ name: string; data: Array<{ x: string; y: number }> }>>([])
 
-/**
- * Issue #704: Helper to get CSS custom property values from design tokens
- */
-function getCssVar(name: string): string {
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
-}
-
 // Computed
 const chartSeries = computed(() => heatmapData.value)
 
@@ -436,6 +429,7 @@ watch(() => props.machine, () => {
 
 // Cleanup
 import { onUnmounted } from 'vue'
+import { getCssVar } from '@/composables/useCssVars'
 onUnmounted(() => {
   if (refreshTimer) {
     clearInterval(refreshTimer)

--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
@@ -515,6 +515,7 @@ import apiClient from '@/utils/ApiClient'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { getConfig } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
 
@@ -526,15 +527,6 @@ const config = getConfig()
 // ============================================================================
 // Issue #704: CSS Design System - Helper to get CSS custom property values
 // ============================================================================
-
-/**
- * Get CSS custom property value from document root.
- * Falls back to provided default if property is not defined or SSR context.
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 // ============================================================================
 // Types

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
@@ -265,6 +265,7 @@
 import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
+import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
 
@@ -331,15 +332,6 @@ const nodeWidth = 140
 const nodeHeight = 60
 const nodeSpacingX = 180
 const nodeSpacingY = 100
-
-/**
- * Get CSS variable value from document root.
- * Issue #704: Helper for design token access in JavaScript
- */
-function getCssVar(name: string, fallback: string): string {
-  if (typeof document === 'undefined') return fallback
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
-}
 
 // Computed
 const nodes = computed(() => {

--- a/autobot-frontend/src/composables/useCssVars.ts
+++ b/autobot-frontend/src/composables/useCssVars.ts
@@ -1,13 +1,53 @@
 /**
  * Shared CSS variable accessor for JavaScript-side color/font values.
  * Issue #704: CSS-to-JS bridge used by charts, Cytoscape, D3, etc.
- * Issue #1602: Extracted from 23 component-local duplicates.
+ * Issue #1602: Extracted from component-local duplicates.
  *
  * @param name - CSS custom property name (e.g., '--chart-blue')
  * @param fallback - Default value for SSR/testing or missing property
  * @returns The resolved CSS variable value or fallback
  */
-export function getCssVar(name: string, fallback: string): string {
+export function getCssVar(name: string, fallback = ''): string {
   if (typeof document === 'undefined') return fallback
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback
+}
+
+/**
+ * Map a single severity level to a theme-aware CSS color.
+ * Issue #704: Design token colors for severity indicators.
+ * Issue #1606: Restored as shared utility (removed in #1587).
+ */
+export function getSeverityColor(severity: string | undefined): string {
+  switch (severity?.toLowerCase()) {
+    case 'critical': return getCssVar('--color-error-hover', '#dc2626')
+    case 'high': return getCssVar('--chart-orange', '#ea580c')
+    case 'medium': return getCssVar('--color-warning-hover', '#d97706')
+    case 'low': return getCssVar('--color-info', '#3b82f6')
+    default: return getCssVar('--color-success-hover', '#059669')
+  }
+}
+
+/**
+ * Map an array of severity labels to theme-aware CSS colors.
+ * Issue #704: Batch color resolution for chart datasets.
+ * Issue #1606: Extracted from SeverityBarChart.vue.
+ */
+export function getSeverityColors(severities: string[]): string[] {
+  const severityColors: Record<string, string> = {
+    critical: getCssVar('--color-error-hover', '#dc2626'),
+    high: getCssVar('--color-error', '#ef4444'),
+    error: getCssVar('--color-error', '#ef4444'),
+    medium: getCssVar('--color-warning', '#f59e0b'),
+    warning: getCssVar('--color-warning', '#f59e0b'),
+    low: getCssVar('--color-info', '#3b82f6'),
+    info: getCssVar('--color-info', '#3b82f6'),
+    hint: getCssVar('--color-success', '#10b981'),
+    suggestion: getCssVar('--color-success', '#10b981'),
+    trivial: getCssVar('--text-tertiary', '#64748b')
+  }
+
+  return severities.map((s) => {
+    const key = s.toLowerCase()
+    return severityColors[key] || getCssVar('--chart-indigo', '#6366f1')
+  })
 }


### PR DESCRIPTION
## Summary

- **#1606**: Restore `getSeverityColor()` and `getSeverityColors()` as shared utilities in `useCssVars.ts` composable — removed in #1587 but was functional code
- **#1647**: Migrate 18 local `getCssVar()` copies across charts, dashboards, and visualizations to the shared `useCssVars.ts` import
- Make `fallback` parameter optional (default `''`) so callers with single-arg signatures work without changes

## Changes

**`useCssVars.ts`** — 3 exports:
- `getCssVar(name, fallback?)` — SSR-safe CSS variable accessor (fallback now optional)
- `getSeverityColor(severity)` — single severity → theme-aware color
- `getSeverityColors(severities[])` — batch severity → color array (10 levels + aliases)

**20 files changed** — 62 insertions, 190 deletions (net -128 lines)

## Files migrated (18 + 2 severity consumers)

Charts: SeverityBarChart, ImportTreeChart, ProblemTypesChart, TopFilesChart, RaceConditionsDonut, FunctionCallGraph, ModuleImportsChart, DependencyTreemap
Analytics: CodebaseAnalytics, BugPredictionDashboard, CodeQualityDashboard, TechnicalDebtDashboard
Visualizations: WorkflowVisualization, SystemArchitectureDiagram, AgentActivityVisualization, ResourceHeatmap
Other: KnowledgeGraph, SecretsManager, ThreatIntelligenceDashboard

## Verification

- `vue-tsc --noEmit` passes with zero errors
- All pre-commit hooks pass

Closes #1606
Closes #1647