### PR TITLE
fix(frontend): remove dead save-workflow/update-workflow emits (#2820)

### DIFF
--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
@@ -54,8 +54,6 @@ const emit = defineEmits<{
   (e: 'skip-step', index: number): void
   (e: 'take-manual-control'): void
   (e: 'execute-all'): void
-  (e: 'save-workflow', data: { name: string; steps: WorkflowStep[] }): void
-  (e: 'update-workflow', steps: WorkflowStep[]): void
   (e: 'close'): void
 }>()
 

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -264,8 +264,6 @@
       @skip-step="skipCurrentStep"
       @take-manual-control="takeManualControl"
       @execute-all="executeAllRemainingSteps"
-      @save-workflow="saveCustomWorkflow"
-      @update-workflow="updateWorkflowSteps"
       @close="closeAdvancedModal"
     />
 
@@ -1453,21 +1451,6 @@ export default {
         automationPaused.value = false;
         waitingForUserConfirmation.value = false;
         processNextAutomationStep();
-      },
-      saveCustomWorkflow: (workflowData) => {
-        addOutputLine({
-          content: `💾 WORKFLOW SAVED: ${workflowData.name}`,
-          type: 'system_message',
-          timestamp: new Date()
-        });
-      },
-      updateWorkflowSteps: (newSteps) => {
-        workflowSteps.value = newSteps;
-        addOutputLine({
-          content: `📋 WORKFLOW UPDATED: ${newSteps.length} steps configured`,
-          type: 'system_message',
-          timestamp: new Date()
-        });
       },
       closeAdvancedModal: () => {
         showManualStepModal.value = false;


### PR DESCRIPTION
## Summary
- Remove dead `save-workflow` and `update-workflow` emit definitions from `AdvancedStepConfirmationModal.vue`
- Remove corresponding unreachable `@save-workflow` / `@update-workflow` listeners from `TerminalWindow.vue`
- Remove dead `saveCustomWorkflow` and `updateWorkflowSteps` handler functions from `TerminalWindow.vue`

## Test plan
- [x] No component calls these emits
- [x] No parent component listens for these events (verified with grep)
- [x] Both files compile without errors

Closes #2820

🤖 Generated with [Claude Code](https://claude.com/claude-code)