### PR TITLE
feat(mesh): add A-RAG autonomous strategy selection (#2136)

### DIFF
--- a/autobot-backend/services/neural_mesh_retriever.py
+++ b/autobot-backend/services/neural_mesh_retriever.py
@@ -10,12 +10,27 @@ Routes queries by complexity:
   MULTI_HOP  -> same as COMPLEX
 """
 import asyncio
+import json
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, Callable, Coroutine, Protocol
+from typing import Any, Callable, Coroutine, Optional, Protocol
 
 logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Agentic tool registry — maps LLM-visible names to human descriptions.
+# Issue #2136: A-RAG ReAct loop for COMPLEX / MULTI_HOP queries.
+# =============================================================================
+
+AVAILABLE_TOOLS: dict[str, str] = {
+    "semantic_search": "Find chunks by meaning similarity",
+    "keyword_search": "Find chunks by exact term matching (BM25)",
+    "mesh_expand": "Follow graph edges from known nodes",
+    "raptor_retrieve": "Search hierarchical summaries at multiple levels",
+    "anchor_lookup": "Find pre-computed topic entry points",
+    "decompose_query": "Break into sub-questions and solve sequentially",
+}
 
 
 # =============================================================================
@@ -79,6 +94,7 @@ class NeuralMeshRetriever:
         reranker: Any,
         classifier: Any,
         mesh_db: Any,
+        llm: Optional[Callable[..., Coroutine[Any, Any, str]]] = None,
     ) -> None:
         """Inject all dependencies.
 
@@ -90,6 +106,8 @@ class NeuralMeshRetriever:
             reranker:       ResultReranker instance.
             classifier:     QueryClassifier instance.
             mesh_db:        Object satisfying _AnchorDB protocol.
+            llm:            Optional async callable(prompt) -> str for A-RAG
+                            ReAct loop (#2136). When None, agentic path is off.
         """
         self.chroma_search = chroma_search
         self.hybrid_search = hybrid_search
@@ -98,6 +116,7 @@ class NeuralMeshRetriever:
         self.reranker = reranker
         self.classifier = classifier
         self.mesh_db = mesh_db
+        self.llm = llm
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -122,7 +141,9 @@ class NeuralMeshRetriever:
             return await self._simple_retrieve(query, top_k)
         if value == "moderate":
             return await self._moderate_retrieve(query, top_k)
-        # complex or multi_hop both use the full pipeline
+        # complex / multi_hop: prefer agentic ReAct loop when an LLM is wired in
+        if value in ("complex", "multi_hop") and self.llm is not None:
+            return await self.retrieve_agentic(query, top_k)
         return await self._full_retrieve(query, top_k)
 
     # ------------------------------------------------------------------
@@ -176,6 +197,171 @@ class NeuralMeshRetriever:
             anchor_used=anchor_used,
             nodes_explored=len(expanded_scores),
         )
+
+    # ------------------------------------------------------------------
+    # A-RAG ReAct loop (Issue #2136)
+    # ------------------------------------------------------------------
+
+    async def retrieve_agentic(
+        self, query: str, top_k: int = 5, max_steps: int = 5
+    ) -> MeshRetrievalResult:
+        """ReAct loop: LLM selects retrieval tools iteratively. Issue #2136.
+
+        Only activated for COMPLEX/MULTI_HOP queries when self.llm is set.
+        Falls back gracefully — a DONE action at any step ends the loop.
+
+        Args:
+            query:     Raw user query string.
+            top_k:     Maximum chunks to return.
+            max_steps: Upper bound on LLM-tool iterations.
+
+        Returns:
+            MeshRetrievalResult assembled from accumulated tool results.
+        """
+        context_tracker: list[dict] = []
+        accumulated: list = []
+
+        for _ in range(max_steps):
+            action = await self._select_next_action(query, context_tracker)
+            if action["tool"] == "DONE":
+                break
+            results = await self._execute_tool(
+                action["tool"], action.get("params", {}), query
+            )
+            context_tracker.append(
+                {"tool": action["tool"], "result_count": len(results)}
+            )
+            accumulated.extend(results)
+
+        chunks = await self._finalize_agentic(query, accumulated, top_k)
+        self._fire_learner(query, chunks)
+        return MeshRetrievalResult(
+            chunks=chunks,
+            expanded=True,
+            complexity="complex",
+            nodes_explored=len(accumulated),
+        )
+
+    async def _finalize_agentic(
+        self, query: str, accumulated: list, top_k: int
+    ) -> list:
+        """Deduplicate and rerank accumulated agentic results. Issue #2136.
+
+        Args:
+            query:       Original query for reranker scoring.
+            accumulated: Raw combined results from all tool calls.
+            top_k:       Number of results to keep after reranking.
+
+        Returns:
+            Ranked and deduplicated result list capped at top_k.
+        """
+        if not accumulated:
+            return []
+        seen: set[str] = set()
+        unique: list = []
+        for r in accumulated:
+            cid = self._chunk_id(r)
+            if cid not in seen:
+                seen.add(cid)
+                unique.append(r)
+        return await self.reranker.rerank(query, unique, top_k=top_k)
+
+    async def _select_next_action(self, query: str, context_so_far: list) -> dict:
+        """Ask the LLM which tool to invoke next. Issue #2136.
+
+        Builds a structured prompt and parses the JSON response.  On any
+        failure the loop receives {"tool": "DONE"} so retrieval degrades
+        gracefully rather than crashing.
+
+        Args:
+            query:          The original user query.
+            context_so_far: List of {"tool": ..., "result_count": ...} dicts.
+
+        Returns:
+            Parsed action dict with at least a "tool" key.
+        """
+        prompt = (
+            f"Query: {query}\n"
+            f"Steps taken: {json.dumps(context_so_far)}\n"
+            f"Available tools: {json.dumps(AVAILABLE_TOOLS)}\n\n"
+            "Choose next tool or DONE. Respond as JSON: "
+            '{"tool": "...", "params": {...}} or {"tool": "DONE"}'
+        )
+        raw = await self.llm(prompt)
+        return self._parse_action(raw)
+
+    async def _execute_tool(self, tool_name: str, params: dict, query: str) -> list:
+        """Dispatch a tool name to the appropriate retrieval method. Issue #2136.
+
+        Unrecognised tool names are logged and return an empty list so the
+        ReAct loop can continue or terminate via DONE on the next step.
+
+        Args:
+            tool_name: One of the keys in AVAILABLE_TOOLS.
+            params:    Optional parameters forwarded from the LLM action.
+            query:     Original query, used as default input for all tools.
+
+        Returns:
+            List of result dicts from the dispatched method.
+        """
+        top_k = params.get("top_k", 5)
+        dispatch: dict[str, Any] = {
+            "semantic_search": lambda: self.chroma_search(query, top_k),
+            "keyword_search": lambda: self.hybrid_search(query, top_k),
+            "mesh_expand": lambda: self._agentic_mesh_expand(query, top_k),
+            "raptor_retrieve": lambda: self.chroma_search(query, top_k),
+            "anchor_lookup": lambda: self._agentic_anchor_lookup(query, top_k),
+            "decompose_query": lambda: self.hybrid_search(query, top_k),
+        }
+        handler = dispatch.get(tool_name)
+        if handler is None:
+            logger.warning(
+                "_execute_tool: unknown tool %r; returning empty list", tool_name
+            )
+            return []
+        return await handler()
+
+    async def _agentic_mesh_expand(self, query: str, top_k: int) -> list:
+        """Seed hybrid search then PPR-expand; returns merged results. Issue #2136."""
+        seeds = await self.hybrid_search(query, top_k)
+        seed_ids = [self._chunk_id(r) for r in seeds[:5]]
+        expanded = await self.ppr.rank(seed_ids, top_k=top_k * 2, max_iterations=5)
+        return self._merge_with_expansion(seeds, expanded)
+
+    async def _agentic_anchor_lookup(self, query: str, top_k: int) -> list:
+        """Seed hybrid search then inject anchor nodes; returns seed list. Issue #2136."""
+        seeds = await self.hybrid_search(query, top_k)
+        seed_ids = [self._chunk_id(r) for r in seeds[:5]]
+        anchors = await self._find_anchors(seed_ids)
+        if anchors:
+            anchor_results = [
+                {"chunk_id": a, "score": 0.5, "content": ""} for a in anchors
+            ]
+            return seeds + anchor_results
+        return seeds
+
+    def _parse_action(self, llm_output: str) -> dict:
+        """Parse a JSON action from LLM output. Issue #2136.
+
+        Tries to extract {"tool": ..., "params": ...}.  Returns
+        {"tool": "DONE"} on any parse or validation failure so the ReAct
+        loop degrades gracefully.
+
+        Args:
+            llm_output: Raw string returned by self.llm().
+
+        Returns:
+            Dict with at minimum a "tool" key.
+        """
+        try:
+            action = json.loads(llm_output.strip())
+            if isinstance(action, dict) and "tool" in action:
+                return action
+        except (json.JSONDecodeError, AttributeError):
+            logger.warning(
+                "_parse_action: could not parse LLM output as JSON; using DONE"
+            )
+        return {"tool": "DONE"}
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/autobot-backend/services/neural_mesh_retriever_agentic_test.py
+++ b/autobot-backend/services/neural_mesh_retriever_agentic_test.py
@@ -1,0 +1,283 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for NeuralMeshRetriever A-RAG ReAct loop (#2136).
+
+All external dependencies are replaced with AsyncMock / MagicMock so the
+tests run without a database, Redis, or model server.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from services.neural_mesh_retriever import MeshRetrievalResult, NeuralMeshRetriever
+
+# =============================================================================
+# Factories
+# =============================================================================
+
+
+def _make_result(chunk_id: str, score: float = 0.5) -> dict:
+    """Return a minimal result dict used as a stand-in for a SearchResult."""
+    return {"metadata": {"chunk_id": chunk_id}, "score": score, "content": "text"}
+
+
+def _make_complexity_mock(value: str):
+    """Return a MagicMock whose .value attribute equals *value*."""
+    mock = MagicMock()
+    mock.value = value
+    return mock
+
+
+def _make_llm(responses: list[str]):
+    """Return an AsyncMock LLM that returns *responses* in sequence."""
+    llm = AsyncMock(side_effect=responses)
+    return llm
+
+
+def _make_retriever_agentic(
+    complexity_value: str = "complex",
+    llm_responses: list[str] | None = None,
+    chroma_results: list | None = None,
+    hybrid_results: list | None = None,
+    ppr_results: list | None = None,
+    rerank_results: list | None = None,
+    anchor_results: list | None = None,
+) -> NeuralMeshRetriever:
+    """Construct a NeuralMeshRetriever with an LLM mock and controllable deps.
+
+    Returns the retriever pre-configured for the given complexity tier.
+    """
+    chroma_results = chroma_results or [_make_result("c1")]
+    hybrid_results = hybrid_results or [_make_result("h1")]
+    ppr_results = ppr_results or [("h1", 0.8)]
+    rerank_results = rerank_results or chroma_results[:1]
+    anchor_results = anchor_results or []
+    llm_responses = llm_responses or ['{"tool": "DONE"}']
+
+    classifier = MagicMock()
+    classifier.classify.return_value = _make_complexity_mock(complexity_value)
+
+    ppr = AsyncMock()
+    ppr.rank = AsyncMock(return_value=ppr_results)
+
+    edge_learner = AsyncMock()
+    edge_learner.on_retrieval = AsyncMock()
+
+    reranker = AsyncMock()
+    reranker.rerank = AsyncMock(return_value=rerank_results)
+
+    mesh_db = AsyncMock()
+    mesh_db.get_anchor_neighbors = AsyncMock(return_value=anchor_results)
+
+    return NeuralMeshRetriever(
+        chroma_search=AsyncMock(return_value=chroma_results),
+        hybrid_search=AsyncMock(return_value=hybrid_results),
+        ppr=ppr,
+        edge_learner=edge_learner,
+        reranker=reranker,
+        classifier=classifier,
+        mesh_db=mesh_db,
+        llm=_make_llm(llm_responses),
+    )
+
+
+# =============================================================================
+# retrieve_agentic — loop behaviour
+# =============================================================================
+
+
+class TestRetrieveAgenticLoop:
+    """retrieve_agentic() drives the ReAct loop correctly."""
+
+    @pytest.mark.asyncio
+    async def test_retrieve_agentic_calls_select_next_action(self):
+        """LLM is called at each step until DONE is returned."""
+        responses = [
+            '{"tool": "semantic_search", "params": {}}',
+            '{"tool": "DONE"}',
+        ]
+        retriever = _make_retriever_agentic(llm_responses=responses)
+
+        with patch("asyncio.create_task"):
+            await retriever.retrieve_agentic("what is mesh expansion", top_k=3)
+
+        assert retriever.llm.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retrieve_agentic_stops_on_done(self):
+        """When the first LLM response is DONE the loop exits after one call."""
+        retriever = _make_retriever_agentic(llm_responses=['{"tool": "DONE"}'])
+
+        with patch("asyncio.create_task"):
+            result = await retriever.retrieve_agentic("simple done query", top_k=3)
+
+        retriever.llm.assert_called_once()
+        assert isinstance(result, MeshRetrievalResult)
+
+    @pytest.mark.asyncio
+    async def test_retrieve_agentic_max_steps_limit(self):
+        """Loop iterates exactly max_steps times when DONE is never returned."""
+        # Always return semantic_search — never DONE
+        never_done = ['{"tool": "semantic_search", "params": {}}'] * 10
+        retriever = _make_retriever_agentic(llm_responses=never_done)
+
+        with patch("asyncio.create_task"):
+            await retriever.retrieve_agentic("multi step query", top_k=3, max_steps=3)
+
+        assert retriever.llm.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retrieve_agentic_returns_mesh_retrieval_result(self):
+        """retrieve_agentic always returns a MeshRetrievalResult. Issue #2136."""
+        retriever = _make_retriever_agentic(llm_responses=['{"tool": "DONE"}'])
+
+        with patch("asyncio.create_task"):
+            result = await retriever.retrieve_agentic("any query", top_k=2)
+
+        assert isinstance(result, MeshRetrievalResult)
+        assert result.complexity == "complex"
+        assert result.expanded is True
+
+
+# =============================================================================
+# _execute_tool dispatch
+# =============================================================================
+
+
+class TestExecuteTool:
+    """_execute_tool dispatches each tool name to the correct method."""
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_semantic_search(self):
+        """semantic_search dispatches to chroma_search callable."""
+        retriever = _make_retriever_agentic()
+        await retriever._execute_tool("semantic_search", {}, "redis caching")
+        retriever.chroma_search.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_keyword_search(self):
+        """keyword_search dispatches to hybrid_search callable."""
+        retriever = _make_retriever_agentic()
+        await retriever._execute_tool("keyword_search", {}, "redis caching")
+        retriever.hybrid_search.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_mesh_expand(self):
+        """mesh_expand calls hybrid_search then ppr.rank."""
+        retriever = _make_retriever_agentic()
+        await retriever._execute_tool("mesh_expand", {}, "redis caching")
+        retriever.hybrid_search.assert_called_once()
+        retriever.ppr.rank.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_unknown_returns_empty(self):
+        """An unrecognised tool name returns an empty list without raising."""
+        retriever = _make_retriever_agentic()
+        result = await retriever._execute_tool("nonexistent_tool", {}, "query")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_anchor_lookup(self):
+        """anchor_lookup calls hybrid_search and mesh_db.get_anchor_neighbors."""
+        retriever = _make_retriever_agentic(anchor_results=["anchor-1"])
+        await retriever._execute_tool("anchor_lookup", {}, "redis caching")
+        retriever.hybrid_search.assert_called_once()
+        retriever.mesh_db.get_anchor_neighbors.assert_called_once()
+
+
+# =============================================================================
+# _parse_action
+# =============================================================================
+
+
+class TestParseAction:
+    """_parse_action parses valid JSON and falls back to DONE on failure."""
+
+    def test_parse_action_valid_json(self):
+        """Valid JSON with a tool key is returned as-is."""
+        retriever = _make_retriever_agentic()
+        action = retriever._parse_action(
+            '{"tool": "semantic_search", "params": {"top_k": 5}}'
+        )
+        assert action["tool"] == "semantic_search"
+        assert action["params"]["top_k"] == 5
+
+    def test_parse_action_done_json(self):
+        """JSON with tool=DONE is returned directly."""
+        retriever = _make_retriever_agentic()
+        action = retriever._parse_action('{"tool": "DONE"}')
+        assert action["tool"] == "DONE"
+
+    def test_parse_action_invalid_json_returns_done(self):
+        """Non-JSON output returns {"tool": "DONE"} without raising."""
+        retriever = _make_retriever_agentic()
+        action = retriever._parse_action("not valid json at all")
+        assert action == {"tool": "DONE"}
+
+    def test_parse_action_json_missing_tool_key_returns_done(self):
+        """Valid JSON that lacks a 'tool' key falls back to DONE."""
+        retriever = _make_retriever_agentic()
+        action = retriever._parse_action('{"action": "search"}')
+        assert action == {"tool": "DONE"}
+
+    def test_parse_action_empty_string_returns_done(self):
+        """Empty string falls back to DONE without raising."""
+        retriever = _make_retriever_agentic()
+        action = retriever._parse_action("")
+        assert action == {"tool": "DONE"}
+
+
+# =============================================================================
+# retrieve() routing to agentic path
+# =============================================================================
+
+
+class TestRetrieveAgenticRouting:
+    """retrieve() directs COMPLEX/MULTI_HOP to retrieve_agentic when llm is set."""
+
+    @pytest.mark.asyncio
+    async def test_retrieve_routes_complex_to_agentic(self):
+        """complexity=COMPLEX with llm set calls retrieve_agentic. Issue #2136."""
+        retriever = _make_retriever_agentic(
+            complexity_value="complex",
+            llm_responses=['{"tool": "DONE"}'],
+        )
+
+        with patch.object(
+            retriever, "retrieve_agentic", wraps=retriever.retrieve_agentic
+        ) as spy:
+            with patch("asyncio.create_task"):
+                await retriever.retrieve("complex multi-faceted query", top_k=3)
+
+        spy.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retrieve_routes_multi_hop_to_agentic(self):
+        """complexity=MULTI_HOP with llm set calls retrieve_agentic. Issue #2136."""
+        retriever = _make_retriever_agentic(
+            complexity_value="multi_hop",
+            llm_responses=['{"tool": "DONE"}'],
+        )
+
+        with patch.object(
+            retriever, "retrieve_agentic", wraps=retriever.retrieve_agentic
+        ) as spy:
+            with patch("asyncio.create_task"):
+                await retriever.retrieve("trace the chain of events", top_k=3)
+
+        spy.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retrieve_complex_without_llm_uses_full_retrieve(self):
+        """COMPLEX query with no llm falls through to _full_retrieve. Issue #2136."""
+        # Build retriever without llm by passing None explicitly
+        retriever = _make_retriever_agentic(complexity_value="complex")
+        retriever.llm = None
+
+        with patch.object(
+            retriever, "_full_retrieve", wraps=retriever._full_retrieve
+        ) as spy:
+            with patch("asyncio.create_task"):
+                await retriever.retrieve("complex query without llm", top_k=3)
+
+        spy.assert_called_once()


### PR DESCRIPTION
## Summary
- ReAct loop: LLM selects retrieval tools (semantic, keyword, mesh_expand, raptor, anchor, decompose) per step
- Max 5 iterations, exits on DONE
- Graceful JSON parse with DONE fallback
- Routes COMPLEX/MULTI_HOP to agentic when LLM available; falls back to _full_retrieve otherwise
- 17 tests

Closes #2136