### PR TITLE
refactor(frontend): replace error.value race with errors array (#2626)

### DIFF
--- a/autobot-frontend/src/composables/useAgentRegistry.ts
+++ b/autobot-frontend/src/composables/useAgentRegistry.ts
@@ -69,7 +69,10 @@ export function useAgentRegistry(options: UseAgentRegistryOptions = {}) {
   const selectedAgent = ref<SpecializedAgent | null>(null)
   const isLoading = ref(false)
   const isLoadingDetail = ref(false)
-  const error = ref<string | null>(null)
+  const errors = ref<string[]>([])
+  const error = computed<string | null>(() =>
+    errors.value.length > 0 ? errors.value.join('; ') : null,
+  )
 
   // ----- Computed -----
 
@@ -96,7 +99,7 @@ export function useAgentRegistry(options: UseAgentRegistryOptions = {}) {
 
   async function fetchAllAgents() {
     isLoading.value = true
-    error.value = null
+    errors.value = []
     try {
       const data = await ApiClient.get('/api/agent_config/agents/all')
       backendAgents.value = data.agents || []
@@ -109,7 +112,7 @@ export function useAgentRegistry(options: UseAgentRegistryOptions = {}) {
       )
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err)
-      error.value = msg
+      errors.value = [...errors.value, msg]
       logger.error('Failed to fetch agents: %s', msg)
     } finally {
       isLoading.value = false

--- a/autobot-frontend/src/composables/useAnalyticsFetch.ts
+++ b/autobot-frontend/src/composables/useAnalyticsFetch.ts
@@ -14,7 +14,7 @@
  * Author: mrveiss
  */
 
-import { ref, type Ref } from 'vue'
+import { ref, computed, type Ref, type ComputedRef } from 'vue'
 import appConfig from '@/config/AppConfig.js'
 import { getConfig } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
@@ -39,7 +39,7 @@ export interface AnalyticsFetchOptions {
 export interface AnalyticsFetchReturn<T> {
   data: Ref<T | null>
   loading: Ref<boolean>
-  error: Ref<string | null>
+  error: ComputedRef<string | null>
   load: (
     query?: Record<string, string>,
     body?: Record<string, unknown>,
@@ -62,7 +62,10 @@ export function useAnalyticsFetch<T = Record<string, unknown>>(
 ): AnalyticsFetchReturn<T> {
   const data: Ref<T | null> = ref(null)
   const loading: Ref<boolean> = ref(false)
-  const error: Ref<string | null> = ref(null)
+  const errors = ref<string[]>([])
+  const error = computed<string | null>(() =>
+    errors.value.length > 0 ? errors.value.join('; ') : null,
+  )
 
   const method = opts?.method ?? 'GET'
 
@@ -71,7 +74,7 @@ export function useAnalyticsFetch<T = Record<string, unknown>>(
     body?: Record<string, unknown>,
   ): Promise<T | null> => {
     loading.value = true
-    error.value = null
+    errors.value = []
     try {
       const backendUrl = await getBackendUrl()
       const qs = query
@@ -104,7 +107,7 @@ export function useAnalyticsFetch<T = Record<string, unknown>>(
       return data.value
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
-      error.value = msg
+      errors.value = [...errors.value, msg]
       logger.error(`Failed to load ${path}: ${msg}`)
       return null
     } finally {
@@ -115,7 +118,7 @@ export function useAnalyticsFetch<T = Record<string, unknown>>(
   const reset = () => {
     data.value = null
     loading.value = false
-    error.value = null
+    errors.value = []
   }
 
   return { data, loading, error, load, reset }

--- a/autobot-frontend/src/composables/useAsyncOperation.ts
+++ b/autobot-frontend/src/composables/useAsyncOperation.ts
@@ -70,9 +70,9 @@ export interface AsyncOperationReturn<T> {
   loading: Ref<boolean>
 
   /**
-   * Reactive error state - contains Error object if operation failed, null otherwise
+   * Reactive error state - computed from accumulated errors, null if none
    */
-  error: Ref<Error | null>
+  error: ComputedRef<Error | null>
 
   /**
    * Reactive data state - contains resolved data from successful operation, null otherwise
@@ -110,12 +110,12 @@ export interface AsyncOperationReturn<T> {
  * frontend. It automatically manages loading states, error handling, and success/error callbacks.
  *
  * **Concurrent Call Handling**:
- * - Latest call wins - if multiple calls are made, all execute but state reflects the last completed call
+ * - Errors from parallel calls accumulate instead of overwriting each other
  * - For sequential execution, use `await execute()` before calling again
  * - For cancellation, implement AbortController in your async function
  *
  * **Error Handling**:
- * - Errors are caught and stored in `error` ref
+ * - Errors are caught and accumulated in internal errors array
  * - Error object or string are normalized to Error type
  * - Optional `onError` callback for custom error handling
  * - Errors are re-thrown after handling, allowing upstream catch blocks
@@ -131,7 +131,12 @@ export function useAsyncOperation<T = any>(
 
   // Reactive state
   const loading = ref<boolean>(initialLoading)
-  const error = ref<Error | null>(null)
+  const errors = ref<Error[]>([])
+  const error = computed<Error | null>(() => {
+    if (errors.value.length === 0) return null
+    if (errors.value.length === 1) return errors.value[0]
+    return new Error(errors.value.map((e) => e.message).join('; '))
+  })
   const data = ref<T | null>(null)
 
   // Computed helpers
@@ -142,15 +147,15 @@ export function useAsyncOperation<T = any>(
    * Execute an async operation with automatic state management
    *
    * **State Management**:
-   * 1. Sets loading=true and clears error
+   * 1. Sets loading=true and clears errors
    * 2. Executes the async function
    * 3. On success: stores data, calls onSuccess callback
-   * 4. On error: stores error, calls onError callback
+   * 4. On error: accumulates error, calls onError callback
    * 5. Finally: sets loading=false
    *
    * **Concurrent Calls**:
-   * Multiple calls will execute in parallel. State (loading, error, data) reflects
-   * the most recently completed operation. If you need sequential execution, use:
+   * Multiple calls will execute in parallel. Errors accumulate rather than
+   * overwriting each other. If you need sequential execution, use:
    * `await execute(fn1); await execute(fn2)`
    *
    * @param fn - Async function to execute
@@ -158,9 +163,9 @@ export function useAsyncOperation<T = any>(
    * @throws Re-throws the error after handling (allows upstream error handling)
    */
   const execute = async (fn: () => Promise<T>): Promise<T> => {
-    // Set loading state and clear error
+    // Set loading state and clear errors
     loading.value = true
-    error.value = null
+    errors.value = []
 
     try {
       // Execute async operation
@@ -185,8 +190,8 @@ export function useAsyncOperation<T = any>(
         normalizedError.message = `${errorMessage}: ${normalizedError.message}`
       }
 
-      // Store error
-      error.value = normalizedError
+      // Accumulate error
+      errors.value = [...errors.value, normalizedError]
 
       // Call error callback if provided
       if (onError) {
@@ -211,7 +216,7 @@ export function useAsyncOperation<T = any>(
    */
   const reset = () => {
     loading.value = initialLoading
-    error.value = null
+    errors.value = []
     data.value = null
   }
 

--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -290,7 +290,10 @@ export function useBatchProcessingState() {
   const completedCount = ref(0)
   const failedCount = ref(0)
   const loading = ref(false)
-  const error = ref<string | null>(null)
+  const errors = ref<string[]>([])
+  const error = computed<string | null>(() =>
+    errors.value.length > 0 ? errors.value.join('; ') : null,
+  )
   const selectedJob = ref<BatchJob | null>(null)
   const jobLogs = ref<BatchJobLogsResponse | null>(null)
   const healthStatus = ref<BatchHealthResponse | null>(null)
@@ -339,7 +342,7 @@ export function useBatchProcessingState() {
    */
   async function loadJobs() {
     loading.value = true
-    error.value = null
+    errors.value = []
 
     try {
       const result = await batchApi.listJobs(filter.value)
@@ -352,7 +355,8 @@ export function useBatchProcessingState() {
         failedCount.value = result.failed_count
       }
     } catch (e) {
-      error.value = e instanceof Error ? e.message : 'Unknown error'
+      const msg = e instanceof Error ? e.message : 'Unknown error'
+      errors.value = [...errors.value, msg]
       logger.error('Failed to load batch jobs:', e)
     } finally {
       loading.value = false

--- a/autobot-frontend/src/composables/useOperationsApi.ts
+++ b/autobot-frontend/src/composables/useOperationsApi.ts
@@ -144,7 +144,10 @@ export function useOperationsState() {
   const completedCount = ref(0)
   const failedCount = ref(0)
   const loading = ref(false)
-  const error = ref<string | null>(null)
+  const errors = ref<string[]>([])
+  const error = computed<string | null>(() =>
+    errors.value.length > 0 ? errors.value.join('; ') : null,
+  )
   const selectedOperation = ref<Operation | null>(null)
   const healthStatus = ref<OperationsHealthResponse | null>(null)
 
@@ -184,7 +187,7 @@ export function useOperationsState() {
    */
   async function loadOperations() {
     loading.value = true
-    error.value = null
+    errors.value = []
 
     try {
       const result = await operationsApi.listOperations(filter.value)
@@ -196,7 +199,8 @@ export function useOperationsState() {
         failedCount.value = result.failed_count
       }
     } catch (e) {
-      error.value = e instanceof Error ? e.message : 'Unknown error'
+      const msg = e instanceof Error ? e.message : 'Unknown error'
+      errors.value = [...errors.value, msg]
       logger.error('Failed to load operations:', e)
     } finally {
       loading.value = false

--- a/autobot-frontend/src/composables/useVncConnection.ts
+++ b/autobot-frontend/src/composables/useVncConnection.ts
@@ -7,7 +7,7 @@
  * Issue #74 - Area 4: Advanced Session Management
  */
 
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -37,7 +37,10 @@ export interface ConnectionMetrics {
 
 export function useVncConnection(sessionId: string = 'default') {
   const loading = ref(false)
-  const error = ref<string | null>(null)
+  const errors = ref<string[]>([])
+  const error = computed<string | null>(() =>
+    errors.value.length > 0 ? errors.value.join('; ') : null,
+  )
   const settings = ref<ConnectionSettings | null>(null)
   const metrics = ref<ConnectionMetrics | null>(null)
 
@@ -46,7 +49,7 @@ export function useVncConnection(sessionId: string = 'default') {
    */
   async function loadSettings(): Promise<void> {
     loading.value = true
-    error.value = null
+    errors.value = []
 
     try {
       const data = await ApiClient.get<ConnectionSettings>(
@@ -55,7 +58,7 @@ export function useVncConnection(sessionId: string = 'default') {
       settings.value = data
     } catch (err: any) {
       logger.error('Failed to load connection settings:', err)
-      error.value = 'Failed to load connection settings'
+      errors.value = [...errors.value, 'Failed to load connection settings']
     } finally {
       loading.value = false
     }
@@ -66,7 +69,7 @@ export function useVncConnection(sessionId: string = 'default') {
    */
   async function updateSettings(newSettings: ConnectionSettings): Promise<boolean> {
     loading.value = true
-    error.value = null
+    errors.value = []
 
     try {
       await ApiClient.post(
@@ -77,7 +80,7 @@ export function useVncConnection(sessionId: string = 'default') {
       return true
     } catch (err: any) {
       logger.error('Failed to update connection settings:', err)
-      error.value = 'Failed to update connection settings'
+      errors.value = [...errors.value, 'Failed to update connection settings']
       return false
     } finally {
       loading.value = false

--- a/autobot-frontend/src/composables/useWebSocket.ts
+++ b/autobot-frontend/src/composables/useWebSocket.ts
@@ -8,7 +8,7 @@
  * For the global singleton WebSocket, use useGlobalWebSocket instead.
  */
 
-import { ref, onUnmounted, watch, unref, type Ref } from 'vue'
+import { ref, computed, onUnmounted, watch, unref, type Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
 // Create scoped logger for useWebSocket
@@ -134,7 +134,12 @@ export function useWebSocket(
   const isConnected = ref(false)
   const isConnecting = ref(false)
   const lastMessage = ref<any>(null)
-  const error = ref<Error | null>(null)
+  const errors = ref<Error[]>([])
+  const error = computed<Error | null>(() => {
+    if (errors.value.length === 0) return null
+    if (errors.value.length === 1) return errors.value[0]
+    return new Error(errors.value.map((e) => e.message).join('; '))
+  })
   const reconnectAttempts = ref(0)
 
   // Timers
@@ -188,7 +193,7 @@ export function useWebSocket(
     }
 
     isConnecting.value = true
-    error.value = null
+    errors.value = []
 
     try {
       ws.value = new WebSocket(wsUrl)
@@ -198,7 +203,7 @@ export function useWebSocket(
         connectionTimeoutTimer = setTimeout(() => {
           if (isConnecting.value) {
             logger.warn('Connection timeout')
-            error.value = new Error('Connection timeout')
+            errors.value = [...errors.value, new Error('Connection timeout')]
             ws.value?.close()
           }
         }, opts.connectionTimeout)
@@ -208,7 +213,7 @@ export function useWebSocket(
         isConnected.value = true
         isConnecting.value = false
         reconnectAttempts.value = 0
-        error.value = null
+        errors.value = []
         clearTimers()
 
         logger.info('Connected to:', wsUrl)
@@ -234,7 +239,7 @@ export function useWebSocket(
 
       ws.value.onerror = (event) => {
         logger.error('Error:', event)
-        error.value = new Error('WebSocket error')
+        errors.value = [...errors.value, new Error('WebSocket error')]
         isConnecting.value = false
         // Clear heartbeat timer - dead socket should not keep sending pings (#820)
         if (heartbeatTimer) {
@@ -272,12 +277,12 @@ export function useWebSocket(
           }, delay)
         } else if (opts.maxReconnectAttempts > 0 && reconnectAttempts.value >= opts.maxReconnectAttempts) {
           logger.warn('Max reconnection attempts reached')
-          error.value = new Error('Max reconnection attempts reached')
+          errors.value = [...errors.value, new Error('Max reconnection attempts reached')]
         }
       }
     } catch (err) {
       logger.error('Connection error:', err)
-      error.value = err instanceof Error ? err : new Error('Connection error')
+      errors.value = [...errors.value, err instanceof Error ? err : new Error('Connection error')]
       isConnecting.value = false
     }
   }
@@ -319,7 +324,7 @@ export function useWebSocket(
       return true
     } catch (err) {
       logger.error('Error sending data:', err)
-      error.value = err instanceof Error ? err : new Error('Send error')
+      errors.value = [...errors.value, err instanceof Error ? err : new Error('Send error')]
       return false
     }
   }

--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -582,8 +582,11 @@ export function useWorkflowBuilder() {
   const loadingCapabilities = ref(false);
   const loadingExamples = ref(false);
 
-  // Error state
-  const error = ref<string | null>(null);
+  // Error state — accumulated to prevent race conditions (#2626)
+  const errors = ref<string[]>([]);
+  const error = computed<string | null>(() =>
+    errors.value.length > 0 ? errors.value.join('; ') : null,
+  );
 
   // Data state
   const activeWorkflows = ref<ActiveWorkflow[]>([]);
@@ -788,7 +791,7 @@ export function useWorkflowBuilder() {
     context?: Record<string, unknown>
   ): Promise<WorkflowExecutionResult | null> {
     executingWorkflow.value = true;
-    error.value = null;
+    errors.value = [];
 
     const response = await apiClient.executeWorkflow(goal, strategy, context);
     executingWorkflow.value = false;
@@ -797,7 +800,7 @@ export function useWorkflowBuilder() {
       logger.info('Workflow executed:', response.data);
       return response.data;
     } else {
-      error.value = response.error || 'Failed to execute workflow';
+      errors.value = [...errors.value, response.error || 'Failed to execute workflow'];
       logger.error('Workflow execution failed:', response.error);
       return null;
     }
@@ -809,7 +812,7 @@ export function useWorkflowBuilder() {
     context?: Record<string, unknown>
   ): Promise<WorkflowPlan | null> {
     loading.value = true;
-    error.value = null;
+    errors.value = [];
 
     const response = await apiClient.createWorkflowPlan(goal, context);
     loading.value = false;
@@ -819,7 +822,7 @@ export function useWorkflowBuilder() {
       logger.info('Workflow plan created:', response.data);
       return response.data.plan;
     } else {
-      error.value = response.error || 'Failed to create workflow plan';
+      errors.value = [...errors.value, response.error || 'Failed to create workflow plan'];
       logger.error('Plan creation failed:', response.error);
       return null;
     }
@@ -872,7 +875,7 @@ export function useWorkflowBuilder() {
     automationMode: AutomationMode = 'semi_automatic'
   ): Promise<string | null> {
     loading.value = true;
-    error.value = null;
+    errors.value = [];
 
     const response = await apiClient.createWorkflow(
       template.name,
@@ -889,7 +892,7 @@ export function useWorkflowBuilder() {
       await loadActiveWorkflows();
       return response.data.workflow_id;
     } else {
-      error.value = response.error || 'Failed to create workflow';
+      errors.value = [...errors.value, response.error || 'Failed to create workflow'];
       logger.error('Workflow creation failed:', response.error);
       return null;
     }
@@ -902,7 +905,7 @@ export function useWorkflowBuilder() {
     requireApproval: boolean = true
   ): Promise<string | null> {
     loading.value = true;
-    error.value = null;
+    errors.value = [];
 
     const response = await apiClient.createWorkflowFromChat(
       request,
@@ -920,7 +923,7 @@ export function useWorkflowBuilder() {
       await loadActiveWorkflows();
       return response.data.workflow_id;
     } else {
-      error.value = response.error || response.data?.message || 'Failed to create workflow';
+      errors.value = [...errors.value, response.error || response.data?.message || 'Failed to create workflow'];
       logger.error('Workflow creation from chat failed:', response.error);
       return null;
     }
@@ -929,7 +932,7 @@ export function useWorkflowBuilder() {
   /** Start workflow execution */
   async function startWorkflow(workflowId: string): Promise<boolean> {
     executingWorkflow.value = true;
-    error.value = null;
+    errors.value = [];
 
     const response = await apiClient.startWorkflow(workflowId);
     executingWorkflow.value = false;
@@ -939,7 +942,7 @@ export function useWorkflowBuilder() {
       await getWorkflowStatus(workflowId);
       return true;
     } else {
-      error.value = response.error || 'Failed to start workflow';
+      errors.value = [...errors.value, response.error || 'Failed to start workflow'];
       logger.error('Workflow start failed:', response.error);
       return false;
     }


### PR DESCRIPTION
## Summary
Apply the same error accumulation pattern from #2588 (useCodeIntelligence) to 8 composables that had the `error.value = null` / `error.value = message` race condition:

- **useWorkflowBuilder** (5 occurrences — highest risk, uses concurrent async ops)
- **useAnalyticsFetch** (2 occurrences)
- **useAsyncOperation** (2 occurrences)
- **useVncConnection** (2 occurrences)
- **useAgentRegistry** (1 occurrence)
- **useBatchProcessing** (1 occurrence)
- **useOperationsApi** (1 occurrence)
- **useWebSocket** (1 occurrence)

### Pattern applied
```typescript
// BEFORE (racy — last error wins):
const error = ref<string | null>(null)

// AFTER (safe — errors accumulate):
const errors = ref<string[]>([])
const error = computed<string | null>(() =>
  errors.value.length > 0 ? errors.value.join('; ') : null
)
```

Return types updated from `Ref<>` to `ComputedRef<>` where interfaces existed.

Closes #2626

## Test plan
- [ ] TypeScript compiles without errors
- [ ] No remaining `const error = ref<` patterns in the 8 files
- [ ] All composables still export `error` (now computed)
- [ ] `errors.value = []` used for clearing, `[...errors.value, msg]` for accumulation