### PR TITLE
fix(security): remove path echo from 403 response (#2307)

### DIFF
--- a/autobot-backend/api/files.py
+++ b/autobot-backend/api/files.py
@@ -1309,7 +1309,7 @@ def _validate_admin_path(path: str) -> Path:
     except ValueError:
         raise HTTPException(
             status_code=403,
-            detail=f"Path outside allowed directories: {path}",
+            detail="Path outside allowed directories",
         )
 
 


### PR DESCRIPTION
## Summary
- Removed user-supplied path from HTTP 403 error detail in `_validate_admin_path`
- Prevents information disclosure of server directory structure

Closes #2307