### PR TITLE
fix(frontend): add withSourceId to loadRedisHealth endpoint (#2374)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
@@ -169,7 +169,7 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     try {
       const backendUrl = await appConfig.getServiceUrl('backend')
       const url = withSourceId(
-        `${backendUrl}/api/code-intelligence/redis/health-score?path=${encodeURIComponent(rootPath.value)}`,
+        withSourceId(`${backendUrl}/api/code-intelligence/redis/health-score?path=${encodeURIComponent(rootPath.value)}`),
       )
       const response = await fetchWithAuth(
         url,


### PR DESCRIPTION
## Summary
- Add `withSourceId` to `loadRedisHealth` URL to include `source_id` query parameter
- Matches the pattern used by all other score/findings endpoints

Closes #2374