### PR TITLE
refactor(analytics): extract methods from long analytics functions (#2735)

### DIFF
--- a/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
+++ b/autobot-backend/api/codebase_analytics/api_endpoint_scanner.py
@@ -382,6 +382,36 @@ class BackendEndpointScanner:
 
         return self.API_PREFIX, "/".join(package_parts)
 
+    def _resolve_router_context(
+        self,
+        py_file: Path,
+        content: str,
+        import_pattern,
+        import_modules_pattern,
+    ) -> tuple:
+        """Resolve parent_module, parent_prefix, child_dir, and imported maps for one file.
+
+        Issue #2735: Extracted from _scan_include_router_patterns for length compliance.
+        Issue #2652: Handles both top-level and subdirectory router files.
+        Returns (parent_module, parent_prefix, child_dir, imported_routers, imported_modules).
+        """
+        is_subdirectory = py_file.parent != self.backend_path
+        parent_module = py_file.stem
+        if is_subdirectory:
+            parent_prefix, child_dir = self._get_prefix_for_subdir_file(py_file)
+            relative_modules = self._extract_relative_imports(content, py_file.parent)
+            imported_routers, imported_modules = self._extract_router_imports(
+                content, import_pattern, import_modules_pattern
+            )
+            imported_modules.update(relative_modules)
+        else:
+            parent_prefix = self._module_prefix_map.get(parent_module, self.API_PREFIX)
+            child_dir = None
+            imported_routers, imported_modules = self._extract_router_imports(
+                content, import_pattern, import_modules_pattern
+            )
+        return parent_module, parent_prefix, child_dir, imported_routers, imported_modules
+
     def _scan_include_router_patterns(self) -> None:
         """
         Scan API files for include_router patterns to map nested routers.
@@ -401,11 +431,7 @@ class BackendEndpointScanner:
             return
 
         # Compile patterns (Issue #665: extracted)
-        (
-            import_pattern,
-            import_modules_pattern,
-            include_pattern,
-        ) = self._compile_router_patterns()
+        import_pattern, import_modules_pattern, include_pattern = self._compile_router_patterns()
 
         # Issue #2652: Use rglob to include subdirectory router files
         for py_file in self.backend_path.rglob("*.py"):
@@ -414,39 +440,14 @@ class BackendEndpointScanner:
 
             try:
                 content = py_file.read_text(encoding="utf-8")
-
-                # Determine if this is a top-level or subdirectory file
-                is_subdirectory = py_file.parent != self.backend_path
-
-                if is_subdirectory:
-                    # Issue #2652: For subdirectory files, resolve prefix from package hierarchy
-                    parent_prefix, child_dir = self._get_prefix_for_subdir_file(py_file)
-                    # Merge relative imports with absolute import maps
-                    relative_modules = self._extract_relative_imports(content, py_file.parent)
-                    imported_routers, imported_modules = self._extract_router_imports(
-                        content, import_pattern, import_modules_pattern
-                    )
-                    imported_modules.update(relative_modules)
-                    parent_module = py_file.stem
-                else:
-                    # Top-level file: existing logic
-                    parent_module = py_file.stem
-                    parent_prefix = self._module_prefix_map.get(parent_module, self.API_PREFIX)
-                    child_dir = None
-                    imported_routers, imported_modules = self._extract_router_imports(
-                        content, import_pattern, import_modules_pattern
-                    )
+                parent_module, parent_prefix, child_dir, imported_routers, imported_modules = (
+                    self._resolve_router_context(py_file, content, import_pattern, import_modules_pattern)
+                )
 
                 # Check which routers are included
                 for match in include_pattern.finditer(content):
                     router_ref = match.group(1)  # e.g., "vectorization_router" or "pattern_analysis.router"
-
-                    child_module = None
-                    if router_ref in imported_routers:
-                        child_module = imported_routers[router_ref]
-                    elif router_ref in imported_modules:
-                        child_module = imported_modules[router_ref]
-
+                    child_module = imported_routers.get(router_ref) or imported_modules.get(router_ref)
                     if child_module:
                         # Register nested router (Issue #665: extracted, #2652: extended)
                         self._register_nested_router(

--- a/autobot-backend/api/codebase_analytics/chromadb_storage.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage.py
@@ -781,15 +781,24 @@ async def _prepare_batch_data(
         source_id=source_id,
     )
 
-    stats_id, stats_doc, stats_meta = _prepare_stats_document(
-        analysis_results, source_id=source_id
-    )
-    batch_ids.append(stats_id)
-    batch_documents.append(stats_doc)
-    batch_metadatas.append(stats_meta)
+    _append_stats_document(analysis_results, batch_ids, batch_documents, batch_metadatas, source_id)
 
     update_phase("prepare", "completed")
     return batch_ids, batch_documents, batch_metadatas
+
+
+def _append_stats_document(
+    analysis_results: Dict,
+    batch_ids: list,
+    batch_documents: list,
+    batch_metadatas: list,
+    source_id: Optional[str] = None,
+) -> None:
+    """Append the codebase_stats document to the batch lists (Issue #2735)."""
+    stats_id, stats_doc, stats_meta = _prepare_stats_document(analysis_results, source_id=source_id)
+    batch_ids.append(stats_id)
+    batch_documents.append(stats_doc)
+    batch_metadatas.append(stats_meta)
 
 
 async def _upsert_with_stale_retry(
@@ -829,6 +838,70 @@ async def _upsert_with_stale_retry(
             raise
 
 
+def _slice_batch(
+    batch_ids: list,
+    batch_documents: list,
+    batch_metadatas: list,
+    batch_embeddings: Optional[List[List[float]]],
+    start_idx: int,
+    batch_size: int,
+) -> tuple:
+    """Slice batch lists to the current window. Returns (ids, docs, metas, embeddings, end_idx).
+
+    Issue #2735: Extracted from _store_single_batch for length compliance.
+    Issue #660: Preserves optional pre-computed embeddings slice.
+    """
+    end_idx = min(start_idx + batch_size, len(batch_ids))
+    slice_embeddings = batch_embeddings[start_idx:end_idx] if batch_embeddings is not None else None
+    return (
+        batch_ids[start_idx:end_idx],
+        batch_documents[start_idx:end_idx],
+        batch_metadatas[start_idx:end_idx],
+        slice_embeddings,
+        end_idx,
+    )
+
+
+async def _record_batch_progress(
+    task_id: str,
+    batch_num: int,
+    total_batches: int,
+    items_in_batch: int,
+    end_idx: int,
+    total_items: int,
+    update_progress,
+    update_stats,
+    tasks_lock: asyncio.Lock,
+    indexing_tasks: Dict,
+) -> None:
+    """Update progress counters and emit a progress event after storing a batch.
+
+    Issue #2735: Extracted from _store_single_batch for length compliance.
+    Issue #539: Thread-safe update for parallel batch processing.
+    """
+    async with tasks_lock:
+        indexing_tasks[task_id]["batches"]["completed_batches"] = batch_num
+
+    await update_progress(
+        operation="Writing to ChromaDB",
+        current=end_idx,
+        total=total_items,
+        current_file=f"Batch {batch_num}/{total_batches}",
+        phase="store",
+        batch_info={"current": batch_num, "total": total_batches, "items": items_in_batch},
+    )
+    update_stats(items_stored=end_idx)
+    logger.info(
+        "[Task %s] Stored batch %d/%d: %d items (%d/%d)",
+        task_id,
+        batch_num,
+        total_batches,
+        items_in_batch,
+        end_idx,
+        total_items,
+    )
+
+
 async def _store_single_batch(
     code_collection,
     batch_ids: list,
@@ -851,56 +924,21 @@ async def _store_single_batch(
     Returns items stored. Retries once on collection errors by
     recreating the collection reference (#1249).
     """
-    end_idx = min(start_idx + batch_size, len(batch_ids))
-    batch_slice_ids = batch_ids[start_idx:end_idx]
-    batch_slice_docs = batch_documents[start_idx:end_idx]
-    batch_slice_metas = batch_metadatas[start_idx:end_idx]
-
-    # Issue #660: Use pre-computed embeddings if available
-    batch_slice_embeddings = None
-    if batch_embeddings is not None:
-        batch_slice_embeddings = batch_embeddings[start_idx:end_idx]
+    slice_ids, slice_docs, slice_metas, slice_embeddings, end_idx = _slice_batch(
+        batch_ids, batch_documents, batch_metadatas, batch_embeddings, start_idx, batch_size
+    )
 
     # Use upsert so the preserved codebase_stats entry (#540) gets
     # updated with fresh values instead of being silently skipped by add().
     # Issue #1249: Retry once on stale collection reference.
     await _upsert_with_stale_retry(
-        code_collection,
-        batch_slice_ids,
-        batch_slice_docs,
-        batch_slice_metas,
-        batch_slice_embeddings,
-        task_id,
-        batch_num,
+        code_collection, slice_ids, slice_docs, slice_metas, slice_embeddings, task_id, batch_num
     )
-    items_in_batch = len(batch_slice_ids)
+    items_in_batch = len(slice_ids)
 
-    # Issue #539: Thread-safe update for parallel batch processing
-    async with tasks_lock:
-        indexing_tasks[task_id]["batches"]["completed_batches"] = batch_num
-
-    await update_progress(
-        operation="Writing to ChromaDB",
-        current=end_idx,
-        total=total_items,
-        current_file=f"Batch {batch_num}/{total_batches}",
-        phase="store",
-        batch_info={
-            "current": batch_num,
-            "total": total_batches,
-            "items": items_in_batch,
-        },
-    )
-    update_stats(items_stored=end_idx)
-
-    logger.info(
-        "[Task %s] Stored batch %d/%d: %d items (%d/%d)",
-        task_id,
-        batch_num,
-        total_batches,
-        items_in_batch,
-        end_idx,
-        total_items,
+    await _record_batch_progress(
+        task_id, batch_num, total_batches, items_in_batch, end_idx, total_items,
+        update_progress, update_stats, tasks_lock, indexing_tasks,
     )
     return items_in_batch
 

--- a/autobot-backend/api/codebase_analytics/endpoints/environment.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/environment.py
@@ -594,6 +594,44 @@ def _build_export_response_json(
     )
 
 
+async def _load_env_analysis_cache() -> tuple:
+    """Thread-safe cache read for export_env_analysis. Returns (full_data, error_response).
+
+    Issue #2735: Extracted from export_env_analysis for length compliance.
+    Issue #559: Thread-safe access to _env_analysis_full_cache.
+    Returns (full_data, None) on success or (None, JSONResponse) when cache is empty.
+    """
+    async with _env_analysis_cache_lock:
+        if not _env_analysis_full_cache:
+            return None, JSONResponse(
+                {
+                    "status": "error",
+                    "message": "No cached analysis available. Run environment analysis first.",
+                    "hardcoded_values": [],
+                    "recommendations": [],
+                    "total": 0,
+                },
+                status_code=404,
+            )
+        return _env_analysis_full_cache.copy(), None
+
+
+def _validate_export_severity(severity: Optional[str]) -> Optional[JSONResponse]:
+    """Return a 400 JSONResponse if severity is invalid, else None. Issue #2735."""
+    if severity and severity.lower() not in _VALID_SEVERITIES:
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": f"Invalid severity '{severity}'. Must be one of: {', '.join(sorted(_VALID_SEVERITIES))}",
+                "hardcoded_values": [],
+                "recommendations": [],
+                "total": 0,
+            },
+            status_code=400,
+        )
+    return None
+
+
 @router.get("/env-analysis/export")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -618,34 +656,15 @@ async def export_env_analysis(
     """
     Export full environment analysis results without truncation (Issue #631).
     Issue #665: Refactored to use extracted helpers for filtering and sorting.
+    Issue #2735: Cache load and severity validation extracted to helpers.
     """
-    # Check cache (thread-safe, Issue #559)
-    async with _env_analysis_cache_lock:
-        if not _env_analysis_full_cache:
-            return JSONResponse(
-                {
-                    "status": "error",
-                    "message": "No cached analysis available. Run environment analysis first.",
-                    "hardcoded_values": [],
-                    "recommendations": [],
-                    "total": 0,
-                },
-                status_code=404,
-            )
-        full_data = _env_analysis_full_cache.copy()
+    full_data, cache_error = await _load_env_analysis_cache()
+    if cache_error is not None:
+        return cache_error
 
-    # Validate severity (Issue #665: use module constant)
-    if severity and severity.lower() not in _VALID_SEVERITIES:
-        return JSONResponse(
-            {
-                "status": "error",
-                "message": f"Invalid severity '{severity}'. Must be one of: {', '.join(sorted(_VALID_SEVERITIES))}",
-                "hardcoded_values": [],
-                "recommendations": [],
-                "total": 0,
-            },
-            status_code=400,
-        )
+    severity_error = _validate_export_severity(severity)
+    if severity_error is not None:
+        return severity_error
 
     # Issue #631: Copy to avoid mutating cache; Issue #665: use helpers
     hardcoded_values = list(full_data.get("hardcoded_values", []))
@@ -658,11 +677,5 @@ async def export_env_analysis(
 
     recommendations = full_data.get("recommendations", [])
     return _build_export_response_json(
-        full_data,
-        hardcoded_values,
-        recommendations,
-        include_recommendations,
-        category,
-        severity,
-        limit,
+        full_data, hardcoded_values, recommendations, include_recommendations, category, severity, limit,
     )


### PR DESCRIPTION
## Summary
- Refactored 4 long functions in codebase analytics using Extract Method pattern
- All functions now ≤65 lines per CLAUDE.md coding standards
- Part of #2735

## Changes
| Function | Before | After | Extracted Helpers |
|----------|--------|-------|-------------------|
| `chromadb_storage._prepare_batch_data` | 66 | 61 | `_append_stats_document` |
| `chromadb_storage._store_single_batch` | 74 | 39 | `_slice_batch`, `_record_batch_progress` |
| `api_endpoint_scanner._scan_include_router_patterns` | 73 | 44 | `_resolve_router_context` |
| `environment.export_env_analysis` | 66 | 41 | `_load_env_analysis_cache`, `_validate_export_severity` |

## Test plan
- [x] Verify all refactored functions ≤65 lines (AST verified)
- [x] Pre-commit hooks pass
- [ ] No behavior changes — pure refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)