### PR TITLE
fix(security): require VNC password auth in all x11vnc launches (#1969)

### DIFF
--- a/autobot-backend/desktop_streaming_manager.py
+++ b/autobot-backend/desktop_streaming_manager.py
@@ -543,6 +543,8 @@ class VNCServerManager:
             f":{display_num}",
             "-rfbport",
             str(vnc_port),
+            "-rfbauth",
+            "/home/autobot/.vnc/x11vnc.passwd",
             "-shared",
             "-forever",
             "-noxdamage",

--- a/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-vnc.yml
+++ b/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-vnc.yml
@@ -49,7 +49,7 @@ services:
         echo 'priority=100' >> /etc/supervisor/conf.d/autobot.conf
         echo '' >> /etc/supervisor/conf.d/autobot.conf
         echo '[program:x11vnc]' >> /etc/supervisor/conf.d/autobot.conf
-        echo 'command=/usr/bin/x11vnc -display :99 -nopw -listen 0.0.0.0 -xkb -ncache 10 -forever -shared -rfbport 5901' >> /etc/supervisor/conf.d/autobot.conf
+        echo 'command=/usr/bin/x11vnc -display :99 -rfbauth /home/autobot/.vnc/x11vnc.passwd -listen localhost -xkb -ncache 10 -forever -shared -rfbport 5901' >> /etc/supervisor/conf.d/autobot.conf
         echo 'autostart=true' >> /etc/supervisor/conf.d/autobot.conf
         echo 'autorestart=true' >> /etc/supervisor/conf.d/autobot.conf
         echo 'priority=200' >> /etc/supervisor/conf.d/autobot.conf

--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -707,7 +707,7 @@
           [Service]
           Type=forking
           User=autobot-service
-          ExecStart=/usr/bin/x11vnc -display :99 -nopw -listen localhost -xkb -ncache 10 -ncache_cr -rfbport 5900 -bg
+          ExecStart=/usr/bin/x11vnc -display :99 -rfbauth /home/autobot/.vnc/x11vnc.passwd -listen localhost -xkb -ncache 10 -ncache_cr -rfbport 5900 -bg
 
           [Install]
           WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Replace `-nopw` with `-rfbauth /home/autobot/.vnc/x11vnc.passwd` in 3 locations:
  - `docker-compose.playwright-vnc.yml` — also changed `0.0.0.0` to `localhost`
  - `deploy-native-services.yml` — systemd unit ExecStart
  - `desktop_streaming_manager.py` — Python VNC command builder
- Ensures all x11vnc instances require password authentication

Closes #1969

## Prerequisites
VNC password file must exist on target hosts:
```bash
mkdir -p /home/autobot/.vnc
x11vnc -storepasswd /home/autobot/.vnc/x11vnc.passwd
chown autobot:autobot /home/autobot/.vnc/x11vnc.passwd
chmod 600 /home/autobot/.vnc/x11vnc.passwd
```

## Test plan
- [ ] Docker compose: `docker compose -f docker-compose.playwright-vnc.yml config` validates
- [ ] Ansible: YAML validates
- [ ] Python: AST parse passes
- [ ] No remaining `-nopw` flags in codebase
- [ ] VNC connection requires password after deployment