### PR TITLE
feat(workflows): implement DROP_OLDEST with cancellation callback (#2573)

### DIFF
--- a/autobot-backend/services/workflow_automation/concurrent_limiter.py
+++ b/autobot-backend/services/workflow_automation/concurrent_limiter.py
@@ -14,7 +14,7 @@ import time
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Deque, Dict, Optional
+from typing import Awaitable, Callable, Deque, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -82,11 +82,15 @@ class ConcurrentWorkflowLimiter:
         self,
         max_concurrent: int = 3,
         overflow_policy: OverflowPolicy = OverflowPolicy.REJECT,
+        cancel_callback: Optional[Callable[[str], Awaitable[None]]] = None,
     ) -> None:
         if max_concurrent < 1:
             raise ValueError("max_concurrent must be >= 1")
         self._max_concurrent = max_concurrent
         self._overflow_policy = overflow_policy
+        self._cancel_callback: Optional[Callable[[str], Awaitable[None]]] = (
+            cancel_callback
+        )
         self._running: Dict[str, float] = {}  # workflow_id → start timestamp
         self._queue: Deque[_QueuedEntry] = deque()
 
@@ -164,6 +168,22 @@ class ConcurrentWorkflowLimiter:
             "running_workflow_ids": list(self._running.keys()),
         }
 
+    def register_cancel_callback(
+        self, callback: Callable[[str], Awaitable[None]]
+    ) -> None:
+        """
+        Register the async callback invoked when DROP_OLDEST evicts a workflow.
+
+        Issue #2573: Allows late binding of the cancellation handler so the
+        limiter can be constructed before the manager is available.
+
+        Args:
+            callback: ``async def callback(workflow_id: str) -> None`` — must
+                stop the given workflow and eventually call ``release()``.
+        """
+        self._cancel_callback = callback
+        logger.debug("ConcurrentWorkflowLimiter: cancel callback registered")
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -203,15 +223,60 @@ class ConcurrentWorkflowLimiter:
         self._running[workflow_id] = time.time()
 
     async def _drop_oldest_and_acquire(self, workflow_id: str) -> None:
-        """Cancel the oldest running workflow and claim its slot.
+        """Cancel the oldest running workflow then claim its slot.
 
-        Requires a cancellation callback to actually stop the evicted workflow.
-        Until that callback mechanism exists, this policy is not safe to use.
+        Issue #2573: Requires a cancellation callback registered via
+        ``register_cancel_callback`` or the *cancel_callback* constructor
+        parameter.  The callback is responsible for stopping the evicted
+        workflow; ``release()`` will be called by the normal workflow teardown
+        path, freeing the slot.
+
+        Raises:
+            ConcurrencyLimitError: If no cancel callback has been registered.
         """
-        raise NotImplementedError(
-            "DROP_OLDEST policy requires a cancellation callback to stop the evicted "
-            "workflow. Use REJECT or QUEUE until this is implemented."
+        if self._cancel_callback is None:
+            raise ConcurrencyLimitError(workflow_id, self._max_concurrent)
+
+        oldest_id = self._find_oldest_workflow_id()
+        if oldest_id is None:
+            # Edge case: slot became free between the capacity check and here.
+            self._running[workflow_id] = time.time()
+            return
+
+        logger.warning(
+            "ConcurrentWorkflowLimiter: DROP_OLDEST evicting %s to make room for %s",
+            oldest_id,
+            workflow_id,
         )
+        await self._cancel_callback(oldest_id)
+
+        # The callback must ultimately call release(), which removes oldest_id
+        # from _running.  Poll briefly (up to 5 s) to confirm the slot opened.
+        deadline = time.monotonic() + 5.0
+        while oldest_id in self._running and time.monotonic() < deadline:
+            await asyncio.sleep(0.05)
+
+        if oldest_id in self._running:
+            logger.error(
+                "ConcurrentWorkflowLimiter: evicted workflow %s still running after "
+                "5 s; forcing slot removal",
+                oldest_id,
+            )
+            del self._running[oldest_id]
+
+        self._running[workflow_id] = time.time()
+        logger.info(
+            "ConcurrentWorkflowLimiter: DROP_OLDEST complete — %s now running (%d/%d)",
+            workflow_id,
+            self.running_count,
+            self._max_concurrent,
+        )
+
+    def _find_oldest_workflow_id(self) -> Optional[str]:
+        """Return the workflow_id with the earliest start timestamp, or None."""
+        if not self._running:
+            return None
+        return min(self._running, key=lambda wid: self._running[wid])
 
     async def _promote_queued(self) -> None:
         """Wake the next waiting workflow if there is capacity.
@@ -230,7 +295,11 @@ class ConcurrentWorkflowLimiter:
 
 
 class ConcurrencyLimitError(Exception):
-    """Raised when max_concurrent is reached and policy is REJECT."""
+    """Raised when max_concurrent is reached and the workflow is rejected.
+
+    This occurs when the policy is REJECT, or when DROP_OLDEST is configured
+    but no cancel callback has been registered (Issue #2573).
+    """
 
     def __init__(self, workflow_id: str, limit: int) -> None:
         self.workflow_id = workflow_id
@@ -250,11 +319,14 @@ _limiter: Optional[ConcurrentWorkflowLimiter] = None
 def get_concurrent_limiter(
     max_concurrent: int = 3,
     overflow_policy: OverflowPolicy = OverflowPolicy.REJECT,
+    cancel_callback: Optional[Callable[[str], Awaitable[None]]] = None,
 ) -> ConcurrentWorkflowLimiter:
     """
     Return the process-level ConcurrentWorkflowLimiter, creating it on first call.
 
     Issue #2159: Singleton so all routes share the same concurrency counter.
+    Issue #2573: *cancel_callback* is forwarded on construction only (first call).
+    For late binding use ``limiter.register_cancel_callback(cb)`` instead.
     Parameters are only used on first call (when the singleton is created).
     """
     global _limiter
@@ -262,5 +334,6 @@ def get_concurrent_limiter(
         _limiter = ConcurrentWorkflowLimiter(
             max_concurrent=max_concurrent,
             overflow_policy=overflow_policy,
+            cancel_callback=cancel_callback,
         )
     return _limiter

--- a/autobot-backend/tests/services/test_concurrent_limiter.py
+++ b/autobot-backend/tests/services/test_concurrent_limiter.py
@@ -1,0 +1,260 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for ConcurrentWorkflowLimiter DROP_OLDEST policy. Issue #2573."""
+
+import asyncio
+
+import pytest
+from services.workflow_automation.concurrent_limiter import (
+    ConcurrencyLimitError,
+    ConcurrentWorkflowLimiter,
+    OverflowPolicy,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_limiter(max_concurrent: int = 1, callback=None) -> ConcurrentWorkflowLimiter:
+    """Create a fresh DROP_OLDEST limiter (not the singleton)."""
+    return ConcurrentWorkflowLimiter(
+        max_concurrent=max_concurrent,
+        overflow_policy=OverflowPolicy.DROP_OLDEST,
+        cancel_callback=callback,
+    )
+
+
+async def _noop_callback(workflow_id: str) -> None:
+    """Callback that does nothing — tests that poll the slot handle cleanup."""
+
+
+# ---------------------------------------------------------------------------
+# DROP_OLDEST: no callback registered → ConcurrencyLimitError
+# ---------------------------------------------------------------------------
+
+
+class TestDropOldestNoCallback:
+    """DROP_OLDEST without a cancel callback must raise ConcurrencyLimitError."""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_callback(self) -> None:
+        limiter = _make_limiter(max_concurrent=1, callback=None)
+        await limiter.acquire("wf-a")
+
+        with pytest.raises(ConcurrencyLimitError) as exc_info:
+            await limiter.acquire("wf-b")
+
+        assert exc_info.value.workflow_id == "wf-b"
+        assert exc_info.value.limit == 1
+
+    @pytest.mark.asyncio
+    async def test_raises_after_callback_cleared(self) -> None:
+        """Setting callback to None after registration must re-raise the error."""
+        limiter = _make_limiter(max_concurrent=1)
+        limiter.register_cancel_callback(None)  # type: ignore[arg-type]
+        await limiter.acquire("wf-a")
+
+        with pytest.raises(ConcurrencyLimitError):
+            await limiter.acquire("wf-b")
+
+
+# ---------------------------------------------------------------------------
+# DROP_OLDEST: callback invoked and slot claimed
+# ---------------------------------------------------------------------------
+
+
+class TestDropOldestCallbackInvoked:
+    """Verify the cancel callback receives the correct workflow_id."""
+
+    @pytest.mark.asyncio
+    async def test_callback_called_with_oldest_id(self) -> None:
+        evicted: list[str] = []
+
+        async def track_cancel(workflow_id: str) -> None:
+            evicted.append(workflow_id)
+
+        limiter = _make_limiter(max_concurrent=1, callback=track_cancel)
+        await limiter.acquire("wf-old")
+
+        # Simulate callback also releasing the slot (normal teardown path)
+        async def releasing_cancel(workflow_id: str) -> None:
+            evicted.append(workflow_id)
+            await limiter.release(workflow_id)
+
+        limiter.register_cancel_callback(releasing_cancel)
+        await limiter.acquire("wf-new")
+
+        assert evicted == ["wf-old"], f"Expected ['wf-old'], got {evicted}"
+
+    @pytest.mark.asyncio
+    async def test_new_workflow_claims_slot_after_eviction(self) -> None:
+        async def releasing_cancel(workflow_id: str) -> None:
+            await limiter.release(workflow_id)
+
+        limiter = _make_limiter(max_concurrent=1, callback=releasing_cancel)
+        await limiter.acquire("wf-old")
+
+        await limiter.acquire("wf-new")
+
+        assert "wf-new" in limiter._running
+        assert "wf-old" not in limiter._running
+        assert limiter.running_count == 1
+
+    @pytest.mark.asyncio
+    async def test_oldest_workflow_is_evicted_not_newest(self) -> None:
+        """With max=2 and 2 running, the one started first must be evicted."""
+        evicted: list[str] = []
+
+        async def releasing_cancel(workflow_id: str) -> None:
+            evicted.append(workflow_id)
+            await limiter.release(workflow_id)
+
+        limiter = _make_limiter(max_concurrent=2, callback=releasing_cancel)
+        await limiter.acquire("wf-first")
+        # Brief sleep so timestamps differ reliably
+        await asyncio.sleep(0.01)
+        await limiter.acquire("wf-second")
+
+        await limiter.acquire("wf-third")
+
+        assert evicted == ["wf-first"], f"Expected ['wf-first'], got {evicted}"
+        assert "wf-third" in limiter._running
+        assert "wf-second" in limiter._running
+        assert "wf-first" not in limiter._running
+
+
+# ---------------------------------------------------------------------------
+# DROP_OLDEST: late callback registration via register_cancel_callback
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterCancelCallback:
+    """register_cancel_callback enables DROP_OLDEST after construction."""
+
+    @pytest.mark.asyncio
+    async def test_late_registration_enables_drop_oldest(self) -> None:
+        limiter = _make_limiter(max_concurrent=1, callback=None)
+        await limiter.acquire("wf-a")
+
+        async def releasing_cancel(workflow_id: str) -> None:
+            await limiter.release(workflow_id)
+
+        limiter.register_cancel_callback(releasing_cancel)
+
+        # Must succeed — no longer raises NotImplementedError or ConcurrencyLimitError
+        await limiter.acquire("wf-b")
+
+        assert "wf-b" in limiter._running
+        assert "wf-a" not in limiter._running
+
+    @pytest.mark.asyncio
+    async def test_callback_can_be_replaced(self) -> None:
+        """A second register_cancel_callback call replaces the previous one."""
+        call_log: list[str] = []
+
+        async def first_cb(workflow_id: str) -> None:
+            call_log.append(f"first:{workflow_id}")
+            await limiter.release(workflow_id)
+
+        async def second_cb(workflow_id: str) -> None:
+            call_log.append(f"second:{workflow_id}")
+            await limiter.release(workflow_id)
+
+        limiter = _make_limiter(max_concurrent=1, callback=first_cb)
+        await limiter.acquire("wf-a")
+        limiter.register_cancel_callback(second_cb)
+        await limiter.acquire("wf-b")
+
+        assert call_log == ["second:wf-a"]
+
+
+# ---------------------------------------------------------------------------
+# DROP_OLDEST: force-eviction when callback does NOT call release()
+# ---------------------------------------------------------------------------
+
+
+class TestDropOldestForceEviction:
+    """When callback does not call release(), limiter force-removes after timeout."""
+
+    @pytest.mark.asyncio
+    async def test_force_eviction_after_stale_callback(self) -> None:
+        """Callback that never calls release() — slot must still be reclaimed."""
+
+        async def stale_cancel(workflow_id: str) -> None:
+            # Intentionally does NOT call limiter.release()
+            pass
+
+        limiter = _make_limiter(max_concurrent=1, callback=stale_cancel)
+        await limiter.acquire("wf-stuck")
+
+        # Monkey-patch the deadline to be very short so the test doesn't take 5 s
+        import time as _time
+
+        original_monotonic = _time.monotonic
+        call_count = 0
+
+        def fast_monotonic():
+            nonlocal call_count
+            call_count += 1
+            # Return a value past the 5-second deadline after the first call
+            return original_monotonic() + 10.0
+
+        import unittest.mock as _mock
+
+        with _mock.patch(
+            "services.workflow_automation.concurrent_limiter.time.monotonic",
+            side_effect=fast_monotonic,
+        ):
+            await limiter.acquire("wf-new")
+
+        assert "wf-new" in limiter._running
+        assert "wf-stuck" not in limiter._running
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: REJECT and QUEUE policies unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestExistingPoliciesUnchanged:
+    """Ensure REJECT and QUEUE still work correctly after the refactor."""
+
+    @pytest.mark.asyncio
+    async def test_reject_still_raises(self) -> None:
+        limiter = ConcurrentWorkflowLimiter(
+            max_concurrent=1, overflow_policy=OverflowPolicy.REJECT
+        )
+        await limiter.acquire("wf-a")
+
+        with pytest.raises(ConcurrencyLimitError):
+            await limiter.acquire("wf-b")
+
+    @pytest.mark.asyncio
+    async def test_queue_still_waits(self) -> None:
+        limiter = ConcurrentWorkflowLimiter(
+            max_concurrent=1, overflow_policy=OverflowPolicy.QUEUE
+        )
+        await limiter.acquire("wf-a")
+
+        acquired = False
+
+        async def acquire_and_flag():
+            nonlocal acquired
+            await limiter.acquire("wf-b")
+            acquired = True
+
+        task = asyncio.create_task(acquire_and_flag())
+        await asyncio.sleep(0.05)
+        assert not acquired, "wf-b should still be queued"
+
+        await limiter.release("wf-a")
+        await asyncio.sleep(0.05)
+        assert acquired, "wf-b should have been promoted after wf-a released"
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass


### PR DESCRIPTION
## Summary
- Implement `cancel_callback` parameter on `ConcurrentWorkflowLimiter` for DROP_OLDEST policy
- `register_cancel_callback()` for late binding (executor registers after init)
- DROP_OLDEST invokes callback, polls 5s for slot release, force-evicts if needed
- Raises `ConcurrencyLimitError` if no callback registered (safe fallback)
- 5 test cases: callback invocation, force eviction, late binding, backward compat

Closes #2573

## Test plan
- [ ] Verify callback invoked with correct workflow_id
- [ ] Verify oldest (not newest) workflow is evicted
- [ ] Verify force eviction after timeout
- [ ] Verify REJECT and QUEUE policies unchanged