### PR TITLE
fix(frontend): track .vscode/settings.json properly in .gitignore (#2412)

### DIFF
--- a/autobot-frontend/.gitignore
+++ b/autobot-frontend/.gitignore
@@ -60,6 +60,7 @@ coverage/
 # === EDITOR DIRECTORIES AND FILES ===
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 *.suo
 *.ntvs*


### PR DESCRIPTION
Closes #2412

## Summary
- Added `!.vscode/settings.json` exception to `autobot-frontend/.gitignore`
- The file was force-added past .gitignore in PR #2332; this properly acknowledges it should be tracked

## Test plan
- [x] `.gitignore` now has `!.vscode/settings.json` exception alongside `!.vscode/extensions.json`
- [x] Other `.vscode/*` files remain ignored