### PR TITLE
fix(chat): return error for unknown tool names instead of silent drop (#2305)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1343,7 +1343,26 @@ class ToolHandlerMixin:
             return
 
         if tool_name != "execute_command":
-            logger.debug("[_process_tool_calls] Skipping unknown tool: %s", tool_name)
+            # Issue #2305: Return a tool error so the agent can self-correct instead of
+            # silently dropping the call and causing an infinite hallucination loop.
+            known_tools = sorted(
+                {"respond", "delegate", "execute_command"} | _BROWSER_TOOL_NAMES
+            )
+            error_msg = (
+                f'Error: Tool "{tool_name}" not found. '
+                f"Available tools: {', '.join(known_tools)}"
+            )
+            logger.warning(
+                "[Issue #2305] Unknown tool call reported to agent: %s", tool_name
+            )
+            execution_results.append(
+                {"tool": tool_name, "status": "error", "error": error_msg}
+            )
+            yield WorkflowMessage(
+                type="error",
+                content=error_msg,
+                metadata={"message_type": "unknown_tool", "tool_name": tool_name},
+            )
             return
 
         async for msg in self._process_single_command(


### PR DESCRIPTION
## Summary
- Unknown tool calls now return an error `WorkflowMessage` listing available tools
- Agent can self-correct instead of silently looping on hallucinated tool names
- Changed log level from `debug` to `warning` for visibility
- Error is also appended to `execution_results` so the summary reflects it

## Impact
Fixes infinite hallucination loops when the LLM emits non-existent tool names (e.g. `google-search`).

Closes #2305