### PR TITLE
fix(infra): restore full secret_id in diagnostic JSON output (#2555)

### DIFF
--- a/autobot-infrastructure/autobot-backend/scripts/migrations/validate_migration.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/validate_migration.py
@@ -193,7 +193,7 @@ class MigrationValidator:
 
             if not secret_data:
                 self.issues.append({
-                    "type": "secret", "id": secret_id[:8] + "...",
+                    "type": "secret", "id": secret_id,
                     "severity": "error", "issue": "Secret data is empty",
                 })
                 return
@@ -220,7 +220,7 @@ class MigrationValidator:
             else:
                 self.stats["secrets"]["unencrypted"] += 1
                 self.issues.append({
-                    "type": "secret", "id": secret_id[:8] + "...",
+                    "type": "secret", "id": secret_id,
                     "severity": "warning",
                     "issue": "Value may not be encrypted",
                 })
@@ -233,7 +233,7 @@ class MigrationValidator:
         except Exception as e:
             logger.error("Error validating secret %s...: %s", secret_id[:8], e)
             self.issues.append({
-                "type": "secret", "id": secret_id[:8] + "...",
+                "type": "secret", "id": secret_id,
                 "severity": "error",
                 "issue": f"Validation error: {e}",
             })
@@ -251,7 +251,7 @@ class MigrationValidator:
         else:
             self.stats["secrets"][absent_key] += 1
             self.issues.append({
-                "type": "secret", "id": secret_id[:8] + "...",
+                "type": "secret", "id": secret_id,
                 "severity": severity, "issue": issue_msg,
             })
 


### PR DESCRIPTION
## Summary
- Restore full `secret_id` in `self.issues` data structure (4 locations) — diagnostic JSON needs full IDs for traceability
- Keep `secret_id[:8]` truncation in `logger.*` calls (2 locations) — log output remains redacted

Closes #2555

## Test plan
- [ ] Run migration validation and verify `/tmp/migration_issues.json` contains full secret IDs
- [ ] Verify log output still shows truncated IDs