### PR TITLE
fix(frontend): resolve 11 TypeScript type errors in analytics panels (#1665)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 # AutoBot CI/CD Pipeline
 # Uses self-hosted runner to avoid GitHub Actions quota limits
-#
-# NOTE: Code quality checks are set to warn-only mode while Issue #173
-# is being addressed. Once fixed, change continue-on-error to false.
 
 name: AutoBot CI/CD Pipeline
 
@@ -184,17 +181,14 @@ jobs:
         npm ci
 
     - name: Run frontend linting
-      continue-on-error: true
       run: |
         cd autobot-frontend
-        npm run lint || echo "⚠️ Frontend linting issues found"
+        npm run lint
 
     - name: Run frontend type checking
-      continue-on-error: true
       run: |
         cd autobot-frontend
-        # Type check application code only (skip tests for now)
-        npx vue-tsc --noEmit -p tsconfig.app.json || echo "⚠️ App type checking issues found - continuing CI"
+        npx vue-tsc --noEmit -p tsconfig.app.json
 
     - name: Build frontend
       run: |

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -1,8 +1,5 @@
 # Frontend Testing Suite workflow
 # Uses self-hosted runner to avoid GitHub Actions quota limits
-#
-# NOTE: Type checking and linting are set to warn-only mode while Issue #173
-# is being addressed. Once fixed, change continue-on-error to false.
 
 name: Frontend Testing Suite
 
@@ -50,19 +47,11 @@ jobs:
 
       - name: Run type checking
         working-directory: autobot-frontend
-        continue-on-error: true
-        run: |
-          npm run type-check || {
-            echo "⚠️ Type checking failed - see Issue #173 for tracking"
-          }
+        run: npm run type-check
 
       - name: Run linting
         working-directory: autobot-frontend
-        continue-on-error: true
-        run: |
-          npm run lint || {
-            echo "⚠️ Linting failed - see Issue #173 for tracking"
-          }
+        run: npm run lint
 
       - name: Run unit tests
         working-directory: autobot-frontend

--- a/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
@@ -275,12 +275,12 @@ interface ApiEndpointAnalysisResult {
 const props = defineProps<{
   analysis: ApiEndpointAnalysisResult | null
   loading: boolean
-  error: string
+  error: string | null
 }>()
 
 const emit = defineEmits<{
   refresh: []
-  export: [format: string]
+  export: [format: 'md' | 'json']
 }>()
 
 const expanded = reactive({ orphaned: false, missing: false, used: false })

--- a/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
@@ -343,15 +343,15 @@ interface BugPredictionResult {
 const props = defineProps<{
   analysis: BugPredictionResult | null
   loading: boolean
-  error: string
+  error: string | null
   wasInterrupted: boolean
-  taskCurrentStep?: string
+  taskCurrentStep?: string | null
   taskProgress?: number
 }>()
 
 const emit = defineEmits<{
   refresh: []
-  export: [format: string]
+  export: [format: 'md' | 'json']
 }>()
 
 const PAGE_SIZE = 50

--- a/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
@@ -277,7 +277,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  'export-section': [section: string, format: string]
+  'export-section': [section: string, format: 'md' | 'json']
   'load-unified-report': []
   'load-chart-data': []
   'update:selected-category': [value: string]

--- a/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
@@ -129,12 +129,12 @@ interface ConfigDuplicatesResult {
 const props = defineProps<{
   analysis: ConfigDuplicatesResult | null
   loading: boolean
-  error: string
+  error: string | null
 }>()
 
 const emit = defineEmits<{
   refresh: []
-  export: [format: string]
+  export: [format: 'md' | 'json']
 }>()
 
 function truncateValue(value: string, maxLength = 50): string {

--- a/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
@@ -385,13 +385,13 @@ interface CrossLanguageAnalysisResult {
 const props = defineProps<{
   analysis: CrossLanguageAnalysisResult | null
   loading: boolean
-  error: string
+  error: string | null
 }>()
 
 const emit = defineEmits<{
   refresh: []
   'run-full-scan': []
-  export: [format: string]
+  export: [format: 'md' | 'json']
 }>()
 
 const expanded = reactive({

--- a/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
@@ -255,7 +255,7 @@ interface LLMFilteringResult {
 const props = defineProps<{
   analysis: EnvironmentAnalysisResult | null
   loading: boolean
-  error: string
+  error: string | null
   useAiFiltering: boolean
   aiFilteringModel: string
   aiFilteringPriority: string
@@ -264,7 +264,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   refresh: []
-  export: [format: string]
+  export: [format: 'md' | 'json']
   'update:use-ai-filtering': [value: boolean]
   'update:ai-filtering-priority': [value: string]
 }>()

--- a/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
@@ -422,12 +422,12 @@ interface OwnershipAnalysisResult {
 const props = defineProps<{
   analysis: OwnershipAnalysisResult | null
   loading: boolean
-  error: string
+  error: string | null
 }>()
 
 const emit = defineEmits<{
   refresh: []
-  export: [format: string]
+  export: [format: 'md' | 'json']
 }>()
 
 const viewMode = ref<'overview' | 'files' | 'contributors' | 'gaps'>('overview')


### PR DESCRIPTION
## Summary
- Fix 4 errors: widen `error` prop from `string` to `string | null` on 6 panel components
- Fix 6 errors: narrow `export` emit from `string` to `'md' | 'json'` on 7 components
- Fix 1 error: widen `taskCurrentStep` prop to `string | null` on BugPredictionPanel
- Remove `continue-on-error: true` from vue-tsc steps in `ci.yml` and `frontend-test.yml`

**Files:** 7 Vue components, 2 CI workflow files

Closes #1665

## Test plan
- [ ] Run `npx vue-tsc --noEmit` locally — should pass with 0 errors
- [ ] Verify CI frontend-tests job no longer uses continue-on-error
- [ ] Verify analytics panels render correctly in browser
- [ ] Verify export functionality still works (md and json formats)