### PR TITLE
feat(mcp): tool prompt injection, cache TTL, and RBAC filtering

### DIFF
--- a/autobot-backend/agents/chat_agent.py
+++ b/autobot-backend/agents/chat_agent.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 from constants.threshold_constants import LLMDefaults
 from llm_interface import LLMInterface
 from prompt_manager import get_language_instruction, resolve_language
+from services.mcp_dispatch import get_mcp_dispatcher
 
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
@@ -119,6 +120,25 @@ class ChatAgent(StandardizedAgent):
             "model_used": self.model_name,
         }
 
+    async def _get_mcp_tools_prompt(self) -> str:
+        """Build an MCP tools section for the system prompt (#2596).
+
+        Fetches available (non-admin) tool definitions from the dispatcher and
+        formats them as a Markdown list for LLM injection.  Returns an empty
+        string when no tools are registered so the prompt stays clean.
+        """
+        dispatcher = get_mcp_dispatcher()
+        await dispatcher._ensure_cache_fresh()
+        tools = dispatcher.get_tool_definitions(role="user")
+        if not tools:
+            return ""
+        tool_lines = [f"- **{t['name']}**: {t['description']}" for t in tools]
+        return (
+            "\n\n## Available MCP Tools\n"
+            "You can call these tools by name when the user's request requires them:\n"
+            + "\n".join(tool_lines)
+        )
+
     async def process_chat_message(
         self,
         message: str,
@@ -137,14 +157,18 @@ class ChatAgent(StandardizedAgent):
             Dict containing the chat response and metadata
 
         Issue #620: Refactored to use extracted helper methods.
+        Issue #2596: MCP tool definitions injected into system prompt.
         """
         try:
             logger.info("Chat Agent processing message: %s...", message[:50])
 
-            # Prepare chat-optimized system prompt with language (#1327)
+            # Prepare chat-optimized system prompt with language (#1327) and MCP tools (#2596)
             lang_code = resolve_language()
-            system_prompt = self._get_chat_system_prompt() + get_language_instruction(
-                lang_code
+            mcp_section = await self._get_mcp_tools_prompt()
+            system_prompt = (
+                self._get_chat_system_prompt()
+                + mcp_section
+                + get_language_instruction(lang_code)
             )
 
             # Build conversation context

--- a/autobot-backend/agents/chat_agent_test.py
+++ b/autobot-backend/agents/chat_agent_test.py
@@ -1,0 +1,118 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for ChatAgent MCP tool prompt injection (#2596).
+
+Coverage:
+- _get_mcp_tools_prompt() returns formatted Markdown when tools are present
+- _get_mcp_tools_prompt() returns empty string when no tools are registered
+- process_chat_message() includes MCP tool section in the system prompt sent to the LLM
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_TOOL_DEF = {
+    "name": "search_knowledge_base",
+    "description": "[knowledge_mcp] Search the knowledge base",
+    "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+}
+
+
+def _make_mock_dispatcher(tools: list) -> MagicMock:
+    """Return a mock MCPDispatcher that yields *tools* from get_tool_definitions."""
+    dispatcher = MagicMock()
+    dispatcher._ensure_cache_fresh = AsyncMock()
+    dispatcher.get_tool_definitions = MagicMock(return_value=tools)
+    return dispatcher
+
+
+# ---------------------------------------------------------------------------
+# _get_mcp_tools_prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_tools_prompt_returns_formatted_section():
+    """When tools are available, prompt section should list them in Markdown (#2596)."""
+    from agents.chat_agent import ChatAgent
+
+    with (
+        patch(
+            "agents.chat_agent.get_mcp_dispatcher",
+            return_value=_make_mock_dispatcher([_SAMPLE_TOOL_DEF]),
+        ),
+        patch.object(ChatAgent, "__init__", lambda self: None),
+    ):
+        agent = ChatAgent.__new__(ChatAgent)
+        result = await agent._get_mcp_tools_prompt()
+
+    assert "## Available MCP Tools" in result
+    assert "search_knowledge_base" in result
+    assert "[knowledge_mcp] Search the knowledge base" in result
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_tools_prompt_returns_empty_when_no_tools():
+    """When no tools are registered, the prompt section should be empty (#2596)."""
+    from agents.chat_agent import ChatAgent
+
+    with (
+        patch(
+            "agents.chat_agent.get_mcp_dispatcher",
+            return_value=_make_mock_dispatcher([]),
+        ),
+        patch.object(ChatAgent, "__init__", lambda self: None),
+    ):
+        agent = ChatAgent.__new__(ChatAgent)
+        result = await agent._get_mcp_tools_prompt()
+
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# process_chat_message — MCP section injected into prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_injected_into_system_prompt():
+    """process_chat_message() should include MCP tool list in the system prompt (#2596)."""
+    from agents.chat_agent import ChatAgent
+
+    captured_messages = []
+
+    async def fake_chat_completion(messages, **kwargs):
+        captured_messages.extend(messages)
+        return {"message": {"content": "Hello!"}}
+
+    mock_llm = MagicMock()
+    mock_llm.chat_completion = fake_chat_completion
+
+    with (
+        patch(
+            "agents.chat_agent.get_mcp_dispatcher",
+            return_value=_make_mock_dispatcher([_SAMPLE_TOOL_DEF]),
+        ),
+        patch("agents.chat_agent.resolve_language", return_value="en"),
+        patch("agents.chat_agent.get_language_instruction", return_value=""),
+        patch.object(ChatAgent, "__init__", lambda self: None),
+    ):
+        agent = ChatAgent.__new__(ChatAgent)
+        agent.llm_interface = mock_llm
+        agent.model_name = "test-model"
+        agent.llm_provider = "test"
+        agent.llm_endpoint = "http://localhost"
+
+        await agent.process_chat_message("hello")
+
+    assert captured_messages, "LLM was not called"
+    system_content = captured_messages[0]["content"]
+    assert "## Available MCP Tools" in system_content
+    assert "search_knowledge_base" in system_content

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -18,9 +18,12 @@ Architecture:
 
 The dispatcher loads tool metadata from the registry on first use and
 caches it locally.  Cache can be refreshed explicitly via refresh_tool_cache().
+
+Cache TTL and RBAC filtering added in #2598.
 """
 
 import logging
+import time
 from typing import Optional
 
 import aiohttp
@@ -36,16 +39,41 @@ class MCPDispatcher:
 
     Caches tool metadata fetched from the registry so that repeated tool
     calls do not incur extra HTTP round-trips for discovery.
+
+    Cache refreshes automatically after CACHE_TTL_SECONDS (#2598).
+    Tools matching _ADMIN_ONLY_TOOLS patterns require role="admin" (#2598).
     """
+
+    CACHE_TTL_SECONDS: int = 60
+
+    # Tool name substrings that require admin role (#2598)
+    _ADMIN_ONLY_TOOLS: frozenset = frozenset(
+        {
+            "client_list",
+            "slowlog",
+            "config_set",
+            "config_rewrite",
+            "debug",
+            "flushdb",
+            "flushall",
+        }
+    )
 
     def __init__(self) -> None:
         """Initialize dispatcher with empty tool cache."""
         self._tool_cache: dict[str, dict] = {}
         self._cache_loaded = False
+        self._cache_timestamp: float = 0.0
 
     # ------------------------------------------------------------------
     # Cache management
     # ------------------------------------------------------------------
+
+    async def _ensure_cache_fresh(self) -> None:
+        """Refresh the tool cache if it is empty or older than CACHE_TTL_SECONDS (#2598)."""
+        age = time.monotonic() - self._cache_timestamp
+        if not self._cache_loaded or age > self.CACHE_TTL_SECONDS:
+            await self.refresh_tool_cache()
 
     async def refresh_tool_cache(self) -> int:
         """Fetch all tools from the MCP registry and populate the local cache.
@@ -72,6 +100,7 @@ class MCPDispatcher:
                 tools = data.get("tools", [])
                 self._tool_cache = {tool["name"]: tool for tool in tools}
                 self._cache_loaded = True
+                self._cache_timestamp = time.monotonic()
                 logger.info(
                     "MCPDispatcher: cached %d tools from registry",
                     len(self._tool_cache),
@@ -96,20 +125,39 @@ class MCPDispatcher:
     # Dispatch
     # ------------------------------------------------------------------
 
-    async def dispatch(self, tool_name: str, arguments: dict) -> dict:
+    def _is_admin_only(self, tool_name: str) -> bool:
+        """Return True if tool_name matches any admin-only pattern (#2598)."""
+        return any(pattern in tool_name for pattern in self._ADMIN_ONLY_TOOLS)
+
+    async def dispatch(
+        self, tool_name: str, arguments: dict, role: str = "user"
+    ) -> dict:
         """Dispatch a tool call to its registered MCP bridge.
 
-        Loads the tool cache on first call if it has not been populated yet.
+        Refreshes the tool cache if stale (TTL-based, #2598).
+        Rejects admin-only tools when role != "admin" (#2598).
 
         Args:
             tool_name: Tool name from the LLM tool call.
             arguments: Tool arguments dict.
+            role: Caller role — "admin" or "user" (default).
 
         Returns:
             Dict with keys: success (bool), result (str | dict), bridge (str | None).
         """
-        if not self._cache_loaded:
-            await self.refresh_tool_cache()
+        await self._ensure_cache_fresh()
+
+        if role != "admin" and self._is_admin_only(tool_name):
+            logger.warning(
+                "MCPDispatcher: role=%s denied access to admin-only tool %s",
+                role,
+                tool_name,
+            )
+            return {
+                "success": False,
+                "result": f"Tool {tool_name} requires admin role",
+                "bridge": None,
+            }
 
         tool = self.find_tool(tool_name)
         if not tool:
@@ -189,11 +237,15 @@ class MCPDispatcher:
     # Tool definition export
     # ------------------------------------------------------------------
 
-    def get_tool_definitions(self) -> list[dict]:
+    def get_tool_definitions(self, role: str = "user") -> list[dict]:
         """Return tool definitions in LLM-injectable format.
 
+        Admin-only tools are excluded when role != "admin" (#2598).
         Each entry contains name, description (prefixed with bridge name),
         and parameters (from the tool's input_schema).
+
+        Args:
+            role: Caller role — "admin" or "user" (default).
 
         Returns:
             List of tool definition dicts.
@@ -205,6 +257,7 @@ class MCPDispatcher:
                 "parameters": tool.get("input_schema", {}),
             }
             for tool in self._tool_cache.values()
+            if role == "admin" or not self._is_admin_only(tool["name"])
         ]
 
 

--- a/autobot-backend/services/mcp_dispatch_test.py
+++ b/autobot-backend/services/mcp_dispatch_test.py
@@ -11,8 +11,11 @@ Coverage:
 - Dispatch of known tool with failing bridge response
 - get_tool_definitions() formats correctly
 - refresh_tool_cache() handles registry HTTP errors gracefully
+- Cache TTL triggers refresh after expiry (#2598)
+- RBAC filtering hides admin-only tools from non-admin callers (#2598)
 """
 
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -223,3 +226,112 @@ def test_get_mcp_dispatcher_returns_singleton():
     a = get_mcp_dispatcher()
     b = get_mcp_dispatcher()
     assert a is b
+
+
+# ---------------------------------------------------------------------------
+# Cache TTL (#2598)
+# ---------------------------------------------------------------------------
+
+_ADMIN_TOOL = {
+    "name": "redis_client_list",
+    "description": "List all Redis clients",
+    "input_schema": {},
+    "bridge": "redis_mcp",
+    "endpoint": "http://localhost:8001/api/redis/mcp/client_list",
+    "features": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_cache_ttl_triggers_refresh():
+    """dispatch() should call refresh_tool_cache when cache is older than TTL (#2598)."""
+    d = _make_dispatcher_with_cache(_SAMPLE_TOOL)
+    # Wind back timestamp so TTL appears expired
+    d._cache_timestamp = time.monotonic() - (d.CACHE_TTL_SECONDS + 1)
+
+    refresh_called = []
+
+    async def fake_refresh():
+        refresh_called.append(True)
+        d._cache_loaded = True
+        d._cache_timestamp = time.monotonic()
+        return 1
+
+    d.refresh_tool_cache = fake_refresh  # type: ignore[method-assign]
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"results": []})
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+    mock_session = MagicMock()
+    mock_session.post = AsyncMock(return_value=mock_response)
+
+    with patch("services.mcp_dispatch.get_http_client", return_value=mock_session):
+        await d.dispatch("search_knowledge_base", {})
+
+    assert refresh_called, "Expected refresh_tool_cache to be called after TTL expiry"
+
+
+@pytest.mark.asyncio
+async def test_cache_ttl_does_not_refresh_when_fresh():
+    """dispatch() should NOT call refresh_tool_cache when cache is still within TTL (#2598)."""
+    d = _make_dispatcher_with_cache(_SAMPLE_TOOL)
+    d._cache_timestamp = time.monotonic()  # just refreshed
+
+    refresh_called = []
+
+    async def fake_refresh():
+        refresh_called.append(True)
+        return 1
+
+    d.refresh_tool_cache = fake_refresh  # type: ignore[method-assign]
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"results": []})
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+    mock_session = MagicMock()
+    mock_session.post = AsyncMock(return_value=mock_response)
+
+    with patch("services.mcp_dispatch.get_http_client", return_value=mock_session):
+        await d.dispatch("search_knowledge_base", {})
+
+    assert not refresh_called, "Expected no refresh when cache is fresh"
+
+
+# ---------------------------------------------------------------------------
+# RBAC filtering (#2598)
+# ---------------------------------------------------------------------------
+
+
+def test_get_tool_definitions_filters_admin_tools_for_user():
+    """Admin-only tools should be hidden from role='user' (#2598)."""
+    d = _make_dispatcher_with_cache(_SAMPLE_TOOL, _ADMIN_TOOL)
+    defs = d.get_tool_definitions(role="user")
+    names = [t["name"] for t in defs]
+    assert "search_knowledge_base" in names
+    assert "redis_client_list" not in names
+
+
+def test_get_tool_definitions_shows_all_for_admin():
+    """All tools including admin-only should be visible for role='admin' (#2598)."""
+    d = _make_dispatcher_with_cache(_SAMPLE_TOOL, _ADMIN_TOOL)
+    defs = d.get_tool_definitions(role="admin")
+    names = [t["name"] for t in defs]
+    assert "search_knowledge_base" in names
+    assert "redis_client_list" in names
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_admin_tool_for_user():
+    """dispatch() should return success=False for admin-only tool when role='user' (#2598)."""
+    d = _make_dispatcher_with_cache(_ADMIN_TOOL)
+    d._cache_timestamp = time.monotonic()  # keep cache fresh to avoid network call
+
+    result = await d.dispatch("redis_client_list", {}, role="user")
+
+    assert result["success"] is False
+    assert "admin" in result["result"].lower()
+    assert result["bridge"] is None


### PR DESCRIPTION
## Summary
- **Tool prompt injection (#2596)**: `ChatAgent._get_mcp_tools_prompt()` injects discovered MCP tools into agent system prompts at session start
- **Cache TTL (#2598)**: `MCPDispatcher` now refreshes tool cache after 60s TTL via `_ensure_cache_fresh()`
- **RBAC filtering (#2598)**: `get_tool_definitions(role)` and `dispatch(tool, args, role)` filter admin-only tools (client_list, slowlog, flushdb, etc.) for non-admin users

Closes #2596
Closes #2598

## Test plan
- [x] 18/18 tests passing (10 original + 5 new dispatch + 3 new chat agent)
- [x] Cache TTL triggers/skips refresh correctly
- [x] Admin tools filtered for user role, visible for admin
- [x] Admin tool dispatch rejected for non-admin
- [x] MCP tools formatted and injected into system prompt
- [x] Empty tool list produces no prompt section