### PR TITLE
fix(security): scope redact_secrets to workflow owner's secrets only

### DIFF
--- a/autobot-backend/services/secrets_service.py
+++ b/autobot-backend/services/secrets_service.py
@@ -171,7 +171,10 @@ class SecretsService:
         return secret
 
     def _row_to_secret_list_item(self, row: tuple) -> Dict:
-        """Convert a database row to a secret list item (without encrypted value)"""
+        """Convert a database row to a secret list item (without encrypted value).
+
+        Row order must match _build_list_secrets_query SELECT columns.
+        """
         return {
             "id": row[0],
             "name": row[1],
@@ -183,6 +186,7 @@ class SecretsService:
             "updated_at": row[7],
             "expires_at": row[8],
             "access_count": row[9],
+            "created_by": row[10],
         }
 
     def _is_secret_expired(self, expires_at: Optional[str]) -> bool:
@@ -372,7 +376,7 @@ class SecretsService:
         """Build query and params for list_secrets."""
         query = """
             SELECT id, name, description, secret_type, scope, chat_id,
-                   created_at, updated_at, expires_at, access_count
+                   created_at, updated_at, expires_at, access_count, created_by
             FROM secrets
             WHERE is_active = 1
         """

--- a/autobot-backend/services/workflow_automation/executor.py
+++ b/autobot-backend/services/workflow_automation/executor.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Callable, Dict, FrozenSet, Optional
 
 from constants.threshold_constants import TimingConstants
 from monitoring.prometheus_metrics import get_metrics_manager
@@ -40,33 +40,55 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _resolve_command_secrets(command: str, owner_id: str) -> str:
+def _resolve_command_secrets(command: str, owner_id: str) -> tuple[str, FrozenSet[str]]:
     """
     Replace ${secrets.NAME} tokens in *command* with their plaintext values.
 
-    Returns the original string unchanged if no tokens are present or if the
-    WorkflowSecretService is unavailable.
+    Returns the original string unchanged (with an empty resolved-names set)
+    if no tokens are present or if the WorkflowSecretService is unavailable.
 
-    SECURITY: the returned string must NEVER be logged. (Issue #2153)
+    SECURITY: the resolved string must NEVER be logged. (Issue #2153)
+
+    Returns:
+        Tuple of (resolved_command, resolved_names).  Pass resolved_names to
+        _redact_result_secrets so only injected secrets are scanned. (#2321)
     """
     try:
         return get_workflow_secret_service().resolve_secrets(command, owner_id)
     except Exception as exc:  # pragma: no cover
         logger.error("Secret resolution failed for workflow command: %s", exc)
-        return command
+        return command, frozenset()
 
 
-def _redact_result_secrets(result: Metadata, owner_id: str) -> Metadata:
+def _redact_result_secrets(
+    result: Metadata,
+    owner_id: str,
+    resolved_names: FrozenSet[str],
+) -> Metadata:
     """
     Replace known secret values in execution result strings with ***.
 
-    Operates on the 'stdout' and 'stderr' fields only. (Issue #2153)
+    Operates on the 'stdout' and 'stderr' fields only.
+
+    Args:
+        result: Step execution result dict.
+        owner_id: Workflow owner — only their secrets are loaded.
+        resolved_names: Names resolved by _resolve_command_secrets for this
+            step.  Passed directly to redact_secrets() to avoid an O(n) full
+            owner-secrets scan on every step completion. (Issue #2321)
+
+    Issue #2153, #2321.
     """
+    if not resolved_names:
+        # Nothing was injected; nothing to redact.
+        return result
     try:
         svc = get_workflow_secret_service()
         for field in ("stdout", "stderr"):
             if isinstance(result.get(field), str):
-                result[field] = svc.redact_secrets(result[field], owner_id)
+                result[field] = svc.redact_secrets(
+                    result[field], owner_id, resolved_names=resolved_names
+                )
     except Exception as exc:  # pragma: no cover
         logger.error("Secret redaction failed for workflow result: %s", exc)
     return result
@@ -385,13 +407,17 @@ class WorkflowExecutor:
 
         try:
             # Issue #2153: Resolve ${secrets.NAME} tokens before execution.
+            # Issue #2321: Capture resolved_names so redaction only scans
+            # injected secrets — not all secrets for all users.
             owner_id = workflow.owner_id or workflow.session_id
-            resolved_command = _resolve_command_secrets(current_step.command, owner_id)
+            resolved_command, resolved_names = _resolve_command_secrets(
+                current_step.command, owner_id
+            )
 
             result = await self._execute_command(workflow.session_id, resolved_command)
 
             # Issue #2153: Redact any secret values that may appear in output.
-            result = _redact_result_secrets(result, owner_id)
+            result = _redact_result_secrets(result, owner_id, resolved_names)
 
             current_step.status = WorkflowStepStatus.COMPLETED
             current_step.execution_result = result

--- a/autobot-backend/services/workflow_secret_service.py
+++ b/autobot-backend/services/workflow_secret_service.py
@@ -14,7 +14,7 @@ Issue #2153 — Secret management for workflow credentials.
 import logging
 import re
 import threading
-from typing import Dict, List, Optional
+from typing import Dict, FrozenSet, List, Optional
 
 from services.secrets_service import SecretsService, get_secrets_service
 
@@ -121,6 +121,9 @@ class WorkflowSecretService:
         """
         Return secret metadata for the given owner (never includes values).
 
+        Only secrets whose ``created_by`` column matches *owner_id* are
+        returned — preventing cross-owner exposure.  (Issue #2321)
+
         Args:
             owner_id: Filter to secrets created by this user.
             workflow_id: If provided, only return secrets for that workflow.
@@ -128,16 +131,16 @@ class WorkflowSecretService:
         Returns:
             List of metadata dicts (name, id, secret_type, scope, created_at, …).
 
-        Issue #2153.
+        Issue #2153, #2321.
         """
         rows = self._svc.list_secrets(
             scope=WORKFLOW_SCOPE,
             chat_id=self._build_chat_id(workflow_id),
         )
-        # Filter by owner via created_by stored in metadata (SecretsService
-        # does not expose created_by in list results so we use it as a hint;
-        # access control is enforced at the API layer).
-        return rows
+        # Filter by owner_id using the created_by field that SecretsService
+        # returns in list results.  This is the authoritative ownership check
+        # at this layer — not a hint. (Issue #2321)
+        return [r for r in rows if r.get("created_by") == owner_id]
 
     def get_secret_value(self, name: str, owner_id: str) -> Optional[str]:
         """
@@ -233,14 +236,14 @@ class WorkflowSecretService:
         """Return all unique secret names referenced in text. Issue #2153."""
         return list(dict.fromkeys(_SECRET_REF_RE.findall(text)))
 
-    def resolve_secrets(self, text: str, owner_id: str) -> str:
+    def resolve_secrets(self, text: str, owner_id: str) -> tuple[str, FrozenSet[str]]:
         """
         Replace every ${secrets.NAME} token in *text* with its plaintext value.
 
         Tokens that reference an unknown or expired secret are left unchanged
         so that downstream execution fails visibly rather than silently.
 
-        SECURITY: the returned string contains live credential values — it must
+        SECURITY: the resolved string contains live credential values — it must
         NEVER be logged or stored.
 
         Args:
@@ -248,15 +251,18 @@ class WorkflowSecretService:
             owner_id: User on whose behalf resolution is performed.
 
         Returns:
-            Resolved string with credential values substituted in.
+            Tuple of (resolved_text, resolved_names) where resolved_names is
+            the frozenset of secret names that were successfully substituted.
+            Pass resolved_names to redact_secrets() to avoid a full-table scan.
 
-        Issue #2153.
+        Issue #2153, #2321.
         """
         names = self._collect_referenced_names(text)
         if not names:
-            return text
+            return text, frozenset()
 
         resolved = text
+        resolved_names = set()
         for name in names:
             value = self.get_secret_value(name, owner_id)
             if value is None:
@@ -268,32 +274,57 @@ class WorkflowSecretService:
                 )
                 continue
             resolved = resolved.replace(f"${{secrets.{name}}}", value)
+            resolved_names.add(name)
 
-        return resolved
+        return resolved, frozenset(resolved_names)
 
-    def redact_secrets(self, text: str, owner_id: str) -> str:
+    def redact_secrets(
+        self,
+        text: str,
+        owner_id: str,
+        resolved_names: Optional[FrozenSet[str]] = None,
+    ) -> str:
         """
         Replace resolved secret values in *text* with ***.
 
         Use this to sanitise command output or log lines that may contain
         credentials that were injected via resolve_secrets().
 
+        Only secrets that belong to *owner_id* are ever decrypted and compared.
+        When *resolved_names* is supplied (the set of names that were actually
+        substituted by resolve_secrets()), only those secrets are checked —
+        avoiding an O(n) full-table scan and cross-owner secret exposure.
+        If *resolved_names* is empty or None and the text contains no
+        ${secrets.NAME} tokens, the scan is skipped entirely.
+
         Args:
             text: Text that may contain live secret values.
-            owner_id: User context — used to look up the same secrets.
+            owner_id: User context — only secrets owned by this user are loaded.
+            resolved_names: Names resolved by resolve_secrets() for this step.
+                Passing this avoids loading all owner secrets on every call.
 
         Returns:
             Text with all known secret values replaced by ***.
 
-        Issue #2153.
+        Issue #2153, #2321.
         """
-        names = self._collect_referenced_names(text)
-        # Even if text no longer has tokens, scan for the actual values.
-        # We also scan without tokens by fetching all workflow secrets.
-        all_names = names or [row["name"] for row in self.list_secrets(owner_id)]
+        # Determine which names to scan.
+        if resolved_names is not None:
+            # Caller provided the exact set — use it; skip any full-table load.
+            names_to_check: List[str] = list(resolved_names)
+        else:
+            # Fall back: look for any tokens still present in the text, then
+            # load only this owner's secrets as a backstop.  The list_secrets
+            # call is now owner-scoped (Issue #2321).
+            names_to_check = self._collect_referenced_names(text)
+            if not names_to_check:
+                names_to_check = [row["name"] for row in self.list_secrets(owner_id)]
+
+        if not names_to_check:
+            return text
 
         redacted = text
-        for name in all_names:
+        for name in names_to_check:
             value = self.get_secret_value(name, owner_id)
             if value and value in redacted:
                 redacted = redacted.replace(value, REDACTED)


### PR DESCRIPTION
## Summary

- `redact_secrets()` previously called `list_secrets()` with no owner filter, decrypting all secrets for all users on every step completion.
- Fix adds `resolved_names` parameter to `redact_secrets()`: when the executor passes the set of names it injected, only those secrets are decrypted — no full-table scan, no cross-owner exposure.
- `resolve_secrets()` now returns `(resolved_text, FrozenSet[str])` so the executor threads the injected names forward without any extra storage.
- `list_secrets()` in `WorkflowSecretService` now filters rows by `created_by == owner_id` for the fallback path.
- `SecretsService._build_list_secrets_query` / `_row_to_secret_list_item` updated to select and expose `created_by`.
- `_redact_result_secrets()` skips the redaction pass entirely when no secrets were resolved for the step.

## Changed files

- `autobot-backend/services/workflow_secret_service.py`
- `autobot-backend/services/secrets_service.py`
- `autobot-backend/services/workflow_automation/executor.py`

## Test plan

- [ ] Verify `resolve_secrets()` returns correct `(str, frozenset)` tuple for commands with and without `${secrets.NAME}` tokens
- [ ] Verify `redact_secrets()` with `resolved_names=frozenset()` returns text unchanged without any DB query
- [ ] Verify `redact_secrets()` with `resolved_names={'MY_KEY'}` only decrypts that one secret
- [ ] Verify `list_secrets()` only returns rows whose `created_by` matches `owner_id`
- [ ] Confirm executor calls do not regress on the happy path (step with secrets resolves and redacts correctly)

Closes #2321

🤖 Generated with [Claude Code](https://claude.com/claude-code)