### PR TITLE
refactor(frontend): extract shared CodeSource interface (#2238)

### DIFF
--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -213,22 +213,7 @@ const { t } = useI18n()
 
 // ---- Types ----------------------------------------------------------------
 
-interface CodeSource {
-  id: string
-  name: string
-  source_type: 'github' | 'local'
-  repo: string | null
-  branch: string
-  credential_id: string | null
-  clone_path: string | null
-  last_synced: string | null
-  status: 'configured' | 'syncing' | 'ready' | 'error'
-  error_message: string | null
-  owner_id: string | null
-  access: 'private' | 'shared' | 'public'
-  shared_with: string[]
-  created_at: string
-}
+import type { CodeSource } from '@/types/analytics'
 
 interface Secret {
   id: string

--- a/autobot-frontend/src/components/analytics/AnalyticsHeader.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeader.vue
@@ -119,22 +119,7 @@
 
 // ---- Types ----------------------------------------------------------------
 
-interface CodeSource {
-  id: string
-  name: string
-  source_type: 'github' | 'local'
-  repo: string | null
-  branch: string
-  credential_id: string | null
-  clone_path: string | null
-  last_synced: string | null
-  status: 'configured' | 'syncing' | 'ready' | 'error'
-  error_message: string | null
-  owner_id: string | null
-  access: 'private' | 'shared' | 'public'
-  shared_with: string[]
-  created_at: string
-}
+import type { CodeSource } from '@/types/analytics'
 
 // ---- Props & Emits --------------------------------------------------------
 

--- a/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
@@ -79,12 +79,7 @@
  * Issue #1579: Extracted from CodebaseAnalytics.vue
  */
 
-interface CodeSource {
-  id: string
-  name: string
-  source_type: 'github' | 'local'
-  [key: string]: unknown
-}
+import type { CodeSource } from '@/types/analytics'
 
 defineProps<{
   analyzing: boolean

--- a/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
@@ -188,18 +188,7 @@ const { t } = useI18n()
 
 // ---- Types ----------------------------------------------------------------
 
-interface CodeSource {
-  id: string
-  name: string
-  source_type: 'github' | 'local'
-  repo: string | null
-  branch: string
-  clone_path: string | null
-  last_synced: string | null
-  status: 'configured' | 'syncing' | 'ready' | 'error'
-  error_message: string | null
-  access: 'private' | 'shared' | 'public'
-}
+import type { CodeSource } from '@/types/analytics'
 
 interface SourceSummary {
   last_indexed: string | null

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -132,22 +132,7 @@ const { t } = useI18n()
 
 // ---- Types ----------------------------------------------------------------
 
-interface CodeSource {
-  id: string
-  name: string
-  source_type: 'github' | 'local'
-  repo: string | null
-  branch: string
-  credential_id: string | null
-  clone_path: string | null
-  last_synced: string | null
-  status: 'configured' | 'syncing' | 'ready' | 'error'
-  error_message: string | null
-  owner_id: string | null
-  access: 'private' | 'shared' | 'public'
-  shared_with: string[]
-  created_at: string
-}
+import type { CodeSource } from '@/types/analytics'
 
 // ---- Props & Emits --------------------------------------------------------
 

--- a/autobot-frontend/src/components/analytics/SourceManager.vue
+++ b/autobot-frontend/src/components/analytics/SourceManager.vue
@@ -181,22 +181,7 @@ const { t } = useI18n()
 
 // ---- Types ----------------------------------------------------------------
 
-interface CodeSource {
-  id: string
-  name: string
-  source_type: 'github' | 'local'
-  repo: string | null
-  branch: string
-  credential_id: string | null
-  clone_path: string | null
-  last_synced: string | null
-  status: 'configured' | 'syncing' | 'ready' | 'error'
-  error_message: string | null
-  owner_id: string | null
-  access: 'private' | 'shared' | 'public'
-  shared_with: string[]
-  created_at: string
-}
+import type { CodeSource } from '@/types/analytics'
 
 interface RunningTask {
   task_id: string

--- a/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
+++ b/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
@@ -19,23 +19,9 @@ import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useSourceRegistry')
 
-// Issue #1133: CodeSource type
-export interface CodeSource {
-  id: string
-  name: string
-  source_type: 'github' | 'local'
-  repo: string | null
-  branch: string
-  credential_id: string | null
-  clone_path: string | null
-  last_synced: string | null
-  status: 'configured' | 'syncing' | 'ready' | 'error'
-  error_message: string | null
-  owner_id: string | null
-  access: 'private' | 'shared' | 'public'
-  shared_with: string[]
-  created_at: string
-}
+// Issue #1133 / #2238: CodeSource type extracted to shared types
+import type { CodeSource } from '@/types/analytics'
+export type { CodeSource }
 
 export interface UseSourceRegistryDeps {
   t: (key: string, params?: Record<string, unknown>) => string

--- a/autobot-frontend/src/types/analytics.ts
+++ b/autobot-frontend/src/types/analytics.ts
@@ -1,0 +1,25 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Shared types for codebase analytics components.
+ * Issue #1133: CodeSource type — extracted from 7 duplications (#2238).
+ */
+
+export interface CodeSource {
+  id: string
+  name: string
+  source_type: 'github' | 'local'
+  repo: string | null
+  branch: string
+  credential_id: string | null
+  clone_path: string | null
+  last_synced: string | null
+  status: 'configured' | 'syncing' | 'ready' | 'error'
+  error_message: string | null
+  owner_id: string | null
+  access: 'private' | 'shared' | 'public'
+  shared_with: string[]
+  created_at: string
+}


### PR DESCRIPTION
## Summary
- Extracted the `CodeSource` interface (duplicated in 7 analytics components/composables) into a shared `types/analytics.ts` file
- All 7 files now import from `@/types/analytics` instead of defining their own local copy
- `useSourceRegistry.ts` re-exports `CodeSource` for backward compatibility
- No runtime behavior changes — types only

Closes #2238

## Test plan
- [x] `npx vue-tsc --noEmit` passes with zero errors
- [x] All 7 files import from shared types file
- [x] No duplicate `interface CodeSource` definitions remain (verified via grep)
- [x] Pre-commit hooks pass