### PR TITLE
fix: check analysis keywords before implementation in _categorize_agent (#1844)

### DIFF
--- a/autobot-backend/services/specialized_agent_service.py
+++ b/autobot-backend/services/specialized_agent_service.py
@@ -24,6 +24,17 @@ _AGENTS_DIR = _REPO_ROOT / ".claude" / "agents"
 # Agent categories inferred from name + description keywords.
 _CATEGORY_RULES: List[tuple] = [
     (
+        "analysis",
+        [
+            "skeptic",
+            "architect",
+            "performance",
+            "security",
+            "auditor",
+            "review",
+        ],
+    ),
+    (
         "implementation",
         [
             "engineer",
@@ -33,17 +44,6 @@ _CATEGORY_RULES: List[tuple] = [
             "database",
             "devops",
             "testing",
-        ],
-    ),
-    (
-        "analysis",
-        [
-            "skeptic",
-            "architect",
-            "performance",
-            "security",
-            "auditor",
-            "review",
         ],
     ),
     (

--- a/autobot-backend/tests/services/test_specialized_agent_service.py
+++ b/autobot-backend/tests/services/test_specialized_agent_service.py
@@ -170,13 +170,12 @@ class TestCategorizeAgent:
         """Names with skeptic/architect/security etc map to analysis."""
         assert _categorize_agent(name, description) == expected
 
-    def test_implementation_wins_over_analysis_without_override(self):
-        """'testing' keyword hits implementation first; no reviewer override."""
-        # "Security Auditor" + "Pen testing" -> "testing" matches
-        # implementation first, and no "review"/"analysis" in combined
-        # text triggers the override.
+    def test_analysis_checked_before_implementation(self):
+        """Analysis keywords checked first — 'security' matches before 'testing'."""
+        # "Security Auditor" + "Pen testing" -> "security" matches
+        # analysis first (#1844), even though "testing" is in the text.
         result = _categorize_agent("Security Auditor", "Pen testing")
-        assert result == "implementation"
+        assert result == "analysis"
 
     @pytest.mark.parametrize(
         "name,description,expected",


### PR DESCRIPTION
## Summary
- Reorder `_CATEGORY_RULES` so analysis keywords (security, auditor, review, etc.) are checked before implementation keywords (testing, engineer, etc.)
- Fixes "Security Auditor" being incorrectly categorized as "implementation" because "testing" matched first
- Updates corresponding test to document the corrected behavior

Closes #1844

## Test plan
- [ ] `pytest autobot-backend/tests/services/test_specialized_agent_service.py -v` passes
- [ ] "Security Auditor" agents now appear under "analysis" category in UI