### PR TITLE
fix(devops): target Dev_new_gui for Dependabot PRs (#2449)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/autobot-backend"
+    target-branch: "Dev_new_gui"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -21,6 +22,7 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/autobot-shared"
+    target-branch: "Dev_new_gui"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -31,6 +33,7 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/autobot-slm-backend"
+    target-branch: "Dev_new_gui"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -41,6 +44,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/autobot-frontend"
+    target-branch: "Dev_new_gui"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -56,6 +60,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "Dev_new_gui"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Closes #2449

## Summary
- Added `target-branch: Dev_new_gui` to all 5 Dependabot update entries
- Dependabot PRs will now target the active development branch instead of stale main

## Test plan
- [x] YAML validated
- [x] All 5 update entries have `target-branch` set