### PR TITLE
fix(backend): read AUTOBOT_OLLAMA_ENDPOINT before OLLAMA_HOST fallback (#1963)

### DIFF
--- a/autobot-backend/config.py
+++ b/autobot-backend/config.py
@@ -25,7 +25,10 @@ def _get_ssot_ollama_url() -> str:
 
         return get_config().ollama_url
     except Exception:
-        return os.getenv("AUTOBOT_OLLAMA_HOST", "http://127.0.0.1:11434")
+        return os.getenv(
+            "AUTOBOT_OLLAMA_ENDPOINT",
+            os.getenv("AUTOBOT_OLLAMA_HOST", "http://127.0.0.1:11434"),
+        )
 
 
 def _get_ssot_ollama_endpoint() -> str:


### PR DESCRIPTION
## Summary

- `config.py:28` reads `AUTOBOT_OLLAMA_HOST` expecting a full URL
- Docker sets this to bare hostname `autobot-ollama` (fix for double-protocol bug)
- Now checks `AUTOBOT_OLLAMA_ENDPOINT` first (full URL), falls back to `AUTOBOT_OLLAMA_HOST`
- Backward compatible with native deployments

## Test Plan

- [ ] Docker: verify Ollama connectivity from backend
- [ ] Native: verify no regression (AUTOBOT_OLLAMA_HOST still works)

Closes #1963