### PR TITLE
feat(docs): add end-user documentation and guides (#1805)

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,41 @@
+# AutoBot User Documentation
+
+Welcome to AutoBot -- your AI-powered assistant for chat, knowledge management,
+workflow automation, and analytics. This documentation is written for everyday
+users; no programming experience is required.
+
+## Getting Started
+
+If you are new to AutoBot, begin here:
+
+1. [Getting Started](getting-started.md) -- Installation overview and first-run setup
+2. [Quick Start: Your First Conversation](quick-start-chat.md) -- Send your first message to AutoBot
+3. [Quick Start: Knowledge Base](quick-start-knowledge.md) -- Upload a document and ask questions about it
+
+## User Guides
+
+Once you are comfortable with the basics, explore the full feature set:
+
+| Guide | Description |
+|-------|-------------|
+| [Chat Interface](guides/chat-interface.md) | Chat features, file attachments, voice, and shortcuts |
+| [Knowledge Management](guides/knowledge-management.md) | Upload, organize, search, and verify knowledge |
+| [Working with Agents](guides/working-with-agents.md) | What agents are and how to use them |
+| [Workflows](guides/workflows.md) | Creating, running, and monitoring automated workflows |
+| [Model Selection](guides/model-selection.md) | How AutoBot chooses AI models and what the tiers mean |
+| [Settings and Preferences](guides/settings.md) | Appearance, language, voice, and other preferences |
+
+## Where to Get Help
+
+- **In-app:** Use the chat interface (`/chat`) to ask AutoBot any question.
+- **Issues:** Report bugs or request features on the
+  [GitHub Issues](https://github.com/mrveiss/AutoBot-AI/issues) page.
+- **Developer docs:** If you are a developer, see `docs/developer/` for
+  technical reference material.
+
+## Conventions Used in This Documentation
+
+- **Bold text** refers to buttons, tabs, or labels you can see on screen.
+- `Monospace text` refers to URLs, keyboard shortcuts, or values you type.
+- `<!-- Screenshot: ... -->` placeholders indicate where screenshots will be
+  added in a future update.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -1,0 +1,84 @@
+# Getting Started with AutoBot
+
+This guide walks you through installing AutoBot and completing your first-run
+setup. By the end, you will have a running instance and be ready to chat.
+
+## What is AutoBot?
+
+AutoBot is an AI-powered automation platform. It provides:
+
+- **AI Chat** -- Converse with an AI assistant that can answer questions, run
+  commands, and coordinate specialized agents.
+- **Knowledge Base** -- Upload documents so the AI can reference them in
+  conversations.
+- **Workflow Automation** -- Build visual workflows that automate repetitive
+  tasks.
+- **Analytics** -- View codebase analytics, conversation insights, and more.
+
+## System Requirements
+
+| Requirement | Minimum |
+|-------------|---------|
+| Disk space | 5 GB free |
+| Memory (RAM) | 2 GB |
+| Operating system | Linux (Ubuntu 22.04+ recommended) |
+| Browser | Any modern browser (Chrome, Firefox, Edge, Safari) |
+
+## Installation
+
+AutoBot ships with a single installer script. Your system administrator will
+typically run this for you. If you are setting it up yourself:
+
+1. Open a terminal on the server where AutoBot will run.
+2. Run the installer:
+
+   ```
+   sudo ./install.sh
+   ```
+
+   Alternatively, install directly from the repository:
+
+   ```
+   curl -fsSL https://raw.githubusercontent.com/mrveiss/AutoBot-AI/main/install.sh | bash
+   ```
+
+3. The installer will check requirements, download dependencies, and configure
+   the platform. This may take several minutes.
+4. When the installer finishes, note the URL it prints -- this is how you will
+   access AutoBot in your browser.
+
+### Unattended Installation
+
+For automated deployments, pass the `--unattended` flag:
+
+```
+sudo ./install.sh --unattended
+```
+
+## First-Run Setup
+
+1. **Open AutoBot in your browser.** Navigate to the URL provided by the
+   installer (for example, `https://your-server:8443`).
+
+<!-- Screenshot: Login page -->
+
+2. **Log in.** Enter the credentials created during installation. If AutoBot is
+   running in single-user mode, you will be logged in automatically.
+
+3. **Explore the navigation bar.** The main sections are:
+   - **AI Assistant** (`/chat`) -- your primary workspace for conversations.
+   - **Knowledge Base** (`/knowledge`) -- manage documents and data sources.
+   - **Workflow Automation** (`/automation`) -- build and run automated workflows.
+   - **Analytics** (`/analytics`) -- dashboards for code and business insights.
+
+4. **Send a test message.** Click **AI Assistant** in the navigation bar, type a
+   greeting such as "Hello, AutoBot!" and press **Enter**. If you receive a
+   reply, everything is working.
+
+<!-- Screenshot: First message in chat -->
+
+## Next Steps
+
+- [Quick Start: Your First Conversation](quick-start-chat.md)
+- [Quick Start: Knowledge Base](quick-start-knowledge.md)
+- [Full User Guide Index](README.md)

--- a/docs/user/guides/chat-interface.md
+++ b/docs/user/guides/chat-interface.md
@@ -1,0 +1,140 @@
+# Chat Interface Guide
+
+The AI Assistant is AutoBot's primary workspace. This guide covers every
+feature of the chat interface so you can get the most out of your
+conversations.
+
+## Accessing the Chat
+
+Click **AI Assistant** in the navigation bar, or navigate to `/chat`. The
+interface is divided into three areas:
+
+- **Sidebar** (left) -- lists your conversation sessions.
+- **Conversation area** (center) -- displays messages between you and AutoBot.
+- **Input area** (bottom) -- where you type and send messages.
+
+<!-- Screenshot: Full chat interface with sidebar, conversation, and input -->
+
+## Conversations and Sessions
+
+Every conversation is stored as a **session**. Sessions are listed in the
+sidebar, with the most recent at the top.
+
+| Action | How |
+|--------|-----|
+| Start a new session | Click **New Chat** at the top of the sidebar |
+| Switch sessions | Click any session in the sidebar |
+| Delete a session | Open the session, then click the trash icon in the header |
+| Export a session | Click the download icon in the header |
+
+Sessions are saved automatically as you type. You never need to manually save.
+
+## Sending Messages
+
+1. Click the input area at the bottom of the screen.
+2. Type your message.
+3. Press **Enter** to send.
+
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Enter` | Send message |
+| `Shift + Enter` | New line (without sending) |
+
+## Attaching Files
+
+You can include files with your messages so AutoBot can analyze, summarize, or
+reference them.
+
+1. Click the **paperclip icon** in the input area.
+2. Select one or more files from your computer.
+3. Attached files appear above the input area with their name and size.
+4. Type an instruction (for example, "Summarize this PDF") and press **Enter**.
+
+To remove a single file, click the **X** next to its name. To remove all
+files, click **Clear All**.
+
+If an upload fails, a **Retry** button will appear next to the file. Click it
+to try again.
+
+<!-- Screenshot: Input area with attached files -->
+
+## File Upload Progress
+
+When files are uploading, a progress bar shows:
+
+- The file name and current status.
+- A percentage or byte counter.
+- An estimated time remaining.
+
+Wait for the upload to finish before sending your message.
+
+## Voice Conversations
+
+AutoBot supports voice input and output. Look for the **microphone icon** in
+the chat interface:
+
+1. Click the microphone icon to start speaking.
+2. AutoBot will transcribe your speech and process it as a message.
+3. If voice output is enabled, AutoBot will read its response aloud.
+
+Voice settings can be configured in **Preferences** (`/preferences`) under the
+**Voice** tab.
+
+<!-- Screenshot: Voice conversation panel -->
+
+## Citations and Sources
+
+When AutoBot references information from your knowledge base, it includes
+**citations** -- small indicators that show which document the information
+came from. Click a citation to view the source document.
+
+## Vision Analysis
+
+If you attach an image, AutoBot can analyze its contents. After attaching an
+image, ask a question such as:
+
+```
+What does this screenshot show?
+```
+
+AutoBot will describe the image, identify UI elements, or extract text
+depending on your question.
+
+<!-- Screenshot: Vision analysis of an attached image -->
+
+## Sharing Conversations
+
+To share a conversation with a colleague:
+
+1. Open the conversation you want to share.
+2. Look for the **Share** option in the session actions.
+3. A shareable link or export will be generated.
+
+## Connection Status
+
+The chat header shows a real-time connection indicator:
+
+| Indicator | Meaning |
+|-----------|---------|
+| Green check | Connected |
+| Yellow spinner | Reconnecting |
+| Red exclamation | Disconnected |
+
+If you see a red indicator, check your network connection. AutoBot will
+automatically attempt to reconnect.
+
+## Tips
+
+- Be specific in your questions for better answers. Instead of "Tell me about
+  the project," try "Summarize the Q3 budget from the uploaded report."
+- Use the knowledge base to give AutoBot context it would not otherwise have.
+- You can ask AutoBot to perform actions across the platform, such as
+  searching knowledge, running workflows, or explaining analytics.
+
+## Related Guides
+
+- [Quick Start: Your First Conversation](../quick-start-chat.md)
+- [Working with Agents](working-with-agents.md)
+- [Knowledge Management](knowledge-management.md)

--- a/docs/user/guides/knowledge-management.md
+++ b/docs/user/guides/knowledge-management.md
@@ -1,0 +1,124 @@
+# Knowledge Management Guide
+
+The Knowledge Base is where AutoBot stores and organizes your documents, notes,
+and data. This guide explains every section of the Knowledge Base and how to
+use it effectively.
+
+## Accessing the Knowledge Base
+
+Click **Knowledge Base** in the navigation bar, or navigate to `/knowledge`.
+A sidebar on the left lists all available sections.
+
+<!-- Screenshot: Knowledge Base view with sidebar sections -->
+
+## Sections Overview
+
+| Section | Path | Purpose |
+|---------|------|---------|
+| Search | `/knowledge/search` | Find information across all documents |
+| Research | `/knowledge/research` | Live research panel with browser collaboration |
+| Categories | `/knowledge/categories` | Browse documents organized by topic |
+| Knowledge Graph | `/knowledge/graph` | Visual map of topics and relationships |
+| Manage | `/knowledge/manage` | Add, edit, and delete knowledge entries |
+| Verification | `/knowledge/verification` | Review and approve imported content |
+| Connectors | `/knowledge/connectors` | Import data from external sources |
+| Statistics | `/knowledge/stats` | View usage metrics and storage details |
+| Maintenance | `/knowledge/maintenance` | Clean up, re-index, and maintain data |
+
+## Uploading Documents
+
+1. Navigate to **Manage** (`/knowledge/manage`).
+2. Click the **Upload** or **Add Entry** button.
+3. Select a file from your computer. Common formats include PDF, TXT, Markdown,
+   CSV, and DOCX.
+4. Optionally add:
+   - **Title** -- a human-readable name for the document.
+   - **Category** -- a topic grouping (for example, "Finance" or "HR Policies").
+   - **Tags** -- keywords to make searching easier.
+5. Click **Save** to upload. Processing happens in the background.
+
+<!-- Screenshot: Upload form with title, category, and tags -->
+
+## Searching Knowledge
+
+1. Go to **Search** (`/knowledge/search`).
+2. Type a keyword, phrase, or full question in the search bar.
+3. Press **Enter**.
+4. Results appear ranked by relevance, showing matching passages and the
+   document they came from.
+
+Search also works from the chat: ask AutoBot a question and it will
+automatically search the knowledge base if relevant documents exist.
+
+## Browsing Categories
+
+1. Go to **Categories** (`/knowledge/categories`).
+2. Categories are displayed as folders or cards.
+3. Click a category to see all documents within it.
+4. Click a document to read its content or edit its metadata.
+
+## Knowledge Graph
+
+The Knowledge Graph (`/knowledge/graph`) is an interactive visualization that
+shows how your documents, topics, and entities relate to each other.
+
+- **Nodes** represent documents, topics, or entities.
+- **Edges** (lines) represent relationships.
+- Click a node to see its details.
+- Zoom in and out to explore large graphs.
+
+Sub-sections within the Knowledge Graph:
+
+| Sub-section | Path | Purpose |
+|-------------|------|---------|
+| Pipeline | `/knowledge/graph/pipeline` | Run processing pipelines on your data |
+| Entities | `/knowledge/graph/entities` | Explore extracted entities |
+| Timeline | `/knowledge/graph/timeline` | View events on a chronological timeline |
+| Summaries | `/knowledge/graph/summaries` | Search and browse auto-generated summaries |
+
+<!-- Screenshot: Knowledge Graph visualization -->
+
+## Source Verification
+
+The Verification Queue (`/knowledge/verification`) lets you review content
+before it is used in AI responses:
+
+1. Open the queue to see pending items.
+2. Review each item for accuracy.
+3. **Approve** to make the content available, or **Reject** to remove it.
+
+This is especially useful when importing content from external sources.
+
+## Connectors
+
+Connectors (`/knowledge/connectors`) pull data from external services
+automatically. To set up a connector:
+
+1. Go to **Connectors**.
+2. Click **Add Connector**.
+3. Choose the source type and provide any required credentials or URLs.
+4. Configure the sync schedule (how often data is refreshed).
+5. Save the connector. Data will begin importing on the configured schedule.
+
+## Statistics and Maintenance
+
+- **Statistics** (`/knowledge/stats`) shows how many documents you have, storage
+  used, and search activity.
+- **Maintenance** (`/knowledge/maintenance`) provides tools to re-index
+  documents, clean up orphaned entries, and optimize storage.
+
+## Tips
+
+- Add meaningful titles and tags when uploading. This dramatically improves
+  search quality.
+- Use the verification queue to ensure imported content is accurate before the
+  AI uses it.
+- Check the Knowledge Graph periodically to discover unexpected connections
+  between your documents.
+
+## Related Guides
+
+- [Quick Start: Knowledge Base](../quick-start-knowledge.md)
+- [Chat Interface](chat-interface.md) -- asking questions about your knowledge
+- [Working with Agents](working-with-agents.md) -- agents can search and manage
+  knowledge on your behalf

--- a/docs/user/guides/model-selection.md
+++ b/docs/user/guides/model-selection.md
@@ -1,0 +1,114 @@
+# Model Selection Guide
+
+AutoBot uses AI language models to understand your messages and generate
+responses. This guide explains how models are selected, what the tier system
+means, and how it affects your experience.
+
+## What is a Model?
+
+A **model** is the AI engine that reads your messages and produces responses.
+Different models have different strengths:
+
+- **Smaller models** respond faster and use fewer resources, but may handle
+  complex tasks less thoroughly.
+- **Larger models** handle nuanced, multi-step tasks better, but take slightly
+  longer to respond.
+
+AutoBot manages model selection automatically so you do not need to choose a
+model yourself.
+
+## How AutoBot Chooses a Model
+
+When you send a message, AutoBot evaluates its **complexity** -- how difficult
+or nuanced your request is. Based on that score, it routes the request to the
+most appropriate model. This process is called **tiered model routing**.
+
+The flow looks like this:
+
+1. You send a message.
+2. AutoBot's complexity scorer analyzes the message (length, topic, required
+   reasoning depth).
+3. The message is routed to the model best suited for that complexity level.
+4. The model generates a response.
+
+This happens in the background and typically adds no noticeable delay.
+
+## The Tier System
+
+AutoBot organizes its AI capabilities into tiers. Each tier is optimized for a
+different kind of workload.
+
+### Agent Tiers
+
+Agents are classified into four tiers based on how they share processing
+resources:
+
+| Tier | Name | Typical Agents | Cache Efficiency |
+|------|------|----------------|-----------------|
+| 1 | Default | Backend Engineer, Frontend Engineer, Database Engineer, Documentation Engineer, Testing Engineer, DevOps Engineer | Highest (90-95%) |
+| 2 | Analysis | Code Reviewer, Performance Engineer, Security Auditor | High (70-80%) |
+| 3 | Specialized | Systems Architect, AI/ML Engineer, Content Writer | Moderate (40-60%) |
+| 4 | Orchestrator | Orchestrator (coordinates all agents) | Session-specific (50-70%) |
+
+**Cache efficiency** means how effectively AutoBot reuses previous computations.
+Higher efficiency means faster response times for you.
+
+### Model Routing Tiers
+
+Separately, messages are routed to models based on complexity:
+
+| Complexity | Routed To | Example Tasks |
+|------------|-----------|---------------|
+| Simple | Lightweight model | Greetings, simple lookups, yes/no questions |
+| Complex | Full-capability model | Multi-step analysis, code generation, research |
+
+AutoBot may also use a **routing model** -- a lightweight model whose only job
+is to decide which main model should handle the request.
+
+## What This Means for You
+
+- **You do not need to select a model.** AutoBot handles this automatically.
+- **Simple questions get fast answers.** Straightforward requests are routed to
+  fast, lightweight models.
+- **Complex questions get thorough answers.** Detailed or multi-step requests
+  are routed to more capable models.
+- **Agents use the best model for their specialty.** A code reviewer uses a
+  model optimized for code analysis, while a documentation writer uses one
+  optimized for language.
+
+## Failsafe System
+
+If the primary model is unavailable (for example, during maintenance), AutoBot
+has a multi-tier failsafe system:
+
+1. **Primary** -- the preferred model for the task.
+2. **Secondary** -- a backup model with similar capabilities.
+3. **Basic** -- a simpler model that can still provide useful responses.
+4. **Emergency** -- a minimal, rule-based system that ensures you always get
+   some form of response.
+
+You will rarely notice the failsafe activating. If it does, responses may be
+simpler than usual until the primary model is restored.
+
+## Frequently Asked Questions
+
+**Can I choose which model to use?**
+Model selection is managed by AutoBot's routing system. This ensures optimal
+performance and resource usage. Administrators can configure which models are
+available through the SLM admin settings.
+
+**Why do some responses feel different from others?**
+Different models have different writing styles. If your request was routed to
+a different model (due to complexity or failover), the tone or level of detail
+may vary slightly.
+
+**Does model selection affect my knowledge base?**
+No. Your documents and knowledge are stored independently. Model selection
+only affects how AutoBot processes and responds to your messages.
+
+## Related Guides
+
+- [Working with Agents](working-with-agents.md) -- agents are assigned to
+  tiers
+- [Chat Interface](chat-interface.md) -- where you interact with models
+- [Settings and Preferences](settings.md) -- configure your AutoBot experience

--- a/docs/user/guides/settings.md
+++ b/docs/user/guides/settings.md
@@ -1,0 +1,138 @@
+# Settings and Preferences Guide
+
+AutoBot lets you personalize your experience through the **Preferences** page.
+This guide walks through every available setting.
+
+## Accessing Preferences
+
+Click **Preferences** in the navigation bar, or navigate to `/preferences`.
+The Preferences page has three tabs:
+
+- **Appearance**
+- **Language**
+- **Voice**
+
+<!-- Screenshot: Preferences page with three tabs -->
+
+## Appearance
+
+The Appearance tab controls how AutoBot looks.
+
+### Theme
+
+Choose between visual themes to suit your environment:
+
+- **Dark** -- dark background with light text. Easier on the eyes in low-light
+  settings.
+- **Light** -- light background with dark text. Better in bright environments.
+- **System** -- automatically matches your operating system's theme setting.
+
+<!-- Screenshot: Theme selection options -->
+
+### Font Size
+
+Adjust the text size throughout the interface. Options typically range from
+small to large. Choose whichever is most comfortable to read.
+
+### Color Accents
+
+Some themes allow you to customize accent colors (the highlight color used for
+buttons, links, and active elements). Pick a color that you find visually
+appealing.
+
+### Layout Density
+
+Control how much spacing appears between elements:
+
+- **Compact** -- less whitespace, more content visible at once.
+- **Comfortable** -- balanced spacing (default).
+- **Spacious** -- more whitespace, easier to scan.
+
+## Language
+
+The Language tab controls the interface language.
+
+1. Open the **Language** tab.
+2. Select your preferred language from the dropdown list.
+3. The interface will update immediately. All labels, buttons, and system
+   messages will appear in the selected language.
+
+Note: AI responses are generated in the language you write in, regardless of
+the interface language. If you write a message in Spanish, AutoBot will
+typically respond in Spanish.
+
+<!-- Screenshot: Language selection dropdown -->
+
+## Voice
+
+The Voice tab controls speech-related features.
+
+### Voice Input
+
+Enable or disable the microphone for voice input in the chat:
+
+1. Toggle **Voice Input** on.
+2. Grant your browser permission to access the microphone when prompted.
+3. A microphone icon will appear in the chat input area.
+
+### Voice Output
+
+Enable or disable AutoBot reading responses aloud:
+
+1. Toggle **Voice Output** on.
+2. Choose a voice from the available options (varies by browser and operating
+   system).
+3. Adjust the speaking rate if available.
+
+### Voice Language
+
+Select the language for speech recognition. This should match the language you
+intend to speak. It does not need to match the interface language.
+
+<!-- Screenshot: Voice settings panel -->
+
+## Secrets Manager
+
+The **Secrets Manager** (`/secrets`) stores API keys and credentials that
+AutoBot uses when connecting to external services on your behalf. This is
+separate from the Preferences page but is related to your personal
+configuration.
+
+1. Navigate to `/secrets` from the navigation bar.
+2. Click **Add Secret** to store a new credential.
+3. Provide a name, the secret value, and an optional description.
+4. Secrets are encrypted and stored securely. Only you and authorized agents
+   can access them.
+
+<!-- Screenshot: Secrets Manager with an example entry -->
+
+## Plugins
+
+The **Plugin Manager** (`/plugins`) lets you extend AutoBot's capabilities:
+
+1. Navigate to `/plugins` from the navigation bar.
+2. Browse available plugins.
+3. Click **Install** to add a plugin to your instance.
+4. Configure the plugin's settings as needed.
+
+Plugins can add new agent types, connectors, UI features, or integrations
+with external tools.
+
+<!-- Screenshot: Plugin Manager browse page -->
+
+## Tips
+
+- If the interface feels too dark or too bright, switch the theme to match
+  your lighting.
+- Increasing the font size can reduce eye strain during long sessions.
+- Enable voice input for a hands-free experience when you are away from the
+  keyboard.
+- Review your secrets periodically and remove any that are no longer needed.
+
+## Related Guides
+
+- [Chat Interface](chat-interface.md) -- voice settings affect the chat
+  experience
+- [Knowledge Management](knowledge-management.md) -- connectors may use
+  secrets you configure here
+- [Getting Started](../getting-started.md) -- return to the setup overview

--- a/docs/user/guides/workflows.md
+++ b/docs/user/guides/workflows.md
@@ -1,0 +1,143 @@
+# Workflows Guide
+
+Workflows let you automate sequences of tasks so they run without manual
+intervention. This guide explains how to create, run, and monitor workflows
+in AutoBot.
+
+## What is a Workflow?
+
+A workflow is a series of steps that AutoBot performs in order. Each step can
+be an AI task, a data operation, a notification, or any other action. For
+example, a workflow might:
+
+1. Check a website for new data every hour.
+2. Summarize the new data using AI.
+3. Save the summary to the knowledge base.
+4. Send a notification that the summary is ready.
+
+Once you set up a workflow, it runs automatically on the schedule you define.
+
+## Accessing Workflows
+
+Click **Workflow Automation** in the navigation bar, or navigate to
+`/automation`. The sidebar on the left provides access to:
+
+- **Overview** -- a dashboard showing all your workflows and their statuses.
+- **Visual Builder** -- a drag-and-drop editor for creating workflows.
+- **Templates** -- pre-built workflow patterns you can start from.
+- **Browser Automation** -- control browser workers for web-based tasks.
+
+<!-- Screenshot: Workflow Automation view with sidebar -->
+
+## Creating a Workflow
+
+### Using a Template
+
+1. Click **Templates** in the sidebar.
+2. Browse the available templates. Each one shows a description and the
+   steps it includes.
+3. Click a template to preview it.
+4. Click **Use Template** (or similar) to create a new workflow based on it.
+5. Customize the steps to match your needs, then save.
+
+### Using the Visual Builder
+
+1. Click **Visual Builder** in the sidebar.
+2. The canvas opens with a blank workspace.
+3. **Add a step:** Drag a block from the palette on the side, or click the
+   **Add Step** button.
+4. **Configure each step:** Click a block on the canvas to open its settings.
+   Fill in the required fields (for example, the URL for a web request, or the
+   prompt for an AI task).
+5. **Connect steps:** Drag a line from one block's output to another block's
+   input to define the order.
+6. **Save:** Click **Save** to store the workflow.
+
+<!-- Screenshot: Visual Builder canvas with connected blocks -->
+
+### Step Types
+
+Common step types include:
+
+| Step Type | Description |
+|-----------|-------------|
+| AI Task | Send a prompt to an AI agent and use its response |
+| Web Request | Fetch data from a URL |
+| Knowledge Query | Search or update the knowledge base |
+| Notification | Send an alert via email, webhook, or in-app message |
+| Condition | Branch the workflow based on a yes/no check |
+| Delay | Wait for a specified time before continuing |
+
+## Running a Workflow
+
+1. Open the workflow you want to run from the **Overview** page.
+2. Click **Run** (or **Execute**) to start it immediately.
+3. The workflow status will change to **Running**.
+4. Each step shows its status as it completes: **Pending**, **Running**,
+   **Completed**, or **Failed**.
+
+### Scheduling a Workflow
+
+To run a workflow on a recurring schedule:
+
+1. Open the workflow's settings.
+2. Look for the **Schedule** section.
+3. Choose the frequency (for example, every hour, daily, or weekly).
+4. Save. The workflow will run automatically at the times you configured.
+
+## Monitoring Workflows
+
+The **Overview** page shows all workflows and their current status:
+
+| Status | Meaning |
+|--------|---------|
+| Idle | Not currently running |
+| Running | Executing steps right now |
+| Completed | Finished successfully |
+| Failed | One or more steps encountered an error |
+
+Click a workflow to see detailed logs for each step, including input, output,
+and any error messages.
+
+<!-- Screenshot: Workflow overview with status indicators -->
+
+## Browser Automation
+
+AutoBot can control a web browser to automate tasks on websites. Access this
+feature at `/automation/browser-automation`.
+
+1. Open **Browser Automation** in the sidebar.
+2. Configure a browser session: provide the target URL and any login
+   credentials if needed.
+3. Define actions such as clicking buttons, filling forms, or extracting data.
+4. Run the session. AutoBot will execute the actions in a real browser and
+   return the results.
+
+<!-- Screenshot: Browser Automation session view -->
+
+## Approval Gates
+
+Some workflows include an **approval gate** -- a step that pauses the workflow
+and asks you (or another user) to approve before continuing. When a workflow
+reaches an approval gate:
+
+1. You receive a notification.
+2. Open the workflow to review what has happened so far.
+3. Click **Approve** to continue or **Reject** to stop the workflow.
+
+## Tips
+
+- Start with a template and modify it rather than building from scratch.
+- Use the **Condition** step to handle different outcomes (for example, only
+  send a notification if new data was found).
+- Check the Overview page regularly to catch failed workflows early.
+- Use descriptive names for your workflows so they are easy to find later.
+
+## Related Guides
+
+- [Working with Agents](working-with-agents.md) -- agents power many workflow
+  steps
+- [Knowledge Management](knowledge-management.md) -- workflows can read from
+  and write to the knowledge base
+- [Chat Interface](chat-interface.md) -- you can trigger workflows from the
+  chat

--- a/docs/user/guides/working-with-agents.md
+++ b/docs/user/guides/working-with-agents.md
@@ -1,0 +1,132 @@
+# Working with Agents
+
+AutoBot uses specialized **agents** to handle different types of tasks. This
+guide explains what agents are, how they work, and how you can interact with
+them.
+
+## What is an Agent?
+
+An agent is a focused AI worker designed for a specific kind of task. Think of
+agents like team members with different specialties:
+
+- One agent is great at writing code.
+- Another excels at reviewing code for bugs.
+- A third specializes in managing your knowledge base.
+
+When you send a message in the chat, AutoBot's **orchestrator** decides which
+agent (or combination of agents) is best suited to handle your request. This
+happens automatically -- you do not need to pick an agent yourself.
+
+## How Agents Work Behind the Scenes
+
+1. You send a message in the chat.
+2. The **orchestrator** analyzes your message to understand what you need.
+3. The orchestrator routes your request to one or more specialized agents.
+4. Each agent processes its part of the task.
+5. The results are combined and delivered back to you as a single response.
+
+This all happens in seconds. From your perspective, it looks like a single
+conversation.
+
+## Types of Agents
+
+AutoBot includes several categories of agents:
+
+### Implementation Agents
+
+These agents build and create things:
+
+| Agent | What It Does |
+|-------|--------------|
+| Backend Engineer | Writes and modifies server-side code |
+| Frontend Engineer | Works on user interface code |
+| Database Engineer | Handles database design and queries |
+| DevOps Engineer | Manages deployment and infrastructure |
+| Documentation Engineer | Creates and updates documentation |
+| Testing Engineer | Writes and runs tests |
+
+### Analysis Agents
+
+These agents review and evaluate:
+
+| Agent | What It Does |
+|-------|--------------|
+| Code Reviewer | Checks code for quality and bugs |
+| Performance Engineer | Finds and fixes performance issues |
+| Security Auditor | Identifies security vulnerabilities |
+
+### Specialized Agents
+
+These agents handle unique tasks:
+
+| Agent | What It Does |
+|-------|--------------|
+| Systems Architect | Designs system architecture |
+| AI/ML Engineer | Works on machine learning components |
+| Content Writer | Creates written content and documentation |
+
+### Orchestrator
+
+The orchestrator is a special agent that coordinates all the others. It
+reads your message, decides which agents to involve, and assembles the final
+response. You interact with the orchestrator whenever you use the chat.
+
+## The Agent Registry
+
+You can browse all available agents in the **Agent Registry**:
+
+1. Navigate to `/agent-registry` from the navigation bar.
+2. The registry has two tabs:
+   - **Backend Agents** -- the built-in AutoBot worker agents.
+   - **Specialized Agents** -- agents defined for specific project workflows.
+3. Click any agent to see its description, capabilities, and current status.
+
+<!-- Screenshot: Agent Registry with backend and specialized tabs -->
+
+### Filtering Agents
+
+Use the category filter to narrow the list. Categories include Implementation,
+Analysis, and Specialized.
+
+## When Do Agents Activate?
+
+Agents activate based on what you ask. Here are some examples:
+
+| Your Message | Agent(s) Used |
+|-------------|---------------|
+| "Summarize this document" | Knowledge retrieval agent, Chat agent |
+| "Review this code for bugs" | Code Reviewer agent |
+| "Deploy the latest changes" | DevOps Engineer agent |
+| "What are the security risks?" | Security Auditor agent |
+| "Write a unit test for this function" | Testing Engineer agent |
+
+You do not need to remember agent names. Simply describe what you need, and
+AutoBot will route it to the right agent.
+
+## Approval Requests
+
+Some agent actions require your approval before they execute. When this
+happens, you will see an **approval card** in the chat:
+
+1. Read the description of what the agent wants to do.
+2. Click **Approve** to allow the action, or **Reject** to cancel it.
+
+This ensures you stay in control of sensitive operations.
+
+<!-- Screenshot: Approval request card in chat -->
+
+## Tips
+
+- Be specific about what you want. "Fix the login bug on line 42 of auth.py"
+  gives the agent more to work with than "Fix the bug."
+- If the response is not what you expected, rephrase your request with more
+  context.
+- Check the Agent Registry to learn what each agent can do before asking
+  complex questions.
+
+## Related Guides
+
+- [Chat Interface](chat-interface.md) -- where you interact with agents
+- [Workflows](workflows.md) -- agents can be part of automated workflows
+- [Model Selection](model-selection.md) -- how the AI models behind agents are
+  chosen

--- a/docs/user/quick-start-chat.md
+++ b/docs/user/quick-start-chat.md
@@ -1,0 +1,86 @@
+# Quick Start: Your First Conversation
+
+This guide takes about five minutes. By the end, you will have sent messages to
+AutoBot, attached a file, and learned the basic chat controls.
+
+## Step 1 -- Open the Chat
+
+1. Open AutoBot in your browser.
+2. Click **AI Assistant** in the navigation bar (or go directly to `/chat`).
+
+<!-- Screenshot: Navigation bar with AI Assistant highlighted -->
+
+You will see the chat interface with a message input area at the bottom and a
+sidebar listing your conversations on the left.
+
+## Step 2 -- Send a Message
+
+1. Click the text input area at the bottom of the screen.
+2. Type a question or instruction. For example:
+
+   ```
+   What can you help me with?
+   ```
+
+3. Press **Enter** (or click the send button) to submit your message.
+4. AutoBot will process your request and display a response in the
+   conversation area.
+
+<!-- Screenshot: Chat with a sample question and response -->
+
+## Step 3 -- Start a New Conversation
+
+Each conversation is called a **session**. To start a fresh session:
+
+1. Look at the **sidebar** on the left side of the chat.
+2. Click the **New Chat** button at the top of the sidebar.
+3. A new, empty conversation will open. Your previous conversation is saved
+   and can be reopened from the sidebar at any time.
+
+## Step 4 -- Attach a File
+
+You can include files (documents, images, or data) in your messages:
+
+1. Click the **attachment button** (paperclip icon) in the input area.
+2. Select a file from your computer.
+3. The file name will appear above the text input, confirming it is attached.
+4. Type a message such as "Summarize this document" and press **Enter**.
+5. AutoBot will read the file and respond based on its contents.
+
+To remove a file before sending, click the **X** next to the file name. To
+clear all attached files, click **Clear All**.
+
+<!-- Screenshot: Chat input with an attached file -->
+
+## Step 5 -- Export or Clear a Session
+
+- **Export:** Click the **download icon** in the chat header to save the
+  conversation to a file.
+- **Clear:** Click the **trash icon** in the chat header to erase messages in
+  the current session.
+
+## Step 6 -- Check Connection Status
+
+The chat header displays a small status indicator on the right side:
+
+| Indicator | Meaning |
+|-----------|---------|
+| Green check | Connected and ready |
+| Yellow spinner | Connecting to the server |
+| Red exclamation | Disconnected -- check your network |
+
+## Tips
+
+- Press **Enter** to send a message. Use **Shift + Enter** to insert a new
+  line without sending.
+- You can ask AutoBot to help you with tasks across the platform, such as
+  "Search my knowledge base for budget reports" or "Create a new workflow."
+- Conversations are saved automatically. You can return to any session by
+  clicking it in the sidebar.
+
+## Next Steps
+
+- [Quick Start: Knowledge Base](quick-start-knowledge.md) -- learn to upload
+  documents and ask questions about them.
+- [Chat Interface Guide](guides/chat-interface.md) -- explore all chat features
+  in depth.

--- a/docs/user/quick-start-knowledge.md
+++ b/docs/user/quick-start-knowledge.md
@@ -1,0 +1,86 @@
+# Quick Start: Uploading Knowledge and Asking Questions
+
+This guide takes about five minutes. By the end, you will have uploaded a
+document to AutoBot's knowledge base and asked a question that uses it.
+
+## What is the Knowledge Base?
+
+The knowledge base is where AutoBot stores documents, notes, and other
+information. When you ask a question in the chat, AutoBot can search the
+knowledge base to give you an informed answer -- even if the information is not
+something the AI model was originally trained on.
+
+## Step 1 -- Open the Knowledge Base
+
+1. Click **Knowledge Base** in the navigation bar (or go to `/knowledge`).
+2. The Knowledge Base view opens with a sidebar on the left showing sections:
+   **Search**, **Research**, **Categories**, **Knowledge Graph**, **Manage**,
+   **Verification**, **Connectors**, **Statistics**, and **Maintenance**.
+
+<!-- Screenshot: Knowledge Base main view with sidebar -->
+
+## Step 2 -- Upload a Document
+
+1. In the sidebar, click **Manage** (under the "Manage" heading).
+2. On the Manage Knowledge page, look for the **Upload** or **Add Entry**
+   button.
+3. Click it and select a file from your computer. Supported formats typically
+   include PDF, TXT, Markdown, and common document types.
+4. Fill in any optional fields such as a title, category, or tags to help you
+   find the document later.
+5. Click **Save** or **Upload** to add the document.
+
+<!-- Screenshot: Knowledge upload form -->
+
+AutoBot will process the document in the background. Processing usually takes
+a few seconds for small files and up to a minute for larger ones.
+
+## Step 3 -- Search Your Knowledge
+
+1. In the sidebar, click **Search**.
+2. Type a keyword or question related to your uploaded document. For example,
+   if you uploaded a company policy document, try "What is the vacation
+   policy?"
+3. Press **Enter** or click the search button.
+4. Results will appear, showing relevant passages from your documents.
+
+<!-- Screenshot: Knowledge search results -->
+
+## Step 4 -- Ask AutoBot About Your Knowledge
+
+1. Go back to the **AI Assistant** (`/chat`).
+2. Type a question that relates to the document you just uploaded. For
+   example:
+
+   ```
+   Based on my uploaded documents, what are the key budget figures for Q3?
+   ```
+
+3. AutoBot will search the knowledge base automatically and include relevant
+   information in its response. You may see **citations** indicating which
+   document the information came from.
+
+## Step 5 -- Browse by Category
+
+1. In the Knowledge Base sidebar, click **Categories**.
+2. Documents are organized by category. Click a category to see all documents
+   within it.
+3. Click any document to read its content or edit its metadata.
+
+## Tips
+
+- **Tags and categories** make it easier to find documents later. Take a
+  moment to add them when uploading.
+- **Verification queue** (`/knowledge/verification`) lets you review and
+  confirm the accuracy of imported content before it is used in answers.
+- **Connectors** (`/knowledge/connectors`) allow you to import data from
+  external sources automatically.
+- The **Knowledge Graph** (`/knowledge/graph`) provides a visual map of how
+  your documents and topics relate to each other.
+
+## Next Steps
+
+- [Knowledge Management Guide](guides/knowledge-management.md) -- full guide
+  to all knowledge features.
+- [Chat Interface Guide](guides/chat-interface.md) -- learn how to get the
+  most out of conversations.


### PR DESCRIPTION
## Summary
- Creates comprehensive end-user documentation in `docs/user/`
- 3 getting-started guides (installation overview, first chat, knowledge upload)
- 6 detailed user guides (chat interface, knowledge management, agents, workflows, model selection, settings)
- README index page linking all guides
- Written for non-technical users with real frontend routes (`/chat`, `/knowledge`, `/automation`, etc.)
- Screenshot placeholders for future visual additions

**10 new files, 1088 lines**

Closes #1805

## Test plan
- [ ] All 10 files created in docs/user/
- [ ] Guides reference actual UI routes from frontend
- [ ] No developer jargon without explanation
- [ ] Each guide is self-contained and focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)