### PR TITLE
refactor(backend): migrate Pydantic V1 patterns to V2 (#2630)

### DIFF
--- a/autobot-backend/config/settings.py
+++ b/autobot-backend/config/settings.py
@@ -9,29 +9,30 @@ Configuration settings for the config manager.
 from pathlib import Path
 
 from pydantic import Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class ConfigSettings(BaseSettings):
     """Configuration settings for the config manager"""
 
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="allow",
+    )
+
     # File paths
-    config_dir: Path = Field(default=Path("config"), env="CONFIG_DIR")
-    config_file: str = Field(default="config.yaml", env="CONFIG_FILE")
-    settings_file: str = Field(default="settings.json", env="SETTINGS_FILE")
+    config_dir: Path = Field(default=Path("config"), validation_alias="CONFIG_DIR")
+    config_file: str = Field(default="config.yaml", validation_alias="CONFIG_FILE")
+    settings_file: str = Field(default="settings.json", validation_alias="SETTINGS_FILE")
 
     # Cache settings
-    cache_ttl: int = Field(default=300, env="CONFIG_CACHE_TTL")  # 5 minutes
-    auto_reload: bool = Field(default=True, env="CONFIG_AUTO_RELOAD")
+    cache_ttl: int = Field(default=300, validation_alias="CONFIG_CACHE_TTL")  # 5 minutes
+    auto_reload: bool = Field(default=True, validation_alias="CONFIG_AUTO_RELOAD")
 
     # Redis settings for distributed config
-    use_redis_cache: bool = Field(default=True, env="USE_REDIS_CONFIG_CACHE")
-    redis_key_prefix: str = Field(default="config:", env="CONFIG_REDIS_PREFIX")
-
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        extra = "allow"
+    use_redis_cache: bool = Field(default=True, validation_alias="USE_REDIS_CONFIG_CACHE")
+    redis_key_prefix: str = Field(default="config:", validation_alias="CONFIG_REDIS_PREFIX")
 
 
 # Deprecated: use ConfigSettings instead

--- a/autobot-backend/type_defs/mcp.py
+++ b/autobot-backend/type_defs/mcp.py
@@ -9,7 +9,7 @@ Provides strongly-typed MCP tool and response structures.
 
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from type_defs.common import JSONValue, Metadata
 
@@ -43,38 +43,35 @@ class MCPInputSchema(BaseModel):
 class MCPToolDefinition(BaseModel):
     """MCP tool definition structure."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     name: MCPToolName
     description: str
     input_schema: MCPInputSchema = Field(alias="inputSchema")
     category: Optional[str] = None
     tags: Optional[List[str]] = None
 
-    class Config:
-        populate_by_name = True
-
 
 class MCPSuccessResponse(BaseModel):
     """MCP success response structure."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     success: bool = True
     content: List[Dict[str, JSONValue]] = Field(default_factory=list)
     is_error: bool = Field(False, alias="isError")
 
-    class Config:
-        populate_by_name = True
-
 
 class MCPErrorResponse(BaseModel):
     """MCP error response structure."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     success: bool = False
     error: str
     error_code: Optional[str] = None
     is_error: bool = Field(True, alias="isError")
     details: Optional[Metadata] = None
-
-    class Config:
-        populate_by_name = True
 
 
 # Union type for MCP tool responses
@@ -91,25 +88,23 @@ class MCPTextContent(BaseModel):
 class MCPImageContent(BaseModel):
     """MCP image content block."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     type: Literal["image"] = "image"
     data: str  # Base64 encoded
     mime_type: str = Field(alias="mimeType")
 
-    class Config:
-        populate_by_name = True
-
 
 class MCPResourceContent(BaseModel):
     """MCP resource content block."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     type: Literal["resource"] = "resource"
     uri: MCPResourceUri
     mime_type: Optional[str] = Field(None, alias="mimeType")
     text: Optional[str] = None
     blob: Optional[str] = None  # Base64 encoded
-
-    class Config:
-        populate_by_name = True
 
 
 # Content types that can appear in MCP responses
@@ -136,13 +131,12 @@ class MCPToolCallResult(BaseModel):
 class MCPResourceDefinition(BaseModel):
     """MCP resource definition structure."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     uri: MCPResourceUri
     name: str
     description: Optional[str] = None
     mime_type: Optional[str] = Field(None, alias="mimeType")
-
-    class Config:
-        populate_by_name = True
 
 
 class MCPPromptDefinition(BaseModel):


### PR DESCRIPTION
## Summary
- Replace 6 deprecated `class Config` inner classes with `model_config = ConfigDict(...)` in type_defs/mcp.py
- Replace `class Config` with `model_config = SettingsConfigDict(...)` in config/settings.py
- Replace 6 deprecated `env=` Field kwargs with `validation_alias=`
- Eliminates 8+ PydanticDeprecatedSince20 warnings from test output

Closes #2630

## Test plan
- [ ] AST parse check passes on both files
- [ ] No deprecation warnings in test output
- [ ] All existing tests pass (no behavioral change)