### PR TITLE
fix(ci): remove continue-on-error from backend code quality checks (#1848)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,23 +92,21 @@ jobs:
         EOF
 
     - name: Run code quality checks
-      continue-on-error: true
       run: |
         source .venv/bin/activate
-        echo "🔍 Running code quality checks..."
-        echo "Note: Checks are in warn-only mode while Issue #173 is being addressed."
+        echo "Running code quality checks..."
 
-        # Code formatting check
+        # Code formatting check (matches pre-commit black config)
         echo "Checking code formatting with black..."
-        black --check autobot-backend/ autobot-slm-backend/ autobot-shared/ --line-length=88 || echo "⚠️ Code formatting issues found"
+        black --check autobot-backend/ autobot-slm-backend/ autobot-shared/ --line-length=88
 
-        # Import sorting check
+        # Import sorting check (matches pre-commit isort config)
         echo "Checking import sorting with isort..."
-        isort --check-only autobot-backend/ autobot-slm-backend/ autobot-shared/ || echo "⚠️ Import sorting issues found"
+        isort --check-only --profile=black --line-length=88 autobot-backend/ autobot-slm-backend/ autobot-shared/
 
-        # Linting
+        # Linting (uses project .flake8 config — same as pre-commit)
         echo "Running flake8 linter..."
-        flake8 autobot-backend/ autobot-slm-backend/ autobot-shared/ --max-line-length=88 --extend-ignore=E203,W503 || echo "⚠️ Linting issues found"
+        flake8 --config=.flake8 autobot-backend/ autobot-slm-backend/ autobot-shared/
 
     - name: Run security analysis
       run: |


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from "Run code quality checks" CI step
- Align CI flake8 with project `.flake8` config (`--config=.flake8`) instead of stricter inline `--max-line-length=88`
- Add `--profile=black --line-length=88` to CI isort for pre-commit parity
- Remove `|| echo` fallbacks so failures actually fail the pipeline
- Remove stale "Issue #173" warn-only comment

**Root cause:** CI used `--max-line-length=88` but `.flake8` config uses `120`. This mismatch caused CI to always fail, which is why `continue-on-error` was added as a workaround.

Closes #1848

## Test plan
- [ ] CI pipeline passes with the new config (black, isort, flake8 all green)
- [ ] Verify flake8 uses `.flake8` config (120 char limit, per-file-ignores)
- [ ] Confirm no regressions in backend test jobs