### PR TITLE
feat(mesh): add PostgreSQL mesh schema and async MeshDB client (#2055)

### DIFF
--- a/autobot-backend/migrations/versions/20260323_013_add_mesh_tables.py
+++ b/autobot-backend/migrations/versions/20260323_013_add_mesh_tables.py
@@ -1,0 +1,154 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Create Neural Mesh RAG tables: mesh_nodes, mesh_edges, mesh_evolution_log (#2055).
+
+Revision ID: 20260323_013
+Revises: 20260315_012
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "20260323_013"
+down_revision = "20260315_012"
+branch_labels = None
+depends_on = None
+
+
+def _create_mesh_nodes_table() -> None:
+    """Create mesh_nodes table. Helper for upgrade() (#2055)."""
+    op.create_table(
+        "mesh_nodes",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("chunk_id", sa.Text, nullable=False, unique=True),
+        sa.Column("source_file", sa.Text, nullable=True),
+        sa.Column("node_type", sa.Text, nullable=False, server_default="doc"),
+        sa.Column("raptor_level", sa.Integer, nullable=True, server_default="0"),
+        sa.Column("access_count", sa.Integer, nullable=True, server_default="0"),
+        sa.Column("is_anchor", sa.Boolean, nullable=True, server_default="false"),
+        sa.Column("last_accessed", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "idx_mesh_nodes_anchor",
+        "mesh_nodes",
+        ["is_anchor"],
+        postgresql_where=sa.text("is_anchor = TRUE"),
+    )
+    op.create_index("idx_mesh_nodes_type", "mesh_nodes", ["node_type"])
+
+
+def _create_mesh_edges_table() -> None:
+    """Create mesh_edges table. Helper for upgrade() (#2055)."""
+    op.create_table(
+        "mesh_edges",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "from_node",
+            UUID(as_uuid=True),
+            sa.ForeignKey("mesh_nodes.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "to_node",
+            UUID(as_uuid=True),
+            sa.ForeignKey("mesh_nodes.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("edge_type", sa.Text, nullable=False),
+        sa.Column("weight", sa.Float, nullable=True, server_default="1.0"),
+        sa.Column("origin", sa.Text, nullable=False, server_default="seeder"),
+        sa.Column("co_access_count", sa.Integer, nullable=True, server_default="0"),
+        sa.Column("last_reinforced", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("from_node", "to_node", "edge_type", name="uq_mesh_edges"),
+    )
+    _create_mesh_edges_indexes()
+
+
+def _create_mesh_edges_indexes() -> None:
+    """Create indexes for mesh_edges. Helper for _create_mesh_edges_table() (#2055)."""
+    op.create_index(
+        "idx_mesh_edges_weight",
+        "mesh_edges",
+        ["weight"],
+        postgresql_where=sa.text("weight > 0.3"),
+    )
+    op.create_index("idx_mesh_edges_origin", "mesh_edges", ["origin"])
+    op.create_index("idx_mesh_edges_from", "mesh_edges", ["from_node"])
+    op.create_index("idx_mesh_edges_to", "mesh_edges", ["to_node"])
+
+
+def _create_mesh_evolution_log_table() -> None:
+    """Create mesh_evolution_log table. Helper for upgrade() (#2055)."""
+    op.create_table(
+        "mesh_evolution_log",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("event_type", sa.Text, nullable=False),
+        sa.Column("entity_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("old_value", JSONB, nullable=True),
+        sa.Column("new_value", JSONB, nullable=True),
+        sa.Column("actor", sa.Text, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "idx_mesh_evolution_type",
+        "mesh_evolution_log",
+        ["event_type", "created_at"],
+    )
+
+
+def upgrade() -> None:
+    """Create mesh_nodes, mesh_edges, and mesh_evolution_log tables."""
+    _create_mesh_nodes_table()
+    _create_mesh_edges_table()
+    _create_mesh_evolution_log_table()
+
+
+def downgrade() -> None:
+    """Drop mesh tables in dependency order."""
+    op.drop_index("idx_mesh_evolution_type", table_name="mesh_evolution_log")
+    op.drop_table("mesh_evolution_log")
+
+    op.drop_index("idx_mesh_edges_to", table_name="mesh_edges")
+    op.drop_index("idx_mesh_edges_from", table_name="mesh_edges")
+    op.drop_index("idx_mesh_edges_origin", table_name="mesh_edges")
+    op.drop_index("idx_mesh_edges_weight", table_name="mesh_edges")
+    op.drop_table("mesh_edges")
+
+    op.drop_index("idx_mesh_nodes_type", table_name="mesh_nodes")
+    op.drop_index("idx_mesh_nodes_anchor", table_name="mesh_nodes")
+    op.drop_table("mesh_nodes")

--- a/autobot-backend/services/mesh_brain/mesh_db.py
+++ b/autobot-backend/services/mesh_brain/mesh_db.py
@@ -1,0 +1,272 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Async PostgreSQL client for Neural Mesh RAG graph operations (#2055)."""
+import logging
+from typing import Any, Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+logger = logging.getLogger(__name__)
+
+
+class MeshDB:
+    """Async PostgreSQL client for mesh_nodes, mesh_edges, and mesh_evolution_log."""
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self.engine = engine
+
+    # ------------------------------------------------------------------
+    # Nodes
+    # ------------------------------------------------------------------
+
+    async def create_node(
+        self,
+        chunk_id: str,
+        source_file: Optional[str],
+        node_type: str,
+        raptor_level: int = 0,
+    ) -> str:
+        """Insert a mesh node and return its UUID string (#2055)."""
+        sql = text(
+            """
+            INSERT INTO mesh_nodes (chunk_id, source_file, node_type, raptor_level)
+            VALUES (:chunk_id, :source_file, :node_type, :raptor_level)
+            RETURNING id::text
+            """
+        )
+        async with self.engine.begin() as conn:
+            row = await conn.execute(
+                sql,
+                {
+                    "chunk_id": chunk_id,
+                    "source_file": source_file,
+                    "node_type": node_type,
+                    "raptor_level": raptor_level,
+                },
+            )
+            node_id = row.scalar_one()
+        logger.info("Created mesh node %s chunk_id=%s", node_id, chunk_id)
+        return node_id
+
+    async def update_access_count(self, node_ids: list[str]) -> None:
+        """Increment access_count and set last_accessed for the given node UUIDs (#2055)."""
+        if not node_ids:
+            return
+        sql = text(
+            """
+            UPDATE mesh_nodes
+            SET access_count = access_count + 1,
+                last_accessed = NOW()
+            WHERE id = ANY(:node_ids::uuid[])
+            """
+        )
+        async with self.engine.begin() as conn:
+            await conn.execute(sql, {"node_ids": node_ids})
+        logger.debug("Updated access_count for %d nodes", len(node_ids))
+
+    # ------------------------------------------------------------------
+    # Edges
+    # ------------------------------------------------------------------
+
+    async def create_edge(
+        self,
+        from_node: str,
+        to_node: str,
+        edge_type: str,
+        weight: float,
+        origin: str,
+    ) -> str:
+        """Insert a mesh edge and return its UUID string (#2055)."""
+        sql = text(
+            """
+            INSERT INTO mesh_edges (from_node, to_node, edge_type, weight, origin)
+            VALUES (:from_node::uuid, :to_node::uuid, :edge_type, :weight, :origin)
+            RETURNING id::text
+            """
+        )
+        async with self.engine.begin() as conn:
+            row = await conn.execute(
+                sql,
+                {
+                    "from_node": from_node,
+                    "to_node": to_node,
+                    "edge_type": edge_type,
+                    "weight": weight,
+                    "origin": origin,
+                },
+            )
+            edge_id = row.scalar_one()
+        logger.info(
+            "Created mesh edge %s %s->%s type=%s",
+            edge_id,
+            from_node,
+            to_node,
+            edge_type,
+        )
+        return edge_id
+
+    async def get_edge(
+        self,
+        from_node: str,
+        to_node: str,
+        edge_type: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Return the first matching edge as a dict, or None if absent (#2055)."""
+        if edge_type is not None:
+            sql = text(
+                """
+                SELECT id::text, from_node::text, to_node::text,
+                       edge_type, weight, origin, co_access_count, last_reinforced
+                FROM mesh_edges
+                WHERE from_node = :from_node::uuid
+                  AND to_node   = :to_node::uuid
+                  AND edge_type = :edge_type
+                LIMIT 1
+                """
+            )
+            params: dict[str, Any] = {
+                "from_node": from_node,
+                "to_node": to_node,
+                "edge_type": edge_type,
+            }
+        else:
+            sql = text(
+                """
+                SELECT id::text, from_node::text, to_node::text,
+                       edge_type, weight, origin, co_access_count, last_reinforced
+                FROM mesh_edges
+                WHERE from_node = :from_node::uuid
+                  AND to_node   = :to_node::uuid
+                LIMIT 1
+                """
+            )
+            params = {"from_node": from_node, "to_node": to_node}
+
+        async with self.engine.connect() as conn:
+            row = await conn.execute(sql, params)
+            result = row.mappings().fetchone()
+        return dict(result) if result else None
+
+    async def update_edge(
+        self,
+        edge_id: str,
+        weight: Optional[float] = None,
+        co_access_count: Optional[int] = None,
+    ) -> None:
+        """Partially update an edge's weight and/or co_access_count (#2055)."""
+        updates: list[str] = ["last_reinforced = NOW()"]
+        params: dict[str, Any] = {"edge_id": edge_id}
+        if weight is not None:
+            updates.append("weight = :weight")
+            params["weight"] = weight
+        if co_access_count is not None:
+            updates.append("co_access_count = :co_access_count")
+            params["co_access_count"] = co_access_count
+        sql = text(
+            f"UPDATE mesh_edges SET {', '.join(updates)} WHERE id = :edge_id::uuid"
+        )
+        async with self.engine.begin() as conn:
+            await conn.execute(sql, params)
+        logger.debug("Updated edge %s", edge_id)
+
+    async def get_neighbors(
+        self,
+        node_id: str,
+        min_weight: float = 0.0,
+        max_hops: int = 1,
+    ) -> list[dict]:
+        """Return direct neighbors of node_id above min_weight (max_hops=1 only) (#2055)."""
+        sql = text(
+            """
+            SELECT e.id::text        AS edge_id,
+                   e.to_node::text   AS neighbor_id,
+                   e.edge_type,
+                   e.weight,
+                   e.origin
+            FROM mesh_edges e
+            WHERE e.from_node = :node_id::uuid
+              AND e.weight    >= :min_weight
+            ORDER BY e.weight DESC
+            """
+        )
+        async with self.engine.connect() as conn:
+            rows = await conn.execute(
+                sql, {"node_id": node_id, "min_weight": min_weight}
+            )
+            return [dict(r) for r in rows.mappings()]
+
+    async def fetch_edges(self, min_weight: float = 0.5) -> list[dict]:
+        """Return all edges above min_weight. Satisfies MeshEdgeSync Protocol (#2029, #2055)."""
+        sql = text(
+            """
+            SELECT id::text, from_node::text, to_node::text,
+                   edge_type, weight, origin
+            FROM mesh_edges
+            WHERE weight >= :min_weight
+            ORDER BY weight DESC
+            """
+        )
+        async with self.engine.connect() as conn:
+            rows = await conn.execute(sql, {"min_weight": min_weight})
+            return [dict(r) for r in rows.mappings()]
+
+    async def get_co_access_count(self, node_a: str, node_b: str) -> int:
+        """Return the co_access_count for the edge between node_a and node_b (#2055)."""
+        sql = text(
+            """
+            SELECT COALESCE(co_access_count, 0)
+            FROM mesh_edges
+            WHERE from_node = :node_a::uuid
+              AND to_node   = :node_b::uuid
+            LIMIT 1
+            """
+        )
+        async with self.engine.connect() as conn:
+            row = await conn.execute(sql, {"node_a": node_a, "node_b": node_b})
+            return row.scalar() or 0
+
+    # ------------------------------------------------------------------
+    # Evolution log
+    # ------------------------------------------------------------------
+
+    async def log_evolution(
+        self,
+        event_type: str,
+        entity_id: Optional[str],
+        old_value: Optional[dict],
+        new_value: Optional[dict],
+        actor: str,
+    ) -> None:
+        """Append an audit entry to mesh_evolution_log (#2055)."""
+        sql = text(
+            """
+            INSERT INTO mesh_evolution_log
+                (event_type, entity_id, old_value, new_value, actor)
+            VALUES
+                (:event_type,
+                 :entity_id::uuid,
+                 :old_value::jsonb,
+                 :new_value::jsonb,
+                 :actor)
+            """
+        )
+        import json
+
+        async with self.engine.begin() as conn:
+            await conn.execute(
+                sql,
+                {
+                    "event_type": event_type,
+                    "entity_id": entity_id,
+                    "old_value": json.dumps(old_value)
+                    if old_value is not None
+                    else None,
+                    "new_value": json.dumps(new_value)
+                    if new_value is not None
+                    else None,
+                    "actor": actor,
+                },
+            )
+        logger.debug("Logged evolution event %s entity=%s", event_type, entity_id)

--- a/autobot-backend/services/mesh_brain/mesh_db_test.py
+++ b/autobot-backend/services/mesh_brain/mesh_db_test.py
@@ -1,0 +1,337 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for MeshDB async PostgreSQL client (#2055)."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from services.mesh_brain.mesh_db import MeshDB
+
+_UNSET = object()  # sentinel for "argument not supplied"
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+_NODE_UUID = "aaaaaaaa-0000-0000-0000-000000000001"
+_EDGE_UUID = "bbbbbbbb-0000-0000-0000-000000000002"
+_OTHER_UUID = "cccccccc-0000-0000-0000-000000000003"
+
+
+def _make_engine(scalar=_UNSET, fetchone=_UNSET, mappings=_UNSET):
+    """Return a mocked AsyncEngine whose begin/connect ctx mgrs behave correctly.
+
+    Use _UNSET sentinel so callers can pass fetchone=None to mean "DB returns no row".
+    AsyncMock context managers are configured via return_value.__aenter__ because
+    AsyncMock intercepts dunder methods and ignores direct attribute assignment.
+    """
+    conn = AsyncMock()
+
+    if scalar is not _UNSET:
+        conn.execute = AsyncMock(return_value=_scalar_result(scalar))
+    elif fetchone is not _UNSET:
+        conn.execute = AsyncMock(return_value=_fetchone_result(fetchone))
+    elif mappings is not _UNSET:
+        conn.execute = AsyncMock(return_value=_mappings_result(mappings))
+    else:
+        conn.execute = AsyncMock(return_value=_scalar_result(None))
+
+    engine = MagicMock()
+    # begin() returns an async context manager that yields conn
+    engine.begin.return_value.__aenter__ = AsyncMock(return_value=conn)
+    engine.begin.return_value.__aexit__ = AsyncMock(return_value=False)
+    # connect() returns an async context manager that yields conn
+    engine.connect.return_value.__aenter__ = AsyncMock(return_value=conn)
+    engine.connect.return_value.__aexit__ = AsyncMock(return_value=False)
+    return engine, conn
+
+
+def _scalar_result(value):
+    """Return a mock result that supports scalar_one() and scalar()."""
+    r = MagicMock()
+    r.scalar_one = MagicMock(return_value=value)
+    r.scalar = MagicMock(return_value=value)
+    return r
+
+
+def _fetchone_result(row_dict):
+    """Return a mock result that supports mappings().fetchone()."""
+    r = MagicMock()
+    mappings_mock = MagicMock()
+    mappings_mock.fetchone = MagicMock(return_value=row_dict)
+    r.mappings = MagicMock(return_value=mappings_mock)
+    return r
+
+
+def _mappings_result(rows):
+    """Return a mock result that supports mappings() iteration."""
+    r = MagicMock()
+    r.mappings = MagicMock(return_value=iter(rows))
+    return r
+
+
+# =============================================================================
+# Tests — create_node
+# =============================================================================
+
+
+class TestCreateNode:
+    """MeshDB.create_node returns the UUID string from the DB."""
+
+    @pytest.mark.asyncio
+    async def test_returns_uuid_string(self):
+        engine, conn = _make_engine(scalar=_NODE_UUID)
+        db = MeshDB(engine)
+
+        result = await db.create_node(
+            chunk_id="chunk-1",
+            source_file="file.txt",
+            node_type="doc",
+            raptor_level=0,
+        )
+
+        assert result == _NODE_UUID
+        conn.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_passes_correct_params(self):
+        engine, conn = _make_engine(scalar=_NODE_UUID)
+        db = MeshDB(engine)
+
+        await db.create_node("c-42", "src.md", "summary", raptor_level=2)
+
+        _, kwargs = conn.execute.call_args
+        # params dict is the second positional arg
+        params = conn.execute.call_args[0][1]
+        assert params["chunk_id"] == "c-42"
+        assert params["node_type"] == "summary"
+        assert params["raptor_level"] == 2
+
+
+# =============================================================================
+# Tests — create_edge
+# =============================================================================
+
+
+class TestCreateEdge:
+    """MeshDB.create_edge returns the edge UUID string."""
+
+    @pytest.mark.asyncio
+    async def test_returns_uuid_string(self):
+        engine, conn = _make_engine(scalar=_EDGE_UUID)
+        db = MeshDB(engine)
+
+        result = await db.create_edge(
+            from_node=_NODE_UUID,
+            to_node=_OTHER_UUID,
+            edge_type="semantic",
+            weight=0.8,
+            origin="seeder",
+        )
+
+        assert result == _EDGE_UUID
+        conn.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_raises_on_db_error(self):
+        """A unique-constraint violation from the DB propagates as an exception."""
+        engine, conn = _make_engine()
+        conn.execute = AsyncMock(side_effect=Exception("UniqueViolation"))
+        db = MeshDB(engine)
+
+        with pytest.raises(Exception, match="UniqueViolation"):
+            await db.create_edge(_NODE_UUID, _OTHER_UUID, "semantic", 0.8, "seeder")
+
+
+# =============================================================================
+# Tests — get_edge
+# =============================================================================
+
+
+class TestGetEdge:
+    """MeshDB.get_edge returns dict or None."""
+
+    @pytest.mark.asyncio
+    async def test_returns_dict_when_found(self):
+        row = {
+            "id": _EDGE_UUID,
+            "from_node": _NODE_UUID,
+            "to_node": _OTHER_UUID,
+            "edge_type": "semantic",
+            "weight": 0.9,
+            "origin": "seeder",
+            "co_access_count": 0,
+            "last_reinforced": None,
+        }
+        engine, _ = _make_engine(fetchone=row)
+        db = MeshDB(engine)
+
+        result = await db.get_edge(_NODE_UUID, _OTHER_UUID, edge_type="semantic")
+
+        assert result is not None
+        assert result["id"] == _EDGE_UUID
+        assert result["weight"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_absent(self):
+        engine, _ = _make_engine(fetchone=None)
+        db = MeshDB(engine)
+
+        result = await db.get_edge(_NODE_UUID, _OTHER_UUID)
+
+        assert result is None
+
+
+# =============================================================================
+# Tests — get_neighbors
+# =============================================================================
+
+
+class TestGetNeighbors:
+    """MeshDB.get_neighbors returns list of dicts."""
+
+    @pytest.mark.asyncio
+    async def test_returns_correct_structure(self):
+        rows = [
+            {
+                "edge_id": _EDGE_UUID,
+                "neighbor_id": _OTHER_UUID,
+                "edge_type": "semantic",
+                "weight": 0.85,
+                "origin": "seeder",
+            }
+        ]
+        engine, _ = _make_engine(mappings=rows)
+        db = MeshDB(engine)
+
+        result = await db.get_neighbors(_NODE_UUID, min_weight=0.5)
+
+        assert len(result) == 1
+        assert result[0]["neighbor_id"] == _OTHER_UUID
+        assert result[0]["weight"] == 0.85
+
+    @pytest.mark.asyncio
+    async def test_empty_when_no_neighbors(self):
+        engine, _ = _make_engine(mappings=[])
+        db = MeshDB(engine)
+
+        result = await db.get_neighbors(_NODE_UUID, min_weight=0.5)
+
+        assert result == []
+
+
+# =============================================================================
+# Tests — fetch_edges
+# =============================================================================
+
+
+class TestFetchEdges:
+    """MeshDB.fetch_edges filters by min_weight and satisfies MeshEdgeSync Protocol."""
+
+    @pytest.mark.asyncio
+    async def test_passes_min_weight_param(self):
+        engine, conn = _make_engine(mappings=[])
+        db = MeshDB(engine)
+
+        await db.fetch_edges(min_weight=0.7)
+
+        params = conn.execute.call_args[0][1]
+        assert params["min_weight"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_returns_list_of_dicts(self):
+        rows = [
+            {
+                "id": _EDGE_UUID,
+                "from_node": _NODE_UUID,
+                "to_node": _OTHER_UUID,
+                "edge_type": "coref",
+                "weight": 0.6,
+                "origin": "seeder",
+            }
+        ]
+        engine, _ = _make_engine(mappings=rows)
+        db = MeshDB(engine)
+
+        result = await db.fetch_edges(min_weight=0.5)
+
+        assert isinstance(result, list)
+        assert result[0]["weight"] == 0.6
+
+
+# =============================================================================
+# Tests — log_evolution
+# =============================================================================
+
+
+class TestLogEvolution:
+    """MeshDB.log_evolution inserts an audit entry without raising."""
+
+    @pytest.mark.asyncio
+    async def test_creates_audit_entry(self):
+        engine, conn = _make_engine()
+        db = MeshDB(engine)
+
+        await db.log_evolution(
+            event_type="weight_updated",
+            entity_id=_EDGE_UUID,
+            old_value={"weight": 0.5},
+            new_value={"weight": 0.8},
+            actor="EdgeLearner",
+        )
+
+        conn.execute.assert_awaited_once()
+        params = conn.execute.call_args[0][1]
+        assert params["event_type"] == "weight_updated"
+        assert params["actor"] == "EdgeLearner"
+        assert json.loads(params["new_value"]) == {"weight": 0.8}
+
+    @pytest.mark.asyncio
+    async def test_none_entity_id_allowed(self):
+        """log_evolution must accept entity_id=None without raising."""
+        engine, conn = _make_engine()
+        db = MeshDB(engine)
+
+        await db.log_evolution(
+            event_type="node_created",
+            entity_id=None,
+            old_value=None,
+            new_value={"chunk_id": "x"},
+            actor="seeder",
+        )
+
+        conn.execute.assert_awaited_once()
+        params = conn.execute.call_args[0][1]
+        assert params["entity_id"] is None
+        assert params["old_value"] is None
+
+
+# =============================================================================
+# Tests — update_access_count
+# =============================================================================
+
+
+class TestUpdateAccessCount:
+    """MeshDB.update_access_count skips on empty list and fires SQL otherwise."""
+
+    @pytest.mark.asyncio
+    async def test_skips_on_empty_list(self):
+        engine, conn = _make_engine()
+        db = MeshDB(engine)
+
+        await db.update_access_count([])
+
+        conn.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_calls_execute_with_node_ids(self):
+        engine, conn = _make_engine()
+        db = MeshDB(engine)
+
+        await db.update_access_count([_NODE_UUID, _OTHER_UUID])
+
+        conn.execute.assert_awaited_once()
+        params = conn.execute.call_args[0][1]
+        assert _NODE_UUID in params["node_ids"]


### PR DESCRIPTION
## Summary
- Alembic migration `20260323_013` creates `mesh_nodes`, `mesh_edges`, `mesh_evolution_log` tables
- Partial indexes on weight>0.3, is_anchor=TRUE, from/to node, origin, type
- `MeshDB` async client with full CRUD: create_node, create_edge, get_edge, update_edge, get_neighbors, fetch_edges, update_access_count, get_co_access_count, log_evolution
- Satisfies `MeshEdgeSync` Protocol from edge_sync.py
- 14 tests

## Test plan
- [x] 14/14 tests pass
- [x] Migration up/down tested (table creation order respects FK dependencies)
- [x] MeshDB methods verified with mocked async engine

Closes #2055