### PR TITLE
fix(ansible): add slm_server/infrastructure groups to production.yml (#2294)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/production.yml
+++ b/autobot-slm-backend/ansible/inventory/production.yml
@@ -273,3 +273,18 @@ compute_services:
   vars:
     performance_monitoring: true
     resource_alerts: true
+
+# Groups required by update-all-nodes.yml (#2294)
+# These alias the role-based groups to match the SLM node naming convention.
+slm_server:
+  children:
+    slm:
+
+infrastructure:
+  children:
+    slm:
+    backend:
+    frontend:
+    npu:
+    aiml:
+    browser:

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -40,6 +40,16 @@
     deploy_tmp: "/tmp/autobot-deploy"
 
   tasks:
+    - name: "[PRE-FLIGHT] Verify required host groups exist"
+      fail:
+        msg: >-
+          Required groups 'slm_server' and 'infrastructure' not found.
+          Use: ansible-playbook -i inventory/slm-nodes.yml playbooks/update-all-nodes.yml
+          Or run against production.yml which now includes these group aliases.
+      when: >-
+        (groups['slm_server'] | default([]) | length == 0) or
+        (groups['infrastructure'] | default([]) | length == 0)
+
     - name: "[PRE-FLIGHT] Sync code from GitHub"
       git:
         repo: "{{ github_repo }}"


### PR DESCRIPTION
## Summary
- Add `slm_server` and `infrastructure` group aliases to `production.yml` that map to existing role groups
- Add pre-flight check in `update-all-nodes.yml` that fails fast with a helpful message if required groups are empty
- Playbook now works with both `production.yml` and `slm-nodes.yml` inventories

Closes #2294

## Test plan
- [ ] `ansible-playbook playbooks/update-all-nodes.yml --list-hosts` shows all nodes (without -i flag)
- [ ] `ansible-playbook -i inventory/slm-nodes.yml playbooks/update-all-nodes.yml --list-hosts` still works
- [ ] Pre-flight check fails with clear message when groups are empty