### PR TITLE
fix(docker): add missing autobot_users database to init script (#1981)

### DIFF
--- a/docker/postgres/init-databases.sql
+++ b/docker/postgres/init-databases.sql
@@ -1,2 +1,3 @@
--- Create additional databases for SLM user management (#1854)
+-- Create additional databases for SLM (#1854, #1981)
 CREATE DATABASE slm_users;
+CREATE DATABASE autobot_users;


### PR DESCRIPTION
## Summary

Adds `CREATE DATABASE autobot_users;` to `docker/postgres/init-databases.sql`.
SLM `config.py` references this database but Docker init never created it.

Closes #1981