### PR TITLE
fix(devtools): disable format-on-save to prevent edit conflicts (#1518)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,14 @@
 {
     "IDX.aI.enableInlineCompletion": true,
-    "IDX.aI.enableCodebaseIndexing": true
+    "IDX.aI.enableCodebaseIndexing": true,
+    "editor.formatOnSave": false,
+    "editor.codeActionsOnSave": {
+        "source.fixAll": "explicit"
+    },
+    "files.watcherExclude": {
+        "**/node_modules/**": true,
+        "**/__pycache__/**": true,
+        "**/dist/**": true,
+        "**/.worktrees/**": true
+    }
 }

--- a/autobot-frontend/.vscode/settings.json
+++ b/autobot-frontend/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "tsconfig.json": "tsconfig.*.json, env.d.ts",
+    "vite.config.*": "jsconfig*, vitest.config.*, cypress.config.*, playwright.config.*",
+    "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*, .eslint*, eslint*, .oxlint*, oxlint*, .prettier*, prettier*, .editorconfig"
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "editor.formatOnSave": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "css.lint.unknownAtRules": "ignore",
+  "scss.lint.unknownAtRules": "ignore",
+  "less.lint.unknownAtRules": "ignore",
+  "css.customData": [
+    ".vscode/tailwind.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- Disable `editor.formatOnSave` in root and frontend `.vscode/settings.json`
- Add `files.watcherExclude` for node_modules, __pycache__, dist, .worktrees
- Pre-commit hooks (Black, isort, Prettier) already handle formatting — format-on-save was redundant and caused silent reverts of external tool edits

Closes #1518

## Test plan
- [ ] Open a Vue file, save — no auto-format on save
- [ ] Run pre-commit hooks — formatting still applied at commit time
- [ ] Manual format (Shift+Alt+F) still works with Prettier
- [ ] Claude Code edits persist after save