### PR TITLE
refactor(config): replace hardcoded mistral:7b-instruct with DEFAULT_LLM_MODEL (#2383)

### DIFF
--- a/autobot-backend/config/config_registry_test.py
+++ b/autobot-backend/config/config_registry_test.py
@@ -8,6 +8,8 @@ import os
 import time
 from unittest.mock import MagicMock, patch
 
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
+
 
 class TestConfigRegistryBasic:
     """Basic ConfigRegistry functionality tests."""
@@ -406,7 +408,7 @@ class TestConfigRegistryDefaults:
 
         with patch.object(ConfigRegistry, "_fetch_from_redis", return_value=None):
             with patch.dict(os.environ, {}, clear=True):
-                assert ConfigRegistry.get("llm.default_model") == "mistral:7b-instruct"
+                assert ConfigRegistry.get("llm.default_model") == DEFAULT_LLM_MODEL
                 assert (
                     ConfigRegistry.get("llm.embedding_model")
                     == "nomic-embed-text:latest"

--- a/autobot-backend/config/manager.py
+++ b/autobot-backend/config/manager.py
@@ -13,7 +13,7 @@ SSOT Migration (Issue #763):
     For infrastructure values, use ConfigRegistry:
         from config.registry import ConfigRegistry
         redis_host = ConfigRegistry.get("vm.redis", "172.16.168.23")  # noqa: ssot-fallback
-        default_model = ConfigRegistry.get("llm.default_model", "mistral:7b-instruct")
+        default_model = ConfigRegistry.get("llm.default_model", DEFAULT_LLM_MODEL)
 """
 
 import asyncio

--- a/autobot-backend/config/registry_defaults.py
+++ b/autobot-backend/config/registry_defaults.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
+
 Registry Defaults - Hardcoded Fallback Values
 ==============================================
 
@@ -13,6 +14,8 @@ Issue: #751 - Consolidate Common Utilities
 """
 
 from typing import Optional
+
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
 
 # VM IP addresses (6-VM distributed architecture + SLM admin)
 REGISTRY_DEFAULTS = {
@@ -57,7 +60,7 @@ REGISTRY_DEFAULTS = {
     "port.prometheus": "9090",
     "port.grafana": "3000",
     # LLM defaults
-    "llm.default_model": "mistral:7b-instruct",
+    "llm.default_model": DEFAULT_LLM_MODEL,
     "llm.embedding_model": "nomic-embed-text:latest",
     # Timeouts
     "timeout.http": "30",

--- a/autobot-backend/constants/model_constants.py
+++ b/autobot-backend/constants/model_constants.py
@@ -28,7 +28,7 @@ Usage:
 
     # Preferred: Use ConfigRegistry directly for live values
     from config.registry import ConfigRegistry
-    model_name = ConfigRegistry.get("llm.default_model", "mistral:7b-instruct")
+    model_name = ConfigRegistry.get("llm.default_model", DEFAULT_LLM_MODEL)
 """
 
 import os
@@ -36,13 +36,15 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional
 
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
+
 # =============================================================================
 # FALLBACK DEFAULTS - DEFINED ONCE, USED EVERYWHERE
 # =============================================================================
 # These are the ultimate fallbacks if SSOT/.env is not configured.
 # Change these values to change the default for the entire system.
 
-FALLBACK_MODEL = "mistral:7b-instruct"  # Default LLM model
+FALLBACK_MODEL = DEFAULT_LLM_MODEL  # Default LLM model
 FALLBACK_OPENAI_MODEL = "gpt-4"
 FALLBACK_ANTHROPIC_MODEL = "claude-3-5-sonnet-20241022"
 FALLBACK_GOOGLE_MODEL = "gemini-pro"
@@ -60,7 +62,7 @@ class ModelConstants:
     hold static defaults; use ConfigRegistry directly for live Redis-backed
     values:
         from config.registry import ConfigRegistry
-        model = ConfigRegistry.get("llm.default_model", "mistral:7b-instruct")
+        model = ConfigRegistry.get("llm.default_model", DEFAULT_LLM_MODEL)
 
     Usage remains unchanged for backward compatibility:
         from constants.model_constants import ModelConstants
@@ -206,7 +208,7 @@ def get_default_model(provider: Optional[str] = None) -> str:
 
     Issue #763: Prefer using ConfigRegistry directly:
         from config.registry import ConfigRegistry
-        model = ConfigRegistry.get("llm.default_model", "mistral:7b-instruct")
+        model = ConfigRegistry.get("llm.default_model", DEFAULT_LLM_MODEL)
 
     Issue #380: Added @lru_cache since models don't change at runtime.
 

--- a/autobot-backend/llm_interface_pkg/tiered_routing/tier_config.py
+++ b/autobot-backend/llm_interface_pkg/tiered_routing/tier_config.py
@@ -1,3 +1,5 @@
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
+
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
@@ -18,7 +20,7 @@ class TierModels:
     """Model definitions for each tier."""
 
     simple: str = "gemma2:2b"
-    complex: str = "mistral:7b-instruct"
+    complex: str = DEFAULT_LLM_MODEL
 
 
 @dataclass
@@ -71,7 +73,7 @@ class TierConfig:
             complexity_threshold=float(tier_config.get("complexity_threshold", 3.0)),
             models=TierModels(
                 simple=models_config.get("simple", "gemma2:2b"),
-                complex=models_config.get("complex", "mistral:7b-instruct"),
+                complex=models_config.get("complex", DEFAULT_LLM_MODEL),
             ),
             fallback_to_complex=tier_config.get("fallback_to_complex", True),
             logging=TierLogging(

--- a/autobot-backend/llm_interface_pkg/tiered_routing_test.py
+++ b/autobot-backend/llm_interface_pkg/tiered_routing_test.py
@@ -1,3 +1,5 @@
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
+
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
@@ -27,7 +29,7 @@ class TestTierConfig:
         assert config.enabled is True
         assert config.complexity_threshold == 3.0
         assert config.models.simple == "gemma2:2b"
-        assert config.models.complex == "mistral:7b-instruct"
+        assert config.models.complex == DEFAULT_LLM_MODEL
         assert config.fallback_to_complex is True
 
     def test_custom_config(self):
@@ -237,7 +239,7 @@ class TestTieredModelRouter:
 
         model, result = router.route(messages)
 
-        assert model == "mistral:7b-instruct"
+        assert model == DEFAULT_LLM_MODEL
         assert result.tier == "complex"
 
     def test_disabled_routing(self):
@@ -249,7 +251,7 @@ class TestTieredModelRouter:
         model, result = router.route(messages)
 
         # Should return complex model when disabled
-        assert model == "mistral:7b-instruct"
+        assert model == DEFAULT_LLM_MODEL
         assert "disabled" in result.reasoning.lower()
 
     def test_metrics_tracking(self, router):
@@ -265,7 +267,7 @@ class TestTieredModelRouter:
     def test_get_model_for_tier(self, router):
         """Test getting model for specific tier."""
         assert router.get_model_for_tier("simple") == "gemma2:2b"
-        assert router.get_model_for_tier("complex") == "mistral:7b-instruct"
+        assert router.get_model_for_tier("complex") == DEFAULT_LLM_MODEL
 
         with pytest.raises(ValueError):
             router.get_model_for_tier("unknown")

--- a/autobot-backend/services/slm_client.py
+++ b/autobot-backend/services/slm_client.py
@@ -33,6 +33,8 @@ import aiohttp
 import websockets
 from websockets.exceptions import ConnectionClosed, WebSocketException
 
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
+
 logger = logging.getLogger(__name__)
 
 # SLM server URL from environment (no hardcoded fallback per SSOT requirements)
@@ -47,7 +49,7 @@ ULTIMATE_FALLBACK_CONFIG = {
     "llm_endpoint": os.getenv(
         "OLLAMA_URL", os.getenv("OLLAMA_HOST", "http://localhost:11434")
     ),
-    "llm_model": os.getenv("AUTOBOT_DEFAULT_LLM_MODEL", "mistral:7b-instruct"),
+    "llm_model": os.getenv("AUTOBOT_DEFAULT_LLM_MODEL", DEFAULT_LLM_MODEL),
     "llm_timeout": int(os.getenv("AUTOBOT_LLM_TIMEOUT", "30")),
     "llm_temperature": float(os.getenv("AUTOBOT_LLM_TEMPERATURE", "0.7")),
     "llm_max_tokens": None,

--- a/autobot-shared/ssot_config.py
+++ b/autobot-shared/ssot_config.py
@@ -63,7 +63,7 @@ PROJECT_ROOT = _find_project_root()
 
 # Default model constants - single source of truth for fallback values
 # These are used when .env doesn't specify a value
-DEFAULT_LLM_MODEL = "mistral:7b-instruct"
+DEFAULT_LLM_MODEL = "qwen3.5:9b"
 DEFAULT_EMBEDDING_MODEL = "nomic-embed-text:latest"
 
 

--- a/autobot-slm-backend/migrations/seed_agents.py
+++ b/autobot-slm-backend/migrations/seed_agents.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
+
 Agent Seed Migration Script (Issue #760 Phase 3)
 
 Seeds the SLM agents table with DEFAULT_AGENT_CONFIGS from the backend.
@@ -17,6 +18,8 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
+
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
 
 # Add parent directories to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -61,7 +64,7 @@ async def seed_agents():
                 continue
 
             # Determine model from config
-            default_model = config.get("default_model", "mistral:7b-instruct")
+            default_model = config.get("default_model", DEFAULT_LLM_MODEL)
 
             # Create agent
             agent = Agent(

--- a/autobot-slm-backend/services/agent_seeder.py
+++ b/autobot-slm-backend/services/agent_seeder.py
@@ -1,3 +1,5 @@
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
+
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
@@ -25,8 +27,8 @@ _DEFAULT_OLLAMA_ENDPOINT = "http://127.0.0.1:11434"
 # Mirrors TIER_*_MODEL defaults from autobot-backend/api/agent_config.py
 _TIER1 = "llama3.2:1b"
 _TIER2 = "llama3.2:3b"
-_TIER3 = "mistral:7b-instruct"
-_TIER4 = "mistral:7b-instruct"
+_TIER3 = DEFAULT_LLM_MODEL
+_TIER4 = DEFAULT_LLM_MODEL
 
 # Gemma model for classification agents (SSOT: agents.yaml llm.models.classification)
 _GEMMA_MODEL = "gemma2:2b"


### PR DESCRIPTION
## Summary
- Change `DEFAULT_LLM_MODEL` from `mistral:7b-instruct` to `qwen3.5:9b` in `ssot_config.py`
- Replace hardcoded `"mistral:7b-instruct"` strings with `DEFAULT_LLM_MODEL` import across 10 files
- Files updated: ssot_config, registry_defaults, model_constants, manager, tier_config, slm_client, agent_seeder, seed_agents, plus 2 test files
- Docstrings/comments that mention the model as examples are left as-is

Closes #2383

## Test plan
- [x] Pre-commit passes (flake8, black, isort)
- [x] Tests updated to use constant instead of literal
- [ ] CI passes