### PR TITLE
fix(docker): use exec form in Dockerfile CMD for graceful shutdown (#2821)

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -95,6 +95,6 @@ EXPOSE 8001
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD curl -f http://localhost:${AUTOBOT_BACKEND_PORT}/api/system/health || exit 1
 
-CMD python3.12 -m uvicorn main:app \
-    --host 0.0.0.0 --port ${AUTOBOT_BACKEND_PORT} \
-    --workers 1 --app-dir /app/autobot-backend
+CMD ["python3.12", "-m", "uvicorn", "main:app", \
+     "--host", "0.0.0.0", "--port", "8001", \
+     "--workers", "1", "--app-dir", "/app/autobot-backend"]


### PR DESCRIPTION
## Summary
- Convert `CMD` in `docker/backend/Dockerfile` from shell form to exec form (JSON array)
- Shell form wraps uvicorn in `/bin/sh`, preventing SIGTERM delivery for graceful shutdown
- Exec form makes uvicorn PID 1 so it receives signals directly
- Port hardcoded to `8001` (matches `ENV`/`EXPOSE`) since exec form doesn't expand env vars

## Test plan
- [x] Dockerfile syntax valid
- [x] CMD uses exec form (JSON array)
- [x] Other 3 Dockerfiles already use exec form — no changes needed

Closes #2821

🤖 Generated with [Claude Code](https://claude.com/claude-code)