### PR TITLE
refactor(auth): remove dead AuthService.authenticate_user() (#2227)

### DIFF
--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -34,10 +34,6 @@ class AuthService:
     def __init__(self):
         self.algorithm = "HS256"
 
-    def verify_password(self, plain_password: str, hashed_password: str) -> bool:
-        """Verify a password against its hash."""
-        return pwd_context.verify(plain_password, hashed_password)
-
     def hash_password(self, password: str) -> str:
         """Hash a password."""
         return pwd_context.hash(password)


### PR DESCRIPTION
## Summary

- Removed dead `AuthService.authenticate_user()` method from `services/auth.py` (#2227)
- Removed dead `AuthService.verify_password()` method — only caller was `authenticate_user()` (#2234)
- Both methods became dead code after #1922 consolidated login to use `UserService`

## Changes

| File | Change |
|------|--------|
| `services/auth.py` | Removed `authenticate_user()` (18 lines) and `verify_password()` (4 lines) |

## Test plan

- [ ] Verify no import errors on SLM backend startup
- [ ] Verify `/api/auth/login` still works (uses `UserService.authenticate`, not these methods)
- [ ] Grep confirms no remaining callers: `grep -rE "authenticate_user|auth_service\.verify_password" autobot-slm-backend/`

Closes #2227
Closes #2234