### PR TITLE
fix(code-intel): enforce TTL check in _learn_bug_patterns_async (#1563)

### DIFF
--- a/autobot-backend/code_intelligence/bug_predictor.py
+++ b/autobot-backend/code_intelligence/bug_predictor.py
@@ -1120,7 +1120,11 @@ class BugPredictor(_BaseClass):
         if not self.use_semantic_analysis:
             return
 
-        if self._bug_history_cache is None:
+        if self._bug_history_cache is None or (
+            self._bug_history_cache_time is not None
+            and time.monotonic() - self._bug_history_cache_time > _BUG_HISTORY_CACHE_TTL
+        ):
+            self._bug_history_cache = None
             self._build_bug_history_cache()
 
         bug_patterns = self._collect_bug_patterns_from_cache()


### PR DESCRIPTION
## Summary
- `_learn_bug_patterns_async` checked only `is None`, bypassing the 6-hour TTL from #1551
- Now uses the same TTL-aware condition as `_get_bug_history`

Closes #1563

## Changes
- `code_intelligence/bug_predictor.py`: Added TTL expiry check (monotonic clock + `_BUG_HISTORY_CACHE_TTL`) alongside the existing `None` check, with cache reset before rebuild

## Test plan
- [ ] Verify bug pattern learning refreshes cache after TTL expiry
- [ ] Confirm no regressions in bug prediction