### PR TITLE
fix(backend): restore await on async Redis call sites (#2707)

### DIFF
--- a/autobot-backend/agents/task_pattern_learner.py
+++ b/autobot-backend/agents/task_pattern_learner.py
@@ -58,7 +58,7 @@ class TaskPatternLearner:
         if self._redis is None:
             from autobot_shared.redis_client import get_redis_client
 
-            self._redis = get_redis_client(async_client=True, database="main")
+            self._redis = await get_redis_client(async_client=True, database="main")
         return self._redis
 
     async def _get_llm(self):

--- a/autobot-backend/api/analytics_controller.py
+++ b/autobot-backend/api/analytics_controller.py
@@ -176,7 +176,7 @@ class AnalyticsController:
                 if isinstance(database, RedisDatabase)
                 else database
             )
-            return get_redis_client(async_client=True, database=db_name)
+            return await get_redis_client(async_client=True, database=db_name)
         except Exception as e:
             logger.error("Failed to get Redis connection for %s: %s", database, e)
             return None

--- a/autobot-backend/api/knowledge_graph_routes.py
+++ b/autobot-backend/api/knowledge_graph_routes.py
@@ -116,7 +116,7 @@ async def list_entities(
     try:
         from autobot_shared.redis_client import get_redis_client
 
-        redis_client = get_redis_client(async_client=True, database="knowledge")
+        redis_client = await get_redis_client(async_client=True, database="knowledge")
         entities = await _list_entities_from_redis(
             redis_client, entity_type, query, limit
         )
@@ -138,7 +138,7 @@ async def get_entity_relationships(
     try:
         from autobot_shared.redis_client import get_redis_client
 
-        redis_client = get_redis_client(async_client=True, database="knowledge")
+        redis_client = await get_redis_client(async_client=True, database="knowledge")
         relationships = await _get_relationships_from_redis(
             redis_client, entity_id, relationship_type, limit
         )
@@ -172,7 +172,7 @@ async def search_events(
         from autobot_shared.redis_client import get_redis_client
         from knowledge.temporal_search import TemporalSearchService
 
-        redis_client = get_redis_client(async_client=True, database="knowledge")
+        redis_client = await get_redis_client(async_client=True, database="knowledge")
         temporal_svc = TemporalSearchService(redis_client)
 
         start = datetime.fromisoformat(start_date) if start_date else datetime.min
@@ -207,7 +207,7 @@ async def get_event_timeline(
         from autobot_shared.redis_client import get_redis_client
         from knowledge.temporal_search import TemporalSearchService
 
-        redis_client = get_redis_client(async_client=True, database="knowledge")
+        redis_client = await get_redis_client(async_client=True, database="knowledge")
         temporal_svc = TemporalSearchService(redis_client)
 
         events = await temporal_svc.get_event_timeline(

--- a/autobot-backend/api/workflow_state.py
+++ b/autobot-backend/api/workflow_state.py
@@ -112,7 +112,7 @@ class WorkflowStateMachine:
 
     async def _redis(self):
         """Get async Redis client for workflows db."""
-        return get_redis_client(async_client=True, database=REDIS_DATABASE)
+        return await get_redis_client(async_client=True, database=REDIS_DATABASE)
 
     async def _persist(self, state: WorkflowState) -> None:
         """Serialize and store *state* in Redis."""

--- a/autobot-backend/config/async_ops.py
+++ b/autobot-backend/config/async_ops.py
@@ -104,7 +104,7 @@ class AsyncOperationsMixin:
             from autobot_shared.redis_client import get_redis_client
 
             cache_key = self._get_redis_cache_key(config_type)
-            redis_client = get_redis_client(async_client=True, database="main")
+            redis_client = await get_redis_client(async_client=True, database="main")
 
             if redis_client:
                 cached_data = await redis_client.get(cache_key)
@@ -132,7 +132,7 @@ class AsyncOperationsMixin:
             filtered_data = self._filter_sensitive_data(data)
 
             cache_key = self._get_redis_cache_key(config_type)
-            redis_client = get_redis_client(async_client=True, database="main")
+            redis_client = await get_redis_client(async_client=True, database="main")
 
             if redis_client:
                 await redis_client.set(

--- a/autobot-backend/dependency_container.py
+++ b/autobot-backend/dependency_container.py
@@ -83,7 +83,7 @@ class AsyncServiceContainer:
 
     async def _create_redis_manager(self) -> async_redis.Redis:
         """Factory for Redis manager"""
-        return get_redis_client(async_client=True, database="main")
+        return await get_redis_client(async_client=True, database="main")
 
     async def _create_config_manager(self) -> ConfigManager:
         """Factory for config manager"""

--- a/autobot-backend/events/stream_manager.py
+++ b/autobot-backend/events/stream_manager.py
@@ -132,7 +132,7 @@ class RedisEventStreamManager(EventStreamManager):
             try:
                 from autobot_shared.redis_client import get_redis_client
 
-                self._redis = get_redis_client(async_client=True, database="main")
+                self._redis = await get_redis_client(async_client=True, database="main")
                 self._initialized = True
                 logger.debug("Event stream Redis connection established")
             except Exception as e:

--- a/autobot-backend/judges/task_outcome_judge.py
+++ b/autobot-backend/judges/task_outcome_judge.py
@@ -53,7 +53,7 @@ class TaskOutcomeJudge(BaseLLMJudge):
         if self._redis_client is None:
             from autobot_shared.redis_client import get_redis_client
 
-            self._redis_client = get_redis_client(async_client=True, database="main")
+            self._redis_client = await get_redis_client(async_client=True, database="main")
         return self._redis_client
 
     async def evaluate_task_outcome(

--- a/autobot-backend/knowledge/pipeline/loaders/redis_graph_loader.py
+++ b/autobot-backend/knowledge/pipeline/loaders/redis_graph_loader.py
@@ -41,7 +41,7 @@ class RedisGraphLoader(BaseLoader):
         Args:
             context: Pipeline context with entities, relationships, events
         """
-        self.redis_client = get_redis_client(async_client=True, database=self.database)
+        self.redis_client = await get_redis_client(async_client=True, database=self.database)
 
         entities: List[Entity] = context.entities
         relationships: List[Relationship] = context.relationships

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -367,14 +367,14 @@ async def update_plugin_config(
 
 async def _save_plugin_config(plugin_name: str, config: Dict) -> None:
     """Save plugin configuration to Redis."""
-    redis = get_redis_client(async_client=True, database="main")
+    redis = await get_redis_client(async_client=True, database="main")
     key = f"plugin:config:{plugin_name}"
     await redis.set(key, json.dumps(config))
 
 
 async def _load_plugin_config(plugin_name: str) -> Optional[Dict]:
     """Load plugin configuration from Redis."""
-    redis = get_redis_client(async_client=True, database="main")
+    redis = await get_redis_client(async_client=True, database="main")
     key = f"plugin:config:{plugin_name}"
     data = await redis.get(key)
     return json.loads(data) if data else None

--- a/autobot-backend/security/service_auth.py
+++ b/autobot-backend/security/service_auth.py
@@ -240,7 +240,7 @@ async def validate_service_auth(request: Request) -> Dict:
         pass
 
         # Get main Redis database for service key storage
-        redis = get_redis_client(async_client=True, database="main")
+        redis = await get_redis_client(async_client=True, database="main")
 
         # Create auth manager and validate
         auth_manager = ServiceAuthManager(redis)

--- a/autobot-backend/services/access_control_metrics.py
+++ b/autobot-backend/services/access_control_metrics.py
@@ -54,7 +54,7 @@ class AccessControlMetrics:
         """Get Redis metrics database (DB 4)"""
         if not self._redis:
             # Get async Redis client for metrics database (returns coroutine, must await)
-            self._redis = get_redis_client(async_client=True, database="metrics")
+            self._redis = await get_redis_client(async_client=True, database="metrics")
         return self._redis
 
     async def record_violation(

--- a/autobot-backend/services/approval_memory.py
+++ b/autobot-backend/services/approval_memory.py
@@ -277,7 +277,7 @@ class ApprovalMemoryManager:
             return False
 
         try:
-            redis = get_redis_client(async_client=True, database="main")
+            redis = await get_redis_client(async_client=True, database="main")
             if not redis:
                 logger.warning("Redis not available for approval memory")
                 return False
@@ -327,7 +327,7 @@ class ApprovalMemoryManager:
             return False
 
         try:
-            redis = get_redis_client(async_client=True, database="main")
+            redis = await get_redis_client(async_client=True, database="main")
             if not redis:
                 return False
 
@@ -389,7 +389,7 @@ class ApprovalMemoryManager:
             return []
 
         try:
-            redis = get_redis_client(async_client=True, database="main")
+            redis = await get_redis_client(async_client=True, database="main")
             if not redis:
                 return []
 
@@ -427,7 +427,7 @@ class ApprovalMemoryManager:
             return False
 
         try:
-            redis = get_redis_client(async_client=True, database="main")
+            redis = await get_redis_client(async_client=True, database="main")
             if not redis:
                 return False
 
@@ -478,7 +478,7 @@ class ApprovalMemoryManager:
             return False
 
         try:
-            redis = get_redis_client(async_client=True, database="main")
+            redis = await get_redis_client(async_client=True, database="main")
             if not redis:
                 return False
 
@@ -533,7 +533,7 @@ class ApprovalMemoryManager:
             return {"enabled": False}
 
         try:
-            redis = get_redis_client(async_client=True, database="main")
+            redis = await get_redis_client(async_client=True, database="main")
             if not redis:
                 return {"enabled": True, "redis_available": False}
 

--- a/autobot-backend/services/audit_logger.py
+++ b/autobot-backend/services/audit_logger.py
@@ -256,7 +256,7 @@ class AuditLogger:
         """Get Redis audit database (DB 10)"""
         try:
             # Use canonical Redis client pattern with 'audit' database
-            return get_redis_client(async_client=True, database="audit")
+            return await get_redis_client(async_client=True, database="audit")
         except Exception as e:
             logger.error("Failed to get audit database: %s", e)
             self._redis_failures += 1

--- a/autobot-backend/services/feature_flags.py
+++ b/autobot-backend/services/feature_flags.py
@@ -68,7 +68,7 @@ class FeatureFlags:
         """Get Redis connection for feature flags (uses cache DB)"""
         if not self.redis:
             # Get async Redis client for cache database (returns coroutine, must await)
-            self.redis = get_redis_client(async_client=True, database="cache")
+            self.redis = await get_redis_client(async_client=True, database="cache")
         return self.redis
 
     async def get_enforcement_mode(self) -> EnforcementMode:

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -374,7 +374,7 @@ class RAGService:
             "timestamp": str(time.time()),
         }
         try:
-            redis = get_redis_client(async_client=True, database="analytics")
+            redis = await get_redis_client(async_client=True, database="analytics")
             if redis is None:
                 logger.debug("Redis unavailable; skipping feedback stream write")
                 return

--- a/autobot-backend/services/redis_service_manager.py
+++ b/autobot-backend/services/redis_service_manager.py
@@ -537,7 +537,7 @@ class RedisServiceManager:
             from autobot_shared.redis_client import get_redis_client
 
             ping_start = datetime.now()
-            client = get_redis_client(async_client=True, database="main")
+            client = await get_redis_client(async_client=True, database="main")
             await client.ping()
             response_time_ms = (datetime.now() - ping_start).total_seconds() * 1000
             return True, response_time_ms

--- a/autobot-backend/services/semantic_query_cache.py
+++ b/autobot-backend/services/semantic_query_cache.py
@@ -344,7 +344,7 @@ class SemanticQueryCache:
     async def _fetch_response(self, key: str) -> Optional[Dict]:
         """Fetch cached response payload from Redis."""
         try:
-            client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
             if client is None:
                 return None
             raw = await client.get(key)
@@ -358,7 +358,7 @@ class SemanticQueryCache:
     async def _store_response(self, key: str, payload: Dict) -> bool:
         """Persist response payload in Redis with TTL."""
         try:
-            client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
             if client is None:
                 return False
             await client.set(

--- a/autobot-backend/services/topic_retrieval_cache.py
+++ b/autobot-backend/services/topic_retrieval_cache.py
@@ -287,7 +287,7 @@ class TopicRetrievalCache:
     async def _fetch_chunks(self, key: str) -> Optional[List[CachedChunk]]:
         """Fetch cached chunks from Redis."""
         try:
-            client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
             if client is None:
                 return None
             raw = await client.get(key)
@@ -309,7 +309,7 @@ class TopicRetrievalCache:
     async def _store_chunks(self, key: str, payload: List[Dict]) -> bool:
         """Persist chunk list in Redis with TTL."""
         try:
-            client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
             if client is None:
                 return False
             await client.set(
@@ -343,7 +343,7 @@ class TopicRetrievalCache:
             results = await self._collection.get(limit=excess, include=["metadatas"])
             if results and results.get("ids"):
                 ids_to_delete = results["ids"]
-                client = get_redis_client(async_client=True, database=_REDIS_DATABASE)
+                client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
                 if client:
                     for meta in results.get("metadatas", []):
                         rkey = meta.get("redis_key", "")

--- a/autobot-backend/services/workflow_automation/state_machine.py
+++ b/autobot-backend/services/workflow_automation/state_machine.py
@@ -130,7 +130,7 @@ class WorkflowStateMachine:
 
     async def _get_redis(self) -> Any:
         if self._redis is None:
-            self._redis = get_redis_client(async_client=True, database="main")
+            self._redis = await get_redis_client(async_client=True, database="main")
         return self._redis
 
     # -- Create --------------------------------------------------------

--- a/autobot-backend/skills/builtin/autonomous_skill_development.py
+++ b/autobot-backend/skills/builtin/autonomous_skill_development.py
@@ -187,7 +187,7 @@ async def _publish_new_draft_event(skill_name: str, skill_id: str, gap: str) -> 
 
         from autobot_shared.redis_client import get_redis_client
 
-        redis = get_redis_client(async_client=True, database="main")
+        redis = await get_redis_client(async_client=True, database="main")
         await redis.publish(
             "skills:new_draft",
             json.dumps(

--- a/autobot-backend/skills/governance.py
+++ b/autobot-backend/skills/governance.py
@@ -113,7 +113,7 @@ class GovernanceEngine:
         try:
             from autobot_shared.redis_client import get_redis_client
 
-            redis = get_redis_client(async_client=True, database="main")
+            redis = await get_redis_client(async_client=True, database="main")
             await redis.publish(
                 REDIS_APPROVAL_CHANNEL,
                 json.dumps(

--- a/autobot-backend/skills/manager.py
+++ b/autobot-backend/skills/manager.py
@@ -93,7 +93,7 @@ class SkillManager:
 
         Returns mapping of skill_name -> enabled.
         """
-        redis_client = _get_redis()
+        redis_client = await _get_redis()
         if not redis_client:
             return {}
         key = f"{REDIS_USER_SKILLS_PREFIX}{user_id}"
@@ -109,7 +109,7 @@ class SkillManager:
         self, user_id: str, preferences: Dict[str, bool]
     ) -> bool:
         """Save per-user skill preferences to Redis."""
-        redis_client = _get_redis()
+        redis_client = await _get_redis()
         if not redis_client:
             return False
         key = f"{REDIS_USER_SKILLS_PREFIX}{user_id}"
@@ -124,7 +124,7 @@ class SkillManager:
         self, skill_name: str, config: Dict[str, Any]
     ) -> bool:
         """Persist a skill's configuration to Redis."""
-        redis_client = _get_redis()
+        redis_client = await _get_redis()
         if not redis_client:
             return False
         key = f"{REDIS_SKILL_PREFIX}{skill_name}"
@@ -137,7 +137,7 @@ class SkillManager:
 
     async def persist_skill_enabled(self, skill_name: str, enabled: bool) -> bool:
         """Persist a skill's enabled/disabled state to Redis (Issue #993)."""
-        redis_client = _get_redis()
+        redis_client = await _get_redis()
         if not redis_client:
             return False
         key = f"{REDIS_SKILL_ENABLED_PREFIX}{skill_name}"
@@ -150,7 +150,7 @@ class SkillManager:
 
     async def _load_persisted_configs(self) -> None:
         """Load persisted configs and enabled states from Redis (Issues #731, #993)."""
-        redis_client = _get_redis()
+        redis_client = await _get_redis()
         if not redis_client:
             return
         for skill_info in self._registry.list_skills():
@@ -209,7 +209,7 @@ def _matches_query(skill_info: Dict[str, Any], query: str) -> bool:
     return False
 
 
-def _get_redis():
+async def _get_redis():
     """Get async Redis client, returning None if unavailable.
 
     Helper for SkillManager Redis operations (Issue #731).
@@ -217,7 +217,7 @@ def _get_redis():
     try:
         from autobot_shared.redis_client import get_redis_client
 
-        return get_redis_client(async_client=True, database="main")
+        return await get_redis_client(async_client=True, database="main")
     except Exception:
         logger.debug("Redis not available for skill persistence")
         return None

--- a/autobot-backend/user_management/middleware/rate_limit.py
+++ b/autobot-backend/user_management/middleware/rate_limit.py
@@ -39,7 +39,7 @@ class PasswordChangeRateLimiter:
         Raises:
             RateLimitExceeded: If limit exceeded
         """
-        redis_client = get_redis_client(async_client=True, database="main")
+        redis_client = await get_redis_client(async_client=True, database="main")
         key = f"password_change_attempts:{user_id}"
 
         attempts = await redis_client.get(key)
@@ -61,7 +61,7 @@ class PasswordChangeRateLimiter:
             user_id: User ID
             success: Whether attempt was successful
         """
-        redis_client = get_redis_client(async_client=True, database="main")
+        redis_client = await get_redis_client(async_client=True, database="main")
         key = f"password_change_attempts:{user_id}"
 
         if success:

--- a/autobot-backend/user_management/services/session_service.py
+++ b/autobot-backend/user_management/services/session_service.py
@@ -45,7 +45,7 @@ class SessionService:
             token: JWT token to invalidate
             ttl: Time to live in seconds (default 24 hours)
         """
-        redis_client = get_redis_client(async_client=True, database="main")
+        redis_client = await get_redis_client(async_client=True, database="main")
         key = f"session:blacklist:{user_id}"
         token_hash = self.hash_token(token)
 
@@ -65,7 +65,7 @@ class SessionService:
         Returns:
             True if token is blacklisted, False otherwise
         """
-        redis_client = get_redis_client(async_client=True, database="main")
+        redis_client = await get_redis_client(async_client=True, database="main")
         key = f"session:blacklist:{user_id}"
         token_hash = self.hash_token(token)
 
@@ -90,7 +90,7 @@ class SessionService:
         Returns:
             Number of sessions invalidated
         """
-        redis_client = get_redis_client(async_client=True, database="main")
+        redis_client = await get_redis_client(async_client=True, database="main")
         key = f"session:blacklist:{user_id}"
 
         # Get existing token hashes (if any)

--- a/autobot-backend/utils/advanced_cache_manager.py
+++ b/autobot-backend/utils/advanced_cache_manager.py
@@ -169,7 +169,7 @@ class AdvancedCacheManager:
             if self._redis_client_initialized:
                 return  # Another coroutine initialized while we waited
             try:
-                self.redis_client = get_redis_client(async_client=True)
+                self.redis_client = await get_redis_client(async_client=True)
                 self._redis_client_initialized = True
                 logger.debug("Async Redis client initialized successfully")
             except Exception as e:

--- a/autobot-backend/utils/cache_manager.py
+++ b/autobot-backend/utils/cache_manager.py
@@ -49,13 +49,7 @@ class CacheManager:
 
         try:
             # Get async Redis client
-            client = get_redis_client(async_client=True)
-
-            # If it's a coroutine, await it
-            if hasattr(client, "__await__"):
-                self._redis_client = await client
-            else:
-                self._redis_client = client
+            self._redis_client = await get_redis_client(async_client=True)
 
             if self._redis_client:
                 logger.info("CacheManager Redis client initialized successfully")

--- a/autobot-backend/utils/experiment_tracker.py
+++ b/autobot-backend/utils/experiment_tracker.py
@@ -76,7 +76,7 @@ class ExperimentTracker:
             rationale=rationale,
             related_issue=related_issue,
         )
-        redis_client = get_redis_client(async_client=True, database="analytics")
+        redis_client = await get_redis_client(async_client=True, database="analytics")
         if redis_client:
             await redis_client.rpush(REDIS_KEY, json.dumps(record.to_dict()))
             await redis_client.ltrim(REDIS_KEY, -10000, -1)  # Cap at 10k (#2031)
@@ -87,7 +87,7 @@ class ExperimentTracker:
         self, area: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         """List all experiments, optionally filtered by area."""
-        redis_client = get_redis_client(async_client=True, database="analytics")
+        redis_client = await get_redis_client(async_client=True, database="analytics")
         if not redis_client:
             return []
         raw = await redis_client.lrange(REDIS_KEY, 0, -1)


### PR DESCRIPTION
## Summary
- Restore `await` on all `get_redis_client(async_client=True)` call sites across 28 files
- PR #2633 incorrectly removed these based on the flawed premise that `get_redis_client()` is fully synchronous
- `get_redis_client(async_client=True)` returns a coroutine from `async def get_async_client()` — callers **must** await it
- Also removed a `hasattr` workaround in `cache_manager.py` that was masking the bug

**Files not changed (intentionally):**
- Sync `__init__` methods where `await` cannot be used — these need architectural refactoring (separate issue)
- Test string literals in `redis_optimizer_test.py` — not executed code

Closes #2707

## Test plan
- [ ] All `get_redis_client(async_client=True)` calls in async functions have `await`
- [ ] `grep -rn 'get_redis_client(async_client=True' --include='*.py' | grep -v await | grep -v '#'` returns only sync `__init__` contexts and test strings
- [ ] No sync call sites were modified
- [ ] Backend starts without `AttributeError` on coroutine objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)