### PR TITLE
fix(analytics): update stale directory paths in pattern_extractor (#1725)

### DIFF
--- a/autobot-backend/services/pattern_extractor.py
+++ b/autobot-backend/services/pattern_extractor.py
@@ -69,7 +69,7 @@ class PatternExtractor:
     def _extract_python_patterns(self) -> None:
         """Extract patterns from Python files."""
         python_dirs = [
-            self.base_path / "autobot-user-backend",
+            self.base_path / "autobot-backend",
             self.base_path / "autobot-slm-backend",
             self.base_path / "autobot-shared",
         ]
@@ -246,7 +246,7 @@ class PatternExtractor:
     def _extract_typescript_vue_patterns(self) -> None:
         """Extract patterns from TypeScript and Vue files."""
         frontend_dirs = [
-            self.base_path / "autobot-user-frontend" / "src",
+            self.base_path / "autobot-frontend" / "src",
             self.base_path / "autobot-slm-frontend" / "src",
         ]
 


### PR DESCRIPTION
## Summary
- Updated `autobot-user-backend` → `autobot-backend` in pattern_extractor.py
- Updated `autobot-user-frontend` → `autobot-frontend` in pattern_extractor.py
- Fixes empty pattern extraction results caused by referencing non-existent pre-restructure directories
- Contributes to fixing #1712 (empty analytics report sections)

Closes #1725