### PR TITLE
feat: add batch vectorization endpoint (#2077)

### DIFF
--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -22,7 +22,7 @@ from knowledge.pipeline.base import PipelineContext
 from knowledge.pipeline.cognifiers.context_generator import ContextGeneratorCognifier
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge_factory import get_or_create_knowledge_base
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from redis.exceptions import RedisError
 from type_defs.common import Metadata
 from utils.async_chromadb_client import get_async_chromadb_client
@@ -1105,6 +1105,17 @@ class BatchVectorizeRequest(BaseModel):
         description="List of document IDs to vectorize (max 100 per request)",
     )
 
+    @field_validator("document_ids")
+    @classmethod
+    def validate_document_ids(cls, v: List[str]) -> List[str]:
+        """Deduplicate and validate individual document IDs."""
+        seen: dict[str, None] = {}
+        for item in v:
+            if not isinstance(item, str) or not item.strip() or len(item) > 255:
+                raise ValueError(f"Invalid document ID: {item!r}")
+            seen[item] = None
+        return list(seen)
+
 
 async def _vectorize_single_document(kb, document_id: str) -> dict:
     """
@@ -1160,9 +1171,15 @@ async def batch_vectorize_documents(
         "Starting batch vectorization for %d documents", len(request.document_ids)
     )
 
-    results = [
-        await _vectorize_single_document(kb, doc_id) for doc_id in request.document_ids
-    ]
+    semaphore = asyncio.Semaphore(10)
+
+    async def _bounded_vectorize(doc_id: str) -> dict:
+        async with semaphore:
+            return await _vectorize_single_document(kb, doc_id)
+
+    results = await asyncio.gather(
+        *[_bounded_vectorize(doc_id) for doc_id in request.document_ids]
+    )
 
     succeeded = sum(1 for r in results if r["status"] == "success")
     logger.info(

--- a/autobot-frontend/src/composables/useKnowledgeVectorization.ts
+++ b/autobot-frontend/src/composables/useKnowledgeVectorization.ts
@@ -352,8 +352,12 @@ export function useKnowledgeVectorization() {
   const _tryBatchEndpoint = async (
     documentIds: string[]
   ): Promise<{ succeeded: string[], failed: string[] }> => {
+    const knowledgeTimeout = appConfig.getTimeout('knowledge')
+    const batchTimeout = Math.min(knowledgeTimeout * documentIds.length, 300000)
     const response = await apiClient.post('/api/knowledge_base/vectorize_documents', {
       document_ids: documentIds
+    }, {
+      timeout: batchTimeout
     })
     const data = await parseApiResponse(response)
 
@@ -390,27 +394,40 @@ export function useKnowledgeVectorization() {
     try {
       // Issue #2077: use single batch request instead of N+1 individual requests
       return await _tryBatchEndpoint(documentIds)
-    } catch (batchError) {
-      // Batch endpoint unavailable — fall back to individual per-document requests
+    } catch (batchError: unknown) {
+      // Only fall back for 404/405 (endpoint not found); rethrow real errors
+      const status = (batchError as Record<string, unknown>)?.response
+        ? ((batchError as Record<string, Record<string, unknown>>).response?.status as number)
+        : undefined
+      if (status && status !== 404 && status !== 405) {
+        throw batchError
+      }
+
       logger.warn(
         'Batch vectorization endpoint unavailable, falling back to individual requests:',
         batchError
       )
 
-      const results = await Promise.allSettled(
-        documentIds.map(docId => vectorizeDocument(docId))
-      )
+      try {
+        const results = await Promise.allSettled(
+          documentIds.map(docId => vectorizeDocument(docId))
+        )
 
-      results.forEach((result, index) => {
-        const docId = documentIds[index]
-        if (result.status === 'fulfilled' && result.value) {
-          succeeded.push(docId)
-        } else {
-          failed.push(docId)
-        }
-      })
+        results.forEach((result, index) => {
+          const docId = documentIds[index]
+          if (result.status === 'fulfilled' && result.value) {
+            succeeded.push(docId)
+          } else {
+            failed.push(docId)
+          }
+        })
 
-      return { succeeded, failed }
+        return { succeeded, failed }
+      } catch (fallbackError) {
+        logger.error('Fallback vectorization also failed:', fallbackError)
+        documentIds.forEach(id => setDocumentStatus(id, 'failed', 0, String(fallbackError)))
+        return { succeeded: [], failed: documentIds }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Added `POST /api/knowledge_base/vectorize_documents` endpoint accepting `{document_ids: string[]}`
- Returns per-document results: `{results, total, succeeded}`
- Reuses existing `kb.vectorize_existing_fact()` — zero duplicated vectorization logic
- Updated frontend `vectorizeBatch` to use batch endpoint, eliminating N+1 round-trips
- Kept original `Promise.allSettled` as graceful fallback

Closes #2077