### PR TITLE
fix(ansible): add autobot_shared symlink to fleet deployment (#2517)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -468,6 +468,17 @@
       when: "'01-Backend' in inventory_hostname"
       tags: [backend, shared]
 
+    - name: "[PLAY 2] Backend | Ensure autobot_shared symlink (#2517)"
+      ansible.builtin.file:
+        src: /opt/autobot/autobot-shared
+        dest: /opt/autobot/autobot_shared
+        state: link
+        owner: autobot
+        group: autobot
+      become: true
+      when: "'01-Backend' in inventory_hostname"
+      tags: [backend, shared, symlink]
+
     - name: "[PLAY 2] Backend | Remove legacy backend symlink"
       file:
         path: /opt/autobot/autobot-backend/backend
@@ -745,6 +756,17 @@
       become: true
       when: "'01-Backend' not in inventory_hostname"
       tags: [shared]
+
+    - name: "[PLAY 2] Shared | Create autobot_shared symlink (#2517)"
+      ansible.builtin.file:
+        src: /opt/autobot/autobot-shared
+        dest: /opt/autobot/autobot_shared
+        state: link
+        owner: autobot
+        group: autobot
+      become: true
+      when: "'01-Backend' not in inventory_hostname"
+      tags: [shared, symlink]
 
     # ----- Mark synced -----
     - name: "[PLAY 2] Mark node as synced in SLM DB"


### PR DESCRIPTION
## Summary
- Adds `autobot_shared` symlink creation to `update-all-nodes.yml` for all fleet nodes
- Two tasks: one for backend node (.20), one for non-backend nodes (.22, .24, .25)
- Creates `/opt/autobot/autobot_shared -> autobot-shared` so Python imports work
- Matches existing pattern from `roles/backend/tasks/main.yml` and `roles/slm_manager/tasks/main.yml`
- Tagged `[shared, symlink]` for selective deployment

## Test plan
- [ ] Deploy with `--tags shared` and verify symlink exists on .22, .24, .25
- [ ] Verify `python3 -c "import autobot_shared"` succeeds on all nodes
- [ ] Confirm idempotent (re-run produces no changes)

Closes #2517