### PR TITLE
refactor(workflow): remove redundant StepTimeoutError except clause (#2746)

### DIFF
--- a/autobot-backend/services/workflow_automation/executor.py
+++ b/autobot-backend/services/workflow_automation/executor.py
@@ -30,7 +30,6 @@ from .models import (
 from .safety_limits import (
     CostTracker,
     StepTimeoutEnforcer,
-    StepTimeoutError,
     WorkflowLimits,
 )
 from .state_machine import WorkflowPhase, WorkflowStateMachine
@@ -510,8 +509,6 @@ class WorkflowExecutor:
 
         try:
             await self._resolve_and_run_step(workflow, current_step, step_id, workflows)
-        except StepTimeoutError as e:
-            await self._handle_step_execution_failure(workflow, current_step, step_id, e)
         except Exception as e:
             await self._handle_step_execution_failure(workflow, current_step, step_id, e)
 


### PR DESCRIPTION
## Summary
- Removed redundant `except StepTimeoutError` clause that was already caught by the subsequent `except Exception` handler
- Removed unused `StepTimeoutError` import from safety_limits
- Both clauses called identical handler with identical arguments — no behavior change

Closes #2746

## Test plan
- [x] py_compile passes
- [ ] Workflow executor still handles timeouts correctly (caught by Exception handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)