### PR TITLE
fix(backend): fix sync for newly added repos in analytics (#2654)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/sources.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources.py
@@ -313,6 +313,25 @@ async def delete_code_source(source_id: str):
     return JSONResponse({"success": ok, "source_id": source_id})
 
 
+@router.get("/sources/summary")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="batch_source_summary",
+    error_code_prefix="CODEBASE",
+)
+async def get_all_source_summaries():
+    """Return summaries for all sources in one request (#1468).
+
+    Replaces N+1 per-source /summary calls from the landing page.
+    Registered before /sources/{source_id}/summary to avoid the literal
+    string "summary" being captured by the {source_id} path parameter (#2654).
+    """
+    sources = await list_sources()
+    results = await asyncio.gather(*[_build_summary(s) for s in sources])
+    summaries = {r["source_id"]: r for r in results}
+    return JSONResponse({"summaries": summaries})
+
+
 @router.post("/sources/{source_id}/sync")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -483,23 +502,6 @@ async def _build_summary(source: CodeSource) -> dict:
         "last_indexed": last_indexed,
         "last_commit": last_commit,
     }
-
-
-@router.get("/sources/summary")
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="batch_source_summary",
-    error_code_prefix="CODEBASE",
-)
-async def get_all_source_summaries():
-    """Return summaries for all sources in one request (#1468).
-
-    Replaces N+1 per-source /summary calls from the landing page.
-    """
-    sources = await list_sources()
-    results = await asyncio.gather(*[_build_summary(s) for s in sources])
-    summaries = {r["source_id"]: r for r in results}
-    return JSONResponse({"summaries": summaries})
 
 
 @router.get("/sources/{source_id}/summary")

--- a/autobot-backend/api/codebase_analytics/source_storage.py
+++ b/autobot-backend/api/codebase_analytics/source_storage.py
@@ -94,8 +94,8 @@ async def get_default_source_id() -> Optional[str]:
     sources = await list_sources()
     if not sources:
         return None
-    # Prefer most recently indexed source
-    sources.sort(key=lambda s: s.last_indexed_at or "", reverse=True)
+    # Prefer most recently synced source
+    sources.sort(key=lambda s: s.last_synced or "", reverse=True)
     return sources[0].id
 
 


### PR DESCRIPTION
## Summary
- **Route collision fix:** Move `GET /sources/summary` before `GET /sources/{source_id}` — FastAPI was matching "summary" as a source_id, returning 404
- **AttributeError fix:** `get_default_source_id()` referenced non-existent `last_indexed_at` — changed to `last_synced`

Closes #2654

## Test plan
- [ ] `GET /api/analytics/codebase/sources/summary` returns batch summaries
- [ ] Newly added repos appear on the landing page with correct status
- [ ] `get_default_source_id()` doesn't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)