### PR TITLE
fix(frontend): make createLogger variadic (#2607)

### DIFF
--- a/autobot-frontend/src/utils/debugUtils.ts
+++ b/autobot-frontend/src/utils/debugUtils.ts
@@ -73,52 +73,28 @@ export interface PerformanceMetrics {
 // ============================================================================
 
 /**
- * Enhanced console logging with timestamps and formatting
+ * Enhanced console logging with timestamps and formatting.
+ * Supports variadic args so callers can use printf-style %s or pass multiple values.
  *
  * @param level - Log level (debug, info, warn, error)
- * @param message - Log message
- * @param data - Optional data to log
+ * @param message - Log message (may contain %s/%d/%o placeholders)
+ * @param args - Additional data forwarded to console.*
  *
  * @example
  * ```ts
  * log('info', 'Component mounted')
- * log('error', 'Failed to load data', { error: e })
+ * log('error', 'Failed to load %s: %s', endpoint, error)
  * ```
  */
-export function log(level: LogLevel, message: string, data?: any): void {
+export function log(level: LogLevel, message: string, ...args: unknown[]): void {
   const timestamp = new Date().toISOString()
   const prefix = `[${timestamp}] [${level.toUpperCase()}]`
+  const consoleFn = level === 'debug' ? console.debug
+    : level === 'info' ? console.info
+    : level === 'warn' ? console.warn
+    : console.error
 
-  switch (level) {
-    case 'debug':
-      if (data) {
-        console.debug(prefix, message, data)
-      } else {
-        console.debug(prefix, message)
-      }
-      break
-    case 'info':
-      if (data) {
-        console.info(prefix, message, data)
-      } else {
-        console.info(prefix, message)
-      }
-      break
-    case 'warn':
-      if (data) {
-        console.warn(prefix, message, data)
-      } else {
-        console.warn(prefix, message)
-      }
-      break
-    case 'error':
-      if (data) {
-        console.error(prefix, message, data)
-      } else {
-        console.error(prefix, message)
-      }
-      break
-  }
+  consoleFn(prefix, message, ...args)
 }
 
 /**
@@ -136,10 +112,10 @@ export function log(level: LogLevel, message: string, data?: any): void {
  */
 export function createLogger(scope: string) {
   return {
-    debug: (message: string, data?: any) => log('debug', `[${scope}] ${message}`, data),
-    info: (message: string, data?: any) => log('info', `[${scope}] ${message}`, data),
-    warn: (message: string, data?: any) => log('warn', `[${scope}] ${message}`, data),
-    error: (message: string, data?: any) => log('error', `[${scope}] ${message}`, data)
+    debug: (message: string, ...args: unknown[]) => log('debug', `[${scope}] ${message}`, ...args),
+    info: (message: string, ...args: unknown[]) => log('info', `[${scope}] ${message}`, ...args),
+    warn: (message: string, ...args: unknown[]) => log('warn', `[${scope}] ${message}`, ...args),
+    error: (message: string, ...args: unknown[]) => log('error', `[${scope}] ${message}`, ...args),
   }
 }
 


### PR DESCRIPTION
## Summary

- Makes `log()` and `createLogger()` methods accept variadic `...args` instead of `(message, data?)`
- Fixes ~26+ call sites using `%s` printf-style formatting that was never interpolated
- Fixes 3+ arg calls (e.g., `logger.debug('msg', val1, val2)`) that silently dropped extra args
- Also simplifies `log()` from a 30-line switch/case to a 4-line lookup (net -24 lines)

## Root cause

`createLogger` methods only accepted `(message: string, data?: any)`. This meant:
1. `%s` placeholders appeared literally in output — `console.*` never got the substitution args
2. Calls with 3+ args silently dropped everything after the 2nd

## Verification

- `vue-tsc --noEmit` → exit 0
- `oxlint` → 0 warnings, 0 errors
- All existing 2-arg call sites work unchanged (variadic is backward-compatible)

## Test plan

- [x] `vue-tsc --noEmit` passes
- [x] `oxlint` passes
- [ ] CI passes

Closes #2607