### PR TITLE
feat(search): add context tracker for multi-step retrieval (#2005)

### DIFF
--- a/autobot-backend/knowledge/search_components/context_tracker.py
+++ b/autobot-backend/knowledge/search_components/context_tracker.py
@@ -1,0 +1,36 @@
+"""Per-query context tracker preventing redundant chunk reads (#1994, #2005)."""
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ContextTracker:
+    """Tracks which chunks have been seen in a query session."""
+
+    def __init__(self, query_session_id: str, token_budget: int = 4096):
+        self.query_session_id = query_session_id
+        self.token_budget = token_budget
+        self._seen_chunk_ids: set[str] = set()
+        self._tokens_used: int = 0
+
+    @property
+    def tokens_remaining(self) -> int:
+        return max(0, self.token_budget - self._tokens_used)
+
+    def filter_unseen(self, chunks: list[dict]) -> list[dict]:
+        """Return only chunks not yet seen in this session."""
+        return [c for c in chunks if c.get("chunk_id") not in self._seen_chunk_ids]
+
+    def record(self, chunk_ids: list[str], tokens: int) -> None:
+        """Mark chunks as seen and update token budget."""
+        self._seen_chunk_ids.update(chunk_ids)
+        self._tokens_used += tokens
+
+    def summary(self) -> dict:
+        """Return session summary for logging/debugging."""
+        return {
+            "session_id": self.query_session_id,
+            "chunks_seen": len(self._seen_chunk_ids),
+            "tokens_used": self._tokens_used,
+            "tokens_remaining": self.tokens_remaining,
+        }

--- a/autobot-backend/knowledge/search_components/context_tracker_test.py
+++ b/autobot-backend/knowledge/search_components/context_tracker_test.py
@@ -1,0 +1,47 @@
+"""Tests for ContextTracker (#2005)."""
+from knowledge.search_components.context_tracker import ContextTracker
+
+
+def make_chunks(chunk_ids: list[str]) -> list[dict]:
+    return [{"chunk_id": cid, "text": f"text_{cid}"} for cid in chunk_ids]
+
+
+def test_filter_returns_all_first_call():
+    tracker = ContextTracker(query_session_id="session-1")
+    chunks = make_chunks(["a", "b", "c"])
+    result = tracker.filter_unseen(chunks)
+    assert result == chunks
+
+
+def test_filter_removes_seen_chunks():
+    tracker = ContextTracker(query_session_id="session-2")
+    chunks = make_chunks(["a", "b", "c"])
+    tracker.record(["a", "b"], tokens=100)
+    result = tracker.filter_unseen(chunks)
+    assert len(result) == 1
+    assert result[0]["chunk_id"] == "c"
+
+
+def test_token_budget_tracking():
+    tracker = ContextTracker(query_session_id="session-3", token_budget=500)
+    assert tracker.tokens_remaining == 500
+    tracker.record(["x"], tokens=200)
+    assert tracker.tokens_remaining == 300
+    tracker.record(["y"], tokens=400)
+    assert tracker.tokens_remaining == 0
+
+
+def test_summary_returns_stats():
+    tracker = ContextTracker(query_session_id="session-4", token_budget=1000)
+    tracker.record(["a", "b"], tokens=150)
+    summary = tracker.summary()
+    assert summary["session_id"] == "session-4"
+    assert summary["chunks_seen"] == 2
+    assert summary["tokens_used"] == 150
+    assert summary["tokens_remaining"] == 850
+
+
+def test_empty_chunks_list():
+    tracker = ContextTracker(query_session_id="session-5")
+    result = tracker.filter_unseen([])
+    assert result == []


### PR DESCRIPTION
## Summary
- Add `ContextTracker` class for per-query-session chunk dedup
- `filter_unseen()` returns only unread chunks
- Token budget tracking with `tokens_remaining`
- Part of Neural Mesh RAG (#1994)

Closes #2005

## Test plan
- [x] 5/5 tests passing
- [x] First call returns all chunks
- [x] Seen chunks filtered on subsequent calls
- [x] Token budget tracked correctly
- [x] flake8 clean