### PR TITLE
fix(backend): lazy-init LLMFailsafeAgent to prevent import-time crash (#1858)

### DIFF
--- a/autobot-backend/agents/llm_failsafe_agent.py
+++ b/autobot-backend/agents/llm_failsafe_agent.py
@@ -733,8 +733,22 @@ class LLMFailsafeAgent:
         return self.tier_health
 
 
-# Global instance for easy access
-llm_failsafe = LLMFailsafeAgent()
+# Module-level singleton — created on first use to avoid import-time side effects.
+_llm_failsafe: Optional["LLMFailsafeAgent"] = None
+
+
+def get_llm_failsafe() -> "LLMFailsafeAgent":
+    """
+    Return the shared LLMFailsafeAgent singleton, creating it on first call.
+
+    Deferred instantiation prevents AgentConfigurationError from being raised
+    at import time when environment variables are not yet configured.
+    """
+    global _llm_failsafe
+    if _llm_failsafe is None:
+        logger.debug("Initializing LLMFailsafeAgent singleton")
+        _llm_failsafe = LLMFailsafeAgent()
+    return _llm_failsafe
 
 
 async def get_robust_llm_response(
@@ -750,14 +764,14 @@ async def get_robust_llm_response(
     Returns:
         LLMResponse with guaranteed content (even if degraded)
     """
-    return await llm_failsafe.get_response(prompt, context)
+    return await get_llm_failsafe().get_response(prompt, context)
 
 
 def get_llm_system_status() -> Dict[str, Any]:
     """Get current LLM system status"""
-    return llm_failsafe.get_system_status()
+    return get_llm_failsafe().get_system_status()
 
 
 async def perform_llm_health_check() -> Dict[LLMTier, bool]:
     """Perform health check on all LLM tiers"""
-    return await llm_failsafe.health_check()
+    return await get_llm_failsafe().health_check()


### PR DESCRIPTION
## Summary
- Replace module-level `llm_failsafe = LLMFailsafeAgent()` with `get_llm_failsafe()` lazy getter
- Prevents `AgentConfigurationError` at import time when failsafe env vars aren't set
- All 3 callers use `get_robust_llm_response` by name — no caller changes needed
- Backend can now start without `AUTOBOT_LLM_FAILSAFE_*` env vars

Closes #1858

## Test plan
- [ ] Backend starts without failsafe agent env vars
- [ ] `get_robust_llm_response()` still works when env vars are set
- [ ] No import errors in orchestration router