### PR TITLE
fix(security): replace f-string SQL with validated identifiers (#2845)

### DIFF
--- a/autobot-backend/api/database_mcp.py
+++ b/autobot-backend/api/database_mcp.py
@@ -47,6 +47,33 @@ router = APIRouter(
 # Issue #380: Module-level tuple for allowed DML operations
 _ALLOWED_DML_OPERATIONS = ("INSERT", "UPDATE", "DELETE")
 
+# Issue #2845: Allowlist pattern for SQL identifiers (table and column names)
+_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_sql_identifier(name: str, label: str = "identifier") -> str:
+    """Validate a SQL identifier (table or column name) against an allowlist pattern.
+
+    Only permits names composed of ASCII letters, digits, and underscores, starting
+    with a letter or underscore. This prevents SQL injection when user-supplied identifiers
+    are interpolated into query strings. (#2845)
+
+    Args:
+        name: The identifier to validate.
+        label: Human-readable label used in the error message.
+
+    Returns:
+        The validated name unchanged.
+
+    Raises:
+        ValueError: If the name contains characters outside the allowed set.
+    """
+    if not _SQL_IDENTIFIER_RE.match(name):
+        raise ValueError(
+            f"Invalid SQL {label} '{name}': only letters, digits, and underscores allowed"
+        )
+    return name
+
 
 # Security Configuration
 
@@ -285,7 +312,8 @@ def _describe_schema_sync(db_path: Path, table: str | None) -> dict:
         schemas = {}
 
         if table:
-            cursor.execute(f"PRAGMA table_info([{table}])")
+            _validate_sql_identifier(table, "table name")
+            cursor.execute(f"PRAGMA table_info([{table}])")  # nosec B608
             columns = cursor.fetchall()
             schemas[table] = [
                 {
@@ -926,6 +954,9 @@ async def database_describe_schema_mcp(request: SchemaRequest) -> Metadata:
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
+    except ValueError as e:
+        logger.warning("Invalid table identifier in describe_schema request: %s", e)
+        raise HTTPException(status_code=400, detail=str(e))
     except sqlite3.Error as e:
         logger.error("SQLite error describing schema: %s", e)
         raise HTTPException(status_code=500, detail="Error describing schema")

--- a/autobot-backend/utils/async_database_pool.py
+++ b/autobot-backend/utils/async_database_pool.py
@@ -9,6 +9,7 @@ to improve performance and prevent blocking operations.
 
 import asyncio
 import logging
+import re
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -403,6 +404,33 @@ async def async_transaction(pool: AsyncSQLiteConnectionPool):
             raise
 
 
+_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_sql_identifier(name: str, label: str = "identifier") -> str:
+    """Validate a SQL identifier (table or column name) against an allowlist pattern.
+
+    Only permits names composed of ASCII letters, digits, and underscores, starting
+    with a letter or underscore. This prevents SQL injection via identifier interpolation
+    in f-string query construction. (#2845)
+
+    Args:
+        name: The identifier to validate.
+        label: Human-readable label used in the error message.
+
+    Returns:
+        The validated name unchanged.
+
+    Raises:
+        ValueError: If the name contains characters outside the allowed set.
+    """
+    if not _SQL_IDENTIFIER_RE.match(name):
+        raise ValueError(
+            f"Invalid SQL {label} '{name}': only letters, digits, and underscores allowed"
+        )
+    return name
+
+
 # Batch operation helpers
 class AsyncBatchOperations:
     """Helper class for efficient batch database operations."""
@@ -425,6 +453,9 @@ class AsyncBatchOperations:
             data: List of tuples with data to insert
             batch_size: Number of records per batch
         """
+        _validate_sql_identifier(table, "table name")
+        for col in columns:
+            _validate_sql_identifier(col, "column name")
         placeholders = ", ".join(["?" for _ in columns])
         column_names = ", ".join(columns)
         query = f"INSERT INTO {table} ({column_names}) VALUES ({placeholders})"  # nosec B608
@@ -456,6 +487,10 @@ class AsyncBatchOperations:
             data: List of tuples with (set_values..., where_value)
             batch_size: Number of records per batch
         """
+        _validate_sql_identifier(table, "table name")
+        for col in set_columns:
+            _validate_sql_identifier(col, "column name")
+        _validate_sql_identifier(where_column, "column name")
         set_clause = ", ".join([f"{col} = ?" for col in set_columns])
         query = (
             f"UPDATE {table} SET {set_clause} WHERE {where_column} = ?"  # nosec B608

--- a/autobot-backend/utils/common.py
+++ b/autobot-backend/utils/common.py
@@ -10,11 +10,37 @@ functionality across the codebase.
 
 import json
 import logging
+import re
 import sqlite3
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 logger = logging.getLogger(__name__)
+
+_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_sql_identifier(name: str, label: str = "identifier") -> str:
+    """Validate a SQL identifier (table or column name) against an allowlist pattern.
+
+    Only permits names composed of ASCII letters, digits, and underscores, starting
+    with a letter or underscore. Prevents SQL injection via identifier interpolation. (#2845)
+
+    Args:
+        name: The identifier to validate.
+        label: Human-readable label used in the error message.
+
+    Returns:
+        The validated name unchanged.
+
+    Raises:
+        ValueError: If the name contains characters outside the allowed set.
+    """
+    if not _SQL_IDENTIFIER_RE.match(name):
+        raise ValueError(
+            f"Invalid SQL {label} '{name}': only letters, digits, and underscores allowed"
+        )
+    return name
 
 
 def _is_path_in_allowed_dir(path_obj: Path, allowed_dirs: list) -> bool:
@@ -417,8 +443,9 @@ class DatabaseUtils:
             Number of rows, 0 if error
         """
         try:
+            _validate_sql_identifier(table_name, "table name")
             cursor = conn.cursor()
-            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")  # nosec B608
             result = cursor.fetchone()
             return result[0] if result else 0
         except Exception:


### PR DESCRIPTION
## Summary
- **CRITICAL**: `database_mcp.py` interpolated HTTP user input into `PRAGMA table_info([{table}])` — exploitable SQL injection
- Added `_validate_sql_identifier()` (regex `^[a-zA-Z_][a-zA-Z0-9_]*$`) to 3 files
- `async_database_pool.py`: validate table/column names in `batch_insert` and `batch_update`
- `common.py`: validate `table_name` in `get_table_row_count`
- All other f-string SQL patterns verified safe (system table sources or hardcoded columns)

## Test plan
- [x] Python syntax valid for all 3 files
- [x] Identifiers with special chars (`; DROP TABLE`) rejected with ValueError
- [x] Normal identifiers (`nodes`, `agent_memory`) pass validation
- [x] No parameterized queries broken

Closes #2845

🤖 Generated with [Claude Code](https://claude.com/claude-code)