### PR TITLE
fix(backend): scope analytics to active source by default (#2653)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -2067,6 +2067,11 @@ async def generate_analysis_report(
     Returns:
         Markdown formatted report as plain text
     """
+    # Default to most recent source to prevent cross-project data mixing (#2653)
+    if not source_id:
+        from api.codebase_analytics.source_storage import get_default_source_id
+
+        source_id = await get_default_source_id()
     problems = await asyncio.to_thread(_fetch_problems_from_chromadb, source_id)
     analyses = await _resolve_analyses(
         quick=quick,

--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -564,6 +564,11 @@ async def get_codebase_problems(
     source_id: Optional[str] = None,
 ):
     """Get real code problems detected during analysis (#1710: per-source)."""
+    # Default to most recent source to prevent cross-project data mixing (#2653)
+    if not source_id:
+        from api.codebase_analytics.source_storage import get_default_source_id
+
+        source_id = await get_default_source_id()
     code_collection = await asyncio.to_thread(get_code_collection)
     all_problems = []
     storage_type = "chromadb"

--- a/autobot-backend/api/codebase_analytics/source_storage.py
+++ b/autobot-backend/api/codebase_analytics/source_storage.py
@@ -89,6 +89,16 @@ async def list_sources(owner_id: Optional[str] = None) -> List[CodeSource]:
     return sources
 
 
+async def get_default_source_id() -> Optional[str]:
+    """Return the ID of the most recently indexed source, or None (#2653)."""
+    sources = await list_sources()
+    if not sources:
+        return None
+    # Prefer most recently indexed source
+    sources.sort(key=lambda s: s.last_indexed_at or "", reverse=True)
+    return sources[0].id
+
+
 async def delete_source(source_id: str) -> bool:
     """Delete a CodeSource from Redis.
 


### PR DESCRIPTION
## Summary
- Add `get_default_source_id()` to `source_storage.py` — returns most recently indexed source
- `report.py` and `stats.py` now default to active source when `source_id` not provided
- Prevents cross-project data mixing (e.g., PXE boot findings appearing in AutoBot reports)

Closes #2653

## Test plan
- [ ] `/problems` without `source_id` returns only active project's data
- [ ] `/report` without `source_id` scoped to active project
- [ ] Explicit `source_id` parameter still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)