### PR TITLE
feat(monitoring): wire GPU acceleration optimizer to API endpoints (#2267)

### DIFF
--- a/autobot-backend/api/gpu_monitoring.py
+++ b/autobot-backend/api/gpu_monitoring.py
@@ -1,0 +1,172 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+GPU Monitoring API
+
+Issue #2267: Expose GPU acceleration optimizer functions as API endpoints.
+Provides endpoints for GPU efficiency monitoring, benchmarking, capability
+reporting, multimodal optimization, and config updates.
+"""
+
+import logging
+from dataclasses import asdict
+from typing import Any, Dict
+
+from auth_middleware import check_admin_permission
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["GPU Monitoring"])
+
+
+class GPUConfigUpdateRequest(BaseModel):
+    """Request body for GPU optimization configuration updates."""
+
+    updates: Dict[str, Any]
+
+
+def _gpu_unavailable_error() -> HTTPException:
+    """Return a 503 error indicating GPU is not available."""
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail={
+            "error": "GPU not available",
+            "message": "No GPU hardware detected on this node.",
+        },
+    )
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_gpu_efficiency",
+    error_code_prefix="GPU_MONITORING",
+)
+@router.get("/gpu/efficiency")
+async def get_gpu_efficiency(
+    admin_check: bool = Depends(check_admin_permission),
+):
+    """Get current GPU acceleration efficiency metrics.
+
+    Issue #2267: Returns real-time efficiency metrics including utilization,
+    throughput estimates, and optimization recommendations.
+    """
+    from utils.gpu_acceleration_optimizer import (
+        gpu_optimizer,
+        monitor_gpu_efficiency,
+    )
+
+    if not gpu_optimizer.gpu_available:
+        raise _gpu_unavailable_error()
+
+    result = await monitor_gpu_efficiency()
+    return {"success": True, "efficiency": result}
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_gpu_capabilities",
+    error_code_prefix="GPU_MONITORING",
+)
+@router.get("/gpu/capabilities")
+async def get_gpu_capabilities(
+    admin_check: bool = Depends(check_admin_permission),
+):
+    """Get GPU hardware capabilities and optimization configuration.
+
+    Issue #2267: Returns detected capabilities (tensor cores, mixed precision,
+    compute capability, memory) and current optimization config.
+    """
+    from utils.gpu_acceleration_optimizer import get_gpu_capabilities
+
+    caps = get_gpu_capabilities()
+    return {"success": True, "capabilities": caps}
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="run_gpu_benchmark",
+    error_code_prefix="GPU_MONITORING",
+)
+@router.post("/gpu/benchmark")
+async def run_gpu_benchmark(
+    admin_check: bool = Depends(check_admin_permission),
+):
+    """Run a comprehensive GPU performance benchmark.
+
+    Issue #2267: Executes compute, memory bandwidth, mixed-precision, and
+    tensor-core benchmarks. May take several seconds to complete.
+    """
+    from utils.gpu_acceleration_optimizer import benchmark_gpu, gpu_optimizer
+
+    if not gpu_optimizer.gpu_available:
+        raise _gpu_unavailable_error()
+
+    result = await benchmark_gpu()
+    return {"success": True, "benchmark": result}
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="optimize_gpu_multimodal",
+    error_code_prefix="GPU_MONITORING",
+)
+@router.post("/gpu/optimize")
+async def optimize_gpu_multimodal(
+    admin_check: bool = Depends(check_admin_permission),
+):
+    """Optimize GPU for multimodal AI processing.
+
+    Issue #2267: Applies memory, batch, mixed-precision, tensor-core, and
+    model-compilation optimizations. Returns a structured result with
+    performance improvement metrics and applied optimization list.
+    """
+    from utils.gpu_acceleration_optimizer import (
+        gpu_optimizer,
+        optimize_gpu_for_multimodal,
+    )
+
+    if not gpu_optimizer.gpu_available:
+        raise _gpu_unavailable_error()
+
+    result = await optimize_gpu_for_multimodal()
+    return {"success": True, "optimization": asdict(result)}
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="update_gpu_config",
+    error_code_prefix="GPU_MONITORING",
+)
+@router.patch("/gpu/config")
+async def update_gpu_config(
+    body: GPUConfigUpdateRequest,
+    admin_check: bool = Depends(check_admin_permission),
+):
+    """Update GPU optimization configuration.
+
+    Issue #2267: Accepts a dict of config field names to new values.
+    Unknown keys are ignored with a warning; valid keys are applied
+    immediately to the running optimizer instance.
+    """
+    from utils.gpu_acceleration_optimizer import update_gpu_config
+
+    if not body.updates:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="'updates' must be a non-empty dict.",
+        )
+
+    updated = await update_gpu_config(body.updates)
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to apply GPU configuration updates.",
+        )
+
+    logger.info("GPU optimization config updated: %s", list(body.updates.keys()))
+    return {"success": True, "updated_keys": list(body.updates.keys())}

--- a/autobot-backend/initialization/router_registry/monitoring_routers.py
+++ b/autobot-backend/initialization/router_registry/monitoring_routers.py
@@ -60,6 +60,14 @@ MONITORING_ROUTER_CONFIGS = [
         ["webhooks", "alertmanager"],
         "alertmanager_webhook",
     ),
+    # Issue #2267: GPU acceleration optimizer monitoring endpoints
+    (
+        "api.gpu_monitoring",
+        "router",
+        "/monitoring",
+        ["GPU Monitoring"],
+        "gpu_monitoring",
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

- Adds `autobot-backend/api/gpu_monitoring.py` with five new admin-auth-gated endpoints under `/api/monitoring/gpu/*`
- Registers the router in `autobot-backend/initialization/router_registry/monitoring_routers.py` (shares the `/monitoring` prefix with the existing monitoring router)
- Uses lazy imports inside each handler so the module loads cleanly on nodes with no GPU hardware
- Returns HTTP 503 with a clear message when `gpu_optimizer.gpu_available` is `False`

## New Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET`  | `/api/monitoring/gpu/efficiency` | Real-time efficiency metrics from `monitor_gpu_efficiency()` |
| `GET`  | `/api/monitoring/gpu/capabilities` | Hardware capabilities report from `get_gpu_capabilities()` |
| `POST` | `/api/monitoring/gpu/benchmark` | Comprehensive benchmark via `benchmark_gpu()` |
| `POST` | `/api/monitoring/gpu/optimize` | Multimodal optimization pass via `optimize_gpu_for_multimodal()` |
| `PATCH`| `/api/monitoring/gpu/config` | Live config update via `update_gpu_config(updates)` |

## Test plan

- [ ] `python -m py_compile autobot-backend/api/gpu_monitoring.py` passes
- [ ] `flake8 --max-line-length=100` passes on both changed files
- [ ] All pre-commit hooks pass (confirmed in commit output)
- [ ] On a node with GPU: `GET /api/monitoring/gpu/capabilities` returns capabilities dict
- [ ] On a node without GPU: all non-capabilities endpoints return HTTP 503

Closes #2267