### PR TITLE
cleanup(backend): remove stale run_autobot from process detection keywords (#2564)

### DIFF
--- a/autobot-backend/utils/hardware_metrics.py
+++ b/autobot-backend/utils/hardware_metrics.py
@@ -563,7 +563,6 @@ class Phase9PerformanceMonitor:
         keywords = [
             "autobot",
             "fast_app_factory",
-            "run_autobot",
             "npu-worker",
             "ai-stack",
             "browser-service",

--- a/autobot-backend/utils/performance_monitoring/types.py
+++ b/autobot-backend/utils/performance_monitoring/types.py
@@ -32,7 +32,6 @@ DEFAULT_RETENTION_HOURS = 24
 AUTOBOT_PROCESS_KEYWORDS = [
     "autobot",
     "fast_app_factory",
-    "run_autobot",
     "npu-worker",
     "ai-stack",
     "browser-service",


### PR DESCRIPTION
## Summary
- Removes stale `"run_autobot"` keyword from process detection lists in 2 files:
  - `autobot-backend/utils/hardware_metrics.py` — `_is_autobot_process()` keyword list
  - `autobot-backend/utils/performance_monitoring/types.py` — matching keyword list
- `run_autobot.sh` was deprecated in #863 and moved to `legacy/` — the keyword never matches a running process

Closes #2564