### PR TITLE
fix(security): add path traversal validation to session_id (#1825)

### DIFF
--- a/autobot-backend/chat_history/session.py
+++ b/autobot-backend/chat_history/session.py
@@ -48,6 +48,30 @@ class SessionMixin:
     - self._extract_conversation_metadata(): method
     """
 
+    @staticmethod
+    def _sanitize_session_id(session_id: str) -> None:
+        """
+        Validate session_id to prevent path traversal attacks. Issue #1825.
+
+        Accepts UUID-like strings and alphanumeric strings with hyphens/underscores.
+        Rejects any ID containing '..', '/', '\\', or null bytes.
+
+        Args:
+            session_id: The session identifier to validate.
+
+        Raises:
+            ValueError: If session_id contains path traversal characters.
+        """
+        if not session_id:
+            raise ValueError("session_id must not be empty")
+        if "\x00" in session_id:
+            raise ValueError("session_id must not contain null bytes")
+        if ".." in session_id or "/" in session_id or "\\" in session_id:
+            raise ValueError(
+                "session_id must not contain path traversal characters "
+                f"('..', '/', '\\'): {session_id!r}"
+            )
+
     def _try_get_from_cache(self, session_id: str) -> Optional[List[Dict[str, Any]]]:
         """Try to get session from Redis cache. (Issue #315 - extracted)"""
         if not self.redis_client:
@@ -202,6 +226,8 @@ class SessionMixin:
 
         if not session_id:
             session_id = f"chat-{int(time.time() * 1000)}-{str(uuid.uuid4())[:8]}"
+        else:
+            self._sanitize_session_id(session_id)
 
         current_time = time.strftime("%Y-%m-%d %H:%M:%S")
         session_title = title or session_name or f"Chat {session_id[:13]}"
@@ -264,6 +290,8 @@ class SessionMixin:
             List of messages in the session
         """
         try:
+            self._sanitize_session_id(session_id)
+
             # Try Redis cache first (Issue #315 - uses helper)
             cached_messages = self._try_get_from_cache(session_id)
             if cached_messages is not None:
@@ -459,6 +487,7 @@ class SessionMixin:
         Issue #665, #620: Refactored to use extracted helper methods.
         """
         try:
+            self._sanitize_session_id(session_id)
             chats_directory = self._get_chats_directory()
             await self._ensure_chats_directory_exists(chats_directory)
 
@@ -684,6 +713,7 @@ class SessionMixin:
         Issue #620: Refactored to use extracted helper methods.
         """
         try:
+            self._sanitize_session_id(session_id)
             chats_directory = self._get_chats_directory()
 
             deleted = await self._delete_session_files(session_id, chats_directory)
@@ -728,6 +758,7 @@ class SessionMixin:
             True if update successful, False otherwise
         """
         try:
+            self._sanitize_session_id(session_id)
             chats_directory = self._get_chats_directory()
             chat_file = await self._resolve_session_file_path(
                 session_id, chats_directory
@@ -775,6 +806,7 @@ class SessionMixin:
             Issue #620: Refactored to use existing helpers.
         """
         try:
+            self._sanitize_session_id(session_id)
             chats_directory = self._get_chats_directory()
 
             # Resolve file path using existing helper
@@ -858,6 +890,7 @@ class SessionMixin:
             Username of session owner, or None if not found/set
         """
         try:
+            self._sanitize_session_id(session_id)
             chats_directory = self._get_chats_directory()
             chat_file = f"{chats_directory}/{session_id}_chat.json"
 


### PR DESCRIPTION
## Summary
- Add `_sanitize_session_id()` to `SessionMixin` that rejects IDs containing `..`, `/`, `\`, or null bytes
- Wire validation into all 7 public entry points: `create_session`, `load_session`, `save_session`, `delete_session`, `update_session`, `update_session_name`, `get_session_owner`
- Addresses CodeQL alerts at lines 96, 110, 230, 379, 740, 751

Closes #1825

## Test plan
- [ ] Verify valid UUID session IDs continue to work
- [ ] Verify `../` in session_id raises ValueError
- [ ] Verify `/etc/passwd` style IDs are rejected
- [ ] Verify null bytes are rejected
- [ ] Verify auto-generated session IDs bypass validation (already safe)