### PR TITLE
fix(shared): re-raise HTTPException in with_error_handling decorator

### DIFF
--- a/autobot-backend/utils/error_boundaries/decorators.py
+++ b/autobot-backend/utils/error_boundaries/decorators.py
@@ -15,6 +15,7 @@ import time
 from typing import Callable
 
 from constants.threshold_constants import RetryConfig
+from fastapi import HTTPException
 
 from .boundary_manager import get_error_boundary_manager
 from .types import APIErrorResponse, ErrorCategory, ErrorContext, RecoveryStrategy
@@ -278,14 +279,9 @@ def _raise_or_return_error(error_response: APIErrorResponse):
         error_response.trace_id,
         error_response.code,
     )
-    try:
-        from fastapi import HTTPException
-
-        raise HTTPException(
-            status_code=error_response.status_code, detail=error_response.to_dict()
-        )
-    except ImportError:
-        return error_response.to_dict()
+    raise HTTPException(
+        status_code=error_response.status_code, detail=error_response.to_dict()
+    )
 
 
 def with_error_handling(
@@ -325,6 +321,8 @@ def with_error_handling(
                 """Async wrapper that catches exceptions and converts to API errors."""
                 try:
                     return await func(*args, **kwargs)
+                except HTTPException:
+                    raise  # Preserve intentional HTTP status codes
                 except Exception as e:
                     error_response = _create_api_error_response(
                         e, category, func_operation, error_code_prefix
@@ -339,6 +337,8 @@ def with_error_handling(
                 """Sync wrapper that catches exceptions and converts to API errors."""
                 try:
                     return func(*args, **kwargs)
+                except HTTPException:
+                    raise  # Preserve intentional HTTP status codes
                 except Exception as e:
                     error_response = _create_api_error_response(
                         e, category, func_operation, error_code_prefix


### PR DESCRIPTION
## Summary

- `@with_error_handling` was catching `HTTPException` inside the generic `except Exception` block, converting intentional HTTP status codes (503, 422, 401) into 500 responses
- Added `except HTTPException: raise` before `except Exception` in both the async and sync wrappers so intentional HTTP errors propagate unchanged
- Promoted the `from fastapi import HTTPException` import to module level and removed the now-dead `ImportError` fallback in `_raise_or_return_error`

## Test plan

- [ ] Verify a decorated endpoint that raises `HTTPException(status_code=422)` now returns 422 (not 500)
- [ ] Verify a decorated endpoint that raises `HTTPException(status_code=503)` now returns 503
- [ ] Verify a decorated endpoint that raises `HTTPException(status_code=401)` now returns 401
- [ ] Verify a decorated endpoint that raises a plain `Exception` still returns the mapped error code via `_create_api_error_response`

Closes #2327

🤖 Generated with [Claude Code](https://claude.com/claude-code)