### PR TITLE
feat(mesh): add QueryDecomposer — MA-RAG multi-hop (#2134)

### DIFF
--- a/autobot-backend/services/neural_mesh/__init__.py
+++ b/autobot-backend/services/neural_mesh/__init__.py
@@ -1,0 +1,3 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss

--- a/autobot-backend/services/neural_mesh/query_decomposer.py
+++ b/autobot-backend/services/neural_mesh/query_decomposer.py
@@ -1,0 +1,224 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""MA-RAG QueryDecomposer for MULTI_HOP queries (#2134).
+
+Breaks a complex question into 2-4 sequential retrieval sub-queries via an
+LLM, executes each step against a mesh retriever, and accumulates evidence
+across steps so later queries can leverage earlier results.
+"""
+import json
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Data classes
+# =============================================================================
+
+
+@dataclass
+class DecompositionStep:
+    """One retrieval step in a decomposition plan.
+
+    Attributes:
+        step:       1-based index for this step.
+        query:      Self-contained search query for this step.
+        depends_on: Step numbers whose evidence this step may reference.
+    """
+
+    step: int
+    query: str
+    depends_on: list[int] = field(default_factory=list)
+
+
+@dataclass
+class DecompositionPlan:
+    """Full decomposition plan produced by QueryDecomposer.decompose().
+
+    Attributes:
+        original_query: The raw user question.
+        steps:          Ordered list of DecompositionStep objects.
+    """
+
+    original_query: str
+    steps: list[DecompositionStep]
+
+
+@dataclass
+class StepResult:
+    """Evidence gathered during a single executed step.
+
+    Attributes:
+        step:     The DecompositionStep that produced this result.
+        evidence: Extracted chunk dicts from the retrieval result.
+    """
+
+    step: DecompositionStep
+    evidence: list[dict]
+
+
+# =============================================================================
+# QueryDecomposer
+# =============================================================================
+
+
+class QueryDecomposer:
+    """MA-RAG decomposer for MULTI_HOP queries (#2134).
+
+    Breaks the user question into ordered sub-queries, runs each against
+    ``mesh_retriever``, and threads earlier evidence into later queries.
+
+    All dependencies are injected so the class is fully unit-testable
+    without a running LLM or retrieval service.
+
+    Args:
+        llm:            Async callable ``(prompt: str) -> str``.
+        mesh_retriever: Object with ``async retrieve(query, top_k) -> result``.
+    """
+
+    def __init__(self, llm, mesh_retriever) -> None:
+        self.llm = llm
+        self.mesh_retriever = mesh_retriever
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def decompose(self, query: str) -> DecompositionPlan:
+        """Break *query* into 2-4 sequential sub-queries via the LLM.
+
+        Args:
+            query: Raw user question.
+
+        Returns:
+            DecompositionPlan with 1-4 ordered steps.
+        """
+        prompt = (
+            "Break this question into 2-4 sequential retrieval steps.\n"
+            "Each step should be a self-contained search query.\n"
+            "Later steps can reference results from earlier steps.\n\n"
+            f"Question: {query}\n\n"
+            'Respond as JSON: [{"step": 1, "query": "...", "depends_on": []}]'
+        )
+        raw = await self.llm(prompt)
+        steps = self._parse_steps(raw, fallback_query=query)
+        return DecompositionPlan(original_query=query, steps=steps)
+
+    async def execute(self, plan: DecompositionPlan) -> list[StepResult]:
+        """Execute each step sequentially, passing prior results as context.
+
+        Args:
+            plan: A DecompositionPlan produced by :meth:`decompose`.
+
+        Returns:
+            List of StepResult, one per plan step, in order.
+        """
+        results: list[StepResult] = []
+        for step in plan.steps:
+            context = self._build_step_context(step, results)
+            augmented_query = f"{step.query} {context}".strip()
+            retrieval = await self.mesh_retriever.retrieve(
+                query=augmented_query, top_k=5
+            )
+            evidence = self._extract_evidence(retrieval)
+            results.append(StepResult(step=step, evidence=evidence))
+        return results
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _parse_steps(
+        self, llm_output: str, fallback_query: str
+    ) -> list[DecompositionStep]:
+        """Parse a JSON array from *llm_output* into DecompositionStep list.
+
+        Attempts to locate the first ``[...]`` block in the output before
+        parsing so that leading/trailing prose is tolerated.  Falls back to
+        a single step containing the original query on any parse failure.
+
+        Args:
+            llm_output:     Raw string from the LLM.
+            fallback_query: Used to build a single fallback step on failure.
+
+        Returns:
+            Non-empty list of DecompositionStep objects.
+        """
+        try:
+            start = llm_output.index("[")
+            end = llm_output.rindex("]") + 1
+            data = json.loads(llm_output[start:end])
+            steps = [
+                DecompositionStep(
+                    step=int(item["step"]),
+                    query=str(item["query"]),
+                    depends_on=[int(d) for d in item.get("depends_on", [])],
+                )
+                for item in data
+            ]
+            if steps:
+                return steps
+        except Exception:
+            logger.warning("QueryDecomposer._parse_steps: parse failed, using fallback")
+        return [DecompositionStep(step=1, query=fallback_query, depends_on=[])]
+
+    def _build_step_context(
+        self, step: DecompositionStep, prior_results: list[StepResult]
+    ) -> str:
+        """Build a context string from evidence of steps this step depends on.
+
+        Args:
+            step:          The step about to be executed.
+            prior_results: All StepResult objects collected so far.
+
+        Returns:
+            Space-joined content snippets, or empty string when no deps.
+        """
+        if not step.depends_on:
+            return ""
+        prior_map = {r.step.step: r for r in prior_results}
+        snippets: list[str] = []
+        for dep_num in step.depends_on:
+            dep_result = prior_map.get(dep_num)
+            if dep_result is None:
+                continue
+            for chunk in dep_result.evidence[:3]:
+                content = chunk.get("content", "")
+                if content:
+                    snippets.append(content)
+        return " ".join(snippets)
+
+    def _extract_evidence(self, retrieval_result) -> list[dict]:
+        """Extract a list of chunk dicts from a retrieval result.
+
+        Handles both a plain list of dicts/objects and an object with a
+        ``.chunks`` attribute (e.g. MeshRetrievalResult).
+
+        Args:
+            retrieval_result: Return value of ``mesh_retriever.retrieve()``.
+
+        Returns:
+            List of dicts, each representing one evidence chunk.
+        """
+        chunks = (
+            retrieval_result.chunks
+            if hasattr(retrieval_result, "chunks")
+            else retrieval_result
+        )
+        evidence: list[dict] = []
+        for chunk in chunks:
+            if isinstance(chunk, dict):
+                evidence.append(chunk)
+            else:
+                evidence.append(
+                    {
+                        "chunk_id": getattr(chunk, "source_path", ""),
+                        "content": getattr(chunk, "content", ""),
+                        "score": getattr(chunk, "score", 0.0),
+                        "metadata": getattr(chunk, "metadata", {}),
+                    }
+                )
+        return evidence

--- a/autobot-backend/services/neural_mesh/query_decomposer_test.py
+++ b/autobot-backend/services/neural_mesh/query_decomposer_test.py
@@ -1,0 +1,232 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for QueryDecomposer (#2134).
+
+All external dependencies (LLM, mesh retriever) are replaced with
+AsyncMock / MagicMock so the tests run without a model server or database.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from services.neural_mesh.query_decomposer import (
+    DecompositionPlan,
+    DecompositionStep,
+    QueryDecomposer,
+    StepResult,
+)
+
+# =============================================================================
+# Factories
+# =============================================================================
+
+
+def _make_retrieval_result(chunks: list[dict] | None = None):
+    """Return a MagicMock that mimics MeshRetrievalResult with .chunks."""
+    result = MagicMock()
+    result.chunks = chunks or [
+        {"chunk_id": "c1", "content": "evidence text", "score": 0.9}
+    ]
+    return result
+
+
+def _make_decomposer(
+    llm_response: str | None = None,
+    retrieval_result=None,
+) -> QueryDecomposer:
+    """Construct a QueryDecomposer with controllable mock dependencies."""
+    default_steps = json.dumps(
+        [
+            {"step": 1, "query": "sub-query one", "depends_on": []},
+            {"step": 2, "query": "sub-query two", "depends_on": [1]},
+        ]
+    )
+    llm = AsyncMock(
+        return_value=llm_response if llm_response is not None else default_steps
+    )
+
+    retriever = AsyncMock()
+    retriever.retrieve = AsyncMock(
+        return_value=retrieval_result
+        if retrieval_result is not None
+        else _make_retrieval_result()
+    )
+
+    return QueryDecomposer(llm=llm, mesh_retriever=retriever)
+
+
+# =============================================================================
+# decompose()
+# =============================================================================
+
+
+class TestDecompose:
+    """QueryDecomposer.decompose() builds a DecompositionPlan from LLM output."""
+
+    @pytest.mark.asyncio
+    async def test_decompose_calls_llm_with_query(self):
+        """LLM callable must receive a prompt that contains the original query."""
+        decomposer = _make_decomposer()
+        query = "How does Redis clustering affect write latency?"
+
+        await decomposer.decompose(query)
+
+        decomposer.llm.assert_called_once()
+        prompt_arg = decomposer.llm.call_args.args[0]
+        assert query in prompt_arg
+
+    @pytest.mark.asyncio
+    async def test_decompose_parses_valid_json(self):
+        """Valid JSON from LLM produces a DecompositionPlan with the expected steps."""
+        steps_json = json.dumps(
+            [
+                {"step": 1, "query": "first sub-query", "depends_on": []},
+                {"step": 2, "query": "second sub-query", "depends_on": [1]},
+                {"step": 3, "query": "third sub-query", "depends_on": [1, 2]},
+            ]
+        )
+        decomposer = _make_decomposer(llm_response=steps_json)
+
+        plan = await decomposer.decompose("multi-hop question")
+
+        assert isinstance(plan, DecompositionPlan)
+        assert plan.original_query == "multi-hop question"
+        assert len(plan.steps) == 3
+        assert plan.steps[0].query == "first sub-query"
+        assert plan.steps[1].depends_on == [1]
+        assert plan.steps[2].depends_on == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_decompose_handles_malformed_json(self):
+        """Malformed LLM output falls back to a single step with the original query."""
+        decomposer = _make_decomposer(llm_response="Sorry, I cannot break that down.")
+
+        plan = await decomposer.decompose("complex question that breaks the LLM")
+
+        assert isinstance(plan, DecompositionPlan)
+        assert len(plan.steps) == 1
+        assert plan.steps[0].query == "complex question that breaks the LLM"
+        assert plan.steps[0].step == 1
+
+    @pytest.mark.asyncio
+    async def test_decompose_tolerates_prose_around_json(self):
+        """JSON array embedded in prose is extracted and parsed correctly."""
+        prose_with_json = (
+            "Sure! Here are the steps: "
+            + json.dumps([{"step": 1, "query": "embedded query", "depends_on": []}])
+            + " Hope that helps!"
+        )
+        decomposer = _make_decomposer(llm_response=prose_with_json)
+
+        plan = await decomposer.decompose("wrapped query")
+
+        assert len(plan.steps) == 1
+        assert plan.steps[0].query == "embedded query"
+
+
+# =============================================================================
+# execute()
+# =============================================================================
+
+
+class TestExecute:
+    """QueryDecomposer.execute() calls the retriever once per plan step."""
+
+    @pytest.mark.asyncio
+    async def test_execute_calls_retriever_per_step(self):
+        """Three plan steps produce exactly three retrieve() calls."""
+        decomposer = _make_decomposer()
+        plan = DecompositionPlan(
+            original_query="original",
+            steps=[
+                DecompositionStep(step=1, query="q1", depends_on=[]),
+                DecompositionStep(step=2, query="q2", depends_on=[]),
+                DecompositionStep(step=3, query="q3", depends_on=[]),
+            ],
+        )
+
+        await decomposer.execute(plan)
+
+        assert decomposer.mesh_retriever.retrieve.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_execute_passes_prior_context(self):
+        """Step 2's retrieve query includes evidence content from step 1."""
+        evidence_chunk = {
+            "chunk_id": "e1",
+            "content": "step one evidence",
+            "score": 0.8,
+        }
+        retrieval = _make_retrieval_result(chunks=[evidence_chunk])
+        decomposer = _make_decomposer(retrieval_result=retrieval)
+
+        plan = DecompositionPlan(
+            original_query="multi-hop",
+            steps=[
+                DecompositionStep(step=1, query="first query", depends_on=[]),
+                DecompositionStep(step=2, query="second query", depends_on=[1]),
+            ],
+        )
+
+        await decomposer.execute(plan)
+
+        second_call_args = decomposer.mesh_retriever.retrieve.call_args_list[1]
+        second_query = second_call_args.kwargs.get("query") or second_call_args.args[0]
+        assert "step one evidence" in second_query
+
+    @pytest.mark.asyncio
+    async def test_step_result_contains_evidence(self):
+        """Each StepResult has a non-empty evidence list from the retrieval."""
+        chunks = [
+            {"chunk_id": "a", "content": "alpha", "score": 0.9},
+            {"chunk_id": "b", "content": "beta", "score": 0.7},
+        ]
+        decomposer = _make_decomposer(
+            retrieval_result=_make_retrieval_result(chunks=chunks)
+        )
+
+        plan = DecompositionPlan(
+            original_query="single step",
+            steps=[DecompositionStep(step=1, query="q1", depends_on=[])],
+        )
+
+        results = await decomposer.execute(plan)
+
+        assert len(results) == 1
+        assert isinstance(results[0], StepResult)
+        assert len(results[0].evidence) == 2
+        assert results[0].evidence[0]["chunk_id"] == "a"
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_one_result_per_step(self):
+        """execute() returns a StepResult list of the same length as plan.steps."""
+        decomposer = _make_decomposer()
+        steps = [
+            DecompositionStep(step=i, query=f"q{i}", depends_on=[]) for i in range(1, 5)
+        ]
+        plan = DecompositionPlan(original_query="four step plan", steps=steps)
+
+        results = await decomposer.execute(plan)
+
+        assert len(results) == 4
+        for i, r in enumerate(results):
+            assert r.step is steps[i]
+
+    @pytest.mark.asyncio
+    async def test_execute_step_without_deps_sends_query_only(self):
+        """A step with no depends_on sends just its own query to the retriever."""
+        decomposer = _make_decomposer()
+        plan = DecompositionPlan(
+            original_query="no deps",
+            steps=[DecompositionStep(step=1, query="standalone query", depends_on=[])],
+        )
+
+        await decomposer.execute(plan)
+
+        call_kwargs = decomposer.mesh_retriever.retrieve.call_args.kwargs
+        query_sent = (
+            call_kwargs.get("query")
+            or decomposer.mesh_retriever.retrieve.call_args.args[0]
+        )
+        assert query_sent == "standalone query"


### PR DESCRIPTION
## Summary
- Decomposes MULTI_HOP queries into 2-4 sequential sub-steps via LLM
- Executes steps through NeuralMeshRetriever with prior context injection
- Graceful JSON parsing with fallback to single step
- 9 tests

Closes #2134