### PR TITLE
fix(analytics): correct inaccurate comment about POST-based triggers (#2271)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -714,7 +714,7 @@ const { exportReport, exportSection } = useCodebaseExport({
 
 // #2258: Bridge code-intel scans into the data-fetcher scan orchestrator.
 // loadCachedAnalyticsData uses lighter cached loaders; runAllAnalysisScans
-// uses full POST-based triggers after indexing completes.
+// uses full re-fetch triggers after indexing completes.
 const codeIntelExtraScans = () => [
   { id: 'configDuplicates', label: t('analytics.codebase.scans.configDuplicates'), run: () => loadConfigDuplicates() },
   { id: 'apiEndpoints', label: t('analytics.codebase.scans.apiEndpoints'), run: () => loadApiEndpointAnalysis() },


### PR DESCRIPTION
## Summary
Fixes inaccurate comment: "POST-based triggers" changed to "re-fetch triggers". Only 1 of 9 loaders in `codeIntelFullScans()` uses POST; the rest use GET. The meaningful distinction is cached vs fresh, not GET vs POST.

Closes #2271