### PR TITLE
fix(hooks): auto-install prepare-commit-msg hook on checkout

### DIFF
--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -3,8 +3,9 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 #
-# Post-checkout hook: Fix WSL2 symlink breakage
-# Issue #886: WSL2's core.symlinks=false causes symlinks to become text files
+# Post-checkout hook:
+#   1. Fix WSL2 symlink breakage (Issue #886)
+#   2. Auto-install prepare-commit-msg hook type (Issue #1679)
 
 set -e
 
@@ -20,7 +21,7 @@ fi
 BACKEND_DIR="$GIT_ROOT/autobot-user-backend"
 BACKEND_SYMLINK="$BACKEND_DIR/backend"
 
-if [ ! -L "$BACKEND_SYMLINK" ] || [ ! -e "$BACKEND_SYMLINK" ]; then
+if [ -d "$BACKEND_DIR" ] && { [ ! -L "$BACKEND_SYMLINK" ] || [ ! -e "$BACKEND_SYMLINK" ]; }; then
     echo "🔧 Fixing backend symlink..."
     cd "$BACKEND_DIR"
     rm -f backend
@@ -37,6 +38,19 @@ if [ ! -L "$SHARED_SYMLINK" ] || [ ! -e "$SHARED_SYMLINK" ]; then
     rm -f autobot_shared
     ln -s autobot-shared autobot_shared
     echo "✅ autobot_shared symlink restored: $SHARED_SYMLINK -> autobot-shared"
+fi
+
+# ---------------------------------------------------------------------------
+# Auto-install prepare-commit-msg hook if missing (Issue #1679)
+# ---------------------------------------------------------------------------
+# The branch-guard (#1670) and warn-untracked (#1503) hooks run at the
+# prepare-commit-msg stage, but pre-commit only installs the pre-commit
+# hook type by default. This ensures the dispatcher exists.
+HOOKS_DIR="$(git rev-parse --git-dir 2>/dev/null)/hooks"
+if [ -d "$HOOKS_DIR" ] && [ ! -f "$HOOKS_DIR/prepare-commit-msg" ]; then
+    if command -v pre-commit > /dev/null 2>&1; then
+        pre-commit install --hook-type prepare-commit-msg > /dev/null 2>&1 || true
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- Extends `scripts/hooks/post-checkout` to auto-run `pre-commit install --hook-type prepare-commit-msg` when the hook is missing
- Ensures branch-guard (#1670) and warn-untracked (#1503) hooks are active for all developers
- Guards backend symlink fix against missing `autobot-user-backend/` directory
- Unsets `core.hooksPath` (was blocking `pre-commit install --hook-type`)

## Root Cause
`core.hooksPath` was set to `.git/hooks` (the default), which caused `pre-commit install --hook-type prepare-commit-msg` to fail. The prepare-commit-msg hook had to be created manually, making it local-only.

## Test Plan
- [x] Post-checkout auto-creates `prepare-commit-msg` when missing
- [x] `core.hooksPath` unset, `pre-commit install --hook-type` works
- [x] Branch guard and warn-untracked hooks fire at prepare-commit-msg stage
- [x] Backend symlink fix gracefully skips when directory absent

Closes #1679