### PR TITLE
fix(security): correct Redis key prefix in validate-service-auth.sh (#1742)

### DIFF
--- a/scripts/service-auth/validate-service-auth.sh
+++ b/scripts/service-auth/validate-service-auth.sh
@@ -163,12 +163,12 @@ test_redis_service_keys() {
     for sid in "${SERVICE_IDS[@]}"; do
         local key_exists
         key_exists=$(redis-cli -h "${REDIS_HOST}" -p "${REDIS_PORT}" \
-            exists "service:auth:key:${sid}" 2>/dev/null || echo "0")
+            exists "service:key:${sid}" 2>/dev/null || echo "0")
 
         if [[ "${key_exists}" == "1" ]] || [[ "${key_exists}" == *"1"* ]]; then
-            record_pass "Key present: service:auth:key:${sid}"
+            record_pass "Key present: service:key:${sid}"
         else
-            record_fail "Key missing: service:auth:key:${sid}"
+            record_fail "Key missing: service:key:${sid}"
         fi
     done
 }


### PR DESCRIPTION
## Summary

Closes #1742

The validation script `scripts/service-auth/validate-service-auth.sh` used the wrong Redis key prefix `service:auth:key:` instead of `service:key:`. This caused it to always report all 6 service keys as MISSING even when they exist in Redis.

## Changes

- Replace `service:auth:key:` with `service:key:` on lines 166, 169, 171

## Test plan

- [ ] Run `validate-service-auth.sh` against a Redis instance with service keys — should report keys as present
- [ ] Verify prefix matches `autobot-backend/security/service_auth.py:53,70`