### PR TITLE
fix(nginx): add /slm/api/ws/ WebSocket proxy location (#2489)

### DIFF
--- a/autobot-slm-frontend/src/composables/useSlmWebSocket.ts
+++ b/autobot-slm-frontend/src/composables/useSlmWebSocket.ts
@@ -19,8 +19,11 @@ import { createLogger } from '@/utils/debugUtils'
 const logger = createLogger('SlmWebSocket')
 
 // Use WebSocket URL from SSOT config
+// Issue #2489: Prefix with apiBaseUrl when it's a relative path (Docker: /slm)
+// but skip when it's a full URL (fleet: http://172.16.168.19:8000)
 const config = getConfig()
-const WS_URL = `${config.wsBaseUrl}/api/ws/events`
+const apiPrefix = config.apiBaseUrl.startsWith('/') ? config.apiBaseUrl : ''
+const WS_URL = `${config.wsBaseUrl}${apiPrefix}/api/ws/events`
 
 // --- Module-level singleton state ---
 const socket = ref<WebSocket | null>(null)

--- a/docker/nginx/nginx-ssl.conf
+++ b/docker/nginx/nginx-ssl.conf
@@ -109,6 +109,19 @@ http {
             proxy_read_timeout 86400s;
         }
 
+        # SLM WebSocket (must come before /slm/api/ to take priority)
+        location /slm/api/ws/ {
+            proxy_pass http://slm/api/ws/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400s;
+        }
+
         location /slm/api/ {
             proxy_pass http://slm/api/;
             proxy_set_header Host $host;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -84,6 +84,19 @@ http {
             proxy_read_timeout 86400s;
         }
 
+        # --- SLM WebSocket (must come before /slm/api/ to take priority) ---
+        location /slm/api/ws/ {
+            proxy_pass http://slm/api/ws/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400s;
+        }
+
         # --- SLM API (must come before SLM frontend catch-all) ---
         location /slm/api/ {
             proxy_pass http://slm/api/;


### PR DESCRIPTION
## Summary
- Adds `/slm/api/ws/` WebSocket proxy location to both `nginx.conf` and `nginx-ssl.conf`
- Location placed before `/slm/api/` to ensure WebSocket upgrade requests take priority
- Includes proper WebSocket headers: `Upgrade`, `Connection "upgrade"`, 86400s read timeout
- Updates `useSlmWebSocket.ts` to use combined `wsBaseUrl + apiBaseUrl` path for Docker routing

## Files Changed
- `docker/nginx/nginx.conf` — new `/slm/api/ws/` location block
- `docker/nginx/nginx-ssl.conf` — new `/slm/api/ws/` location block
- `autobot-slm-frontend/src/composables/useSlmWebSocket.ts` — WebSocket URL path fix

## Closes #2489

## Test plan
- [ ] nginx -t passes config validation
- [ ] WebSocket connections to /slm/api/ws/events are proxied correctly
- [ ] Existing /slm/api/ REST routes unaffected