### PR TITLE
refactor(i18n): derive SUPPORTED_LOCALES from locale file glob (#1675)

### DIFF
--- a/autobot-frontend/src/i18n/index.ts
+++ b/autobot-frontend/src/i18n/index.ts
@@ -10,10 +10,11 @@ export type MessageSchema = typeof en
 // Locales that use right-to-left text direction (#1337)
 const RTL_LOCALES = new Set(['ar', 'he', 'fa', 'ur'])
 
-// All locales with available translation files (#1336, #1508)
-export const SUPPORTED_LOCALES = [
-  'ar', 'de', 'en', 'es', 'fa', 'fr', 'he', 'lv', 'pl', 'pt', 'ur',
-] as const
+// Derive supported locales from locale files on disk — no manual sync needed (#1675)
+const localeModules = import.meta.glob('./locales/*.json')
+export const SUPPORTED_LOCALES = Object.keys(localeModules)
+  .map(path => path.replace('./locales/', '').replace('.json', ''))
+  .sort()
 
 /**
  * Detect the user's preferred locale from browser settings.
@@ -24,11 +25,11 @@ export function detectBrowserLocale(): string {
   const browserLocales = navigator.languages ?? [navigator.language]
   for (const browserLocale of browserLocales) {
     const exact = browserLocale.toLowerCase()
-    if ((SUPPORTED_LOCALES as readonly string[]).includes(exact)) {
+    if (SUPPORTED_LOCALES.includes(exact)) {
       return exact
     }
     const base = exact.split('-')[0]
-    if ((SUPPORTED_LOCALES as readonly string[]).includes(base)) {
+    if (SUPPORTED_LOCALES.includes(base)) {
       return base
     }
   }


### PR DESCRIPTION
## Summary

- Replace hardcoded `SUPPORTED_LOCALES` array with `import.meta.glob('./locales/*.json')` to auto-discover locale files at build time
- Remove unnecessary `as readonly string[]` casts in `detectBrowserLocale()` since array is now `string[]`
- New locale files are automatically picked up without manual array updates

## Changes

- `autobot-frontend/src/i18n/index.ts` — derive `SUPPORTED_LOCALES` from glob, simplify type casts

## Test plan

- [x] Existing RTL tests pass (16/16)
- [ ] Build succeeds with `import.meta.glob` resolution
- [ ] Adding a new `.json` locale file auto-includes it in `SUPPORTED_LOCALES`

Closes #1675