### PR TITLE
cleanup(frontend): remove dead defineExpose({ getCssVar }) (#1671)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
@@ -328,7 +328,6 @@
 import { ref, computed, onMounted } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
-import { getCssVar } from '@/composables/useCssVars'
 
 const logger = createLogger('CodeGenerationDashboard')
 
@@ -584,8 +583,6 @@ onMounted(() => {
   fetchRefactoringTypes()
 })
 
-// Export getCssVar for potential external use (e.g., chart libraries)
-defineExpose({ getCssVar })
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
@@ -264,7 +264,6 @@
 import { ref, onMounted, computed } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
-import { getCssVar } from '@/composables/useCssVars'
 
 const logger = createLogger('ConversationFlowDashboard')
 
@@ -378,8 +377,6 @@ onMounted(() => {
   runAnalysis()
 })
 
-// Expose getCssVar for potential external usage (e.g., charts)
-defineExpose({ getCssVar })
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- Removed unused `import { getCssVar }` and `defineExpose({ getCssVar })` from CodeGenerationDashboard and ConversationFlowDashboard
- No parent component accesses the exposed method (confirmed by full codebase grep)
- Depends on PR #1669 (#1666 migration)

## Files Changed
- `CodeGenerationDashboard.vue` — removed import + defineExpose (2 lines)
- `ConversationFlowDashboard.vue` — removed import + defineExpose (2 lines)

## Test Plan
- [x] `vue-tsc --noEmit` passes with no errors
- [x] No remaining `getCssVar` references in either file
- [x] Pre-commit hooks pass

Closes #1671

🤖 Generated with [Claude Code](https://claude.com/claude-code)