### PR TITLE
fix(infra): add dependabot.yml for dependency update monitoring (#1938)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+# Dependabot configuration — Issue #1938
+# Guards against incompatible major version bumps in pip and npm deps.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/autobot-backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+    ignore:
+      - dependency-name: "numpy"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "sqlalchemy"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "pip"
+    directory: "/autobot-shared"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "pip"
+    directory: "/autobot-slm-backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/autobot-frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    ignore:
+      - dependency-name: "vue"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "devops"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` covering pip (3 dirs), npm, and GitHub Actions
- Blocks major version bumps on critical deps: numpy, pydantic, sqlalchemy, vue, vite
- Weekly schedule (Mondays), rate-limited to 5 PRs per ecosystem
- Auto-labels PRs with `dependencies` + area tag

## Test Plan

- [ ] Verify Dependabot activates after merge to default branch
- [ ] Confirm major version bumps are ignored per config

Closes #1938