### PR TITLE
fix(auth): restore user_type field in /me response (#2241)

### DIFF
--- a/autobot-slm-backend/api/auth.py
+++ b/autobot-slm-backend/api/auth.py
@@ -141,6 +141,7 @@ async def get_current_user_info(
     return {
         "username": current_user.get("sub"),
         "is_admin": current_user.get("admin", False),
+        "user_type": "slm_admin",
     }
 
 


### PR DESCRIPTION
## Summary
- Added `user_type: "slm_admin"` to `/api/auth/me` response
- Restores field that was present in deleted `/api/slm-auth/me` endpoint (#1922)

## Test plan
- [ ] `GET /api/auth/me` returns `{"username": "...", "is_admin": true, "user_type": "slm_admin"}`

Closes #2241