### PR TITLE
fix(backend): add missing __init__.py for search_components test discovery (#2395)

### DIFF
--- a/autobot-backend/tests/knowledge/__init__.py
+++ b/autobot-backend/tests/knowledge/__init__.py
@@ -1,0 +1,3 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss

--- a/autobot-backend/tests/knowledge/search_components/__init__.py
+++ b/autobot-backend/tests/knowledge/search_components/__init__.py
@@ -1,0 +1,3 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss


### PR DESCRIPTION
Closes #2395

## Summary
- Added missing `__init__.py` files for `tests/knowledge/` and `tests/knowledge/search_components/`
- Without these, pytest couldn't apply `pythonpath` config before test collection, causing `ModuleNotFoundError: No module named 'models.task_context'`
- Follows existing pattern: `tests/services/__init__.py`, `tests/utils/__init__.py`, etc. all exist

## Test plan
- [x] All 49 tests in `tests/knowledge/search_components/` pass
- [x] No more `ModuleNotFoundError` during collection