### PR TITLE
deps(python): upgrade backend requirements to latest compatible (#2557)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -1,28 +1,28 @@
 -e ../autobot-shared
 
 # Core
-fastapi>=0.125.0                # SECURITY UPDATE - requires starlette >=0.52.1
-uvicorn>=0.23.0
-python-dotenv>=1.0.0
-aiofiles>=23.0.0
-pydantic>=2.0
-cachetools>=5.0.0
-celery>=5.0.0  # Issue #892: Background task processing
-psutil>=5.9.0  # Issue #927: CPU monitoring for wake word optimization
+fastapi>=0.135.2                # SECURITY UPDATE - requires starlette >=0.52.1
+uvicorn>=0.42.0
+python-dotenv>=1.2.2
+aiofiles>=25.1.0
+pydantic>=2.12.5
+cachetools>=7.0.5
+celery>=5.6.3  # Issue #892: Background task processing
+psutil>=7.2.2  # Issue #927: CPU monitoring for wake word optimization
 
 # Database
-sqlalchemy>=2.0
-alembic>=1.12.0
+sqlalchemy>=2.0.48
+alembic>=1.18.4
 # aiosqlite>=0.19.0  # Included from ../requirements.txt (>=0.21.0)
 
 # AI/ML
-openai>=1.0.0
-anthropic>=0.18.0
-chromadb>=0.4.0
-sentence-transformers>=2.2.0
-torch>=2.6.0  # Issue #904: ML model training
-torchmetrics>=1.0.0  # Issue #904: Training metrics
-vanna>=0.7.0  # Issue #723: Natural language to SQL via Vanna.ai
+openai>=2.30.0
+anthropic>=0.86.0
+chromadb>=1.5.5
+sentence-transformers>=5.3.0
+torch>=2.11.0  # Issue #904: ML model training
+torchmetrics>=1.9.0  # Issue #904: Training metrics
+vanna>=2.0.2  # Issue #723: Natural language to SQL via Vanna.ai
 
 # Include existing requirements
 -r ../requirements.txt
@@ -33,28 +33,28 @@ structlog>=25.5.0      # Structured logging for service auth
 llama-index>=0.13.0,<0.14.0    # 0.14.x has breaking API changes; sub-packages below target 0.13.x — verified 2026-03-26 (#2471)
 llama-index-llms-ollama>=0.7.0,<1.0.0  # Ollama LLM integration (0.7.0+ for core 0.13.0)
 llama-index-embeddings-ollama>=0.7.0,<1.0.0  # Ollama embeddings (0.7.0+ for core 0.13.0)
-llama-index-vector-stores-chroma>=0.5.0,<1.0.0  # ChromaDB vector store
+llama-index-vector-stores-chroma>=0.5.5,<1.0.0  # ChromaDB vector store
 # LangChain 1.x ecosystem — migrated from 0.3.x to fix SSRF CVE (#1572)
-langchain>=1.2.0,<2.0.0               # Issue #1572: Migrated to 1.x (was 0.3.x)
-langchain-core>=1.2.11,<2.0.0         # Issue #1572: SSRF CVE fix requires >=1.2.11
-langchain-community>=0.4.0,<0.5.0     # Issue #1572: Compatible with langchain 1.x
-langchain-ollama>=1.0.0,<2.0.0        # Issue #1572: ChatOllama for QA chain
-langgraph>=1.1.1,<2.0.0               # Issue #1043: StateGraph for chat orchestration
+langchain>=1.2.13,<2.0.0               # Issue #1572: Migrated to 1.x (was 0.3.x)
+langchain-core>=1.2.22,<2.0.0         # Issue #1572: SSRF CVE fix requires >=1.2.11
+langchain-community>=0.4.1,<0.5.0     # Issue #1572: Compatible with langchain 1.x
+langchain-ollama>=1.0.1,<2.0.0        # Issue #1572: ChatOllama for QA chain
+langgraph>=1.1.3,<2.0.0               # Issue #1043: StateGraph for chat orchestration
 langgraph-checkpoint-redis>=0.4.0,<1.0.0  # Issue #1043: Redis checkpointer for thread persistence
-markdownify>=0.11.0  # HTML to Markdown conversion
-mcp>=1.23.0            # MCP protocol for skill subprocesses (Issue #731)
-PyYAML>=6.0            # SKILL.md frontmatter parsing (Phase 3 sync engine)
+markdownify>=1.2.2  # HTML to Markdown conversion
+mcp>=1.26.0            # MCP protocol for skill subprocesses (Issue #731)
+PyYAML>=6.0.3            # SKILL.md frontmatter parsing (Phase 3 sync engine)
 
 # Community growth skill (Issue #1161)
-praw>=7.7.0             # Reddit OAuth API for CommunityGrowthSkill
+praw>=7.8.1             # Reddit OAuth API for CommunityGrowthSkill
 
 # NLP / Neural Mesh RAG (Issue #1994)
-spacy>=3.7                  # Issue #2025: NLP entity extraction
-scikit-learn>=1.3           # Issue #2027: RAPTOR clustering
+spacy>=3.8.13                  # Issue #2025: NLP entity extraction
+scikit-learn>=1.8.0           # Issue #2027: RAPTOR clustering
 
 # Media processing pipelines (Issue #932)
 aiohttp>=3.13.3         # Async HTTP client - SECURITY UPDATE (7 CVE fixes)
-beautifulsoup4>=4.12.0  # HTML parsing for link pipeline
+beautifulsoup4>=4.14.3  # HTML parsing for link pipeline
 Pillow>=12.1.1          # Image processing - SECURITY UPDATE (OOB write fix)
 # Optional (install separately for full media support):
 # opencv-python>=4.8.0   # Frame extraction for video pipeline

--- a/autobot-shared/requirements.txt
+++ b/autobot-shared/requirements.txt
@@ -1,12 +1,12 @@
-redis>=4.0.0
-pyyaml>=6.0
-pydantic>=2.0
-python-dotenv>=1.0.0
+redis>=7.4.0
+pyyaml>=6.0.3
+pydantic>=2.12.5
+python-dotenv>=1.2.2
 
 # OpenTelemetry distributed tracing (Issue #697)
-opentelemetry-api>=1.20.0
-opentelemetry-sdk>=1.20.0
-opentelemetry-exporter-otlp>=1.20.0
-opentelemetry-instrumentation-fastapi>=0.41b0
-opentelemetry-instrumentation-redis>=0.41b0
-opentelemetry-instrumentation-aiohttp-client>=0.41b0
+opentelemetry-api>=1.40.0
+opentelemetry-sdk>=1.40.0
+opentelemetry-exporter-otlp>=1.40.0
+opentelemetry-instrumentation-fastapi>=0.61b0
+opentelemetry-instrumentation-redis>=0.61b0
+opentelemetry-instrumentation-aiohttp-client>=0.61b0

--- a/autobot-slm-backend/requirements.txt
+++ b/autobot-slm-backend/requirements.txt
@@ -7,51 +7,51 @@
 #
 
 # Prometheus metrics (Issue #937: shared monitoring implementation)
-prometheus-client>=0.20.0
+prometheus-client>=0.24.1
 
 # Web framework
-fastapi>=0.125.0                # SECURITY UPDATE - requires starlette >=0.52.1
-uvicorn[standard]>=0.27.0
+fastapi>=0.135.2                # SECURITY UPDATE - requires starlette >=0.52.1
+uvicorn[standard]>=0.42.0
 
 # Database - PostgreSQL (Issue #786)
-sqlalchemy>=2.0.0
-asyncpg>=0.29.0  # Async PostgreSQL driver for SQLAlchemy
-psycopg2-binary>=2.9.9  # Sync PostgreSQL driver for migrations
+sqlalchemy>=2.0.48
+asyncpg>=0.31.0  # Async PostgreSQL driver for SQLAlchemy
+psycopg2-binary>=2.9.11  # Sync PostgreSQL driver for migrations
 
 # Data validation
-pydantic[email]>=2.5.0
-pydantic-settings>=2.1.0
-typing_extensions>=4.0.0  # For Python 3.8 compatibility
+pydantic[email]>=2.12.5
+pydantic-settings>=2.13.1
+typing_extensions>=4.15.0  # For Python 3.8 compatibility
 
 # Authentication
-PyJWT[crypto]>=2.8.0
+PyJWT[crypto]>=2.12.1
 passlib[bcrypt]>=1.7.4
-bcrypt>=4.0.0,<5.0.0  # passlib 1.7.4 (unmaintained) does not support bcrypt 5.x API — verified 2026-03-26 (#2471)
+bcrypt>=4.2.1,<5.0.0  # passlib 1.7.4 (unmaintained) does not support bcrypt 5.x API — verified 2026-03-26 (#2471)
 python-multipart>=0.0.22          # SECURITY UPDATE - arbitrary file write fix
 
 # Async utilities
-aiofiles>=23.2.0
-websockets>=12.0
+aiofiles>=25.1.0
+websockets>=16.0
 
 # Ansible integration
-ansible-runner>=2.3.0
+ansible-runner>=2.4.3
 
 # HTTP client (for health checks)
-httpx>=0.26.0
+httpx>=0.28.1
 
 # System metrics
-psutil>=5.9.0
+psutil>=7.2.2
 
 # SSH connectivity (for connection testing and node management)
-paramiko>=3.4.0
+paramiko>=4.0.0
 
 # Cron expression parsing (Issue #741 - Scheduled updates)
-croniter>=2.0.0
+croniter>=6.2.2
 
 # SSO Integration (Issue #576 Phase 4)
-authlib>=1.3.0  # OAuth2/OIDC client
-ldap3>=2.9.0  # LDAP/Active Directory
-pysaml2>=7.3.0  # SAML 2.0 Service Provider
+authlib>=1.6.9  # OAuth2/OIDC client
+ldap3>=2.9.1  # LDAP/Active Directory
+pysaml2>=7.5.4  # SAML 2.0 Service Provider
 
 # 2FA/MFA (Issue #576 Phase 5)
 pyotp>=2.9.0  # TOTP generation and verification

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 paramiko>=4.0.0
 
 # Retry logic for resilient operations
-tenacity>=8.5.0
+tenacity>=9.1.4
 
 # Async SSH for PKI certificate distribution (Issue #166)
 asyncssh>=2.22.0
@@ -14,12 +14,12 @@ protobuf>=5.29.6,<6.0.0
 # Provides 3-4x throughput improvement with 98.7% cache efficiency
 # Requires: CUDA-compatible GPU, Python 3.12
 # Enable in config: llm.vllm.enabled = true
-vllm>=0.14.1
+vllm>=0.18.0
 
 # Document parsing libraries for knowledge base
 # Supports PDF, Word, Excel, PowerPoint, OpenDocument formats
-pypdf>=6.9.1              # PDF parsing - SECURITY UPDATE (improved permission checks)
-python-docx>=1.1.2        # Microsoft Word (.docx)
+pypdf>=6.9.2              # PDF parsing - SECURITY UPDATE (improved permission checks)
+python-docx>=1.2.0        # Microsoft Word (.docx)
 openpyxl>=3.1.5           # Microsoft Excel (.xlsx)
 python-pptx>=1.0.2        # Microsoft PowerPoint (.pptx)
 odfpy>=1.4.1              # OpenDocument formats (.odt, .ods, .odp, .odg)
@@ -32,18 +32,18 @@ opentelemetry-exporter-otlp==1.40.0
 opentelemetry-exporter-otlp-proto-grpc==1.40.0
 opentelemetry-exporter-otlp-proto-http==1.40.0
 opentelemetry-proto==1.40.0
-opentelemetry-instrumentation-fastapi>=0.55b0
+opentelemetry-instrumentation-fastapi>=0.61b0
 opentelemetry-propagator-b3==1.40.0
 # Issue #697: Additional instrumentation for comprehensive tracing
-opentelemetry-instrumentation-redis>=0.55b0
-opentelemetry-instrumentation-aiohttp-client>=0.55b0
+opentelemetry-instrumentation-redis>=0.61b0
+opentelemetry-instrumentation-aiohttp-client>=0.61b0
 
 # FAISS - Vector Similarity Search (Issue #387, #856)
 # Provides efficient vector similarity search operations
 # Using CPU version for Python 3.12 compatibility (GPU version requires conda)
 # For GPU acceleration: conda install -c conda-forge faiss-gpu (Python 3.12)
-faiss-cpu>=1.7.4
-aiosqlite>=0.21.0
+faiss-cpu>=1.13.2
+aiosqlite>=0.22.1
 
 # Security - XML parsing protection (Issue #67)
 # Prevents XXE (XML External Entity) attacks in threat intelligence parsing
@@ -51,4 +51,4 @@ defusedxml>=0.7.1
 
 # MinHash LSH - Locality-Sensitive Hashing for duplicate detection (Issue #659)
 # Provides 10-100x speedup for similarity search via O(n) expected complexity
-datasketch>=1.6.0
+datasketch>=1.9.0


### PR DESCRIPTION
## Summary
- Bumped all Python backend dependency minimum versions to latest compatible releases
- Part of #1836 (full-stack dependency upgrade)

## Key Upgrades
| Package | From | To | Notes |
|---------|------|----|-------|
| fastapi | >=0.125.0 | >=0.135.2 | Security updates |
| uvicorn | >=0.23.0 | >=0.42.0 | |
| openai | >=1.0.0 | >=2.30.0 | Major API changes |
| anthropic | >=0.18.0 | >=0.86.0 | |
| chromadb | >=0.4.0 | >=1.5.5 | Major version |
| sentence-transformers | >=2.2.0 | >=5.3.0 | Major version |
| torch | >=2.6.0 | >=2.11.0 | |
| redis | >=4.0.0 | >=7.4.0 | Major version |
| aiohttp | kept >=3.13.3 | | Already at security fix |
| Pillow | kept >=12.1.1 | | Already at security fix |
| langchain | >=1.2.0 | >=1.2.13 | Kept <2.0.0 |
| spacy | >=3.7 | >=3.8.13 | |
| scikit-learn | >=1.3 | >=1.8.0 | |
| pydantic | >=2.0 | >=2.12.5 | |
| sqlalchemy | >=2.0 | >=2.0.48 | |
| OpenTelemetry suite | 1.20/0.41b | 1.40/0.61b | |

## Preserved Constraints
- `llama-index>=0.13.0,<0.14.0` — 0.14.x has breaking API changes
- `bcrypt>=4.2.1,<5.0.0` — passlib 1.7.4 doesn't support bcrypt 5.x
- `protobuf>=5.29.6,<6.0.0` — TensorFlow constraint
- All langchain/langgraph upper bounds preserved

## Test plan
- [ ] `pip install --dry-run` succeeds for all requirements files
- [ ] Backend starts and health check passes
- [ ] Pre-commit passes

Closes #2557