### PR TITLE
fix(search): trigger BM25 corpus stats recomputation on KB changes (#2033)

### DIFF
--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -433,6 +433,21 @@ class FactsMixin:
     initialized: bool
     embedding_model_name: str
 
+    def _schedule_bm25_refresh(self) -> None:
+        """Schedule a background BM25 corpus-stats recompute (#2033).
+
+        Called after fact mutations so IDF values stay current.
+        Uses ``asyncio.create_task`` to avoid blocking the caller.
+        """
+        # _get_keyword_searcher is defined on SearchMixin (same composed class)
+        if not hasattr(self, "_get_keyword_searcher"):
+            return
+        try:
+            searcher = self._get_keyword_searcher()
+            asyncio.create_task(searcher.recompute_corpus_stats())
+        except Exception as exc:
+            logger.warning("BM25 stats refresh scheduling failed: %s", exc)
+
     async def _find_fact_by_unique_key(
         self, unique_key: str
     ) -> Optional[Dict[str, Any]]:
@@ -682,6 +697,7 @@ class FactsMixin:
             self._increment_stat("total_facts"),
             self._increment_stat("total_vectors"),
         )
+        self._schedule_bm25_refresh()
         return {"status": "success", "fact_id": fact_id, "action": "created"}
 
     async def store_fact(
@@ -1069,6 +1085,7 @@ class FactsMixin:
                 self._decrement_stat("total_vectors"),
             )
 
+            self._schedule_bm25_refresh()
             logger.info("Deleted fact %s", fact_id)
             return {"status": "success", "fact_id": fact_id, "action": "deleted"}
 

--- a/autobot-backend/knowledge/search_components/keyword_search.py
+++ b/autobot-backend/knowledge/search_components/keyword_search.py
@@ -65,9 +65,17 @@ class KeywordSearcher:
         return BM25Scorer(_DEFAULT_TOTAL_DOCS, _DEFAULT_AVG_LENGTH, {})
 
     async def _get_bm25(self) -> BM25Scorer:
-        """Return cached BM25Scorer, loading from Redis on first call (#1720)."""
+        """Return cached BM25Scorer, loading from Redis on first call (#1720).
+
+        When the corpus stats key is absent (first run or after flush),
+        triggers an initial ``recompute_corpus_stats()`` so BM25 uses
+        real IDF values instead of falling back to defaults (#2033).
+        """
         if self._bm25 is None:
             self._bm25 = await self._load_corpus_stats()
+            if self._bm25.total_docs == _DEFAULT_TOTAL_DOCS:
+                await self.recompute_corpus_stats()
+                self._bm25 = await self._load_corpus_stats()
         return self._bm25
 
     def _invalidate_bm25_cache(self) -> None:


### PR DESCRIPTION
## Summary
- `_get_bm25()` now auto-recomputes corpus stats on first search when key is missing (lazy init)
- `_store_and_vectorize_fact()` and `delete_fact()` schedule background BM25 stats refresh via `asyncio.create_task`
- BM25 IDF and document length stats now stay current as facts are added/removed
- Prevents fallback to default stats that negate BM25 scoring improvements

## Changes
- `keyword_search.py`: Lazy recompute in `_get_bm25()` when stats key absent
- `facts.py`: `_schedule_bm25_refresh()` helper + calls after store/delete success

Closes #2033