### PR TITLE
fix(frontend): replace empty catch blocks with logged errors in composables (#2859)

### DIFF
--- a/autobot-frontend/src/composables/useTLSCredentials.ts
+++ b/autobot-frontend/src/composables/useTLSCredentials.ts
@@ -125,7 +125,7 @@ async function slmFetch(
   })
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}))
+    const errorData = await response.json().catch((err) => { logger.warn('Failed to parse TLS error response: %s', err); return {} })
     throw new Error(errorData.detail || `HTTP ${response.status}: ${response.statusText}`)
   }
 

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -256,7 +256,7 @@ function _teardownVad(): void {
     _vadNode = null
   }
   if (_vadAudioCtx) {
-    _vadAudioCtx.close().catch(() => {})
+    _vadAudioCtx.close().catch((err) => { logger.warn('Audio context close failed: %s', err) })
     _vadAudioCtx = null
   }
   if (_micStream) {

--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -271,7 +271,7 @@ class WorkflowBuilderApiClient {
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
+        const errorData = await response.json().catch((err) => { logger.warn('Failed to parse error response: %s', err); return {} });
         return {
           success: false,
           error: errorData.detail || `HTTP ${response.status}: ${response.statusText}`,


### PR DESCRIPTION
## Summary
- `useVoiceConversation.ts`: log audio context close failures instead of `catch(() => {})`
- `useWorkflowBuilder.ts`: log JSON parse failures in error responses instead of `catch(() => ({}))`
- `useTLSCredentials.ts`: log TLS error response parse failures instead of `catch(() => ({}))`

All 3 composables already had loggers — just needed to use them in catch blocks.

## Test plan
- [x] All 3 files compile without errors
- [x] Errors now logged via existing `createLogger` instances

Closes #2859

🤖 Generated with [Claude Code](https://claude.com/claude-code)