### PR TITLE
fix(backend): add advisory lock to fleet sync guard (#2401)

### DIFF
--- a/autobot-slm-backend/services/fleet_sync_guard.py
+++ b/autobot-slm-backend/services/fleet_sync_guard.py
@@ -16,11 +16,16 @@ import asyncio
 
 from fastapi import HTTPException, status
 from models.database import FleetSyncJob as FleetSyncJobModel
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 # Serialise check-and-insert across all fleet sync entry points to prevent
 # TOCTOU races (#1730, #1937, #1979).
 fleet_sync_lock = asyncio.Lock()
+
+# Stable advisory lock ID for the fleet sync guard.  The value is arbitrary
+# but must be unique across the application.  Using a named constant makes
+# it easy to audit all callers.
+_FLEET_SYNC_ADVISORY_LOCK_ID = 2401  # matches issue #2401
 
 
 async def assert_no_running_sync(db) -> None:
@@ -28,11 +33,32 @@ async def assert_no_running_sync(db) -> None:
 
     Shared guard for sync_fleet, run_schedule, and execute_schedule.
     Must be called while holding ``fleet_sync_lock`` to prevent TOCTOU races.
+
+    Two complementary locks prevent the TOCTOU race described in #2401:
+
+    1. ``pg_advisory_xact_lock`` — transaction-scoped advisory lock acquired
+       before the SELECT.  Serialises concurrent callers even when the
+       FleetSyncJob table is empty (i.e. when FOR UPDATE would lock zero rows
+       and therefore provide no protection).
+
+    2. ``.with_for_update()`` — row-level lock kept as defence-in-depth for
+       the case where a running job row already exists.  Prevents a second
+       transaction from reading a stale "no running job" snapshot after the
+       advisory lock is released.
     """
+    # Acquire a transaction-scoped advisory lock before reading.  This
+    # serialises all concurrent callers regardless of whether any rows exist
+    # in the table, closing the zero-row TOCTOU window identified in #2401.
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(:lock_id)").bindparams(
+            lock_id=_FLEET_SYNC_ADVISORY_LOCK_ID
+        )
+    )
+
     running_result = await db.execute(
         select(FleetSyncJobModel)
         .where(FleetSyncJobModel.status == "running")
-        .with_for_update()  # Row-level lock to prevent TOCTOU race (#1937)
+        .with_for_update()  # Defence-in-depth: row-level lock when rows exist (#1937)
     )
     if running_result.scalar_one_or_none():
         raise HTTPException(


### PR DESCRIPTION
Closes #2401

## Summary
- Added `pg_advisory_xact_lock` before the fleet sync guard query
- Prevents TOCTOU race when FleetSyncJob table is empty (FOR UPDATE locks zero rows in that case)
- Kept existing `.with_for_update()` as defence-in-depth for when rows exist
- Uses named constant `_FLEET_SYNC_ADVISORY_LOCK_ID = 2401` for auditability

## Test plan
- [x] File compiles without errors
- [x] Advisory lock acquired with bound parameter (safe against injection)
- [x] Existing FOR UPDATE logic preserved