### PR TITLE
fix(security): remove hardcoded emergency admin password hash (#2853)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/enroll-local.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-local.yml
@@ -23,9 +23,8 @@
     slm_server_pubkey: "{{ lookup('env', 'SLM_PUBKEY') | default('', true) }}"
     # Emergency admin user - fallback access when SSH keys fail
     emergency_admin_user: autobot_admin
-    # Password hash for emergency admin (AutoBot!Admin2025)
-    # Generated with: python3 -c "from passlib.hash import sha512_crypt; print(sha512_crypt.hash('AutoBot!Admin2025'))"
-    emergency_admin_password_hash: "$6$rounds=656000$VqQZbIggJvVNjHfl$hunhLQdMKj/TCyE.ftDknskbz4SCnGz5e6Yo4YJzHeIIhdRAp/oIDKdwd54oktyBwmb2nP09MWRyXNu0mLg1L1"
+    # Password hash MUST come from Ansible Vault or --extra-vars (#2853)
+    emergency_admin_password_hash: "{{ vault_emergency_admin_password_hash | default(omit) }}"
 
   tasks:
     # ==========================================================

--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -60,6 +60,7 @@
     password: "{{ emergency_admin_password_hash }}"
     state: present
   become: yes
+  when: emergency_admin_password_hash is defined
   tags: ['common', 'users', 'emergency']
 
 - name: "Common | Configure passwordless sudo for emergency admin"
@@ -71,6 +72,7 @@
     mode: '0440'
     validate: 'visudo -cf %s'
   become: yes
+  when: emergency_admin_password_hash is defined
   tags: ['common', 'users', 'emergency']
 
 - name: "Common | Create AutoBot directory structure"

--- a/autobot-slm-backend/ansible/roles/common/vars/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/vars/main.yml
@@ -26,7 +26,9 @@ autobot_home: /home/autobot
 
 # Emergency admin user for fallback access when SSH keys fail
 emergency_admin_user: autobot_admin
-emergency_admin_password_hash: "$6$rounds=656000$VqQZbIggJvVNjHfl$hunhLQdMKj/TCyE.ftDknskbz4SCnGz5e6Yo4YJzHeIIhdRAp/oIDKdwd54oktyBwmb2nP09MWRyXNu0mLg1L1"
+# Password hash MUST come from Ansible Vault (vault_emergency_admin_password_hash)
+# or --extra-vars. Never hardcode hashes in version control (#2853).
+emergency_admin_password_hash: "{{ vault_emergency_admin_password_hash | default(omit) }}"
 
 autobot_directories:
   - "{{ autobot_home }}/autobot-vue"


### PR DESCRIPTION
## Summary
- **CRITICAL**: Remove hardcoded SHA-512 password hash from `common/vars/main.yml` and `enroll-local.yml`
- **CRITICAL**: Remove plaintext password `AutoBot!Admin2025` from comment in `enroll-local.yml`
- Replace with `vault_emergency_admin_password_hash` Ansible Vault reference
- Add `when: emergency_admin_password_hash is defined` guards so tasks skip when vault not configured
- `enroll-node.yml` already had the correct pattern — now all files are consistent

## Post-merge action required
The password `AutoBot!Admin2025` is **compromised** (was in plaintext in VCS). After merge:
1. Generate new hash: `python3 -c "from passlib.hash import sha512_crypt; print(sha512_crypt.hash('NEW_PASSWORD'))"`
2. Store in Ansible Vault: `vault_emergency_admin_password_hash`
3. Re-provision all nodes: `ansible-playbook update-all-nodes.yml --tags emergency`

## Test plan
- [x] YAML syntax valid
- [x] No hardcoded hashes remain in repo
- [x] Tasks skip gracefully when vault not configured

Closes #2853

🤖 Generated with [Claude Code](https://claude.com/claude-code)