### PR TITLE
fix(frontend): replace hardcoded model ref with SSOT config (#2480)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useEnvironmentAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useEnvironmentAnalysis.ts
@@ -12,6 +12,7 @@
 import { ref } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
+import { getConfig } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import type {
   UseCodeIntelAnalysisDeps,
@@ -30,7 +31,7 @@ export function useEnvironmentAnalysis(
   const loadingEnvAnalysis = ref(false)
   const envAnalysisError = ref('')
   const useAiFiltering = ref(false)
-  const aiFilteringModel = ref('llama3.2:1b')
+  const aiFilteringModel = ref(getConfig().llm.defaultModel)
   const aiFilteringPriority = ref('high')
   const llmFilteringResult = ref<{
     enabled: boolean


### PR DESCRIPTION
## Summary
- Replaces hardcoded `llama3.2:1b` model reference with `getConfig().llm.defaultModel` from SSOT config
- Model now reads from `VITE_LLM_DEFAULT_MODEL` env var

## Closes #2480

## Test plan
- [ ] No remaining hardcoded model references in useEnvironmentAnalysis.ts
- [ ] Environment analysis composable still functions correctly
- [ ] TypeScript compiles without errors