### PR TITLE
fix(slm): remove escaped $ so REDIS_HOST resolves at bootstrap (#2326)

### DIFF
--- a/autobot-infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh
+++ b/autobot-infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh
@@ -397,12 +397,12 @@ backend_setup() {
 HOST=127.0.0.1
 PORT=8000
 
-# Database (PostgreSQL — Issue #786)
+# Database (PostgreSQL -- Issue #786)
 SLM_DATABASE_URL=postgresql+asyncpg://slm_app@127.0.0.1:5432/slm
 
 # Redis (optional but recommended)
 # AUTOBOT_REDIS_HOST must be set in the deployment environment (#2224)
-REDIS_HOST=\${AUTOBOT_REDIS_HOST:?AUTOBOT_REDIS_HOST is required — set it in your environment}
+REDIS_HOST=${AUTOBOT_REDIS_HOST:?AUTOBOT_REDIS_HOST is required -- set it in your environment}
 REDIS_PORT=6379
 REDIS_DB=0
 


### PR DESCRIPTION
## Summary
- Removed `\` escape before `$` on REDIS_HOST line in bootstrap-slm.sh heredoc
- The heredoc is inside a double-quoted string — `\$` writes literal `${AUTOBOT_REDIS_HOST:?...}` into .env, which python-dotenv cannot interpret
- Without the escape, the local shell expands the variable at bootstrap time (failing fast if unset)
- Replaced em dashes with `--` for shell portability

Closes #2326