### PR TITLE
fix(backend): replace hardcoded GPU/NPU benchmark placeholders with real queries (#2871)

### DIFF
--- a/autobot-slm-backend/monitoring/ai_performance_analytics.py
+++ b/autobot-slm-backend/monitoring/ai_performance_analytics.py
@@ -28,18 +28,24 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class NPUMetrics:
-    """NPU (Neural Processing Unit) performance metrics."""
+    """NPU (Neural Processing Unit) performance metrics.
+
+    Fields that require Intel NPU monitoring tools or benchmark_app are typed
+    Optional[float] and set to None when the hardware is detected but the data
+    cannot be retrieved.  Callers must check for None before using these values.
+    Ref: #2871.
+    """
 
     timestamp: str
     device_id: str
-    utilization_percent: float
-    memory_used_mb: float
-    memory_total_mb: float
+    utilization_percent: Optional[float]  # None when Intel NPU tools unavailable
+    memory_used_mb: Optional[float]  # None when Intel NPU tools unavailable
+    memory_total_mb: Optional[float]  # None when Intel NPU tools unavailable
     power_draw_watts: Optional[float]
     temperature_celsius: Optional[float]
     operations_per_second: Optional[float]
-    inference_latency_ms: float
-    throughput_mbps: float
+    inference_latency_ms: Optional[float]  # None when benchmark not performed
+    throughput_mbps: Optional[float]  # None when not measurable
     error_count: int = 0
 
 
@@ -179,10 +185,15 @@ else:
             if "NPU_FOUND" in openvino_output:
                 device_id = openvino_output.split(":")[1].strip()
 
-                # Get NPU utilization (simulated for now, requires Intel tools)
                 utilization = await self._get_npu_utilization()
                 memory_used, memory_total = await self._get_npu_memory()
                 inference_latency = await self._benchmark_npu_inference()
+
+                ops_per_sec = (
+                    1000.0 / inference_latency
+                    if inference_latency is not None and inference_latency > 0
+                    else None
+                )
 
                 return NPUMetrics(
                     timestamp=datetime.now(timezone.utc).isoformat(),
@@ -192,11 +203,9 @@ else:
                     memory_total_mb=memory_total,
                     power_draw_watts=None,  # Requires Intel NPU monitoring tools
                     temperature_celsius=None,
-                    operations_per_second=(
-                        1000.0 / inference_latency if inference_latency > 0 else 0
-                    ),
+                    operations_per_second=ops_per_sec,
                     inference_latency_ms=inference_latency,
-                    throughput_mbps=100.0,  # Estimated
+                    throughput_mbps=None,  # Cannot be measured without benchmark_app (#2871)
                     error_count=0,
                 )
         except Exception as e:
@@ -204,35 +213,40 @@ else:
 
         return None
 
-    async def _get_npu_utilization(self) -> float:
-        """Get current NPU utilization percentage."""
-        try:
-            # This would use Intel NPU monitoring APIs
-            # For now, simulate based on system load
-            cpu_percent = psutil.cpu_percent(interval=0.1)
-            # Estimate NPU usage based on AI workload indicators
-            return min(cpu_percent * 0.3, 100.0)  # Conservative estimate
-        except Exception:
-            return 0.0
+    async def _get_npu_utilization(self) -> Optional[float]:
+        """Get current NPU utilization percentage.
 
-    async def _get_npu_memory(self) -> Tuple[float, float]:
-        """Get NPU memory usage in MB."""
-        try:
-            # Intel NPU typically has dedicated memory
-            # This would use Intel NPU APIs
-            return 512.0, 2048.0  # Example: 512MB used of 2GB total
-        except Exception:
-            return 0.0, 0.0
+        Returns None when Intel NPU monitoring tools are unavailable.  Callers
+        must handle None explicitly.  Ref: #2871.
+        """
+        self.logger.debug(
+            "NPU utilization unavailable: Intel NPU monitoring tools not present (#2871)"
+        )
+        return None
 
-    async def _benchmark_npu_inference(self) -> float:
-        """Benchmark NPU inference latency."""
-        try:
-            start_time = time.time()
-            # Simple inference benchmark (placeholder)
-            await asyncio.sleep(0.05)  # Simulate 50ms inference
-            return (time.time() - start_time) * 1000
-        except Exception:
-            return 0.0
+    async def _get_npu_memory(self) -> Tuple[Optional[float], Optional[float]]:
+        """Get NPU memory usage in MB.
+
+        Returns (None, None) when Intel NPU monitoring tools are unavailable.
+        Callers must handle None explicitly.  Ref: #2871.
+        """
+        self.logger.debug(
+            "NPU memory unavailable: Intel NPU monitoring tools not present (#2871)"
+        )
+        return None, None
+
+    async def _benchmark_npu_inference(self) -> Optional[float]:
+        """Benchmark NPU inference latency.
+
+        Returns None when a real inference benchmark cannot be performed.
+        A real implementation requires loading a model via OpenVINO and timing
+        actual inference, which is not available in the current environment.
+        Callers must handle None explicitly.  Ref: #2871.
+        """
+        self.logger.debug(
+            "NPU inference benchmark not performed: no model/benchmark_app available (#2871)"
+        )
+        return None
 
     async def _run_pipeline_stages(self, start_time: float) -> tuple:
         """Simulate and time the three pipeline stages: load, inference, post-process.

--- a/autobot-slm-backend/monitoring/performance_benchmark.py
+++ b/autobot-slm-backend/monitoring/performance_benchmark.py
@@ -761,9 +761,15 @@ class PerformanceBenchmark:
             try:
                 stdout, _ = await asyncio.wait_for(process.communicate(), timeout=5.0)
                 if process.returncode == 0:
-                    # GPU is available, return a simple score
-                    # This is a placeholder - actual GPU benchmarking requires CUDA/OpenCL
-                    return 85.0  # Placeholder score for RTX 4070
+                    # GPU detected. Attempt to read actual utilization via nvidia-smi.
+                    score = await self._query_gpu_utilization_score()
+                    if score is not None:
+                        return score
+                    self.logger.warning(
+                        "GPU detected but utilization query failed; "
+                        "returning None instead of a placeholder score (#2871)"
+                    )
+                    return None
             except asyncio.TimeoutError:
                 process.kill()
                 await process.wait()
@@ -771,6 +777,32 @@ class PerformanceBenchmark:
         except Exception as e:
             self.logger.debug(f"GPU benchmark error: {e}")
 
+        return None
+
+    async def _query_gpu_utilization_score(self) -> Optional[float]:
+        """Query real GPU utilization via nvidia-smi and return a normalised score.
+
+        Returns the GPU utilization percentage (0-100) as the score, or None if the
+        query fails.  Ref: #2871.
+        """
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "nvidia-smi",
+                "--query-gpu=utilization.gpu",
+                "--format=csv,noheader,nounits",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(process.communicate(), timeout=5.0)
+                if process.returncode == 0:
+                    value = stdout.decode("utf-8").strip().split("\n")[0].strip()
+                    return float(value)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+        except Exception as e:
+            self.logger.debug(f"GPU utilization query error: {e}")
         return None
 
     async def _benchmark_npu(self) -> Optional[float]:
@@ -792,9 +824,15 @@ class PerformanceBenchmark:
             try:
                 stdout, _ = await asyncio.wait_for(process.communicate(), timeout=5.0)
                 if process.returncode == 0 and "NPU" in stdout.decode("utf-8"):
-                    # NPU is available, return a simple score
-                    # Placeholder - actual NPU benchmarking requires specific Intel tools
-                    return 45.0  # Placeholder score for Intel NPU
+                    # NPU detected, but a real benchmark requires Intel's benchmark_app
+                    # or the OpenVINO benchmark_python tool which we do not invoke here.
+                    # Return None so callers know the score is unavailable rather than
+                    # trusting a hardcoded placeholder.  Ref: #2871.
+                    self.logger.warning(
+                        "Intel NPU detected but no benchmark_app available; "
+                        "returning None instead of a placeholder score (#2871)"
+                    )
+                    return None
             except asyncio.TimeoutError:
                 process.kill()
                 await process.wait()

--- a/autobot-slm-backend/monitoring/performance_monitor.py
+++ b/autobot-slm-backend/monitoring/performance_monitor.py
@@ -245,10 +245,15 @@ class PerformanceMonitor:
         return None, None
 
     async def get_npu_metrics(self) -> Optional[float]:
-        """Get NPU utilization (Intel AI Boost chip)."""
+        """Get NPU utilization (Intel AI Boost chip).
+
+        Returns the NPU utilization percentage when Intel NPU monitoring tools are
+        available, or None when they are not.  The legacy placeholder value of 0.0
+        has been removed — 0.0 is indistinguishable from "idle" and misleads callers.
+        Ref: #2871.
+        """
         try:
-            # Check Intel NPU via OpenVINO tools using async subprocess
-            # This is a placeholder - actual implementation depends on Intel NPU drivers
+            # Detect NPU via OpenVINO using async subprocess
             process = await asyncio.create_subprocess_exec(
                 "python3",
                 "-c",
@@ -259,8 +264,15 @@ class PerformanceMonitor:
             try:
                 stdout, _ = await asyncio.wait_for(process.communicate(), timeout=3.0)
                 if process.returncode == 0:
-                    # NPU is available but actual utilization requires specific Intel tools
-                    return 0.0  # Placeholder
+                    # NPU hardware detected. Actual utilization percentage requires
+                    # Intel NPU monitoring tools (e.g., intel_npu_top) which are not
+                    # available in this environment.  Return None so dashboards can
+                    # display "unavailable" rather than a misleading 0%.  Ref: #2871.
+                    self.logger.debug(
+                        "Intel NPU detected but utilization monitoring tools absent; "
+                        "returning None (#2871)"
+                    )
+                    return None
             except asyncio.TimeoutError:
                 process.kill()
                 await process.wait()

--- a/autobot-slm-backend/monitoring/performance_optimizer.py
+++ b/autobot-slm-backend/monitoring/performance_optimizer.py
@@ -519,9 +519,9 @@ class PerformanceOptimizer:
         """Analyze hardware utilization for optimization opportunities."""
         recommendations = []
 
-        # GPU optimization recommendations
+        # GPU optimization recommendations — append a static advisory when GPU is present.
+        # Ref: #2871 (no fake scores; hardware_metrics["gpu_available"] is set by real detection).
         if hardware_metrics.get("gpu_available", False):
-            # This would require actual GPU metrics, placeholder for now
             recommendations.append(
                 OptimizationRecommendation(
                     category="hardware",


### PR DESCRIPTION
## Summary
- **GPU**: Query `nvidia-smi` for real utilization instead of returning hardcoded `85.0`
- **NPU**: Return `None` instead of fake scores (`45.0`, simulated 50ms latency, `512MB/2GB` memory)
- Updated `NPUMetrics` fields to `Optional[float]`
- All placeholders replaced with `None` + warning/debug logs
- Dashboards now show real data or explicitly missing — never fake numbers

| Scenario | Before | After |
|---|---|---|
| GPU + nvidia-smi | `85.0` (fake) | Real utilization % |
| NPU, no tools | `45.0` (fake) | `None` + warning |
| NPU memory | `512/2048` (fake) | `None` + debug |
| NPU latency | Simulated 50ms | `None` + debug |

## Test plan
- [x] All 4 Python files pass syntax validation
- [x] `None` values handled in downstream calculations
- [ ] Verify dashboard displays "N/A" for missing metrics

Closes #2871

🤖 Generated with [Claude Code](https://claude.com/claude-code)