### PR TITLE
fix(ci): add pyproject.toml isort config and fix celery_app imports (#2667)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -16,9 +16,9 @@ import urllib.parse
 from pathlib import Path
 
 from celery import Celery
+from config import ConfigManager
 
 from autobot_shared.ssot_config import config as ssot_config
-from config import ConfigManager
 
 # Create singleton config instance for extended config values
 config = ConfigManager()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.isort]
+profile = "black"
+line_length = 88


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` with `[tool.isort]` config (`profile=black`, `line_length=88`) so IDE plugins and standalone `isort` runs match CI settings
- Fix import ordering in `celery_app.py` — the one file failing isort locally

## Note on CI
The code-quality CI has not passed in the last 50+ runs due to longstanding isort failures across ~13 files (ansible node copies, tool_handler.py). These failures are caused by Python version differences between local (3.10) and CI runner (3.12) affecting import categorization. A full fix requires running isort with `src_paths` config which changes 700+ files — that's a separate effort.

## Test plan
- [x] `python3 -m isort --check --profile=black --line-length=88 autobot-backend/ autobot-slm-backend/ autobot-shared/` passes locally
- [x] pyproject.toml provides IDE-consistent isort config

Closes #2667