### PR TITLE
fix(frontend): add source_id to Redis health endpoint (#2374)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
@@ -28,7 +28,7 @@ import type {
 const logger = createLogger('useCodeIntelScores')
 
 export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
-  const { rootPath } = deps
+  const { rootPath, withSourceId } = deps
 
   // --- Security score (useTaskLoader) ---
 
@@ -168,8 +168,11 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     redisHealthError.value = ''
     try {
       const backendUrl = await appConfig.getServiceUrl('backend')
-      const response = await fetchWithAuth(
+      const url = withSourceId(
         `${backendUrl}/api/code-intelligence/redis/health-score?path=${encodeURIComponent(rootPath.value)}`,
+      )
+      const response = await fetchWithAuth(
+        url,
         {
           method: 'GET',
           headers: {


### PR DESCRIPTION
## Summary
Add `withSourceId()` to `loadRedisHealth` URL in `useCodeIntelScores.ts`, matching the pattern used by `loadSecurityScore` and `loadPerformanceScore`. Without this, Redis health requests don't include `source_id` and could return data for the wrong source.

## Test plan
- [ ] Redis health panel loads correctly with source selected
- [ ] URL includes `source_id` parameter in network tab

Closes #2374