### PR TITLE
fix(deps): align oxlint version with eslint-plugin-oxlint peer dep (#2518)

### DIFF
--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -102,7 +102,7 @@
     "mock-socket": "^9.3.0",
     "msw": "^2.8.8",
     "npm-run-all2": "^8.0.4",
-    "oxlint": "~1.1.0",
+    "oxlint": "~1.57.0",
     "playwright": "^1.54.2",
     "postcss": "^8.5.6",
     "prettier": "3.5.3",


### PR DESCRIPTION
## Summary
- Updates `oxlint` from `~1.1.0` to `~1.57.0` to match `eslint-plugin-oxlint@~1.57.0` peer dependency
- Fixes frontend Docker build failure caused by peer dependency mismatch

## Closes #2518

## Test plan
- [ ] `npm ls oxlint eslint-plugin-oxlint` shows no peer dep warnings
- [ ] Frontend Docker build succeeds
- [ ] Linting still works correctly