### PR TITLE
fix(models): replace postgresql.UUID in 6 remaining model files (#2533)

### DIFF
--- a/autobot-backend/user_management/models/api_key.py
+++ b/autobot-backend/user_management/models/api_key.py
@@ -12,8 +12,9 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
@@ -40,7 +41,7 @@ class APIKey(Base, TimestampMixin):
     __tablename__ = "api_keys"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
@@ -62,7 +63,7 @@ class APIKey(Base, TimestampMixin):
 
     # Owner (always required)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -70,7 +71,7 @@ class APIKey(Base, TimestampMixin):
 
     # Optional team scope
     team_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("teams.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
@@ -126,7 +127,7 @@ class APIKey(Base, TimestampMixin):
     )
 
     revoked_by: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )

--- a/autobot-backend/user_management/models/audit.py
+++ b/autobot-backend/user_management/models/audit.py
@@ -12,8 +12,9 @@ from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import DateTime, ForeignKey, Index, String, func
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base
 
 
@@ -28,14 +29,14 @@ class AuditLog(Base):
     __tablename__ = "audit_logs"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Organization context (nullable for platform-level events)
     org_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
@@ -43,7 +44,7 @@ class AuditLog(Base):
 
     # Actor (who performed the action)
     user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
@@ -65,7 +66,7 @@ class AuditLog(Base):
 
     # Resource ID affected
     resource_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         nullable=True,
     )
 

--- a/autobot-backend/user_management/models/organization.py
+++ b/autobot-backend/user_management/models/organization.py
@@ -13,8 +13,9 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, Integer, String, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
@@ -41,7 +42,7 @@ class Organization(Base, TimestampMixin):
     __tablename__ = "organizations"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )

--- a/autobot-backend/user_management/models/sso.py
+++ b/autobot-backend/user_management/models/sso.py
@@ -16,8 +16,9 @@ from typing import TYPE_CHECKING, Optional
 
 from constants.threshold_constants import CategoryDefaults
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, UniqueConstraint
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
@@ -52,14 +53,14 @@ class SSOProvider(Base, TimestampMixin):
     __tablename__ = "sso_providers"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Organization (nullable for global/social providers)
     org_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
@@ -171,20 +172,20 @@ class UserSSOLink(Base, TimestampMixin):
     __tablename__ = "user_sso_links"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
     provider_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("sso_providers.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/autobot-backend/user_management/models/team.py
+++ b/autobot-backend/user_management/models/team.py
@@ -13,8 +13,9 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, UniqueConstraint
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TenantMixin, TimestampMixin
 
 if TYPE_CHECKING:
@@ -47,7 +48,7 @@ class Team(Base, TenantMixin, TimestampMixin):
     __tablename__ = "teams"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
@@ -149,20 +150,20 @@ class TeamMembership(Base, TimestampMixin):
     __tablename__ = "team_memberships"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     team_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("teams.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/autobot-backend/user_management/models/user.py
+++ b/autobot-backend/user_management/models/user.py
@@ -12,8 +12,9 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
@@ -53,14 +54,14 @@ class User(Base, TimestampMixin):
     __tablename__ = "users"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Organization association (nullable for platform admins in provider mode)
     org_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=True,
         index=True,


### PR DESCRIPTION
## Summary
- Splits `from sqlalchemy.dialects.postgresql import JSONB, UUID` into separate imports
- Keeps `JSONB` from postgresql (legitimately dialect-specific)
- Moves `UUID` to `from sqlalchemy.types import Uuid` (dialect-agnostic)
- Completes the migration started in PR #2532

## Files Changed
- `user_management/models/user.py` — 2 columns
- `user_management/models/audit.py` — 4 columns
- `user_management/models/organization.py` — 1 column
- `user_management/models/api_key.py` — 4 columns
- `user_management/models/team.py` — 4 columns
- `user_management/models/sso.py` — 5 columns

## Closes #2533

## Test plan
- [ ] Zero `postgresql.UUID` remaining in model files (excluding migrations)
- [ ] All files pass Python AST parse
- [ ] Backend starts without import errors