### PR TITLE
test: add edge case tests for flash attention and token optimizer (#2576)

### DIFF
--- a/autobot-backend/llm_interface_pkg/optimization/flash_attention_test.py
+++ b/autobot-backend/llm_interface_pkg/optimization/flash_attention_test.py
@@ -16,6 +16,7 @@ from llm_interface_pkg.optimization.flash_attention import (
     FlashAttentionConfig,
     FlashAttentionV2,
     GrowingKVCache,
+    KVCacheState,
     _rotate_half_apply,
     create_flash_attention,
     detect_backend,
@@ -231,6 +232,182 @@ class TestRotateHalfApply:
         sin = torch.zeros_like(x)
         result = _rotate_half_apply(x, cos, sin)
         assert torch.allclose(result, x, atol=1e-6)
+
+
+class TestEmptySequence:
+    """Tests for empty (seq_len=0) sequence handling."""
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_empty_sequence_returns_empty_output(self, mock_backend):
+        """Forward with seq_len=0 should return an empty output tensor."""
+        attn = FlashAttentionV2()
+        q = torch.randn(1, 0, 4, 32)
+        kv = torch.randn(1, 0, 2, 4, 32)
+        result = attn.forward(q, kv)
+        assert result.output.shape == (1, 0, 4, 32)
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_empty_sequence_with_mask(self, mock_backend):
+        """Forward with seq_len=0 and an empty mask should not crash."""
+        attn = FlashAttentionV2()
+        q = torch.randn(2, 0, 4, 32)
+        kv = torch.randn(2, 0, 2, 4, 32)
+        mask = torch.ones(2, 0, dtype=torch.bool)
+        result = attn.forward(q, kv, key_padding_mask=mask)
+        assert result.output.shape == (2, 0, 4, 32)
+
+
+class TestAllFalsePaddingMask:
+    """Tests for entirely-masked batches (all padding)."""
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_all_false_mask_does_not_crash(self, mock_backend):
+        """All-False mask (entire batch is padding) should not raise."""
+        attn = FlashAttentionV2()
+        q = torch.randn(1, 4, 2, 16)
+        kv = torch.randn(1, 4, 2, 2, 16)
+        mask = torch.zeros(1, 4, dtype=torch.bool)  # all padding
+        result = attn.forward(q, kv, key_padding_mask=mask)
+        assert result.output.shape == (1, 4, 2, 16)
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_all_false_mask_produces_nan_or_zero(self, mock_backend):
+        """With all tokens masked, softmax(-inf) yields NaN; output should not be finite."""
+        config = FlashAttentionConfig(causal=False)
+        attn = FlashAttentionV2(config)
+        q = torch.randn(1, 4, 2, 16)
+        kv = torch.randn(1, 4, 2, 2, 16)
+        mask = torch.zeros(1, 4, dtype=torch.bool)
+        result = attn.forward(q, kv, key_padding_mask=mask)
+        # When every key is masked, softmax over all -inf produces NaN
+        assert not torch.isfinite(result.output).all() or torch.all(result.output == 0)
+
+
+class TestSingleTokenSequence:
+    """Tests for single-token (seq_len=1) boundary conditions."""
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_single_token_causal(self, mock_backend):
+        """Single token with causal=True should produce finite output."""
+        config = FlashAttentionConfig(causal=True)
+        attn = FlashAttentionV2(config)
+        q = torch.randn(1, 1, 4, 32)
+        kv = torch.randn(1, 1, 2, 4, 32)
+        result = attn.forward(q, kv)
+        assert result.output.shape == (1, 1, 4, 32)
+        assert torch.isfinite(result.output).all()
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_single_token_non_causal(self, mock_backend):
+        """Single token with causal=False should produce finite output."""
+        config = FlashAttentionConfig(causal=False)
+        attn = FlashAttentionV2(config)
+        q = torch.randn(1, 1, 4, 32)
+        kv = torch.randn(1, 1, 2, 4, 32)
+        result = attn.forward(q, kv)
+        assert result.output.shape == (1, 1, 4, 32)
+        assert torch.isfinite(result.output).all()
+
+    @patch(
+        "llm_interface_pkg.optimization.flash_attention.detect_backend",
+        return_value=AttentionBackend.VANILLA,
+    )
+    def test_single_token_with_padding_mask(self, mock_backend):
+        """Single token marked valid in padding mask should be finite."""
+        config = FlashAttentionConfig(causal=True)
+        attn = FlashAttentionV2(config)
+        q = torch.randn(1, 1, 4, 32)
+        kv = torch.randn(1, 1, 2, 4, 32)
+        mask = torch.ones(1, 1, dtype=torch.bool)
+        result = attn.forward(q, kv, key_padding_mask=mask)
+        assert torch.isfinite(result.output).all()
+
+
+class TestBuildSdpaMask:
+    """Direct tests for _build_sdpa_mask mask construction."""
+
+    def _make_attn(self, causal: bool = True) -> FlashAttentionV2:
+        """Create a FlashAttentionV2 with specified causal setting."""
+        with patch(
+            "llm_interface_pkg.optimization.flash_attention.detect_backend",
+            return_value=AttentionBackend.VANILLA,
+        ):
+            return FlashAttentionV2(FlashAttentionConfig(causal=causal))
+
+    def test_returns_none_when_no_mask_no_causal(self):
+        """No mask and causal=False should return None."""
+        attn = self._make_attn(causal=False)
+        result = attn._build_sdpa_mask(None, 4, torch.device("cpu"))
+        assert result is None
+
+    def test_padding_only_mask_shape(self):
+        """Padding mask alone should produce [batch, 1, 1, seq_len] shape."""
+        attn = self._make_attn(causal=False)
+        pad_mask = torch.tensor([[True, True, False, False]])
+        result = attn._build_sdpa_mask(pad_mask, 4, torch.device("cpu"))
+        assert result.shape == (1, 1, 1, 4)
+        assert result[0, 0, 0, 0].item() is True
+        assert result[0, 0, 0, 3].item() is False
+
+    def test_causal_plus_padding_mask_shape(self):
+        """Combined causal + padding mask should be [batch, 1, seq, seq]."""
+        attn = self._make_attn(causal=True)
+        pad_mask = torch.ones(1, 4, dtype=torch.bool)
+        result = attn._build_sdpa_mask(pad_mask, 4, torch.device("cpu"))
+        assert result.shape == (1, 1, 4, 4)
+        # Causal: position 0 should not attend to position 1
+        assert result[0, 0, 0, 1].item() is False
+        # Causal: position 3 should attend to position 0
+        assert result[0, 0, 3, 0].item() is True
+
+    def test_causal_mask_without_padding_returns_none(self):
+        """Causal=True but no padding mask returns None (SDPA uses is_causal flag)."""
+        attn = self._make_attn(causal=True)
+        result = attn._build_sdpa_mask(None, 4, torch.device("cpu"))
+        assert result is None
+
+
+class TestKVCacheStateDataclass:
+    """Tests for the KVCacheState dataclass export and behavior."""
+
+    def test_kvcachestate_default_values(self):
+        """KVCacheState should have correct defaults."""
+        state = KVCacheState()
+        assert state.cache is None
+        assert state.seq_offset == 0
+        assert state.chunk_size == 256
+
+    def test_kvcachestate_custom_values(self):
+        """KVCacheState should accept custom values."""
+        cache_tensor = torch.zeros(1, 8, 2, 4, 32)
+        state = KVCacheState(cache=cache_tensor, seq_offset=5, chunk_size=128)
+        assert state.cache is cache_tensor
+        assert state.seq_offset == 5
+        assert state.chunk_size == 128
+
+    def test_kvcachestate_in_module_all(self):
+        """KVCacheState should be importable from the module."""
+        from llm_interface_pkg.optimization.flash_attention import __all__
+
+        assert "KVCacheState" in __all__
 
 
 class TestGQAExpansion:

--- a/autobot-backend/llm_interface_pkg/optimization/token_optimizer_test.py
+++ b/autobot-backend/llm_interface_pkg/optimization/token_optimizer_test.py
@@ -3,13 +3,18 @@
 # Author: mrveiss
 """Tests for TokenOptimizer — Issue #2098."""
 
+import json
+from unittest.mock import MagicMock, patch
+
 from .token_optimizer import (
     CompactionEntry,
     ContextFingerprinter,
     FrequencyTracker,
     L1Cache,
+    L2Cache,
     TokenOptimizer,
     TokenOptimizerConfig,
+    get_token_optimizer,
 )
 
 
@@ -141,3 +146,189 @@ class TestTokenOptimizer:
             opt.optimize(msgs, f"req{i}")
         _, record = opt.optimize(msgs, "final")
         assert record.blocks_compacted >= 1
+
+
+class TestL2CacheWithMockedRedis:
+    """Tests for L2Cache with mocked Redis client."""
+
+    def _make_entry(self, fingerprint: str = "abc123") -> CompactionEntry:
+        """Create a test CompactionEntry."""
+        return CompactionEntry(
+            fingerprint=fingerprint,
+            original_length=500,
+            compacted_text="compacted content",
+            compacted_length=17,
+            hit_count=0,
+            created_at=1000.0,
+            last_accessed=1000.0,
+        )
+
+    @patch("llm_interface_pkg.optimization.token_optimizer.REDIS_AVAILABLE", True)
+    @patch("llm_interface_pkg.optimization.token_optimizer.get_redis_client")
+    def test_put_and_get_round_trip(self, mock_get_redis):
+        """L2Cache put/get should round-trip a CompactionEntry via Redis."""
+        store = {}
+        mock_redis = MagicMock()
+        mock_redis.get.side_effect = lambda key: store.get(key)
+        mock_redis.setex.side_effect = lambda key, ttl, data: store.__setitem__(
+            key, data
+        )
+        mock_get_redis.return_value = mock_redis
+
+        cache = L2Cache(ttl_seconds=3600, key_prefix="test:")
+        entry = self._make_entry()
+        cache.put("abc123", entry)
+        result = cache.get("abc123")
+
+        assert result is not None
+        assert result.fingerprint == "abc123"
+        assert result.compacted_text == "compacted content"
+        assert result.original_length == 500
+
+    @patch("llm_interface_pkg.optimization.token_optimizer.REDIS_AVAILABLE", True)
+    @patch("llm_interface_pkg.optimization.token_optimizer.get_redis_client")
+    def test_get_missing_key_returns_none(self, mock_get_redis):
+        """L2Cache.get for a missing key should return None."""
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        mock_get_redis.return_value = mock_redis
+
+        cache = L2Cache(ttl_seconds=3600, key_prefix="test:")
+        result = cache.get("nonexistent")
+        assert result is None
+
+
+class TestL2CacheGracefulDegradation:
+    """Tests for L2Cache when Redis is unavailable."""
+
+    @patch("llm_interface_pkg.optimization.token_optimizer.REDIS_AVAILABLE", True)
+    @patch(
+        "llm_interface_pkg.optimization.token_optimizer.get_redis_client",
+        side_effect=Exception("Connection refused"),
+    )
+    def test_get_returns_none_when_redis_fails(self, mock_get_redis):
+        """L2Cache.get should return None when Redis connection fails."""
+        cache = L2Cache()
+        result = cache.get("any_key")
+        assert result is None
+
+    @patch("llm_interface_pkg.optimization.token_optimizer.REDIS_AVAILABLE", True)
+    @patch(
+        "llm_interface_pkg.optimization.token_optimizer.get_redis_client",
+        side_effect=Exception("Connection refused"),
+    )
+    def test_put_does_not_raise_when_redis_fails(self, mock_get_redis):
+        """L2Cache.put should not raise when Redis connection fails."""
+        cache = L2Cache()
+        entry = CompactionEntry(
+            fingerprint="abc",
+            original_length=100,
+            compacted_text="short",
+            compacted_length=5,
+        )
+        # Should not raise
+        cache.put("abc", entry)
+
+    @patch("llm_interface_pkg.optimization.token_optimizer.REDIS_AVAILABLE", False)
+    def test_get_returns_none_when_redis_unavailable(self):
+        """L2Cache.get should return None when redis module not importable."""
+        cache = L2Cache()
+        result = cache.get("any_key")
+        assert result is None
+
+    @patch("llm_interface_pkg.optimization.token_optimizer.REDIS_AVAILABLE", False)
+    def test_put_noop_when_redis_unavailable(self):
+        """L2Cache.put should silently no-op when redis not importable."""
+        cache = L2Cache()
+        entry = CompactionEntry(
+            fingerprint="abc",
+            original_length=100,
+            compacted_text="short",
+            compacted_length=5,
+        )
+        cache.put("abc", entry)  # should not raise
+
+
+class TestL1ToL2Fallback:
+    """Tests for L1 miss -> L2 hit fallback in TokenOptimizer._lookup."""
+
+    @patch("llm_interface_pkg.optimization.token_optimizer.REDIS_AVAILABLE", True)
+    @patch("llm_interface_pkg.optimization.token_optimizer.get_redis_client")
+    def test_l2_hit_promotes_to_l1(self, mock_get_redis):
+        """When L1 misses but L2 hits, entry should be promoted to L1."""
+        entry = CompactionEntry(
+            fingerprint="fp_test",
+            original_length=500,
+            compacted_text="compact",
+            compacted_length=7,
+            hit_count=0,
+            created_at=1000.0,
+            last_accessed=1000.0,
+        )
+        serialized = json.dumps(
+            {
+                "fingerprint": entry.fingerprint,
+                "original_length": entry.original_length,
+                "compacted_text": entry.compacted_text,
+                "compacted_length": entry.compacted_length,
+                "hit_count": entry.hit_count,
+                "created_at": entry.created_at,
+                "last_accessed": entry.last_accessed,
+            }
+        )
+
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = serialized
+        mock_get_redis.return_value = mock_redis
+
+        opt = TokenOptimizer(TokenOptimizerConfig(enabled=True))
+        # L1 is empty, L2 has the entry
+        result = opt._lookup("fp_test")
+        assert result is not None
+        assert result.compacted_text == "compact"
+
+        # Verify it was promoted to L1
+        l1_result = opt._l1.get("fp_test")
+        assert l1_result is not None
+        assert l1_result.compacted_text == "compact"
+
+    @patch("llm_interface_pkg.optimization.token_optimizer.REDIS_AVAILABLE", False)
+    def test_returns_none_when_both_caches_miss(self):
+        """_lookup returns None when both L1 and L2 miss."""
+        opt = TokenOptimizer(TokenOptimizerConfig(enabled=True))
+        result = opt._lookup("nonexistent_fp")
+        assert result is None
+
+
+class TestGetTokenOptimizerSingleton:
+    """Tests for the get_token_optimizer module-level singleton."""
+
+    @patch("llm_interface_pkg.optimization.token_optimizer._optimizer", None)
+    def test_returns_token_optimizer_instance(self):
+        """get_token_optimizer should return a TokenOptimizer."""
+        result = get_token_optimizer()
+        assert isinstance(result, TokenOptimizer)
+
+    @patch("llm_interface_pkg.optimization.token_optimizer._optimizer", None)
+    def test_returns_same_instance_on_repeated_calls(self):
+        """get_token_optimizer should return the same singleton instance."""
+        first = get_token_optimizer()
+        second = get_token_optimizer()
+        assert first is second
+
+    @patch("llm_interface_pkg.optimization.token_optimizer._optimizer", None)
+    def test_accepts_custom_config(self):
+        """get_token_optimizer should accept a custom config on first call."""
+        config = TokenOptimizerConfig(enabled=False, min_repeat_threshold=5)
+        result = get_token_optimizer(config)
+        assert result.enabled is False
+
+    @patch("llm_interface_pkg.optimization.token_optimizer._optimizer", None)
+    def test_ignores_config_on_subsequent_calls(self):
+        """Once created, get_token_optimizer ignores new config args."""
+        config1 = TokenOptimizerConfig(enabled=True)
+        first = get_token_optimizer(config1)
+        config2 = TokenOptimizerConfig(enabled=False)
+        second = get_token_optimizer(config2)
+        assert first is second
+        assert second.enabled is True


### PR DESCRIPTION
## Summary
- 13 new Flash Attention edge case tests: empty sequence, all-False mask, single-token, _build_sdpa_mask, KVCacheState
- 12 new Token Optimizer tests: L2Cache mock Redis, graceful degradation, L1→L2 fallback, singleton

Closes #2576

## Test plan
- [ ] All new tests pass locally
- [ ] No regressions in existing tests