### PR TITLE
feat(inference): only-last-logit optimization for generation (#1968)

### DIFF
--- a/autobot-backend/llm_interface_pkg/inference_utils_test.py
+++ b/autobot-backend/llm_interface_pkg/inference_utils_test.py
@@ -1,0 +1,193 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for only-last-logit inference optimization.
+
+Issue #1968: Only-last-logit optimization for autoregressive generation.
+"""
+
+import pytest
+import torch
+from llm_interface_pkg.optimization.inference_utils import (
+    InferenceConfig,
+    InferenceMode,
+    LastLogitOptimizer,
+    MemoryStats,
+    slice_hidden_for_generation,
+)
+
+
+class TestLastLogitOptimizer:
+    """Tests for LastLogitOptimizer class."""
+
+    def _make_hidden(self, batch: int = 1, seq_len: int = 2048, hidden_dim: int = 4096):
+        """Create a dummy hidden states tensor."""
+        return torch.randn(batch, seq_len, hidden_dim)
+
+    def test_default_config_slices_for_generation(self):
+        """Default config should slice in generation mode."""
+        optimizer = LastLogitOptimizer()
+        hidden = self._make_hidden(seq_len=2048)
+        result = optimizer.slice_for_lm_head(hidden)
+
+        assert result.was_sliced is True
+        assert result.output_seq_len == 1
+        assert result.original_seq_len == 2048
+        assert result.hidden_states.shape == (1, 1, 4096)
+
+    def test_last_position_logits_identical(self):
+        """Sliced last-position values must match full tensor's last position."""
+        hidden = self._make_hidden(batch=2, seq_len=512, hidden_dim=768)
+        optimizer = LastLogitOptimizer()
+        result = optimizer.slice_for_lm_head(hidden)
+
+        expected = hidden[:, -1:, :]
+        assert torch.equal(result.hidden_states, expected)
+
+    def test_perplexity_mode_preserves_all_positions(self):
+        """Perplexity mode must return full hidden states for scoring."""
+        config = InferenceConfig(mode=InferenceMode.PERPLEXITY)
+        optimizer = LastLogitOptimizer(config)
+        hidden = self._make_hidden(seq_len=256)
+        result = optimizer.slice_for_lm_head(hidden)
+
+        assert result.was_sliced is False
+        assert result.output_seq_len == 256
+        assert torch.equal(result.hidden_states, hidden)
+
+    def test_evaluation_mode_preserves_all_positions(self):
+        """Evaluation mode must return full hidden states."""
+        config = InferenceConfig(mode=InferenceMode.EVALUATION)
+        optimizer = LastLogitOptimizer(config)
+        hidden = self._make_hidden(seq_len=128)
+        result = optimizer.slice_for_lm_head(hidden)
+
+        assert result.was_sliced is False
+        assert result.output_seq_len == 128
+
+    def test_explicit_override_forces_full(self):
+        """Explicit only_last_logit=False overrides generation config."""
+        optimizer = LastLogitOptimizer()
+        hidden = self._make_hidden(seq_len=512)
+        result = optimizer.slice_for_lm_head(hidden, only_last_logit=False)
+
+        assert result.was_sliced is False
+        assert result.output_seq_len == 512
+
+    def test_explicit_override_forces_slice(self):
+        """Explicit only_last_logit=True overrides perplexity config."""
+        config = InferenceConfig(mode=InferenceMode.PERPLEXITY)
+        optimizer = LastLogitOptimizer(config)
+        hidden = self._make_hidden(seq_len=256)
+        result = optimizer.slice_for_lm_head(hidden, only_last_logit=True)
+
+        assert result.was_sliced is True
+        assert result.output_seq_len == 1
+
+    def test_seq_len_1_no_slice(self):
+        """Single-token sequences should not be sliced (already minimal)."""
+        optimizer = LastLogitOptimizer()
+        hidden = self._make_hidden(seq_len=1)
+        result = optimizer.slice_for_lm_head(hidden)
+
+        assert result.was_sliced is False
+        assert result.output_seq_len == 1
+        assert result.memory_saved_bytes == 0
+
+    def test_memory_savings_estimation(self):
+        """Memory savings should be approximately correct for fp16."""
+        config = InferenceConfig(vocab_size=32000, dtype_bytes=2)
+        optimizer = LastLogitOptimizer(config)
+        hidden = self._make_hidden(batch=1, seq_len=2048, hidden_dim=4096)
+        result = optimizer.slice_for_lm_head(hidden)
+
+        # Expected: (2048 - 1) * 32000 * 2 = ~125 MB
+        expected_bytes = 1 * 2047 * 32000 * 2
+        assert result.memory_saved_bytes == expected_bytes
+        assert result.memory_saved_bytes > 100 * 1024 * 1024  # > 100 MB
+
+    def test_stats_accumulate(self):
+        """Statistics should accumulate across multiple forward passes."""
+        optimizer = LastLogitOptimizer()
+        hidden = self._make_hidden(seq_len=512)
+
+        optimizer.slice_for_lm_head(hidden)
+        optimizer.slice_for_lm_head(hidden)
+        optimizer.slice_for_lm_head(hidden, only_last_logit=False)
+
+        assert optimizer.stats.forward_pass_count == 3
+        assert optimizer.stats.sliced_count == 2
+        assert optimizer.stats.total_saved_bytes > 0
+
+    def test_reset_stats(self):
+        """reset_stats should return previous stats and zero the counters."""
+        optimizer = LastLogitOptimizer()
+        hidden = self._make_hidden(seq_len=512)
+        optimizer.slice_for_lm_head(hidden)
+
+        previous = optimizer.reset_stats()
+        assert previous.forward_pass_count == 1
+        assert previous.sliced_count == 1
+
+        assert optimizer.stats.forward_pass_count == 0
+        assert optimizer.stats.sliced_count == 0
+        assert optimizer.stats.total_saved_bytes == 0
+
+    def test_invalid_dimensions_raises(self):
+        """Non-3D tensors should raise ValueError."""
+        optimizer = LastLogitOptimizer()
+        with pytest.raises(ValueError, match="Expected 3D tensor"):
+            optimizer.slice_for_lm_head(torch.randn(10, 768))
+
+    def test_total_saved_mb_property(self):
+        """MemoryStats.total_saved_mb should convert bytes correctly."""
+        stats = MemoryStats(total_saved_bytes=1024 * 1024 * 50)
+        assert stats.total_saved_mb == pytest.approx(50.0)
+
+
+class TestSliceHiddenForGeneration:
+    """Tests for the convenience function."""
+
+    def test_slices_by_default(self):
+        """Default call should slice to last position."""
+        hidden = torch.randn(1, 1024, 768)
+        result = slice_hidden_for_generation(hidden)
+        assert result.shape == (1, 1, 768)
+        assert torch.equal(result, hidden[:, -1:, :])
+
+    def test_no_slice_when_disabled(self):
+        """Passing only_last_logit=False returns original tensor."""
+        hidden = torch.randn(1, 1024, 768)
+        result = slice_hidden_for_generation(hidden, only_last_logit=False)
+        assert torch.equal(result, hidden)
+
+    def test_no_slice_for_single_token(self):
+        """Single-token input should pass through unchanged."""
+        hidden = torch.randn(1, 1, 768)
+        result = slice_hidden_for_generation(hidden)
+        assert torch.equal(result, hidden)
+
+
+class TestInferenceConfig:
+    """Tests for InferenceConfig."""
+
+    def test_generation_should_slice(self):
+        """Generation mode with default flag should slice."""
+        config = InferenceConfig(mode=InferenceMode.GENERATION)
+        assert config.should_slice is True
+
+    def test_generation_disabled_should_not_slice(self):
+        """Generation mode with explicit disable should not slice."""
+        config = InferenceConfig(mode=InferenceMode.GENERATION, only_last_logit=False)
+        assert config.should_slice is False
+
+    def test_perplexity_should_not_slice(self):
+        """Perplexity mode should never slice regardless of flag."""
+        config = InferenceConfig(mode=InferenceMode.PERPLEXITY, only_last_logit=True)
+        assert config.should_slice is False
+
+    def test_evaluation_should_not_slice(self):
+        """Evaluation mode should never slice regardless of flag."""
+        config = InferenceConfig(mode=InferenceMode.EVALUATION, only_last_logit=True)
+        assert config.should_slice is False

--- a/autobot-backend/llm_interface_pkg/optimization/__init__.py
+++ b/autobot-backend/llm_interface_pkg/optimization/__init__.py
@@ -13,6 +13,14 @@ Issue #717: Efficient Inference Design implementation.
 
 from .cloud_batcher import BatchResult, CloudRequestBatcher
 from .connection_pool import ConnectionPoolManager, PoolConfig
+from .inference_utils import (
+    InferenceConfig,
+    InferenceMode,
+    LastLogitOptimizer,
+    LogitSliceResult,
+    MemoryStats,
+    slice_hidden_for_generation,
+)
 from .integration import (
     OptimizationMetrics,
     OptimizedLLMMiddleware,
@@ -47,6 +55,13 @@ __all__ = [
     "PromptCompressor",
     "CompressionResult",
     "CompressionConfig",
+    # Inference Utilities (Issue #1968)
+    "LastLogitOptimizer",
+    "InferenceConfig",
+    "InferenceMode",
+    "LogitSliceResult",
+    "MemoryStats",
+    "slice_hidden_for_generation",
     # Integration
     "OptimizedLLMMiddleware",
     "OptimizationMetrics",

--- a/autobot-backend/llm_interface_pkg/optimization/inference_utils.py
+++ b/autobot-backend/llm_interface_pkg/optimization/inference_utils.py
@@ -1,0 +1,265 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Inference Utilities - Only-last-logit optimization for autoregressive generation.
+
+During autoregressive generation, only the last token position's logits determine
+the next token. Computing the full vocabulary projection (lm_head) for all positions
+is wasteful. This module provides utilities to slice hidden states before projection,
+yielding up to 2048x reduction in the final projection computation.
+
+Issue #1968: Only-last-logit optimization for autoregressive generation.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Conditional torch import — module degrades gracefully without it
+try:
+    import torch
+except ImportError:
+    torch = None  # type: ignore[assignment]
+
+
+class InferenceMode(str, Enum):
+    """Inference mode controlling logit computation scope."""
+
+    GENERATION = "generation"
+    PERPLEXITY = "perplexity"
+    EVALUATION = "evaluation"
+
+
+@dataclass
+class LogitSliceResult:
+    """Result of a logit slicing operation.
+
+    Attributes:
+        hidden_states: The (possibly sliced) hidden states ready for lm_head.
+        was_sliced: Whether the hidden states were sliced to last position.
+        original_seq_len: Original sequence length before slicing.
+        output_seq_len: Sequence length after slicing.
+        memory_saved_bytes: Estimated memory saved by slicing (bytes).
+    """
+
+    hidden_states: "torch.Tensor"
+    was_sliced: bool
+    original_seq_len: int
+    output_seq_len: int
+    memory_saved_bytes: int
+
+
+@dataclass
+class InferenceConfig:
+    """Configuration for inference optimization.
+
+    Attributes:
+        only_last_logit: Slice to last position for generation (default True).
+        mode: Inference mode controlling default behavior.
+        vocab_size: Vocabulary size for memory estimation.
+        dtype_bytes: Bytes per element for memory estimation (2=fp16, 4=fp32).
+    """
+
+    only_last_logit: bool = True
+    mode: InferenceMode = InferenceMode.GENERATION
+    vocab_size: int = 32000
+    dtype_bytes: int = 2
+
+    @property
+    def should_slice(self) -> bool:
+        """Determine whether to slice based on mode and explicit flag."""
+        if self.mode in (InferenceMode.PERPLEXITY, InferenceMode.EVALUATION):
+            return False
+        return self.only_last_logit
+
+
+@dataclass
+class MemoryStats:
+    """Cumulative memory savings statistics.
+
+    Attributes:
+        total_saved_bytes: Total bytes saved across all forward passes.
+        forward_pass_count: Number of forward passes processed.
+        sliced_count: Number of passes where slicing was applied.
+    """
+
+    total_saved_bytes: int = 0
+    forward_pass_count: int = 0
+    sliced_count: int = 0
+
+    @property
+    def total_saved_mb(self) -> float:
+        """Total memory saved in megabytes."""
+        return self.total_saved_bytes / (1024 * 1024)
+
+
+class LastLogitOptimizer:
+    """Optimizer that slices hidden states to last position before lm_head projection.
+
+    For autoregressive generation, only the last token position determines the
+    next token. By slicing hidden_states[:, -1:, :] before the lm_head linear
+    layer, we avoid computing vocab_size logits for all other positions.
+
+    Savings example (seq_len=2048, vocab_size=32000, fp16):
+        Full:    batch * 2048 * 32000 * 2 bytes = ~125 MB
+        Sliced:  batch * 1    * 32000 * 2 bytes = ~62 KB
+
+    Issue #1968.
+    """
+
+    def __init__(self, config: Optional[InferenceConfig] = None):
+        """Initialize with optional configuration.
+
+        Args:
+            config: Inference configuration. Defaults to generation mode.
+        """
+        self._config = config or InferenceConfig()
+        self._stats = MemoryStats()
+
+    @property
+    def config(self) -> InferenceConfig:
+        """Current inference configuration."""
+        return self._config
+
+    @property
+    def stats(self) -> MemoryStats:
+        """Cumulative memory savings statistics."""
+        return self._stats
+
+    def slice_for_lm_head(
+        self,
+        hidden_states: "torch.Tensor",
+        only_last_logit: Optional[bool] = None,
+    ) -> LogitSliceResult:
+        """Slice hidden states to last position for efficient lm_head projection.
+
+        Args:
+            hidden_states: Model hidden states [batch, seq_len, hidden_dim].
+            only_last_logit: Override config's only_last_logit setting.
+                None uses the config default.
+
+        Returns:
+            LogitSliceResult with sliced (or unmodified) hidden states.
+
+        Raises:
+            ValueError: If hidden_states does not have 3 dimensions.
+        """
+        if torch is None:
+            raise RuntimeError("PyTorch is required for LastLogitOptimizer")
+
+        if hidden_states.ndim != 3:
+            raise ValueError(
+                f"Expected 3D tensor [batch, seq_len, hidden_dim], "
+                f"got {hidden_states.ndim}D"
+            )
+
+        batch_size, seq_len, hidden_dim = hidden_states.shape
+        should_slice = (
+            only_last_logit
+            if only_last_logit is not None
+            else self._config.should_slice
+        )
+
+        self._stats.forward_pass_count += 1
+
+        if should_slice and seq_len > 1:
+            sliced = hidden_states[:, -1:, :]
+            saved = self._estimate_memory_saved(batch_size, seq_len, hidden_dim)
+            self._stats.total_saved_bytes += saved
+            self._stats.sliced_count += 1
+
+            logger.debug(
+                "Last-logit slice: seq_len %d -> 1, saved ~%.2f MB",
+                seq_len,
+                saved / (1024 * 1024),
+            )
+
+            return LogitSliceResult(
+                hidden_states=sliced,
+                was_sliced=True,
+                original_seq_len=seq_len,
+                output_seq_len=1,
+                memory_saved_bytes=saved,
+            )
+
+        return LogitSliceResult(
+            hidden_states=hidden_states,
+            was_sliced=False,
+            original_seq_len=seq_len,
+            output_seq_len=seq_len,
+            memory_saved_bytes=0,
+        )
+
+    def _estimate_memory_saved(
+        self, batch_size: int, seq_len: int, hidden_dim: int
+    ) -> int:
+        """Estimate bytes saved by slicing hidden states before lm_head.
+
+        The lm_head output is [batch, seq_len, vocab_size]. Slicing reduces
+        seq_len to 1, saving (seq_len - 1) / seq_len of the output memory.
+
+        Args:
+            batch_size: Batch size.
+            seq_len: Original sequence length.
+            hidden_dim: Hidden dimension (unused in output calc, kept for API).
+
+        Returns:
+            Estimated bytes saved.
+        """
+        full_output_bytes = (
+            batch_size * seq_len * self._config.vocab_size * self._config.dtype_bytes
+        )
+        sliced_output_bytes = (
+            batch_size * 1 * self._config.vocab_size * self._config.dtype_bytes
+        )
+        return full_output_bytes - sliced_output_bytes
+
+    def reset_stats(self) -> MemoryStats:
+        """Reset and return the accumulated statistics.
+
+        Returns:
+            The stats as they were before resetting.
+        """
+        previous = MemoryStats(
+            total_saved_bytes=self._stats.total_saved_bytes,
+            forward_pass_count=self._stats.forward_pass_count,
+            sliced_count=self._stats.sliced_count,
+        )
+        self._stats = MemoryStats()
+        return previous
+
+
+def slice_hidden_for_generation(
+    hidden_states: "torch.Tensor",
+    only_last_logit: bool = True,
+) -> "torch.Tensor":
+    """Convenience function: slice hidden states for generation.
+
+    Stateless version for simple use cases that don't need tracking.
+
+    Args:
+        hidden_states: Model hidden states [batch, seq_len, hidden_dim].
+        only_last_logit: If True, return only last position.
+
+    Returns:
+        Sliced or original hidden states tensor.
+
+    Issue #1968.
+    """
+    if only_last_logit and hidden_states.ndim == 3 and hidden_states.shape[1] > 1:
+        return hidden_states[:, -1:, :]
+    return hidden_states
+
+
+__all__ = [
+    "InferenceConfig",
+    "InferenceMode",
+    "LastLogitOptimizer",
+    "LogitSliceResult",
+    "MemoryStats",
+    "slice_hidden_for_generation",
+]


### PR DESCRIPTION
## Summary
- Only compute lm_head projection for last token position during generation
- Up to 2048x reduction in final projection computation
- ~125MB memory savings per forward pass at seq_len=2048
- Full logit mode preserved for perplexity scoring/evaluation
- 19 unit tests covering all modes, edge cases, and memory estimation

Closes #1968

## Test plan
- [ ] Verify last-position logits match full-projection logits
- [ ] Verify memory savings at various sequence lengths
- [ ] Verify perplexity scoring mode still works with full logits
- [ ] Verify evaluation mode preserves all positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)