### PR TITLE
fix(backend): harden local node detection in code source (#2721)

### DIFF
--- a/autobot-slm-backend/api/code_source.py
+++ b/autobot-slm-backend/api/code_source.py
@@ -186,11 +186,14 @@ def _get_local_ips() -> set:
     except Exception:
         pass
     # Also include the configured external_url IP
-    from config import settings
+    try:
+        from config import settings
 
-    own_ip = urlparse(settings.external_url).hostname or ""
-    if own_ip:
-        local_ips.add(own_ip)
+        own_ip = urlparse(settings.external_url).hostname or ""
+        if own_ip:
+            local_ips.add(own_ip)
+    except Exception:
+        pass
     return local_ips
 
 

--- a/autobot-slm-backend/api/code_source_test.py
+++ b/autobot-slm-backend/api/code_source_test.py
@@ -36,6 +36,9 @@ code_source_module = __import__("importlib.util").util.module_from_spec(spec)
 sys.modules["services.auth"] = MagicMock()
 sys.modules["services.database"] = MagicMock()
 sys.modules["models.database"] = MagicMock()
+_mock_config = MagicMock()
+_mock_config.settings.external_url = "http://172.16.168.19:8080"
+sys.modules["config"] = _mock_config
 
 spec.loader.exec_module(code_source_module)
 


### PR DESCRIPTION
## Summary
- Wrap config import in `_get_local_ips()` with try/except for graceful degradation
- Add config mock to test setup for `_is_local_node` tests
- Core local-vs-SSH branching logic was already implemented in upstream — this hardens edge cases

Closes #2721

## Test plan
- [ ] Code source assignment works on SLM Manager without SSH
- [ ] `_get_local_ips()` doesn't crash when config unavailable
- [ ] Tests pass with config mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)