### PR TITLE
refactor(infra): standardize Python to deadsnakes PPA + venv (#1898)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,19 +24,19 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Install Python 3.10 via deadsnakes PPA
+    - name: Install Python 3.12 via deadsnakes PPA
       run: |
-        if ! command -v python3.10 &> /dev/null; then
+        if ! command -v python3.12 &> /dev/null; then
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update -y
-          sudo apt-get install -y python3.10 python3.10-venv python3.10-dev
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
         fi
 
     - name: Free disk space and set up venv
       run: |
         pip cache purge 2>/dev/null || true
         rm -rf .venv 2>/dev/null || true
-        python3.10 -m venv .venv
+        python3.12 -m venv .venv
         source .venv/bin/activate
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
@@ -213,19 +213,19 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Install Python 3.10 via deadsnakes PPA
+    - name: Install Python 3.12 via deadsnakes PPA
       run: |
-        if ! command -v python3.10 &> /dev/null; then
+        if ! command -v python3.12 &> /dev/null; then
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update -y
-          sudo apt-get install -y python3.10 python3.10-venv python3.10-dev
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
         fi
 
     - name: Free disk space and set up venv
       run: |
         pip cache purge 2>/dev/null || true
         rm -rf .venv 2>/dev/null || true
-        python3.10 -m venv .venv
+        python3.12 -m venv .venv
         source .venv/bin/activate
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,18 +26,18 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Install Python 3.10 via deadsnakes PPA
+    - name: Install Python 3.12 via deadsnakes PPA
       run: |
-        if ! command -v python3.10 &> /dev/null; then
+        if ! command -v python3.12 &> /dev/null; then
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update -y
-          sudo apt-get install -y python3.10 python3.10-venv python3.10-dev
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
         fi
 
     - name: Set up Python virtual environment
       run: |
         rm -rf .venv 2>/dev/null || true
-        python3.10 -m venv .venv
+        python3.12 -m venv .venv
         source .venv/bin/activate
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH

--- a/.github/workflows/phase_validation.yml
+++ b/.github/workflows/phase_validation.yml
@@ -33,19 +33,19 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Install Python 3.10 via deadsnakes PPA
+    - name: Install Python 3.12 via deadsnakes PPA
       run: |
-        if ! command -v python3.10 &> /dev/null; then
+        if ! command -v python3.12 &> /dev/null; then
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update -y
-          sudo apt-get install -y python3.10 python3.10-venv python3.10-dev
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
         fi
 
     - name: Set up Python virtual environment
       run: |
         pip cache purge 2>/dev/null || true
         rm -rf .venv 2>/dev/null || true
-        python3.10 -m venv .venv
+        python3.12 -m venv .venv
         source .venv/bin/activate
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,19 +36,19 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Install Python 3.10 via deadsnakes PPA
+    - name: Install Python 3.12 via deadsnakes PPA
       run: |
-        if ! command -v python3.10 &> /dev/null; then
+        if ! command -v python3.12 &> /dev/null; then
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update -y
-          sudo apt-get install -y python3.10 python3.10-venv python3.10-dev
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
         fi
 
     - name: Set up Python virtual environment
       run: |
         pip cache purge 2>/dev/null || true
         rm -rf .venv 2>/dev/null || true
-        python3.10 -m venv .venv
+        python3.12 -m venv .venv
         source .venv/bin/activate
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
@@ -120,19 +120,19 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Install Python 3.10 via deadsnakes PPA
+    - name: Install Python 3.12 via deadsnakes PPA
       run: |
-        if ! command -v python3.10 &> /dev/null; then
+        if ! command -v python3.12 &> /dev/null; then
           sudo add-apt-repository -y ppa:deadsnakes/ppa
           sudo apt-get update -y
-          sudo apt-get install -y python3.10 python3.10-venv python3.10-dev
+          sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
         fi
 
     - name: Set up Python virtual environment
       run: |
         pip cache purge 2>/dev/null || true
         rm -rf .venv 2>/dev/null || true
-        python3.10 -m venv .venv
+        python3.12 -m venv .venv
         source .venv/bin/activate
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ git diff --staged           # Ensure nothing unexpectedly left staged
 **Deployment Verification Checklist — after deploying to ANY remote server:**
 
 1. **No .env override conflicts:** `grep -E "(HOST|PORT|PASSWORD)" /path/to/.env`
-2. **Correct Python interpreter:** `which python3` — Main: Python 3.12 conda env; SLM/fleet: Python 3.10 venv `/opt/autobot/venv`
+2. **Correct Python interpreter:** `which python3` — All nodes: Python 3.12 deadsnakes PPA venv at `/opt/autobot/<component>/venv` (Issue #1898)
 3. **Database migrations current:** `cd /opt/autobot && source venv/bin/activate && alembic current`
 4. **Service actually restarted:** `sudo systemctl status autobot-backend --no-pager && journalctl -u autobot-backend -n 50 --no-pager`
 5. **Endpoints responding:** `curl -sk https://localhost:8443/api/health | jq`
@@ -356,9 +356,9 @@ Each session stays in its issue scope. If Session A discovers a bug in Session B
 - If Black and isort conflict: run Black first, then isort, then `git add -u` before committing
 
 **CI/Production Parity:**
-- CI runs Python 3.10 (deadsnakes PPA) — never use 3.11+ features or 3.13-only packages
+- CI runs Python 3.12 (deadsnakes PPA) — never use 3.13-only packages (Issue #1898)
 - Match production dependency versions exactly — never upgrade major versions without explicit approval
-- Backend: conda env (Python 3.12 on `.20`), SLM/fleet: venv Python 3.10 on `/opt/autobot/venv`
+- All nodes: deadsnakes PPA python3.12 venv at `/opt/autobot/<component>/venv`
 
 **Branch Strategy:**
 - Always target `Dev_new_gui` for PRs and merges unless explicitly told otherwise

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ AutoBot is a self-hosted platform that combines a conversational AI assistant wi
 | CPU | 8 cores | 16+ cores |
 | Storage | 50 GB | 200 GB+ (model + knowledge base storage) |
 | GPU | — | NVIDIA (CUDA) or Intel NPU for accelerated inference |
-| Python | 3.10 | 3.12 (conda env) |
+| Python | 3.12 | 3.12 (deadsnakes PPA + venv) |
 | Node.js | 18 | 20 |
 
 ---

--- a/autobot-infrastructure/autobot-backend/README.md
+++ b/autobot-infrastructure/autobot-backend/README.md
@@ -92,7 +92,7 @@ ssh autobot@172.16.168.20 'journalctl -u autobot-celery -f'
 - **WSL2 loopback**: Cannot health-check 172.16.168.20 from the backend node itself. Use .19 as a relay.
 - **6-minute startup**: The backend loads large ML models at init. nginx returns 504 during this window.
 - **Restart cost**: Each restart causes a 6-minute outage. Avoid unless essential.
-- **Python env**: Uses conda env at `/home/autobot/miniconda3/envs/autobot-backend` (Python 3.12).
+- **Python env**: Uses deadsnakes PPA venv at `/opt/autobot/autobot-backend/venv` (Python 3.12).
 - **Log location**: `StandardOutput=append:/var/log/autobot/backend.log` — not journald.
 
 ---

--- a/autobot-infrastructure/autobot-backend/manifest.yml
+++ b/autobot-infrastructure/autobot-backend/manifest.yml
@@ -84,4 +84,4 @@ notes: |
   RAG optimizer, ChromaDB). During init uvicorn binds the socket but workers
   don't accept connections — nginx returns 504 until ready.
   Never restart unless essential.
-  Python runtime: conda env autobot-backend at /home/autobot/miniconda3/envs/autobot-backend
+  Python runtime: deadsnakes PPA python3.12 venv at /opt/autobot/autobot-backend/venv (Issue #1898)

--- a/autobot-infrastructure/shared/scripts/setup-runner-pyenv.sh
+++ b/autobot-infrastructure/shared/scripts/setup-runner-pyenv.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
-# AutoBot - Self-Hosted Runner Pyenv Setup Script
+# AutoBot - Self-Hosted Runner Python Setup Script
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 #
-# This script installs pyenv on the GitHub Actions self-hosted runner
-# and configures Python 3.10 with pip for CI/CD workflows.
+# Issue #1898: Standardize Python to deadsnakes PPA + Python 3.12 venv.
+# Replaced pyenv with deadsnakes PPA for consistency with Docker and production.
+#
+# This script installs Python 3.12 via deadsnakes PPA on the GitHub Actions
+# self-hosted runner (github-runner, user 'martins').
 #
 # Usage: Run this script on the self-hosted runner machine (github-runner)
 # as user 'martins': bash setup-runner-pyenv.sh
@@ -12,14 +15,14 @@
 set -e  # Exit on error
 
 echo "=================================================="
-echo "🐍 AutoBot Self-Hosted Runner Pyenv Setup"
+echo "AutoBot Self-Hosted Runner Python 3.12 Setup"
 echo "=================================================="
 echo ""
 
 # Check if running as correct user
 CURRENT_USER=$(whoami)
 if [ "$CURRENT_USER" != "martins" ]; then
-    echo "⚠️  Warning: This script should be run as user 'martins'"
+    echo "Warning: This script should be run as user 'martins'"
     echo "   Current user: $CURRENT_USER"
     read -p "Continue anyway? (y/n) " -n 1 -r
     echo
@@ -28,88 +31,39 @@ if [ "$CURRENT_USER" != "martins" ]; then
     fi
 fi
 
-echo "📦 Step 1: Installing pyenv dependencies..."
-sudo apt update
-sudo apt install -y build-essential libssl-dev zlib1g-dev \
-    libbz2-dev libreadline-dev libsqlite3-dev curl git \
-    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
-    libffi-dev liblzma-dev
+echo "Step 1: Installing software-properties-common..."
+sudo apt-get update
+sudo apt-get install -y software-properties-common
 
 echo ""
-echo "📥 Step 2: Installing pyenv..."
-if [ -d "$HOME/.pyenv" ]; then
-    echo "⚠️  Pyenv already exists at $HOME/.pyenv"
-    read -p "Remove and reinstall? (y/n) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        rm -rf "$HOME/.pyenv"
-    else
-        echo "Skipping pyenv installation"
-    fi
-fi
-
-if [ ! -d "$HOME/.pyenv" ]; then
-    curl https://pyenv.run | bash
-fi
+echo "Step 2: Adding deadsnakes PPA..."
+sudo add-apt-repository -y ppa:deadsnakes/ppa
+sudo apt-get update
 
 echo ""
-echo "⚙️  Step 3: Configuring shell environment..."
-
-# Backup existing .bashrc
-if [ -f "$HOME/.bashrc" ]; then
-    cp "$HOME/.bashrc" "$HOME/.bashrc.backup.$(date +%Y%m%d_%H%M%S)"
-fi
-
-# Add pyenv to .bashrc if not already present
-if ! grep -q "PYENV_ROOT" "$HOME/.bashrc"; then
-    echo '' >> "$HOME/.bashrc"
-    echo '# Pyenv configuration' >> "$HOME/.bashrc"
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> "$HOME/.bashrc"
-    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> "$HOME/.bashrc"
-    echo 'eval "$(pyenv init -)"' >> "$HOME/.bashrc"
-    echo "✅ Added pyenv to .bashrc"
-else
-    echo "✅ Pyenv already configured in .bashrc"
-fi
-
-# Source the configuration
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
+echo "Step 3: Installing Python 3.12..."
+sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
 
 echo ""
-echo "🐍 Step 4: Installing Python 3.10.15..."
-if pyenv versions | grep -q "3.10.15"; then
-    echo "✅ Python 3.10.15 already installed"
-else
-    pyenv install 3.10.15
-fi
-
-echo ""
-echo "🎯 Step 5: Setting Python 3.10.15 as global default..."
-pyenv global 3.10.15
-
-echo ""
-echo "✅ Step 6: Verifying installation..."
+echo "Step 4: Verifying installation..."
 echo "Python version:"
-python3 --version
+python3.12 --version
 echo ""
 echo "Python location:"
-which python3
+which python3.12
 echo ""
 echo "Pip version:"
-python3 -m pip --version
+python3.12 -m pip --version 2>/dev/null || echo "pip not available in base install (use venv)"
 
 echo ""
 echo "=================================================="
-echo "✅ Pyenv Setup Complete!"
+echo "Python 3.12 Setup Complete!"
 echo "=================================================="
 echo ""
-echo "📋 Next Steps:"
-echo "1. Restart your shell or run: source ~/.bashrc"
-echo "2. Verify pyenv is working: pyenv version"
-echo "3. Re-run GitHub Actions workflows"
+echo "Next Steps:"
+echo "1. Re-run GitHub Actions workflows"
+echo "2. Workflows use: python3.12 -m venv .venv"
 echo ""
-echo "📍 Python 3.10.15 is now the global default"
-echo "📍 All GitHub Actions workflows will use this Python"
+echo "Python 3.12 (deadsnakes PPA) is now installed"
+echo "All GitHub Actions workflows will use python3.12"
 echo ""

--- a/autobot-slm-backend/ansible/inventory/group_vars/aiml.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/aiml.yml
@@ -94,7 +94,7 @@ ai_stack:
     # OpenVINO configuration
     OPENVINO_DEVICE: "AUTO"
     OV_LOG_LEVEL: "ERROR"
-    LD_LIBRARY_PATH: "/usr/local/lib:/usr/lib/x86_64-linux-gnu:/usr/local/lib/python3.10"
+    LD_LIBRARY_PATH: "/usr/local/lib:/usr/lib/x86_64-linux-gnu:/usr/local/lib/python3.12"
 
     # GPU configuration (if available)
     NVIDIA_VISIBLE_DEVICES: "all"

--- a/autobot-slm-backend/ansible/playbooks/README-backend-fixes.md
+++ b/autobot-slm-backend/ansible/playbooks/README-backend-fixes.md
@@ -65,7 +65,7 @@ ansible-playbook playbooks/fix-backend-symlink.yml -e "symlink_action=restore"
 **Fixes:**
 - Corrects `.env` path in systemd service
 - Updates PYTHONPATH to include all required directories
-- Verifies conda environment
+- Verifies Python venv
 - Tests imports
 
 ```bash
@@ -181,7 +181,7 @@ ansible autobot-backend -m shell -a "journalctl -u autobot-backend -n 50 --no-pa
    ```bash
    ssh autobot@172.16.168.20
    cd /opt/autobot/autobot-user-backend
-   source /home/autobot/miniconda3/envs/autobot-backend/bin/activate
+   source /opt/autobot/autobot-backend/venv/bin/activate
    uvicorn main:app --host 0.0.0.0 --port 8443
    ```
 

--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -467,9 +467,9 @@
     - name: Install Python dependencies for AI services
       apt:
         name:
-          - python3.10
-          - python3.10-venv
-          - python3.10-dev
+          - python3.12
+          - python3.12-venv
+          - python3.12-dev
           - build-essential
           - pkg-config
           - libssl-dev
@@ -498,7 +498,7 @@
     - name: Create Python virtual environment
       shell: |
         cd /opt/autobot
-        python3.10 -m venv venv
+        python3.12 -m venv venv
         source venv/bin/activate
         pip install --upgrade pip setuptools wheel
       become_user: autobot-service

--- a/autobot-slm-backend/ansible/playbooks/diagnose-backend-crash.yml
+++ b/autobot-slm-backend/ansible/playbooks/diagnose-backend-crash.yml
@@ -121,14 +121,14 @@
         path: "{{ backend_install_dir }}/.env"
       register: env_file
 
-    - name: Check conda environment
+    - name: Check Python venv
       shell: |
-        if [ -d /home/autobot/miniconda3/envs/autobot-backend ]; then
-          /home/autobot/miniconda3/envs/autobot-backend/bin/python --version
+        if [ -f {{ backend_code_dir }}/venv/bin/python ]; then
+          {{ backend_code_dir }}/venv/bin/python --version
           echo "---"
-          /home/autobot/miniconda3/envs/autobot-backend/bin/uvicorn --version
+          {{ backend_code_dir }}/venv/bin/uvicorn --version
         else
-          echo "Conda environment not found"
+          echo "Python venv not found at {{ backend_code_dir }}/venv"
         fi
       become_user: autobot
       register: conda_check
@@ -146,7 +146,7 @@
           {% endif %}
           .env file exists: {{ env_file.stat.exists }}
 
-          Conda environment:
+          Python venv:
           {{ conda_check.stdout }}
         dest: "{{ diagnostic_output_dir }}/08-environment.txt"
 
@@ -158,7 +158,7 @@
       shell: |
         cd {{ backend_code_dir }}
         export PYTHONPATH={{ backend_install_dir }}:{{ backend_code_dir }}
-        /home/autobot/miniconda3/envs/autobot-backend/bin/python -c "
+        {{ backend_code_dir }}/venv/bin/python -c "
         import sys
         print('Python version:', sys.version)
         print('Python path:', sys.path[:5])
@@ -227,7 +227,7 @@
       shell: |
         cd {{ backend_code_dir }}
         export PYTHONPATH={{ backend_install_dir }}:{{ backend_code_dir }}
-        timeout 10s /home/autobot/miniconda3/envs/autobot-backend/bin/uvicorn main:app --host 0.0.0.0 --port 8443 --workers 1 2>&1 || echo "Manual start attempt completed/timeout"
+        timeout 10s {{ backend_code_dir }}/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8443 --workers 1 2>&1 || echo "Manual start attempt completed/timeout"
       become_user: autobot
       register: manual_start
       failed_when: false

--- a/autobot-slm-backend/ansible/playbooks/fix-backend-environment.yml
+++ b/autobot-slm-backend/ansible/playbooks/fix-backend-environment.yml
@@ -1,6 +1,6 @@
 ---
 # Fix Backend Environment Configuration
-# Issue #893: Corrects PYTHONPATH, .env paths, and conda environment
+# Issue #893: Corrects PYTHONPATH, .env paths, and Python venv
 #
 # Usage from SLM server:
 #   ansible-playbook playbooks/fix-backend-environment.yml
@@ -22,24 +22,26 @@
 
   tasks:
     # ============================================================
-    # Phase 1: Verify Conda Environment
+    # Phase 1: Verify Python venv
     # ============================================================
 
-    - name: Check if conda environment exists
+    - name: Check if Python venv exists
       stat:
-        path: /home/autobot/miniconda3/envs/autobot-backend
-      register: conda_env
+        path: "{{ backend_code_dir }}/venv/bin/python"
+      register: venv_python
 
-    - name: Verify uvicorn in conda environment
+    - name: Verify uvicorn in venv
       stat:
-        path: /home/autobot/miniconda3/envs/autobot-backend/bin/uvicorn
+        path: "{{ backend_code_dir }}/venv/bin/uvicorn"
       register: uvicorn_binary
-      when: conda_env.stat.exists
+      when: venv_python.stat.exists
 
-    - name: Fail if conda environment missing
+    - name: Fail if venv missing
       fail:
-        msg: "Conda environment autobot-backend not found! Run backend role deployment first."
-      when: not conda_env.stat.exists or not uvicorn_binary.stat.exists
+        msg: >-
+          Python venv not found at {{ backend_code_dir }}/venv.
+          Run backend role deployment first (Issue #1898: deadsnakes PPA + python3.12 -m venv).
+      when: not venv_python.stat.exists or not uvicorn_binary.stat.exists
 
     # ============================================================
     # Phase 2: Verify .env File Location
@@ -125,14 +127,14 @@
       shell: |
         cd {{ backend_code_dir }}
         export PYTHONPATH={{ backend_install_dir }}:{{ backend_code_dir }}:{{ backend_install_dir }}/autobot-shared
-        /home/autobot/miniconda3/envs/autobot-backend/bin/python -c "
+        {{ backend_code_dir }}/venv/bin/python -c "
         import sys
         print('PYTHONPATH:', sys.path[:5])
         try:
             import main
-            print('✅ SUCCESS: main.py imports correctly')
+            print('SUCCESS: main.py imports correctly')
         except Exception as e:
-            print('❌ ERROR:', str(e))
+            print('ERROR:', str(e))
             import traceback
             traceback.print_exc()
             exit(1)
@@ -176,9 +178,9 @@
           Environment configuration fixed!
 
           Changes applied:
-          - ✅ .env path: {{ backend_install_dir }}/.env
-          - ✅ PYTHONPATH: {{ backend_install_dir }}:{{ backend_code_dir }}:{{ backend_install_dir }}/autobot-shared
-          - ✅ Conda env: /home/autobot/miniconda3/envs/autobot-backend
+          - .env path: {{ backend_install_dir }}/.env
+          - PYTHONPATH: {{ backend_install_dir }}:{{ backend_code_dir }}:{{ backend_install_dir }}/autobot-shared
+          - Python venv: {{ backend_code_dir }}/venv (deadsnakes python3.12)
 
           Next steps:
           1. Monitor: journalctl -u autobot-backend -f

--- a/autobot-slm-backend/ansible/playbooks/fix-backend-symlink.yml
+++ b/autobot-slm-backend/ansible/playbooks/fix-backend-symlink.yml
@@ -97,7 +97,7 @@
           shell: |
             cd {{ backend_code_dir }}
             export PYTHONPATH=/opt/autobot:{{ backend_code_dir }}
-            /home/autobot/miniconda3/envs/autobot-backend/bin/python -c "
+            {{ backend_code_dir }}/venv/bin/python -c "
             try:
                 from backend.models.user import User
                 print('SUCCESS: backend.models import works with symlink')

--- a/autobot-slm-backend/ansible/roles/agent_config/README.md
+++ b/autobot-slm-backend/ansible/roles/agent_config/README.md
@@ -27,7 +27,7 @@ Ansible role for configuring AutoBot agents with Python environment, AI/ML frame
 service_user: autobot          # Service account
 service_group: autobot         # Service group
 project_root: /opt/autobot     # Installation directory
-python_version: "3.10.13"      # Python version to install
+python_version: "3.12"         # Python version to install (deadsnakes PPA)
 agent_role: general            # Agent role (general, ai_stack, browser, etc.)
 agent_port: 8090               # Agent API port
 ```
@@ -171,10 +171,10 @@ curl http://localhost:8090/health
 
 ### Python version mismatch
 
-If Python installation fails, ensure pyenv is properly configured:
+If Python 3.12 is missing, install via deadsnakes PPA (Issue #1898):
 ```bash
-sudo -u autobot pyenv versions
-sudo -u autobot pyenv install 3.10.13
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
 ```
 
 ### OpenVINO GPU access denied

--- a/autobot-slm-backend/ansible/roles/agent_config/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/defaults/main.yml
@@ -5,8 +5,8 @@
 # agent_config role - Default variables
 
 # Python configuration
-python_version: "3.10.13"
-use_pyenv: true
+python_version: "3.12"
+use_pyenv: false
 venv_dir: "/opt/autobot/venv"
 requirements_file: "requirements.txt"
 

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -50,12 +50,26 @@
   tags: ['backend', 'config']
 
 # ============================================================
-- name: Install Python and build dependencies for pyenv
+# Issue #1898: Standardize Python — deadsnakes PPA + Python 3.12 venv
+# ============================================================
+- name: Install software-properties-common for PPA support
+  ansible.builtin.apt:
+    name: software-properties-common
+    state: present
+    update_cache: true
+
+- name: Add deadsnakes PPA for Python 3.12
+  ansible.builtin.apt_repository:
+    repo: "ppa:deadsnakes/ppa"
+    state: present
+    update_cache: true
+
+- name: Install Python 3.12 and build dependencies
   ansible.builtin.apt:
     name:
-      - python3
-      - python3-pip
-      - python3-venv
+      - python3.12
+      - python3.12-venv
+      - python3.12-dev
       - git
       - curl
       - build-essential
@@ -87,44 +101,6 @@
       - python3-tk
     state: present
     update_cache: true
-
-- name: Check if pyenv is already installed
-  ansible.builtin.stat:
-    path: "/home/{{ backend_user }}/.pyenv"
-  register: pyenv_exists
-  become_user: "{{ backend_user }}"
-
-- name: Install pyenv for Python 3.12 management
-  ansible.builtin.shell: |
-    curl https://pyenv.run | bash
-  args:
-    creates: "/home/{{ backend_user }}/.pyenv/bin/pyenv"
-  become_user: "{{ backend_user }}"
-  when: not pyenv_exists.stat.exists
-
-- name: Add pyenv to backend user's bashrc
-  ansible.builtin.blockinfile:
-    path: "/home/{{ backend_user }}/.bashrc"
-    marker: "# {mark} ANSIBLE MANAGED BLOCK - PYENV"
-    block: |
-      export PYENV_ROOT="$HOME/.pyenv"
-      export PATH="$PYENV_ROOT/bin:$PATH"
-      eval "$(pyenv init --path)"
-      eval "$(pyenv init -)"
-    create: yes
-  become_user: "{{ backend_user }}"
-
-- name: Install Python 3.12.7 via pyenv
-  ansible.builtin.shell: |
-    export PYENV_ROOT="/home/{{ backend_user }}/.pyenv"
-    export PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init --path)"
-    pyenv install 3.12.7 --skip-existing
-  args:
-    executable: /bin/bash
-  become_user: "{{ backend_user }}"
-  register: pyenv_install
-  changed_when: "'Installed' in pyenv_install.stdout"
 
 
 - name: Create autobot user
@@ -203,15 +179,10 @@
     state: absent
   when: venv_check.stat.exists and venv_check.stat.islnk
 
-- name: Create Python 3.12 virtual environment with pyenv
-  ansible.builtin.shell: |
-    export PYENV_ROOT="/home/{{ backend_user }}/.pyenv"
-    export PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init --path)"
-    /home/{{ backend_user }}/.pyenv/versions/3.12.7/bin/python3.12 -m venv {{ backend_code_dir }}/venv
-  args:
+- name: Create Python 3.12 virtual environment via deadsnakes
+  ansible.builtin.command:
+    cmd: "python3.12 -m venv {{ backend_code_dir }}/venv"
     creates: "{{ backend_code_dir }}/venv/bin/activate"
-    executable: /bin/bash
   become_user: "{{ backend_user }}"
 
 - name: Fix venv ownership

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
@@ -10,7 +10,7 @@ Type=simple
 User={{ backend_user }}
 Group={{ backend_group }}
 WorkingDirectory={{ backend_code_dir | default(backend_install_dir) }}
-Environment="PATH=/home/{{ backend_user }}/miniconda3/envs/autobot-backend/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="PATH={{ backend_code_dir | default(backend_install_dir) }}/venv/bin:/usr/local/bin:/usr/bin:/bin"
 Environment="PYTHONPATH={{ backend_install_dir }}:{{ backend_code_dir | default(backend_install_dir) }}:{{ backend_install_dir | dirname }}/autobot-shared:{{ backend_install_dir | dirname }}"
 EnvironmentFile=/opt/autobot/.env
 EnvironmentFile=-{{ service_auth_keys_dir | default('/etc/autobot/service-keys') }}/{{ service_auth_service_id | default('main-backend') }}.env

--- a/autobot-slm-backend/ansible/roles/backend_services/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend_services/tasks/main.yml
@@ -25,7 +25,7 @@
   pip:
     requirements: /opt/autobot/app/requirements.txt
     virtualenv: /opt/autobot/venv
-    virtualenv_python: python3.10
+    virtualenv_python: python3.12
   become_user: autobot
 
 - name: Copy AutoBot application files

--- a/docs/developer/BACKEND_DEBUGGING.md
+++ b/docs/developer/BACKEND_DEBUGGING.md
@@ -207,8 +207,8 @@ which python3
 python3 --version
 /opt/autobot/venv/bin/python --version
 
-# Conda env (main backend on WSL)
-conda activate autobot-backend
+# Python venv (main backend on WSL — deadsnakes PPA + python3.12)
+source /opt/autobot/autobot-backend/venv/bin/activate
 python --version
 ```
 

--- a/docs/developer/OPENVINO_SETUP.md
+++ b/docs/developer/OPENVINO_SETUP.md
@@ -16,7 +16,7 @@ OpenVINO (Open Visual Inference and Neural Network Optimization) provides CPU an
 
 | Component | Status | Location |
 |-----------|--------|----------|
-| OpenVINO Runtime | ✅ Installed | `venv/lib/python3.10/site-packages/openvino/` |
+| OpenVINO Runtime | ✅ Installed | `venv/lib/python3.12/site-packages/openvino/` |
 | CPU Plugin | ✅ Available | `libopenvino_intel_cpu_plugin.so` |
 | GPU Plugin | ✅ Installed | `libopenvino_intel_gpu_plugin.so` |
 | NPU Plugin | ✅ Installed | `libopenvino_intel_npu_plugin.so` |

--- a/docs/developer/ROLES.md
+++ b/docs/developer/ROLES.md
@@ -165,7 +165,7 @@ These conflicts drive the default fleet layout:
 | **Internal port** | 8001 (uvicorn HTTP, localhost only) |
 | **External port** | 8443 (nginx HTTPS reverse proxy) |
 | **Install dir** | `/opt/autobot/autobot-backend` |
-| **Python** | 3.12 (conda env: `/home/autobot/miniconda3/envs/autobot-backend`) |
+| **Python** | 3.12 (deadsnakes PPA venv: `/opt/autobot/autobot-backend/venv`) |
 | **Node.js** | — |
 | **System packages** | `build-essential libssl-dev ffmpeg libsndfile1 libsndfile1-dev portaudio19-dev tesseract-ocr libtesseract-dev nginx` |
 | **External deps** | Redis :6379, PostgreSQL :5432, Ollama :11434, ChromaDB :8000 |
@@ -187,7 +187,7 @@ These conflicts drive the default fleet layout:
 | **Systemd service** | `autobot-celery` |
 | **Port** | — (no HTTP; uses Redis as broker) |
 | **Install dir** | Shares `/opt/autobot/autobot-backend` venv with `backend` |
-| **Python** | 3.12 (shared conda env with `backend`) |
+| **Python** | 3.12 (shared deadsnakes PPA venv with `backend`) |
 | **Node.js** | — |
 | **System packages** | — (shared with `backend`) |
 | **External deps** | Redis :6379 (broker + result backend), PostgreSQL :5432 |
@@ -560,7 +560,7 @@ optional roles:
 │  celery workers   │       ┌─────────────────────────────────────────────────┐
 │  ollama :11434    │       │  .23  DATABASES                                  │
 │  (Python 3.12     │──────▶│  Redis Stack :6379   redis_exporter :9121        │
-│   conda env)      │       │  PostgreSQL :5432    (backend user mgmt)          │
+│   deadsnakes venv)│       │  PostgreSQL :5432    (backend user mgmt)          │
 └───────────────────┘       └─────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────────┐
@@ -612,7 +612,7 @@ Provisioned by: `playbooks/deploy_role.yml` (postgresql role)
 
 **Only active when** `AUTOBOT_DEPLOYMENT_MODE != single_user`.
 Set `AUTOBOT_DEPLOYMENT_MODE=single_company` (or higher) to enable.
-Schema applied by: `alembic upgrade head` inside the backend conda env
+Schema applied by: `alembic upgrade head` inside the backend venv
 Credentials file: `/etc/autobot/db-credentials.env` (prefix `AUTOBOT_DB_`)
 
 ### SQLite on `.20` — Backend Primary Storage

--- a/docs/guides/rag-pdf-workflow.md
+++ b/docs/guides/rag-pdf-workflow.md
@@ -1649,8 +1649,8 @@ curl -sk "https://172.16.168.20:8443/api/knowledge_base/entries?limit=5" \
 
 **Fixes:**
 
-- Verify `pypdf` is installed: `pip list | grep pypdf`. If missing, install it on the
-  backend conda environment.
+- Verify `pypdf` is installed: `pip list | grep pypdf`. If missing, install it into the
+  backend venv (`/opt/autobot/autobot-backend/venv`).
 - Check if the PDF contains actual text (not scanned images). `pypdf` cannot OCR images.
   For scanned PDFs, pre-process with an OCR tool before uploading.
 - Check the upload response `word_count` -- if 0, no text was extracted.

--- a/docs/guides/realtime-monitoring-notifications.md
+++ b/docs/guides/realtime-monitoring-notifications.md
@@ -430,7 +430,7 @@ curl -sk -H "Authorization: Bearer $TOKEN" \
     },
     "python": {
         "version": "3.12.2",
-        "executable": "/home/autobot/miniconda3/envs/autobot-backend/bin/python3"
+        "executable": "/opt/autobot/autobot-backend/venv/bin/python3"
     },
     "cache": {
         "status": "active",

--- a/docs/user-guide/01-installation.md
+++ b/docs/user-guide/01-installation.md
@@ -373,11 +373,10 @@ sudo ./setup_agent.sh
 
 **Issue: Python version not found**
 ```bash
-# Install pyenv for Python version management
-curl https://pyenv.run | bash
-exec $SHELL  # Restart shell
-pyenv install 3.10.13
-pyenv global 3.10.13
+# Install Python 3.12 via deadsnakes PPA (Issue #1898)
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt-get update
+sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
 ```
 
 **Issue: Redis connection failed**

--- a/docs/user-guide/04-troubleshooting.md
+++ b/docs/user-guide/04-troubleshooting.md
@@ -16,19 +16,17 @@ sudo ./setup_agent.sh
 ```
 
 #### Issue: Python version conflicts
-**Symptoms**: "Python 3.10 not found" or version mismatch errors
+**Symptoms**: "Python 3.12 not found" or version mismatch errors
 **Solution**:
 ```bash
-# Check pyenv installation
-pyenv versions
-
-# Install correct Python version
-pyenv install 3.10.13
-pyenv global 3.10.13
+# Install Python 3.12 via deadsnakes PPA (Issue #1898)
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt-get update
+sudo apt-get install -y python3.12 python3.12-venv python3.12-dev
 
 # Recreate virtual environment
 rm -rf venv
-python -m venv venv
+python3.12 -m venv venv
 ```
 
 ### Runtime Issues


### PR DESCRIPTION
## Summary

- Replace conda, pyenv, and system Python 3.10 with **deadsnakes PPA + Python 3.12 venv** across the entire infrastructure
- Update CI workflows (4), Ansible roles/playbooks (10), systemd templates (1), infrastructure scripts (1), and documentation (7)
- Aligns all environments with the Docker stack (#1809) which already uses deadsnakes + Python 3.12

## Changes by Area

### CI Workflows (`.github/workflows/`)
- `ci.yml`, `code-quality.yml`, `security.yml`, `phase_validation.yml`: `python3.10` → `python3.12`

### Ansible
- **backend role**: Replaced pyenv install block with deadsnakes PPA + `apt install python3.12`
- **backend service template**: conda PATH → venv PATH
- **backend_services**: `virtualenv_python: python3.10` → `python3.12`
- **agent_config**: `python_version: "3.10.13"` → `"3.12"`, `use_pyenv: false`
- **Playbooks**: Updated `deploy-native-services`, `diagnose-backend-crash`, `fix-backend-environment`, `fix-backend-symlink`
- **Inventory**: `aiml.yml` LD_LIBRARY_PATH `python3.10` → `python3.12`

### Infrastructure & Docs
- `setup-runner-pyenv.sh`: Rewritten from pyenv to deadsnakes PPA
- `CLAUDE.md`, `README.md`: Updated Python version references
- 5 doc files: conda/pyenv references updated

## Deployment Notes

- **Code-only change** — actual deployment to VMs requires running updated Ansible playbooks
- Existing conda/pyenv installs remain on VMs (inert) — no automatic cleanup
- GPU packages on .20 may still need evaluation (conda vs pip wheels for torch/vLLM)

## Test plan

- [ ] CI workflows pass with python3.12 on self-hosted runner
- [ ] `ansible-playbook deploy-full.yml` on a test node creates deadsnakes venv
- [ ] Systemd service starts with new venv PATH
- [ ] Verify no python3.10-only packages in requirements.txt

Closes #1898