### PR TITLE
refactor(devops): extract shared backend env vars (#2727)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-backend-env.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-backend-env.yml
@@ -8,35 +8,12 @@
   become: true
   gather_facts: true
 
+  vars_files:
+    - vars/backend-env.yml  # Shared backend vars (#2727)
+
   vars:
-    backend_user: autobot
-    backend_group: autobot
-    backend_install_dir: /opt/autobot/autobot-backend
-    backend_code_dir: /opt/autobot/autobot-backend
-    backend_log_dir: /var/log/autobot
-    backend_data_dir: /var/lib/autobot
-    backend_host: "0.0.0.0"
-    backend_port: 8443
-    backend_workers: 1  # Issue #876: Single worker to prevent deadlock
-    backend_redis_host: "{{ hostvars[groups['database'][0]]['ansible_host'] | default('127.0.0.1') }}"
-    backend_redis_port: 6379
-    backend_redis_password: ""
+    # backend_secret_key uses a register var specific to this playbook
     backend_secret_key: "{{ _existing_secret.stdout | default(lookup('env', 'AUTOBOT_SECRET_KEY') | default('autobot-dev-secret-' + (9999999999 | random | string), true), true) }}"
-    backend_cors_origins: "http://{{ hostvars[groups['frontend'][0]]['ansible_host'] | default('127.0.0.1') }},https://{{ hostvars[groups['frontend'][0]]['ansible_host'] | default('127.0.0.1') }},http://{{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }},https://{{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }}"
-    backend_llm_provider: "ollama"
-    backend_llm_endpoint: "http://127.0.0.1:11434"
-    # 3-tier model mapping (#2553) — defaults from SSOT, overridable via env
-    backend_llm_model: "{{ lookup('env', 'AUTOBOT_DEFAULT_LLM_MODEL') | default('qwen3.5:9b', true) }}"
-    backend_routing_model: "{{ lookup('env', 'AUTOBOT_ROUTING_MODEL') | default('llama3.2:1b', true) }}"
-    backend_classification_model: "{{ lookup('env', 'AUTOBOT_CLASSIFICATION_MODEL') | default('gemma3:4b', true) }}"
-    service_auth_service_id: "main-backend"
-    service_auth_keys_dir: "/etc/autobot/service-keys"
-    service_auth_enforcement_mode: false  # Disabled for testing
-    service_auth_override_token: ""
-    service_auth_circuit_breaker_percentage: 100
-    service_auth_timestamp_window: 300
-    service_auth_rate_limit_window: 300
-    service_auth_rate_limit_max_failures: 10
 
   pre_tasks:
     - name: Read existing secret key from .env if present (#2726)

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -545,6 +545,12 @@
       changed_when: false
       tags: [backend, env]
 
+    - name: "[PLAY 2] Backend | Load shared backend env vars (#2727)"
+      ansible.builtin.include_vars:
+        file: vars/backend-env.yml
+      when: "'01-Backend' in inventory_hostname"
+      tags: [backend, env]
+
     - name: "[PLAY 2] Backend | Regenerate .env from template (#2649)"
       ansible.builtin.template:
         src: ../roles/backend/templates/backend.env.j2
@@ -556,31 +562,8 @@
       become: true
       when: "'01-Backend' in inventory_hostname"
       vars:
-        backend_install_dir: /opt/autobot/autobot-backend
-        backend_code_dir: /opt/autobot/autobot-backend
-        backend_log_dir: /var/log/autobot
-        backend_data_dir: /var/lib/autobot
-        backend_host: "0.0.0.0"
-        backend_port: 8443
-        backend_workers: 1
-        backend_redis_host: "{{ hostvars[groups['database'][0]]['ansible_host'] | default('127.0.0.1') }}"
-        backend_redis_port: 6379
-        backend_redis_password: ""
+        # backend_secret_key uses a register var specific to this playbook
         backend_secret_key: "{{ existing_secret_key.stdout | default(lookup('env', 'AUTOBOT_SECRET_KEY') | default('autobot-dev-secret-' + (9999999999 | random | string), true), true) }}"
-        backend_cors_origins: "http://{{ hostvars[groups['frontend'][0]]['ansible_host'] | default('127.0.0.1') }},https://{{ hostvars[groups['frontend'][0]]['ansible_host'] | default('127.0.0.1') }},http://{{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }},https://{{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }}"
-        backend_llm_provider: "ollama"
-        backend_llm_endpoint: "http://127.0.0.1:11434"
-        backend_llm_model: "{{ lookup('env', 'AUTOBOT_DEFAULT_LLM_MODEL') | default('qwen3.5:9b', true) }}"
-        backend_routing_model: "{{ lookup('env', 'AUTOBOT_ROUTING_MODEL') | default('llama3.2:1b', true) }}"
-        backend_classification_model: "{{ lookup('env', 'AUTOBOT_CLASSIFICATION_MODEL') | default('gemma3:4b', true) }}"
-        service_auth_service_id: "main-backend"
-        service_auth_keys_dir: "/etc/autobot/service-keys"
-        service_auth_enforcement_mode: false
-        service_auth_override_token: ""
-        service_auth_circuit_breaker_percentage: 100
-        service_auth_timestamp_window: 300
-        service_auth_rate_limit_window: 300
-        service_auth_rate_limit_max_failures: 10
       tags: [backend, env]
 
     - name: "[PLAY 2] Backend | Restart service"

--- a/autobot-slm-backend/ansible/playbooks/vars/backend-env.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/backend-env.yml
@@ -1,0 +1,35 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Shared backend .env template variables (#2727)
+# Used by both deploy-backend-env.yml and update-all-nodes.yml
+# to avoid duplication and keep vars in sync.
+---
+backend_user: autobot
+backend_group: autobot
+backend_install_dir: /opt/autobot/autobot-backend
+backend_code_dir: /opt/autobot/autobot-backend
+backend_log_dir: /var/log/autobot
+backend_data_dir: /var/lib/autobot
+backend_host: "0.0.0.0"
+backend_port: 8443
+backend_workers: 1  # Issue #876: Single worker to prevent deadlock
+backend_redis_host: "{{ hostvars[groups['database'][0]]['ansible_host'] | default('127.0.0.1') }}"
+backend_redis_port: 6379
+backend_redis_password: ""
+backend_cors_origins: "http://{{ hostvars[groups['frontend'][0]]['ansible_host'] | default('127.0.0.1') }},https://{{ hostvars[groups['frontend'][0]]['ansible_host'] | default('127.0.0.1') }},http://{{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }},https://{{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }}"
+backend_llm_provider: "ollama"
+backend_llm_endpoint: "http://127.0.0.1:11434"
+# 3-tier model mapping (#2553) — defaults from SSOT, overridable via env
+backend_llm_model: "{{ lookup('env', 'AUTOBOT_DEFAULT_LLM_MODEL') | default('qwen3.5:9b', true) }}"
+backend_routing_model: "{{ lookup('env', 'AUTOBOT_ROUTING_MODEL') | default('llama3.2:1b', true) }}"
+backend_classification_model: "{{ lookup('env', 'AUTOBOT_CLASSIFICATION_MODEL') | default('gemma3:4b', true) }}"
+service_auth_service_id: "main-backend"
+service_auth_keys_dir: "/etc/autobot/service-keys"
+service_auth_enforcement_mode: false
+service_auth_override_token: ""
+service_auth_circuit_breaker_percentage: 100
+service_auth_timestamp_window: 300
+service_auth_rate_limit_window: 300
+service_auth_rate_limit_max_failures: 10


### PR DESCRIPTION
## Summary
- Extracted duplicated backend .env vars from deploy-backend-env.yml and update-all-nodes.yml into `vars/backend-env.yml`
- Both playbooks now include shared vars via `vars_files`/`include_vars`
- Only `backend_secret_key` remains inline (depends on playbook-specific register variables)

## Test plan
- [ ] Verify `ansible-playbook --syntax-check deploy-backend-env.yml`
- [ ] Verify `ansible-playbook --syntax-check update-all-nodes.yml`
- [ ] Deploy to test node and confirm .env is generated correctly

Closes #2727

🤖 Generated with [Claude Code](https://claude.com/claude-code)