### PR TITLE
fix(frontend): auto-load CodebaseSecurityPanel on page visit (#2404)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -726,6 +726,7 @@ const codeIntelExtraScans = () => [
   { id: 'environment', label: t('analytics.codebase.scans.environment'), run: () => loadEnvironmentAnalysis() },
   { id: 'ownership', label: t('analytics.codebase.scans.ownership'), run: () => loadOwnershipAnalysis() },
   { id: 'crossLanguage', label: t('analytics.codebase.scans.crossLanguage'), run: () => getCrossLanguageAnalysis() },
+  { id: 'codeIntelligence', label: t('analytics.codebase.scans.codeIntelligence'), run: () => runCodeIntelligenceAnalysis() },
 ]
 
 const codeIntelFullScans = () => [
@@ -738,6 +739,7 @@ const codeIntelFullScans = () => [
   { id: 'environment', label: t('analytics.codebase.scans.environment'), run: () => loadEnvironmentAnalysis() },
   { id: 'ownership', label: t('analytics.codebase.scans.ownership'), run: () => loadOwnershipAnalysis() },
   { id: 'crossLanguage', label: t('analytics.codebase.scans.crossLanguage'), run: () => getCrossLanguageAnalysis() },
+  { id: 'codeIntelligence', label: t('analytics.codebase.scans.codeIntelligence'), run: () => runCodeIntelligenceAnalysis() },
 ]
 
 // Issue #208: Pattern Analysis component ref

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -635,7 +635,8 @@
         "ownership": "Code Ownership",
         "crossLanguage": "Cross-Language",
         "indexing": "Codebase Indexing",
-        "patterns": "Pattern Analysis"
+        "patterns": "Pattern Analysis",
+        "codeIntelligence": "Code Intelligence"
       },
       "pathPlaceholder": "/path/to/analyze",
       "available": "Available",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -635,7 +635,8 @@
         "ownership": "Code-Eigentum",
         "crossLanguage": "Sprachübergreifend",
         "indexing": "Codebasis-Indizierung",
-        "patterns": "Musteranalyse"
+        "patterns": "Musteranalyse",
+        "codeIntelligence": "Code-Intelligenz"
       },
       "pathPlaceholder": "/pfad/zum/analysieren",
       "available": "Verfügbar",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -635,7 +635,8 @@
         "ownership": "Code Ownership",
         "crossLanguage": "Cross-Language",
         "indexing": "Codebase Indexing",
-        "patterns": "Pattern Analysis"
+        "patterns": "Pattern Analysis",
+        "codeIntelligence": "Code Intelligence"
       },
       "pathPlaceholder": "/path/to/analyze",
       "available": "Available",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -635,7 +635,8 @@
         "ownership": "Propiedad del código",
         "crossLanguage": "Idioma cruzado",
         "indexing": "Indexación de base de código",
-        "patterns": "Análisis de patrones"
+        "patterns": "Análisis de patrones",
+        "codeIntelligence": "Inteligencia de código"
       },
       "pathPlaceholder": "/ruta/para/analizar",
       "available": "Disponible",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -635,7 +635,8 @@
         "ownership": "Propriété du code",
         "crossLanguage": "Multilingue",
         "indexing": "Indexation de la base de code",
-        "patterns": "Analyse de modèle"
+        "patterns": "Analyse de modèle",
+        "codeIntelligence": "Intelligence de code"
       },
       "pathPlaceholder": "/chemin/vers/analyse",
       "available": "Disponible",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -635,7 +635,8 @@
         "ownership": "Koda īpašumtiesības",
         "crossLanguage": "Pārrobežu valoda",
         "indexing": "Koda bāzes indeksācija",
-        "patterns": "Modeļa analīze"
+        "patterns": "Modeļa analīze",
+        "codeIntelligence": "Koda intelekts"
       },
       "pathPlaceholder": "/path/to/analyze",
       "available": "Pieejams",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -635,7 +635,8 @@
         "ownership": "Własność kodu",
         "crossLanguage": "Międzyjęzykowy",
         "indexing": "Indeksowanie bazy kodu",
-        "patterns": "Analiza wzorców"
+        "patterns": "Analiza wzorców",
+        "codeIntelligence": "Analiza inteligencji kodu"
       },
       "pathPlaceholder": "/path/to/analyze",
       "available": "Dostępny",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -635,7 +635,8 @@
         "ownership": "Propriedade do código",
         "crossLanguage": "Vários idiomas",
         "indexing": "Indexação de base de código",
-        "patterns": "Análise de padrões"
+        "patterns": "Análise de padrões",
+        "codeIntelligence": "Inteligência de código"
       },
       "pathPlaceholder": "/path/to/analyze",
       "available": "Disponível",


### PR DESCRIPTION
Closes #2404

## Summary
- Added `runCodeIntelligenceAnalysis` to both `codeIntelExtraScans` and `codeIntelFullScans` scan lists
- Panel now auto-populates on page visit, consistent with other analytics panels fixed in #2390
- Added `codeIntelligence` i18n key to all 9 locale files with scans section

## Test plan
- [x] No TypeScript/syntax errors
- [x] Follows same pattern as #2390 fix
- [x] i18n keys added to all locale files