### PR TITLE
fix(security): move emergency admin password hash to Ansible Vault (#1743)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -37,8 +37,10 @@
 
     # Emergency admin user for fallback access when SSH keys fail
     emergency_admin_user: "autobot_admin"
-    # Password hash generated with: python3 -c "from passlib.hash import sha512_crypt; print(sha512_crypt.hash('password'))"
-    emergency_admin_password_hash: "$6$rounds=656000$VqQZbIggJvVNjHfl$hunhLQdMKj/TCyE.ftDknskbz4SCnGz5e6Yo4YJzHeIIhdRAp/oIDKdwd54oktyBwmb2nP09MWRyXNu0mLg1L1"
+    # Password hash must be provided via Ansible Vault or --extra-vars.
+    # Generate with: python3 -c "from passlib.hash import sha512_crypt; print(sha512_crypt.hash('YOUR_PASSWORD'))"
+    # See: inventory/group_vars/vault.yml
+    emergency_admin_password_hash: "{{ vault_emergency_admin_password_hash | default(omit) }}"
 
     # Role-specific defaults
     role_configs:
@@ -168,6 +170,7 @@
             append: yes
             password: "{{ emergency_admin_password_hash }}"
             state: present
+          when: vault_emergency_admin_password_hash is defined
 
         - name: "Configure passwordless sudo for emergency admin"
           copy:
@@ -177,6 +180,7 @@
             group: root
             mode: '0440'
             validate: 'visudo -cf %s'
+          when: vault_emergency_admin_password_hash is defined
 
         - name: "Configure passwordless sudo for autobot user"
           copy:


### PR DESCRIPTION
## Summary

Closes #1743

Remove the hardcoded SHA-512 password hash from `enroll-node.yml` and replace with an Ansible Vault variable reference. The emergency admin user/sudo tasks are now conditional on the vault variable being defined.

## Changes

- Replace hardcoded hash with `{{ vault_emergency_admin_password_hash | default(omit) }}`
- Add `when: vault_emergency_admin_password_hash is defined` to emergency admin user creation and sudo config
- Add comments documenting how to generate the hash

## Setup

After merging, set the vault variable via:
```bash
# Create/edit vault file
ansible-vault create inventory/group_vars/vault.yml
# Add: vault_emergency_admin_password_hash: "<hash>"

# Generate hash:
python3 -c "from passlib.hash import sha512_crypt; print(sha512_crypt.hash('YOUR_PASSWORD'))"

# Run with vault:
ansible-playbook enroll-node.yml --ask-vault-pass
```

## Test plan

- [ ] Run `ansible-playbook --syntax-check enroll-node.yml`
- [ ] Enroll without vault var set — emergency admin tasks should be skipped
- [ ] Enroll with vault var set via `--extra-vars` — emergency admin should be created