### PR TITLE
fix(frontend): accumulate errors in useCodeIntelligence for parallel calls (#2588)

### DIFF
--- a/autobot-frontend/src/composables/useCodeIntelligence.ts
+++ b/autobot-frontend/src/composables/useCodeIntelligence.ts
@@ -7,7 +7,7 @@
  * Issue #899 - Code Intelligence Tools
  */
 
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -145,7 +145,10 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   const securityScoreCached = ref<SecurityScoreCached | null>(null)
   const isLoading = ref(false)
   const loadingCount = ref(0)
-  const error = ref<string | null>(null)
+  const errors = ref<string[]>([])
+  const error = computed<string | null>(() =>
+    errors.value.length > 0 ? errors.value.join('; ') : null,
+  )
 
   // ===== API Methods =====
 
@@ -165,7 +168,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function analyzeCode(request: CodeAnalysisRequest): Promise<CodeAnalysisResult | null> {
     startLoading()
-    error.value = null
     try {
       const data = await ApiClient.post('/api/code-intelligence/analyze', request)
       currentAnalysis.value = data
@@ -174,7 +176,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to analyze code'
       logger.error('Code analysis failed:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
       return null
     } finally {
       stopLoading()
@@ -183,7 +185,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function getAnalysis(analysisId: string): Promise<CodeAnalysisResult | null> {
     startLoading()
-    error.value = null
     try {
       const data = await ApiClient.get(`/api/code-intelligence/analysis/${analysisId}`)
       currentAnalysis.value = data
@@ -192,7 +193,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch analysis'
       logger.error('Failed to fetch analysis:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
       return null
     } finally {
       stopLoading()
@@ -201,7 +202,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function getQualityScore(code: string, language?: string): Promise<QualityScore | null> {
     startLoading()
-    error.value = null
     try {
       const data = await ApiClient.post('/api/code-intelligence/quality-score', { code, language })
       qualityScore.value = data
@@ -210,7 +210,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to get quality score'
       logger.error('Failed to get quality score:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
       return null
     } finally {
       stopLoading()
@@ -219,7 +219,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function getSuggestions(code: string, language?: string): Promise<void> {
     startLoading()
-    error.value = null
     try {
       const data = await ApiClient.post('/api/code-intelligence/suggestions', { code, language })
       suggestions.value = data.suggestions || []
@@ -227,7 +226,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch suggestions'
       logger.error('Failed to fetch suggestions:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
     } finally {
       stopLoading()
     }
@@ -235,7 +234,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function getHealthScore(path?: string): Promise<void> {
     startLoading()
-    error.value = null
     try {
       const url = path
         ? `/api/code-intelligence/health-score?path=${encodeURIComponent(path)}`
@@ -246,7 +244,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch health score'
       logger.error('Failed to fetch health score:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
     } finally {
       stopLoading()
     }
@@ -254,7 +252,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function getSecurityScoreCached(): Promise<SecurityScoreCached | null> {
     startLoading()
-    error.value = null
     try {
       const data = await ApiClient.get('/api/code-intelligence/security/score/cached')
       securityScoreCached.value = data
@@ -263,7 +260,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch cached security score'
       logger.error('Failed to fetch cached security score:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
       return null
     } finally {
       stopLoading()
@@ -272,7 +269,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function getTrends(days: number = 30): Promise<void> {
     startLoading()
-    error.value = null
     try {
       const data = await ApiClient.get(`/api/code-intelligence/trends?days=${days}`)
       trends.value = data.trends || []
@@ -280,7 +276,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch trends'
       logger.error('Failed to fetch trends:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
     } finally {
       stopLoading()
     }
@@ -288,7 +284,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function compareCode(file1: string, file2: string): Promise<ComparisonResult | null> {
     startLoading()
-    error.value = null
     try {
       const data = await ApiClient.post('/api/code-intelligence/compare', { file1, file2 })
       logger.debug('Comparison result:', data)
@@ -296,7 +291,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to compare code'
       logger.error('Failed to compare code:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
       return null
     } finally {
       stopLoading()
@@ -305,7 +300,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function getAnalysisHistory(limit: number = 50): Promise<void> {
     startLoading()
-    error.value = null
     try {
       const data = await ApiClient.get(`/api/code-intelligence/history?limit=${limit}`)
       analysisHistory.value = data.analyses || []
@@ -313,7 +307,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch history'
       logger.error('Failed to fetch history:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
     } finally {
       stopLoading()
     }
@@ -321,7 +315,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function deleteAnalysis(analysisId: string): Promise<boolean> {
     startLoading()
-    error.value = null
     try {
       await ApiClient.delete(`/api/code-intelligence/analysis/${analysisId}`)
       analysisHistory.value = analysisHistory.value.filter(a => a.id !== analysisId)
@@ -330,7 +323,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to delete analysis'
       logger.error('Failed to delete analysis:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
       return false
     } finally {
       stopLoading()
@@ -339,7 +332,6 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   async function batchAnalyze(files: Array<{ code: string; filename: string; language?: string }>): Promise<CodeAnalysisResult[]> {
     startLoading()
-    error.value = null
     try {
       const data = await ApiClient.post('/api/code-intelligence/batch-analyze', { files })
       logger.debug('Batch analysis complete:', data.results?.length)
@@ -347,17 +339,23 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to batch analyze'
       logger.error('Failed to batch analyze:', err)
-      error.value = message
+      errors.value = [...errors.value, message]
       return []
     } finally {
       stopLoading()
     }
   }
 
+  /** Clear all accumulated errors. */
+  function clearErrors(): void {
+    errors.value = []
+  }
+
   // ===== Lifecycle =====
 
   onMounted(() => {
     if (autoFetch) {
+      clearErrors()
       Promise.all([
         getSecurityScoreCached(),
         getAnalysisHistory(),
@@ -376,6 +374,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     trends,
     isLoading,
     error,
+    errors,
 
     // Methods
     analyzeCode,
@@ -389,6 +388,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     getAnalysisHistory,
     deleteAnalysis,
     batchAnalyze,
+    clearErrors,
   }
 }
 


### PR DESCRIPTION
## Summary
- Replaces single `error` ref with `errors` array to prevent parallel call race
- `error` becomes a computed that joins all errors (backward compatible)
- Adds `clearErrors()` for explicit reset before new batches
- No more silently lost error messages from `Promise.all` calls

## Closes #2588

## Test plan
- [ ] `error.value` still works for existing consumers
- [ ] Multiple parallel failures show all errors joined by '; '
- [ ] `clearErrors()` resets the state
- [ ] vue-tsc passes