### PR TITLE
fix(backend): classify security updates by repo origin (#1827)

### DIFF
--- a/autobot-slm-backend/ansible/check-system-updates.yml
+++ b/autobot-slm-backend/ansible/check-system-updates.yml
@@ -33,33 +33,22 @@
       changed_when: false
       when: ansible_os_family == "Debian"
 
-    - name: Get security sources
-      ansible.builtin.shell: |
-        grep -l security /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null | head -1 || echo ""
-      register: security_source
-      changed_when: false
-      when: ansible_os_family == "Debian"
-
-    - name: Check security updates separately
-      ansible.builtin.shell: |
-        apt list --upgradable 2>/dev/null | grep -i security | head -200 || true
-      register: security_updates_raw
-      changed_when: false
-      when: ansible_os_family == "Debian"
-
     - name: Parse upgradable packages into JSON
       ansible.builtin.set_fact:
         parsed_packages: >-
           {{
             upgradable_raw.stdout_lines | default([])
-            | map('regex_replace', '^([^ /]+)/\S+ (\S+) \S+ \[upgradable from: ([^\]]+)\]$', '{"p":"\1","a":"\2","c":"\3"}')
+            | map('regex_replace',
+                '^([^ /]+)/(\S+) (\S+) \S+ \[upgradable from: ([^\]]+)\]$',
+                '{"p":"\1","r":"\2","a":"\3","c":"\4"}')
             | select('match', '^\{')
             | list
           }}
         held_list: "{{ (held_packages.stdout_lines | default([])) }}"
         security_pkgs: >-
           {{
-            security_updates_raw.stdout_lines | default([])
+            upgradable_raw.stdout_lines | default([])
+            | select('search', '-security')
             | map('regex_replace', '^([^ /]+)/.*', '\1')
             | list
           }}

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -363,9 +363,18 @@ async def _resolve_host_to_node(
     return None
 
 
-def _classify_severity(pkg_name: str, security_packages: List[str]) -> str:
-    """Classify package update severity."""
-    if pkg_name in security_packages:
+def _classify_severity(
+    pkg_name: str, security_packages: List[str], repo: str = ""
+) -> str:
+    """Classify package update severity.
+
+    A package is classified as 'security' when its name appears in the
+    security_packages list (packages whose apt repo field contained '-security')
+    OR when the repo field captured from the apt output itself contains '-security'.
+    Using both signals handles cases where the Ansible grep and the regex capture
+    produce slightly different sets.
+    """
+    if "-security" in repo or pkg_name in security_packages:
         return "security"
     return "standard"
 
@@ -521,7 +530,7 @@ async def _store_host_packages(
                 continue
         if not isinstance(pkg, dict) or pkg.get("p") in held:
             continue
-        severity = _classify_severity(pkg["p"], security_pkgs)
+        severity = _classify_severity(pkg["p"], security_pkgs, pkg.get("r", ""))
         await _upsert_update_info(db, node_id, pkg, severity)
         count += 1
 


### PR DESCRIPTION
## Summary
- Parse repo/suite field from `apt list --upgradable` output into package JSON (`"r"` field)
- Remove redundant second `apt list` shell invocation and unused security sources task
- Update `_classify_severity()` to accept `repo` parameter — classifies as security when repo contains `-security`
- Dual-signal: both repo field AND security_packages list checked for robustness

**Files:** `check-system-updates.yml`, `api/updates.py`

Closes #1827

## Test plan
- [ ] Run playbook on a test node and verify `-security` repo packages get `severity: security`
- [ ] Verify `parsed_packages` JSON includes `"r"` field with repo name
- [ ] Verify UI shows non-zero security update count when applicable
- [ ] Verify packages from `jammy-updates` (non-security) remain `severity: standard`