### PR TITLE
chore(deps): audit and clean stale comments in requirements.txt files (#2471)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -30,7 +30,7 @@ vanna>=0.7.0  # Issue #723: Natural language to SQL via Vanna.ai
 # Issue #858: Additional runtime dependencies for Python 3.13
 xxhash>=3.6.0          # Hash functions for LLM caching
 structlog>=25.5.0      # Structured logging for service auth
-llama-index>=0.13.0,<0.14.0    # RAG framework (pinned for API compatibility)
+llama-index>=0.13.0,<0.14.0    # 0.14.x has breaking API changes; sub-packages below target 0.13.x — verified 2026-03-26 (#2471)
 llama-index-llms-ollama>=0.7.0,<1.0.0  # Ollama LLM integration (0.7.0+ for core 0.13.0)
 llama-index-embeddings-ollama>=0.7.0,<1.0.0  # Ollama embeddings (0.7.0+ for core 0.13.0)
 llama-index-vector-stores-chroma>=0.5.0,<1.0.0  # ChromaDB vector store

--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -26,7 +26,7 @@ typing_extensions>=4.0.0  # For Python 3.8 compatibility
 # Authentication
 PyJWT[crypto]>=2.8.0
 passlib[bcrypt]>=1.7.4
-bcrypt>=4.0.0,<5.0.0  # bcrypt 5.0.0 incompatible with passlib
+bcrypt>=4.0.0,<5.0.0  # passlib 1.7.4 (unmaintained) does not support bcrypt 5.x API — verified 2026-03-26 (#2471)
 python-multipart>=0.0.22          # SECURITY UPDATE - arbitrary file write fix
 
 # Async utilities

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tenacity>=8.5.0
 # Async SSH for PKI certificate distribution (Issue #166)
 asyncssh>=2.22.0
 
-# TensorFlow 2.19.1 supports protobuf <6.0.0dev (verified from PyPI metadata)
+# TensorFlow 2.19.1 requires protobuf<6.0.0dev per PyPI metadata — verified 2026-03-26 (#2471)
 # Bumped to 5.29.6+ for JSON recursion depth bypass fix
 protobuf>=5.29.6,<6.0.0
 


### PR DESCRIPTION
## Summary
- Clarify 3 stale/vague dependency constraint comments across requirements files
- No version pins changed — comment-only updates with verification dates
- Files: `requirements.txt`, `autobot-backend/requirements.txt`, `autobot-slm-backend/requirements.txt`

Closes #2471