### PR TITLE
feat(docker): resource limits + production hardening (#1897)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 # AutoBot Docker Compose — Single-Node Deployment (#1809)
 # All core services on one machine. Frontend at /, SLM at /slm.
+# Requires Docker Compose v2+ for resource limits (deploy.resources).
 #
 # Usage:
 #   docker compose up -d                    # Start all core services
@@ -9,6 +10,12 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
+
+x-default-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "5"
 
 services:
   # ---- Data Layer ----
@@ -34,11 +41,7 @@ services:
         limits:
           memory: 1G
           cpus: '1.0'
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "5"
+    logging: *default-logging
     security_opt:
       - no-new-privileges:true
     networks:
@@ -49,7 +52,7 @@ services:
     container_name: autobot-postgres
     restart: unless-stopped
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./docker/postgres/init-databases.sql:/docker-entrypoint-initdb.d/init-databases.sql
@@ -67,11 +70,7 @@ services:
         limits:
           memory: 1G
           cpus: '1.0'
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "5"
+    logging: *default-logging
     security_opt:
       - no-new-privileges:true
     networks:
@@ -82,7 +81,7 @@ services:
     container_name: autobot-chromadb
     restart: unless-stopped
     ports:
-      - "8100:8000"
+      - "127.0.0.1:8100:8000"
     volumes:
       - chroma_data:/chroma/chroma
     environment:
@@ -98,11 +97,7 @@ services:
         limits:
           memory: 1G
           cpus: '1.0'
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "5"
+    logging: *default-logging
     security_opt:
       - no-new-privileges:true
     networks:
@@ -158,11 +153,7 @@ services:
         limits:
           memory: 2G
           cpus: '2.0'
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "5"
+    logging: *default-logging
     security_opt:
       - no-new-privileges:true
     networks:
@@ -239,11 +230,7 @@ services:
         limits:
           memory: 1G
           cpus: '1.0'
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "5"
+    logging: *default-logging
     security_opt:
       - no-new-privileges:true
     networks:
@@ -273,11 +260,7 @@ services:
         limits:
           memory: 512M
           cpus: '0.5'
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "5"
+    logging: *default-logging
     security_opt:
       - no-new-privileges:true
     networks:
@@ -290,7 +273,7 @@ services:
     container_name: autobot-ollama
     restart: unless-stopped
     ports:
-      - "11434:11434"
+      - "127.0.0.1:11434:11434"
     volumes:
       - ollama_data:/root/.ollama
     environment:
@@ -304,13 +287,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          memory: 8G  # 7B models need ~5.5GB; increase for larger models
           cpus: '4.0'
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "5"
+    logging: *default-logging
     security_opt:
       - no-new-privileges:true
     networks:
@@ -325,19 +304,20 @@ services:
     container_name: autobot-prometheus
     restart: unless-stopped
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     volumes:
       - prometheus_data:/prometheus
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     deploy:
       resources:
         limits:
           memory: 512M
           cpus: '0.5'
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "5"
+    logging: *default-logging
     security_opt:
       - no-new-privileges:true
     networks:
@@ -350,7 +330,7 @@ services:
     container_name: autobot-grafana
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - grafana_data:/var/lib/grafana
     environment:
@@ -358,16 +338,17 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
     depends_on:
       - autobot-prometheus
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     deploy:
       resources:
         limits:
           memory: 512M
           cpus: '0.5'
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "5"
+    logging: *default-logging
     security_opt:
       - no-new-privileges:true
     networks:


### PR DESCRIPTION
## Summary
- Added memory/CPU resource limits to all 9 services
- Added log rotation (json-file driver, 50MB max, 5 files)
- Restricted RedisInsight UI to localhost (was exposed to all interfaces)
- Split flat `autobot` network into `autobot-data` + `autobot-app` tiers
- Added `no-new-privileges` security option to all containers

Closes #1897

## Test plan
- [ ] Run `docker compose config` — verify YAML is valid
- [ ] Run `docker compose up -d` — verify all services start
- [ ] Verify RedisInsight only accessible from localhost
- [ ] Verify containers respect memory limits: `docker stats`