### PR TITLE
fix(backend): move imports after copyright header in 2 files (#2414)

### DIFF
--- a/autobot-backend/llm_interface_pkg/tiered_routing/tier_config.py
+++ b/autobot-backend/llm_interface_pkg/tiered_routing/tier_config.py
@@ -1,5 +1,3 @@
-from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
-
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss

--- a/autobot-slm-backend/services/agent_seeder.py
+++ b/autobot-slm-backend/services/agent_seeder.py
@@ -1,5 +1,3 @@
-from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
-
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
@@ -18,6 +16,8 @@ import logging
 from models.database import Agent
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Closes #2414

## Summary
- Removed duplicate `from autobot_shared.ssot_config import DEFAULT_LLM_MODEL` that isort placed before the copyright header in `tier_config.py` and `agent_seeder.py`
- Imports now correctly appear after the copyright header and docstring

## Test plan
- [x] Both files compile without errors
- [x] isort passes (import order stable)