### PR TITLE
fix(config): replace legacy AUTOBOT_REDIS_DB with named SSOT key (#2813)

### DIFF
--- a/autobot-backend/config.py
+++ b/autobot-backend/config.py
@@ -731,7 +731,7 @@ class ConfigManager:
             "enabled": os.getenv("AUTOBOT_REDIS_ENABLED", "true").lower() == "true",
             "host": os.getenv("AUTOBOT_REDIS_HOST", "localhost"),
             "port": int(os.getenv("AUTOBOT_REDIS_PORT", "6379")),
-            "db": int(os.getenv("AUTOBOT_REDIS_DB", "1")),
+            "db": int(os.getenv("AUTOBOT_REDIS_DB_MAIN", "0")),
         }
 
         return self._deep_merge(defaults, redis_config)

--- a/autobot-backend/config/config_consolidation_p2_test.py
+++ b/autobot-backend/config/config_consolidation_p2_test.py
@@ -161,7 +161,7 @@ async def test_config_consolidation():
         env_vars = [
             "AUTOBOT_DEFAULT_LLM_MODEL",
             "AUTOBOT_BACKEND_PORT",
-            "AUTOBOT_REDIS_DB",
+            "AUTOBOT_REDIS_DB_MAIN",
         ]
 
         for var in env_vars:

--- a/autobot-backend/config/defaults.py
+++ b/autobot-backend/config/defaults.py
@@ -298,7 +298,7 @@ def _get_redis_config(redis_host: str, redis_port: int) -> Dict[str, Any]:
     return {
         "host": redis_host,
         "port": redis_port,
-        "db": int(os.getenv("AUTOBOT_REDIS_DB", "0")),
+        "db": int(os.getenv("AUTOBOT_REDIS_DB_MAIN", "0")),
         "password": os.getenv("AUTOBOT_REDIS_PASSWORD"),
     }
 

--- a/autobot-backend/config/loader.py
+++ b/autobot-backend/config/loader.py
@@ -52,7 +52,7 @@ ENV_VAR_MAPPINGS = {
     # Redis configuration
     "AUTOBOT_REDIS_HOST": ["memory", "redis", "host"],
     "AUTOBOT_REDIS_PORT": ["memory", "redis", "port"],
-    "AUTOBOT_REDIS_DB": ["memory", "redis", "db"],
+    "AUTOBOT_REDIS_DB_MAIN": ["memory", "redis", "db"],
     "AUTOBOT_REDIS_PASSWORD": ["memory", "redis", "password"],
     "AUTOBOT_REDIS_ENABLED": ["memory", "redis", "enabled"],
     # UI configuration


### PR DESCRIPTION
## Summary
- Replace bare `AUTOBOT_REDIS_DB` with `AUTOBOT_REDIS_DB_MAIN` in 4 files
- Fix wrong default in `config.py` (was `"1"`/knowledge, now `"0"`/main)
- Update env var mapping in `loader.py` and test file

Closes #2813

🤖 Generated with [Claude Code](https://claude.com/claude-code)