### PR TITLE
fix(slm): use correct admin URL for single-host installs (#2747)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/defaults/main.yml
@@ -6,7 +6,12 @@
 # Override these in inventory or playbook variables
 
 # Admin connectivity
-slm_admin_url: "https://{{ slm_host | default('172.16.168.19') }}"
+# slm_host must be provided by inventory or via -e.  The setup wizard
+# injects it from settings.external_url (#2747); static inventories derive
+# it from hostvars['autobot-slm']['ansible_host'].  The loopback fallback
+# here is intentionally safe: it triggers an obvious connection failure
+# rather than silently routing to a different machine's IP.
+slm_admin_url: "https://{{ slm_host | default('127.0.0.1') }}"
 slm_heartbeat_interval: 30
 
 # Agent user/group (should match common role's autobot user)

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
@@ -86,8 +86,11 @@ def _get_default_admin_url() -> str:
 
         return get_config().slm_url
     except Exception:
-        # Fallback for standalone deployments without full AutoBot
-        slm_host = os.getenv("SLM_HOST", "172.16.168.19")  # noqa: ssot-fallback
+        # Fallback for standalone deployments without full AutoBot.
+        # Use 127.0.0.1 rather than a hardcoded fleet IP so the agent fails
+        # clearly on a misconfigured node instead of routing to the wrong host
+        # (#2747).  Set SLM_ADMIN_URL or SLM_HOST env vars to override.
+        slm_host = os.getenv("SLM_HOST", "127.0.0.1")  # noqa: ssot-fallback
         return f"http://{slm_host}:8000"
 
 

--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -261,11 +261,27 @@ async def _generate_dynamic_inventory(
         hosts, all_node_roles, node_id_to_hostname
     )
     infra_vars = _build_infra_vars(all_active, all_ip_map)
+
+    # Derive slm_host from external_url so the slm_agent role resolves the
+    # correct admin URL on single-host installs (#2747).  On single-host the
+    # SLM Manager runs on the same machine as the backend; external_url holds
+    # the routable IP that remote nodes should use.  The slm_agent role's
+    # default builds slm_admin_url from this value, and the template's
+    # auto-detect logic then rewrites it to 127.0.0.1 when the agent is
+    # co-located — but only after slm_host contains the real local IP rather
+    # than the hardcoded multi-node default (172.16.168.19).
+    from urllib.parse import urlparse
+
+    from config import settings as _slm_settings
+
+    _slm_host = urlparse(_slm_settings.external_url).hostname or "127.0.0.1"
+
     inventory = {
         "all": {
             "vars": {
                 "ansible_ssh_private_key_file": "~/.ssh/autobot_key",
                 "ansible_python_interpreter": "/usr/bin/python3",
+                "slm_host": _slm_host,
                 **infra_vars,
             },
             "hosts": hosts,

--- a/autobot-slm-backend/slm/agent/agent.py
+++ b/autobot-slm-backend/slm/agent/agent.py
@@ -86,8 +86,11 @@ def _get_default_admin_url() -> str:
 
         return get_config().slm_url
     except Exception:
-        # Fallback for standalone deployments without full AutoBot
-        slm_host = os.getenv("SLM_HOST", "172.16.168.19")  # noqa: ssot-fallback
+        # Fallback for standalone deployments without full AutoBot.
+        # Use 127.0.0.1 rather than a hardcoded fleet IP so the agent fails
+        # clearly on a misconfigured node instead of routing to the wrong host
+        # (#2747).  Set SLM_ADMIN_URL or SLM_HOST env vars to override.
+        slm_host = os.getenv("SLM_HOST", "127.0.0.1")  # noqa: ssot-fallback
         return f"http://{slm_host}:8000"
 
 


### PR DESCRIPTION
## Summary
- Changed `slm_admin_url` default fallback from `172.16.168.19` to `127.0.0.1` in Ansible role defaults
- Inject `slm_host` from `settings.external_url` into the dynamic inventory generated by `setup_wizard.py`
- Updated `agent.py` `SLM_HOST` env var fallback to `127.0.0.1` (both source and Ansible-deployed copy)

## Root cause
On single-host installs, `slm_host` was never set in the dynamic inventory, so the Ansible role fell through to the hardcoded `.19` default. The template's auto-detect logic (`admin_host == ansible_host`) also never matched because `ansible_host` was `127.0.0.1` while `admin_host` was `172.16.168.19`.

## Test plan
- [ ] Single-host install: SLM agent connects to `127.0.0.1` (or local IP), not `172.16.168.19`
- [ ] Multi-host install: SLM agent connects to the correct SLM Manager IP
- [ ] Standalone agent without SSOT config: falls back to `127.0.0.1` instead of `.19`

Closes #2747

🤖 Generated with [Claude Code](https://claude.com/claude-code)