### PR TITLE
refactor(chat): extract methods from long chat/service functions (#2735)

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -1687,26 +1687,19 @@ class ChatWorkflowManager(
 
         return f"**Step {step_num}:** `{cmd}`\n- Status: {status}\n- Output:\n```\n{output_text}\n```"
 
-    def _get_continuation_instructions(
-        self,
-        original_message: str,
-        steps_completed: int,
-        consecutive_invalid_tool_calls: int = 0,
-    ) -> str:
-        """Get the critical instructions for continuation prompts.
+    def _build_tools_reminder(self, consecutive_invalid_tool_calls: int) -> str:
+        """Build an optional tool-name correction block for continuation prompts. Issue #2735.
 
-        Issue #651: Enhanced instructions to prevent premature task completion.
-        Issue #2310: Injects available-tools reminder after 2+ consecutive invalid tool calls.
+        Returns a non-empty string only when the LLM has made 2+ consecutive invalid
+        tool calls (Issue #2310), so the reminder is injected into the next prompt.
         """
-        # Issue #2310: Build optional tools reminder block when LLM has repeatedly
-        # hallucinated non-existent tool names.
-        tools_reminder = ""
-        if consecutive_invalid_tool_calls >= 2:
-            logger.warning(
-                "[Issue #2310] Injecting available-tools reminder after %d consecutive invalid tool calls",
-                consecutive_invalid_tool_calls,
-            )
-            tools_reminder = f"""
+        if consecutive_invalid_tool_calls < 2:
+            return ""
+        logger.warning(
+            "[Issue #2310] Injecting available-tools reminder after %d consecutive invalid tool calls",
+            consecutive_invalid_tool_calls,
+        )
+        return f"""
 **[SYSTEM] TOOL NAME CORRECTION REQUIRED:**
 Your last {consecutive_invalid_tool_calls} tool call(s) used invalid tool names. \
 You MUST use ONLY the following tool names:
@@ -1727,6 +1720,21 @@ You MUST use ONLY the following tool names:
 Do NOT invent new tool names. Use ONLY the names listed above.
 
 """
+
+    def _get_continuation_instructions(
+        self,
+        original_message: str,
+        steps_completed: int,
+        consecutive_invalid_tool_calls: int = 0,
+    ) -> str:
+        """Get the critical instructions for continuation prompts.
+
+        Issue #651: Enhanced instructions to prevent premature task completion.
+        Issue #2310: Injects available-tools reminder after 2+ consecutive invalid tool calls.
+        """
+        # Issue #2310: Build optional tools reminder block when LLM has repeatedly
+        # hallucinated non-existent tool names.
+        tools_reminder = self._build_tools_reminder(consecutive_invalid_tool_calls)
 
         return f"""**CRITICAL MULTI-STEP TASK INSTRUCTIONS - READ CAREFULLY:**
 {tools_reminder}

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1309,21 +1309,7 @@ class ToolHandlerMixin:
             from api.browser_mcp import send_to_browser_vm
 
             result = await send_to_browser_vm(tool_name, params)
-            summary = self._format_browser_result(tool_name, params, result)
-
-            execution_results.append(
-                {"tool": tool_name, "status": "success", "output": summary}
-            )
-            yield WorkflowMessage(
-                type="command_output",
-                content=summary,
-                metadata={
-                    "tool": tool_name,
-                    "params": params,
-                    "result": result,
-                    "status": "success",
-                },
-            )
+            yield self._record_browser_success(tool_name, params, result, execution_results)
 
         except Exception as e:
             error_msg = f"Browser tool '{tool_name}' failed: {e}"
@@ -1336,6 +1322,30 @@ class ToolHandlerMixin:
                 content=error_msg,
                 metadata={"tool": tool_name, "error": True},
             )
+
+    def _record_browser_success(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+        result: dict[str, Any],
+        execution_results: list[dict[str, Any]],
+    ) -> "WorkflowMessage":
+        """Record a successful browser tool execution and return its WorkflowMessage. Issue #2735.
+
+        Extracted from _handle_browser_tool to keep parent under 65 lines.
+        """
+        summary = self._format_browser_result(tool_name, params, result)
+        execution_results.append({"tool": tool_name, "status": "success", "output": summary})
+        return WorkflowMessage(
+            type="command_output",
+            content=summary,
+            metadata={
+                "tool": tool_name,
+                "params": params,
+                "result": result,
+                "status": "success",
+            },
+        )
 
     def _format_browser_result(
         self,
@@ -1584,15 +1594,10 @@ class ToolHandlerMixin:
         ctx: "LLMIterationContext" | None = None,
         role: str = "user",
     ):
-        """Dispatch a single tool call to appropriate handler. Issue #620.
+        """Route a tool call to the appropriate handler. Issue #620/#2310/#2629.
 
-        Issue #2310: Accepts optional ctx to track consecutive invalid tool calls
-        and inject available-tools reminder after 2 consecutive failures.
-        Issue #2629: Accepts role to forward RBAC context to MCP dispatch.
-
-        Yields:
-            WorkflowMessage for tool execution stages
-            Tuple of (break_loop, respond_content) for respond tool
+        Yields WorkflowMessage for execution stages, or (break_loop, respond_content) tuple
+        for the respond tool. Helpers handle MCP, browser, web_search, and execute_command.
         """
         tool_name = tool_call["name"]
 
@@ -1627,21 +1632,56 @@ class ToolHandlerMixin:
             return
 
         if tool_name != "execute_command":
-            # Issue #2513: Check MCP registry before reporting unknown tool.
-            # Issue #2629: Forward RBAC role so admin-only tools are enforced.
-            mcp_result = await _try_mcp_dispatch(
-                tool_name, tool_call, execution_results, role=role
-            )
-            if mcp_result is not None:
-                yield mcp_result
-                return
-
-            # Issue #2305/#2310: Report unknown tool and track consecutive failures.
-            yield self._build_unknown_tool_error(tool_name, ctx, execution_results)
+            async for msg in self._dispatch_mcp_or_unknown(tool_name, tool_call, execution_results, ctx, role):
+                yield msg
             return
 
         if ctx is not None:
             ctx.consecutive_invalid_tool_calls = 0
+        async for msg in self._dispatch_execute_command(
+            tool_call, session_id, terminal_session_id, ollama_endpoint,
+            selected_model, execution_results, additional_response_parts,
+        ):
+            yield msg
+
+    async def _dispatch_mcp_or_unknown(
+        self,
+        tool_name: str,
+        tool_call: dict[str, Any],
+        execution_results: list[dict[str, Any]],
+        ctx: "LLMIterationContext" | None,
+        role: str,
+    ):
+        """Try MCP dispatch; yield unknown-tool error if not registered. Issue #2513/#2629.
+
+        Extracted from _dispatch_tool_call (#2735) to keep parent under 65 lines.
+        """
+        # Issue #2513: Check MCP registry before reporting unknown tool.
+        # Issue #2629: Forward RBAC role so admin-only tools are enforced.
+        mcp_result = await _try_mcp_dispatch(
+            tool_name, tool_call, execution_results, role=role
+        )
+        if mcp_result is not None:
+            yield mcp_result
+            return
+
+        # Issue #2305/#2310: Report unknown tool and track consecutive failures.
+        yield self._build_unknown_tool_error(tool_name, ctx, execution_results)
+
+    async def _dispatch_execute_command(
+        self,
+        tool_call: dict[str, Any],
+        session_id: str,
+        terminal_session_id: str,
+        ollama_endpoint: str,
+        selected_model: str,
+        execution_results: list[dict[str, Any]],
+        additional_response_parts: list[str],
+    ):
+        """Delegate execute_command tool call to _process_single_command. Issue #2735.
+
+        Extracted from _dispatch_tool_call to keep parent under 65 lines.
+        """
         async for msg in self._process_single_command(
             tool_call,
             session_id,

--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -667,6 +667,46 @@ class DocIndexerService:
             logger.error("Failed to index chunk %s: %s", chunk_id, e)
             return False
 
+    def _check_hash_and_update_cache(self, file_str: str, force: bool) -> bool:
+        """Check incremental hash cache; update cache entry if changed. Issue #2735.
+
+        Returns True if the file should be skipped (hash unchanged and not forced).
+        Extracted from index_file to keep parent under 65 lines.
+        """
+        if force:
+            return False
+        rel_path = os.path.relpath(file_str, self._root_dir)
+        cache = _load_hash_cache()
+        current_hash = _compute_file_hash(file_str)
+        if cache.get(rel_path) == current_hash:
+            return True
+        cache[rel_path] = current_hash
+        _save_hash_cache(cache)
+        return False
+
+    async def _index_file_chunks(
+        self, file_str: str, content: str, rel_path: str, tier: int
+    ) -> tuple[int, int]:
+        """Chunk content and index all chunks; return (success_count, chunk_count). Issue #2735.
+
+        Extracted from index_file to keep parent under 65 lines.
+        """
+        import asyncio
+
+        chunks = _chunk_markdown(content, file_str)
+        if not chunks:
+            return 0, 0
+
+        file_tags = _extract_tags(content, file_str)
+        indexed = 0
+        for i, chunk in enumerate(chunks):
+            ok = await asyncio.to_thread(
+                self._index_chunk, chunk, i, len(chunks), rel_path, file_tags, tier
+            )
+            if ok:
+                indexed += 1
+        return indexed, len(chunks)
+
     async def index_file(
         self, file_path: Path, tier: int = 3, force: bool = False
     ) -> IndexResult:
@@ -680,8 +720,6 @@ class DocIndexerService:
         Returns:
             IndexResult with counts.
         """
-        import asyncio
-
         if not self._initialized:
             await self.initialize()
 
@@ -693,17 +731,9 @@ class DocIndexerService:
             result.errors.append(f"File not found: {file_str}")
             return result
 
-        # Hash check for incremental
-        if not force:
-            rel_path = os.path.relpath(file_str, self._root_dir)
-            cache = _load_hash_cache()
-            current_hash = _compute_file_hash(file_str)
-            if cache.get(rel_path) == current_hash:
-                result.skipped = 1
-                return result
-            # Update cache
-            cache[rel_path] = current_hash
-            _save_hash_cache(cache)
+        if self._check_hash_and_update_cache(file_str, force):
+            result.skipped = 1
+            return result
 
         try:
             content = file_path.read_text(encoding="utf-8")
@@ -711,27 +741,12 @@ class DocIndexerService:
                 result.skipped = 1
                 return result
 
-            chunks = _chunk_markdown(content, file_str)
-            if not chunks:
+            rel_path = os.path.relpath(file_str, self._root_dir)
+            indexed, total_chunks = await self._index_file_chunks(file_str, content, rel_path, tier)
+
+            if total_chunks == 0:
                 result.skipped = 1
                 return result
-
-            rel_path = os.path.relpath(file_str, self._root_dir)
-            file_tags = _extract_tags(content, file_str)
-
-            indexed = 0
-            for i, chunk in enumerate(chunks):
-                ok = await asyncio.to_thread(
-                    self._index_chunk,
-                    chunk,
-                    i,
-                    len(chunks),
-                    rel_path,
-                    file_tags,
-                    tier,
-                )
-                if ok:
-                    indexed += 1
 
             result.success = 1 if indexed > 0 else 0
             result.failed = 0 if indexed > 0 else 1

--- a/autobot-backend/services/workflow_automation/executor.py
+++ b/autobot-backend/services/workflow_automation/executor.py
@@ -509,57 +509,60 @@ class WorkflowExecutor:
             return
 
         try:
-            # Issue #2153: Resolve ${secrets.NAME} tokens before execution.
-            # Issue #2321: Capture resolved_names so redaction only scans
-            # injected secrets — not all secrets for all users.
-            owner_id = workflow.owner_id or workflow.session_id
-            resolved_command, resolved_names = _resolve_command_secrets(
-                current_step.command, owner_id
-            )
-
-            # Issue #2632: Resolve ${steps.<id>.<path>} references for ALL step
-            # types, not just vision.  Resolution is cheap and harmless for steps
-            # that have no step_config or no references in their config.
-            resolved_config = _resolve_step_references(
-                current_step.step_config or {}, workflow.step_results
-            )
-
-            # Issue #2397: Route vision node types to the vision step handler.
-            # All other step types fall through to the standard command executor.
-            if current_step.step_type in VISION_STEP_TYPES:
-                result = await self._timeout_enforcer.run_with_timeout(
-                    coro=execute_vision_step(
-                        current_step.step_type,
-                        resolved_config,
-                    ),
-                    step_id=step_id,
-                    timeout_seconds=current_step.timeout_seconds,
-                    limits=self.limits,
-                )
-            else:
-                # Issue #2159: Wrap execution in per-step timeout enforcer
-                result = await self._timeout_enforcer.run_with_timeout(
-                    coro=self._execute_command(workflow.session_id, resolved_command),
-                    step_id=step_id,
-                    timeout_seconds=current_step.timeout_seconds,
-                    limits=self.limits,
-                )
-
-            # Issue #2153: Redact any secret values that may appear in output.
-            result = _redact_result_secrets(result, owner_id, resolved_names)
-
-            await self._finalize_step_result(
-                workflow, current_step, step_id, result, workflows
-            )
-
+            await self._resolve_and_run_step(workflow, current_step, step_id, workflows)
         except StepTimeoutError as e:
-            await self._handle_step_execution_failure(
-                workflow, current_step, step_id, e
-            )
+            await self._handle_step_execution_failure(workflow, current_step, step_id, e)
         except Exception as e:
-            await self._handle_step_execution_failure(
-                workflow, current_step, step_id, e
+            await self._handle_step_execution_failure(workflow, current_step, step_id, e)
+
+    async def _resolve_and_run_step(
+        self,
+        workflow: ActiveWorkflow,
+        current_step,
+        step_id: str,
+        workflows: Dict[str, ActiveWorkflow],
+    ) -> None:
+        """Resolve secrets/step-refs, execute the step, redact output, and finalize. Issue #2735.
+
+        Extracted from approve_and_execute_step to keep parent under 65 lines.
+        Handles both vision and command step types (Issues #2153, #2321, #2397, #2632).
+        """
+        # Issue #2153: Resolve ${secrets.NAME} tokens before execution.
+        # Issue #2321: Capture resolved_names so redaction only scans
+        # injected secrets — not all secrets for all users.
+        owner_id = workflow.owner_id or workflow.session_id
+        resolved_command, resolved_names = _resolve_command_secrets(
+            current_step.command, owner_id
+        )
+
+        # Issue #2632: Resolve ${steps.<id>.<path>} references for ALL step
+        # types, not just vision.  Resolution is cheap and harmless for steps
+        # that have no step_config or no references in their config.
+        resolved_config = _resolve_step_references(
+            current_step.step_config or {}, workflow.step_results
+        )
+
+        # Issue #2397: Route vision node types to the vision step handler.
+        # All other step types fall through to the standard command executor.
+        if current_step.step_type in VISION_STEP_TYPES:
+            result = await self._timeout_enforcer.run_with_timeout(
+                coro=execute_vision_step(current_step.step_type, resolved_config),
+                step_id=step_id,
+                timeout_seconds=current_step.timeout_seconds,
+                limits=self.limits,
             )
+        else:
+            # Issue #2159: Wrap execution in per-step timeout enforcer
+            result = await self._timeout_enforcer.run_with_timeout(
+                coro=self._execute_command(workflow.session_id, resolved_command),
+                step_id=step_id,
+                timeout_seconds=current_step.timeout_seconds,
+                limits=self.limits,
+            )
+
+        # Issue #2153: Redact any secret values that may appear in output.
+        result = _redact_result_secrets(result, owner_id, resolved_names)
+        await self._finalize_step_result(workflow, current_step, step_id, result, workflows)
 
     async def _finalize_step_result(
         self,


### PR DESCRIPTION
## Summary
- Refactored 5 long functions in chat workflow and services using Extract Method pattern
- All functions now ≤65 lines per CLAUDE.md coding standards
- Part of #2735

## Changes
| Function | Before | After | Extracted Helpers |
|----------|--------|-------|-------------------|
| `tool_handler._dispatch_tool_call` | 80 | 61 | `_dispatch_mcp_or_unknown`, `_dispatch_execute_command` |
| `tool_handler._handle_browser_tool` | 68 | 54 | `_record_browser_success` |
| `manager._get_continuation_instructions` | 68 | 42 | `_build_tools_reminder` |
| `executor.approve_and_execute_step` | 79 | 33 | `_resolve_and_run_step` |
| `doc_indexer.index_file` | 75 | 50 | `_check_hash_and_update_cache`, `_index_file_chunks` |

## Test plan
- [x] Verify all refactored functions ≤65 lines (AST verified)
- [x] Pre-commit hooks pass
- [ ] No behavior changes — pure refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)