### PR TITLE
fix(testing): add pythonpath to pytest.ini for reliable test collection (#1884)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,14 @@
 [pytest]
 # AutoBot pytest configuration
 
+# Ensure backend and shared modules are importable before collection starts.
+# pytest processes `pythonpath` before any test collection, so bare imports
+# like `from models.task_context import ...` resolve correctly.
+# Requires pytest >= 7.0 (built-in mechanism; more reliable than conftest.py
+# sys.path manipulation which runs too late to prevent collection errors).
+# Issue: #1884
+pythonpath = autobot-backend autobot-shared
+
 # Test markers
 markers =
     integration: Integration tests that may require external services


### PR DESCRIPTION
## Summary
- Add `pythonpath = autobot-backend autobot-shared` to `[pytest]` config
- Ensures `sys.path` includes backend/shared dirs before test collection
- Fixes ~60 `ModuleNotFoundError` failures during bulk pytest runs

Closes #1884

## Test plan
- [ ] `python -m pytest autobot-backend -q --co` collects without ModuleNotFoundError
- [ ] Tests still pass individually and in bulk