### PR TITLE
fix(deps): add upper version bounds to llama-index dependencies (#2822)

### DIFF
--- a/autobot-infrastructure/shared/config/requirements-ci.txt
+++ b/autobot-infrastructure/shared/config/requirements-ci.txt
@@ -71,11 +71,11 @@ markdownify>=1.2.2              # SECURITY UPDATE - CVE fix (GHSA-7mpr-5m44-h73r
 langchain>=1.2.13
 langchain-community>=0.4.1
 langchain-experimental>=0.4.1
-llama-index>=0.14.19  # Unified across all components (#2669)
-llama-index-llms-ollama>=0.10.1
-llama-index-embeddings-ollama>=0.9.0
-llama-index-vector-stores-redis>=0.8.0
-llama-index-readers-file>=0.6.0
+llama-index>=0.14.19,<0.15.0  # Unified across all components (#2669); upper bound added (#2822)
+llama-index-llms-ollama>=0.10.1,<1.0.0
+llama-index-embeddings-ollama>=0.9.0,<1.0.0
+llama-index-vector-stores-redis>=0.8.0,<1.0.0
+llama-index-readers-file>=0.6.0,<1.0.0
 
 # ===== VOICE INTERFACE DEPENDENCIES (EXCLUDED FOR CI) =====
 # speechrecognition==3.10.0

--- a/autobot-infrastructure/shared/config/requirements.txt
+++ b/autobot-infrastructure/shared/config/requirements.txt
@@ -82,11 +82,11 @@ markdownify>=1.2.2              # SECURITY UPDATE - CVE fix (GHSA-7mpr-5m44-h73r
 langchain>=1.2.13
 langchain-community>=0.4.1
 langchain-experimental>=0.4.1      # For advanced LangChain features
-llama-index>=0.14.19
-llama-index-llms-ollama>=0.10.1
-llama-index-embeddings-ollama>=0.9.0
-llama-index-vector-stores-redis>=0.8.0
-llama-index-readers-file>=0.6.0   # File readers for RAG - 0.6.0+ for core 0.13.0 + pypdf 6.x compatibility
+llama-index>=0.14.19,<0.15.0
+llama-index-llms-ollama>=0.10.1,<1.0.0
+llama-index-embeddings-ollama>=0.9.0,<1.0.0
+llama-index-vector-stores-redis>=0.8.0,<1.0.0
+llama-index-readers-file>=0.6.0,<1.0.0   # File readers for RAG - 0.6.0+ for core 0.13.0 + pypdf 6.x compatibility
 
 # ===== VOICE INTERFACE DEPENDENCIES =====
 # Moved to requirements-voice.txt to avoid CI/CD build failures

--- a/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
+++ b/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
@@ -5,12 +5,12 @@
 langchain>=1.2.13
 langchain-core>=1.2.22
 langchain-community>=0.4.1
-llama-index>=0.14.19
-llama-index-core>=0.14.19
-llama-index-vector-stores-chroma>=0.5.5
-llama-index-vector-stores-redis>=0.8.0
-llama-index-embeddings-ollama>=0.9.0
-llama-index-llms-ollama>=0.10.1
+llama-index>=0.14.19,<0.15.0
+llama-index-core>=0.14.19,<0.15.0
+llama-index-vector-stores-chroma>=0.5.5,<1.0.0
+llama-index-vector-stores-redis>=0.8.0,<1.0.0
+llama-index-embeddings-ollama>=0.9.0,<1.0.0
+llama-index-llms-ollama>=0.10.1,<1.0.0
 
 # Vector Database
 chromadb>=1.5.5

--- a/requirements-ci/llama-index.txt
+++ b/requirements-ci/llama-index.txt
@@ -1,7 +1,7 @@
-# LlamaIndex ecosystem — unified at 0.14.x (#2669, #2642)
-llama-index-core>=0.14.19
-llama-index-llms-ollama>=0.10.1
-llama-index-embeddings-ollama>=0.9.0
-llama-index-vector-stores-chroma>=0.5.5
-llama-index-vector-stores-redis>=0.8.0
-llama-index-readers-file>=0.6.0
+# LlamaIndex ecosystem — unified at 0.14.x (#2669, #2642, #2822)
+llama-index-core>=0.14.19,<0.15.0
+llama-index-llms-ollama>=0.10.1,<1.0.0
+llama-index-embeddings-ollama>=0.9.0,<1.0.0
+llama-index-vector-stores-chroma>=0.5.5,<1.0.0
+llama-index-vector-stores-redis>=0.8.0,<1.0.0
+llama-index-readers-file>=0.6.0,<1.0.0


### PR DESCRIPTION
## Summary
- Add `<0.15.0` upper bound to `llama-index` and `llama-index-core` across all requirements files
- Add `<1.0.0` upper bound to all llama-index sub-packages, consistent with existing `autobot-backend/requirements.txt` pins
- 4 files updated: `requirements-ci/llama-index.txt`, `autobot-infrastructure/shared/config/requirements.txt`, `autobot-infrastructure/shared/config/requirements-ci.txt`, `autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt`

## Test plan
- [x] All llama-index deps have upper bounds matching the 0.14.x series
- [x] Sub-package upper bounds use `<1.0.0` consistent with existing pins
- [x] No CI requirement files reference unbounded llama-index packages

Closes #2822

🤖 Generated with [Claude Code](https://claude.com/claude-code)