### PR TITLE
fix(docker): target specific worker in celery healthcheck (#2565)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -229,7 +229,7 @@ services:
       - AUTOBOT_CHROMADB_HOST=autobot-chromadb
       - AUTOBOT_CHROMADB_PORT=8000
     healthcheck:
-      test: ["CMD", "python3.12", "-m", "celery", "-A", "celery_app", "inspect", "ping", "--timeout", "5"]
+      test: ["CMD-SHELL", "python3.12 -m celery -A celery_app inspect ping --destination celery@$HOSTNAME --timeout 5"]
       interval: 30s
       timeout: 10s
       start_period: 30s


### PR DESCRIPTION
## Summary
- Changes Celery worker healthcheck from broadcast ping to targeted ping using `--destination celery@$HOSTNAME`
- Uses `CMD-SHELL` instead of `CMD` so `$HOSTNAME` gets shell-expanded
- Ensures each worker container only reports healthy if *its own* Celery process responds, not a sibling

Closes #2565