### PR TITLE
refactor: extract helpers from infra scripts exceeding 65-line limit (#1792)

### DIFF
--- a/autobot-infrastructure/shared/scripts/secrets_manager.py
+++ b/autobot-infrastructure/shared/scripts/secrets_manager.py
@@ -817,27 +817,8 @@ def _handle_security_report_command(secrets_manager: SecretsManager, args) -> in
     return 0
 
 
-def _create_argument_parser() -> argparse.ArgumentParser:
-    """Create and configure argument parser.
-
-    Helper for main (Issue #825).
-    """
-    parser = argparse.ArgumentParser(
-        description="AutoBot Secrets Management System",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  python scripts/secrets_manager.py --add --name "api_key" --type "api_key" --scope "general"
-  python scripts/secrets_manager.py --list --scope "general"
-  python scripts/secrets_manager.py --list --scope "chat" --chat-id "chat_123"
-  python scripts/secrets_manager.py --get --secret-id "abc123..." --chat-id "chat_123"
-  python scripts/secrets_manager.py --transfer --secret-id "abc123..." --chat-id "chat_123"
-  python scripts/secrets_manager.py --cleanup-chat "chat_456" --transfer
-  python scripts/secrets_manager.py --security-report
-        """,
-    )
-
-    # Actions
+def _add_action_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register action flags on the argument parser (#1792)."""
     parser.add_argument("--add", action="store_true", help="Add new secret")
     parser.add_argument("--list", action="store_true", help="List secrets")
     parser.add_argument("--get", action="store_true", help="Get secret value")
@@ -851,7 +832,9 @@ Examples:
         "--security-report", action="store_true", help="Generate security report"
     )
 
-    # Parameters
+
+def _add_parameter_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register parameter and option flags on the argument parser (#1792)."""
     parser.add_argument("--secret-id", help="Secret ID")
     parser.add_argument("--name", help="Secret name")
     parser.add_argument("--value", help="Secret value (will prompt if not provided)")
@@ -875,13 +858,34 @@ Examples:
         action="store_true",
         help="Transfer secrets to general instead of deleting",
     )
-
-    # Options
     parser.add_argument(
         "--secrets-dir", default="data/secrets", help="Secrets directory"
     )
     parser.add_argument("--json", action="store_true", help="Output in JSON format")
 
+
+def _create_argument_parser() -> argparse.ArgumentParser:
+    """Create and configure argument parser (#1792).
+
+    Helper for main. Actions registered via _add_action_arguments,
+    parameters via _add_parameter_arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="AutoBot Secrets Management System",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python scripts/secrets_manager.py --add --name "api_key" --type "api_key" --scope "general"
+  python scripts/secrets_manager.py --list --scope "general"
+  python scripts/secrets_manager.py --list --scope "chat" --chat-id "chat_123"
+  python scripts/secrets_manager.py --get --secret-id "abc123..." --chat-id "chat_123"
+  python scripts/secrets_manager.py --transfer --secret-id "abc123..." --chat-id "chat_123"
+  python scripts/secrets_manager.py --cleanup-chat "chat_456" --transfer
+  python scripts/secrets_manager.py --security-report
+        """,
+    )
+    _add_action_arguments(parser)
+    _add_parameter_arguments(parser)
     return parser
 
 

--- a/autobot-infrastructure/shared/scripts/setup/analytics/seq_auth_setup.py
+++ b/autobot-infrastructure/shared/scripts/setup/analytics/seq_auth_setup.py
@@ -80,76 +80,83 @@ def create_seq_api_key(
         return None
 
 
+def _find_seq_container() -> str:
+    """Find the running Seq Docker container name (#1792).
+
+    Returns the first matching container name, or empty string if none found.
+    """
+    import subprocess
+
+    result = subprocess.run(
+        ["docker", "ps", "--format", "{{.Names}}", "--filter", "name=seq"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    containers = [line for line in result.stdout.strip().split("\n") if line]
+    return containers[0] if containers else ""
+
+
+def _prompt_new_password() -> str:
+    """Prompt user for a new password with confirmation (#1792).
+
+    Returns the confirmed password, or empty string on mismatch/blank.
+    """
+    new_password = input("Enter new admin password: ").strip()
+    confirm_password = input("Confirm new password: ").strip()
+    if new_password != confirm_password:
+        print("❌ Passwords do not match")
+        return ""
+    return new_password
+
+
+def _run_seqcli_password_reset(seq_container: str, new_password: str) -> bool:
+    """Execute seqcli password reset inside the given Docker container (#1792).
+
+    Returns True on success, False on failure.
+    """
+    import subprocess
+
+    reset_command = [
+        "docker", "exec", seq_container,
+        "seqcli", "user", "update",
+        "-n", "admin",
+        "-p", new_password,
+        "-s", "http://localhost",
+    ]
+    print("🔐 Resetting admin password...")
+    result = subprocess.run(reset_command, capture_output=True, text=True)
+    if result.returncode == 0:
+        print("✅ Password reset successfully")
+        os.environ["SEQ_PASSWORD"] = new_password
+        print("💡 Password set in environment variable SEQ_PASSWORD")
+        return True
+    print(f"❌ Password reset failed: {result.stderr}")
+    return False
+
+
 def reset_seq_admin_password(seq_url=None, new_password=None):
-    """Reset Seq admin password using Docker container access."""
+    """Reset Seq admin password using Docker container access (#1792)."""
+    import subprocess
 
     seq_url = seq_url or os.getenv("AUTOBOT_LOG_VIEWER_URL", "http://localhost:5341")
-
     print("🔄 Attempting to reset Seq admin password...")
 
     try:
-        import subprocess
-
-        # Find the Seq container
-        result = subprocess.run(
-            ["docker", "ps", "--format", "{{.Names}}", "--filter", "name=seq"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-        seq_containers = [line for line in result.stdout.strip().split("\n") if line]
-
-        if not seq_containers:
+        seq_container = _find_seq_container()
+        if not seq_container:
             print("❌ No Seq container found")
             return False
-
-        seq_container = seq_containers[0]
         print(f"📦 Found Seq container: {seq_container}")
 
-        # Get new password if not provided
         if not new_password:
-            new_password = input("Enter new admin password: ").strip()
-            confirm_password = input("Confirm new password: ").strip()
-
-            if new_password != confirm_password:
-                print("❌ Passwords do not match")
-                return False
+            new_password = _prompt_new_password()
 
         if not new_password:
             print("❌ Password cannot be empty")
             return False
 
-        # Reset password using seqcli in the container
-        reset_command = [
-            "docker",
-            "exec",
-            seq_container,
-            "seqcli",
-            "user",
-            "update",
-            "-n",
-            "admin",
-            "-p",
-            new_password,
-            "-s",
-            "http://localhost",
-        ]
-
-        print("🔐 Resetting admin password...")
-        result = subprocess.run(reset_command, capture_output=True, text=True)
-
-        if result.returncode == 0:
-            print("✅ Password reset successfully")
-
-            # Set environment variable for future use
-            os.environ["SEQ_PASSWORD"] = new_password
-            print("💡 Password set in environment variable SEQ_PASSWORD")
-
-            return True
-        else:
-            print(f"❌ Password reset failed: {result.stderr}")
-            return False
+        return _run_seqcli_password_reset(seq_container, new_password)
 
     except subprocess.CalledProcessError as e:
         print(f"❌ Docker command failed: {e}")

--- a/autobot-infrastructure/shared/scripts/utilities/validate-security-fixes.py
+++ b/autobot-infrastructure/shared/scripts/utilities/validate-security-fixes.py
@@ -21,75 +21,69 @@ class SecurityValidator:
         self.vulnerabilities_found = []
         self.fixes_verified = []
 
+    def _build_rg_command(self, pattern: str, excluded_paths: List[str]) -> List[str]:
+        """Build ripgrep command for a single secret pattern (#1792).
+
+        Returns the full argv list ready for subprocess.run.
+        """
+        base_cmd = [
+            "rg", pattern, str(self.project_root),
+            "--type", "py",
+            "--type", "js",
+            "--type", "ts",
+            "--type", "sh",
+            "--ignore-case",
+            "--line-number",
+        ]
+        return base_cmd + [f"--glob=!{path}" for path in excluded_paths]
+
+    def _parse_rg_output(self, stdout: str, description: str) -> List[Dict]:
+        """Parse ripgrep line-number output into finding dicts (#1792).
+
+        Skips lines annotated with 'pragma: allowlist secret'.
+        """
+        findings = []
+        for line in stdout.strip().split("\n"):
+            if ":" not in line:
+                continue
+            file_path, line_num, content = line.split(":", 2)
+            if "pragma: allowlist secret" in content:
+                continue
+            findings.append(
+                {
+                    "type": description,
+                    "file": file_path,
+                    "line": line_num,
+                    "content": content.strip(),
+                }
+            )
+        return findings
+
     def scan_for_hardcoded_secrets(self) -> List[Dict]:
-        """Scan codebase for remaining hardcoded secrets"""
+        """Scan codebase for remaining hardcoded secrets (#1792)."""
         print("🔍 Scanning for hardcoded secrets...")
 
         patterns = [
             (r'password\s*[=:]\s*["\'][^"\']{4,}["\']', "Hardcoded password"),
             (r'api_key\s*[=:]\s*["\'][^"\']{10,}["\']', "Hardcoded API key"),
             (r'token\s*[=:]\s*["\'][^"\']{10,}["\']', "Hardcoded token"),
-            (
-                r'redis\.Redis\([^)]*password=["\'][^"\']+["\']',
-                "Redis hardcoded password",
-            ),
+            (r'redis\.Redis\([^)]*password=["\'][^"\']+["\']', "Redis hardcoded password"),
             (r'sshpass\s+-p\s+["\'][^"\']+["\']', "SSH hardcoded password"),
         ]
-
         excluded_paths = [
-            "reports/",
-            "archives/",
-            "docs/",
-            "node_modules/",
-            ".git/",
-            "tests/results/",
-            "reports/finished/",
-            ".claude/",
+            "reports/", "archives/", "docs/", "node_modules/",
+            ".git/", "tests/results/", "reports/finished/", ".claude/",
         ]
 
         findings = []
-
         for pattern, description in patterns:
             try:
-                result = subprocess.run(
-                    [
-                        "rg",
-                        pattern,
-                        str(self.project_root),
-                        "--type",
-                        "py",
-                        "--type",
-                        "js",
-                        "--type",
-                        "ts",
-                        "--type",
-                        "sh",
-                        "--ignore-case",
-                        "--line-number",
-                    ]
-                    + [f"--glob=!{path}" for path in excluded_paths],
-                    capture_output=True,
-                    text=True,
-                )
-
+                cmd = self._build_rg_command(pattern, excluded_paths)
+                result = subprocess.run(cmd, capture_output=True, text=True)
                 if result.stdout:
-                    for line in result.stdout.strip().split("\n"):
-                        if ":" in line:
-                            file_path, line_num, content = line.split(":", 2)
-                            # Skip files with pragma allowlist secret
-                            if "pragma: allowlist secret" in content:
-                                continue
-                            findings.append(
-                                {
-                                    "type": description,
-                                    "file": file_path,
-                                    "line": line_num,
-                                    "content": content.strip(),
-                                }
-                            )
+                    findings.extend(self._parse_rg_output(result.stdout, description))
             except subprocess.CalledProcessError:
                 pass  # ripgrep not found or no matches
-
         return findings
 
     def validate_redis_password_fixes(self) -> bool:


### PR DESCRIPTION
## Summary
- **seq_auth_setup.py**: `reset_seq_admin_password` 77→29 lines — extracted `_find_seq_container`, `_prompt_new_password`, `_run_seqcli_password_reset`
- **validate-security-fixes.py**: `scan_for_hardcoded_secrets` 70→26 lines — extracted `_build_rg_command`, `_parse_rg_output`
- **secrets_manager.py**: `_create_argument_parser` 66→23 lines — extracted `_add_action_arguments`, `_add_parameter_arguments`
- `setup_seq_analytics.py`: already compliant at 30 lines (prior fix)

Pure refactoring — no behavior changes. Unblocks CodeQL security fixes in these files.

Closes #1792

## Test plan
- [ ] Function Length Check pre-commit hook passes
- [ ] `secrets_manager.py --help` still shows all options
- [ ] `validate-security-fixes.py` still scans correctly