### PR TITLE
fix(hooks): serialize worktree commits via flock (#1684)

### DIFF
--- a/autobot-infrastructure/shared/scripts/hooks/inject-flock-wrapper
+++ b/autobot-infrastructure/shared/scripts/hooks/inject-flock-wrapper
@@ -1,0 +1,60 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Inject flock serialization into .git/hooks/pre-commit (Issue #1684)
+#
+# Git worktrees share .git/refs/stash. When multiple worktrees run
+# pre-commit hooks in parallel, the stash push/pop operations collide
+# and commits leak across branches. This script injects an exclusive
+# flock that serializes pre-commit across all worktrees.
+#
+# Called by post-checkout hook after every checkout/worktree creation.
+# Idempotent — skips injection if AUTOBOT_FLOCK marker already present.
+
+HOOKS_DIR="$(git rev-parse --git-dir 2>/dev/null)/hooks"
+PRE_COMMIT_HOOK="$HOOKS_DIR/pre-commit"
+
+# Skip if no pre-commit hook or already injected
+if [ ! -f "$PRE_COMMIT_HOOK" ]; then
+    exit 0
+fi
+
+if grep -q 'AUTOBOT_FLOCK' "$PRE_COMMIT_HOOK"; then
+    exit 0
+fi
+
+# Create a temp file with the flock block
+FLOCK_BLOCK=$(cat <<'FLOCK_EOF'
+
+# --- AUTOBOT_FLOCK: serialize pre-commit across worktrees (Issue #1684) ---
+# Prevents stash cross-contamination when multiple worktrees commit in parallel.
+_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || git rev-parse --git-dir)"
+exec 200>"${_COMMON_DIR}/pre-commit.lock"
+flock -x 200
+# --- END AUTOBOT_FLOCK ---
+FLOCK_EOF
+)
+
+# Find the right insertion point based on hook format
+if grep -q 'set -uo pipefail' "$PRE_COMMIT_HOOK"; then
+    # #1689 wrapper format — insert after 'set -uo pipefail'
+    ANCHOR='set -uo pipefail'
+elif grep -q 'INSTALL_PYTHON' "$PRE_COMMIT_HOOK"; then
+    # Standard pre-commit format — insert after ARGS line
+    ANCHOR='ARGS+=(--hook-dir'
+else
+    # Unknown format — insert after shebang
+    ANCHOR='^#!'
+fi
+
+# Use awk with index() for reliable fixed-string matching + multi-line insertion
+awk -v block="$FLOCK_BLOCK" -v anchor="$ANCHOR" '
+    index($0, anchor) && !done { print; print block; done=1; next }
+    { print }
+' "$PRE_COMMIT_HOOK" > "${PRE_COMMIT_HOOK}.tmp" \
+    && mv "${PRE_COMMIT_HOOK}.tmp" "$PRE_COMMIT_HOOK" \
+    && chmod +x "$PRE_COMMIT_HOOK"
+
+echo "✅ Injected flock wrapper into pre-commit hook (Issue #1684)"

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -5,8 +5,10 @@
 #
 # Post-checkout hook:
 #   1. Fix WSL2 symlink breakage (Issue #886)
-#   2. Auto-install prepare-commit-msg hook type (Issue #1679)
-#   3. Auto-install pre-commit branch guard wrapper (Issue #1689)
+#   2. Fix pre-commit hook script permissions (Issue #1683)
+#   3. Auto-install prepare-commit-msg hook type (Issue #1679)
+#   4. Auto-install pre-commit branch guard wrapper (Issue #1689)
+#   5. Inject flock wrapper into pre-commit hook (Issue #1684)
 
 # Determine git root directory
 if [ -n "$GIT_DIR" ]; then
@@ -15,7 +17,9 @@ else
     GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 fi
 
-# Fix backend symlink (self-referencing in autobot-user-backend/)
+# ---------------------------------------------------------------------------
+# 1. Fix WSL2 symlinks (Issue #886)
+# ---------------------------------------------------------------------------
 BACKEND_DIR="$GIT_ROOT/autobot-user-backend"
 BACKEND_SYMLINK="$BACKEND_DIR/backend"
 
@@ -28,7 +32,6 @@ if [ -d "$BACKEND_DIR" ] && { [ ! -L "$BACKEND_SYMLINK" ] || [ ! -e "$BACKEND_SY
     fi
 fi
 
-# Fix autobot_shared symlink (root level)
 SHARED_SYMLINK="$GIT_ROOT/autobot_shared"
 
 if [ ! -L "$SHARED_SYMLINK" ] || [ ! -e "$SHARED_SYMLINK" ]; then
@@ -41,7 +44,24 @@ if [ ! -L "$SHARED_SYMLINK" ] || [ ! -e "$SHARED_SYMLINK" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Auto-install prepare-commit-msg hook if missing (Issue #1679)
+# 2. Fix hook script permissions (Issue #1683)
+# ---------------------------------------------------------------------------
+HOOK_SCRIPTS_DIR="$GIT_ROOT/autobot-infrastructure/shared/scripts"
+FIXED=0
+if [ -d "$HOOK_SCRIPTS_DIR" ]; then
+    while IFS= read -r -d '' f; do
+        chmod +x "$f"
+        FIXED=$((FIXED + 1))
+    done < <(find "$HOOK_SCRIPTS_DIR/hooks" "$HOOK_SCRIPTS_DIR/utilities" \
+                  -type f \( -name "pre-commit-*" -o -name "*.sh" \) \
+                  -not -perm -u+x -print0 2>/dev/null)
+    if [ "$FIXED" -gt 0 ]; then
+        echo "✅ Fixed permissions on $FIXED hook script(s)"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Auto-install prepare-commit-msg hook if missing (Issue #1679)
 # ---------------------------------------------------------------------------
 HOOKS_DIR="$(git rev-parse --git-dir 2>/dev/null)/hooks"
 if [ -d "$HOOKS_DIR" ] && [ ! -f "$HOOKS_DIR/prepare-commit-msg" ]; then
@@ -51,7 +71,7 @@ if [ -d "$HOOKS_DIR" ] && [ ! -f "$HOOKS_DIR/prepare-commit-msg" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Auto-install pre-commit branch guard wrapper (Issue #1689)
+# 4. Auto-install pre-commit branch guard wrapper (Issue #1689)
 # ---------------------------------------------------------------------------
 # The pre-commit framework's stash/pop can silently switch branches.
 # This wraps .git/hooks/pre-commit to detect the switch AFTER the
@@ -85,6 +105,24 @@ if [ -d "$HOOKS_DIR" ] && [ -f "$WRAPPER_SRC" ]; then
             fi
         fi
     fi
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Inject flock wrapper into pre-commit hook (Issue #1684)
+# ---------------------------------------------------------------------------
+# Git worktrees share .git/refs/stash. When multiple worktrees run
+# pre-commit hooks in parallel, the stash push/pop operations collide
+# and commits leak across branches. This injects an exclusive flock
+# that serializes pre-commit across all worktrees.
+#
+# The lock file lives in git-common-dir (shared across worktrees).
+# The fd (200) is inherited by the exec'd pre-commit process and
+# auto-released when pre-commit exits.
+INJECT_SCRIPT="$GIT_ROOT/autobot-infrastructure/shared/scripts/hooks/inject-flock-wrapper"
+if [ -x "$INJECT_SCRIPT" ]; then
+    "$INJECT_SCRIPT"
+elif [ -f "$INJECT_SCRIPT" ]; then
+    bash "$INJECT_SCRIPT"
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
- Add `inject-flock-wrapper` script that injects `flock -x` serialization into `.git/hooks/pre-commit`
- Update `post-checkout` hook to auto-inject flock after `pre-commit install` regenerates the hook
- Also includes #1683 hook permission fix in the merged post-checkout

## Problem
Git worktrees share `.git/refs/stash`. When multiple worktrees run pre-commit hooks in parallel, the `stash push/pop` operations collide and commits leak across branches (#1503 mitigation was worktree isolation — this adds defense-in-depth).

## How it works
1. `flock -x 200` acquires an exclusive lock on `${git-common-dir}/pre-commit.lock`
2. Lock serializes pre-commit execution across all worktrees
3. fd 200 is inherited by the `exec`'d pre-commit process and auto-released on exit
4. `inject-flock-wrapper` is idempotent — skips if `AUTOBOT_FLOCK` marker already present
5. Handles both #1689 wrapper format and standard pre-commit format

## Test Plan
- [x] `pre-commit install -f` → clean hook
- [x] Run `inject-flock-wrapper` → flock block injected at correct position
- [x] Run again → idempotent (silent skip)
- [x] Test commit with flock active → all hooks pass
- [x] Lock file created in `.git/pre-commit.lock`
- [ ] Manual: parallel commits from two worktrees no longer contaminate

Closes #1684

🤖 Generated with Claude Code