### PR TITLE
refactor(tests): migrate legacy redis_client imports to autobot_shared (#2047)

### DIFF
--- a/autobot-backend/async_baseline.performance_test.py
+++ b/autobot-backend/async_baseline.performance_test.py
@@ -35,7 +35,7 @@ import aiohttp
 from constants.network_constants import NetworkConstants, ServiceURLs
 
 # Import canonical Redis client pattern
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client
 
 # Configure logging
 logging.basicConfig(

--- a/autobot-backend/monitoring/redis_prometheus_metrics_test.py
+++ b/autobot-backend/monitoring/redis_prometheus_metrics_test.py
@@ -7,7 +7,8 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 from monitoring.prometheus_metrics import get_metrics_manager
-from utils.redis_client import RedisConnectionManager
+
+from autobot_shared.redis_client import RedisConnectionManager
 
 
 @pytest.fixture

--- a/autobot-backend/services/redis_listeners.e2e_test.py
+++ b/autobot-backend/services/redis_listeners.e2e_test.py
@@ -10,7 +10,8 @@ import time
 
 import redis
 from config import config as global_config_manager
-from utils.redis_client import get_redis_client
+
+from autobot_shared.redis_client import get_redis_client
 
 
 def test_worker_capabilities():

--- a/autobot-backend/utils/redis_consolidation_test.py
+++ b/autobot-backend/utils/redis_consolidation_test.py
@@ -11,7 +11,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
-from utils.redis_client import (
+from autobot_shared.redis_client import (
     ConnectionState,
     ManagerStats,
     PoolStatistics,
@@ -255,7 +255,7 @@ class TestFeatureIntegration:
 
 def test_module_imports():
     """Test all expected exports are available"""
-    from utils import redis_client
+    from autobot_shared import redis_client
 
     # Check all main exports
     assert hasattr(redis_client, "get_redis_client")

--- a/autobot-backend/utils/redis_thread_safety_test.py
+++ b/autobot-backend/utils/redis_thread_safety_test.py
@@ -13,7 +13,8 @@ from datetime import datetime
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from utils.redis_client import RedisConnectionManager
+
+from autobot_shared.redis_client import RedisConnectionManager
 
 
 class TestPoolStatisticsThreadSafety:
@@ -275,7 +276,7 @@ class TestIdleCleanupThreadSafety:
 
         # Use freezegun or manual datetime mocking
         # Mock datetime.now() to return consistent value
-        import utils.redis_client as redis_client_module
+        import autobot_shared.redis_client as redis_client_module
 
         original_datetime = redis_client_module.datetime
 


### PR DESCRIPTION
## Summary
- Replaces all `from utils.redis_client` imports in 5 backend test files with canonical `from autobot_shared.redis_client`
- Files changed: `async_baseline.performance_test.py`, `redis_listeners.e2e_test.py`, `redis_prometheus_metrics_test.py`, `redis_thread_safety_test.py`, `redis_consolidation_test.py`
- Leaves string literals in `redis_optimizer_test.py` untouched (they are test fixture code, not actual imports)
- Closes #2047

## Test plan
- [ ] Verify no remaining `from utils.redis_client` in backend test files
- [ ] Pre-commit hooks pass (flake8, isort, black)

🤖 Generated with [Claude Code](https://claude.com/claude-code)