### PR TITLE
fix(frontend): add missing event listener cleanup to prevent memory leaks (#2849)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -534,6 +534,14 @@ export default {
       }
     };
 
+    // Named handlers for global error listeners (#2849)
+    const handleWindowError = (event: ErrorEvent) => {
+      handleGlobalError(event.error || event);
+    };
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      handleGlobalError(event.reason);
+    };
+
     // Unified loading event handlers
     const handleLoadingComplete = () => {
       logger.debug('Loading completed successfully');
@@ -649,14 +657,9 @@ export default {
       // Add global click listener for mobile nav
       document.addEventListener('click', closeNavbarOnClickOutside);
 
-      // Set up global error handling
-      window.addEventListener('error', (event) => {
-        handleGlobalError(event.error || event);
-      });
-
-      window.addEventListener('unhandledrejection', (event) => {
-        handleGlobalError(event.reason);
-      });
+      // Set up global error handling (#2849: use named handlers for cleanup)
+      window.addEventListener('error', handleWindowError);
+      window.addEventListener('unhandledrejection', handleUnhandledRejection);
 
       // CRITICAL FIX: Clear any stuck system notifications on startup
       logger.debug('Clearing stuck system notifications on startup...');
@@ -705,14 +708,16 @@ export default {
         appStore.setLoading(false);
       }
 
-      logger.debug('✅ Optimized AutoBot initialized - monitoring restored with <50ms performance budget');
+      logger.debug('Optimized AutoBot initialized - monitoring restored with <50ms performance budget');
     });
 
     onUnmounted(() => {
       logger.debug('Cleaning up optimized monitoring systems...');
 
-      // Clean up listeners
+      // Clean up listeners (#2849: remove all event listeners added in onMounted)
       document.removeEventListener('click', closeNavbarOnClickOutside);
+      window.removeEventListener('error', handleWindowError);
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection);
       stopOptimizedNotificationCleanup();
 
       // Destroy optimized health monitor

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -510,6 +510,7 @@ const codebaseStats = ref({ files: 0, lines: 0, issues: 0 });
 const drillDownData = ref({ total_files: 0, total_issues: 0, average_score: 0, files: [] as any[] });
 
 let ws: WebSocket | null = null;
+let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Computed
 const scoreCircleLength = computed(() => 2 * Math.PI * 54);
@@ -795,7 +796,7 @@ function connectWebSocket(): void {
     wsConnected.value = false;
     logger.debug('WebSocket disconnected');
     // Reconnect after 5 seconds
-    setTimeout(connectWebSocket, 5000);
+    wsReconnectTimer = setTimeout(connectWebSocket, 5000);
   };
 
   ws.onerror = (error) => {
@@ -944,7 +945,12 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  if (wsReconnectTimer) {
+    clearTimeout(wsReconnectTimer);
+    wsReconnectTimer = null;
+  }
   if (ws) {
+    ws.onclose = null;
     ws.close();
   }
 });

--- a/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
+++ b/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
@@ -16,7 +16,7 @@
  * - Slide animation
  */
 
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
@@ -159,12 +159,18 @@ function getTypeIcon(type?: string): string {
   return icons[type || 'document'] || 'fas fa-file'
 }
 
-// Cleanup on unmount
+// Cleanup on close
 watch(() => props.modelValue, (isOpen) => {
   if (!isOpen) {
     document.removeEventListener('mousemove', handleResize)
     document.removeEventListener('mouseup', stopResize)
   }
+})
+
+// #2849: Ensure resize listeners are removed if component unmounts mid-resize
+onUnmounted(() => {
+  document.removeEventListener('mousemove', handleResize)
+  document.removeEventListener('mouseup', stopResize)
 })
 </script>
 

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -1270,6 +1270,15 @@ export default {
       }
     };
 
+    // Named click handler for focus recovery — must be named for removeEventListener (#2849)
+    const handleTerminalFocusClick = (event) => {
+      const terminalArea = document.querySelector('.terminal-window-standalone');
+      if (terminalArea && terminalArea.contains(event.target) &&
+          event.target !== terminalInput.value && canInput.value) {
+        nextTick(() => focusInput());
+      }
+    };
+
     // Lifecycle
     onMounted(async () => {
       startCursorBlink();
@@ -1288,15 +1297,8 @@ export default {
       nextTick(() => {
         focusInput();
 
-        // Add additional focus recovery mechanisms for automated testing
-        document.addEventListener('click', (event) => {
-          // If click is inside terminal area but not on input, restore focus
-          const terminalArea = document.querySelector('.terminal-window-standalone');
-          if (terminalArea && terminalArea.contains(event.target) &&
-              event.target !== terminalInput.value && canInput.value) {
-            nextTick(() => focusInput());
-          }
-        });
+        // Named click handler for focus recovery (#2849)
+        document.addEventListener('click', handleTerminalFocusClick);
 
         // Periodic focus check for automation scenarios (clean up on unmount)
         const focusInterval = setInterval(() => {
@@ -1319,6 +1321,7 @@ export default {
       }
 
       // Remove event listeners
+      document.removeEventListener('click', handleTerminalFocusClick);
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('beforeunload', handleBeforeUnload);
 


### PR DESCRIPTION
## Summary
4 components with event listener memory leaks fixed:

- **App.vue**: Named `error`/`unhandledrejection` handlers + `removeEventListener` in `onUnmounted`
- **TerminalWindow.vue**: Named click handler for focus recovery + cleanup on unmount
- **SourcePreviewPanel.vue**: Added `onUnmounted` for resize `mousemove`/`mouseup` cleanup
- **CodeQualityDashboard.vue**: Track WS reconnect timer + `clearTimeout` + null `onclose` before close

15+ other components verified as already having proper cleanup.

## Test plan
- [x] All 4 files compile
- [x] Named handlers match between addEventListener and removeEventListener
- [x] WebSocket reconnect timer cleared on unmount

Closes #2849

🤖 Generated with [Claude Code](https://claude.com/claude-code)