### PR TITLE
fix(backend): add missing Celery DB entries to redis-databases.yaml (#2675)

### DIFF
--- a/autobot-infrastructure/shared/config/redis-databases.yaml
+++ b/autobot-infrastructure/shared/config/redis-databases.yaml
@@ -46,6 +46,12 @@ redis_databases:
   codebase:
     db: 11
     description: "Codebase analytics (alias for analytics DB)"
+  celery_broker:
+    db: 14
+    description: "Celery task broker"
+  celery_results:
+    db: 15
+    description: "Celery task results backend"
 
 # Connection settings
 host: localhost


### PR DESCRIPTION
## Summary
- Add missing Celery broker (DB 14) and results backend (DB 15) entries to redis-databases.yaml
- Aligns with complete.yaml which already defines these DB numbers
- No conflicts with existing allocations (existing entries use DBs 0-11)

Closes #2675

## Test plan
- [ ] redis-databases.yaml includes celery_broker (DB 14) and celery_results (DB 15)
- [ ] No DB number conflicts with existing allocations
- [ ] Consistent with complete.yaml definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)