### PR TITLE
fix(backend): centralize DB connection pool sizes via SSOT config (#2860)

### DIFF
--- a/autobot-backend/user_management/database.py
+++ b/autobot-backend/user_management/database.py
@@ -6,6 +6,7 @@ PostgreSQL Database Connection Utilities
 
 Provides async SQLAlchemy session management with connection pooling.
 Follows the canonical client pattern established by Redis utilities.
+Pool sizes are coordinated via SSOT config (#2860).
 """
 
 import logging
@@ -28,12 +29,36 @@ _async_engine: Optional[AsyncEngine] = None
 _async_session_factory: Optional[async_sessionmaker[AsyncSession]] = None
 
 
+def _get_pool_config() -> dict:
+    """Get database pool settings from SSOT config (#2860)."""
+    try:
+        from autobot_shared.ssot_config import get_config
+
+        pool_cfg = get_config().database_pool
+        return {
+            "pool_size": pool_cfg.pool_size,
+            "max_overflow": pool_cfg.max_overflow,
+            "pool_recycle": pool_cfg.pool_recycle,
+            "pool_timeout": pool_cfg.pool_timeout,
+        }
+    except Exception:
+        logger.warning(
+            "Could not load SSOT database pool config, using defaults"
+        )
+        return {
+            "pool_size": 10,
+            "max_overflow": 10,
+            "pool_recycle": 3600,
+            "pool_timeout": 30,
+        }
+
+
 def get_async_engine() -> AsyncEngine:
     """
     Get the async SQLAlchemy engine singleton.
 
     Creates the engine on first call with connection pooling configured
-    to match the Redis pool size (20 connections).
+    from SSOT config (#2860).
     """
     global _async_engine
 
@@ -49,12 +74,16 @@ def get_async_engine() -> AsyncEngine:
             "single_company, multi_company, or provider."
         )
 
+    pool = _get_pool_config()
+
     _async_engine = create_async_engine(
         config.postgres_url,
-        pool_size=5,  # Number of connections to maintain
-        max_overflow=10,  # Max additional connections under load
-        pool_pre_ping=True,  # Verify connections before use
-        echo=False,  # Set to True for SQL debugging
+        pool_size=pool["pool_size"],
+        max_overflow=pool["max_overflow"],
+        pool_recycle=pool["pool_recycle"],
+        pool_timeout=pool["pool_timeout"],
+        pool_pre_ping=True,
+        echo=False,
         future=True,
     )
 
@@ -137,10 +166,11 @@ async def init_database() -> None:
 
     Call this during application startup.
     """
-    logger.info("🔍 DEBUG: init_database() called")
+    logger.info("init_database() called")
     config = get_deployment_config()
     logger.info(
-        f"🔍 DEBUG: Got deployment config - postgres_enabled={config.postgres_enabled}"
+        "Got deployment config - postgres_enabled=%s",
+        config.postgres_enabled,
     )
 
     if not config.postgres_enabled:
@@ -150,34 +180,18 @@ async def init_database() -> None:
         )
         return
 
-    logger.info("🔍 DEBUG: PostgreSQL enabled, proceeding with initialization")
-    logger.info(
-        "🔍 DEBUG: Connection string: postgresql+asyncpg://"
-        f"{config.postgres_user}@{config.postgres_host}:"
-        f"{config.postgres_port}/{config.postgres_db}"
-    )
+    logger.info("PostgreSQL enabled, proceeding with initialization")
 
     try:
         from sqlalchemy import text
 
-        logger.info("🔍 DEBUG: About to call get_async_engine()")
         engine = get_async_engine()
-        logger.info(f"🔍 DEBUG: Engine created: {engine}")
 
-        logger.info(
-            "🔍 DEBUG: About to begin connection (this may hang if DB unreachable)"
-        )
         async with engine.begin() as conn:
-            logger.info("🔍 DEBUG: Connection established, executing SELECT 1")
-            # Simple connectivity check
             await conn.execute(text("SELECT 1"))
-            logger.info("🔍 DEBUG: SELECT 1 executed successfully")
         logger.info("PostgreSQL connection verified successfully")
     except Exception as e:
         logger.error("Failed to connect to PostgreSQL: %s", e)
-        import traceback
-
-        logger.error(f"Traceback: {traceback.format_exc()}")
         raise
 
 

--- a/autobot-backend/utils/async_database_pool.py
+++ b/autobot-backend/utils/async_database_pool.py
@@ -5,6 +5,8 @@
 Async Database Connection Pool Manager
 Provides async connection pooling for SQLite and other databases using aiosqlite
 to improve performance and prevent blocking operations.
+
+Pool sizes are coordinated via SSOT config (#2860).
 """
 
 import asyncio
@@ -25,6 +27,16 @@ from utils.database_helpers import join_results  # noqa: F401 - re-export
 logger = logging.getLogger(__name__)
 
 
+def _get_sqlite_pool_size() -> int:
+    """Get SQLite pool size from SSOT config (#2860)."""
+    try:
+        from autobot_shared.ssot_config import get_config
+
+        return get_config().database_pool.sqlite_pool_size
+    except Exception:
+        return 10
+
+
 @dataclass
 class PoolStats:
     """Connection pool statistics"""
@@ -42,7 +54,7 @@ class AsyncSQLiteConnectionPool:
     def __init__(
         self,
         db_path: str,
-        pool_size: int = 20,
+        pool_size: int | None = None,
         timeout: float = TimingConstants.SHORT_TIMEOUT,
     ):
         """
@@ -50,13 +62,14 @@ class AsyncSQLiteConnectionPool:
 
         Args:
             db_path: Path to SQLite database file
-            pool_size: Maximum number of connections in pool
+            pool_size: Maximum number of connections in pool.
+                       Defaults to SSOT config sqlite_pool_size (#2860).
             timeout: Timeout for acquiring connection from pool
         """
         self.db_path = db_path
-        self.pool_size = pool_size
+        self.pool_size = pool_size if pool_size is not None else _get_sqlite_pool_size()
         self.timeout = timeout
-        self._pool = asyncio.Queue(maxsize=pool_size)
+        self._pool = asyncio.Queue(maxsize=self.pool_size)
         self._lock = asyncio.Lock()
         self._created_connections = 0
         self._stats = PoolStats()
@@ -119,7 +132,8 @@ class AsyncSQLiteConnectionPool:
 
             self._initialized = True
             logger.info(
-                f"Async connection pool initialized with {initial_size} connections"
+                "Async connection pool initialized with %s connections",
+                initial_size,
             )
 
     async def _acquire_connection(self) -> aiosqlite.Connection:
@@ -249,14 +263,14 @@ _async_pools_lock = asyncio.Lock()
 
 
 async def get_async_connection_pool(
-    db_path: str, pool_size: int = 20
+    db_path: str, pool_size: int | None = None
 ) -> AsyncSQLiteConnectionPool:
     """
     Get or create an async connection pool for a database.
 
     Args:
         db_path: Path to database file
-        pool_size: Maximum pool size
+        pool_size: Maximum pool size. Defaults to SSOT config (#2860).
 
     Returns:
         AsyncSQLiteConnectionPool: Async connection pool instance
@@ -279,7 +293,9 @@ async def get_async_connection_pool(
         await pool._initialize_pool()
         _async_connection_pools[db_path] = pool
         logger.info(
-            f"Created async connection pool for {db_path} with size {pool_size}"
+            "Created async connection pool for %s with size %s",
+            db_path,
+            pool.pool_size,
         )
         return pool
 

--- a/autobot-backend/utils/database_pool.py
+++ b/autobot-backend/utils/database_pool.py
@@ -5,6 +5,8 @@
 Database Connection Pool Manager
 Provides connection pooling for SQLite and other databases to improve performance
 and prevent N+1 query issues.
+
+Pool sizes are coordinated via SSOT config (#2860).
 """
 
 import asyncio
@@ -24,13 +26,23 @@ from utils.database_helpers import join_results  # noqa: F401 - re-export
 logger = logging.getLogger(__name__)
 
 
+def _get_sqlite_pool_size() -> int:
+    """Get SQLite pool size from SSOT config (#2860)."""
+    try:
+        from autobot_shared.ssot_config import get_config
+
+        return get_config().database_pool.sqlite_pool_size
+    except Exception:
+        return 10
+
+
 class SQLiteConnectionPool:
     """Thread-safe SQLite connection pool with proper resource management."""
 
     def __init__(
         self,
         db_path: str,
-        pool_size: int = 10,
+        pool_size: int | None = None,
         timeout: float = TimingConstants.SHORT_TIMEOUT,
     ):
         """
@@ -38,13 +50,14 @@ class SQLiteConnectionPool:
 
         Args:
             db_path: Path to SQLite database file
-            pool_size: Maximum number of connections in pool
+            pool_size: Maximum number of connections in pool.
+                       Defaults to SSOT config sqlite_pool_size (#2860).
             timeout: Timeout for acquiring connection from pool
         """
         self.db_path = db_path
-        self.pool_size = pool_size
+        self.pool_size = pool_size if pool_size is not None else _get_sqlite_pool_size()
         self.timeout = timeout
-        self._pool = Queue(maxsize=pool_size)
+        self._pool = Queue(maxsize=self.pool_size)
         self._lock = threading.Lock()
         self._created_connections = 0
         self._stats = {
@@ -215,13 +228,13 @@ class SQLiteConnectionPool:
 class AsyncSQLiteConnectionPool:
     """Async version of SQLite connection pool using asyncio."""
 
-    def __init__(self, db_path: str, pool_size: int = 10):
+    def __init__(self, db_path: str, pool_size: int | None = None):
         """Initialize async SQLite connection pool."""
         self.db_path = db_path
-        self.pool_size = pool_size
-        self._pool = asyncio.Queue(maxsize=pool_size)
+        self.pool_size = pool_size if pool_size is not None else _get_sqlite_pool_size()
+        self._pool = asyncio.Queue(maxsize=self.pool_size)
         self._created_connections = 0
-        self._sync_pool = SQLiteConnectionPool(db_path, pool_size)
+        self._sync_pool = SQLiteConnectionPool(db_path, self.pool_size)
         self._executor = None
 
     async def initialize(self):
@@ -259,13 +272,15 @@ _connection_pools: Dict[str, SQLiteConnectionPool] = {}
 _pools_lock = threading.Lock()
 
 
-def get_connection_pool(db_path: str, pool_size: int = 10) -> SQLiteConnectionPool:
+def get_connection_pool(
+    db_path: str, pool_size: int | None = None
+) -> SQLiteConnectionPool:
     """
     Get or create a connection pool for a database.
 
     Args:
         db_path: Path to database file
-        pool_size: Maximum pool size
+        pool_size: Maximum pool size. Defaults to SSOT config (#2860).
 
     Returns:
         SQLiteConnectionPool: Connection pool instance
@@ -286,7 +301,9 @@ def get_connection_pool(db_path: str, pool_size: int = 10) -> SQLiteConnectionPo
         # Create new pool
         pool = SQLiteConnectionPool(db_path, pool_size)
         _connection_pools[db_path] = pool
-        logger.info("Created connection pool for %s with size %s", db_path, pool_size)
+        logger.info(
+            "Created connection pool for %s with size %s", db_path, pool.pool_size
+        )
         return pool
 
 

--- a/autobot-shared/ssot_config.py
+++ b/autobot-shared/ssot_config.py
@@ -885,6 +885,59 @@ class TLSConfig(BaseSettings):
         )
 
 
+class DatabasePoolConfig(BaseSettings):
+    """Database connection pool configuration (#2860).
+
+    Centralizes SQLAlchemy and SQLite pool settings so all services use
+    coordinated pool sizes. Override via AUTOBOT_DB_POOL_* environment variables.
+
+    Usage:
+        from autobot_shared.ssot_config import config
+
+        # PostgreSQL (SQLAlchemy) pools
+        pool_size = config.database_pool.pool_size
+        max_overflow = config.database_pool.max_overflow
+
+        # SQLite pools
+        sqlite_size = config.database_pool.sqlite_pool_size
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=str(PROJECT_ROOT / ".env"),
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    pool_size: int = Field(
+        default=10,
+        alias="AUTOBOT_DB_POOL_SIZE",
+        description="Number of persistent connections per SQLAlchemy engine",
+    )
+    max_overflow: int = Field(
+        default=10,
+        alias="AUTOBOT_DB_POOL_MAX_OVERFLOW",
+        description="Extra connections allowed above pool_size under load",
+    )
+    pool_recycle: int = Field(
+        default=3600,
+        alias="AUTOBOT_DB_POOL_RECYCLE",
+        description="Seconds before a connection is recycled",
+    )
+    pool_timeout: int = Field(
+        default=30,
+        alias="AUTOBOT_DB_POOL_TIMEOUT",
+        description="Seconds to wait for a connection from the pool",
+    )
+
+    # SQLite-specific pool size (separate because SQLite has lower
+    # concurrency limits than PostgreSQL)
+    sqlite_pool_size: int = Field(
+        default=10,
+        alias="AUTOBOT_SQLITE_POOL_SIZE",
+        description="Max connections per SQLite connection pool",
+    )
+
+
 class FeatureConfig(BaseSettings):
     """Feature flags configuration."""
 
@@ -940,6 +993,7 @@ class AutoBotConfig(BaseSettings):
     tls: TLSConfig = Field(default_factory=TLSConfig)
     feature: FeatureConfig = Field(default_factory=FeatureConfig)
     permission: PermissionConfig = Field(default_factory=PermissionConfig)
+    database_pool: DatabasePoolConfig = Field(default_factory=DatabasePoolConfig)
 
     # Top-level settings
     deployment_mode: str = Field(default="distributed", alias="AUTOBOT_DEPLOYMENT_MODE")
@@ -1451,6 +1505,7 @@ __all__ = [
     "CacheRedisConfig",
     "CacheL1Config",
     "CacheL2Config",
+    "DatabasePoolConfig",
     "FeatureConfig",
     "get_config",
     "reload_config",

--- a/autobot-slm-backend/config.py
+++ b/autobot-slm-backend/config.py
@@ -102,6 +102,25 @@ def _get_trusted_proxies() -> list:
     return proxies
 
 
+def _get_ssot_pool_defaults() -> tuple:
+    """Load database pool defaults from SSOT config (#2860).
+
+    Returns:
+        Tuple of (pool_size, max_overflow, pool_recycle) from SSOT config.
+    """
+    try:
+        from autobot_shared.ssot_config import get_config
+
+        pool_cfg = get_config().database_pool
+        return (pool_cfg.pool_size, pool_cfg.max_overflow, pool_cfg.pool_recycle)
+    except Exception:
+        return (10, 10, 3600)
+
+
+# Load SSOT defaults at module level so Settings class can reference them.
+_SSOT_POOL_SIZE, _SSOT_MAX_OVERFLOW, _SSOT_POOL_RECYCLE = _get_ssot_pool_defaults()
+
+
 class Settings(BaseSettings):
     """SLM Server Settings."""
 
@@ -135,10 +154,17 @@ class Settings(BaseSettings):
         "postgresql+asyncpg://slm_app@127.0.0.1:5432/autobot_users",
     )
 
-    # Database connection pool settings
-    db_pool_size: int = int(os.getenv("SLM_DB_POOL_SIZE", "20"))
-    db_pool_max_overflow: int = int(os.getenv("SLM_DB_POOL_MAX_OVERFLOW", "10"))
-    db_pool_recycle: int = int(os.getenv("SLM_DB_POOL_RECYCLE", "3600"))
+    # Database connection pool settings (#2860) — SSOT-coordinated defaults.
+    # SLM_DB_POOL_* env vars still override for per-service tuning.
+    db_pool_size: int = int(
+        os.getenv("SLM_DB_POOL_SIZE", str(_SSOT_POOL_SIZE))
+    )
+    db_pool_max_overflow: int = int(
+        os.getenv("SLM_DB_POOL_MAX_OVERFLOW", str(_SSOT_MAX_OVERFLOW))
+    )
+    db_pool_recycle: int = int(
+        os.getenv("SLM_DB_POOL_RECYCLE", str(_SSOT_POOL_RECYCLE))
+    )
 
     # Server
     host: str = "0.0.0.0"  # nosec B104 — bound behind nginx reverse proxy

--- a/autobot-slm-backend/user_management/database.py
+++ b/autobot-slm-backend/user_management/database.py
@@ -7,6 +7,8 @@ Dual Database Engine Management for SLM
 Two SQLAlchemy async engines:
 - slm_engine: Local SLM admin users
 - autobot_engine: Remote AutoBot application users
+
+Pool sizes are coordinated via SSOT config (#2860).
 """
 
 import logging
@@ -43,6 +45,30 @@ _slm_session_maker_lock = threading.Lock()
 _autobot_session_maker_lock = threading.Lock()
 
 
+def _get_pool_config() -> dict:
+    """Get database pool settings from SSOT config (#2860)."""
+    try:
+        from autobot_shared.ssot_config import get_config
+
+        pool_cfg = get_config().database_pool
+        return {
+            "pool_size": pool_cfg.pool_size,
+            "max_overflow": pool_cfg.max_overflow,
+            "pool_recycle": pool_cfg.pool_recycle,
+            "pool_timeout": pool_cfg.pool_timeout,
+        }
+    except Exception:
+        logger.warning(
+            "Could not load SSOT database pool config, using defaults"
+        )
+        return {
+            "pool_size": 10,
+            "max_overflow": 10,
+            "pool_recycle": 3600,
+            "pool_timeout": 30,
+        }
+
+
 def get_slm_engine() -> AsyncEngine:
     """Get or create SLM database engine (local).
 
@@ -53,11 +79,14 @@ def get_slm_engine() -> AsyncEngine:
         with _slm_engine_lock:
             if _slm_engine is None:
                 config = get_slm_db_config()
+                pool = _get_pool_config()
                 _slm_engine = create_async_engine(
                     config.url,
                     echo=False,
-                    pool_size=10,
-                    max_overflow=10,
+                    pool_size=pool["pool_size"],
+                    max_overflow=pool["max_overflow"],
+                    pool_recycle=pool["pool_recycle"],
+                    pool_timeout=pool["pool_timeout"],
                     pool_pre_ping=True,
                 )
                 logger.info("Created SLM database engine")
@@ -74,11 +103,14 @@ def get_autobot_engine() -> AsyncEngine:
         with _autobot_engine_lock:
             if _autobot_engine is None:
                 config = get_autobot_db_config()
+                pool = _get_pool_config()
                 _autobot_engine = create_async_engine(
                     config.url,
                     echo=False,
-                    pool_size=20,
-                    max_overflow=20,
+                    pool_size=pool["pool_size"],
+                    max_overflow=pool["max_overflow"],
+                    pool_recycle=pool["pool_recycle"],
+                    pool_timeout=pool["pool_timeout"],
                     pool_pre_ping=True,
                 )
                 logger.info("Created AutoBot database engine")


### PR DESCRIPTION
## Summary
Rebased version of #2905 (closed due to merge conflict with #2854).
- Add `DatabasePoolConfig` to `ssot_config.py` with env-var-controlled defaults
- 6 files updated to use coordinated pool settings (unified at 10, was 5-20)

Closes #2860

🤖 Generated with [Claude Code](https://claude.com/claude-code)