### PR TITLE
fix(docker): replace inherited HTTP healthcheck with Celery ping for worker (#2488)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,6 +192,12 @@ services:
       - CELERY_RESULT_BACKEND=redis://autobot-redis:6379/2
       - AUTOBOT_CHROMADB_HOST=autobot-chromadb
       - AUTOBOT_CHROMADB_PORT=8000
+    healthcheck:
+      test: ["CMD", "python3.12", "-m", "celery", "-A", "celery_app", "inspect", "ping", "--timeout", "5"]
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 3
     depends_on:
       autobot-redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Worker container inherited HTTP healthcheck from backend Dockerfile but runs Celery (no HTTP server)
- Adds `celery inspect ping` healthcheck override in docker-compose.yml
- Worker will now correctly report healthy when Celery is responsive

## Closes #2488

## Test plan
- [ ] `docker compose up` shows worker as healthy
- [ ] `celery inspect ping` returns OK from worker container
- [ ] Backend healthcheck still works independently