### PR TITLE
fix(hardware): check correct key in NPU selection (#2022)

### DIFF
--- a/autobot-backend/llm_interface_pkg/hardware.py
+++ b/autobot-backend/llm_interface_pkg/hardware.py
@@ -121,7 +121,7 @@ class HardwareDetector:
 
     def _select_openvino_npu(self, detected_hardware: Set[str]) -> Optional[str]:
         """Select OpenVINO NPU if available."""
-        return "openvino_npu" if "openvino" in detected_hardware else None
+        return "openvino_npu" if "openvino_npu" in detected_hardware else None
 
     def _select_openvino_variant(self, detected_hardware: Set[str]) -> Optional[str]:
         """Select OpenVINO variant."""


### PR DESCRIPTION
## Summary
- `_select_openvino_npu()` now checks for `openvino_npu` in detected hardware set instead of `openvino`
- Prevents incorrectly selecting NPU backend on systems with OpenVINO but no NPU hardware

Closes #2022