### PR TITLE
fix(docs): update CLAUDE.md line length to match .flake8 (#2217)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ Wait for user confirmation before writing code. Do NOT assume `systemd` vs `dock
 
 **Pre-commit & Linting:**
 
-- Maximum line length: 100 characters (enforced by flake8/ruff)
+- Maximum line length: 120 characters (enforced by flake8/ruff)
 - After ANY commit attempt, verify changes were actually committed:
   ```bash
   git log -1 --stat


### PR DESCRIPTION
## Summary
- Updates CLAUDE.md Rule 5 to document 120-char max line length, matching `.flake8` config
- The `.flake8` file has enforced 120 chars since inception; CLAUDE.md incorrectly said 100

Closes #2217