### PR TITLE
feat(frontend): add routes for 11 analytics dashboard components (#1677)

### DIFF
--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -361,6 +361,105 @@ const routes: RouteRecordRaw[] = [
           requiresAuth: true
         }
       },
+      {
+        path: 'bug-prediction',
+        name: 'analytics-bug-prediction',
+        component: () => import('@/components/analytics/BugPredictionDashboard.vue'),
+        meta: {
+          title: 'Bug Prediction',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'code-generation',
+        name: 'analytics-code-generation',
+        component: () => import('@/components/analytics/CodeGenerationDashboard.vue'),
+        meta: {
+          title: 'Code Generation',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'code-intelligence',
+        name: 'analytics-code-intelligence',
+        component: () => import('@/components/analytics/CodeIntelligenceDashboard.vue'),
+        meta: {
+          title: 'Code Intelligence',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'code-quality',
+        name: 'analytics-code-quality',
+        component: () => import('@/components/analytics/CodeQualityDashboard.vue'),
+        meta: {
+          title: 'Code Quality',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'code-review',
+        name: 'analytics-code-review',
+        component: () => import('@/components/analytics/CodeReviewDashboard.vue'),
+        meta: {
+          title: 'Code Review',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'conversation-flow',
+        name: 'analytics-conversation-flow',
+        component: () => import('@/components/analytics/ConversationFlowDashboard.vue'),
+        meta: {
+          title: 'Conversation Flow',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'llm-patterns',
+        name: 'analytics-llm-patterns',
+        component: () => import('@/components/analytics/LLMPatternDashboard.vue'),
+        meta: {
+          title: 'LLM Patterns',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'log-patterns',
+        name: 'analytics-log-patterns',
+        component: () => import('@/components/analytics/LogPatternDashboard.vue'),
+        meta: {
+          title: 'Log Patterns',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'performance',
+        name: 'analytics-performance',
+        component: () => import('@/components/analytics/PerformanceAnalysisDashboard.vue'),
+        meta: {
+          title: 'Performance Analysis',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'precommit-hooks',
+        name: 'analytics-precommit-hooks',
+        component: () => import('@/components/analytics/PrecommitHookDashboard.vue'),
+        meta: {
+          title: 'Pre-commit Hooks',
+          parent: 'analytics'
+        }
+      },
+      {
+        path: 'technical-debt',
+        name: 'analytics-technical-debt',
+        component: () => import('@/components/analytics/TechnicalDebtDashboard.vue'),
+        meta: {
+          title: 'Technical Debt',
+          parent: 'analytics'
+        }
+      },
     ]
   },
   // Issue #753: User preferences (appearance, font size, colors, etc.)


### PR DESCRIPTION
## Summary
- Added 11 lazy-loaded child routes under `/analytics` for all analytics dashboard components
- Follows existing route pattern (evolution, security, audit, etc.)

### Routes Added
| Path | Component |
|------|-----------|
| `/analytics/bug-prediction` | BugPredictionDashboard |
| `/analytics/code-generation` | CodeGenerationDashboard |
| `/analytics/code-intelligence` | CodeIntelligenceDashboard |
| `/analytics/code-quality` | CodeQualityDashboard |
| `/analytics/code-review` | CodeReviewDashboard |
| `/analytics/conversation-flow` | ConversationFlowDashboard |
| `/analytics/llm-patterns` | LLMPatternDashboard |
| `/analytics/log-patterns` | LogPatternDashboard |
| `/analytics/performance` | PerformanceAnalysisDashboard |
| `/analytics/precommit-hooks` | PrecommitHookDashboard |
| `/analytics/technical-debt` | TechnicalDebtDashboard |

## Test Plan
- [x] `vue-tsc --noEmit` passes with no errors
- [x] Pre-commit hooks pass
- [ ] Navigate to each route in browser and verify dashboard renders

Closes #1677

🤖 Generated with [Claude Code](https://claude.com/claude-code)