### PR TITLE
fix(slm): add fleet sync guard to schedule and executor paths (#1979)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1850,13 +1850,14 @@ async def run_schedule(
             job_id=None,
         )
 
-    # Create a fleet sync job
-    job = _create_fleet_sync_job(nodes, schedule)
+    # Guard: prevent overlapping fleet sync jobs (#1979)
+    async with _fleet_sync_lock:
+        await assert_no_running_sync(db)
 
-    # Persist job to DB and start background task (#1707)
-    await _persist_fleet_sync_job(job)
-    task = asyncio.create_task(_run_fleet_sync_job(job))
-    _running_tasks[job.job_id] = task
+        job = _create_fleet_sync_job(nodes, schedule)
+        await _persist_fleet_sync_job(job)
+        task = asyncio.create_task(_run_fleet_sync_job(job))
+        _running_tasks[job.job_id] = task
 
     # Update schedule last_run
     schedule.last_run = datetime.utcnow()

--- a/autobot-slm-backend/services/schedule_executor.py
+++ b/autobot-slm-backend/services/schedule_executor.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from typing import Optional, Tuple
 
 from croniter import croniter
-from models.database import CodeStatus, Node, UpdateSchedule
+from models.database import CodeStatus, FleetSyncJobModel, Node, UpdateSchedule
 from services.code_distributor import get_code_distributor
 from services.database import db_service
 from sqlalchemy import select
@@ -234,6 +234,17 @@ async def execute_schedule(schedule: UpdateSchedule) -> Tuple[bool, str]:
 
     try:
         async with db_service.session() as db:
+            # Skip if a fleet sync job is already running (#1979)
+            running = await db.execute(
+                select(FleetSyncJobModel).where(FleetSyncJobModel.status == "running")
+            )
+            if running.scalar_one_or_none():
+                logger.info(
+                    "Skipping schedule '%s' — fleet sync already running",
+                    schedule.name,
+                )
+                return False, "Fleet sync already in progress"
+
             # Determine target nodes based on schedule configuration
             nodes = await _get_target_nodes(db, schedule)
 


### PR DESCRIPTION
## Summary

- Wraps `run_schedule()` job creation in `_fleet_sync_lock` + `assert_no_running_sync()`
- Adds running-job check to `execute_schedule()` before starting node syncs
- Prevents overlapping fleet sync jobs from any trigger path

Closes #1979