### PR TITLE
fix(install): wait for HTTPS readiness before Phase 6 node registration (#2830)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -496,6 +496,25 @@ register_local_node() {
     phase "Register Local Node"
 
     local api_url="https://127.0.0.1"
+
+    # Wait for HTTPS to be ready before registering (#2830)
+    # After Ansible deployment, nginx may still be loading TLS certificates
+    # or the reverse-proxy upstream may not be connected yet.
+    info "Waiting for HTTPS endpoint to be ready..."
+    local max_wait=60
+    local waited=0
+    while ! curl -sk --max-time 3 "${api_url}/api/health" >/dev/null 2>&1; do
+        sleep 2
+        waited=$((waited + 2))
+        if [[ ${waited} -ge ${max_wait} ]]; then
+            warn "HTTPS not ready after ${max_wait}s — skipping node registration"
+            warn "Register manually once services are up: SLM UI > Fleet > Add Node"
+            return
+        fi
+        log "  Waiting for HTTPS (${waited}s / ${max_wait}s)..."
+    done
+    success "HTTPS endpoint is ready"
+
     local local_ip
     local_ip="${OVERRIDE_IP:-$(ip route get 1.1.1.1 2>/dev/null | awk '{print $7; exit}' || hostname -I | awk '{print $1}')}"
     local hostname_val


### PR DESCRIPTION
## Summary
- Add HTTPS readiness wait loop at start of `register_local_node()` 
- Polls `https://127.0.0.1/api/health` every 2s for up to 60s
- On timeout: warns and returns with manual registration instructions (graceful degradation)
- Prevents all Phase 6 API calls from silently failing when nginx/TLS isn't ready

## Test plan
- [x] Bash syntax valid
- [x] Graceful degradation on timeout (not fatal)
- [ ] Verify on fresh install: Phase 6 waits for HTTPS then registers successfully

Closes #2830

🤖 Generated with [Claude Code](https://claude.com/claude-code)