### PR TITLE
fix(security): validate X-Forwarded-For against trusted proxies (#2252)

### DIFF
--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -33,6 +33,7 @@ from autobot_memory_graph import AutoBotMemoryGraph
 from cryptography.fernet import Fernet
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
+from middleware.proxy_utils import get_client_ip
 from pydantic import BaseModel, Field, field_validator
 from type_defs.common import Metadata
 
@@ -628,12 +629,12 @@ secrets_manager = SecretsManager()
 
 
 def get_client_id(request: Request) -> str:
-    """Extract client identifier for rate limiting"""
-    # Use forwarded header if behind proxy, otherwise client host
-    forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+    """Extract client identifier for rate limiting.
+
+    Only trusts X-Forwarded-For when the direct TCP peer is a known
+    reverse proxy (Issue #2252).  Delegates to get_client_ip().
+    """
+    return get_client_ip(request) or "unknown"
 
 
 def check_rate_limit(request: Request) -> None:

--- a/autobot-backend/middleware/audit_middleware.py
+++ b/autobot-backend/middleware/audit_middleware.py
@@ -36,6 +36,7 @@ import time
 from typing import Any, Callable, Optional
 
 from fastapi import Request
+from middleware.proxy_utils import get_client_ip
 from services.audit_logger import AuditResult, get_audit_logger
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
@@ -263,18 +264,12 @@ class AuditMiddleware(BaseHTTPMiddleware):
         return request.headers.get("X-Session-ID") or request.headers.get("X-Session")
 
     def _get_client_ip(self, request: Request) -> Optional[str]:
-        """Extract client IP from request"""
-        # Check for proxy headers first
-        forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            # Get first IP (client)
-            return forwarded.split(",")[0].strip()
+        """Extract client IP from request.
 
-        # Get from client directly
-        if request.client:
-            return request.client.host
-
-        return None
+        Delegates to get_client_ip() which only trusts X-Forwarded-For
+        when the direct TCP peer is a known reverse proxy (Issue #2252).
+        """
+        return get_client_ip(request)
 
     async def _log_audit(
         self,
@@ -639,13 +634,12 @@ def _extract_session(request: Request) -> Optional[str]:
 
 
 def _extract_ip(request: Request) -> Optional[str]:
-    """Extract client IP from request"""
-    forwarded = request.headers.get("X-Forwarded-For")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    if request.client:
-        return request.client.host
-    return None
+    """Extract client IP from request.
+
+    Only trusts X-Forwarded-For when TCP peer is a known reverse proxy
+    (Issue #2252).  Delegates to the shared get_client_ip() helper.
+    """
+    return get_client_ip(request)
 
 
 async def _log_audit_async(

--- a/autobot-backend/middleware/proxy_utils.py
+++ b/autobot-backend/middleware/proxy_utils.py
@@ -1,0 +1,97 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Trusted-proxy utilities for IP extraction (Issue #2252).
+
+Provides get_client_ip() — the canonical function for extracting the real
+client IP from a FastAPI/Starlette request.  X-Forwarded-For is only
+trusted when the direct TCP peer is a known reverse proxy; an attacker
+connecting directly cannot spoof their IP via that header.
+
+Configuration
+-------------
+Set AUTOBOT_TRUSTED_PROXIES (comma-separated) to override the default
+list.  Defaults include localhost addresses and the nginx frontend VM
+(172.16.168.21).  The comment ``# noqa: ssot-proxy`` suppresses the
+hardcoding pre-commit check for the fallback string only.
+
+Usage
+-----
+    from middleware.proxy_utils import get_client_ip
+
+    ip = get_client_ip(request)           # returns str | None
+"""
+
+import ipaddress
+import logging
+import os
+from typing import Optional
+
+from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Trusted-proxy list — read once at import time.
+# Override via AUTOBOT_TRUSTED_PROXIES env var (comma-separated IPs).
+# Defaults: localhost (IPv4 + IPv6) and the nginx frontend VM (.21).
+# ---------------------------------------------------------------------------
+_RAW_TRUSTED = os.getenv(
+    "AUTOBOT_TRUSTED_PROXIES",
+    "127.0.0.1,::1,172.16.168.21",  # noqa: ssot-proxy
+)
+_TRUSTED_PROXIES: frozenset = frozenset(
+    ip.strip() for ip in _RAW_TRUSTED.split(",") if ip.strip()
+)
+
+
+def _normalize_ip(ip_str: str) -> str:
+    """Normalize an IP string, mapping ::ffff:x.x.x.x to x.x.x.x.
+
+    This handles dual-stack sockets that present IPv4 addresses as
+    IPv6-mapped addresses (e.g. ``::ffff:127.0.0.1``).
+
+    Args:
+        ip_str: Raw IP string from socket or header.
+
+    Returns:
+        Canonical IP string.
+    """
+    try:
+        addr = ipaddress.ip_address(ip_str)
+        if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+            return str(addr.ipv4_mapped)
+        return str(addr)
+    except ValueError:
+        return ip_str
+
+
+def get_client_ip(request: Request) -> Optional[str]:
+    """Extract the real client IP from a Starlette/FastAPI request.
+
+    X-Forwarded-For is only honoured when the direct TCP connection
+    originates from a trusted reverse proxy (Issue #2252).  If the
+    connecting peer is not in AUTOBOT_TRUSTED_PROXIES the header is
+    ignored and the raw peer IP is returned, preventing IP spoofing by
+    clients that connect directly.
+
+    Args:
+        request: Incoming Starlette request.
+
+    Returns:
+        Client IP string, or ``None`` when no connection info is available.
+    """
+    peer_ip = request.client.host if request.client else None
+    if peer_ip is None:
+        return None
+
+    forwarded = request.headers.get("X-Forwarded-For", "")
+    if forwarded:
+        normalized_peer = _normalize_ip(peer_ip)
+        if normalized_peer in _TRUSTED_PROXIES:
+            candidate = forwarded.split(",")[0].strip()
+            if candidate:
+                return candidate
+
+    return peer_ip

--- a/autobot-backend/middleware/tracing_middleware.py
+++ b/autobot-backend/middleware/tracing_middleware.py
@@ -21,6 +21,7 @@ import re
 import time
 from typing import Callable, Optional
 
+from middleware.proxy_utils import get_client_ip
 from opentelemetry.trace import SpanKind, Status, StatusCode
 from services.tracing_service import get_tracing_service
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -176,7 +177,11 @@ class TracingMiddleware(BaseHTTPMiddleware):
 
     def _get_client_ip(self, request: Request) -> Optional[str]:
         """
-        Extract client IP from request headers.
+        Extract client IP from request.
+
+        Only trusts X-Forwarded-For when the direct TCP peer is a known
+        reverse proxy (Issue #2252).  Delegates to the shared
+        get_client_ip() helper from middleware.proxy_utils.
 
         Args:
             request: The request object
@@ -184,22 +189,7 @@ class TracingMiddleware(BaseHTTPMiddleware):
         Returns:
             Client IP address or None
         """
-        # Check forwarded headers first (for proxy scenarios)
-        forwarded = request.headers.get("x-forwarded-for")
-        if forwarded:
-            # Take the first IP in the chain
-            return forwarded.split(",")[0].strip()
-
-        # Check real IP header
-        real_ip = request.headers.get("x-real-ip")
-        if real_ip:
-            return real_ip
-
-        # Fall back to direct client connection
-        if request.client:
-            return request.client.host
-
-        return None
+        return get_client_ip(request)
 
     def _build_span_attributes(self, request: Request, path: str) -> dict:
         """


### PR DESCRIPTION
## Summary

- Add `autobot-backend/middleware/proxy_utils.py` with a canonical `get_client_ip()` helper that only trusts `X-Forwarded-For` when the direct TCP peer is a known reverse proxy (configurable via `AUTOBOT_TRUSTED_PROXIES` env var, defaults to `127.0.0.1`, `::1`, and `172.16.168.21`)
- Replace blind `X-Forwarded-For` trust in `AuditMiddleware._get_client_ip` and the `_extract_ip()` decorator helper in `audit_middleware.py`
- Replace blind `X-Forwarded-For` trust in `TracingMiddleware._get_client_ip` in `tracing_middleware.py`
- Fix the same class of vulnerability in `api/secrets.py` `get_client_id()` (rate-limit bypass via spoofed IP — discovered during review of #2252)

Follows the same pattern established for the SLM backend in #2239 (`autobot-slm-backend/api/auth.py` + `config.py`).

## Test plan

- [ ] Verify `get_client_ip()` returns `request.client.host` when peer is not in `TRUSTED_PROXIES`, ignoring any `X-Forwarded-For` header
- [ ] Verify `get_client_ip()` returns the first value from `X-Forwarded-For` when peer IP is `127.0.0.1`
- [ ] Verify `_normalize_ip()` correctly maps `::ffff:127.0.0.1` to `127.0.0.1` so localhost on dual-stack sockets is trusted
- [ ] Verify `AUTOBOT_TRUSTED_PROXIES` env var overrides the default list
- [ ] Confirm audit log entries in production use real peer IP when request arrives directly (not via nginx)
- [ ] Confirm tracing spans record correct `http.client_ip` attribute
- [ ] Confirm secrets rate-limiter uses non-spoofable client ID

Closes #2252