### PR TITLE
fix: correct _PROJECT_ROOT path for Docker in conversation_file_manager (#1861)

### DIFF
--- a/autobot-backend/conversation_file_manager.py
+++ b/autobot-backend/conversation_file_manager.py
@@ -38,7 +38,10 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 from autobot_shared.redis_client import get_redis_client as get_redis_manager
 
 # Module-level project root constant (Issue #380 - avoid repeated Path computation)
-_PROJECT_ROOT = Path(__file__).parent.parent
+# Use .parent (autobot-backend/) so paths work in both Docker (/app/autobot-backend/)
+# and bare-metal deployments.  .parent.parent was wrong in Docker — resolved to /app
+# instead of /app/autobot-backend/, causing schema/data lookups to miss. (#1861)
+_PROJECT_ROOT = Path(__file__).parent
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Change `Path(__file__).parent.parent` to `Path(__file__).parent` so `_PROJECT_ROOT` resolves to `autobot-backend/`
- Fixes schema and data path resolution in Docker (`/app/autobot-backend/` vs `/app/`)
- Works on both bare metal and Docker

Closes #1861

## Test plan
- [ ] Backend starts in Docker without schema file errors
- [ ] Conversation file operations work on bare metal