### PR TITLE
fix(backend): populate empty codebase analytics sections (#2655)

### DIFF
--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -1759,6 +1759,8 @@ async def get_performance_score(
     Get performance health score for a codebase.
 
     Issue #744: Requires admin authentication.
+    Issue #2655: Return no_data (200) instead of 400 when path does not exist
+    so the frontend can display an informative message without treating it as an error.
 
     Returns a score from 0-100 based on the number and severity
     of performance issues detected. Higher scores indicate
@@ -1766,9 +1768,14 @@ async def get_performance_score(
     """
     path_exists = await asyncio.to_thread(os.path.exists, path)
     if not path_exists:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Path does not exist: {path}",
+        logger.warning("Performance score: path does not exist: %s", path)
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "no_data",
+                "message": f"Path does not exist: {path}",
+                "performance_score": 0,
+            },
         )
 
     try:
@@ -2225,13 +2232,25 @@ async def start_security_analysis(
     path: str = Query(..., description="Directory path to analyze"),
     admin_check: bool = Depends(check_admin_permission),
 ):
-    """Start background security score analysis (#1304)."""
+    """Start background security score analysis (#1304).
+
+    Issue #2655: Return a completed no_data task instead of 400 when the path
+    does not exist. This allows the frontend to display an informative message
+    rather than treating a missing path as a hard error.
+    """
     path_exists = await asyncio.to_thread(os.path.exists, path)
     if not path_exists:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Path does not exist: {path}",
+        logger.warning("Security score analysis: path does not exist: %s", path)
+        task_id = await _sec_manager.create_task(params={"path": path})
+        await _sec_manager.complete_task(
+            task_id,
+            {
+                "status": "no_data",
+                "message": f"Path does not exist: {path}",
+                "security_score": 0,
+            },
         )
+        return {"task_id": task_id, "status": "completed"}
     task_id = await _sec_manager.create_task(params={"path": path})
     background_tasks.add_task(_run_security_analysis, task_id, path)
     return {"task_id": task_id, "status": "pending"}

--- a/autobot-backend/api/codebase_analytics/endpoints/environment.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/environment.py
@@ -199,16 +199,20 @@ def _get_environment_analyzer():
     try:
         import importlib.util
 
-        # Issue #542: Add project root so env_analyzer.py can import from utils
+        # Issue #542: Add backend root so env_analyzer.py can import from utils
+        # Issue #2655: Use autobot-backend/ (parents[3]) not repo root (parents[4])
+        backend_root = str(Path(__file__).resolve().parents[3])
         project_root = str(Path(__file__).resolve().parents[4])
-        if project_root not in sys.path:
-            sys.path.insert(0, project_root)
+        for path_entry in (backend_root, project_root):
+            if path_entry not in sys.path:
+                sys.path.insert(0, path_entry)
 
         # Issue #611: Load env_analyzer directly from file to avoid namespace conflict
+        # Issue #2655: Fixed path — env_analyzer lives in autobot-backend/code_analysis/src/,
+        # not in tools/code-analysis-suite/src/ (which does not exist in this layout).
         env_analyzer_path = (
-            Path(__file__).resolve().parents[4]
-            / "tools"
-            / "code-analysis-suite"
+            Path(__file__).resolve().parents[3]
+            / "code_analysis"
             / "src"
             / "env_analyzer.py"
         )

--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -20,6 +20,7 @@ from fastapi.responses import PlainTextResponse
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from code_intelligence.bug_predictor import BugPredictor, PredictionResult
+from constants.path_constants import PATH
 
 # Issue #244: Cross-Language Pattern Detection
 from code_intelligence.cross_language_patterns import (
@@ -1519,11 +1520,14 @@ async def _get_pattern_analysis() -> Optional[PatternAnalysisReport]:
     """
     Get code pattern analysis for the project (Issue #208).
 
+    Issue #2655: Scope analysis to autobot-backend/ (PATH.BACKEND_DIR) instead of
+    the full repo root to avoid the 180s timeout on large codebases.
+
     Returns:
         PatternAnalysisReport or None if analysis fails
     """
     try:
-        project_root = str(Path(__file__).resolve().parents[4])
+        project_root = str(PATH.BACKEND_DIR)
 
         analyzer = CodePatternAnalyzer(
             enable_clone_detection=True,
@@ -1565,12 +1569,14 @@ async def _get_duplicate_analysis() -> Optional[DuplicateAnalysis]:
 
         # Issue #1233: Use dedicated analytics executor to prevent
         # default thread pool starvation
+        # Issue #2655: Increased timeout from 60s to 120s — large codebases
+        # need more time for duplicate hash comparison across all Python/TS files.
         analysis = await asyncio.wait_for(
             asyncio.get_running_loop().run_in_executor(
                 get_analytics_executor(),
                 lambda: DuplicateCodeDetector(project_root=project_root).run_analysis(),
             ),
-            timeout=60.0,  # 60 second timeout for duplicate detection
+            timeout=120.0,  # 120 second timeout for duplicate detection
         )
 
         logger.info(
@@ -1635,8 +1641,10 @@ async def _get_bug_prediction(
         PredictionResult or None if analysis fails or times out
     """
     try:
-        # Use project root or default to current working directory
-        root = project_root or str(Path.cwd())
+        # Issue #2655: Use PATH.PROJECT_ROOT as fallback — Path.cwd() is unreliable
+        # in deployed environments where the backend process CWD may differ from
+        # the project root, causing FileNotFoundError in git subprocess calls.
+        root = project_root or str(PATH.PROJECT_ROOT)
 
         # Issue #1233: Use dedicated analytics executor to prevent
         # default thread pool starvation

--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -332,17 +332,24 @@ class CrossLanguagePatternDetector:
         return any(skip in path.parts for skip in _SKIP_DIRS)
 
     async def _collect_files(self) -> Tuple[List[Path], List[Path], List[Path]]:
-        """Collect files to analyze by language."""
+        """Collect files to analyze by language.
+
+        Issue #2655: Fixed Python search dirs — AutoBot uses 'autobot-backend/'
+        at the project root, not 'backend/' or 'src/'.
+        """
         python_files = []
         typescript_files = []
         vue_files = []
 
-        backend_dir = self.project_root / "backend"
+        # Issue #2655: Search 'autobot-backend/' (AutoBot layout) as well as the
+        # legacy 'backend/' and 'src/' paths for compatibility with other project layouts.
+        backend_dir = self.project_root / "autobot-backend"
+        legacy_backend_dir = self.project_root / "backend"
         src_dir = self.project_root / "src"
         frontend_dir = self.project_root / "autobot-frontend" / "src"
 
         # Collect Python files
-        for search_dir in [backend_dir, src_dir]:
+        for search_dir in [backend_dir, legacy_backend_dir, src_dir]:
             if search_dir.exists():
                 for file_path in search_dir.rglob("*.py"):
                     if not self._should_skip_directory(file_path):


### PR DESCRIPTION
## Summary
- Fix cross-language patterns detector to search `autobot-backend/` instead of non-existent `src/`
- Fix environment endpoint to find `env_analyzer.py` at correct path
- Fix report endpoint to scope pattern analysis to backend dir (prevents 180s timeout)
- Fix `code_intelligence.py` to return `no_data` status instead of HTTP 400 for missing paths

Closes #2655

## Test plan
- [ ] Cross-language patterns section returns data
- [ ] Environment analysis section returns data
- [ ] Pattern analysis completes within timeout
- [ ] Security/performance scores return `no_data` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)