### PR TITLE
fix(devops): add autobot_shared symlink inside backend dir after fleet sync (#2651)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -479,6 +479,18 @@
       when: "'01-Backend' in inventory_hostname"
       tags: [backend, shared, symlink]
 
+    - name: "[PLAY 2] Backend | Ensure autobot_shared symlink inside backend dir (#2651)"
+      ansible.builtin.file:
+        src: /opt/autobot/autobot-shared
+        dest: /opt/autobot/autobot-backend/autobot_shared
+        state: link
+        force: true
+        owner: autobot
+        group: autobot
+      become: true
+      when: "'01-Backend' in inventory_hostname"
+      tags: [backend, shared, symlink]
+
     - name: "[PLAY 2] Backend | Remove legacy backend symlink"
       file:
         path: /opt/autobot/autobot-backend/backend


### PR DESCRIPTION
## Summary
- Add Ansible task to create `/opt/autobot/autobot-backend/autobot_shared` → `/opt/autobot/autobot-shared` symlink
- Existing task only creates `/opt/autobot/autobot_shared` (project root level), but Python imports in backend need the symlink inside the backend directory
- Uses `force: true` to recreate if a stale file/dir exists from git-archive extraction

Closes #2651

## Test plan
- [ ] Playbook includes new symlink task after existing #2517 task
- [ ] Symlink target and destination paths are correct
- [ ] Task runs only on Backend nodes (`'01-Backend' in inventory_hostname`)
- [ ] `ansible-playbook --check` passes (dry run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)