### PR TITLE
refactor(shared): consolidate proxy_utils into autobot-shared (#2408)

### DIFF
--- a/autobot-backend/middleware/proxy_utils.py
+++ b/autobot-backend/middleware/proxy_utils.py
@@ -2,96 +2,18 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Trusted-proxy utilities for IP extraction (Issue #2252).
+Backward-compatibility shim for trusted-proxy utilities (Issue #2408).
 
-Provides get_client_ip() — the canonical function for extracting the real
-client IP from a FastAPI/Starlette request.  X-Forwarded-For is only
-trusted when the direct TCP peer is a known reverse proxy; an attacker
-connecting directly cannot spoof their IP via that header.
-
-Configuration
--------------
-Set AUTOBOT_TRUSTED_PROXIES (comma-separated) to override the default
-list.  Defaults include localhost addresses and the nginx frontend VM
-(172.16.168.21).  The comment ``# noqa: ssot-proxy`` suppresses the
-hardcoding pre-commit check for the fallback string only.
+The canonical implementation has moved to autobot_shared.proxy_utils.
+All existing imports of ``from middleware.proxy_utils import get_client_ip``
+continue to work unchanged via this re-export.
 
 Usage
 -----
-    from middleware.proxy_utils import get_client_ip
-
-    ip = get_client_ip(request)           # returns str | None
+    from middleware.proxy_utils import get_client_ip   # legacy — still works
+    from autobot_shared.proxy_utils import get_client_ip  # preferred
 """
 
-import ipaddress
-import logging
-import os
-from typing import Optional
+from autobot_shared.proxy_utils import _normalize_ip, get_client_ip
 
-from starlette.requests import Request
-
-logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Trusted-proxy list — read once at import time.
-# Override via AUTOBOT_TRUSTED_PROXIES env var (comma-separated IPs).
-# Defaults: localhost (IPv4 + IPv6) and the nginx frontend VM (.21).
-# ---------------------------------------------------------------------------
-_RAW_TRUSTED = os.getenv(
-    "AUTOBOT_TRUSTED_PROXIES",
-    "127.0.0.1,::1,172.16.168.21",  # noqa: ssot-proxy
-)
-_TRUSTED_PROXIES: frozenset = frozenset(
-    ip.strip() for ip in _RAW_TRUSTED.split(",") if ip.strip()
-)
-
-
-def _normalize_ip(ip_str: str) -> str:
-    """Normalize an IP string, mapping ::ffff:x.x.x.x to x.x.x.x.
-
-    This handles dual-stack sockets that present IPv4 addresses as
-    IPv6-mapped addresses (e.g. ``::ffff:127.0.0.1``).
-
-    Args:
-        ip_str: Raw IP string from socket or header.
-
-    Returns:
-        Canonical IP string.
-    """
-    try:
-        addr = ipaddress.ip_address(ip_str)
-        if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
-            return str(addr.ipv4_mapped)
-        return str(addr)
-    except ValueError:
-        return ip_str
-
-
-def get_client_ip(request: Request) -> Optional[str]:
-    """Extract the real client IP from a Starlette/FastAPI request.
-
-    X-Forwarded-For is only honoured when the direct TCP connection
-    originates from a trusted reverse proxy (Issue #2252).  If the
-    connecting peer is not in AUTOBOT_TRUSTED_PROXIES the header is
-    ignored and the raw peer IP is returned, preventing IP spoofing by
-    clients that connect directly.
-
-    Args:
-        request: Incoming Starlette request.
-
-    Returns:
-        Client IP string, or ``None`` when no connection info is available.
-    """
-    peer_ip = request.client.host if request.client else None
-    if peer_ip is None:
-        return None
-
-    forwarded = request.headers.get("X-Forwarded-For", "")
-    if forwarded:
-        normalized_peer = _normalize_ip(peer_ip)
-        if normalized_peer in _TRUSTED_PROXIES:
-            candidate = forwarded.split(",")[0].strip()
-            if candidate:
-                return candidate
-
-    return peer_ip
+__all__ = ["get_client_ip", "_normalize_ip"]

--- a/autobot-shared/__init__.py
+++ b/autobot-shared/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "serialize_message",
     "deserialize_message",
     "create_reply",
+    "get_client_ip",
 ]
 
 # Lazy import map — module attribute → (submodule, name)
@@ -41,6 +42,7 @@ _LAZY_IMPORTS = {
     "serialize_message": (".models.service_message", "serialize_message"),
     "deserialize_message": (".models.service_message", "deserialize_message"),
     "create_reply": (".models.service_message", "create_reply"),
+    "get_client_ip": (".proxy_utils", "get_client_ip"),
 }
 
 

--- a/autobot-shared/proxy_utils.py
+++ b/autobot-shared/proxy_utils.py
@@ -1,0 +1,126 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Trusted-proxy utilities for IP extraction (Issue #2408).
+
+Provides get_client_ip() — the canonical shared function for extracting the
+real client IP from a FastAPI/Starlette request.  X-Forwarded-For is only
+trusted when the direct TCP peer is a known reverse proxy; an attacker
+connecting directly cannot spoof their IP via that header.
+
+Both autobot-backend and autobot-slm-backend import from this module so the
+trusted-proxy logic has a single source of truth and cannot diverge.
+
+Configuration
+-------------
+Two calling conventions are supported:
+
+1. Environment-driven (autobot-backend style):
+   Set AUTOBOT_TRUSTED_PROXIES (comma-separated) to override the default
+   list.  Defaults include localhost addresses and the nginx frontend VM
+   (172.16.168.21).  The ``# noqa: ssot-proxy`` comment suppresses the
+   hardcoding pre-commit check for the fallback string only.
+
+       ip = get_client_ip(request)  # uses module-level default set
+
+2. Caller-supplied (autobot-slm-backend style):
+   Pass an explicit iterable of trusted proxy IPs:
+
+       ip = get_client_ip(request, trusted_proxies=settings.trusted_proxies)
+
+Usage
+-----
+    from autobot_shared.proxy_utils import get_client_ip
+
+    # Default (uses AUTOBOT_TRUSTED_PROXIES env var or built-in fallback)
+    ip = get_client_ip(request)
+
+    # Explicit proxy list
+    ip = get_client_ip(request, trusted_proxies=["127.0.0.1", "::1"])
+"""
+
+import ipaddress
+import logging
+import os
+from typing import Iterable, Optional
+
+from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default trusted-proxy list — read once at import time.
+# Override via AUTOBOT_TRUSTED_PROXIES env var (comma-separated IPs).
+# Defaults: localhost (IPv4 + IPv6) and the nginx frontend VM (.21).
+# ---------------------------------------------------------------------------
+_RAW_TRUSTED = os.getenv(
+    "AUTOBOT_TRUSTED_PROXIES",
+    "127.0.0.1,::1,172.16.168.21",  # noqa: ssot-proxy
+)
+_DEFAULT_TRUSTED_PROXIES: frozenset = frozenset(
+    ip.strip() for ip in _RAW_TRUSTED.split(",") if ip.strip()
+)
+
+
+def _normalize_ip(ip_str: str) -> str:
+    """Normalize an IP string, mapping ::ffff:x.x.x.x to x.x.x.x.
+
+    This handles dual-stack sockets that present IPv4 addresses as
+    IPv6-mapped addresses (e.g. ``::ffff:127.0.0.1``).
+
+    Args:
+        ip_str: Raw IP string from socket or header.
+
+    Returns:
+        Canonical IP string.
+    """
+    try:
+        addr = ipaddress.ip_address(ip_str)
+        if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+            return str(addr.ipv4_mapped)
+        return str(addr)
+    except ValueError:
+        return ip_str
+
+
+def get_client_ip(
+    request: Request,
+    trusted_proxies: Optional[Iterable[str]] = None,
+) -> Optional[str]:
+    """Extract the real client IP from a Starlette/FastAPI request.
+
+    X-Forwarded-For is only honoured when the direct TCP connection
+    originates from a trusted reverse proxy (Issue #2252, #2239).  If the
+    connecting peer is not in the trusted set the header is ignored and the
+    raw peer IP is returned, preventing IP spoofing by clients that connect
+    directly.
+
+    Args:
+        request: Incoming Starlette request.
+        trusted_proxies: Iterable of trusted proxy IP strings.  When
+            ``None`` (the default) the module-level set is used, which
+            is populated from the ``AUTOBOT_TRUSTED_PROXIES`` environment
+            variable or the built-in fallback list.
+
+    Returns:
+        Client IP string, or ``None`` when no connection info is available.
+    """
+    peer_ip = request.client.host if request.client else None
+    if peer_ip is None:
+        return None
+
+    forwarded = request.headers.get("X-Forwarded-For", "")
+    if forwarded:
+        normalized_peer = _normalize_ip(peer_ip)
+        if trusted_proxies is None:
+            trusted_set: frozenset = _DEFAULT_TRUSTED_PROXIES
+        else:
+            trusted_set = frozenset(_normalize_ip(p) for p in trusted_proxies)
+
+        if normalized_peer in trusted_set:
+            candidate = forwarded.split(",")[0].strip()
+            if candidate:
+                return candidate
+
+    return peer_ip

--- a/autobot-slm-backend/api/auth.py
+++ b/autobot-slm-backend/api/auth.py
@@ -9,10 +9,9 @@ login, MFA challenges (Issue #576 Phase 5), and audit logging (Issue #998).
 Consolidated from legacy auth.py and slm_auth.py in Issue #1922.
 """
 
-import ipaddress
 import logging
 from datetime import timedelta
-from typing import Optional, Union
+from typing import Union
 
 from api.security import create_audit_log
 from config import settings
@@ -31,38 +30,10 @@ from typing_extensions import Annotated
 from user_management.models.user import User
 from user_management.services import TenantContext, UserService
 
+from autobot_shared.proxy_utils import get_client_ip
+
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["auth"])
-
-
-def _normalize_ip(ip_str: str) -> str:
-    """Normalize IP, mapping ::ffff:x.x.x.x to x.x.x.x (#2239)."""
-    try:
-        addr = ipaddress.ip_address(ip_str)
-        if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
-            return str(addr.ipv4_mapped)
-        return str(addr)
-    except ValueError:
-        return ip_str
-
-
-def _get_client_ip(http_request: Request) -> Optional[str]:
-    """Extract the real client IP from the request.
-
-    X-Forwarded-For is only trusted when the direct TCP peer is a known
-    reverse proxy (Issue #2239).  An attacker connecting directly cannot
-    spoof their IP via that header.
-    """
-    direct_ip = http_request.client.host if http_request.client else None
-    forwarded_for = http_request.headers.get("X-Forwarded-For")
-    if forwarded_for and direct_ip:
-        normalized = _normalize_ip(direct_ip)
-        trusted = {_normalize_ip(p) for p in settings.trusted_proxies}
-        if normalized in trusted:
-            candidate = forwarded_for.split(",")[0].strip()
-            if candidate:
-                return candidate
-    return direct_ip
 
 
 def _create_mfa_challenge(user: User) -> MfaChallengeResponse:
@@ -103,7 +74,7 @@ async def login(
     Accepts username or email. Returns JWT token or MFA challenge.
     Records audit log entry (Issue #998). Consolidated in Issue #1922.
     """
-    client_ip = _get_client_ip(http_request)
+    client_ip = get_client_ip(http_request, trusted_proxies=settings.trusted_proxies)
     context = TenantContext(is_platform_admin=True)
     user_service = UserService(db, context)
 


### PR DESCRIPTION
## Summary
- Created `autobot_shared.proxy_utils` as the single source of truth for trusted-proxy IP extraction
- `autobot-backend/middleware/proxy_utils.py` is now a backward-compat shim (re-exports from shared)
- `autobot-slm-backend/api/auth.py` removed duplicate `_normalize_ip`/`_get_client_ip`, now imports from shared
- Added `get_client_ip` to `autobot_shared.__init__.__all__` with lazy import support
- The shared function supports both env-driven defaults and caller-supplied proxy lists

Closes #2408

## Test plan
- [x] All pre-commit hooks pass (black, isort, flake8, bandit)
- [ ] Existing `middleware.proxy_utils` imports still resolve (backward compat shim)
- [ ] SLM auth login endpoint correctly extracts client IP
- [ ] `from autobot_shared.proxy_utils import get_client_ip` works