### PR TITLE
fix(slm): remove hardcoded external_url default, write SLM_EXTERNAL_URL at deploy (#2758)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-secrets.env.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-secrets.env.j2
@@ -13,3 +13,8 @@ SLM_ADMIN_PASSWORD={{ slm_admin_password }}
 # Override /opt/autobot/.env which has 0.0.0.0 (backend bind addr, not target)
 # SLM must connect to the backend at its actual IP (#915)
 AUTOBOT_BACKEND_HOST={{ main_host | default('172.16.168.20') }}
+
+# Issue #2758: set external_url to this node's actual routable IP so that
+# self-detection logic (e.g. _is_local_node) works correctly.
+# ansible_default_ipv4.address is the primary non-loopback interface IP.
+SLM_EXTERNAL_URL=https://{{ ansible_default_ipv4.address }}

--- a/autobot-slm-backend/config.py
+++ b/autobot-slm-backend/config.py
@@ -11,6 +11,7 @@ PostgreSQL replaces SQLite for all database operations (Issue #786).
 import logging
 import os
 import secrets
+import socket
 import stat
 from pathlib import Path
 from typing import Optional
@@ -23,6 +24,25 @@ logger = logging.getLogger(__name__)
 # Filename for the auto-generated persistent keys file inside data_dir.
 # Issue #1726 — keeps keys stable across restarts when env vars are absent.
 _SLM_KEYS_FILE = ".slm_keys"
+
+
+def _get_local_ip() -> str:
+    """Return the machine's primary outbound IP address.
+
+    Opens a UDP socket toward a public address (no packet is actually sent)
+    to let the OS select the correct source interface, then reads the bound
+    address.  Falls back to ``127.0.0.1`` if the probe fails (e.g. no
+    network at import time), which is safe because callers that need a
+    routable IP should always set ``SLM_EXTERNAL_URL`` via the env file.
+
+    Issue #2758 — prevents external_url from defaulting to a hardcoded IP.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            return sock.getsockname()[0]
+    except OSError:
+        return "127.0.0.1"
 
 
 def _get_cors_origins() -> list:
@@ -236,9 +256,11 @@ class Settings(BaseSettings):
         if ip.strip()
     ]
 
-    # External URL - remote nodes use nginx reverse proxy
+    # External URL - remote nodes use nginx reverse proxy.
+    # Issue #2758: derive dynamically from local IP when SLM_EXTERNAL_URL is
+    # not set, instead of defaulting to a hardcoded address.
     external_url: str = os.getenv(
-        "SLM_EXTERNAL_URL", "https://172.16.168.19"  # noqa: ssot-fallback
+        "SLM_EXTERNAL_URL", f"https://{_get_local_ip()}"
     )
 
     model_config = ConfigDict(

--- a/install.sh
+++ b/install.sh
@@ -392,13 +392,18 @@ INVENTORY
 
     if [[ ! -f "${SECRETS_FILE}" ]] || [[ "${REINSTALL}" == true ]]; then
         info "Writing secrets file..."
-        local secret_key encryption_key
+        local secret_key encryption_key local_ip
         secret_key=$(openssl rand -hex 32)
         encryption_key=$(openssl rand -hex 32)
+        # Issue #2758: detect the machine's primary outbound IP so that
+        # SLM_EXTERNAL_URL is set correctly and not left to the Python fallback.
+        local_ip=$(ip route get 1.1.1.1 2>/dev/null | awk '{print $7; exit}' \
+            || hostname -I | awk '{print $1}')
         cat > "${SECRETS_FILE}" << EOF
 SLM_SECRET_KEY=${secret_key}
 SLM_ENCRYPTION_KEY=${encryption_key}
 SLM_ADMIN_PASSWORD=${ADMIN_PASSWORD}
+SLM_EXTERNAL_URL=https://${local_ip}
 EOF
         chmod 600 "${SECRETS_FILE}"
         success "  Secrets written to ${SECRETS_FILE}"


### PR DESCRIPTION
## Summary
- Replaced hardcoded `https://172.16.168.19` fallback in `config.py` with a socket-based local IP probe (`_get_local_ip()`)
- Added `SLM_EXTERNAL_URL=https://{{ ansible_default_ipv4.address }}` to `slm-secrets.env.j2` — Ansible now writes correct IP for fleet deploys
- Added `SLM_EXTERNAL_URL=https://${local_ip}` to `install.sh` secrets file — single-host installs get correct IP at install time

## Test plan
- [ ] Fresh install: verify `/etc/autobot/slm-secrets.env` contains `SLM_EXTERNAL_URL` with the machine's actual IP
- [ ] Fleet deploy: verify `slm-secrets.env` on SLM Manager node contains correct IP from `ansible_default_ipv4.address`
- [ ] With `.env` absent: verify `settings.external_url` equals the machine's primary interface IP (not 172.16.168.19)
- [ ] With `SLM_EXTERNAL_URL` set in env: verify explicit value is still honoured

Closes #2758

🤖 Generated with [Claude Code](https://claude.com/claude-code)