### PR TITLE
feat(mesh): add MeshPruner — weekly entropy control (#2118)

### DIFF
--- a/autobot-backend/services/mesh_brain/mesh_pruner.py
+++ b/autobot-backend/services/mesh_brain/mesh_pruner.py
@@ -1,0 +1,144 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Weekly entropy control and decay for Neural Mesh RAG (#1994, #2118)."""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+_LEARNER_ORIGINS = ["learner", "discoverer"]
+
+
+@dataclass
+class PruningReport:
+    """Summary counts from a single MeshPruner.prune() run."""
+
+    edges_decayed: int = 0
+    edges_deleted: int = 0
+    nodes_archived: int = 0
+    edges_merged: int = 0
+    density_warning: bool = False
+
+
+class MeshDB(Protocol):
+    """Protocol for mesh database operations required by MeshPruner."""
+
+    async def decay_edges(
+        self, origins: list[str], not_reinforced_since: datetime, decay_factor: float
+    ) -> int:
+        ...
+
+    async def delete_edges(self, max_weight: float) -> int:
+        ...
+
+    async def archive_orphan_nodes(self, no_access_since: datetime) -> int:
+        ...
+
+    async def merge_duplicate_edges(self) -> int:
+        ...
+
+    async def get_graph_density(self) -> float:
+        ...
+
+
+class MeshPruner:
+    """AutoBot manages its own graph health. Runs weekly.
+
+    Rules:
+    1. Decay unreinforced learner/discoverer edges (decay_days, decay_factor).
+    2. Delete edges whose weight falls below min_weight.
+    3. Archive orphaned nodes (no edges, no access for orphan_days).
+    4. Merge near-duplicate edges.
+    5. Graph density check — emit warning when avg edges/node > max_avg_edges.
+
+    Seeder edges (origin='seeder') are NEVER decayed.
+    Orphaned nodes are archived (not deleted) and remain recoverable.
+    """
+
+    def __init__(
+        self,
+        db: MeshDB,
+        edge_sync=None,
+        decay_days: int = 30,
+        decay_factor: float = 0.8,
+        min_weight: float = 0.1,
+        orphan_days: int = 60,
+        max_avg_edges: int = 20,
+    ) -> None:
+        self.db = db
+        self.edge_sync = edge_sync
+        self.decay_days = decay_days
+        self.decay_factor = decay_factor
+        self.min_weight = min_weight
+        self.orphan_days = orphan_days
+        self.max_avg_edges = max_avg_edges
+
+    async def prune(self) -> PruningReport:
+        """Run all five pruning steps and return a consolidated report."""
+        report = PruningReport()
+
+        report.edges_decayed = await self._decay_stale_edges()
+        report.edges_deleted = await self._delete_weak_edges()
+        report.nodes_archived = await self._archive_orphans()
+        report.edges_merged = await self._merge_duplicates()
+        report.density_warning = await self._check_density()
+
+        if self.edge_sync is not None:
+            await self.edge_sync.sync()
+
+        await self._log_report(report)
+        return report
+
+    async def _decay_stale_edges(self) -> int:
+        """Decay learner/discoverer edges not reinforced within decay_days."""
+        cutoff = _utc_ago(days=self.decay_days)
+        return await self.db.decay_edges(
+            origins=_LEARNER_ORIGINS,
+            not_reinforced_since=cutoff,
+            decay_factor=self.decay_factor,
+        )
+
+    async def _delete_weak_edges(self) -> int:
+        """Delete edges whose weight is at or below min_weight."""
+        return await self.db.delete_edges(max_weight=self.min_weight)
+
+    async def _archive_orphans(self) -> int:
+        """Archive nodes with no edges and no access within orphan_days."""
+        cutoff = _utc_ago(days=self.orphan_days)
+        return await self.db.archive_orphan_nodes(no_access_since=cutoff)
+
+    async def _merge_duplicates(self) -> int:
+        """Merge near-duplicate edges and return the count merged."""
+        return await self.db.merge_duplicate_edges()
+
+    async def _check_density(self) -> bool:
+        """Return True if avg edges/node exceeds max_avg_edges threshold."""
+        density = await self.db.get_graph_density()
+        exceeded = density > self.max_avg_edges
+        if exceeded:
+            logger.warning(
+                "MeshPruner: graph density %.2f exceeds threshold %d",
+                density,
+                self.max_avg_edges,
+            )
+        return exceeded
+
+    async def _log_report(self, report: PruningReport) -> None:
+        """Emit a structured log line summarising the pruning run."""
+        logger.info(
+            "MeshPruner complete: decayed=%d deleted=%d archived=%d merged=%d density_warning=%s",
+            report.edges_decayed,
+            report.edges_deleted,
+            report.nodes_archived,
+            report.edges_merged,
+            report.density_warning,
+        )
+
+
+def _utc_ago(*, days: int) -> datetime:
+    """Return a UTC datetime exactly ``days`` days in the past."""
+    return datetime.now(tz=timezone.utc) - timedelta(days=days)

--- a/autobot-backend/services/mesh_brain/mesh_pruner_test.py
+++ b/autobot-backend/services/mesh_brain/mesh_pruner_test.py
@@ -1,0 +1,192 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for MeshPruner — weekly entropy control and decay (#1994, #2118)."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from services.mesh_brain.mesh_pruner import MeshPruner, PruningReport
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+_DECAY_DAYS = 30
+_DECAY_FACTOR = 0.8
+_MIN_WEIGHT = 0.1
+_ORPHAN_DAYS = 60
+_MAX_AVG_EDGES = 20
+
+
+def _make_db_mock(density: float = 5.0) -> AsyncMock:
+    """Return a MeshDB mock with sensible non-zero defaults."""
+    db = AsyncMock()
+    db.decay_edges = AsyncMock(return_value=10)
+    db.delete_edges = AsyncMock(return_value=3)
+    db.archive_orphan_nodes = AsyncMock(return_value=2)
+    db.merge_duplicate_edges = AsyncMock(return_value=1)
+    db.get_graph_density = AsyncMock(return_value=density)
+    return db
+
+
+def _make_pruner(db: AsyncMock, edge_sync=None) -> MeshPruner:
+    return MeshPruner(
+        db=db,
+        edge_sync=edge_sync,
+        decay_days=_DECAY_DAYS,
+        decay_factor=_DECAY_FACTOR,
+        min_weight=_MIN_WEIGHT,
+        orphan_days=_ORPHAN_DAYS,
+        max_avg_edges=_MAX_AVG_EDGES,
+    )
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestMeshPrunerAllSteps:
+    """Verify that prune() calls every db method exactly once."""
+
+    @pytest.mark.asyncio
+    async def test_prune_runs_all_steps(self):
+        """All five db methods are awaited during a single prune() call."""
+        db = _make_db_mock()
+        pruner = _make_pruner(db)
+
+        await pruner.prune()
+
+        db.decay_edges.assert_awaited_once()
+        db.delete_edges.assert_awaited_once()
+        db.archive_orphan_nodes.assert_awaited_once()
+        db.merge_duplicate_edges.assert_awaited_once()
+        db.get_graph_density.assert_awaited_once()
+
+
+class TestDecayExcludesSeeder:
+    """Seeder edges must not appear in the origins list passed to decay_edges."""
+
+    @pytest.mark.asyncio
+    async def test_decay_excludes_seeder_edges(self):
+        """decay_edges is called with origins=['learner','discoverer'], never 'seeder'."""
+        db = _make_db_mock()
+        pruner = _make_pruner(db)
+
+        await pruner.prune()
+
+        call_kwargs = db.decay_edges.call_args
+        origins = call_kwargs.kwargs.get("origins") or call_kwargs.args[0]
+        assert "seeder" not in origins
+        assert set(origins) == {"learner", "discoverer"}
+
+
+class TestDeleteWeakEdges:
+    """delete_edges must receive min_weight as max_weight."""
+
+    @pytest.mark.asyncio
+    async def test_delete_weak_edges_uses_min_weight(self):
+        """delete_edges is called with max_weight equal to min_weight config."""
+        db = _make_db_mock()
+        pruner = _make_pruner(db)
+
+        await pruner.prune()
+
+        db.delete_edges.assert_awaited_once_with(max_weight=_MIN_WEIGHT)
+
+
+class TestArchiveOrphans:
+    """archive_orphan_nodes must use a cutoff derived from orphan_days."""
+
+    @pytest.mark.asyncio
+    async def test_archive_orphans_uses_orphan_days(self):
+        """archive_orphan_nodes receives a datetime roughly orphan_days ago."""
+        db = _make_db_mock()
+        pruner = _make_pruner(db)
+
+        await pruner.prune()
+
+        call_kwargs = db.archive_orphan_nodes.call_args
+        cutoff = call_kwargs.kwargs.get("no_access_since") or call_kwargs.args[0]
+
+        from datetime import datetime, timezone
+
+        now = datetime.now(tz=timezone.utc)
+        expected_cutoff = now - timedelta(days=_ORPHAN_DAYS)
+        # Allow a 5-second window for test execution time
+        assert abs((cutoff - expected_cutoff).total_seconds()) < 5
+
+
+class TestDensityWarning:
+    """density_warning reflects whether avg edges/node exceeds max_avg_edges."""
+
+    @pytest.mark.asyncio
+    async def test_density_warning_set_when_exceeded(self):
+        """density > max_avg_edges → PruningReport.density_warning is True."""
+        db = _make_db_mock(density=25.0)
+        pruner = _make_pruner(db)
+
+        report = await pruner.prune()
+
+        assert report.density_warning is True
+
+    @pytest.mark.asyncio
+    async def test_density_warning_false_when_normal(self):
+        """density < max_avg_edges → PruningReport.density_warning is False."""
+        db = _make_db_mock(density=10.0)
+        pruner = _make_pruner(db)
+
+        report = await pruner.prune()
+
+        assert report.density_warning is False
+
+
+class TestEdgeSyncBehaviour:
+    """edge_sync.sync() is called after pruning only when a sync object is provided."""
+
+    @pytest.mark.asyncio
+    async def test_edge_sync_called_after_prune(self):
+        """edge_sync.sync() is awaited once at the end of prune()."""
+        db = _make_db_mock()
+        edge_sync = AsyncMock()
+        edge_sync.sync = AsyncMock()
+        pruner = _make_pruner(db, edge_sync=edge_sync)
+
+        await pruner.prune()
+
+        edge_sync.sync.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_edge_sync_skipped_when_none(self):
+        """prune() completes without error when edge_sync is None."""
+        db = _make_db_mock()
+        pruner = _make_pruner(db, edge_sync=None)
+
+        # Should not raise
+        report = await pruner.prune()
+
+        assert isinstance(report, PruningReport)
+
+
+class TestPruningReportCounts:
+    """PruningReport is populated with return values from every db method."""
+
+    @pytest.mark.asyncio
+    async def test_report_contains_all_counts(self):
+        """PruningReport fields mirror the int values returned by each db method."""
+        db = _make_db_mock(density=5.0)
+        db.decay_edges = AsyncMock(return_value=7)
+        db.delete_edges = AsyncMock(return_value=4)
+        db.archive_orphan_nodes = AsyncMock(return_value=2)
+        db.merge_duplicate_edges = AsyncMock(return_value=1)
+
+        pruner = _make_pruner(db)
+        report = await pruner.prune()
+
+        assert report.edges_decayed == 7
+        assert report.edges_deleted == 4
+        assert report.nodes_archived == 2
+        assert report.edges_merged == 1
+        assert report.density_warning is False


### PR DESCRIPTION
## Summary
- Decays unreinforced learner/discoverer edges (30d threshold, 0.8 factor)
- Deletes edges below weight 0.1
- Archives orphaned nodes (no edges, 60d inactive)
- Merges near-duplicate edges
- Density check: warns if avg edges/node > 20
- Seeder edges NEVER decayed
- 9 tests

## Test plan
- [x] 9/9 tests pass
- [x] Seeder exclusion verified
- [x] Edge sync called after prune

Closes #2118