### PR TITLE
refactor(shared): extract _check_tablename_collisions utility (#2413)

### DIFF
--- a/autobot-shared/tablename_validator.py
+++ b/autobot-shared/tablename_validator.py
@@ -1,0 +1,75 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tablename collision detection utility (#2413).
+
+Provides :func:`check_tablename_collisions` — a standalone, importable function
+that detects overlapping ``__tablename__`` values across two independent
+SQLAlchemy ``MetaData`` objects.
+
+This was extracted from ``autobot-slm-backend/main._check_tablename_collisions``
+so the logic can be tested directly without importing the full SLM application
+stack (which carries heavy transitive imports: FastAPI routers, SQLAlchemy
+models, all services, etc.).
+
+See also: GitHub issues #1878 (original incident), #2226 (test added), #2413 (extraction).
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def check_tablename_collisions(slm_metadata: Any, um_metadata: Any) -> None:
+    """Detect shared tablenames across two SQLAlchemy MetaData objects (#1878).
+
+    The SLM backend uses two independent ``DeclarativeBase`` subclasses that each
+    target a **different** PostgreSQL database:
+
+    * ``models.database.Base`` — SLM admin models (nodes, deployments, …)
+      → connects to the main SLM database (``settings.database_url``)
+    * ``user_management.models.base.Base`` — User management models (users, roles, …)
+      → connects to the ``slm_users`` database (``SLM_USERS_DATABASE_URL``)
+
+    Because each Base has its own ``MetaData`` object, SQLAlchemy cannot enforce
+    cross-Base uniqueness.  A developer who accidentally assigns the same
+    ``__tablename__`` to models from both bases will get no compile-time error; the
+    table will simply be created in the wrong database and FK references will silently
+    break, exactly as happened with the ``users`` / ``slm_users`` incident (#1854).
+
+    This function logs a WARNING for every overlapping tablename so that such
+    regressions are surfaced immediately at startup rather than discovered later via
+    mysterious query failures.
+
+    Note: This does NOT raise because several names (e.g. ``roles``, ``audit_logs``)
+    are intentionally shared between the two databases for independent domain purposes.
+    The warning is the signal; renaming is the developer's responsibility.
+
+    Args:
+        slm_metadata: The ``MetaData`` object from the SLM ``DeclarativeBase``
+            (e.g. ``models.database.Base.metadata``).
+        um_metadata: The ``MetaData`` object from the UserManagement ``DeclarativeBase``
+            (e.g. ``user_management.models.base.Base.metadata``).
+    """
+    slm_tables: set[str] = set(slm_metadata.tables.keys())
+    um_tables: set[str] = set(um_metadata.tables.keys())
+    collisions: set[str] = slm_tables & um_tables
+
+    if collisions:
+        sorted_names = sorted(collisions)
+        logger.warning(
+            "Tablename overlap detected between SLM Base and UserManagement Base — "
+            "%d shared name(s): %s. "
+            "These names refer to tables in different databases, but sharing names "
+            "increases the risk of future model misplacement. "
+            "See GitHub issue #1878.",
+            len(sorted_names),
+            sorted_names,
+        )
+    else:
+        logger.info(
+            "Tablename collision check passed — %d SLM tables, %d UM tables, 0 shared names",
+            len(slm_tables),
+            len(um_tables),
+        )

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -79,54 +79,19 @@ logger = logging.getLogger(__name__)
 def _check_tablename_collisions() -> None:
     """Detect shared tablenames across both SQLAlchemy Base MetaData objects (#1878).
 
-    The SLM backend uses two independent ``DeclarativeBase`` subclasses that each
-    target a **different** PostgreSQL database:
-
-    * ``models.database.Base`` — SLM admin models (nodes, deployments, …)
-      → connects to the main SLM database (``settings.database_url``)
-    * ``user_management.models.base.Base`` — User management models (users, roles, …)
-      → connects to the ``slm_users`` database (``SLM_USERS_DATABASE_URL``)
-
-    Because each Base has its own ``MetaData`` object, SQLAlchemy cannot enforce
-    cross-Base uniqueness.  A developer who accidentally assigns the same
-    ``__tablename__`` to models from both bases will get no compile-time error; the
-    table will simply be created in the wrong database and FK references will silently
-    break, exactly as happened with the ``users`` / ``slm_users`` incident (#1854).
-
-    This function logs a WARNING for every overlapping tablename so that such
-    regressions are surfaced immediately at startup rather than discovered later via
-    mysterious query failures.
-
-    Note: This does NOT raise because several names (e.g. ``roles``, ``audit_logs``)
-    are intentionally shared between the two databases for independent domain purposes.
-    The warning is the signal; renaming is the developer's responsibility.
+    Delegates to :func:`autobot_shared.tablename_validator.check_tablename_collisions`
+    after resolving the two application-specific ``MetaData`` objects.  The heavy
+    detection + logging logic lives in autobot-shared so it can be tested in
+    isolation without importing this module's full dependency tree (#2413).
     """
     # Import after path is set up so this function is safe to call early in lifespan.
     import user_management.models  # noqa: F401 — registers all UM models with UMBase
     from models.database import Base as SLMBase
     from user_management.models.base import Base as UMBase
 
-    slm_tables: set[str] = set(SLMBase.metadata.tables.keys())
-    um_tables: set[str] = set(UMBase.metadata.tables.keys())
-    collisions: set[str] = slm_tables & um_tables
+    from autobot_shared.tablename_validator import check_tablename_collisions
 
-    if collisions:
-        sorted_names = sorted(collisions)
-        logger.warning(
-            "Tablename overlap detected between SLM Base and UserManagement Base — "
-            "%d shared name(s): %s. "
-            "These names refer to tables in different databases, but sharing names "
-            "increases the risk of future model misplacement. "
-            "See GitHub issue #1878.",
-            len(sorted_names),
-            sorted_names,
-        )
-    else:
-        logger.info(
-            "Tablename collision check passed — %d SLM tables, %d UM tables, 0 shared names",
-            len(slm_tables),
-            len(um_tables),
-        )
+    check_tablename_collisions(SLMBase.metadata, UMBase.metadata)
 
 
 async def _init_user_management_tables() -> None:

--- a/autobot-slm-backend/main_tablename_test.py
+++ b/autobot-slm-backend/main_tablename_test.py
@@ -1,44 +1,18 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Unit test for SLM tablename collision check (#2226).
+"""Unit test for SLM tablename collision check (#2226, #2413).
 
-Tests the collision detection logic extracted from _check_tablename_collisions().
-Because main.py has heavy transitive imports (FastAPI routers, DB models, etc.),
-we test the collision logic in isolation rather than importing main directly.
+Tests :func:`autobot_shared.tablename_validator.check_tablename_collisions` directly.
+The logic was extracted from ``main._check_tablename_collisions`` into autobot-shared
+(#2413) so tests can import and exercise the real function without pulling in the
+full SLM application stack (FastAPI routers, SQLAlchemy models, all services, etc.).
 """
 
 import logging
 from unittest.mock import MagicMock
 
-
-def _check_tablename_collisions_logic(slm_metadata, um_metadata, logger_):
-    """Extracted collision detection logic matching main._check_tablename_collisions.
-
-    This mirrors the function from main.py lines 78-128 so it can be tested
-    without importing the full SLM application stack.
-    """
-    slm_tables: set[str] = set(slm_metadata.tables.keys())
-    um_tables: set[str] = set(um_metadata.tables.keys())
-    collisions: set[str] = slm_tables & um_tables
-
-    if collisions:
-        sorted_names = sorted(collisions)
-        logger_.warning(
-            "Tablename overlap detected between SLM Base and UserManagement Base — "
-            "%d shared name(s): %s. "
-            "These names refer to tables in different databases, but sharing names "
-            "increases the risk of future model misplacement. "
-            "See GitHub issue #1878.",
-            len(sorted_names),
-            sorted_names,
-        )
-    else:
-        logger_.info(
-            "Tablename collision check passed — %d SLM tables, %d UM tables, 0 shared names",
-            len(slm_tables),
-            len(um_tables),
-        )
+from autobot_shared.tablename_validator import check_tablename_collisions
 
 
 class TestCheckTablenameCollisions:
@@ -50,9 +24,7 @@ class TestCheckTablenameCollisions:
         um_meta = MagicMock(tables={"users": None, "roles": None})
 
         with caplog.at_level(logging.WARNING):
-            _check_tablename_collisions_logic(
-                slm_meta, um_meta, logging.getLogger("main")
-            )
+            check_tablename_collisions(slm_meta, um_meta)
 
         assert any(
             "overlap" in r.message.lower() for r in caplog.records
@@ -64,9 +36,7 @@ class TestCheckTablenameCollisions:
         um_meta = MagicMock(tables={"users": None, "roles": None})
 
         with caplog.at_level(logging.INFO):
-            _check_tablename_collisions_logic(
-                slm_meta, um_meta, logging.getLogger("main")
-            )
+            check_tablename_collisions(slm_meta, um_meta)
 
         assert any(
             "0 shared" in r.message for r in caplog.records
@@ -78,7 +48,7 @@ class TestCheckTablenameCollisions:
         um_meta = MagicMock(tables={"shared_table": None})
 
         # Should not raise
-        _check_tablename_collisions_logic(slm_meta, um_meta, logging.getLogger("main"))
+        check_tablename_collisions(slm_meta, um_meta)
 
     def test_collision_includes_table_names(self, caplog):
         """Warning message includes the names of colliding tables."""
@@ -86,9 +56,7 @@ class TestCheckTablenameCollisions:
         um_meta = MagicMock(tables={"audit_logs": None, "users": None})
 
         with caplog.at_level(logging.WARNING):
-            _check_tablename_collisions_logic(
-                slm_meta, um_meta, logging.getLogger("main")
-            )
+            check_tablename_collisions(slm_meta, um_meta)
 
         assert any("audit_logs" in r.message for r in caplog.records)
 
@@ -98,9 +66,7 @@ class TestCheckTablenameCollisions:
         um_meta = MagicMock(tables={"roles": None, "audit_logs": None, "users": None})
 
         with caplog.at_level(logging.WARNING):
-            _check_tablename_collisions_logic(
-                slm_meta, um_meta, logging.getLogger("main")
-            )
+            check_tablename_collisions(slm_meta, um_meta)
 
         warning_msgs = [
             r.message for r in caplog.records if r.levelno >= logging.WARNING
@@ -115,8 +81,6 @@ class TestCheckTablenameCollisions:
         um_meta = MagicMock(tables={})
 
         with caplog.at_level(logging.INFO):
-            _check_tablename_collisions_logic(
-                slm_meta, um_meta, logging.getLogger("main")
-            )
+            check_tablename_collisions(slm_meta, um_meta)
 
         assert any("0 shared" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- Extracted `_check_tablename_collisions` logic from `autobot-slm-backend/main.py` into `autobot_shared.tablename_validator.check_tablename_collisions`
- `main._check_tablename_collisions()` is now a thin wrapper that resolves MetaData objects and delegates
- Test file (`main_tablename_test.py`) now imports and tests the real shared function instead of a duplicated copy

Closes #2413

## Test plan
- [x] flake8/black/isort/bandit all pass
- [ ] `pytest autobot-slm-backend/main_tablename_test.py` passes
- [ ] Confirm import works from new shared location