### PR TITLE
fix(backend): move testing DB from 15 to 13 (#2720)

### DIFF
--- a/autobot-infrastructure/shared/config/complete.yaml
+++ b/autobot-infrastructure/shared/config/complete.yaml
@@ -327,7 +327,7 @@ redis:
     sessions: 6
     chat_history: 8
     backup: 10
-    testing: 15
+    testing: 13    # Moved from 15 to avoid collision with celery_results (#2720)
 
   # Knowledge base specific - DB 1 per ADR-002 and ssot_config.py
   kb_db: 1


### PR DESCRIPTION
## Summary
- Move `testing` Redis DB from 15 to 13 in `complete.yaml`
- DB 15 was shared with `celery_results`, risking data cross-contamination
- DB 13 is unused in the current allocation scheme

Closes #2720

## Test plan
- [ ] No other config file references testing DB 15
- [ ] DB 13 not used by any other entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)