### PR TITLE
feat(mesh): add NodePromoter — daily anchor emergence (#2119)

### DIFF
--- a/autobot-backend/services/mesh_brain/node_promoter.py
+++ b/autobot-backend/services/mesh_brain/node_promoter.py
@@ -1,0 +1,188 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Daily anchor emergence: promotes hot nodes to anchor status for Neural Mesh RAG (#2119)."""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Coroutine, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Protocols
+# =============================================================================
+
+
+class MeshDB(Protocol):
+    """Protocol for mesh database operations required by NodePromoter."""
+
+    async def get_promotion_candidates(
+        self, min_access: int, min_edges: int
+    ) -> list[dict]:
+        """Return nodes eligible for promotion: access_count >= min_access and
+        edge_count >= min_edges, not already anchors."""
+        ...
+
+    async def get_stale_anchors(
+        self, max_access: int, inactive_days: int
+    ) -> list[dict]:
+        """Return anchor nodes with access_count <= max_access inactive for >= inactive_days."""
+        ...
+
+    async def get_neighborhood(self, node_id: str, hops: int) -> list[dict]:
+        """Return all nodes within *hops* of node_id, each as a dict with 'content'."""
+        ...
+
+    async def promote_to_anchor(self, node_id: str) -> None:
+        """Mark node as an anchor in mesh_nodes."""
+        ...
+
+    async def demote_anchor(self, node_id: str) -> None:
+        """Clear anchor flag on node in mesh_nodes."""
+        ...
+
+
+class ChromaCollection(Protocol):
+    """Minimal ChromaDB client protocol for anchor embedding storage."""
+
+    async def upsert(
+        self,
+        collection: str,
+        ids: list[str],
+        documents: list[str],
+        metadatas: list[dict],
+    ) -> None:
+        """Upsert documents into the named collection."""
+        ...
+
+    async def delete(self, collection: str, ids: list[str]) -> None:
+        """Delete documents by ID from the named collection."""
+        ...
+
+
+# =============================================================================
+# Result type
+# =============================================================================
+
+
+@dataclass
+class PromotionReport:
+    """Summary of a single NodePromoter.evaluate() run.
+
+    Attributes:
+        nodes_promoted: UUIDs of nodes promoted to anchor status.
+        nodes_demoted:  UUIDs of nodes demoted from anchor status.
+    """
+
+    nodes_promoted: list = field(default_factory=list)
+    nodes_demoted: list = field(default_factory=list)
+
+
+# =============================================================================
+# NodePromoter
+# =============================================================================
+
+
+class NodePromoter:
+    """Promotes hot nodes to anchor status for faster retrieval.
+
+    Anchor nodes: retriever checks these first before graph walk.
+    When a node is promoted, its 2-hop neighborhood is summarized
+    and stored as an anchor embedding in ChromaDB (#2119).
+    """
+
+    def __init__(
+        self,
+        db: MeshDB,
+        llm: Callable[[str], Coroutine],
+        chroma_client: ChromaCollection,
+        promote_access_threshold: int = 50,
+        promote_min_edges: int = 5,
+        demote_access_threshold: int = 10,
+        demote_days: int = 30,
+    ) -> None:
+        self.db = db
+        self.llm = llm
+        self.chroma = chroma_client
+        self.promote_access_threshold = promote_access_threshold
+        self.promote_min_edges = promote_min_edges
+        self.demote_access_threshold = demote_access_threshold
+        self.demote_days = demote_days
+
+    async def evaluate(self) -> PromotionReport:
+        """Run one promotion/demotion cycle and return a PromotionReport.
+
+        Promotes all hot candidates then demotes all stale anchors.
+        """
+        report = PromotionReport()
+        await self._promote_candidates(report)
+        await self._demote_stale(report)
+        logger.info(
+            "NodePromoter: promoted=%d demoted=%d",
+            len(report.nodes_promoted),
+            len(report.nodes_demoted),
+        )
+        return report
+
+    # ------------------------------------------------------------------
+    # Private helpers — each under 30 lines
+    # ------------------------------------------------------------------
+
+    async def _promote_candidates(self, report: PromotionReport) -> None:
+        """Fetch promotion candidates and promote each one."""
+        candidates = await self.db.get_promotion_candidates(
+            min_access=self.promote_access_threshold,
+            min_edges=self.promote_min_edges,
+        )
+        for node in candidates:
+            await self._promote_node(node, report)
+
+    async def _demote_stale(self, report: PromotionReport) -> None:
+        """Fetch stale anchors and demote each one."""
+        stale = await self.db.get_stale_anchors(
+            max_access=self.demote_access_threshold,
+            inactive_days=self.demote_days,
+        )
+        for node in stale:
+            await self._demote_node(node, report)
+
+    async def _promote_node(self, node: dict, report: PromotionReport) -> None:
+        """Summarize 2-hop neighborhood, store in ChromaDB, mark anchor in DB."""
+        neighborhood = await self.db.get_neighborhood(node["id"], hops=2)
+        summary = await self._summarize_neighborhood(neighborhood)
+        await self.chroma.upsert(
+            collection="mesh_anchors",
+            ids=[f"anchor_{node['id']}"],
+            documents=[summary],
+            metadatas=[
+                {"node_id": str(node["id"]), "neighborhood_size": len(neighborhood)}
+            ],
+        )
+        await self.db.promote_to_anchor(node["id"])
+        report.nodes_promoted.append(node["id"])
+        logger.info(
+            "NodePromoter: promoted node %s (neighborhood=%d)",
+            node["id"],
+            len(neighborhood),
+        )
+
+    async def _demote_node(self, node: dict, report: PromotionReport) -> None:
+        """Clear anchor flag in DB and remove embedding from ChromaDB."""
+        await self.db.demote_anchor(node["id"])
+        await self.chroma.delete(
+            collection="mesh_anchors",
+            ids=[f"anchor_{node['id']}"],
+        )
+        report.nodes_demoted.append(node["id"])
+        logger.info("NodePromoter: demoted anchor %s", node["id"])
+
+    async def _summarize_neighborhood(self, neighborhood: list[dict]) -> str:
+        """Call LLM to produce a 2-3 sentence theme summary of the neighborhood."""
+        texts = [n.get("content", "")[:200] for n in neighborhood[:10]]
+        prompt = (
+            "Summarize the theme of these related knowledge chunks "
+            "in 2-3 sentences:\n\n" + "\n---\n".join(texts)
+        )
+        return await self.llm(prompt)

--- a/autobot-backend/services/mesh_brain/node_promoter_test.py
+++ b/autobot-backend/services/mesh_brain/node_promoter_test.py
@@ -1,0 +1,336 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for NodePromoter — daily anchor emergence for Neural Mesh RAG (#2119)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from services.mesh_brain.node_promoter import NodePromoter
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+_NODE_ID = "aaaaaaaa-0000-0000-0000-000000000001"
+_NODE_ID_2 = "bbbbbbbb-0000-0000-0000-000000000002"
+_ANCHOR_ID = "cccccccc-0000-0000-0000-000000000003"
+
+_SUMMARY = "These chunks share a common theme about networking."
+
+
+def _make_db() -> AsyncMock:
+    """Return a MeshDB mock with safe defaults (no candidates, no stale anchors)."""
+    db = AsyncMock()
+    db.get_promotion_candidates = AsyncMock(return_value=[])
+    db.get_stale_anchors = AsyncMock(return_value=[])
+    db.get_neighborhood = AsyncMock(return_value=[])
+    db.promote_to_anchor = AsyncMock()
+    db.demote_anchor = AsyncMock()
+    return db
+
+
+def _make_chroma() -> AsyncMock:
+    """Return a ChromaCollection mock."""
+    chroma = AsyncMock()
+    chroma.upsert = AsyncMock()
+    chroma.delete = AsyncMock()
+    return chroma
+
+
+async def _llm(prompt: str) -> str:
+    """Stub LLM callable that always returns a fixed summary."""
+    return _SUMMARY
+
+
+def _make_promoter(db: AsyncMock, chroma: AsyncMock) -> NodePromoter:
+    return NodePromoter(
+        db=db,
+        llm=_llm,
+        chroma_client=chroma,
+        promote_access_threshold=50,
+        promote_min_edges=5,
+        demote_access_threshold=10,
+        demote_days=30,
+    )
+
+
+def _candidate(node_id: str = _NODE_ID) -> dict:
+    return {"id": node_id, "access_count": 60, "edge_count": 7}
+
+
+def _stale_anchor(node_id: str = _ANCHOR_ID) -> dict:
+    return {"id": node_id, "access_count": 3, "days_inactive": 45}
+
+
+def _neighborhood(size: int = 3) -> list[dict]:
+    return [{"id": f"n-{i}", "content": f"chunk content {i}"} for i in range(size)]
+
+
+# =============================================================================
+# Tests — promote hot nodes
+# =============================================================================
+
+
+class TestEvaluatePromotesHotNodes:
+    """evaluate() calls promote_to_anchor for every returned candidate."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_promotes_hot_nodes(self):
+        """When a candidate is returned, promote_to_anchor is called with its ID."""
+        db = _make_db()
+        db.get_promotion_candidates = AsyncMock(return_value=[_candidate()])
+        db.get_neighborhood = AsyncMock(return_value=_neighborhood())
+        chroma = _make_chroma()
+
+        promoter = _make_promoter(db, chroma)
+        report = await promoter.evaluate()
+
+        db.promote_to_anchor.assert_awaited_once_with(_NODE_ID)
+        assert _NODE_ID in report.nodes_promoted
+
+    @pytest.mark.asyncio
+    async def test_promote_passes_correct_thresholds(self):
+        """get_promotion_candidates is called with the configured thresholds."""
+        db = _make_db()
+        chroma = _make_chroma()
+
+        promoter = NodePromoter(
+            db=db,
+            llm=_llm,
+            chroma_client=chroma,
+            promote_access_threshold=100,
+            promote_min_edges=8,
+            demote_access_threshold=10,
+            demote_days=30,
+        )
+        await promoter.evaluate()
+
+        db.get_promotion_candidates.assert_awaited_once_with(
+            min_access=100, min_edges=8
+        )
+
+
+# =============================================================================
+# Tests — demote stale anchors
+# =============================================================================
+
+
+class TestEvaluateDemotesStaleAnchors:
+    """evaluate() calls demote_anchor for every stale anchor returned."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_demotes_stale_anchors(self):
+        """When a stale anchor is returned, demote_anchor is called with its ID."""
+        db = _make_db()
+        db.get_stale_anchors = AsyncMock(return_value=[_stale_anchor()])
+        chroma = _make_chroma()
+
+        promoter = _make_promoter(db, chroma)
+        report = await promoter.evaluate()
+
+        db.demote_anchor.assert_awaited_once_with(_ANCHOR_ID)
+        assert _ANCHOR_ID in report.nodes_demoted
+
+    @pytest.mark.asyncio
+    async def test_demote_passes_correct_thresholds(self):
+        """get_stale_anchors is called with the configured thresholds."""
+        db = _make_db()
+        chroma = _make_chroma()
+
+        promoter = NodePromoter(
+            db=db,
+            llm=_llm,
+            chroma_client=chroma,
+            promote_access_threshold=50,
+            promote_min_edges=5,
+            demote_access_threshold=5,
+            demote_days=60,
+        )
+        await promoter.evaluate()
+
+        db.get_stale_anchors.assert_awaited_once_with(max_access=5, inactive_days=60)
+
+
+# =============================================================================
+# Tests — ChromaDB interactions
+# =============================================================================
+
+
+class TestPromoteStoresAnchorInChroma:
+    """_promote_node upserts the neighborhood summary into mesh_anchors."""
+
+    @pytest.mark.asyncio
+    async def test_promote_stores_anchor_in_chroma(self):
+        """chroma.upsert is called with collection='mesh_anchors' and correct id."""
+        db = _make_db()
+        db.get_promotion_candidates = AsyncMock(return_value=[_candidate()])
+        db.get_neighborhood = AsyncMock(return_value=_neighborhood(size=3))
+        chroma = _make_chroma()
+
+        promoter = _make_promoter(db, chroma)
+        await promoter.evaluate()
+
+        chroma.upsert.assert_awaited_once()
+        _, kwargs = chroma.upsert.call_args
+        assert kwargs["collection"] == "mesh_anchors"
+        assert kwargs["ids"] == [f"anchor_{_NODE_ID}"]
+        assert kwargs["documents"] == [_SUMMARY]
+
+    @pytest.mark.asyncio
+    async def test_promote_metadata_contains_node_id_and_size(self):
+        """Metadata passed to chroma.upsert includes node_id and neighborhood_size."""
+        db = _make_db()
+        neighborhood = _neighborhood(size=4)
+        db.get_promotion_candidates = AsyncMock(return_value=[_candidate()])
+        db.get_neighborhood = AsyncMock(return_value=neighborhood)
+        chroma = _make_chroma()
+
+        promoter = _make_promoter(db, chroma)
+        await promoter.evaluate()
+
+        _, kwargs = chroma.upsert.call_args
+        meta = kwargs["metadatas"][0]
+        assert meta["node_id"] == str(_NODE_ID)
+        assert meta["neighborhood_size"] == 4
+
+
+class TestDemoteRemovesFromChroma:
+    """_demote_node calls chroma.delete with the anchor ID."""
+
+    @pytest.mark.asyncio
+    async def test_demote_removes_from_chroma(self):
+        """chroma.delete is called with collection='mesh_anchors' and correct id."""
+        db = _make_db()
+        db.get_stale_anchors = AsyncMock(return_value=[_stale_anchor()])
+        chroma = _make_chroma()
+
+        promoter = _make_promoter(db, chroma)
+        await promoter.evaluate()
+
+        chroma.delete.assert_awaited_once_with(
+            collection="mesh_anchors",
+            ids=[f"anchor_{_ANCHOR_ID}"],
+        )
+
+
+# =============================================================================
+# Tests — LLM neighborhood summary
+# =============================================================================
+
+
+class TestPromoteGeneratesNeighborhoodSummary:
+    """_summarize_neighborhood passes neighborhood content to the LLM."""
+
+    @pytest.mark.asyncio
+    async def test_promote_generates_neighborhood_summary(self):
+        """LLM is called once per promoted node and its result stored as the document."""
+        db = _make_db()
+        db.get_promotion_candidates = AsyncMock(return_value=[_candidate()])
+        db.get_neighborhood = AsyncMock(return_value=_neighborhood(size=2))
+        chroma = _make_chroma()
+
+        llm_calls: list[str] = []
+
+        async def recording_llm(prompt: str) -> str:
+            llm_calls.append(prompt)
+            return _SUMMARY
+
+        promoter = NodePromoter(
+            db=db,
+            llm=recording_llm,
+            chroma_client=chroma,
+            promote_access_threshold=50,
+            promote_min_edges=5,
+            demote_access_threshold=10,
+            demote_days=30,
+        )
+        await promoter.evaluate()
+
+        assert len(llm_calls) == 1
+        assert "chunk content 0" in llm_calls[0]
+        assert "chunk content 1" in llm_calls[0]
+
+    @pytest.mark.asyncio
+    async def test_summarize_caps_neighborhood_at_ten_nodes(self):
+        """Only the first 10 neighborhood nodes are included in the LLM prompt."""
+        db = _make_db()
+        db.get_promotion_candidates = AsyncMock(return_value=[_candidate()])
+        db.get_neighborhood = AsyncMock(return_value=_neighborhood(size=15))
+        chroma = _make_chroma()
+
+        llm_calls: list[str] = []
+
+        async def recording_llm(prompt: str) -> str:
+            llm_calls.append(prompt)
+            return _SUMMARY
+
+        promoter = NodePromoter(
+            db=db,
+            llm=recording_llm,
+            chroma_client=chroma,
+            promote_access_threshold=50,
+            promote_min_edges=5,
+            demote_access_threshold=10,
+            demote_days=30,
+        )
+        await promoter.evaluate()
+
+        # Nodes 10-14 must not appear in the prompt
+        assert "chunk content 10" not in llm_calls[0]
+        assert "chunk content 9" in llm_calls[0]
+
+
+# =============================================================================
+# Tests — PromotionReport contents
+# =============================================================================
+
+
+class TestReportContents:
+    """evaluate() returns a PromotionReport with the correct node ID lists."""
+
+    @pytest.mark.asyncio
+    async def test_report_contains_promoted_ids(self):
+        """nodes_promoted contains all promoted node IDs."""
+        db = _make_db()
+        db.get_promotion_candidates = AsyncMock(
+            return_value=[_candidate(_NODE_ID), _candidate(_NODE_ID_2)]
+        )
+        db.get_neighborhood = AsyncMock(return_value=_neighborhood())
+        chroma = _make_chroma()
+
+        promoter = _make_promoter(db, chroma)
+        report = await promoter.evaluate()
+
+        assert _NODE_ID in report.nodes_promoted
+        assert _NODE_ID_2 in report.nodes_promoted
+        assert len(report.nodes_promoted) == 2
+
+    @pytest.mark.asyncio
+    async def test_report_contains_demoted_ids(self):
+        """nodes_demoted contains all demoted node IDs."""
+        db = _make_db()
+        db.get_stale_anchors = AsyncMock(return_value=[_stale_anchor()])
+        chroma = _make_chroma()
+
+        promoter = _make_promoter(db, chroma)
+        report = await promoter.evaluate()
+
+        assert _ANCHOR_ID in report.nodes_demoted
+        assert len(report.nodes_demoted) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_candidates_returns_empty_report(self):
+        """When there are no candidates and no stale anchors, both lists are empty."""
+        db = _make_db()
+        chroma = _make_chroma()
+
+        promoter = _make_promoter(db, chroma)
+        report = await promoter.evaluate()
+
+        assert report.nodes_promoted == []
+        assert report.nodes_demoted == []
+        db.promote_to_anchor.assert_not_awaited()
+        db.demote_anchor.assert_not_awaited()
+        chroma.upsert.assert_not_awaited()
+        chroma.delete.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Promotes hot nodes (access>50, edges>5) to anchor status
- Generates 2-hop neighborhood summary via LLM
- Stores anchor embedding in ChromaDB `mesh_anchors` collection
- Demotes stale anchors (access dropped, 30d inactive)
- 12 tests

## Test plan
- [x] 12/12 tests pass
- [x] Promotion thresholds forwarded correctly
- [x] ChromaDB upsert/delete verified
- [x] Neighborhood capped at 10 nodes

Closes #2119