### PR TITLE
feat(config): config audit trail with versioning and rollback (#1404)

### DIFF
--- a/autobot-backend/api/config_revisions.py
+++ b/autobot-backend/api/config_revisions.py
@@ -1,0 +1,141 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Config Revisions API (#1404)
+
+Endpoints for listing, inspecting, and rolling back configuration revisions.
+"""
+
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+from api.user_management.dependencies import get_db_session
+from auth_middleware import get_current_user
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from services.config_revision_service import ConfigRevisionService
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# -- Response schemas --------------------------------------------------
+
+
+class ConfigRevisionResponse(BaseModel):
+    """Response for a single config revision."""
+
+    id: str
+    entity_type: str
+    entity_id: str
+    before_config: Optional[Dict[str, Any]] = None
+    after_config: Dict[str, Any]
+    changed_keys: List[str] = Field(default_factory=list)
+    source: str
+    created_by: str
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+# -- Helpers -----------------------------------------------------------
+
+
+def _to_response(revision) -> ConfigRevisionResponse:
+    """Convert a ConfigRevision ORM object to response schema (#1404)."""
+    return ConfigRevisionResponse(
+        id=str(revision.id),
+        entity_type=revision.entity_type,
+        entity_id=revision.entity_id,
+        before_config=revision.before_config,
+        after_config=revision.after_config,
+        changed_keys=revision.changed_keys or [],
+        source=revision.source,
+        created_by=revision.created_by,
+        created_at=(revision.created_at.isoformat() if revision.created_at else None),
+        updated_at=(revision.updated_at.isoformat() if revision.updated_at else None),
+    )
+
+
+# -- Endpoints ---------------------------------------------------------
+
+
+@router.get(
+    "/config-revisions/{entity_type}/{entity_id}",
+    response_model=List[ConfigRevisionResponse],
+)
+async def list_revisions(
+    entity_type: str,
+    entity_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+):
+    """List revision history for an entity, newest first (#1404)."""
+    svc = ConfigRevisionService(session)
+    revisions = await svc.get_revisions(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        limit=limit,
+        offset=offset,
+    )
+    return [_to_response(r) for r in revisions]
+
+
+@router.get(
+    "/config-revisions/{entity_type}/{entity_id}/{revision_id}",
+    response_model=ConfigRevisionResponse,
+)
+async def get_revision(
+    entity_type: str,
+    entity_id: str,
+    revision_id: uuid.UUID,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+):
+    """Get a specific revision with diff metadata (#1404)."""
+    svc = ConfigRevisionService(session)
+    revision = await svc.get_revision(revision_id)
+    if revision is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Revision {revision_id} not found",
+        )
+    if revision.entity_type != entity_type or revision.entity_id != entity_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Revision {revision_id} does not belong to {entity_type}/{entity_id}",
+        )
+    return _to_response(revision)
+
+
+@router.post(
+    "/config-revisions/{entity_type}/{entity_id}/{revision_id}/rollback",
+    response_model=ConfigRevisionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def rollback_to_revision(
+    entity_type: str,
+    entity_id: str,
+    revision_id: uuid.UUID,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+):
+    """Roll back entity config to a prior revision (#1404).
+
+    Creates a new revision capturing the rollback so the action is
+    itself part of the audit trail.
+    """
+    svc = ConfigRevisionService(session)
+    username = current_user.get("username", "unknown")
+    try:
+        new_revision = await svc.rollback_to_revision(revision_id, username)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        )
+    return _to_response(new_revision)

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -19,6 +19,7 @@ from api.auth import router as auth_router
 from api.browser_mcp import router as browser_mcp_router
 from api.chat import router as chat_router
 from api.collaboration import router as collaboration_router
+from api.config_revisions import router as config_revisions_router  # #1404
 from api.data_storage import router as data_storage_router
 from api.database_mcp import router as database_mcp_router
 from api.developer import router as developer_router
@@ -271,6 +272,7 @@ def _get_agent_routers() -> list:
     return [
         (agent_router, "/agent", ["agent"], "agent"),
         (approval_gates_router, "", ["approval-gates"], "approval_gates"),
+        (config_revisions_router, "", ["config-revisions"], "config_revisions"),
         (agent_config_router, "/agent_config", ["agent_config"], "agent_config"),
         (
             intelligent_agent_router,

--- a/autobot-backend/migrations/versions/20260315_008_config_revisions.py
+++ b/autobot-backend/migrations/versions/20260315_008_config_revisions.py
@@ -1,0 +1,94 @@
+"""Add config_revisions table for audit trail and rollback
+
+Revision ID: 20260315_008
+Revises: 20260309_007
+Create Date: 2026-03-15 00:00:00.000000
+
+Issue #1404: Config audit trail with versioning and rollback
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20260315_008"
+down_revision = "20260309_007"
+branch_labels = None
+depends_on = None
+
+_JSONB = postgresql.JSONB(astext_type=sa.Text())
+_UUID = postgresql.UUID(as_uuid=True)
+
+
+def _common_ts_cols():
+    """Return created_at/updated_at Column defs. Helper (#1404)."""
+    return [
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    ]
+
+
+def upgrade() -> None:
+    """Create config_revisions table."""
+    op.create_table(
+        "config_revisions",
+        sa.Column("id", _UUID, nullable=False),
+        sa.Column("entity_type", sa.String(100), nullable=False),
+        sa.Column("entity_id", sa.String(255), nullable=False),
+        sa.Column("before_config", _JSONB, nullable=True),
+        sa.Column("after_config", _JSONB, nullable=False),
+        sa.Column("changed_keys", _JSONB, nullable=False, server_default="[]"),
+        sa.Column("source", sa.String(50), nullable=False),
+        sa.Column("created_by", sa.String(255), nullable=False),
+        *_common_ts_cols(),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_config_revisions_entity_type",
+        "config_revisions",
+        ["entity_type"],
+    )
+    op.create_index(
+        "ix_config_revisions_entity_id",
+        "config_revisions",
+        ["entity_id"],
+    )
+    op.create_index(
+        "ix_config_revisions_source",
+        "config_revisions",
+        ["source"],
+    )
+    op.create_index(
+        "ix_config_revisions_created_by",
+        "config_revisions",
+        ["created_by"],
+    )
+    # Composite index for the primary query pattern: list by entity
+    op.create_index(
+        "ix_config_revisions_entity_type_entity_id",
+        "config_revisions",
+        ["entity_type", "entity_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop config_revisions table."""
+    for idx in [
+        "ix_config_revisions_entity_type_entity_id",
+        "ix_config_revisions_created_by",
+        "ix_config_revisions_source",
+        "ix_config_revisions_entity_id",
+        "ix_config_revisions_entity_type",
+    ]:
+        op.drop_index(idx, table_name="config_revisions")
+    op.drop_table("config_revisions")

--- a/autobot-backend/models/__init__.py
+++ b/autobot-backend/models/__init__.py
@@ -27,6 +27,9 @@ from models.approval import Approval, ApprovalComment, TaskApprovalLink
 # Other backend models (SQLAlchemy models only)
 from models.code_pattern import CodePattern
 from models.completion_feedback import CompletionFeedback
+
+# Config revision model (#1404)
+from models.config_revision import ConfigRevision
 from models.ml_model import MLModel
 from models.secret import Secret
 from models.session_collaboration import SessionCollaboration
@@ -48,4 +51,6 @@ __all__ = [
     "Approval",
     "ApprovalComment",
     "TaskApprovalLink",
+    # Config revision model (#1404)
+    "ConfigRevision",
 ]

--- a/autobot-backend/models/config_revision.py
+++ b/autobot-backend/models/config_revision.py
@@ -1,0 +1,51 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Config Revision Model (#1404)
+
+SQLAlchemy model for configuration audit trail with versioning and rollback.
+Stores before/after snapshots for every configuration change.
+"""
+
+import uuid
+
+from sqlalchemy import Column, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from user_management.models.base import Base, TimestampMixin
+
+
+class ConfigRevision(Base, TimestampMixin):
+    """One recorded configuration change with before/after snapshots (#1404).
+
+    Secret values are redacted before storage to prevent credential leakage.
+    """
+
+    __tablename__ = "config_revisions"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # What kind of entity changed: "agent", "system", "llm", etc.
+    entity_type = Column(String(100), nullable=False, index=True)
+    # Identifier of the specific entity instance.
+    entity_id = Column(String(255), nullable=False, index=True)
+    # Full configuration snapshot before the change (secrets redacted).
+    before_config = Column(JSONB, nullable=True)
+    # Full configuration snapshot after the change (secrets redacted).
+    after_config = Column(JSONB, nullable=False)
+    # List of top-level keys that changed between before and after.
+    changed_keys = Column(JSONB, nullable=False, default=list)
+    # Origin of the change: "api", "system", "rollback", etc.
+    source = Column(String(50), nullable=False, index=True)
+    # Username or service identity that triggered the change.
+    created_by = Column(String(255), nullable=False, index=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<ConfigRevision id={self.id} "
+            f"entity={self.entity_type}/{self.entity_id} "
+            f"by={self.created_by}>"
+        )

--- a/autobot-backend/services/config_revision_service.py
+++ b/autobot-backend/services/config_revision_service.py
@@ -1,0 +1,182 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Config Revision Service (#1404)
+
+Manages configuration audit trail: recording changes with before/after
+snapshots, computing diffs, redacting secrets, and rolling back to any
+prior revision.
+"""
+
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+from models.config_revision import ConfigRevision
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+# Keys whose values must be redacted in stored snapshots.
+_SECRET_SUBSTRINGS = frozenset(["password", "secret", "key", "token", "api_key"])
+_REDACTED = "***REDACTED***"
+
+
+def _is_secret_key(key: str) -> bool:
+    """Return True if key name suggests a sensitive value (#1404)."""
+    lower = key.lower()
+    return any(sub in lower for sub in _SECRET_SUBSTRINGS)
+
+
+def redact_secrets(config_dict: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Return a copy of config_dict with secret values replaced (#1404).
+
+    Only top-level keys are inspected. Nested structures are not
+    recursively redacted to keep the implementation focused.
+    """
+    if config_dict is None:
+        return None
+    return {k: (_REDACTED if _is_secret_key(k) else v) for k, v in config_dict.items()}
+
+
+def compute_diff(
+    before: Optional[Dict[str, Any]],
+    after: Dict[str, Any],
+) -> List[str]:
+    """Return sorted list of top-level keys that differ between snapshots (#1404)."""
+    before = before or {}
+    all_keys = set(before) | set(after)
+    return sorted(k for k in all_keys if before.get(k) != after.get(k))
+
+
+class ConfigRevisionService:
+    """Service for config revision CRUD and rollback (#1404)."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    # -- Write ---------------------------------------------------------
+
+    async def create_revision(
+        self,
+        entity_type: str,
+        entity_id: str,
+        before_config: Optional[Dict[str, Any]],
+        after_config: Dict[str, Any],
+        source: str,
+        created_by: str,
+    ) -> ConfigRevision:
+        """Persist a new config revision with redacted snapshots (#1404)."""
+        safe_before = redact_secrets(before_config)
+        safe_after = redact_secrets(after_config)
+        changed = compute_diff(safe_before, safe_after)
+
+        revision = ConfigRevision(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            before_config=safe_before,
+            after_config=safe_after,
+            changed_keys=changed,
+            source=source,
+            created_by=created_by,
+        )
+        self.session.add(revision)
+        await self.session.commit()
+        await self.session.refresh(revision)
+
+        logger.info(
+            "Config revision %s created: %s/%s by %s (%s keys changed)",
+            revision.id,
+            entity_type,
+            entity_id,
+            created_by,
+            len(changed),
+        )
+        return revision
+
+    async def rollback_to_revision(
+        self,
+        revision_id: uuid.UUID,
+        created_by: str,
+    ) -> ConfigRevision:
+        """Restore config to a prior snapshot and record the rollback (#1404).
+
+        Returns the new revision that captures the rollback action.
+        """
+        target = await self._get_or_raise(revision_id)
+        current = await self._get_latest(target.entity_type, target.entity_id)
+
+        new_revision = await self.create_revision(
+            entity_type=target.entity_type,
+            entity_id=target.entity_id,
+            before_config=current.after_config if current else None,
+            after_config=target.after_config or {},
+            source="rollback",
+            created_by=created_by,
+        )
+        logger.info(
+            "Rolled back %s/%s to revision %s (new revision %s)",
+            target.entity_type,
+            target.entity_id,
+            revision_id,
+            new_revision.id,
+        )
+        return new_revision
+
+    # -- Read ----------------------------------------------------------
+
+    async def get_revisions(
+        self,
+        entity_type: str,
+        entity_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[ConfigRevision]:
+        """List revisions for an entity, newest first (#1404)."""
+        stmt = (
+            select(ConfigRevision)
+            .where(
+                ConfigRevision.entity_type == entity_type,
+                ConfigRevision.entity_id == entity_id,
+            )
+            .order_by(ConfigRevision.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_revision(self, revision_id: uuid.UUID) -> Optional[ConfigRevision]:
+        """Fetch a single revision by primary key (#1404)."""
+        stmt = select(ConfigRevision).where(ConfigRevision.id == revision_id)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    # -- Internal helpers ----------------------------------------------
+
+    async def _get_or_raise(self, revision_id: uuid.UUID) -> ConfigRevision:
+        """Load revision or raise ValueError if not found (#1404)."""
+        revision = await self.get_revision(revision_id)
+        if revision is None:
+            raise ValueError(f"ConfigRevision {revision_id} not found")
+        return revision
+
+    async def _get_latest(
+        self,
+        entity_type: str,
+        entity_id: str,
+    ) -> Optional[ConfigRevision]:
+        """Return the most recent revision for an entity (#1404)."""
+        stmt = (
+            select(ConfigRevision)
+            .where(
+                ConfigRevision.entity_type == entity_type,
+                ConfigRevision.entity_id == entity_id,
+            )
+            .order_by(ConfigRevision.created_at.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()


### PR DESCRIPTION
## Summary
- Add `config_revisions` table (migration 008) for tracking all configuration changes with before/after JSONB snapshots
- `ConfigRevisionService` with automatic changed-keys diffing, secret redaction (password/token/key/secret/api_key), and rollback support
- 3 API endpoints: list revisions, get revision with diff, rollback to revision (creates its own audit entry)
- Router registered in `core_routers.py`, model registered in `models/__init__.py`

Closes #1404

## Test plan
- [ ] Verify migration 008 applies cleanly (`alembic upgrade head`)
- [ ] Test `POST /api/config-revisions/{type}/{id}/{rev}/rollback` creates a new revision with source="rollback"
- [ ] Verify secret redaction replaces values containing password/token/key/secret/api_key with `***REDACTED***`
- [ ] Verify `changed_keys` correctly lists only modified keys between before/after configs
- [ ] Test pagination on `GET /api/config-revisions/{type}/{id}` with limit/offset params