### PR TITLE
fix(backend): update agent admin_url when node IP changes (#2833)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -33,9 +33,9 @@ Environment=SLM_ADMIN_URL={{ effective_admin_url }}
 Environment=PYTHONPATH={{ slm_agent_dir }}
 Environment=PYTHONUNBUFFERED=1
 
-# Agent execution
+# Agent execution — admin_url resolved from SLM_ADMIN_URL env var above,
+# not baked into CLI args, so re-provisioning updates it (#2833).
 ExecStart=/usr/bin/python3 -m slm.agent.agent \
-    --admin-url {{ effective_admin_url }} \
     --node-id {{ slm_node_id }} \
     --interval {{ slm_heartbeat_interval }}{% if slm_services_to_monitor | length > 0 %} \
     --services {{ slm_services_to_monitor | join(' ') }}{% endif %}{% if slm_agent_debug %} \

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -536,6 +536,7 @@ async def update_node(
             detail="Node not found",
         )
 
+    old_ip = node.ip_address
     update_data = node_data.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         if value is not None:
@@ -554,6 +555,16 @@ async def update_node(
             )
         raise
     await db.refresh(node)
+
+    # Warn when IP changes — agent config has a stale admin_url until
+    # re-provisioned (#2833).
+    if "ip_address" in update_data and node.ip_address != old_ip:
+        logger.warning(
+            "Node %s IP changed %s -> %s; re-provision to update agent config",
+            node_id,
+            old_ip,
+            node.ip_address,
+        )
 
     logger.info("Node updated: %s", node_id)
     return NodeResponse.model_validate(node)


### PR DESCRIPTION
## Summary
- `update_node()` now detects IP address changes and logs a warning that re-provisioning is needed
- Removed redundant `--admin-url` CLI arg from `slm-agent.service.j2` — agent already reads `SLM_ADMIN_URL` from the env var in the same unit, eliminating a second source of truth
- After re-provisioning, only the env var line needs updating (single source)

## Test plan
- [x] Python syntax valid
- [x] Jinja2 template syntax valid
- [x] Agent still reads `SLM_ADMIN_URL` env var correctly via `_get_default_admin_url()`
- [ ] Verify on deployed node: `systemctl show slm-agent -p ExecStart` no longer has `--admin-url`

Closes #2833

🤖 Generated with [Claude Code](https://claude.com/claude-code)