### PR TITLE
fix(models): replace postgresql.UUID with Uuid in 9 more model files (#2563)

### DIFF
--- a/autobot-backend/models/activities.py
+++ b/autobot-backend/models/activities.py
@@ -21,8 +21,9 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
@@ -40,14 +41,14 @@ class TerminalActivityModel(Base, TimestampMixin):
     __tablename__ = "terminal_activities"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # User attribution (REQUIRED)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -74,7 +75,7 @@ class TerminalActivityModel(Base, TimestampMixin):
 
     # Secret usage tracking
     secrets_used: Mapped[list[uuid.UUID]] = mapped_column(
-        ARRAY(UUID(as_uuid=True)),
+        ARRAY(Uuid(as_uuid=True)),
         nullable=False,
         default=list,
     )
@@ -115,14 +116,14 @@ class FileActivityModel(Base, TimestampMixin):
     __tablename__ = "file_activities"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # User attribution (REQUIRED)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -192,14 +193,14 @@ class BrowserActivityModel(Base, TimestampMixin):
     __tablename__ = "browser_activities"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # User attribution (REQUIRED)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -230,7 +231,7 @@ class BrowserActivityModel(Base, TimestampMixin):
 
     # Secret usage tracking
     secrets_used: Mapped[list[uuid.UUID]] = mapped_column(
-        ARRAY(UUID(as_uuid=True)),
+        ARRAY(Uuid(as_uuid=True)),
         nullable=False,
         default=list,
     )
@@ -271,14 +272,14 @@ class DesktopActivityModel(Base, TimestampMixin):
     __tablename__ = "desktop_activities"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # User attribution (REQUIRED)
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -351,20 +352,20 @@ class SecretUsageModel(Base, TimestampMixin):
     __tablename__ = "secret_usage"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Secret and user (REQUIRED)
     secret_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         nullable=False,
         index=True,
     )
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -378,7 +379,7 @@ class SecretUsageModel(Base, TimestampMixin):
     )
 
     activity_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         nullable=False,
         index=True,
     )

--- a/autobot-backend/models/approval.py
+++ b/autobot-backend/models/approval.py
@@ -11,8 +11,9 @@ import uuid
 from enum import Enum
 
 from sqlalchemy import Column, DateTime, ForeignKey, String, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 
@@ -40,7 +41,7 @@ class Approval(Base, TimestampMixin):
     __tablename__ = "approvals"
 
     id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
@@ -99,12 +100,12 @@ class ApprovalComment(Base, TimestampMixin):
     __tablename__ = "approval_comments"
 
     id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
     approval_id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("approvals.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -133,12 +134,12 @@ class TaskApprovalLink(Base):
     __tablename__ = "task_approval_links"
 
     id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
     approval_id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("approvals.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/autobot-backend/models/config_revision.py
+++ b/autobot-backend/models/config_revision.py
@@ -11,7 +11,8 @@ Stores before/after snapshots for every configuration change.
 import uuid
 
 from sqlalchemy import Column, String
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 
@@ -24,7 +25,7 @@ class ConfigRevision(Base, TimestampMixin):
     __tablename__ = "config_revisions"
 
     id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )

--- a/autobot-backend/models/heartbeat.py
+++ b/autobot-backend/models/heartbeat.py
@@ -22,8 +22,9 @@ from sqlalchemy import (
     String,
     Text,
 )
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 
@@ -51,7 +52,7 @@ class AgentRuntimeState(Base, TimestampMixin):
 
     __tablename__ = "agent_runtime_state"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id = Column(String(255), nullable=False, unique=True, index=True)
     heartbeat_enabled = Column(Boolean, nullable=False, default=False)
     heartbeat_interval_seconds = Column(Integer, nullable=False, default=300)
@@ -83,10 +84,10 @@ class HeartbeatRun(Base, TimestampMixin):
 
     __tablename__ = "heartbeat_runs"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id = Column(String(255), nullable=False, index=True)
     runtime_state_id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("agent_runtime_state.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -124,9 +125,9 @@ class HeartbeatRunEvent(Base):
 
     __tablename__ = "heartbeat_run_events"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     run_id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("heartbeat_runs.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -147,10 +148,10 @@ class AgentWakeupRequest(Base, TimestampMixin):
 
     __tablename__ = "agent_wakeup_requests"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id = Column(String(255), nullable=False, index=True)
     runtime_state_id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("agent_runtime_state.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -159,7 +160,7 @@ class AgentWakeupRequest(Base, TimestampMixin):
     context = Column(JSONB, nullable=True)
     reason = Column(String(255), nullable=True)
     consumed_at = Column(DateTime, nullable=True)
-    consumed_by_run_id = Column(UUID(as_uuid=True), nullable=True)
+    consumed_by_run_id = Column(Uuid(as_uuid=True), nullable=True)
 
     runtime_state = relationship("AgentRuntimeState", back_populates="wakeup_requests")
 

--- a/autobot-backend/models/process_run.py
+++ b/autobot-backend/models/process_run.py
@@ -13,8 +13,9 @@ import uuid
 from enum import Enum
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 
@@ -34,7 +35,7 @@ class ProcessRun(Base, TimestampMixin):
 
     __tablename__ = "process_runs"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id = Column(String(255), nullable=False, index=True)
     task_id = Column(String(255), nullable=True, index=True)
     command = Column(Text, nullable=False)
@@ -73,11 +74,11 @@ class TaskDecomposition(Base, TimestampMixin):
 
     __tablename__ = "task_decompositions"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     parent_task_id = Column(String(255), nullable=False, index=True)
     subtask_order = Column(Integer, nullable=False)
     process_run_id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("process_runs.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -106,7 +107,7 @@ class AgentSession(Base, TimestampMixin):
 
     __tablename__ = "agent_sessions"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     agent_id = Column(String(255), nullable=False, index=True)
     task_id = Column(String(255), nullable=False, index=True)
     session_state = Column(JSONB, nullable=True)

--- a/autobot-backend/models/secret.py
+++ b/autobot-backend/models/secret.py
@@ -14,8 +14,9 @@ from enum import Enum
 from typing import Optional
 
 from sqlalchemy import Boolean, DateTime, String, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 
@@ -68,21 +69,21 @@ class Secret(Base, TimestampMixin):
     __tablename__ = "secrets"
 
     id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )
 
     # Ownership (Issue #870, #685)
     owner_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         nullable=False,
         index=True,
         comment="User ID who owns this secret",
     )
 
     org_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         nullable=True,
         index=True,
         comment="Organization ID for org-level secrets (Issue #685)",

--- a/autobot-backend/models/session_collaboration.py
+++ b/autobot-backend/models/session_collaboration.py
@@ -14,8 +14,9 @@ from enum import Enum
 from typing import Optional
 
 from sqlalchemy import ForeignKey, String
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 
@@ -50,7 +51,7 @@ class SessionCollaboration(Base, TimestampMixin):
     )
 
     owner_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/autobot-backend/models/task_delegation.py
+++ b/autobot-backend/models/task_delegation.py
@@ -12,7 +12,8 @@ import uuid
 from enum import Enum
 
 from sqlalchemy import Column, String, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base, TimestampMixin
 
 
@@ -37,7 +38,7 @@ class TaskDelegation(Base, TimestampMixin):
 
     __tablename__ = "task_delegations"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id = Column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     delegator_id = Column(String(255), nullable=False, index=True)
     assignee_id = Column(String(255), nullable=False, index=True)
     task_description = Column(Text, nullable=False)

--- a/autobot-backend/models/workflow_audit.py
+++ b/autobot-backend/models/workflow_audit.py
@@ -11,8 +11,9 @@ create, edit, run, approve, delete, view, grant, revoke.
 import uuid
 
 from sqlalchemy import Column, DateTime, String
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
+from sqlalchemy.types import Uuid
 from user_management.models.base import Base
 
 
@@ -26,7 +27,7 @@ class WorkflowAuditLog(Base):
     __tablename__ = "workflow_audit_log"
 
     id = Column(
-        UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
     )


### PR DESCRIPTION
## Summary
- Splits JSONB/UUID imports in 9 `autobot-backend/models/` files
- Keeps `JSONB` (and `ARRAY` where applicable) from `sqlalchemy.dialects.postgresql`
- Replaces `UUID` with dialect-agnostic `sqlalchemy.types.Uuid`
- Follows same pattern as PRs #2532 and #2551
- Files: process_run, workflow_audit, session_collaboration, activities, heartbeat, task_delegation, config_revision, approval, secret

Closes #2563