### PR TITLE
fix: resolve ESM package installed versions via dpkg-query (#1856)

### DIFF
--- a/autobot-slm-backend/ansible/check-system-updates.yml
+++ b/autobot-slm-backend/ansible/check-system-updates.yml
@@ -92,13 +92,47 @@
         - ansible_os_family == "Debian"
         - _esm_upgradable | default([]) | length > 0
 
+    - name: Resolve installed versions for ESM packages via dpkg-query
+      ansible.builtin.shell: |
+        dpkg-query -W -f='${Package}=${Version}\n' \
+          {{ _esm_upgradable | map(attribute='package') | join(' ') }} \
+          2>/dev/null || true
+      register: _esm_dpkg_raw
+      changed_when: false
+      when:
+        - ansible_os_family == "Debian"
+        - _esm_upgradable | default([]) | length > 0
+
+    - name: Build ESM installed-version lookup dict
+      ansible.builtin.set_fact:
+        _esm_installed_versions: >-
+          {{
+            dict(
+              _esm_dpkg_raw.stdout_lines
+              | select('match', '^[^=]+=.+')
+              | map('regex_replace', '^([^=]+)=(.+)$', '\1')
+              | list
+              | zip(
+                _esm_dpkg_raw.stdout_lines
+                | select('match', '^[^=]+=.+')
+                | map('regex_replace', '^([^=]+)=(.+)$', '\2')
+                | list
+              )
+            )
+          }}
+      when:
+        - ansible_os_family == "Debian"
+        - _esm_upgradable | default([]) | length > 0
+
     - name: Append ESM-only package entry (not in apt list) to parsed packages
       ansible.builtin.set_fact:
         parsed_packages: >-
           {{
             parsed_packages | default([])
             + [{'p': item.package, 'r': 'esm-security',
-                'a': item.version, 'c': 'unknown'}]
+                'a': item.version,
+                'c': (_esm_installed_versions | default({}))
+                     .get(item.package, 'unknown')}]
           }}
       loop: "{{ _esm_upgradable | default([]) }}"
       loop_control:


### PR DESCRIPTION
## Summary
- Add `dpkg-query` task to retrieve installed versions for ESM-only packages
- Build lookup dict from `Package=Version` output
- Replace hardcoded `'c': 'unknown'` with actual installed version
- `default({})` fallback ensures safe evaluation when no ESM packages exist

Closes #1856

## Test plan
- [ ] Run `check-system-updates.yml` on a node with ESM packages
- [ ] ESM packages now show real version in "Current Version" column
- [ ] Nodes without ESM packages still work (empty loop)