### PR TITLE
fix(slm): add SELECT FOR UPDATE to fleet sync guard (#1937)

### DIFF
--- a/autobot-slm-backend/services/fleet_sync_guard.py
+++ b/autobot-slm-backend/services/fleet_sync_guard.py
@@ -30,7 +30,9 @@ async def assert_no_running_sync(db) -> None:
     Must be called while holding ``fleet_sync_lock`` to prevent TOCTOU races.
     """
     running_result = await db.execute(
-        select(FleetSyncJobModel).where(FleetSyncJobModel.status == "running")
+        select(FleetSyncJobModel)
+        .where(FleetSyncJobModel.status == "running")
+        .with_for_update()  # Row-level lock to prevent TOCTOU race (#1937)
     )
     if running_result.scalar_one_or_none():
         raise HTTPException(


### PR DESCRIPTION
## Summary
- Added `.with_for_update()` to the running-sync-job query in `assert_no_running_sync`
- Row-level lock prevents TOCTOU race when multiple workers check for running jobs simultaneously
- The existing `asyncio.Lock` guards in-process; this adds DB-level locking for multi-worker safety

Closes #1937