### PR TITLE
fix(hooks): branch guard to prevent stash-induced branch switches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,19 @@
 # Install: pip install pre-commit && pre-commit install
 
 repos:
+  # Record branch name BEFORE stash cycle for post-stash verification (Issue #1670)
+  # Must be the FIRST hook so the branch is captured before any stash/pop occurs.
+  - repo: local
+    hooks:
+      - id: record-branch
+        name: Record Branch for Branch Guard (Issue #1670)
+        entry: autobot-infrastructure/shared/scripts/hooks/pre-commit-record-branch
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+        description: "Records current branch to detect silent branch switches from stash/pop"
+
   # Python code formatting with Black
   - repo: https://github.com/psf/black
     rev: 23.12.1
@@ -143,6 +156,21 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
         description: Blocks commits with print() in Python or console.* in TypeScript/Vue production code
+
+  # Branch guard — abort commit if stash/pop silently switched branches (Issue #1670)
+  # Runs at prepare-commit-msg stage (AFTER stash/pop) to compare the current
+  # branch against the branch recorded by record-branch (BEFORE stash/pop).
+  # Exits non-zero to ABORT the commit if they differ.
+  - repo: local
+    hooks:
+      - id: branch-guard
+        name: Branch Guard — Abort on Silent Branch Switch (Issue #1670)
+        entry: autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [prepare-commit-msg]
+        description: "Aborts commit if pre-commit stash/pop silently switched the active branch"
 
   # Warn when untracked source files exist at commit time (Issue #1503)
   # Runs at prepare-commit-msg stage — AFTER the pre-commit stash/restore cycle —

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-branch-guard
@@ -1,0 +1,84 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Prepare-Commit-Msg Hook: Branch Guard — Abort on Silent Branch Switch
+# ======================================================================
+#
+# Runs at the prepare-commit-msg stage (AFTER the pre-commit framework's
+# stash/restore cycle). Compares the current branch to the branch recorded
+# by pre-commit-record-branch (which runs INSIDE the stash cycle).
+#
+# If the branch has changed — the stash pop silently switched branches —
+# this hook exits non-zero to ABORT the commit before it lands on the
+# wrong branch.
+#
+# Root cause: pre-commit's `git stash push --include-untracked` followed
+# by `git stash pop` can, under certain conditions with multiple local
+# branches and dirty working trees, restore state onto a different branch.
+#
+# Issue: #1670 - pre-commit stash/pop silently switches active branch
+# Related: #1503 - pre-commit stash/restore stages untracked files
+#
+# Install: pre-commit install --hook-type prepare-commit-msg
+
+set -uo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
+if [ -z "$GIT_DIR_PATH" ]; then
+    exit 0
+fi
+
+RECORD_FILE="${GIT_DIR_PATH}/.autobot-pre-commit-branch"
+
+if [ ! -f "$RECORD_FILE" ]; then
+    # No record file — pre-commit-record-branch didn't run (first install?)
+    # Skip silently to avoid blocking commits during setup
+    exit 0
+fi
+
+EXPECTED_BRANCH=$(cat "$RECORD_FILE" 2>/dev/null)
+ACTUAL_BRANCH=$(git branch --show-current 2>/dev/null)
+
+# Clean up the record file regardless of outcome
+rm -f "$RECORD_FILE"
+
+if [ -z "$EXPECTED_BRANCH" ] || [ -z "$ACTUAL_BRANCH" ]; then
+    # Detached HEAD or empty — nothing to guard
+    exit 0
+fi
+
+if [ "$EXPECTED_BRANCH" != "$ACTUAL_BRANCH" ]; then
+    echo ""
+    echo -e "${BOLD}${RED}COMMIT ABORTED: Branch switch detected (Issue #1670)${NC}"
+    echo -e "${CYAN}──────────────────────────────────────────────────────${NC}"
+    echo -e "  Expected branch: ${BOLD}${EXPECTED_BRANCH}${NC}"
+    echo -e "  Actual branch:   ${BOLD}${RED}${ACTUAL_BRANCH}${NC}"
+    echo ""
+    echo "  The pre-commit stash/pop cycle silently switched your branch."
+    echo "  Your commit would have landed on the WRONG branch."
+    echo ""
+    echo -e "  ${BOLD}To fix:${NC}"
+    echo "    1. Switch back to your intended branch:"
+    echo "       git checkout ${EXPECTED_BRANCH}"
+    echo ""
+    echo "    2. Re-stage your files and commit again:"
+    echo "       git add <files>"
+    echo "       git commit"
+    echo ""
+    echo -e "  ${BOLD}To prevent this:${NC}"
+    echo "    Use worktrees for parallel branch work:"
+    echo "    git worktree add .worktrees/feat-XXXX -b feat/XXXX origin/Dev_new_gui"
+    echo -e "${CYAN}──────────────────────────────────────────────────────${NC}"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-record-branch
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-record-branch
@@ -1,0 +1,34 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Pre-commit Hook: Record Branch Name Before Stash/Pop Cycle
+# ===========================================================
+#
+# Runs at the pre-commit stage (INSIDE the pre-commit framework's
+# stash/restore cycle) where the branch is still correct.
+# Saves the current branch to $GIT_DIR/.autobot-pre-commit-branch
+# so the prepare-commit-msg stage branch-guard hook can verify
+# the branch hasn't changed after stash pop.
+#
+# Issue: #1670 - pre-commit stash/pop silently switches active branch
+# Related: #1503 - pre-commit stash/restore stages untracked files
+#
+# Install: pre-commit install (uses .pre-commit-config.yaml)
+
+set -uo pipefail
+
+GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
+if [ -z "$GIT_DIR_PATH" ]; then
+    exit 0
+fi
+
+BRANCH=$(git branch --show-current 2>/dev/null)
+if [ -z "$BRANCH" ]; then
+    # Detached HEAD — nothing to guard
+    exit 0
+fi
+
+echo "$BRANCH" > "${GIT_DIR_PATH}/.autobot-pre-commit-branch"
+exit 0


### PR DESCRIPTION
## Summary
- Adds two-stage branch guard to detect and **abort** commits when pre-commit's stash/pop cycle silently switches the active branch
- Stage 1 (`record-branch`, pre-commit stage): records current branch to `$GIT_DIR/.autobot-pre-commit-branch` inside the stash cycle where the branch is still correct
- Stage 2 (`branch-guard`, prepare-commit-msg stage): runs after stash pop and compares current branch to recorded branch — exits non-zero to abort if they differ
- Installs `prepare-commit-msg` hook type, also fixing #1570 (warn-untracked-files was silently skipped)

## Test Plan
- [x] Both hooks pass on normal commit (branch stays the same)
- [x] `record-branch` runs as first pre-commit hook
- [x] `branch-guard` runs at prepare-commit-msg stage
- [ ] Manual test: simulate branch switch scenario to verify abort behavior

Closes #1670

🤖 Generated with Claude Code