### PR TITLE
fix(devops): add post-commit auto-heal for stash-pop conflicts (#2416)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -203,6 +203,20 @@ repos:
         stages: [pre-commit]
         description: "Copies tracked post-checkout hook into .git/hooks/ so it runs on checkout and worktree creation"
 
+  # Bootstrap: install post-commit hook from tracked source (Issue #2416)
+  # Mirrors the install-post-checkout pattern above. The post-commit hook
+  # auto-heals working tree files corrupted by pre-commit's stash/pop cycle.
+  - repo: local
+    hooks:
+      - id: install-post-commit
+        name: Install post-commit hook (Issue #2416)
+        entry: bash -c 'SRC="scripts/hooks/post-commit"; DST="$(git rev-parse --git-common-dir)/hooks/post-commit"; [ -f "$SRC" ] && { [ ! -f "$DST" ] || ! diff -q "$SRC" "$DST" >/dev/null 2>&1; } && cp "$SRC" "$DST" && chmod +x "$DST" && echo "post-commit hook installed" || true'
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+        description: "Copies tracked post-commit hook into .git/hooks/ so it heals stash-pop conflicts"
+
 # Configuration for specific file types
 default_language_version:
   python: python3

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,0 +1,55 @@
+#!/bin/bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Post-commit hook:
+#   1. Auto-heal stash-pop conflict markers in working tree (Issue #2416)
+#   2. Chain to doc-sync post-commit hook (Issue #250)
+#
+# When pre-commit's stash push/pop cycle conflicts with PostToolUse
+# formatting changes (Black + isort), the working tree can end up with
+# merge conflict markers even though the committed content is correct.
+# This hook detects and restores those files from HEAD.
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# ---------------------------------------------------------------------------
+# 1. Auto-heal stash-pop conflict markers (Issue #2416)
+# ---------------------------------------------------------------------------
+# Check tracked files with unstaged changes for conflict markers.
+# git diff --name-only lists files that differ between index and working tree.
+changed_files="$(git diff --name-only 2>/dev/null)"
+if [ -n "$changed_files" ]; then
+    conflicted=""
+    while IFS= read -r f; do
+        [ -f "$f" ] || continue
+        if grep -q '^<<<<<<< ' "$f" 2>/dev/null; then
+            conflicted="${conflicted}${f}"$'\n'
+        fi
+    done <<< "$changed_files"
+
+    if [ -n "$conflicted" ]; then
+        echo ""
+        echo "Post-commit heal: restoring files with stash-pop conflict markers (#2416):"
+        while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            echo "  -> $f"
+            git checkout HEAD -- "$f"
+        done <<< "$conflicted"
+        echo "Working tree restored from committed versions."
+        echo ""
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Chain to doc-sync post-commit hook (Issue #250)
+# ---------------------------------------------------------------------------
+DOC_SYNC="$GIT_ROOT/autobot-infrastructure/shared/scripts/hooks/post-commit-doc-sync"
+if [ -x "$DOC_SYNC" ]; then
+    "$DOC_SYNC"
+elif [ -f "$DOC_SYNC" ]; then
+    bash "$DOC_SYNC"
+fi
+
+exit 0


### PR DESCRIPTION
Closes #2416

## Summary
- Added `scripts/hooks/post-commit` that detects conflict markers left by pre-commit stash/pop
- Automatically restores files from HEAD when conflicts detected
- Added `install-post-commit` entry in `.pre-commit-config.yaml` (mirrors existing `install-post-checkout` pattern)

## Test plan
- [x] Script passes `bash -n` syntax check
- [x] `install-post-commit` hook runs successfully during commit
- [x] No-op when no conflicts exist