### PR TITLE
fix(ci): remove || echo from frontend-test.yml test steps (#1867)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -55,15 +55,15 @@ jobs:
 
       - name: Run unit tests
         working-directory: autobot-frontend
-        run: npm run test:unit || echo "⚠️ Unit tests failed - continuing"
+        run: npm run test:unit
 
       - name: Run integration tests
         working-directory: autobot-frontend
-        run: npm run test:integration || echo "⚠️ Integration tests failed - continuing"
+        run: npm run test:integration
 
       - name: Generate coverage report
         working-directory: autobot-frontend
-        run: npm run test:coverage || echo "⚠️ Coverage generation failed - continuing"
+        run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary
Remove 3 `|| echo` fallbacks from `frontend-test.yml` that silently swallowed frontend test failures:
- `npm run test:unit` — unit tests
- `npm run test:integration` — integration tests
- `npm run test:coverage` — coverage generation

Companion to #1855 / PR #1859 which cleaned up `ci.yml`.

Closes #1867

## Test plan
- [ ] CI frontend-tests job runs — test failures now properly fail the pipeline
- [ ] Passing tests still pass without issues