### PR TITLE
fix(i18n): add noPreviousScan key to all locale files (#2572)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -1211,7 +1211,8 @@
       "noResultsDescription": "Paste code above and click Analyze to get AI-powered insights",
       "suggestions": "Suggestions",
       "issuesFound": "Issues Found",
-      "analysisHistory": "Analysis History"
+      "analysisHistory": "Analysis History",
+      "noPreviousScan": "No previous scan available"
     },
     "evolution": {
       "title": "Code Evolution",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -1212,7 +1212,8 @@
       "noResultsDescription": "Starte eine Analyse, um Ergebnisse zu sehen",
       "suggestions": "Vorschläge",
       "issuesFound": "Gefundene Probleme",
-      "analysisHistory": "Analyse-Historie"
+      "analysisHistory": "Analyse-Historie",
+      "noPreviousScan": "No previous scan available"
     },
     "evolution": {
       "title": "Code-Evolution",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -1212,7 +1212,8 @@
       "noResultsDescription": "Inicia un análisis para ver resultados",
       "suggestions": "Sugerencias",
       "issuesFound": "Problemas encontrados",
-      "analysisHistory": "Historial de análisis"
+      "analysisHistory": "Historial de análisis",
+      "noPreviousScan": "No previous scan available"
     },
     "evolution": {
       "title": "Evolución del código",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -125,5 +125,10 @@
   },
   "_meta": {
     "dir": "rtl"
+  },
+  "analytics": {
+    "codeIntelligence": {
+      "noPreviousScan": "No previous scan available"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -1212,7 +1212,8 @@
       "noResultsDescription": "Lance une analyse pour voir les résultats",
       "suggestions": "Suggestions",
       "issuesFound": "Problèmes trouvés",
-      "analysisHistory": "Historique d'analyse"
+      "analysisHistory": "Historique d'analyse",
+      "noPreviousScan": "No previous scan available"
     },
     "evolution": {
       "title": "Évolution du code",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -125,5 +125,10 @@
   },
   "_meta": {
     "dir": "rtl"
+  },
+  "analytics": {
+    "codeIntelligence": {
+      "noPreviousScan": "No previous scan available"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -1212,7 +1212,8 @@
       "noResultsDescription": "Paste code above and click Analyze to get AI-powered insights",
       "suggestions": "Suggestions",
       "issuesFound": "Issues Found",
-      "analysisHistory": "Analysis History"
+      "analysisHistory": "Analysis History",
+      "noPreviousScan": "No previous scan available"
     },
     "evolution": {
       "title": "Code Evolution",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -1212,7 +1212,8 @@
       "noResultsDescription": "Paste code above and click Analyze to get AI-powered insights",
       "suggestions": "Suggestions",
       "issuesFound": "Issues Found",
-      "analysisHistory": "Analysis History"
+      "analysisHistory": "Analysis History",
+      "noPreviousScan": "No previous scan available"
     },
     "evolution": {
       "title": "Code Evolution",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -1212,7 +1212,8 @@
       "noResultsDescription": "Paste code above and click Analyze to get AI-powered insights",
       "suggestions": "Suggestions",
       "issuesFound": "Issues Found",
-      "analysisHistory": "Analysis History"
+      "analysisHistory": "Analysis History",
+      "noPreviousScan": "No previous scan available"
     },
     "evolution": {
       "title": "Code Evolution",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -125,5 +125,10 @@
   },
   "_meta": {
     "dir": "rtl"
+  },
+  "analytics": {
+    "codeIntelligence": {
+      "noPreviousScan": "No previous scan available"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `noPreviousScan` i18n key to all 10 non-English locale files
- English placeholder used — translators can update with proper translations
- Key path: `analytics.codeIntelligence.noPreviousScan`

## Closes #2572

## Test plan
- [ ] All locale JSON files are valid
- [ ] Key resolves in all languages (fallback to English)