### PR TITLE
fix(ansible): add fix-node-ownership playbook (#2296)

### DIFF
--- a/autobot-infrastructure/shared/scripts/utilities/sync-to-vm.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/sync-to-vm.sh
@@ -237,15 +237,20 @@ sync_to_vm() {
             --exclude=dist/
             --exclude=.env
         )
+        # Use sudo rsync on remote to handle root-owned files (#2296).
+        # The autobot user has passwordless sudo on all fleet nodes.
+        local RSYNC_PATH="--rsync-path=sudo rsync"
         if [ -d "$local_path" ]; then
             log_info "Syncing directory (rsync with --delete): $local_path -> $vm_name:$remote_path"
             rsync -avz --delete --progress \
                 "${RSYNC_EXCLUDES[@]}" \
+                "$RSYNC_PATH" \
                 -e "ssh -i $SSH_KEY -o StrictHostKeyChecking=no" \
                 "$local_path/" "$REMOTE_USER@$vm_ip:$remote_path/"
         else
             log_info "Syncing file (rsync): $local_path -> $vm_name:$remote_path"
             rsync -avz --progress \
+                "$RSYNC_PATH" \
                 -e "ssh -i $SSH_KEY -o StrictHostKeyChecking=no" \
                 "$local_path" "$REMOTE_USER@$vm_ip:$remote_path"
         fi

--- a/autobot-slm-backend/ansible/playbooks/fix-node-ownership.yml
+++ b/autobot-slm-backend/ansible/playbooks/fix-node-ownership.yml
@@ -1,0 +1,31 @@
+---
+# Fix file ownership across all fleet nodes
+# Usage: ansible-playbook -i inventory/slm-nodes.yml playbooks/fix-node-ownership.yml
+# Limit to specific node: --limit npu-worker
+#
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+
+- name: "Fix AutoBot file ownership on all nodes"
+  hosts: infrastructure:!slm_server
+  gather_facts: false
+  serial: 3
+
+  tasks:
+    - name: "Fix ownership on /opt/autobot"
+      file:
+        path: /opt/autobot
+        owner: autobot
+        group: autobot
+        recurse: true
+      become: true
+
+    - name: "Verify ownership"
+      command: stat -c '%U:%G' /opt/autobot
+      register: owner_check
+      changed_when: false
+
+    - name: "Report"
+      debug:
+        msg: "{{ inventory_hostname }}: /opt/autobot owned by {{ owner_check.stdout }}"


### PR DESCRIPTION
## Summary
- Add `fix-node-ownership.yml` utility playbook to fix `/opt/autobot` ownership across all fleet nodes
- Update `sync-to-vm.sh` to use `--rsync-path='sudo rsync'` on remote, preventing deploy failures when files are root-owned
- Root cause: `update-all-nodes.yml` uses `unarchive` with `become: true`, leaving files owned by root; subsequent rsync deploys via `sync-to-vm.sh` then fail with permission errors

Closes #2296

## Test plan
- [ ] Run playbook against .22: `ansible-playbook -i inventory/slm-nodes.yml playbooks/fix-node-ownership.yml --limit npu-worker`
- [ ] Verify ownership: `ssh autobot@172.16.168.22 stat -c '%U:%G' /opt/autobot/autobot-npu-worker`
- [ ] Confirm rsync deploy works after fix: `./sync-to-vm.sh npu-worker autobot-npu-worker /opt/autobot/autobot-npu-worker`