### PR TITLE
fix(shared): update redis_client.py docstring to canonical import path (#2219)

### DIFF
--- a/autobot-shared/redis_client.py
+++ b/autobot-shared/redis_client.py
@@ -46,7 +46,7 @@ FEATURES (Consolidated from 8 implementations):
 
 MANDATORY USAGE PATTERN:
 ========================
-from utils.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client
 
 # Synchronous client
 redis_client = get_redis_client(database="main")
@@ -493,7 +493,7 @@ class RedisDatabaseManager:
         """Initialize deprecated manager with deprecation warning."""
         logger.warning(
             "DEPRECATED: RedisDatabaseManager is deprecated. "
-            "Use get_redis_client() from backend.utils.redis_client instead."
+            "Use get_redis_client() from autobot_shared.redis_client instead."
         )
 
     def get_connection(


### PR DESCRIPTION
## Summary
- Updates stale docstring in `autobot-shared/redis_client.py`
- Changes `from utils.redis_client` references to `from autobot_shared.redis_client`
- Also fixes deprecated manager warning message to use canonical path
- Matches CLAUDE.md Rule 2 canonical import

Closes #2219