### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24 runtime (#1664)

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Close referenced issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Python 3.10 via deadsnakes PPA
       run: |
@@ -152,9 +152,9 @@ jobs:
         fi
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
@@ -167,10 +167,10 @@ jobs:
   frontend-tests:
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
 
@@ -213,7 +213,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/Dev_new_gui'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Python 3.10 via deadsnakes PPA
       run: |
@@ -317,7 +317,7 @@ jobs:
         cat DEPLOYMENT_SUMMARY.md
 
     - name: Upload deployment artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: deployment-summary
         path: DEPLOYMENT_SUMMARY.md

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Python 3.10 via deadsnakes PPA
       run: |

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -73,16 +73,16 @@ jobs:
         run: npm run test:coverage || echo "⚠️ Coverage generation failed - continuing"
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./autobot-frontend/coverage/lcov.info
+          files: ./autobot-frontend/coverage/lcov.info
           directory: ./autobot-frontend/coverage
           flags: frontend
           name: autobot-frontend-coverage
           fail_ci_if_error: false
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-unit
@@ -103,10 +103,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -126,7 +126,7 @@ jobs:
           npx auditjs ossi || true
 
       - name: Upload security scan results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: security-scan-results
@@ -146,10 +146,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -181,7 +181,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: test-artifacts
 

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Python 3.10 via deadsnakes PPA
       run: |
@@ -137,7 +137,7 @@ jobs:
         fi
 
     - name: Upload Validation Reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: phase-validation-reports
@@ -148,7 +148,7 @@ jobs:
 
     - name: Comment Phase Status on PR
       if: github.event_name == 'pull_request' && always()
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const fs = require('fs');
@@ -206,10 +206,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Download validation results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: phase-validation-reports
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Python 3.10 via deadsnakes PPA
       run: |
@@ -75,7 +75,7 @@ jobs:
         safety check || true
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
 
@@ -92,7 +92,7 @@ jobs:
         npm audit --audit-level=moderate || true
 
     - name: Upload Security Reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: dependency-security-reports
@@ -113,7 +113,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Python 3.10 via deadsnakes PPA
       run: |
@@ -199,7 +199,7 @@ jobs:
         fi
 
     - name: Upload SAST Reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: sast-security-reports
@@ -220,7 +220,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Check for Security Files
       run: |
@@ -270,7 +270,7 @@ jobs:
 
     steps:
     - name: Download all security reports
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
 
     - name: Generate Security Summary
       run: |
@@ -303,7 +303,7 @@ jobs:
         echo "3. Address any SAST findings in critical code paths" >> security-summary.md
 
     - name: Upload Security Summary
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: security-summary
         path: security-summary.md

--- a/.github/workflows/ssot-coverage.yml
+++ b/.github/workflows/ssot-coverage.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run SSOT-aware hardcoded value detection
       id: ssot_check
@@ -74,7 +74,7 @@ jobs:
 
     - name: Comment on PR with SSOT status
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const totalViolations = '${{ steps.ssot_check.outputs.total_violations }}';


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions from Node.js 20 to Node.js 24 runtime ahead of June 2, 2026 forced migration deadline
- Updated 8 workflow files, 36 action references total
- Fixed `codecov-action` v5 breaking change: `file` param renamed to `files`

### Version Changes
| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `codecov/codecov-action` | v4 | v5 |
| `actions/github-script` | v7 | v8 |

**Unchanged** (not affected): `orhun/git-cliff-action@v4` (Docker), `softprops/action-gh-release@v2`

## Test Plan
- [ ] CI pipeline runs without deprecation warnings
- [ ] All workflow jobs complete successfully
- [ ] Artifact upload/download works correctly
- [ ] Codecov coverage upload works with `files` parameter
- [ ] PR comment bots (SSOT, phase validation) still function

Closes #1664

🤖 Generated with Claude Code