### PR TITLE
fix(backend): use shared get_local_ips() for single-host provisioning (#2722)

### DIFF
--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -177,23 +177,13 @@ async def _generate_dynamic_inventory(
         if not db_nodes:
             return None
 
+        from autobot_shared.network_utils import get_local_ips
+
         hosts: dict[str, dict] = {}
         node_id_to_hostname: dict[str, str] = {}
         node_id_to_ip: dict[str, str] = {}
         # Detect local IPs for ansible_connection: local (#2722)
-        local_ips = {"127.0.0.1", "localhost"}
-        try:
-            import subprocess
-
-            result = subprocess.run(
-                ["hostname", "-I"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            local_ips.update(result.stdout.split())
-        except (OSError, subprocess.TimeoutExpired):
-            pass
+        local_ips = get_local_ips()
 
         for node in db_nodes:
             host_vars = {


### PR DESCRIPTION
## Summary
- Replaced 13-line inline `hostname -I` subprocess block with single call to `autobot_shared.network_utils.get_local_ips()`
- The shared utility uses the more robust `ip -4 addr show` method plus external URL hostname resolution
- `ansible_connection: local` detection logic is preserved — only the IP collection was improved

## Context
PR #2774 (#2759) added `network_utils.py` to consolidate local-node detection. This PR makes `setup_wizard.py` use it instead of duplicating the pattern inline.

## Test plan
- [ ] Single-host install: `_generate_dynamic_inventory()` sets `ansible_connection: local` for the SLM Manager node
- [ ] Multi-host install: remote nodes still use SSH (no `ansible_connection: local`)
- [ ] `get_local_ips()` returns the machine's actual IPs including 127.0.0.1

Closes #2722

🤖 Generated with [Claude Code](https://claude.com/claude-code)