### PR TITLE
fix(analytics): expand INTERNAL_MODULE_PREFIXES for call graph (#2360)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -12,7 +12,29 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Performance optimization: O(1) lookup for internal modules (Issue #326)
-INTERNAL_MODULE_PREFIXES = {"src", "backend", "autobot"}
+INTERNAL_MODULE_PREFIXES = {
+    "a2a",
+    "agents",
+    "api",
+    "autobot",
+    "autobot_shared",
+    "backend",
+    "cache",
+    "chat_workflow",
+    "config",
+    "constants",
+    "database",
+    "extensions",
+    "initialization",
+    "knowledge",
+    "models",
+    "orchestration",
+    "routers",
+    "security",
+    "services",
+    "src",
+    "utils",
+}
 
 # In-memory storage fallback
 _in_memory_storage = {}


### PR DESCRIPTION
## Summary
Expand `INTERNAL_MODULE_PREFIXES` from 3 entries (`src`, `backend`, `autobot`) to 21 entries covering all project top-level packages (`api`, `services`, `utils`, `config`, `knowledge`, `agents`, etc.).

Fixes `test_internal_module` assertion where `api.routes` was incorrectly classified as external.

## Test plan
- [x] `TestIsExternalModule` — 4/4 pass (including previously failing `test_internal_module`)
- [x] Pre-commit passes

Closes #2360