### PR TITLE
fix(ansible): add SLM service safety guards to co-located roles (#2900)

### DIFF
--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/clean.yml
@@ -15,12 +15,14 @@
   ansible.builtin.file:
     path: /opt/autobot/autobot-backend
     state: absent
+  when: "'backend' not in (node_roles | default([]))"
   tags: ['clean']
 
 - name: "AI Stack | Clean: wrong-node autobot-frontend dir"
   ansible.builtin.file:
     path: /opt/autobot/autobot-frontend
     state: absent
+  when: "'frontend' not in (node_roles | default([]))"
   tags: ['clean']
 
 - name: "AI Stack | Clean: wrong-node autobot-slm-backend dir"

--- a/autobot-slm-backend/ansible/roles/backend/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/handlers/main.yml
@@ -24,4 +24,4 @@
 - name: restart nginx backend
   ansible.builtin.systemd:
     name: nginx
-    state: restarted
+    state: reloaded

--- a/autobot-slm-backend/ansible/roles/browser/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/clean.yml
@@ -15,12 +15,14 @@
   ansible.builtin.file:
     path: /opt/autobot/autobot-backend
     state: absent
+  when: "'backend' not in (node_roles | default([]))"
   tags: ['clean']
 
 - name: "Browser | Clean: wrong-node autobot-frontend dir"
   ansible.builtin.file:
     path: /opt/autobot/autobot-frontend
     state: absent
+  when: "'frontend' not in (node_roles | default([]))"
   tags: ['clean']
 
 - name: "Browser | Clean: wrong-node autobot-slm-backend dir"

--- a/autobot-slm-backend/ansible/roles/frontend/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/handlers/main.yml
@@ -4,7 +4,7 @@
 - name: restart nginx
   systemd:
     name: nginx
-    state: restarted
+    state: reloaded
   become: yes
 
 - name: test nginx config

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/clean.yml
@@ -15,12 +15,14 @@
   ansible.builtin.file:
     path: /opt/autobot/autobot-backend
     state: absent
+  when: "'backend' not in (node_roles | default([]))"
   tags: ['clean']
 
 - name: "NPU Worker | Clean: wrong-node autobot-frontend dir"
   ansible.builtin.file:
     path: /opt/autobot/autobot-frontend
     state: absent
+  when: "'frontend' not in (node_roles | default([]))"
   tags: ['clean']
 
 - name: "NPU Worker | Clean: wrong-node autobot-slm-backend dir"

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/clean.yml
@@ -11,12 +11,14 @@
   ansible.builtin.file:
     path: /opt/autobot/autobot-backend
     state: absent
+  when: "'backend' not in (node_roles | default([]))"
   tags: ['clean']
 
 - name: "SLM | Clean: wrong-node autobot-frontend dir"
   ansible.builtin.file:
     path: /opt/autobot/autobot-frontend
     state: absent
+  when: "'frontend' not in (node_roles | default([]))"
   tags: ['clean']
 
 - name: "SLM | Clean: wrong-node autobot-user-backend dir"
@@ -53,10 +55,12 @@
   ansible.builtin.file:
     path: /opt/autobot/autobot-npu-worker
     state: absent
+  when: "'npu-worker' not in (node_roles | default([]))"
   tags: ['clean']
 
 - name: "SLM | Clean: wrong-node autobot-browser-worker dir"
   ansible.builtin.file:
     path: /opt/autobot/autobot-browser-worker
     state: absent
+  when: "'browser' not in (node_roles | default([]))"
   tags: ['clean']


### PR DESCRIPTION
## Summary
- Added `node_roles` guards to clean tasks in 4 roles (ai-stack, browser, npu-worker, slm_manager) that unconditionally deleted `autobot-backend`, `autobot-frontend`, `autobot-npu-worker`, `autobot-browser-worker` dirs — dangerous on co-located hosts
- Changed backend and frontend nginx handlers from `state: restarted` to `state: reloaded` (graceful) to prevent dropping SLM connections on shared hosts
- Frontend role already had `slm_colocated_frontend` guards from #2829 — no changes needed there

## Files changed
- `ansible/roles/ai-stack/tasks/clean.yml` — guard `autobot-backend` and `autobot-frontend` removal
- `ansible/roles/browser/tasks/clean.yml` — guard `autobot-backend` and `autobot-frontend` removal
- `ansible/roles/npu-worker/tasks/clean.yml` — guard `autobot-backend` and `autobot-frontend` removal
- `ansible/roles/slm_manager/tasks/clean.yml` — guard `autobot-backend`, `autobot-frontend`, `autobot-npu-worker`, `autobot-browser-worker` removal
- `ansible/roles/backend/handlers/main.yml` — nginx restart → reload (graceful)
- `ansible/roles/frontend/handlers/main.yml` — nginx restart → reload (graceful)

Closes #2900

## Test plan
- [ ] Deploy backend role to SLM host with `node_roles: [slm-backend, backend]` — verify backend dir preserved
- [ ] Deploy frontend role to SLM host with `node_roles: [slm-backend, frontend]` — verify SLM services untouched
- [ ] Run clean tasks on SLM host — verify SLM directories preserved
- [ ] Deploy to dedicated (non-SLM) host — verify no behavior change (clean tasks still remove wrong-node dirs)
- [ ] Verify nginx reload (not restart) works correctly for config changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)