### PR TITLE
feat(search): configurable reranker blend weights (#2004)

### DIFF
--- a/autobot-backend/knowledge/search_components/reranking.py
+++ b/autobot-backend/knowledge/search_components/reranking.py
@@ -6,15 +6,96 @@ Result Reranking Module
 
 Issue #381: Extracted from search.py god class refactoring.
 Contains cross-encoder reranking functionality.
+Issue #2004: Configurable blend weights (RerankWeights, compute_blended_score,
+recency_score) replace the hardcoded 0.8/0.2 split.
 """
 
 import asyncio
 import logging
 import math
 import threading
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RerankWeights:
+    """Blend weights for multi-factor reranker scoring.
+
+    Issue #2004: Replaces the hardcoded 0.8 * reranker + 0.2 * vector split.
+    Weights do not need to sum to 1.0; compute_blended_score normalises them.
+
+    Attributes:
+        reranker: Weight for the cross-encoder reranker score.
+        vector:   Weight for the original vector-similarity score.
+        edge:     Weight for graph edge strength (Neural Mesh phase 3+).
+        recency:  Weight for time-based recency score (Neural Mesh phase 3+).
+    """
+
+    reranker: float = 0.8
+    vector: float = 0.2
+    edge: float = 0.0
+    recency: float = 0.0
+
+
+def recency_score(days_since_access: float) -> float:
+    """Return a 0-1 recency score that decays with age.
+
+    Issue #2004: Used by compute_blended_score when RerankWeights.recency > 0.
+
+    Args:
+        days_since_access: Number of days since the document was last accessed.
+
+    Returns:
+        1.0 for a document accessed today, approaching 0 for very old ones.
+        Formula: 1 / (1 + days_since_access).
+    """
+    return 1.0 / (1.0 + days_since_access)
+
+
+def compute_blended_score(
+    reranker_score: float,
+    vector_score: float,
+    edge_weight: float = 0.0,
+    recency_score_value: float = 0.0,
+    weights: Optional[RerankWeights] = None,
+) -> float:
+    """Compute a weighted blend of reranker, vector, edge, and recency scores.
+
+    Issue #2004: Replaces the hardcoded 0.8 * reranker + 0.2 * original
+    expression in _apply_rerank_scores().
+
+    Weights are normalised so that callers do not need to ensure they sum
+    to exactly 1.0.  If the total weight is 0 the function falls back to
+    the plain reranker score.
+
+    Args:
+        reranker_score:      Sigmoid-normalised cross-encoder score (0-1).
+        vector_score:        Original vector-similarity score (0-1).
+        edge_weight:         Graph edge strength contribution (0-1).
+        recency_score_value: Time-based recency score (0-1).
+        weights:             RerankWeights instance; defaults to RerankWeights().
+
+    Returns:
+        Blended score in the same 0-1 range.
+    """
+    if weights is None:
+        weights = RerankWeights()
+
+    total_weight = weights.reranker + weights.vector + weights.edge + weights.recency
+    if total_weight == 0.0:
+        logger.warning("All RerankWeights are zero; returning raw reranker score")
+        return reranker_score
+
+    blended = (
+        weights.reranker * reranker_score
+        + weights.vector * vector_score
+        + weights.edge * edge_weight
+        + weights.recency * recency_score_value
+    )
+    return blended / total_weight
 
 
 class ResultReranker:
@@ -40,39 +121,58 @@ class ResultReranker:
             self._cross_encoder = await asyncio.to_thread(get_cross_encoder)
         return self._cross_encoder
 
-    def _apply_rerank_scores(self, results: List[Dict[str, Any]], scores: list) -> None:
+    def _apply_rerank_scores(
+        self,
+        results: List[Dict[str, Any]],
+        scores: list,
+        weights: Optional[RerankWeights] = None,
+    ) -> None:
         """Apply rerank scores to results.
 
         Issue #281: Extracted helper.
         Issue #1533: Normalize raw cross-encoder logits with sigmoid
         so rerank_score stays in 0-1 range. Combine with original
         similarity score instead of overwriting it.
+        Issue #2004: Blend is now driven by compute_blended_score() so
+        caller-supplied weights replace the former hardcoded 0.8/0.2 split.
         """
+        effective_weights = weights if weights is not None else RerankWeights()
         for i, result in enumerate(results):
             # Sigmoid: raw logits → 0-1 probability
             normalized = 1.0 / (1.0 + math.exp(-float(scores[i])))
             original_score = result.get("score", 0)
             result["original_score"] = original_score
-            result["rerank_score"] = normalized * 0.8 + original_score * 0.2
+            result["rerank_score"] = compute_blended_score(
+                reranker_score=normalized,
+                vector_score=original_score,
+                weights=effective_weights,
+            )
         results.sort(key=lambda x: x.get("rerank_score", 0), reverse=True)
         for result in results:
             result["score"] = result.get("rerank_score", 0)
 
     async def rerank(
-        self, query: str, results: List[Dict[str, Any]], top_k: Optional[int] = None
+        self,
+        query: str,
+        results: List[Dict[str, Any]],
+        top_k: Optional[int] = None,
+        weights: Optional[RerankWeights] = None,
     ) -> List[Dict[str, Any]]:
         """
         Rerank results using cross-encoder for improved relevance.
 
         Issue #281 refactor.
+        Issue #2004: Optional weights parameter forwards blend configuration
+        to _apply_rerank_scores(); defaults to RerankWeights() (0.8/0.2).
 
         Args:
-            query: Search query
-            results: Search results to rerank
-            top_k: Optional limit on returned results
+            query:   Search query.
+            results: Search results to rerank.
+            top_k:   Optional limit on returned results.
+            weights: Optional RerankWeights for multi-factor blending.
 
         Returns:
-            Reranked results list
+            Reranked results list.
         """
         try:
             try:
@@ -87,7 +187,7 @@ class ResultReranker:
             cross_encoder = await self._ensure_cross_encoder()
             pairs = [(query, r.get("content", "")) for r in results]
             scores = await asyncio.to_thread(cross_encoder.predict, pairs)
-            self._apply_rerank_scores(results, scores)
+            self._apply_rerank_scores(results, scores, weights=weights)
 
             return results[:top_k] if top_k else results
 

--- a/autobot-backend/knowledge/search_components/reranking_blend_test.py
+++ b/autobot-backend/knowledge/search_components/reranking_blend_test.py
@@ -1,0 +1,111 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for configurable reranker blend weights.
+
+Issue #2004: Verifies RerankWeights, compute_blended_score, and recency_score.
+"""
+
+from knowledge.search_components.reranking import (
+    RerankWeights,
+    compute_blended_score,
+    recency_score,
+)
+
+
+class TestDefaultWeightsMatchLegacy:
+    """Default RerankWeights reproduce the old hardcoded 0.8/0.2 blend."""
+
+    def test_default_weights_match_legacy(self):
+        """compute_blended_score with defaults equals 0.8*reranker + 0.2*vector."""
+        reranker = 0.9
+        vector = 0.5
+        expected = 0.8 * reranker + 0.2 * vector
+        result = compute_blended_score(reranker_score=reranker, vector_score=vector)
+        assert abs(result - expected) < 1e-9
+
+    def test_default_weights_dataclass(self):
+        """RerankWeights() defaults are 0.8/0.2/0.0/0.0."""
+        w = RerankWeights()
+        assert w.reranker == 0.8
+        assert w.vector == 0.2
+        assert w.edge == 0.0
+        assert w.recency == 0.0
+
+    def test_explicit_default_weights_equal_no_weights(self):
+        """Passing RerankWeights() explicitly produces the same result as no weights."""
+        reranker, vector = 0.7, 0.3
+        assert compute_blended_score(reranker, vector) == compute_blended_score(
+            reranker, vector, weights=RerankWeights()
+        )
+
+
+class TestCustomBlend:
+    """Custom weight configurations produce the correct weighted sum."""
+
+    def test_reranker_only_weights(self):
+        """All weight on reranker returns reranker score unchanged."""
+        w = RerankWeights(reranker=1.0, vector=0.0)
+        result = compute_blended_score(0.75, 0.25, weights=w)
+        assert abs(result - 0.75) < 1e-9
+
+    def test_vector_only_weights(self):
+        """All weight on vector returns vector score unchanged."""
+        w = RerankWeights(reranker=0.0, vector=1.0)
+        result = compute_blended_score(0.75, 0.25, weights=w)
+        assert abs(result - 0.25) < 1e-9
+
+    def test_equal_four_factor_blend(self):
+        """Equal weights across all four factors produce simple average."""
+        w = RerankWeights(reranker=1.0, vector=1.0, edge=1.0, recency=1.0)
+        result = compute_blended_score(
+            reranker_score=0.8,
+            vector_score=0.4,
+            edge_weight=0.6,
+            recency_score_value=0.2,
+            weights=w,
+        )
+        expected = (0.8 + 0.4 + 0.6 + 0.2) / 4.0
+        assert abs(result - expected) < 1e-9
+
+    def test_unnormalised_weights_are_normalised(self):
+        """Weights that do not sum to 1 are normalised inside the function."""
+        w = RerankWeights(reranker=4.0, vector=1.0)
+        result = compute_blended_score(1.0, 0.0, weights=w)
+        # After normalisation: 4/5 * 1.0 + 1/5 * 0.0 = 0.8
+        assert abs(result - 0.8) < 1e-9
+
+    def test_custom_three_factor_blend(self):
+        """Three-factor blend matches manual calculation."""
+        w = RerankWeights(reranker=0.5, vector=0.3, edge=0.2)
+        reranker, vector, edge = 0.9, 0.6, 0.4
+        expected = 0.5 * reranker + 0.3 * vector + 0.2 * edge
+        result = compute_blended_score(reranker, vector, edge_weight=edge, weights=w)
+        assert abs(result - expected) < 1e-9
+
+
+class TestRecencyScore:
+    """recency_score() returns the correct decay value."""
+
+    def test_zero_days(self):
+        """A document accessed today has recency score 1.0."""
+        assert recency_score(0.0) == 1.0
+
+    def test_one_day(self):
+        """A document accessed one day ago has recency score 0.5."""
+        assert abs(recency_score(1.0) - 0.5) < 1e-9
+
+    def test_nine_days(self):
+        """A document accessed nine days ago has recency score 0.1."""
+        assert abs(recency_score(9.0) - 0.1) < 1e-9
+
+    def test_monotone_decreasing(self):
+        """Recency score strictly decreases as days_since_access increases."""
+        scores = [recency_score(float(d)) for d in range(10)]
+        for a, b in zip(scores, scores[1:]):
+            assert a > b
+
+    def test_always_positive(self):
+        """Recency score is always positive, even for very large values."""
+        assert recency_score(1_000_000.0) > 0.0

--- a/autobot-backend/services/rag_config.py
+++ b/autobot-backend/services/rag_config.py
@@ -9,10 +9,11 @@ Loads configuration from config/complete.yaml under knowledge.rag section.
 All reranking parameters are configurable without code changes.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 from constants.model_constants import model_config
+from knowledge.search_components.reranking import RerankWeights
 from type_defs.common import Metadata
 
 from autobot_shared.logging_manager import get_llm_logger
@@ -44,6 +45,8 @@ class RAGConfig:
     # Reranking
     enable_reranking: bool = True
     reranking_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    # Issue #2004: Configurable blend weights; defaults preserve legacy 0.8/0.2 behaviour.
+    rerank_weights: RerankWeights = field(default_factory=RerankWeights)
 
     # Performance (from model_config)
     cache_ttl_seconds: int = model_config.DEFAULT_CACHE_TTL
@@ -111,6 +114,9 @@ class RAGConfig:
         """
         Create RAGConfig from dictionary.
 
+        Issue #2004: Deserialises the nested ``rerank_weights`` sub-dict into
+        a RerankWeights dataclass so callers can pass plain YAML structures.
+
         Args:
             config_dict: Configuration dictionary from YAML
 
@@ -118,8 +124,14 @@ class RAGConfig:
             RAGConfig instance
         """
         # Extract only known fields
-        known_fields = {field.name for field in cls.__dataclass_fields__.values()}
+        known_fields = {f.name for f in cls.__dataclass_fields__.values()}
         filtered_config = {k: v for k, v in config_dict.items() if k in known_fields}
+
+        # Deserialise nested RerankWeights when the value is a plain dict.
+        if isinstance(filtered_config.get("rerank_weights"), dict):
+            filtered_config["rerank_weights"] = RerankWeights(
+                **filtered_config["rerank_weights"]
+            )
 
         return cls(**filtered_config)
 
@@ -140,6 +152,13 @@ class RAGConfig:
             "max_context_length": self.max_context_length,
             "enable_reranking": self.enable_reranking,
             "reranking_model": self.reranking_model,
+            # Issue #2004: serialise as a plain dict for YAML round-trips.
+            "rerank_weights": {
+                "reranker": self.rerank_weights.reranker,
+                "vector": self.rerank_weights.vector,
+                "edge": self.rerank_weights.edge,
+                "recency": self.rerank_weights.recency,
+            },
             "cache_ttl_seconds": self.cache_ttl_seconds,
             "timeout_seconds": self.timeout_seconds,
             "enable_advanced_rag": self.enable_advanced_rag,


### PR DESCRIPTION
## Summary
- Add `RerankWeights` dataclass (reranker, vector, edge, recency)
- Add `compute_blended_score()` with weight normalization
- Add `recency_score()` decay helper
- Replace hardcoded 80/20 in `ResultReranker.rerank()`
- Add `rerank_weights` to `RAGConfig` with serialization
- Part of Neural Mesh RAG (#1994)

Closes #2004

## Test plan
- [x] 13/13 tests passing
- [x] Default weights match legacy behavior
- [x] Custom multi-factor blend works
- [x] Weight normalization for unnormalized inputs
- [x] Recency score monotone decreasing
- [x] flake8 clean