### PR TITLE
fix(backend): add logging to silent exception handler in database session (#2850)

### DIFF
--- a/autobot-slm-backend/services/database.py
+++ b/autobot-slm-backend/services/database.py
@@ -201,6 +201,7 @@ class DatabaseService:
                 yield session
                 await session.commit()
             except Exception:
+                logger.exception("Database session error, rolling back")
                 await session.rollback()
                 raise
 


### PR DESCRIPTION
## Summary
- Add `logger.exception()` before rollback in `database.py` session context manager — previously rolled back silently
- Other instances flagged in the issue are **string literals inside test fixtures** (not real code):
  - `analytics_precommit.py:931` — inside `get_demo_content()` return string
  - `precommit_analyzer_test.py:236,254` — inside `textwrap.dedent()` test input
  - `llm_code_generator_test.py:425` — inside code validation test string

## Test plan
- [x] Python syntax valid
- [x] Logger already exists at module level
- [x] Exception still re-raised after logging (no behavior change)

Closes #2850

🤖 Generated with [Claude Code](https://claude.com/claude-code)