### PR TITLE
refactor(config): centralize Redis DB allocation (#2670)

### DIFF
--- a/autobot-infrastructure/shared/config/complete.yaml
+++ b/autobot-infrastructure/shared/config/complete.yaml
@@ -314,23 +314,23 @@ redis:
     socket_connect_timeout: 2
     retry_on_timeout: true
 
-  # Database allocation
+  # Database allocation — aligned with redis-databases.yaml (#2670)
   databases:
     main: 0
-    knowledge: 1  # Knowledge base and documents (see ADR-002, ssot_config.py db_knowledge=1)
-    celery_broker: 14     # Celery task broker (moved from 1/2 to avoid knowledge/prompts clash)
-    celery_results: 15    # Celery task results
-    metrics: 4    # Performance metrics and monitoring data (see network_constants.py METRICS_DB=4)
+    knowledge: 1
     prompts: 2
     agents: 3
-    cache: 5    # General purpose caching (see ssot_config.py db_cache=5)
+    metrics: 4
+    cache: 5
     sessions: 6
-    chat_history: 8
-    backup: 10
-    testing: 13    # Moved from 15 to avoid collision with celery_results (#2720)
-
-  # Knowledge base specific - DB 1 per ADR-002 and ssot_config.py
-  kb_db: 1
+    workflows: 7
+    logs: 8
+    temp: 9
+    audit: 10
+    analytics: 11
+    testing: 13       # Moved from 15 to avoid collision with celery_results (#2720)
+    celery_broker: 14
+    celery_results: 15
 
   # Pub/Sub channels
   channels:

--- a/autobot-infrastructure/shared/config/redis-databases.yaml
+++ b/autobot-infrastructure/shared/config/redis-databases.yaml
@@ -46,6 +46,9 @@ redis_databases:
   codebase:
     db: 11
     description: "Codebase analytics (alias for analytics DB)"
+  testing:
+    db: 13
+    description: "Test suite isolation database (#2720)"
   celery_broker:
     db: 14
     description: "Celery task broker"

--- a/autobot-shared/redis_management/types.py
+++ b/autobot-shared/redis_management/types.py
@@ -59,11 +59,12 @@ class ConnectionState(Enum):
     FAILED = "failed"
 
 
-# Database name to number mapping (canonical source)
-# Complete mapping matching all usage across AutoBot codebase
+# Database name to number mapping — aligned with redis-databases.yaml (#2670)
+# Canonical allocation: autobot-infrastructure/shared/config/redis-databases.yaml
 DATABASE_MAPPING = {
-    # Core databases
+    # Core databases (0-6)
     "main": 0,
+    "memory": 0,  # Alias — RediSearch indexing (FT.* commands) on main DB
     "knowledge": 1,
     "prompts": 2,
     "agents": 3,
@@ -72,15 +73,17 @@ DATABASE_MAPPING = {
     "cache": 5,
     "sessions": 6,
     "locks": 6,  # Alias for sessions (distributed locks)
+    # Extended databases (7-11)
     "workflows": 7,
-    "monitoring": 7,  # Alias for workflows (monitoring data)
-    "vectors": 8,
-    "rate_limiting": 8,  # Alias for vectors (rate limit counters)
-    "models": 9,
-    "memory": 0,  # Uses DB 0 - required for RediSearch indexing (FT.* commands)
-    "analytics": 9,  # Maps to models database
-    "websockets": 10,
-    "config": 11,  # CRITICAL: Cache configuration storage
-    "facts": 11,  # Knowledge facts and rules (consolidated from redis_pool.py)
-    "audit": 12,  # Security audit logging (OWASP/NIST compliant)
+    "monitoring": 7,  # Alias for workflows
+    "logs": 8,
+    "vectors": 8,  # Legacy alias — vector_search.py uses this; shares DB with logs
+    "temp": 9,
+    "audit": 10,
+    "analytics": 11,
+    "codebase": 11,  # Alias for analytics
+    # Reserved (12 unused, 13 testing, 14-15 Celery)
+    "testing": 13,
+    "celery_broker": 14,
+    "celery_results": 15,
 }

--- a/autobot-shared/ssot_config.py
+++ b/autobot-shared/ssot_config.py
@@ -483,7 +483,10 @@ class RedisConfig(BaseSettings):
     db_logs: int = Field(default=8, alias="AUTOBOT_REDIS_DB_LOGS")
     db_temp: int = Field(default=9, alias="AUTOBOT_REDIS_DB_TEMP")
     db_backup: int = Field(default=10, alias="AUTOBOT_REDIS_DB_BACKUP")
-    db_testing: int = Field(default=15, alias="AUTOBOT_REDIS_DB_TESTING")
+    db_analytics: int = Field(default=11, alias="AUTOBOT_REDIS_DB_ANALYTICS")
+    db_testing: int = Field(default=13, alias="AUTOBOT_REDIS_DB_TESTING")
+    db_celery_broker: int = Field(default=14, alias="AUTOBOT_REDIS_DB_CELERY_BROKER")
+    db_celery_results: int = Field(default=15, alias="AUTOBOT_REDIS_DB_CELERY_RESULTS")
 
     # LangGraph checkpoint TTL (#1481)
     checkpoint_ttl_minutes: int = Field(


### PR DESCRIPTION
## Summary
- Align all 4 Redis DB config sources to a single truth (redis-databases.yaml)
- Fix `ssot_config.py` `db_testing` default from 15→13 (was wrong since #2720)
- Add missing DB fields to ssot_config.py: `db_analytics` (11), `db_celery_broker` (14), `db_celery_results` (15)
- Align `DATABASE_MAPPING` in types.py: remove stale aliases, add `testing`, `celery_broker`, `celery_results`
- Align `complete.yaml` database section, remove redundant `kb_db` key
- Add `testing: 13` to redis-databases.yaml

### Config alignment after this PR:

| DB | redis-databases.yaml | complete.yaml | ssot_config.py | types.py |
|----|---------------------|---------------|----------------|----------|
| 0 | main | main | db_main | main |
| 1 | knowledge | knowledge | db_knowledge | knowledge |
| 2 | prompts | prompts | db_prompts | prompts |
| 3 | agents | agents | db_agents | agents |
| 4 | metrics | metrics | db_metrics | metrics |
| 5 | cache | cache | db_cache | cache |
| 6 | sessions | sessions | db_sessions | sessions |
| 7 | workflows | workflows | db_tasks | workflows |
| 8 | logs | logs | db_logs | logs |
| 9 | temp | temp | db_temp | temp |
| 10 | audit | audit | db_backup | audit |
| 11 | analytics | analytics | db_analytics | analytics |
| 13 | testing | testing | db_testing | testing |
| 14 | celery_broker | celery_broker | db_celery_broker | celery_broker |
| 15 | celery_results | celery_results | db_celery_results | celery_results |

Closes #2670

## Test plan
- [ ] All 4 config files parse without errors (Python AST + YAML)
- [ ] DATABASE_MAPPING covers all databases in redis-databases.yaml
- [ ] No hardcoded DB numbers remain outside config files
- [ ] `vectors` alias preserved for backward compat (vector_search.py)