### PR TITLE
feat(chat): auto-inject tools reminder after invalid tool calls (#2310)

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -1689,14 +1689,47 @@ class ChatWorkflowManager(
         return f"**Step {step_num}:** `{cmd}`\n- Status: {status}\n- Output:\n```\n{output_text}\n```"
 
     def _get_continuation_instructions(
-        self, original_message: str, steps_completed: int
+        self,
+        original_message: str,
+        steps_completed: int,
+        consecutive_invalid_tool_calls: int = 0,
     ) -> str:
         """Get the critical instructions for continuation prompts.
 
         Issue #651: Enhanced instructions to prevent premature task completion.
+        Issue #2310: Injects available-tools reminder after 2+ consecutive invalid tool calls.
         """
-        return f"""**CRITICAL MULTI-STEP TASK INSTRUCTIONS - READ CAREFULLY:**
+        # Issue #2310: Build optional tools reminder block when LLM has repeatedly
+        # hallucinated non-existent tool names.
+        tools_reminder = ""
+        if consecutive_invalid_tool_calls >= 2:
+            logger.warning(
+                "[Issue #2310] Injecting available-tools reminder after %d consecutive invalid tool calls",
+                consecutive_invalid_tool_calls,
+            )
+            tools_reminder = f"""
+**[SYSTEM] TOOL NAME CORRECTION REQUIRED:**
+Your last {consecutive_invalid_tool_calls} tool call(s) used invalid tool names. \
+You MUST use ONLY the following tool names:
+- execute_command: Run shell commands
+- navigate: Browse to a URL
+- click: Click an element on a web page
+- fill: Fill a form field on a web page
+- select: Select an option on a web page
+- hover: Hover over an element
+- screenshot: Capture the current page
+- evaluate: Evaluate JavaScript on a web page
+- get_text: Get text from an element
+- get_attribute: Get an attribute from an element
+- wait_for_selector: Wait for an element to appear
+- delegate: Delegate a subtask to a subordinate agent
+- respond: Signal task completion with a final message
+Do NOT invent new tool names. Use ONLY the names listed above.
 
+"""
+
+        return f"""**CRITICAL MULTI-STEP TASK INSTRUCTIONS - READ CAREFULLY:**
+{tools_reminder}
 You are in the middle of a multi-step task. {steps_completed} step(s) have been completed.
 
 **ORIGINAL USER REQUEST (analyze this to determine if more steps needed):**
@@ -1728,10 +1761,12 @@ before summarizing.
         original_message: str,
         execution_history: List[Dict[str, Any]],
         system_prompt: str,
+        consecutive_invalid_tool_calls: int = 0,
     ) -> str:
         """Build continuation prompt with execution results for multi-step tasks.
 
         Issue #651: Enhanced prompt structure for better multi-step task handling.
+        Issue #2310: Passes consecutive_invalid_tool_calls to inject tools reminder.
         """
         history_parts = [
             self._format_execution_step(i, result)
@@ -1740,7 +1775,7 @@ before summarizing.
         history_text = "\n\n".join(history_parts)
         steps_completed = len(execution_history)
         instructions = self._get_continuation_instructions(
-            original_message, steps_completed
+            original_message, steps_completed, consecutive_invalid_tool_calls
         )
 
         return f"""{system_prompt}
@@ -1995,11 +2030,13 @@ before summarizing.
         selected_model: str,
         execution_history: List[Dict[str, Any]],
         workflow_messages: List[WorkflowMessage],
+        ctx: Optional[LLMIterationContext] = None,
     ):
         """Issue #665: Refactored - Process tool calls and collect results.
 
         Issue #651: Fixed logic that incorrectly broke continuation loop.
         Issue #654: Added support for 'respond' tool with break_loop pattern.
+        Issue #2310: Accepts optional ctx for consecutive-invalid-tool tracking.
 
         Yields:
             WorkflowMessage items, then (results, has_pending_approval, should_break, break_loop_requested)
@@ -2009,7 +2046,12 @@ before summarizing.
         break_loop_requested = False
 
         async for tool_msg in self._process_tool_calls(
-            tool_calls, session_id, terminal_session_id, ollama_endpoint, selected_model
+            tool_calls,
+            session_id,
+            terminal_session_id,
+            ollama_endpoint,
+            selected_model,
+            ctx=ctx,
         ):
             is_tuple, loop_requested = self._handle_break_loop_tuple(tool_msg)
             if is_tuple:
@@ -2176,6 +2218,7 @@ before summarizing.
             ctx.selected_model,
             ctx.execution_history,
             ctx.workflow_messages,
+            ctx=ctx,
         ):
             if isinstance(item, tuple):
                 (
@@ -2429,7 +2472,10 @@ before summarizing.
         Build continuation prompt and log debug info.
         """
         current_prompt = self._build_continuation_prompt(
-            ctx.message, execution_history, ctx.system_prompt
+            ctx.message,
+            execution_history,
+            ctx.system_prompt,
+            ctx.consecutive_invalid_tool_calls,
         )
         logger.info(
             "[Issue #651] Built continuation prompt: %d chars, %d executed steps",

--- a/autobot-backend/chat_workflow/models.py
+++ b/autobot-backend/chat_workflow/models.py
@@ -338,6 +338,8 @@ class LLMIterationContext:
 
     Issue #375: Groups related parameters passed through multiple methods
     in the LLM continuation loop to reduce long parameter lists.
+    Issue #2310: Added consecutive_invalid_tool_calls counter for auto-inject
+    available-tools reminder after repeated invalid tool calls.
     """
 
     ollama_endpoint: str
@@ -352,6 +354,7 @@ class LLMIterationContext:
     initial_prompt: Optional[str] = None
     message: Optional[str] = None
     agent_context: Optional[AgentContext] = None  # Issue #657: Agent hierarchy
+    consecutive_invalid_tool_calls: int = 0  # Issue #2310: Track invalid tool calls
 
 
 @dataclass

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -13,10 +13,13 @@ import html
 import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from async_chat_workflow import WorkflowMessage
 from utils.errors import RepairableException
+
+if TYPE_CHECKING:
+    from .models import LLMIterationContext
 
 logger = logging.getLogger(__name__)
 
@@ -1317,8 +1320,12 @@ class ToolHandlerMixin:
         selected_model: str,
         execution_results: List[Dict[str, Any]],
         additional_response_parts: List[str],
+        ctx: Optional["LLMIterationContext"] = None,
     ):
         """Dispatch a single tool call to appropriate handler. Issue #620.
+
+        Issue #2310: Accepts optional ctx to track consecutive invalid tool calls
+        and inject available-tools reminder after 2 consecutive failures.
 
         Yields:
             WorkflowMessage for tool execution stages
@@ -1327,17 +1334,23 @@ class ToolHandlerMixin:
         tool_name = tool_call["name"]
 
         if tool_name == "respond":
+            if ctx is not None:
+                ctx.consecutive_invalid_tool_calls = 0
             msg, break_loop, respond_content = self._handle_respond_tool(tool_call)
             yield msg
             yield (break_loop, respond_content)
             return
 
         if tool_name == "delegate":
+            if ctx is not None:
+                ctx.consecutive_invalid_tool_calls = 0
             yield self._handle_delegate_tool(tool_call, execution_results)
             return
 
         # Issue #1368: Route browser tools to browser VM
         if tool_name in _BROWSER_TOOL_NAMES:
+            if ctx is not None:
+                ctx.consecutive_invalid_tool_calls = 0
             async for msg in self._handle_browser_tool(tool_call, execution_results):
                 yield msg
             return
@@ -1345,15 +1358,21 @@ class ToolHandlerMixin:
         if tool_name != "execute_command":
             # Issue #2305: Return a tool error so the agent can self-correct instead of
             # silently dropping the call and causing an infinite hallucination loop.
+            # Issue #2310: Track consecutive invalid calls; reminder injected at prompt-build time.
             known_tools = sorted(
                 {"respond", "delegate", "execute_command"} | _BROWSER_TOOL_NAMES
             )
+            if ctx is not None:
+                ctx.consecutive_invalid_tool_calls += 1
+            consecutive = ctx.consecutive_invalid_tool_calls if ctx is not None else 0
             error_msg = (
                 f'Error: Tool "{tool_name}" not found. '
                 f"Available tools: {', '.join(known_tools)}"
             )
             logger.warning(
-                "[Issue #2305] Unknown tool call reported to agent: %s", tool_name
+                "[Issue #2305] Unknown tool call reported to agent: %s (consecutive_invalid=%d)",
+                tool_name,
+                consecutive,
             )
             execution_results.append(
                 {"tool": tool_name, "status": "error", "error": error_msg}
@@ -1365,6 +1384,8 @@ class ToolHandlerMixin:
             )
             return
 
+        if ctx is not None:
+            ctx.consecutive_invalid_tool_calls = 0
         async for msg in self._process_single_command(
             tool_call,
             session_id,
@@ -1383,12 +1404,14 @@ class ToolHandlerMixin:
         terminal_session_id: str,
         ollama_endpoint: str,
         selected_model: str,
+        ctx: Optional["LLMIterationContext"] = None,
     ):
         """Process all tool calls from LLM response.
 
         Issue #315: Refactored to use helper methods for reduced nesting.
         Issue #654: Added support for 'respond' tool with break_loop pattern.
         Issue #620: Refactored using Extract Method pattern.
+        Issue #2310: Accepts optional ctx for consecutive-invalid-tool tracking.
 
         Yields:
             WorkflowMessage for each stage of execution
@@ -1409,6 +1432,7 @@ class ToolHandlerMixin:
                 selected_model,
                 execution_results,
                 additional_response_parts,
+                ctx=ctx,
             ):
                 if isinstance(result, tuple):
                     break_loop_requested, respond_content = result


### PR DESCRIPTION
## Summary
- Tracks consecutive invalid tool call attempts in chat workflow
- After 2+ consecutive invalid calls, injects a system reminder listing all 13 valid tools
- Counter resets on any successful tool dispatch
- All new parameters are optional — backward compatible

## Files Changed
- `chat_workflow/models.py` — added `consecutive_invalid_tool_calls` counter to `LLMIterationContext`
- `chat_workflow/tool_handler.py` — tracks valid/invalid dispatches, increments/resets counter
- `chat_workflow/manager.py` — injects tool list into continuation prompt when threshold reached

## Closes #2310

## Test plan
- [ ] Chat agent self-corrects after 2 invalid tool calls
- [ ] Counter resets after valid tool use
- [ ] No regression in normal tool execution flow
- [ ] Python syntax valid, no import errors