### PR TITLE
fix(chat): wire knowledge base into chat manager after Phase 2 init (#2309)

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -140,6 +140,26 @@ class ChatWorkflowManager(
             )
             self.knowledge_service = None
 
+    async def set_knowledge_base(self, kb) -> None:
+        """Wire an already-initialized KnowledgeBase into the knowledge service.
+
+        Issue #2309: Called by lifespan Phase 2 after the knowledge base is ready
+        so that RAG is available even when the KB was not ready during Phase 1.
+        """
+        if kb is None:
+            logger.warning("set_knowledge_base called with None -- RAG stays disabled")
+            return
+        try:
+            from services.chat_knowledge_service import ChatKnowledgeService
+            from services.rag_service import RAGService
+
+            rag_service = RAGService(kb)
+            await rag_service.initialize()
+            self.knowledge_service = ChatKnowledgeService(rag_service)
+            logger.info("Knowledge service wired from app-level knowledge base (#2309)")
+        except Exception as exc:
+            logger.warning("Failed to wire knowledge service from app KB: %s", exc)
+
     @error_boundary(component="chat_workflow_manager", function="initialize")
     async def initialize(self) -> bool:
         """Initialize the workflow manager with default workflow and async Redis."""

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -360,6 +360,17 @@ async def _init_knowledge_base(app: FastAPI):
         app.state.knowledge_base = knowledge_base
         await update_app_state("knowledge_base", knowledge_base)
         logger.info("✅ [ 70%] Knowledge Base: Knowledge base ready")
+
+        # Issue #2309: Wire KB into the already-initialized chat workflow manager.
+        # Phase 1 initializes the manager before the KB is ready, leaving
+        # knowledge_service=None. Re-wire here once the KB succeeds.
+        mgr = getattr(app.state, "chat_workflow_manager", None)
+        if (
+            mgr is not None
+            and knowledge_base is not None
+            and mgr.knowledge_service is None
+        ):
+            await mgr.set_knowledge_base(knowledge_base)
     except Exception as kb_error:
         logger.warning("Knowledge base initialization failed: %s", kb_error)
         app.state.knowledge_base = None


### PR DESCRIPTION
## Summary
- Root cause: ChatWorkflowManager initializes in Phase 1 before ChromaDB is ready, leaving `knowledge_service=None` permanently
- Added `set_knowledge_base()` method on ChatWorkflowManager for late-binding the KB
- Called from `_init_knowledge_base()` in Phase 2 lifespan after KB is ready
- Guarded with `mgr.knowledge_service is None` to avoid overwriting if Phase 1 succeeded

## Files Changed
- `autobot-backend/chat_workflow/manager.py` — new `set_knowledge_base()` method
- `autobot-backend/initialization/lifespan.py` — wire KB into manager in `_init_knowledge_base()`

Closes #2309