### PR TITLE
fix(devops): add missing tier models to nested settings.json defaults (#2794)

### DIFF
--- a/autobot-infrastructure/shared/config/settings.json
+++ b/autobot-infrastructure/shared/config/settings.json
@@ -324,6 +324,8 @@
         "base_url": "http://localhost:11434",
         "models": {
           "qwen3.5:9b": "qwen3.5:9b",
+          "gemma3:4b": "gemma3:4b",
+          "llama3.2:1b": "llama3.2:1b",
           "nomic-embed-text": "nomic-embed-text"
         }
       },


### PR DESCRIPTION
## Summary
- Added `gemma3:4b` and `llama3.2:1b` to the nested `defaults.llm_config.ollama.models` map
- Gap from #2585 where only the top-level section was updated

## Test plan
- [ ] Verify `python -m json.tool < settings.json` passes
- [ ] Verify both models maps now match

Closes #2794

🤖 Generated with [Claude Code](https://claude.com/claude-code)