### PR TITLE
feat(inference): Flash Attention v2 with variable-length sequences (#1955)

### DIFF
--- a/autobot-backend/llm_interface_pkg/optimization/__init__.py
+++ b/autobot-backend/llm_interface_pkg/optimization/__init__.py
@@ -13,6 +13,15 @@ Issue #717: Efficient Inference Design implementation.
 
 from .cloud_batcher import BatchResult, CloudRequestBatcher
 from .connection_pool import ConnectionPoolManager, PoolConfig
+from .flash_attention import (
+    AttentionBackend,
+    AttentionOutput,
+    FlashAttentionConfig,
+    FlashAttentionV2,
+    GrowingKVCache,
+    create_flash_attention,
+    detect_backend,
+)
 from .inference_utils import (
     InferenceConfig,
     InferenceMode,
@@ -47,6 +56,14 @@ __all__ = [
     "OptimizationCategory",
     "OptimizationConfig",
     "get_optimization_router",
+    # Flash Attention
+    "FlashAttentionV2",
+    "FlashAttentionConfig",
+    "AttentionBackend",
+    "AttentionOutput",
+    "GrowingKVCache",
+    "create_flash_attention",
+    "detect_backend",
     # Cloud Batcher
     "CloudRequestBatcher",
     "BatchResult",

--- a/autobot-backend/llm_interface_pkg/optimization/flash_attention.py
+++ b/autobot-backend/llm_interface_pkg/optimization/flash_attention.py
@@ -1,0 +1,621 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Flash Attention v2 with variable-length sequence optimization.
+
+Provides padded and unpadded attention paths for batch inference,
+using unpadding to avoid wasting GPU compute on padding tokens.
+Includes fused RoPE kernel, growing KV cache, and JIT-compiled
+GQA expansion. Graceful fallback: Flash Attn -> SDPA -> vanilla.
+
+Issue #1955: Flash Attention v2 with variable-length sequence optimization.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Lazy imports for optional dependencies
+_flash_attn_available: Optional[bool] = None
+_flash_attn_modules: dict = {}
+
+
+class AttentionBackend(Enum):
+    """Available attention computation backends."""
+
+    FLASH_ATTN_V2 = "flash_attn_v2"
+    SDPA = "sdpa"
+    VANILLA = "vanilla"
+
+
+@dataclass
+class FlashAttentionConfig:
+    """Configuration for Flash Attention v2.
+
+    Attributes:
+        dropout_p: Dropout probability during training (0.0 for inference).
+        softmax_scale: Scaling factor for QK^T. None = 1/sqrt(head_dim).
+        causal: Whether to apply causal masking.
+        kv_cache_chunk_size: Grow KV cache by this many positions at a time.
+        num_kv_heads: Number of key-value heads (for GQA). None = same as query heads.
+        max_sequence_length: Maximum expected sequence length for cache pre-allocation.
+    """
+
+    dropout_p: float = 0.0
+    softmax_scale: Optional[float] = None
+    causal: bool = True
+    kv_cache_chunk_size: int = 256
+    num_kv_heads: Optional[int] = None
+    max_sequence_length: int = 8192
+
+
+@dataclass
+class AttentionOutput:
+    """Result of an attention computation.
+
+    Attributes:
+        output: The attention output tensor [batch, seq_len, num_heads, head_dim].
+        backend_used: Which backend actually executed the computation.
+    """
+
+    output: torch.Tensor
+    backend_used: AttentionBackend
+
+
+@dataclass
+class KVCacheState:
+    """Growing KV cache state for incremental decoding.
+
+    Issue #1955: Grows in chunks to reduce allocation overhead.
+
+    Attributes:
+        cache: The KV cache tensor or None if uninitialized.
+        seq_offset: Current position in the cache (number of filled positions).
+        chunk_size: Number of positions to grow by when cache is full.
+    """
+
+    cache: Optional[torch.Tensor] = None
+    seq_offset: int = 0
+    chunk_size: int = 256
+
+
+def _probe_flash_attn() -> bool:
+    """Check if flash_attn package is available and load modules lazily."""
+    global _flash_attn_available  # noqa: PLW0603
+    if _flash_attn_available is not None:
+        return _flash_attn_available
+
+    try:
+        from flash_attn import flash_attn_kvpacked_func, flash_attn_varlen_kvpacked_func
+        from flash_attn.bert_padding import pad_input, unpad_input
+
+        _flash_attn_modules["flash_attn_kvpacked_func"] = flash_attn_kvpacked_func
+        _flash_attn_modules["flash_attn_varlen_kvpacked_func"] = (
+            flash_attn_varlen_kvpacked_func
+        )
+        _flash_attn_modules["unpad_input"] = unpad_input
+        _flash_attn_modules["pad_input"] = pad_input
+        _flash_attn_available = True
+        logger.info("Flash Attention v2 loaded successfully")
+    except ImportError:
+        _flash_attn_available = False
+        logger.info("flash_attn not available, will use fallback backends")
+
+    _try_load_fused_rope()
+    return _flash_attn_available
+
+
+def _try_load_fused_rope() -> None:
+    """Attempt to load fused RoPE kernel from flash_attn."""
+    try:
+        from flash_attn.layers.rotary import apply_rotary_emb as fused_rope
+
+        _flash_attn_modules["fused_rope"] = fused_rope
+        logger.info("Fused RoPE kernel loaded from flash_attn")
+    except ImportError:
+        logger.debug("Fused RoPE kernel not available, using standard implementation")
+
+
+def _has_sdpa() -> bool:
+    """Check if PyTorch scaled_dot_product_attention is available."""
+    return hasattr(torch.nn.functional, "scaled_dot_product_attention")
+
+
+def detect_backend() -> AttentionBackend:
+    """Detect the best available attention backend.
+
+    Returns:
+        The highest-tier available backend.
+    """
+    if _probe_flash_attn():
+        return AttentionBackend.FLASH_ATTN_V2
+    if _has_sdpa():
+        return AttentionBackend.SDPA
+    return AttentionBackend.VANILLA
+
+
+def _build_repeat_kv_fn():
+    """Build a JIT-compiled repeat_kv function for GQA expansion.
+
+    Issue #1955: JIT compilation avoids Python overhead on repeated calls.
+    """
+
+    @torch.jit.script
+    def repeat_kv(kv: torch.Tensor, n_rep: int) -> torch.Tensor:
+        """Expand KV heads for Grouped Query Attention.
+
+        Args:
+            kv: Key or value tensor [batch, seq_len, num_kv_heads, head_dim].
+            n_rep: Number of times to repeat each KV head.
+
+        Returns:
+            Expanded tensor [batch, seq_len, num_kv_heads * n_rep, head_dim].
+        """
+        if n_rep == 1:
+            return kv
+        batch, seq_len, num_kv_heads, head_dim = kv.shape
+        kv = kv[:, :, :, None, :].expand(batch, seq_len, num_kv_heads, n_rep, head_dim)
+        return kv.reshape(batch, seq_len, num_kv_heads * n_rep, head_dim)
+
+    return repeat_kv
+
+
+# Module-level JIT-compiled function
+repeat_kv = _build_repeat_kv_fn()
+
+
+class GrowingKVCache:
+    """KV cache that grows in fixed-size chunks to reduce allocation overhead.
+
+    Issue #1955: Instead of reallocating per token, extends by chunk_size
+    positions at a time using torch.cat with pre-allocated empty tensors.
+
+    Args:
+        chunk_size: Number of positions to add per growth step.
+        device: Torch device for cache tensors.
+        dtype: Torch dtype for cache tensors.
+    """
+
+    def __init__(
+        self,
+        chunk_size: int = 256,
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float16,
+    ):
+        self.chunk_size = chunk_size
+        self.device = device or torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+        self.dtype = dtype
+        self._state = KVCacheState(chunk_size=chunk_size)
+
+    @property
+    def seq_offset(self) -> int:
+        """Current number of filled positions in the cache."""
+        return self._state.seq_offset
+
+    def update(self, new_kv: torch.Tensor) -> torch.Tensor:
+        """Append new KV entries to the cache, growing if needed.
+
+        Args:
+            new_kv: New key-value tensor [batch, new_seq, 2, num_heads, head_dim].
+
+        Returns:
+            Full KV cache up to current position [batch, total_seq, 2, num_heads, head_dim].
+        """
+        new_seq_len = new_kv.shape[1]
+
+        if self._state.cache is None:
+            self._state.cache = self._allocate_initial(new_kv)
+
+        needed = self._state.seq_offset + new_seq_len
+        self._grow_if_needed(new_kv, needed)
+        self._write_entries(new_kv, new_seq_len)
+
+        return self._state.cache[:, : self._state.seq_offset]
+
+    def _allocate_initial(self, new_kv: torch.Tensor) -> torch.Tensor:
+        """Allocate the initial cache with chunk-aligned capacity."""
+        batch, _, kv_pair, num_heads, head_dim = new_kv.shape
+        initial_len = self.chunk_size
+        return torch.zeros(
+            batch,
+            initial_len,
+            kv_pair,
+            num_heads,
+            head_dim,
+            device=self.device,
+            dtype=self.dtype,
+        )
+
+    def _grow_if_needed(self, new_kv: torch.Tensor, needed: int) -> None:
+        """Grow cache capacity in chunk increments if needed."""
+        current_capacity = self._state.cache.shape[1]
+        if needed <= current_capacity:
+            return
+
+        extra_chunks = ((needed - current_capacity - 1) // self.chunk_size) + 1
+        extra_len = extra_chunks * self.chunk_size
+        batch, _, kv_pair, num_heads, head_dim = new_kv.shape
+        extension = torch.zeros(
+            batch,
+            extra_len,
+            kv_pair,
+            num_heads,
+            head_dim,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        self._state.cache = torch.cat([self._state.cache, extension], dim=1)
+        logger.debug(
+            "KV cache grown by %d positions to %d total",
+            extra_len,
+            self._state.cache.shape[1],
+        )
+
+    def _write_entries(self, new_kv: torch.Tensor, new_seq_len: int) -> None:
+        """Write new entries into the cache at current offset."""
+        start = self._state.seq_offset
+        end = start + new_seq_len
+        self._state.cache[:, start:end] = new_kv
+        self._state.seq_offset = end
+
+    def reset(self) -> None:
+        """Clear the cache for a new sequence."""
+        self._state = KVCacheState(chunk_size=self.chunk_size)
+
+
+class FlashAttentionV2:
+    """Flash Attention v2 with variable-length sequence optimization.
+
+    Provides two paths:
+    - Padded path: standard flash_attn_kvpacked_func (no padding mask needed)
+    - Unpadded path: unpad -> flash_attn_varlen_kvpacked_func -> pad
+      for batches with mixed sequence lengths
+
+    Falls back to SDPA or vanilla attention when flash_attn is not installed.
+
+    Issue #1955.
+
+    Args:
+        config: Flash attention configuration.
+    """
+
+    def __init__(self, config: Optional[FlashAttentionConfig] = None):
+        self.config = config or FlashAttentionConfig()
+        self.backend = detect_backend()
+        self.kv_cache = GrowingKVCache(
+            chunk_size=self.config.kv_cache_chunk_size,
+        )
+        logger.info("FlashAttentionV2 initialized with backend=%s", self.backend.value)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        key_padding_mask: Optional[torch.Tensor] = None,
+    ) -> AttentionOutput:
+        """Run attention with automatic backend and path selection.
+
+        Args:
+            q: Query tensor [batch, seq_len, num_heads, head_dim].
+            kv: Key-value tensor [batch, seq_len, 2, num_kv_heads, head_dim].
+            key_padding_mask: Boolean mask [batch, seq_len] where True = valid token.
+                None means no padding (all tokens valid).
+
+        Returns:
+            AttentionOutput with result tensor and backend used.
+        """
+        if self.config.num_kv_heads is not None:
+            kv = self._expand_kv_for_gqa(q, kv)
+
+        if self.backend == AttentionBackend.FLASH_ATTN_V2:
+            return self._forward_flash(q, kv, key_padding_mask)
+        if self.backend == AttentionBackend.SDPA:
+            return self._forward_sdpa(q, kv, key_padding_mask)
+        return self._forward_vanilla(q, kv, key_padding_mask)
+
+    def _expand_kv_for_gqa(self, q: torch.Tensor, kv: torch.Tensor) -> torch.Tensor:
+        """Expand KV heads to match query heads for GQA models."""
+        num_q_heads = q.shape[2]
+        num_kv_heads = kv.shape[3]
+        if num_q_heads == num_kv_heads:
+            return kv
+        n_rep = num_q_heads // num_kv_heads
+        k = repeat_kv(kv[:, :, 0], n_rep)
+        v = repeat_kv(kv[:, :, 1], n_rep)
+        return torch.stack([k, v], dim=2)
+
+    def _forward_flash(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        key_padding_mask: Optional[torch.Tensor],
+    ) -> AttentionOutput:
+        """Execute using Flash Attention v2 backend."""
+        if key_padding_mask is None:
+            output = self._flash_padded(q, kv)
+        else:
+            output = self._flash_unpadded(q, kv, key_padding_mask)
+        return AttentionOutput(
+            output=output, backend_used=AttentionBackend.FLASH_ATTN_V2
+        )
+
+    def _flash_padded(self, q: torch.Tensor, kv: torch.Tensor) -> torch.Tensor:
+        """Fastest path: no padding mask needed.
+
+        Issue #1955: Direct call to flash_attn_kvpacked_func.
+        """
+        flash_fn = _flash_attn_modules["flash_attn_kvpacked_func"]
+        return flash_fn(
+            q,
+            kv,
+            dropout_p=self.config.dropout_p,
+            softmax_scale=self.config.softmax_scale,
+            causal=self.config.causal,
+        )
+
+    def _flash_unpadded(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        key_padding_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Variable-length path: unpad -> compute -> repad.
+
+        Issue #1955: Avoids wasting GPU compute on padding tokens by using
+        flash_attn_varlen_kvpacked_func with cumulative sequence lengths.
+        """
+        unpad_fn = _flash_attn_modules["unpad_input"]
+        pad_fn = _flash_attn_modules["pad_input"]
+        varlen_fn = _flash_attn_modules["flash_attn_varlen_kvpacked_func"]
+
+        batch_size = q.shape[0]
+        q_unpad, indices_q, cu_seqlens_q, max_seqlen_q = unpad_fn(
+            q.reshape(batch_size, -1, q.shape[-2] * q.shape[-1]),
+            key_padding_mask,
+        )
+        q_unpad = q_unpad.reshape(-1, q.shape[-2], q.shape[-1])
+
+        kv_flat = kv.reshape(batch_size, -1, 2 * kv.shape[-2] * kv.shape[-1])
+        kv_unpad, _indices_kv, cu_seqlens_k, max_seqlen_k = unpad_fn(
+            kv_flat,
+            key_padding_mask,
+        )
+        kv_unpad = kv_unpad.reshape(-1, 2, kv.shape[-2], kv.shape[-1])
+
+        output_unpad = varlen_fn(
+            q_unpad,
+            kv_unpad,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            dropout_p=self.config.dropout_p,
+            softmax_scale=self.config.softmax_scale,
+            causal=self.config.causal,
+        )
+
+        output_flat = output_unpad.reshape(-1, q.shape[-2] * q.shape[-1])
+        output = pad_fn(output_flat, indices_q, batch_size, max_seqlen_q)
+        return output.reshape(batch_size, -1, q.shape[-2], q.shape[-1])
+
+    def _forward_sdpa(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        key_padding_mask: Optional[torch.Tensor],
+    ) -> AttentionOutput:
+        """Fallback: PyTorch scaled_dot_product_attention.
+
+        Issue #1955: Second-tier fallback when flash_attn is not installed.
+        """
+        k, v = kv[:, :, 0], kv[:, :, 1]
+        q_t = q.transpose(1, 2)
+        k_t = k.transpose(1, 2)
+        v_t = v.transpose(1, 2)
+
+        attn_mask = self._build_sdpa_mask(key_padding_mask, q.shape[1], q.device)
+
+        output = torch.nn.functional.scaled_dot_product_attention(
+            q_t,
+            k_t,
+            v_t,
+            attn_mask=attn_mask,
+            dropout_p=self.config.dropout_p if self.training else 0.0,
+            is_causal=self.config.causal and attn_mask is None,
+        )
+        return AttentionOutput(
+            output=output.transpose(1, 2),
+            backend_used=AttentionBackend.SDPA,
+        )
+
+    def _build_sdpa_mask(
+        self,
+        key_padding_mask: Optional[torch.Tensor],
+        seq_len: int,
+        device: torch.device,
+    ) -> Optional[torch.Tensor]:
+        """Build combined causal + padding mask for SDPA."""
+        if key_padding_mask is None and not self.config.causal:
+            return None
+
+        mask = None
+        if self.config.causal and key_padding_mask is not None:
+            causal = torch.tril(
+                torch.ones(seq_len, seq_len, device=device, dtype=torch.bool)
+            )
+            pad_mask = key_padding_mask[:, None, None, :]
+            mask = causal[None, None, :, :] & pad_mask
+        elif key_padding_mask is not None:
+            mask = key_padding_mask[:, None, None, :]
+
+        return mask
+
+    def _forward_vanilla(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        key_padding_mask: Optional[torch.Tensor],
+    ) -> AttentionOutput:
+        """Lowest-tier fallback: manual scaled dot-product attention.
+
+        Issue #1955: Vanilla implementation for environments without
+        flash_attn or SDPA support.
+        """
+        k, v = kv[:, :, 0], kv[:, :, 1]
+        head_dim = q.shape[-1]
+        scale = self.config.softmax_scale or (head_dim**-0.5)
+
+        q_t = q.transpose(1, 2)
+        k_t = k.transpose(1, 2)
+        v_t = v.transpose(1, 2)
+
+        scores = torch.matmul(q_t, k_t.transpose(-2, -1)) * scale
+        scores = self._apply_masks_to_scores(
+            scores, key_padding_mask, q.shape[1], q.device
+        )
+        weights = torch.softmax(scores, dim=-1)
+
+        output = torch.matmul(weights, v_t)
+        return AttentionOutput(
+            output=output.transpose(1, 2),
+            backend_used=AttentionBackend.VANILLA,
+        )
+
+    def _apply_masks_to_scores(
+        self,
+        scores: torch.Tensor,
+        key_padding_mask: Optional[torch.Tensor],
+        seq_len: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Apply causal and padding masks to attention scores."""
+        if self.config.causal:
+            causal_mask = torch.triu(
+                torch.ones(seq_len, seq_len, device=device, dtype=torch.bool),
+                diagonal=1,
+            )
+            scores = scores.masked_fill(causal_mask[None, None, :, :], float("-inf"))
+
+        if key_padding_mask is not None:
+            pad_mask = ~key_padding_mask[:, None, None, :]
+            scores = scores.masked_fill(pad_mask, float("-inf"))
+
+        return scores
+
+    @property
+    def training(self) -> bool:
+        """Whether the module is in training mode (always False for inference)."""
+        return False
+
+    def apply_fused_rope(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Apply rotary position embedding using fused kernel if available.
+
+        Issue #1955: Fused RoPE avoids a separate kernel launch.
+
+        Args:
+            q: Query tensor.
+            k: Key tensor.
+            cos: Cosine frequencies.
+            sin: Sine frequencies.
+
+        Returns:
+            Tuple of (rotated_q, rotated_k).
+        """
+        fused_rope_fn = _flash_attn_modules.get("fused_rope")
+        if fused_rope_fn is not None:
+            return self._apply_fused_rope_kernel(fused_rope_fn, q, k, cos, sin)
+        return self._apply_standard_rope(q, k, cos, sin)
+
+    def _apply_fused_rope_kernel(
+        self,
+        fused_fn,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Apply RoPE using the fused flash_attn kernel."""
+        freqs = torch.stack([cos, sin], dim=-1)
+        q_rot = fused_fn(q, freqs)
+        k_rot = fused_fn(k, freqs)
+        return q_rot, k_rot
+
+    @staticmethod
+    def _apply_standard_rope(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Standard RoPE implementation as fallback."""
+        q_rot = _rotate_half_apply(q, cos, sin)
+        k_rot = _rotate_half_apply(k, cos, sin)
+        return q_rot, k_rot
+
+    def reset_cache(self) -> None:
+        """Reset the KV cache for a new generation sequence."""
+        self.kv_cache.reset()
+
+
+def _rotate_half_apply(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    """Apply rotary embedding to a tensor using the rotate-half method.
+
+    Args:
+        x: Input tensor [..., head_dim].
+        cos: Cosine frequencies, broadcastable to x.
+        sin: Sine frequencies, broadcastable to x.
+
+    Returns:
+        Rotated tensor with same shape as x.
+    """
+    half = x.shape[-1] // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    rotated = torch.cat([-x2, x1], dim=-1)
+    return x * cos + rotated * sin
+
+
+def create_flash_attention(
+    config: Optional[FlashAttentionConfig] = None,
+) -> FlashAttentionV2:
+    """Factory function to create a FlashAttentionV2 instance.
+
+    Issue #1955.
+
+    Args:
+        config: Optional configuration. Uses defaults if None.
+
+    Returns:
+        Configured FlashAttentionV2 instance.
+    """
+    return FlashAttentionV2(config)
+
+
+__all__ = [
+    "AttentionBackend",
+    "AttentionOutput",
+    "FlashAttentionConfig",
+    "FlashAttentionV2",
+    "GrowingKVCache",
+    "KVCacheState",
+    "create_flash_attention",
+    "detect_backend",
+    "repeat_kv",
+]

--- a/autobot-backend/llm_interface_pkg/optimization/flash_attention_test.py
+++ b/autobot-backend/llm_interface_pkg/optimization/flash_attention_test.py
@@ -1,0 +1,300 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for Flash Attention v2 with variable-length sequence optimization.
+
+Issue #1955: Flash Attention v2 with variable-length sequence optimization.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from llm_interface_pkg.optimization.flash_attention import (
+    AttentionBackend,
+    FlashAttentionConfig,
+    FlashAttentionV2,
+    GrowingKVCache,
+    _rotate_half_apply,
+    create_flash_attention,
+    detect_backend,
+)
+
+
+class TestDetectBackend:
+    """Tests for attention backend detection."""
+
+    def test_returns_valid_backend(self):
+        """detect_backend should return a valid AttentionBackend."""
+        backend = detect_backend()
+        assert isinstance(backend, AttentionBackend)
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention._probe_flash_attn",
+        return_value=False,
+    )
+    def test_falls_back_to_sdpa_when_no_flash(self, mock_probe):
+        """Should fall back to SDPA when flash_attn not available."""
+        if hasattr(torch.nn.functional, "scaled_dot_product_attention"):
+            backend = detect_backend()
+            assert backend in (AttentionBackend.SDPA, AttentionBackend.VANILLA)
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention._probe_flash_attn",
+        return_value=False,
+    )
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention._has_sdpa",
+        return_value=False,
+    )
+    def test_falls_back_to_vanilla(self, mock_sdpa, mock_probe):
+        """Should fall back to vanilla when nothing else is available."""
+        backend = detect_backend()
+        assert backend == AttentionBackend.VANILLA
+
+
+class TestGrowingKVCache:
+    """Tests for the growing KV cache."""
+
+    def _make_kv(self, batch: int, seq: int, heads: int = 4, dim: int = 32):
+        """Create a test KV tensor [batch, seq, 2, heads, dim]."""
+        return torch.randn(batch, seq, 2, heads, dim)
+
+    def test_initial_allocation(self):
+        """First update should allocate cache."""
+        cache = GrowingKVCache(chunk_size=256, device=torch.device("cpu"))
+        kv = self._make_kv(2, 10)
+        result = cache.update(kv)
+        assert result.shape == (2, 10, 2, 4, 32)
+        assert cache.seq_offset == 10
+
+    def test_grows_in_chunks(self):
+        """Cache should grow by chunk_size when capacity exceeded."""
+        cache = GrowingKVCache(chunk_size=8, device=torch.device("cpu"))
+        kv1 = self._make_kv(1, 6)
+        cache.update(kv1)
+        assert cache._state.cache.shape[1] == 8  # initial chunk
+
+        kv2 = self._make_kv(1, 5)
+        cache.update(kv2)
+        # Needed 11, had 8, so grew by 8 -> 16
+        assert cache._state.cache.shape[1] == 16
+        assert cache.seq_offset == 11
+
+    def test_preserves_existing_data(self):
+        """Growth should not corrupt existing cached data."""
+        cache = GrowingKVCache(chunk_size=4, device=torch.device("cpu"))
+        kv1 = torch.ones(1, 3, 2, 2, 8)
+        cache.update(kv1)
+
+        kv2 = torch.ones(1, 3, 2, 2, 8) * 2.0
+        result = cache.update(kv2)
+
+        assert torch.allclose(result[:, :3], kv1)
+        assert torch.allclose(result[:, 3:6], kv2)
+
+    def test_reset_clears_state(self):
+        """Reset should clear cache and offset."""
+        cache = GrowingKVCache(chunk_size=8, device=torch.device("cpu"))
+        cache.update(self._make_kv(1, 5))
+        cache.reset()
+        assert cache._state.cache is None
+        assert cache.seq_offset == 0
+
+    def test_multiple_growth_steps(self):
+        """Cache should handle multiple growth steps correctly."""
+        cache = GrowingKVCache(chunk_size=4, device=torch.device("cpu"))
+        for _ in range(10):
+            cache.update(self._make_kv(1, 3))
+        assert cache.seq_offset == 30
+        assert cache._state.cache.shape[1] >= 30
+
+
+class TestFlashAttentionV2:
+    """Tests for the FlashAttentionV2 class."""
+
+    def _make_qkv(self, batch: int, seq: int, heads: int = 4, dim: int = 32):
+        """Create matching Q and KV tensors."""
+        q = torch.randn(batch, seq, heads, dim)
+        kv = torch.randn(batch, seq, 2, heads, dim)
+        return q, kv
+
+    def test_init_defaults(self):
+        """Should initialize with default config."""
+        attn = FlashAttentionV2()
+        assert attn.config.dropout_p == 0.0
+        assert attn.config.causal is True
+        assert isinstance(attn.backend, AttentionBackend)
+
+    def test_init_custom_config(self):
+        """Should accept custom configuration."""
+        config = FlashAttentionConfig(
+            dropout_p=0.1,
+            causal=False,
+            kv_cache_chunk_size=512,
+        )
+        attn = FlashAttentionV2(config)
+        assert attn.config.dropout_p == 0.1
+        assert attn.config.causal is False
+        assert attn.kv_cache.chunk_size == 512
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_vanilla_fallback_no_mask(self, mock_backend):
+        """Vanilla backend should produce correct output shape without mask."""
+        attn = FlashAttentionV2()
+        q, kv = self._make_qkv(2, 8)
+        result = attn.forward(q, kv)
+        assert result.output.shape == (2, 8, 4, 32)
+        assert result.backend_used == AttentionBackend.VANILLA
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_vanilla_fallback_with_mask(self, mock_backend):
+        """Vanilla backend should handle padding mask correctly."""
+        attn = FlashAttentionV2()
+        q, kv = self._make_qkv(2, 8)
+        mask = torch.ones(2, 8, dtype=torch.bool)
+        mask[1, 5:] = False  # Second sequence shorter
+        result = attn.forward(q, kv, key_padding_mask=mask)
+        assert result.output.shape == (2, 8, 4, 32)
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.SDPA,
+    )
+    def test_sdpa_fallback(self, mock_backend):
+        """SDPA backend should produce correct output shape."""
+        if not hasattr(torch.nn.functional, "scaled_dot_product_attention"):
+            pytest.skip("SDPA not available in this PyTorch version")
+        attn = FlashAttentionV2()
+        q, kv = self._make_qkv(2, 8)
+        result = attn.forward(q, kv)
+        assert result.output.shape == (2, 8, 4, 32)
+        assert result.backend_used == AttentionBackend.SDPA
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_causal_masking(self, mock_backend):
+        """Causal attention should not attend to future tokens."""
+        config = FlashAttentionConfig(causal=True)
+        attn = FlashAttentionV2(config)
+        q, kv = self._make_qkv(1, 4, heads=1, dim=8)
+        result = attn.forward(q, kv)
+        # Output should be finite (no NaN from masking issues)
+        assert torch.isfinite(result.output).all()
+
+    def test_reset_cache(self):
+        """reset_cache should clear the internal KV cache."""
+        attn = FlashAttentionV2()
+        kv = torch.randn(1, 5, 2, 4, 32)
+        attn.kv_cache.update(kv)
+        assert attn.kv_cache.seq_offset == 5
+        attn.reset_cache()
+        assert attn.kv_cache.seq_offset == 0
+
+    def test_factory_function(self):
+        """create_flash_attention should return configured instance."""
+        config = FlashAttentionConfig(kv_cache_chunk_size=128)
+        attn = create_flash_attention(config)
+        assert isinstance(attn, FlashAttentionV2)
+        assert attn.config.kv_cache_chunk_size == 128
+
+    def test_factory_function_default(self):
+        """create_flash_attention with no args should use defaults."""
+        attn = create_flash_attention()
+        assert attn.config.kv_cache_chunk_size == 256
+
+
+class TestRotateHalfApply:
+    """Tests for the standard RoPE implementation."""
+
+    def test_output_shape(self):
+        """_rotate_half_apply should preserve input shape."""
+        x = torch.randn(2, 4, 8, 64)
+        cos = torch.ones_like(x)
+        sin = torch.zeros_like(x)
+        result = _rotate_half_apply(x, cos, sin)
+        assert result.shape == x.shape
+
+    def test_identity_with_zero_sin(self):
+        """With sin=0 and cos=1, output should equal input."""
+        x = torch.randn(1, 1, 1, 16)
+        cos = torch.ones_like(x)
+        sin = torch.zeros_like(x)
+        result = _rotate_half_apply(x, cos, sin)
+        assert torch.allclose(result, x, atol=1e-6)
+
+
+class TestGQAExpansion:
+    """Tests for Grouped Query Attention KV head expansion."""
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_gqa_expansion(self, mock_backend):
+        """GQA should expand KV heads to match query heads."""
+        config = FlashAttentionConfig(num_kv_heads=2)
+        attn = FlashAttentionV2(config)
+        q = torch.randn(1, 4, 8, 32)  # 8 query heads
+        kv = torch.randn(1, 4, 2, 2, 32)  # 2 KV heads
+        result = attn.forward(q, kv)
+        assert result.output.shape == (1, 4, 8, 32)
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_no_expansion_when_heads_match(self, mock_backend):
+        """No expansion should occur when KV heads match query heads."""
+        config = FlashAttentionConfig(num_kv_heads=4)
+        attn = FlashAttentionV2(config)
+        q = torch.randn(1, 4, 4, 32)
+        kv = torch.randn(1, 4, 2, 4, 32)
+        result = attn.forward(q, kv)
+        assert result.output.shape == (1, 4, 4, 32)
+
+
+class TestFusedRoPE:
+    """Tests for fused RoPE kernel integration."""
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_standard_rope_fallback(self, mock_backend):
+        """Should use standard RoPE when fused kernel not available."""
+        attn = FlashAttentionV2()
+        q = torch.randn(1, 4, 8, 64)
+        k = torch.randn(1, 4, 8, 64)
+        cos = torch.ones(1, 4, 1, 64)
+        sin = torch.zeros(1, 4, 1, 64)
+        q_rot, k_rot = attn.apply_fused_rope(q, k, cos, sin)
+        assert q_rot.shape == q.shape
+        assert k_rot.shape == k.shape
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention._flash_attn_modules",
+        {"fused_rope": MagicMock(side_effect=lambda x, freqs: x)},
+    )
+    def test_fused_rope_when_available(self, mock_backend):
+        """Should use fused kernel when available."""
+        attn = FlashAttentionV2()
+        q = torch.randn(1, 4, 8, 64)
+        k = torch.randn(1, 4, 8, 64)
+        cos = torch.ones(1, 4, 1, 64)
+        sin = torch.zeros(1, 4, 1, 64)
+        q_rot, k_rot = attn.apply_fused_rope(q, k, cos, sin)
+        assert q_rot.shape == q.shape


### PR DESCRIPTION
## Summary
- Flash Attention v2 with two paths: padded (fastest) and unpadded (variable-length sequences)
- Fallback chain: Flash Attn v2 → PyTorch SDPA → vanilla scaled dot-product
- Fused RoPE kernel from flash_attn (falls back to standard rotate-half)
- Growing KV cache in 256-position chunks to reduce allocation overhead
- JIT-compiled `repeat_kv` for Grouped Query Attention models
- Lazy dependency detection — loads cleanly without flash_attn installed

Closes #1955

## Test plan
- [ ] Verify padded and unpadded attention paths produce correct output
- [ ] Verify fallback chain when flash_attn not installed
- [ ] Verify growing KV cache allocation and data preservation
- [ ] Verify fused RoPE vs standard RoPE equivalence
- [ ] Benchmark batch of 4 requests with varying lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)