### PR TITLE
cleanup(analytics): remove dead barrel exports for deleted components (#2262)

### DIFF
--- a/autobot-frontend/src/components/analytics/index.ts
+++ b/autobot-frontend/src/components/analytics/index.ts
@@ -13,8 +13,6 @@
 export { default as AnalyticsHeader } from './AnalyticsHeader.vue'
 export { default as IndexingProgress } from './IndexingProgress.vue'
 export { default as EnhancedAnalyticsGrid } from './EnhancedAnalyticsGrid.vue'
-export { default as CodebaseStatsSection } from './CodebaseStatsSection.vue'
-export { default as ProblemsReportSection } from './ProblemsReportSection.vue'
 export { default as DuplicatesSection } from './DuplicatesSection.vue'
 export { default as DeclarationsSection } from './DeclarationsSection.vue'
 export { default as CodeSmellsSection } from './CodeSmellsSection.vue'


### PR DESCRIPTION
## Summary
- Remove barrel exports of `CodebaseStatsSection` and `ProblemsReportSection` from `analytics/index.ts`
- Neither export is consumed via the barrel file (direct imports are used instead)
- Prevents misleading exports that would break if component files are later removed

## Test plan
- [x] No imports reference these components via the barrel file
- [ ] TypeScript compilation unaffected

Closes #2262