### PR TITLE
fix(analytics): update stale autobot-vue path references (#2016)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -647,7 +647,7 @@ class FrontendAPICallScanner:
 
     def __init__(self, project_root: Optional[Path] = None):
         self.project_root = project_root or get_project_root()
-        self.frontend_path = self.project_root / "autobot-vue" / "src"
+        self.frontend_path = self.project_root / "autobot-frontend" / "src"
 
     def scan_all_calls(self) -> List[FrontendAPICallItem]:
         """

--- a/autobot-backend/code_analysis/auto-tools/accessibility_enhancer.py
+++ b/autobot-backend/code_analysis/auto-tools/accessibility_enhancer.py
@@ -22,7 +22,7 @@ from typing import List, Optional, Tuple
 # Override with AUTOBOT_VUE_ROOT env var. Issue #1183.
 _DEFAULT_VUE_ROOT = os.getenv(
     "AUTOBOT_VUE_ROOT",
-    str(Path(__file__).resolve().parent.parent.parent / "autobot-vue"),
+    str(Path(__file__).resolve().parent.parent.parent / "autobot-frontend"),
 )
 
 # Static WCAG/implementation section for the markdown report. Issue #1183.
@@ -71,7 +71,7 @@ All modified files have been backed up to: `.accessibility-fix-backups/`
 
 To restore original files:
 ```bash
-cp .accessibility-fix-backups/ComponentName.vue.YYYYMMDD_HHMMSS.backup autobot-vue/src/components/ComponentName.vue
+cp .accessibility-fix-backups/ComponentName.vue.YYYYMMDD_HHMMSS.backup autobot-frontend/src/components/ComponentName.vue
 python3 code-analysis-suite/auto-tools/restore_accessibility_backups.py
 ```
 

--- a/autobot-backend/code_analysis/auto-tools/logging_standardizer.py
+++ b/autobot-backend/code_analysis/auto-tools/logging_standardizer.py
@@ -647,7 +647,7 @@ if __name__ == "__main__":
         # Default to AutoBot frontend directory - use project-relative path
         # This script is in tools/code-analysis-suite/auto-tools/, so project root is 3 levels up
         project_root = str(Path(__file__).parent.parent.parent.parent)
-        target_dir = "autobot-vue/src"
+        target_dir = "autobot-frontend/src"
 
         print("🚀 AutoBot Development Logging Conversion Agent")  # noqa: print
         print("=" * 50)  # noqa: print

--- a/autobot-backend/code_analysis/auto-tools/performance_optimizer.py
+++ b/autobot-backend/code_analysis/auto-tools/performance_optimizer.py
@@ -497,7 +497,7 @@ if __name__ == "__main__":
         project_root = os.environ.get(
             "AUTOBOT_BASE_DIR", "/opt/autobot"
         )  # noqa: ssot-path
-        target_dir = "autobot-vue/src"
+        target_dir = "autobot-frontend/src"
 
         print("🚀 AutoBot Console.log Performance Fix Agent")  # noqa: print
         print("=" * 50)  # noqa: print

--- a/autobot-backend/code_analysis/auto-tools/results/vue_analysis_results.json
+++ b/autobot-backend/code_analysis/auto-tools/results/vue_analysis_results.json
@@ -10,7 +10,7 @@
   },
   "files": [
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/App.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/App.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -25,7 +25,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/ChatInterface.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/ChatInterface.vue",
       "vfor_index_keys": [
         {
           "line": 125,
@@ -57,7 +57,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/PhaseStatusIndicator.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/PhaseStatusIndicator.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -93,7 +93,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/SettingsPanel.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/SettingsPanel.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -108,7 +108,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/KnowledgePersistenceDialog.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/KnowledgePersistenceDialog.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -137,7 +137,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/TerminalSidebar.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/TerminalSidebar.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -173,14 +173,14 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/WorkflowNotifications.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/WorkflowNotifications.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/SystemMonitor.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/SystemMonitor.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -223,28 +223,28 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/VoiceInterface.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/VoiceInterface.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/ElevationDialog.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/ElevationDialog.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/WorkflowApproval.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/WorkflowApproval.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/HistoryView.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/HistoryView.vue",
       "vfor_index_keys": [
         {
           "line": 11,
@@ -260,7 +260,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/AdvancedStepConfirmationModal.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/AdvancedStepConfirmationModal.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -296,14 +296,14 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/TheWelcome.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/TheWelcome.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/KnowledgeManager.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/KnowledgeManager.vue",
       "vfor_index_keys": [
         {
           "line": 32,
@@ -327,7 +327,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/WorkflowProgressWidget.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/WorkflowProgressWidget.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -370,7 +370,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/FileBrowser.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/FileBrowser.vue",
       "vfor_index_keys": [
         {
           "line": 70,
@@ -386,14 +386,14 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/WelcomeItem.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/WelcomeItem.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/TerminalWindow.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/TerminalWindow.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -422,7 +422,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/base/BaseButton.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/base/BaseButton.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -437,7 +437,7 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/base/BasePanel.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/base/BasePanel.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [
@@ -459,49 +459,49 @@
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/icons/IconSupport.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/icons/IconSupport.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/icons/IconEcosystem.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/icons/IconEcosystem.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/icons/IconCommunity.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/icons/IconCommunity.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/icons/IconDocumentation.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/icons/IconDocumentation.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/components/icons/IconTooling.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/icons/IconTooling.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/views/AboutView.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/views/AboutView.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],
       "accessibility_issues": []
     },
     {
-      "file": "/home/kali/Desktop/AutoBot/autobot-vue/src/views/HomeView.vue",
+      "file": "/home/kali/Desktop/AutoBot/autobot-frontend/src/views/HomeView.vue",
       "vfor_index_keys": [],
       "missing_event_cleanup": [],
       "performance_issues": [],

--- a/autobot-backend/code_analysis/auto-tools/results/vue_quality_results.json
+++ b/autobot-backend/code_analysis/auto-tools/results/vue_quality_results.json
@@ -3,10 +3,10 @@
   "successful_fixes": 6,
   "failed_fixes": 0,
   "files_modified": [
-    "/home/kali/Desktop/AutoBot/autobot-vue/src/components/HistoryView.vue",
-    "/home/kali/Desktop/AutoBot/autobot-vue/src/components/FileBrowser.vue",
-    "/home/kali/Desktop/AutoBot/autobot-vue/src/components/KnowledgeManager.vue",
-    "/home/kali/Desktop/AutoBot/autobot-vue/src/components/ChatInterface.vue"
+    "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/HistoryView.vue",
+    "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/FileBrowser.vue",
+    "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/KnowledgeManager.vue",
+    "/home/kali/Desktop/AutoBot/autobot-frontend/src/components/ChatInterface.vue"
   ],
   "fixes_by_type": {
     "vfor_key_fix": 6,

--- a/autobot-backend/code_analysis/auto-tools/vue_quality_tool.py
+++ b/autobot-backend/code_analysis/auto-tools/vue_quality_tool.py
@@ -32,7 +32,7 @@ class VueSpecificFixAgent:
         self.project_root = Path(
             project_root or os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot")
         )
-        self.vue_dir = self.project_root / "autobot-vue" / "src"
+        self.vue_dir = self.project_root / "autobot-frontend" / "src"
         self.fixes_applied = []
         self.errors = []
 

--- a/autobot-backend/code_analysis/scripts/analyze_env_vars.py
+++ b/autobot-backend/code_analysis/scripts/analyze_env_vars.py
@@ -76,8 +76,8 @@ async def analyze_environment_variables():
         patterns=[
             "src/**/*.py",
             "backend/**/*.py",
-            "autobot-vue/src/**/*.js",
-            "autobot-vue/src/**/*.vue",
+            "autobot-frontend/src/**/*.js",
+            "autobot-frontend/src/**/*.vue",
         ],
     )
     _print_analysis_summary(results)

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -885,7 +885,7 @@ async def main():
 
     results = await analyzer.analyze_ownership(
         root_path=".",
-        patterns=["src/**/*.py", "backend/**/*.py", "autobot-vue/src/**/*.vue"],
+        patterns=["src/**/*.py", "backend/**/*.py", "autobot-frontend/src/**/*.vue"],
     )
 
     print("\n=== Code Ownership Analysis Results ===")  # noqa: print

--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -339,7 +339,7 @@ class CrossLanguagePatternDetector:
 
         backend_dir = self.project_root / "backend"
         src_dir = self.project_root / "src"
-        frontend_dir = self.project_root / "autobot-vue" / "src"
+        frontend_dir = self.project_root / "autobot-frontend" / "src"
 
         # Collect Python files
         for search_dir in [backend_dir, src_dir]:

--- a/autobot-backend/project_state_manager.py
+++ b/autobot-backend/project_state_manager.py
@@ -220,7 +220,7 @@ class ProjectStateManager:
                 "web_interface",
                 "Vue.js frontend application",
                 "file_exists",
-                "autobot-vue/src/App.vue",
+                "autobot-frontend/src/App.vue",
             ),
         ]
 
@@ -311,7 +311,7 @@ class ProjectStateManager:
                 "session_takeover",
                 "Human-in-the-loop control",
                 "file_exists",
-                "autobot-vue/src/components/AdvancedStepConfirmationModal.vue",
+                "autobot-frontend/src/components/AdvancedStepConfirmationModal.vue",
             ),
             PhaseCapability(
                 "chat_knowledge",
@@ -340,7 +340,7 @@ class ProjectStateManager:
                 "visual_indicators",
                 "Phase status in Web UI",
                 "file_exists",
-                "autobot-vue/src/components/PhaseStatusIndicator.vue",
+                "autobot-frontend/src/components/PhaseStatusIndicator.vue",
             ),
             PhaseCapability(
                 "automated_progression",

--- a/autobot-backend/services/codebase_indexing_service.py
+++ b/autobot-backend/services/codebase_indexing_service.py
@@ -582,7 +582,7 @@ class CodebaseIndexingService:
         """
         return {
             "backend": ["backend/", "src/", "api/", "services/", "models/", "utils/"],
-            "frontend": ["autobot-vue/", "frontend/", "static/", "public/"],
+            "frontend": ["autobot-frontend/", "frontend/", "static/", "public/"],
             "docs": ["docs/", "documentation/", "README", "CHANGELOG", ".md"],
             "config": ["config/", "settings/", ".env", ".yaml", ".yml", ".json"],
             "scripts": ["scripts/", "bin/", ".sh", ".bash"],


### PR DESCRIPTION
## Summary
Replace `autobot-vue` → `autobot-frontend` across 12 files that still referenced the old directory name. Fixes silent empty results in:
- Cross-language analysis
- API endpoint scanning  
- Frontend ownership analysis
- Vue quality/accessibility tooling

## Test plan
- [ ] Cross-language analysis detects frontend files
- [ ] API endpoint scanner finds Vue routes

Closes #2016