### PR TITLE
feat(pipeline): add MeshSeeder loader (#2028)

### DIFF
--- a/autobot-backend/knowledge/pipeline/loaders/__init__.py
+++ b/autobot-backend/knowledge/pipeline/loaders/__init__.py
@@ -8,11 +8,13 @@ Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
 """
 
 from knowledge.pipeline.loaders.chromadb_loader import ChromaDBLoader
+from knowledge.pipeline.loaders.mesh_seeder import MeshSeeder
 from knowledge.pipeline.loaders.redis_graph_loader import RedisGraphLoader
 from knowledge.pipeline.loaders.sqlite_loader import SQLiteLoader
 
 __all__ = [
     "ChromaDBLoader",
+    "MeshSeeder",
     "RedisGraphLoader",
     "SQLiteLoader",
 ]

--- a/autobot-backend/knowledge/pipeline/loaders/mesh_seeder.py
+++ b/autobot-backend/knowledge/pipeline/loaders/mesh_seeder.py
@@ -1,0 +1,190 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+MeshSeeder — creates structural and semantic edges in the mesh graph (#1994, #2028).
+
+Part of Neural Mesh RAG Phase 2, Task 2.4.
+"""
+
+import logging
+from itertools import combinations
+from typing import Any, Dict, List, Optional, Tuple
+
+from knowledge.pipeline.base import BaseLoader, PipelineContext
+from knowledge.pipeline.registry import TaskRegistry
+
+logger = logging.getLogger(__name__)
+
+_EdgeDict = Dict[str, Any]
+
+
+@TaskRegistry.register_loader("mesh_seeder")
+class MeshSeeder(BaseLoader):
+    """Seeds the mesh graph with structural, entity-based, and typed relationship edges."""
+
+    def __init__(
+        self, db: Optional[Any] = None, similarity_threshold: float = 0.82
+    ) -> None:
+        """
+        Initialize MeshSeeder.
+
+        Args:
+            db: Async graph database client exposing create_edge(**edge_dict).
+            similarity_threshold: Cosine similarity cutoff for SIMILAR_TO edges.
+        """
+        self.db = db
+        self.similarity_threshold = similarity_threshold
+
+    async def load(self, context: PipelineContext) -> Dict[str, int]:
+        """
+        Build and persist mesh edges from pipeline context.
+
+        Args:
+            context: Pipeline context populated by extractors and cognifiers.
+
+        Returns:
+            Dict with counts: nodes_created, edges_created.
+        """
+        chunks = context.chunks or []
+        entities = context.entities or []
+        relationships = context.relationships or []
+
+        nodes = self._build_node_list(chunks)
+        edges: List[_EdgeDict] = []
+        edges.extend(self._build_part_of_edges(nodes))
+        edges.extend(self._build_sequence_edges(nodes))
+        if entities:
+            edges.extend(self._build_entity_edges(nodes, entities))
+        if relationships:
+            edges.extend(self._build_relationship_edges(relationships))
+
+        if self.db:
+            await self._persist_edges(edges)
+
+        logger.info(
+            "MeshSeeder: %s nodes, %s edges created (#2028)",
+            len(nodes),
+            len(edges),
+        )
+        return {"nodes_created": len(nodes), "edges_created": len(edges)}
+
+    # ------------------------------------------------------------------
+    # Node builder
+    # ------------------------------------------------------------------
+
+    def _build_node_list(self, chunks: List[Any]) -> List[Dict[str, Any]]:
+        """Map pipeline chunks to lightweight node dicts for edge construction."""
+        return [
+            {
+                "id": f"n_{i}",
+                "chunk_id": str(getattr(c, "id", f"chunk_{i}")),
+                "source_file": getattr(c, "metadata", {}).get("source_file", ""),
+                "chunk_index": getattr(c, "chunk_index", i),
+            }
+            for i, c in enumerate(chunks)
+        ]
+
+    # ------------------------------------------------------------------
+    # Edge builders
+    # ------------------------------------------------------------------
+
+    def _group_nodes_by_file(
+        self, nodes: List[Dict[str, Any]]
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Return nodes grouped by source_file, omitting nodes without a file."""
+        by_file: Dict[str, List[Dict[str, Any]]] = {}
+        for n in nodes:
+            source_file = n.get("source_file")
+            if source_file:
+                by_file.setdefault(source_file, []).append(n)
+        return by_file
+
+    def _build_part_of_edges(self, nodes: List[Dict[str, Any]]) -> List[_EdgeDict]:
+        """Create PART_OF edges between all chunks sharing the same source file."""
+        edges: List[_EdgeDict] = []
+        for file_nodes in self._group_nodes_by_file(nodes).values():
+            for a, b in combinations(file_nodes, 2):
+                edges.append(
+                    {
+                        "from_node": a["id"],
+                        "to_node": b["id"],
+                        "edge_type": "PART_OF",
+                        "origin": "seeder",
+                        "weight": 1.0,
+                    }
+                )
+        return edges
+
+    def _build_sequence_edges(self, nodes: List[Dict[str, Any]]) -> List[_EdgeDict]:
+        """Create NEXT edges between adjacent chunks within the same source file."""
+        edges: List[_EdgeDict] = []
+        for file_nodes in self._group_nodes_by_file(nodes).values():
+            sorted_nodes = sorted(file_nodes, key=lambda x: x.get("chunk_index", 0))
+            for i in range(len(sorted_nodes) - 1):
+                edges.append(
+                    {
+                        "from_node": sorted_nodes[i]["id"],
+                        "to_node": sorted_nodes[i + 1]["id"],
+                        "edge_type": "NEXT",
+                        "origin": "seeder",
+                        "weight": 1.0,
+                    }
+                )
+        return edges
+
+    def _build_entity_edges(
+        self, nodes: List[Dict[str, Any]], entities: List[Any]
+    ) -> List[_EdgeDict]:
+        """Create SHARED_ENTITY edges between chunk-pairs that mention the same entity."""
+        entity_to_chunks = self._map_entity_to_chunks(entities)
+        edges: List[_EdgeDict] = []
+        seen: set = set()
+        for chunk_ids in entity_to_chunks.values():
+            chunk_list = sorted(chunk_ids)
+            for a, b in combinations(chunk_list, 2):
+                key: Tuple[str, str] = (a, b)
+                if key not in seen:
+                    seen.add(key)
+                    edges.append(
+                        {
+                            "from_node": a,
+                            "to_node": b,
+                            "edge_type": "SHARED_ENTITY",
+                            "origin": "seeder",
+                            "weight": 0.8,
+                        }
+                    )
+        return edges
+
+    def _map_entity_to_chunks(self, entities: List[Any]) -> Dict[str, set]:
+        """Return a mapping from canonical entity name to set of chunk id strings."""
+        entity_chunks: Dict[str, set] = {}
+        for e in entities:
+            canonical = getattr(e, "canonical_name", getattr(e, "name", "")).lower()
+            for cid in getattr(e, "source_chunk_ids", []):
+                entity_chunks.setdefault(canonical, set()).add(str(cid))
+        return entity_chunks
+
+    def _build_relationship_edges(self, relationships: List[Any]) -> List[_EdgeDict]:
+        """Create typed edges from ECL-extracted entity relationships."""
+        return [
+            {
+                "from_node": str(getattr(r, "source_entity_id", "")),
+                "to_node": str(getattr(r, "target_entity_id", "")),
+                "edge_type": str(getattr(r, "relationship_type", "RELATES_TO")),
+                "origin": "seeder",
+                "weight": 0.9,
+            }
+            for r in relationships
+        ]
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    async def _persist_edges(self, edges: List[_EdgeDict]) -> None:
+        """Write all edges to the graph database via db.create_edge."""
+        for edge in edges:
+            await self.db.create_edge(**edge)
+        logger.info("MeshSeeder: persisted %s edges to graph db (#2028)", len(edges))

--- a/autobot-backend/knowledge/pipeline/loaders/mesh_seeder_test.py
+++ b/autobot-backend/knowledge/pipeline/loaders/mesh_seeder_test.py
@@ -1,0 +1,227 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for MeshSeeder loader.
+
+Issue #2028: MeshSeeder loader for graph edge creation (Neural Mesh RAG Phase 2).
+"""
+
+from typing import Any, List
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from knowledge.pipeline.base import PipelineContext
+from knowledge.pipeline.loaders.mesh_seeder import MeshSeeder
+from knowledge.pipeline.models.chunk import ProcessedChunk
+from knowledge.pipeline.models.entity import Entity
+from knowledge.pipeline.models.relationship import Relationship
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(doc_id: Any, chunk_index: int, source_file: str) -> ProcessedChunk:
+    """Create a ProcessedChunk with a source_file in metadata."""
+    return ProcessedChunk(
+        content=f"chunk content {chunk_index}",
+        document_id=doc_id,
+        chunk_index=chunk_index,
+        metadata={"source_file": source_file},
+    )
+
+
+def _make_entity(doc_id: Any, chunk_ids: List[Any], name: str = "Python") -> Entity:
+    """Create an Entity referencing specified chunk IDs."""
+    return Entity(
+        name=name,
+        canonical_name=name.lower(),
+        entity_type="TECHNOLOGY",
+        source_document_id=doc_id,
+        source_chunk_ids=chunk_ids,
+    )
+
+
+def _make_relationship(src_id: Any, tgt_id: Any) -> Relationship:
+    """Create a Relationship between two entity IDs."""
+    return Relationship(
+        source_entity_id=src_id,
+        target_entity_id=tgt_id,
+        relationship_type="USES",
+    )
+
+
+def _context_with(chunks=None, entities=None, relationships=None) -> PipelineContext:
+    """Build a PipelineContext pre-populated with the given data."""
+    ctx = PipelineContext()
+    ctx.chunks = chunks or []
+    ctx.entities = entities or []
+    ctx.relationships = relationships or []
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMeshSeederPartOfEdges:
+    """PART_OF edge generation — chunks sharing a source file."""
+
+    @pytest.mark.asyncio
+    async def test_two_chunks_same_file_yields_one_part_of_edge(self):
+        doc_id = uuid4()
+        chunks = [
+            _make_chunk(doc_id, 0, "file_a.txt"),
+            _make_chunk(doc_id, 1, "file_a.txt"),
+        ]
+        seeder = MeshSeeder()
+        nodes = seeder._build_node_list(chunks)
+        edges = seeder._build_part_of_edges(nodes)
+
+        assert len(edges) == 1
+        assert edges[0]["edge_type"] == "PART_OF"
+
+    @pytest.mark.asyncio
+    async def test_different_files_produce_no_part_of_edges(self):
+        doc_id = uuid4()
+        chunks = [
+            _make_chunk(doc_id, 0, "file_a.txt"),
+            _make_chunk(doc_id, 1, "file_b.txt"),
+        ]
+        seeder = MeshSeeder()
+        nodes = seeder._build_node_list(chunks)
+        edges = seeder._build_part_of_edges(nodes)
+
+        assert edges == []
+
+
+class TestMeshSeederSequenceEdges:
+    """NEXT edge generation — sequential chunks within a file."""
+
+    @pytest.mark.asyncio
+    async def test_three_sequential_chunks_yield_two_next_edges(self):
+        doc_id = uuid4()
+        chunks = [
+            _make_chunk(doc_id, 0, "doc.md"),
+            _make_chunk(doc_id, 1, "doc.md"),
+            _make_chunk(doc_id, 2, "doc.md"),
+        ]
+        seeder = MeshSeeder()
+        nodes = seeder._build_node_list(chunks)
+        edges = seeder._build_sequence_edges(nodes)
+
+        assert len(edges) == 2
+        assert all(e["edge_type"] == "NEXT" for e in edges)
+
+    @pytest.mark.asyncio
+    async def test_sequence_edge_order_follows_chunk_index(self):
+        doc_id = uuid4()
+        # Intentionally out-of-order to verify sort
+        chunks = [
+            _make_chunk(doc_id, 2, "doc.md"),
+            _make_chunk(doc_id, 0, "doc.md"),
+            _make_chunk(doc_id, 1, "doc.md"),
+        ]
+        seeder = MeshSeeder()
+        nodes = seeder._build_node_list(chunks)
+        edges = seeder._build_sequence_edges(nodes)
+
+        # from_node of second edge must be the to_node of first edge
+        assert edges[0]["to_node"] == edges[1]["from_node"]
+
+
+class TestMeshSeederEntityEdges:
+    """SHARED_ENTITY edge generation."""
+
+    @pytest.mark.asyncio
+    async def test_two_chunks_sharing_entity_yield_one_shared_entity_edge(self):
+        doc_id = uuid4()
+        chunks = [
+            _make_chunk(doc_id, 0, "doc.md"),
+            _make_chunk(doc_id, 1, "doc.md"),
+        ]
+        entity = _make_entity(doc_id, [chunks[0].id, chunks[1].id])
+        seeder = MeshSeeder()
+        nodes = seeder._build_node_list(chunks)
+        edges = seeder._build_entity_edges(nodes, [entity])
+
+        assert len(edges) == 1
+        assert edges[0]["edge_type"] == "SHARED_ENTITY"
+        assert edges[0]["weight"] == 0.8
+
+    @pytest.mark.asyncio
+    async def test_duplicate_entity_pairs_deduplicated(self):
+        doc_id = uuid4()
+        chunks = [
+            _make_chunk(doc_id, 0, "doc.md"),
+            _make_chunk(doc_id, 1, "doc.md"),
+        ]
+        # Two entities both reference the same chunk pair
+        entity_a = _make_entity(doc_id, [chunks[0].id, chunks[1].id], "Python")
+        entity_b = _make_entity(doc_id, [chunks[0].id, chunks[1].id], "Python")
+        seeder = MeshSeeder()
+        nodes = seeder._build_node_list(chunks)
+        edges = seeder._build_entity_edges(nodes, [entity_a, entity_b])
+
+        assert len(edges) == 1
+
+
+class TestMeshSeederSingleChunk:
+    """Edge generation with a single chunk — no edges expected."""
+
+    @pytest.mark.asyncio
+    async def test_single_chunk_produces_no_edges(self):
+        doc_id = uuid4()
+        chunks = [_make_chunk(doc_id, 0, "solo.txt")]
+        seeder = MeshSeeder()
+        result = await seeder.load(_context_with(chunks=chunks))
+
+        assert result["nodes_created"] == 1
+        assert result["edges_created"] == 0
+
+
+class TestMeshSeederPersistence:
+    """Persistence — db.create_edge is called for each edge."""
+
+    @pytest.mark.asyncio
+    async def test_db_create_edge_called_for_each_edge(self):
+        doc_id = uuid4()
+        chunks = [
+            _make_chunk(doc_id, 0, "file.py"),
+            _make_chunk(doc_id, 1, "file.py"),
+        ]
+        mock_db = AsyncMock()
+        seeder = MeshSeeder(db=mock_db)
+        result = await seeder.load(_context_with(chunks=chunks))
+
+        assert mock_db.create_edge.call_count == result["edges_created"]
+
+    @pytest.mark.asyncio
+    async def test_no_db_does_not_raise(self):
+        doc_id = uuid4()
+        chunks = [_make_chunk(doc_id, 0, "file.py")]
+        seeder = MeshSeeder(db=None)
+        result = await seeder.load(_context_with(chunks=chunks))
+
+        assert result["nodes_created"] == 1
+
+
+class TestMeshSeederRelationshipEdges:
+    """Typed relationship edges from ECL-extracted relationships."""
+
+    @pytest.mark.asyncio
+    async def test_relationship_edges_preserve_type(self):
+        src_id = uuid4()
+        tgt_id = uuid4()
+        rel = _make_relationship(src_id, tgt_id)
+        seeder = MeshSeeder()
+        edges = seeder._build_relationship_edges([rel])
+
+        assert len(edges) == 1
+        assert edges[0]["edge_type"] == "USES"
+        assert edges[0]["from_node"] == str(src_id)
+        assert edges[0]["to_node"] == str(tgt_id)
+        assert edges[0]["weight"] == 0.9


### PR DESCRIPTION
## Summary
- Add `MeshSeeder` as registered ECL loader (`@TaskRegistry.register_loader`)
- Build PART_OF edges (same file), NEXT edges (adjacent chunks)
- Build SHARED_ENTITY edges (chunks sharing entities, deduplicated)
- Build typed relationship edges from ECL extraction
- Extracted `_group_nodes_by_file()` helper for DRY
- Part of Neural Mesh RAG (#1994)

Closes #2028

## Test plan
- [x] 10/10 tests passing
- [x] PART_OF edge creation verified
- [x] NEXT edge ordering verified
- [x] Entity deduplication verified
- [x] Single chunk produces no edges
- [x] DB persistence call count verified