### PR TITLE
refactor(backend): derive ToolRegistry tools from shared constant (#2609)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -25,8 +25,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Issue #1368: Browser tool names that route to browser_mcp handlers
-_BROWSER_TOOL_NAMES = frozenset(
+# Issue #1368: Browser tool names that route to browser_mcp handlers.
+# Exported (no leading underscore) so ToolRegistry can derive its list from this
+# single source of truth rather than maintaining a duplicate. Issue #2609.
+BROWSER_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "navigate",
         "click",
@@ -1562,7 +1564,7 @@ class ToolHandlerMixin:
         """Build error message for an unknown tool call (#2305, #2310)."""
         known_tools = sorted(
             {"respond", "delegate", "execute_command", "web_search"}
-            | _BROWSER_TOOL_NAMES
+            | BROWSER_TOOL_NAMES
         )
         if ctx is not None:
             ctx.consecutive_invalid_tool_calls += 1
@@ -1616,7 +1618,7 @@ class ToolHandlerMixin:
             return
 
         # Issue #1368: Route browser tools to browser VM
-        if tool_name in _BROWSER_TOOL_NAMES:
+        if tool_name in BROWSER_TOOL_NAMES:
             if ctx is not None:
                 ctx.consecutive_invalid_tool_calls = 0
             async for msg in self._handle_browser_tool(tool_call, execution_results):

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -14,6 +14,8 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from chat_workflow.tool_handler import BROWSER_TOOL_NAMES
+
 if TYPE_CHECKING:
     from knowledge_base import KnowledgeBase
     from worker_node import WorkerNode
@@ -530,10 +532,12 @@ class ToolRegistry:
     def get_available_tools(self) -> List[str]:
         """Get list of available tool names.
 
-        Issue #2594: Includes browser tools (Issue #1368) and web_search (Issue #2306)
-        to match the chat workflow's ToolHandlerMixin dispatch capabilities.
+        Browser tool names are derived from BROWSER_TOOL_NAMES in
+        chat_workflow.tool_handler (Issue #2609) so both layers share a single
+        source of truth. Issue #2594: also includes web_search (Issue #2306).
         """
-        return [
+        # Registry-owned tools (system, knowledge-base, GUI, conversation)
+        registry_tools = [
             "execute_system_command",
             "query_system_information",
             "list_system_services",
@@ -551,15 +555,7 @@ class ToolRegistry:
             "bring_window_to_front",
             "ask_user_for_manual",
             "respond_conversationally",
-            # Issue #1368: Browser tools routed to browser VM
-            "navigate",
-            "click",
-            "fill",
-            "select",
-            "hover",
-            "screenshot",
-            "evaluate",
-            "get_text",
-            "get_attribute",
-            "wait_for_selector",
         ]
+        # Issue #1368/#2609: Browser tools are defined once in BROWSER_TOOL_NAMES
+        # and imported here so the two lists cannot drift independently.
+        return registry_tools + sorted(BROWSER_TOOL_NAMES)


### PR DESCRIPTION
## Summary
- Export `BROWSER_TOOL_NAMES` from `chat_workflow/tool_handler.py` (was private `_BROWSER_TOOL_NAMES`)
- Import and use it in `tools/tool_registry.py` `get_available_tools()`
- Eliminates duplicate hardcoded browser tool list that has drifted before (#1368, #2306)
- Both dispatch and registry now share a single source of truth

Closes #2609

## Test plan
- [ ] AST parse check passes on both files
- [ ] `get_available_tools()` returns same tools as before (browser tools now sorted)
- [ ] No duplicate browser tool definitions remain