### PR TITLE
Bug: Dockerfile HEALTHCHECK uses shell variable expansion inconsi (#2909)

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -93,7 +93,7 @@ ENV AUTOBOT_BACKEND_PORT=8001
 EXPOSE 8001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -f http://localhost:${AUTOBOT_BACKEND_PORT}/api/system/health || exit 1
+    CMD curl -f http://localhost:8001/api/system/health || exit 1
 
 CMD ["python3.12", "-m", "uvicorn", "main:app", \
      "--host", "0.0.0.0", "--port", "8001", \


### PR DESCRIPTION
Closes #2909

🤖 Generated with [Claude Code](https://claude.com/claude-code)