### PR TITLE
perf(autoresearch): parallelize get_stats() with asyncio.gather (#2718)

### DIFF
--- a/autobot-backend/services/autoresearch/store.py
+++ b/autobot-backend/services/autoresearch/store.py
@@ -10,6 +10,7 @@ ChromaDB for semantic knowledge search over experiment findings.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any, Dict, List, Optional
@@ -252,10 +253,10 @@ class ExperimentStore:
             stats.baseline_val_bpb = float(baseline)
 
         # Compute timing stats from completed experiments
-        completed = await self.list_experiments(
-            limit=100, state=ExperimentState.COMPLETED
+        completed, kept = await asyncio.gather(
+            self.list_experiments(limit=100, state=ExperimentState.COMPLETED),
+            self.list_experiments(limit=100, state=ExperimentState.KEPT),
         )
-        kept = await self.list_experiments(limit=100, state=ExperimentState.KEPT)
         all_done = completed + kept
 
         if all_done:


### PR DESCRIPTION
## Summary
- Replaced two sequential `list_experiments()` calls with `asyncio.gather` for concurrent execution
- Saves one sequential Redis round-trip per `get_stats()` call

Closes #2718

## Test plan
- [x] py_compile passes
- [ ] get_stats() returns same results as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)