### PR TITLE
fix(security): make TLS verification configurable, default to enabled (#2852)

### DIFF
--- a/autobot-backend/services/slm_client.py
+++ b/autobot-backend/services/slm_client.py
@@ -124,14 +124,16 @@ class ServiceDiscoveryCache:
 
 
 def _create_permissive_ssl_context():
-    """Create SSL context that accepts self-signed certificates.
+    """Create SSL context for internal SLM communication (#1048, #2852).
 
-    Used for internal SLM communication where nginx uses self-signed TLS.
-    Issue #1048.
+    By default TLS verification is enabled.  Set AUTOBOT_SKIP_TLS_VERIFY=true
+    ONLY in dev/test environments that use self-signed certificates — never in
+    production.
     """
     ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    if os.environ.get("AUTOBOT_SKIP_TLS_VERIFY", "").lower() == "true":
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
     return ctx
 
 

--- a/autobot-backend/services/workflow_automation/vision_step_handler.py
+++ b/autobot-backend/services/workflow_automation/vision_step_handler.py
@@ -9,12 +9,18 @@ based on the step's target property (vnc or web).
 
 import asyncio
 import logging
+import os
 import time
 from typing import Any
 
 import httpx
 
 from autobot_shared.ssot_config import config as ssot_config
+
+# TLS verification for outbound calls to internal vision/browser services.
+# Set AUTOBOT_SKIP_TLS_VERIFY=true ONLY in dev/test environments that use
+# self-signed certificates.  Production must leave this unset (#2852).
+_VERIFY_TLS = os.environ.get("AUTOBOT_SKIP_TLS_VERIFY", "").lower() != "true"
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +113,7 @@ async def _execute_vnc_step(
     if not endpoint:
         raise ValueError(f"Unknown vision step type: {step_type}")
 
-    async with httpx.AsyncClient(verify=False, timeout=30.0) as client:  # nosec B501
+    async with httpx.AsyncClient(verify=_VERIFY_TLS, timeout=30.0) as client:
         if step_type == "vision-wait":
             payload = _build_vnc_payload(step_type, config)
             return await _poll_vnc_element(
@@ -210,7 +216,7 @@ async def _execute_web_step(
 
     action_payload = _build_web_action_payload(step_type, action_base, config)
 
-    async with httpx.AsyncClient(verify=False, timeout=30.0) as client:  # nosec B501
+    async with httpx.AsyncClient(verify=_VERIFY_TLS, timeout=30.0) as client:
         response = await client.post(
             f"{backend_url}/api/research-browser/session/action",
             json={"session_id": session_id, **action_payload},
@@ -247,7 +253,7 @@ async def _web_ocr_step(
       1. POST to /api/research-browser/session/action with action=screenshot
       2. POST the screenshot image data to /api/vision/ocr
     """
-    async with httpx.AsyncClient(verify=False, timeout=30.0) as client:  # nosec B501
+    async with httpx.AsyncClient(verify=_VERIFY_TLS, timeout=30.0) as client:
         screenshot_data = await _capture_browser_screenshot(
             client, session_id, backend_url
         )

--- a/autobot-infrastructure/shared/scripts/slm-agent-standalone.py
+++ b/autobot-infrastructure/shared/scripts/slm-agent-standalone.py
@@ -23,11 +23,11 @@ from typing import Dict, List
 
 import psutil
 import requests
-import urllib3
 import yaml
 
-# Suppress InsecureRequestWarning for self-signed certs
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+# TLS verification for heartbeat calls to the SLM admin (#2852).
+# Set AUTOBOT_SKIP_TLS_VERIFY=true ONLY in dev/test with self-signed certs.
+_VERIFY_TLS = os.environ.get("AUTOBOT_SKIP_TLS_VERIFY", "").lower() != "true"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -202,7 +202,7 @@ class SLMAgent:
             }
 
             url = f"{self.config['admin_url']}/api/nodes/{self.config['node_id']}/heartbeat"
-            response = requests.post(url, json=payload, timeout=10, verify=False)
+            response = requests.post(url, json=payload, timeout=10, verify=_VERIFY_TLS)
             response.raise_for_status()
 
             logger.debug(

--- a/autobot-slm-backend/api/personality_proxy.py
+++ b/autobot-slm-backend/api/personality_proxy.py
@@ -35,6 +35,9 @@ AUTOBOT_INTERNAL_API_KEY = os.getenv("AUTOBOT_INTERNAL_API_KEY", "")
 
 _MUTATION_METHODS = {"POST", "PUT", "DELETE", "PATCH"}
 _TIMEOUT = 15.0
+# TLS verification for proxy calls to the main backend.
+# Set AUTOBOT_SKIP_TLS_VERIFY=true ONLY in dev/test with self-signed certs (#2852).
+_VERIFY_TLS = os.environ.get("AUTOBOT_SKIP_TLS_VERIFY", "").lower() != "true"
 
 
 async def _proxy_to_main_backend(request: Request, path: str) -> Response:
@@ -54,8 +57,8 @@ async def _proxy_to_main_backend(request: Request, path: str) -> Response:
 
     try:
         async with httpx.AsyncClient(
-            verify=False, timeout=_TIMEOUT
-        ) as client:  # nosec B501 — self-signed internal cert
+            verify=_VERIFY_TLS, timeout=_TIMEOUT
+        ) as client:
             response = await client.request(
                 method=request.method,
                 url=target_url,

--- a/autobot-slm-backend/api/voice_proxy.py
+++ b/autobot-slm-backend/api/voice_proxy.py
@@ -32,6 +32,9 @@ AUTOBOT_BACKEND_URL = os.getenv(
 AUTOBOT_INTERNAL_API_KEY = os.getenv("AUTOBOT_INTERNAL_API_KEY", "")
 
 _TIMEOUT = 15.0
+# TLS verification for proxy calls to the main backend.
+# Set AUTOBOT_SKIP_TLS_VERIFY=true ONLY in dev/test with self-signed certs (#2852).
+_VERIFY_TLS = os.environ.get("AUTOBOT_SKIP_TLS_VERIFY", "").lower() != "true"
 
 
 async def _proxy_to_main_backend(request: Request, path: str) -> Response:
@@ -51,8 +54,8 @@ async def _proxy_to_main_backend(request: Request, path: str) -> Response:
 
     try:
         async with httpx.AsyncClient(
-            verify=False, timeout=_TIMEOUT
-        ) as client:  # nosec B501 — self-signed internal cert
+            verify=_VERIFY_TLS, timeout=_TIMEOUT
+        ) as client:
             response = await client.request(
                 method=request.method,
                 url=target_url,

--- a/autobot-slm-backend/config.py
+++ b/autobot-slm-backend/config.py
@@ -263,6 +263,16 @@ class Settings(BaseSettings):
         "SLM_EXTERNAL_URL", f"https://{_get_local_ip()}"
     )
 
+    # TLS verification for outbound HTTPS calls to internal nodes.
+    # Set SLM_VERIFY_SSL=false ONLY in dev/test environments that use
+    # self-signed certificates.  Production must leave this at the default
+    # True value (#2852).
+    verify_ssl: bool = os.getenv("SLM_VERIFY_SSL", "true").lower() not in (
+        "false",
+        "0",
+        "no",
+    )
+
     model_config = ConfigDict(
         env_prefix="SLM_",
         env_file=(".env", "/etc/autobot/db-credentials.env"),

--- a/autobot-slm-backend/services/a2a_card_fetcher.py
+++ b/autobot-slm-backend/services/a2a_card_fetcher.py
@@ -16,10 +16,15 @@ Public API:
 
 import asyncio
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+# TLS verification for A2A card fetches from internal backend nodes.
+# Set AUTOBOT_SKIP_TLS_VERIFY=true ONLY in dev/test with self-signed certs (#2852).
+_VERIFY_TLS = os.environ.get("AUTOBOT_SKIP_TLS_VERIFY", "").lower() != "true"
 
 # Only nodes with this role expose the A2A endpoint
 _A2A_ROLE = "backend"
@@ -41,8 +46,9 @@ async def _fetch_one(ip_address: str) -> Optional[Dict[str, Any]]:
 
     url = f"https://{ip_address}:{_A2A_PORT}{_WELL_KNOWN_PATH}"
     ssl_ctx = ssl.create_default_context()
-    ssl_ctx.check_hostname = False
-    ssl_ctx.verify_mode = ssl.CERT_NONE
+    if not _VERIFY_TLS:
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
     try:
         timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT)
         async with aiohttp.ClientSession(timeout=timeout) as session:

--- a/autobot-slm-backend/services/blue_green.py
+++ b/autobot-slm-backend/services/blue_green.py
@@ -176,8 +176,9 @@ class BlueGreenService:
         self.ansible_dir = Path(settings.ansible_dir)
         self._running_deployments: Dict[str, asyncio.Task] = {}
         self._monitoring_tasks: Dict[str, asyncio.Task] = {}
-        # SSL verification - configurable via settings
-        self._verify_ssl = getattr(settings, "verify_ssl", False)
+        # SSL verification - configurable via SLM_VERIFY_SSL env var (#2852).
+        # Defaults to True (verify); only set False in dev/test with self-signed certs.
+        self._verify_ssl = getattr(settings, "verify_ssl", True)
 
     # =========================================================================
     # Public Methods

--- a/autobot-slm-backend/services/deployment.py
+++ b/autobot-slm-backend/services/deployment.py
@@ -186,17 +186,17 @@ _ENROLLMENT_PLAYBOOK_TEMPLATE = """# AutoBot - AI-Powered Automation Platform
 
           import psutil
           import requests
-          import urllib3
           import yaml
-
-          # Suppress InsecureRequestWarning for self-signed certs
-          urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
           logging.basicConfig(
               level=logging.INFO,
               format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
           )
           logger = logging.getLogger("slm-agent")
+
+          # TLS verification for heartbeat calls to the SLM admin (#2852).
+          # Set AUTOBOT_SKIP_TLS_VERIFY=true ONLY in dev/test with self-signed certs.
+          _VERIFY_TLS = os.environ.get("AUTOBOT_SKIP_TLS_VERIFY", "").lower() != "true"
 
 
           class SLMAgent:
@@ -229,8 +229,7 @@ _ENROLLMENT_PLAYBOOK_TEMPLATE = """# AutoBot - AI-Powered Automation Platform
                   try:
                       health = self.collect_health()
                       url = f"{self.config['admin_url']}/api/nodes/{self.config['node_id']}/heartbeat"
-                      # verify=False for self-signed certs on nginx proxy
-                      response = requests.post(url, json=health, timeout=10, verify=False)
+                      response = requests.post(url, json=health, timeout=10, verify=_VERIFY_TLS)
                       response.raise_for_status()
                       logger.debug("Heartbeat sent successfully")
                       return True

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -1505,8 +1505,9 @@ class ReconcilerService:
             import aiohttp
 
             ssl_ctx = ssl.create_default_context()
-            ssl_ctx.check_hostname = False
-            ssl_ctx.verify_mode = ssl.CERT_NONE
+            if not settings.verify_ssl:
+                ssl_ctx.check_hostname = False
+                ssl_ctx.verify_mode = ssl.CERT_NONE
             timeout = aiohttp.ClientTimeout(total=10)
             async with aiohttp.ClientSession(timeout=timeout) as session:
                 async with session.get(url, ssl=ssl_ctx) as resp:


### PR DESCRIPTION
## Summary
10 files had `verify=False` hardcoded in HTTP requests. Replaced with env-var-controlled toggle:
- `AUTOBOT_SKIP_TLS_VERIFY=true` for backend services
- `SLM_VERIFY_SSL=false` for SLM backend (via Settings model)

**Secure by default** — TLS bypass requires explicit opt-in for dev/test environments.

### Files changed
- `slm_client.py` — SSL context now conditional
- `vision_step_handler.py` — 3x `verify=False` replaced
- `voice_proxy.py`, `personality_proxy.py` — proxy forwarding
- `a2a_card_fetcher.py` — A2A card discovery
- `reconciler.py`, `blue_green.py` — health checks
- `deployment.py`, `slm-agent-standalone.py` — agent heartbeat
- `config.py` — added `verify_ssl` Settings field

## Test plan
- [x] Python syntax valid for all 10 files
- [x] Default behavior: TLS verification enabled
- [x] `AUTOBOT_SKIP_TLS_VERIFY=true` disables for dev/test
- [ ] Verify deployed services still connect with self-signed certs when env var set

Closes #2852

🤖 Generated with [Claude Code](https://claude.com/claude-code)