### PR TITLE
fix(backend): suppress false positive db.execute in blocking detection (#2656)

### DIFF
--- a/autobot-backend/code_intelligence/performance_analysis/ast_visitor.py
+++ b/autobot-backend/code_intelligence/performance_analysis/ast_visitor.py
@@ -10,7 +10,7 @@ Contains the AST visitor that analyzes code for performance patterns.
 
 import ast
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from .patterns import (
     BLOCKING_IO_OPERATIONS,
@@ -47,28 +47,38 @@ class PerformanceASTVisitor(ast.NodeVisitor):
         self.loop_stack: List[ast.AST] = []
         self.function_calls_in_loop: List[tuple] = []
         self.awaits_in_function: List[ast.Await] = []
+        # Issue #2656: Track node IDs of Call nodes that are directly awaited.
+        # When visit_Await fires before generic_visit descends into the awaited
+        # Call, we record the Call's id() so _check_blocking_in_async can skip
+        # it — an awaited call is already async-safe by definition.
+        self._awaited_call_ids: Set[int] = set()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         """Analyze synchronous function definitions."""
         old_function = self.current_function
         old_async = self.async_context
+        old_awaited_ids = self._awaited_call_ids
         self.current_function = node.name
         self.async_context = False
         self.awaits_in_function = []
+        self._awaited_call_ids = set()
 
         self._analyze_function(node)
         self.generic_visit(node)
 
         self.current_function = old_function
         self.async_context = old_async
+        self._awaited_call_ids = old_awaited_ids
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         """Analyze async function definitions."""
         old_function = self.current_function
         old_async = self.async_context
+        old_awaited_ids = self._awaited_call_ids
         self.current_function = node.name
         self.async_context = True
         self.awaits_in_function = []
+        self._awaited_call_ids = set()
 
         self._analyze_function(node)
         self._check_sequential_awaits(node)
@@ -76,6 +86,7 @@ class PerformanceASTVisitor(ast.NodeVisitor):
 
         self.current_function = old_function
         self.async_context = old_async
+        self._awaited_call_ids = old_awaited_ids
 
     def visit_For(self, node: ast.For) -> None:
         """Analyze for loops."""
@@ -115,8 +126,15 @@ class PerformanceASTVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Await(self, node: ast.Await) -> None:
-        """Track await expressions."""
+        """Track await expressions.
+
+        Issue #2656: Record the node ID of any Call that is directly awaited so
+        that _check_blocking_in_async can skip it.  A call inside ``await``
+        is already async-safe — flagging it as blocking is a false positive.
+        """
         self.awaits_in_function.append(node)
+        if isinstance(node.value, ast.Call):
+            self._awaited_call_ids.add(id(node.value))
         self.generic_visit(node)
 
     def visit_BinOp(self, node: ast.BinOp) -> None:
@@ -559,8 +577,17 @@ class PerformanceASTVisitor(ast.NodeVisitor):
         """Check for blocking operations in async context.
 
         Issue #281/#385/#665: Refactored with confidence-based pattern matching.
+        Issue #2656: Skip calls that are directly awaited — they are async-safe
+        by definition (e.g. ``await db.execute(...)`` with SQLAlchemy AsyncSession).
         """
         if not self.async_context:
+            return
+
+        # Issue #2656: A call wrapped in ``await`` is already async-safe.
+        # visit_Await registers the inner Call's id() before generic_visit
+        # descends into it, so by the time visit_Call fires for that node
+        # the id is already present in _awaited_call_ids.
+        if id(node) in self._awaited_call_ids:
             return
 
         call_name = self._get_call_name(node)

--- a/autobot-backend/code_intelligence/performance_analysis/patterns.py
+++ b/autobot-backend/code_intelligence/performance_analysis/patterns.py
@@ -150,6 +150,12 @@ SAFE_PATTERNS = {
     # Async wrapping - already offloaded to thread
     "asyncio.to_thread": "already offloaded via asyncio.to_thread()",
     "run_in_executor": "already offloaded via run_in_executor()",
+    # Issue #2656: SQLAlchemy AsyncSession / async-engine execute() is
+    # async-safe and always used with ``await`` in async FastAPI handlers.
+    # Flagging these as blocking produces a false positive.
+    "db.execute": "SQLAlchemy AsyncSession.execute() - async-safe",
+    "session.execute": "SQLAlchemy AsyncSession.execute() - async-safe",
+    "conn.execute": "SQLAlchemy async connection.execute() - async-safe",
     # Logging calls - non-blocking in practice (Issue #1226)
     "logger.info": "logger call (non-blocking)",
     "logger.debug": "logger call (non-blocking)",

--- a/autobot-backend/code_intelligence/performance_analyzer_test.py
+++ b/autobot-backend/code_intelligence/performance_analyzer_test.py
@@ -280,6 +280,90 @@ class TestAsyncSyncMismatch:
 
             assert len(sync_results) == 0
 
+    def test_no_false_positive_sqlalchemy_async_execute(self):
+        """Issue #2656: awaited db.execute() must not be flagged as blocking.
+
+        SQLAlchemy's AsyncSession.execute() is async-safe.  The analyzer was
+        matching the generic ``.execute(`` medium-confidence pattern and
+        reporting a false positive for every ``await db.execute(...)`` call.
+        """
+        code = textwrap.dedent("""
+            from sqlalchemy.ext.asyncio import AsyncSession
+
+            async def get_users(db: AsyncSession):
+                result = await db.execute(
+                    "SELECT * FROM users"
+                )
+                return result.fetchall()
+
+            async def get_order(db: AsyncSession, order_id: int):
+                result = await db.execute(
+                    "SELECT * FROM orders WHERE id = :id",
+                    {"id": order_id},
+                )
+                return result.fetchone()
+
+            async def get_items(session: AsyncSession):
+                result = await session.execute(
+                    "SELECT * FROM items"
+                )
+                return result.scalars().all()
+        """)
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", delete=False, mode="w", encoding="utf-8"
+        ) as f:
+            f.write(code)
+            f.flush()
+
+            analyzer = PerformanceAnalyzer()
+            results = analyzer.analyze_file(f.name)
+
+            blocking_results = [
+                r
+                for r in results
+                if r.issue_type == PerformanceIssueType.BLOCKING_IO_IN_ASYNC
+                and "execute" in (r.current_code or "").lower()
+            ]
+
+            assert blocking_results == [], (
+                f"False positive: awaited db.execute() was flagged as blocking: "
+                f"{[r.description for r in blocking_results]}"
+            )
+
+    def test_no_false_positive_awaited_call_generic(self):
+        """Issue #2656: any directly-awaited call must not be flagged as blocking.
+
+        The AST-level fix ensures that any call wrapped in ``await`` is
+        recognised as async-safe before pattern matching runs.
+        """
+        code = textwrap.dedent("""
+            async def fetch_data(client):
+                data = await client.execute("query")
+                row = await client.fetchone()
+                return data, row
+        """)
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", delete=False, mode="w", encoding="utf-8"
+        ) as f:
+            f.write(code)
+            f.flush()
+
+            analyzer = PerformanceAnalyzer()
+            results = analyzer.analyze_file(f.name)
+
+            blocking_results = [
+                r
+                for r in results
+                if r.issue_type == PerformanceIssueType.BLOCKING_IO_IN_ASYNC
+            ]
+
+            assert blocking_results == [], (
+                f"False positive: directly-awaited call flagged as blocking: "
+                f"{[r.description for r in blocking_results]}"
+            )
+
 
 class TestStringConcatenation:
     """Test string concatenation pattern detection."""


### PR DESCRIPTION
## Summary
- AST visitor tracks awaited call node IDs — directly-awaited calls excluded from blocking detection
- Added `db.execute`, `session.execute`, `conn.execute` to `SAFE_PATTERNS`
- Two new test cases: SQLAlchemy async execute and generic awaited calls

Closes #2656

## Test plan
- [ ] `await db.execute(...)` not flagged as blocking
- [ ] `await session.execute(...)` not flagged
- [ ] Non-awaited blocking calls still detected
- [ ] New tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)