### PR TITLE
fix: update test import path after agent service rename (#1846)

### DIFF
--- a/autobot-backend/tests/services/test_specialized_agent_service.py
+++ b/autobot-backend/tests/services/test_specialized_agent_service.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from services.claude_agent_service import (
+from services.specialized_agent_service import (
     SpecializedAgentService,
     _categorize_agent,
     _extract_system_prompt_excerpt,


### PR DESCRIPTION
## Summary
- Update import from `services.claude_agent_service` to `services.specialized_agent_service` in test file
- Fixes ModuleNotFoundError after #1819 renamed the file

Closes #1846

## Test plan
- [ ] `pytest autobot-backend/tests/services/test_specialized_agent_service.py` passes