### PR TITLE
fix(analytics): remove dead api_call_tracker code (#1731)

### DIFF
--- a/autobot-backend/api/analytics_controller.py
+++ b/autobot-backend/api/analytics_controller.py
@@ -100,7 +100,6 @@ class AnalyticsController:
         self.code_index_path = PATH.PROJECT_ROOT / "mcp-tools" / "code-index-mcp"
 
         # Performance tracking
-        self.api_call_tracker = defaultdict(list)
         self.websocket_activity = defaultdict(int)
         self.system_bottlenecks = []
 


### PR DESCRIPTION
## Summary
- Removed unused `api_call_tracker = defaultdict(list)` from `AnalyticsController.__init__()`
- Confirmed via git history and full codebase grep: never written to or read — dead code, not an incomplete feature
- `defaultdict` import retained (still used by 5+ other fields)

Closes #1731