### PR TITLE
fix(deps): unify langchain upper bounds across all requirements files (#2808)

### DIFF
--- a/autobot-infrastructure/shared/config/requirements-ci.txt
+++ b/autobot-infrastructure/shared/config/requirements-ci.txt
@@ -68,9 +68,10 @@ pygetwindow>=0.0.9
 
 # ===== EXISTING INTEGRATIONS =====
 markdownify>=1.2.2              # SECURITY UPDATE - CVE fix (GHSA-7mpr-5m44-h73r)
-langchain>=1.2.13
-langchain-community>=0.4.1
-langchain-experimental>=0.4.1
+langchain>=1.2.13,<2.0.0         # Issue #2808: upper bound unified with backend canonical
+langchain-core>=1.2.22,<2.0.0   # Issue #2808: added to match backend canonical
+langchain-community>=0.4.1,<0.5.0  # Issue #2808: upper bound unified with backend canonical
+langchain-experimental>=0.4.1,<0.5.0  # Issue #2808: upper bound added for consistency
 llama-index>=0.14.19,<0.15.0  # Unified across all components (#2669); upper bound added (#2822)
 llama-index-llms-ollama>=0.10.1,<1.0.0
 llama-index-embeddings-ollama>=0.9.0,<1.0.0

--- a/autobot-infrastructure/shared/config/requirements.txt
+++ b/autobot-infrastructure/shared/config/requirements.txt
@@ -79,9 +79,10 @@ pygetwindow>=0.0.9               # Window management
 
 # ===== EXISTING INTEGRATIONS =====
 markdownify>=1.2.2              # SECURITY UPDATE - CVE fix (GHSA-7mpr-5m44-h73r)
-langchain>=1.2.13
-langchain-community>=0.4.1
-langchain-experimental>=0.4.1      # For advanced LangChain features
+langchain>=1.2.13,<2.0.0         # Issue #2808: upper bound unified with backend canonical
+langchain-core>=1.2.22,<2.0.0   # Issue #2808: added to match backend canonical
+langchain-community>=0.4.1,<0.5.0  # Issue #2808: upper bound unified with backend canonical
+langchain-experimental>=0.4.1,<0.5.0  # Issue #2808: upper bound added for consistency; for advanced LangChain features
 llama-index>=0.14.19,<0.15.0
 llama-index-llms-ollama>=0.10.1,<1.0.0
 llama-index-embeddings-ollama>=0.9.0,<1.0.0

--- a/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
+++ b/autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt
@@ -2,9 +2,9 @@
 # Includes LangChain, LlamaIndex and related packages with compatible versions
 
 # Core AI Frameworks
-langchain>=1.2.13
-langchain-core>=1.2.22
-langchain-community>=0.4.1
+langchain>=1.2.13,<2.0.0         # Issue #2808: upper bound unified with backend canonical
+langchain-core>=1.2.22,<2.0.0   # Issue #2808: upper bound unified with backend canonical
+langchain-community>=0.4.1,<0.5.0  # Issue #2808: upper bound unified with backend canonical
 llama-index>=0.14.19,<0.15.0
 llama-index-core>=0.14.19,<0.15.0
 llama-index-vector-stores-chroma>=0.5.5,<1.0.0

--- a/requirements-ci/langchain.txt
+++ b/requirements-ci/langchain.txt
@@ -1,5 +1,5 @@
 # LangChain ecosystem — tightly coupled versions
-langchain==1.2.12
+langchain==1.2.13                # Issue #2808: bumped to match canonical minimum (was 1.2.12)
 langchain-classic==1.0.2
 langchain-community==0.4.1
 langchain-core==1.2.22


### PR DESCRIPTION
## Summary
- Add `<2.0.0` upper bound to `langchain`/`langchain-core` across 4 files
- Add `<0.5.0` upper bound to `langchain-community`/`langchain-experimental`
- Matches canonical pins in `autobot-backend/requirements.txt`
- Bumped CI exact pin from `1.2.12` to `1.2.13` (was below canonical minimum)

Closes #2808

🤖 Generated with [Claude Code](https://claude.com/claude-code)