### PR TITLE
fix(topology): set last_updated in _update_pair (#2213)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/topology.py
+++ b/autobot-backend/agents/agent_orchestration/topology.py
@@ -72,8 +72,9 @@ class AgentTopologyDB(Protocol):
         weight: float,
         co_success_count: Optional[int] = None,
         co_failure_count: Optional[int] = None,
+        last_updated: Optional[datetime] = None,
     ) -> None:
-        """Persist updated weight and counter fields."""
+        """Persist updated weight, counter, and timestamp fields (#2213)."""
         ...
 
     async def record_agent_task(
@@ -199,17 +200,20 @@ class AgentTopology:
         target = 1.0 if success else 0.0
         new_weight = conn.weight * _DECAY + target * _LEARNING_RATE
 
+        now = datetime.now(tz=timezone.utc)
         if success:
             await self.db.update_agent_connection(
                 conn.id,
                 weight=new_weight,
                 co_success_count=conn.co_success_count + 1,
+                last_updated=now,
             )
         else:
             await self.db.update_agent_connection(
                 conn.id,
                 weight=new_weight,
                 co_failure_count=conn.co_failure_count + 1,
+                last_updated=now,
             )
 
     async def prune_weak_connections(

--- a/autobot-backend/agents/agent_orchestration/topology_test.py
+++ b/autobot-backend/agents/agent_orchestration/topology_test.py
@@ -10,7 +10,7 @@ using in-memory stubs — no database required.
 
 import dataclasses
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -93,6 +93,7 @@ async def test_record_outcome_success_reinforces():
         conn.id,
         weight=pytest.approx(expected_weight),
         co_success_count=1,
+        last_updated=ANY,
     )
 
 
@@ -111,6 +112,7 @@ async def test_record_outcome_failure_weakens():
         conn.id,
         weight=pytest.approx(expected_weight),
         co_failure_count=1,
+        last_updated=ANY,
     )
 
 


### PR DESCRIPTION
## Summary
- Added `last_updated=datetime.now(tz=timezone.utc)` to both `update_agent_connection` calls in `_update_pair`
- Added `last_updated` as optional kwarg to the `AgentTopologyDB` protocol method
- Updated test assertions to expect the new `last_updated` parameter
- All 9 topology tests passing

Closes #2213