### PR TITLE
fix(ansible): add cross-inventory group aliases (#2515)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/hosts-router.yml
+++ b/autobot-slm-backend/ansible/inventory/hosts-router.yml
@@ -47,3 +47,17 @@ all:
           hosts:
             autobot-redis:
               ansible_host: 192.168.1.150
+
+# Cross-inventory aliases (#2515)
+# Ensure group names from production.yml resolve in hosts-router.yml.
+aiml:
+  children:
+    ai_stack:
+
+npu:
+  children:
+    npu_workers:
+
+redis:
+  children:
+    database:

--- a/autobot-slm-backend/ansible/inventory/hosts.yml
+++ b/autobot-slm-backend/ansible/inventory/hosts.yml
@@ -60,3 +60,17 @@ all:
               services:
                 - { name: "redis-stack", port: 6379, command: "redis-stack-server --bind 0.0.0.0" }
               storage_gb: 100
+
+# Cross-inventory aliases (#2515)
+# Ensure group names from production.yml resolve in hosts.yml.
+aiml:
+  children:
+    ai_stack:
+
+npu:
+  children:
+    npu_workers:
+
+redis:
+  children:
+    database:

--- a/autobot-slm-backend/ansible/inventory/production.yml
+++ b/autobot-slm-backend/ansible/inventory/production.yml
@@ -288,3 +288,33 @@ infrastructure:
     npu:
     aiml:
     browser:
+
+# Cross-inventory aliases (#2515)
+# Ensure group names from hosts.yml and slm-nodes.yml resolve in production.yml.
+redis:
+  children:
+    database:
+
+npu_workers:
+  children:
+    npu:
+
+npu_worker:
+  children:
+    npu:
+
+ai_stack:
+  children:
+    aiml:
+
+# slm_nodes group used by SLM-specific playbooks (deploy-slm-agent, cleanup-nodes, etc.)
+# Maps all nodes managed by the SLM system.
+slm_nodes:
+  children:
+    slm:
+    backend:
+    frontend:
+    npu:
+    database:
+    aiml:
+    browser:

--- a/autobot-slm-backend/ansible/inventory/slm-nodes.yml
+++ b/autobot-slm-backend/ansible/inventory/slm-nodes.yml
@@ -136,3 +136,33 @@ all:
         ai_stack:
         slm_server:
         llm_nodes:
+
+    # Cross-inventory aliases (#2515)
+    # Ensure group names from production.yml resolve in slm-nodes.yml.
+    database:
+      children:
+        redis:
+
+    aiml:
+      children:
+        ai_stack:
+
+    npu:
+      children:
+        npu_worker:
+
+    npu_workers:
+      children:
+        npu_worker:
+
+    backend:
+      children:
+        main:
+
+    browser:
+      children:
+        browser_worker:
+
+    slm:
+      children:
+        slm_server:


### PR DESCRIPTION
## Summary
- Adds cross-inventory group aliases to all 4 inventory files
- Ensures group names from one inventory resolve in another (e.g., `npu` ↔ `npu_workers`, `aiml` ↔ `ai_stack`, `redis` ↔ `database`)
- Adds `slm_nodes` parent group in production.yml for SLM-specific playbooks

## Files Changed
- `autobot-slm-backend/ansible/inventory/hosts-router.yml` — 3 aliases
- `autobot-slm-backend/ansible/inventory/hosts.yml` — 3 aliases
- `autobot-slm-backend/ansible/inventory/production.yml` — 5 aliases + slm_nodes
- `autobot-slm-backend/ansible/inventory/slm-nodes.yml` — 7 aliases

## Closes #2515

## Test plan
- [ ] All YAML files pass syntax validation
- [ ] `ansible-playbook --list-hosts` resolves correctly for affected playbooks
- [ ] No duplicate host entries from alias resolution