### PR TITLE
fix(hooks): fix flock deadlock, fallback anchor, permissions pattern (#1699, #1700)

### DIFF
--- a/autobot-infrastructure/shared/scripts/hooks/inject-flock-wrapper
+++ b/autobot-infrastructure/shared/scripts/hooks/inject-flock-wrapper
@@ -45,8 +45,8 @@ elif grep -q 'INSTALL_PYTHON' "$PRE_COMMIT_HOOK"; then
     # Standard pre-commit format — insert after ARGS line
     ANCHOR='ARGS+=(--hook-dir'
 else
-    # Unknown format — insert after shebang
-    ANCHOR='^#!'
+    # Unknown format — insert after shebang (literal match for index())
+    ANCHOR='#!/'
 fi
 
 # Use awk with index() for reliable fixed-string matching + multi-line insertion
@@ -56,5 +56,16 @@ awk -v block="$FLOCK_BLOCK" -v anchor="$ANCHOR" '
 ' "$PRE_COMMIT_HOOK" > "${PRE_COMMIT_HOOK}.tmp" \
     && mv "${PRE_COMMIT_HOOK}.tmp" "$PRE_COMMIT_HOOK" \
     && chmod +x "$PRE_COMMIT_HOOK"
+
+# Strip flock from framework hook if present — prevents deadlock when
+# the #1689 wrapper holds the lock and calls the framework hook which
+# tries to acquire the same lock (#1699)
+FRAMEWORK_HOOK="$HOOKS_DIR/pre-commit.pre-commit-framework"
+if [ -f "$FRAMEWORK_HOOK" ] && grep -q 'AUTOBOT_FLOCK' "$FRAMEWORK_HOOK"; then
+    sed '/^# --- AUTOBOT_FLOCK/,/^# --- END AUTOBOT_FLOCK/d' \
+        "$FRAMEWORK_HOOK" > "${FRAMEWORK_HOOK}.tmp" \
+        && mv "${FRAMEWORK_HOOK}.tmp" "$FRAMEWORK_HOOK" \
+        && chmod +x "$FRAMEWORK_HOOK"
+fi
 
 echo "✅ Injected flock wrapper into pre-commit hook (Issue #1684)"

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -53,7 +53,9 @@ if [ -d "$HOOK_SCRIPTS_DIR" ]; then
         chmod +x "$f"
         FIXED=$((FIXED + 1))
     done < <(find "$HOOK_SCRIPTS_DIR/hooks" "$HOOK_SCRIPTS_DIR/utilities" \
-                  -type f \( -name "pre-commit-*" -o -name "*.sh" \) \
+                  -type f \( -name "pre-commit-*" -o -name "post-commit-*" \
+                             -o -name "inject-*" -o -name "slm-*" \
+                             -o -name "*.sh" \) \
                   -not -perm -u+x -print0 2>/dev/null)
     if [ "$FIXED" -gt 0 ]; then
         echo "✅ Fixed permissions on $FIXED hook script(s)"


### PR DESCRIPTION
## Summary
- Fix flock deadlock when #1689 wrapper + flock both hold the same lock
- Fix fallback anchor `^#!` → `#!/` for `index()` fixed-string matching
- Broaden permissions fix pattern to catch `post-commit-*`, `inject-*`, `slm-*`

## Problem
Three bugs in the #1684 flock implementation:

1. **Deadlock** (critical): When #1689 wrapper wraps a hook that already has flock injected, both the wrapper AND framework hook try to acquire the same exclusive lock → deadlock. Fix: strip flock from `.pre-commit-framework` after injection.

2. **#1699**: Fallback anchor `^#!` is regex syntax but `index()` does fixed-string matching → unknown hook formats silently fail to get flock protection.

3. **#1700**: Permissions fix pattern only matches `pre-commit-*` and `*.sh` → misses `inject-flock-wrapper`, `slm-post-commit`, `post-commit-doc-sync`.

## Test Plan
- [x] Full cycle: install → wrap → inject → verify wrapper has flock, framework does NOT
- [x] Reverse cycle: install → inject → wrap → re-inject → verify no deadlock
- [x] Commit succeeds with flock active (no hang)
- [x] Fallback anchor `#!/` matches unknown hook shebang lines
- [x] Broadened pattern catches all 5 script types

Closes #1699
Closes #1700

🤖 Generated with Claude Code