### PR TITLE
fix(frontend): align type-check script with CI (#2643)

### DIFF
--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -28,7 +28,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:all": "run-s test:unit test:integration test:playwright",
     "build-only": "vite build",
-    "type-check": "vue-tsc --build",
+    "type-check": "vue-tsc --noEmit -p tsconfig.app.json",
     "lint:oxlint": "oxlint . --fix -D correctness --ignore-path .gitignore",
     "lint:eslint": "eslint . --fix",
     "lint": "run-s lint:*",
@@ -116,4 +116,3 @@
     "vue-tsc": "^3.2.6"
   }
 }
-


### PR DESCRIPTION
## Summary
- Changed `npm run type-check` from `vue-tsc --build` to `vue-tsc --noEmit -p tsconfig.app.json`
- Matches CI command (`.github/workflows/ci.yml` line 191)
- Eliminates ~449 false-positive `$t` type errors from `--build` mode's stricter project-reference resolution

## Context
`--build` mode uses TypeScript project references and doesn't resolve vue-i18n's `$t` type augmentation. CI already uses `--noEmit` and reports only 1 pre-existing error. The build itself (`vite build`) was never affected.

## Test plan
- [ ] `npm run type-check` reports 0-1 errors (not ~449)
- [ ] CI type-check step still passes

Closes #2643

🤖 Generated with [Claude Code](https://claude.com/claude-code)