### PR TITLE
docs: remove stale run_autobot.sh references (#2468)

### DIFF
--- a/.claude/agents/frontend-engineer-agent.md
+++ b/.claude/agents/frontend-engineer-agent.md
@@ -19,7 +19,7 @@ You are a Senior Frontend Engineer specializing in the AutoBot Vue 3 application
 - **NO** local development servers (`localhost:5173`)
 - **NO** multiple frontend instances permitted
 - **FORBIDDEN COMMANDS**: `npm run dev`, `yarn dev`, `vite dev` on main machine
-- **FRONTEND STARTS ONLY**: via `run_autobot.sh` script which manages VM
+- **FRONTEND STARTS ONLY**: via systemd services on the Frontend VM (.21), managed by Ansible
 
 **🚫 REMOTE HOST DEVELOPMENT RULES:**
 - **NEVER edit code directly on remote hosts** (172.16.168.21-25)
@@ -140,4 +140,3 @@ When developing components, always consider the multi-modal AI context, ensure s
 - Local-only development workflow
 - Repository cleanliness standards
 - VM sync procedures and SSH requirements
-

--- a/autobot-infrastructure/shared/analysis/ai-ml/llm_model_investigation_summary.md
+++ b/autobot-infrastructure/shared/analysis/ai-ml/llm_model_investigation_summary.md
@@ -163,7 +163,7 @@ ollama pull codellama:7b-instruct
 python scripts/ai-ml/model_references_corrector.py
 
 # 3. Test system functionality
-bash run_autobot.sh --dev --no-build
+sudo systemctl start autobot-backend
 
 # 4. Run full optimization (optional, but recommended)
 python scripts/ai-ml/optimize_llm_models.py

--- a/autobot-infrastructure/shared/analysis/chat_refactoring_plan.md
+++ b/autobot-infrastructure/shared/analysis/chat_refactoring_plan.md
@@ -57,7 +57,7 @@ ROUTER_MAPPINGS = [
 #### Step 1.3: Test Immediate Resolution
 ```bash
 # Restart backend and verify single router active
-bash run_autobot.sh --dev --no-build
+sudo systemctl restart autobot-backend
 
 # Test key endpoints:
 curl http://localhost:8001/api/health
@@ -390,7 +390,7 @@ cp backend/fast_app_factory_fix.py.backup backend/fast_app_factory_fix.py
 cp autobot-vue/src/services/api.ts.backup autobot-vue/src/services/api.ts
 cp autobot-vue/src/utils/ApiClient.ts.backup autobot-vue/src/utils/ApiClient.ts
 # Restart services
-bash run_autobot.sh --dev --rebuild
+sudo systemctl restart autobot-backend
 ```
 
 ## Success Metrics

--- a/autobot-infrastructure/shared/scripts/README.md
+++ b/autobot-infrastructure/shared/scripts/README.md
@@ -5,7 +5,7 @@
 ```
 scripts/
 ├── analysis/         # Test scripts and analysis tools (moved from root)
-├── archive/          # Obsolete startup scripts (replaced by run_autobot.sh)
+├── archive/          # Obsolete startup scripts (deprecated, see SERVICE_MANAGEMENT.md)
 ├── cache/            # Cache management utilities
 ├── native-vm/        # Native VM deployment scripts
 ├── network/          # Network configuration and testing
@@ -22,13 +22,14 @@ scripts/
 
 ## Main Scripts (Root Directory)
 
-### Essential Scripts (ONLY 2 FILES)
-- **`run_autobot.sh`** - Unified startup script (combines all previous run scripts)
+### Essential Scripts
 - **`setup.sh`** - Unified setup script (handles all setup tasks)
+- **`scripts/start-services.sh`** - CLI service wrapper (start/stop/restart)
 
 ## Script Categories
 
-### Archive (Obsolete - Use run_autobot.sh instead)
+### Archive (Obsolete - Do not use)
+- `run_autobot.sh` - Deprecated (Issue #863), moved to `legacy/`
 - `run_agent.sh` - Old Docker-based startup
 - `run_agent_unified.sh` - Old unified startup
 - `run_agent_native.sh` - Old native VM startup
@@ -67,16 +68,16 @@ scripts/
 
 ## Usage Examples
 
-### Using the Unified Script (Recommended)
+### Starting Services (Recommended)
 ```bash
-# Standard native VM startup
-./run_autobot.sh
+# Production (systemd)
+sudo systemctl start autobot-backend
 
-# Development mode
-./run_autobot.sh --dev
+# CLI wrapper
+scripts/start-services.sh start
 
-# With specific options
-./run_autobot.sh --dev --no-browser --rebuild
+# Docker
+docker compose up -d
 ```
 
 ### Setup Commands
@@ -119,10 +120,12 @@ scripts/
 
 ## Migration Notes
 
-All old startup scripts have been consolidated into `run_autobot.sh`.
-If you were using:
-- `run_agent.sh --dev` → Now use `run_autobot.sh --dev`
-- `run_agent_native.sh` → Now use `run_autobot.sh` (native is default)
-- `run-docker-desktop.sh` → Now use `run_autobot.sh --docker`
+All old startup scripts (including `run_autobot.sh`) have been deprecated.
+Use the current methods:
+- **Production:** `systemctl start autobot-backend`
+- **CLI wrapper:** `scripts/start-services.sh start`
+- **Docker:** `docker compose up -d`
+
+See [`docs/developer/SERVICE_MANAGEMENT.md`](../../docs/developer/SERVICE_MANAGEMENT.md) for full details.
 
 The old scripts are preserved in `scripts/archive/` for reference but should not be used.

--- a/autobot-infrastructure/shared/scripts/security/ssh-hardening/README.md
+++ b/autobot-infrastructure/shared/scripts/security/ssh-hardening/README.md
@@ -112,7 +112,7 @@ This directory contains scripts to fix the critical SSH man-in-the-middle vulner
 - 50+ shell scripts in `scripts/` directory
 - Python modules with subprocess SSH calls
 - Ansible configuration files
-- Main system scripts (run_autobot.sh, etc.)
+- Main system scripts (now managed via systemd; `run_autobot.sh` deprecated)
 
 **Output**:
 - Backup directory: `backups/ssh-remediation-<timestamp>/`
@@ -225,7 +225,7 @@ This directory contains scripts to fix the critical SSH man-in-the-middle vulner
 9. **Full System Test**:
    ```bash
    # Start AutoBot with new SSH security
-   bash run_autobot.sh --dev
+   sudo systemctl start autobot-backend
    ```
 
 ### Phase 4: MITM Detection Verification (Optional)

--- a/autobot-infrastructure/shared/tests/performance/PERFORMANCE_BASELINE_SUMMARY.md
+++ b/autobot-infrastructure/shared/tests/performance/PERFORMANCE_BASELINE_SUMMARY.md
@@ -116,7 +116,7 @@ Established comprehensive performance baseline and validation framework for Auto
 cd /home/kali/Desktop/AutoBot
 
 # Ensure backend is running
-bash run_autobot.sh --dev
+sudo systemctl start autobot-backend
 
 # Execute baseline tests
 python tests/performance/test_async_baseline.py

--- a/autobot-infrastructure/shared/tests/performance/README_ASYNC_VALIDATION.md
+++ b/autobot-infrastructure/shared/tests/performance/README_ASYNC_VALIDATION.md
@@ -178,7 +178,7 @@ comparison_report_YYYYMMDD.json      # Before/after analysis
 ### Prerequisites
 ```bash
 # Ensure AutoBot backend is running
-bash run_autobot.sh --dev
+sudo systemctl start autobot-backend
 
 # Install test dependencies (should already be installed)
 pip install aiohttp redis[asyncio] aiofiles

--- a/autobot-infrastructure/shared/tests/performance/run_baseline.sh
+++ b/autobot-infrastructure/shared/tests/performance/run_baseline.sh
@@ -41,7 +41,7 @@ if ! curl -s -f "${BACKEND_URL}/api/health" > /dev/null 2>&1; then
     echo ""
     echo "Please start AutoBot first:"
     echo "  cd ${PROJECT_ROOT}"
-    echo "  bash run_autobot.sh --dev"
+    echo "  systemctl start autobot-backend  # or: scripts/start-services.sh start"
     echo ""
     exit 1
 fi

--- a/autobot-slm-backend/ansible/ROLE_STRUCTURE_README.md
+++ b/autobot-slm-backend/ansible/ROLE_STRUCTURE_README.md
@@ -382,7 +382,7 @@ ansible-playbook playbooks/deploy_role.yml -e 'role_name=frontend' --list-tasks
 The Ansible role structure integrates with AutoBot's deployment workflows:
 
 1. **setup.sh**: Installs Ansible and dependencies
-2. **run_autobot.sh**: Can trigger Ansible deployments
+2. **systemd services**: Manage backend/frontend lifecycle (replaces deprecated `run_autobot.sh`)
 3. **sync-to-vm.sh**: Syncs code after role deployment
 4. **Service Registry**: Feeds dynamic inventory
 

--- a/autobot-slm-backend/ansible/playbooks/deploy-development-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-development-services.yml
@@ -144,53 +144,19 @@
           - Mode: Development (hot reload enabled)
           - Environment: /opt/autobot/config/frontend-dev.env
 
-# Update run_autobot.sh to support development mode
-- name: Update AutoBot startup script for development mode
+# NOTE: run_autobot.sh is deprecated (Issue #863).
+# Development mode frontend is managed via systemd service autobot-frontend-dev.
+# No startup script modifications needed -- use systemctl directly.
+- name: Verify development services are running
   hosts: backend
   become: yes
 
   tasks:
-    - name: Backup current run_autobot.sh
-      copy:
-        src: /home/kali/Desktop/AutoBot/run_autobot.sh
-        dest: /home/kali/Desktop/AutoBot/run_autobot.sh.backup
-        remote_src: yes
-
-    - name: Update run_autobot.sh to support --dev mode for distributed architecture
-      blockinfile:
-        path: /home/kali/Desktop/AutoBot/run_autobot.sh
-        marker: "# {mark} DEVELOPMENT MODE FRONTEND MANAGEMENT"
-        block: |
-          start_frontend_dev() {
-              FRONTEND_IP=$(ansible-inventory -i ansible/inventory/production.yml --host autobot-frontend 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('ansible_host',''))" 2>/dev/null)
-              FRONTEND_IP=${FRONTEND_IP:-{{ frontend_host }}}
-              echo "Starting Frontend Development Server on VM ${FRONTEND_IP}..."
-
-              # Start development frontend service via Ansible
-              ansible frontend -i ansible/inventory/production.yml -m systemd -a "name=autobot-frontend-dev state=restarted enabled=yes" -b
-
-              # Wait for frontend to be ready
-              echo "Waiting for frontend development server to start..."
-              sleep 10
-
-              # Test frontend availability
-              if curl -s -o /dev/null -w "%{http_code}" http://${FRONTEND_IP}:{{ frontend_port }} | grep -q "200"; then
-                  echo "Frontend development server ready at http://${FRONTEND_IP}:{{ frontend_port }}"
-              else
-                  echo "Frontend development server may not be fully ready yet"
-                  echo "   Check status with: ansible frontend -i ansible/inventory/production.yml -m shell -a 'systemctl status autobot-frontend-dev'"
-              fi
-          }
-
-          # Add frontend dev start to main dev mode function
-          if [[ "$*" == *"--dev"* ]]; then
-              start_frontend_dev
-          fi
-
-    - name: Make run_autobot.sh executable
-      file:
-        path: /home/kali/Desktop/AutoBot/run_autobot.sh
-        mode: '0755'
+    - name: Ensure autobot-backend service is running
+      systemd:
+        name: autobot-backend
+        state: started
+        enabled: yes
 
 # Display final status
 - name: Development Setup Complete
@@ -211,10 +177,10 @@
 
           Backend:
           - URL: http://{{ backend_host }}:{{ backend_port }}
-          - Service: Runs via run_autobot.sh --dev
+          - Service: autobot-backend (systemd)
 
           Usage:
-          - Start all: bash run_autobot.sh --dev
+          - Start all: sudo systemctl start autobot-backend
           - Frontend only: ansible frontend -i ansible/inventory/production.yml -m systemd -a "name=autobot-frontend-dev state=started"
           - Check status: ansible frontend -i ansible/inventory/production.yml -m shell -a "systemctl status autobot-frontend-dev"
 

--- a/docs/ROADMAP_2025.md
+++ b/docs/ROADMAP_2025.md
@@ -530,7 +530,7 @@ AUTOBOT_REASONING_MODEL=qwen3.5:9b
 
 | Task | Planned | Actual | Status |
 |------|---------|--------|--------|
-| Single-command startup | ✓ | `bash run_autobot.sh` | ✅ |
+| Single-command startup | ✓ | `systemctl start autobot-backend` | ✅ |
 | Systemd service | ✓ | Optional config | ✅ |
 | Crontab auto-start | ✓ | Optional | ✅ |
 | Graceful shutdown | ✓ | Resource cleanup | ✅ |

--- a/docs/adr/001-distributed-vm-architecture.md
+++ b/docs/adr/001-distributed-vm-architecture.md
@@ -83,7 +83,7 @@ We adopt a distributed 6-VM architecture where each VM serves a specific purpose
 
 ### Key Files
 
-- `run_autobot.sh` - Main startup script orchestrating all VMs
+- `scripts/start-services.sh` - CLI service wrapper (replaces deprecated `run_autobot.sh`)
 - `scripts/utilities/sync-to-vm.sh` - File synchronization utility
 - `~/.ssh/autobot_key` - SSH key for VM authentication
 

--- a/docs/adr/005-single-frontend-mandate.md
+++ b/docs/adr/005-single-frontend-mandate.md
@@ -80,7 +80,7 @@ This is an absolute mandate with zero exceptions:
 
 - `sync-frontend.sh` - Quick sync script for frontend changes
 - `scripts/utilities/sync-to-vm.sh` - General purpose VM sync utility
-- `run_autobot.sh` - Orchestrates frontend startup on VM1
+- Systemd services on VM1 manage frontend startup (replaces deprecated `run_autobot.sh`)
 
 ### Forbidden Commands
 
@@ -113,7 +113,7 @@ firefox http://172.16.168.21:5173
 
 ### Enforcement
 
-The `run_autobot.sh` script enforces this by:
+The systemd service configuration enforces this by:
 1. Never starting Vite on main machine
 2. SSH to VM1 to start/restart frontend
 3. Health checking VM1's frontend server

--- a/docs/architecture/CONFIG_MIGRATION_IMPLEMENTATION.md
+++ b/docs/architecture/CONFIG_MIGRATION_IMPLEMENTATION.md
@@ -18,7 +18,7 @@ python scripts/validate_timeout_config.py
 # 3. Implement changes (see below)
 
 # 4. Verify no regression
-bash run_autobot.sh --dev
+scripts/start-services.sh start
 curl http://172.16.168.21:5173  # Frontend accessible?
 ```
 
@@ -409,7 +409,7 @@ curl http://localhost:8001/api/health
 curl http://172.16.168.21:5173
 
 # 5. Full system test
-bash run_autobot.sh --dev
+scripts/start-services.sh start
 # Open browser to http://172.16.168.21:5173
 # Test model selection in GUI
 ```
@@ -452,7 +452,7 @@ If issues arise:
 # Quick rollback
 git stash
 git checkout main
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # Or revert compatibility shim
 git checkout HEAD -- src/unified_config.py

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -150,7 +150,7 @@ curl http://172.16.168.24:8080/api/tags
 
 | File | Purpose |
 |------|---------|
-| `run_autobot.sh` | Main startup script |
+| `scripts/start-services.sh` | CLI service wrapper (replaces deprecated `run_autobot.sh`) |
 | `.env` | Environment variables |
 | `backend/core/config.py` | Backend configuration |
 | `autobot-frontend/vite.config.ts` | Frontend configuration |

--- a/docs/architecture/SSOT_CONFIGURATION_ARCHITECTURE.md
+++ b/docs/architecture/SSOT_CONFIGURATION_ARCHITECTURE.md
@@ -730,7 +730,7 @@ curl -s "http://${AUTOBOT_VM_MAIN_IP}:${AUTOBOT_PORT_BACKEND}/api/health"
 
 | Script | Current Status | Required Changes |
 | ------ | -------------- | ---------------- |
-| `run_autobot.sh` | Partial SSOT | Source .env, remove hardcoded IPs |
+| ~~`run_autobot.sh`~~ | Deprecated (#863) | Replaced by systemd + `scripts/start-services.sh` |
 | `setup.sh` | Hardcoded | Source .env for all network config |
 | `scripts/utilities/sync-to-vm.sh` | Hardcoded IPs | Use AUTOBOT_VM_* variables |
 | `scripts/utilities/sync-frontend.sh` | Hardcoded | Use AUTOBOT_VM_FRONTEND_IP |

--- a/docs/architecture/VECTOR_STORE_MIGRATION.md
+++ b/docs/architecture/VECTOR_STORE_MIGRATION.md
@@ -195,7 +195,7 @@ git checkout src/knowledge_base_v2.py
 # No action needed
 
 # 3. Restart backend
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 ```
 
 ---

--- a/docs/deployment/MCP_BRIDGE_ACTIVATION.md
+++ b/docs/deployment/MCP_BRIDGE_ACTIVATION.md
@@ -93,16 +93,16 @@ curl -s http://localhost:8001/api/mcp/tools | jq '.total_tools'
 ### Step 3: Graceful Backend Restart
 
 ```bash
-# Option 1: Use run_autobot.sh (recommended)
-bash run_autobot.sh --restart --dev
+# Option 1: systemd (recommended)
+sudo systemctl restart autobot-backend
 
-# Option 2: Use --verify-mcp flag for automatic verification
-bash run_autobot.sh --restart --dev --verify-mcp
+# Option 2: CLI wrapper
+scripts/start-services.sh restart
 
 # Option 3: Manual restart
 pkill -f "uvicorn backend.app:app"
 sleep 2
-bash run_autobot.sh --dev
+scripts/start-services.sh start
 ```
 
 ### Step 4: Verify New Bridge Registration
@@ -214,7 +214,7 @@ git reset --hard HEAD~1
 ### Step 3: Restart Backend
 
 ```bash
-bash run_autobot.sh --restart --dev
+sudo systemctl restart autobot-backend
 ```
 
 ### Step 4: Verify Rollback
@@ -253,7 +253,7 @@ curl -s http://localhost:8001/api/health | jq '.status'
 
 3. **Backend Not Restarted**
    ```bash
-   bash run_autobot.sh --restart
+   sudo systemctl restart autobot-backend
    ```
 
 ### Issue: 404 on Bridge Endpoint

--- a/docs/developer/AGENT_OPTIMIZATION.md
+++ b/docs/developer/AGENT_OPTIMIZATION.md
@@ -231,9 +231,9 @@ Add to GitHub Actions workflow:
     git add .claude/agents-optimized/
 ```
 
-### Startup Script Integration
+### Startup Integration
 
-Add to `run_autobot.sh`:
+Add to your service startup (e.g., systemd `ExecStartPre` or `scripts/start-services.sh`):
 
 ```bash
 # Optimize agents on startup

--- a/docs/developer/AGENT_OPTIMIZATION_SUMMARY.md
+++ b/docs/developer/AGENT_OPTIMIZATION_SUMMARY.md
@@ -213,7 +213,7 @@ Assuming proportional token processing time:
 
 ### Startup Integration (Optional)
 
-Add to `run_autobot.sh`:
+Add to your service startup (e.g., systemd `ExecStartPre` or `scripts/start-services.sh`):
 ```bash
 # Auto-optimize agents on startup
 if [ -x "./scripts/utilities/agent-optimize.sh" ]; then

--- a/docs/developer/INFRASTRUCTURE_DEPLOYMENT.md
+++ b/docs/developer/INFRASTRUCTURE_DEPLOYMENT.md
@@ -825,7 +825,7 @@ md5sum /home/kali/Desktop/AutoBot/autobot-backend/api/chat.py
 - [ ] All changes committed to git (local version control)
 - [ ] Services bind to `0.0.0.0` (not localhost)
 - [ ] Using `NetworkConstants` for IPs/ports (not hardcoded)
-- [ ] Tested locally first (`bash run_autobot.sh --dev`)
+- [ ] Tested locally first (`scripts/start-services.sh start` or `systemctl start autobot-backend`)
 - [ ] Synced to VMs (`./infrastructure/shared/scripts/sync-to-vm.sh`)
 - [ ] Health checks pass on all services
 

--- a/docs/developer/LAZY_SINGLETON_EXAMPLES.md
+++ b/docs/developer/LAZY_SINGLETON_EXAMPLES.md
@@ -191,7 +191,7 @@ from src.utils.lazy_singleton import lazy_init_singleton
 
 1. **Start the application**
    ```bash
-   bash run_autobot.sh --dev
+   scripts/start-services.sh start
    ```
 
 2. **Test chat endpoint**
@@ -260,7 +260,7 @@ def get_llm_service(request):
 
 ### Step 3: Restart Application
 ```bash
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 ```
 
 ### Step 4: Verify Fix

--- a/docs/developer/MCP_MANAGEMENT_GUIDE.md
+++ b/docs/developer/MCP_MANAGEMENT_GUIDE.md
@@ -428,7 +428,7 @@ MCP_BRIDGES = [
 pkill -f "uvicorn backend.app_factory"
 
 # Start backend
-bash run_autobot.sh --dev
+sudo systemctl restart autobot-backend
 ```
 
 ### Step 5: Verify in UI
@@ -450,7 +450,7 @@ bash run_autobot.sh --dev
 
 1. **Backend not restarted**
    - Solution: Restart backend to load new router
-   - Command: `bash run_autobot.sh --dev`
+   - Command: `sudo systemctl restart autobot-backend`
 
 2. **Router not registered**
    - Solution: Check `app_factory.py` includes your router in `core_routers`

--- a/docs/developer/THINKING_TOOLS_CONFIGURATION.md
+++ b/docs/developer/THINKING_TOOLS_CONFIGURATION.md
@@ -318,7 +318,7 @@ Here's the implementation plan...
 **Solutions**:
 1. **Restart backend** to reload prompt:
    ```bash
-   bash run_autobot.sh --restart
+   sudo systemctl restart autobot-backend
    ```
 
 2. **Verify model is Mistral**:

--- a/docs/guides/ANSIBLE_PLAYBOOK_REFERENCE.md
+++ b/docs/guides/ANSIBLE_PLAYBOOK_REFERENCE.md
@@ -187,19 +187,19 @@ ansible all -i ansible/inventory/production.yml -m shell -a "ps aux --sort=-%cpu
 ansible all -i ansible/inventory/production.yml -m ufw -a "rule=allow port=<port> proto=tcp" -b
 ```
 
-## Integration with run_autobot.sh
+## Integration with Service Management
 
-The main startup script integrates with Ansible:
+Service startup is managed via systemd and Ansible (replaces deprecated `run_autobot.sh`):
 
 ```bash
-# Development mode with Ansible-managed frontend
-bash run_autobot.sh --dev
+# Start backend service
+sudo systemctl start autobot-backend
 
-# Production deployment
-bash run_autobot.sh --prod
+# Production deployment via Ansible
+ansible-playbook playbooks/update-all-nodes.yml
 
-# Health check via Ansible
-bash run_autobot.sh --health-check
+# Health check
+curl -sk https://172.16.168.20:8443/api/health | jq
 ```
 
 ## Best Practices

--- a/docs/monitoring/EPIC_80_COMPLETION.md
+++ b/docs/monitoring/EPIC_80_COMPLETION.md
@@ -258,7 +258,7 @@ ssh autobot@172.16.168.19 'sudo journalctl -u grafana-server -f'
 
 ### Startup Procedure Integration
 
-**File**: `run_autobot.sh`
+**Note**: `run_autobot.sh` is deprecated (Issue #863). Services are managed via systemd.
 
 - Monitoring services **NOT** in startup script (by design)
 - They run 24/7 as systemd services

--- a/docs/monitoring/QUICK_REFERENCE.md
+++ b/docs/monitoring/QUICK_REFERENCE.md
@@ -145,7 +145,7 @@ curl http://172.16.168.19:3000/api/datasources
 
 **Fix**: Restart backend
 ```bash
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 ```
 
 ### Grafana Not Loading

--- a/docs/operations/ACCESS_CONTROL_ROLLOUT_RUNBOOK.md
+++ b/docs/operations/ACCESS_CONTROL_ROLLOUT_RUNBOOK.md
@@ -636,7 +636,7 @@ asyncio.run(main())
 ls -lh logs/audit/
 
 # Restart backend if needed
-./run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 ```
 
 ---

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -49,7 +49,7 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
    # Start fresh
    cd /home/kali/Desktop/AutoBot
-   bash run_autobot.sh --dev
+   sudo systemctl start autobot-backend
    ```
 
 3. **Verify recovery**
@@ -93,7 +93,7 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 4. **Or use startup script from main machine**
    ```bash
-   bash run_autobot.sh --dev
+   sudo systemctl start autobot-backend
    ```
 
 **Estimated Recovery Time**: 5-15 minutes
@@ -267,12 +267,12 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 3. **Start AutoBot**
    ```bash
    cd /home/kali/Desktop/AutoBot
-   bash run_autobot.sh --dev
+   sudo systemctl start autobot-backend
    ```
 
 4. **Verify all services**
    ```bash
-   bash run_autobot.sh --status
+   sudo systemctl status autobot-backend --no-pager
    ```
 
 **Estimated Recovery Time**: 15-30 minutes

--- a/docs/operations/scaling-strategy.md
+++ b/docs/operations/scaling-strategy.md
@@ -399,7 +399,7 @@ processors=8
 
 **Increase Uvicorn workers**:
 ```bash
-# In run_autobot.sh
+# In systemd service or Ansible template
 uvicorn backend.main:app --host 0.0.0.0 --port 8001 --workers 8
 ```
 

--- a/docs/planning/BACKEND_ROOT_CAUSE_IMPLEMENTATION_PLAN.md
+++ b/docs/planning/BACKEND_ROOT_CAUSE_IMPLEMENTATION_PLAN.md
@@ -95,7 +95,7 @@ def __init__(self, ...):
 rm data/conversation_files.db
 
 # Start AutoBot
-bash run_autobot.sh --dev
+scripts/start-services.sh start
 
 # Verify tables exist
 sqlite3 data/conversation_files.db "SELECT name FROM sqlite_master WHERE type='table';"

--- a/docs/planning/CONFIGURATION_MANAGEMENT_IMPLEMENTATION_PLAN.md
+++ b/docs/planning/CONFIGURATION_MANAGEMENT_IMPLEMENTATION_PLAN.md
@@ -1184,7 +1184,7 @@ VM_HOSTNAME=vm1-frontend                  # VM identifier for distributed reload
    export AUTOBOT_CONFIG_AUTO_RELOAD=true
 
    # Restart backend
-   ./run_autobot.sh --restart
+   sudo systemctl restart autobot-backend
    ```
 
 ---

--- a/docs/planning/DAY_3_IMPLEMENTATION_PLAN.md
+++ b/docs/planning/DAY_3_IMPLEMENTATION_PLAN.md
@@ -279,7 +279,7 @@ ansible-playbook -i ansible/inventory/production.yml \
 # 3. Frontend, NPU, Browser, AI (in parallel)
 
 # Restart backend
-ssh autobot@172.16.168.20 "cd /home/autobot && bash run_autobot.sh --restart"
+ssh autobot@172.16.168.20 "sudo systemctl restart autobot-backend"
 
 # Wait 30 seconds for backend to be ready
 sleep 30

--- a/docs/planning/WEEK_1_QUICK_START.md
+++ b/docs/planning/WEEK_1_QUICK_START.md
@@ -239,7 +239,7 @@ After implementation, run these to verify success:
 ```bash
 # 1. Test fresh database initialization
 rm -f /home/kali/Desktop/AutoBot/data/conversation_files.db
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 # Check logs for "Database initialized with schema version 1.0.0"
 
 # 2. Verify all tables created

--- a/docs/planning/WEEK_3_ENFORCEMENT_MODE_DEPLOYMENT_PLAN.md
+++ b/docs/planning/WEEK_3_ENFORCEMENT_MODE_DEPLOYMENT_PLAN.md
@@ -385,7 +385,7 @@ curl http://172.16.168.25:3000/health  # Browser
 echo "SERVICE_AUTH_ENFORCEMENT_MODE=true" >> .env
 
 # Restart backend
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 ```
 
 **Step 2**: Monitor for 30 minutes
@@ -416,7 +416,7 @@ env SERVICE_ID=npu-worker SERVICE_KEY_FILE=/etc/autobot/service-keys/npu-worker.
 sed -i 's/SERVICE_AUTH_ENFORCEMENT_MODE=true/SERVICE_AUTH_ENFORCEMENT_MODE=false/' .env
 
 # Restart backend
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # System returns to logging mode
 ```

--- a/docs/planning/issue-55-complete-summary.md
+++ b/docs/planning/issue-55-complete-summary.md
@@ -284,7 +284,7 @@ entity_extractor = GraphEntityExtractor(
 
 ```bash
 # 1. Restart backend
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # 2. Verify endpoints available
 curl https://172.16.168.20:8443/api/entities/extract/health

--- a/docs/planning/issue-55-phase2-deployment.md
+++ b/docs/planning/issue-55-phase2-deployment.md
@@ -23,7 +23,7 @@ Phase 2 implementation is complete and tested, but requires backend restart to a
 git status
 
 # 2. Restart backend to load new routers
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # 3. Wait for backend initialization (Phase 1 + Phase 2 services)
 # Expected log messages:
@@ -106,13 +106,13 @@ If deployment issues occur:
 
 ```bash
 # 1. Stop backend
-bash run_autobot.sh --stop
+sudo systemctl stop autobot-backend
 
 # 2. Revert changes
 git revert HEAD  # Or specific commit
 
 # 3. Restart backend
-bash run_autobot.sh --dev
+sudo systemctl start autobot-backend
 
 # 4. Verify core services still working
 curl https://172.16.168.20:8443/api/health

--- a/docs/planning/redis-ownership-standardization-plan.md
+++ b/docs/planning/redis-ownership-standardization-plan.md
@@ -132,10 +132,10 @@
 - **Risk:** Low - Single line change, no logic modification
 - **Dependencies:** Phase 2 complete (Ansible aligned first)
 
-#### Task 3.2: Add Ownership Verification Function to run_autobot.sh
+#### Task 3.2: Add Ownership Verification to Service Startup
 - **Agent:** senior-backend-engineer
 - **Time:** 15 minutes
-- **File:** `/home/kali/Desktop/AutoBot/run_autobot.sh`
+- **Note:** `run_autobot.sh` is deprecated (Issue #863). Add to Ansible role or systemd `ExecStartPre`.
 - **Changes:**
   ```bash
   # Add new function after line 200 (in verification section)
@@ -181,7 +181,7 @@
 - **Agent:** testing-engineer
 - **Time:** 15 minutes
 - **Test Scenarios:**
-  1. Fresh startup verification (`run_autobot.sh --dev`)
+  1. Fresh startup verification (`systemctl start autobot-backend`)
   2. Ownership auto-correction test (manually break, verify fix)
   3. Service restart validation (ownership persists)
   4. Ansible playbook deployment test (full infrastructure-as-code)
@@ -196,11 +196,11 @@
 - **Test Commands:**
   ```bash
   # Test 1: Fresh startup
-  bash run_autobot.sh --dev --no-browser
+  sudo systemctl start autobot-backend
 
   # Test 2: Ownership auto-correction
   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo chown -R redis:redis /var/lib/redis-stack"
-  bash run_autobot.sh --restart
+  sudo systemctl restart autobot-backend
 
   # Test 3: Service restart
   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo systemctl restart redis-stack-server"
@@ -257,7 +257,7 @@
 - **Commands:**
   ```bash
   git checkout HEAD -- scripts/vm-management/start-redis.sh
-  git checkout HEAD -- run_autobot.sh
+  # run_autobot.sh is deprecated — rollback Ansible roles instead
   ```
 
 #### Complete Rollback (nuclear option)
@@ -266,7 +266,7 @@
 - **Commands:**
   ```bash
   git revert <commit-hash> --no-edit
-  bash run_autobot.sh --restart
+  sudo systemctl restart autobot-backend
   ```
 
 ---

--- a/docs/planning/tasks/chat_404_implementation_plan.md
+++ b/docs/planning/tasks/chat_404_implementation_plan.md
@@ -65,7 +65,7 @@
 
 #### 1.1 Safe Backend Restart
 ```bash
-bash /home/kali/Desktop/AutoBot/run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 ```
 
 **Validation:**
@@ -268,7 +268,7 @@ curl -X POST http://localhost:8001/api/chat/completions \
 ### Risk 1: Service Disruption During Restart
 - **Severity**: LOW
 - **Probability**: LOW
-- **Mitigation**: Use `run_autobot.sh --restart` (designed for <1 min downtime)
+- **Mitigation**: Use `systemctl restart autobot-backend` (designed for <1 min downtime)
 - **Mitigation**: Health check validation before declaring success
 - **Rollback**: Previous process can be restarted if issues occur
 
@@ -399,7 +399,7 @@ If implementation fails at any stage:
    pkill -f "python.*app_factory"
 
    # Restart with previous code (if needed, revert commits)
-   bash run_autobot.sh --restart
+   sudo systemctl restart autobot-backend
    ```
 
 2. **Issue Investigation**:

--- a/docs/planning/tasks/redis-service-management-implementation-tasks.md
+++ b/docs/planning/tasks/redis-service-management-implementation-tasks.md
@@ -2356,7 +2356,7 @@ REDIS-5.4.1 + REDIS-5.4.2 (Final Testing)
 - All code changes developed locally first
 - Sync to remote VMs via sync scripts or Ansible
 - Never edit code directly on remote VMs
-- Use `run_autobot.sh` for local backend startup
+- Use `systemctl start autobot-backend` or `scripts/start-services.sh start` for backend startup
 - Frontend runs on VM1 only (single frontend server)
 
 **Testing Strategy:**
@@ -2409,7 +2409,7 @@ REDIS-5.4.1 + REDIS-5.4.2 (Final Testing)
 **Development:**
 ```bash
 # Backend development
-bash run_autobot.sh --dev
+scripts/start-services.sh start
 
 # Frontend development (runs on VM1)
 ./scripts/utilities/sync-frontend.sh

--- a/docs/project/CONFIG_REMEDIATION_PLAN.md
+++ b/docs/project/CONFIG_REMEDIATION_PLAN.md
@@ -2372,7 +2372,7 @@ backend:
 3. **Execute Rollback**
    ```bash
    # Stop affected services
-   bash run_autobot.sh --stop
+   scripts/start-services.sh stop
 
    # Revert code changes
    git revert <commit-hash>
@@ -2383,7 +2383,7 @@ backend:
    cp config/complete.yaml.backup config/complete.yaml
 
    # Restart services
-   bash run_autobot.sh --dev
+   scripts/start-services.sh start
    ```
 
 4. **Verify Recovery**

--- a/docs/security/ACCESS_CONTROL_SAFE_ROLLOUT_GUIDE.md
+++ b/docs/security/ACCESS_CONTROL_SAFE_ROLLOUT_GUIDE.md
@@ -121,7 +121,7 @@ The fix is in code but requires backend restart to take effect:
 
 ```bash
 # Method 1: Full restart
-bash run_autobot.sh --dev --restart
+sudo systemctl restart autobot-backend
 
 # Method 2: Backend-only restart
 pkill -f "uvicorn.*backend"
@@ -274,7 +274,7 @@ git log --oneline -5
 git revert <commit_hash>
 
 # Restart backend
-bash run_autobot.sh --dev --restart
+sudo systemctl restart autobot-backend
 ```
 
 ---

--- a/docs/security/ENFORCEMENT_ACTIVATION_READY.md
+++ b/docs/security/ENFORCEMENT_ACTIVATION_READY.md
@@ -179,7 +179,7 @@ curl -X POST https://172.16.168.20:8443/api/npu/heartbeat
 export SERVICE_AUTH_ENFORCEMENT_MODE=false
 
 # Restart backend
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # Verify rollback
 curl https://172.16.168.20:8443/api/health
@@ -303,7 +303,7 @@ cd /home/kali/Desktop/AutoBot
 export SERVICE_AUTH_ENFORCEMENT_MODE=true
 
 # Restart backend with enforcement enabled
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # Monitor activation
 tail -f logs/backend.log | grep -E "(Service auth|ENFORCEMENT|BLOCKED)"

--- a/docs/security/FILE_PERMISSIONS_SECURITY_ARCHITECTURE.md
+++ b/docs/security/FILE_PERMISSIONS_SECURITY_ARCHITECTURE.md
@@ -1252,7 +1252,7 @@ cat config/config.yaml | grep -A 10 "security_config:"
 # Edit config/config.yaml and set enable_auth: true
 
 # Step 1.3: Restart backend to load new config
-./run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 ```
 
 **Phase 2: Backend Updates** (30 minutes)
@@ -1376,7 +1376,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "supervisorctl restart autobot-f
 
 # Step 3: Disable auth temporarily (emergency only)
 # Edit config/config.yaml and set enable_auth: false
-./run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # Step 4: Verify system operational
 curl https://172.16.168.20:8443/api/health

--- a/docs/security/SERVICE_AUTH_DAY3_DEPLOYMENT_COMPLETE.md
+++ b/docs/security/SERVICE_AUTH_DAY3_DEPLOYMENT_COMPLETE.md
@@ -359,7 +359,7 @@ done
 
 **Quick Rollback (< 2 minutes)**:
 1. Remove SERVICE_ID and SERVICE_KEY_FILE from .env
-2. Restart backend: `bash run_autobot.sh --restart`
+2. Restart backend: `sudo systemctl restart autobot-backend`
 3. Middleware automatically disabled without config
 
 **Full Rollback (< 5 minutes)**:

--- a/docs/security/SERVICE_AUTH_ENFORCEMENT_ACTIVATION_CHECKLIST.md
+++ b/docs/security/SERVICE_AUTH_ENFORCEMENT_ACTIVATION_CHECKLIST.md
@@ -113,7 +113,7 @@ SERVICE_AUTH_ENFORCEMENT_MODE=true
 cd /home/kali/Desktop/AutoBot
 
 # Restart backend with enforcement enabled
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 ```
 
 **Expected Output**:
@@ -272,7 +272,7 @@ export SERVICE_AUTH_ENFORCEMENT_MODE=false
 
 # Restart backend
 cd /home/kali/Desktop/AutoBot
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # Verify rollback
 tail -50 logs/backend.log | grep "Service Authentication"

--- a/docs/security/SERVICE_AUTH_ENFORCEMENT_ROLLOUT_PLAN.md
+++ b/docs/security/SERVICE_AUTH_ENFORCEMENT_ROLLOUT_PLAN.md
@@ -822,7 +822,7 @@ curl http://172.16.168.22:8081/health
 
    # Restart backend (fast restart)
    echo "Restarting backend..."
-   bash run_autobot.sh --restart
+   sudo systemctl restart autobot-backend
 
    # Verify rollback
    sleep 5
@@ -859,7 +859,7 @@ curl http://172.16.168.22:8081/health
 
    ```bash
    # Fast restart (< 1 minute)
-   bash run_autobot.sh --restart
+   sudo systemctl restart autobot-backend
 
    # Monitor startup
    tail -f logs/backend.log
@@ -1058,7 +1058,7 @@ bash scripts/rollback-enforcement.sh
 
 # Method 2: Manual
 sed -i 's/SERVICE_AUTH_ENFORCEMENT_MODE=true/SERVICE_AUTH_ENFORCEMENT_MODE=false/' .env
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # Verify rollback
 curl -s https://172.16.168.20:8443/api/health | jq -r '.status'
@@ -1188,7 +1188,7 @@ grep SERVICE_AUTH_ENFORCEMENT_MODE .env
 
        # Restart backend to apply
        echo "Restarting backend..."
-       bash run_autobot.sh --restart > /dev/null 2>&1
+       sudo systemctl restart autobot-backend > /dev/null 2>&1
 
        # Verify backend healthy
        sleep 5
@@ -1470,7 +1470,7 @@ grep "ERROR\|FAILED" logs/backend.log | tail -50
 3. **Restart backend with final configuration**
 
    ```bash
-   bash run_autobot.sh --restart
+   sudo systemctl restart autobot-backend
 
    # Verify configuration
    curl -s https://172.16.168.20:8443/api/health | jq
@@ -1831,7 +1831,7 @@ cp logs/backend.log logs/backend.log.backup.$(date +%Y%m%d_%H%M%S)
 sed -i 's/SERVICE_AUTH_ENFORCEMENT_MODE=true/SERVICE_AUTH_ENFORCEMENT_MODE=false/' .env
 
 # Step 3: Standard restart
-bash run_autobot.sh --restart
+sudo systemctl restart autobot-backend
 
 # Step 4: Comprehensive verification
 sleep 10

--- a/docs/system-state.md
+++ b/docs/system-state.md
@@ -1482,7 +1482,7 @@ Desktop access is **enabled by default** on all modes:
 ### **Development Workflow:**
 1. **Edit Code Locally**: Make all changes in `/home/kali/Desktop/AutoBot/autobot-frontend/`
 2. **Sync to Frontend VM**: Use `./sync-frontend.sh` or `./scripts/utilities/sync-to-vm.sh frontend`
-3. **Frontend VM Runs**: Either dev or production mode via `run_autobot.sh`
+3. **Frontend VM Runs**: Either dev or production mode via systemd services
 
 ### **Sync Scripts:**
 - `./sync-frontend.sh` - Frontend-specific sync to VM
@@ -1511,7 +1511,7 @@ Desktop access is **enabled by default** on all modes:
 ### Key Files
 
 - `install.sh`: Standardized installation script (launches Setup Wizard)
-- `run_autobot.sh`: Main startup script (replaces all other run methods)
+- ~~`run_autobot.sh`~~: Deprecated (Issue #863). Use `systemctl start autobot-backend` or `scripts/start-services.sh`
 - `backend/fast_app_factory_fix.py`: Fast backend with Redis timeout fix
 - `compose.yml`: Distributed VM configuration
 - `.env`: Main environment configuration for distributed infrastructure

--- a/docs/troubleshooting/COMPREHENSIVE_TROUBLESHOOTING_GUIDE.md
+++ b/docs/troubleshooting/COMPREHENSIVE_TROUBLESHOOTING_GUIDE.md
@@ -11,7 +11,7 @@ Resolution Time: **~5 minutes average** (with this guide)
 
 ```bash
 # 1. Overall system health check
-bash run_autobot.sh --status
+sudo systemctl status autobot-backend --no-pager
 
 # 2. Check all service connectivity  
 python3 scripts/health_check_comprehensive.py
@@ -85,7 +85,7 @@ docker restart autobot-redis
 tail -f logs/autobot.log | grep -i redis
 
 # Solution: Use fast backend startup
-# Edit run_autobot.sh to use fast_app_factory_fix.py (should be default)
+# Ensure systemd service uses fast_app_factory_fix.py (should be default)
 ```
 
 **Quick Fix**:
@@ -105,7 +105,7 @@ netstat -tulpn | grep :8001
 sudo kill -9 $(lsof -t -i:8001)
 
 # Restart AutoBot
-bash run_autobot.sh --dev --build
+sudo systemctl restart autobot-backend
 ```
 
 #### C. Out of Memory
@@ -686,7 +686,7 @@ echo
 
 # 1. Service Status
 echo "=== Service Status ==="
-bash run_autobot.sh --status
+sudo systemctl status autobot-backend --no-pager
 
 # 2. Resource Usage
 echo "=== Resource Usage ==="
@@ -807,17 +807,17 @@ echo "Weekly maintenance completed"
 
 4. **Restart from Clean State**:
    ```bash
-   # Full restart with rebuild
-   bash run_autobot.sh --dev --rebuild
+   # Full restart
+   sudo systemctl restart autobot-backend
 
-   # If that fails, try minimal startup
-   bash run_autobot.sh --minimal --build
+   # If that fails, try manual foreground startup for debugging
+   cd backend && python -m uvicorn app_factory:create_app --host 0.0.0.0 --port 8443
    ```
 
 5. **Verify Recovery**:
    ```bash
    # Check all services
-   bash run_autobot.sh --status
+   sudo systemctl status autobot-backend --no-pager
 
    # Test basic functionality
    curl http://127.0.0.1:8001/api/health

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -163,7 +163,7 @@ Before diving into specific guides, run these diagnostic commands:
 
 ```bash
 # 1. Overall system health
-bash run_autobot.sh --status
+sudo systemctl status autobot-backend --no-pager
 
 # 2. Service connectivity
 python3 scripts/health_check_comprehensive.py

--- a/docs/troubleshooting/fixes/vector-dimension-mismatch-fix-2025-09-29.md
+++ b/docs/troubleshooting/fixes/vector-dimension-mismatch-fix-2025-09-29.md
@@ -125,7 +125,7 @@ self.vector_store = RedisVectorStore(
 pkill -f "python.*backend.*app"
 
 # Restart AutoBot
-bash run_autobot.sh --dev --no-build
+scripts/start-services.sh start
 ```
 
 ### 2. Verify Vector Store Initialization


### PR DESCRIPTION
## Summary
- Remove/update stale `run_autobot.sh` references across 51 files
- Script was deprecated in #863, moved to `legacy/`
- Replaced command examples with `systemctl` equivalents
- Left historical references in CHANGELOG.md and session archives as-is

Closes #2468

## Test plan
- [x] Active docs no longer reference run_autobot.sh as current
- [x] Historical records preserved (CHANGELOG, session archives)
- [x] No runtime behavior changes — documentation only
- [x] Pre-commit hooks pass