### PR TITLE
fix(agents): normalise task_type in clear_strategy (#2325)

### DIFF
--- a/autobot-backend/agents/task_pattern_learner.py
+++ b/autobot-backend/agents/task_pattern_learner.py
@@ -222,7 +222,8 @@ class TaskPatternLearner:
         return None
 
     async def clear_strategy(self, task_type: str) -> None:
-        """Clear the learned strategy for a task type."""
+        """Clear the learned strategy for a task type (#2325)."""
+        task_type = self.normalize_task_type(task_type)
         try:
             redis = await self._get_redis()
             key = REDIS_PATTERNS_KEY.format(task_type=task_type)

--- a/autobot-backend/agents/task_pattern_learner_test.py
+++ b/autobot-backend/agents/task_pattern_learner_test.py
@@ -143,6 +143,24 @@ class TestTaskPatternLearner:
         assert "code_gen" in types
         assert "analysis" in types
 
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("Code-Gen", "code_gen"),
+            ("  DATA ANALYSIS ", "data_analysis"),
+            ("code_gen", "code_gen"),
+        ],
+    )
+    def test_normalize_task_type(self, learner, raw, expected):
+        assert learner.normalize_task_type(raw) == expected
+
+    @pytest.mark.asyncio
+    async def test_clear_strategy_normalizes_task_type(self, learner):
+        mock_redis = AsyncMock()
+        learner._redis = mock_redis
+        await learner.clear_strategy("Code-Gen")
+        mock_redis.delete.assert_awaited_once_with("task:patterns:code_gen")
+
     def test_build_synthesis_prompt_includes_task_type(self, learner, sample_outcomes):
         best = sample_outcomes[2]
         prompt = learner._build_synthesis_prompt("code_gen", sample_outcomes, best)


### PR DESCRIPTION
## Summary
- Added `normalize_task_type()` call at the start of `clear_strategy()`
- Without this, "Code-Gen" would attempt to delete `task:patterns:Code-Gen` but the actual key is `task:patterns:code_gen`
- Added parametrised unit test for `normalize_task_type`
- Added integration test verifying `clear_strategy("Code-Gen")` deletes the correct key

Closes #2325