### PR TITLE
fix(security): make HMAC API key secret configurable (#2160)

### DIFF
--- a/autobot-slm-backend/config.py
+++ b/autobot-slm-backend/config.py
@@ -103,6 +103,13 @@ class Settings(BaseSettings):
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24  # 24 hours
 
+    # HMAC signing key for API key hashing (#2160).
+    # Default preserves backward compatibility with existing hashed keys.
+    # Override in production via SLM_HMAC_API_KEY_SECRET env var.
+    hmac_api_key_secret: str = os.getenv(
+        "SLM_HMAC_API_KEY_SECRET", "autobot-api-key-v1"
+    )
+
     # Encryption for sensitive data (credentials, etc.)
     encryption_key: str = os.getenv("SLM_ENCRYPTION_KEY", "")
 

--- a/autobot-slm-backend/user_management/services/api_key_service.py
+++ b/autobot-slm-backend/user_management/services/api_key_service.py
@@ -15,6 +15,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Optional
 
+from config import settings
 from sqlalchemy import select
 from user_management.models.api_key import APIKey
 from user_management.services.base_service import BaseService
@@ -144,13 +145,13 @@ class APIKeyService(BaseService):
 
     @staticmethod
     def _hash_key(key: str) -> str:
-        """Hash an API key using HMAC-SHA256 (#1721, #2083).
+        """Hash an API key using HMAC-SHA256 (#1721, #2083, #2160).
 
-        Uses a fixed application-level key so that hashes remain
-        deterministic for lookup while being stronger than bare SHA-256.
+        The signing key is read from SLM_HMAC_API_KEY_SECRET (default:
+        "autobot-api-key-v1" for backward compatibility with existing hashes).
         """
         return hmac.new(
-            key=b"autobot-api-key-v1",
+            key=settings.hmac_api_key_secret.encode("utf-8"),
             msg=key.encode("utf-8"),
             digestmod=hashlib.sha256,
         ).hexdigest()


### PR DESCRIPTION
## Summary

- Removes the hardcoded `b"autobot-api-key-v1"` HMAC signing key from `api_key_service.py`
- Adds `hmac_api_key_secret` to the SLM `Settings` class, readable from `SLM_HMAC_API_KEY_SECRET` env var
- Default value remains `"autobot-api-key-v1"` — all existing hashed keys in the database continue to work without any migration

## Changed files

- `autobot-slm-backend/config.py` — new `hmac_api_key_secret` field in `Settings`
- `autobot-slm-backend/user_management/services/api_key_service.py` — `_hash_key` reads from `settings.hmac_api_key_secret` instead of the literal bytes

## Test plan

- [ ] Deploy to SLM node; existing API keys validate without change (backward-compatible default)
- [ ] Set `SLM_HMAC_API_KEY_SECRET=<new-secret>` and confirm newly created keys hash with the new secret
- [ ] Confirm `bandit` / pre-commit pass (they do — see CI)

Closes #2160

🤖 Generated with [Claude Code](https://claude.com/claude-code)