### PR TITLE
fix(tracker): cap experiment Redis list at 10k entries (#2031)

### DIFF
--- a/autobot-backend/utils/experiment_tracker.py
+++ b/autobot-backend/utils/experiment_tracker.py
@@ -79,6 +79,7 @@ class ExperimentTracker:
         redis_client = await get_redis_client(async_client=True, database="analytics")
         if redis_client:
             await redis_client.rpush(REDIS_KEY, json.dumps(record.to_dict()))
+            await redis_client.ltrim(REDIS_KEY, -10000, -1)  # Cap at 10k (#2031)
         logger.info("Experiment logged: %s -> %s", name, result)
         return record
 


### PR DESCRIPTION
## Summary
- Add `ltrim(-10000, -1)` after `rpush` to cap at 10k experiments
- Matches pattern used by `llm_cost_tracker.py` (100k) and `stream_manager.py` (10k maxlen)

Closes #2031