### PR TITLE
fix(devops): replace obsolete model names in config (#2585)

### DIFF
--- a/autobot-infrastructure/shared/config/complete.yaml
+++ b/autobot-infrastructure/shared/config/complete.yaml
@@ -610,7 +610,7 @@ llm:
     rag: "gemma3:270m"              # Lightweight model for RAG operations (291MB)
     chat: "llama3.2:1b-instruct-q4_K_M"  # Balanced model for chat (807MB)
     classification: "gemma3:270m"    # Fast model for message classification
-    fallback: "llama3.2:3b-instruct-q4_K_M"  # Heavier model for complex tasks
+    fallback: "qwen3.5:9b"  # Quality model for complex tasks (#2585)
 
   # Model optimization settings
   optimization:
@@ -637,9 +637,9 @@ llm:
     strategy: "performance"    # "performance", "size", "speed"
     max_retries: 3            # Maximum retries before falling back
     fallback_models:          # Ordered list of fallback models
-      - "llama3.2:3b-instruct-q4_K_M"
-      - "llama3.2:1b-instruct-q4_K_M"
-      - "gemma2:2b"
+      - "qwen3.5:9b"
+      - "gemma3:4b"
+      - "llama3.2:1b"
 
   # Performance targets
   targets:
@@ -649,10 +649,10 @@ llm:
 
   # Existing LLM Configuration (continued)
   fallback_models:
-    - "dolphin-llama3:8b"
-    - "llama3.2:3b"
-    - "nomic-embed-text:latest"
-  emergency_fallback_model: "phi:2.7b"
+    - "qwen3.5:9b"
+    - "gemma3:4b"
+    - "llama3.2:1b"
+  emergency_fallback_model: "llama3.2:1b"
 
   # Embedding settings
   embedding:

--- a/autobot-infrastructure/shared/config/settings.json
+++ b/autobot-infrastructure/shared/config/settings.json
@@ -12,14 +12,14 @@
     "timeout": 60,
     "streaming": true,
     "max_retries": 3,
-    "use_phi2": true,
+    "use_phi2": false,
     "ollama_endpoint": "http://localhost:11434/api/generate",
-    "ollama_model": "phi:2.7b"
+    "ollama_model": "qwen3.5:9b"
   },
   "llm_config": {
     "default_llm": "ollama",
     "task_llm": "ollama",
-    "orchestrator_llm": "phi:2.7b",
+    "orchestrator_llm": "qwen3.5:9b",
     "orchestrator_llm_settings": {
       "temperature": 0.7,
       "structured_output": true
@@ -31,10 +31,12 @@
     "ollama": {
       "host": "http://localhost:11434",
       "port": 11434,
-      "model": "phi:2.7b",
+      "model": "qwen3.5:9b",
       "base_url": "http://localhost:11434",
       "models": {
-        "phi:2.7b": "phi:2.7b",
+        "qwen3.5:9b": "qwen3.5:9b",
+        "gemma3:4b": "gemma3:4b",
+        "llama3.2:1b": "llama3.2:1b",
         "nomic-embed-text": "nomic-embed-text"
       }
     },
@@ -50,7 +52,7 @@
     "models": {
       "chat": {
         "provider": "ollama",
-        "model": "phi:2.7b",
+        "model": "qwen3.5:9b",
         "endpoint": "http://localhost:11434"
       },
       "embedding": {
@@ -217,9 +219,9 @@
           }
         }
       },
-      "use_phi2": true,
+      "use_phi2": false,
       "ollama_endpoint": "http://localhost:11434/api/generate",
-      "ollama_model": "phi:2.7b"
+      "ollama_model": "qwen3.5:9b"
     },
     "ui": {
       "theme": "light",
@@ -306,7 +308,7 @@
     "llm_config": {
       "default_llm": "ollama",
       "task_llm": "ollama",
-      "orchestrator_llm": "phi:2.7b",
+      "orchestrator_llm": "qwen3.5:9b",
       "orchestrator_llm_settings": {
         "temperature": 0.7,
         "structured_output": true
@@ -318,10 +320,10 @@
       "ollama": {
         "host": "http://localhost:11434",
         "port": 11434,
-        "model": "phi:2.7b",
+        "model": "qwen3.5:9b",
         "base_url": "http://localhost:11434",
         "models": {
-          "phi:2.7b": "phi:2.7b",
+          "qwen3.5:9b": "qwen3.5:9b",
           "nomic-embed-text": "nomic-embed-text"
         }
       },
@@ -337,7 +339,7 @@
       "models": {
         "chat": {
           "provider": "ollama",
-          "model": "phi:2.7b",
+          "model": "qwen3.5:9b",
           "endpoint": "http://localhost:11434"
         },
         "embedding": {


### PR DESCRIPTION
## Summary
- Replaced all `phi:2.7b` references in settings.json with `qwen3.5:9b` (10 occurrences)
- Updated complete.yaml fallback models from uninstalled models to 3-tier mapping (qwen3.5:9b, gemma3:4b, llama3.2:1b)
- Set `use_phi2: false` since phi:2.7b is no longer the default

## Test plan
- [ ] Verify `grep -r 'phi:2.7b' autobot-infrastructure/` returns no matches
- [ ] Verify settings.json is valid JSON: `python -m json.tool < settings.json`

Closes #2585

🤖 Generated with [Claude Code](https://claude.com/claude-code)