### PR TITLE
fix(backend): convert sync __init__ Redis calls to lazy async init (#2725)

### DIFF
--- a/autobot-backend/agents/npu_code_search_agent.py
+++ b/autobot-backend/agents/npu_code_search_agent.py
@@ -192,7 +192,7 @@ class NPUCodeSearchAgent(StandardizedAgent):
 
         # Redis setup
         self.redis_client = get_redis_client(async_client=False)
-        self.redis_async_client = get_redis_client(async_client=True)
+        self.redis_async_client = None  # Lazy init (#2725)
 
         # Worker node for NPU capabilities
         self.worker_node = WorkerNode()
@@ -246,6 +246,13 @@ class NPUCodeSearchAgent(StandardizedAgent):
         except Exception as e:
             self.logger.warning("Failed to initialize NPU: %s", e)
             self.npu_available = False
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_async_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_async_client = await get_redis_client(async_client=True)
 
     async def _ensure_search_engine_initialized(self):
         """Lazy-initialize NPU semantic search engine when needed (Issue #68)"""

--- a/autobot-backend/code_analysis/src/api_consistency_analyzer.py
+++ b/autobot-backend/code_analysis/src/api_consistency_analyzer.py
@@ -66,7 +66,7 @@ class APIConsistencyAnalyzer:
     """Analyzes API endpoints for consistency and best practices"""
 
     def __init__(self, redis_client=None):
-        self.redis_client = redis_client or get_redis_client(async_client=True)
+        self.redis_client = redis_client  # Lazy init if None (#2725)
         self.config = config
 
         # Caching keys
@@ -112,6 +112,14 @@ class APIConsistencyAnalyzer:
             self._compiled_framework_patterns[framework] = compiled_list
 
         logger.info("API Consistency Analyzer initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def analyze_api_consistency(
         self, root_path: str = ".", patterns: List[str] = None
@@ -889,6 +897,7 @@ class APIConsistencyAnalyzer:
 
     async def _cache_results(self, results: Dict[str, Any]):
         """Cache analysis results in Redis"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 key = self.API_KEY
@@ -899,6 +908,7 @@ class APIConsistencyAnalyzer:
 
     async def _clear_cache(self):
         """Clear analysis cache"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 cursor = 0

--- a/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
+++ b/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
@@ -58,7 +58,7 @@ class ArchitecturalPatternAnalyzer:
         Args:
             redis_client: Optional Redis client for caching
         """
-        self.redis_client = redis_client or get_redis_client(async_client=True)
+        self.redis_client = redis_client  # Lazy init if None (#2725)
         self.config = config
 
         # Caching keys
@@ -72,6 +72,14 @@ class ArchitecturalPatternAnalyzer:
         self._issue_detector = IssueDetector(self._dependency_analyzer)
 
         logger.info("Architectural Pattern Analyzer initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def analyze_architecture(
         self, root_path: str = ".", patterns: List[str] = None
@@ -173,6 +181,7 @@ class ArchitecturalPatternAnalyzer:
 
     async def _cache_results(self, results: Dict[str, Any]) -> None:
         """Cache analysis results in Redis."""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 key = self.ARCHITECTURE_KEY
@@ -183,6 +192,7 @@ class ArchitecturalPatternAnalyzer:
 
     async def _clear_cache(self) -> None:
         """Clear analysis cache."""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 cursor = 0

--- a/autobot-backend/code_analysis/src/code_analyzer.py
+++ b/autobot-backend/code_analysis/src/code_analyzer.py
@@ -62,7 +62,7 @@ class CodeAnalyzer:
     """Analyzes code for duplicates using Redis caching and NPU acceleration"""
 
     def __init__(self, redis_client=None, use_npu: bool = True):
-        self.redis_client = redis_client or get_redis_client(async_client=True)
+        self.redis_client = redis_client  # Lazy init if None (#2725)
         self.use_npu = use_npu
         self.config = config
 
@@ -81,6 +81,14 @@ class CodeAnalyzer:
         )
 
         logger.info(f"Code Analyzer initialized (NPU: {self.use_npu})")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def analyze_codebase(
         self, root_path: str = ".", patterns: List[str] = None
@@ -529,6 +537,7 @@ from utils.{module_name}_utils import {func.name}
 
     async def _cache_function(self, func: CodeFunction):
         """Cache function information in Redis"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 key = self.FUNCTION_KEY.format(func.ast_hash)
@@ -548,6 +557,7 @@ from utils.{module_name}_utils import {func.name}
 
     async def _cache_embedding(self, ast_hash: str, embedding: np.ndarray):
         """Cache function embedding in Redis"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 key = self.EMBEDDING_KEY.format(ast_hash)
@@ -559,6 +569,7 @@ from utils.{module_name}_utils import {func.name}
 
     async def _cache_results(self, results: Dict[str, Any]):
         """Cache analysis results in Redis"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 key = self.DUPLICATE_KEY
@@ -569,6 +580,7 @@ from utils.{module_name}_utils import {func.name}
 
     async def _clear_cache(self):
         """Clear analysis cache"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 # Clear all analysis keys
@@ -586,6 +598,7 @@ from utils.{module_name}_utils import {func.name}
 
     async def get_cached_results(self) -> Optional[Dict[str, Any]]:
         """Get cached analysis results"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 value = await self.redis_client.get(self.DUPLICATE_KEY)

--- a/autobot-backend/code_analysis/src/code_quality_dashboard.py
+++ b/autobot-backend/code_analysis/src/code_quality_dashboard.py
@@ -74,7 +74,7 @@ class CodeQualityDashboard:
     """Comprehensive code quality dashboard"""
 
     def __init__(self, redis_client=None):
-        self.redis_client = redis_client or get_redis_client(async_client=True)
+        self.redis_client = redis_client  # Lazy init if None (#2725)
         self.config = config
 
         # Initialize all analyzers
@@ -92,6 +92,14 @@ class CodeQualityDashboard:
         self.ISSUES_KEY = "code_quality:issues"
 
         logger.info("Code Quality Dashboard initialized with all analyzers")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def _gather_analysis_results(
         self, root_path: str, patterns: List[str]
@@ -791,6 +799,7 @@ class CodeQualityDashboard:
 
     async def _save_quality_trend(self, metrics: QualityMetrics, issue_count: int):
         """Save quality trend data"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 trend = QualityTrend(
@@ -818,6 +827,7 @@ class CodeQualityDashboard:
 
     async def _get_quality_trends(self) -> List[Dict[str, Any]]:
         """Get historical quality trends"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 trends = await self.redis_client.lrange(self.TRENDS_KEY, 0, -1)
@@ -828,6 +838,7 @@ class CodeQualityDashboard:
 
     async def _cache_dashboard_report(self, report: Dict[str, Any]):
         """Cache dashboard report"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 await self.redis_client.setex(

--- a/autobot-backend/code_analysis/src/env_analyzer.py
+++ b/autobot-backend/code_analysis/src/env_analyzer.py
@@ -330,7 +330,7 @@ class EnvironmentAnalyzer:
         if redis_client is not None:
             self.redis_client = redis_client
         elif _REDIS_AVAILABLE and get_redis_client is not None:
-            self.redis_client = get_redis_client(async_client=True)
+            self.redis_client = None  # Lazy init (#2725)
         else:
             self.redis_client = None
             logger.info(
@@ -386,6 +386,14 @@ class EnvironmentAnalyzer:
             self._compiled_patterns[category] = re.compile(combined)
 
         logger.info("Environment Analyzer initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def analyze_codebase(
         self, root_path: str = ".", patterns: list[str] = None
@@ -1284,6 +1292,7 @@ class EnvironmentAnalyzer:
 
     async def _cache_results(self, results: dict[str, Any]):
         """Cache analysis results in Redis"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 key = self.RECOMMENDATIONS_KEY
@@ -1294,6 +1303,7 @@ class EnvironmentAnalyzer:
 
     async def _clear_cache(self):
         """Clear analysis cache"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 # Clear all analysis keys
@@ -1311,6 +1321,7 @@ class EnvironmentAnalyzer:
 
     async def get_cached_results(self) -> dict[str, Any | None]:
         """Get cached analysis results"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 value = await self.redis_client.get(self.RECOMMENDATIONS_KEY)

--- a/autobot-backend/code_analysis/src/frontend_analyzer.py
+++ b/autobot-backend/code_analysis/src/frontend_analyzer.py
@@ -198,7 +198,7 @@ class FrontendAnalyzer:
         }
 
     def __init__(self, redis_client=None):
-        self.redis_client = redis_client or get_redis_client(async_client=True)
+        self.redis_client = redis_client  # Lazy init if None (#2725)
         self.config = config
         self.FRONTEND_KEY = "frontend_analysis:results"
         self.framework_patterns = self._build_framework_patterns()
@@ -216,6 +216,14 @@ class FrontendAnalyzer:
             for category, pattern_list in self.frontend_issues.items()
         }
         logger.info("Frontend Analyzer initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def analyze_frontend_code(
         self, root_path: str = ".", patterns: List[str] = None
@@ -842,6 +850,7 @@ class FrontendAnalyzer:
 
     async def _cache_results(self, results: Dict[str, Any]):
         """Cache analysis results"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 await self.redis_client.setex(

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -151,7 +151,7 @@ class OwnershipAnalyzer:
         if redis_client is not None:
             self.redis_client = redis_client
         elif _REDIS_AVAILABLE and get_redis_client is not None:
-            self.redis_client = get_redis_client(async_client=True)
+            self.redis_client = None  # Lazy init (#2725)
         else:
             self.redis_client = None
             logger.info("Redis not available - caching disabled for OwnershipAnalyzer")
@@ -163,6 +163,14 @@ class OwnershipAnalyzer:
         self.GAPS_KEY = "ownership_analysis:gaps"
 
         logger.info("OwnershipAnalyzer initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def analyze_ownership(
         self,
@@ -843,6 +851,7 @@ class OwnershipAnalyzer:
 
     async def _cache_results(self, results: Dict[str, Any]) -> None:
         """Cache analysis results in Redis"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 value = json.dumps(results, default=str)
@@ -852,6 +861,7 @@ class OwnershipAnalyzer:
 
     async def _clear_cache(self) -> None:
         """Clear analysis cache"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 cursor = 0
@@ -868,6 +878,7 @@ class OwnershipAnalyzer:
 
     async def get_cached_results(self) -> Optional[Dict[str, Any]]:
         """Get cached analysis results"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 value = await self.redis_client.get(self.OWNERSHIP_KEY)

--- a/autobot-backend/code_analysis/src/patch_generator.py
+++ b/autobot-backend/code_analysis/src/patch_generator.py
@@ -52,7 +52,7 @@ class AutomatedFixGenerator:
     """Generates automated code fixes based on analysis results"""
 
     def __init__(self, redis_client=None):
-        self.redis_client = redis_client or get_redis_client(async_client=True)
+        self.redis_client = redis_client  # Lazy init if None (#2725)
         self.config = config
 
         # Caching key
@@ -62,6 +62,14 @@ class AutomatedFixGenerator:
         self.fix_templates = self._initialize_fix_templates()
 
         logger.info("Automated Fix Generator initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     def _initialize_fix_templates(self) -> Dict[str, List[FixTemplate]]:
         """Initialize fix templates for common code issues.
@@ -659,6 +667,7 @@ class AutomatedFixGenerator:
 
     async def _cache_fixes(self, results: Dict[str, Any]):
         """Cache generated fixes"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 await self.redis_client.setex(

--- a/autobot-backend/code_analysis/src/performance_analyzer.py
+++ b/autobot-backend/code_analysis/src/performance_analyzer.py
@@ -100,7 +100,7 @@ class PerformanceAnalyzer:
         }
 
     def __init__(self, redis_client=None):
-        self.redis_client = redis_client or get_redis_client(async_client=True)
+        self.redis_client = redis_client  # Lazy init if None (#2725)
         self.config = config
 
         # Caching keys
@@ -111,6 +111,14 @@ class PerformanceAnalyzer:
         self.performance_patterns = self._build_performance_patterns()
 
         logger.info("Performance Analyzer initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def analyze_performance(
         self, root_path: str = ".", patterns: List[str] = None
@@ -745,6 +753,7 @@ class PerformanceAnalyzer:
 
     async def _cache_results(self, results: Dict[str, Any]):
         """Cache analysis results in Redis"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 key = self.PERFORMANCE_KEY
@@ -755,6 +764,7 @@ class PerformanceAnalyzer:
 
     async def _clear_cache(self):
         """Clear analysis cache"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 cursor = 0

--- a/autobot-backend/code_analysis/src/security_analyzer.py
+++ b/autobot-backend/code_analysis/src/security_analyzer.py
@@ -214,7 +214,7 @@ class SecurityAnalyzer:
         }
 
     def __init__(self, redis_client=None):
-        self.redis_client = redis_client or get_redis_client(async_client=True)
+        self.redis_client = redis_client  # Lazy init if None (#2725)
         self.config = config
         self.SECURITY_KEY = "security_analysis:vulnerabilities"
         self.RECOMMENDATIONS_KEY = "security_analysis:recommendations"
@@ -224,6 +224,14 @@ class SecurityAnalyzer:
             **self._build_xss_disclosure_patterns(),
         }
         logger.info("Security Analyzer initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def analyze_security(
         self, root_path: str = ".", patterns: List[str] = None
@@ -835,6 +843,7 @@ class SecurityAnalyzer:
 
     async def _cache_results(self, results: Dict[str, Any]):
         """Cache analysis results in Redis"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 key = self.SECURITY_KEY
@@ -845,6 +854,7 @@ class SecurityAnalyzer:
 
     async def _clear_cache(self):
         """Clear analysis cache"""
+        await self._ensure_redis()
         if self.redis_client:
             try:
                 cursor = 0

--- a/autobot-backend/enhanced_multi_agent_orchestrator.py
+++ b/autobot-backend/enhanced_multi_agent_orchestrator.py
@@ -80,7 +80,7 @@ class EnhancedMultiAgentOrchestrator:
 
         # Redis for distributed coordination
         self.redis_client = get_redis_client(async_client=False)
-        self.redis_async = get_redis_client(async_client=True)
+        self.redis_async = None  # Lazy init (#2725)
 
         # Agent registry with capabilities
         self.agent_capabilities = {
@@ -125,6 +125,14 @@ class EnhancedMultiAgentOrchestrator:
 
         # Agent client registry for actual agent instances
         self._agent_client_registry = AgentClientRegistry()
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_async is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_async = await get_redis_client(async_client=True)
 
     def _get_strategy_handler(self) -> ExecutionStrategyHandler:
         """Lazy initialization of strategy handler."""
@@ -450,6 +458,7 @@ class EnhancedMultiAgentOrchestrator:
 
     async def _coordinate_collaboration(self, plan: WorkflowPlan, collab_channel: str):
         """Coordinate inter-agent collaboration"""
+        await self._ensure_redis()
         try:
             pubsub = self.redis_async.pubsub()
             await pubsub.subscribe(collab_channel)
@@ -483,6 +492,7 @@ class EnhancedMultiAgentOrchestrator:
 
     async def _broadcast_to_agents(self, channel: str, data: Dict[str, Any]):
         """Broadcast data to agents on collaboration channel"""
+        await self._ensure_redis()
         await self.redis_async.publish(channel, json.dumps(data))
 
     async def _update_performance_metrics(

--- a/autobot-backend/services/fact_extraction_service.py
+++ b/autobot-backend/services/fact_extraction_service.py
@@ -40,7 +40,7 @@ class FactExtractionService:
         """
         self.knowledge_base = knowledge_base
         self.extraction_agent = KnowledgeExtractionAgent()
-        self.redis_client = get_redis_client(async_client=True)
+        self.redis_client = None  # Lazy init (#2725)
 
         # Configuration
         self.fact_storage_prefix = "atomic_fact:"
@@ -58,6 +58,14 @@ class FactExtractionService:
         )
 
         logger.info("Fact Extraction Service initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     async def _apply_fact_processing(self, extraction_result) -> None:
         """Apply deduplication and entity resolution to extracted facts (Issue #398: extracted).
@@ -857,6 +865,7 @@ class FactExtractionService:
         Returns:
             Dictionary with extraction statistics
         """
+        await self._ensure_redis()
         try:
             if not self.redis_client:
                 return {"error": "Redis client not available"}

--- a/autobot-backend/services/temporal_invalidation_service.py
+++ b/autobot-backend/services/temporal_invalidation_service.py
@@ -146,7 +146,7 @@ class TemporalInvalidationService:
             fact_extraction_service: Service for fact operations
         """
         self.fact_extraction_service = fact_extraction_service
-        self.redis_client = get_redis_client(async_client=True)
+        self.redis_client = None  # Lazy init (#2725)
 
         # Configuration
         self.invalidation_rules_key = "temporal_invalidation_rules"
@@ -167,6 +167,14 @@ class TemporalInvalidationService:
         )
 
         logger.info("Temporal Invalidation Service initialized")
+
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     def _create_default_rules(self) -> List[InvalidationRule]:
         """Create default invalidation rules."""
@@ -219,6 +227,7 @@ class TemporalInvalidationService:
 
     async def initialize_rules(self) -> Dict[str, Any]:
         """Initialize invalidation rules in Redis."""
+        await self._ensure_redis()
         try:
             if not self.redis_client:
                 return {"status": "error", "message": "Redis client not available"}
@@ -255,6 +264,7 @@ class TemporalInvalidationService:
 
     async def _load_invalidation_rules(self) -> Dict[str, InvalidationRule]:
         """Load invalidation rules from Redis."""
+        await self._ensure_redis()
         try:
             if not self.redis_client:
                 return {}
@@ -279,6 +289,7 @@ class TemporalInvalidationService:
 
     async def _store_invalidation_rules(self, rules: Dict[str, InvalidationRule]):
         """Store invalidation rules to Redis."""
+        await self._ensure_redis()
         try:
             if not self.redis_client or not rules:
                 return
@@ -717,6 +728,7 @@ class TemporalInvalidationService:
 
     async def _record_invalidation_sweep(self, **kwargs):
         """Record invalidation sweep history."""
+        await self._ensure_redis()
         try:
             if not self.redis_client:
                 return
@@ -901,6 +913,7 @@ class TemporalInvalidationService:
 
     async def get_invalidation_statistics(self) -> Dict[str, Any]:
         """Get statistics about temporal invalidation operations."""
+        await self._ensure_redis()
         try:
             if not self.redis_client:
                 return {"error": "Redis client not available"}

--- a/autobot-backend/utils/entity_resolver.py
+++ b/autobot-backend/utils/entity_resolver.py
@@ -105,7 +105,7 @@ class EntityResolver:
 
         # Models and clients
         self.embedding_model = None
-        self.redis_client = get_redis_client(async_client=True)
+        self.redis_client = None  # Lazy init (#2725)
 
         # Storage keys
         self.entity_mappings_key = "entity_mappings"
@@ -113,6 +113,13 @@ class EntityResolver:
         self.resolution_history_key = "entity_resolution_history"
 
         logger.info("Entity Resolver initialized")
+
+    async def _ensure_redis(self):
+        """Lazy-init async Redis client on first use (#2725)."""
+        if self.redis_client is None:
+            from autobot_shared.redis_client import get_redis_client
+
+            self.redis_client = await get_redis_client(async_client=True)
 
     def _get_embedding_model(self):
         """Lazy load the sentence transformer model."""
@@ -378,6 +385,7 @@ class EntityResolver:
 
     async def _load_entity_mappings(self) -> Dict[str, EntityMapping]:
         """Load existing entity mappings from Redis."""
+        await self._ensure_redis()
         try:
             if not self.redis_client:
                 return {}
@@ -404,6 +412,7 @@ class EntityResolver:
 
     async def _store_entity_mappings(self, mappings: List[EntityMapping]):
         """Store entity mappings to Redis."""
+        await self._ensure_redis()
         try:
             if not self.redis_client or not mappings:
                 return
@@ -620,6 +629,7 @@ class EntityResolver:
 
     async def get_resolution_statistics(self) -> Dict[str, Any]:
         """Get entity resolution statistics."""
+        await self._ensure_redis()
         try:
             if not self.redis_client:
                 return {"error": "Redis client not available"}


### PR DESCRIPTION
## Summary
- Convert 15 `get_redis_client(async_client=True)` calls in sync `__init__` methods to lazy async initialization
- Pattern: set `self.redis_client = None` in `__init__`, resolve via `_ensure_redis()` async helper on first use
- Zero remaining un-awaited `async_client=True` calls in codebase (verified by grep)

**Files changed (15):**
- 9 `code_analysis/src/*.py` analyzers
- `utils/entity_resolver.py`
- `services/temporal_invalidation_service.py`, `fact_extraction_service.py`
- `enhanced_multi_agent_orchestrator.py`
- `agents/npu_code_search_agent.py`

Closes #2725

## Test plan
- [ ] `grep -rn 'get_redis_client(async_client=True' --include='*.py' | grep -v await | grep -v test` returns 0 results
- [ ] Each `_ensure_redis()` correctly resolves the client and caches it
- [ ] Services that accept `redis_client` in `__init__` still work when one is passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)