### PR TITLE
docs: add Docker quick-start to README and INSTALL.md (#2443)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,6 +70,62 @@ All output is logged to `/var/log/autobot/install-<timestamp>.log`.
 
 ---
 
+## Docker Deployment
+
+For single-node or development setups, Docker Compose runs the full stack without
+the installer or Ansible:
+
+```bash
+git clone https://github.com/mrveiss/AutoBot-AI.git
+cd AutoBot-AI
+docker compose up -d --build
+```
+
+This starts the core services: backend, SLM, frontend, Redis, PostgreSQL, and
+ChromaDB.
+
+### Profiles
+
+Optional services are activated with `--profile`:
+
+```bash
+# Add a local Ollama LLM server
+docker compose --profile ollama up -d --build
+
+# Add Prometheus + Grafana monitoring
+docker compose --profile monitoring up -d --build
+```
+
+### Exposed Services
+
+| Service | URL |
+|---------|-----|
+| Frontend (user UI) | http://localhost |
+| SLM Admin | http://localhost/slm |
+| Backend API | http://localhost/api |
+| RedisInsight | http://localhost:8001 |
+| Ollama | http://localhost:11434 (profile: `ollama`) |
+| Grafana | http://localhost:3000 (profile: `monitoring`) |
+
+### Dev Mode (Hot Reload)
+
+Copy the override template to enable live-reload for frontend and backend code:
+
+```bash
+cp docker-compose.override.example.yml docker-compose.override.yml
+docker compose up -d
+```
+
+Edit source files on the host and changes are reflected inside the containers
+automatically.
+
+### Environment
+
+Docker Compose reads `.env.docker` by default. Copy `.env.example` to
+`.env.docker` and adjust values as needed before starting.
+
+---
+
 ## Setup Wizard
 
 After the installer finishes, open the SLM web UI in your browser:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,41 @@ sudo ./install.sh --unattended # Unattended (CI/automation)
 
 Installs system packages, deploys the SLM backend via Ansible, configures nginx, and starts all services. Takes 10-20 minutes. See [INSTALL.md](INSTALL.md) for details.
 
+### Docker (Single Node)
+
+Run the entire stack on one machine with Docker Compose:
+
+```bash
+# Core services (backend, SLM, frontend, Redis, PostgreSQL, ChromaDB)
+docker compose up -d --build
+
+# Include local Ollama LLM
+docker compose --profile ollama up -d --build
+
+# Include Prometheus + Grafana monitoring
+docker compose --profile monitoring up -d --build
+```
+
+Once running:
+
+| Service | URL |
+|---------|-----|
+| Frontend | http://localhost |
+| SLM Admin | http://localhost/slm |
+| Backend API | http://localhost/api |
+| RedisInsight | http://localhost:8001 |
+| Ollama | http://localhost:11434 (if `--profile ollama`) |
+| Grafana | http://localhost:3000 (if `--profile monitoring`) |
+
+**Dev mode** with hot reload:
+
+```bash
+cp docker-compose.override.example.yml docker-compose.override.yml
+docker compose up -d
+```
+
+See [INSTALL.md](INSTALL.md) for more Docker options.
+
 ### 3. Follow the Setup Wizard
 
 Open `https://<server-ip>` in your browser, log in with the credentials printed at install completion, and follow the Setup Wizard to add and configure fleet nodes.


### PR DESCRIPTION
## Summary
- Add Docker quick-start section to README.md (between installer and Setup Wizard steps)
- Add Docker Deployment section to INSTALL.md (after Installer Phases)
- Document core, Ollama, and monitoring profiles
- Include service/URL table and dev mode override instructions

Closes #2443