### PR TITLE
fix(hooks): wrap pre-commit with branch guard at git hook level

### DIFF
--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -3,16 +3,15 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 #
-# Post-checkout hook: Fix WSL2 symlink breakage
-# Issue #886: WSL2's core.symlinks=false causes symlinks to become text files
-
-set -e
+# Post-checkout hook:
+#   1. Fix WSL2 symlink breakage (Issue #886)
+#   2. Auto-install prepare-commit-msg hook type (Issue #1679)
+#   3. Auto-install pre-commit branch guard wrapper (Issue #1689)
 
 # Determine git root directory
 if [ -n "$GIT_DIR" ]; then
-    GIT_ROOT="$(cd "$GIT_DIR/.." && pwd)"
+    GIT_ROOT="$(cd "$GIT_DIR/.." 2>/dev/null && pwd)" || exit 0
 else
-    # When run manually, find git root
     GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 fi
 
@@ -20,23 +19,72 @@ fi
 BACKEND_DIR="$GIT_ROOT/autobot-user-backend"
 BACKEND_SYMLINK="$BACKEND_DIR/backend"
 
-if [ ! -L "$BACKEND_SYMLINK" ] || [ ! -e "$BACKEND_SYMLINK" ]; then
-    echo "🔧 Fixing backend symlink..."
-    cd "$BACKEND_DIR"
-    rm -f backend
-    ln -s . backend
-    echo "✅ Backend symlink restored: $BACKEND_SYMLINK -> ."
+if [ -d "$BACKEND_DIR" ] && { [ ! -L "$BACKEND_SYMLINK" ] || [ ! -e "$BACKEND_SYMLINK" ]; }; then
+    if cd "$BACKEND_DIR" 2>/dev/null; then
+        echo "🔧 Fixing backend symlink..."
+        rm -f backend
+        ln -s . backend
+        echo "✅ Backend symlink restored: $BACKEND_SYMLINK -> ."
+    fi
 fi
 
 # Fix autobot_shared symlink (root level)
 SHARED_SYMLINK="$GIT_ROOT/autobot_shared"
 
 if [ ! -L "$SHARED_SYMLINK" ] || [ ! -e "$SHARED_SYMLINK" ]; then
-    echo "🔧 Fixing autobot_shared symlink..."
-    cd "$GIT_ROOT"
-    rm -f autobot_shared
-    ln -s autobot-shared autobot_shared
-    echo "✅ autobot_shared symlink restored: $SHARED_SYMLINK -> autobot-shared"
+    if cd "$GIT_ROOT" 2>/dev/null; then
+        echo "🔧 Fixing autobot_shared symlink..."
+        rm -f autobot_shared
+        ln -s autobot-shared autobot_shared
+        echo "✅ autobot_shared symlink restored: $SHARED_SYMLINK -> autobot-shared"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Auto-install prepare-commit-msg hook if missing (Issue #1679)
+# ---------------------------------------------------------------------------
+HOOKS_DIR="$(git rev-parse --git-dir 2>/dev/null)/hooks"
+if [ -d "$HOOKS_DIR" ] && [ ! -f "$HOOKS_DIR/prepare-commit-msg" ]; then
+    if command -v pre-commit > /dev/null 2>&1; then
+        pre-commit install --hook-type prepare-commit-msg > /dev/null 2>&1 || true
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Auto-install pre-commit branch guard wrapper (Issue #1689)
+# ---------------------------------------------------------------------------
+# The pre-commit framework's stash/pop can silently switch branches.
+# This wraps .git/hooks/pre-commit to detect the switch AFTER the
+# framework returns but BEFORE git proceeds — catching cases where
+# git would abort before prepare-commit-msg even runs.
+#
+# Layout:
+#   .git/hooks/pre-commit                   → branch guard wrapper
+#   .git/hooks/pre-commit.pre-commit-framework → original pre-commit hook
+WRAPPER_SRC="$GIT_ROOT/scripts/hooks/pre-commit-branch-guard-wrapper"
+if [ -d "$HOOKS_DIR" ] && [ -f "$WRAPPER_SRC" ]; then
+    PRECOMMIT_HOOK="$HOOKS_DIR/pre-commit"
+    FRAMEWORK_HOOK="$HOOKS_DIR/pre-commit.pre-commit-framework"
+
+    # Only wrap if the current pre-commit hook is NOT already the wrapper
+    if [ -f "$PRECOMMIT_HOOK" ] && ! grep -q "Issue #1689" "$PRECOMMIT_HOOK" 2>/dev/null; then
+        mv "$PRECOMMIT_HOOK" "$FRAMEWORK_HOOK"
+        cp "$WRAPPER_SRC" "$PRECOMMIT_HOOK"
+        chmod +x "$PRECOMMIT_HOOK" "$FRAMEWORK_HOOK"
+    fi
+
+    # If wrapper exists but framework hook is missing (fresh clone),
+    # install pre-commit first, then wrap it
+    if [ ! -f "$PRECOMMIT_HOOK" ] && [ ! -f "$FRAMEWORK_HOOK" ]; then
+        if command -v pre-commit > /dev/null 2>&1; then
+            pre-commit install > /dev/null 2>&1 || true
+            if [ -f "$PRECOMMIT_HOOK" ]; then
+                mv "$PRECOMMIT_HOOK" "$FRAMEWORK_HOOK"
+                cp "$WRAPPER_SRC" "$PRECOMMIT_HOOK"
+                chmod +x "$PRECOMMIT_HOOK" "$FRAMEWORK_HOOK"
+            fi
+        fi
+    fi
 fi
 
 exit 0

--- a/scripts/hooks/pre-commit-branch-guard-wrapper
+++ b/scripts/hooks/pre-commit-branch-guard-wrapper
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Pre-commit wrapper: Branch Guard at the git hook level (Issue #1689)
+# ====================================================================
+#
+# Wraps the pre-commit framework's hook to detect branch switches
+# caused by the stash/pop cycle. This runs OUTSIDE the framework,
+# so it catches the switch even when git aborts before prepare-commit-msg.
+#
+# The wrapper:
+#   1. Records the current branch
+#   2. Calls the original pre-commit framework hook (.pre-commit-framework)
+#   3. After the framework returns (stash pop has occurred), checks
+#      if the branch changed
+#   4. If changed: switches back and aborts with a clear error
+#
+# The post-checkout hook auto-installs this wrapper. If `pre-commit install`
+# overwrites it, the next checkout re-wraps it.
+#
+# Related: #1670 (prepare-commit-msg guard), #1503 (stash file promotion)
+
+set -uo pipefail
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# --- 1. Record branch BEFORE the pre-commit framework runs ---
+BRANCH_BEFORE=$(git branch --show-current 2>/dev/null)
+
+# --- 2. Call the original pre-commit framework hook ---
+HERE="$(cd "$(dirname "$0")" && pwd)"
+FRAMEWORK_HOOK="$HERE/pre-commit.pre-commit-framework"
+
+if [ ! -x "$FRAMEWORK_HOOK" ]; then
+    echo "Error: pre-commit framework hook not found at $FRAMEWORK_HOOK" >&2
+    echo "Run: pre-commit install" >&2
+    exit 1
+fi
+
+"$FRAMEWORK_HOOK" "$@"
+HOOK_EXIT=$?
+
+# If hooks failed, propagate the failure immediately
+if [ $HOOK_EXIT -ne 0 ]; then
+    exit $HOOK_EXIT
+fi
+
+# --- 3. Check if branch changed after stash/pop ---
+BRANCH_AFTER=$(git branch --show-current 2>/dev/null)
+
+if [ -z "$BRANCH_BEFORE" ] || [ -z "$BRANCH_AFTER" ]; then
+    # Detached HEAD — nothing to guard
+    exit 0
+fi
+
+if [ "$BRANCH_BEFORE" != "$BRANCH_AFTER" ]; then
+    echo ""
+    echo -e "${BOLD}${RED}COMMIT ABORTED: Branch switch detected (Issue #1689)${NC}"
+    echo -e "${CYAN}──────────────────────────────────────────────────────${NC}"
+    echo -e "  Expected branch: ${BOLD}${BRANCH_BEFORE}${NC}"
+    echo -e "  Actual branch:   ${BOLD}${RED}${BRANCH_AFTER}${NC}"
+    echo ""
+    echo "  The pre-commit stash/pop cycle silently switched your branch."
+    echo "  Switching back and aborting to prevent wrong-branch commits."
+    echo ""
+    echo -e "  ${BOLD}Recovering:${NC} switching back to ${BRANCH_BEFORE}..."
+
+    # Switch back to the original branch
+    if git checkout "$BRANCH_BEFORE" 2>/dev/null; then
+        echo -e "  ${BOLD}Recovered.${NC} Re-stage your files and commit again:"
+        echo "    git add <files>"
+        echo "    git commit"
+    else
+        echo -e "  ${RED}Could not switch back automatically.${NC}"
+        echo "    git checkout ${BRANCH_BEFORE}"
+    fi
+
+    echo ""
+    echo -e "  ${BOLD}To prevent this:${NC}"
+    echo "    Ensure no unstaged files exist before committing, or"
+    echo "    use worktrees: git worktree add .worktrees/feat-XXXX -b feat/XXXX"
+    echo -e "${CYAN}──────────────────────────────────────────────────────${NC}"
+    echo ""
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Creates `scripts/hooks/pre-commit-branch-guard-wrapper` that wraps the pre-commit framework hook with branch verification at the git hook level
- The wrapper records the branch BEFORE calling the framework, then checks it AFTER the stash/pop cycle — catching branch switches even when git aborts before `prepare-commit-msg`
- Updates `scripts/hooks/post-checkout` to auto-install the wrapper (renames original to `.pre-commit-framework`, installs wrapper as `pre-commit`)
- Also includes #1679 fix (auto-install `prepare-commit-msg` hook type on checkout)

## How It Works
```
.git/hooks/pre-commit (wrapper)
  → records branch
  → calls .git/hooks/pre-commit.pre-commit-framework (original)
    → pre-commit framework: stash push → hooks → stash pop
  → verifies branch unchanged
  → if switched: recovers and aborts
```

## Test Plan
- [x] Wrapper calls framework correctly, all hooks pass
- [x] Commit lands on correct branch
- [x] Post-checkout auto-installs wrapper when missing
- [ ] Manual: simulate branch switch to verify abort + recovery

Closes #1689
Supersedes #1686 (#1679 changes included here)

🤖 Generated with Claude Code