### PR TITLE
fix(ci): replace global B113 bandit skip with per-file annotations (#2272)

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -20,7 +20,6 @@ skips:
   - B108  # hardcoded_tmp_directory - /tmp used for legitimate temp files
   - B110  # try_except_pass - intentional exception suppression pattern
   - B112  # try_except_continue - intentional exception-and-continue pattern
-  - B113  # request_without_timeout - all 21 instances in test files (not production)
   - B311  # random - used for demo data variance, not cryptographic purposes
   - B324  # hashlib weak hash - MD5 used for caching fingerprints, not security
   - B404  # import_subprocess - subprocess use is intentional and reviewed

--- a/autobot-backend/api/infrastructure.integration_test.py
+++ b/autobot-backend/api/infrastructure.integration_test.py
@@ -19,7 +19,7 @@ BASE_URL = f"{ServiceURLs.BACKEND_API}/api/iac"
 
 def test_health():
     """Test 1: Health Check"""
-    response = requests.get(f"{BASE_URL}/health")
+    response = requests.get(f"{BASE_URL}/health")  # nosec B113
     data = response.json()
     print("✅ Test 1: Health Check - PASSED")  # noqa: print
     print(  # noqa: print
@@ -30,7 +30,7 @@ def test_health():
 
 def test_list_roles():
     """Test 2: List Infrastructure Roles"""
-    response = requests.get(f"{BASE_URL}/roles")
+    response = requests.get(f"{BASE_URL}/roles")  # nosec B113
     data = response.json()
     role_names = [r["name"] for r in data]
     print("✅ Test 2: List Roles - PASSED")  # noqa: print
@@ -40,7 +40,7 @@ def test_list_roles():
 
 def test_statistics():
     """Test 3: Get Statistics"""
-    response = requests.get(f"{BASE_URL}/statistics")
+    response = requests.get(f"{BASE_URL}/statistics")  # nosec B113
     data = response.json()
     print("✅ Test 3: Statistics - PASSED")  # noqa: print
     print(  # noqa: print
@@ -51,7 +51,9 @@ def test_statistics():
 
 def test_list_hosts_empty():
     """Test 4: List Hosts (Empty Database)"""
-    response = requests.get(f"{BASE_URL}/hosts", params={"page": 1, "page_size": 20})
+    response = requests.get(
+        f"{BASE_URL}/hosts", params={"page": 1, "page_size": 20}
+    )  # nosec B113
     data = response.json()
     print("✅ Test 4: List Hosts (Empty) - PASSED")  # noqa: print
     print(  # noqa: print
@@ -71,7 +73,7 @@ def test_create_host():
         "auth_method": "password",
         "password": "test123",
     }
-    response = requests.post(f"{BASE_URL}/hosts", data=form_data)
+    response = requests.post(f"{BASE_URL}/hosts", data=form_data)  # nosec B113
 
     if response.status_code != 201:
         print(  # noqa: print
@@ -90,7 +92,7 @@ def test_create_host():
 
 def test_get_host_details(host_id):
     """Test 6: Get Host Details (Relationship Loading)"""
-    response = requests.get(f"{BASE_URL}/hosts/{host_id}")
+    response = requests.get(f"{BASE_URL}/hosts/{host_id}")  # nosec B113
     data = response.json()
     print("✅ Test 6: Get Host Details - PASSED")  # noqa: print
     print(  # noqa: print
@@ -101,7 +103,7 @@ def test_get_host_details(host_id):
 
 def test_list_hosts_after_create():
     """Test 7: List Hosts After Creation"""
-    response = requests.get(f"{BASE_URL}/hosts")
+    response = requests.get(f"{BASE_URL}/hosts")  # nosec B113
     data = response.json()
     first_host = data["hosts"][0]["hostname"] if data["hosts"] else "None"
     print("✅ Test 7: List Hosts After Creation - PASSED")  # noqa: print
@@ -113,12 +115,12 @@ def test_list_hosts_after_create():
 
 def test_delete_host(host_id):
     """Test 8: Delete Test Host"""
-    response = requests.delete(f"{BASE_URL}/hosts/{host_id}")
+    response = requests.delete(f"{BASE_URL}/hosts/{host_id}")  # nosec B113
     print("✅ Test 8: Delete Host - PASSED")  # noqa: print
     print(f"   HTTP Status: {response.status_code}")  # noqa: print
 
     # Verify deletion
-    response = requests.get(f"{BASE_URL}/hosts")
+    response = requests.get(f"{BASE_URL}/hosts")  # nosec B113
     data = response.json()
     print(  # noqa: print
         f"   Remaining hosts after deletion: {data['pagination']['total']}"

--- a/autobot-backend/api/voice_integration_test.py
+++ b/autobot-backend/api/voice_integration_test.py
@@ -78,7 +78,7 @@ class TestTTSWorkerSynthesize:
         resp = requests.post(
             f"{TTS_WORKER_URL}/tts/synthesize",
             data={"text": "Hello from AutoBot."},
-            timeout=LATENCY_BUDGET_SEC * 2,
+            timeout=LATENCY_BUDGET_SEC * 2,  # nosec B113
         )
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "audio/wav"
@@ -89,7 +89,7 @@ class TestTTSWorkerSynthesize:
         resp = requests.post(
             f"{TTS_WORKER_URL}/tts/synthesize",
             data={"text": "Latency test."},
-            timeout=LATENCY_BUDGET_SEC * 2,
+            timeout=LATENCY_BUDGET_SEC * 2,  # nosec B113
         )
         elapsed = time.monotonic() - start
         assert resp.status_code == 200
@@ -101,7 +101,7 @@ class TestTTSWorkerSynthesize:
         resp = requests.post(
             f"{TTS_WORKER_URL}/tts/synthesize",
             data={"text": "Testing audio content."},
-            timeout=LATENCY_BUDGET_SEC * 2,
+            timeout=LATENCY_BUDGET_SEC * 2,  # nosec B113
         )
         assert resp.status_code == 200
         assert len(resp.content) > 1000  # real WAV is more than a few bytes
@@ -114,7 +114,7 @@ class TestTTSWorkerCloneVoice:
             f"{TTS_WORKER_URL}/tts/clone-voice",
             data={"text": "Voice clone test."},
             files={"reference_audio": ("ref.wav", silent_wav, "audio/wav")},
-            timeout=LATENCY_BUDGET_SEC * 2,
+            timeout=LATENCY_BUDGET_SEC * 2,  # nosec B113
         )
         # 200 if model supports cloning, 500 if reference is too short (acceptable)
         assert resp.status_code in (200, 500)
@@ -132,7 +132,7 @@ class TestBackendVoiceSynthesize:
         resp = requests.post(
             f"{BACKEND_URL}/api/voice/synthesize",
             data={"text": "AutoBot speaking.", "user_role": "user"},
-            timeout=LATENCY_BUDGET_SEC * 2,
+            timeout=LATENCY_BUDGET_SEC * 2,  # nosec B113
         )
         assert resp.status_code == 200
         assert "audio" in resp.headers.get("content-type", "")
@@ -146,7 +146,7 @@ class TestBackendVoiceSynthesize:
         resp = requests.post(
             f"{BACKEND_URL}/api/voice/synthesize",
             data={"text": "Full pipeline latency test.", "user_role": "user"},
-            timeout=LATENCY_BUDGET_SEC * 2,
+            timeout=LATENCY_BUDGET_SEC * 2,  # nosec B113
         )
         elapsed = time.monotonic() - start
         assert resp.status_code == 200
@@ -160,7 +160,7 @@ class TestBackendVoiceSynthesize:
             f"{BACKEND_URL}/api/voice/clone-voice",
             data={"text": "Clone proxy test.", "user_role": "user"},
             files={"reference_audio": ("ref.wav", silent_wav, "audio/wav")},
-            timeout=LATENCY_BUDGET_SEC * 2,
+            timeout=LATENCY_BUDGET_SEC * 2,  # nosec B113
         )
         assert resp.status_code in (200, 500)
         if resp.status_code == 200:

--- a/autobot-backend/phase8_control_panel_test.py
+++ b/autobot-backend/phase8_control_panel_test.py
@@ -167,7 +167,7 @@ def test_api_endpoints():
     # Test 1: System health
     print("\n1. Testing System Health Endpoint...")  # noqa: print
     try:
-        response = requests.get(f"{base_url}/system/health")
+        response = requests.get(f"{base_url}/system/health")  # nosec B113
         if response.status_code == 200:
             health_data = response.json()
             print(f"✅ Health check: {health_data['status']}")  # noqa: print
@@ -179,7 +179,7 @@ def test_api_endpoints():
     # Test 2: Streaming capabilities
     print("\n2. Testing Streaming Capabilities...")  # noqa: print
     try:
-        response = requests.get(f"{base_url}/streaming/capabilities")
+        response = requests.get(f"{base_url}/streaming/capabilities")  # nosec B113
         if response.status_code == 200:
             capabilities = response.json()
             print(f"✅ Streaming capabilities: {capabilities}")  # noqa: print
@@ -193,7 +193,7 @@ def test_api_endpoints():
     # Test 3: Takeover status
     print("\n3. Testing Takeover Status...")  # noqa: print
     try:
-        response = requests.get(f"{base_url}/takeover/status")
+        response = requests.get(f"{base_url}/takeover/status")  # nosec B113
         if response.status_code == 200:
             takeover_status = response.json()
             print(f"✅ Takeover status: {takeover_status}")  # noqa: print
@@ -205,7 +205,7 @@ def test_api_endpoints():
     # Test 4: System status
     print("\n4. Testing System Status...")  # noqa: print
     try:
-        response = requests.get(f"{base_url}/system/status")
+        response = requests.get(f"{base_url}/system/status")  # nosec B113
         if response.status_code == 200:
             system_status = response.json()
             print(  # noqa: print
@@ -219,7 +219,7 @@ def test_api_endpoints():
     # Test 5: API info
     print("\n5. Testing API Information...")  # noqa: print
     try:
-        response = requests.get(f"{base_url}/")
+        response = requests.get(f"{base_url}/")  # nosec B113
         if response.status_code == 200:
             api_info = response.json()
             print(  # noqa: print


### PR DESCRIPTION
## Summary
- Removes B113 (`request_without_timeout`) from global `.bandit` skips
- Adds per-line `# nosec B113` to test files that use `requests.*`:
  - `infrastructure.integration_test.py` (9 calls)
  - `phase8_control_panel_test.py` (5 calls)
  - `voice_integration_test.py` (7 calls — bandit false positive, all have `timeout=`)
- Future production code using `requests.*` without timeout will now be caught by CI
- Verified: `bandit -c .bandit -r autobot-backend/ autobot-slm-backend/ autobot-shared/ -t B113` returns 0 issues

Closes #2272