### PR TITLE
feat(search): upgrade keyword search to BM25 scoring (#1720)

### DIFF
--- a/autobot-backend/knowledge/search_components/__init__.py
+++ b/autobot-backend/knowledge/search_components/__init__.py
@@ -19,6 +19,7 @@ Note: Package is named search_components to avoid conflict with search.py.
 """
 
 from .analytics import SearchAnalytics, get_analytics
+from .bm25 import BM25Scorer
 from .helpers import (
     build_search_result,
     decode_redis_hash,
@@ -33,6 +34,8 @@ from .response_builder import ResponseBuilder, get_response_builder
 from .tag_filter import TagFilter
 
 __all__ = [
+    # BM25 scoring (#1720)
+    "BM25Scorer",
     # Helper functions
     "decode_redis_hash",
     "matches_category",

--- a/autobot-backend/knowledge/search_components/bm25.py
+++ b/autobot-backend/knowledge/search_components/bm25.py
@@ -1,0 +1,93 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+BM25 Scorer Module
+
+Issue #1720: Upgrade keyword search from TF-only to BM25 Okapi scoring.
+Provides IDF with Laplace smoothing and document length normalization.
+"""
+
+import logging
+import math
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class BM25Scorer:
+    """
+    BM25 Okapi scorer with IDF smoothing and length normalization.
+
+    Replaces the TF-only `score_fact_by_terms()` helper with proper
+    BM25 scoring:
+    - IDF: log((N - df + 0.5) / (df + 0.5) + 1.0)  — Laplace-smoothed
+    - TF saturation: tf * (k1 + 1) / (tf + k1 * (1 - b + b * dl / avgdl))
+
+    Args:
+        total_docs:      Total number of documents in the corpus (N).
+        avg_doc_length:  Average document length in tokens (avgdl).
+        doc_frequencies: Mapping of term → number of docs containing it (df).
+        k1:              Term frequency saturation parameter (default 1.2).
+        b:               Length normalization parameter (default 0.75).
+    """
+
+    def __init__(
+        self,
+        total_docs: int,
+        avg_doc_length: float,
+        doc_frequencies: Dict[str, int],
+        k1: float = 1.2,
+        b: float = 0.75,
+    ) -> None:
+        """Initialize BM25Scorer with corpus statistics and tuning parameters."""
+        self.total_docs = max(total_docs, 1)
+        self.avg_doc_length = max(avg_doc_length, 1.0)
+        self.doc_frequencies = doc_frequencies
+        self.k1 = k1
+        self.b = b
+
+    def idf(self, term: str) -> float:
+        """
+        Compute IDF for a term using Laplace smoothing (#1720).
+
+        Returns log((N - df + 0.5) / (df + 0.5) + 1.0) so unknown terms
+        still receive a positive score rather than zero or negative IDF.
+        """
+        df = self.doc_frequencies.get(term, 0)
+        n = self.total_docs
+        return math.log((n - df + 0.5) / (df + 0.5) + 1.0)
+
+    def _tf_normalized(self, term: str, doc_text: str, doc_length: int) -> float:
+        """
+        Compute BM25 TF component with length normalization (#1720).
+
+        Uses exact token count via split() for consistency with
+        corpus stat computation in KeywordSearcher.
+        """
+        tokens = doc_text.lower().split()
+        tf = tokens.count(term.lower())
+        if tf == 0:
+            return 0.0
+        dl = max(doc_length, 1)
+        denom = tf + self.k1 * (1.0 - self.b + self.b * dl / self.avg_doc_length)
+        return (tf * (self.k1 + 1.0)) / denom
+
+    def score(self, query_terms: List[str], doc_text: str, doc_length: int) -> float:
+        """
+        Compute BM25 Okapi score for a document given a list of query terms.
+
+        Args:
+            query_terms: Tokenised query terms (lower-case expected).
+            doc_text:    Full document text for in-document TF counting.
+            doc_length:  Pre-computed document length (token count).
+
+        Returns:
+            Non-negative BM25 score; higher means more relevant.
+        """
+        total = 0.0
+        for term in query_terms:
+            tf_norm = self._tf_normalized(term, doc_text, doc_length)
+            if tf_norm > 0.0:
+                total += self.idf(term) * tf_norm
+        return total

--- a/autobot-backend/knowledge/search_components/bm25_test.py
+++ b/autobot-backend/knowledge/search_components/bm25_test.py
@@ -1,0 +1,87 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for BM25Scorer — Issue #1720.
+
+Verifies IDF smoothing, length normalization, unknown-term handling,
+and configurable k1/b parameters.
+"""
+
+import pytest
+from knowledge.search_components.bm25 import BM25Scorer
+
+
+class TestBM25Scorer:
+    """Unit tests for BM25Scorer (#1720)."""
+
+    def test_rare_terms_score_higher(self):
+        """Rare terms (low df) must score higher than common terms for identical TF."""
+        scorer = BM25Scorer(
+            total_docs=100,
+            avg_doc_length=50.0,
+            doc_frequencies={"python": 10, "banana": 1},
+        )
+        score_rare = scorer.score(["banana"], "banana fruit", 2)
+        score_common = scorer.score(["python"], "python lang", 2)
+        assert (
+            score_rare > score_common
+        ), f"Expected rare term score {score_rare:.4f} > common term score {score_common:.4f}"
+
+    def test_shorter_docs_score_higher(self):
+        """Same TF in a shorter document must yield a higher score than in a longer one."""
+        scorer = BM25Scorer(
+            total_docs=100,
+            avg_doc_length=50.0,
+            doc_frequencies={"x": 10},
+        )
+        short_doc = "x y"
+        long_doc = "x " + "w " * 100
+
+        score_short = scorer.score(["x"], short_doc, 2)
+        score_long = scorer.score(["x"], long_doc, 101)
+        assert (
+            score_short > score_long
+        ), f"Expected short doc score {score_short:.4f} > long doc score {score_long:.4f}"
+
+    def test_unknown_terms_smoothed(self):
+        """Terms absent from doc_frequencies must still receive a positive BM25 score."""
+        scorer = BM25Scorer(
+            total_docs=100,
+            avg_doc_length=50.0,
+            doc_frequencies={},
+        )
+        score = scorer.score(["unknown"], "unknown term", 2)
+        assert score > 0, f"Expected positive score for unknown term, got {score}"
+
+    @pytest.mark.parametrize("k1,b", [(1.2, 0.75), (0.5, 0.3)])
+    def test_configurable_parameters(self, k1, b):
+        """Scorer must return a positive score for any valid k1/b combination."""
+        scorer = BM25Scorer(
+            total_docs=10,
+            avg_doc_length=20.0,
+            doc_frequencies={"t": 5},
+            k1=k1,
+            b=b,
+        )
+        score = scorer.score(["t"], "t doc", 2)
+        assert score > 0, f"Expected positive score with k1={k1}, b={b}, got {score}"
+
+    def test_no_matching_terms_returns_zero(self):
+        """Query terms absent from document must yield a score of exactly 0."""
+        scorer = BM25Scorer(
+            total_docs=50,
+            avg_doc_length=30.0,
+            doc_frequencies={"redis": 5},
+        )
+        score = scorer.score(["redis"], "completely unrelated content", 3)
+        assert score == 0.0, f"Expected 0 for no token match, got {score}"
+
+    def test_idf_increases_as_df_decreases(self):
+        """IDF value must increase as document frequency decreases."""
+        scorer_common = BM25Scorer(100, 50.0, {"term": 80})
+        scorer_rare = BM25Scorer(100, 50.0, {"term": 2})
+        assert scorer_rare.idf("term") > scorer_common.idf("term"), (
+            f"Expected rare idf {scorer_rare.idf('term'):.4f} "
+            f"> common idf {scorer_common.idf('term'):.4f}"
+        )

--- a/autobot-backend/knowledge/search_components/keyword_search.py
+++ b/autobot-backend/knowledge/search_components/keyword_search.py
@@ -5,41 +5,156 @@
 Keyword Search Module
 
 Issue #381: Extracted from search.py god class refactoring.
+Issue #1720: Upgraded keyword scoring to BM25 Okapi (IDF + length normalization).
 Contains keyword-based search functionality using Redis.
 """
 
+import json
 import logging
 from typing import Any, Dict, List, Optional, Set
 
-from .helpers import (
-    build_search_result,
-    decode_redis_hash,
-    matches_category,
-    score_fact_by_terms,
-)
+from .bm25 import BM25Scorer
+from .helpers import build_search_result, decode_redis_hash, matches_category
 
 logger = logging.getLogger(__name__)
+
+_CORPUS_STATS_KEY = "bm25:corpus_stats"
+_DEFAULT_TOTAL_DOCS = 1
+_DEFAULT_AVG_LENGTH = 50.0
 
 
 class KeywordSearcher:
     """
-    Performs keyword-based search using Redis.
+    Performs keyword-based search using Redis with BM25 Okapi scoring.
 
     Features:
-    - Term matching against fact content
+    - BM25 scoring: IDF + TF saturation + document length normalization (#1720)
     - Category filtering
     - Batch processing with Redis pipelines
     - Efficient cursor-based scanning
+    - Corpus statistics cached at Redis key ``bm25:corpus_stats``
     """
 
     def __init__(self, redis_client=None):
         """Initialize keyword searcher with Redis client."""
         self.redis_client = redis_client
+        self._bm25: Optional[BM25Scorer] = None
+
+    # ------------------------------------------------------------------
+    # Corpus statistics
+    # ------------------------------------------------------------------
+
+    async def _load_corpus_stats(self) -> BM25Scorer:
+        """
+        Load BM25 corpus statistics from Redis and return a scorer (#1720).
+
+        Falls back to default stats when the key is absent so the searcher
+        degrades gracefully before the first recompute_corpus_stats() call.
+        """
+        try:
+            raw = await self.redis_client.get(_CORPUS_STATS_KEY)
+            if raw:
+                stats = json.loads(raw)
+                return BM25Scorer(
+                    total_docs=stats.get("total_docs", _DEFAULT_TOTAL_DOCS),
+                    avg_doc_length=stats.get("avg_doc_length", _DEFAULT_AVG_LENGTH),
+                    doc_frequencies=stats.get("doc_frequencies", {}),
+                )
+        except Exception as exc:
+            logger.warning("Failed to load BM25 corpus stats: %s", exc)
+        return BM25Scorer(_DEFAULT_TOTAL_DOCS, _DEFAULT_AVG_LENGTH, {})
+
+    async def _get_bm25(self) -> BM25Scorer:
+        """Return cached BM25Scorer, loading from Redis on first call (#1720)."""
+        if self._bm25 is None:
+            self._bm25 = await self._load_corpus_stats()
+        return self._bm25
+
+    def _invalidate_bm25_cache(self) -> None:
+        """Discard cached BM25Scorer so the next search reloads from Redis."""
+        self._bm25 = None
+
+    async def recompute_corpus_stats(self) -> None:
+        """
+        Scan all ``fact:*`` keys and persist BM25 corpus stats to Redis (#1720).
+
+        Call this after facts are added or removed so IDF values stay current.
+        Stats are stored as JSON at ``bm25:corpus_stats``.
+        """
+        if not self.redis_client:
+            return
+        try:
+            total_docs = 0
+            total_length = 0
+            doc_freq: Dict[str, int] = {}
+
+            cursor = b"0"
+            while True:
+                cursor, keys = await self.redis_client.scan(
+                    cursor=cursor, match="fact:*", count=100
+                )
+                if keys:
+                    pipeline = self.redis_client.pipeline()
+                    for key in keys:
+                        pipeline.hgetall(key)
+                    facts_data = await pipeline.execute()
+
+                    for fact_data in facts_data:
+                        if not fact_data:
+                            continue
+                        content = fact_data.get(b"content", b"") or fact_data.get(
+                            "content", ""
+                        )
+                        if isinstance(content, bytes):
+                            content = content.decode("utf-8", errors="replace")
+                        tokens = content.lower().split()
+                        total_docs += 1
+                        total_length += len(tokens)
+                        for term in set(tokens):
+                            doc_freq[term] = doc_freq.get(term, 0) + 1
+
+                if cursor == b"0":
+                    break
+
+            avg_len = float(total_length) / max(total_docs, 1)
+            stats = {
+                "total_docs": total_docs,
+                "avg_doc_length": avg_len,
+                "doc_frequencies": doc_freq,
+            }
+            await self.redis_client.set(
+                _CORPUS_STATS_KEY, json.dumps(stats, ensure_ascii=False)
+            )
+            self._invalidate_bm25_cache()
+            logger.info(
+                "BM25 corpus stats recomputed: %d docs, avg_len=%.1f, vocab=%d",
+                total_docs,
+                avg_len,
+                len(doc_freq),
+            )
+        except Exception as exc:
+            logger.error("Failed to recompute BM25 corpus stats: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Batch processing
+    # ------------------------------------------------------------------
+
+    def _doc_length(self, decoded: Dict[str, str]) -> int:
+        """Return token count for a decoded fact's content field."""
+        return len(decoded.get("content", "").split())
 
     async def process_keyword_batch(
-        self, keys: list, query_terms: Set[str], category: Optional[str]
+        self,
+        keys: list,
+        query_terms: Set[str],
+        category: Optional[str],
+        bm25: BM25Scorer,
     ) -> List[Dict[str, Any]]:
-        """Process a batch of Redis keys for keyword search. Issue #281: Extracted helper."""
+        """
+        Process a batch of Redis keys for BM25 keyword search (#1720).
+
+        Issue #281: Extracted helper. Replaces TF-only score_fact_by_terms().
+        """
         results = []
         pipeline = self.redis_client.pipeline()
         for key in keys:
@@ -52,15 +167,23 @@ class KeywordSearcher:
             decoded = decode_redis_hash(fact_data)
             if not matches_category(decoded, category):
                 continue
-            score = score_fact_by_terms(decoded, query_terms)
+            score = bm25.score(
+                list(query_terms),
+                decoded.get("content", ""),
+                self._doc_length(decoded),
+            )
             if score > 0:
                 results.append(build_search_result(decoded, key, score))
         return results
 
+    # ------------------------------------------------------------------
+    # Search entry point
+    # ------------------------------------------------------------------
+
     async def search(
         self, query: str, limit: int, category: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        """Perform keyword-based search using Redis (Issue #281 refactor)."""
+        """Perform BM25 keyword search using Redis (Issue #1720 upgrade)."""
         try:
             if not self.redis_client:
                 return []
@@ -69,6 +192,7 @@ class KeywordSearcher:
             if not query_terms:
                 return []
 
+            bm25 = await self._get_bm25()
             results: List[Dict[str, Any]] = []
             cursor = b"0"
             scanned = 0
@@ -82,7 +206,7 @@ class KeywordSearcher:
 
                 if keys:
                     batch_results = await self.process_keyword_batch(
-                        keys, query_terms, category
+                        keys, query_terms, category, bm25
                     )
                     results.extend(batch_results)
 


### PR DESCRIPTION
## Summary
- Add `BM25Scorer` class with IDF smoothing + length normalization
- Replace TF-only `score_fact_by_terms()` in `KeywordSearcher`
- Add Redis-backed corpus stats (`bm25:corpus_stats`) with lazy load
- Add `recompute_corpus_stats()` for KB change triggers
- Part of Neural Mesh RAG (#1994)

Closes #1720

## Test plan
- [x] 7/7 tests passing
- [x] Rare terms score higher than common terms
- [x] Shorter docs score higher (length normalization)
- [x] Unknown terms get smoothed IDF
- [x] Configurable k1/b parameters
- [x] flake8 clean