### PR TITLE
fix(security): remove stack trace exposure from API responses (#2195)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -447,7 +447,7 @@ async def _get_status_for_config(cfg: ConnectorConfig) -> Dict[str, Any]:
         return {
             "connector_id": cfg.connector_id,
             "is_healthy": False,
-            "error": str(exc),
+            "error": "Status check failed",
         }
 
 

--- a/autobot-backend/integrations/monitoring_integration.py
+++ b/autobot-backend/integrations/monitoring_integration.py
@@ -85,14 +85,14 @@ class DatadogIntegration(BaseIntegration):
             logger.error("Datadog connection failed: %s", e)
             return IntegrationHealth(
                 status=IntegrationStatus.ERROR,
-                message=f"Connection failed: {str(e)}",
+                message="Connection failed",
                 details={"exception": type(e).__name__},
             )
         except Exception as e:
             logger.exception("Unexpected error testing Datadog connection")
             return IntegrationHealth(
                 status=IntegrationStatus.ERROR,
-                message=f"Unexpected error: {str(e)}",
+                message="Connection test failed",
                 details={"exception": type(e).__name__},
             )
 
@@ -315,14 +315,14 @@ class NewRelicIntegration(BaseIntegration):
             logger.error("New Relic connection failed: %s", e)
             return IntegrationHealth(
                 status=IntegrationStatus.ERROR,
-                message=f"Connection failed: {str(e)}",
+                message="Connection failed",
                 details={"exception": type(e).__name__},
             )
         except Exception as e:
             logger.exception("Unexpected error testing New Relic connection")
             return IntegrationHealth(
                 status=IntegrationStatus.ERROR,
-                message=f"Unexpected error: {str(e)}",
+                message="Connection test failed",
                 details={"exception": type(e).__name__},
             )
 

--- a/autobot-backend/integrations/project_management_integration.py
+++ b/autobot-backend/integrations/project_management_integration.py
@@ -80,13 +80,13 @@ class JiraIntegration(BaseIntegration):
                     status=IntegrationStatus.ERROR,
                     message=f"HTTP {result.get('status_code')}",
                 )
-        except Exception as exc:
+        except Exception:
             self.logger.exception("Jira connection test failed")
             self._status = IntegrationStatus.ERROR
             return IntegrationHealth(
                 provider="jira",
                 status=IntegrationStatus.ERROR,
-                message=str(exc),
+                message="Connection test failed",
             )
 
     def get_available_actions(self) -> List[IntegrationAction]:
@@ -153,9 +153,9 @@ class JiraIntegration(BaseIntegration):
 
         try:
             return await handler(params)
-        except Exception as exc:
+        except Exception:
             self.logger.exception("Jira action %s failed", action)
-            return {"error": str(exc)}
+            return {"error": "Action failed"}
 
     async def _list_projects(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """List all accessible projects."""
@@ -328,13 +328,13 @@ class TrelloIntegration(BaseIntegration):
                     status=IntegrationStatus.ERROR,
                     message=f"HTTP {result.get('status_code')}",
                 )
-        except Exception as exc:
+        except Exception:
             self.logger.exception("Trello connection test failed")
             self._status = IntegrationStatus.ERROR
             return IntegrationHealth(
                 provider="trello",
                 status=IntegrationStatus.ERROR,
-                message=str(exc),
+                message="Connection test failed",
             )
 
     def get_available_actions(self) -> List[IntegrationAction]:
@@ -394,9 +394,9 @@ class TrelloIntegration(BaseIntegration):
 
         try:
             return await handler(params)
-        except Exception as exc:
+        except Exception:
             self.logger.exception("Trello action %s failed", action)
-            return {"error": str(exc)}
+            return {"error": "Action failed"}
 
     async def _list_boards(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """List all accessible boards."""
@@ -549,13 +549,13 @@ class AsanaIntegration(BaseIntegration):
                     status=IntegrationStatus.ERROR,
                     message=f"HTTP {result.get('status_code')}",
                 )
-        except Exception as exc:
+        except Exception:
             self.logger.exception("Asana connection test failed")
             self._status = IntegrationStatus.ERROR
             return IntegrationHealth(
                 provider="asana",
                 status=IntegrationStatus.ERROR,
-                message=str(exc),
+                message="Connection test failed",
             )
 
     def get_available_actions(self) -> List[IntegrationAction]:
@@ -621,9 +621,9 @@ class AsanaIntegration(BaseIntegration):
 
         try:
             return await handler(params)
-        except Exception as exc:
+        except Exception:
             self.logger.exception("Asana action %s failed", action)
-            return {"error": str(exc)}
+            return {"error": "Action failed"}
 
     async def _list_workspaces(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """List all accessible workspaces."""


### PR DESCRIPTION
## Summary

- Replace `str(e)` / `str(exc)` in HTTP API responses with generic messages across 3 files
- Affected: `knowledge_connectors._get_status_for_config`, `project_management_integration` (Jira/Trello/Asana `execute_action` and `test_connection`), `monitoring_integration` (Datadog/New Relic `test_connection`)
- Full exception details are still logged server-side via `logger.exception()` / `logger.error()`

## Test plan

- [ ] Verify Jira/Trello/Asana connection test failures return `"Connection test failed"` not the raw exception message
- [ ] Verify execute_action failures return `"Action failed"` not the raw exception
- [ ] Verify knowledge connector status check failures return `"Status check failed"` not raw exception
- [ ] Verify server logs still contain full exception details for debugging

Closes #2195