### PR TITLE
fix(frontend): add withSourceId to loadRedisHealth endpoint (#2374)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
@@ -28,7 +28,7 @@ import type {
 const logger = createLogger('useCodeIntelScores')
 
 export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
-  const { rootPath } = deps
+  const { rootPath, withSourceId } = deps
 
   // --- Security score (useTaskLoader) ---
 
@@ -169,7 +169,7 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     try {
       const backendUrl = await appConfig.getServiceUrl('backend')
       const response = await fetchWithAuth(
-        `${backendUrl}/api/code-intelligence/redis/health-score?path=${encodeURIComponent(rootPath.value)}`,
+        withSourceId(`${backendUrl}/api/code-intelligence/redis/health-score?path=${encodeURIComponent(rootPath.value)}`),
         {
           method: 'GET',
           headers: {


### PR DESCRIPTION
## Summary
- Destructure `withSourceId` from deps in `useCodeIntelScores`
- Wrap the Redis health-score URL with `withSourceId()` to include `source_id` parameter
- Matches the pattern used by all other score/findings endpoints

Closes #2374

## Test plan
- [x] Verified `withSourceId` is in `UseCodeIntelAnalysisDeps` interface
- [x] Matches pattern from `loadSecurityScore`, `loadPerformanceScore`, and `useSpecializedAnalysis`
- [ ] CI passes