### PR TITLE
security(docker): add filesystem hardening — read_only, cap_drop, tmpfs (#1983)

### DIFF
--- a/autobot-infrastructure/shared/config/logging/loki/docker-compose-loki.yml
+++ b/autobot-infrastructure/shared/config/logging/loki/docker-compose-loki.yml
@@ -13,6 +13,17 @@ services:
     networks:
       - autobot-logging
     restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - DAC_OVERRIDE
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
     healthcheck:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1"]
       interval: 30s
@@ -34,6 +45,18 @@ services:
     networks:
       - autobot-logging
     restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
+    tmpfs:
+      - /tmp
+      - /var/run
+    security_opt:
+      - no-new-privileges:true
     depends_on:
       - loki
 

--- a/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-backup.yml
+++ b/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-backup.yml
@@ -364,6 +364,18 @@ services:
         exec node server.js
       "
     restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
+      - SYS_ADMIN
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s

--- a/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-vnc.yml
+++ b/autobot-infrastructure/shared/docker/compose/docker-compose.playwright-vnc.yml
@@ -75,6 +75,18 @@ services:
         echo '🚀 Starting all services with supervisor...'
         exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
       "
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
+      - SYS_ADMIN
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000/health && curl -f http://localhost:6080/ || exit 1"]
       interval: 30s

--- a/autobot-infrastructure/shared/docker/compose/docker-compose.playwright.yml
+++ b/autobot-infrastructure/shared/docker/compose/docker-compose.playwright.yml
@@ -27,6 +27,18 @@ services:
         node server.js
       "
     restart: unless-stopped
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
+      - SYS_ADMIN
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 30s

--- a/autobot-infrastructure/shared/docker/compose/docker-compose.secure-sandbox.yml
+++ b/autobot-infrastructure/shared/docker/compose/docker-compose.secure-sandbox.yml
@@ -105,6 +105,12 @@ services:
       - no-new-privileges:true
       - apparmor:docker-default
 
+    # Capabilities
+    cap_drop:
+      - ALL
+    cap_add:
+      - DAC_OVERRIDE
+
     # Resource limits
     deploy:
       resources:
@@ -114,6 +120,11 @@ services:
 
     # Read-only root filesystem
     read_only: true
+
+    # Temporary filesystems
+    tmpfs:
+      - /tmp:size=50M,mode=1777
+      - /var/run:size=10M,mode=755
 
     # Volumes
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,15 @@ services:
           memory: 1G
           cpus: '1.0'
     logging: *default-logging
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - DAC_OVERRIDE
+    tmpfs:
+      - /tmp
     security_opt:
       - no-new-privileges:true
     networks:
@@ -75,6 +84,15 @@ services:
           memory: 1G
           cpus: '1.0'
     logging: *default-logging
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - DAC_OVERRIDE
+    tmpfs:
+      - /tmp
     security_opt:
       - no-new-privileges:true
     networks:
@@ -102,6 +120,15 @@ services:
           memory: 1G
           cpus: '1.0'
     logging: *default-logging
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - DAC_OVERRIDE
+    tmpfs:
+      - /tmp
     security_opt:
       - no-new-privileges:true
     networks:
@@ -158,6 +185,15 @@ services:
           memory: 2G
           cpus: '2.0'
     logging: *default-logging
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
+    tmpfs:
+      - /tmp
     security_opt:
       - no-new-privileges:true
     networks:
@@ -203,6 +239,15 @@ services:
         condition: service_healthy
       autobot-chromadb:
         condition: service_healthy
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
+    tmpfs:
+      - /tmp
     networks:
       - autobot-data
       - autobot-app
@@ -243,6 +288,15 @@ services:
           memory: 1G
           cpus: '1.0'
     logging: *default-logging
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
+    tmpfs:
+      - /tmp
     security_opt:
       - no-new-privileges:true
     networks:
@@ -281,6 +335,18 @@ services:
           memory: 512M
           cpus: '0.5'
     logging: *default-logging
+    read_only: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
+    tmpfs:
+      - /tmp
+      - /var/run
+      - /var/cache/nginx
     security_opt:
       - no-new-privileges:true
     networks:
@@ -310,6 +376,14 @@ services:
           memory: 8G  # 7B models need ~5.5GB; increase for larger models
           cpus: '4.0'
     logging: *default-logging
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+    tmpfs:
+      - /tmp
     security_opt:
       - no-new-privileges:true
     networks:
@@ -338,6 +412,12 @@ services:
           memory: 512M
           cpus: '0.5'
     logging: *default-logging
+    read_only: true
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp
+      - /var/run
     security_opt:
       - no-new-privileges:true
     networks:
@@ -369,6 +449,16 @@ services:
           memory: 512M
           cpus: '0.5'
     logging: *default-logging
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
+    tmpfs:
+      - /tmp
+      - /var/run
     security_opt:
       - no-new-privileges:true
     networks:


### PR DESCRIPTION
## Summary
- Add `cap_drop: [ALL]` with selective `cap_add` to all Docker services
- Add `read_only: true` to stateless containers (frontend, prometheus)
- Add `tmpfs` mounts for `/tmp`, `/var/run`, `/var/cache/nginx` where applicable
- Applied to all 6 compose files: main, 3 playwright variants, secure-sandbox, loki/grafana

Closes #1983

## Test plan
- [ ] `docker compose config` validates without errors
- [ ] All services start and pass health checks
- [ ] Stateful services (redis, postgres, backend) can still write to data volumes
- [ ] Frontend/nginx serves content correctly with read_only filesystem
- [ ] Playwright services can launch Chromium (SYS_ADMIN cap preserved)