### PR TITLE
feat(i18n): browser locale auto-detection with Arabic support

### DIFF
--- a/autobot-frontend/src/i18n/index.ts
+++ b/autobot-frontend/src/i18n/index.ts
@@ -10,9 +10,34 @@ export type MessageSchema = typeof en
 // Locales that use right-to-left text direction (#1337)
 const RTL_LOCALES = new Set(['ar', 'he', 'fa', 'ur'])
 
+// All locales with available translation files (#1336, #1508)
+export const SUPPORTED_LOCALES = [
+  'ar', 'de', 'en', 'es', 'fa', 'fr', 'he', 'lv', 'pl', 'pt', 'ur',
+] as const
+
+/**
+ * Detect the user's preferred locale from browser settings.
+ * Matches navigator.languages against SUPPORTED_LOCALES.
+ * Returns the first match or 'en' as fallback. (#1336, #1508)
+ */
+export function detectBrowserLocale(): string {
+  const browserLocales = navigator.languages ?? [navigator.language]
+  for (const browserLocale of browserLocales) {
+    const exact = browserLocale.toLowerCase()
+    if ((SUPPORTED_LOCALES as readonly string[]).includes(exact)) {
+      return exact
+    }
+    const base = exact.split('-')[0]
+    if ((SUPPORTED_LOCALES as readonly string[]).includes(base)) {
+      return base
+    }
+  }
+  return 'en'
+}
+
 const i18n = createI18n<[MessageSchema], 'en'>({
   legacy: false,
-  locale: localStorage.getItem('autobot-language') || 'en',
+  locale: localStorage.getItem('autobot-language') || detectBrowserLocale(),
   fallbackLocale: 'en',
   messages: {
     en,


### PR DESCRIPTION
## Summary
- Re-implements `detectBrowserLocale()` and `SUPPORTED_LOCALES` from #1336 (reverted in 476933b14)
- Includes `'ar'` (Arabic) in `SUPPORTED_LOCALES` from the start, resolving #1508
- Saved language preference (`localStorage`) still takes priority over browser detection
- Supports exact matches (`es` -> `es`) and base-language fallback (`es-MX` -> `es`)

## Changes
- `autobot-frontend/src/i18n/index.ts`: Added `SUPPORTED_LOCALES` constant, `detectBrowserLocale()` function, updated `createI18n` locale initialization

## Test plan
- [ ] Verify first-time visitor with Spanish browser gets Spanish UI
- [ ] Verify saved language preference overrides browser detection
- [ ] Verify Arabic browser language is detected and RTL applied
- [ ] Verify unsupported browser locale falls back to English
- [ ] Verify `es-MX` region variant maps to `es`

Closes #1508
Closes #1336