### PR TITLE
feat(mesh): EWC++ catastrophic forgetting prevention for EdgeLearner

### DIFF
--- a/autobot-backend/services/mesh_brain/edge_learner.py
+++ b/autobot-backend/services/mesh_brain/edge_learner.py
@@ -62,6 +62,8 @@ class EdgeLearner:
         self.creation_threshold = creation_threshold
         self.initial_weight = initial_weight
         # EWC++ parameters (#2097)
+        if ewc_lambda < 0:
+            raise ValueError(f"ewc_lambda must be >= 0, got {ewc_lambda}")
         self.ewc_lambda = ewc_lambda
         self.ewc_consolidation_interval = ewc_consolidation_interval
         self._update_count: int = 0

--- a/autobot-backend/services/mesh_brain/edge_learner_test.py
+++ b/autobot-backend/services/mesh_brain/edge_learner_test.py
@@ -33,6 +33,7 @@ def _make_redis_mock() -> AsyncMock:
     """Return a Redis mock with xrange returning empty by default."""
     redis = AsyncMock()
     redis.xrange = AsyncMock(return_value=[])
+    redis.hgetall = AsyncMock(return_value={})
     return redis
 
 

--- a/autobot-backend/services/rag_config.py
+++ b/autobot-backend/services/rag_config.py
@@ -121,6 +121,14 @@ class RAGConfig:
         if self.timeout_seconds <= 0:
             raise ValueError(f"timeout_seconds must be > 0, got {self.timeout_seconds}")
 
+        if self.ewc_lambda < 0:
+            raise ValueError(f"ewc_lambda must be >= 0, got {self.ewc_lambda}")
+
+        if self.ewc_consolidation_interval < 1:
+            raise ValueError(
+                f"ewc_consolidation_interval must be >= 1, got {self.ewc_consolidation_interval}"
+            )
+
     @classmethod
     def from_dict(cls, config_dict: Metadata) -> "RAGConfig":
         """


### PR DESCRIPTION
## Summary
- Add Elastic Weight Consolidation (EWC++) to EdgeLearner to prevent new feedback from overwriting high-confidence learned edges
- Per-edge importance tracking based on retrieval success frequency
- Configurable λ strength and consolidation interval in RAGConfig
- No effect when disabled (λ=0) — fully backwards compatible

Closes #2097

## Test plan
- [x] Unit tests: high-importance edges resist drift under new feedback
- [x] Unit tests: λ=0 produces identical behavior to original EMA
- [x] Unit tests: consolidation fires at correct interval
- [x] Unit tests: importance tracking updates correctly on success/failure
- [x] All 18 edge_learner tests passing