### PR TITLE
chore: add deprecation warnings for langchain_community OllamaEmbeddings fallback (#1845)

### DIFF
--- a/autobot-infrastructure/shared/scripts/analysis/redis_final_analysis.py
+++ b/autobot-infrastructure/shared/scripts/analysis/redis_final_analysis.py
@@ -383,8 +383,17 @@ class AutoBotVectorStoreAnalysis:
         fixes_attempted = []
 
         try:
-            from langchain_community.embeddings import OllamaEmbeddings
             from langchain_redis import RedisVectorStore
+
+            try:
+                from langchain_ollama import OllamaEmbeddings
+            except ImportError:
+                from langchain_community.embeddings import OllamaEmbeddings
+
+                logger.warning(
+                    "langchain-ollama not installed, using deprecated "
+                    "langchain_community fallback"
+                )
 
             embeddings = OllamaEmbeddings(
                 model="nomic-embed-text:latest",
@@ -626,6 +635,10 @@ class AutoBotVectorStoreAnalysis:
             except ImportError:
                 from langchain_community.embeddings import OllamaEmbeddings
 
+                logger.warning(
+                    "langchain-ollama not installed, using deprecated "
+                    "langchain_community fallback"
+                )
                 fixes_attempted.append("Using langchain-community embeddings")
 
             embeddings = OllamaEmbeddings(

--- a/autobot-infrastructure/shared/scripts/analysis/redis_vector_analysis.py
+++ b/autobot-infrastructure/shared/scripts/analysis/redis_vector_analysis.py
@@ -144,7 +144,10 @@ def _init_langchain_embeddings(embedding_model, ollama_base_url):
     except ImportError:
         from langchain_community.embeddings import OllamaEmbeddings
 
-        logger.info("Using community ollama embeddings")
+        logger.warning(
+            "langchain-ollama not installed, using deprecated "
+            "langchain_community.embeddings.OllamaEmbeddings fallback"
+        )
 
     return OllamaEmbeddings(
         model=embedding_model,

--- a/autobot-infrastructure/shared/scripts/analysis/test_redis_comparison.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_redis_comparison.py
@@ -195,7 +195,15 @@ async def test_langchain_redis():
             logger.info("Using langchain-community Redis")
             modern_langchain = False
 
-        from langchain_community.embeddings import OllamaEmbeddings
+        try:
+            from langchain_ollama import OllamaEmbeddings
+        except ImportError:
+            from langchain_community.embeddings import OllamaEmbeddings
+
+            logger.warning(
+                "langchain-ollama not installed, using deprecated "
+                "langchain_community fallback"
+            )
 
         # Initialize embedding model
         embeddings = OllamaEmbeddings(


### PR DESCRIPTION
## Summary
- Add `logger.warning()` when falling back to deprecated `langchain_community.embeddings.OllamaEmbeddings`
- Convert one direct import in `test_redis_comparison.py` to try/except with `langchain_ollama` as preferred path
- Affects 3 analysis scripts (offline tools, not production)

Closes #1845

## Test plan
- [ ] Analysis scripts still run when `langchain-ollama` is installed (preferred path)
- [ ] Analysis scripts still run when only `langchain-community` is installed (fallback with warning)