### PR TITLE
fix(backend): revert_prompt returns 404 instead of 500 (#2745)

### DIFF
--- a/autobot-backend/api/prompts.py
+++ b/autobot-backend/api/prompts.py
@@ -452,6 +452,9 @@ async def revert_prompt(
             )
         )
         return await _write_prompt_from_default(prompt_id, default_file_path, prompts_dir)
+    except HTTPException:
+        # Re-raise HTTP exceptions (e.g. 404 from _write_prompt_from_default) — #2745
+        raise
     except OSError as e:
         logger.error("Failed to read/write prompt file during revert %s: %s", prompt_id, e)
         raise HTTPException(status_code=500, detail="Failed to access prompt file")


### PR DESCRIPTION
## Summary
- Add `except HTTPException: raise` before catch-all in `revert_prompt` endpoint
- Prevents 404 from `_write_prompt_from_default` being swallowed and replaced with 500
- Same pattern already used in `get_prompts` (line 277)

Closes #2745

## Test plan
- [ ] `revert_prompt` returns 404 when default file missing
- [ ] Other errors still return 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)