### PR TITLE
fix(security): replace hardcoded CORS origins and proxy IPs with SSOT (#2862)

### DIFF
--- a/autobot-shared/proxy_utils.py
+++ b/autobot-shared/proxy_utils.py
@@ -18,9 +18,9 @@ Two calling conventions are supported:
 
 1. Environment-driven (autobot-backend style):
    Set AUTOBOT_TRUSTED_PROXIES (comma-separated) to override the default
-   list.  Defaults include localhost addresses and the nginx frontend VM
-   (172.16.168.21).  The ``# noqa: ssot-proxy`` comment suppresses the
-   hardcoding pre-commit check for the fallback string only.
+   list.  Defaults include localhost addresses and the nginx frontend VM IP
+   derived from NetworkConstants (ConfigRegistry SSOT).
+   Issue #2862 — removed hardcoded IP fallback; values flow through SSOT.
 
        ip = get_client_ip(request)  # uses module-level default set
 
@@ -49,18 +49,42 @@ from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
 
+
+def _build_default_trusted_proxies() -> frozenset:
+    """Build the default trusted-proxy frozenset.
+
+    Priority:
+    1. AUTOBOT_TRUSTED_PROXIES environment variable (comma-separated IPs).
+    2. Localhost addresses plus the frontend VM IP from NetworkConstants
+       (backed by ConfigRegistry SSOT).
+
+    Issue #2862 — replaces the hardcoded IP string with SSOT-derived values.
+    The lazy import of NetworkConstants avoids circular import issues because
+    autobot-shared/network_constants.py itself depends on autobot-backend's
+    config.registry at runtime.
+    """
+    raw = os.getenv("AUTOBOT_TRUSTED_PROXIES", "")
+    if raw:
+        return frozenset(ip.strip() for ip in raw.split(",") if ip.strip())
+
+    proxies = {"127.0.0.1", "::1"}
+    try:
+        from autobot_shared.network_constants import NetworkConstants  # lazy import
+
+        proxies.add(NetworkConstants.FRONTEND_VM_IP)
+    except Exception:  # pragma: no cover — ImportError or AttributeError at startup
+        logger.warning(
+            "NetworkConstants unavailable; AUTOBOT_TRUSTED_PROXIES limited to localhost. "
+            "Set AUTOBOT_TRUSTED_PROXIES explicitly to include nginx proxy IPs."
+        )
+    return frozenset(proxies)
+
+
 # ---------------------------------------------------------------------------
-# Default trusted-proxy list — read once at import time.
+# Default trusted-proxy set — built once at import time.
 # Override via AUTOBOT_TRUSTED_PROXIES env var (comma-separated IPs).
-# Defaults: localhost (IPv4 + IPv6) and the nginx frontend VM (.21).
 # ---------------------------------------------------------------------------
-_RAW_TRUSTED = os.getenv(
-    "AUTOBOT_TRUSTED_PROXIES",
-    "127.0.0.1,::1,172.16.168.21",  # noqa: ssot-proxy
-)
-_DEFAULT_TRUSTED_PROXIES: frozenset = frozenset(
-    ip.strip() for ip in _RAW_TRUSTED.split(",") if ip.strip()
-)
+_DEFAULT_TRUSTED_PROXIES: frozenset = _build_default_trusted_proxies()
 
 
 def _normalize_ip(ip_str: str) -> str:

--- a/autobot-slm-backend/config.py
+++ b/autobot-slm-backend/config.py
@@ -49,7 +49,11 @@ def _get_cors_origins() -> list:
     """Build CORS origins from env var or infrastructure SSOT.
 
     Override with SLM_CORS_ORIGINS (comma-separated).
-    Otherwise, generates origins from all known infrastructure VMs.
+    Otherwise, generates origins from all known infrastructure VMs via
+    NetworkConstants (backed by ConfigRegistry / redis-databases.yaml SSOT).
+
+    Issue #2862 — removed hardcoded fallback IPs; all values now flow through
+    NetworkConstants so ConfigRegistry overrides are respected.
     """
     env_origins = os.getenv("SLM_CORS_ORIGINS", "")
     if env_origins:
@@ -64,15 +68,38 @@ def _get_cors_origins() -> list:
             port = host["port"]
             origins.add(f"http://{ip}:{port}")
             origins.add(f"https://{ip}")
-        origins.add("https://172.16.168.19")  # noqa: ssot-cors
-        origins.add("https://172.16.168.21")  # noqa: ssot-cors
+        # Ensure the SLM VM and frontend VM are always included as HTTPS origins
+        # (they may only appear with their service port in get_host_configs()).
+        origins.add(f"https://{NetworkConstants.SLM_VM_IP}")
+        origins.add(f"https://{NetworkConstants.FRONTEND_VM_IP}")
         return sorted(origins)
     except ImportError:
-        logger.warning("autobot_shared not available; using SLM-only CORS")
-        return [
-            "https://172.16.168.19",  # noqa: ssot-cors
-            "https://172.16.168.21",  # noqa: ssot-cors
-        ]
+        logger.warning("autobot_shared not available; falling back to localhost CORS only")
+        return ["https://127.0.0.1", "http://127.0.0.1"]
+
+
+def _get_trusted_proxies() -> list:
+    """Build the trusted reverse-proxy list from env var or SSOT.
+
+    Override with SLM_TRUSTED_PROXIES (comma-separated IPs).
+    Otherwise, includes localhost addresses and the SLM/frontend VM IPs
+    read from NetworkConstants (backed by ConfigRegistry SSOT).
+
+    Issue #2862 — replaced hardcoded IP fallback with SSOT-derived values.
+    """
+    env_proxies = os.getenv("SLM_TRUSTED_PROXIES", "")
+    if env_proxies:
+        return [ip.strip() for ip in env_proxies.split(",") if ip.strip()]
+
+    proxies = ["127.0.0.1", "::1"]
+    try:
+        from autobot_shared.network_constants import NetworkConstants
+
+        proxies.append(NetworkConstants.SLM_VM_IP)
+        proxies.append(NetworkConstants.FRONTEND_VM_IP)
+    except ImportError:
+        logger.warning("autobot_shared not available; trusted_proxies limited to localhost")
+    return proxies
 
 
 class Settings(BaseSettings):
@@ -242,19 +269,12 @@ class Settings(BaseSettings):
     # CORS settings
     cors_origins: list = _get_cors_origins()
 
-    # Trusted reverse-proxy IPs (Issue #2239).
+    # Trusted reverse-proxy IPs (Issue #2239, #2862).
     # X-Forwarded-For is only honoured when the direct TCP connection comes
     # from one of these addresses.  Override with SLM_TRUSTED_PROXIES
-    # (comma-separated).  Defaults cover localhost and the two nginx nodes
-    # (.19 SLM VM, .21 Frontend VM).
-    trusted_proxies: list = [
-        ip.strip()
-        for ip in os.getenv(
-            "SLM_TRUSTED_PROXIES",
-            "127.0.0.1,::1,172.16.168.19,172.16.168.21",  # noqa: ssot-proxy
-        ).split(",")
-        if ip.strip()
-    ]
+    # (comma-separated).  The default is derived from NetworkConstants so the
+    # ConfigRegistry SSOT is respected; no IPs are hardcoded here.
+    trusted_proxies: list = _get_trusted_proxies()
 
     # External URL - remote nodes use nginx reverse proxy.
     # Issue #2758: derive dynamically from local IP when SLM_EXTERNAL_URL is


### PR DESCRIPTION
## Summary
- Remove hardcoded `172.16.168.19`/`172.16.168.21` from CORS origins and trusted proxy lists
- Use `NetworkConstants` from SSOT config instead of `# noqa: ssot-cors/ssot-proxy` suppressions
- Add `_get_trusted_proxies()` helper that reads `SLM_TRUSTED_PROXIES` env var → SSOT fallback
- `proxy_utils.py`: build defaults from env var + `NetworkConstants.FRONTEND_VM_IP`

## Test plan
- [x] Python syntax valid
- [x] Env var overrides still work (`SLM_CORS_ORIGINS`, `SLM_TRUSTED_PROXIES`)
- [x] Fallback to localhost-only when `autobot_shared` unavailable

Closes #2862

🤖 Generated with [Claude Code](https://claude.com/claude-code)