### PR TITLE
feat(pipeline): wire RAPTOR build_raptor_tree into process() (#2051)

### DIFF
--- a/autobot-backend/knowledge/pipeline/base.py
+++ b/autobot-backend/knowledge/pipeline/base.py
@@ -25,6 +25,8 @@ class PipelineContext:
         self.summaries: List[Any] = []
         self.metadata: Dict[str, Any] = {}
         self.document_id: Optional[UUID] = None
+        self.embeddings: Optional[Any] = None  # numpy array of chunk embeddings (#2051)
+        self.raptor_tree: Optional[Dict] = None  # RAPTOR level hierarchy (#2051)
 
 
 class PipelineResult:

--- a/autobot-backend/knowledge/pipeline/cognifiers/summarizer.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/summarizer.py
@@ -103,6 +103,19 @@ class HierarchicalSummarizer(BaseCognifier):
 
         context.summaries = all_summaries
         logger.info("Generated %s summaries", len(all_summaries))
+
+        # RAPTOR tree building (#2051)
+        if getattr(context, "embeddings", None) is not None:
+            try:
+                context.raptor_tree = await self.build_raptor_tree(
+                    chunks, context.embeddings
+                )
+                logger.info(
+                    "Built RAPTOR tree with %d levels", len(context.raptor_tree)
+                )
+            except Exception as exc:
+                logger.warning("RAPTOR tree building failed (non-fatal): %s", exc)
+
         return context
 
     def _group_into_sections(
@@ -361,7 +374,7 @@ class HierarchicalSummarizer(BaseCognifier):
                 entity_map=entity_map,
                 document_id=document_id,
                 level=SummaryLevel.SECTION,
-                source_ids=[],
+                source_chunk_ids=[],
             )
             if summary:
                 summaries.append(summary)

--- a/autobot-backend/knowledge/pipeline/cognifiers/summarizer_raptor_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/summarizer_raptor_test.py
@@ -1,12 +1,15 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Tests for RAPTOR recursive clustering in HierarchicalSummarizer (#2027)."""
+"""Tests for RAPTOR recursive clustering in HierarchicalSummarizer (#2027, #2051)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import numpy as np
 import pytest
 
 sklearn = pytest.importorskip("sklearn")
 
+from knowledge.pipeline.base import PipelineContext
 from knowledge.pipeline.cognifiers.summarizer import HierarchicalSummarizer
 
 
@@ -69,8 +72,6 @@ class TestBuildRaptorTree:
     @pytest.mark.asyncio
     async def test_single_chunk_no_clustering(self):
         s = HierarchicalSummarizer()
-        from unittest.mock import MagicMock
-
         chunk = MagicMock()
         chunk.content = "Single chunk content"
         embeddings = np.array([[1.0, 0.0]])
@@ -78,3 +79,68 @@ class TestBuildRaptorTree:
         assert "L0" in tree
         assert len(tree["L0"]) == 1
         assert "L1" not in tree
+
+
+class TestProcessPopulatesRaptorTree:
+    """Verify process() wires build_raptor_tree when embeddings are present (#2051)."""
+
+    @pytest.mark.asyncio
+    async def test_raptor_tree_set_when_embeddings_present(self):
+        """process() must populate context.raptor_tree when context.embeddings is set."""
+        s = HierarchicalSummarizer()
+
+        # Stub every LLM call so no real network I/O occurs.
+        stub_summary = MagicMock()
+        stub_summary.id = "s1"
+        stub_summary.content = "stub"
+        stub_summary.parent_summary_id = None
+        stub_summary.child_summary_ids = []
+
+        context = PipelineContext()
+        chunk = MagicMock()
+        chunk.content = "chunk content"
+        chunk.id = "c1"
+        chunk.document_id = "doc1"
+        context.chunks = [chunk]
+        context.embeddings = np.array([[1.0, 0.0]])
+
+        fake_tree = {"L0": [chunk]}
+
+        with patch.object(
+            s, "_summarize_text", new=AsyncMock(return_value=stub_summary)
+        ):
+            with patch.object(
+                s, "build_raptor_tree", new=AsyncMock(return_value=fake_tree)
+            ):
+                result = await s.process(context)
+
+        assert result.raptor_tree is not None
+        assert "L0" in result.raptor_tree
+
+    @pytest.mark.asyncio
+    async def test_raptor_tree_skipped_when_no_embeddings(self):
+        """process() must leave context.raptor_tree as None when no embeddings."""
+        s = HierarchicalSummarizer()
+
+        stub_summary = MagicMock()
+        stub_summary.id = "s1"
+        stub_summary.content = "stub"
+        stub_summary.parent_summary_id = None
+        stub_summary.child_summary_ids = []
+
+        context = PipelineContext()
+        chunk = MagicMock()
+        chunk.content = "chunk content"
+        chunk.id = "c1"
+        chunk.document_id = "doc1"
+        context.chunks = [chunk]
+        # embeddings intentionally left as None
+
+        with patch.object(
+            s, "_summarize_text", new=AsyncMock(return_value=stub_summary)
+        ):
+            with patch.object(s, "build_raptor_tree", new=AsyncMock()) as mock_brt:
+                result = await s.process(context)
+
+        mock_brt.assert_not_called()
+        assert result.raptor_tree is None


### PR DESCRIPTION
## Summary
- Adds `embeddings` and `raptor_tree` optional fields to `PipelineContext`
- `HierarchicalSummarizer.process()` now builds RAPTOR tree when embeddings are present
- Fixes `source_ids` → `source_chunk_ids` kwarg bug in `_summarize_groups` that would crash RAPTOR at runtime
- 2 new tests (9 total for RAPTOR)

## Test plan
- [x] 9/9 RAPTOR tests pass
- [x] RAPTOR tree populated when embeddings present
- [x] RAPTOR tree skipped when no embeddings

Closes #2051