### PR TITLE
feat(mesh): add AgentTopology — dynamic DAG (#2137)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/topology.py
+++ b/autobot-backend/agents/agent_orchestration/topology.py
@@ -1,0 +1,198 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Agent Topology Module
+
+Issue #2137: Dynamic DAG of agent connections with Hebbian evolution.
+
+Applies the same Hebbian reinforcement principle used by the knowledge mesh:
+agents that succeed together build stronger connections; those that fail
+together weaken.  The topology is queried at routing time to bias agent
+selection toward historically effective collaborations.
+"""
+
+import logging
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Hebbian learning rate: how much each outcome shifts the weight.
+_LEARNING_RATE: float = 0.1
+# Decay factor applied to the current weight each update.
+_DECAY: float = 1.0 - _LEARNING_RATE
+
+
+@dataclass
+class AgentConnection:
+    """A directed, weighted edge between two agents in the topology DAG."""
+
+    id: str
+    from_agent: str
+    to_agent: str
+    task_type: Optional[str]  # None means the connection applies to all task types
+    weight: float
+    co_success_count: int
+    co_failure_count: int
+
+
+@runtime_checkable
+class AgentTopologyDB(Protocol):
+    """Database access protocol for agent topology persistence.
+
+    Issue #2137: Kept as a Protocol so the topology layer stays testable
+    without a real database connection.
+    """
+
+    async def get_agent_connections(
+        self,
+        from_agent: str,
+        task_type: Optional[str],
+        min_weight: float,
+        limit: int,
+    ) -> list[AgentConnection]:
+        """Return connections from *from_agent* matching the filter criteria."""
+        ...
+
+    async def get_or_create_agent_connection(
+        self, from_agent: str, to_agent: str, task_type: Optional[str]
+    ) -> AgentConnection:
+        """Fetch the connection or create it with a neutral starting weight."""
+        ...
+
+    async def update_agent_connection(
+        self,
+        connection_id: str,
+        weight: float,
+        co_success_count: Optional[int] = None,
+        co_failure_count: Optional[int] = None,
+    ) -> None:
+        """Persist updated weight and counter fields."""
+        ...
+
+    async def record_agent_task(
+        self,
+        agent_id: str,
+        task_type: Optional[str],
+        workflow_id: str,
+        success: bool,
+    ) -> None:
+        """Append a task history entry for *agent_id*."""
+        ...
+
+
+class AgentTopology:
+    """Dynamic DAG of agent connections.  Evolves from task outcomes.
+
+    Same Hebbian principle as the knowledge mesh: agents that succeed
+    together get stronger connections.
+
+    Issue #2137.
+    """
+
+    def __init__(self, db: AgentTopologyDB) -> None:
+        self.db = db
+
+    async def get_collaborators(
+        self,
+        agent_id: str,
+        task_type: Optional[str] = None,
+        min_weight: float = 0.3,
+        limit: int = 5,
+    ) -> list[AgentConnection]:
+        """Return agents that *agent_id* works well with.
+
+        Args:
+            agent_id: The agent whose outgoing connections are queried.
+            task_type: Filter to connections for a specific task type.
+                       Pass ``None`` to include all task types.
+            min_weight: Only return connections above this weight threshold.
+            limit: Maximum number of connections to return.
+
+        Returns:
+            List of :class:`AgentConnection` sorted by weight descending.
+        """
+        return await self.db.get_agent_connections(
+            from_agent=agent_id,
+            task_type=task_type,
+            min_weight=min_weight,
+            limit=limit,
+        )
+
+    async def record_outcome(
+        self,
+        workflow_id: str,
+        agents: list[str],
+        task_type: Optional[str],
+        success: bool,
+    ) -> None:
+        """Update connection weights after a multi-agent workflow completes.
+
+        For every pair of agents in *agents*, applies Hebbian reinforcement:
+        - success: exponential moving average toward 1.0 (strengthen)
+        - failure: exponential moving average toward 0.0 (weaken)
+
+        Also appends a task history entry for every participating agent.
+
+        Args:
+            workflow_id: Unique identifier for the completed workflow.
+            agents: Ordered list of agent IDs that participated.
+            task_type: Task type label for the workflow; may be ``None``.
+            success: Whether the workflow succeeded overall.
+        """
+        for from_agent, to_agent in combinations(agents, 2):
+            await self._update_pair(from_agent, to_agent, task_type, success)
+        await self._record_agent_histories(workflow_id, agents, task_type, success)
+
+    async def _record_agent_histories(
+        self,
+        workflow_id: str,
+        agents: list[str],
+        task_type: Optional[str],
+        success: bool,
+    ) -> None:
+        """Persist per-agent task history and emit a summary log entry.
+
+        Issue #2137: Extracted from record_outcome to stay within 30-line limit.
+        """
+        for agent_id in agents:
+            await self.db.record_agent_task(agent_id, task_type, workflow_id, success)
+        logger.info(
+            "Recorded %s outcome for workflow %s: %d agents, %d pairs",
+            "success" if success else "failure",
+            workflow_id,
+            len(agents),
+            len(agents) * (len(agents) - 1) // 2,
+        )
+
+    async def _update_pair(
+        self,
+        from_agent: str,
+        to_agent: str,
+        task_type: Optional[str],
+        success: bool,
+    ) -> None:
+        """Apply one Hebbian update to a single agent pair.
+
+        Issue #2137: Extracted to keep *record_outcome* under 30 lines.
+        """
+        conn = await self.db.get_or_create_agent_connection(
+            from_agent, to_agent, task_type
+        )
+        target = 1.0 if success else 0.0
+        new_weight = conn.weight * _DECAY + target * _LEARNING_RATE
+
+        if success:
+            await self.db.update_agent_connection(
+                conn.id,
+                weight=new_weight,
+                co_success_count=conn.co_success_count + 1,
+            )
+        else:
+            await self.db.update_agent_connection(
+                conn.id,
+                weight=new_weight,
+                co_failure_count=conn.co_failure_count + 1,
+            )

--- a/autobot-backend/agents/agent_orchestration/topology_test.py
+++ b/autobot-backend/agents/agent_orchestration/topology_test.py
@@ -1,0 +1,204 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for AgentTopology (Issue #2137).
+
+Verifies Hebbian weight evolution, pair generation, and history recording
+using in-memory stubs — no database required.
+"""
+
+import dataclasses
+from unittest.mock import AsyncMock
+
+import pytest
+
+from .topology import AgentConnection, AgentTopology
+
+# ---------------------------------------------------------------------------
+# Helpers / Stubs
+# ---------------------------------------------------------------------------
+
+
+def _make_connection(
+    from_agent: str = "agent_a",
+    to_agent: str = "agent_b",
+    task_type: str | None = "research",
+    weight: float = 0.5,
+    co_success_count: int = 0,
+    co_failure_count: int = 0,
+) -> AgentConnection:
+    return AgentConnection(
+        id="conn-1",
+        from_agent=from_agent,
+        to_agent=to_agent,
+        task_type=task_type,
+        weight=weight,
+        co_success_count=co_success_count,
+        co_failure_count=co_failure_count,
+    )
+
+
+def _make_db(connection: AgentConnection | None = None) -> AsyncMock:
+    """Return a mock that satisfies the AgentTopologyDB Protocol."""
+    db = AsyncMock()
+    db.get_agent_connections.return_value = [connection] if connection else []
+    db.get_or_create_agent_connection.return_value = connection or _make_connection()
+    db.update_agent_connection.return_value = None
+    db.record_agent_task.return_value = None
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_collaborators_queries_db():
+    """get_collaborators forwards all parameters to db.get_agent_connections."""
+    conn = _make_connection()
+    db = _make_db(conn)
+    topology = AgentTopology(db)
+
+    result = await topology.get_collaborators(
+        "agent_a", task_type="research", min_weight=0.4, limit=3
+    )
+
+    db.get_agent_connections.assert_awaited_once_with(
+        from_agent="agent_a",
+        task_type="research",
+        min_weight=0.4,
+        limit=3,
+    )
+    assert result == [conn]
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_success_reinforces():
+    """Successful outcome moves the weight toward 1.0 (Hebbian reinforcement)."""
+    initial_weight = 0.5
+    conn = _make_connection(weight=initial_weight)
+    db = _make_db(conn)
+    topology = AgentTopology(db)
+
+    await topology.record_outcome("wf-1", ["agent_a", "agent_b"], "research", True)
+
+    expected_weight = initial_weight * 0.9 + 1.0 * 0.1  # == 0.55
+    db.update_agent_connection.assert_awaited_once_with(
+        conn.id,
+        weight=pytest.approx(expected_weight),
+        co_success_count=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_failure_weakens():
+    """Failed outcome moves the weight toward 0.0 (Hebbian weakening)."""
+    initial_weight = 0.5
+    conn = _make_connection(weight=initial_weight)
+    db = _make_db(conn)
+    topology = AgentTopology(db)
+
+    await topology.record_outcome("wf-2", ["agent_a", "agent_b"], "research", False)
+
+    expected_weight = initial_weight * 0.9 + 0.0 * 0.1  # == 0.45
+    db.update_agent_connection.assert_awaited_once_with(
+        conn.id,
+        weight=pytest.approx(expected_weight),
+        co_failure_count=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_creates_connections_for_all_pairs():
+    """Three agents produce exactly three pair updates (C(3,2) = 3)."""
+    conn = _make_connection()
+    db = _make_db(conn)
+    topology = AgentTopology(db)
+
+    await topology.record_outcome(
+        "wf-3", ["agent_a", "agent_b", "agent_c"], "analysis", True
+    )
+
+    assert db.get_or_create_agent_connection.await_count == 3
+    assert db.update_agent_connection.await_count == 3
+
+    expected_pairs = {
+        ("agent_a", "agent_b"),
+        ("agent_a", "agent_c"),
+        ("agent_b", "agent_c"),
+    }
+    actual_pairs = {
+        (c.args[0], c.args[1])
+        for c in db.get_or_create_agent_connection.await_args_list
+    }
+    assert actual_pairs == expected_pairs
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_records_task_history():
+    """record_agent_task is called once per participating agent."""
+    conn = _make_connection()
+    db = _make_db(conn)
+    topology = AgentTopology(db)
+
+    agents = ["agent_a", "agent_b", "agent_c"]
+    await topology.record_outcome("wf-4", agents, "summary", True)
+
+    assert db.record_agent_task.await_count == 3
+    called_agents = {c.args[0] for c in db.record_agent_task.await_args_list}
+    assert called_agents == set(agents)
+
+    # Workflow ID and success flag must be forwarded correctly.
+    for recorded_call in db.record_agent_task.await_args_list:
+        assert recorded_call.args[2] == "wf-4"
+        assert recorded_call.args[3] is True
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_single_agent_no_pairs():
+    """A single-agent workflow produces zero pair updates."""
+    conn = _make_connection()
+    db = _make_db(conn)
+    topology = AgentTopology(db)
+
+    await topology.record_outcome("wf-5", ["agent_a"], "chat", True)
+
+    db.get_or_create_agent_connection.assert_not_awaited()
+    db.update_agent_connection.assert_not_awaited()
+    # But task history must still be recorded.
+    db.record_agent_task.assert_awaited_once()
+
+
+def test_agent_connection_dataclass_fields():
+    """AgentConnection exposes exactly the required fields with correct types."""
+    conn = AgentConnection(
+        id="abc",
+        from_agent="agent_x",
+        to_agent="agent_y",
+        task_type="qa",
+        weight=0.75,
+        co_success_count=10,
+        co_failure_count=2,
+    )
+
+    assert conn.id == "abc"
+    assert conn.from_agent == "agent_x"
+    assert conn.to_agent == "agent_y"
+    assert conn.task_type == "qa"
+    assert conn.weight == 0.75
+    assert conn.co_success_count == 10
+    assert conn.co_failure_count == 2
+
+    # Verify it is a proper dataclass (supports equality, fields introspection).
+    field_names = {f.name for f in dataclasses.fields(conn)}
+    assert field_names == {
+        "id",
+        "from_agent",
+        "to_agent",
+        "task_type",
+        "weight",
+        "co_success_count",
+        "co_failure_count",
+    }


### PR DESCRIPTION
## Summary
- AgentTopology tracks connections between agent pairs
- Hebbian: success reinforces (EMA 0.9+0.1), failure weakens
- Records per-agent task history for specialization tracking
- 7 tests including single-agent boundary case

Closes #2137