### PR TITLE
fix(frontend): unify ChatMessage type definitions (#2066)

### DIFF
--- a/autobot-frontend/src/models/repositories/ChatRepository.ts
+++ b/autobot-frontend/src/models/repositories/ChatRepository.ts
@@ -2,21 +2,14 @@ import axios from 'axios'
 import type { AxiosInstance, AxiosResponse } from 'axios'
 import { getBackendUrl } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
+import type { ChatMessage } from '@/types/api'
 
 // Create scoped logger for ChatRepository
 const logger = createLogger('ChatRepository')
 
-export interface ChatMessage {
-  id: string
-  role: 'user' | 'assistant' | 'system'
-  content: string
-  timestamp?: string
-  metadata?: {
-    model?: string
-    tokens?: number
-    duration?: number
-  }
-}
+// Issue #2066: ChatMessage is now the canonical type from types/api.ts.
+// Re-exported here for backward compatibility with models/repositories/index.ts.
+export type { ChatMessage } from '@/types/api'
 
 export interface ChatSession {
   id: string

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -3,31 +3,13 @@ import { defineStore } from 'pinia'
 import { generateChatId, generateMessageId } from '@/utils/ChatIdGenerator.js'
 import { NetworkConstants } from '@/constants/network'
 import { createLogger } from '@/utils/debugUtils'
+import type { ChatMessage } from '@/types/api'
+
+// Issue #2066: ChatMessage is now the canonical type from types/api.ts.
+// Re-export so existing consumers that import from this store still work.
+export type { ChatMessage } from '@/types/api'
 
 const logger = createLogger('useChatStore')
-
-export interface ChatMessage {
-  id: string
-  content: string
-  sender: 'user' | 'assistant' | 'system'
-  timestamp: Date
-  status?: 'sending' | 'sent' | 'error'
-  error?: string // Error message if status is 'error'
-  type?: 'thought' | 'planning' | 'debug' | 'utility' | 'sources' | 'json' | 'response' | 'message' | 'command_approval_request' | 'overseer_plan' | 'overseer_step' | 'terminal_output' | 'terminal_command' // For filtering
-  attachments?: Array<{
-    id: string
-    name: string
-    type: string
-    size: number
-    url: string
-  }>
-  metadata?: {
-    model?: string
-    tokens?: number
-    duration?: number
-    [key: string]: any // Allow additional metadata fields
-  }
-}
 
 // Issue #608: User context for session tracking
 export interface UserContext {

--- a/autobot-frontend/src/types/api.ts
+++ b/autobot-frontend/src/types/api.ts
@@ -8,15 +8,63 @@ export interface ApiResponse<T = any> {
 }
 
 // Chat API Types
+//
+// Canonical ChatMessage type — single source of truth for all chat messages.
+// Matches backend ChatMessageRequest (content, role, message_type, session_id)
+// while preserving frontend-specific fields (sender, type, status, attachments).
+// Issue #2066: Unified from four divergent definitions.
+
+/** All valid sender/speaker values across frontend rendering contexts. */
+export type MessageSender =
+  | 'user'
+  | 'assistant'
+  | 'bot'        // Legacy alias for 'assistant' in some WebSocket paths
+  | 'system'
+  | 'error'
+  | 'thought'
+  | 'tool-code'
+  | 'tool-output';
+
+/** Display-layer message type used for filtering in the chat UI. */
+export type ChatMessageDisplayType =
+  | 'thought'
+  | 'planning'
+  | 'debug'
+  | 'utility'
+  | 'sources'
+  | 'json'
+  | 'response'
+  | 'message'
+  | 'command_approval_request'
+  | 'overseer_plan'
+  | 'overseer_step'
+  | 'terminal_output'
+  | 'terminal_command';
+
 export interface ChatMessage {
   id: string;
+  /** Message text content — canonical field name, matches backend `content`. */
   content: string;
-  sender: 'user' | 'assistant' | 'system';
-  timestamp: string;
-  messageType?: string;
-  type?: string;
+  /** Speaker identity for frontend rendering. Backend equivalent: `role`. */
+  sender: MessageSender;
+  timestamp: string | Date;
+  /** Backend message type identifier (snake_case, e.g. 'llm_response'). */
+  message_type?: string;
+  /** Frontend display type for UI filtering (thought, planning, debug, etc.). */
+  type?: ChatMessageDisplayType | string;
+  /** Session this message belongs to (matches backend `session_id`). */
+  session_id?: string;
+  /** Delivery status — frontend-only, not persisted to backend. */
+  status?: 'sending' | 'sent' | 'error';
+  /** Error detail when status is 'error' — frontend-only. */
+  error?: string;
   attachments?: FileAttachment[];
-  metadata?: Record<string, any>;
+  metadata?: {
+    model?: string;
+    tokens?: number;
+    duration?: number;
+    [key: string]: any;
+  };
 }
 
 export interface ChatSession {

--- a/autobot-frontend/src/types/models.ts
+++ b/autobot-frontend/src/types/models.ts
@@ -90,17 +90,11 @@ export interface AutoBotSettings {
 
 // ============================================================================
 // Chat Models
+// Issue #2066: ChatMessage is now defined canonically in types/api.ts.
+// Re-exported here for backward compatibility.
 // ============================================================================
 
-export interface ChatMessage {
-  id: string
-  sender: 'user' | 'bot' | 'system' | 'error' | 'thought' | 'tool-code' | 'tool-output'
-  text: string
-  timestamp: string
-  message_type?: string
-  metadata?: Record<string, any>
-  session_id?: string
-}
+export type { ChatMessage, MessageSender, ChatMessageDisplayType } from '@/types/api'
 
 export interface ChatSession {
   id: string
@@ -460,7 +454,7 @@ export interface WorkflowResponse {
 // Utility Types
 // ============================================================================
 
-export type MessageSender = ChatMessage['sender']
+// MessageSender re-exported from '@/types/api' above (Issue #2066)
 export type TaskStatus = AgentTask['status']
 export type TaskPriority = AgentTask['priority']
 export type LogLevel = BackendSettings['log_level']
@@ -476,12 +470,12 @@ export type Priority = 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT'
 // Type Guards and Validators
 // ============================================================================
 
-export function isChatMessage(obj: any): obj is ChatMessage {
+export function isChatMessage(obj: any): obj is import('@/types/api').ChatMessage {
   return obj &&
     typeof obj.id === 'string' &&
     typeof obj.sender === 'string' &&
-    typeof obj.text === 'string' &&
-    typeof obj.timestamp === 'string'
+    typeof obj.content === 'string' &&
+    (typeof obj.timestamp === 'string' || obj.timestamp instanceof Date)
 }
 
 export function isWebSocketEvent(obj: any): obj is WebSocketEvent {
@@ -506,7 +500,7 @@ export function isApiError(obj: any): obj is ApiError {
 // Default Values and Constants
 // ============================================================================
 
-export const DEFAULT_CHAT_MESSAGE: Partial<ChatMessage> = {
+export const DEFAULT_CHAT_MESSAGE: Partial<import('@/types/api').ChatMessage> = {
   sender: 'user',
   message_type: 'text',
   metadata: {}


### PR DESCRIPTION
## Summary
- Created single canonical ChatMessage interface in `types/api.ts`
- Unified `content` (not `text`), `sender` with all 8 values, `message_type` (snake_case)
- Removed duplicate definitions from `models.ts`, `useChatStore.ts`, `ChatRepository.ts`
- Re-exported from all previous locations for backwards compatibility
- TypeScript compilation passes with zero errors

## Changes
- `types/api.ts` — Canonical ChatMessage with MessageSender + ChatMessageDisplayType types
- `types/models.ts` — Re-exports from api.ts, updated type guard to check `content`
- `stores/useChatStore.ts` — Removed local definition, imports from api.ts
- `models/repositories/ChatRepository.ts` — Removed local definition, imports from api.ts

Closes #2066