### PR TITLE
chore(docs): worktree --unset-upstream to prevent PR bypass (#1695)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,7 +404,10 @@ Each session stays in its issue scope. If Session A discovers a bug in Session B
 Do NOT use `isolation: "worktree"` for agents that create PRs. The auto-created worktree branches from local HEAD, which may diverge from `origin/Dev_new_gui` — causing PRs with unrelated files and merge conflicts. Instead, create manual worktrees:
 ```bash
 git worktree add .worktrees/issue-XXXX -b <branch> origin/Dev_new_gui
+cd .worktrees/issue-XXXX && git branch --unset-upstream
 ```
+
+The `--unset-upstream` prevents accidental fast-forward merges into `Dev_new_gui` that bypass PRs — all changes must go through a PR.
 
 **If subagent fails:** Switch to direct implementation immediately. Do NOT retry.
 


### PR DESCRIPTION
## Summary

- Adds `git branch --unset-upstream` to the worktree creation instructions in CLAUDE.md
- Prevents worktree branches from tracking `origin/Dev_new_gui` directly, which can cause commits to land on Dev_new_gui via fast-forward merge without going through a PR

### Root cause

When `git worktree add -b <branch> origin/Dev_new_gui` creates a branch, it automatically sets upstream tracking to `origin/Dev_new_gui`. If another session rebases or fast-forwards Dev_new_gui past the worktree's commit, the commit bypasses code review.

### Retroactive review

Commit `e4517859b` (the direct push that prompted this issue) was reviewed:
- 2 files changed: `auto-close-issues.yml` (text-only, workflow rename + comment-only behavior), `CLAUDE.md` (ritual text update)
- No logic bugs, no security issues, no concerns

Closes #1695

## Test plan

- [ ] Verify CLAUDE.md worktree section includes `--unset-upstream` command
- [ ] Verify explanatory text follows the code block