### PR TITLE
fix(ci): add missing autoflake flags to match pre-commit (#2218)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -82,6 +82,8 @@ jobs:
         python3 -m autoflake --check --recursive \
           --remove-all-unused-imports \
           --remove-unused-variables \
+          --expand-star-imports \
+          --ignore-init-module-imports \
           autobot-backend/ autobot-slm-backend/ autobot-shared/ || {
           echo "⚠️ Unused imports/variables detected"
           exit 1


### PR DESCRIPTION
## Summary
- Adds `--expand-star-imports` and `--ignore-init-module-imports` to CI autoflake invocation
- Matches the flags already used in `.pre-commit-config.yaml`
- Ensures CI and pre-commit produce identical autoflake results

Closes #2218