### PR TITLE
feat(agents): agent org charts with role hierarchy (#1405)

### DIFF
--- a/autobot-backend/api/agent_org.py
+++ b/autobot-backend/api/agent_org.py
@@ -1,0 +1,226 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Agent Org API (#1405)
+
+Endpoints for agent organizational hierarchy: org tree, chain of command,
+direct reports, and org metadata updates with cycle detection.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from api.user_management.dependencies import get_db_session
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from services.agent_org_service import AgentOrgService
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+# -- Schemas ---------------------------------------------------------------
+
+
+class OrgNodeResponse(BaseModel):
+    """Single node in the org tree response (#1405)."""
+
+    agent_id: str
+    name: str
+    org_role: str
+    title: Optional[str] = None
+    capabilities: Optional[str] = None
+    direct_reports_count: int = 0
+    children: List["OrgNodeResponse"] = Field(default_factory=list)
+
+
+OrgNodeResponse.model_rebuild()
+
+
+class AgentSummary(BaseModel):
+    """Compact agent summary used in chain of command (#1405)."""
+
+    agent_id: str
+    name: str
+    org_role: str
+    title: Optional[str] = None
+
+
+class ChainOfCommandResponse(BaseModel):
+    """Ordered list from agent to org root (#1405)."""
+
+    chain: List[AgentSummary]
+
+
+class UpdateOrgRequest(BaseModel):
+    """Request body for PATCH /agents/{agent_id}/org (#1405)."""
+
+    reports_to: Optional[str] = Field(
+        default=None,
+        description="agent_id of the new manager, or null to clear",
+    )
+    org_role: Optional[str] = Field(
+        default=None,
+        description="One of: manager, coordinator, specialist, worker",
+    )
+    title: Optional[str] = Field(default=None, description="Human-readable job title")
+    capabilities: Optional[str] = Field(
+        default=None, description="Free-text capability description"
+    )
+
+
+class UpsertOrgRequest(BaseModel):
+    """Request body for PUT /agents/{agent_id}/org (#1405)."""
+
+    name: str
+    org_role: str = "worker"
+    reports_to: Optional[str] = None
+    title: Optional[str] = None
+    capabilities: Optional[str] = None
+
+
+# -- Endpoints -------------------------------------------------------------
+
+
+@router.get(
+    "/org",
+    response_model=List[OrgNodeResponse],
+    tags=["agent-org"],
+)
+async def get_org_tree(
+    session: AsyncSession = Depends(get_db_session),
+) -> List[Dict[str, Any]]:
+    """
+    Return the full org tree from root agents (#1405).
+
+    Each node contains nested children recursively.
+    """
+    svc = AgentOrgService(session)
+    return await svc.get_org_tree()
+
+
+@router.get(
+    "/{agent_id}/chain",
+    response_model=ChainOfCommandResponse,
+    tags=["agent-org"],
+)
+async def get_chain_of_command(
+    agent_id: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> ChainOfCommandResponse:
+    """
+    Return chain of command from agent_id up to org root (#1405).
+
+    First entry is the agent itself; last is the root manager.
+    """
+    svc = AgentOrgService(session)
+    try:
+        chain = await svc.get_chain_of_command(agent_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    return ChainOfCommandResponse(chain=[AgentSummary(**item) for item in chain])
+
+
+@router.get(
+    "/{agent_id}/reports",
+    response_model=List[AgentSummary],
+    tags=["agent-org"],
+)
+async def get_direct_reports(
+    agent_id: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> List[Dict[str, Any]]:
+    """Return agents that directly report to agent_id (#1405)."""
+    svc = AgentOrgService(session)
+    return await svc.get_direct_reports(agent_id)
+
+
+@router.patch(
+    "/{agent_id}/org",
+    response_model=AgentSummary,
+    tags=["agent-org"],
+)
+async def update_agent_org(
+    agent_id: str,
+    body: UpdateOrgRequest,
+    session: AsyncSession = Depends(get_db_session),
+) -> AgentSummary:
+    """
+    Update reporting line, role, or title for an agent (#1405).
+
+    Returns 400 if the new reporting line would create a cycle.
+    Returns 404 if the agent is not registered in the org hierarchy.
+    """
+    svc = AgentOrgService(session)
+    try:
+        node = await svc.update_reporting_line(
+            agent_id=agent_id,
+            new_manager_id=body.reports_to,
+            org_role=body.org_role,
+            title=body.title,
+            capabilities=body.capabilities,
+        )
+    except ValueError as exc:
+        detail = str(exc)
+        if "cycle" in detail:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=detail,
+            )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+    return AgentSummary(
+        agent_id=node.agent_id,
+        name=node.name,
+        org_role=node.org_role,
+        title=node.title,
+    )
+
+
+@router.put(
+    "/{agent_id}/org",
+    response_model=AgentSummary,
+    tags=["agent-org"],
+    status_code=status.HTTP_200_OK,
+)
+async def upsert_agent_org(
+    agent_id: str,
+    body: UpsertOrgRequest,
+    session: AsyncSession = Depends(get_db_session),
+) -> AgentSummary:
+    """
+    Register or update an agent in the org hierarchy (#1405).
+
+    Creates the record if it does not exist.
+    """
+    svc = AgentOrgService(session)
+    node = await svc.upsert_node(
+        agent_id=agent_id,
+        name=body.name,
+        org_role=body.org_role,
+        reports_to=body.reports_to,
+        title=body.title,
+        capabilities=body.capabilities,
+    )
+    return AgentSummary(
+        agent_id=node.agent_id,
+        name=node.name,
+        org_role=node.org_role,
+        title=node.title,
+    )
+
+
+@router.get(
+    "/{agent_id}/org/role-defaults",
+    response_model=Dict[str, Any],
+    tags=["agent-org"],
+)
+async def get_role_defaults(
+    agent_id: str,
+    role: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> Dict[str, Any]:
+    """Return default permission set for the given org role (#1405)."""
+    svc = AgentOrgService(session)
+    return svc.get_role_defaults(role)

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -13,6 +13,7 @@ and are imported at module level to fail fast if missing.
 from api.adapters import router as adapters_router  # Issue #1403
 from api.agent import router as agent_router
 from api.agent_config import router as agent_config_router
+from api.agent_org import router as agent_org_router  # #1405
 from api.approval_gates import router as approval_gates_router  # #1402
 from api.audit import router as audit_router
 from api.auth import router as auth_router
@@ -279,6 +280,7 @@ def _get_agent_routers() -> list:
             "intelligent_agent",
         ),
         (overseer_router, "/overseer", ["overseer", "agent"], "overseer"),
+        (agent_org_router, "/agents", ["agent-org"], "agent_org"),
         (files_router, "/files", ["files"], "files"),
         (developer_router, "/developer", ["developer"], "developer"),
         (memory_router, "/memory", ["memory"], "memory"),

--- a/autobot-backend/migrations/versions/20260315_009_agent_org_hierarchy.py
+++ b/autobot-backend/migrations/versions/20260315_009_agent_org_hierarchy.py
@@ -1,0 +1,90 @@
+"""Add agent org hierarchy: agent_org_nodes table with reporting lines
+
+Revision ID: 20260315_009
+Revises: 20260315_008
+Create Date: 2026-03-15 00:00:00.000000
+
+Issue #1405: Agent org charts with role hierarchy and reporting lines.
+
+No existing SQL 'agents' table exists in the schema — agents are identified
+by string IDs across the codebase. This migration creates agent_org_nodes,
+which stores org-hierarchy metadata keyed by agent_id (String), matching
+the convention used in agent_runtime_state and heartbeat_runs.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20260315_009"
+down_revision = "20260315_008"
+branch_labels = None
+depends_on = None
+
+_UUID = postgresql.UUID(as_uuid=True)
+
+
+def _common_ts_cols():
+    """Return created_at/updated_at Column defs. Helper (#1405)."""
+    return [
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    ]
+
+
+def upgrade() -> None:
+    """Create agent_org_nodes table for org hierarchy (#1405)."""
+    op.create_table(
+        "agent_org_nodes",
+        sa.Column("id", _UUID, nullable=False),
+        sa.Column("agent_id", sa.String(255), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("reports_to", sa.String(255), nullable=True),
+        sa.Column(
+            "org_role",
+            sa.String(50),
+            nullable=False,
+            server_default="worker",
+        ),
+        sa.Column("title", sa.String(255), nullable=True),
+        sa.Column("capabilities", sa.Text(), nullable=True),
+        *_common_ts_cols(),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("agent_id", name="uq_agent_org_nodes_agent_id"),
+    )
+    op.create_index(
+        "ix_agent_org_nodes_agent_id",
+        "agent_org_nodes",
+        ["agent_id"],
+    )
+    op.create_index(
+        "ix_agent_org_nodes_reports_to",
+        "agent_org_nodes",
+        ["reports_to"],
+    )
+    op.create_index(
+        "ix_agent_org_nodes_org_role",
+        "agent_org_nodes",
+        ["org_role"],
+    )
+
+
+def downgrade() -> None:
+    """Drop agent_org_nodes table (#1405)."""
+    for idx, tbl in [
+        ("ix_agent_org_nodes_org_role", "agent_org_nodes"),
+        ("ix_agent_org_nodes_reports_to", "agent_org_nodes"),
+        ("ix_agent_org_nodes_agent_id", "agent_org_nodes"),
+    ]:
+        op.drop_index(idx, table_name=tbl)
+    op.drop_table("agent_org_nodes")

--- a/autobot-backend/models/__init__.py
+++ b/autobot-backend/models/__init__.py
@@ -21,6 +21,9 @@ from models.activities import (
     TerminalActivityModel,
 )
 
+# Agent org hierarchy models (#1405)
+from models.agent_org import AgentOrgNode
+
 # Approval gate models (#1402)
 from models.approval import Approval, ApprovalComment, TaskApprovalLink
 
@@ -44,6 +47,8 @@ __all__ = [
     "MLModel",
     "Secret",
     "SessionCollaboration",
+    # Agent org hierarchy (#1405)
+    "AgentOrgNode",
     # Approval gate models (#1402)
     "Approval",
     "ApprovalComment",

--- a/autobot-backend/models/agent_org.py
+++ b/autobot-backend/models/agent_org.py
@@ -1,0 +1,52 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Agent Org Node Model (#1405)
+
+SQLAlchemy model for agent organizational hierarchy.
+Table: agent_org_nodes
+"""
+
+import uuid
+from enum import Enum
+
+from sqlalchemy import Column, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from user_management.models.base import Base, TimestampMixin
+
+
+class OrgRole(str, Enum):
+    """Valid org roles for agents (#1405)."""
+
+    MANAGER = "manager"
+    COORDINATOR = "coordinator"
+    SPECIALIST = "specialist"
+    WORKER = "worker"
+
+
+class AgentOrgNode(Base, TimestampMixin):
+    """
+    Organizational hierarchy node for an agent (#1405).
+
+    agent_id is a String FK to the logical agent registry (no SQL agents table).
+    reports_to is a self-referencing String pointing to another agent_id.
+    """
+
+    __tablename__ = "agent_org_nodes"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    agent_id = Column(String(255), nullable=False, unique=True, index=True)
+    name = Column(String(255), nullable=False)
+    reports_to = Column(String(255), nullable=True, index=True)
+    org_role = Column(
+        String(50), nullable=False, default=OrgRole.WORKER.value, index=True
+    )
+    title = Column(String(255), nullable=True)
+    capabilities = Column(Text, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<AgentOrgNode agent={self.agent_id!r} role={self.org_role!r} "
+            f"reports_to={self.reports_to!r}>"
+        )

--- a/autobot-backend/services/agent_org_service.py
+++ b/autobot-backend/services/agent_org_service.py
@@ -1,0 +1,274 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Agent Org Service (#1405)
+
+Business logic for agent organizational hierarchy: trees, chains of command,
+direct reports, reporting-line updates with cycle detection, and role defaults.
+"""
+
+import logging
+import uuid
+from typing import Any, Dict, List, Optional
+
+from models.agent_org import AgentOrgNode, OrgRole
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+# Default permissions per org role (manager can delegate, workers execute)
+_ROLE_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    OrgRole.MANAGER.value: {
+        "can_delegate": True,
+        "can_approve": True,
+        "can_execute": True,
+        "max_direct_reports": 10,
+    },
+    OrgRole.COORDINATOR.value: {
+        "can_delegate": True,
+        "can_approve": False,
+        "can_execute": True,
+        "max_direct_reports": 5,
+    },
+    OrgRole.SPECIALIST.value: {
+        "can_delegate": False,
+        "can_approve": False,
+        "can_execute": True,
+        "max_direct_reports": 0,
+    },
+    OrgRole.WORKER.value: {
+        "can_delegate": False,
+        "can_approve": False,
+        "can_execute": True,
+        "max_direct_reports": 0,
+    },
+}
+
+
+class AgentOrgService:
+    """Service for agent organizational hierarchy operations (#1405)."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    # -- Queries -----------------------------------------------------------
+
+    async def get_all_nodes(self) -> List[AgentOrgNode]:
+        """Fetch all org nodes in one query. Helper to avoid N+1 (#1405)."""
+        result = await self.session.execute(select(AgentOrgNode))
+        return list(result.scalars().all())
+
+    async def get_node(self, agent_id: str) -> Optional[AgentOrgNode]:
+        """Return the org node for agent_id or None if not registered."""
+        result = await self.session.execute(
+            select(AgentOrgNode).where(AgentOrgNode.agent_id == agent_id)
+        )
+        return result.scalar_one_or_none()
+
+    # -- Tree / hierarchy --------------------------------------------------
+
+    def _build_tree(
+        self, nodes: List[AgentOrgNode], parent_id: Optional[str]
+    ) -> List[Dict[str, Any]]:
+        """Recursively build tree from flat node list. Helper (#1405)."""
+        children = [n for n in nodes if n.reports_to == parent_id]
+        return [
+            {
+                "agent_id": node.agent_id,
+                "name": node.name,
+                "org_role": node.org_role,
+                "title": node.title,
+                "capabilities": node.capabilities,
+                "direct_reports_count": sum(
+                    1 for n in nodes if n.reports_to == node.agent_id
+                ),
+                "children": self._build_tree(nodes, node.agent_id),
+            }
+            for node in children
+        ]
+
+    async def get_org_tree(self) -> List[Dict[str, Any]]:
+        """
+        Return recursive org tree from root agents (#1405).
+
+        Root agents are those with reports_to == None.
+        """
+        nodes = await self.get_all_nodes()
+        return self._build_tree(nodes, parent_id=None)
+
+    async def get_chain_of_command(self, agent_id: str) -> List[Dict[str, Any]]:
+        """
+        Walk from agent_id up to the root (#1405).
+
+        First entry is the agent itself; last is the root.
+        Raises ValueError if agent_id is not found.
+        """
+        nodes = await self.get_all_nodes()
+        index = {n.agent_id: n for n in nodes}
+
+        if agent_id not in index:
+            raise ValueError(f"Agent not found in org hierarchy: {agent_id!r}")
+
+        chain: List[Dict[str, Any]] = []
+        current_id: Optional[str] = agent_id
+        seen: set = set()
+
+        while current_id is not None:
+            if current_id in seen:
+                logger.warning("Cycle detected in org hierarchy at %s", current_id)
+                break
+            seen.add(current_id)
+            node = index.get(current_id)
+            if node is None:
+                break
+            chain.append(
+                {
+                    "agent_id": node.agent_id,
+                    "name": node.name,
+                    "org_role": node.org_role,
+                    "title": node.title,
+                }
+            )
+            current_id = node.reports_to
+
+        return chain
+
+    async def get_direct_reports(self, agent_id: str) -> List[Dict[str, Any]]:
+        """Return agents whose reports_to equals agent_id (#1405)."""
+        result = await self.session.execute(
+            select(AgentOrgNode).where(AgentOrgNode.reports_to == agent_id)
+        )
+        nodes = result.scalars().all()
+        return [
+            {
+                "agent_id": n.agent_id,
+                "name": n.name,
+                "org_role": n.org_role,
+                "title": n.title,
+            }
+            for n in nodes
+        ]
+
+    # -- Cycle detection ---------------------------------------------------
+
+    async def detect_cycle(self, agent_id: str, proposed_manager_id: str) -> bool:
+        """
+        Return True if assigning proposed_manager_id creates a cycle (#1405).
+
+        Walk UP from proposed_manager_id; if we reach agent_id, it's a cycle.
+        """
+        nodes = await self.get_all_nodes()
+        index = {n.agent_id: n for n in nodes}
+
+        current: Optional[str] = proposed_manager_id
+        visited: set = set()
+
+        while current is not None:
+            if current == agent_id:
+                return True
+            if current in visited:
+                break
+            visited.add(current)
+            node = index.get(current)
+            current = node.reports_to if node else None
+
+        return False
+
+    # -- Updates -----------------------------------------------------------
+
+    async def update_reporting_line(
+        self,
+        agent_id: str,
+        new_manager_id: Optional[str],
+        org_role: Optional[str] = None,
+        title: Optional[str] = None,
+        capabilities: Optional[str] = None,
+    ) -> AgentOrgNode:
+        """
+        Update reporting line with cycle detection (#1405).
+
+        Raises ValueError on cycle or unknown agent.
+        """
+        node = await self.get_node(agent_id)
+        if node is None:
+            raise ValueError(f"Agent not found in org hierarchy: {agent_id!r}")
+
+        if new_manager_id is not None and new_manager_id != node.reports_to:
+            if await self.detect_cycle(agent_id, new_manager_id):
+                raise ValueError(
+                    f"Setting manager to {new_manager_id!r} " f"would create a cycle"
+                )
+            node.reports_to = new_manager_id
+        elif new_manager_id is None:
+            node.reports_to = None
+
+        if org_role is not None:
+            node.org_role = org_role
+        if title is not None:
+            node.title = title
+        if capabilities is not None:
+            node.capabilities = capabilities
+
+        await self.session.flush()
+        logger.info(
+            "Updated org node agent_id=%s reports_to=%s role=%s",
+            agent_id,
+            node.reports_to,
+            node.org_role,
+        )
+        return node
+
+    # -- Role defaults -----------------------------------------------------
+
+    def get_role_defaults(self, role: str) -> Dict[str, Any]:
+        """Return default permissions for the given org role (#1405)."""
+        return dict(_ROLE_DEFAULTS.get(role, _ROLE_DEFAULTS[OrgRole.WORKER.value]))
+
+    # -- Upsert ------------------------------------------------------------
+
+    async def upsert_node(
+        self,
+        agent_id: str,
+        name: str,
+        org_role: str = OrgRole.WORKER.value,
+        reports_to: Optional[str] = None,
+        title: Optional[str] = None,
+        capabilities: Optional[str] = None,
+    ) -> AgentOrgNode:
+        """
+        Create or update an agent_org_nodes record (#1405).
+
+        Used to register agents in the hierarchy on demand.
+        """
+        node = await self.get_node(agent_id)
+        if node is None:
+            node = AgentOrgNode(
+                id=uuid.uuid4(),
+                agent_id=agent_id,
+                name=name,
+                org_role=org_role,
+                reports_to=reports_to,
+                title=title,
+                capabilities=capabilities,
+            )
+            self.session.add(node)
+            logger.info(
+                "Registered new org node agent_id=%s role=%s",
+                agent_id,
+                org_role,
+            )
+        else:
+            node.name = name
+            node.org_role = org_role
+            if reports_to is not None:
+                node.reports_to = reports_to
+            if title is not None:
+                node.title = title
+            if capabilities is not None:
+                node.capabilities = capabilities
+            logger.info("Updated org node agent_id=%s", agent_id)
+
+        await self.session.flush()
+        return node


### PR DESCRIPTION
## Summary
- Add `agent_org_nodes` table (migration 009) for organizational hierarchy with string-based agent IDs matching existing codebase convention
- `AgentOrgService` with recursive org tree builder, chain-of-command traversal, cycle detection on reporting-line changes, and role-based permission defaults
- 6 API endpoints: full org tree, chain of command, direct reports, update org (PATCH with cycle check), upsert org (PUT), role defaults
- Roles: manager, coordinator, specialist, worker — each with default permission sets

Closes #1405

## Test plan
- [ ] Verify migration 009 applies cleanly after 008 (`alembic upgrade head`)
- [ ] Test cycle detection: set A reports_to B, B reports_to A — expect 400
- [ ] Verify `GET /api/agents/org` returns nested tree structure
- [ ] Test `GET /api/agents/{id}/chain` walks up to root correctly
- [ ] Verify `PUT /api/agents/{id}/org` creates new node if not exists
- [ ] Test `PATCH /api/agents/{id}/org` updates role/title/reporting line