### PR TITLE
refactor(analytics): extract duplicated source-root resolution (#2760)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/report.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/report.py
@@ -51,7 +51,7 @@ from ..api_endpoint_scanner import APIEndpointChecker
 from ..duplicate_detector import DuplicateAnalysis, DuplicateCodeDetector  # noqa: F401
 from ..models import APIEndpointAnalysis
 from ..storage import get_code_collection
-from .shared import filter_problems_by_file_existence, get_project_root
+from .shared import filter_problems_by_file_existence, get_project_root, resolve_source_root
 
 logger = logging.getLogger(__name__)
 
@@ -2100,18 +2100,9 @@ async def generate_analysis_report(
 
         source_id = await get_default_source_id()
 
-    # Issue #2724: Resolve source root asynchronously so _fetch_problems_from_chromadb
+    # Issue #2724 / #2760: Resolve source root via shared helper so _fetch_problems_from_chromadb
     # (which runs in a thread) can validate file paths without blocking the event loop.
-    source_root: Optional[Path] = None
-    if source_id:
-        try:
-            from api.codebase_analytics.source_storage import get_source
-
-            source = await get_source(source_id)
-            if source and source.clone_path:
-                source_root = Path(source.clone_path)
-        except Exception as _src_exc:
-            logger.debug("Could not resolve source root for %s: %s", source_id, _src_exc)
+    source_root = await resolve_source_root(source_id)
 
     problems = await asyncio.to_thread(_fetch_problems_from_chromadb, source_id, source_root)
     analyses = await _resolve_analyses(

--- a/autobot-backend/api/codebase_analytics/endpoints/shared.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/shared.py
@@ -147,6 +147,32 @@ COMMON_THIRD_PARTY = {
 }
 
 
+async def resolve_source_root(source_id: "str | None") -> "Path | None":
+    """Resolve the filesystem root for a given source ID.
+
+    Issue #2760: Extracted from duplicated blocks in report.py and stats.py.
+    Both endpoints contained identical 10-line blocks; this single helper
+    replaces both.
+
+    Args:
+        source_id: The source identifier to look up, or None.
+
+    Returns:
+        Path to the source clone directory, or None if unresolvable.
+    """
+    if not source_id:
+        return None
+    try:
+        from api.codebase_analytics.source_storage import get_source
+
+        source = await get_source(source_id)
+        if source and source.clone_path:
+            return Path(source.clone_path)
+    except Exception as exc:
+        logger.debug("Could not resolve source root for %s: %s", source_id, exc)
+    return None
+
+
 # Project root helper
 def get_project_root() -> Path:
     """

--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -19,7 +19,7 @@ from utils.chromadb_client import get_all_paginated
 
 from ..scanner import _tasks_sync_lock, indexing_tasks
 from ..storage import get_code_collection, get_redis_connection
-from .shared import _in_memory_storage, filter_problems_by_file_existence, get_project_root
+from .shared import _in_memory_storage, filter_problems_by_file_existence, get_project_root, resolve_source_root
 
 logger = logging.getLogger(__name__)
 
@@ -416,7 +416,7 @@ def _fetch_problems_from_chromadb(
     problems = [_parse_problem_metadata(m) for m in results.get("metadatas", [])]
 
     # Issue #2724: Validate file paths against the indexed repository root.
-    root = Path(source_root) if source_root else get_project_root()
+    root = source_root if source_root else get_project_root()
     return filter_problems_by_file_existence(problems, root)
 
 
@@ -581,18 +581,9 @@ async def get_codebase_problems(
 
         source_id = await get_default_source_id()
 
-    # Issue #2724: Resolve source root asynchronously so _fetch_problems_from_chromadb
+    # Issue #2724 / #2760: Resolve source root via shared helper so _fetch_problems_from_chromadb
     # can validate file paths without needing to do async I/O in a sync context.
-    source_root: Optional[Path] = None
-    if source_id:
-        try:
-            from api.codebase_analytics.source_storage import get_source
-
-            source = await get_source(source_id)
-            if source and source.clone_path:
-                source_root = Path(source.clone_path)
-        except Exception as _src_exc:
-            logger.debug("Could not resolve source root for %s: %s", source_id, _src_exc)
+    source_root = await resolve_source_root(source_id)
 
     code_collection = await asyncio.to_thread(get_code_collection)
     all_problems = []


### PR DESCRIPTION
## Summary
- Extracted duplicated source-root resolution logic from report.py and stats.py into shared `resolve_source_root()` helper
- Fixed redundant `Path()` re-wrapping in stats.py
- Both endpoints now call the single shared function

Closes #2760

## Test plan
- [x] py_compile passes on all 3 changed files
- [ ] Existing analytics tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)