### PR TITLE
cleanup(backend): remove placeholder Issue #XXX comment (#2481)

### DIFF
--- a/autobot-backend/api/codebase_analytics/indexing_executor.py
+++ b/autobot-backend/api/codebase_analytics/indexing_executor.py
@@ -26,7 +26,7 @@ _SUBPROCESS_PROGRESS_TIMEOUT = 300  # 5 min without progress = stale
 _SUBPROCESS_WATCHDOG_INTERVAL = 30  # Check progress every 30 seconds
 
 # ---------------------------------------------------------------------------
-# Dedicated Indexing Thread Pool (Issue #XXX: Prevent thread starvation)
+# Dedicated Indexing Thread Pool (#2364: Prevent thread starvation on large repos)
 # ---------------------------------------------------------------------------
 _INDEXING_EXECUTOR: ThreadPoolExecutor | None = None
 _INDEXING_EXECUTOR_MAX_WORKERS = 4  # Dedicated threads for indexing operations


### PR DESCRIPTION
## Summary
- Replaces placeholder `Issue #XXX` comment with correct `#2364` in `indexing_executor.py`
- `#2364` is the issue that extracted the indexing thread pool from `scanner.py`, already referenced in the module docstring

Closes #2481