### PR TITLE
fix(devops): add Docker TLS cert path to docker/.env.docker (#2458)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,13 @@
 # Requires Docker Compose v2+ for resource limits (deploy.resources).
 #
 # Usage:
-#   docker compose up -d                    # Start all core services
-#   docker compose --profile monitoring up -d  # Include Prometheus + Grafana
-#   docker compose --profile ollama up -d      # Include local Ollama LLM
+#   docker compose --env-file docker/.env.docker up -d          # Start all core services
+#   docker compose --env-file docker/.env.docker --profile monitoring up -d
+#   docker compose --env-file docker/.env.docker --profile ollama up -d
+#
+# NOTE: --env-file docker/.env.docker is required when the root .env contains
+# fleet-specific paths (e.g. AUTOBOT_TLS_CERT_DIR=infrastructure/shared/certs)
+# that are invalid in a Docker context. See #2458.
 #
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss

--- a/docker/.env.docker
+++ b/docker/.env.docker
@@ -86,10 +86,13 @@ AUTOBOT_DB_USER=autobot
 AUTOBOT_DB_PASSWORD=autobot
 AUTOBOT_DB_NAME=autobot_slm
 
-# --- TLS (optional) ---
-# To enable HTTPS, uncomment and run: bash docker/certs/generate-self-signed.sh
+# --- TLS ---
+# Docker-specific cert path override: prevents the fleet .env value
+# (infrastructure/shared/certs) from breaking compose volume validation.
+# For HTTPS, also uncomment AUTOBOT_NGINX_CONF and run:
+#   bash docker/certs/generate-self-signed.sh
 # AUTOBOT_NGINX_CONF=./docker/nginx/nginx-ssl.conf
-# AUTOBOT_TLS_CERT_DIR=./docker/certs
+AUTOBOT_TLS_CERT_DIR=./docker/certs
 
 # --- Logging ---
 AUTOBOT_LOG_LEVEL=INFO


### PR DESCRIPTION
Closes #2458

## Summary
- Uncommented `AUTOBOT_TLS_CERT_DIR=./docker/certs` in `docker/.env.docker`
- Updated `docker-compose.yml` usage header to show `--env-file docker/.env.docker` in all commands
- Root `.env` fleet path (`infrastructure/shared/certs`) caused Docker compose validation failure

## Test plan
- [x] `docker/.env.docker` sets correct Docker TLS cert path
- [x] `docker-compose.yml` usage comments updated
- [x] Root `.env` unchanged (fleet path preserved)