### PR TITLE
feat(workflow): add per-workflow RBAC and audit trail (#2152)

### DIFF
--- a/autobot-backend/api/workflow_permissions.py
+++ b/autobot-backend/api/workflow_permissions.py
@@ -1,0 +1,224 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Workflow Permissions & Audit Log API (#2152)
+
+Endpoints for per-workflow RBAC management and audit trail retrieval.
+
+Routes:
+  GET    /api/workflows/{workflow_id}/permissions         — list permissions
+  PUT    /api/workflows/{workflow_id}/permissions         — grant / update role
+  DELETE /api/workflows/{workflow_id}/permissions/{user_id} — revoke access
+  GET    /api/workflows/{workflow_id}/audit               — view audit log
+"""
+
+import logging
+from typing import List, Optional
+
+from api.user_management.dependencies import get_db_session
+from auth_middleware import get_current_user
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from services.workflow_permission_service import (
+    ROLE_HIERARCHY,
+    WorkflowPermissionService,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+from workflow_rbac import require_workflow_permission
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["workflow-permissions"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+class GrantPermissionRequest(BaseModel):
+    """Request body for granting or updating a workflow role."""
+
+    user_id: str = Field(..., description="User receiving the role")
+    role: str = Field(..., description="owner | editor | runner | viewer")
+
+
+class PermissionResponse(BaseModel):
+    """Serialised workflow permission entry."""
+
+    workflow_id: str
+    user_id: str
+    role: str
+    granted_by: Optional[str]
+    created_at: str
+    updated_at: str
+
+
+class AuditLogEntry(BaseModel):
+    """Serialised workflow audit log entry."""
+
+    id: str
+    timestamp: str
+    user_id: str
+    workflow_id: str
+    action: str
+    details: Optional[dict]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _current_user_id(current_user: dict) -> str:
+    """Extract a stable user identifier from the current user dict."""
+    return current_user.get("username") or current_user.get("user_id", "unknown")
+
+
+def _permission_to_response(perm) -> PermissionResponse:
+    """Convert a WorkflowPermission ORM row to its response schema."""
+    return PermissionResponse(
+        workflow_id=perm.workflow_id,
+        user_id=perm.user_id,
+        role=perm.role,
+        granted_by=perm.granted_by,
+        created_at=perm.created_at.isoformat() if perm.created_at else "",
+        updated_at=perm.updated_at.isoformat() if perm.updated_at else "",
+    )
+
+
+def _audit_to_response(entry) -> AuditLogEntry:
+    """Convert a WorkflowAuditLog ORM row to its response schema."""
+    return AuditLogEntry(
+        id=str(entry.id),
+        timestamp=entry.timestamp.isoformat() if entry.timestamp else "",
+        user_id=entry.user_id,
+        workflow_id=entry.workflow_id,
+        action=entry.action,
+        details=entry.details,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/workflows/{workflow_id}/permissions",
+    response_model=List[PermissionResponse],
+    summary="List workflow permissions",
+)
+async def list_workflow_permissions(
+    workflow_id: str,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+    _: bool = Depends(require_workflow_permission("view")),
+) -> List[PermissionResponse]:
+    """Return all permission entries for the specified workflow (#2152)."""
+    svc = WorkflowPermissionService(session)
+    rows = await svc.get_permissions(workflow_id)
+    await svc.log_action(
+        user_id=_current_user_id(current_user),
+        workflow_id=workflow_id,
+        action="view",
+        details={"endpoint": "list_permissions"},
+    )
+    return [_permission_to_response(r) for r in rows]
+
+
+@router.put(
+    "/workflows/{workflow_id}/permissions",
+    response_model=PermissionResponse,
+    summary="Grant or update a workflow permission",
+)
+async def grant_workflow_permission(
+    workflow_id: str,
+    body: GrantPermissionRequest,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+    _: bool = Depends(require_workflow_permission("grant")),
+) -> PermissionResponse:
+    """
+    Grant (or update) a role for *body.user_id* on the workflow (#2152).
+
+    Only owners and admins may call this endpoint.
+    """
+    if body.role not in ROLE_HIERARCHY:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid role '{body.role}'. Valid roles: {ROLE_HIERARCHY}",
+        )
+
+    actor = _current_user_id(current_user)
+    svc = WorkflowPermissionService(session)
+    perm = await svc.grant_permission(
+        workflow_id=workflow_id,
+        user_id=body.user_id,
+        role=body.role,
+        granted_by=actor,
+    )
+    await svc.log_action(
+        user_id=actor,
+        workflow_id=workflow_id,
+        action="grant",
+        details={"target_user": body.user_id, "role": body.role},
+    )
+    return _permission_to_response(perm)
+
+
+@router.delete(
+    "/workflows/{workflow_id}/permissions/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Revoke a workflow permission",
+)
+async def revoke_workflow_permission(
+    workflow_id: str,
+    user_id: str,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+    _: bool = Depends(require_workflow_permission("revoke")),
+) -> None:
+    """
+    Remove *user_id*'s permission entry for the workflow (#2152).
+
+    Only owners and admins may call this endpoint.
+    """
+    actor = _current_user_id(current_user)
+    svc = WorkflowPermissionService(session)
+    deleted = await svc.revoke_permission(
+        workflow_id=workflow_id,
+        user_id=user_id,
+        revoked_by=actor,
+    )
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No permission entry for user '{user_id}' on workflow '{workflow_id}'",
+        )
+    await svc.log_action(
+        user_id=actor,
+        workflow_id=workflow_id,
+        action="revoke",
+        details={"target_user": user_id},
+    )
+
+
+@router.get(
+    "/workflows/{workflow_id}/audit",
+    response_model=List[AuditLogEntry],
+    summary="Get workflow audit log",
+)
+async def get_workflow_audit_log(
+    workflow_id: str,
+    limit: int = Query(default=100, ge=1, le=1000),
+    offset: int = Query(default=0, ge=0),
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+    _: bool = Depends(require_workflow_permission("view")),
+) -> List[AuditLogEntry]:
+    """Return the audit trail for the specified workflow, newest first (#2152)."""
+    svc = WorkflowPermissionService(session)
+    entries = await svc.get_audit_log(workflow_id, limit=limit, offset=offset)
+    return [_audit_to_response(e) for e in entries]

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -66,6 +66,7 @@ from api.vnc_proxy import router as vnc_proxy_router
 from api.voice import router as voice_router
 from api.voice_stream import router as voice_stream_router
 from api.wake_word import router as wake_word_router
+from api.workflow_permissions import router as workflow_permissions_router  # #2152
 from plugin_manager import router as plugin_manager_router
 from services.knowledge_sync_service import router as knowledge_sync_router
 
@@ -274,6 +275,12 @@ def _get_agent_routers() -> list:
     return [
         (agent_router, "/agent", ["agent"], "agent"),
         (approval_gates_router, "", ["approval-gates"], "approval_gates"),
+        (
+            workflow_permissions_router,
+            "",
+            ["workflow-permissions"],
+            "workflow_permissions",
+        ),  # #2152
         (config_revisions_router, "", ["config-revisions"], "config_revisions"),
         (agent_config_router, "/agent_config", ["agent_config"], "agent_config"),
         (

--- a/autobot-backend/migrations/versions/20260324_015_workflow_rbac.py
+++ b/autobot-backend/migrations/versions/20260324_015_workflow_rbac.py
@@ -1,0 +1,130 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Add workflow_permissions and workflow_audit_log tables (#2152).
+
+Revision ID: 20260324_015
+Revises: 20260323_014
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "20260324_015"
+down_revision = "20260323_014"
+branch_labels = None
+depends_on = None
+
+
+def _create_workflow_permissions_table() -> None:
+    """Create workflow_permissions table. Helper for upgrade() (#2152)."""
+    op.create_table(
+        "workflow_permissions",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("workflow_id", sa.String(255), nullable=False),
+        sa.Column("user_id", sa.String(255), nullable=False),
+        sa.Column("role", sa.String(50), nullable=False),
+        sa.Column("granted_by", sa.String(255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("workflow_id", "user_id", name="uq_workflow_permission"),
+    )
+    _create_workflow_permissions_indexes()
+
+
+def _create_workflow_permissions_indexes() -> None:
+    """Create indexes for workflow_permissions. Helper (#2152)."""
+    op.create_index(
+        "idx_wp_workflow_id",
+        "workflow_permissions",
+        ["workflow_id"],
+    )
+    op.create_index(
+        "idx_wp_user_id",
+        "workflow_permissions",
+        ["user_id"],
+    )
+
+
+def _create_workflow_audit_log_table() -> None:
+    """Create workflow_audit_log table. Helper for upgrade() (#2152)."""
+    op.create_table(
+        "workflow_audit_log",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("user_id", sa.String(255), nullable=False),
+        sa.Column("workflow_id", sa.String(255), nullable=False),
+        sa.Column("action", sa.String(50), nullable=False),
+        sa.Column("details", JSONB, nullable=True),
+    )
+    _create_workflow_audit_log_indexes()
+
+
+def _create_workflow_audit_log_indexes() -> None:
+    """Create indexes for workflow_audit_log. Helper (#2152)."""
+    op.create_index(
+        "idx_wal_workflow_id",
+        "workflow_audit_log",
+        ["workflow_id"],
+    )
+    op.create_index(
+        "idx_wal_user_id",
+        "workflow_audit_log",
+        ["user_id"],
+    )
+    op.create_index(
+        "idx_wal_timestamp",
+        "workflow_audit_log",
+        ["timestamp"],
+    )
+    op.create_index(
+        "idx_wal_action",
+        "workflow_audit_log",
+        ["action"],
+    )
+
+
+def upgrade() -> None:
+    """Create workflow_permissions and workflow_audit_log tables."""
+    _create_workflow_permissions_table()
+    _create_workflow_audit_log_table()
+
+
+def downgrade() -> None:
+    """Drop workflow RBAC tables in reverse dependency order."""
+    op.drop_index("idx_wal_action", table_name="workflow_audit_log")
+    op.drop_index("idx_wal_timestamp", table_name="workflow_audit_log")
+    op.drop_index("idx_wal_user_id", table_name="workflow_audit_log")
+    op.drop_index("idx_wal_workflow_id", table_name="workflow_audit_log")
+    op.drop_table("workflow_audit_log")
+
+    op.drop_index("idx_wp_user_id", table_name="workflow_permissions")
+    op.drop_index("idx_wp_workflow_id", table_name="workflow_permissions")
+    op.drop_table("workflow_permissions")

--- a/autobot-backend/models/__init__.py
+++ b/autobot-backend/models/__init__.py
@@ -46,6 +46,10 @@ from models.session_collaboration import SessionCollaboration
 # Task delegation model (#1753)
 from models.task_delegation import TaskDelegation
 
+# Workflow RBAC models (#2152)
+from models.workflow_audit import WorkflowAuditLog
+from models.workflow_permission import WorkflowPermission
+
 __all__ = [
     # Activity models (referenced by User model)
     "TerminalActivityModel",
@@ -75,4 +79,7 @@ __all__ = [
     "ProcessRun",
     "TaskDecomposition",
     "AgentSession",
+    # Workflow RBAC models (#2152)
+    "WorkflowPermission",
+    "WorkflowAuditLog",
 ]

--- a/autobot-backend/models/workflow_audit.py
+++ b/autobot-backend/models/workflow_audit.py
@@ -1,0 +1,49 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+WorkflowAuditLog Model (#2152)
+
+Immutable audit trail for all workflow lifecycle actions:
+create, edit, run, approve, delete, view, grant, revoke.
+"""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import func
+from user_management.models.base import Base
+
+
+class WorkflowAuditLog(Base):
+    """
+    Immutable audit log entry for a workflow action (#2152).
+
+    Written once; never updated or deleted by the application.
+    """
+
+    __tablename__ = "workflow_audit_log"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    timestamp = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        index=True,
+    )
+    user_id = Column(String(255), nullable=False, index=True)
+    workflow_id = Column(String(255), nullable=False, index=True)
+    # create | edit | run | approve | delete | view | grant | revoke
+    action = Column(String(50), nullable=False, index=True)
+    details = Column(JSONB, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<WorkflowAuditLog workflow={self.workflow_id} "
+            f"user={self.user_id} action={self.action}>"
+        )

--- a/autobot-backend/models/workflow_permission.py
+++ b/autobot-backend/models/workflow_permission.py
@@ -1,0 +1,59 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+WorkflowPermission Model (#2152)
+
+Per-workflow access control: tracks which users have which roles on a given workflow.
+Roles: owner, editor, viewer, runner.
+"""
+
+import uuid
+
+from sqlalchemy import Column, DateTime, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+from user_management.models.base import Base
+
+
+class WorkflowPermission(Base):
+    """
+    Per-workflow permission entry (#2152).
+
+    Associates a user with a role on a specific workflow.
+    One row per (workflow_id, user_id) pair.
+    """
+
+    __tablename__ = "workflow_permissions"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    workflow_id = Column(String(255), nullable=False, index=True)
+    user_id = Column(String(255), nullable=False, index=True)
+    # owner | editor | viewer | runner
+    role = Column(String(50), nullable=False)
+    granted_by = Column(String(255), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("workflow_id", "user_id", name="uq_workflow_permission"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<WorkflowPermission workflow={self.workflow_id} "
+            f"user={self.user_id} role={self.role}>"
+        )

--- a/autobot-backend/services/workflow_permission_service.py
+++ b/autobot-backend/services/workflow_permission_service.py
@@ -1,0 +1,284 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+WorkflowPermissionService (#2152)
+
+Provides per-workflow access control (grant, revoke, check) and the
+append-only audit trail (log_action).
+
+Roles and their capabilities:
+  owner  — full control, can grant/revoke permissions
+  editor — create, edit, delete the workflow
+  runner — execute / trigger the workflow
+  viewer — read-only access
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from models.workflow_audit import WorkflowAuditLog
+from models.workflow_permission import WorkflowPermission
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+# Ordered from most to least privileged; used for hierarchy checks.
+ROLE_HIERARCHY = ["owner", "editor", "runner", "viewer"]
+
+# Minimum role required for each action type.
+ROLE_REQUIRED: Dict[str, str] = {
+    "view": "viewer",
+    "run": "runner",
+    "edit": "editor",
+    "create": "editor",
+    "delete": "owner",
+    "approve": "owner",
+    "grant": "owner",
+    "revoke": "owner",
+}
+
+
+def _role_satisfies(user_role: str, required_role: str) -> bool:
+    """
+    Return True when *user_role* is at least as privileged as *required_role*.
+
+    Roles not present in ROLE_HIERARCHY are treated as unprivileged.
+
+    Args:
+        user_role: The role the user actually holds.
+        required_role: The minimum role needed for the action.
+    """
+    try:
+        user_idx = ROLE_HIERARCHY.index(user_role)
+        required_idx = ROLE_HIERARCHY.index(required_role)
+        return user_idx <= required_idx
+    except ValueError:
+        return False
+
+
+class WorkflowPermissionService:
+    """
+    Per-workflow RBAC service (#2152).
+
+    Each method expects a live AsyncSession injected by the caller.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    # ------------------------------------------------------------------
+    # Permission checks
+    # ------------------------------------------------------------------
+
+    async def check_permission(
+        self,
+        user_id: str,
+        workflow_id: str,
+        action: str,
+    ) -> bool:
+        """
+        Return True when *user_id* may perform *action* on *workflow_id*.
+
+        Args:
+            user_id: Authenticated user identifier.
+            workflow_id: Target workflow identifier.
+            action: One of the keys in ROLE_REQUIRED.
+        """
+        required_role = ROLE_REQUIRED.get(action, "owner")
+        row = await self._fetch_permission(user_id, workflow_id)
+        if row is None:
+            return False
+        return _role_satisfies(row.role, required_role)
+
+    async def _fetch_permission(
+        self, user_id: str, workflow_id: str
+    ) -> Optional[WorkflowPermission]:
+        """Retrieve the permission row for (user_id, workflow_id), or None."""
+        stmt = select(WorkflowPermission).where(
+            WorkflowPermission.user_id == user_id,
+            WorkflowPermission.workflow_id == workflow_id,
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    # ------------------------------------------------------------------
+    # Permission mutations
+    # ------------------------------------------------------------------
+
+    async def grant_permission(
+        self,
+        workflow_id: str,
+        user_id: str,
+        role: str,
+        granted_by: str,
+    ) -> WorkflowPermission:
+        """
+        Grant *role* on *workflow_id* to *user_id* (upsert).
+
+        Raises ValueError when *role* is not in ROLE_HIERARCHY.
+
+        Args:
+            workflow_id: Target workflow identifier.
+            user_id: User receiving the role.
+            role: One of owner | editor | runner | viewer.
+            granted_by: User performing the grant.
+        """
+        if role not in ROLE_HIERARCHY:
+            raise ValueError(f"Invalid workflow role '{role}'")
+
+        stmt = (
+            pg_insert(WorkflowPermission)
+            .values(
+                workflow_id=workflow_id,
+                user_id=user_id,
+                role=role,
+                granted_by=granted_by,
+            )
+            .on_conflict_do_update(
+                constraint="uq_workflow_permission",
+                set_={"role": role, "granted_by": granted_by},
+            )
+            .returning(WorkflowPermission)
+        )
+        result = await self.session.execute(stmt)
+        await self.session.commit()
+        perm = result.scalar_one()
+        logger.info(
+            "Workflow permission granted: workflow=%s user=%s role=%s by=%s",
+            workflow_id,
+            user_id,
+            role,
+            granted_by,
+        )
+        return perm
+
+    async def grant_owner(self, workflow_id: str, user_id: str) -> WorkflowPermission:
+        """
+        Convenience wrapper — assign owner role to the workflow creator (#2152).
+
+        Args:
+            workflow_id: Newly created workflow identifier.
+            user_id: Creator's user identifier.
+        """
+        return await self.grant_permission(
+            workflow_id=workflow_id,
+            user_id=user_id,
+            role="owner",
+            granted_by=user_id,
+        )
+
+    async def revoke_permission(
+        self,
+        workflow_id: str,
+        user_id: str,
+        revoked_by: str,
+    ) -> bool:
+        """
+        Remove the permission entry for *user_id* on *workflow_id*.
+
+        Returns True when a row was deleted, False when none existed.
+
+        Args:
+            workflow_id: Target workflow identifier.
+            user_id: User losing access.
+            revoked_by: User performing the revocation.
+        """
+        stmt = delete(WorkflowPermission).where(
+            WorkflowPermission.workflow_id == workflow_id,
+            WorkflowPermission.user_id == user_id,
+        )
+        result = await self.session.execute(stmt)
+        await self.session.commit()
+        deleted = result.rowcount > 0
+        if deleted:
+            logger.info(
+                "Workflow permission revoked: workflow=%s user=%s by=%s",
+                workflow_id,
+                user_id,
+                revoked_by,
+            )
+        return deleted
+
+    # ------------------------------------------------------------------
+    # Permission queries
+    # ------------------------------------------------------------------
+
+    async def get_permissions(self, workflow_id: str) -> List[WorkflowPermission]:
+        """
+        Return all permission entries for *workflow_id*.
+
+        Args:
+            workflow_id: Target workflow identifier.
+        """
+        stmt = select(WorkflowPermission).where(
+            WorkflowPermission.workflow_id == workflow_id
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    # ------------------------------------------------------------------
+    # Audit logging
+    # ------------------------------------------------------------------
+
+    async def log_action(
+        self,
+        user_id: str,
+        workflow_id: str,
+        action: str,
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Append an audit log entry for a workflow lifecycle event (#2152).
+
+        This method never raises; failures are logged as warnings so that
+        audit errors never break the caller's happy path.
+
+        Args:
+            user_id: User performing the action.
+            workflow_id: Target workflow identifier.
+            action: Lifecycle action label (e.g. 'create', 'run').
+            details: Optional structured metadata for the entry.
+        """
+        try:
+            entry = WorkflowAuditLog(
+                user_id=user_id,
+                workflow_id=workflow_id,
+                action=action,
+                details=details,
+            )
+            self.session.add(entry)
+            await self.session.commit()
+        except Exception as exc:
+            logger.warning(
+                "Failed to write workflow audit log: workflow=%s action=%s error=%s",
+                workflow_id,
+                action,
+                exc,
+            )
+
+    async def get_audit_log(
+        self,
+        workflow_id: str,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[WorkflowAuditLog]:
+        """
+        Return audit log entries for *workflow_id*, newest first.
+
+        Args:
+            workflow_id: Target workflow identifier.
+            limit: Maximum rows to return (1–1000).
+            offset: Pagination offset.
+        """
+        stmt = (
+            select(WorkflowAuditLog)
+            .where(WorkflowAuditLog.workflow_id == workflow_id)
+            .order_by(WorkflowAuditLog.timestamp.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())

--- a/autobot-backend/workflow_rbac.py
+++ b/autobot-backend/workflow_rbac.py
@@ -1,0 +1,101 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Workflow RBAC FastAPI dependencies (#2152).
+
+Provides per-workflow permission enforcement via FastAPI Depends():
+
+    @router.get("/workflows/{workflow_id}/steps")
+    async def get_steps(
+        workflow_id: str,
+        session: AsyncSession = Depends(get_db_session),
+        current_user: dict = Depends(get_current_user),
+        _: bool = Depends(require_workflow_permission("view")),
+    ):
+        ...
+
+The dependency resolves *workflow_id* from the path parameter automatically.
+Admins bypass the per-workflow check (they hold all permissions).
+"""
+
+import logging
+from typing import Callable
+
+from api.user_management.dependencies import get_db_session
+from auth_middleware import get_current_user
+from fastapi import Depends, HTTPException, Request, status
+from services.workflow_permission_service import WorkflowPermissionService
+from sqlalchemy.ext.asyncio import AsyncSession
+from user_management.config import DeploymentMode, get_deployment_config
+
+logger = logging.getLogger(__name__)
+
+_ADMIN_ROLES = {"admin"}
+
+
+def _is_admin(user_data: dict) -> bool:
+    """Return True when the user holds a system-wide admin role."""
+    return user_data.get("role", "").lower() in _ADMIN_ROLES
+
+
+def require_workflow_permission(action: str) -> Callable:
+    """
+    FastAPI dependency factory — enforce a per-workflow permission.
+
+    Reads *workflow_id* from the request path parameters.
+    Admins and single-user mode bypass the check.
+
+    Args:
+        action: Lifecycle action to enforce (view | edit | run | delete | …).
+
+    Returns:
+        An async FastAPI dependency.
+
+    Issue #2152: Per-workflow RBAC.
+    """
+
+    async def dependency(
+        request: Request,
+        current_user: dict = Depends(get_current_user),
+        session: AsyncSession = Depends(get_db_session),
+    ) -> bool:
+        """Check per-workflow permission and return True or raise 403."""
+        # Single-user mode bypass
+        deployment_config = get_deployment_config()
+        if deployment_config.mode == DeploymentMode.SINGLE_USER:
+            return True
+
+        # System-wide admins always have access
+        if _is_admin(current_user):
+            return True
+
+        workflow_id = request.path_params.get("workflow_id") or request.path_params.get(
+            "id"
+        )
+        if not workflow_id:
+            logger.warning("require_workflow_permission: workflow_id missing from path")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="workflow_id is required",
+            )
+
+        user_id = current_user.get("username") or current_user.get("user_id", "")
+        svc = WorkflowPermissionService(session)
+        allowed = await svc.check_permission(user_id, workflow_id, action)
+
+        if not allowed:
+            logger.warning(
+                "Workflow permission denied: user=%s workflow=%s action=%s",
+                user_id,
+                workflow_id,
+                action,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Permission '{action}' required for workflow {workflow_id}",
+            )
+
+        return True
+
+    return dependency


### PR DESCRIPTION
## Summary

- **WorkflowPermission model** — per-workflow user roles (owner/editor/runner/viewer) with unique constraint
- **WorkflowAuditLog model** — immutable append-only audit trail for all workflow operations
- **WorkflowPermissionService** — permission checking with role hierarchy, upsert grant, paginated audit
- **FastAPI dependency** `require_workflow_permission(action)` — checks permissions, bypasses in single-user mode
- **4 API endpoints** — list/grant/revoke permissions + view audit log
- **Alembic migration** — creates both tables with indexes
- Wired into router registry

## Test plan

- [ ] `GET /workflows/{id}/permissions` returns permission list
- [ ] `PUT /workflows/{id}/permissions` grants/updates roles
- [ ] Unauthorized users get 403 on protected endpoints
- [ ] Audit log records all workflow mutations
- [ ] Single-user mode bypasses permission checks
- [ ] Migration runs cleanly (up and down)

Closes #2152

🤖 Generated with [Claude Code](https://claude.com/claude-code)