### PR TITLE
fix(security): add authentication to knowledge_vectorization endpoints (#1738)

### DIFF
--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -14,9 +14,10 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
+from auth_middleware import check_admin_permission, get_current_user
 from background_vectorization import get_background_vectorizer
 from exceptions import InternalError
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from knowledge.pipeline.base import PipelineContext
 from knowledge.pipeline.cognifiers.context_generator import ContextGeneratorCognifier
 from knowledge.pipeline.models.chunk import ProcessedChunk
@@ -312,7 +313,9 @@ async def _perform_uncached_batch_check(
 
 
 @router.post("/vectorization_status")
-async def check_vectorization_status_batch(request: dict, req: Request):
+async def check_vectorization_status_batch(
+    request: dict, req: Request, _user: dict = Depends(get_current_user)
+):
     """
     Check vectorization status for multiple facts in a single efficient batch operation.
 
@@ -584,6 +587,7 @@ async def vectorize_existing_facts(
     batch_size: int = 50,
     batch_delay: float = 0.5,
     skip_existing: bool = True,
+    _admin: bool = Depends(check_admin_permission),
 ):
     """
     Generate vector embeddings for facts in Redis.
@@ -1040,7 +1044,11 @@ async def _vectorize_fact_background(
 )
 @router.post("/vectorize_fact/{fact_id}")
 async def vectorize_individual_fact(
-    fact_id: str, req: Request, background_tasks: BackgroundTasks, force: bool = False
+    fact_id: str,
+    req: Request,
+    background_tasks: BackgroundTasks,
+    force: bool = False,
+    _admin: bool = Depends(check_admin_permission),
 ):
     """
     Vectorize a single fact by ID with progress tracking.
@@ -1087,7 +1095,9 @@ async def vectorize_individual_fact(
     error_code_prefix="KNOWLEDGE",
 )
 @router.get("/vectorize_job/{job_id}")
-async def get_vectorization_job_status(job_id: str, req: Request):
+async def get_vectorization_job_status(
+    job_id: str, req: Request, _user: dict = Depends(get_current_user)
+):
     """
     Get the status of a vectorization job.
 
@@ -1148,7 +1158,9 @@ def _collect_failed_keys(keys: list, results: list) -> List[str]:
     error_code_prefix="KNOWLEDGE",
 )
 @router.get("/vectorize_jobs/failed")
-async def get_failed_vectorization_jobs(req: Request):
+async def get_failed_vectorization_jobs(
+    req: Request, _user: dict = Depends(get_current_user)
+):
     """
     Get all failed vectorization jobs from Redis.
 
@@ -1204,7 +1216,11 @@ async def get_failed_vectorization_jobs(req: Request):
 )
 @router.post("/vectorize_jobs/{job_id}/retry")
 async def retry_vectorization_job(
-    job_id: str, req: Request, background_tasks: BackgroundTasks, force: bool = False
+    job_id: str,
+    req: Request,
+    background_tasks: BackgroundTasks,
+    force: bool = False,
+    _admin: bool = Depends(check_admin_permission),
 ):
     """
     Retry a failed vectorization job.
@@ -1251,7 +1267,9 @@ async def retry_vectorization_job(
     error_code_prefix="KNOWLEDGE",
 )
 @router.delete("/vectorize_jobs/{job_id}")
-async def delete_vectorization_job(job_id: str, req: Request):
+async def delete_vectorization_job(
+    job_id: str, req: Request, _admin: bool = Depends(check_admin_permission)
+):
     """
     Delete a vectorization job record from Redis.
 
@@ -1290,7 +1308,9 @@ async def delete_vectorization_job(job_id: str, req: Request):
     error_code_prefix="KNOWLEDGE",
 )
 @router.delete("/vectorize_jobs/failed/clear")
-async def clear_failed_vectorization_jobs(req: Request):
+async def clear_failed_vectorization_jobs(
+    req: Request, _admin: bool = Depends(check_admin_permission)
+):
     """
     Clear all failed vectorization jobs from Redis.
 
@@ -1352,7 +1372,9 @@ async def clear_failed_vectorization_jobs(req: Request):
 )
 @router.post("/vectorize_facts/background")
 async def start_background_vectorization(
-    req: Request, background_tasks: BackgroundTasks
+    req: Request,
+    background_tasks: BackgroundTasks,
+    _admin: bool = Depends(check_admin_permission),
 ):
     """
     Start background vectorization of all pending facts.
@@ -1381,7 +1403,9 @@ async def start_background_vectorization(
     error_code_prefix="KNOWLEDGE",
 )
 @router.get("/vectorize_facts/status")
-async def get_vectorization_status(req: Request):
+async def get_vectorization_status(
+    req: Request, _user: dict = Depends(get_current_user)
+):
     """Get the status of background vectorization"""
     vectorizer = get_background_vectorizer()
 
@@ -1612,6 +1636,7 @@ async def _run_reindex(collection_name: str, batch_size: int) -> None:
 async def reindex_with_context(
     request: ReindexWithContextRequest,
     background_tasks: BackgroundTasks,
+    _admin: bool = Depends(check_admin_permission),
 ) -> ReindexWithContextResponse:
     """Retroactively enrich chunks with contextual retrieval.
 


### PR DESCRIPTION
## Summary

- All 11 endpoints in the `knowledge_vectorization` router now require authentication
- POST/DELETE mutation endpoints use `Depends(check_admin_permission)` — 7 endpoints
- GET/status read endpoints use `Depends(get_current_user)` — 4 endpoints
- Matches the auth pattern used by `api/knowledge.py` and other knowledge routers

## Endpoints Protected

| Endpoint | Method | Auth |
|----------|--------|------|
| `/vectorization_status` | POST | `get_current_user` |
| `/vectorize_facts` | POST | `check_admin_permission` |
| `/vectorize_fact/{fact_id}` | POST | `check_admin_permission` |
| `/vectorize_job/{job_id}` | GET | `get_current_user` |
| `/vectorize_jobs/failed` | GET | `get_current_user` |
| `/vectorize_jobs/{job_id}/retry` | POST | `check_admin_permission` |
| `/vectorize_jobs/{job_id}` | DELETE | `check_admin_permission` |
| `/vectorize_jobs/failed/clear` | DELETE | `check_admin_permission` |
| `/vectorize_facts/background` | POST | `check_admin_permission` |
| `/vectorize_facts/status` | GET | `get_current_user` |
| `/reindex_with_context` | POST | `check_admin_permission` |

## Test plan

- [ ] Verify unauthenticated requests return 401/403
- [ ] Verify admin-authenticated requests succeed on POST/DELETE endpoints
- [ ] Verify user-authenticated requests succeed on GET endpoints

Closes #1738