### PR TITLE
fix(security): add VNC passwd pre-check before server start (#1965)

### DIFF
--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -137,6 +137,21 @@ def is_vnc_running() -> bool:
 
 def start_vnc_server() -> Dict[str, str]:
     """Start VNC server on display :1 with full XFCE desktop"""
+    # Pre-check: VncAuth requires ~/.vnc/passwd to exist
+    vnc_passwd = Path.home() / ".vnc" / "passwd"
+    if not vnc_passwd.exists():
+        logger.error(
+            "VNC passwd file not found at %s; run vncpasswd before starting VNC server",
+            vnc_passwd,
+        )
+        return {
+            "status": "error",
+            "message": (
+                f"VNC passwd file not found at {vnc_passwd}. "
+                "Run `vncpasswd` to create it before starting the VNC server."
+            ),
+        }
+
     try:
         # Start VNC server
         result = subprocess.run(  # nosec B607


### PR DESCRIPTION
## Summary

- Add pre-check for `~/.vnc/passwd` existence before launching VNC server
- SecurityTypes was already fixed to `VncAuth,TLSVnc` on Dev_new_gui — this adds the missing guard
- Returns structured error with instructions if passwd file is missing

## Test plan

- [ ] VNC start fails gracefully when `~/.vnc/passwd` doesn't exist
- [ ] VNC starts normally when passwd file exists
- [ ] Zero matches for `SecurityTypes None` in codebase (verified)

Closes #1965

🤖 Generated with [Claude Code](https://claude.com/claude-code)