### PR TITLE
feat(mesh): add PersonalizedPageRank for graph expansion (#2057)

### DIFF
--- a/autobot-backend/services/mesh_brain/ppr.py
+++ b/autobot-backend/services/mesh_brain/ppr.py
@@ -1,0 +1,192 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Personalized PageRank over the mesh graph for importance-weighted expansion (#1994, #2057)."""
+import logging
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Protocol
+# =============================================================================
+
+
+class MeshDB(Protocol):
+    """Protocol for mesh database neighbor lookups used by PPR."""
+
+    async def get_neighbors(self, node_id: str, min_weight: float) -> list[dict]:
+        """Return list of {"to_node": str, "weight": float} for node_id."""
+        ...
+
+
+# =============================================================================
+# Subgraph
+# =============================================================================
+
+
+class Subgraph:
+    """Lightweight in-memory directed graph for PPR computation."""
+
+    def __init__(self, nodes: set, edges: list[tuple[str, str, float]]):
+        self.nodes = nodes
+        self._in_edges: dict[str, list[tuple[str, float]]] = {}
+        self._out_degree: dict[str, int] = {}
+        for src, tgt, weight in edges:
+            self._in_edges.setdefault(tgt, []).append((src, weight))
+            self._out_degree[src] = self._out_degree.get(src, 0) + 1
+
+    def in_edges(self, node: str) -> list[tuple[str, float]]:
+        """Return [(source_node, weight), ...] for all edges into node."""
+        return self._in_edges.get(node, [])
+
+    def out_degree(self, node: str) -> int:
+        """Return the number of outgoing edges from node."""
+        return self._out_degree.get(node, 0)
+
+
+# =============================================================================
+# PersonalizedPageRank
+# =============================================================================
+
+
+class PersonalizedPageRank:
+    """PPR over the mesh graph for importance-weighted expansion.
+
+    Replaces BFS for knowledge retrieval graph expansion. Edge weights
+    directly influence propagation — high-weight edges (reinforced by
+    EdgeLearner) propagate more relevance.
+    """
+
+    def __init__(self, db: MeshDB):
+        """
+        Args:
+            db: MeshDB instance for subgraph loading (get_neighbors).
+        """
+        self.db = db
+
+    async def rank(
+        self,
+        seed_node_ids: list[str],
+        alpha: float = 0.15,
+        max_iterations: int = 20,
+        min_weight: float = 0.3,
+        top_k: int = 20,
+    ) -> list[tuple[str, float]]:
+        """Run PPR from seed nodes. Returns [(node_id, ppr_score), ...] sorted desc."""
+        subgraph = await self._load_subgraph(
+            seed_node_ids, max_hops=3, min_weight=min_weight
+        )
+        if not subgraph.nodes:
+            return self._uniform_seed_scores(seed_node_ids)
+        scores = self._init_scores(seed_node_ids, subgraph.nodes)
+        scores = self._power_iterate(
+            scores, subgraph, seed_node_ids, alpha, max_iterations
+        )
+        return sorted(scores.items(), key=lambda x: -x[1])[:top_k]
+
+    # ------------------------------------------------------------------
+    # Private helpers — each kept under 30 lines
+    # ------------------------------------------------------------------
+
+    def _uniform_seed_scores(self, seed_node_ids: list[str]) -> list[tuple[str, float]]:
+        """Return uniform 1/n scores for each seed when subgraph is empty."""
+        uniform = 1.0 / len(seed_node_ids)
+        return [(nid, uniform) for nid in seed_node_ids]
+
+    def _init_scores(
+        self, seed_node_ids: list[str], all_nodes: set
+    ) -> dict[str, float]:
+        """Initialise PPR score vector: 1/n for seeds, 0 for others."""
+        n_seeds = len(seed_node_ids)
+        seed_set = set(seed_node_ids)
+        return {nid: (1.0 / n_seeds if nid in seed_set else 0.0) for nid in all_nodes}
+
+    def _power_iterate(
+        self,
+        scores: dict[str, float],
+        subgraph: Subgraph,
+        seed_node_ids: list[str],
+        alpha: float,
+        max_iterations: int,
+    ) -> dict[str, float]:
+        """Run power iterations until convergence or max_iterations reached."""
+        n_seeds = len(seed_node_ids)
+        seed_set = set(seed_node_ids)
+        for _ in range(max_iterations):
+            new_scores = self._single_iteration(
+                scores, subgraph, seed_set, n_seeds, alpha
+            )
+            if self._converged(scores, new_scores):
+                return new_scores
+            scores = new_scores
+        return scores
+
+    def _single_iteration(
+        self,
+        scores: dict[str, float],
+        subgraph: Subgraph,
+        seed_set: set,
+        n_seeds: int,
+        alpha: float,
+    ) -> dict[str, float]:
+        """Compute one PPR power-iteration step and return new score vector."""
+        new_scores: dict[str, float] = {}
+        for node in subgraph.nodes:
+            teleport = alpha * (1.0 / n_seeds if node in seed_set else 0.0)
+            propagation = self._propagation_sum(node, scores, subgraph)
+            new_scores[node] = teleport + (1 - alpha) * propagation
+        return new_scores
+
+    def _propagation_sum(
+        self, node: str, scores: dict[str, float], subgraph: Subgraph
+    ) -> float:
+        """Sum weighted contributions from in-edge neighbors for one node."""
+        total = 0.0
+        for neighbor, edge_weight in subgraph.in_edges(node):
+            out_deg = subgraph.out_degree(neighbor)
+            if out_deg > 0:
+                total += scores.get(neighbor, 0.0) * edge_weight / out_deg
+        return total
+
+    async def _load_subgraph(
+        self, seed_ids: list[str], max_hops: int, min_weight: float
+    ) -> Subgraph:
+        """BFS from seed_ids up to max_hops; returns Subgraph of collected nodes/edges."""
+        visited: set[str] = set(seed_ids)
+        frontier: list[str] = list(seed_ids)
+        edges: list[tuple[str, str, float]] = []
+
+        for _ in range(max_hops):
+            frontier, new_edges = await self._expand_frontier(
+                frontier, visited, min_weight
+            )
+            edges.extend(new_edges)
+            if not frontier:
+                break
+
+        return Subgraph(visited, edges)
+
+    async def _expand_frontier(
+        self, frontier: list[str], visited: set[str], min_weight: float
+    ) -> tuple[list[str], list[tuple[str, str, float]]]:
+        """Expand one BFS hop. Returns (next_frontier, new_edges)."""
+        next_frontier: list[str] = []
+        new_edges: list[tuple[str, str, float]] = []
+        for node_id in frontier:
+            neighbors = await self.db.get_neighbors(node_id, min_weight=min_weight)
+            for neighbor in neighbors:
+                nid = neighbor["to_node"]
+                new_edges.append((node_id, nid, neighbor["weight"]))
+                if nid not in visited:
+                    visited.add(nid)
+                    next_frontier.append(nid)
+        return next_frontier, new_edges
+
+    @staticmethod
+    def _converged(
+        old: dict[str, float], new: dict[str, float], tol: float = 1e-6
+    ) -> bool:
+        """Return True when L1 distance between score vectors is below tol."""
+        return sum(abs(old.get(k, 0.0) - new.get(k, 0.0)) for k in new) < tol

--- a/autobot-backend/services/mesh_brain/ppr_test.py
+++ b/autobot-backend/services/mesh_brain/ppr_test.py
@@ -1,0 +1,194 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for PersonalizedPageRank — mesh graph expansion (#1994, #2057)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from services.mesh_brain.ppr import PersonalizedPageRank
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_db_mock(neighbor_map: dict[str, list[dict]]) -> AsyncMock:
+    """Return a MeshDB mock whose get_neighbors returns from neighbor_map.
+
+    neighbor_map keys are node_id strings; values are lists of
+    {"to_node": str, "weight": float} dicts.  Unknown nodes return [].
+    """
+    db = AsyncMock()
+    db.get_neighbors = AsyncMock(
+        side_effect=lambda node_id, min_weight=0.0: neighbor_map.get(node_id, [])
+    )
+    return db
+
+
+def _ppr(neighbor_map: dict) -> PersonalizedPageRank:
+    """Construct a PersonalizedPageRank with the given neighbor map."""
+    return PersonalizedPageRank(db=_make_db_mock(neighbor_map))
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestPersonalizedPageRank:
+    """Tests for PersonalizedPageRank.rank() and its helpers."""
+
+    @pytest.mark.asyncio
+    async def test_single_seed_node_gets_highest_score(self):
+        """The seed node must receive the highest PPR score in any connected graph."""
+        neighbor_map = {
+            "A": [{"to_node": "B", "weight": 0.8}],
+            "B": [],
+        }
+        ppr = _ppr(neighbor_map)
+
+        results = await ppr.rank(seed_node_ids=["A"], alpha=0.15, top_k=10)
+
+        assert results, "Expected non-empty results"
+        top_node, top_score = results[0]
+        assert top_node == "A", f"Expected seed 'A' as top node, got {top_node!r}"
+        assert top_score > 0.0
+
+    @pytest.mark.asyncio
+    async def test_connected_neighbor_gets_score(self):
+        """A directly connected neighbor with high weight receives a meaningful score."""
+        neighbor_map = {
+            "seed": [{"to_node": "neighbor", "weight": 0.9}],
+            "neighbor": [],
+        }
+        ppr = _ppr(neighbor_map)
+
+        results = await ppr.rank(seed_node_ids=["seed"], alpha=0.15, top_k=10)
+
+        node_ids = [nid for nid, _ in results]
+        assert "neighbor" in node_ids, "Neighbor should appear in PPR results"
+
+        scores = dict(results)
+        assert scores["neighbor"] > 0.0, "Neighbor score should be positive"
+
+    @pytest.mark.asyncio
+    async def test_disconnected_node_gets_zero(self):
+        """A node not reachable from seeds must not appear in results."""
+        neighbor_map = {
+            "seed": [],
+            "isolated": [{"to_node": "seed", "weight": 0.9}],
+        }
+        ppr = _ppr(neighbor_map)
+
+        # BFS from "seed" will not visit "isolated" (no outgoing edge from seed to it)
+        results = await ppr.rank(seed_node_ids=["seed"], alpha=0.15, top_k=20)
+
+        node_ids = {nid for nid, _ in results}
+        assert (
+            "isolated" not in node_ids
+        ), "'isolated' is unreachable and must not appear"
+
+    @pytest.mark.asyncio
+    async def test_alpha_controls_teleport(self):
+        """High alpha concentrates scores on seeds; low alpha spreads to neighbors."""
+        neighbor_map = {
+            "seed": [{"to_node": "far", "weight": 0.9}],
+            "far": [],
+        }
+
+        high_alpha_ppr = _ppr(neighbor_map)
+        low_alpha_ppr = _ppr(neighbor_map)
+
+        high_results = dict(await high_alpha_ppr.rank(["seed"], alpha=0.9, top_k=10))
+        low_results = dict(await low_alpha_ppr.rank(["seed"], alpha=0.05, top_k=10))
+
+        # With high alpha, seed dominates far more strongly
+        seed_dominance_high = high_results.get("seed", 0.0) - high_results.get(
+            "far", 0.0
+        )
+        seed_dominance_low = low_results.get("seed", 0.0) - low_results.get("far", 0.0)
+        assert (
+            seed_dominance_high > seed_dominance_low
+        ), "High alpha should produce greater seed dominance than low alpha"
+
+    @pytest.mark.asyncio
+    async def test_edge_weight_influences_propagation(self):
+        """A higher-weight edge propagates more PPR score than a lower-weight edge."""
+        high_weight_map = {
+            "seed": [{"to_node": "target", "weight": 0.95}],
+            "target": [],
+        }
+        low_weight_map = {
+            "seed": [{"to_node": "target", "weight": 0.1}],
+            "target": [],
+        }
+
+        high_results = dict(
+            await _ppr(high_weight_map).rank(["seed"], alpha=0.15, top_k=10)
+        )
+        low_results = dict(
+            await _ppr(low_weight_map).rank(["seed"], alpha=0.15, top_k=10)
+        )
+
+        assert high_results.get("target", 0.0) > low_results.get(
+            "target", 0.0
+        ), "Higher edge weight must propagate more score to the target"
+
+    def test_convergence_check_identical_dicts(self):
+        """_converged returns True when old and new score vectors are identical."""
+        scores = {"A": 0.5, "B": 0.3, "C": 0.2}
+        ppr = PersonalizedPageRank(db=AsyncMock())
+        assert ppr._converged(scores, scores.copy()) is True
+
+    def test_convergence_check_different_dicts(self):
+        """_converged returns False when score vectors differ beyond tolerance."""
+        old = {"A": 0.5, "B": 0.5}
+        new = {"A": 0.9, "B": 0.1}
+        ppr = PersonalizedPageRank(db=AsyncMock())
+        assert ppr._converged(old, new) is False
+
+    @pytest.mark.asyncio
+    async def test_empty_subgraph_returns_seed_scores(self):
+        """When no neighbors exist, seeds receive uniform 1/n scores."""
+        neighbor_map: dict = {}  # get_neighbors returns [] for all nodes
+        ppr = _ppr(neighbor_map)
+
+        results = await ppr.rank(seed_node_ids=["X", "Y"], alpha=0.15, top_k=10)
+
+        assert len(results) == 2
+        scores = dict(results)
+        # Both seeds should get equal scores (no edges to break symmetry)
+        assert abs(scores["X"] - scores["Y"]) < 1e-9, "Seeds should get equal scores"
+        assert scores["X"] > 0, "Seed scores should be positive"
+
+    @pytest.mark.asyncio
+    async def test_top_k_limits_results(self):
+        """rank() returns at most top_k results regardless of subgraph size."""
+        # Build a star graph: seed → n0..n9
+        neighbor_map: dict = {
+            "seed": [{"to_node": f"n{i}", "weight": 0.8} for i in range(10)],
+        }
+        for i in range(10):
+            neighbor_map[f"n{i}"] = []
+
+        ppr = _ppr(neighbor_map)
+        results = await ppr.rank(seed_node_ids=["seed"], alpha=0.15, top_k=5)
+
+        assert len(results) == 5, f"Expected 5 results, got {len(results)}"
+
+    @pytest.mark.asyncio
+    async def test_results_sorted_descending(self):
+        """rank() results are sorted by score in descending order."""
+        neighbor_map = {
+            "seed": [{"to_node": "B", "weight": 0.8}],
+            "B": [],
+        }
+        ppr = _ppr(neighbor_map)
+
+        results = await ppr.rank(seed_node_ids=["seed"], alpha=0.15, top_k=10)
+
+        scores = [score for _, score in results]
+        assert scores == sorted(
+            scores, reverse=True
+        ), "Results must be sorted descending"


### PR DESCRIPTION
## Summary
- PPR replaces BFS for knowledge retrieval graph expansion
- Edge weights directly influence propagation (Hebbian-reinforced edges spread more relevance)
- Subgraph loaded via BFS (max 3 hops), then power iteration with alpha=0.15 teleport
- Lightweight `Subgraph` class with pre-built in-edge/out-degree indexes
- 10 tests covering seed dominance, edge weight influence, alpha control, convergence, top-k

## Test plan
- [x] 10/10 tests pass
- [x] Empty subgraph returns equal seed scores
- [x] Edge weight influences propagation correctly

Closes #2057