### PR TITLE
refactor(knowledge): make ContextGeneratorCognifier.is_enabled() public (#1760)

### DIFF
--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -1647,7 +1647,7 @@ async def reindex_with_context(
     has_context metadata. Guarded by CONTEXT_ENABLED env var.
     Issue #1513.
     """
-    if not ContextGeneratorCognifier._is_enabled():
+    if not ContextGeneratorCognifier.is_enabled():
         raise HTTPException(
             status_code=400,
             detail=(

--- a/autobot-backend/knowledge/pipeline/cognifiers/context_generator.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/context_generator.py
@@ -52,7 +52,7 @@ class ContextGeneratorCognifier(BaseCognifier):
         self.llm = LLMInterface()
 
     async def process(self, context: PipelineContext) -> PipelineContext:
-        if not self._is_enabled() or not context.chunks:
+        if not self.is_enabled() or not context.chunks:
             return context
         doc_text = "\n\n".join(c.content for c in context.chunks)
         doc_id = str(context.document_id or "")
@@ -119,5 +119,5 @@ class ContextGeneratorCognifier(BaseCognifier):
             return ""
 
     @staticmethod
-    def _is_enabled() -> bool:
+    def is_enabled() -> bool:
         return os.getenv("CONTEXT_ENABLED", "false").lower() == "true"


### PR DESCRIPTION
## Summary

- Rename `_is_enabled` → `is_enabled` on `ContextGeneratorCognifier` (drop private underscore)
- Update all 3 call sites: the class itself (2) and `api/knowledge_vectorization.py` (1)

## Test plan

- [x] Syntax check passes
- [x] flake8 clean
- [x] All pre-commit hooks pass

Closes #1760