### PR TITLE
fix(backend): enforce TTL for lpush/rpush/xadd and fix ttl=0 override in redis_mcp (#2793)

### DIFF
--- a/autobot-backend/api/redis_mcp/data_access.py
+++ b/autobot-backend/api/redis_mcp/data_access.py
@@ -24,6 +24,22 @@ AGENT_MEMORY_TTL_SECONDS = 86400  # 24 hours
 AGENT_MEMORY_PREFIX = "autobot:agent:memory:"
 
 
+def _resolve_ttl(ttl: Optional[int], key: str) -> Optional[int]:
+    """Return the effective TTL for a write operation.
+
+    Rules (Issue #2793):
+    - ttl=None  → apply AGENT_MEMORY_TTL_SECONDS for matching keys, else None
+    - ttl=0     → caller explicitly requested no expiry; return None (no expire call)
+    - ttl>0     → use caller-supplied value as-is
+    """
+    if ttl is not None:
+        # Explicit caller value: treat 0 as "no expiry" sentinel
+        return ttl if ttl > 0 else None
+    if key.startswith(AGENT_MEMORY_PREFIX):
+        return AGENT_MEMORY_TTL_SECONDS
+    return None
+
+
 def _decode(value):
     """Decode bytes to UTF-8 string, pass through other types."""
     return value.decode("utf-8") if isinstance(value, bytes) else value
@@ -60,12 +76,11 @@ async def handle_redis_set(
     """Set a string value with optional TTL.
 
     Keys matching AGENT_MEMORY_PREFIX receive a 24h TTL automatically when
-    no explicit TTL is provided (Issue #2646).
+    no explicit TTL is provided (Issue #2646).  Pass ttl=0 to explicitly
+    suppress the automatic TTL (i.e. store with no expiry).
     """
     client = await _get_client(database)
-    effective_ttl = ttl
-    if not effective_ttl and key.startswith(AGENT_MEMORY_PREFIX):
-        effective_ttl = AGENT_MEMORY_TTL_SECONDS
+    effective_ttl = _resolve_ttl(ttl, key)
     if effective_ttl and effective_ttl > 0:
         await client.setex(key, effective_ttl, value)
     else:
@@ -161,21 +176,43 @@ async def handle_redis_lrange(
 
 
 async def handle_redis_lpush(
-    key: str, values: List[str], database: str = "main"
+    key: str,
+    values: List[str],
+    ttl: Optional[int] = None,
+    database: str = "main",
 ) -> Metadata:
-    """Push values to the left of a list."""
+    """Push values to the left of a list.
+
+    Keys matching AGENT_MEMORY_PREFIX receive a 24h TTL automatically when
+    no explicit TTL is provided (Issue #2793).  Pass ttl=0 to suppress the
+    automatic TTL.
+    """
     client = await _get_client(database)
     length = await client.lpush(key, *values)
-    return {"status": "success", "key": key, "list_length": length}
+    effective_ttl = _resolve_ttl(ttl, key)
+    if effective_ttl:
+        await client.expire(key, effective_ttl)
+    return {"status": "success", "key": key, "list_length": length, "ttl": effective_ttl}
 
 
 async def handle_redis_rpush(
-    key: str, values: List[str], database: str = "main"
+    key: str,
+    values: List[str],
+    ttl: Optional[int] = None,
+    database: str = "main",
 ) -> Metadata:
-    """Push values to the right of a list."""
+    """Push values to the right of a list.
+
+    Keys matching AGENT_MEMORY_PREFIX receive a 24h TTL automatically when
+    no explicit TTL is provided (Issue #2793).  Pass ttl=0 to suppress the
+    automatic TTL.
+    """
     client = await _get_client(database)
     length = await client.rpush(key, *values)
-    return {"status": "success", "key": key, "list_length": length}
+    effective_ttl = _resolve_ttl(ttl, key)
+    if effective_ttl:
+        await client.expire(key, effective_ttl)
+    return {"status": "success", "key": key, "list_length": length, "ttl": effective_ttl}
 
 
 # ---------------------------------------------------------------------------
@@ -245,9 +282,15 @@ async def handle_redis_xadd(
     key: str,
     fields: Dict[str, str],
     maxlen: Optional[int] = None,
+    ttl: Optional[int] = None,
     database: str = "main",
 ) -> Metadata:
-    """Add an entry to a stream."""
+    """Add an entry to a stream.
+
+    Keys matching AGENT_MEMORY_PREFIX receive a 24h TTL automatically when
+    no explicit TTL is provided (Issue #2793).  Pass ttl=0 to suppress the
+    automatic TTL.
+    """
     client = await _get_client(database)
     kwargs: Dict[str, Any] = {}
     if maxlen is not None:
@@ -255,7 +298,10 @@ async def handle_redis_xadd(
         kwargs["approximate"] = True
     entry_id = await client.xadd(key, fields, **kwargs)
     decoded_id = entry_id.decode("utf-8") if isinstance(entry_id, bytes) else entry_id
-    return {"status": "success", "key": key, "entry_id": decoded_id}
+    effective_ttl = _resolve_ttl(ttl, key)
+    if effective_ttl:
+        await client.expire(key, effective_ttl)
+    return {"status": "success", "key": key, "entry_id": decoded_id, "ttl": effective_ttl}
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/redis_mcp/router.py
+++ b/autobot-backend/api/redis_mcp/router.py
@@ -252,6 +252,7 @@ async def _wrap_data_lpush(args: dict) -> Metadata:
     return await handle_redis_lpush(
         key=args["key"],
         values=args["values"],
+        ttl=args.get("ttl"),
         database=args.get("database", "main"),
     )
 
@@ -260,6 +261,7 @@ async def _wrap_data_rpush(args: dict) -> Metadata:
     return await handle_redis_rpush(
         key=args["key"],
         values=args["values"],
+        ttl=args.get("ttl"),
         database=args.get("database", "main"),
     )
 
@@ -289,6 +291,7 @@ async def _wrap_data_xadd(args: dict) -> Metadata:
         key=args["key"],
         fields=args["fields"],
         maxlen=args.get("maxlen"),
+        ttl=args.get("ttl"),
         database=args.get("database", "main"),
     )
 

--- a/autobot-backend/api/redis_mcp/tools.py
+++ b/autobot-backend/api/redis_mcp/tools.py
@@ -172,7 +172,10 @@ def _tool_redis_lrange() -> MCPTool:
 def _tool_redis_lpush() -> MCPTool:
     return MCPTool(
         name="redis_lpush",
-        description="Push values to the left of a Redis list. Users: autobot:agent:* only.",
+        description=(
+            "Push values to the left of a Redis list. Users: autobot:agent:* only. "
+            "autobot:agent:memory:* keys receive a 24h TTL automatically; pass ttl=0 to suppress."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -181,6 +184,10 @@ def _tool_redis_lpush() -> MCPTool:
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Values to push",
+                },
+                "ttl": {
+                    "type": "integer",
+                    "description": "Optional TTL in seconds (0 = no expiry)",
                 },
                 "database": {"type": "string", "default": "main"},
             },
@@ -192,7 +199,10 @@ def _tool_redis_lpush() -> MCPTool:
 def _tool_redis_rpush() -> MCPTool:
     return MCPTool(
         name="redis_rpush",
-        description="Push values to the right of a Redis list. Users: autobot:agent:* only.",
+        description=(
+            "Push values to the right of a Redis list. Users: autobot:agent:* only. "
+            "autobot:agent:memory:* keys receive a 24h TTL automatically; pass ttl=0 to suppress."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -201,6 +211,10 @@ def _tool_redis_rpush() -> MCPTool:
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Values to push",
+                },
+                "ttl": {
+                    "type": "integer",
+                    "description": "Optional TTL in seconds (0 = no expiry)",
                 },
                 "database": {"type": "string", "default": "main"},
             },
@@ -263,7 +277,10 @@ def _tool_redis_xrange() -> MCPTool:
 def _tool_redis_xadd() -> MCPTool:
     return MCPTool(
         name="redis_xadd",
-        description="Add an entry to a Redis stream. Users: autobot:agent:* only.",
+        description=(
+            "Add an entry to a Redis stream. Users: autobot:agent:* only. "
+            "autobot:agent:memory:* keys receive a 24h TTL automatically; pass ttl=0 to suppress."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -275,6 +292,10 @@ def _tool_redis_xadd() -> MCPTool:
                 "maxlen": {
                     "type": "integer",
                     "description": "Optional max stream length (approximate trim)",
+                },
+                "ttl": {
+                    "type": "integer",
+                    "description": "Optional TTL in seconds (0 = no expiry)",
                 },
                 "database": {"type": "string", "default": "main"},
             },


### PR DESCRIPTION
## Summary
- Add `_resolve_ttl()` helper that correctly distinguishes `ttl=None` (auto-apply for agent memory), `ttl=0` (no expiry), and `ttl>0` (explicit)
- Fix `ttl=0` override bug in `handle_redis_set` — `not 0` evaluates to `True`, causing agent memory TTL to be applied even when caller explicitly passed 0
- Add TTL enforcement to `handle_redis_lpush`, `handle_redis_rpush`, and `handle_redis_xadd` via `client.expire()` after write
- Update MCP tool schemas to expose `ttl` parameter for list/stream operations

## Test plan
- [x] Python syntax valid for all 3 files
- [x] `ttl=0` correctly bypasses TTL (no expiry)
- [x] `ttl=None` auto-applies agent memory TTL for matching keys
- [x] lpush/rpush/xadd now set expiry after write

Closes #2793

🤖 Generated with [Claude Code](https://claude.com/claude-code)