### PR TITLE
fix(backend): remove erroneous await on sync get_redis_client() (#2628)

### DIFF
--- a/autobot-backend/agents/task_pattern_learner.py
+++ b/autobot-backend/agents/task_pattern_learner.py
@@ -58,7 +58,7 @@ class TaskPatternLearner:
         if self._redis is None:
             from autobot_shared.redis_client import get_redis_client
 
-            self._redis = await get_redis_client(async_client=True, database="main")
+            self._redis = get_redis_client(async_client=True, database="main")
         return self._redis
 
     async def _get_llm(self):

--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -201,7 +201,7 @@ class AIHardwareAccelerator:
 
         # Initialize Redis client
         try:
-            self.redis_client = await get_redis_client("main")
+            self.redis_client = get_redis_client("main")
             if self.redis_client:
                 logger.info("✅ Connected to Redis for task coordination")
         except Exception as e:

--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -542,7 +542,7 @@ class CodeGenerationEngine:
     async def _get_redis(self):
         """Get Redis client lazily"""
         if self._redis is None:
-            self._redis = await get_redis_client(
+            self._redis = get_redis_client(
                 async_client=True, database=RedisDatabase.MAIN
             )
         return self._redis

--- a/autobot-backend/api/analytics_controller.py
+++ b/autobot-backend/api/analytics_controller.py
@@ -177,7 +177,7 @@ class AnalyticsController:
                 if isinstance(database, RedisDatabase)
                 else database
             )
-            return await get_redis_client(async_client=True, database=db_name)
+            return get_redis_client(async_client=True, database=db_name)
         except Exception as e:
             logger.error("Failed to get Redis connection for %s: %s", database, e)
             return None

--- a/autobot-backend/api/analytics_embedding_patterns.py
+++ b/autobot-backend/api/analytics_embedding_patterns.py
@@ -215,7 +215,7 @@ class EmbeddingPatternAnalyzer:
         if self._redis is None:
             async with self._lock:
                 if self._redis is None:
-                    self._redis = await get_redis_client(
+                    self._redis = get_redis_client(
                         async_client=True, database=RedisDatabase.ANALYTICS
                     )
         return self._redis

--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -292,7 +292,7 @@ class LLMPatternAnalyzer:
     async def _get_redis(self):
         """Get Redis client lazily"""
         if self._redis is None:
-            self._redis = await get_redis_client(
+            self._redis = get_redis_client(
                 async_client=True, database=RedisDatabase.MAIN
             )
         return self._redis

--- a/autobot-backend/api/analytics_pattern_learning.py
+++ b/autobot-backend/api/analytics_pattern_learning.py
@@ -342,7 +342,7 @@ class PatternLearningEngine:
             try:
                 from autobot_shared.redis_client import get_redis_client
 
-                self.redis_client = await get_redis_client(
+                self.redis_client = get_redis_client(
                     async_client=True, database="analytics"
                 )
                 # Issue #379: Parallelize independent Redis loading operations

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -93,7 +93,7 @@ async def _get_checkpoint_redis():
     try:
         from autobot_shared.redis_client import get_redis_client
 
-        return await get_redis_client(database="analytics", async_client=True)
+        return get_redis_client(database="analytics", async_client=True)
     except Exception:
         return None
 

--- a/autobot-backend/api/codebase_analytics/source_storage.py
+++ b/autobot-backend/api/codebase_analytics/source_storage.py
@@ -24,7 +24,7 @@ async def _get_redis():
     """Return an async Redis client for the analytics database."""
     from autobot_shared.redis_client import get_redis_client
 
-    return await get_redis_client(database="analytics", async_client=True)
+    return get_redis_client(database="analytics", async_client=True)
 
 
 async def save_source(source: CodeSource) -> bool:

--- a/autobot-backend/api/codebase_analytics/storage.py
+++ b/autobot-backend/api/codebase_analytics/storage.py
@@ -54,7 +54,7 @@ async def get_redis_connection_async():
     """
     from autobot_shared.redis_client import get_redis_client
 
-    redis_client = await get_redis_client(database="analytics", async_client=True)
+    redis_client = get_redis_client(database="analytics", async_client=True)
     if redis_client is None:
         logger.warning("Async Redis client initialization returned None")
         return None

--- a/autobot-backend/api/workflow_state.py
+++ b/autobot-backend/api/workflow_state.py
@@ -112,7 +112,7 @@ class WorkflowStateMachine:
 
     async def _redis(self):
         """Get async Redis client for workflows db."""
-        return await get_redis_client(async_client=True, database=REDIS_DATABASE)
+        return get_redis_client(async_client=True, database=REDIS_DATABASE)
 
     async def _persist(self, state: WorkflowState) -> None:
         """Serialize and store *state* in Redis."""

--- a/autobot-backend/async_baseline.performance_test.py
+++ b/autobot-backend/async_baseline.performance_test.py
@@ -257,7 +257,7 @@ class AsyncBaselineTest:
         start_time = time.perf_counter()
 
         # Create async Redis connection using canonical pattern
-        redis_client = await get_redis_client(
+        redis_client = get_redis_client(
             async_client=True, database="metrics"
         )  # METRICS_DB
 
@@ -361,7 +361,7 @@ class AsyncBaselineTest:
         start_time = time.perf_counter()
 
         # Create async Redis connection using canonical pattern
-        redis_client = await get_redis_client(
+        redis_client = get_redis_client(
             async_client=True, database="metrics"
         )  # METRICS_DB
 
@@ -432,7 +432,7 @@ class AsyncBaselineTest:
             try:
                 if vm_name == "redis":
                     # Special handling for Redis (not HTTP) using canonical pattern
-                    redis_client = await get_redis_client(
+                    redis_client = get_redis_client(
                         async_client=True, database="main"  # MAIN_DB (default DB 0)
                     )
                     try:

--- a/autobot-backend/code_intelligence/analytics_infrastructure.py
+++ b/autobot-backend/code_intelligence/analytics_infrastructure.py
@@ -220,7 +220,7 @@ class AnalyticsInfrastructureMixin:
                     try:
                         from autobot_shared.redis_client import get_redis_client
 
-                        self._redis_client = await get_redis_client(
+                        self._redis_client = get_redis_client(
                             async_client=True, database=self._redis_database
                         )
                         logger.info(

--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -168,7 +168,7 @@ class CrossLanguagePatternDetector:
             try:
                 from autobot_shared.redis_client import get_redis_client
 
-                self._redis_client = await get_redis_client(
+                self._redis_client = get_redis_client(
                     async_client=True, database="analytics"
                 )
                 logger.info("Redis client initialized for analytics")

--- a/autobot-backend/code_intelligence/redis_optimizer_test.py
+++ b/autobot-backend/code_intelligence/redis_optimizer_test.py
@@ -202,7 +202,7 @@ class TestRedisOptimizer:
             from utils.redis_client import get_redis_client
 
             async def good_pipeline_usage():
-                redis = await get_redis_client(async_client=True)
+                redis = get_redis_client(async_client=True)
                 async with redis.pipeline() as pipe:
                     pipe.set("key1", "value1")
                     pipe.set("key2", "value2")
@@ -232,7 +232,7 @@ class TestRedisOptimizer:
             from utils.redis_client import get_redis_client
 
             async def good_code():
-                redis = await get_redis_client(async_client=True)
+                redis = get_redis_client(async_client=True)
                 return await redis.get("key")
         """))
 

--- a/autobot-backend/config/async_ops.py
+++ b/autobot-backend/config/async_ops.py
@@ -104,7 +104,7 @@ class AsyncOperationsMixin:
             from autobot_shared.redis_client import get_redis_client
 
             cache_key = self._get_redis_cache_key(config_type)
-            redis_client = await get_redis_client(async_client=True, database="main")
+            redis_client = get_redis_client(async_client=True, database="main")
 
             if redis_client:
                 cached_data = await redis_client.get(cache_key)
@@ -132,7 +132,7 @@ class AsyncOperationsMixin:
             filtered_data = self._filter_sensitive_data(data)
 
             cache_key = self._get_redis_cache_key(config_type)
-            redis_client = await get_redis_client(async_client=True, database="main")
+            redis_client = get_redis_client(async_client=True, database="main")
 
             if redis_client:
                 await redis_client.set(

--- a/autobot-backend/dependency_container.py
+++ b/autobot-backend/dependency_container.py
@@ -83,7 +83,7 @@ class AsyncServiceContainer:
 
     async def _create_redis_manager(self) -> async_redis.Redis:
         """Factory for Redis manager"""
-        return await get_redis_client(async_client=True, database="main")
+        return get_redis_client(async_client=True, database="main")
 
     async def _create_config_manager(self) -> ConfigManager:
         """Factory for config manager"""

--- a/autobot-backend/events/stream_manager.py
+++ b/autobot-backend/events/stream_manager.py
@@ -132,7 +132,7 @@ class RedisEventStreamManager(EventStreamManager):
             try:
                 from autobot_shared.redis_client import get_redis_client
 
-                self._redis = await get_redis_client(async_client=True, database="main")
+                self._redis = get_redis_client(async_client=True, database="main")
                 self._initialized = True
                 logger.debug("Event stream Redis connection established")
             except Exception as e:

--- a/autobot-backend/judges/task_outcome_judge.py
+++ b/autobot-backend/judges/task_outcome_judge.py
@@ -53,9 +53,7 @@ class TaskOutcomeJudge(BaseLLMJudge):
         if self._redis_client is None:
             from autobot_shared.redis_client import get_redis_client
 
-            self._redis_client = await get_redis_client(
-                async_client=True, database="main"
-            )
+            self._redis_client = get_redis_client(async_client=True, database="main")
         return self._redis_client
 
     async def evaluate_task_outcome(

--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -333,7 +333,7 @@ class KnowledgeBaseCore:
             )
 
             # Get async Redis client using pool manager
-            self.aioredis_client = await get_redis_client(
+            self.aioredis_client = get_redis_client(
                 async_client=True, database="knowledge"
             )
 

--- a/autobot-backend/llm_interface_pkg/cache.py
+++ b/autobot-backend/llm_interface_pkg/cache.py
@@ -189,7 +189,7 @@ class LLMResponseCache:
         Returns:
             CachedResponse if found, None otherwise
         """
-        redis_client = await get_redis_client(
+        redis_client = get_redis_client(
             async_client=True, database=self._redis_database
         )
         if not redis_client:
@@ -295,7 +295,7 @@ class LLMResponseCache:
 
         # Store in L2 Redis cache
         try:
-            redis_client = await get_redis_client(
+            redis_client = get_redis_client(
                 async_client=True, database=self._redis_database
             )
             if redis_client:
@@ -403,7 +403,7 @@ class LLMResponseCache:
             Number of entries deleted
         """
         try:
-            redis_client = await get_redis_client(
+            redis_client = get_redis_client(
                 async_client=True, database=self._redis_database
             )
             if redis_client:

--- a/autobot-backend/security/service_auth.py
+++ b/autobot-backend/security/service_auth.py
@@ -240,7 +240,7 @@ async def validate_service_auth(request: Request) -> Dict:
         pass
 
         # Get main Redis database for service key storage
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = get_redis_client(async_client=True, database="main")
 
         # Create auth manager and validate
         auth_manager = ServiceAuthManager(redis)

--- a/autobot-backend/services/access_control_metrics.py
+++ b/autobot-backend/services/access_control_metrics.py
@@ -55,7 +55,7 @@ class AccessControlMetrics:
         """Get Redis metrics database (DB 4)"""
         if not self._redis:
             # Get async Redis client for metrics database (returns coroutine, must await)
-            self._redis = await get_redis_client(async_client=True, database="metrics")
+            self._redis = get_redis_client(async_client=True, database="metrics")
         return self._redis
 
     async def record_violation(

--- a/autobot-backend/services/agent_analytics.py
+++ b/autobot-backend/services/agent_analytics.py
@@ -207,7 +207,7 @@ class AgentAnalytics:
     async def get_redis(self):
         """Get async Redis client"""
         if self._redis_client is None:
-            self._redis_client = await get_redis_client(
+            self._redis_client = get_redis_client(
                 async_client=True, database=RedisDatabase.ANALYTICS
             )
         return self._redis_client

--- a/autobot-backend/services/analytics_service.py
+++ b/autobot-backend/services/analytics_service.py
@@ -170,7 +170,7 @@ class AnalyticsService:
     async def get_redis(self):
         """Get Redis client for analytics database."""
         if self._redis is None:
-            self._redis = await get_redis_client(
+            self._redis = get_redis_client(
                 async_client=True, database=RedisDatabase.ANALYTICS
             )
         return self._redis

--- a/autobot-backend/services/audit_logger.py
+++ b/autobot-backend/services/audit_logger.py
@@ -256,7 +256,7 @@ class AuditLogger:
         """Get Redis audit database (DB 10)"""
         try:
             # Use canonical Redis client pattern with 'audit' database
-            return await get_redis_client(async_client=True, database="audit")
+            return get_redis_client(async_client=True, database="audit")
         except Exception as e:
             logger.error("Failed to get audit database: %s", e)
             self._redis_failures += 1

--- a/autobot-backend/services/feature_flags.py
+++ b/autobot-backend/services/feature_flags.py
@@ -69,7 +69,7 @@ class FeatureFlags:
         """Get Redis connection for feature flags (uses cache DB)"""
         if not self.redis:
             # Get async Redis client for cache database (returns coroutine, must await)
-            self.redis = await get_redis_client(async_client=True, database="cache")
+            self.redis = get_redis_client(async_client=True, database="cache")
         return self.redis
 
     async def get_enforcement_mode(self) -> EnforcementMode:

--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -256,7 +256,7 @@ class LLMCostTracker:
     async def get_redis(self):
         """Get async Redis client"""
         if self._redis_client is None:
-            self._redis_client = await get_redis_client(
+            self._redis_client = get_redis_client(
                 async_client=True, database=RedisDatabase.ANALYTICS
             )
         return self._redis_client

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -375,7 +375,7 @@ class RAGService:
             "timestamp": str(time.time()),
         }
         try:
-            redis = await get_redis_client(async_client=True, database="analytics")
+            redis = get_redis_client(async_client=True, database="analytics")
             if redis is None:
                 logger.debug("Redis unavailable; skipping feedback stream write")
                 return

--- a/autobot-backend/services/saved_reports_service.py
+++ b/autobot-backend/services/saved_reports_service.py
@@ -37,7 +37,7 @@ class SavedReportsService:
     async def _get_redis(self):
         """Get async Redis client for the analytics database."""
         if self._redis is None:
-            self._redis = await get_redis_client(
+            self._redis = get_redis_client(
                 async_client=True, database=RedisDatabase.ANALYTICS
             )
         return self._redis

--- a/autobot-backend/services/security_workflow_manager.py
+++ b/autobot-backend/services/security_workflow_manager.py
@@ -313,7 +313,7 @@ class SecurityWorkflowManager:
     async def _get_redis(self) -> Any:
         """Get Redis client for workflow database."""
         if self._redis_client is None:
-            self._redis_client = await get_redis_client(
+            self._redis_client = get_redis_client(
                 async_client=True, database="workflows"
             )
         return self._redis_client

--- a/autobot-backend/services/semantic_query_cache.py
+++ b/autobot-backend/services/semantic_query_cache.py
@@ -344,7 +344,7 @@ class SemanticQueryCache:
     async def _fetch_response(self, key: str) -> Optional[Dict]:
         """Fetch cached response payload from Redis."""
         try:
-            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
             if client is None:
                 return None
             raw = await client.get(key)
@@ -358,7 +358,7 @@ class SemanticQueryCache:
     async def _store_response(self, key: str, payload: Dict) -> bool:
         """Persist response payload in Redis with TTL."""
         try:
-            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
             if client is None:
                 return False
             await client.set(
@@ -402,7 +402,7 @@ class SemanticQueryCache:
                     rkey = meta.get("response_key", "")
                     if rkey:
                         try:
-                            client = await get_redis_client(
+                            client = get_redis_client(
                                 async_client=True,
                                 database=_REDIS_DATABASE,
                             )
@@ -449,7 +449,7 @@ class SemanticQueryCache:
                 results = await self._collection.get(include=["metadatas"])
                 if results and results.get("ids"):
                     # Clean Redis
-                    client = await get_redis_client(
+                    client = get_redis_client(
                         async_client=True, database=_REDIS_DATABASE
                     )
                     if client:

--- a/autobot-backend/services/topic_retrieval_cache.py
+++ b/autobot-backend/services/topic_retrieval_cache.py
@@ -287,7 +287,7 @@ class TopicRetrievalCache:
     async def _fetch_chunks(self, key: str) -> Optional[List[CachedChunk]]:
         """Fetch cached chunks from Redis."""
         try:
-            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
             if client is None:
                 return None
             raw = await client.get(key)
@@ -309,7 +309,7 @@ class TopicRetrievalCache:
     async def _store_chunks(self, key: str, payload: List[Dict]) -> bool:
         """Persist chunk list in Redis with TTL."""
         try:
-            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
             if client is None:
                 return False
             await client.set(
@@ -343,9 +343,7 @@ class TopicRetrievalCache:
             results = await self._collection.get(limit=excess, include=["metadatas"])
             if results and results.get("ids"):
                 ids_to_delete = results["ids"]
-                client = await get_redis_client(
-                    async_client=True, database=_REDIS_DATABASE
-                )
+                client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
                 if client:
                     for meta in results.get("metadatas", []):
                         rkey = meta.get("redis_key", "")

--- a/autobot-backend/services/user_behavior_analytics.py
+++ b/autobot-backend/services/user_behavior_analytics.py
@@ -102,7 +102,7 @@ class UserBehaviorAnalytics:
     async def get_redis(self):
         """Get Redis client for analytics database"""
         if self._redis is None:
-            self._redis = await get_redis_client(
+            self._redis = get_redis_client(
                 async_client=True, database=RedisDatabase.ANALYTICS
             )
         return self._redis

--- a/autobot-backend/services/workflow_automation/state_machine.py
+++ b/autobot-backend/services/workflow_automation/state_machine.py
@@ -130,7 +130,7 @@ class WorkflowStateMachine:
 
     async def _get_redis(self) -> Any:
         if self._redis is None:
-            self._redis = await get_redis_client(async_client=True, database="main")
+            self._redis = get_redis_client(async_client=True, database="main")
         return self._redis
 
     # -- Create --------------------------------------------------------

--- a/autobot-backend/utils/advanced_cache_manager.py
+++ b/autobot-backend/utils/advanced_cache_manager.py
@@ -169,7 +169,7 @@ class AdvancedCacheManager:
             if self._redis_client_initialized:
                 return  # Another coroutine initialized while we waited
             try:
-                self.redis_client = await get_redis_client(async_client=True)
+                self.redis_client = get_redis_client(async_client=True)
                 self._redis_client_initialized = True
                 logger.debug("Async Redis client initialized successfully")
             except Exception as e:

--- a/autobot-backend/utils/background_task_manager.py
+++ b/autobot-backend/utils/background_task_manager.py
@@ -69,7 +69,7 @@ class BackgroundTaskManager:
         try:
             from autobot_shared.redis_client import get_redis_client
 
-            return await get_redis_client(database="analytics", async_client=True)
+            return get_redis_client(database="analytics", async_client=True)
         except Exception as exc:
             logger.debug("Redis unavailable (non-fatal): %s", exc)
             return None

--- a/autobot-backend/utils/experiment_tracker.py
+++ b/autobot-backend/utils/experiment_tracker.py
@@ -76,7 +76,7 @@ class ExperimentTracker:
             rationale=rationale,
             related_issue=related_issue,
         )
-        redis_client = await get_redis_client(async_client=True, database="analytics")
+        redis_client = get_redis_client(async_client=True, database="analytics")
         if redis_client:
             await redis_client.rpush(REDIS_KEY, json.dumps(record.to_dict()))
             await redis_client.ltrim(REDIS_KEY, -10000, -1)  # Cap at 10k (#2031)
@@ -87,7 +87,7 @@ class ExperimentTracker:
         self, area: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         """List all experiments, optionally filtered by area."""
-        redis_client = await get_redis_client(async_client=True, database="analytics")
+        redis_client = get_redis_client(async_client=True, database="analytics")
         if not redis_client:
             return []
         raw = await redis_client.lrange(REDIS_KEY, 0, -1)


### PR DESCRIPTION
## Summary

`get_redis_client()` in `autobot_shared/redis_client.py:183` is a **synchronous function** that returns a Redis client object. However, 50 call sites across 38 files incorrectly used `await get_redis_client(...)`, which raises `TypeError` at runtime when the code path is hit.

- **Root cause:** The function returns an async Redis client when `async_client=True`, but the function itself is `def` not `async def` — callers assumed it was awaitable
- **Fix:** Remove `await` from all 50 occurrences
- **Skipped:** 1 occurrence in `redis_optimizer.py:861` (inside a string literal suggestion, not actual code)

### Affected areas
Services: `rag_service`, `audit_logger`, `analytics_service`, `llm_cost_tracker`, `feature_flags`, `security_workflow_manager`, and 32 more  
Critical paths: `dependency_container.py`, `knowledge/base.py`, `security/service_auth.py`

## Test plan
- [x] Pre-commit hooks pass on all 38 files (black, flake8, bandit, etc.)
- [x] Verified only 1 occurrence remains (string literal in redis_optimizer.py)
- [x] Tested on 3 sample files before bulk application
- [ ] Full test suite on CI

Closes #2628
Discovered during code review of #2597 (AutoResearch M1)