### PR TITLE
fix(docker): add dev entrypoint scripts to fix bind mount issues (#1985)

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,4 +1,4 @@
-# AutoBot Docker Compose — Development Override (#1911)
+# AutoBot Docker Compose — Development Override (#1911, #1985)
 # Activated automatically when copied to docker-compose.override.yml.
 # Provides: live code reloading, debug ports, relaxed health checks.
 #
@@ -8,10 +8,19 @@
 #   docker compose -f docker-compose.yml up -d  # Skip override (production)
 #
 # Known limitations:
-#   - autobot-shared changes require container restart (pip -e install at boot)
-#   - Frontend: run `npm run build` on host; dist/ is served by nginx (no HMR)
-#   - On WSL2 (core.symlinks=false): symlinks are recreated at container start
+#   - autobot-shared changes require container restart (pip -e at boot)
+#   - Frontend: run `npm run build` on host; dist/ is served by nginx
 #   - env_file from base compose is still active; these vars override it
+#
+# Dev entrypoint (#1985):
+#   Bind mounts replace directories that the Dockerfile populated with
+#   symlinks and pip-installed packages.  The dev-entrypoint.sh scripts
+#   run at container start to:
+#     1. Recreate symlinks destroyed by bind mounts
+#     2. Re-install autobot-shared as editable pip package
+#     3. Exec the original command (uvicorn with --reload)
+#   This fixes ImportError on WSL2 where symlinks cannot be created
+#   on the host filesystem (core.symlinks=false).
 #
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
@@ -19,28 +28,29 @@
 
 services:
   autobot-backend:
+    # Dev entrypoint restores symlinks and pip packages before starting
+    # the application. See docker/backend/dev-entrypoint.sh for details.
+    entrypoint: ["/app/docker/backend/dev-entrypoint.sh"]
     volumes:
       - ./autobot-backend:/app/autobot-backend
       - ./autobot-shared:/app/autobot-shared
+      # Mount the dev entrypoint script into the container
+      - ./docker/backend/dev-entrypoint.sh:/app/docker/backend/dev-entrypoint.sh
     command: >
-      bash -c "
-        ln -sf /app/autobot-shared /app/autobot_shared &&
-        ln -sf /app/autobot-shared /app/autobot-backend/autobot_shared &&
-        pip install -e /app/autobot-shared --quiet &&
-        python3.12 -m uvicorn main:app
-          --host 0.0.0.0 --port 8000
-          --reload
-          --reload-dir /app/autobot-backend
-          --reload-dir /app/autobot-shared
-          --app-dir /app/autobot-backend
-      "
+      python3.12 -m uvicorn main:app
+        --host 0.0.0.0 --port 8000
+        --reload
+        --reload-dir /app/autobot-backend
+        --reload-dir /app/autobot-shared
+        --app-dir /app/autobot-backend
     environment:
       - AUTOBOT_ENVIRONMENT=development
       - AUTOBOT_LOG_LEVEL=DEBUG
     ports:
       # debugpy remote debugging — to enable, install debugpy in container:
       #   docker exec -it autobot-backend pip install debugpy
-      # then restart with: python -m debugpy --listen 0.0.0.0:5678 -m uvicorn ...
+      # then restart with:
+      #   python -m debugpy --listen 0.0.0.0:5678 -m uvicorn ...
       - "5678:5678"
     healthcheck:
       interval: 30s
@@ -54,20 +64,21 @@ services:
           cpus: '4.0'
 
   autobot-slm:
+    # Dev entrypoint restores symlinks, pip packages, and runs migrations
+    # before starting the application. Replaces the production entrypoint.
+    entrypoint: ["/app/docker/slm/dev-entrypoint.sh"]
     volumes:
       - ./autobot-slm-backend:/app/autobot-slm-backend
       - ./autobot-shared:/app/autobot-shared
+      # Mount the dev entrypoint script into the container
+      - ./docker/slm/dev-entrypoint.sh:/app/docker/slm/dev-entrypoint.sh
     command: >
-      bash -c "
-        ln -sf /app/autobot-shared /app/autobot_shared &&
-        pip install -e /app/autobot-shared --quiet &&
-        python3.12 -m uvicorn main:app
-          --host 0.0.0.0 --port 8000
-          --reload
-          --reload-dir /app/autobot-slm-backend
-          --reload-dir /app/autobot-shared
-          --app-dir /app/autobot-slm-backend
-      "
+      python3.12 -m uvicorn main:app
+        --host 0.0.0.0 --port 8000
+        --reload
+        --reload-dir /app/autobot-slm-backend
+        --reload-dir /app/autobot-shared
+        --app-dir /app/autobot-slm-backend
     environment:
       - AUTOBOT_ENVIRONMENT=development
       - AUTOBOT_LOG_LEVEL=DEBUG

--- a/docker/backend/dev-entrypoint.sh
+++ b/docker/backend/dev-entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Dev-mode entrypoint for the backend container (#1985).
+#
+# Problem: bind mounts in docker-compose.override.yml replace directories
+# that contain Dockerfile-created symlinks and pip-installed packages.
+# Specifically:
+#   - ./autobot-backend:/app/autobot-backend  destroys the symlink at
+#     /app/autobot-backend/autobot_shared -> /app/autobot-shared
+#   - ./autobot-shared:/app/autobot-shared    replaces the directory that
+#     pip installed as a package, shadowing the pip copy
+#
+# This script runs before the main command to restore the environment:
+#   1. Recreates symlinks that bind mounts destroyed
+#   2. Re-installs autobot-shared as editable pip package so imports work
+#   3. Exec's the original command (passed as arguments)
+set -e
+
+echo "[dev-entrypoint] Recreating symlinks destroyed by bind mounts..."
+
+# Symlink: /app/autobot_shared -> /app/autobot-shared
+# Used by: PYTHONPATH imports of autobot_shared at /app level
+ln -sf /app/autobot-shared /app/autobot_shared
+
+# Symlink: /app/autobot-backend/autobot_shared -> /app/autobot-shared
+# Used by: relative imports from within autobot-backend/
+ln -sf /app/autobot-shared /app/autobot-backend/autobot_shared
+
+# Symlink: /app/database -> /app/autobot-backend/database
+# Used by: legacy imports that reference database at /app level
+ln -sf /app/autobot-backend/database /app/database
+
+echo "[dev-entrypoint] Re-installing autobot-shared (editable)..."
+
+# The bind mount for autobot-shared replaces the pip-installed copy.
+# Re-install in editable mode so code changes take effect immediately
+# without rebuilding the container.
+pip install -e /app/autobot-shared --quiet 2>/dev/null || true
+
+echo "[dev-entrypoint] Dev environment ready. Starting application..."
+exec "$@"

--- a/docker/slm/dev-entrypoint.sh
+++ b/docker/slm/dev-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Dev-mode entrypoint for the SLM container (#1985).
+#
+# Same bind-mount problem as the backend: host volume mounts destroy
+# Dockerfile-created symlinks and shadow the pip-installed autobot-shared
+# package. This script restores the environment before starting the app.
+#
+# In dev mode this script replaces the production entrypoint.sh which
+# runs database migrations. Migrations still run here first.
+set -e
+
+echo "[dev-entrypoint] Recreating symlinks destroyed by bind mounts..."
+
+# Symlink: /app/autobot_shared -> /app/autobot-shared
+ln -sf /app/autobot-shared /app/autobot_shared
+
+# Symlink: /app/autobot-slm-backend/autobot_shared -> /app/autobot-shared
+ln -sf /app/autobot-shared /app/autobot-slm-backend/autobot_shared
+
+echo "[dev-entrypoint] Re-installing autobot-shared (editable)..."
+pip install -e /app/autobot-shared --quiet 2>/dev/null || true
+
+echo "[dev-entrypoint] Running SLM database migrations..."
+cd /app/autobot-slm-backend
+python3.12 -m migrations.runner || {
+    echo "ERROR: Migration failed -- retrying in 5s..."
+    sleep 5
+    python3.12 -m migrations.runner || {
+        echo "FATAL: Migration failed after retry. Aborting."
+        exit 1
+    }
+}
+echo "[dev-entrypoint] Migrations complete. Starting application..."
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Adds `docker/backend/dev-entrypoint.sh` and `docker/slm/dev-entrypoint.sh` that run before the application to restore the container environment after bind mounts
- Recreates symlinks destroyed by bind mounts (`autobot_shared`, `database`)
- Re-installs `autobot-shared` as editable pip package so import changes reflect immediately
- Updates `docker-compose.override.example.yml` to use the new entrypoints

Closes #1985

## Test plan

- [ ] Run `docker compose -f docker-compose.yml -f docker-compose.override.example.yml up -d`
- [ ] Verify backend container starts without ImportError for autobot_shared
- [ ] Verify SLM container runs migrations and starts
- [ ] Verify code changes in bind-mounted directories are reflected with --reload