### PR TITLE
chore(deps): audit and update dependency constraint comments (#2471)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -30,10 +30,10 @@ vanna>=0.7.0  # Issue #723: Natural language to SQL via Vanna.ai
 # Issue #858: Additional runtime dependencies for Python 3.13
 xxhash>=3.6.0          # Hash functions for LLM caching
 structlog>=25.5.0      # Structured logging for service auth
-llama-index>=0.13.0,<0.14.0    # RAG framework (pinned for API compatibility)
-llama-index-llms-ollama>=0.7.0,<1.0.0  # Ollama LLM integration (0.7.0+ for core 0.13.0)
-llama-index-embeddings-ollama>=0.7.0,<1.0.0  # Ollama embeddings (0.7.0+ for core 0.13.0)
-llama-index-vector-stores-chroma>=0.5.0,<1.0.0  # ChromaDB vector store
+llama-index>=0.13.0,<0.15.0    # RAG framework; 0.14.x verified compatible with sub-packages (verified 2026-03-26)
+llama-index-llms-ollama>=0.7.0,<1.0.0  # Ollama LLM integration (0.7.0+ for core >=0.13.0)
+llama-index-embeddings-ollama>=0.7.0,<1.0.0  # Ollama embeddings (0.7.0+ for core >=0.13.0)
+llama-index-vector-stores-chroma>=0.5.0,<1.0.0  # ChromaDB vector store (0.5.0+ for core >=0.13.0)
 # LangChain 1.x ecosystem — migrated from 0.3.x to fix SSRF CVE (#1572)
 langchain>=1.2.0,<2.0.0               # Issue #1572: Migrated to 1.x (was 0.3.x)
 langchain-core>=1.2.11,<2.0.0         # Issue #1572: SSRF CVE fix requires >=1.2.11

--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -26,7 +26,7 @@ typing_extensions>=4.0.0  # For Python 3.8 compatibility
 # Authentication
 PyJWT[crypto]>=2.8.0
 passlib[bcrypt]>=1.7.4
-bcrypt>=4.0.0,<5.0.0  # bcrypt 5.0.0 incompatible with passlib
+bcrypt>=4.0.0,<5.0.0  # bcrypt 5.0.0 raises ValueError for >72-byte passwords, breaking passlib 1.7.4 (unmaintained, verified 2026-03-26)
 python-multipart>=0.0.22          # SECURITY UPDATE - arbitrary file write fix
 
 # Async utilities

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ tenacity>=8.5.0
 # Async SSH for PKI certificate distribution (Issue #166)
 asyncssh>=2.22.0
 
-# TensorFlow 2.19.1 supports protobuf <6.0.0dev (verified from PyPI metadata)
+# TensorFlow 2.19.1 requires protobuf<6.0.0dev (verified 2026-03-26 from PyPI metadata)
+# TF 2.20+ requires protobuf>=5.28.0; TF 2.21+ requires protobuf>=6.31.1 — upgrade TF first before widening
 # Bumped to 5.29.6+ for JSON recursion depth bypass fix
 protobuf>=5.29.6,<6.0.0
 


### PR DESCRIPTION
Closes #2471

## Findings

**bcrypt** (`autobot-slm-backend/requirements.txt`): Constraint `<5.0.0` **KEPT**. bcrypt 5.0.0 raises `ValueError` for >72-byte passwords. passlib 1.7.4 (unmaintained since 2020) doesn't pre-truncate. Updated comment with specific breaking behavior + verification date.

**protobuf** (`requirements.txt`): Constraint `<6.0.0` **KEPT**. TF 2.19.1 requires `protobuf<6.0.0dev` (verified from PyPI metadata). Added roadmap: TF 2.21+ needs `protobuf>=6.31.1`, so TF must be upgraded first. 

**llama-index** (`autobot-backend/requirements.txt`): **WIDENED** `<0.14.0` → `<0.15.0`. 0.14.x released and sub-packages at 0.7.x/0.5.x lower bounds all support `llama-index-core>=0.13.0` (verified via PyPI JSON metadata).