### PR TITLE
fix(slm): wire fleet sync concurrent guard into schedule paths (#1979)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -46,6 +46,7 @@ from pydantic import BaseModel
 from services.auth import get_current_user
 from services.code_distributor import get_code_distributor
 from services.database import get_db
+from services.fleet_sync_guard import assert_no_running_sync, fleet_sync_lock
 from services.git_tracker import DEFAULT_BRANCH, DEFAULT_REPO_PATH, get_git_tracker
 from services.playbook_executor import get_playbook_executor
 from services.sync_orchestrator import get_sync_orchestrator
@@ -90,9 +91,8 @@ class FleetSyncJob:
 # In-memory tracking for running asyncio tasks only (not job state)
 _running_tasks: Dict[str, asyncio.Task] = {}
 
-# Serialise the check-and-insert in sync_fleet so two concurrent
-# requests cannot both pass the "no running job" guard (#1730, #1937).
-_fleet_sync_lock = asyncio.Lock()
+# fleet_sync_lock and assert_no_running_sync live in services/fleet_sync_guard.py
+# so schedule_executor.py can also import them without a circular dependency (#1979).
 
 
 async def reconcile_stale_fleet_sync_jobs() -> int:
@@ -127,22 +127,6 @@ async def reconcile_stale_fleet_sync_jobs() -> int:
             await db.commit()
 
     return count
-
-
-async def assert_no_running_sync(db) -> None:
-    """Raise 409 if a fleet sync is already running (#1730).
-
-    Shared guard for sync_fleet, run_schedule, and execute_schedule.
-    Must be called inside ``_fleet_sync_lock`` to prevent TOCTOU races.
-    """
-    running_result = await db.execute(
-        select(FleetSyncJobModel).where(FleetSyncJobModel.status == "running")
-    )
-    if running_result.scalar_one_or_none():
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Fleet sync already in progress",
-        )
 
 
 async def _persist_fleet_sync_job(
@@ -1317,7 +1301,7 @@ async def sync_fleet(
     Supports rolling, immediate, graceful, and manual strategies.
     """
     # Lock covers check-through-persist to prevent TOCTOU race (#1937)
-    async with _fleet_sync_lock:
+    async with fleet_sync_lock:
         await assert_no_running_sync(db)
 
         # Get target nodes
@@ -1851,7 +1835,7 @@ async def run_schedule(
         )
 
     # Guard: prevent overlapping fleet sync jobs (#1979)
-    async with _fleet_sync_lock:
+    async with fleet_sync_lock:
         await assert_no_running_sync(db)
 
         job = _create_fleet_sync_job(nodes, schedule)

--- a/autobot-slm-backend/services/fleet_sync_guard.py
+++ b/autobot-slm-backend/services/fleet_sync_guard.py
@@ -1,0 +1,39 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Fleet sync concurrency guard (Issue #1979).
+
+Provides the shared asyncio lock and guard function used by both the
+API layer (code_sync.py) and the background schedule executor
+(schedule_executor.py) to prevent overlapping fleet sync jobs.
+
+The lock and guard live here — in the services layer — so both callers
+can import them without creating a circular dependency.
+"""
+
+import asyncio
+
+from fastapi import HTTPException, status
+from models.database import FleetSyncJob as FleetSyncJobModel
+from sqlalchemy import select
+
+# Serialise check-and-insert across all fleet sync entry points to prevent
+# TOCTOU races (#1730, #1937, #1979).
+fleet_sync_lock = asyncio.Lock()
+
+
+async def assert_no_running_sync(db) -> None:
+    """Raise 409 if a fleet sync is already running (#1730).
+
+    Shared guard for sync_fleet, run_schedule, and execute_schedule.
+    Must be called while holding ``fleet_sync_lock`` to prevent TOCTOU races.
+    """
+    running_result = await db.execute(
+        select(FleetSyncJobModel).where(FleetSyncJobModel.status == "running")
+    )
+    if running_result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Fleet sync already in progress",
+        )

--- a/autobot-slm-backend/services/schedule_executor.py
+++ b/autobot-slm-backend/services/schedule_executor.py
@@ -15,9 +15,11 @@ from datetime import datetime
 from typing import Optional, Tuple
 
 from croniter import croniter
-from models.database import CodeStatus, FleetSyncJobModel, Node, UpdateSchedule
+from fastapi import HTTPException
+from models.database import CodeStatus, Node, UpdateSchedule
 from services.code_distributor import get_code_distributor
 from services.database import db_service
+from services.fleet_sync_guard import assert_no_running_sync, fleet_sync_lock
 from sqlalchemy import select
 
 logger = logging.getLogger(__name__)
@@ -234,16 +236,18 @@ async def execute_schedule(schedule: UpdateSchedule) -> Tuple[bool, str]:
 
     try:
         async with db_service.session() as db:
-            # Skip if a fleet sync job is already running (#1979)
-            running = await db.execute(
-                select(FleetSyncJobModel).where(FleetSyncJobModel.status == "running")
-            )
-            if running.scalar_one_or_none():
-                logger.info(
-                    "Skipping schedule '%s' — fleet sync already running",
-                    schedule.name,
-                )
-                return False, "Fleet sync already in progress"
+            # Guard: prevent overlapping fleet sync jobs (#1979).
+            # Hold fleet_sync_lock while checking so concurrent API requests and
+            # background schedule firings cannot both pass the guard simultaneously.
+            async with fleet_sync_lock:
+                try:
+                    await assert_no_running_sync(db)
+                except HTTPException:
+                    logger.warning(
+                        "Skipping schedule '%s' — fleet sync already running (#1979)",
+                        schedule.name,
+                    )
+                    return False, "Fleet sync already in progress"
 
             # Determine target nodes based on schedule configuration
             nodes = await _get_target_nodes(db, schedule)


### PR DESCRIPTION
## Summary

- Extracts `assert_no_running_sync` + `fleet_sync_lock` into `services/fleet_sync_guard.py` (shared module)
- Wires the guard into `run_schedule` endpoint (manual schedule trigger) and `execute_schedule` (background executor)
- Removes duplicate inline guard in schedule_executor that lacked lock protection (TOCTOU race)
- Background executor catches 409 and logs warning instead of crashing

Closes #1979

## Test plan

- [ ] Trigger manual fleet sync via `POST /api/code-sync/fleet/sync`
- [ ] While running, trigger schedule via `POST /api/code-sync/schedules/{id}/run` — should get 409
- [ ] Verify background schedule executor skips with warning when sync is in progress