### PR TITLE
feat(pipeline): add NLP-light entity extraction (#2025)

### DIFF
--- a/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor.py
@@ -5,10 +5,11 @@
 Entity Extractor Cognifier - Extract named entities from text chunks.
 
 Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
+Issue #2025: Dual-mode entity extraction — LLM + NLP (Neural Mesh RAG Phase 2).
 """
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from knowledge.pipeline.base import BaseCognifier, PipelineContext
@@ -20,6 +21,19 @@ from llm_interface_pkg import LLMInterface
 
 logger = logging.getLogger(__name__)
 
+# spaCy NER label → EntityType mapping (Issue #2025)
+_SPACY_LABEL_MAP: Dict[str, str] = {
+    "PERSON": "PERSON",
+    "ORG": "ORGANIZATION",
+    "GPE": "LOCATION",
+    "LOC": "LOCATION",
+    "EVENT": "EVENT",
+    "PRODUCT": "TECHNOLOGY",
+    "LAW": "DOCUMENT",
+    "WORK_OF_ART": "DOCUMENT",
+    "FAC": "LOCATION",
+    "NORP": "ORGANIZATION",
+}
 
 ENTITY_EXTRACTION_PROMPT = """Extract named entities from the following text.
 For each entity, provide:
@@ -38,21 +52,156 @@ Text:
 
 @TaskRegistry.register_cognifier("extract_entities")
 class EntityExtractor(BaseCognifier):
-    """Extract named entities from text chunks using LLM."""
+    """Extract named entities from text chunks using LLM or NLP (spaCy)."""
 
-    def __init__(self, batch_size: int = 5) -> None:
+    def __init__(
+        self,
+        batch_size: int = 5,
+        mode: str = "auto",
+        nlp_threshold: int = 500,
+    ) -> None:
         """
         Initialize entity extractor.
 
         Args:
-            batch_size: Number of chunks to process per batch
+            batch_size: Number of chunks to process per LLM batch
+            mode: Extraction mode — "llm", "nlp", or "auto"
+            nlp_threshold: Chunk count above which auto selects NLP (Issue #2025)
         """
         self.batch_size = batch_size
+        self.mode = mode
+        self.nlp_threshold = nlp_threshold
         self.llm = LLMInterface()
+        self._nlp_model: Optional[Any] = None
+
+    def _get_nlp(self) -> Any:
+        """
+        Lazy-load spaCy en_core_web_sm model (Issue #2025).
+
+        Returns:
+            Loaded spaCy language model
+        """
+        if self._nlp_model is None:
+            import spacy  # noqa: PLC0415
+
+            self._nlp_model = spacy.load("en_core_web_sm")
+        return self._nlp_model
+
+    def _select_mode(self, chunks: List[ProcessedChunk]) -> str:
+        """
+        Select extraction mode based on chunk count and configured mode (Issue #2025).
+
+        Args:
+            chunks: Input chunks
+
+        Returns:
+            "nlp" or "llm"
+        """
+        if self.mode != "auto":
+            return self.mode
+        return "nlp" if len(chunks) > self.nlp_threshold else "llm"
+
+    def _nlp_extract(
+        self, chunks: List[ProcessedChunk], document_id: Optional[UUID]
+    ) -> List[Entity]:
+        """
+        Extract entities from chunks using spaCy NER + noun phrases (Issue #2025).
+
+        Named entities are mapped to EntityType via _SPACY_LABEL_MAP; unrecognised
+        labels default to CONCEPT.  Noun chunks are added as CONCEPT entities with
+        confidence 0.5.  Results are deduplicated by canonical_name before returning.
+
+        Args:
+            chunks: Chunks to process
+            document_id: Source document ID
+
+        Returns:
+            Deduplicated list of Entity objects
+        """
+        nlp = self._get_nlp()
+        seen: Dict[str, Entity] = {}
+
+        for chunk in chunks:
+            doc = nlp(chunk.content)
+            self._collect_ner_entities(doc, chunk, document_id, seen)
+            self._collect_noun_chunks(doc, chunk, document_id, seen)
+
+        return list(seen.values())
+
+    def _collect_ner_entities(
+        self,
+        doc: Any,
+        chunk: ProcessedChunk,
+        document_id: Optional[UUID],
+        seen: Dict[str, Entity],
+    ) -> None:
+        """Add spaCy NER spans to the seen map (Issue #2025)."""
+        for ent in doc.ents:
+            entity_type = _SPACY_LABEL_MAP.get(ent.label_, "CONCEPT")
+            self._upsert_entity(
+                name=ent.text,
+                entity_type=entity_type,
+                confidence=0.8,
+                chunk=chunk,
+                document_id=document_id,
+                seen=seen,
+            )
+
+    def _collect_noun_chunks(
+        self,
+        doc: Any,
+        chunk: ProcessedChunk,
+        document_id: Optional[UUID],
+        seen: Dict[str, Entity],
+    ) -> None:
+        """Add spaCy noun-phrase chunks to the seen map (Issue #2025)."""
+        for nc in doc.noun_chunks:
+            self._upsert_entity(
+                name=nc.text,
+                entity_type="CONCEPT",
+                confidence=0.5,
+                chunk=chunk,
+                document_id=document_id,
+                seen=seen,
+            )
+
+    def _upsert_entity(
+        self,
+        name: str,
+        entity_type: str,
+        confidence: float,
+        chunk: ProcessedChunk,
+        document_id: Optional[UUID],
+        seen: Dict[str, Entity],
+    ) -> None:
+        """Insert or update an entity in the seen map by canonical name (Issue #2025)."""
+        canonical = self._normalize_name(name)
+        if not canonical:
+            return
+        if canonical in seen:
+            existing = seen[canonical]
+            existing.source_chunk_ids.append(chunk.id)
+            existing.extraction_count += 1
+            existing.confidence = min(1.0, existing.confidence + 0.1)
+        else:
+            try:
+                entity = Entity(
+                    name=name,
+                    canonical_name=canonical,
+                    entity_type=entity_type,
+                    confidence=confidence,
+                    source_chunk_ids=[chunk.id],
+                    source_document_id=document_id or chunk.document_id,
+                )
+                seen[canonical] = entity
+            except Exception as exc:
+                logger.warning("NLP entity creation failed for %r: %s", name, exc)
 
     async def process(self, context: PipelineContext) -> PipelineContext:
         """
         Extract entities from chunks in context.
+
+        Selects LLM or NLP extraction based on mode/threshold (Issue #2025).
 
         Args:
             context: Pipeline context with chunks
@@ -61,17 +210,29 @@ class EntityExtractor(BaseCognifier):
             Updated context with entities
         """
         chunks: List[ProcessedChunk] = context.chunks
-        all_entities: List[Entity] = []
+        selected = self._select_mode(chunks)
+        logger.info("Entity extraction mode: %s (%d chunks)", selected, len(chunks))
 
+        if selected == "nlp":
+            all_entities = self._nlp_extract(chunks, context.document_id)
+            merged_entities = self._merge_entities(all_entities)
+        else:
+            merged_entities = await self._llm_process(chunks, context)
+
+        context.entities = merged_entities
+        logger.info("Extracted %s entities", len(merged_entities))
+        return context
+
+    async def _llm_process(
+        self, chunks: List[ProcessedChunk], context: PipelineContext
+    ) -> List[Entity]:
+        """Run LLM-based extraction over all chunks in batches."""
+        all_entities: List[Entity] = []
         for i in range(0, len(chunks), self.batch_size):
             batch = chunks[i : i + self.batch_size]
             batch_entities = await self._process_batch(batch, context)
             all_entities.extend(batch_entities)
-
-        merged_entities = self._merge_entities(all_entities)
-        context.entities = merged_entities
-        logger.info("Extracted %s entities", len(merged_entities))
-        return context
+        return self._merge_entities(all_entities)
 
     async def _process_batch(
         self, chunks: List[ProcessedChunk], context: PipelineContext

--- a/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/entity_extractor_test.py
@@ -1,0 +1,131 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for EntityExtractor NLP mode (Issue #2025).
+
+Covers _nlp_extract(), _select_mode(), and dual-mode dispatch added in
+Issue #2025: Dual-mode entity extraction — LLM + NLP (Neural Mesh RAG Phase 2).
+"""
+
+import sys
+from types import ModuleType
+from uuid import uuid4
+
+import pytest
+
+spacy = pytest.importorskip("spacy")
+
+# ---------------------------------------------------------------------------
+# Stub out llm_interface_pkg so EntityExtractor can be imported without the
+# real LLM stack being installed.
+# ---------------------------------------------------------------------------
+_mock_llm_mod = ModuleType("llm_interface_pkg")
+_mock_llm_mod.LLMInterface = type("LLMInterface", (), {})  # type: ignore[attr-defined]
+sys.modules.setdefault("llm_interface_pkg", _mock_llm_mod)
+
+# Stub autobot_shared to satisfy any transitive imports.
+_mock_shared = ModuleType("autobot_shared")
+_mock_redis_mod = ModuleType("autobot_shared.redis_client")
+_mock_redis_mod.get_redis_client = lambda *a, **kw: None  # type: ignore[attr-defined]
+sys.modules.setdefault("autobot_shared", _mock_shared)
+sys.modules.setdefault("autobot_shared.redis_client", _mock_redis_mod)
+
+from knowledge.pipeline.cognifiers.entity_extractor import EntityExtractor  # noqa: E402
+from knowledge.pipeline.models.chunk import ProcessedChunk  # noqa: E402
+from knowledge.pipeline.models.entity import Entity  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(content: str) -> ProcessedChunk:
+    return ProcessedChunk(content=content, document_id=uuid4(), chunk_index=0)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNlpExtractsNamedEntities:
+    """_nlp_extract() produces Entity instances for NER spans in text."""
+
+    def test_finds_entities_in_sentence(self) -> None:
+        extractor = EntityExtractor(mode="nlp")
+        doc_id = uuid4()
+        chunks = [_make_chunk("Redis is used by Microsoft")]
+        entities = extractor._nlp_extract(chunks, doc_id)
+
+        names = [e.name for e in entities]
+        # spaCy en_core_web_sm recognises "Microsoft" as ORG → ORGANIZATION
+        assert any(
+            "microsoft" in n.lower() for n in names
+        ), f"Expected 'Microsoft' in extracted entities, got: {names}"
+
+    def test_returns_entity_model_instances(self) -> None:
+        """All items returned by _nlp_extract() must be Entity instances."""
+        extractor = EntityExtractor(mode="nlp")
+        doc_id = uuid4()
+        chunks = [_make_chunk("Apple was founded by Steve Jobs in California.")]
+        entities = extractor._nlp_extract(chunks, doc_id)
+
+        assert len(entities) > 0, "Expected at least one entity"
+        for entity in entities:
+            assert isinstance(entity, Entity), f"Expected Entity, got {type(entity)}"
+
+
+class TestAutoModeSelection:
+    """_select_mode() returns 'nlp' above threshold, 'llm' below."""
+
+    def test_auto_selects_nlp_for_large_input(self) -> None:
+        extractor = EntityExtractor(mode="auto", nlp_threshold=5)
+        chunks = [_make_chunk(f"chunk {i}") for i in range(10)]
+        assert extractor._select_mode(chunks) == "nlp"
+
+    def test_auto_selects_llm_for_small_input(self) -> None:
+        extractor = EntityExtractor(mode="auto", nlp_threshold=50)
+        chunks = [_make_chunk("only one chunk")]
+        assert extractor._select_mode(chunks) == "llm"
+
+    def test_explicit_nlp_mode_ignores_threshold(self) -> None:
+        extractor = EntityExtractor(mode="nlp", nlp_threshold=50)
+        chunks = [_make_chunk("small")]
+        assert extractor._select_mode(chunks) == "nlp"
+
+    def test_explicit_llm_mode_ignores_threshold(self) -> None:
+        extractor = EntityExtractor(mode="llm", nlp_threshold=0)
+        chunks = [_make_chunk("many " * 100)]
+        assert extractor._select_mode(chunks) == "llm"
+
+
+class TestNlpDeduplication:
+    """_nlp_extract() deduplicates by canonical_name (lowercase strip)."""
+
+    def test_deduplicates_across_chunks(self) -> None:
+        extractor = EntityExtractor(mode="nlp")
+        doc_id = uuid4()
+        # Two chunks that both mention "Microsoft" — should appear once.
+        chunks = [
+            _make_chunk("Microsoft builds Azure."),
+            _make_chunk("Microsoft also builds Office."),
+        ]
+        entities = extractor._nlp_extract(chunks, doc_id)
+        canonical_names = [e.canonical_name for e in entities]
+        microsoft_entries = [n for n in canonical_names if n == "microsoft"]
+        assert (
+            len(microsoft_entries) == 1
+        ), f"Expected one 'microsoft' entry after dedup, got: {canonical_names}"
+
+    def test_extraction_count_increments_on_duplicate(self) -> None:
+        extractor = EntityExtractor(mode="nlp")
+        doc_id = uuid4()
+        chunks = [
+            _make_chunk("Microsoft builds Azure."),
+            _make_chunk("Microsoft also builds Office."),
+        ]
+        entities = extractor._nlp_extract(chunks, doc_id)
+        microsoft = next((e for e in entities if e.canonical_name == "microsoft"), None)
+        assert microsoft is not None
+        assert microsoft.extraction_count >= 2


### PR DESCRIPTION
## Summary
- Add `_nlp_extract()` using spaCy NER + noun phrases
- Add `_select_mode()` for auto LLM/NLP selection (threshold: 500 chunks)
- Lazy-load spaCy model, deduplicate by canonical name
- Part of Neural Mesh RAG (#1994)

Closes #2025

## Test plan
- [x] 8/8 tests passing
- [x] NLP extracts named entities from text
- [x] Auto mode selects NLP for large input
- [x] Auto mode selects LLM for small input
- [x] Deduplication by canonical name works
- [x] Graceful skip when spaCy not installed