### PR TITLE
cleanup(devops): remove orphaned init-databases.sh (#2491)

### DIFF
--- a/docker/postgres/init-databases.sh
+++ b/docker/postgres/init-databases.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Create additional databases for SLM user management (#1854)
-set -e
-
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-    CREATE DATABASE slm_users OWNER $POSTGRES_USER;
-EOSQL


### PR DESCRIPTION
## Summary
- Removes orphaned `docker/postgres/init-databases.sh` which only created `slm_users` database
- The `.sql` replacement (`docker/postgres/init-databases.sql`) already handles both `slm_users` and `autobot_users` and is mounted in `docker-compose.yml`
- Zero references to the `.sh` file found anywhere in the codebase

Closes #2491