### PR TITLE
fix(prompts): add doc-first safeguard to 3 intent context files (#1517)

### DIFF
--- a/autobot-backend/resources/prompts/chat/api_documentation.md
+++ b/autobot-backend/resources/prompts/chat/api_documentation.md
@@ -2,7 +2,24 @@
 
 **Context**: User needs information about AutoBot's API endpoints, request/response formats, or integration.
 
-## API Documentation Expertise
+## CRITICAL: Read Actual Docs Before Answering
+
+**This is a static context file and may be outdated.** Before providing ANY API guidance:
+
+1. Execute commands to find the authoritative documentation:
+   ```
+   find /home/kali/Desktop/AutoBot/docs/api -name "*.md" | head -20
+   ```
+2. Read the relevant files:
+   ```
+   cat /home/kali/Desktop/AutoBot/docs/api/COMPREHENSIVE_API_DOCUMENTATION.md
+   cat /home/kali/Desktop/AutoBot/docs/api/API_ENDPOINT_MAPPING.md
+   cat /home/kali/Desktop/AutoBot/docs/developer/AUTOBOT_REFERENCE.md
+   ```
+3. Base your answer on the **actual file contents**, not the static guidance below.
+4. If file contents contradict this document, **trust the files**.
+
+## API Documentation Expertise (Static Reference — Verify Against Actual Docs)
 
 You are providing detailed information about AutoBot's 518+ API endpoints. Focus on accuracy and practical examples.
 

--- a/autobot-backend/resources/prompts/chat/architecture_explanation.md
+++ b/autobot-backend/resources/prompts/chat/architecture_explanation.md
@@ -2,7 +2,24 @@
 
 **Context**: User has questions about AutoBot's system architecture, design decisions, or technical implementation.
 
-## Architecture Expertise
+## CRITICAL: Read Actual Docs Before Answering
+
+**This is a static context file and may be outdated.** Before providing ANY architecture guidance:
+
+1. Execute commands to find the authoritative documentation:
+   ```
+   find /home/kali/Desktop/AutoBot/docs/architecture -name "*.md" | head -20
+   ```
+2. Read the relevant files:
+   ```
+   cat /home/kali/Desktop/AutoBot/docs/architecture/PHASE_5_DISTRIBUTED_ARCHITECTURE.md
+   cat /home/kali/Desktop/AutoBot/docs/architecture/DISTRIBUTED_6VM_ARCHITECTURE.md
+   cat /home/kali/Desktop/AutoBot/docs/developer/AUTOBOT_REFERENCE.md
+   ```
+3. Base your answer on the **actual file contents**, not the static guidance below.
+4. If file contents contradict this document, **trust the files**.
+
+## Architecture Expertise (Static Reference — Verify Against Actual Docs)
 
 You are explaining AutoBot's distributed VM architecture and technical design. Focus on clarity and technical accuracy.
 

--- a/autobot-backend/resources/prompts/chat/troubleshooting.md
+++ b/autobot-backend/resources/prompts/chat/troubleshooting.md
@@ -2,7 +2,24 @@
 
 **Context**: User is experiencing issues, errors, or unexpected behavior with AutoBot.
 
-## Troubleshooting Expertise
+## CRITICAL: Read Actual Docs Before Answering
+
+**This is a static context file and may be outdated.** Before providing ANY troubleshooting guidance:
+
+1. Execute commands to find the authoritative documentation:
+   ```
+   find /home/kali/Desktop/AutoBot/docs/troubleshooting -name "*.md" | head -20
+   ```
+2. Read the relevant files:
+   ```
+   cat /home/kali/Desktop/AutoBot/docs/troubleshooting/COMPREHENSIVE_TROUBLESHOOTING_GUIDE.md
+   cat /home/kali/Desktop/AutoBot/docs/system-state.md
+   cat /home/kali/Desktop/AutoBot/docs/developer/AUTOBOT_REFERENCE.md
+   ```
+3. Base your answer on the **actual file contents**, not the static guidance below.
+4. If file contents contradict this document, **trust the files**.
+
+## Troubleshooting Expertise (Static Reference — Verify Against Actual Docs)
 
 You are helping diagnose and resolve AutoBot issues. Focus on systematic debugging and root cause analysis.
 


### PR DESCRIPTION
## Summary
- Added `CRITICAL: Read Actual Docs Before Answering` block to:
  - `architecture_explanation.md` → references architecture docs
  - `troubleshooting.md` → references troubleshooting guide
  - `api_documentation.md` → references API documentation
- Matches pattern established in `installation_help.md` (#1476)
- Updated section headings to include "(Static Reference — Verify Against Actual Docs)"

Closes #1517

## Test plan
- [ ] All 3 files contain the CRITICAL warning block
- [ ] Referenced documentation files exist in the repo
- [ ] Format matches `installation_help.md` pattern