### PR TITLE
fix(backend): correct await pattern in redis_optimizer.py (#2635)

### DIFF
--- a/autobot-backend/code_intelligence/redis_optimizer.py
+++ b/autobot-backend/code_intelligence/redis_optimizer.py
@@ -858,7 +858,7 @@ class RedisOptimizer:
                         line_start=block_start,
                         line_end=block_start + block.count("\n"),
                         description="Potentially blocking Redis call in async function",
-                        suggestion="Use async Redis client: redis = await get_redis_client(async_client=True)",
+                        suggestion="Use async Redis client: redis = get_redis_client(async_client=True)",
                         estimated_improvement="Non-blocking async I/O, better concurrency",
                         metrics={"blocking_calls": len(sync_calls)},
                     )


### PR DESCRIPTION
## Summary
- Remove incorrect `await` from suggestion string in redis_optimizer.py line 861
- `get_redis_client()` is a regular sync function, not async — `await`-ing it causes TypeError
- The suggestion now correctly reads: `redis = get_redis_client(async_client=True)`

Closes #2635

## Test plan
- [ ] Suggestion string no longer includes erroneous `await`
- [ ] Consistent with `autobot-shared/redis_client.py` where `get_redis_client` is a sync `def`

🤖 Generated with [Claude Code](https://claude.com/claude-code)