### PR TITLE
fix(models): replace postgresql.UUID with database-agnostic UUID (#2495)

### DIFF
--- a/autobot-backend/models/agent.py
+++ b/autobot-backend/models/agent.py
@@ -14,7 +14,7 @@ import uuid
 from enum import Enum
 
 from sqlalchemy import Column, String, Text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 
@@ -37,7 +37,7 @@ class Agent(Base, TimestampMixin):
 
     __tablename__ = "agents"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id = Column(String(255), nullable=False, unique=True, index=True)
     name = Column(String(255), nullable=False)
     description = Column(Text, nullable=True)

--- a/autobot-backend/models/agent_org.py
+++ b/autobot-backend/models/agent_org.py
@@ -12,7 +12,7 @@ import uuid
 from enum import Enum
 
 from sqlalchemy import Column, String, Text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 
@@ -35,7 +35,7 @@ class AgentOrgNode(Base, TimestampMixin):
 
     __tablename__ = "agent_org_nodes"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id = Column(String(255), nullable=False, unique=True, index=True)
     name = Column(String(255), nullable=False)
     reports_to = Column(String(255), nullable=True, index=True)

--- a/autobot-backend/user_management/models/base.py
+++ b/autobot-backend/user_management/models/base.py
@@ -14,8 +14,8 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKey, func
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, declared_attr, mapped_column
+from sqlalchemy.types import Uuid
 
 
 class Base(DeclarativeBase):
@@ -23,7 +23,7 @@ class Base(DeclarativeBase):
 
     # Use UUID as default type annotation for id columns
     type_annotation_map = {
-        uuid.UUID: UUID(as_uuid=True),
+        uuid.UUID: Uuid(as_uuid=True),
     }
 
 
@@ -55,7 +55,7 @@ class TenantMixin:
     @declared_attr
     def org_id(cls) -> Mapped[uuid.UUID]:
         return mapped_column(
-            UUID(as_uuid=True),
+            Uuid(as_uuid=True),
             ForeignKey("organizations.id", ondelete="CASCADE"),
             nullable=False,
             index=True,

--- a/autobot-backend/user_management/models/mfa.py
+++ b/autobot-backend/user_management/models/mfa.py
@@ -13,8 +13,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
@@ -40,13 +40,13 @@ class UserMFA(Base, TimestampMixin):
     __tablename__ = "user_mfa"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         unique=True,

--- a/autobot-backend/user_management/models/role.py
+++ b/autobot-backend/user_management/models/role.py
@@ -11,8 +11,8 @@ import uuid
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, ForeignKey, String, Text
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ class Permission(Base, TimestampMixin):
     __tablename__ = "permissions"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
@@ -94,14 +94,14 @@ class Role(Base, TimestampMixin):
     __tablename__ = "roles"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Nullable org_id means system role
     org_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
@@ -178,13 +178,13 @@ class RolePermission(Base):
     __tablename__ = "role_permissions"
 
     role_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("roles.id", ondelete="CASCADE"),
         primary_key=True,
     )
 
     permission_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("permissions.id", ondelete="CASCADE"),
         primary_key=True,
     )
@@ -214,20 +214,20 @@ class UserRole(Base, TimestampMixin):
     __tablename__ = "user_roles"
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         primary_key=True,
     )
 
     role_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("roles.id", ondelete="CASCADE"),
         primary_key=True,
     )
 
     # Who assigned this role
     assigned_by: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )


### PR DESCRIPTION
## Summary
- Replaces `sqlalchemy.dialects.postgresql.UUID` with `sqlalchemy.types.Uuid` in 5 model files
- Matches pattern from PR #2424 for `workflow_permission.py`
- `sqlalchemy.types.Uuid` is SQLAlchemy 2.0's dialect-neutral type: native UUID on PostgreSQL, 32-char string on SQLite
- Enables SQLite compatibility for dev/test environments

## Files Changed
- `autobot-backend/user_management/models/base.py` — import + `type_annotation_map` + `TenantMixin`
- `autobot-backend/user_management/models/role.py` — import + 9 columns
- `autobot-backend/user_management/models/mfa.py` — import + 2 columns
- `autobot-backend/models/agent.py` — import + 1 column
- `autobot-backend/models/agent_org.py` — import + 1 column

## Note
6 additional model files also use `postgresql.UUID` alongside `JSONB` — these need a separate fix (split import). Not in scope for this PR.

## Closes #2495

## Test plan
- [ ] No remaining `postgresql.UUID` in the 5 fixed files
- [ ] Python AST parse passes for all changed files
- [ ] Backend starts without import errors