### PR TITLE
fix(ci): prevent stale CodeQL check status on PRs (#2699)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,15 +8,19 @@ name: CodeQL Analysis
 on:
   push:
     branches: [main, Dev_new_gui]
+    paths: ["autobot-backend/**", "autobot-shared/**", "autobot-slm-backend/**", "*.py"]
   pull_request:
     branches: [main, Dev_new_gui]
+    paths: ["autobot-backend/**", "autobot-shared/**", "autobot-slm-backend/**", "*.py"]
   schedule:
     # Run CodeQL analysis weekly on Sundays at 3 AM UTC
     - cron: "0 3 * * 0"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Let CodeQL runs complete — cancelling produces stale 3s failures (#2699)
+  cancel-in-progress: false
 
 permissions:
   actions: read


### PR DESCRIPTION
## Summary
- Changed `cancel-in-progress` to `false` — cancelled CodeQL runs were producing misleading 3s failure statuses
- Added `paths` filter so CodeQL only triggers on Python file changes (avoids unnecessary runs on docs/frontend PRs)
- Added `workflow_dispatch` trigger for manual re-runs

## Root cause
When multiple pushes happen on the same PR branch quickly, `cancel-in-progress: true` kills the older CodeQL run. The cancelled run reports as "failed" with ~3s duration, creating noise in PR check status.

## Test plan
- [ ] Push to a PR and verify CodeQL either runs fully or is skipped (no 3s stale failures)
- [ ] Frontend-only PR: CodeQL should not trigger at all
- [ ] Manual trigger via Actions tab works

Closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)