### PR TITLE
refactor(frontend): align ConsoleLogEntry with variadic log() (#2627)

### DIFF
--- a/autobot-frontend/src/utils/debugUtils.ts
+++ b/autobot-frontend/src/utils/debugUtils.ts
@@ -27,7 +27,7 @@ export interface ConsoleLogEntry {
   level: LogLevel
   message: string
   timestamp: number
-  data?: any
+  args?: unknown[]
 }
 
 /**


### PR DESCRIPTION
## Summary
- Change `ConsoleLogEntry.data?: any` to `args?: unknown[]` to match the variadic `log()` and `createLogger()` signatures updated in PR #2616
- No runtime references to `.data` exist — type-only consistency fix

Closes #2627

## Test plan
- [ ] TypeScript compiles without errors
- [ ] No references to old `.data` property on ConsoleLogEntry remain