### PR TITLE
fix(backend): remove unused DEFAULT_ROLES import (#2817)

### DIFF
--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -586,7 +586,6 @@ async def validate_fleet(
     from sqlalchemy import func, select
 
     from models.database import Node, NodeRole
-    from services.role_registry import DEFAULT_ROLES
 
     async with db_service.session() as session:
         node_count_result = await session.execute(select(func.count(Node.id)))


### PR DESCRIPTION
## Summary
- Remove unused `DEFAULT_ROLES` import in `setup_wizard.py:validate_fleet` (flake8 F401)
- Import was left behind after #2747 refactored to query roles from the database

## Test plan
- [x] flake8 F401 resolved
- [x] Python syntax valid
- [x] `DEFAULT_ROLES` still correctly used in `deployments.py`

Closes #2817

🤖 Generated with [Claude Code](https://claude.com/claude-code)