### PR TITLE
fix(ci): add known_first_party config and fix celery_app isort (#2679)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -16,9 +16,9 @@ import urllib.parse
 from pathlib import Path
 
 from celery import Celery
-from config import ConfigManager
 
 from autobot_shared.ssot_config import config as ssot_config
+from config import ConfigManager
 
 # Create singleton config instance for extended config values
 config = ConfigManager()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.isort]
 profile = "black"
 line_length = 88
+known_first_party = ["autobot_shared"]


### PR DESCRIPTION
## Summary
- Add `known_first_party = ["autobot_shared"]` to `pyproject.toml` isort config
- Fix celery_app.py import ordering (autobot_shared before local config)

Split from #2682 — decommission-node.yml changes removed (separate concern).

## Test plan
- [x] Code reviewed
- [ ] CI code-quality check

Closes #2679