### PR TITLE
fix(deps): add spacy + scikit-learn for Neural Mesh RAG (#2043)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -48,6 +48,10 @@ PyYAML>=6.0            # SKILL.md frontmatter parsing (Phase 3 sync engine)
 # Community growth skill (Issue #1161)
 praw>=7.7.0             # Reddit OAuth API for CommunityGrowthSkill
 
+# NLP / Neural Mesh RAG (Issue #1994)
+spacy>=3.7                  # Issue #2025: NLP entity extraction
+scikit-learn>=1.3           # Issue #2027: RAPTOR clustering
+
 # Media processing pipelines (Issue #932)
 aiohttp>=3.13.3         # Async HTTP client - SECURITY UPDATE (7 CVE fixes)
 beautifulsoup4>=4.12.0  # HTML parsing for link pipeline


### PR DESCRIPTION
## Summary
- Adds `spacy>=3.7` and `scikit-learn>=1.3` to `autobot-backend/requirements.txt`
- Required by #2025 (NLP entity extraction) and #2027 (RAPTOR clustering)
- Without these, CI fails on import and entity extractor tests skip

## Test plan
- [ ] CI passes with new deps
- [ ] `pytest entity_extractor_test.py` no longer skips (spaCy available)
- [ ] `pytest summarizer_raptor_test.py` no longer skips (sklearn available)

Closes #2043