### PR TITLE
feat(mesh): add EdgeDiscoverer — LLM relationship naming (#2117)

### DIFF
--- a/autobot-backend/services/mesh_brain/edge_discoverer.py
+++ b/autobot-backend/services/mesh_brain/edge_discoverer.py
@@ -1,0 +1,198 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""LLM-based relationship naming for high-weight CO_RETRIEVED edges (#2117).
+
+Runs as a scheduled background job (nightly).  EdgeLearner creates CO_RETRIEVED
+edges from usage patterns; EdgeDiscoverer promotes the strongest ones to named
+relationship types by asking an LLM to classify the pair of chunks.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, Coroutine, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Relationship labels offered to the LLM as constrained choices.
+_KNOWN_LABELS = (
+    "CALLS",
+    "CONFIGURES",
+    "VALIDATES",
+    "EXTENDS",
+    "TRIGGERS",
+    "IMPLEMENTS",
+    "DEPENDS_ON",
+    "DOCUMENTS",
+    "TESTS",
+    "DEPLOYS",
+    "MONITORS",
+    "SIMILAR_TO",
+)
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class DiscovererDB(Protocol):
+    """Subset of MeshDB operations required by EdgeDiscoverer (#2117)."""
+
+    async def fetch_candidate_edges(
+        self,
+        edge_type: str,
+        min_weight: float,
+        min_co_access: int,
+        origin: str,
+        limit: int,
+    ) -> list[dict]:
+        ...
+
+    async def update_edge(
+        self,
+        edge_id: str,
+        edge_type: str | None = None,
+        origin: str | None = None,
+    ) -> None:
+        ...
+
+    async def log_evolution(
+        self,
+        event_type: str,
+        entity_id: str | None,
+        old_value: dict | None,
+        new_value: dict | None,
+        actor: str,
+    ) -> None:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DiscoveryReport:
+    """Summary of a single EdgeDiscoverer run."""
+
+    edges_typed: int
+    llm_calls: int
+
+
+# ---------------------------------------------------------------------------
+# EdgeDiscoverer
+# ---------------------------------------------------------------------------
+
+# Type alias for the async LLM callable injected by the caller.
+LLMCallable = Callable[[str], Coroutine[None, None, str]]
+
+
+class EdgeDiscoverer:
+    """Finds and names relationship types AutoBot learns from usage.
+
+    Runs as a scheduled background job (nightly).  Processes high-weight
+    CO_RETRIEVED edges that EdgeLearner created, clusters similar pairs to
+    reduce LLM calls, then upgrades edge types to descriptive labels.
+    """
+
+    def __init__(
+        self,
+        db: DiscovererDB,
+        llm: LLMCallable,
+        batch_size: int = 50,
+    ) -> None:
+        self.db = db
+        self.llm = llm
+        self.batch_size = batch_size
+
+    async def discover(self) -> DiscoveryReport:
+        """Run one discovery cycle. Returns report of edges typed (#2117)."""
+        candidates = await self.db.fetch_candidate_edges(
+            edge_type="CO_RETRIEVED",
+            min_weight=0.7,
+            min_co_access=5,
+            origin="learner",
+            limit=self.batch_size,
+        )
+        if not candidates:
+            return DiscoveryReport(edges_typed=0, llm_calls=0)
+
+        clusters = self._cluster_by_content_similarity(candidates)
+        typed_count, llm_calls = await self._classify_clusters(clusters)
+        logger.info(
+            "EdgeDiscoverer: typed %d edges in %d LLM calls",
+            typed_count,
+            llm_calls,
+        )
+        return DiscoveryReport(edges_typed=typed_count, llm_calls=llm_calls)
+
+    async def _classify_clusters(self, clusters: list[list[dict]]) -> tuple[int, int]:
+        """Classify each cluster with one LLM call and apply label to all members."""
+        typed_count = 0
+        llm_calls = 0
+        for cluster in clusters:
+            label = await self._classify_relationship(cluster[0])
+            llm_calls += 1
+            for edge in cluster:
+                await self._apply_label(edge, label)
+                typed_count += 1
+        return typed_count, llm_calls
+
+    async def _apply_label(self, edge: dict, label: str) -> None:
+        """Write the discovered label to the DB and record the evolution event."""
+        await self.db.update_edge(edge["id"], edge_type=label, origin="discoverer")
+        await self.db.log_evolution(
+            "edge_typed",
+            edge["id"],
+            {"edge_type": "CO_RETRIEVED"},
+            {"edge_type": label},
+            "discoverer",
+        )
+
+    async def _classify_relationship(self, edge: dict) -> str:
+        """Ask the LLM to name the relationship between two chunk texts (#2117)."""
+        content_a = _truncate(
+            edge.get("from_content", "") or edge.get("from_chunk_id", "")
+        )
+        content_b = _truncate(edge.get("to_content", "") or edge.get("to_chunk_id", ""))
+        prompt = _build_classification_prompt(content_a, content_b)
+        result = await self.llm(prompt)
+        return result.strip().upper()
+
+    def _cluster_by_content_similarity(self, edges: list[dict]) -> list[list[dict]]:
+        """Group edges whose from_node is identical to share one LLM call (#2117).
+
+        Simple heuristic: edges sharing a from_node are likely related in
+        topic, so the representative chunk text is similar enough that a single
+        LLM call covers the whole group.
+        """
+        groups: dict[str, list[dict]] = {}
+        for edge in edges:
+            key = edge.get("from_node", "")
+            groups.setdefault(key, []).append(edge)
+        return list(groups.values())
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (kept under 30 lines each)
+# ---------------------------------------------------------------------------
+
+
+def _truncate(text: str, max_chars: int = 300) -> str:
+    """Return at most max_chars characters of text."""
+    return text[:max_chars]
+
+
+def _build_classification_prompt(content_a: str, content_b: str) -> str:
+    """Construct the LLM prompt for relationship classification (#2117)."""
+    labels = ", ".join(_KNOWN_LABELS)
+    return (
+        "These two knowledge chunks are frequently retrieved together.\n"
+        f"Chunk A: {content_a}\n"
+        f"Chunk B: {content_b}\n\n"
+        "What is the relationship? Respond with ONE word from:\n"
+        f"{labels}\n"
+        "Or suggest a new relationship word if none fit."
+    )

--- a/autobot-backend/services/mesh_brain/edge_discoverer_test.py
+++ b/autobot-backend/services/mesh_brain/edge_discoverer_test.py
@@ -1,0 +1,249 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for EdgeDiscoverer — LLM-based relationship naming (#2117)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from services.mesh_brain.edge_discoverer import DiscoveryReport, EdgeDiscoverer
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+_EDGE_A = "aaaaaaaa-0000-0000-0000-000000000001"
+_EDGE_B = "bbbbbbbb-0000-0000-0000-000000000002"
+_NODE_X = "xxxxxxxx-0000-0000-0000-000000000010"
+_NODE_Y = "yyyyyyyy-0000-0000-0000-000000000011"
+_NODE_Z = "zzzzzzzz-0000-0000-0000-000000000012"
+
+
+def _make_db_mock() -> AsyncMock:
+    """Return a DiscovererDB mock with empty defaults."""
+    db = AsyncMock()
+    db.fetch_candidate_edges = AsyncMock(return_value=[])
+    db.update_edge = AsyncMock()
+    db.log_evolution = AsyncMock()
+    return db
+
+
+async def _llm_returning(label: str):
+    """Return a coroutine factory whose calls always resolve to label."""
+
+    async def _llm(prompt: str) -> str:
+        return label
+
+    return _llm
+
+
+def _make_edge(
+    edge_id: str,
+    from_node: str,
+    from_content: str = "chunk text A",
+    to_content: str = "chunk text B",
+) -> dict:
+    return {
+        "id": edge_id,
+        "from_node": from_node,
+        "to_node": _NODE_Z,
+        "edge_type": "CO_RETRIEVED",
+        "weight": 0.85,
+        "co_access_count": 7,
+        "origin": "learner",
+        "from_content": from_content,
+        "to_content": to_content,
+    }
+
+
+def _make_discoverer(db: AsyncMock, llm_label: str = "CALLS") -> EdgeDiscoverer:
+    async def _llm(prompt: str) -> str:
+        return llm_label
+
+    return EdgeDiscoverer(db=db, llm=_llm, batch_size=50)
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestDiscoverTypesEdges:
+    """EdgeDiscoverer.discover() calls update_edge with the LLM label."""
+
+    @pytest.mark.asyncio
+    async def test_discover_types_candidate_edges(self):
+        """update_edge is called for each candidate with the LLM-assigned label."""
+        db = _make_db_mock()
+        edge1 = _make_edge(_EDGE_A, _NODE_X)
+        edge2 = _make_edge(_EDGE_B, _NODE_Y)
+        db.fetch_candidate_edges = AsyncMock(return_value=[edge1, edge2])
+
+        discoverer = _make_discoverer(db, llm_label="CALLS")
+        await discoverer.discover()
+
+        db.update_edge.assert_any_call(_EDGE_A, edge_type="CALLS", origin="discoverer")
+        db.update_edge.assert_any_call(_EDGE_B, edge_type="CALLS", origin="discoverer")
+
+    @pytest.mark.asyncio
+    async def test_discover_returns_report_with_counts(self):
+        """DiscoveryReport reflects the number of edges typed and LLM calls made."""
+        db = _make_db_mock()
+        # Two edges from different from_nodes → 2 clusters → 2 LLM calls
+        edge1 = _make_edge(_EDGE_A, _NODE_X)
+        edge2 = _make_edge(_EDGE_B, _NODE_Y)
+        db.fetch_candidate_edges = AsyncMock(return_value=[edge1, edge2])
+
+        discoverer = _make_discoverer(db, llm_label="DEPENDS_ON")
+        report = await discoverer.discover()
+
+        assert isinstance(report, DiscoveryReport)
+        assert report.edges_typed == 2
+        assert report.llm_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_discover_clusters_same_from_node_into_one_llm_call(self):
+        """Two edges sharing from_node use one LLM call, but both get typed."""
+        db = _make_db_mock()
+        edge1 = _make_edge(_EDGE_A, _NODE_X)
+        edge2 = _make_edge(_EDGE_B, _NODE_X)  # same from_node as edge1
+        db.fetch_candidate_edges = AsyncMock(return_value=[edge1, edge2])
+
+        call_count = 0
+
+        async def _counting_llm(prompt: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            return "TRIGGERS"
+
+        discoverer = EdgeDiscoverer(db=db, llm=_counting_llm, batch_size=50)
+        report = await discoverer.discover()
+
+        assert call_count == 1
+        assert report.edges_typed == 2
+        assert report.llm_calls == 1
+
+
+class TestDiscoverSkipsOnEmpty:
+    """discover() does nothing and does not call LLM when candidates are empty."""
+
+    @pytest.mark.asyncio
+    async def test_discover_skips_on_empty_candidates(self):
+        """No candidates → DiscoveryReport(0, 0) and LLM is never called."""
+        db = _make_db_mock()
+        db.fetch_candidate_edges = AsyncMock(return_value=[])
+
+        llm_called = False
+
+        async def _llm(prompt: str) -> str:
+            nonlocal llm_called
+            llm_called = True
+            return "CALLS"
+
+        discoverer = EdgeDiscoverer(db=db, llm=_llm, batch_size=50)
+        report = await discoverer.discover()
+
+        assert report.edges_typed == 0
+        assert report.llm_calls == 0
+        assert not llm_called
+        db.update_edge.assert_not_awaited()
+        db.log_evolution.assert_not_awaited()
+
+
+class TestClassifyRelationship:
+    """_classify_relationship sends chunk text to LLM and normalises the result."""
+
+    @pytest.mark.asyncio
+    async def test_classify_relationship_calls_llm(self):
+        """LLM prompt includes from_content and to_content of the edge."""
+        db = _make_db_mock()
+        received_prompt: list[str] = []
+
+        async def _llm(prompt: str) -> str:
+            received_prompt.append(prompt)
+            return "CALLS"
+
+        discoverer = EdgeDiscoverer(db=db, llm=_llm)
+        edge = _make_edge(
+            _EDGE_A, _NODE_X, from_content="service A code", to_content="service B code"
+        )
+        await discoverer._classify_relationship(edge)
+
+        assert len(received_prompt) == 1
+        assert "service A code" in received_prompt[0]
+        assert "service B code" in received_prompt[0]
+
+    @pytest.mark.asyncio
+    async def test_classify_relationship_normalizes_output(self):
+        """LLM response with surrounding whitespace/newlines is stripped and uppercased."""
+        db = _make_db_mock()
+
+        async def _llm(prompt: str) -> str:
+            return " calls\n"
+
+        discoverer = EdgeDiscoverer(db=db, llm=_llm)
+        edge = _make_edge(_EDGE_A, _NODE_X)
+        result = await discoverer._classify_relationship(edge)
+
+        assert result == "CALLS"
+
+
+class TestClustering:
+    """_cluster_by_content_similarity groups edges by from_node."""
+
+    def test_clustering_groups_by_from_node(self):
+        """Edges with the same from_node form one cluster; different from_nodes → two clusters."""
+        db = _make_db_mock()
+        discoverer = EdgeDiscoverer(db=db, llm=AsyncMock())
+
+        edge1 = _make_edge(_EDGE_A, _NODE_X)
+        edge2 = _make_edge(_EDGE_B, _NODE_X)  # same from_node
+        edge3 = _make_edge("edge-c", _NODE_Y)  # different from_node
+
+        clusters = discoverer._cluster_by_content_similarity([edge1, edge2, edge3])
+
+        assert len(clusters) == 2
+        cluster_sizes = sorted(len(c) for c in clusters)
+        assert cluster_sizes == [1, 2]
+
+    def test_clustering_single_from_node_is_one_cluster(self):
+        """All edges from the same node → exactly one cluster."""
+        db = _make_db_mock()
+        discoverer = EdgeDiscoverer(db=db, llm=AsyncMock())
+
+        edges = [_make_edge(f"e-{i}", _NODE_X) for i in range(4)]
+        clusters = discoverer._cluster_by_content_similarity(edges)
+
+        assert len(clusters) == 1
+        assert len(clusters[0]) == 4
+
+
+class TestEvolutionLogging:
+    """log_evolution is called once per typed edge."""
+
+    @pytest.mark.asyncio
+    async def test_evolution_logged_for_each_typed_edge(self):
+        """log_evolution is called for every edge, recording CO_RETRIEVED → new label."""
+        db = _make_db_mock()
+        edge1 = _make_edge(_EDGE_A, _NODE_X)
+        edge2 = _make_edge(_EDGE_B, _NODE_Y)
+        db.fetch_candidate_edges = AsyncMock(return_value=[edge1, edge2])
+
+        discoverer = _make_discoverer(db, llm_label="VALIDATES")
+        await discoverer.discover()
+
+        assert db.log_evolution.await_count == 2
+        db.log_evolution.assert_any_call(
+            "edge_typed",
+            _EDGE_A,
+            {"edge_type": "CO_RETRIEVED"},
+            {"edge_type": "VALIDATES"},
+            "discoverer",
+        )
+        db.log_evolution.assert_any_call(
+            "edge_typed",
+            _EDGE_B,
+            {"edge_type": "CO_RETRIEVED"},
+            {"edge_type": "VALIDATES"},
+            "discoverer",
+        )

--- a/autobot-backend/services/mesh_brain/mesh_db.py
+++ b/autobot-backend/services/mesh_brain/mesh_db.py
@@ -154,8 +154,14 @@ class MeshDB:
         edge_id: str,
         weight: Optional[float] = None,
         co_access_count: Optional[int] = None,
+        edge_type: Optional[str] = None,
+        origin: Optional[str] = None,
     ) -> None:
-        """Partially update an edge's weight and/or co_access_count (#2055)."""
+        """Partially update an edge's mutable fields (#2055, #2117).
+
+        Supports weight, co_access_count (EdgeLearner) and edge_type, origin
+        (EdgeDiscoverer) in a single generic method.
+        """
         updates: list[str] = ["last_reinforced = NOW()"]
         params: dict[str, Any] = {"edge_id": edge_id}
         if weight is not None:
@@ -164,6 +170,12 @@ class MeshDB:
         if co_access_count is not None:
             updates.append("co_access_count = :co_access_count")
             params["co_access_count"] = co_access_count
+        if edge_type is not None:
+            updates.append("edge_type = :edge_type")
+            params["edge_type"] = edge_type
+        if origin is not None:
+            updates.append("origin = :origin")
+            params["origin"] = origin
         sql = text(
             f"UPDATE mesh_edges SET {', '.join(updates)} WHERE id = :edge_id::uuid"
         )
@@ -195,6 +207,52 @@ class MeshDB:
             rows = await conn.execute(
                 sql, {"node_id": node_id, "min_weight": min_weight}
             )
+            return [dict(r) for r in rows.mappings()]
+
+    async def fetch_candidate_edges(
+        self,
+        edge_type: str,
+        min_weight: float,
+        min_co_access: int,
+        origin: str,
+        limit: int,
+    ) -> list[dict]:
+        """Return high-weight, well-travelled edges for EdgeDiscoverer (#2117).
+
+        Joins mesh_edges with mesh_nodes to include from_content/to_content so
+        the LLM can read the chunk text when naming the relationship.
+        """
+        sql = text(
+            """
+            SELECT e.id::text          AS id,
+                   e.from_node::text   AS from_node,
+                   e.to_node::text     AS to_node,
+                   e.edge_type,
+                   e.weight,
+                   e.origin,
+                   e.co_access_count,
+                   fn.chunk_id         AS from_chunk_id,
+                   tn.chunk_id         AS to_chunk_id
+            FROM mesh_edges e
+            JOIN mesh_nodes fn ON fn.id = e.from_node
+            JOIN mesh_nodes tn ON tn.id = e.to_node
+            WHERE e.edge_type      = :edge_type
+              AND e.weight         >= :min_weight
+              AND e.co_access_count >= :min_co_access
+              AND e.origin         = :origin
+            ORDER BY e.weight DESC
+            LIMIT :limit
+            """
+        )
+        params: dict[str, Any] = {
+            "edge_type": edge_type,
+            "min_weight": min_weight,
+            "min_co_access": min_co_access,
+            "origin": origin,
+            "limit": limit,
+        }
+        async with self.engine.connect() as conn:
+            rows = await conn.execute(sql, params)
             return [dict(r) for r in rows.mappings()]
 
     async def fetch_edges(self, min_weight: float = 0.5) -> list[dict]:


### PR DESCRIPTION
## Summary
- Clusters high-weight CO_RETRIEVED edges by from_node
- Classifies each cluster via LLM → named relationship type (CALLS, CONFIGURES, etc.)
- Upgrades edge_type and origin, logs evolution
- Adds `fetch_candidate_edges()` and edge_type/origin update to MeshDB
- 9 tests

## Test plan
- [x] 9/9 tests pass
- [x] Clustering reduces LLM calls verified
- [x] Evolution logging verified per edge

Closes #2117