### PR TITLE
fix(devops): restore 0.0.0.0 bind for Docker VNC x11vnc (#2409)

### DIFF
--- a/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-vnc.yml
+++ b/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-vnc.yml
@@ -48,8 +48,10 @@ services:
         echo 'autorestart=true' >> /etc/supervisor/conf.d/autobot.conf
         echo 'priority=100' >> /etc/supervisor/conf.d/autobot.conf
         echo '' >> /etc/supervisor/conf.d/autobot.conf
+        # x11vnc binds 0.0.0.0 inside the container — Docker network isolation
+        # handles security; localhost would block inter-container VNC access
         echo '[program:x11vnc]' >> /etc/supervisor/conf.d/autobot.conf
-        echo 'command=/usr/bin/x11vnc -display :99 -rfbauth /home/autobot/.vnc/x11vnc.passwd -listen localhost -xkb -ncache 10 -forever -shared -rfbport 5901' >> /etc/supervisor/conf.d/autobot.conf
+        echo 'command=/usr/bin/x11vnc -display :99 -rfbauth /home/autobot/.vnc/x11vnc.passwd -listen 0.0.0.0 -xkb -ncache 10 -forever -shared -rfbport 5901' >> /etc/supervisor/conf.d/autobot.conf
         echo 'autostart=true' >> /etc/supervisor/conf.d/autobot.conf
         echo 'autorestart=true' >> /etc/supervisor/conf.d/autobot.conf
         echo 'priority=200' >> /etc/supervisor/conf.d/autobot.conf


### PR DESCRIPTION
Closes #2409

## Summary
- Restored x11vnc `-listen 0.0.0.0` inside Docker container (was `localhost` after PR #2350)
- `localhost` bind blocked inter-container VNC access
- Docker network isolation + `--ssl-only` handle security at the container level
- Added comments explaining the rationale

## Test plan
- [x] YAML validated
- [x] x11vnc listens on 0.0.0.0
- [x] websockify `--vnc localhost:5901` unchanged (correct for same-container)