### PR TITLE
fix(codebase): persist indexing queue to Redis (#1717)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/indexing.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/indexing.py
@@ -38,6 +38,8 @@ from ..scanner import (
     _current_indexing_task_id,
     _index_queue,
     _load_task_from_redis,
+    _persist_queue_entry,
+    _pop_queue_entry_redis,
     _run_indexing_subprocess,
     _tasks_lock,
     _tasks_sync_lock,
@@ -49,13 +51,14 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def _check_existing_task_and_queue(
+async def _check_existing_task_and_queue(
     source_id: Optional[str], root_path_for_queue: str
 ) -> Optional[JSONResponse]:
     """If a job is running, enqueue the request and return a queued response.
 
     Returns None when no job is running (caller should start a new job).
     Issue #1133: queuing replaces the old "already_running" rejection.
+    Issue #1717: persists queue entry to Redis for restart survival.
     """
     if _current_indexing_task_id is None:
         return None
@@ -63,18 +66,16 @@ def _check_existing_task_and_queue(
     if existing_task is None or existing_task.done():
         return None
     # A job is running — add to FIFO queue
-    from datetime import datetime as _dt
-
     position = len(_index_queue) + 1
-    _index_queue.append(
-        {
-            "source_id": source_id,
-            "root_path": root_path_for_queue,
-            "queued_at": _dt.now().isoformat(),
-            "requested_by": "api",
-        }
-    )
-    logger.info("📋 Indexing queued (position %d): %s", position, root_path_for_queue)
+    entry = {
+        "source_id": source_id,
+        "root_path": root_path_for_queue,
+        "queued_at": datetime.now().isoformat(),
+        "requested_by": "api",
+    }
+    _index_queue.append(entry)
+    await _persist_queue_entry(entry)
+    logger.info("Indexing queued (position %d): %s", position, root_path_for_queue)
     return JSONResponse(
         {
             "task_id": None,
@@ -82,7 +83,8 @@ def _check_existing_task_and_queue(
             "position": position,
             "message": (
                 f"Queued behind current job (position {position}). "
-                "The job will start automatically when the running job finishes."
+                "The job will start automatically when the running "
+                "job finishes."
             ),
         }
     )
@@ -151,20 +153,21 @@ async def _validate_and_get_path(
 
 
 def _start_next_queued_job() -> None:
-    """Dequeue and start the next pending indexing job if any (#1133)."""
+    """Dequeue and start the next pending indexing job (#1133, #1717)."""
     global _current_indexing_task_id
     if not _index_queue:
         return
     next_job = _index_queue.popleft()
+    # Remove from Redis queue (#1717: keep in-memory and Redis in sync)
+    loop = asyncio.get_event_loop()
+    loop.create_task(_pop_queue_entry_redis())
     next_path = next_job.get("root_path", str(PATH.PROJECT_ROOT))
     next_task_id = str(uuid.uuid4())
     _current_indexing_task_id = next_task_id
-    task = asyncio.get_event_loop().create_task(
-        _run_indexing_subprocess(next_task_id, next_path)
-    )
+    task = loop.create_task(_run_indexing_subprocess(next_task_id, next_path))
     _active_tasks[next_task_id] = task
     task.add_done_callback(_create_cleanup_callback(next_task_id))
-    logger.info("▶️  Auto-started queued job %s for %s", next_task_id, next_path)
+    logger.info("Auto-started queued job %s for %s", next_task_id, next_path)
 
 
 def _create_cleanup_callback(task_id: str):
@@ -223,7 +226,7 @@ async def index_codebase(request: Optional[IndexCodebaseRequest] = None):
     logger.info("Indexing path: %s", root_path)
 
     async with _tasks_lock:
-        queued_response = _check_existing_task_and_queue(source_id, root_path)
+        queued_response = await _check_existing_task_and_queue(source_id, root_path)
         if queued_response:
             return queued_response
 

--- a/autobot-backend/api/codebase_analytics/endpoints/queue.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/queue.py
@@ -19,6 +19,7 @@ from ..scanner import (
     _active_tasks,
     _current_indexing_task_id,
     _index_queue,
+    _remove_queue_entries_redis,
     _tasks_lock,
     indexing_tasks,
 )
@@ -77,7 +78,7 @@ async def get_index_queue():
     error_code_prefix="CODEBASE",
 )
 async def dequeue_source(source_id: str):
-    """Remove all pending queue entries for a given source_id."""
+    """Remove all pending queue entries for a given source_id (#1717)."""
     async with _tasks_lock:
         before = len(_index_queue)
         to_keep = [item for item in _index_queue if item.get("source_id") != source_id]
@@ -85,6 +86,8 @@ async def dequeue_source(source_id: str):
         _index_queue.extend(to_keep)
         removed = before - len(_index_queue)
 
+    if removed:
+        await _remove_queue_entries_redis(source_id)
     logger.info("Removed %d queue entries for source %s", removed, source_id)
     return JSONResponse(
         {

--- a/autobot-backend/api/codebase_analytics/endpoints/sources.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources.py
@@ -170,6 +170,7 @@ async def _trigger_indexing(source: CodeSource) -> None:
             _active_tasks,
             _current_indexing_task_id,
             _index_queue,
+            _persist_queue_entry,
             _run_indexing_subprocess,
             _tasks_lock,
         )
@@ -187,14 +188,14 @@ async def _trigger_indexing(source: CodeSource) -> None:
                 _active_tasks[task_id] = task
                 task.add_done_callback(_create_cleanup_callback(task_id))
             else:
-                _index_queue.append(
-                    {
-                        "source_id": source.id,
-                        "root_path": source.clone_path,
-                        "queued_at": datetime.now().isoformat(),
-                        "requested_by": "sync",
-                    }
-                )
+                entry = {
+                    "source_id": source.id,
+                    "root_path": source.clone_path,
+                    "queued_at": datetime.now().isoformat(),
+                    "requested_by": "sync",
+                }
+                _index_queue.append(entry)
+                await _persist_queue_entry(entry)
     except Exception as exc:
         logger.warning("Could not trigger indexing for %s: %s", source.id, exc)
 

--- a/autobot-backend/api/codebase_analytics/scanner.py
+++ b/autobot-backend/api/codebase_analytics/scanner.py
@@ -573,6 +573,9 @@ _index_queue: deque = deque()
 _TASK_REDIS_PREFIX = "indexing_task:"
 _TASK_REDIS_TTL = 86400  # 24 hours
 
+# Redis key for persistent index queue (#1717: survive restarts)
+_QUEUE_REDIS_KEY = "codebase:index_queue"
+
 
 async def _save_task_to_redis(task_id: str) -> None:
     """Persist task state to Redis so all uvicorn workers can read it (#1179)."""
@@ -605,6 +608,83 @@ async def _load_task_from_redis(task_id: str) -> Optional[Dict]:
             "[Task %s] Redis task state load failed (non-fatal): %s", task_id, e
         )
     return None
+
+
+# =============================================================================
+# Redis-backed index queue persistence (#1717)
+# =============================================================================
+
+
+async def _persist_queue_entry(entry: Dict) -> None:
+    """Append a queue entry to Redis list (#1717)."""
+    try:
+        redis = await get_redis_connection_async()
+        if redis:
+            await redis.rpush(_QUEUE_REDIS_KEY, json.dumps(entry, default=str))
+    except Exception as e:
+        logger.debug("Redis queue persist failed (non-fatal): %s", e)
+
+
+async def _pop_queue_entry_redis() -> None:
+    """Remove the front entry from the Redis queue (#1717)."""
+    try:
+        redis = await get_redis_connection_async()
+        if redis:
+            await redis.lpop(_QUEUE_REDIS_KEY)
+    except Exception as e:
+        logger.debug("Redis queue pop failed (non-fatal): %s", e)
+
+
+async def _remove_queue_entries_redis(source_id: str) -> None:
+    """Remove all Redis queue entries matching *source_id* (#1717)."""
+    try:
+        redis = await get_redis_connection_async()
+        if not redis:
+            return
+        raw_items = await redis.lrange(_QUEUE_REDIS_KEY, 0, -1)
+        keep = [
+            item for item in raw_items if json.loads(item).get("source_id") != source_id
+        ]
+        pipe = redis.pipeline()
+        pipe.delete(_QUEUE_REDIS_KEY)
+        for item in keep:
+            pipe.rpush(_QUEUE_REDIS_KEY, item)
+        await pipe.execute()
+    except Exception as e:
+        logger.debug("Redis queue remove failed (non-fatal): %s", e)
+
+
+async def _load_queue_from_redis() -> List[Dict]:
+    """Load all queued entries from Redis (#1717: startup recovery)."""
+    try:
+        redis = await get_redis_connection_async()
+        if not redis:
+            return []
+        raw_items = await redis.lrange(_QUEUE_REDIS_KEY, 0, -1)
+        return [json.loads(item) for item in raw_items]
+    except Exception as e:
+        logger.debug("Redis queue load failed (non-fatal): %s", e)
+        return []
+
+
+async def recover_index_queue() -> int:
+    """Restore in-memory queue from Redis on startup (#1717).
+
+    Returns the number of recovered entries.
+    """
+    entries = await _load_queue_from_redis()
+    if not entries:
+        return 0
+    async with _tasks_lock:
+        for entry in entries:
+            if not any(
+                e.get("source_id") == entry.get("source_id")
+                and e.get("root_path") == entry.get("root_path")
+                for e in _index_queue
+            ):
+                _index_queue.append(entry)
+    logger.info("Recovered %d queued indexing jobs from Redis (#1717)", len(entries))
+    return len(entries)
 
 
 # =============================================================================

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -17,6 +17,7 @@ from contextlib import asynccontextmanager
 
 from chat_history import ChatHistoryManager
 from chat_workflow import ChatWorkflowManager
+from config import ConfigManager
 from fastapi import FastAPI
 from knowledge_factory import get_or_create_knowledge_base
 from security_layer import SecurityLayer
@@ -31,7 +32,6 @@ from autobot_shared.tracing import (
     instrument_redis,
     shutdown_tracing,
 )
-from config import ConfigManager
 
 # Bounded thread pool to prevent unbounded thread creation
 # Default asyncio executor creates min(32, cpu_count + 4) threads per invocation
@@ -786,6 +786,23 @@ async def _init_background_llm_sync(app: FastAPI):
         logger.warning("Background LLM sync initialization failed: %s", sync_error)
 
 
+async def _recover_index_queue():
+    """Restore queued indexing jobs from Redis after restart (#1717)."""
+    try:
+        from api.codebase_analytics.scanner import recover_index_queue
+
+        count = await recover_index_queue()
+        if count:
+            logger.info(
+                "[ 95%%] Index Queue: Recovered %d jobs from Redis",
+                count,
+            )
+        else:
+            logger.info("[ 95%%] Index Queue: No pending jobs to recover")
+    except Exception as e:
+        logger.warning("Index queue recovery failed (non-fatal): %s", e)
+
+
 async def initialize_background_services(app: FastAPI):
     """
     Phase 2: Initialize background services (NON-BLOCKING).
@@ -819,6 +836,7 @@ async def initialize_background_services(app: FastAPI):
         await _init_heartbeat_scheduler(app)
         await _init_slm_reconciler(app)
         await _init_metrics_collection()
+        await _recover_index_queue()
 
         await update_app_state_multi(
             initialization_status="ready",


### PR DESCRIPTION
## Summary

Fixes #1717 — the in-memory `deque` used for queued indexing jobs was silently lost on backend restart.

- **Redis persistence**: Queue entries are now mirrored to Redis list `codebase:index_queue` (analytics DB) on every enqueue/dequeue operation
- **Startup recovery**: `recover_index_queue()` runs during Phase 2 background init, restoring any orphaned entries back into the in-memory deque
- **All queue mutation points covered**: `_check_existing_task_and_queue` (API enqueue), `_trigger_indexing` (sync enqueue), `_start_next_queued_job` (dequeue), `dequeue_source` endpoint (manual removal)

## Changes

| File | Change |
|------|--------|
| `scanner.py` | Added 6 Redis queue functions: `_persist_queue_entry`, `_pop_queue_entry_redis`, `_remove_queue_entries_redis`, `_load_queue_from_redis`, `recover_index_queue` |
| `endpoints/indexing.py` | Made `_check_existing_task_and_queue` async, added Redis persist on enqueue + Redis pop on dequeue |
| `endpoints/sources.py` | Added Redis persist when sync triggers a queued indexing job |
| `endpoints/queue.py` | Added Redis removal when `DELETE /index/queue/{source_id}` removes entries |
| `initialization/lifespan.py` | Added `_recover_index_queue()` to Phase 2 startup |

## Design decisions

- **Non-fatal Redis ops**: All Redis queue operations are wrapped in try/except — if Redis is unavailable, the in-memory queue still works exactly as before
- **Fire-and-forget in sync callback**: `_start_next_queued_job` runs in a sync `add_done_callback` context, so the Redis pop is scheduled via `loop.create_task()` (same pattern already used there)
- **Dedup on recovery**: `recover_index_queue()` checks for duplicates before appending to prevent double-processing

## Test plan

- [ ] Queue an indexing job while another is running → verify Redis key `codebase:index_queue` contains the entry
- [ ] Restart backend → verify recovered jobs appear in `/api/analytics/codebase/index/queue`
- [ ] Remove a queued source via `DELETE /index/queue/{source_id}` → verify Redis list updated
- [ ] Verify normal indexing flow still works without Redis available (graceful degradation)