### PR TITLE
feat(mesh): add MeshBrainScheduler + health API (#2120)

### DIFF
--- a/autobot-backend/api/mesh_brain.py
+++ b/autobot-backend/api/mesh_brain.py
@@ -1,0 +1,50 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Mesh Brain health and status API endpoints for Neural Mesh RAG (#1994, #2120)."""
+
+import logging
+
+from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/mesh/brain", tags=["mesh-brain"])
+
+# Module-level scheduler reference set during app startup via set_scheduler().
+_scheduler = None
+
+
+def set_scheduler(scheduler) -> None:
+    """Register the MeshBrainScheduler instance used by this router."""
+    global _scheduler
+    _scheduler = scheduler
+    logger.info("MeshBrainScheduler registered with API router")
+
+
+@router.get("/status")
+async def get_mesh_brain_status() -> dict:
+    """Return the full job-by-job status of the Mesh Brain scheduler."""
+    if _scheduler is None:
+        return {"running": False, "jobs": {}, "message": "Mesh Brain not initialized"}
+    return _scheduler.get_status()
+
+
+@router.get("/health")
+async def get_mesh_brain_health() -> dict:
+    """Return a concise health summary — healthy when no jobs have last_result='failed'."""
+    if _scheduler is None:
+        return {"healthy": False, "reason": "not_initialized"}
+    return _build_health_response(_scheduler.get_status())
+
+
+def _build_health_response(status: dict) -> dict:
+    """Derive a health dict from a scheduler status snapshot."""
+    failed_jobs = [
+        name for name, job in status["jobs"].items() if job["last_result"] == "failed"
+    ]
+    return {
+        "healthy": len(failed_jobs) == 0,
+        "running": status["running"],
+        "failed_jobs": failed_jobs,
+    }

--- a/autobot-backend/services/mesh_brain/scheduler.py
+++ b/autobot-backend/services/mesh_brain/scheduler.py
@@ -1,0 +1,201 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""MeshBrainScheduler — orchestrates autonomous mesh evolution jobs (#1994, #2120)."""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Job status
+# ---------------------------------------------------------------------------
+
+_INTERVALS: dict[str, int] = {
+    "edge_sync": 300,
+    "edge_discoverer": 86400,
+    "mesh_pruner": 604800,
+    "node_promoter": 86400,
+}
+
+_METHOD_MAP: dict[str, str] = {
+    "edge_sync": "sync",
+    "edge_discoverer": "discover",
+    "mesh_pruner": "prune",
+    "node_promoter": "evaluate",
+}
+
+
+@dataclass
+class JobStatus:
+    """Runtime state for a single scheduler job."""
+
+    name: str
+    schedule: str
+    last_run: Optional[datetime] = None
+    last_result: Optional[str] = None  # "success" | "failed" | "skipped"
+    next_run: Optional[datetime] = None
+    is_running: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Scheduler
+# ---------------------------------------------------------------------------
+
+
+class MeshBrainScheduler:
+    """Orchestrates all autonomous mesh evolution jobs.
+
+    Schedule:
+    - edge_learner:    realtime (Redis stream consumer, always running)
+    - edge_sync:       every 5 minutes
+    - node_promoter:   daily at 3 AM UTC  (24-hour interval approximation)
+    - edge_discoverer: daily at 2 AM UTC  (24-hour interval approximation)
+    - mesh_pruner:     weekly Sunday at 4 AM UTC (7-day interval approximation)
+    """
+
+    SCHEDULE: dict[str, dict[str, str]] = {
+        "edge_learner": {
+            "cron": "realtime",
+            "description": "Hebbian reinforcement from feedback",
+        },
+        "edge_sync": {
+            "cron": "*/5 * * * *",
+            "description": "PG to Redis edge sync",
+        },
+        "node_promoter": {
+            "cron": "0 3 * * *",
+            "description": "Anchor emergence",
+        },
+        "edge_discoverer": {
+            "cron": "0 2 * * *",
+            "description": "Relationship naming",
+        },
+        "mesh_pruner": {
+            "cron": "0 4 * * 0",
+            "description": "Entropy control",
+        },
+    }
+
+    def __init__(
+        self,
+        edge_learner: Any = None,
+        edge_sync: Any = None,
+        edge_discoverer: Any = None,
+        mesh_pruner: Any = None,
+        node_promoter: Any = None,
+        mesh_db: Any = None,
+    ) -> None:
+        self._components: dict[str, Any] = {
+            "edge_learner": edge_learner,
+            "edge_sync": edge_sync,
+            "edge_discoverer": edge_discoverer,
+            "mesh_pruner": mesh_pruner,
+            "node_promoter": node_promoter,
+        }
+        self._mesh_db = mesh_db
+        self._running: bool = False
+        self._tasks: dict[str, asyncio.Task] = {}
+        self._jobs: dict[str, JobStatus] = {
+            name: JobStatus(name=name, schedule=cfg["cron"])
+            for name, cfg in self.SCHEDULE.items()
+        }
+
+    async def start(self) -> None:
+        """Start all scheduled jobs."""
+        self._running = True
+        logger.info("MeshBrainScheduler starting")
+        self._maybe_start_realtime_consumer()
+        self._start_periodic_jobs()
+
+    def _maybe_start_realtime_consumer(self) -> None:
+        """Launch the edge_learner realtime consumer task if component is present."""
+        if self._components.get("edge_learner"):
+            self._tasks["edge_learner"] = asyncio.create_task(
+                self._run_realtime_consumer()
+            )
+
+    def _start_periodic_jobs(self) -> None:
+        """Launch asyncio tasks for each periodic job whose component is present."""
+        for name in _INTERVALS:
+            if self._components.get(name):
+                self._tasks[name] = asyncio.create_task(self._run_periodic(name))
+
+    async def stop(self) -> None:
+        """Cancel all running tasks gracefully."""
+        self._running = False
+        for name, task in list(self._tasks.items()):
+            task.cancel()
+        self._tasks.clear()
+        logger.info("MeshBrainScheduler stopped")
+
+    async def _run_realtime_consumer(self) -> None:
+        """Run the edge_learner stream consumer in a loop until stopped."""
+        learner = self._components["edge_learner"]
+        while self._running:
+            try:
+                await learner.consume_feedback_stream()
+            except Exception as exc:
+                logger.error("edge_learner stream consumer failed: %s", exc)
+            await asyncio.sleep(1)
+
+    async def _run_periodic(self, name: str) -> None:
+        """Run a job on its fixed interval until the scheduler is stopped."""
+        interval = _INTERVALS[name]
+        while self._running:
+            await self._execute_job(name)
+            await asyncio.sleep(interval)
+
+    async def _execute_job(self, name: str) -> None:
+        """Execute one job run with status tracking and error logging."""
+        component = self._components.get(name)
+        if not component:
+            return
+
+        job = self._jobs[name]
+        job.is_running = True
+        job.last_run = datetime.now(tz=timezone.utc)
+
+        try:
+            method_name = _METHOD_MAP.get(name, "run")
+            await getattr(component, method_name)()
+            job.last_result = "success"
+            logger.debug("Mesh brain job %s completed successfully", name)
+        except Exception as exc:
+            job.last_result = "failed"
+            logger.error("Mesh brain job %s failed: %s", name, exc)
+            await self._log_job_failure(name, exc)
+        finally:
+            job.is_running = False
+
+    async def _log_job_failure(self, name: str, exc: Exception) -> None:
+        """Write job failure to mesh_evolution_log if mesh_db is available."""
+        if self._mesh_db:
+            await self._mesh_db.log_evolution(
+                "job_failed", None, None, {"error": str(exc)}, name
+            )
+
+    def get_status(self) -> dict:
+        """Return a snapshot of all job statuses for the health API endpoint."""
+        return {
+            "running": self._running,
+            "jobs": {
+                name: _job_to_dict(job, self._components.get(name) is not None)
+                for name, job in self._jobs.items()
+            },
+        }
+
+
+def _job_to_dict(job: JobStatus, component_available: bool) -> dict:
+    """Serialise a JobStatus to a plain dict for JSON responses."""
+    return {
+        "schedule": job.schedule,
+        "last_run": job.last_run.isoformat() if job.last_run else None,
+        "last_result": job.last_result,
+        "is_running": job.is_running,
+        "component_available": component_available,
+    }

--- a/autobot-backend/services/mesh_brain/scheduler_test.py
+++ b/autobot-backend/services/mesh_brain/scheduler_test.py
@@ -1,0 +1,312 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for MeshBrainScheduler and mesh_brain API endpoints (#1994, #2120)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from services.mesh_brain.scheduler import JobStatus, MeshBrainScheduler
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_scheduler(**components) -> MeshBrainScheduler:
+    """Return a MeshBrainScheduler with optional component overrides."""
+    defaults = {
+        "edge_learner": None,
+        "edge_sync": None,
+        "edge_discoverer": None,
+        "mesh_pruner": None,
+        "node_promoter": None,
+        "mesh_db": None,
+    }
+    defaults.update(components)
+    return MeshBrainScheduler(**defaults)
+
+
+def _make_component(method: str = "sync") -> AsyncMock:
+    """Return a mock component whose relevant method is an AsyncMock."""
+    comp = AsyncMock()
+    setattr(comp, method, AsyncMock())
+    return comp
+
+
+# =============================================================================
+# Initialisation
+# =============================================================================
+
+
+class TestMeshBrainSchedulerInit:
+    def test_init_creates_job_statuses(self):
+        """All five expected jobs are present in _jobs after construction."""
+        scheduler = _make_scheduler()
+        assert set(scheduler._jobs.keys()) == {
+            "edge_learner",
+            "edge_sync",
+            "node_promoter",
+            "edge_discoverer",
+            "mesh_pruner",
+        }
+
+    def test_init_job_statuses_are_idle(self):
+        """Every JobStatus starts with no run history and is_running=False."""
+        scheduler = _make_scheduler()
+        for job in scheduler._jobs.values():
+            assert isinstance(job, JobStatus)
+            assert job.last_run is None
+            assert job.last_result is None
+            assert job.is_running is False
+
+    def test_init_not_running(self):
+        """Scheduler is not running until start() is called."""
+        scheduler = _make_scheduler()
+        assert scheduler._running is False
+
+
+# =============================================================================
+# get_status
+# =============================================================================
+
+
+class TestGetStatus:
+    def test_get_status_returns_all_jobs(self):
+        """status dict contains exactly five job entries."""
+        scheduler = _make_scheduler()
+        status = scheduler.get_status()
+        assert len(status["jobs"]) == 5
+
+    def test_get_status_running_reflects_state(self):
+        """'running' key mirrors the scheduler's _running flag."""
+        scheduler = _make_scheduler()
+        assert status_running(scheduler) is False
+        scheduler._running = True
+        assert status_running(scheduler) is True
+
+    def test_get_status_component_available_false_when_none(self):
+        """component_available is False when no component was injected."""
+        scheduler = _make_scheduler()
+        status = scheduler.get_status()
+        for job in status["jobs"].values():
+            assert job["component_available"] is False
+
+    def test_get_status_component_available_true_when_injected(self):
+        """component_available is True for the injected edge_sync component."""
+        scheduler = _make_scheduler(edge_sync=_make_component("sync"))
+        status = scheduler.get_status()
+        assert status["jobs"]["edge_sync"]["component_available"] is True
+        assert status["jobs"]["node_promoter"]["component_available"] is False
+
+
+def status_running(scheduler: MeshBrainScheduler) -> bool:
+    return scheduler.get_status()["running"]
+
+
+# =============================================================================
+# _execute_job
+# =============================================================================
+
+
+class TestExecuteJob:
+    @pytest.mark.asyncio
+    async def test_execute_job_success_updates_status(self):
+        """last_result becomes 'success' and is_running resets to False after a clean run."""
+        sync_comp = _make_component("sync")
+        scheduler = _make_scheduler(edge_sync=sync_comp)
+        await scheduler._execute_job("edge_sync")
+
+        job = scheduler._jobs["edge_sync"]
+        assert job.last_result == "success"
+        assert job.is_running is False
+        assert job.last_run is not None
+        sync_comp.sync.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_job_failure_logs_evolution(self):
+        """last_result becomes 'failed' and log_evolution is called when a job raises."""
+        sync_comp = AsyncMock()
+        sync_comp.sync = AsyncMock(side_effect=RuntimeError("db down"))
+        mesh_db = AsyncMock()
+        mesh_db.log_evolution = AsyncMock()
+
+        scheduler = _make_scheduler(edge_sync=sync_comp, mesh_db=mesh_db)
+        await scheduler._execute_job("edge_sync")
+
+        assert scheduler._jobs["edge_sync"].last_result == "failed"
+        assert scheduler._jobs["edge_sync"].is_running is False
+        mesh_db.log_evolution.assert_awaited_once()
+        call_args = mesh_db.log_evolution.call_args[0]
+        assert call_args[0] == "job_failed"
+        assert call_args[4] == "edge_sync"
+
+    @pytest.mark.asyncio
+    async def test_execute_job_failure_no_mesh_db_does_not_raise(self):
+        """A job failure without mesh_db does not propagate an exception."""
+        sync_comp = AsyncMock()
+        sync_comp.sync = AsyncMock(side_effect=ValueError("fail"))
+        scheduler = _make_scheduler(edge_sync=sync_comp)
+        # Should complete without raising
+        await scheduler._execute_job("edge_sync")
+        assert scheduler._jobs["edge_sync"].last_result == "failed"
+
+    @pytest.mark.asyncio
+    async def test_execute_job_skips_missing_component(self):
+        """_execute_job is a no-op and raises nothing when no component is injected."""
+        scheduler = _make_scheduler()
+        await scheduler._execute_job("edge_sync")
+        assert scheduler._jobs["edge_sync"].last_result is None
+
+    @pytest.mark.asyncio
+    async def test_execute_job_node_promoter_calls_evaluate(self):
+        """node_promoter job invokes .evaluate() on its component."""
+        promoter = _make_component("evaluate")
+        scheduler = _make_scheduler(node_promoter=promoter)
+        await scheduler._execute_job("node_promoter")
+        promoter.evaluate.assert_awaited_once()
+
+
+# =============================================================================
+# start / stop
+# =============================================================================
+
+
+class TestStartStop:
+    @pytest.mark.asyncio
+    async def test_start_creates_tasks_for_available_components(self):
+        """asyncio.Task entries are created for each injected component."""
+        sync_comp = _make_component("sync")
+        promoter_comp = _make_component("evaluate")
+
+        scheduler = _make_scheduler(edge_sync=sync_comp, node_promoter=promoter_comp)
+
+        with _patch_sleep():
+            await scheduler.start()
+
+        assert "edge_sync" in scheduler._tasks
+        assert "node_promoter" in scheduler._tasks
+        assert "edge_learner" not in scheduler._tasks
+        assert scheduler._running is True
+
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_creates_realtime_task_for_edge_learner(self):
+        """edge_learner gets a task when that component is injected."""
+        learner = AsyncMock()
+        learner.consume_feedback_stream = AsyncMock()
+
+        scheduler = _make_scheduler(edge_learner=learner)
+
+        with _patch_sleep():
+            await scheduler.start()
+
+        assert "edge_learner" in scheduler._tasks
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_tasks(self):
+        """stop() cancels all tasks and clears the _tasks dict."""
+        mock_task_a = MagicMock(spec=asyncio.Task)
+        mock_task_b = MagicMock(spec=asyncio.Task)
+
+        scheduler = _make_scheduler()
+        scheduler._running = True
+        scheduler._tasks = {"edge_sync": mock_task_a, "node_promoter": mock_task_b}
+
+        await scheduler.stop()
+
+        mock_task_a.cancel.assert_called_once()
+        mock_task_b.cancel.assert_called_once()
+        assert scheduler._tasks == {}
+        assert scheduler._running is False
+
+
+# =============================================================================
+# API endpoint helpers (mesh_brain.py)
+# =============================================================================
+
+
+class TestMeshBrainApiHelpers:
+    def test_health_endpoint_returns_healthy_when_no_failed_jobs(self):
+        """_build_health_response returns healthy=True when no jobs have failed."""
+        from api.mesh_brain import _build_health_response
+
+        status = {
+            "running": True,
+            "jobs": {
+                "edge_sync": {"last_result": "success"},
+                "node_promoter": {"last_result": None},
+            },
+        }
+        result = _build_health_response(status)
+        assert result["healthy"] is True
+        assert result["failed_jobs"] == []
+        assert result["running"] is True
+
+    def test_health_endpoint_returns_unhealthy_when_job_failed(self):
+        """_build_health_response returns healthy=False and lists the failed job."""
+        from api.mesh_brain import _build_health_response
+
+        status = {
+            "running": True,
+            "jobs": {
+                "edge_sync": {"last_result": "failed"},
+                "node_promoter": {"last_result": "success"},
+            },
+        }
+        result = _build_health_response(status)
+        assert result["healthy"] is False
+        assert "edge_sync" in result["failed_jobs"]
+
+    def test_set_scheduler_registers_instance(self):
+        """set_scheduler() stores the scheduler so get_status endpoint can use it."""
+        import api.mesh_brain as mb
+
+        original = mb._scheduler
+        try:
+            mock_scheduler = MagicMock()
+            mb.set_scheduler(mock_scheduler)
+            assert mb._scheduler is mock_scheduler
+        finally:
+            mb._scheduler = original
+
+    @pytest.mark.asyncio
+    async def test_status_endpoint_returns_not_initialized_message(self):
+        """get_mesh_brain_status returns a safe dict when _scheduler is None."""
+        import api.mesh_brain as mb
+
+        original = mb._scheduler
+        try:
+            mb._scheduler = None
+            result = await mb.get_mesh_brain_status()
+            assert result["running"] is False
+            assert "message" in result
+        finally:
+            mb._scheduler = original
+
+    @pytest.mark.asyncio
+    async def test_health_endpoint_returns_not_initialized(self):
+        """get_mesh_brain_health returns healthy=False with reason when _scheduler is None."""
+        import api.mesh_brain as mb
+
+        original = mb._scheduler
+        try:
+            mb._scheduler = None
+            result = await mb.get_mesh_brain_health()
+            assert result["healthy"] is False
+            assert result["reason"] == "not_initialized"
+        finally:
+            mb._scheduler = original
+
+
+# =============================================================================
+# Internal helpers
+# =============================================================================
+
+
+def _patch_sleep():
+    """Patch asyncio.sleep to return immediately during start() tests."""
+    return patch("services.mesh_brain.scheduler.asyncio.sleep", new=AsyncMock())


### PR DESCRIPTION
## Summary
- Schedules all 5 mesh brain jobs: edge_learner (realtime), edge_sync (5min), edge_discoverer (daily 2AM), node_promoter (daily 3AM), mesh_pruner (weekly Sun 4AM)
- Job status tracking with last_run, last_result, is_running
- Failure logging to mesh_evolution_log
- Health/status API at `/api/mesh/brain/status` and `/api/mesh/brain/health`
- 20 tests

## Test plan
- [x] 20/20 tests pass
- [x] Job execution, success/failure status verified
- [x] Start/stop lifecycle verified
- [x] Health endpoint healthy/unhealthy/not_initialized cases

Closes #2120