### PR TITLE
fix(security): deploy service auth keys via Ansible setup + safe rotation (#1734)

### DIFF
--- a/autobot-infrastructure/shared/scripts/generate_service_keys.py
+++ b/autobot-infrastructure/shared/scripts/generate_service_keys.py
@@ -3,8 +3,12 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Generate service API keys for AutoBot distributed infrastructure
-Stores keys in Redis and creates backup configuration file
+Generate service API keys for AutoBot distributed infrastructure.
+
+Stores keys in Redis and creates backup configuration file.
+
+Usage:
+    python3 scripts/generate_service_keys.py
 """
 
 import asyncio
@@ -13,155 +17,88 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+import yaml
+
 logger = logging.getLogger(__name__)
 
-# Add backend to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Add project paths
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "autobot-backend"))
+sys.path.insert(0, str(PROJECT_ROOT / "autobot-shared"))
 
-import structlog
-from backend.security.service_auth import ServiceAuthManager
-from utils.redis_client import get_redis_client
+from autobot_shared.ssot_config import config  # noqa: E402
 
-logger = structlog.get_logger()
+from autobot_shared.redis_client import get_redis_client  # noqa: E402
+from security.service_auth import ServiceAuthManager  # noqa: E402
 
-
-# Service definitions for AutoBot's 6-VM infrastructure
+# Service definitions for AutoBot's distributed VM infrastructure.
+# Hosts are resolved from SSOT config — never hardcoded.
 SERVICES = [
     {
         "id": "main-backend",
-        "host": "172.16.168.20",
+        "host_attr": "main",
         "description": "Main backend API server",
     },
     {
         "id": "frontend",
-        "host": "172.16.168.21",
+        "host_attr": "frontend",
         "description": "Vue.js frontend web interface",
     },
     {
         "id": "npu-worker",
-        "host": "172.16.168.22",
+        "host_attr": "npu",
         "description": "NPU hardware acceleration worker",
     },
     {
         "id": "redis-stack",
-        "host": "172.16.168.23",
+        "host_attr": "redis",
         "description": "Redis Stack database",
     },
     {
         "id": "ai-stack",
-        "host": "172.16.168.24",
+        "host_attr": "aistack",
         "description": "AI/ML processing stack",
     },
     {
         "id": "browser-service",
-        "host": "172.16.168.25",
+        "host_attr": "browser",
         "description": "Playwright browser automation",
     },
 ]
 
 
-async def _generate_keys_block_3():
-    """Generate 256-bit key.
+def _resolve_host(host_attr: str) -> str:
+    """Resolve host IP from SSOT config."""
+    return getattr(config.vms, host_attr)
 
-    Helper for generate_keys (Issue #825).
+
+async def _generate_all_keys(auth_manager):
+    """Generate keys for all services and return dict.
+
+    Helper for generate_keys (#1734).
     """
-    # Generate 256-bit key
-    logger.info(f"Generating key for {service_id}...", end=" ")
-    key = await auth_manager.generate_service_key(service_id)
-    generated_keys[service_id] = {
-        "key": key,
-        "host": service["host"],
-        "description": service["description"],
-        "generated_at": datetime.now().isoformat(),
-    }
-    logger.info(f"✅ {key[:16]}...{key[-8:]}")
-
-
-async def _generate_keys_block_2():
-    """with open(backup_file, "w") as f:.
-
-    Helper for generate_keys (Issue #825).
-    """
-    with open(backup_file, "w") as f:
-        yaml.safe_dump(
-            {
-                "generated_at": datetime.now().isoformat(),
-                "redis_host": "172.16.168.23",
-                "redis_port": 6379,
-                "services": generated_keys,
-            },
-            f,
-            default_flow_style=False,
-        )
-
-
-async def _generate_keys_block_4():
-    """Verify keys are in Redis.
-
-    Helper for generate_keys (Issue #825).
-    """
-    # Verify keys are in Redis
-    logger.info("🔍 Verifying keys in Redis...")
-    for service_id in generated_keys:
-        stored_key = await auth_manager.get_service_key(service_id)
-        if stored_key:
-            logger.info(f"  ✅ {service_id}: Key verified in Redis")
-        else:
-            logger.error(f"  ❌ {service_id}: FAILED - Key not found in Redis!")
-
-
-async def _generate_keys_block_1():
-    """logger.info("").
-
-    Helper for generate_keys (Issue #825).
-    """
-    logger.info("")
-    logger.info("=" * 60)
-    logger.info("🎉 Service key generation complete!")
-    logger.info("")
-    logger.info("Next steps:")
-    logger.info(
-        "  1. Deploy keys to VMs: ansible-playbook ansible/playbooks/deploy-service-auth.yml"
-    )
-    logger.info(
-        "  2. Verify deployment: ansible all -m shell -a 'ls -la /etc/autobot/service-keys/'"
-    )
-    logger.info(f"  3. Backup location: {backup_file}")
-    logger.info("")
-    logger.info(
-        "⚠️  SECURITY: Keep backup file secure and delete after deployment verification"
-    )
-
-
-async def generate_keys():
-    """Generate API keys for all services and store in Redis"""
-
-    logger.info("🔐 AutoBot Service Key Generation")
-    logger.info("=" * 60)
-    logger.info(f"Timestamp: {datetime.now().isoformat()}")
-    logger.info("Redis Host: 172.16.168.23:6379")
-    logger.info(f"Services: {len(SERVICES)}")
-    logger.info("")
-
-    # Get Redis client for main database
-    redis = await get_redis_client(async_client=True, database="main")
-
-    # Create auth manager
-    ServiceAuthManager(redis)
-
-    # Store generated keys
     generated_keys = {}
-
     for service in SERVICES:
-        service["id"]
+        service_id = service["id"]
+        host = _resolve_host(service["host_attr"])
 
-    await _generate_keys_block_3()
+        logger.info("Generating key for %s...", service_id)
+        key = await auth_manager.generate_service_key(service_id)
+        generated_keys[service_id] = {
+            "key": key,
+            "host": host,
+            "description": service["description"],
+            "generated_at": datetime.now().isoformat(),
+        }
+        logger.info("  %s: %s***", service_id, key[:8])
+    return generated_keys
 
-    logger.info("")
-    logger.info(f"✅ Generated {len(generated_keys)} service keys")
-    logger.info("")
 
-    # Create backup configuration file
+def _save_backup(generated_keys, redis_host, redis_port):
+    """Write keys backup YAML and return file path.
+
+    Helper for generate_keys (#1734).
+    """
     backup_dir = Path("config/service-keys")
     backup_dir.mkdir(parents=True, exist_ok=True)
 
@@ -169,17 +106,73 @@ async def generate_keys():
         backup_dir / f"service-keys-{datetime.now().strftime('%Y%m%d-%H%M%S')}.yaml"
     )
 
-    await _generate_keys_block_2()
+    with open(backup_file, "w", encoding="utf-8") as f:
+        yaml.safe_dump(
+            {
+                "generated_at": datetime.now().isoformat(),
+                "redis_host": redis_host,
+                "redis_port": redis_port,
+                "services": generated_keys,
+            },
+            f,
+            default_flow_style=False,
+        )
 
-    logger.info(f"💾 Backup saved: {backup_file}")
+    logger.info("Backup saved: %s", backup_file)
+    return backup_file
+
+
+async def _verify_keys_in_redis(auth_manager, generated_keys):
+    """Verify all generated keys are stored in Redis.
+
+    Helper for generate_keys (#1734).
+    """
+    logger.info("Verifying keys in Redis...")
+    for service_id in generated_keys:
+        stored_key = await auth_manager.get_service_key(service_id)
+        if stored_key:
+            logger.info("  %s: Key verified in Redis", service_id)
+        else:
+            logger.error("  %s: FAILED - Key not found!", service_id)
+
+
+async def generate_keys():
+    """Generate API keys for all services and store in Redis."""
+    redis_host = config.vms.redis
+    redis_port = config.ports.redis
+
+    logger.info("AutoBot Service Key Generation")
+    logger.info("=" * 60)
+    logger.info("Timestamp: %s", datetime.now().isoformat())
+    logger.info("Redis: %s:%s", redis_host, redis_port)
+    logger.info("Services: %d", len(SERVICES))
     logger.info("")
 
-    await _generate_keys_block_4()
+    redis = await get_redis_client(async_client=True, database="main")
+    auth_manager = ServiceAuthManager(redis)
 
-    await _generate_keys_block_1()
+    generated_keys = await _generate_all_keys(auth_manager)
+    logger.info("")
+    logger.info("Generated %d service keys", len(generated_keys))
+    logger.info("")
+
+    backup_file = _save_backup(generated_keys, redis_host, redis_port)
+    logger.info("")
+
+    await _verify_keys_in_redis(auth_manager, generated_keys)
+
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info("Service key generation complete!")
+    logger.info("  Deploy: ansible-playbook playbooks/deploy-service-auth.yml")
+    logger.info("  Backup: %s", backup_file)
 
     return generated_keys
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
     asyncio.run(generate_keys())

--- a/autobot-infrastructure/shared/scripts/verify-service-auth.py
+++ b/autobot-infrastructure/shared/scripts/verify-service-auth.py
@@ -8,17 +8,16 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
-import logging
 
 logger = logging.getLogger(__name__)
 
-logger = logging.getLogger(__name__)
+# Add project paths
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "autobot-backend"))
+sys.path.insert(0, str(PROJECT_ROOT / "autobot-shared"))
 
-# Add project root to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from backend.security.service_auth import ServiceAuthManager
-from utils.redis_client import get_redis_client as get_redis_manager
+from autobot_shared.redis_client import get_redis_client  # noqa: E402
+from security.service_auth import ServiceAuthManager  # noqa: E402
 
 # All 6 services that should have keys
 SERVICES = [
@@ -31,87 +30,82 @@ SERVICES = [
 ]
 
 
+async def _check_service_keys(auth_mgr):
+    """Verify all service keys exist in Redis.
+
+    Helper for verify (#1734).
+    Returns True if all keys are present.
+    """
+    logger.info("Checking service keys:")
+    logger.info("-" * 50)
+    all_present = True
+    for service_id in SERVICES:
+        key = await auth_mgr.get_service_key(service_id)
+        status = "OK" if key else "MISSING"
+        key_preview = f"{key[:8]}***" if key else "MISSING"
+        logger.info("  %s  %-20s %s", status, service_id, key_preview)
+        if not key:
+            all_present = False
+    logger.info("")
+    return all_present
+
+
+def _check_signature_generation(auth_mgr):
+    """Test HMAC signature generation.
+
+    Helper for verify (#1734).
+    Returns True if signature generation works.
+    """
+    logger.info("Testing signature generation:")
+    logger.info("-" * 50)
+    try:
+        test_sig = auth_mgr.generate_signature(
+            "test-service", "a" * 64, "POST", "/api/test", 1234567890
+        )
+        logger.info("  Signature: %s*** (%d chars)", test_sig[:8], len(test_sig))
+        logger.info("")
+        return True
+    except Exception:
+        logger.exception("Signature generation failed")
+        logger.info("")
+        return False
+
+
 async def verify():
     """Verify service authentication infrastructure."""
-    logger.info("🔐 Service Authentication Verification")
+    logger.info("Service Authentication Verification")
     logger.info("=" * 50)
     logger.info("")
 
     try:
-        # Get Redis connection
-        redis_mgr = await get_redis_manager()
-        redis = await redis_mgr.main()
+        redis = await get_redis_client(async_client=True, database="main")
         auth_mgr = ServiceAuthManager(redis)
-
-        logger.info("✅ ServiceAuthManager initialized successfully")
+        logger.info("ServiceAuthManager initialized successfully")
         logger.info("")
 
-        # Verify all service keys
-        logger.info("Checking service keys:")
-        logger.info("-" * 50)
-        all_present = True
-        for service_id in SERVICES:
-            key = await auth_mgr.get_service_key(service_id)
-            status = "✅" if key else "❌"
-            key_preview = f"{key[:16]}..." if key else "MISSING"
-            logger.info(f"{status} {service_id:<20} {key_preview}")
-            if not key:
-                all_present = False
+        keys_ok = await _check_service_keys(auth_mgr)
+        sig_ok = _check_signature_generation(auth_mgr)
 
-        logger.info("")
-
-        # Test signature generation
-        logger.info("Testing signature generation:")
-        logger.info("-" * 50)
-        try:
-            test_sig = auth_mgr.generate_signature(
-                "test-service",
-                "a" * 64,  # 256-bit hex key
-                "POST",
-                "/api/test",
-                1234567890,
-            )
-            logger.info(f"✅ Signature generated: {test_sig[:32]}...")
-            logger.info(f"   Full length: {len(test_sig)} chars")
-            logger.info("")
-        except Exception as e:
-            logger.error(f"❌ Signature generation failed: {e}")
-            logger.info("")
-            all_present = False
-
-        # Summary
         logger.info("=" * 50)
-        if all_present:
-            logger.info("✅ Service authentication ready for deployment")
-            logger.info("")
-            logger.info("All checks passed:")
-            logger.info("  • All 6 service keys present")
-            logger.info("  • Signature generation working")
-            logger.info("  • ServiceAuthManager operational")
+        if keys_ok and sig_ok:
+            logger.info("Service authentication ready for deployment")
+            logger.info("  - All %d service keys present", len(SERVICES))
+            logger.info("  - Signature generation working")
             return 0
-        else:
-            logger.error("❌ Service authentication NOT ready")
-            logger.info("")
-            logger.info("Issues detected:")
-            missing_count = sum(
-                1 for svc in SERVICES if not await auth_mgr.get_service_key(svc)
-            )
-            if missing_count > 0:
-                logger.info(f"  • {missing_count} service key(s) missing")
-            logger.info("")
-            logger.info("Action required:")
-            logger.info("  Run: python3 scripts/generate_service_keys.py")
-            return 1
 
-    except Exception as e:
-        logger.error(f"❌ Fatal error during verification: {e}")
-        logger.info("")
-        import traceback
+        logger.error("Service authentication NOT ready")
+        logger.info("Action: python3 scripts/generate_service_keys.py")
+        return 1
 
-        traceback.print_exc()
+    except Exception:
+        logger.exception("Fatal error during verification")
         return 1
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
     exit_code = asyncio.run(verify())
     sys.exit(exit_code)

--- a/autobot-slm-backend/ansible/playbooks/deploy-full.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-full.yml
@@ -51,6 +51,16 @@
     deployment_phase: "database"
     phase_description: "Redis Stack, data persistence, model storage"
 
+# Phase 2.5: Service Authentication Keys (#1734)
+# Must run after database (Redis needed for key storage) and before backend
+# (backend reads keys on startup). Generates keys, stores in Redis, deploys
+# .env key files to each VM via the service_auth role.
+- name: "Phase 2.5: Service Authentication"
+  import_playbook: deploy-service-auth.yml
+  vars:
+    deployment_phase: "service-auth"
+    phase_description: "Generate and deploy service-to-service auth keys"
+
 # Phase 3: Backend Services
 - name: "Phase 3: Backend Services"
   import_playbook: deploy-backend.yml

--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -190,6 +190,19 @@
       tags: ['base', 'common']
 
     # ===========================================
+    # Phase 1.5: Service Authentication (#1734)
+    # Deploy service auth keys during node enrollment.
+    # Keys must exist in Redis before this step — run
+    # generate_service_keys.py or deploy-service-auth.yml first.
+    # ===========================================
+    - name: "Phase 1.5 - Service Authentication Keys"
+      ansible.builtin.include_role:
+        name: service_auth
+      vars:
+        service_auth_enabled: true
+      tags: ['service_auth', 'keys']
+
+    # ===========================================
     # Phase 2: Role-Specific Configuration
     # ===========================================
     - name: "Phase 2 - Role-Specific Setup for {{ node_role }}"

--- a/autobot-slm-backend/ansible/playbooks/rotate-service-keys.yml
+++ b/autobot-slm-backend/ansible/playbooks/rotate-service-keys.yml
@@ -3,14 +3,77 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 #
-# Rotate Service Authentication Keys
-# Should be run every 80 days (before 90-day TTL expires)
+# Rotate Service Authentication Keys (#1734)
+# Should be run every 80 days (before 90-day TTL expires).
+# Automated via systemd timer: autobot-key-rotation.timer
 #
-# Usage: ansible-playbook playbooks/rotate-service-keys.yml
-#        ansible-playbook playbooks/rotate-service-keys.yml --tags generate
-#        ansible-playbook playbooks/rotate-service-keys.yml --tags distribute
+# Usage:
+#   Full rotation:
+#     ansible-playbook -i inventory/production.yml playbooks/rotate-service-keys.yml
+#   Generate only:
+#     ansible-playbook ... --tags generate
+#   Distribute only (keys must exist):
+#     ansible-playbook ... --tags distribute
 #
 # Run from: autobot-slm-backend/ansible/
+
+# ======================================================================
+# Phase 0: Pre-rotation validation — verify current keys work
+# ======================================================================
+- name: "Phase 0 - Pre-Rotation Validation"
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    service_auth_keys_dir: /etc/autobot/service-keys
+    redis_host: >-
+      {{ hostvars[groups['database'][0]]['ansible_host']
+         | default('127.0.0.1') }}
+    redis_port: 6379
+
+  tasks:
+    - name: Determine this host service ID
+      ansible.builtin.set_fact:
+        this_service_id: >-
+          {%- if inventory_hostname in groups['backend'] -%}main-backend
+          {%- elif inventory_hostname in groups['frontend'] -%}frontend
+          {%- elif inventory_hostname in groups['npu'] -%}npu-worker
+          {%- elif inventory_hostname in groups['database'] -%}redis-stack
+          {%- elif inventory_hostname in groups['aiml'] -%}ai-stack
+          {%- elif inventory_hostname in groups['browser'] -%}browser-service
+          {%- else -%}unknown{%- endif -%}
+      tags: [validate]
+
+    - name: Check current key file exists
+      ansible.builtin.stat:
+        path: "{{ service_auth_keys_dir }}/{{ this_service_id }}.env"
+      register: _pre_key_file
+      when: this_service_id != 'unknown'
+      tags: [validate]
+
+    - name: Warn if current key file is missing
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: No existing key file for {{ this_service_id }}.
+          This is expected for first-time deployment.
+      when:
+        - this_service_id != 'unknown'
+        - not (_pre_key_file.stat.exists | default(false))
+      tags: [validate]
+
+    - name: Backup current key file before rotation
+      ansible.builtin.copy:
+        src: "{{ service_auth_keys_dir }}/{{ this_service_id }}.env"
+        dest: "{{ service_auth_keys_dir }}/{{ this_service_id }}.env.pre-rotate"
+        remote_src: true
+        mode: "0600"
+        owner: autobot
+        group: autobot
+      when:
+        - this_service_id != 'unknown'
+        - _pre_key_file.stat.exists | default(false)
+      tags: [validate]
 
 # ======================================================================
 # Phase 1: Generate new service keys on localhost
@@ -22,9 +85,12 @@
 
   vars:
     autobot_root: /opt/autobot
-    key_generator: "{{ autobot_root }}/infrastructure/shared/scripts/generate_service_keys.py"
+    key_generator: >-
+      {{ autobot_root }}/autobot-infrastructure/shared/scripts/generate_service_keys.py
     keys_backup_dir: "{{ autobot_root }}/config/service-keys"
-    redis_host: 172.16.168.23
+    redis_host: >-
+      {{ hostvars[groups['database'][0]]['ansible_host']
+         | default('127.0.0.1') }}
     redis_port: 6379
 
   tasks:
@@ -47,7 +113,8 @@
       ansible.builtin.fail:
         msg: >-
           Key generator not found at {{ key_generator }}.
-          Ensure infrastructure/shared/scripts/generate_service_keys.py exists.
+          Ensure autobot-infrastructure/shared/scripts/generate_service_keys.py
+          exists.
       when: not generator_stat.stat.exists
       tags: [generate]
 
@@ -121,30 +188,18 @@
 - name: "Phase 3 - Restart Backend Service"
   hosts: backend
   gather_facts: false
-  become: false  # backend host is local WSL
+  become: true
 
   vars:
-    backend_health_url: "http://172.16.168.20:8001/api/health"
-    startup_delay: 5
+    backend_health_url: >-
+      {{ backend_protocol | default('https') }}://{{ ansible_host }}:{{ backend_port | default(8443) }}/api/health
+    startup_delay: 10
 
   tasks:
     - name: Restart backend via systemctl
       ansible.builtin.systemd:
         name: autobot-backend
         state: restarted
-      register: systemd_restart
-      ignore_errors: true
-      tags: [restart]
-
-    - name: Fallback restart via process signal
-      ansible.builtin.shell: |
-        pkill -f "uvicorn.*8001" || true
-        sleep 1
-        cd /opt/autobot/autobot-user-backend
-        nohup python -m uvicorn autobot_user_backend.main:app \
-          --host 0.0.0.0 --port 8001 \
-          > /tmp/autobot-backend-keyrotate.log 2>&1 &
-      when: systemd_restart is failed
       tags: [restart]
 
     - name: Wait for backend startup
@@ -158,9 +213,10 @@
         method: GET
         timeout: 15
         status_code: 200
+        validate_certs: false
       register: health_check
-      retries: 3
-      delay: 5
+      retries: 6
+      delay: 10
       until: health_check.status == 200
       tags: [restart, verify]
 
@@ -173,7 +229,9 @@
 
   vars:
     service_auth_keys_dir: /etc/autobot/service-keys
-    redis_host: 172.16.168.23
+    redis_host: >-
+      {{ hostvars[groups['database'][0]]['ansible_host']
+         | default('127.0.0.1') }}
     redis_port: 6379
 
   tasks:
@@ -211,7 +269,7 @@
       ansible.builtin.command:
         cmd: >-
           redis-cli -h {{ redis_host }} -p {{ redis_port }}
-          exists service:auth:key:{{ this_service_id }}
+          exists service:key:{{ this_service_id }}
       register: redis_key_check
       changed_when: false
       delegate_to: localhost
@@ -225,6 +283,13 @@
         fail_msg: >-
           Key for {{ this_service_id }} NOT found in Redis.
           Run key generation again.
+      when: this_service_id != 'unknown'
+      tags: [verify]
+
+    - name: Remove pre-rotation backup (rotation succeeded)
+      ansible.builtin.file:
+        path: "{{ service_auth_keys_dir }}/{{ this_service_id }}.env.pre-rotate"
+        state: absent
       when: this_service_id != 'unknown'
       tags: [verify]
 
@@ -268,6 +333,5 @@
           - "Backup: {{ (final_backup_files.files | sort(attribute='mtime') | last).path | default('N/A') }}"
           - ""
           - "Next rotation due: ~80 days (before 90-day TTL)"
-          - "Schedule: crontab -e"
-          - "  0 2 1 */3 * cd /opt/autobot/autobot-slm-backend/ansible && ansible-playbook playbooks/rotate-service-keys.yml"
+          - "Automated via: systemctl status autobot-key-rotation.timer"
       tags: [summary]

--- a/autobot-slm-backend/ansible/roles/service_auth/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/service_auth/defaults/main.yml
@@ -14,32 +14,36 @@ service_auth_rate_limit_window: 300
 service_auth_rate_limit_max_failures: 10
 service_auth_timestamp_window: 300
 service_auth_key_ttl_days: 90
+service_auth_rotation_days: 80
+service_auth_rotation_timer_enabled: true
 
 # Key storage paths
 service_auth_keys_dir: /etc/autobot/service-keys
 service_auth_config_dir: /etc/autobot
 
-# Service definitions - maps inventory groups to service IDs
+# Service definitions - maps inventory groups to service IDs.
+# Host IPs are resolved from inventory (ansible_host), not hardcoded here.
 service_auth_services:
   main-backend:
     group: backend
-    host: "172.16.168.20"
   frontend:
     group: frontend
-    host: "172.16.168.21"
   npu-worker:
     group: npu
-    host: "172.16.168.22"
   redis-stack:
     group: database
-    host: "172.16.168.23"
   ai-stack:
     group: aiml
-    host: "172.16.168.24"
   browser-service:
     group: browser
-    host: "172.16.168.25"
 
-# Redis connection for key storage
-service_auth_redis_host: "172.16.168.23"
+# Redis connection for key storage.
+# Override via inventory group_vars or -e flags. Falls back to the
+# ansible_host of the first host in the 'database' inventory group.
+service_auth_redis_host: >-
+  {{ hostvars[groups['database'][0]]['ansible_host']
+     | default('127.0.0.1') }}
 service_auth_redis_port: 6379
+
+# Ansible working directory for rotation playbook invocation
+autobot_ansible_dir: /opt/autobot/autobot-slm-backend/ansible

--- a/autobot-slm-backend/ansible/roles/service_auth/tasks/configure-rotation-timer.yml
+++ b/autobot-slm-backend/ansible/roles/service_auth/tasks/configure-rotation-timer.yml
@@ -1,0 +1,51 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Service Authentication - Automated Rotation Timer (#1734)
+# Deploys a systemd timer that triggers key rotation every N days.
+# Only installed on the SLM manager host (where Ansible runs from).
+---
+- name: "ServiceAuth | Deploy rotation service unit"
+  ansible.builtin.template:
+    src: autobot-key-rotation.service.j2
+    dest: /etc/systemd/system/autobot-key-rotation.service
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: reload systemd
+
+- name: "ServiceAuth | Deploy rotation timer unit"
+  ansible.builtin.template:
+    src: autobot-key-rotation.timer.j2
+    dest: /etc/systemd/system/autobot-key-rotation.timer
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: reload systemd
+
+- name: "ServiceAuth | Flush handlers to reload systemd"
+  ansible.builtin.meta: flush_handlers
+
+- name: "ServiceAuth | Enable and start rotation timer"
+  ansible.builtin.systemd:
+    name: autobot-key-rotation.timer
+    state: started
+    enabled: true
+  become: true
+
+- name: "ServiceAuth | Report timer status"
+  ansible.builtin.command:
+    cmd: systemctl list-timers autobot-key-rotation.timer --no-pager
+  register: _timer_status
+  changed_when: false
+
+- name: "ServiceAuth | Display rotation timer schedule"
+  ansible.builtin.debug:
+    msg:
+      - "Rotation timer installed and active"
+      - "Interval: every {{ service_auth_rotation_days }} days"
+      - "TTL: {{ service_auth_key_ttl_days }} days"
+      - "{{ _timer_status.stdout_lines | default(['(timer output unavailable)']) }}"

--- a/autobot-slm-backend/ansible/roles/service_auth/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/service_auth/tasks/main.yml
@@ -27,3 +27,11 @@
   ansible.builtin.include_tasks: configure-monitoring.yml
   when: service_auth_enabled | bool
   tags: ['service_auth', 'monitoring']
+
+- name: "ServiceAuth | Configure rotation timer"
+  ansible.builtin.include_tasks: configure-rotation-timer.yml
+  when:
+    - service_auth_enabled | bool
+    - service_auth_rotation_timer_enabled | bool
+    - inventory_hostname in groups.get('slm_manager', groups.get('backend', []))
+  tags: ['service_auth', 'rotation']

--- a/autobot-slm-backend/ansible/roles/service_auth/templates/autobot-key-rotation.service.j2
+++ b/autobot-slm-backend/ansible/roles/service_auth/templates/autobot-key-rotation.service.j2
@@ -1,0 +1,21 @@
+# AutoBot Service Key Rotation - Ansible Managed (#1734)
+# Runs the key rotation playbook on a schedule.
+# Deployed to the SLM manager host only.
+[Unit]
+Description=AutoBot Service Key Rotation
+After=network-online.target redis-stack-server.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=autobot
+Group=autobot
+WorkingDirectory={{ autobot_ansible_dir }}
+ExecStart=/usr/bin/ansible-playbook \
+  -i inventory/production.yml \
+  -i inventory/slm-nodes.yml \
+  playbooks/rotate-service-keys.yml
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=autobot-key-rotation
+TimeoutStartSec=600

--- a/autobot-slm-backend/ansible/roles/service_auth/templates/autobot-key-rotation.timer.j2
+++ b/autobot-slm-backend/ansible/roles/service_auth/templates/autobot-key-rotation.timer.j2
@@ -1,0 +1,14 @@
+# AutoBot Service Key Rotation Timer - Ansible Managed (#1734)
+# Triggers key rotation every 80 days (before 90-day TTL expires).
+# Check status: systemctl status autobot-key-rotation.timer
+# View schedule: systemctl list-timers autobot-key-rotation*
+[Unit]
+Description=AutoBot Service Key Rotation Timer (every {{ service_auth_rotation_days }} days)
+
+[Timer]
+OnCalendar=*-*-01/{{ service_auth_rotation_days }} 02:00:00
+RandomizedDelaySec=3600
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Closes #1734

- **Fix broken scripts**: `generate_service_keys.py` had broken variable scoping from bad auto-extraction; `verify-service-auth.py` had duplicate imports and wrong Redis API usage
- **Deploy keys on system setup**: Integrated `service_auth` role into `deploy-full.yml` (Phase 2.5) and `enroll-node.yml` (Phase 1.5) so keys are provisioned automatically during Ansible setup
- **Fix rotation playbook**: Removed hardcoded IPs (use inventory vars), fixed backend health URL (HTTPS port 8443), added pre-rotation backup of existing keys
- **Remove hardcoded IPs from role defaults**: Service definitions no longer embed IPs; Redis host derived from inventory `database` group
- **Automated rotation**: Added systemd timer (`autobot-key-rotation.timer`) for 80-day automated key rotation before 90-day TTL expires

## Files Changed

| File | Change |
|------|--------|
| `generate_service_keys.py` | Rewrote — fixed scoping, SSOT config, proper helpers |
| `verify-service-auth.py` | Rewrote — fixed imports, Redis API, extracted helpers |
| `deploy-full.yml` | Added Phase 2.5 for service auth deployment |
| `enroll-node.yml` | Added Phase 1.5 for service auth during enrollment |
| `rotate-service-keys.yml` | Fixed IPs, backend restart, added pre-rotation validation |
| `service_auth/defaults/main.yml` | Removed hardcoded IPs, added rotation vars |
| `service_auth/tasks/main.yml` | Added rotation timer task inclusion |
| `configure-rotation-timer.yml` | New — deploys systemd timer |
| `autobot-key-rotation.service.j2` | New — systemd service template |
| `autobot-key-rotation.timer.j2` | New — systemd timer template (80-day) |

## Test plan

- [ ] Verify `generate_service_keys.py` syntax: `python3 -c "import ast; ast.parse(open('autobot-infrastructure/shared/scripts/generate_service_keys.py').read())"`
- [ ] Verify `verify-service-auth.py` syntax: same AST check
- [ ] Verify YAML validity of all changed playbooks: `python3 -c "import yaml; yaml.safe_load(open('...'))" `
- [ ] Run `ansible-playbook --syntax-check` on deploy-full.yml, enroll-node.yml, rotate-service-keys.yml
- [ ] Deploy to staging and verify keys appear in `/etc/autobot/service-keys/` on each VM
- [ ] Verify rotation timer is active: `systemctl list-timers autobot-key-rotation*`