### PR TITLE
feat(workflow): vision step chaining, SSOT URL, and web OCR pipeline

### DIFF
--- a/autobot-backend/services/workflow_automation/executor.py
+++ b/autobot-backend/services/workflow_automation/executor.py
@@ -9,9 +9,10 @@ Handles workflow step execution, dependency checking, and command execution.
 
 import asyncio
 import logging
+import re
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING, Callable, Dict, FrozenSet, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, FrozenSet, Optional
 
 from constants.threshold_constants import TimingConstants
 from monitoring.prometheus_metrics import get_metrics_manager
@@ -99,6 +100,58 @@ def _redact_result_secrets(
     except Exception as exc:  # pragma: no cover
         logger.error("Secret redaction failed for workflow result: %s", exc)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Issue #2601 — Step reference resolution for vision step chaining
+# ---------------------------------------------------------------------------
+
+_REF_PATTERN = re.compile(r"\$\{steps\.(\w+)\.(.+?)\}")
+_ARRAY_PART = re.compile(r"^(\w+)\[(\d+)\]$")
+
+
+def _navigate_path(data: Any, path: str) -> Any:
+    """Navigate a dot-separated path with optional array indexing into *data*.
+
+    Example path: ``result.elements[0].coordinates``
+    Returns ``None`` for missing keys or out-of-range indices. (#2601)
+    """
+    current = data
+    for part in path.split("."):
+        if current is None:
+            return None
+        array_match = _ARRAY_PART.match(part)
+        if array_match:
+            key, index = array_match.group(1), int(array_match.group(2))
+            if isinstance(current, dict):
+                current = current.get(key)
+            if isinstance(current, (list, tuple)) and index < len(current):
+                current = current[index]
+            else:
+                return None
+        elif isinstance(current, dict):
+            current = current.get(part)
+        else:
+            return None
+    return current
+
+
+def _resolve_step_references(config: dict, step_results: dict) -> dict:
+    """Resolve ``${steps.<step_id>.<path>}`` references in step config values.
+
+    Only string values are scanned.  Non-matching strings and non-string values
+    are returned unchanged.  Unknown step IDs resolve to ``None``. (#2601)
+    """
+    resolved: dict = {}
+    for key, value in config.items():
+        if isinstance(value, str):
+            match = _REF_PATTERN.search(value)
+            if match:
+                step_id, path = match.group(1), match.group(2)
+                resolved[key] = _navigate_path(step_results.get(step_id), path)
+                continue
+        resolved[key] = value
+    return resolved
 
 
 class WorkflowExecutor:
@@ -452,12 +505,16 @@ class WorkflowExecutor:
             )
 
             # Issue #2397: Route vision node types to the vision step handler.
+            # Issue #2601: Resolve ${steps.<id>.<path>} references before executing.
             # All other step types fall through to the standard command executor.
             if current_step.step_type in VISION_STEP_TYPES:
+                resolved_config = _resolve_step_references(
+                    current_step.step_config or {}, workflow.step_results
+                )
                 result = await self._timeout_enforcer.run_with_timeout(
                     coro=execute_vision_step(
                         current_step.step_type,
-                        current_step.step_config or {},
+                        resolved_config,
                     ),
                     step_id=step_id,
                     timeout_seconds=current_step.timeout_seconds,
@@ -515,6 +572,9 @@ class WorkflowExecutor:
         current_step.status = WorkflowStepStatus.COMPLETED
         current_step.execution_result = result
         current_step.completed_at = datetime.now()
+
+        # Issue #2601: Store result so later vision steps can reference it.
+        workflow.step_results[step_id] = result
 
         self._record_step_metric("completed", current_step.step_type)
 

--- a/autobot-backend/services/workflow_automation/models.py
+++ b/autobot-backend/services/workflow_automation/models.py
@@ -10,7 +10,7 @@ Enums, dataclasses, and Pydantic models for workflow automation.
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 from type_defs.common import Metadata
@@ -180,6 +180,8 @@ class ActiveWorkflow:
     prometheus_start_time: Optional[float] = None  # For Prometheus duration tracking
     # Issue #2153: Owner identifier for workflow secret resolution.
     owner_id: Optional[str] = None
+    # Issue #2601: Store step execution results keyed by step_id for reference passing.
+    step_results: Dict[str, Metadata] = field(default_factory=dict)
 
     def __post_init__(self):
         """Set default values for created_at and user_interventions."""

--- a/autobot-backend/services/workflow_automation/vision_step_handler.py
+++ b/autobot-backend/services/workflow_automation/vision_step_handler.py
@@ -1,7 +1,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Vision workflow step execution handlers (#2397).
+"""Vision workflow step execution handlers (#2397, #2601).
 
 Routes vision node types to the appropriate backend API endpoint
 based on the step's target property (vnc or web).
@@ -13,6 +13,8 @@ import time
 from typing import Any
 
 import httpx
+
+from autobot_shared.ssot_config import config as ssot_config
 
 logger = logging.getLogger(__name__)
 
@@ -32,10 +34,15 @@ VISION_STEP_TYPES: frozenset[str] = frozenset(_VNC_ENDPOINT.keys())
 _VNC_GET_STEPS: frozenset[str] = frozenset({"vision-click", "vision-type-text"})
 
 
+def _get_backend_url() -> str:
+    """Return the backend base URL from SSOT config (#2601)."""
+    return ssot_config.backend_url
+
+
 async def execute_vision_step(
     step_type: str,
     step_config: dict[str, Any],
-    backend_url: str = "https://localhost:8443",
+    backend_url: str | None = None,
 ) -> dict[str, Any]:
     """Execute a vision workflow step by routing to the appropriate API.
 
@@ -43,12 +50,14 @@ async def execute_vision_step(
         step_type: One of the VISION_STEP_TYPES (e.g. "vision-capture").
         step_config: Step configuration from the workflow definition.
             Expected keys: target ("vnc" or "web"), plus type-specific params.
-        backend_url: Backend base URL.
+        backend_url: Backend base URL. Defaults to SSOT config value (#2601).
 
     Returns:
         Execution result dict with keys: success, result, execution_time,
-        step_type, target.  (#2397)
+        step_type, target.  (#2397, #2601)
     """
+    if backend_url is None:
+        backend_url = _get_backend_url()
     target = step_config.get("target", "vnc")
     start = time.monotonic()
 
@@ -232,28 +241,46 @@ def _build_web_action_payload(
 async def _web_ocr_step(
     session_id: str, config: dict[str, Any], backend_url: str
 ) -> dict:
-    """Capture a browser screenshot then delegate OCR via the vision pipeline.
+    """Capture a browser screenshot then run OCR via the vision pipeline (#2601).
 
-    Full pipeline integration (screenshot bytes → vision OCR) is tracked
-    separately.  This step captures the screenshot and returns it so the
-    caller can chain with a vision-ocr VNC step if needed.  (#2397)
+    Two-stage pipeline:
+      1. POST to /api/research-browser/session/action with action=screenshot
+      2. POST the screenshot image data to /api/vision/ocr
     """
     async with httpx.AsyncClient(verify=False, timeout=30.0) as client:  # nosec B501
-        screenshot_resp = await client.post(
-            f"{backend_url}/api/research-browser/session/action",
-            json={"session_id": session_id, "action": "screenshot"},
+        screenshot_data = await _capture_browser_screenshot(
+            client, session_id, backend_url
         )
-        screenshot_resp.raise_for_status()
-        screenshot_data = screenshot_resp.json()
+        return await _run_ocr_on_screenshot(
+            client, screenshot_data, config, backend_url
+        )
 
-    logger.info(
-        "vision-ocr web step captured screenshot for session %s; "
-        "full OCR pipeline integration pending (#2397)",
-        session_id,
+
+async def _capture_browser_screenshot(
+    client: httpx.AsyncClient, session_id: str, backend_url: str
+) -> dict:
+    """POST screenshot action to the browser session API and return response JSON."""
+    resp = await client.post(
+        f"{backend_url}/api/research-browser/session/action",
+        json={"session_id": session_id, "action": "screenshot"},
     )
-    return {
-        "step_type": "vision-ocr",
-        "target": "web",
-        "screenshot": screenshot_data,
-        "note": "OCR on web target requires screenshot-to-vision pipeline (#2397)",
+    resp.raise_for_status()
+    data = resp.json()
+    logger.info("vision-ocr web step captured screenshot for session %s", session_id)
+    return data
+
+
+async def _run_ocr_on_screenshot(
+    client: httpx.AsyncClient,
+    screenshot_data: dict,
+    config: dict[str, Any],
+    backend_url: str,
+) -> dict:
+    """POST screenshot image data to /api/vision/ocr and return OCR result."""
+    ocr_payload = {
+        "image_data": screenshot_data.get("screenshot", ""),
+        "region": config.get("region"),
     }
+    ocr_resp = await client.post(f"{backend_url}/api/vision/ocr", json=ocr_payload)
+    ocr_resp.raise_for_status()
+    return ocr_resp.json()

--- a/autobot-backend/services/workflow_automation/vision_step_handler_test.py
+++ b/autobot-backend/services/workflow_automation/vision_step_handler_test.py
@@ -1,17 +1,22 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Unit tests for vision workflow step execution handlers (#2397)."""
+"""Unit tests for vision workflow step execution handlers (#2397, #2601)."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from services.workflow_automation.executor import (
+    _navigate_path,
+    _resolve_step_references,
+)
 from services.workflow_automation.vision_step_handler import (
     VISION_STEP_TYPES,
     _build_vnc_payload,
     _build_web_action_payload,
     _element_matches,
+    _get_backend_url,
     execute_vision_step,
 )
 
@@ -202,3 +207,135 @@ class TestExecuteVisionStep:
             result = await execute_vision_step("vision-click", {})
 
         assert result["target"] == "vnc"
+
+
+class TestGetBackendUrl:
+    """Tests for SSOT-based backend URL resolution (#2601)."""
+
+    def test_get_backend_url_uses_ssot(self):
+        """_get_backend_url delegates to ssot_config.backend_url."""
+        with patch(
+            "services.workflow_automation.vision_step_handler.ssot_config"
+        ) as mock_cfg:
+            mock_cfg.backend_url = "https://192.0.2.1:8443"
+            url = _get_backend_url()
+        assert url == "https://192.0.2.1:8443"
+
+    @pytest.mark.asyncio
+    async def test_execute_vision_step_default_url_from_ssot(self):
+        """When backend_url is omitted, execute_vision_step uses SSOT config."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "services.workflow_automation.vision_step_handler.ssot_config"
+        ) as mock_cfg, patch(
+            "services.workflow_automation.vision_step_handler.httpx.AsyncClient"
+        ) as mock_client:
+            mock_cfg.backend_url = "https://192.0.2.20:8443"
+            mock_instance = AsyncMock()
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_instance.post = AsyncMock(return_value=mock_response)
+
+            await execute_vision_step("vision-capture", {"target": "vnc"})
+
+        call_url = mock_instance.post.call_args[0][0]
+        assert call_url.startswith("https://192.0.2.20:8443")
+
+
+class TestWebOcrPipeline:
+    """Tests for the connected web OCR pipeline (#2601)."""
+
+    @pytest.mark.asyncio
+    async def test_web_ocr_calls_vision_endpoint(self):
+        """Web OCR captures screenshot then POSTs to /api/vision/ocr."""
+        screenshot_resp = MagicMock()
+        screenshot_resp.raise_for_status = MagicMock()
+        screenshot_resp.json.return_value = {"screenshot": "base64imgdata"}
+
+        ocr_resp = MagicMock()
+        ocr_resp.raise_for_status = MagicMock()
+        ocr_resp.json.return_value = {"text": "Hello World", "confidence": 0.99}
+
+        with patch(
+            "services.workflow_automation.vision_step_handler.httpx.AsyncClient"
+        ) as mock_client:
+            mock_instance = AsyncMock()
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_instance.post = AsyncMock(side_effect=[screenshot_resp, ocr_resp])
+
+            result = await execute_vision_step(
+                "vision-ocr",
+                {
+                    "target": "web",
+                    "browser_session_id": "sess-1",
+                    "region": [0, 0, 100, 100],
+                },
+                backend_url="https://localhost:8443",
+            )
+
+        assert result["success"] is True
+        ocr_call_kwargs = mock_instance.post.call_args_list[1]
+        assert "/api/vision/ocr" in ocr_call_kwargs[0][0]
+        sent_payload = ocr_call_kwargs[1]["json"]
+        assert sent_payload["image_data"] == "base64imgdata"
+        assert sent_payload["region"] == [0, 0, 100, 100]
+
+
+class TestNavigatePath:
+    """Tests for the path navigation helper (#2601)."""
+
+    def test_simple_key(self):
+        """Navigates a single-level key."""
+        assert _navigate_path({"a": 1}, "a") == 1
+
+    def test_nested_key(self):
+        """Navigates dot-separated nested keys."""
+        data = {"result": {"elements": [{"id": "btn"}]}}
+        assert _navigate_path(data, "result.elements[0].id") == "btn"
+
+    def test_array_index(self):
+        """Navigates array index in path."""
+        data = {"items": ["x", "y", "z"]}
+        assert _navigate_path(data, "items[1]") == "y"
+
+    def test_missing_key_returns_none(self):
+        """Missing key returns None rather than raising."""
+        assert _navigate_path({"a": 1}, "b") is None
+
+    def test_out_of_range_index_returns_none(self):
+        """Out-of-range array index returns None."""
+        assert _navigate_path({"items": [1]}, "items[5]") is None
+
+
+class TestResolveStepReferences:
+    """Tests for step config reference resolution (#2601)."""
+
+    def test_simple_reference_resolved(self):
+        """${steps.s1.result.elements[0].id} resolves from step_results."""
+        step_results = {"s1": {"result": {"elements": [{"id": "btn-42"}]}}}
+        config = {"target_element": "${steps.s1.result.elements[0].id}"}
+        resolved = _resolve_step_references(config, step_results)
+        assert resolved["target_element"] == "btn-42"
+
+    def test_no_reference_passes_through(self):
+        """Non-reference strings pass through unchanged."""
+        config = {"selector": "#my-button", "timeout": 5000}
+        resolved = _resolve_step_references(config, {})
+        assert resolved == {"selector": "#my-button", "timeout": 5000}
+
+    def test_unknown_step_id_resolves_to_none(self):
+        """Reference to an unknown step_id resolves to None."""
+        config = {"coord": "${steps.missing.x}"}
+        resolved = _resolve_step_references(config, {})
+        assert resolved["coord"] is None
+
+    def test_non_string_values_unchanged(self):
+        """Non-string config values (int, list, dict) are not modified."""
+        config = {"count": 3, "tags": ["a", "b"]}
+        resolved = _resolve_step_references(config, {})
+        assert resolved == {"count": 3, "tags": ["a", "b"]}


### PR DESCRIPTION
## Summary
- **SSOT URL**: `execute_vision_step()` now uses `ssot_config.backend_url` instead of hardcoded `localhost:8443`
- **Step reference passing**: `${steps.<step_id>.<path>}` syntax resolves upstream step outputs in `step_config` via `_resolve_step_references()`
- **Web OCR pipeline**: `_web_ocr_step()` now captures browser screenshot then POSTs to `/api/vision/ocr` (was a stub)
- **Step results store**: `ActiveWorkflow.step_results` dict accumulates completed step outputs for downstream reference

Closes #2601

## Test plan
- [x] 30/30 tests passing (18 original + 12 new)
- [x] SSOT backend URL resolution tests
- [x] Web OCR pipeline mock tests (screenshot + OCR endpoint chain)
- [x] Path navigation with dot notation and array indexing
- [x] Step reference resolution (found, missing, non-string passthrough)
- [x] All pre-commit hooks passing (bandit, function length, etc.)