### PR TITLE
fix(backend): replace postgresql.UUID with dialect-neutral Uuid (#2402)

### DIFF
--- a/autobot-backend/models/workflow_permission.py
+++ b/autobot-backend/models/workflow_permission.py
@@ -11,8 +11,8 @@ Roles: owner, editor, viewer, runner.
 import uuid
 
 from sqlalchemy import Column, DateTime, String, UniqueConstraint
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base
 
 
@@ -27,7 +27,7 @@ class WorkflowPermission(Base):
     __tablename__ = "workflow_permissions"
 
     id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )


### PR DESCRIPTION
Closes #2402

## Summary
- Replaced `sqlalchemy.dialects.postgresql.UUID` with `sqlalchemy.types.Uuid` in WorkflowPermission model
- `Uuid` is SQLAlchemy 2.0's dialect-neutral type: native UUID on PostgreSQL, 32-char string on SQLite
- Allows workflow permission tests to run on SQLite dev/test environments

## Test plan
- [x] Model file compiles without errors
- [x] Pre-commit hooks pass