### PR TITLE
fix(frontend): restore backend-wait polling after max reconnects (#1795)

### DIFF
--- a/autobot-frontend/src/services/GlobalWebSocketService.ts
+++ b/autobot-frontend/src/services/GlobalWebSocketService.ts
@@ -420,10 +420,11 @@ class GlobalWebSocketService {
 
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       logger.debug(
-        'Max reconnection attempts reached, waiting for backend'
+        'Max reconnection attempts reached, entering backend-wait mode'
       )
       this.state.lastError =
         'Connection failed. Waiting for backend to become available...'
+      this._startBackendWait()
       return
     }
 
@@ -449,6 +450,40 @@ class GlobalWebSocketService {
         })
       }
     }, delay)
+  }
+
+  // -----------------------------------------------------------------------
+  // Backend-Wait Mode (#1463, restored #1795)
+  // -----------------------------------------------------------------------
+
+  /**
+   * Poll /api/health every 30s until backend is available, then reconnect.
+   * Activates when normal reconnect attempts are exhausted — handles the
+   * ~6-minute backend restart window without giving up.
+   */
+  private _startBackendWait(): void {
+    if (this._backendWaitTimer) return
+
+    this._backendWaitTimer = setInterval(() => {
+      this.quickHealthCheck()
+        .then((healthy) => {
+          if (healthy) {
+            logger.debug('Backend healthy, reconnecting from wait mode')
+            if (this._backendWaitTimer) {
+              clearInterval(this._backendWaitTimer)
+              this._backendWaitTimer = null
+            }
+            this.reconnectAttempts = 0
+            this.state.reconnectCount = 0
+            this.connect().catch((err: unknown) => {
+              logger.error('Post-wait reconnect failed:', err)
+            })
+          }
+        })
+        .catch(() => {
+          /* backend still down, keep polling */
+        })
+    }, 30_000)
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Restored `_startBackendWait()` method that was removed in PR #1776 (#1519)
- When max reconnect attempts (5) are exhausted, enters backend-wait mode
- Polls `/api/health` every 30 seconds until backend responds healthy
- On healthy response: resets reconnect counter and reconnects
- Handles the ~6-minute backend restart window on .20 without requiring manual page reload

## Why this was needed
PR #1776 removed `_startBackendWait()` as "superseded by normal reconnect logic," but the normal reconnect has `maxReconnectAttempts = 5` with exponential backoff. After 5 failed attempts, `scheduleReconnect()` hit a dead return — no further polling occurred. Users had to manually reload after any backend restart.

Closes #1795