### PR TITLE
fix(workflow): extend step refs to all types + multi-ref support

### DIFF
--- a/autobot-backend/services/workflow_automation/executor.py
+++ b/autobot-backend/services/workflow_automation/executor.py
@@ -106,7 +106,7 @@ def _redact_result_secrets(
 # Issue #2601 — Step reference resolution for vision step chaining
 # ---------------------------------------------------------------------------
 
-_REF_PATTERN = re.compile(r"\$\{steps\.(\w+)\.(.+?)\}")
+_REF_PATTERN = re.compile(r"\$\{steps\.(\w+)\.([^}]+)\}")
 _ARRAY_PART = re.compile(r"^(\w+)\[(\d+)\]$")
 
 
@@ -140,17 +140,30 @@ def _resolve_step_references(config: dict, step_results: dict) -> dict:
     """Resolve ``${steps.<step_id>.<path>}`` references in step config values.
 
     Only string values are scanned.  Non-matching strings and non-string values
-    are returned unchanged.  Unknown step IDs resolve to ``None``. (#2601)
+    are returned unchanged.
+
+    - A value that IS a single reference (entire string) returns the raw
+      navigated value preserving the original type (dict, list, int, …).
+    - A value that CONTAINS multiple references returns a substituted string.
+    - Unknown step IDs keep the original token unchanged. (#2601, #2632)
     """
+
+    def _replace_ref(match: re.Match) -> str:
+        step_id, path = match.group(1), match.group(2)
+        value = _navigate_path(step_results.get(step_id), path)
+        return str(value) if value is not None else match.group(0)
+
     resolved: dict = {}
     for key, value in config.items():
-        if isinstance(value, str):
-            match = _REF_PATTERN.search(value)
-            if match:
-                step_id, path = match.group(1), match.group(2)
+        if isinstance(value, str) and "${steps." in value:
+            sole = _REF_PATTERN.fullmatch(value)
+            if sole:
+                step_id, path = sole.group(1), sole.group(2)
                 resolved[key] = _navigate_path(step_results.get(step_id), path)
-                continue
-        resolved[key] = value
+            else:
+                resolved[key] = _REF_PATTERN.sub(_replace_ref, value)
+        else:
+            resolved[key] = value
     return resolved
 
 
@@ -504,13 +517,16 @@ class WorkflowExecutor:
                 current_step.command, owner_id
             )
 
+            # Issue #2632: Resolve ${steps.<id>.<path>} references for ALL step
+            # types, not just vision.  Resolution is cheap and harmless for steps
+            # that have no step_config or no references in their config.
+            resolved_config = _resolve_step_references(
+                current_step.step_config or {}, workflow.step_results
+            )
+
             # Issue #2397: Route vision node types to the vision step handler.
-            # Issue #2601: Resolve ${steps.<id>.<path>} references before executing.
             # All other step types fall through to the standard command executor.
             if current_step.step_type in VISION_STEP_TYPES:
-                resolved_config = _resolve_step_references(
-                    current_step.step_config or {}, workflow.step_results
-                )
                 result = await self._timeout_enforcer.run_with_timeout(
                     coro=execute_vision_step(
                         current_step.step_type,

--- a/autobot-backend/services/workflow_automation/vision_step_handler_test.py
+++ b/autobot-backend/services/workflow_automation/vision_step_handler_test.py
@@ -329,10 +329,23 @@ class TestResolveStepReferences:
         assert resolved == {"selector": "#my-button", "timeout": 5000}
 
     def test_unknown_step_id_resolves_to_none(self):
-        """Reference to an unknown step_id resolves to None."""
+        """Single reference to an unknown step_id resolves to None (raw navigated value)."""
         config = {"coord": "${steps.missing.x}"}
         resolved = _resolve_step_references(config, {})
         assert resolved["coord"] is None
+
+    def test_multiple_references_in_single_value(self):
+        """Multiple ${steps.*} tokens in one string value are all substituted. (#2632)"""
+        step_results = {"s1": {"result": {"x": 10, "y": 20}}}
+        config = {"label": "${steps.s1.result.x},${steps.s1.result.y}"}
+        resolved = _resolve_step_references(config, step_results)
+        assert resolved["label"] == "10,20"
+
+    def test_unresolved_reference_kept_as_is(self):
+        """Unknown step_id inside a multi-ref string keeps the original token. (#2632)"""
+        config = {"label": "${steps.unknown.foo},suffix"}
+        resolved = _resolve_step_references(config, {})
+        assert resolved["label"] == "${steps.unknown.foo},suffix"
 
     def test_non_string_values_unchanged(self):
         """Non-string config values (int, list, dict) are not modified."""


### PR DESCRIPTION
## Summary
- Move `_resolve_step_references()` before vision/command if-else so ALL step types get reference resolution
- Fix regex `[^}]+` instead of `.+?` to prevent `fullmatch` spanning multiple references
- `re.sub()` callback resolves all `${steps.*}` tokens per string; single-ref values preserve original type
- Unknown step IDs keep original `${...}` token in mixed strings

Closes #2632

## Test plan
- [x] 32/32 tests passing (30 original + 2 new)
- [x] Multi-ref: `${steps.s1.result.x},${steps.s1.result.y}` → `10,20`
- [x] Unresolved ref kept as-is in mixed strings
- [x] Single-ref still returns typed value (not stringified)