### PR TITLE
fix(nginx): inject X-Internal-API-Key into /autobot-api proxy (#1791)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
@@ -52,6 +52,13 @@ slm_encryption_key: ""
 slm_admin_password: ""
 
 # ==========================================================
+# Main Backend Proxy (#1791)
+# ==========================================================
+# Internal API key shared between SLM and main backend.
+# Set via Ansible Vault or inventory; injected into nginx proxy.
+autobot_internal_api_key: ""
+
+# ==========================================================
 # Grafana Configuration
 # Issue #853: Support both local and external Grafana
 # ==========================================================

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
@@ -136,6 +136,7 @@ server {
 
     # Main AutoBot backend proxy (user backend skills, cache, etc.)
     # /autobot-api/* → https://main_backend/api/* (strips /autobot-api prefix)
+    # Issue #1791: inject X-Internal-API-Key for service auth + WebSocket support
     location /autobot-api/ {
         proxy_pass https://{{ autobot_backend_host | default('172.16.168.20') }}:{{ autobot_backend_port | default(8443) }}/api/;
         proxy_http_version 1.1;
@@ -144,9 +145,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+{% if autobot_internal_api_key %}
+        proxy_set_header X-Internal-API-Key "{{ autobot_internal_api_key }}";
+{% endif %}
+        # WebSocket support for /processes/{id}/stream (#1777)
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
     }
 
     # noVNC WebSocket/HTTP proxy — Issue #1002


### PR DESCRIPTION
## Summary

Adds `X-Internal-API-Key` header injection and WebSocket support to the SLM nginx `/autobot-api` proxy location block.

Without this, the Config History and Process Monitor SLM admin tabs return 401 in production (they work in dev via Vite proxy).

## Changes
- `autobot-slm.conf.j2`: Add `proxy_set_header X-Internal-API-Key` (conditional on variable), WebSocket upgrade headers, increase timeouts to 300s
- `defaults/main.yml`: Add `autobot_internal_api_key` variable (empty default, set via Vault/inventory)

## Deployment
After merging, set the variable in inventory or Vault and re-run:
```bash
ansible-playbook deploy-full.yml -i inventory/production.yml -i inventory/slm-nodes.yml --tags nginx
```

## Test Plan
- [ ] `AUTOBOT_INTERNAL_API_KEY` set in both .20 backend .env and Ansible inventory
- [ ] nginx config renders with `proxy_set_header X-Internal-API-Key`
- [ ] Config History tab loads revisions without 401
- [ ] Process Monitor tab loads processes without 401
- [ ] WebSocket streaming connects through nginx