### PR TITLE
fix(knowledge): align score_threshold defaults to 0.3 (#1532)

### DIFF
--- a/autobot-backend/api/knowledge_search_aggregator.py
+++ b/autobot-backend/api/knowledge_search_aggregator.py
@@ -186,7 +186,7 @@ def _process_documentation_context(
     if not doc_searcher or not doc_searcher.is_documentation_query(query):
         return total_length
 
-    doc_results = doc_searcher.search(query=query, n_results=2, score_threshold=0.6)
+    doc_results = doc_searcher.search(query=query, n_results=2, score_threshold=0.3)
     if not doc_results:
         return total_length
 
@@ -252,7 +252,7 @@ class UnifiedSearchRequest(BaseModel):
     doc_results: int = Field(3, ge=0, le=10, description="Max documentation results")
     expand_relations: bool = Field(True, description="Include related facts via graph")
     score_threshold: float = Field(
-        0.6, ge=0.0, le=1.0, description="Minimum relevance score"
+        0.3, ge=0.0, le=1.0, description="Minimum relevance score"
     )
     include_sources: List[str] = Field(
         default=["facts", "relations", "documentation"],
@@ -554,7 +554,7 @@ async def get_llm_context(req: Request, body: ContextRequest):
 async def search_documentation(
     query: str,
     n_results: int = 5,
-    score_threshold: float = 0.5,
+    score_threshold: float = 0.3,
 ):
     """
     Search indexed AutoBot documentation.

--- a/autobot-backend/services/knowledge/doc_searcher.py
+++ b/autobot-backend/services/knowledge/doc_searcher.py
@@ -182,7 +182,7 @@ class DocumentationSearcher:
         }
 
     def search(
-        self, query: str, n_results: int = 3, score_threshold: float = 0.6
+        self, query: str, n_results: int = 3, score_threshold: float = 0.3
     ) -> List[Dict[str, Any]]:
         """Search documentation for relevant content.
 

--- a/autobot-backend/services/knowledge/service.py
+++ b/autobot-backend/services/knowledge/service.py
@@ -650,7 +650,7 @@ class ChatKnowledgeService:
         return context_string, citations, intent_result, enhanced_query
 
     def _retrieve_documentation_context(
-        self, query: str, n_results: int = 3, score_threshold: float = 0.5
+        self, query: str, n_results: int = 3, score_threshold: float = 0.3
     ) -> str:
         """Retrieve documentation context if query matches doc patterns.
 
@@ -729,7 +729,7 @@ class ChatKnowledgeService:
         self,
         query: str,
         n_results: int = 3,
-        score_threshold: float = 0.6,
+        score_threshold: float = 0.3,
     ) -> Tuple[str, List[Dict[str, Any]]]:
         """
         Retrieve relevant AutoBot documentation for a query.


### PR DESCRIPTION
## Summary
- Aligns all `score_threshold` defaults to `0.3` across 6 locations in 3 files
- After #1526 lowered the main RAG pipeline threshold, alternative retrieval paths still used `0.5`–`0.6`, creating asymmetric filtering

Closes #1532

## Changes
- `knowledge_search_aggregator.py`: 3 defaults aligned (lines 189, 255, 557)
- `services/knowledge/service.py`: 2 defaults aligned (lines 653, 732)
- `services/knowledge/doc_searcher.py`: 1 default aligned (line 185)

## Test plan
- [ ] Verify documentation search returns results at the lower threshold
- [ ] Confirm no regressions in unified search endpoint