### PR TITLE
fix(ansible): update stale llama3.2:3b references to llama3.2:1b (#2809)

### DIFF
--- a/autobot-infrastructure/shared/config/config.yaml.template
+++ b/autobot-infrastructure/shared/config/config.yaml.template
@@ -111,13 +111,13 @@ llm:
     - phi:latest
     - tinyllama:latest
     - llama2:latest
-    - llama3.2:3b
+    - llama3.2:1b
     - qwen3.5:9b
     - nomic-embed-text:latest
   classification_model: gemma2:2b
   vllm:
     enabled: false
-    default_model: meta-llama/Llama-3.2-3B-Instruct
+    default_model: meta-llama/Llama-3.2-1B-Instruct
     tensor_parallel_size: 1
     gpu_memory_utilization: 0.9
     max_model_len: 8192

--- a/autobot-infrastructure/shared/config/llm_models.example.yaml
+++ b/autobot-infrastructure/shared/config/llm_models.example.yaml
@@ -65,7 +65,7 @@ performance_classification:
 
   # Standard models (2-8B parameters) - Balanced performance/quality
   standard:
-    - llama3.2:3b
+    - llama3.2:1b
     - gemma2:2b
     - gemma3:latest
     - artifish/llama3.2-uncensored


### PR DESCRIPTION
## Summary
- Ansible role defaults already use `llama3.2:1b` but config templates still referenced the uninstalled `3b` variant
- Updated `config.yaml.template`: available models list + vLLM default model
- Updated `llm_models.example.yaml`: standard tier model list

## Test plan
- [x] YAML syntax valid
- [x] All `llama3.2:3b` references replaced with `llama3.2:1b`
- [x] Consistent with Ansible role defaults

Closes #2809

🤖 Generated with [Claude Code](https://claude.com/claude-code)