### PR TITLE
fix(migrations): resolve duplicate revision 20260324_015 collision (#2302)

### DIFF
--- a/autobot-backend/migrations/versions/20260324_016_workflow_rbac.py
+++ b/autobot-backend/migrations/versions/20260324_016_workflow_rbac.py
@@ -4,16 +4,16 @@
 """
 Add workflow_permissions and workflow_audit_log tables (#2152).
 
-Revision ID: 20260324_015
-Revises: 20260323_014
+Revision ID: 20260324_016
+Revises: 20260324_015
 """
 
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
-revision = "20260324_015"
-down_revision = "20260323_014"
+revision = "20260324_016"
+down_revision = "20260324_015"
 branch_labels = None
 depends_on = None
 

--- a/autobot-backend/migrations/versions/20260324_017_add_workflow_secret_scope.py
+++ b/autobot-backend/migrations/versions/20260324_017_add_workflow_secret_scope.py
@@ -8,8 +8,8 @@ can be scoped to a specific workflow in addition to user/session/shared/group/
 organization scopes.  Also updates the ``scope`` column comment to document the
 new ``workflow`` scope value.
 
-Revision ID: 20260324_015
-Revises: 20260323_014
+Revision ID: 20260324_017
+Revises: 20260324_016
 Issue #2153 — Secret management for workflow credentials.
 """
 
@@ -18,8 +18,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "20260324_015"
-down_revision: Union[str, None] = "20260323_014"
+revision: str = "20260324_017"
+down_revision: Union[str, None] = "20260324_016"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

- Rename `20260324_015_workflow_rbac.py` to `20260324_016_workflow_rbac.py` (revision 016, down_revision 015)
- Rename `20260324_015_add_workflow_secret_scope.py` to `20260324_017_add_workflow_secret_scope.py` (revision 017, down_revision 016)
- Chain: `014 → 015 (mesh archive) → 016 (RBAC) → 017 (secrets)`

## Test plan

- [x] `grep` confirms no duplicate revision IDs
- [ ] `alembic upgrade head` runs without "Multiple heads" error

Closes #2302