### PR TITLE
fix(hooks): update header comments to include new exclusions (#2273)

### DIFF
--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-function-length
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-function-length
@@ -46,7 +46,7 @@ find_python() {
     fi
 }
 
-# Get staged Python files (excluding tests, __init__, temp directories)
+# Get staged Python files (excluding tests, __init__, temp directories, migrations)
 get_staged_files() {
     git diff --cached --name-only --diff-filter=ACM 2>/dev/null | \
         grep -E '\.py$' | \

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-no-print-console
@@ -14,6 +14,7 @@
 # - Test files (*_test.py, *.spec.ts, *.e2e_test.*, *-test.js)
 # - debugUtils.ts, RumConsoleHelper.ts (logging infrastructure)
 # - Lines with "# noqa: print" or "// noqa: console" comments
+# - ansible/ (deployed copies with doctest examples)
 #
 # Issue: #1082 - Pre-commit hooks not blocking print/console violations
 #


### PR DESCRIPTION
## Summary
- Updates `pre-commit-no-print-console` header to list `ansible/` in intentional exceptions
- Updates `pre-commit-function-length` comment to include `migrations/` in exclusion list
- Keeps documentation in sync with actual grep filter patterns

Closes #2273