### PR TITLE
fix(orchestrator): address code review findings from PR #2233 (#2235)

### DIFF
--- a/autobot-backend/api/workflow.py
+++ b/autobot-backend/api/workflow.py
@@ -8,7 +8,6 @@ Handles workflow approvals, progress tracking, and coordination
 
 import asyncio
 import logging
-import re
 import time
 import uuid
 from datetime import datetime
@@ -22,6 +21,7 @@ from metrics.system_monitor import system_monitor
 from metrics.workflow_metrics import workflow_metrics
 from models.task_context import WorkflowStepContext
 from monitoring.prometheus_metrics import get_metrics_manager
+from patterns.conversation_patterns import conversation_patterns
 from pydantic import BaseModel
 from type_defs.common import Metadata
 
@@ -253,49 +253,29 @@ def _validate_orchestrator(request: Request):
     return orchestrator
 
 
-# Issue #2181: Simple conversational patterns consolidated from LightweightOrchestrator.
-# New code should use these module-level constants rather than instantiating
-# LightweightOrchestrator (which is now deleted).
-_SIMPLE_PATTERNS = [
-    re.compile(r"^(hello|hi|hey)!?$", re.IGNORECASE),
-    re.compile(r"^(thanks?|thank you)!?$", re.IGNORECASE),
-    re.compile(r"^(bye|goodbye|see you)!?$", re.IGNORECASE),
-    re.compile(r"^(ok|okay|yes|no)!?$", re.IGNORECASE),
-]
-
-_SIMPLE_RESPONSES = {
-    "hello": "Hello! How can I help you today?",
-    "hi": "Hello! How can I help you today?",
-    "hey": "Hello! How can I help you today?",
-    "thanks": "You're welcome!",
-    "thank you": "You're welcome!",
-    "bye": "Goodbye! Feel free to ask if you need anything else.",
-    "goodbye": "Goodbye! Feel free to ask if you need anything else.",
-    "see you": "Goodbye! Feel free to ask if you need anything else.",
-    "ok": "Understood!",
-    "okay": "Understood!",
-    "yes": "Understood!",
-    "no": "Understood!",
-}
+# Issue #2181/#2235: Use the centralized ConversationPatterns module for
+# simple-message detection.  This preserves ALL conversation types (greeting,
+# farewell, gratitude, status inquiry, affirmation, negation) and their
+# response templates rather than a reduced set of hardcoded regexes.
+_conversation_patterns = conversation_patterns
 
 
 def _try_simple_response(user_message: str) -> Optional[Dict]:
     """Return a canned response for trivial messages, or None for complex ones.
 
-    Consolidated from LightweightOrchestrator (Issue #2181). Handles greetings,
-    acknowledgements, and other short conversational messages without invoking
-    the full orchestration pipeline.
+    Consolidated from LightweightOrchestrator (Issue #2181).  Uses the
+    centralized ConversationPatterns module (#2235 review fix) to cover all
+    six conversation types with their canonical response templates.
     """
-    message_stripped = user_message.strip()
-    message_clean = message_stripped.lower().rstrip("!")
-    if any(pattern.match(message_stripped) for pattern in _SIMPLE_PATTERNS):
-        return {
-            "success": True,
-            "type": "lightweight_response",
-            "result": _SIMPLE_RESPONSES.get(message_clean, "Understood!"),
-            "routing_method": "simple_pattern_match",
-        }
-    return None
+    conv_type = _conversation_patterns.classify_message(user_message)
+    if conv_type is None:
+        return None
+    return {
+        "success": True,
+        "type": "lightweight_response",
+        "result": _conversation_patterns.get_response_template(conv_type),
+        "routing_method": "conversation_pattern_match",
+    }
 
 
 class _ComplexWorkflowRequired(Exception):

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -17,6 +17,7 @@ from contextlib import asynccontextmanager
 
 from chat_history import ChatHistoryManager
 from chat_workflow import ChatWorkflowManager
+from config import ConfigManager
 from fastapi import FastAPI
 from knowledge_factory import get_or_create_knowledge_base
 from security_layer import SecurityLayer
@@ -31,7 +32,6 @@ from autobot_shared.tracing import (
     instrument_redis,
     shutdown_tracing,
 )
-from config import ConfigManager
 
 # Bounded thread pool to prevent unbounded thread creation
 # Default asyncio executor creates min(32, cpu_count + 4) threads per invocation
@@ -844,18 +844,18 @@ async def _recover_index_queue():
 async def _init_orchestrator(app: FastAPI) -> None:
     """Initialize and store the orchestrator on app.state (#2235).
 
-    Creates a ConsolidatedOrchestrator (aliased as Orchestrator) and stores it
-    on ``app.state.orchestrator`` so that ``api/workflow.py`` and ``api/agent.py``
-    can access it.  NON-CRITICAL: endpoints that need it will return 422 if this
-    fails rather than crashing the whole application.
+    Uses the existing ``get_orchestrator()`` async singleton which calls
+    ``await orchestrator.initialize()`` (LLM interface, memory manager, agent
+    manager, Ollama validation).  NON-CRITICAL: endpoints that need it will
+    return 422 if this fails rather than crashing the whole application.
     """
     logger.info("[ 97%%] Orchestrator: Initializing...")
     try:
-        from orchestrator import Orchestrator
+        from orchestrator import get_orchestrator
 
-        orchestrator = Orchestrator()
+        orchestrator = await get_orchestrator()
         app.state.orchestrator = orchestrator
-        logger.info("[ 97%%] Orchestrator: Stored on app.state")
+        logger.info("[ 97%%] Orchestrator: Initialized and stored on app.state")
     except Exception as e:
         logger.warning("Orchestrator initialization failed (non-fatal): %s", e)
         app.state.orchestrator = None


### PR DESCRIPTION
## Summary

Fixes 3 issues found during code review of PR #2233 (orchestrator consolidation):

1. **`_init_orchestrator` used bare `Orchestrator()` instead of `await get_orchestrator()`** — the async singleton calls `initialize()` which sets up LLM interface, memory manager, agent manager, and validates Ollama. Without this, `is_running` stays `False` and the instance is disconnected.

2. **`_SIMPLE_RESPONSES` was missing the key `"thank"`** — regex `thanks?` matched it but dict lookup fell back to `"Understood!"` instead of `"You're welcome!"`.

3. **`ConversationPatterns` integration was dropped** — the hardcoded 4-pattern replacement only covered greetings, thanks, farewell, and ok/yes/no. The original `LightweightOrchestrator` used `ConversationPatterns` which also handles status inquiries ("how are you"), extended affirmations ("sounds good", "sure"), and negations ("nope", "not now").

## Fix

- Use `await get_orchestrator()` in `_init_orchestrator` (reuses existing singleton pattern per CLAUDE.md Rule 2)
- Replace hardcoded `_SIMPLE_PATTERNS`/`_SIMPLE_RESPONSES` with the centralized `ConversationPatterns` module — preserves all 6 conversation types and their response templates
- Remove unused `re` import

## Files Changed

- `autobot-backend/initialization/lifespan.py` — `get_orchestrator()` instead of `Orchestrator()`
- `autobot-backend/api/workflow.py` — use `ConversationPatterns` instead of hardcoded dicts

Closes #2235