### PR TITLE
refactor: consolidate EnhancedOrchestrator into singleton (#2207)

### DIFF
--- a/autobot-backend/enhanced_orchestrator.py
+++ b/autobot-backend/enhanced_orchestrator.py
@@ -53,9 +53,29 @@ __all__ = [
     "DocumentationType",
     "EnhancedOrchestrator",
     "WorkflowDocumentation",
+    "get_orchestrator",
 ]
 
 logger = logging.getLogger(__name__)
+
+# Issue #2207: Module-level singleton — all callers share one instance
+_instance: Optional["EnhancedOrchestrator"] = None
+_instance_lock = __import__("threading").Lock()
+
+
+def get_orchestrator() -> "EnhancedOrchestrator":
+    """Return the shared EnhancedOrchestrator singleton.
+
+    Issue #2207: Ensures agent registry, knowledge base, and LLM interface
+    state is shared across all consumers (workflow automation, scheduler, etc.).
+    """
+    global _instance
+    if _instance is None:
+        with _instance_lock:
+            if _instance is None:
+                logger.info("Creating shared EnhancedOrchestrator singleton")
+                _instance = EnhancedOrchestrator()
+    return _instance
 
 
 class EnhancedOrchestrator:

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -873,10 +873,10 @@ async def _wire_scheduler_executor() -> None:
     """
     logger.info("[ 98%%] Scheduler: Wiring orchestration executor...")
     try:
-        from enhanced_orchestrator import EnhancedOrchestrator
+        from enhanced_orchestrator import get_orchestrator
         from workflow_scheduler import ScheduledWorkflow, workflow_scheduler
 
-        orchestrator = EnhancedOrchestrator()
+        orchestrator = get_orchestrator()
 
         async def _orchestration_executor(workflow: ScheduledWorkflow):
             """Adapter: ScheduledWorkflow → EnhancedOrchestrator.execute_enhanced_workflow.

--- a/autobot-backend/services/advanced_workflow/orchestrator.py
+++ b/autobot-backend/services/advanced_workflow/orchestrator.py
@@ -11,7 +11,7 @@ import logging
 import uuid
 from typing import Dict, List
 
-from enhanced_orchestrator import EnhancedOrchestrator
+from enhanced_orchestrator import get_orchestrator
 from knowledge_base import KnowledgeBase
 from llm_interface import LLMInterface
 from services.workflow_automation import (
@@ -39,7 +39,7 @@ class AdvancedWorkflowOrchestrator:
         """Initialize orchestrator with core and specialized components."""
         # Core components
         self.base_manager = WorkflowAutomationManager()
-        self.enhanced_orchestrator = EnhancedOrchestrator()
+        self.enhanced_orchestrator = get_orchestrator()
         self.llm_interface = LLMInterface()
         self.knowledge_base = KnowledgeBase()
 

--- a/autobot-backend/services/advanced_workflow/step_generator.py
+++ b/autobot-backend/services/advanced_workflow/step_generator.py
@@ -11,7 +11,7 @@ import logging
 from typing import List, Optional
 
 from autobot_types import TaskComplexity
-from enhanced_orchestrator import EnhancedOrchestrator
+from enhanced_orchestrator import EnhancedOrchestrator, get_orchestrator
 from type_defs.common import Metadata
 
 from .models import SmartWorkflowStep, WorkflowIntent
@@ -40,7 +40,7 @@ class StepGenerator:
 
     def __init__(self, enhanced_orchestrator: EnhancedOrchestrator = None):
         """Initialize step generator with optional enhanced orchestrator."""
-        self.enhanced_orchestrator = enhanced_orchestrator or EnhancedOrchestrator()
+        self.enhanced_orchestrator = enhanced_orchestrator or get_orchestrator()
 
     async def generate_smart_steps(
         self,

--- a/autobot-backend/services/workflow_automation/manager.py
+++ b/autobot-backend/services/workflow_automation/manager.py
@@ -11,7 +11,7 @@ import logging
 import uuid
 from typing import Dict, List, Optional
 
-from enhanced_orchestrator import EnhancedOrchestrator
+from enhanced_orchestrator import get_orchestrator
 from orchestrator import Orchestrator
 from type_defs.common import Metadata
 
@@ -51,7 +51,7 @@ class WorkflowAutomationManager:
 
         # Orchestrators for chat request processing
         self.orchestrator = Orchestrator()
-        self.enhanced_orchestrator = EnhancedOrchestrator()
+        self.enhanced_orchestrator = get_orchestrator()
 
     @property
     def terminal_sessions(self) -> Dict:

--- a/autobot-backend/utils/resource_factory.py
+++ b/autobot-backend/utils/resource_factory.py
@@ -78,38 +78,15 @@ class ResourceFactory:
 
     @staticmethod
     async def get_enhanced_orchestrator(request: Request = None):
-        """Get or create EnhancedOrchestrator instance with app.state caching"""
-        try:
-            # Try app.state first
-            if request is not None:
-                orch = getattr(request.app.state, "enhanced_orchestrator", None)
-                if orch is not None:
-                    logger.debug(
-                        "Using pre-initialized EnhancedOrchestrator from app.state"
-                    )
-                    return orch
+        """Get the shared EnhancedOrchestrator singleton.
 
-            # Fallback to module-level import and creation
-            from enhanced_orchestrator import EnhancedOrchestrator
+        Issue #2207: Delegates to module-level singleton in enhanced_orchestrator.
+        The request parameter is kept for backward compatibility but no longer
+        used for app.state caching — the singleton handles its own lifecycle.
+        """
+        from enhanced_orchestrator import get_orchestrator
 
-            logger.info(
-                "Creating new EnhancedOrchestrator instance (expensive operation)"
-            )
-
-            orch = EnhancedOrchestrator()
-
-            # Cache in app state if available
-            if request is not None:
-                request.app.state.enhanced_orchestrator = orch
-                logger.info(
-                    "Cached EnhancedOrchestrator in app.state for future requests"
-                )
-
-            return orch
-
-        except Exception as e:
-            logger.error("Failed to create EnhancedOrchestrator: %s", e)
-            raise
+        return get_orchestrator()
 
     @staticmethod
     async def get_chat_history_manager(request: Request = None):


### PR DESCRIPTION
## Summary
- Add thread-safe `get_orchestrator()` singleton in `enhanced_orchestrator.py`
- Replace all 5 direct `EnhancedOrchestrator()` instantiations with shared singleton
- Agent registry, knowledge base, and LLM interface state now shared across scheduler, workflow automation, and advanced workflow orchestrator
- Simplify `ResourceFactory.get_enhanced_orchestrator()` to delegate to module-level singleton

## Files changed
- `enhanced_orchestrator.py` — add `get_orchestrator()` with `threading.Lock`
- `initialization/lifespan.py` — use `get_orchestrator()`
- `services/advanced_workflow/orchestrator.py` — use `get_orchestrator()`
- `services/advanced_workflow/step_generator.py` — use `get_orchestrator()`
- `services/workflow_automation/manager.py` — use `get_orchestrator()`
- `utils/resource_factory.py` — simplified to delegate

## Test plan
- [ ] Backend starts without errors
- [ ] Workflow creation still works
- [ ] Scheduler fires workflows correctly
- [ ] Only one `Creating shared EnhancedOrchestrator singleton` log line appears

Closes #2207