### PR TITLE
feat(mesh): add NeuralMeshRetriever — unified mesh-aware retrieval (#2058)

### DIFF
--- a/autobot-backend/services/neural_mesh_retriever.py
+++ b/autobot-backend/services/neural_mesh_retriever.py
@@ -1,0 +1,301 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unified mesh-aware retriever for Neural Mesh RAG Phase 3 (#1994, #2058).
+
+Routes queries by complexity:
+  SIMPLE     -> semantic search only (~50 ms fast path)
+  MODERATE   -> hybrid search + 1-hop PPR expansion
+  COMPLEX    -> full pipeline: hybrid + anchor lookup + PPR + rerank
+  MULTI_HOP  -> same as COMPLEX
+"""
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Coroutine, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Protocols — duck-typed for testability
+# =============================================================================
+
+
+class _AnchorDB(Protocol):
+    """Minimal protocol for anchor-node lookups used by _find_anchors."""
+
+    async def get_anchor_neighbors(self, seed_ids: list[str]) -> list[str]:
+        """Return node IDs of anchor nodes adjacent to any of seed_ids."""
+        ...
+
+
+# =============================================================================
+# Result type
+# =============================================================================
+
+
+@dataclass
+class MeshRetrievalResult:
+    """Output of NeuralMeshRetriever.retrieve().
+
+    Attributes:
+        chunks:         Ranked result dicts / SearchResult objects.
+        expanded:       True when PPR expansion was applied.
+        complexity:     String value of the QueryComplexity tier used.
+        anchor_used:    True when at least one anchor node was injected.
+        nodes_explored: Approximate count of graph nodes visited.
+    """
+
+    chunks: list
+    expanded: bool
+    complexity: str
+    anchor_used: bool = False
+    nodes_explored: int = 0
+
+
+# =============================================================================
+# Retriever
+# =============================================================================
+
+
+class NeuralMeshRetriever:
+    """Self-evolving retrieval: vector seed -> mesh expansion -> rerank -> learn.
+
+    All dependencies are injected as callables or Protocol instances so the
+    class can be fully unit-tested with AsyncMock / MagicMock without a
+    running database, Redis, or model server.
+
+    Issue #2058: Phase 3 integration point for Neural Mesh RAG.
+    """
+
+    def __init__(
+        self,
+        chroma_search: Callable[..., Coroutine[Any, Any, list]],
+        hybrid_search: Callable[..., Coroutine[Any, Any, list]],
+        ppr: Any,
+        edge_learner: Any,
+        reranker: Any,
+        classifier: Any,
+        mesh_db: Any,
+    ) -> None:
+        """Inject all dependencies.
+
+        Args:
+            chroma_search:  async callable(query, k) -> list of results.
+            hybrid_search:  async callable(query, top_k) -> list of results.
+            ppr:            PersonalizedPageRank instance.
+            edge_learner:   EdgeLearner instance.
+            reranker:       ResultReranker instance.
+            classifier:     QueryClassifier instance.
+            mesh_db:        Object satisfying _AnchorDB protocol.
+        """
+        self.chroma_search = chroma_search
+        self.hybrid_search = hybrid_search
+        self.ppr = ppr
+        self.edge_learner = edge_learner
+        self.reranker = reranker
+        self.classifier = classifier
+        self.mesh_db = mesh_db
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    async def retrieve(self, query: str, top_k: int = 5) -> MeshRetrievalResult:
+        """Main entry point. Routes by query complexity.
+
+        Args:
+            query: Raw user query string.
+            top_k: Maximum number of chunks to return.
+
+        Returns:
+            MeshRetrievalResult with ranked chunks and metadata.
+        """
+        complexity = self.classifier.classify(query)
+        value = complexity.value
+
+        logger.debug("NeuralMeshRetriever: query complexity=%s top_k=%d", value, top_k)
+
+        if value == "simple":
+            return await self._simple_retrieve(query, top_k)
+        if value == "moderate":
+            return await self._moderate_retrieve(query, top_k)
+        # complex or multi_hop both use the full pipeline
+        return await self._full_retrieve(query, top_k)
+
+    # ------------------------------------------------------------------
+    # Retrieval paths
+    # ------------------------------------------------------------------
+
+    async def _simple_retrieve(self, query: str, top_k: int) -> MeshRetrievalResult:
+        """Semantic search only — fast path (~50 ms). Issue #2058."""
+        results = await self.chroma_search(query, top_k)
+        self._fire_learner(query, results)
+        return MeshRetrievalResult(chunks=results, expanded=False, complexity="simple")
+
+    async def _moderate_retrieve(self, query: str, top_k: int) -> MeshRetrievalResult:
+        """Hybrid search + 1-hop PPR expansion. Issue #2058."""
+        seeds = await self.hybrid_search(query, top_k * 2)
+        seed_ids = [self._chunk_id(r) for r in seeds[:5]]
+
+        expanded_scores = await self.ppr.rank(
+            seed_ids, top_k=top_k * 3, max_iterations=5
+        )
+        merged = self._merge_with_expansion(seeds, expanded_scores)
+
+        ranked = await self.reranker.rerank(query, merged, top_k=top_k)
+        self._fire_learner(query, ranked)
+        return MeshRetrievalResult(
+            chunks=ranked,
+            expanded=True,
+            complexity="moderate",
+            nodes_explored=len(expanded_scores),
+        )
+
+    async def _full_retrieve(self, query: str, top_k: int) -> MeshRetrievalResult:
+        """Full pipeline: hybrid + anchor check + PPR + rerank. Issue #2058."""
+        seeds = await self.hybrid_search(query, top_k * 2)
+        seed_ids = [self._chunk_id(r) for r in seeds[:5]]
+
+        anchors = await self._find_anchors(seed_ids)
+        anchor_used = bool(anchors)
+        if anchor_used:
+            seed_ids = list(set(seed_ids + anchors))
+
+        expanded_scores = await self.ppr.rank(seed_ids, top_k=top_k * 4)
+        merged = self._merge_with_expansion(seeds, expanded_scores)
+
+        ranked = await self.reranker.rerank(query, merged, top_k=top_k)
+        self._fire_learner(query, ranked)
+        return MeshRetrievalResult(
+            chunks=ranked,
+            expanded=True,
+            complexity="complex",
+            anchor_used=anchor_used,
+            nodes_explored=len(expanded_scores),
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _find_anchors(self, seed_ids: list[str]) -> list[str]:
+        """Look up anchor nodes adjacent to seed IDs via mesh_db.
+
+        Delegates to mesh_db.get_anchor_neighbors() so the Protocol
+        implementation decides what constitutes an anchor node.
+
+        Args:
+            seed_ids: List of chunk/node IDs to search around.
+
+        Returns:
+            List of anchor node IDs (may be empty).
+        """
+        try:
+            return await self.mesh_db.get_anchor_neighbors(seed_ids)
+        except Exception:
+            logger.exception("_find_anchors failed; proceeding without anchors")
+            return []
+
+    def _merge_with_expansion(
+        self,
+        seeds: list,
+        expanded_scores: list[tuple[str, float]],
+    ) -> list:
+        """Merge seed results with PPR-expanded node score map.
+
+        Seed results already present are score-boosted by their PPR rank.
+        Expanded nodes not in seeds are appended as synthetic result dicts
+        so that the reranker can consider them.
+
+        Args:
+            seeds:           Original search results (dicts or SearchResult).
+            expanded_scores: [(node_id, ppr_score), ...] from ppr.rank().
+
+        Returns:
+            Combined list of result dicts for the reranker.
+        """
+        score_map = dict(expanded_scores)
+        merged: list = []
+        seen_ids: set[str] = set()
+
+        for r in seeds:
+            cid = self._chunk_id(r)
+            seen_ids.add(cid)
+            merged.append(self._as_dict(r, ppr_boost=score_map.get(cid, 0.0)))
+
+        for node_id, ppr_score in expanded_scores:
+            if node_id not in seen_ids:
+                merged.append({"chunk_id": node_id, "score": ppr_score, "content": ""})
+
+        return merged
+
+    def _fire_learner(self, query: str, results: list) -> None:
+        """Schedule EdgeLearner.on_retrieval as a background asyncio task.
+
+        Non-blocking: failures are logged but do not affect the caller.
+
+        Args:
+            query:   Original query text for feedback attribution.
+            results: Ranked result list (top-5 IDs are recorded).
+        """
+        event = {
+            "query_text": query,
+            "final_ranked_ids": [self._chunk_id(r) for r in results[:5]],
+            "timestamp": str(time.time()),
+        }
+        asyncio.create_task(self._run_learner(event))
+
+    async def _run_learner(self, event: dict) -> None:
+        """Await EdgeLearner.on_retrieval and swallow exceptions. Issue #2058."""
+        try:
+            await self.edge_learner.on_retrieval(event)
+        except Exception:
+            logger.exception("EdgeLearner.on_retrieval raised an exception")
+
+    def _chunk_id(self, result: Any) -> str:
+        """Extract chunk ID from a result dict or SearchResult-like object.
+
+        Priority for dicts:   metadata.chunk_id -> chunk_id -> source_path -> ""
+        Priority for objects: metadata.chunk_id -> source_path -> ""
+
+        Args:
+            result: A dict or object with metadata/source_path attributes.
+
+        Returns:
+            Chunk ID string, empty string on failure.
+        """
+        if isinstance(result, dict):
+            return (
+                result.get("metadata", {}).get("chunk_id")
+                or result.get("chunk_id")
+                or result.get("source_path", "")
+            )
+        meta = getattr(result, "metadata", {}) or {}
+        return meta.get("chunk_id") or getattr(result, "source_path", "")
+
+    @staticmethod
+    def _as_dict(result: Any, ppr_boost: float = 0.0) -> dict:
+        """Normalise a result to a dict, optionally applying a PPR score boost.
+
+        Args:
+            result:    A dict or SearchResult-like object.
+            ppr_boost: PPR score from expansion; added to the base score.
+
+        Returns:
+            A dict suitable for the reranker.
+        """
+        if isinstance(result, dict):
+            out = dict(result)
+            out["score"] = out.get("score", 0.0) + ppr_boost
+            return out
+        base_score = getattr(result, "score", 0.0) or 0.0
+        return {
+            "chunk_id": getattr(result, "source_path", ""),
+            "content": getattr(result, "content", ""),
+            "score": base_score + ppr_boost,
+            "metadata": getattr(result, "metadata", {}),
+            "source_path": getattr(result, "source_path", ""),
+        }

--- a/autobot-backend/services/neural_mesh_retriever_test.py
+++ b/autobot-backend/services/neural_mesh_retriever_test.py
@@ -1,0 +1,342 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for NeuralMeshRetriever (#1994, #2058).
+
+All external dependencies are replaced with AsyncMock / MagicMock so the
+tests run without a database, Redis, or model server.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from services.neural_mesh_retriever import MeshRetrievalResult, NeuralMeshRetriever
+
+# =============================================================================
+# Factories
+# =============================================================================
+
+
+def _make_result(chunk_id: str, score: float = 0.5) -> dict:
+    """Return a minimal result dict used as a stand-in for a SearchResult."""
+    return {"metadata": {"chunk_id": chunk_id}, "score": score, "content": "text"}
+
+
+def _make_complexity_mock(value: str):
+    """Return a MagicMock whose .value attribute equals *value*."""
+    mock = MagicMock()
+    mock.value = value
+    return mock
+
+
+def _make_retriever(
+    complexity_value: str = "simple",
+    chroma_results: list | None = None,
+    hybrid_results: list | None = None,
+    ppr_results: list | None = None,
+    rerank_results: list | None = None,
+    anchor_results: list | None = None,
+) -> NeuralMeshRetriever:
+    """Construct a NeuralMeshRetriever with controllable mock dependencies.
+
+    Returns the retriever pre-configured for the given complexity tier.
+    """
+    chroma_results = chroma_results or [_make_result("c1"), _make_result("c2")]
+    hybrid_results = hybrid_results or [_make_result("h1"), _make_result("h2")]
+    ppr_results = ppr_results or [("h1", 0.8), ("h2", 0.6)]
+    rerank_results = rerank_results or hybrid_results[:1]
+    anchor_results = anchor_results or []
+
+    classifier = MagicMock()
+    classifier.classify.return_value = _make_complexity_mock(complexity_value)
+
+    ppr = AsyncMock()
+    ppr.rank = AsyncMock(return_value=ppr_results)
+
+    edge_learner = AsyncMock()
+    edge_learner.on_retrieval = AsyncMock()
+
+    reranker = AsyncMock()
+    reranker.rerank = AsyncMock(return_value=rerank_results)
+
+    mesh_db = AsyncMock()
+    mesh_db.get_anchor_neighbors = AsyncMock(return_value=anchor_results)
+
+    return NeuralMeshRetriever(
+        chroma_search=AsyncMock(return_value=chroma_results),
+        hybrid_search=AsyncMock(return_value=hybrid_results),
+        ppr=ppr,
+        edge_learner=edge_learner,
+        reranker=reranker,
+        classifier=classifier,
+        mesh_db=mesh_db,
+    )
+
+
+# =============================================================================
+# Route selection
+# =============================================================================
+
+
+class TestRouting:
+    """retrieve() dispatches to the correct path based on complexity."""
+
+    @pytest.mark.asyncio
+    async def test_simple_query_skips_ppr(self):
+        """SIMPLE complexity must not call ppr.rank."""
+        retriever = _make_retriever(complexity_value="simple")
+
+        result = await retriever.retrieve("what is redis", top_k=3)
+
+        retriever.ppr.rank.assert_not_called()
+        assert isinstance(result, MeshRetrievalResult)
+        assert result.complexity == "simple"
+        assert result.expanded is False
+
+    @pytest.mark.asyncio
+    async def test_moderate_query_uses_ppr_expansion(self):
+        """MODERATE complexity must call ppr.rank with seed IDs."""
+        retriever = _make_retriever(complexity_value="moderate")
+
+        result = await retriever.retrieve("how does redis relate to caching", top_k=3)
+
+        retriever.ppr.rank.assert_called_once()
+        call_args = retriever.ppr.rank.call_args
+        seed_ids_arg = (
+            call_args.args[0]
+            if call_args.args
+            else call_args.kwargs.get("seed_node_ids", [])
+        )
+        assert len(seed_ids_arg) > 0
+        assert result.expanded is True
+        assert result.complexity == "moderate"
+
+    @pytest.mark.asyncio
+    async def test_complex_query_checks_anchors(self):
+        """COMPLEX complexity must call mesh_db.get_anchor_neighbors."""
+        retriever = _make_retriever(complexity_value="complex")
+
+        await retriever.retrieve("compare redis vs memcached advantages", top_k=3)
+
+        retriever.mesh_db.get_anchor_neighbors.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_multi_hop_uses_full_pipeline(self):
+        """MULTI_HOP complexity routes through _full_retrieve (same as complex)."""
+        retriever = _make_retriever(complexity_value="multi_hop")
+
+        result = await retriever.retrieve(
+            "trace the chain of events that led to failure", top_k=3
+        )
+
+        retriever.mesh_db.get_anchor_neighbors.assert_called_once()
+        assert result.expanded is True
+
+
+# =============================================================================
+# EdgeLearner integration
+# =============================================================================
+
+
+class TestFireLearner:
+    """_fire_learner schedules on_retrieval for every retrieval path."""
+
+    @pytest.mark.asyncio
+    async def test_fire_learner_called_after_simple_retrieval(self):
+        """EdgeLearner.on_retrieval is scheduled after a SIMPLE retrieval."""
+        retriever = _make_retriever(complexity_value="simple")
+
+        with patch("asyncio.create_task") as mock_create_task:
+            await retriever.retrieve("what is redis", top_k=3)
+
+        mock_create_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fire_learner_called_after_retrieval(self):
+        """on_retrieval is awaited with final_ranked_ids from ranked results."""
+        retriever = _make_retriever(
+            complexity_value="simple",
+            chroma_results=[_make_result("id_alpha"), _make_result("id_beta")],
+        )
+
+        with patch("asyncio.create_task") as mock_create_task:
+            await retriever.retrieve("query text", top_k=2)
+            # Manually run the coroutine that was scheduled
+            coro = mock_create_task.call_args.args[0]
+            await coro
+
+        retriever.edge_learner.on_retrieval.assert_called_once()
+        event = retriever.edge_learner.on_retrieval.call_args.args[0]
+        assert "final_ranked_ids" in event
+        assert "id_alpha" in event["final_ranked_ids"]
+        assert "timestamp" in event
+
+
+# =============================================================================
+# _chunk_id extraction
+# =============================================================================
+
+
+class TestChunkId:
+    """_chunk_id extracts the correct ID from dict and object results."""
+
+    def test_chunk_id_extracts_from_dict_with_metadata(self):
+        """Dict with metadata.chunk_id returns that chunk_id."""
+        retriever = _make_retriever()
+        result = {"metadata": {"chunk_id": "abc-123"}, "score": 0.9}
+        assert retriever._chunk_id(result) == "abc-123"
+
+    def test_chunk_id_extracts_from_dict_with_top_level_chunk_id(self):
+        """Dict with top-level chunk_id (no metadata) returns that ID."""
+        retriever = _make_retriever()
+        result = {"chunk_id": "top-level-id", "score": 0.7}
+        assert retriever._chunk_id(result) == "top-level-id"
+
+    def test_chunk_id_extracts_from_dict_source_path_fallback(self):
+        """Dict with only source_path falls back to source_path."""
+        retriever = _make_retriever()
+        result = {"source_path": "/docs/file.md", "score": 0.5}
+        assert retriever._chunk_id(result) == "/docs/file.md"
+
+    def test_chunk_id_extracts_from_search_result_object(self):
+        """Object with metadata.chunk_id attribute returns that chunk_id."""
+        retriever = _make_retriever()
+
+        class SearchResult:
+            metadata = {"chunk_id": "obj-456"}
+            source_path = "/some/path"
+            score = 0.8
+
+        assert retriever._chunk_id(SearchResult()) == "obj-456"
+
+    def test_chunk_id_falls_back_to_source_path_on_object(self):
+        """Object without metadata.chunk_id falls back to source_path."""
+        retriever = _make_retriever()
+
+        class SearchResult:
+            metadata = {}
+            source_path = "/fallback/path.md"
+            score = 0.6
+
+        assert retriever._chunk_id(SearchResult()) == "/fallback/path.md"
+
+    def test_chunk_id_returns_empty_string_for_empty_dict(self):
+        """Empty dict returns empty string without raising."""
+        retriever = _make_retriever()
+        assert retriever._chunk_id({}) == ""
+
+
+# =============================================================================
+# _merge_with_expansion
+# =============================================================================
+
+
+class TestMergeWithExpansion:
+    """_merge_with_expansion combines seeds with PPR-scored expansion nodes."""
+
+    def test_merge_keeps_seed_results(self):
+        """All seed results must be present in the merged output."""
+        retriever = _make_retriever()
+        seeds = [_make_result("s1"), _make_result("s2")]
+        expanded_scores = [("s1", 0.9), ("s2", 0.7)]
+
+        merged = retriever._merge_with_expansion(seeds, expanded_scores)
+
+        chunk_ids = {
+            r.get("metadata", {}).get("chunk_id") or r.get("chunk_id") for r in merged
+        }
+        assert "s1" in chunk_ids
+        assert "s2" in chunk_ids
+
+    def test_merge_appends_expanded_nodes_not_in_seeds(self):
+        """Nodes returned by PPR but absent from seeds are appended."""
+        retriever = _make_retriever()
+        seeds = [_make_result("s1")]
+        expanded_scores = [("s1", 0.8), ("new_node", 0.4)]
+
+        merged = retriever._merge_with_expansion(seeds, expanded_scores)
+
+        merged_ids = {
+            r.get("metadata", {}).get("chunk_id") or r.get("chunk_id") for r in merged
+        }
+        assert "new_node" in merged_ids
+
+    def test_merge_boosts_seed_score_with_ppr(self):
+        """Seed results receive their PPR score added to the base score."""
+        retriever = _make_retriever()
+        seeds = [{"metadata": {"chunk_id": "s1"}, "score": 0.3, "content": "x"}]
+        expanded_scores = [("s1", 0.5)]
+
+        merged = retriever._merge_with_expansion(seeds, expanded_scores)
+
+        s1_result = next(
+            r for r in merged if r.get("metadata", {}).get("chunk_id") == "s1"
+        )
+        assert abs(s1_result["score"] - 0.8) < 1e-9
+
+    def test_merge_with_empty_expansion(self):
+        """Empty expanded_scores returns only seed results unchanged."""
+        retriever = _make_retriever()
+        seeds = [_make_result("s1")]
+
+        merged = retriever._merge_with_expansion(seeds, [])
+
+        assert len(merged) == 1
+
+    def test_merge_deduplicates_expanded_ids(self):
+        """A node already in seeds must not appear twice in merged output."""
+        retriever = _make_retriever()
+        seeds = [_make_result("shared")]
+        expanded_scores = [("shared", 0.9), ("extra", 0.4)]
+
+        merged = retriever._merge_with_expansion(seeds, expanded_scores)
+
+        chunk_ids = [
+            r.get("metadata", {}).get("chunk_id") or r.get("chunk_id") for r in merged
+        ]
+        assert chunk_ids.count("shared") == 1
+
+
+# =============================================================================
+# Anchor injection
+# =============================================================================
+
+
+class TestAnchorInjection:
+    """anchor_used flag and seed expansion when anchors are found."""
+
+    @pytest.mark.asyncio
+    async def test_anchor_used_true_when_anchors_found(self):
+        """anchor_used is True when mesh_db returns non-empty anchor list."""
+        retriever = _make_retriever(
+            complexity_value="complex",
+            anchor_results=["anchor-node-1"],
+        )
+
+        result = await retriever.retrieve("compare A vs B", top_k=3)
+
+        assert result.anchor_used is True
+
+    @pytest.mark.asyncio
+    async def test_anchor_used_false_when_no_anchors(self):
+        """anchor_used is False when mesh_db returns an empty list."""
+        retriever = _make_retriever(
+            complexity_value="complex",
+            anchor_results=[],
+        )
+
+        result = await retriever.retrieve("compare A vs B", top_k=3)
+
+        assert result.anchor_used is False
+
+    @pytest.mark.asyncio
+    async def test_anchor_failure_is_gracefully_handled(self):
+        """If mesh_db.get_anchor_neighbors raises, retrieval still completes."""
+        retriever = _make_retriever(complexity_value="complex")
+        retriever.mesh_db.get_anchor_neighbors = AsyncMock(
+            side_effect=RuntimeError("db error")
+        )
+
+        result = await retriever.retrieve("compare A vs B", top_k=3)
+
+        assert result.anchor_used is False
+        assert isinstance(result.chunks, list)


### PR DESCRIPTION
## Summary
- Complexity-gated retriever: SIMPLE=semantic only, MODERATE=hybrid+PPR, COMPLEX/MULTI_HOP=full pipeline with anchor lookup
- Fires EdgeLearner async after every retrieval (non-blocking)
- Merges seed results with PPR expansion scores, deduplicates
- `MeshRetrievalResult` dataclass with chunks, expanded, complexity, anchor_used, nodes_explored
- 20 tests covering routing, learner fire, chunk ID extraction, merge logic, anchor injection

## Test plan
- [x] 20/20 tests pass
- [x] SIMPLE skips PPR, MODERATE uses PPR, COMPLEX checks anchors
- [x] EdgeLearner fires for all complexity levels
- [x] Anchor failure handled gracefully

Closes #2058