### PR TITLE
security(deps): bump pypdf >=6.8.0 → >=6.9.1 (#1972)

### DIFF
--- a/autobot-infrastructure/shared/config/requirements-ci.txt
+++ b/autobot-infrastructure/shared/config/requirements-ci.txt
@@ -47,7 +47,7 @@ python-magic>=0.4.27
 
 # RAG Agent & Knowledge Processing
 python-docx>=1.1.0
-pypdf>=6.4.0                     # PDF processing - SECURITY UPDATE (4 CVE fixes)
+pypdf>=6.9.1                     # PDF processing - SECURITY UPDATE (improved permission checks)
 python-pptx>=0.6.23
 openpyxl>=3.1.0
 markdown>=3.5.0

--- a/autobot-infrastructure/shared/config/requirements.txt
+++ b/autobot-infrastructure/shared/config/requirements.txt
@@ -53,7 +53,7 @@ python-magic>=0.4.27             # File type detection
 
 # RAG Agent & Knowledge Processing
 python-docx>=1.1.0               # Document processing
-pypdf>=6.8.0                     # PDF processing - SECURITY UPDATE (4 CVE fixes)
+pypdf>=6.9.1                     # PDF processing - SECURITY UPDATE (improved permission checks)
 python-pptx>=0.6.23              # PowerPoint processing
 openpyxl>=3.1.0                  # Excel processing
 markdown>=3.8.1                  # Markdown processing

--- a/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
+++ b/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
@@ -74,7 +74,7 @@ accelerate>=1.2.0
 
 # Document Processing
 python-docx>=1.1.0
-pypdf>=6.8.0
+pypdf>=6.9.1
 
 # Development and Testing
 pytest>=8.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ vllm>=0.14.1
 
 # Document parsing libraries for knowledge base
 # Supports PDF, Word, Excel, PowerPoint, OpenDocument formats
-pypdf>=6.8.0              # PDF parsing - SECURITY UPDATE (13 CVE fixes)
+pypdf>=6.9.1              # PDF parsing - SECURITY UPDATE (improved permission checks)
 python-docx>=1.1.2        # Microsoft Word (.docx)
 openpyxl>=3.1.5           # Microsoft Excel (.xlsx)
 python-pptx>=1.0.2        # Microsoft PowerPoint (.pptx)


### PR DESCRIPTION
## Summary
- Bump pypdf minimum version from >=6.8.0 to >=6.9.1 across all requirement files (security patch — improved permission checks)
- `requirements-ci/document.txt` already pinned at 6.9.2, no change needed

**Files updated (4):**
- `requirements.txt`
- `autobot-infrastructure/shared/config/requirements.txt`
- `autobot-infrastructure/shared/config/requirements-ci.txt`
- `autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt`

Closes #1972

## Test plan
- [ ] Verify `pip install pypdf>=6.9.1` resolves correctly
- [ ] Run document processing tests with updated version
- [ ] Verify PDF ingestion in knowledge pipeline