### PR TITLE
fix: rename SLM admin users table to resolve user_mfa FK mismatch (#1854)

### DIFF
--- a/autobot-slm-backend/migrations/rename_users_to_slm_users.py
+++ b/autobot-slm-backend/migrations/rename_users_to_slm_users.py
@@ -1,0 +1,89 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Migration: Rename SLM admin 'users' table to 'slm_users' (#1854).
+
+The 'users' table in models/database.py (INTEGER PK) collided with the
+user_management 'users' table (UUID PK), causing the user_mfa FK constraint
+to fail on fresh PostgreSQL databases:
+
+    asyncpg.exceptions.DatatypeMismatchError: foreign key constraint
+    "user_mfa_user_id_fkey" cannot be implemented
+
+This migration renames the old INTEGER-PK 'users' table to 'slm_users'.
+It is safe to re-run: it checks whether the old table exists before acting.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def migrate(db_url: str) -> None:
+    """Rename the SLM admin users table from 'users' to 'slm_users'.
+
+    Only renames if the legacy INTEGER-PK 'users' table still exists.
+    On fresh installations the table is never created as 'users', so this
+    migration is a no-op there.
+    """
+    import psycopg2
+    from migrations.runner import _parse_db_url
+
+    params = _parse_db_url(db_url)
+    if params.get("password") is None:
+        params.pop("password", None)
+
+    conn = psycopg2.connect(**params)
+    try:
+        with conn.cursor() as cur:
+            # Check whether a table named 'users' with an INTEGER PK exists.
+            # If user_management has already created a UUID-PK 'users' table we
+            # must not touch it.
+            cur.execute(
+                """
+                SELECT data_type
+                FROM information_schema.columns
+                WHERE table_name = 'users'
+                  AND column_name = 'id'
+                  AND table_schema = 'public'
+                """
+            )
+            row = cur.fetchone()
+
+            if row is None:
+                logger.info(
+                    "Table 'users' not found — skipping rename "
+                    "(fresh install or already migrated)"
+                )
+                return
+
+            pk_type = row[0].lower()
+            if pk_type not in ("integer", "bigint", "smallint"):
+                logger.info(
+                    "Table 'users' exists but has PK type '%s' (not integer) "
+                    "— this is the user_management table, skipping rename",
+                    pk_type,
+                )
+                return
+
+            # Rename the INTEGER-PK users table.
+            cur.execute("ALTER TABLE users RENAME TO slm_users")
+            logger.info("Renamed table 'users' -> 'slm_users'")
+
+            # Rename the associated sequence if it follows the default naming
+            # convention (users_id_seq -> slm_users_id_seq).
+            cur.execute(
+                """
+                SELECT relname FROM pg_class
+                WHERE relname = 'users_id_seq' AND relkind = 'S'
+                """
+            )
+            if cur.fetchone():
+                cur.execute("ALTER SEQUENCE users_id_seq RENAME TO slm_users_id_seq")
+                logger.info("Renamed sequence 'users_id_seq' -> 'slm_users_id_seq'")
+
+        conn.commit()
+        logger.info("Migration rename_users_to_slm_users completed")
+    finally:
+        conn.close()

--- a/autobot-slm-backend/migrations/runner.py
+++ b/autobot-slm-backend/migrations/runner.py
@@ -48,6 +48,9 @@ MIGRATIONS = [
     "add_role_metadata_fields",
     "widen_code_status_column",
     "add_fleet_sync_jobs_table",
+    # Issue #1854: rename SLM admin table to avoid FK collision with
+    # user_management users table (UUID PK).
+    "rename_users_to_slm_users",
 ]
 
 

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -193,9 +193,14 @@ class Setting(Base):
 
 
 class User(Base):
-    """User model for authentication."""
+    """SLM admin user model for authentication.
 
-    __tablename__ = "users"
+    Stored in the slm_users table to avoid a table-name collision with the
+    user_management.models.user.User model, which owns the 'users' table with
+    a UUID primary key (Issue #1854).
+    """
+
+    __tablename__ = "slm_users"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     username = Column(String(64), unique=True, nullable=False, index=True)


### PR DESCRIPTION
## Summary
- SLM admin `User` model (INTEGER PK) and user_management `User` model (UUID PK) both used `__tablename__="users"`, causing `DatatypeMismatchError` on `user_mfa` FK creation
- Rename SLM admin table to `slm_users` — resolves the conflict
- Add migration `rename_users_to_slm_users` for existing installations (checks PK type before renaming)
- No code changes needed in auth.py/main.py — they import by class reference

Closes #1854

## Test plan
- [ ] Fresh DB: `db_service.initialize()` creates both `slm_users` and `users` (UUID) without error
- [ ] `user_mfa` table creates successfully with UUID FK to `users.id`
- [ ] Existing DB: migration renames INTEGER-PK `users` → `slm_users`
- [ ] SLM login still works after migration