### PR TITLE
deps(infra): align Ansible node OpenTelemetry pins with main requirements (#2562)

### DIFF
--- a/autobot-slm-backend/ansible/autobot@172.16.168.19/requirements.txt
+++ b/autobot-slm-backend/ansible/autobot@172.16.168.19/requirements.txt
@@ -4,9 +4,10 @@ pydantic>=2.0
 python-dotenv>=1.0.0
 
 # OpenTelemetry distributed tracing (Issue #697)
-opentelemetry-api>=1.20.0
-opentelemetry-sdk>=1.20.0
-opentelemetry-exporter-otlp>=1.20.0
-opentelemetry-instrumentation-fastapi>=0.41b0
-opentelemetry-instrumentation-redis>=0.41b0
-opentelemetry-instrumentation-aiohttp-client>=0.41b0
+# Aligned with main project requirements.txt pins (#2562)
+opentelemetry-api>=1.40.0
+opentelemetry-sdk>=1.40.0
+opentelemetry-exporter-otlp>=1.40.0
+opentelemetry-instrumentation-fastapi>=0.55b0
+opentelemetry-instrumentation-redis>=0.55b0
+opentelemetry-instrumentation-aiohttp-client>=0.55b0

--- a/autobot-slm-backend/ansible/autobot@172.16.168.20/requirements.txt
+++ b/autobot-slm-backend/ansible/autobot@172.16.168.20/requirements.txt
@@ -4,9 +4,10 @@ pydantic>=2.0
 python-dotenv>=1.0.0
 
 # OpenTelemetry distributed tracing (Issue #697)
-opentelemetry-api>=1.20.0
-opentelemetry-sdk>=1.20.0
-opentelemetry-exporter-otlp>=1.20.0
-opentelemetry-instrumentation-fastapi>=0.41b0
-opentelemetry-instrumentation-redis>=0.41b0
-opentelemetry-instrumentation-aiohttp-client>=0.41b0
+# Aligned with main project requirements.txt pins (#2562)
+opentelemetry-api>=1.40.0
+opentelemetry-sdk>=1.40.0
+opentelemetry-exporter-otlp>=1.40.0
+opentelemetry-instrumentation-fastapi>=0.55b0
+opentelemetry-instrumentation-redis>=0.55b0
+opentelemetry-instrumentation-aiohttp-client>=0.55b0

--- a/autobot-slm-backend/ansible/autobot@172.16.168.21/requirements.txt
+++ b/autobot-slm-backend/ansible/autobot@172.16.168.21/requirements.txt
@@ -4,9 +4,10 @@ pydantic>=2.0
 python-dotenv>=1.0.0
 
 # OpenTelemetry distributed tracing (Issue #697)
-opentelemetry-api>=1.20.0
-opentelemetry-sdk>=1.20.0
-opentelemetry-exporter-otlp>=1.20.0
-opentelemetry-instrumentation-fastapi>=0.41b0
-opentelemetry-instrumentation-redis>=0.41b0
-opentelemetry-instrumentation-aiohttp-client>=0.41b0
+# Aligned with main project requirements.txt pins (#2562)
+opentelemetry-api>=1.40.0
+opentelemetry-sdk>=1.40.0
+opentelemetry-exporter-otlp>=1.40.0
+opentelemetry-instrumentation-fastapi>=0.55b0
+opentelemetry-instrumentation-redis>=0.55b0
+opentelemetry-instrumentation-aiohttp-client>=0.55b0

--- a/autobot-slm-backend/ansible/autobot@172.16.168.22/requirements.txt
+++ b/autobot-slm-backend/ansible/autobot@172.16.168.22/requirements.txt
@@ -4,9 +4,10 @@ pydantic>=2.0
 python-dotenv>=1.0.0
 
 # OpenTelemetry distributed tracing (Issue #697)
-opentelemetry-api>=1.20.0
-opentelemetry-sdk>=1.20.0
-opentelemetry-exporter-otlp>=1.20.0
-opentelemetry-instrumentation-fastapi>=0.41b0
-opentelemetry-instrumentation-redis>=0.41b0
-opentelemetry-instrumentation-aiohttp-client>=0.41b0
+# Aligned with main project requirements.txt pins (#2562)
+opentelemetry-api>=1.40.0
+opentelemetry-sdk>=1.40.0
+opentelemetry-exporter-otlp>=1.40.0
+opentelemetry-instrumentation-fastapi>=0.55b0
+opentelemetry-instrumentation-redis>=0.55b0
+opentelemetry-instrumentation-aiohttp-client>=0.55b0

--- a/autobot-slm-backend/ansible/autobot@172.16.168.23/requirements.txt
+++ b/autobot-slm-backend/ansible/autobot@172.16.168.23/requirements.txt
@@ -4,9 +4,10 @@ pydantic>=2.0
 python-dotenv>=1.0.0
 
 # OpenTelemetry distributed tracing (Issue #697)
-opentelemetry-api>=1.20.0
-opentelemetry-sdk>=1.20.0
-opentelemetry-exporter-otlp>=1.20.0
-opentelemetry-instrumentation-fastapi>=0.41b0
-opentelemetry-instrumentation-redis>=0.41b0
-opentelemetry-instrumentation-aiohttp-client>=0.41b0
+# Aligned with main project requirements.txt pins (#2562)
+opentelemetry-api>=1.40.0
+opentelemetry-sdk>=1.40.0
+opentelemetry-exporter-otlp>=1.40.0
+opentelemetry-instrumentation-fastapi>=0.55b0
+opentelemetry-instrumentation-redis>=0.55b0
+opentelemetry-instrumentation-aiohttp-client>=0.55b0

--- a/autobot-slm-backend/ansible/autobot@172.16.168.24/requirements.txt
+++ b/autobot-slm-backend/ansible/autobot@172.16.168.24/requirements.txt
@@ -4,9 +4,10 @@ pydantic>=2.0
 python-dotenv>=1.0.0
 
 # OpenTelemetry distributed tracing (Issue #697)
-opentelemetry-api>=1.20.0
-opentelemetry-sdk>=1.20.0
-opentelemetry-exporter-otlp>=1.20.0
-opentelemetry-instrumentation-fastapi>=0.41b0
-opentelemetry-instrumentation-redis>=0.41b0
-opentelemetry-instrumentation-aiohttp-client>=0.41b0
+# Aligned with main project requirements.txt pins (#2562)
+opentelemetry-api>=1.40.0
+opentelemetry-sdk>=1.40.0
+opentelemetry-exporter-otlp>=1.40.0
+opentelemetry-instrumentation-fastapi>=0.55b0
+opentelemetry-instrumentation-redis>=0.55b0
+opentelemetry-instrumentation-aiohttp-client>=0.55b0


### PR DESCRIPTION
## Summary
- Updated OpenTelemetry package pins in all 6 Ansible node requirements files to match main project requirements
- Audited all Dockerfiles and CI workflows — already on latest versions

## Changes
### Ansible Node Requirements (6 files)
- `opentelemetry-api`: `>=1.20.0` → `>=1.40.0`
- `opentelemetry-sdk`: `>=1.20.0` → `>=1.40.0`
- `opentelemetry-exporter-otlp`: `>=1.20.0` → `>=1.40.0`
- `opentelemetry-instrumentation-fastapi`: `>=0.41b0` → `>=0.55b0`
- `opentelemetry-instrumentation-redis`: `>=0.41b0` → `>=0.55b0`
- `opentelemetry-instrumentation-aiohttp-client`: `>=0.41b0` → `>=0.55b0`

### No Changes Needed
- Dockerfiles: backend/frontend/SLM already on Python 3.12 / Node 20
- MCP tool Dockerfiles: code-index-mcp and mcp-github-project-manager don't exist in this branch
- context7 Dockerfile: already uses `node:lts-alpine`
- CI Actions: already on latest (checkout@v6, setup-node@v6, etc.)

## Test plan
- [ ] Pre-commit passes
- [ ] CI workflows pass
- [ ] No version conflicts

Closes #2562