### PR TITLE
fix(backend): detect Ubuntu Pro ESM security updates (#1847)

### DIFF
--- a/autobot-slm-backend/ansible/check-system-updates.yml
+++ b/autobot-slm-backend/ansible/check-system-updates.yml
@@ -52,7 +52,60 @@
             | map('regex_replace', '^([^ /]+)/.*', '\1')
             | list
           }}
+        apt_pkg_names: >-
+          {{
+            upgradable_raw.stdout_lines | default([])
+            | select('match', '^[a-zA-Z0-9]')
+            | map('regex_replace', '^([^ /]+)/.*', '\1')
+            | list
+          }}
       when: ansible_os_family == "Debian"
+
+    - name: Collect Ubuntu Pro ESM security status
+      ansible.builtin.shell: |
+        pro security-status --format json 2>/dev/null || true
+      register: esm_status_raw
+      changed_when: false
+      when: ansible_os_family == "Debian"
+
+    - name: Set ESM package facts when pro output is available
+      ansible.builtin.set_fact:
+        _esm_upgradable: >-
+          {{
+            (esm_status_raw.stdout | from_json).get('packages', [])
+            | selectattr('status', 'equalto', 'upgrade_available')
+            | list
+          }}
+      when:
+        - ansible_os_family == "Debian"
+        - esm_status_raw.stdout | default('') | regex_search('^\s*\{') is not none
+
+    - name: Merge ESM security package names into security list
+      ansible.builtin.set_fact:
+        security_pkgs: >-
+          {{
+            (security_pkgs | default([]))
+            + (_esm_upgradable | map(attribute='package') | list)
+            | unique
+          }}
+      when:
+        - ansible_os_family == "Debian"
+        - _esm_upgradable | default([]) | length > 0
+
+    - name: Append ESM-only package entry (not in apt list) to parsed packages
+      ansible.builtin.set_fact:
+        parsed_packages: >-
+          {{
+            parsed_packages | default([])
+            + [{'p': item.package, 'r': 'esm-security',
+                'a': item.version, 'c': 'unknown'}]
+          }}
+      loop: "{{ _esm_upgradable | default([]) }}"
+      loop_control:
+        label: "{{ item.package }}"
+      when:
+        - ansible_os_family == "Debian"
+        - item.package not in (apt_pkg_names | default([]))
 
     - name: Output discovered packages as JSON
       ansible.builtin.debug:


### PR DESCRIPTION
## Summary
- Add `pro security-status --format json` task to discover ESM packages invisible to `apt list`
- Parse ESM JSON output, filter to `upgrade_available` status entries
- Merge ESM package names into `security_pkgs` list for correct severity classification
- Append ESM-only packages (not in apt output) to `parsed_packages` with `r: esm-security`
- All tasks gracefully skip on nodes without `ubuntu-advantage-tools` installed
- No backend changes needed — `_classify_severity` already handles `"-security" in repo`

Closes #1847

## Test plan
- [ ] Run playbook on node with Ubuntu Pro — verify ESM packages appear with `severity: security`
- [ ] Run playbook on node without Ubuntu Pro — verify graceful skip (no errors)
- [ ] Verify packages in both apt and ESM lists are not duplicated
- [ ] Verify UI shows ESM security count when applicable