### PR TITLE
fix(deps): tighten Node engine constraint to >=20.19.0 (#2583)

### DIFF
--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.19.0"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Updates `engines.node` from `>=20.0.0` to `>=20.19.0`
- Aligns with `oxlint@1.57.0` requirement of `^20.19.0 || >=22.12.0`

## Closes #2583

## Test plan
- [ ] npm install still works on Node 20.19+
- [ ] Docker build (node:20-bookworm-slim = 20.20.2) unaffected