### PR TITLE
refactor(i18n): derive RTL_LOCALES from locale file _meta.dir (#1812)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/usePreferences.rtl.spec.ts
+++ b/autobot-frontend/src/composables/__tests__/usePreferences.rtl.spec.ts
@@ -48,9 +48,24 @@ vi.mock('@/utils/debugUtils', () => ({
 }))
 
 // Mock @/i18n so we can intercept setLocale and apply the same RTL dir logic
-// the real worktree implementation uses, without loading actual locale files.
-vi.mock('@/i18n', () => {
-  const RTL_LOCALES = new Set(['ar', 'he', 'fa', 'ur'])
+// the real implementation uses. Direction is derived from locale _meta.dir fields
+// rather than a hardcoded set (#1812).
+vi.mock('@/i18n', async () => {
+  // Eagerly load all locale files to build RTL set from _meta.dir
+  const localeModules = import.meta.glob(
+    '@/i18n/locales/*.json',
+    { eager: true },
+  ) as Record<string, { default?: Record<string, unknown> } & Record<string, unknown>>
+
+  const RTL_LOCALES = new Set<string>()
+  for (const [path, mod] of Object.entries(localeModules)) {
+    const code = path.replace(/.*\//, '').replace('.json', '')
+    const messages = mod.default ?? mod
+    const meta = messages._meta as Record<string, string> | undefined
+    if (meta?.dir === 'rtl') {
+      RTL_LOCALES.add(code)
+    }
+  }
 
   const setLocale = vi.fn().mockImplementation(async (locale: string) => {
     lastSetLocaleCall = locale
@@ -63,6 +78,9 @@ vi.mock('@/i18n', () => {
   return {
     setLocale,
     loadLocaleMessages: vi.fn().mockResolvedValue(true),
+    getLocaleDir: vi.fn().mockImplementation((locale: string) =>
+      RTL_LOCALES.has(locale) ? 'rtl' : 'ltr',
+    ),
     default: {
       global: {
         locale: { value: 'en' },

--- a/autobot-frontend/src/i18n/index.ts
+++ b/autobot-frontend/src/i18n/index.ts
@@ -7,9 +7,6 @@ import en from './locales/en.json'
 
 export type MessageSchema = typeof en
 
-// Locales that use right-to-left text direction (#1337)
-const RTL_LOCALES = new Set(['ar', 'he', 'fa', 'ur'])
-
 // Derive supported locales from locale files on disk — no manual sync needed (#1675)
 const localeModules = import.meta.glob('./locales/*.json')
 export const SUPPORTED_LOCALES = Object.keys(localeModules)
@@ -64,15 +61,25 @@ export async function loadLocaleMessages(locale: string): Promise<boolean> {
 }
 
 /**
+ * Read the text direction from a locale's _meta.dir field.
+ * Returns 'rtl' or 'ltr'. Falls back to 'ltr' if _meta.dir is absent. (#1812)
+ */
+export function getLocaleDir(locale: string): 'rtl' | 'ltr' {
+  const messages = i18n.global.getLocaleMessage(locale)
+  const meta = messages._meta as Record<string, string> | undefined
+  return meta?.dir === 'rtl' ? 'rtl' : 'ltr'
+}
+
+/**
  * Set the active locale. Loads the locale file if not yet loaded.
- * Also updates the html[dir] attribute for RTL languages (#1337).
+ * Also updates the html[dir] attribute for RTL languages (#1337, #1812).
  */
 export async function setLocale(locale: string): Promise<void> {
   await loadLocaleMessages(locale)
   i18n.global.locale.value = locale
   localStorage.setItem('autobot-language', locale)
   document.documentElement.setAttribute('lang', locale)
-  document.documentElement.setAttribute('dir', RTL_LOCALES.has(locale) ? 'rtl' : 'ltr')
+  document.documentElement.setAttribute('dir', getLocaleDir(locale))
 }
 
 export default i18n

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -3793,6 +3793,7 @@
     }
   },
   "_meta": {
+    "dir": "rtl",
     "batch": "4-C",
     "issue": "#1358",
     "scope": "Knowledge Root K-Z (20 components)",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -3805,6 +3805,7 @@
     }
   },
   "_meta": {
+    "dir": "ltr",
     "batch": "4-C",
     "issue": "#1358",
     "scope": "Wissens-Stammbereich K-Z (20 Komponenten)",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -3806,6 +3806,7 @@
     }
   },
   "_meta": {
+    "dir": "ltr",
     "batch": "4-C",
     "issue": "#1358",
     "scope": "Knowledge Root K-Z (20 components)",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -3805,6 +3805,7 @@
     }
   },
   "_meta": {
+    "dir": "ltr",
     "batch": "4-C",
     "issue": "#1358",
     "scope": "Raíz de conocimiento K-Z (20 componentes)",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -115,5 +115,8 @@
       "moreCount": "+{count} \u0628\u06cc\u0634\u062a\u0631",
       "summaryStats": "{backend} \u067e\u0634\u062a\u06cc\u0628\u0627\u0646 \u2022 {specialized} \u0639\u0627\u0645\u0644 \u062a\u062e\u0635\u0635\u06cc"
     }
+  },
+  "_meta": {
+    "dir": "rtl"
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -3805,6 +3805,7 @@
     }
   },
   "_meta": {
+    "dir": "ltr",
     "batch": "4-C",
     "issue": "#1358",
     "scope": "Racine de connaissances K-Z (20 composants)",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -115,5 +115,8 @@
       "moreCount": "+{count} \u05e0\u05d5\u05e1\u05e4\u05d9\u05dd",
       "summaryStats": "{backend} \u05e9\u05e8\u05ea \u2022 {specialized} \u05e1\u05d5\u05db\u05e0\u05d9\u05dd \u05de\u05ea\u05de\u05d7\u05d9\u05dd"
     }
+  },
+  "_meta": {
+    "dir": "rtl"
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -3805,6 +3805,7 @@
     }
   },
   "_meta": {
+    "dir": "ltr",
     "batch": "4-C",
     "issue": "#1358",
     "scope": "Zināšanu sakne K-Z (20 komponenti)",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -3805,6 +3805,7 @@
     }
   },
   "_meta": {
+    "dir": "ltr",
     "batch": "4-C",
     "issue": "#1358",
     "scope": "Korzeń wiedzy K-Z (20 komponentów)",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -3805,6 +3805,7 @@
     }
   },
   "_meta": {
+    "dir": "ltr",
     "batch": "4-C",
     "issue": "#1358",
     "scope": "Raiz de conhecimento K-Z (20 componentes)",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -115,5 +115,8 @@
       "moreCount": "+{count} \u0645\u0632\u06cc\u062f",
       "summaryStats": "{backend} \u0628\u06cc\u06a9 \u0627\u06cc\u0646\u0688 \u2022 {specialized} \u0645\u0627\u06c1\u0631 \u0627\u06cc\u062c\u0646\u0679\u0633"
     }
+  },
+  "_meta": {
+    "dir": "rtl"
   }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded `RTL_LOCALES` Set with `getLocaleDir()` that reads `_meta.dir` from locale JSON
- Add `_meta.dir` to all 11 locale files (`rtl` for ar/he/fa/ur, `ltr` for others)
- Export `getLocaleDir()` for reuse by components needing direction info
- Update `usePreferences.rtl.spec.ts` mock to derive RTL from metadata
- Falls back to `ltr` if `_meta.dir` is absent

Closes #1812

## Test plan
- [ ] `setLocale('ar')` sets `dir="rtl"` on document
- [ ] `setLocale('en')` sets `dir="ltr"` on document
- [ ] `vue-tsc --noEmit` passes (already verified)
- [ ] RTL test suite passes