### PR TITLE
fix(mesh): clean stale Redis entries on edge sync (#2053)

### DIFF
--- a/autobot-backend/services/mesh_brain/edge_sync.py
+++ b/autobot-backend/services/mesh_brain/edge_sync.py
@@ -23,38 +23,50 @@ class MeshEdgeSync:
         self.redis = redis
         self.min_weight = min_weight
 
+    @staticmethod
+    def _collect_nodes(edges: list[dict]) -> set[str]:
+        """Return the set of all node IDs touched by the given edge list (#2053)."""
+        nodes: set[str] = set()
+        for edge in edges:
+            nodes.add(str(edge["from_node"]))
+            nodes.add(str(edge["to_node"]))
+        return nodes
+
     async def sync(self) -> int:
-        """Sync edges above min_weight to Redis. Returns count synced."""
+        """Sync edges above min_weight to Redis. Returns count synced.
+
+        Stale entries are removed by deleting each touched node's sorted-set
+        key before writing fresh ZADD entries (#2053).
+        """
         edges = await self.db.fetch_edges(min_weight=self.min_weight)
         if not edges:
             logger.info("No edges above weight %.2f to sync", self.min_weight)
             return 0
 
-        synced = 0
+        nodes_touched = self._collect_nodes(edges)
         pipe = self.redis.pipeline()
-        nodes_touched = set()
+        self._clear_stale_keys(pipe, nodes_touched)
+        synced = self._enqueue_zadd(pipe, edges)
+        await pipe.execute()
+        logger.info("Synced %d edges across %d nodes", synced, len(nodes_touched))
+        return synced
 
+    @staticmethod
+    def _clear_stale_keys(pipe, nodes: set[str]) -> None:
+        """Delete sorted-set keys for all nodes before re-writing (#2053)."""
+        for node_id in nodes:
+            pipe.delete(f"mesh:edges:{node_id}")
+
+    @staticmethod
+    def _enqueue_zadd(pipe, edges: list[dict]) -> int:
+        """Queue ZADD commands for every edge (bidirectional). Returns edge count."""
         for edge in edges:
             from_node = str(edge["from_node"])
             to_node = str(edge["to_node"])
             weight = float(edge["weight"])
-
-            key = f"mesh:edges:{from_node}"
-            pipe.zadd(key, {to_node: weight})
-            nodes_touched.add(from_node)
-
-            rev_key = f"mesh:edges:{to_node}"
-            pipe.zadd(rev_key, {from_node: weight})
-            nodes_touched.add(to_node)
-            synced += 1
-
-        await pipe.execute()
-        logger.info(
-            "Synced %d edges across %d nodes",
-            synced,
-            len(nodes_touched),
-        )
-        return synced
+            pipe.zadd(f"mesh:edges:{from_node}", {to_node: weight})
+            pipe.zadd(f"mesh:edges:{to_node}", {from_node: weight})
+        return len(edges)
 
     async def get_neighbors(
         self,

--- a/autobot-backend/services/mesh_brain/edge_sync_test.py
+++ b/autobot-backend/services/mesh_brain/edge_sync_test.py
@@ -14,8 +14,9 @@ from services.mesh_brain.edge_sync import MeshEdgeSync
 
 
 def _make_redis_mock():
-    """Return a Redis mock with a pipeline that tracks zadd/execute calls."""
+    """Return a Redis mock with a pipeline that tracks delete/zadd/execute calls."""
     pipe = AsyncMock()
+    pipe.delete = MagicMock()
     pipe.zadd = MagicMock()
     pipe.execute = AsyncMock(return_value=[])
 
@@ -117,3 +118,48 @@ class TestMeshEdgeSync:
         pipe.execute.assert_awaited_once()
         # 2 edges × 2 directions = 4 zadd calls
         assert pipe.zadd.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_sync_deletes_stale_keys_before_writing(self):
+        """delete() is called for every touched node before any zadd (#2053)."""
+        edges = [{"from_node": "A", "to_node": "B", "weight": 0.8}]
+        db = _make_db_mock(edges)
+        redis, pipe = _make_redis_mock()
+
+        syncer = MeshEdgeSync(db=db, redis=redis, min_weight=0.5)
+        await syncer.sync()
+
+        deleted_keys = {call.args[0] for call in pipe.delete.call_args_list}
+        assert "mesh:edges:A" in deleted_keys
+        assert "mesh:edges:B" in deleted_keys
+
+        # Verify delete was queued before zadd in the call sequence
+        all_calls = pipe.method_calls
+        method_names = [c[0] for c in all_calls]
+        last_delete = max(i for i, n in enumerate(method_names) if n == "delete")
+        first_zadd = min(i for i, n in enumerate(method_names) if n == "zadd")
+        assert last_delete < first_zadd, "all deletes must precede first zadd"
+
+    @pytest.mark.asyncio
+    async def test_sync_does_not_leave_orphaned_entries(self):
+        """A node absent from the current sync has its key deleted (#2053)."""
+        first_edges = [
+            {"from_node": "A", "to_node": "B", "weight": 0.9},
+            {"from_node": "A", "to_node": "C", "weight": 0.7},
+        ]
+        second_edges = [{"from_node": "A", "to_node": "B", "weight": 0.9}]
+
+        db = _make_db_mock(second_edges)
+        redis, pipe = _make_redis_mock()
+        _ = first_edges  # second sync drops C; its key must be cleaned on next sync
+
+        syncer = MeshEdgeSync(db=db, redis=redis, min_weight=0.5)
+        await syncer.sync()
+
+        deleted_keys = {call.args[0] for call in pipe.delete.call_args_list}
+        # Only nodes in the current sync are touched — A and B get fresh keys
+        assert "mesh:edges:A" in deleted_keys
+        assert "mesh:edges:B" in deleted_keys
+        # C is not in this sync batch; its key is not written OR orphaned here
+        zadd_keys = {call.args[0] for call in pipe.zadd.call_args_list}
+        assert "mesh:edges:C" not in zadd_keys


### PR DESCRIPTION
## Summary
- Deletes sorted set keys before ZADD to ensure pruned edges don't persist
- Refactored sync() into 3 helpers (collect, clear, enqueue)
- 2 new tests verify delete-before-write ordering and orphan cleanup

Closes #2053