### PR TITLE
fix(frontend): wire LiveEventService into app startup (#2064)

### DIFF
--- a/autobot-frontend/src/composables/useLiveEvents.ts
+++ b/autobot-frontend/src/composables/useLiveEvents.ts
@@ -1,0 +1,123 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * Live Events Composable (#2064)
+ *
+ * Provides Vue-friendly access to the scoped LiveEventService for
+ * channel-based real-time event streaming (agent:{id}, task:{id},
+ * workflow:{id}, global).
+ *
+ * Usage:
+ *   const { subscribe, isConnected, connectionState } = useLiveEvents()
+ *   const unsub = subscribe('global', (event) => { ... })
+ *   // unsub() to stop listening, or it auto-cleans on component unmount
+ */
+
+import { computed, onUnmounted, getCurrentInstance, type ComputedRef } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+import liveEventService, {
+  type LiveEvent,
+  type LiveEventCallback,
+  type LiveEventConnectionState,
+} from '@/services/LiveEventService'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseLiveEventsReturn {
+  /** Whether the WebSocket is currently connected */
+  isConnected: ComputedRef<boolean>
+  /** Current connection lifecycle state */
+  connectionState: ComputedRef<LiveEventConnectionState>
+
+  /**
+   * Subscribe to a channel. Returns an unsubscribe function.
+   * Automatically cleans up on component unmount.
+   */
+  subscribe: (channel: string, callback: LiveEventCallback) => () => void
+
+  /** Manually unsubscribe a specific callback from a channel */
+  unsubscribe: (channel: string, callback: LiveEventCallback) => void
+
+  /** Manually trigger connection (normally auto-connects on import) */
+  connect: (token?: string) => Promise<void>
+
+  /** Disconnect the live event WebSocket */
+  disconnect: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Logger
+// ---------------------------------------------------------------------------
+
+const logger = createLogger('useLiveEvents')
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+export function useLiveEvents(): UseLiveEventsReturn {
+  const unsubscribers: Array<() => void> = []
+
+  // Reactive connection state
+  const isConnected = computed(() => liveEventService.isConnected.value)
+  const connectionState = computed(
+    () => liveEventService.connectionState.value,
+  )
+
+  // Subscribe to a channel with auto-cleanup tracking
+  const subscribe = (
+    channel: string,
+    callback: LiveEventCallback,
+  ): (() => void) => {
+    const unsub = liveEventService.subscribe(channel, callback)
+    unsubscribers.push(unsub)
+    return unsub
+  }
+
+  // Unsubscribe from a channel
+  const unsubscribe = (
+    channel: string,
+    callback: LiveEventCallback,
+  ): void => {
+    liveEventService.unsubscribe(channel, callback)
+  }
+
+  // Manual connect
+  const connect = (token?: string): Promise<void> => {
+    return liveEventService.connect(token)
+  }
+
+  // Manual disconnect
+  const disconnect = (): void => {
+    liveEventService.disconnect()
+  }
+
+  // Cleanup on unmount - only if inside a Vue component
+  const instance = getCurrentInstance()
+  if (instance) {
+    onUnmounted(() => {
+      unsubscribers.forEach((unsub) => unsub())
+    })
+  } else {
+    logger.warn(
+      'useLiveEvents: Not inside Vue component, manual cleanup required',
+    )
+  }
+
+  return {
+    isConnected,
+    connectionState,
+    subscribe,
+    unsubscribe,
+    connect,
+    disconnect,
+  }
+}
+
+export default useLiveEvents
+
+// Re-export types for convenience
+export type { LiveEvent, LiveEventCallback, LiveEventConnectionState }

--- a/autobot-frontend/src/main.ts
+++ b/autobot-frontend/src/main.ts
@@ -40,6 +40,7 @@ import ApiPlugin from './plugins/api'
 
 // Import global services
 import './services/GlobalWebSocketService'
+import './services/LiveEventService'
 
 // Import async component error handling setup
 import { setupAsyncComponentErrorHandler } from './utils/asyncComponentHelpers'

--- a/autobot-frontend/src/services/LiveEventService.ts
+++ b/autobot-frontend/src/services/LiveEventService.ts
@@ -12,8 +12,12 @@
 import { ref, type Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
-type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error'
-type LiveEventCallback = (event: LiveEvent) => void
+export type LiveEventConnectionState =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'error'
+export type LiveEventCallback = (event: LiveEvent) => void
 
 /** Parsed live event received from the server */
 export interface LiveEvent {
@@ -48,7 +52,7 @@ class LiveEventService {
   private readonly channelListeners = new Map<string, Set<LiveEventCallback>>()
 
   readonly isConnected: Ref<boolean> = ref(false)
-  readonly connectionState: Ref<ConnectionState> = ref('disconnected')
+  readonly connectionState: Ref<LiveEventConnectionState> = ref('disconnected')
 
   private getUrl(token?: string): string {
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
@@ -273,5 +277,40 @@ class LiveEventService {
 }
 
 const liveEventService = new LiveEventService()
+
+// Auto-connect with delay to allow app initialization.
+// Only connect if this is the first import and not already connected.
+if (typeof window !== 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- one-time init flag on window with no type definition
+  const win = window as any
+
+  if (!win._autobotLiveEventInitialized) {
+    win._autobotLiveEventInitialized = true
+
+    setTimeout(() => {
+      if (
+        !liveEventService.isConnected.value &&
+        liveEventService.connectionState.value !== 'connecting'
+      ) {
+        liveEventService
+          .connect()
+          .then(() => {
+            // Subscribe to the global channel by default so
+            // rag_retrieval and other broadcast events are received.
+            liveEventService.subscribe('global', (event) => {
+              logger.debug('Global live event received:', {
+                event_type: event.event_type,
+                event_id: event.event_id,
+              })
+            })
+          })
+          .catch((error: unknown) => {
+            logger.error('Initial LiveEventService connection failed:', error)
+          })
+      }
+    }, 1000)
+  }
+}
+
 export default liveEventService
 export { LiveEventService }


### PR DESCRIPTION
## Summary
- Created `useLiveEvents` composable wrapping `LiveEventService`
- Auto-connect on app startup (same pattern as GlobalWebSocketService)
- Added default `global` channel subscription for `rag_retrieval` events
- Exported types for external consumers

## Changes
- `autobot-frontend/src/composables/useLiveEvents.ts` — New composable
- `autobot-frontend/src/services/LiveEventService.ts` — Added auto-connect, types export
- `autobot-frontend/src/main.ts` — Import LiveEventService on startup

Closes #2064