### PR TITLE
refactor(gpu): reuse nvidia-smi GPU name from initial probe (#2222)

### DIFF
--- a/autobot-backend/utils/gpu_optimization/gpu_detection.py
+++ b/autobot-backend/utils/gpu_optimization/gpu_detection.py
@@ -52,7 +52,8 @@ def _check_nvidia_gpu() -> Optional[str]:
             text=True,
             timeout=5,
         )
-        name = result.stdout.strip()
+        lines = result.stdout.strip().splitlines()
+        name = lines[0].strip() if lines else ""
         if result.returncode == 0 and name:
             return name
         return None
@@ -132,6 +133,13 @@ def _detect_vendor() -> Optional[str]:
     return None
 
 
+def _reset_detection_state() -> None:
+    """Reset cached vendor and GPU name state (for test isolation)."""
+    global _nvidia_gpu_name
+    _nvidia_gpu_name = None
+    _detect_vendor.cache_clear()
+
+
 def check_gpu_availability() -> bool:
     """Check if any supported GPU is available."""
     return _detect_vendor() is not None
@@ -179,7 +187,10 @@ def _detect_nvidia_capabilities(
             timeout=10,
         )
         if result.returncode == 0:
-            parts = result.stdout.strip().split(", ")
+            first_line = (
+                result.stdout.strip().splitlines()[0] if result.stdout.strip() else ""
+            )
+            parts = first_line.split(", ")
             if len(parts) >= 2:
                 memory_mb = int(parts[0].strip())
                 cuda_version = parts[1].strip()


### PR DESCRIPTION
## Summary

- Changes `_check_nvidia_gpu()` to return the GPU name string (or `None`) instead of `bool`
- `_detect_vendor()` stashes the name in `_nvidia_gpu_name` during initial detection
- `_detect_nvidia_capabilities()` reuses the stashed name and queries only `memory.total` + `cuda_version` from `nvidia-smi`, eliminating the redundant subprocess call that re-queried the name

**Depends on:** PR #2221 (#1990 — vendor detection caching). Cherry-picked those commits as foundation.

## Test plan

- [ ] Verify NVIDIA GPU name is correctly detected (should match `nvidia-smi --query-gpu=name`)
- [ ] Verify memory and CUDA version are still populated correctly
- [ ] Verify tensor core detection works with stashed name
- [ ] Verify flake8 clean (confirmed locally)

Closes #2222