### PR TITLE
fix(ci): remove || echo patterns from frontend test steps (#1855)

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -55,15 +55,15 @@ jobs:
 
       - name: Run unit tests
         working-directory: autobot-frontend
-        run: npm run test:unit || echo "⚠️ Unit tests failed - continuing"
+        run: npm run test:unit
 
       - name: Run integration tests
         working-directory: autobot-frontend
-        run: npm run test:integration || echo "⚠️ Integration tests failed - continuing"
+        run: npm run test:integration
 
       - name: Generate coverage report
         working-directory: autobot-frontend
-        run: npm run test:coverage || echo "⚠️ Coverage generation failed - continuing"
+        run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary
- Remove `|| echo` from 3 frontend test steps in `frontend-test.yml` (unit tests, integration tests, coverage)
- Test failures now correctly fail the CI pipeline
- Non-critical parsing fallbacks in `ssot-coverage.yml` and `phase_validation.yml` left as-is (these are grep/jq fallbacks, not test results)

Closes #1855

## Test plan
- [ ] CI pipeline fails when frontend tests fail (no longer silently passes)
- [ ] `ssot-coverage.yml` and `phase_validation.yml` still work