### PR TITLE
feat(search): add query complexity classifier (#1719)

### DIFF
--- a/autobot-backend/knowledge/search_components/query_classifier.py
+++ b/autobot-backend/knowledge/search_components/query_classifier.py
@@ -1,0 +1,177 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Query Complexity Classifier for Dynamic Hybrid Search Weight Selection
+
+Issue #1719: Dynamic per-query hybrid search weight selection.
+Classifies incoming queries into complexity tiers so that hybrid search
+fusion weights can be adapted per query rather than using static globals.
+"""
+
+import logging
+import re
+import threading
+from enum import Enum
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Complexity tier
+# ---------------------------------------------------------------------------
+
+
+class QueryComplexity(Enum):
+    """Complexity tiers used to select hybrid search fusion weights.
+
+    Issue #1719: Maps to weight presets consumed by HybridSearcher.
+    """
+
+    SIMPLE = "simple"
+    MODERATE = "moderate"
+    COMPLEX = "complex"
+    MULTI_HOP = "multi_hop"
+
+
+# ---------------------------------------------------------------------------
+# Pattern tables (compiled once at import time)
+# ---------------------------------------------------------------------------
+
+_MULTI_HOP_PATTERNS: List[re.Pattern] = [
+    re.compile(r"what\s+caused\s+\w+.*that\s+led\s+to", re.IGNORECASE),
+    re.compile(r"trace\s+\w+.*from\s+\w+.*to\s+\w+", re.IGNORECASE),
+    re.compile(r"chain\s+of\s+\w+\s+that", re.IGNORECASE),
+    re.compile(r"sequence\s+of\s+events\s+that\s+caused", re.IGNORECASE),
+    re.compile(r"how\s+did\s+\w+.*lead\s+to\s+\w+", re.IGNORECASE),
+]
+
+_COMPLEX_PATTERNS: List[re.Pattern] = [
+    re.compile(r"\bcompare\b.*\band\b", re.IGNORECASE),
+    re.compile(r"\banalyze\b.*\bacross\b", re.IGNORECASE),
+    re.compile(r"\bpros\s+and\s+cons\b", re.IGNORECASE),
+    re.compile(r"\bsimilarities\s+between\b", re.IGNORECASE),
+    re.compile(r"\bdifferences\s+between\b", re.IGNORECASE),
+    re.compile(r"\bcontrast\b.*\bwith\b", re.IGNORECASE),
+    re.compile(r"\badvantages\s+and\s+disadvantages\b", re.IGNORECASE),
+]
+
+_MODERATE_PATTERNS: List[re.Pattern] = [
+    re.compile(r"\bhow\s+does\s+\w+\s+relate\b", re.IGNORECASE),
+    re.compile(r"\bconnection\s+between\b", re.IGNORECASE),
+    re.compile(r"\bwhy\s+does\b", re.IGNORECASE),
+    re.compile(r"\bwhy\s+did\b", re.IGNORECASE),
+    re.compile(r"\bexplain\s+how\s+\w+\s+works\b", re.IGNORECASE),
+    re.compile(r"\brelationship\s+between\b", re.IGNORECASE),
+    re.compile(r"\bwhat\s+is\s+the\s+impact\s+of\b", re.IGNORECASE),
+]
+
+# Clause-boundary markers for heuristic complexity scoring
+_CLAUSE_BOUNDARY = re.compile(
+    r"[,;]|\b(and|but|or|because|although|whereas|while)\b",
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+class QueryClassifier:
+    """Rule-based query complexity classifier with heuristic fallback.
+
+    Classification order (first match wins):
+    1. MULTI_HOP  — multi-step causal / tracing patterns
+    2. COMPLEX    — comparison / analysis patterns
+    3. MODERATE   — relational / explanatory patterns
+    4. Heuristic  — clause count or word count thresholds
+    5. SIMPLE     — default
+
+    Issue #1719: Enables adaptive hybrid search weight selection.
+    """
+
+    def classify(self, query: str) -> QueryComplexity:
+        """Classify a query string into a QueryComplexity tier.
+
+        Args:
+            query: Raw user query string.
+
+        Returns:
+            QueryComplexity enum value for this query.
+        """
+        if not query or not query.strip():
+            logger.debug("Empty query — defaulting to SIMPLE")
+            return QueryComplexity.SIMPLE
+
+        normalized = query.strip()
+
+        tier = self._match_patterns(normalized)
+        if tier is None:
+            tier = self._heuristic_classify(normalized)
+
+        logger.debug("Query classified as %s: %r", tier.value, query[:80])
+        return tier
+
+    def _match_patterns(self, query: str) -> "QueryComplexity | None":
+        """Apply ordered regex pattern tables. Returns None if no match.
+
+        Issue #1719: Fast path — avoids heuristic cost when pattern hits.
+        """
+        if self._any_match(query, _MULTI_HOP_PATTERNS):
+            return QueryComplexity.MULTI_HOP
+        if self._any_match(query, _COMPLEX_PATTERNS):
+            return QueryComplexity.COMPLEX
+        if self._any_match(query, _MODERATE_PATTERNS):
+            return QueryComplexity.MODERATE
+        return None
+
+    @staticmethod
+    def _any_match(query: str, patterns: List[re.Pattern]) -> bool:
+        """Return True if any compiled pattern matches the query."""
+        return any(p.search(query) for p in patterns)
+
+    def _heuristic_classify(self, query: str) -> QueryComplexity:
+        """Classify by clause count and word count when patterns miss.
+
+        Thresholds (Issue #1719):
+        - clause_count >= 3 OR word_count >= 20  → COMPLEX
+        - clause_count >= 2 OR word_count >= 12  → MODERATE
+        - otherwise                               → SIMPLE
+        """
+        clause_count, word_count = self._query_metrics(query)
+        if clause_count >= 3 or word_count >= 20:
+            return QueryComplexity.COMPLEX
+        if clause_count >= 2 or word_count >= 12:
+            return QueryComplexity.MODERATE
+        return QueryComplexity.SIMPLE
+
+    @staticmethod
+    def _query_metrics(query: str) -> Tuple[int, int]:
+        """Return (clause_count, word_count) for a normalized query string."""
+        word_count = len(query.split())
+        clause_boundaries = _CLAUSE_BOUNDARY.findall(query)
+        # Number of clauses = boundaries + 1
+        clause_count = len(clause_boundaries) + 1
+        return clause_count, word_count
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (thread-safe, mirrors QueryProcessor pattern)
+# ---------------------------------------------------------------------------
+
+_query_classifier: "QueryClassifier | None" = None
+_query_classifier_lock = threading.Lock()
+
+
+def get_query_classifier() -> QueryClassifier:
+    """Return the shared QueryClassifier singleton (thread-safe).
+
+    Uses double-check locking to minimise contention after initialisation.
+    Issue #1719: Mirrors get_query_processor() pattern from query_processor.py.
+    """
+    global _query_classifier
+    if _query_classifier is None:
+        with _query_classifier_lock:
+            if _query_classifier is None:
+                _query_classifier = QueryClassifier()
+    return _query_classifier

--- a/autobot-backend/knowledge/search_components/query_classifier_test.py
+++ b/autobot-backend/knowledge/search_components/query_classifier_test.py
@@ -1,0 +1,147 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for QueryClassifier
+
+Issue #1719: Dynamic per-query hybrid search weight selection.
+Verifies that rule-based patterns and heuristic fallbacks correctly
+classify queries into QueryComplexity tiers.
+"""
+
+import pytest
+from knowledge.search_components.query_classifier import (
+    QueryClassifier,
+    QueryComplexity,
+    get_query_classifier,
+)
+
+
+@pytest.fixture
+def classifier() -> QueryClassifier:
+    """Return a fresh QueryClassifier for each test."""
+    return QueryClassifier()
+
+
+# ---------------------------------------------------------------------------
+# Parametrized classification correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        # SIMPLE — single-concept lookups
+        ("What is Redis?", QueryComplexity.SIMPLE),
+        ("List all tables", QueryComplexity.SIMPLE),
+        ("GAN architecture", QueryComplexity.SIMPLE),
+        ("error 0x80070005", QueryComplexity.SIMPLE),
+        # MODERATE — relational / explanatory
+        ("How does Redis relate to ChromaDB?", QueryComplexity.MODERATE),
+        ("Explain how authentication works", QueryComplexity.MODERATE),
+        ("Why does the service crash?", QueryComplexity.MODERATE),
+        (
+            "What is the connection between LangChain and LlamaIndex?",
+            QueryComplexity.MODERATE,
+        ),
+        ("Why did the deployment fail?", QueryComplexity.MODERATE),
+        # COMPLEX — comparative / analytical
+        (
+            "Compare Redis and Postgres and explain their trade-offs",
+            QueryComplexity.COMPLEX,
+        ),
+        ("Pros and cons of using Docker Swarm", QueryComplexity.COMPLEX),
+        (
+            "Analyze performance differences across all worker nodes",
+            QueryComplexity.COMPLEX,
+        ),
+        ("Similarities between BERT and GPT architectures", QueryComplexity.COMPLEX),
+        # MULTI_HOP — causal chains
+        (
+            "What caused the memory leak that led to the service outage?",
+            QueryComplexity.MULTI_HOP,
+        ),
+        (
+            "Trace the request from the frontend to the database",
+            QueryComplexity.MULTI_HOP,
+        ),
+        (
+            "Describe the chain of events that caused the data loss",
+            QueryComplexity.MULTI_HOP,
+        ),
+    ],
+)
+def test_classify_parametrized(
+    classifier: QueryClassifier, query: str, expected: QueryComplexity
+) -> None:
+    """Each query maps to the expected complexity tier."""
+    result = classifier.classify(query)
+    assert result == expected, f"Query {query!r}: expected {expected}, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_query_defaults_simple(classifier: QueryClassifier) -> None:
+    """Empty string should default to SIMPLE without raising."""
+    assert classifier.classify("") == QueryComplexity.SIMPLE
+
+
+def test_whitespace_only_query_defaults_simple(classifier: QueryClassifier) -> None:
+    """Whitespace-only string should default to SIMPLE without raising."""
+    assert classifier.classify("   ") == QueryComplexity.SIMPLE
+
+
+def test_returns_enum_type(classifier: QueryClassifier) -> None:
+    """classify() must always return a QueryComplexity instance."""
+    result = classifier.classify("What is a vector database?")
+    assert isinstance(result, QueryComplexity)
+
+
+# ---------------------------------------------------------------------------
+# Heuristic fallback
+# ---------------------------------------------------------------------------
+
+
+def test_long_query_heuristic_complex(classifier: QueryClassifier) -> None:
+    """A long multi-clause query with no matching patterns classifies COMPLEX."""
+    # 21 words, 3 clause boundaries (commas) — no pattern match
+    long_query = (
+        "first item, second item, third item, fourth item fifth sixth seventh "
+        "eighth ninth tenth eleventh twelfth thirteenth fourteenth fifteenth"
+    )
+    result = classifier.classify(long_query)
+    assert result == QueryComplexity.COMPLEX
+
+
+def test_medium_query_heuristic_moderate(classifier: QueryClassifier) -> None:
+    """A medium-length query with one clause boundary classifies MODERATE."""
+    # 13 words, 1 clause boundary — no pattern match
+    medium_query = "the quick brown fox jumps over, the lazy dog in the field"
+    result = classifier.classify(medium_query)
+    assert result == QueryComplexity.MODERATE
+
+
+def test_short_query_heuristic_simple(classifier: QueryClassifier) -> None:
+    """A short single-clause query with no patterns classifies SIMPLE."""
+    result = classifier.classify("quick brown fox")
+    assert result == QueryComplexity.SIMPLE
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+
+def test_get_query_classifier_singleton() -> None:
+    """get_query_classifier() returns the same instance on repeated calls."""
+    a = get_query_classifier()
+    b = get_query_classifier()
+    assert a is b
+
+
+def test_get_query_classifier_returns_correct_type() -> None:
+    """get_query_classifier() returns a QueryClassifier."""
+    assert isinstance(get_query_classifier(), QueryClassifier)


### PR DESCRIPTION
## Summary
- Add `QueryComplexity` enum (SIMPLE, MODERATE, COMPLEX, MULTI_HOP)
- Add `QueryClassifier` with rule-based + heuristic classification
- Enables adaptive retrieval strategy per query type
- Part of Neural Mesh RAG (#1994)

Closes #1719

## Test plan
- [x] 24 parametrized classification tests passing
- [x] Empty/whitespace queries default to SIMPLE
- [x] Long multi-clause queries classify correctly
- [x] Singleton accessor works
- [x] flake8 clean