### PR TITLE
fix(backend): replace datetime.UTC with timezone.utc for Python 3.10 (#1889)

### DIFF
--- a/autobot-backend/services/agent_session_service.py
+++ b/autobot-backend/services/agent_session_service.py
@@ -11,7 +11,7 @@ absent and are cleaned up by cleanup_expired_sessions().
 
 import logging
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 from models.process_run import AgentSession
@@ -42,7 +42,7 @@ class AgentSessionService:
         Overwrites any existing session for the same (agent_id, task_id) pair.
         Returns the UUID of the saved row.
         """
-        now = datetime.now(UTC)
+        now = datetime.now(timezone.utc)
         expires_at = now + timedelta(seconds=ttl_seconds)
         session_id = await self._upsert_session(
             agent_id, task_id, state, ttl_seconds, expires_at
@@ -64,7 +64,7 @@ class AgentSessionService:
             row = await _fetch_session(session, agent_id, task_id)
         if row is None:
             return None
-        if row.expires_at.replace(tzinfo=UTC) < datetime.now(UTC):
+        if row.expires_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
             logger.debug("Session expired for agent=%s task=%s", agent_id, task_id)
             return None
         return row.session_state
@@ -75,7 +75,7 @@ class AgentSessionService:
 
         Returns the number of rows deleted.
         """
-        now = datetime.now(UTC)
+        now = datetime.now(timezone.utc)
         async with self._session_factory() as session:
             result = await session.execute(
                 delete(AgentSession).where(AgentSession.expires_at < now)

--- a/autobot-backend/services/approval_gate_service.py
+++ b/autobot-backend/services/approval_gate_service.py
@@ -11,7 +11,7 @@ notifications for pending approvals.
 
 import logging
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from models.approval import Approval, ApprovalComment, ApprovalStatus, TaskApprovalLink
@@ -316,7 +316,7 @@ class ApprovalGateService:
 
         approval.status = new_status.value
         approval.decided_by_user = decided_by
-        approval.decided_at = datetime.now(UTC)
+        approval.decided_at = datetime.now(timezone.utc)
 
         if comment:
             c = ApprovalComment(

--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -15,7 +15,7 @@ cold-starting across heartbeat runs.
 import asyncio
 import logging
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 
 from models.heartbeat import (
@@ -180,7 +180,7 @@ class HeartbeatScheduler:
                 status=HeartbeatRunStatus.RUNNING.value,
                 trigger=trigger.value,
                 wakeup_context=wakeup_req.context if wakeup_req else None,
-                started_at=datetime.now(UTC),
+                started_at=datetime.now(timezone.utc),
             )
             session.add(run)
             await session.flush()
@@ -231,7 +231,7 @@ class HeartbeatScheduler:
             run_row = await session.get(HeartbeatRun, run_id)
             if run_row:
                 run_row.status = final_status
-                run_row.finished_at = datetime.now(UTC)
+                run_row.finished_at = datetime.now(timezone.utc)
                 run_row.error_message = error_msg
                 run_row.tokens_used = usage.get("tokens_used")
                 run_row.cost_usd = usage.get("cost_usd")
@@ -239,7 +239,7 @@ class HeartbeatScheduler:
                 run_row.provider = usage.get("provider")
             state_row = await session.get(AgentRuntimeState, state_id)
             if state_row:
-                state_row.last_heartbeat_at = datetime.now(UTC)
+                state_row.last_heartbeat_at = datetime.now(timezone.utc)
                 if usage.get("session_params") is not None:
                     state_row.session_params = usage["session_params"]
             await _append_event(
@@ -300,7 +300,7 @@ async def _consume_top_wakeup(
     )
     req = result.scalar_one_or_none()
     if req is not None:
-        req.consumed_at = datetime.now(UTC)
+        req.consumed_at = datetime.now(timezone.utc)
         await session.flush()
     return req
 
@@ -320,6 +320,6 @@ async def _append_event(
             event_type=event_type,
             message=message,
             payload=payload,
-            occurred_at=datetime.now(UTC).isoformat(),
+            occurred_at=datetime.now(timezone.utc).isoformat(),
         )
     )

--- a/autobot-backend/services/process_adapter_service.py
+++ b/autobot-backend/services/process_adapter_service.py
@@ -29,7 +29,7 @@ import logging
 import os
 import signal as signal_module
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from models.process_run import ProcessRun, ProcessRunStatus
@@ -218,7 +218,7 @@ class ProcessAdapterService:
         async with self._session_factory() as session:
             row = await session.get(ProcessRun, run_id)
             row.status = ProcessRunStatus.RUNNING.value
-            row.started_at = datetime.now(UTC)
+            row.started_at = datetime.now(timezone.utc)
             cmd, args, timeout = row.command, row.args or [], row.timeout_seconds
             await session.commit()
         logger.info("Process %s started", run_id)
@@ -263,7 +263,7 @@ class ProcessAdapterService:
                 row.signal = sig_name
                 row.log_excerpt = excerpt
                 row.log_path = log_path
-                row.completed_at = datetime.now(UTC)
+                row.completed_at = datetime.now(timezone.utc)
             await session.commit()
         logger.info(
             "Process %s finalised: status=%s exit=%s", run_id, status, exit_code
@@ -276,7 +276,7 @@ class ProcessAdapterService:
             if row:
                 row.status = ProcessRunStatus.FAILED.value
                 row.log_excerpt = reason[:_LOG_EXCERPT_MAX]
-                row.completed_at = datetime.now(UTC)
+                row.completed_at = datetime.now(timezone.utc)
             await session.commit()
 
     async def _create_run_row(


### PR DESCRIPTION
## Summary
- Replace `datetime.UTC` (Python 3.11+) with `datetime.timezone.utc` (Python 3.2+)
- 4 service files, 12 call sites updated
- Compatible with Python 3.10 (dev/CI) through 3.13

Closes #1889

## Test plan
- [ ] Affected tests pass on Python 3.10
- [ ] No `ImportError: cannot import name 'UTC'` in CI