### PR TITLE
fix: use per-node service list in apply-system-updates verification (#1828)

### DIFF
--- a/autobot-slm-backend/ansible/apply-system-updates.yml
+++ b/autobot-slm-backend/ansible/apply-system-updates.yml
@@ -212,12 +212,7 @@
       ansible.builtin.systemd:
         name: "{{ item }}"
         state: started
-      loop:
-        - autobot-backend
-        - autobot-slm-backend
-        - autobot-npu-worker
-        - nginx
-        - redis-stack-server
+      loop: "{{ slm_services_to_monitor | default([]) }}"
       ignore_errors: true
       when: "'slm_nodes' in group_names"
 


### PR DESCRIPTION
## Summary
- Replace hardcoded 5-service loop with `slm_services_to_monitor` inventory variable
- Each node now verifies only the services it actually runs
- `default([])` ensures graceful skip for nodes without the variable

Closes #1828

## Test plan
- [ ] Run `apply-system-updates.yml` — no spurious "service not found" errors
- [ ] Nodes only verify their own services