### PR TITLE
feat(mesh): implement MeshDB Pruner/Promoter methods (#2178)

### DIFF
--- a/autobot-backend/services/mesh_brain/mesh_db.py
+++ b/autobot-backend/services/mesh_brain/mesh_db.py
@@ -3,6 +3,7 @@
 # Author: mrveiss
 """Async PostgreSQL client for Neural Mesh RAG graph operations (#2055)."""
 import logging
+from datetime import datetime
 from typing import Any, Optional
 
 from sqlalchemy import text
@@ -284,6 +285,198 @@ class MeshDB:
         async with self.engine.connect() as conn:
             row = await conn.execute(sql, {"node_a": node_a, "node_b": node_b})
             return row.scalar() or 0
+
+    # ------------------------------------------------------------------
+    # MeshPruner operations
+    # ------------------------------------------------------------------
+
+    async def decay_edges(
+        self,
+        origins: list[str],
+        not_reinforced_since: datetime,
+        decay_factor: float,
+    ) -> int:
+        """Multiply weight by decay_factor for matching edges. Returns count affected (#2178)."""
+        sql = text(
+            """
+            UPDATE mesh_edges
+            SET weight = weight * :factor,
+                last_reinforced = NOW()
+            WHERE origin = ANY(:origins)
+              AND (last_reinforced IS NULL OR last_reinforced < :cutoff)
+            """
+        )
+        async with self.engine.begin() as conn:
+            result = await conn.execute(
+                sql,
+                {
+                    "factor": decay_factor,
+                    "origins": origins,
+                    "cutoff": not_reinforced_since,
+                },
+            )
+        logger.debug("Decayed %d edges factor=%.3f", result.rowcount, decay_factor)
+        return result.rowcount
+
+    async def delete_edges(self, max_weight: float) -> int:
+        """Delete edges at or below max_weight. Returns count deleted (#2178)."""
+        sql = text("DELETE FROM mesh_edges WHERE weight <= :max_weight")
+        async with self.engine.begin() as conn:
+            result = await conn.execute(sql, {"max_weight": max_weight})
+        logger.debug(
+            "Deleted %d edges at or below weight=%.3f", result.rowcount, max_weight
+        )
+        return result.rowcount
+
+    async def archive_orphan_nodes(self, no_access_since: datetime) -> int:
+        """Archive nodes with no edges and no access since cutoff. Returns count (#2178)."""
+        sql = text(
+            """
+            WITH archived AS (
+                DELETE FROM mesh_nodes n
+                WHERE (last_accessed IS NULL OR last_accessed < :cutoff)
+                  AND NOT EXISTS (
+                      SELECT 1 FROM mesh_edges e
+                      WHERE e.from_node = n.id OR e.to_node = n.id
+                  )
+                RETURNING n.*
+            )
+            INSERT INTO mesh_nodes_archive
+            SELECT * FROM archived
+            ON CONFLICT DO NOTHING
+            """
+        )
+        async with self.engine.begin() as conn:
+            result = await conn.execute(sql, {"cutoff": no_access_since})
+        logger.debug("Archived %d orphan nodes", result.rowcount)
+        return result.rowcount
+
+    async def merge_duplicate_edges(self) -> int:
+        """Merge edges with same from/to but different types; keep highest weight (#2178)."""
+        sql = text(
+            """
+            WITH ranked AS (
+                SELECT id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY from_node, to_node
+                           ORDER BY weight DESC
+                       ) AS rn
+                FROM mesh_edges
+            ),
+            deleted AS (
+                DELETE FROM mesh_edges
+                WHERE id IN (SELECT id FROM ranked WHERE rn > 1)
+                RETURNING id
+            )
+            SELECT COUNT(*) FROM deleted
+            """
+        )
+        async with self.engine.begin() as conn:
+            result = await conn.execute(sql)
+            count = result.scalar() or 0
+        logger.debug("Merged %d duplicate edges", count)
+        return count
+
+    async def get_graph_density(self) -> float:
+        """Return avg edges per node (#2178)."""
+        sql = text(
+            """
+            SELECT CASE WHEN COUNT(DISTINCT n.id) = 0 THEN 0.0
+                        ELSE COUNT(e.id)::float / COUNT(DISTINCT n.id)
+                   END
+            FROM mesh_nodes n
+            LEFT JOIN mesh_edges e ON e.from_node = n.id
+            """
+        )
+        async with self.engine.connect() as conn:
+            result = await conn.execute(sql)
+            return float(result.scalar() or 0.0)
+
+    # ------------------------------------------------------------------
+    # NodePromoter operations
+    # ------------------------------------------------------------------
+
+    async def get_promotion_candidates(
+        self, min_access: int, min_edges: int
+    ) -> list[dict]:
+        """Return nodes with access_count >= min_access, edge_count >= min_edges, not anchor (#2178)."""
+        sql = text(
+            """
+            SELECT n.id::text,
+                   n.chunk_id,
+                   n.node_type,
+                   n.access_count,
+                   COUNT(e.id) AS edge_count
+            FROM mesh_nodes n
+            LEFT JOIN mesh_edges e ON e.from_node = n.id
+            WHERE n.is_anchor = FALSE
+              AND n.access_count >= :min_access
+            GROUP BY n.id
+            HAVING COUNT(e.id) >= :min_edges
+            """
+        )
+        async with self.engine.connect() as conn:
+            rows = await conn.execute(
+                sql, {"min_access": min_access, "min_edges": min_edges}
+            )
+            return [dict(r) for r in rows.mappings()]
+
+    async def get_stale_anchors(
+        self, max_access: int, inactive_days: int
+    ) -> list[dict]:
+        """Return anchor nodes with access below threshold, inactive for N days (#2178)."""
+        sql = text(
+            """
+            SELECT id::text, chunk_id, node_type, access_count, last_accessed
+            FROM mesh_nodes
+            WHERE is_anchor = TRUE
+              AND access_count <= :max_access
+              AND (last_accessed IS NULL
+                   OR last_accessed < NOW() - make_interval(days => :inactive_days))
+            """
+        )
+        async with self.engine.connect() as conn:
+            rows = await conn.execute(
+                sql, {"max_access": max_access, "inactive_days": inactive_days}
+            )
+            return [dict(r) for r in rows.mappings()]
+
+    async def get_neighborhood(self, node_id: str, hops: int) -> list[dict]:
+        """BFS to collect nodes within N hops. Returns list of dicts with content (#2178)."""
+        sql = text(
+            """
+            WITH RECURSIVE bfs AS (
+                SELECT id, 0 AS depth
+                FROM mesh_nodes
+                WHERE id = :node_id::uuid
+                UNION
+                SELECT e.to_node, b.depth + 1
+                FROM bfs b
+                JOIN mesh_edges e ON e.from_node = b.id
+                WHERE b.depth < :hops
+            )
+            SELECT DISTINCT n.id::text, n.chunk_id, n.node_type, n.raptor_level
+            FROM bfs b
+            JOIN mesh_nodes n ON n.id = b.id
+            """
+        )
+        async with self.engine.connect() as conn:
+            rows = await conn.execute(sql, {"node_id": node_id, "hops": hops})
+            return [dict(r) for r in rows.mappings()]
+
+    async def promote_to_anchor(self, node_id: str) -> None:
+        """Set is_anchor=True for node_id (#2178)."""
+        sql = text("UPDATE mesh_nodes SET is_anchor = TRUE WHERE id = :node_id::uuid")
+        async with self.engine.begin() as conn:
+            await conn.execute(sql, {"node_id": node_id})
+        logger.info("Promoted node %s to anchor", node_id)
+
+    async def demote_anchor(self, node_id: str) -> None:
+        """Set is_anchor=False for node_id (#2178)."""
+        sql = text("UPDATE mesh_nodes SET is_anchor = FALSE WHERE id = :node_id::uuid")
+        async with self.engine.begin() as conn:
+            await conn.execute(sql, {"node_id": node_id})
+        logger.info("Demoted anchor node %s", node_id)
 
     # ------------------------------------------------------------------
     # Evolution log

--- a/autobot-backend/services/mesh_brain/mesh_db_test.py
+++ b/autobot-backend/services/mesh_brain/mesh_db_test.py
@@ -72,6 +72,14 @@ def _mappings_result(rows):
     return r
 
 
+def _rowcount_result(count: int):
+    """Return a mock result whose rowcount attribute equals count."""
+    r = MagicMock()
+    r.rowcount = count
+    r.scalar = MagicMock(return_value=count)
+    return r
+
+
 # =============================================================================
 # Tests — create_node
 # =============================================================================
@@ -335,3 +343,133 @@ class TestUpdateAccessCount:
         conn.execute.assert_awaited_once()
         params = conn.execute.call_args[0][1]
         assert _NODE_UUID in params["node_ids"]
+
+
+# =============================================================================
+# Tests — decay_edges
+# =============================================================================
+
+
+class TestDecayEdges:
+    """MeshDB.decay_edges passes correct SQL params and returns rowcount."""
+
+    @pytest.mark.asyncio
+    async def test_decay_edges_passes_correct_params(self):
+        from datetime import datetime, timezone
+
+        engine, conn = _make_engine()
+        conn.execute = AsyncMock(return_value=_rowcount_result(3))
+        db = MeshDB(engine)
+        cutoff = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        count = await db.decay_edges(
+            origins=["seeder", "learner"],
+            not_reinforced_since=cutoff,
+            decay_factor=0.9,
+        )
+
+        assert count == 3
+        params = conn.execute.call_args[0][1]
+        assert params["factor"] == 0.9
+        assert params["cutoff"] == cutoff
+        assert "seeder" in params["origins"]
+
+
+# =============================================================================
+# Tests — delete_edges
+# =============================================================================
+
+
+class TestDeleteEdges:
+    """MeshDB.delete_edges returns rowcount of deleted rows."""
+
+    @pytest.mark.asyncio
+    async def test_delete_edges_returns_count(self):
+        engine, conn = _make_engine()
+        conn.execute = AsyncMock(return_value=_rowcount_result(5))
+        db = MeshDB(engine)
+
+        count = await db.delete_edges(max_weight=0.1)
+
+        assert count == 5
+        params = conn.execute.call_args[0][1]
+        assert params["max_weight"] == 0.1
+
+
+# =============================================================================
+# Tests — get_promotion_candidates
+# =============================================================================
+
+
+class TestGetPromotionCandidates:
+    """MeshDB.get_promotion_candidates forwards min_access and min_edges."""
+
+    @pytest.mark.asyncio
+    async def test_get_promotion_candidates_filters_correctly(self):
+        rows = [
+            {
+                "id": _NODE_UUID,
+                "chunk_id": "c-1",
+                "node_type": "doc",
+                "access_count": 10,
+                "edge_count": 4,
+            }
+        ]
+        engine, conn = _make_engine(mappings=rows)
+        db = MeshDB(engine)
+
+        result = await db.get_promotion_candidates(min_access=5, min_edges=3)
+
+        assert len(result) == 1
+        assert result[0]["id"] == _NODE_UUID
+        params = conn.execute.call_args[0][1]
+        assert params["min_access"] == 5
+        assert params["min_edges"] == 3
+
+
+# =============================================================================
+# Tests — promote_to_anchor
+# =============================================================================
+
+
+class TestPromoteToAnchor:
+    """MeshDB.promote_to_anchor executes UPDATE with correct node_id."""
+
+    @pytest.mark.asyncio
+    async def test_promote_to_anchor_updates_flag(self):
+        engine, conn = _make_engine()
+        db = MeshDB(engine)
+
+        await db.promote_to_anchor(_NODE_UUID)
+
+        conn.execute.assert_awaited_once()
+        params = conn.execute.call_args[0][1]
+        assert params["node_id"] == _NODE_UUID
+
+
+# =============================================================================
+# Tests — get_graph_density
+# =============================================================================
+
+
+class TestGetGraphDensity:
+    """MeshDB.get_graph_density returns a float value."""
+
+    @pytest.mark.asyncio
+    async def test_get_graph_density_returns_float(self):
+        engine, conn = _make_engine(scalar=2.5)
+        db = MeshDB(engine)
+
+        density = await db.get_graph_density()
+
+        assert isinstance(density, float)
+        assert density == 2.5
+
+    @pytest.mark.asyncio
+    async def test_get_graph_density_returns_zero_when_empty(self):
+        engine, conn = _make_engine(scalar=None)
+        db = MeshDB(engine)
+
+        density = await db.get_graph_density()
+
+        assert density == 0.0


### PR DESCRIPTION
## Summary
- 10 new MeshDB methods for MeshPruner and NodePromoter
- decay_edges, delete_edges, archive_orphan_nodes, merge_duplicate_edges, get_graph_density
- get_promotion_candidates, get_stale_anchors, get_neighborhood (recursive CTE), promote/demote_anchor
- 6 new tests (20 total for MeshDB)

Closes #2178