### PR TITLE
fix(frontend): replace hardcoded English plural with i18n in MessageAttachments (#2805)

### DIFF
--- a/autobot-frontend/src/components/chat/MessageAttachments.vue
+++ b/autobot-frontend/src/components/chat/MessageAttachments.vue
@@ -2,7 +2,7 @@
   <div v-if="attachments && attachments.length > 0" class="message-attachments">
     <div class="attachment-header">
       <i class="fas fa-paperclip" aria-hidden="true"></i>
-      <span>{{ attachments.length }} attachment{{ attachments.length > 1 ? 's' : '' }}</span>
+      <span>{{ $t('chat.messages.attachments', { count: attachments.length }) }}</span>
     </div>
     <div class="attachment-list">
       <div


### PR DESCRIPTION
## Summary
- Replace hardcoded `attachment/attachments` plural with existing `chat.messages.attachments` i18n key
- Uses Vue I18n pluralization (`{ count }`)

## Test plan
- [x] No hardcoded English strings remain in the component
- [x] i18n key already exists in `en.json`

Closes #2805

🤖 Generated with [Claude Code](https://claude.com/claude-code)