### PR TITLE
feat(mcp): dynamic tool discovery and dispatch for agents

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -208,6 +208,56 @@ def _create_execution_result(
     }
 
 
+async def _try_mcp_dispatch(
+    tool_name: str,
+    tool_call: Dict[str, Any],
+    execution_results: List[Dict[str, Any]],
+) -> Optional[WorkflowMessage]:
+    """Attempt to dispatch tool_name via the MCP registry. Issue #2513.
+
+    Returns a WorkflowMessage on success, or None if the tool is not found
+    in the registry (so the caller can fall through to the unknown-tool error).
+    """
+    from services.mcp_dispatch import get_mcp_dispatcher
+
+    dispatcher = get_mcp_dispatcher()
+    # Lazy-load cache on first call; if cache is already loaded and tool is
+    # absent, skip a network round-trip.
+    if not dispatcher._cache_loaded:
+        await dispatcher.refresh_tool_cache()
+
+    tool = dispatcher.find_tool(tool_name)
+    if tool is None:
+        return None
+
+    arguments = tool_call.get("arguments", {})
+    mcp_result = await dispatcher.dispatch(tool_name, arguments)
+    bridge = mcp_result.get("bridge", "unknown")
+    success = mcp_result.get("success", False)
+    result_text = str(mcp_result.get("result", ""))
+
+    execution_results.append(
+        {
+            "tool": tool_name,
+            "bridge": bridge,
+            "result": result_text,
+            "status": "success" if success else "error",
+        }
+    )
+    msg_type = "tool_result" if success else "error"
+    logger.info(
+        "[Issue #2513] MCP dispatch: tool=%s bridge=%s success=%s",
+        tool_name,
+        bridge,
+        success,
+    )
+    return WorkflowMessage(
+        type=msg_type,
+        content=f"[{bridge}] {result_text}",
+        metadata={"tool_name": tool_name, "bridge": bridge, "mcp_dispatch": True},
+    )
+
+
 class ToolHandlerMixin:
     """Mixin for tool and command handling."""
 
@@ -1356,6 +1406,14 @@ class ToolHandlerMixin:
             return
 
         if tool_name != "execute_command":
+            # Issue #2513: Check MCP registry before reporting unknown tool.
+            mcp_result = await _try_mcp_dispatch(
+                tool_name, tool_call, execution_results
+            )
+            if mcp_result is not None:
+                yield mcp_result
+                return
+
             # Issue #2305: Return a tool error so the agent can self-correct instead of
             # silently dropping the call and causing an infinite hallucination loop.
             # Issue #2310: Track consecutive invalid calls; reminder injected at prompt-build time.

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -1,0 +1,223 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Dynamic MCP tool dispatch service for agent runtime (#2513).
+
+Bridges the MCP registry to the tool handler so that agents can call any
+registered MCP tool without hardcoded routing in _dispatch_tool_call().
+
+Architecture:
+  _dispatch_tool_call() (tool_handler.py)
+        |
+        v
+  MCPDispatcher.dispatch(tool_name, arguments)
+        |
+        v
+  MCP bridge endpoint  (e.g. /api/filesystem/mcp/<tool_name>)
+
+The dispatcher loads tool metadata from the registry on first use and
+caches it locally.  Cache can be refreshed explicitly via refresh_tool_cache().
+"""
+
+import logging
+from typing import Optional
+
+import aiohttp
+from constants.network_constants import NetworkConstants
+
+from autobot_shared.http_client import get_http_client
+
+logger = logging.getLogger(__name__)
+
+
+class MCPDispatcher:
+    """Routes unknown tool calls to registered MCP bridges via the registry.
+
+    Caches tool metadata fetched from the registry so that repeated tool
+    calls do not incur extra HTTP round-trips for discovery.
+    """
+
+    def __init__(self) -> None:
+        """Initialize dispatcher with empty tool cache."""
+        self._tool_cache: dict[str, dict] = {}
+        self._cache_loaded = False
+
+    # ------------------------------------------------------------------
+    # Cache management
+    # ------------------------------------------------------------------
+
+    async def refresh_tool_cache(self) -> int:
+        """Fetch all tools from the MCP registry and populate the local cache.
+
+        Makes a single HTTP request to /api/mcp/tools which aggregates all
+        bridges.  Returns the number of tools cached.
+        """
+        backend_url = (
+            f"http://{NetworkConstants.MAIN_MACHINE_IP}:{NetworkConstants.BACKEND_PORT}"
+        )
+        try:
+            http_client = get_http_client()
+            async with await http_client.get(
+                f"{backend_url}/api/mcp/tools",
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as response:
+                if response.status != 200:
+                    logger.warning(
+                        "MCPDispatcher: registry returned %s when refreshing tools",
+                        response.status,
+                    )
+                    return 0
+                data = await response.json()
+                tools = data.get("tools", [])
+                self._tool_cache = {tool["name"]: tool for tool in tools}
+                self._cache_loaded = True
+                logger.info(
+                    "MCPDispatcher: cached %d tools from registry",
+                    len(self._tool_cache),
+                )
+                return len(self._tool_cache)
+        except aiohttp.ClientError as exc:
+            logger.warning("MCPDispatcher: HTTP error refreshing tool cache: %s", exc)
+            return 0
+        except Exception as exc:
+            logger.warning("MCPDispatcher: failed to refresh tool cache: %s", exc)
+            return 0
+
+    # ------------------------------------------------------------------
+    # Tool lookup
+    # ------------------------------------------------------------------
+
+    def find_tool(self, tool_name: str) -> Optional[dict]:
+        """Return the cached tool entry for tool_name, or None if not found."""
+        return self._tool_cache.get(tool_name)
+
+    # ------------------------------------------------------------------
+    # Dispatch
+    # ------------------------------------------------------------------
+
+    async def dispatch(self, tool_name: str, arguments: dict) -> dict:
+        """Dispatch a tool call to its registered MCP bridge.
+
+        Loads the tool cache on first call if it has not been populated yet.
+
+        Args:
+            tool_name: Tool name from the LLM tool call.
+            arguments: Tool arguments dict.
+
+        Returns:
+            Dict with keys: success (bool), result (str | dict), bridge (str | None).
+        """
+        if not self._cache_loaded:
+            await self.refresh_tool_cache()
+
+        tool = self.find_tool(tool_name)
+        if not tool:
+            return {
+                "success": False,
+                "result": f"Unknown tool: {tool_name}",
+                "bridge": None,
+            }
+
+        bridge = tool.get("bridge", "unknown")
+        endpoint = tool.get("endpoint", "")
+        return await self._call_bridge(tool_name, bridge, endpoint, arguments)
+
+    async def _call_bridge(
+        self, tool_name: str, bridge: str, endpoint: str, arguments: dict
+    ) -> dict:
+        """Execute the HTTP call to the MCP bridge endpoint.
+
+        Args:
+            tool_name: Name of the tool being called.
+            bridge: Bridge identifier (for logging/result metadata).
+            endpoint: Full URL path of the tool's bridge endpoint.
+            arguments: Arguments to pass to the bridge.
+
+        Returns:
+            Dict with keys: success, result, bridge.
+        """
+        try:
+            http_client = get_http_client()
+            async with await http_client.post(
+                endpoint,
+                json={"arguments": arguments},
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as response:
+                if response.status == 200:
+                    result = await response.json()
+                    return {"success": True, "result": result, "bridge": bridge}
+                text = await response.text()
+                logger.error(
+                    "MCPDispatcher: bridge %s returned %s for tool %s: %s",
+                    bridge,
+                    response.status,
+                    tool_name,
+                    text[:200],
+                )
+                return {
+                    "success": False,
+                    "result": f"Bridge {bridge} returned {response.status}: {text[:200]}",
+                    "bridge": bridge,
+                }
+        except aiohttp.ClientError as exc:
+            logger.error(
+                "MCPDispatcher: HTTP error calling %s via %s: %s",
+                tool_name,
+                bridge,
+                exc,
+            )
+            return {
+                "success": False,
+                "result": f"Bridge call failed: {exc}",
+                "bridge": bridge,
+            }
+        except Exception as exc:
+            logger.error(
+                "MCPDispatcher: unexpected error calling %s via %s: %s",
+                tool_name,
+                bridge,
+                exc,
+            )
+            return {
+                "success": False,
+                "result": f"Bridge call failed: {exc}",
+                "bridge": bridge,
+            }
+
+    # ------------------------------------------------------------------
+    # Tool definition export
+    # ------------------------------------------------------------------
+
+    def get_tool_definitions(self) -> list[dict]:
+        """Return tool definitions in LLM-injectable format.
+
+        Each entry contains name, description (prefixed with bridge name),
+        and parameters (from the tool's input_schema).
+
+        Returns:
+            List of tool definition dicts.
+        """
+        return [
+            {
+                "name": tool["name"],
+                "description": f"[{tool['bridge']}] {tool['description']}",
+                "parameters": tool.get("input_schema", {}),
+            }
+            for tool in self._tool_cache.values()
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_dispatcher: Optional[MCPDispatcher] = None
+
+
+def get_mcp_dispatcher() -> MCPDispatcher:
+    """Return the singleton MCPDispatcher instance (created on first call)."""
+    global _dispatcher
+    if _dispatcher is None:
+        _dispatcher = MCPDispatcher()
+    return _dispatcher

--- a/autobot-backend/services/mcp_dispatch_test.py
+++ b/autobot-backend/services/mcp_dispatch_test.py
@@ -1,0 +1,225 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for MCPDispatcher — dynamic MCP tool discovery and dispatch (#2513).
+
+Coverage:
+- Tool cache lookup (empty and populated)
+- Dispatch of unknown tool returns error dict
+- Dispatch of known tool with successful bridge response
+- Dispatch of known tool with failing bridge response
+- get_tool_definitions() formats correctly
+- refresh_tool_cache() handles registry HTTP errors gracefully
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from services.mcp_dispatch import MCPDispatcher, get_mcp_dispatcher
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_TOOL = {
+    "name": "search_knowledge_base",
+    "description": "Search the knowledge base",
+    "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+    "bridge": "knowledge_mcp",
+    "endpoint": "http://localhost:8001/api/knowledge/mcp/search_knowledge_base",
+    "features": ["search"],
+}
+
+
+def _make_dispatcher_with_cache(*tools) -> MCPDispatcher:
+    """Return a dispatcher pre-loaded with the given tool dicts."""
+    d = MCPDispatcher()
+    d._tool_cache = {t["name"]: t for t in tools}
+    d._cache_loaded = True
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Cache lookup
+# ---------------------------------------------------------------------------
+
+
+def test_find_tool_returns_none_when_empty():
+    """Empty cache should return None for any name."""
+    d = MCPDispatcher()
+    assert d.find_tool("search_knowledge_base") is None
+
+
+def test_find_tool_returns_cached_tool():
+    """After populating the cache manually, find_tool should return the entry."""
+    d = _make_dispatcher_with_cache(_SAMPLE_TOOL)
+    result = d.find_tool("search_knowledge_base")
+    assert result is not None
+    assert result["bridge"] == "knowledge_mcp"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — unknown tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_tool_returns_error():
+    """Dispatching a tool not in cache should return success=False."""
+    d = _make_dispatcher_with_cache()  # empty cache
+    result = await d.dispatch("nonexistent_tool", {})
+    assert result["success"] is False
+    assert "nonexistent_tool" in result["result"]
+    assert result["bridge"] is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — successful bridge call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_calls_bridge_endpoint():
+    """A known tool should call the bridge endpoint and return success=True."""
+    d = _make_dispatcher_with_cache(_SAMPLE_TOOL)
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"results": ["doc1"]})
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.post = AsyncMock(return_value=mock_response)
+
+    with patch("services.mcp_dispatch.get_http_client", return_value=mock_session):
+        result = await d.dispatch("search_knowledge_base", {"query": "test"})
+
+    assert result["success"] is True
+    assert result["bridge"] == "knowledge_mcp"
+    assert result["result"] == {"results": ["doc1"]}
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — bridge error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_handles_bridge_error():
+    """When the bridge returns a non-200 status, success should be False."""
+    d = _make_dispatcher_with_cache(_SAMPLE_TOOL)
+
+    mock_response = AsyncMock()
+    mock_response.status = 503
+    mock_response.text = AsyncMock(return_value="Service Unavailable")
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.post = AsyncMock(return_value=mock_response)
+
+    with patch("services.mcp_dispatch.get_http_client", return_value=mock_session):
+        result = await d.dispatch("search_knowledge_base", {})
+
+    assert result["success"] is False
+    assert "503" in result["result"]
+    assert result["bridge"] == "knowledge_mcp"
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+
+def test_get_tool_definitions_formats_correctly():
+    """Tool definitions should include bridge prefix in description."""
+    d = _make_dispatcher_with_cache(_SAMPLE_TOOL)
+    defs = d.get_tool_definitions()
+    assert len(defs) == 1
+    defn = defs[0]
+    assert defn["name"] == "search_knowledge_base"
+    assert defn["description"].startswith("[knowledge_mcp]")
+    assert "Search the knowledge base" in defn["description"]
+    assert defn["parameters"] == _SAMPLE_TOOL["input_schema"]
+
+
+# ---------------------------------------------------------------------------
+# refresh_tool_cache — error handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_cache_handles_registry_unavailable():
+    """refresh_tool_cache() should return 0 and not crash when registry is down."""
+    d = MCPDispatcher()
+
+    import aiohttp
+
+    with patch(
+        "services.mcp_dispatch.get_http_client",
+        side_effect=aiohttp.ClientConnectionError("refused"),
+    ):
+        count = await d.refresh_tool_cache()
+
+    assert count == 0
+    assert d._cache_loaded is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_cache_handles_non_200_response():
+    """refresh_tool_cache() should return 0 when registry returns non-200."""
+    d = MCPDispatcher()
+
+    mock_response = AsyncMock()
+    mock_response.status = 503
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=mock_response)
+
+    with patch("services.mcp_dispatch.get_http_client", return_value=mock_session):
+        count = await d.refresh_tool_cache()
+
+    assert count == 0
+    assert not d._cache_loaded
+
+
+@pytest.mark.asyncio
+async def test_refresh_cache_populates_tool_dict():
+    """refresh_tool_cache() should populate _tool_cache from registry response."""
+    d = MCPDispatcher()
+
+    registry_response = {
+        "tools": [_SAMPLE_TOOL],
+        "total_tools": 1,
+    }
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value=registry_response)
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=mock_response)
+
+    with patch("services.mcp_dispatch.get_http_client", return_value=mock_session):
+        count = await d.refresh_tool_cache()
+
+    assert count == 1
+    assert d._cache_loaded is True
+    assert "search_knowledge_base" in d._tool_cache
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+
+def test_get_mcp_dispatcher_returns_singleton():
+    """get_mcp_dispatcher() should always return the same instance."""
+    a = get_mcp_dispatcher()
+    b = get_mcp_dispatcher()
+    assert a is b


### PR DESCRIPTION
## Summary
- New `MCPDispatcher` service bridges the MCP registry to `_dispatch_tool_call()`
- Registry-aware fallback: unknown tools are checked against the MCP registry before returning an error
- Tool cache populated from `/api/mcp/tools` on first use with in-memory caching
- `get_tool_definitions()` exports tool schemas in LLM-injectable format
- Uses existing `autobot_shared.http_client.get_http_client()` for all HTTP calls

Closes #2513

## Test plan
- [x] 10/10 MCP dispatch tests passing
- [x] Cache lookup (empty/populated)
- [x] Dispatch unknown tool returns error
- [x] Dispatch known tool routes to bridge endpoint
- [x] Bridge error handling (non-200 response)
- [x] Registry unavailable graceful fallback
- [x] Singleton pattern verified