### PR TITLE
fix: use AUTOBOT_BASE_DIR for CompletionTrainer model_dir (#1857)

### DIFF
--- a/autobot-backend/training/completion_trainer.py
+++ b/autobot-backend/training/completion_trainer.py
@@ -9,6 +9,7 @@ Training orchestration for code completion model.
 
 import json
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional
@@ -33,7 +34,9 @@ class CompletionTrainer:
 
     def __init__(
         self,
-        model_dir: str = "/opt/autobot/models",
+        model_dir: str = os.path.join(
+            os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot"), "models"
+        ),
         language: Optional[str] = None,
         pattern_type: Optional[str] = None,
         device: Optional[str] = None,
@@ -48,7 +51,14 @@ class CompletionTrainer:
             device: Device for training (auto-detect if None)
         """
         self.model_dir = Path(model_dir)
-        self.model_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self.model_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "Could not create model_dir %s: %s — directory will be created on first save",
+                self.model_dir,
+                exc,
+            )
 
         self.language = language
         self.pattern_type = pattern_type


### PR DESCRIPTION
## Summary
- Replace hardcoded `/opt/autobot/models` with `AUTOBOT_BASE_DIR` env var (fallback to `/opt/autobot`)
- Wrap `mkdir` in `try/except OSError` so Docker startup doesn't crash when path is missing
- Matches existing pattern used across 12+ backend files

Closes #1857

## Test plan
- [ ] Backend starts in Docker without PermissionError
- [ ] Backend starts on bare metal (existing `/opt/autobot` path still works)
- [ ] `AUTOBOT_BASE_DIR=/tmp/test` uses the custom path