### PR TITLE
fix(frontend): add router-view to WorkflowBuilderView for child routes (#2368)

### DIFF
--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -273,19 +273,21 @@ const routes: RouteRecordRaw[] = [
       icon: 'fas fa-project-diagram',
       description: 'Visual workflow builder and automation (Issue #585)',
       requiresAuth: true
-    }
-  },
-  // Issue #900: Browser Automation Dashboard — moved under /automation (#2367)
-  {
-    path: '/automation/browser-automation',
-    name: 'browser-automation',
-    component: () => import('@/views/BrowserAutomationView.vue'),
-    meta: {
-      title: 'Browser Automation',
-      icon: 'fas fa-globe',
-      description: 'Control browser workers and automate web tasks',
-      requiresAuth: true
-    }
+    },
+    // Child routes render inside WorkflowBuilderView's <router-view /> (#2368)
+    children: [
+      {
+        path: 'browser-automation',
+        name: 'browser-automation',
+        component: () => import('@/views/BrowserAutomationView.vue'),
+        meta: {
+          title: 'Browser Automation',
+          icon: 'fas fa-globe',
+          description: 'Control browser workers and automate web tasks',
+          requiresAuth: true
+        }
+      }
+    ]
   },
   // Redirect old path (#2367)
   {

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -214,6 +214,11 @@
 
     <!-- Main Content -->
     <main class="workflow-content">
+      <!-- Child route content (#2368) -->
+      <router-view v-if="isChildRoute" />
+
+      <!-- Workflow Builder own content -->
+      <template v-else>
       <!-- Header -->
       <header class="content-header">
         <div class="header-left">
@@ -581,12 +586,14 @@
           </div>
         </section>
       </div>
+      </template>
     </main>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
 import { useToast } from '@/composables/useToast';
@@ -615,6 +622,10 @@ import {
 
 const logger = createLogger('WorkflowBuilderView');
 const { t } = useI18n();
+const route = useRoute();
+
+/** True when a child route (e.g. /automation/browser-automation) is active (#2368) */
+const isChildRoute = computed(() => route.matched.length > 1);
 const { showToast } = useToast();
 
 // Section Types


### PR DESCRIPTION
## Summary
- Adds `<router-view>` to WorkflowBuilderView for rendering child route components
- Restructures router: moves `/automation/browser-automation` into `children` array
- Parent content shows when no child route is active; child routes render in place
- TypeScript verified with `vue-tsc --noEmit`

## Files Changed
- `autobot-frontend/src/views/WorkflowBuilderView.vue` — conditional router-view + isChildRoute computed
- `autobot-frontend/src/router/index.ts` — browser-automation moved to children array

## Closes #2368

## Test plan
- [ ] `/automation` shows workflow builder content
- [ ] `/automation/browser-automation` renders BrowserAutomationView inside the layout
- [ ] Redirect from `/browser-automation` still works
- [ ] vue-tsc passes