### PR TITLE
refactor(shared): consolidate local-node detection (#2759)

### DIFF
--- a/autobot-shared/network_utils.py
+++ b/autobot-shared/network_utils.py
@@ -1,0 +1,95 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Network utility helpers for local-node detection (Issue #2759).
+
+Consolidates three separate implementations of 'is this the local machine?'
+logic from sync_orchestrator, code_sync, and code_source into one place.
+
+The most robust implementation (from code_source.py, hardened in #2721) is
+used as the base: it runs ``ip -4 addr show`` to enumerate all interface IPs
+and also includes the hostname resolved from ``settings.external_url`` so the
+check works even when the process is behind a reverse proxy.
+"""
+
+import logging
+import re
+import subprocess
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Loopback / well-known local aliases always considered local
+_LOOPBACK: frozenset = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def get_local_ips() -> set:
+    """Return all IP addresses (and aliases) that identify this machine.
+
+    Includes:
+    - Loopback addresses (127.0.0.1, localhost, ::1)
+    - All IPv4 addresses reported by ``ip -4 addr show``
+    - The hostname extracted from ``settings.external_url`` (SSOT config)
+
+    Returns:
+        A set of strings that are considered local identifiers.
+    """
+    local_ips: set = set(_LOOPBACK)
+
+    # Enumerate all interface IPs via ``ip addr``
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "addr", "show"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=5,
+        )
+        for match in re.finditer(r"inet (\d+\.\d+\.\d+\.\d+)", result.stdout):
+            local_ips.add(match.group(1))
+    except Exception:
+        pass
+
+    # Also include the IP/hostname from the configured external_url
+    try:
+        from config import settings  # local import — only available in backend context
+
+        own_host = urlparse(settings.external_url).hostname or ""
+        if own_host:
+            local_ips.add(own_host)
+    except Exception:
+        pass
+
+    return local_ips
+
+
+def is_local_ip(ip: str) -> bool:
+    """Return True if *ip* resolves to this machine.
+
+    Args:
+        ip: An IPv4 address string (or ``localhost`` / ``127.0.0.1``).
+
+    Returns:
+        True when the given address is one of the local IPs for this host.
+    """
+    return ip in get_local_ips()
+
+
+def is_local_host(hostname_or_url: str) -> bool:
+    """Return True if *hostname_or_url* identifies this machine.
+
+    Accepts either a bare hostname / IP or a full URL.  If a URL is given
+    the hostname is extracted first via ``urlparse``.
+
+    Args:
+        hostname_or_url: A bare IP / hostname, or a URL such as
+            ``https://172.16.168.19:8443``.
+
+    Returns:
+        True when the extracted host is one of the local addresses.
+    """
+    # Try as URL first; fall back to treating the whole string as a host
+    parsed = urlparse(hostname_or_url)
+    host = parsed.hostname or hostname_or_url
+    return is_local_ip(host)

--- a/autobot-slm-backend/api/code_source.py
+++ b/autobot-slm-backend/api/code_source.py
@@ -15,8 +15,6 @@ import tempfile
 from pathlib import Path
 from datetime import datetime
 from typing import List, Optional
-from urllib.parse import urlparse
-
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -168,38 +166,16 @@ async def _ensure_code_source_role(db: AsyncSession, node_id: str) -> None:
         )
 
 
-def _get_local_ips() -> set:
-    """Return all IPv4 addresses assigned to this machine (#2721)."""
-    import re
-    import subprocess
-
-    local_ips = {"127.0.0.1", "localhost"}
-    try:
-        result = subprocess.run(
-            ["ip", "-4", "addr", "show"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        for match in re.finditer(r"inet (\d+\.\d+\.\d+\.\d+)", result.stdout):
-            local_ips.add(match.group(1))
-    except Exception:
-        pass
-    # Also include the configured external_url IP
-    try:
-        from config import settings
-
-        own_ip = urlparse(settings.external_url).hostname or ""
-        if own_ip:
-            local_ips.add(own_ip)
-    except Exception:
-        pass
-    return local_ips
-
-
 def _is_local_node(node: Node) -> bool:
-    """Return True if the node is the local SLM Manager (#2721)."""
-    return node.ip_address in _get_local_ips()
+    """Return True if the node is the local SLM Manager (#2721, #2759).
+
+    Delegates to ``autobot_shared.network_utils.is_local_ip`` which uses the
+    most robust detection strategy: ``ip addr`` enumeration plus the
+    ``settings.external_url`` hostname fallback.
+    """
+    from autobot_shared.network_utils import is_local_ip
+
+    return is_local_ip(node.ip_address)
 
 
 async def _find_similar_paths(node: Node, target_path: str) -> Optional[str]:

--- a/autobot-slm-backend/api/code_source_test.py
+++ b/autobot-slm-backend/api/code_source_test.py
@@ -261,27 +261,34 @@ class TestLocalNodeValidation:
 
     @pytest.mark.asyncio
     async def test_is_local_node_localhost(self):
-        """Test _is_local_node detects localhost (#2721)."""
+        """Test _is_local_node detects localhost (#2721, #2759)."""
         node = MockNode()
         node.ip_address = "127.0.0.1"
-        with patch("code_source_module.urlparse") as mock_parse:
-            mock_parse.return_value.hostname = "172.16.168.19"
+        # Patch shared utility so the test is deterministic regardless of host (#2759)
+        with patch(
+            "autobot_shared.network_utils.get_local_ips",
+            return_value={"127.0.0.1", "localhost", "::1", "172.16.168.19"},
+        ):
             assert _is_local_node(node) is True
 
     @pytest.mark.asyncio
     async def test_is_local_node_own_ip(self):
-        """Test _is_local_node detects own IP from settings (#2721)."""
+        """Test _is_local_node detects own IP from settings (#2721, #2759)."""
         node = MockNode()
         node.ip_address = "172.16.168.19"
-        with patch("code_source_module.urlparse") as mock_parse:
-            mock_parse.return_value.hostname = "172.16.168.19"
+        with patch(
+            "autobot_shared.network_utils.get_local_ips",
+            return_value={"127.0.0.1", "localhost", "::1", "172.16.168.19"},
+        ):
             assert _is_local_node(node) is True
 
     @pytest.mark.asyncio
     async def test_is_local_node_remote(self):
-        """Test _is_local_node returns False for remote nodes (#2721)."""
+        """Test _is_local_node returns False for remote nodes (#2721, #2759)."""
         node = MockNode()
         node.ip_address = "172.16.168.20"
-        with patch("code_source_module.urlparse") as mock_parse:
-            mock_parse.return_value.hostname = "172.16.168.19"
+        with patch(
+            "autobot_shared.network_utils.get_local_ips",
+            return_value={"127.0.0.1", "localhost", "::1", "172.16.168.19"},
+        ):
             assert _is_local_node(node) is False

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -800,9 +800,10 @@ async def _sync_slm_from_code_source(node_id: str) -> None:
         return
     source_ip, source_user, repo_path = conn_info
 
-    # Detect if code source is on the same host — skip SSH entirely (#1191)
-    own_ip = urlparse(settings.external_url).hostname or ""
-    is_local_source = source_ip in {"127.0.0.1", "localhost", own_ip}
+    # Detect if code source is on the same host — skip SSH entirely (#1191, #2759)
+    from autobot_shared.network_utils import is_local_ip
+
+    is_local_source = is_local_ip(source_ip)
 
     if is_local_source:
         logger.info(

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -453,13 +453,15 @@ class SyncOrchestrator:
             return False, str(e), None
 
     def _is_local_source(self, node_ip: str) -> bool:
-        """Return True if the code-source node is this machine. Helper for #1194."""
-        from urllib.parse import urlparse
+        """Return True if the code-source node is this machine (#1194, #2759).
 
-        from config import settings
+        Delegates to ``autobot_shared.network_utils.is_local_ip`` which uses
+        the most robust detection strategy: ``ip addr`` enumeration plus the
+        ``settings.external_url`` hostname fallback.
+        """
+        from autobot_shared.network_utils import is_local_ip
 
-        own_ip = urlparse(settings.external_url).hostname or ""
-        return node_ip in {"127.0.0.1", "localhost", own_ip}
+        return is_local_ip(node_ip)
 
     async def _git_pull_local(self, repo_path: str, branch: str) -> Tuple[bool, str]:
         """Run git pull origin <branch> in a local repo. Helper for #1194."""


### PR DESCRIPTION
## Summary
- Created `autobot-shared/network_utils.py` with `get_local_ips()`, `is_local_ip()`, `is_local_host()` — uses most robust approach from code_source.py (ip addr + config fallback)
- Replaced 3 separate local-node detection implementations:
  - `code_source.py`: removed `_get_local_ips()`, simplified `_is_local_node()` to delegate to shared util
  - `sync_orchestrator.py`: replaced `_is_local_source()` body with shared util
  - `code_sync.py`: replaced inline 2-line check with `is_local_ip()` call
- Updated tests to patch the shared utility

Closes #2759

## Test plan
- [x] py_compile passes on all changed files
- [ ] Local node detection still works correctly
- [ ] sync_orchestrator, code_sync, and code_source all use shared utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)