### PR TITLE
fix(frontend): align ServiceStatus with backend health enum (#2076)

### DIFF
--- a/autobot-frontend/src/composables/useSystemStatus.ts
+++ b/autobot-frontend/src/composables/useSystemStatus.ts
@@ -119,10 +119,41 @@ const logger = createLogger('useSystemStatus')
 // Helper: map a raw status string to ServiceHealthStatus
 // ---------------------------------------------------------------------------
 
+/**
+ * Map any raw backend/VM status string to a frontend display status.
+ *
+ * Backend health endpoint sends: 'healthy', 'unhealthy', 'degraded'.
+ * VM status endpoint may send: 'online', 'offline', 'warning'.
+ * Frontend displays: 'healthy' | 'warning' | 'error'.
+ *
+ * Issue #2076: Added 'healthy', 'degraded', 'unhealthy' mappings.
+ */
 function toHealthStatus(raw: string): ServiceHealthStatus {
-  if (raw === 'online') return 'healthy'
-  if (raw === 'warning') return 'warning'
-  return 'error'
+  const normalized = raw.toLowerCase()
+  switch (normalized) {
+    case 'healthy':
+    case 'online':
+    case 'up':
+    case 'running':
+    case 'available':
+    case 'connected':
+      return 'healthy'
+    case 'degraded':
+    case 'warning':
+    case 'pending':
+      return 'warning'
+    case 'unhealthy':
+    case 'error':
+    case 'offline':
+    case 'down':
+    case 'unavailable':
+    case 'not_configured':
+    case 'not_initialized':
+    case 'import_error':
+      return 'error'
+    default:
+      return 'error'
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/autobot-frontend/src/models/repositories/SystemRepository.ts
+++ b/autobot-frontend/src/models/repositories/SystemRepository.ts
@@ -2,11 +2,11 @@ import { ApiRepository } from './ApiRepository'
 import type { AutoBotSettings, SystemMetrics, DiagnosticsReport } from '@/types/models'
 
 export interface HealthCheckResponse {
-  status: 'healthy' | 'warning' | 'error'
+  status: 'healthy' | 'unhealthy' | 'degraded' | 'warning' | 'error'
   version: string
   uptime: number
   services: Record<string, {
-    status: 'up' | 'down' | 'degraded'
+    status: 'up' | 'down' | 'degraded' | 'healthy' | 'unhealthy'
     latency?: number
     message?: string
   }>

--- a/autobot-frontend/src/types/api.ts
+++ b/autobot-frontend/src/types/api.ts
@@ -64,16 +64,32 @@ export interface LLMResponse {
 }
 
 // System Health Types
+
+/**
+ * All status values that the backend health endpoint may return.
+ * Backend sends: 'healthy', 'unhealthy', 'degraded'.
+ * Frontend display layer uses: 'healthy', 'warning', 'error'.
+ * Legacy values kept for backward compatibility: 'online', 'offline'.
+ */
+export type ServiceHealthStatusValue =
+  | 'healthy'
+  | 'unhealthy'
+  | 'degraded'
+  | 'warning'
+  | 'error'
+  | 'online'
+  | 'offline';
+
 export interface ServiceStatus {
   name: string;
   version?: string;
-  status: 'online' | 'warning' | 'error' | 'offline';
-  statusText: string;
+  status: ServiceHealthStatusValue;
+  statusText?: string;
   responseTime?: number;
-  lastCheck?: number;
+  lastCheck?: number | string;
   consecutiveFailures?: number;
   error?: string;
-  timestamp?: number;
+  timestamp?: number | string;
   details?: Record<string, any>;
 }
 

--- a/autobot-frontend/src/utils/__tests__/iconMappings.test.ts
+++ b/autobot-frontend/src/utils/__tests__/iconMappings.test.ts
@@ -15,6 +15,7 @@ import {
   getFileIconByMimeType,
   getStatusColorClass,
   getStatusIconWithColor,
+  normalizeServiceStatus,
   type StatusType,
   type FileType,
   type DocumentType,
@@ -83,6 +84,49 @@ describe('iconMappings utility', () => {
 
   // Issue #156 Fix: Removed tests for non-existent functions (getConnectionIcon, getActionIcon, getIcon, iconMappings object)
   // The current API only exports: getFileIcon, getStatusIcon, getPlatformIcon, getDocumentTypeIcon,
-  // getFileIconByMimeType, getStatusColorClass, getStatusIconWithColor
+  // getFileIconByMimeType, getStatusColorClass, getStatusIconWithColor, normalizeServiceStatus
   // Tests for these additional functions should be added as needed
+
+  // ========================================
+  // normalizeServiceStatus() Tests (#2076)
+  // ========================================
+
+  describe('normalizeServiceStatus', () => {
+    it('should map backend healthy values to healthy', () => {
+      expect(normalizeServiceStatus('healthy')).toBe('healthy')
+      expect(normalizeServiceStatus('online')).toBe('healthy')
+      expect(normalizeServiceStatus('up')).toBe('healthy')
+      expect(normalizeServiceStatus('running')).toBe('healthy')
+      expect(normalizeServiceStatus('available')).toBe('healthy')
+      expect(normalizeServiceStatus('connected')).toBe('healthy')
+    })
+
+    it('should map backend degraded values to warning', () => {
+      expect(normalizeServiceStatus('degraded')).toBe('warning')
+      expect(normalizeServiceStatus('warning')).toBe('warning')
+      expect(normalizeServiceStatus('pending')).toBe('warning')
+    })
+
+    it('should map backend unhealthy values to error', () => {
+      expect(normalizeServiceStatus('unhealthy')).toBe('error')
+      expect(normalizeServiceStatus('error')).toBe('error')
+      expect(normalizeServiceStatus('offline')).toBe('error')
+      expect(normalizeServiceStatus('down')).toBe('error')
+      expect(normalizeServiceStatus('unavailable')).toBe('error')
+      expect(normalizeServiceStatus('not_configured')).toBe('error')
+      expect(normalizeServiceStatus('not_initialized')).toBe('error')
+      expect(normalizeServiceStatus('import_error')).toBe('error')
+    })
+
+    it('should handle case-insensitive input', () => {
+      expect(normalizeServiceStatus('HEALTHY')).toBe('healthy')
+      expect(normalizeServiceStatus('Degraded')).toBe('warning')
+      expect(normalizeServiceStatus('UNHEALTHY')).toBe('error')
+    })
+
+    it('should return error for unknown status values', () => {
+      expect(normalizeServiceStatus('unknown-value')).toBe('error')
+      expect(normalizeServiceStatus('')).toBe('error')
+    })
+  })
 })

--- a/autobot-frontend/src/utils/iconMappings.ts
+++ b/autobot-frontend/src/utils/iconMappings.ts
@@ -17,9 +17,11 @@ export const statusIcons = {
   active: 'fas fa-circle',
 
   warning: 'fas fa-exclamation-triangle',
+  degraded: 'fas fa-exclamation-triangle',
   pending: 'fas fa-clock',
 
   error: 'fas fa-times-circle',
+  unhealthy: 'fas fa-times-circle',
   failed: 'fas fa-times-circle',
   offline: 'fas fa-times-circle',
   disconnected: 'fas fa-plug',
@@ -200,9 +202,11 @@ export function getStatusColorClass(status: string): string {
     online: 'text-green-600',
 
     warning: 'text-yellow-600',
+    degraded: 'text-yellow-600',
     pending: 'text-yellow-600',
 
     error: 'text-red-600',
+    unhealthy: 'text-red-600',
     failed: 'text-red-600',
     offline: 'text-red-600',
 
@@ -221,6 +225,45 @@ export function getStatusIconWithColor(status: string): string {
   const icon = getStatusIcon(status)
   const color = getStatusColorClass(status)
   return `${icon} ${color}`
+}
+
+/**
+ * Normalize a backend health status string to a frontend display status.
+ *
+ * Backend health endpoint returns: 'healthy', 'unhealthy', 'degraded'.
+ * Frontend display layer uses: 'healthy', 'warning', 'error'.
+ * Legacy/VM values ('online', 'offline') are also handled.
+ *
+ * Issue #2076: Centralised mapping for all service status consumers.
+ */
+export function normalizeServiceStatus(
+  backendStatus: string,
+): 'healthy' | 'warning' | 'error' {
+  const normalized = backendStatus.toLowerCase()
+  switch (normalized) {
+    case 'healthy':
+    case 'online':
+    case 'up':
+    case 'running':
+    case 'available':
+    case 'connected':
+      return 'healthy'
+    case 'degraded':
+    case 'warning':
+    case 'pending':
+      return 'warning'
+    case 'unhealthy':
+    case 'error':
+    case 'offline':
+    case 'down':
+    case 'unavailable':
+    case 'not_configured':
+    case 'not_initialized':
+    case 'import_error':
+      return 'error'
+    default:
+      return 'error'
+  }
 }
 
 export type StatusType = keyof typeof statusIcons


### PR DESCRIPTION
## Summary
- Updated ServiceStatus type to accept backend health values (healthy, unhealthy, degraded)
- Fixed timestamp/lastCheck types to accept both number and string (ISO 8601)
- Fixed root cause bug: `toHealthStatus()` didn't recognize backend's `'healthy'` status, causing all healthy services to show as errored
- Added `normalizeServiceStatus()` shared utility for centralized mapping
- Added unit tests for status normalization

## Root Cause
`toHealthStatus()` in `useSystemStatus.ts` only mapped `'online'` -> `'healthy'`, with everything else (including the backend's `'healthy'`) falling through to `'error'`.

Closes #2076