### PR TITLE
refactor: replace deprecated asyncio.get_event_loop() across backend (#1752)

### DIFF
--- a/autobot-backend/agents/classification_agent.py
+++ b/autobot-backend/agents/classification_agent.py
@@ -81,13 +81,9 @@ class ClassificationAgent(StandardizedAgent):
         import asyncio
 
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                asyncio.create_task(self.initialize_communication(self.capabilities))
-            else:
-                loop.run_until_complete(
-                    self.initialize_communication(self.capabilities)
-                )
+            asyncio.get_running_loop()
+            # A running loop exists — schedule as a task
+            asyncio.create_task(self.initialize_communication(self.capabilities))
         except RuntimeError:
             # Event loop not available yet, will initialize later
             logger.debug(

--- a/autobot-backend/agents/development_speedup_agent.py
+++ b/autobot-backend/agents/development_speedup_agent.py
@@ -125,7 +125,7 @@ class DevelopmentSpeedupAgent:
             "quality_issues",
         ]
         report = {
-            "analysis_timestamp": asyncio.get_event_loop().time(),
+            "analysis_timestamp": asyncio.get_running_loop().time(),
             "root_path": root_path,
         }
         for i, key in enumerate(report_keys):

--- a/autobot-backend/agents/multi_agent_workflow_validation_test.py
+++ b/autobot-backend/agents/multi_agent_workflow_validation_test.py
@@ -193,8 +193,7 @@ class MultiAgentWorkflowValidator:
         # Execute requests in parallel using asyncio
         async def make_request(endpoint):
             try:
-                loop = asyncio.get_event_loop()
-                response = await loop.run_in_executor(
+                response = await asyncio.get_running_loop().run_in_executor(
                     None, lambda: requests.get(f"{self.base_url}{endpoint}", timeout=5)
                 )
                 return {

--- a/autobot-backend/agents/npu_code_search_agent.py
+++ b/autobot-backend/agents/npu_code_search_agent.py
@@ -173,13 +173,9 @@ class NPUCodeSearchAgent(StandardizedAgent):
     def _init_communication(self) -> None:
         """Initialize communication protocol for agent-to-agent messaging."""
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                asyncio.create_task(self.initialize_communication(self.capabilities))
-            else:
-                loop.run_until_complete(
-                    self.initialize_communication(self.capabilities)
-                )
+            asyncio.get_running_loop()
+            # A running loop exists — schedule as a task
+            asyncio.create_task(self.initialize_communication(self.capabilities))
         except RuntimeError:
             logger.debug(
                 "Event loop not available, will initialize communication later"

--- a/autobot-backend/api/base_terminal.py
+++ b/autobot-backend/api/base_terminal.py
@@ -80,7 +80,7 @@ class BaseTerminalWebSocket(ABC):
 
         # Schedule async output sender
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             self._output_sender_task = asyncio.run_coroutine_threadsafe(
                 self._async_output_sender(), loop
             )
@@ -175,7 +175,7 @@ class BaseTerminalWebSocket(ABC):
                 try:
                     # Wait for message with timeout
                     message = await asyncio.wait_for(
-                        asyncio.get_event_loop().run_in_executor(
+                        asyncio.get_running_loop().run_in_executor(
                             None, self.output_queue.get, True, 0.1
                         ),
                         timeout=0.2,

--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -82,12 +82,11 @@ async def _run_standard_analysis(project_root: str, min_similarity: float):
     Returns:
         Analysis result or None if timed out
     """
-    loop = asyncio.get_event_loop()
     try:
         # Issue #1233: Use dedicated analytics executor to prevent
         # default thread pool starvation
         analysis = await asyncio.wait_for(
-            loop.run_in_executor(
+            asyncio.get_running_loop().run_in_executor(
                 get_analytics_executor(),
                 lambda: DuplicateCodeDetector(
                     project_root=project_root,

--- a/autobot-backend/api/codebase_analytics/endpoints/environment.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/environment.py
@@ -93,9 +93,9 @@ async def _run_environment_analysis(analyzer, path: str, pattern_list: list):
         if asyncio.iscoroutine(coro):
             return await asyncio.wait_for(coro, timeout=ANALYSIS_TIMEOUT)
         else:
-            loop = asyncio.get_event_loop()
             return await asyncio.wait_for(
-                loop.run_in_executor(None, lambda: coro), timeout=ANALYSIS_TIMEOUT
+                asyncio.get_running_loop().run_in_executor(None, lambda: coro),
+                timeout=ANALYSIS_TIMEOUT,
             )
     except asyncio.TimeoutError:
         logger.warning(
@@ -136,9 +136,9 @@ async def _run_llm_filtered_analysis(
         if asyncio.iscoroutine(coro):
             return await asyncio.wait_for(coro, timeout=LLM_ANALYSIS_TIMEOUT)
         else:
-            loop = asyncio.get_event_loop()
             return await asyncio.wait_for(
-                loop.run_in_executor(None, lambda: coro), timeout=LLM_ANALYSIS_TIMEOUT
+                asyncio.get_running_loop().run_in_executor(None, lambda: coro),
+                timeout=LLM_ANALYSIS_TIMEOUT,
             )
     except asyncio.TimeoutError:
         logger.warning(

--- a/autobot-backend/api/codebase_analytics/endpoints/indexing.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/indexing.py
@@ -159,13 +159,12 @@ def _start_next_queued_job() -> None:
         return
     next_job = _index_queue.popleft()
     # Remove from Redis queue (#1717: keep in-memory and Redis in sync)
-    loop = asyncio.get_event_loop()
-    loop.create_task(_pop_queue_entry_redis())
+    asyncio.get_running_loop().create_task(_pop_queue_entry_redis())
     next_path = next_job.get("root_path", str(PATH.PROJECT_ROOT))
     next_source_id = next_job.get("source_id")
     next_task_id = str(uuid.uuid4())
     _current_indexing_task_id = next_task_id
-    task = loop.create_task(
+    task = asyncio.get_running_loop().create_task(
         _run_indexing_subprocess(next_task_id, next_path, source_id=next_source_id)
     )
     _active_tasks[next_task_id] = task

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership.py
@@ -138,9 +138,9 @@ async def _run_ownership_analysis(analyzer, path: str, pattern_list: list, days:
         if asyncio.iscoroutine(coro):
             return await asyncio.wait_for(coro, timeout=ANALYSIS_TIMEOUT)
         else:
-            loop = asyncio.get_event_loop()
             return await asyncio.wait_for(
-                loop.run_in_executor(None, lambda: coro), timeout=ANALYSIS_TIMEOUT
+                asyncio.get_running_loop().run_in_executor(None, lambda: coro),
+                timeout=ANALYSIS_TIMEOUT,
             )
     except asyncio.TimeoutError:
         logger.warning(

--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -1561,13 +1561,12 @@ async def _get_duplicate_analysis() -> Optional[DuplicateAnalysis]:
         DuplicateAnalysis or None if analysis fails
     """
     try:
-        loop = asyncio.get_event_loop()
         project_root = str(Path(__file__).resolve().parents[4])
 
         # Issue #1233: Use dedicated analytics executor to prevent
         # default thread pool starvation
         analysis = await asyncio.wait_for(
-            loop.run_in_executor(
+            asyncio.get_running_loop().run_in_executor(
                 get_analytics_executor(),
                 lambda: DuplicateCodeDetector(project_root=project_root).run_analysis(),
             ),
@@ -1641,13 +1640,12 @@ async def _get_bug_prediction(
 
         # Issue #1233: Use dedicated analytics executor to prevent
         # default thread pool starvation
-        loop = asyncio.get_event_loop()
 
         # Issue #554: Pass semantic analysis flag
         predictor = BugPredictor(project_root=root, use_semantic_analysis=use_semantic)
 
         result = await asyncio.wait_for(
-            loop.run_in_executor(
+            asyncio.get_running_loop().run_in_executor(
                 get_analytics_executor(),
                 lambda: predictor.analyze_directory(pattern="*.py", limit=limit),
             ),

--- a/autobot-backend/api/codebase_analytics/scanner.py
+++ b/autobot-backend/api/codebase_analytics/scanner.py
@@ -3158,7 +3158,7 @@ async def _wait_with_watchdog(
     for _SUBPROCESS_PROGRESS_TIMEOUT seconds, kills the subprocess.
     """
     last_progress_hash = None
-    last_progress_time = asyncio.get_event_loop().time()
+    last_progress_time = asyncio.get_running_loop().time()
 
     while True:
         try:
@@ -3182,7 +3182,7 @@ async def _wait_with_watchdog(
                 progress.get("total"),
                 progress.get("operation"),
             )
-            now = asyncio.get_event_loop().time()
+            now = asyncio.get_running_loop().time()
 
             if progress_hash != last_progress_hash:
                 last_progress_hash = progress_hash

--- a/autobot-backend/code_intelligence/pattern_analysis/analyzer.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/analyzer.py
@@ -220,12 +220,11 @@ class CodePatternAnalyzer:
         """Run regex detection on a batch of files."""
         if not self._regex_detector:
             return []
-        loop = asyncio.get_event_loop()
         executor = get_analytics_executor()
         results = []
         for fp in file_paths:
             try:
-                opps = await loop.run_in_executor(
+                opps = await asyncio.get_running_loop().run_in_executor(
                     executor, self._regex_detector.detect_in_file, fp
                 )
                 results.extend(opps)
@@ -237,12 +236,11 @@ class CodePatternAnalyzer:
         """Run complexity analysis on a batch of files."""
         if not self._complexity_analyzer:
             return []
-        loop = asyncio.get_event_loop()
         executor = get_analytics_executor()
         modules = []
         for fp in file_paths:
             try:
-                module = await loop.run_in_executor(
+                module = await asyncio.get_running_loop().run_in_executor(
                     executor, self._complexity_analyzer.analyze_file, fp
                 )
                 modules.append(module)
@@ -254,13 +252,12 @@ class CodePatternAnalyzer:
         """Run anti-pattern detection on a batch of files."""
         if not self._anti_pattern_detector:
             return {"modularization": [], "other_patterns": []}
-        loop = asyncio.get_event_loop()
         executor = get_analytics_executor()
         modularization: List = []
         other_patterns: List = []
         for fp in file_paths:
             try:
-                file_result = await loop.run_in_executor(
+                file_result = await asyncio.get_running_loop().run_in_executor(
                     executor,
                     self._anti_pattern_detector.analyze_file,
                     fp,
@@ -576,8 +573,7 @@ class CodePatternAnalyzer:
 
         try:
             # Issue #1233: Use dedicated analytics executor
-            loop = asyncio.get_event_loop()
-            report = await loop.run_in_executor(
+            report = await asyncio.get_running_loop().run_in_executor(
                 get_analytics_executor(),
                 self._clone_detector.detect_clones,
                 directory,
@@ -614,8 +610,7 @@ class CodePatternAnalyzer:
 
         try:
             # Issue #1233: Use dedicated analytics executor
-            loop = asyncio.get_event_loop()
-            opportunities = await loop.run_in_executor(
+            opportunities = await asyncio.get_running_loop().run_in_executor(
                 get_analytics_executor(),
                 self._regex_detector.detect_in_directory,
                 directory,
@@ -641,8 +636,7 @@ class CodePatternAnalyzer:
 
         try:
             # Issue #1233: Use dedicated analytics executor
-            loop = asyncio.get_event_loop()
-            modules = await loop.run_in_executor(
+            modules = await asyncio.get_running_loop().run_in_executor(
                 get_analytics_executor(),
                 self._complexity_analyzer.analyze_directory,
                 directory,
@@ -680,8 +674,7 @@ class CodePatternAnalyzer:
 
         try:
             # Issue #1233: Use dedicated analytics executor
-            loop = asyncio.get_event_loop()
-            report = await loop.run_in_executor(
+            report = await asyncio.get_running_loop().run_in_executor(
                 get_analytics_executor(),
                 self._anti_pattern_detector.analyze_directory,
                 directory,

--- a/autobot-backend/computer_vision/phase9_multimodal_ai_test.py
+++ b/autobot-backend/computer_vision/phase9_multimodal_ai_test.py
@@ -75,7 +75,7 @@ async def test_multimodal_processor():
         processing_intent=ProcessingIntent.CONTENT_GENERATION,
         content="Generate a summary of AutoBot's capabilities",
         metadata={"source": "test"},
-        timestamp=asyncio.get_event_loop().time(),
+        timestamp=asyncio.get_running_loop().time(),
     )
 
     try:
@@ -100,7 +100,7 @@ async def test_multimodal_processor():
             processing_intent=ProcessingIntent.SCREEN_ANALYSIS,
             content=test_image_bytes,
             metadata={"source": "synthetic_test"},
-            timestamp=asyncio.get_event_loop().time(),
+            timestamp=asyncio.get_running_loop().time(),
         )
 
         result = await multimodal_processor.process_input(image_input)
@@ -124,7 +124,7 @@ async def test_multimodal_processor():
                 "image": base64.b64encode(test_image_bytes).decode("utf-8"),
             },
             metadata={"source": "combined_test"},
-            timestamp=asyncio.get_event_loop().time(),
+            timestamp=asyncio.get_running_loop().time(),
         )
 
         result = await multimodal_processor.process_input(combined_input)
@@ -220,7 +220,7 @@ async def test_voice_processing_system():
             duration=duration,
             format="raw",
             channels=1,
-            timestamp=asyncio.get_event_loop().time(),
+            timestamp=asyncio.get_running_loop().time(),
             metadata={"source": "synthetic_test"},
         )
 
@@ -420,7 +420,7 @@ async def test_integration():
             processing_intent=ProcessingIntent.AUTOMATION_TASK,
             content=test_image_bytes,
             metadata={"integration_test": True},
-            timestamp=asyncio.get_event_loop().time(),
+            timestamp=asyncio.get_running_loop().time(),
         )
 
         modal_result = await multimodal_processor.process_input(modal_input)

--- a/autobot-backend/conversation.py
+++ b/autobot-backend/conversation.py
@@ -17,6 +17,7 @@ from agents import get_kb_librarian
 from agents.classification_agent import ClassificationAgent, ClassificationResult
 from agents.llm_failsafe_agent import get_robust_llm_response
 from autobot_types import TaskComplexity
+from config import config as global_config_manager
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import TimingConstants
 from research_browser_manager import research_browser_manager
@@ -27,8 +28,6 @@ from source_attribution import (
     source_manager,
     track_source,
 )
-
-from config import config as global_config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +146,7 @@ class Conversation:
         Returns:
             Dict containing response, sources, and metadata
         """
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
 
         try:
             # Clear previous sources and add user message
@@ -184,7 +183,7 @@ class Conversation:
             self._add_source_message(sources_block)
 
             # Update conversation state
-            self.state.processing_time = asyncio.get_event_loop().time() - start_time
+            self.state.processing_time = asyncio.get_running_loop().time() - start_time
             self.state.sources_used = [
                 s.to_dict() for s in source_manager.current_response_sources
             ]

--- a/autobot-backend/enhanced_security_layer_test.py
+++ b/autobot-backend/enhanced_security_layer_test.py
@@ -168,7 +168,7 @@ class TestEnhancedSecurityLayer:
             "command": "mkdir test",
             "risk": CommandRisk.MODERATE.value,
             "reasons": ["Moderate risk"],
-            "timestamp": asyncio.get_event_loop().time(),
+            "timestamp": asyncio.get_running_loop().time(),
         }
 
         result = await self.security._command_approval_callback(approval_data)
@@ -181,7 +181,7 @@ class TestEnhancedSecurityLayer:
             "command": "rm file.txt",
             "risk": CommandRisk.HIGH.value,
             "reasons": ["High risk"],
-            "timestamp": asyncio.get_event_loop().time(),
+            "timestamp": asyncio.get_running_loop().time(),
         }
 
         # Start approval in background
@@ -207,7 +207,7 @@ class TestEnhancedSecurityLayer:
             "command": "rm file.txt",
             "risk": CommandRisk.HIGH.value,
             "reasons": ["High risk"],
-            "timestamp": asyncio.get_event_loop().time(),
+            "timestamp": asyncio.get_running_loop().time(),
         }
 
         # Mock asyncio.wait_for to raise TimeoutError

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -975,7 +975,7 @@ def create_lifespan_manager():
         _executor = ThreadPoolExecutor(
             max_workers=MAX_WORKER_THREADS, thread_name_prefix="autobot_worker"
         )
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         loop.set_default_executor(_executor)
         logger.info(
             "🧵 Bounded thread pool configured (max %d workers)", MAX_WORKER_THREADS

--- a/autobot-backend/judges/task_outcome_judge_test.py
+++ b/autobot-backend/judges/task_outcome_judge_test.py
@@ -148,7 +148,7 @@ class TestTaskOutcomeJudge:
         judge = TaskOutcomeJudge()
         import asyncio
 
-        prompt = asyncio.get_event_loop().run_until_complete(
+        prompt = asyncio.run(
             judge._prepare_judgment_prompt(
                 subject={"goal": "my goal", "output": "my output"},
                 criteria=[],

--- a/autobot-backend/knowledge/pipeline/cognifiers/cognifiers_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/cognifiers_test.py
@@ -579,7 +579,7 @@ class TestContextGeneratorDisabled:
         cog = ContextGeneratorCognifier()
         ctx = _make_context()
         original_contents = [c.content for c in ctx.chunks]
-        result = asyncio.get_event_loop().run_until_complete(cog.process(ctx))
+        result = asyncio.run(cog.process(ctx))
         assert [c.content for c in result.chunks] == original_contents
 
     def test_empty_chunks_returns_early(self):
@@ -589,7 +589,7 @@ class TestContextGeneratorDisabled:
 
         cog = ContextGeneratorCognifier()
         ctx = _make_context(n_chunks=0)
-        result = asyncio.get_event_loop().run_until_complete(cog.process(ctx))
+        result = asyncio.run(cog.process(ctx))
         assert result.chunks == []
 
 
@@ -624,7 +624,7 @@ class TestContextGeneratorEnabled:
         )
 
         ctx = _make_context(n_chunks=2)
-        result = asyncio.get_event_loop().run_until_complete(cog.process(ctx))
+        result = asyncio.run(cog.process(ctx))
 
         for chunk in result.chunks:
             assert chunk.metadata["has_context"] is True
@@ -651,7 +651,7 @@ class TestContextGeneratorEnabled:
         cog.llm.chat_completion = AsyncMock(return_value=chunk_resp)
 
         ctx = _make_context(n_chunks=2)
-        asyncio.get_event_loop().run_until_complete(cog.process(ctx))
+        asyncio.run(cog.process(ctx))
 
         assert cog.llm.chat_completion.call_count == 2
 
@@ -667,7 +667,7 @@ class TestContextGeneratorEnabled:
         cog.llm.chat_completion = AsyncMock(side_effect=RuntimeError("LLM down"))
 
         ctx = _make_context(n_chunks=1)
-        result = asyncio.get_event_loop().run_until_complete(cog.process(ctx))
+        result = asyncio.run(cog.process(ctx))
 
         assert result.chunks[0].metadata["has_context"] is False
         assert result.chunks[0].metadata["contextual_text"] == ""
@@ -690,6 +690,6 @@ class TestContextGeneratorEnabled:
 
         ctx = _make_context(n_chunks=1)
         original = ctx.chunks[0].content
-        result = asyncio.get_event_loop().run_until_complete(cog.process(ctx))
+        result = asyncio.run(cog.process(ctx))
 
         assert result.chunks[0].content == f"ctx sentence\n\n{original}"

--- a/autobot-backend/llm_interface_pkg/optimization/cloud_batcher.py
+++ b/autobot-backend/llm_interface_pkg/optimization/cloud_batcher.py
@@ -121,7 +121,7 @@ class CloudRequestBatcher:
             raise RuntimeError("Batcher is shutting down")
 
         request_id = str(uuid4())
-        future = asyncio.get_event_loop().create_future()
+        future = asyncio.get_running_loop().create_future()
         batched_request = BatchedRequest(
             request_id=request_id, payload=payload, future=future
         )

--- a/autobot-backend/llm_providers/vllm_provider.py
+++ b/autobot-backend/llm_providers/vllm_provider.py
@@ -69,8 +69,9 @@ class VLLMProvider:
             logger.info("Initializing vLLM with model: %s", self.model_name)
 
             # Initialize vLLM in a thread to avoid blocking
-            loop = asyncio.get_event_loop()
-            self.llm = await loop.run_in_executor(None, self._create_vllm_instance)
+            self.llm = await asyncio.get_running_loop().run_in_executor(
+                None, self._create_vllm_instance
+            )
 
             self.is_initialized = True
             logger.info("vLLM model %s initialized successfully", self.model_name)
@@ -141,8 +142,7 @@ class VLLMProvider:
             sampling_params = self._create_sampling_params(**kwargs)
             start_time = time.time()
 
-            loop = asyncio.get_event_loop()
-            outputs = await loop.run_in_executor(
+            outputs = await asyncio.get_running_loop().run_in_executor(
                 None, self._generate_completion, prompt, sampling_params
             )
 

--- a/autobot-backend/media/audio/pipeline_test.py
+++ b/autobot-backend/media/audio/pipeline_test.py
@@ -110,7 +110,7 @@ class TestAudioPipelineWhisper:
             return await pipe._process_audio(media_input)
 
         with patch("media.audio.pipeline._TRANSFORMERS_AVAILABLE", False):
-            result = asyncio.get_event_loop().run_until_complete(_run())
+            result = asyncio.run(_run())
         assert result["processing_status"] == "unavailable"
 
     def test_run_whisper_writes_temp_file_and_cleans_up(self):

--- a/autobot-backend/media/link/pipeline_test.py
+++ b/autobot-backend/media/link/pipeline_test.py
@@ -144,7 +144,7 @@ class TestLinkPipelineErrorHandling:
 
         import asyncio
 
-        result = asyncio.get_event_loop().run_until_complete(_run())
+        result = asyncio.run(_run())
         assert result["processing_status"] == "error"
 
 

--- a/autobot-backend/project_state_tracking/tracking.py
+++ b/autobot-backend/project_state_tracking/tracking.py
@@ -129,11 +129,15 @@ def _handle_sync_error_tracking(
     }
 
     try:
-        loop = asyncio.get_event_loop()
-        if loop.is_running():
-            _schedule_error_tracking(error, error_context)
-        else:
+        asyncio.get_running_loop()
+        # A running loop exists — schedule as a task
+        _schedule_error_tracking(error, error_context)
+    except RuntimeError:
+        # No running loop — run synchronously
+        try:
             _run_error_tracking(error, error_context)
+        except Exception:
+            logger.error("Error in %s: %s", func.__name__, error)
     except Exception:
         logger.error("Error in %s: %s", func.__name__, error)
 

--- a/autobot-backend/research_browser_manager.py
+++ b/autobot-backend/research_browser_manager.py
@@ -379,9 +379,9 @@ class ResearchBrowserSession:
         if not self.page or not self.interaction_required:
             return True
 
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
 
-        while asyncio.get_event_loop().time() - start_time < timeout_seconds:
+        while asyncio.get_running_loop().time() - start_time < timeout_seconds:
             try:
                 # Check if interaction is still required
                 interaction_data = await self.page.evaluate(

--- a/autobot-backend/secure_command_executor.py
+++ b/autobot-backend/secure_command_executor.py
@@ -497,7 +497,7 @@ class SecureCommandExecutor:
                 "command": command,
                 "risk": risk.value,
                 "reasons": reasons,
-                "timestamp": asyncio.get_event_loop().time(),
+                "timestamp": asyncio.get_running_loop().time(),
             }
             return await self.require_approval_callback(approval_data)
 
@@ -652,7 +652,7 @@ class SecureCommandExecutor:
             "command": command,
             "risk": risk.value,
             "reasons": reasons,
-            "timestamp": asyncio.get_event_loop().time(),
+            "timestamp": asyncio.get_running_loop().time(),
             "approved": True,
             "executed": False,
             "auto_approved_by": auto_approved_by,
@@ -678,7 +678,7 @@ class SecureCommandExecutor:
             "command": command,
             "risk": risk.value,
             "reasons": reasons,
-            "timestamp": asyncio.get_event_loop().time(),
+            "timestamp": asyncio.get_running_loop().time(),
             "approved": False,
             "executed": False,
         }

--- a/autobot-backend/skills/builtin/community_growth.py
+++ b/autobot-backend/skills/builtin/community_growth.py
@@ -202,8 +202,7 @@ class CommunityGrowthSkill(BaseSkill):
                         )
             return results
 
-        loop = asyncio.get_event_loop()
-        matches = await loop.run_in_executor(None, _sync_search)
+        matches = await asyncio.get_running_loop().run_in_executor(None, _sync_search)
         return {"success": True, "matches": matches}
 
     async def _reddit_reply(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -228,9 +227,10 @@ class CommunityGrowthSkill(BaseSkill):
             comment = submission.reply(content)
             return f"https://reddit.com{comment.permalink}"
 
-        loop = asyncio.get_event_loop()
         try:
-            comment_url = await loop.run_in_executor(None, _sync_reply)
+            comment_url = await asyncio.get_running_loop().run_in_executor(
+                None, _sync_reply
+            )
             return {"success": True, "comment_url": comment_url}
         except Exception as exc:
             logger.exception("reddit_reply failed for post %s", post_id)
@@ -262,9 +262,10 @@ class CommunityGrowthSkill(BaseSkill):
                 post.flair.select(flair)
             return f"https://reddit.com{post.permalink}"
 
-        loop = asyncio.get_event_loop()
         try:
-            post_url = await loop.run_in_executor(None, _sync_post)
+            post_url = await asyncio.get_running_loop().run_in_executor(
+                None, _sync_post
+            )
             return {"success": True, "post_url": post_url}
         except Exception as exc:
             logger.exception("reddit_post failed to r/%s", subreddit)

--- a/autobot-backend/utils/async_cancellation.py
+++ b/autobot-backend/utils/async_cancellation.py
@@ -317,7 +317,7 @@ async def _execute_sync_with_cancellation(
     """Execute sync operation with cancellation checks"""
 
     # Run in thread pool with periodic cancellation checks
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     # Create a future that will be resolved in the thread
     future = loop.create_future()

--- a/autobot-backend/utils/async_stream_processor.py
+++ b/autobot-backend/utils/async_stream_processor.py
@@ -396,7 +396,7 @@ async def process_llm_stream(
         Tuple of (accumulated_content, completed_successfully)
     """
     processor = StreamProcessorFactory.create_processor(provider, max_chunks)
-    processor.start_time = asyncio.get_event_loop().time()
+    processor.start_time = asyncio.get_running_loop().time()
 
     logger.info(
         "Starting %s stream processing (max_chunks: %s, max_buffer: %d MB)",
@@ -416,7 +416,7 @@ async def process_llm_stream(
         chunk_count = 0
 
     accumulated_content = "".join(content_parts)
-    processing_time = asyncio.get_event_loop().time() - processor.start_time
+    processing_time = asyncio.get_running_loop().time() - processor.start_time
     completed_successfully = _determine_stream_completion(completion_signal)
 
     _log_stream_completion(
@@ -437,7 +437,7 @@ async def process_stream_with_cancellation(
     Combines natural completion detection with cancellation tokens.
     """
 
-    start_time = asyncio.get_event_loop().time()
+    start_time = asyncio.get_running_loop().time()
 
     try:
         # Check cancellation before starting
@@ -451,7 +451,7 @@ async def process_stream_with_cancellation(
         if hasattr(cancellation_token, "raise_if_cancelled"):
             cancellation_token.raise_if_cancelled()
 
-        processing_time = asyncio.get_event_loop().time() - start_time
+        processing_time = asyncio.get_running_loop().time() - start_time
 
         return StreamProcessingResult(
             content=content,
@@ -467,7 +467,7 @@ async def process_stream_with_cancellation(
         )
 
     except Exception as e:
-        processing_time = asyncio.get_event_loop().time() - start_time
+        processing_time = asyncio.get_running_loop().time() - start_time
 
         return StreamProcessingResult(
             content="",

--- a/autobot-backend/utils/database_pool.py
+++ b/autobot-backend/utils/database_pool.py
@@ -226,7 +226,7 @@ class AsyncSQLiteConnectionPool:
 
     async def initialize(self):
         """Initialize the async pool."""
-        self._executor = asyncio.get_event_loop().run_in_executor
+        self._executor = asyncio.get_running_loop().run_in_executor
 
     @asynccontextmanager
     async def get_connection(self):

--- a/autobot-backend/utils/document_parser.py
+++ b/autobot-backend/utils/document_parser.py
@@ -73,8 +73,7 @@ class DocumentParser:
             )
 
         # Run extraction in thread pool to avoid blocking
-        loop = asyncio.get_event_loop()
-        text, metadata = await loop.run_in_executor(
+        text, metadata = await asyncio.get_running_loop().run_in_executor(
             None, self._extract_text_sync, file_path, extension
         )
 

--- a/autobot-backend/utils/redis_immediate_test.py
+++ b/autobot-backend/utils/redis_immediate_test.py
@@ -207,7 +207,7 @@ class RedisCircuitBreaker:
             self.failure_count = 0
             self.is_circuit_open = False
             try:
-                self.last_success_time = asyncio.get_event_loop().time()
+                self.last_success_time = asyncio.get_running_loop().time()
             except RuntimeError:
                 # No event loop running, use 0
                 self.last_success_time = 0
@@ -217,7 +217,7 @@ class RedisCircuitBreaker:
         with self._lock:
             self.failure_count += 1
             try:
-                self.last_failure_time = asyncio.get_event_loop().time()
+                self.last_failure_time = asyncio.get_running_loop().time()
             except RuntimeError:
                 # No event loop running, use 0
                 self.last_failure_time = 0

--- a/autobot-backend/utils/semantic_chunker.py
+++ b/autobot-backend/utils/semantic_chunker.py
@@ -142,11 +142,10 @@ class AutoBotSemanticChunker:
             batch_sentences = sentences[i : i + batch_size]
 
             # Run embedding computation in thread pool to avoid blocking event loop
-            loop = asyncio.get_event_loop()
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=max_workers
             ) as executor:
-                embeddings = await loop.run_in_executor(
+                embeddings = await asyncio.get_running_loop().run_in_executor(
                     executor,
                     lambda: self._embedding_model.encode(
                         batch_sentences,
@@ -364,13 +363,16 @@ class AutoBotSemanticChunker:
                 model = self._load_model_with_retry(device)
                 return self._optimize_loaded_model(model, device)
 
-            loop = asyncio.get_event_loop()
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
                 logger.info(
                     "Loading embedding model '%s' in background thread...",
                     self.embedding_model_name,
                 )
-                self._embedding_model = await loop.run_in_executor(executor, load_model)
+                self._embedding_model = (
+                    await asyncio.get_running_loop().run_in_executor(
+                        executor, load_model
+                    )
+                )
                 logger.info("Embedding model loading completed")
 
         except Exception as e:
@@ -546,32 +548,24 @@ class AutoBotSemanticChunker:
         import asyncio
 
         try:
-            # Try to get existing event loop
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # If we're in an async context, we shouldn't use this sync method
-                logger.warning(
-                    "Using sync embedding method in async context. "
-                    "Use _compute_sentence_embeddings_async instead."
-                )
-                logger.warning(
-                    "WARNING: Model initialization may block event loop - use async method instead"
-                )
-                # Fall back to direct computation (blocking) - creates a new sync version for
-                # fallback
-                if self._embedding_model is None:
-                    self._sync_initialize_model()
-                embeddings = self._embedding_model.encode(
-                    sentences, convert_to_tensor=False
-                )
-                return np.array(embeddings)
-            else:
-                # Run the async version
-                return loop.run_until_complete(
-                    self._compute_sentence_embeddings_async(sentences)
-                )
+            asyncio.get_running_loop()
+            # A running loop exists — we're in an async context; sync method should not block
+            logger.warning(
+                "Using sync embedding method in async context. "
+                "Use _compute_sentence_embeddings_async instead."
+            )
+            logger.warning(
+                "WARNING: Model initialization may block event loop - use async method instead"
+            )
+            # Fall back to direct computation (blocking)
+            if self._embedding_model is None:
+                self._sync_initialize_model()
+            embeddings = self._embedding_model.encode(
+                sentences, convert_to_tensor=False
+            )
+            return np.array(embeddings)
         except RuntimeError:
-            # No event loop, create one
+            # No running loop — run the async version synchronously
             return asyncio.run(self._compute_sentence_embeddings_async(sentences))
 
     def _compute_semantic_distances(self, embeddings: np.ndarray) -> List[float]:

--- a/autobot-backend/utils/semantic_chunker_gpu.py
+++ b/autobot-backend/utils/semantic_chunker_gpu.py
@@ -194,11 +194,12 @@ class GPUSemanticChunker:
 
             try:
                 # Load model in thread pool to avoid blocking
-                loop = asyncio.get_event_loop()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
                     logger.info("Loading GPU embedding model...")
-                    self._embedding_model = await loop.run_in_executor(
-                        executor, self._load_model_with_optimizations
+                    self._embedding_model = (
+                        await asyncio.get_running_loop().run_in_executor(
+                            executor, self._load_model_with_optimizations
+                        )
                     )
 
                 logger.info("GPU model loading completed")
@@ -370,9 +371,8 @@ class GPUSemanticChunker:
                         return embeddings
 
                 # Execute in thread pool
-                loop = asyncio.get_event_loop()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                    batch_embeddings = await loop.run_in_executor(
+                    batch_embeddings = await asyncio.get_running_loop().run_in_executor(
                         executor, gpu_encode_batch, batch_sentences
                     )
 

--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -627,8 +627,9 @@ class TaskQueue:
             return await func(*args, **kwargs)
         else:
             # Run sync function in thread pool
-            loop = asyncio.get_event_loop()
-            return await loop.run_in_executor(None, lambda: func(*args, **kwargs))
+            return await asyncio.get_running_loop().run_in_executor(
+                None, lambda: func(*args, **kwargs)
+            )
 
     async def _handle_task_completion(self, task: Task, result: TaskResult) -> None:
         """Handle task completion (success or failure)."""

--- a/autobot-backend/utils/terminal_input_handler.py
+++ b/autobot-backend/utils/terminal_input_handler.py
@@ -285,9 +285,8 @@ class TerminalInputHandler:
             return self._get_testing_response(prompt, default)
 
         # Run input in thread pool to avoid blocking event loop
-        loop = asyncio.get_event_loop()
         try:
-            return await loop.run_in_executor(
+            return await asyncio.get_running_loop().run_in_executor(
                 None, lambda: self.get_input(prompt, timeout, default)
             )
         except InputTimeoutError:

--- a/autobot-backend/utils/terminal_websocket_manager.py
+++ b/autobot-backend/utils/terminal_websocket_manager.py
@@ -370,7 +370,7 @@ class TerminalWebSocketManager:
         """
         try:
             return await asyncio.wait_for(
-                asyncio.get_event_loop().run_in_executor(
+                asyncio.get_running_loop().run_in_executor(
                     None, self.output_queue.get, True, 0.1
                 ),
                 timeout=0.2,
@@ -424,7 +424,7 @@ class TerminalWebSocketManager:
                 processed_input = self.input_processor(text)
 
             # Write to PTY in executor to avoid blocking
-            await asyncio.get_event_loop().run_in_executor(
+            await asyncio.get_running_loop().run_in_executor(
                 None, os.write, self.pty_fd, processed_input.encode("utf-8")
             )
 

--- a/autobot-backend/utils/timeout_migration_examples.py
+++ b/autobot-backend/utils/timeout_migration_examples.py
@@ -671,7 +671,7 @@ class ExistingOperationMigrator:
             Test result dictionary.
         """
         future = executor.submit(self._run_single_test, test_file)
-        test_result = await asyncio.get_event_loop().run_in_executor(
+        test_result = await asyncio.get_running_loop().run_in_executor(
             None, lambda: future.result(timeout=300)
         )
         return test_result

--- a/autobot-backend/voice_interface.py
+++ b/autobot-backend/voice_interface.py
@@ -181,11 +181,11 @@ def _vosk_recognize_blocking(
         callback=callback,
     ):
         logger.debug("Vosk listening started...")
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         speech_detected = False
 
         while True:
-            elapsed = asyncio.get_event_loop().time() - start_time
+            elapsed = asyncio.get_running_loop().time() - start_time
 
             if result := _check_vosk_timeout(elapsed, timeout, speech_detected):
                 return result


### PR DESCRIPTION
## Summary
- Replace all 76 occurrences of deprecated `asyncio.get_event_loop()` across 38 files
- Context-appropriate replacements applied per the fix table in #1752:
  - `.time()` → `asyncio.get_running_loop().time()`
  - `.run_in_executor()` → `asyncio.get_running_loop().run_in_executor()`
  - `.create_task()` → `asyncio.get_running_loop().create_task()`
  - `.create_future()` → `asyncio.get_running_loop().create_future()`
  - Tests: `loop.run_until_complete()` → `asyncio.run()`
  - Sync guards: `loop.is_running()` → `try/except RuntimeError`
- Only remaining match is a comment reference in `audit_middleware.py`

Closes #1752

## Test plan
- [ ] Backend starts without errors
- [ ] `grep -rn "get_event_loop()" autobot-backend/ --include="*.py"` returns only the comment
- [ ] Existing test suite passes
- [ ] No deprecation warnings in logs on Python 3.10+