### PR TITLE
fix(slm): remove stale SQLite references, use PostgreSQL in bootstrap (#1815)

### DIFF
--- a/autobot-infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh
+++ b/autobot-infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh
@@ -397,8 +397,8 @@ backend_setup() {
 HOST=127.0.0.1
 PORT=8000
 
-# Database
-DATABASE_URL=sqlite:///${REMOTE_BACKEND}/data/slm.db
+# Database (PostgreSQL — Issue #786)
+SLM_DATABASE_URL=postgresql+asyncpg://slm_app@127.0.0.1:5432/slm
 
 # Redis (optional but recommended)
 REDIS_HOST=${AUTOBOT_REDIS_HOST:-172.16.168.23}

--- a/autobot-slm-backend/README_NEW_ENDPOINTS.md
+++ b/autobot-slm-backend/README_NEW_ENDPOINTS.md
@@ -49,11 +49,8 @@ pip install -r requirements.txt
 python migrations/add_events_certificates_updates_tables.py
 ```
 
-Or specify custom database path:
-
-```bash
-python migrations/add_events_certificates_updates_tables.py /path/to/slm.db
-```
+Note: The SLM backend uses PostgreSQL (Issue #786). SQLite-based
+migrations in this directory are legacy and no longer apply.
 
 ### 3. Verify Installation
 

--- a/autobot-slm-backend/migrations/__init__.py
+++ b/autobot-slm-backend/migrations/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-SLM Database Migrations
+SLM Database Migrations.
 
-Simple migration system for SQLite database updates.
+PostgreSQL is used for all database operations (Issue #786).
 """


### PR DESCRIPTION
## Summary
- Updates `bootstrap-slm.sh` to generate PostgreSQL `SLM_DATABASE_URL` instead of SQLite `DATABASE_URL`, preventing recreation of the stale `slm.db` file
- Updates migration docstring and README to reflect PostgreSQL migration (#786)
- Operational: stale `/opt/autobot/data/slm.db` on .19 needs manual removal (not a code change)
- Closes #1815

## Test plan
- [ ] Verify bootstrap script generates correct PostgreSQL URL
- [ ] Verify no remaining code references create SQLite `slm.db`
- [ ] Manual: remove `/opt/autobot/data/slm.db` from .19 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)