### PR TITLE
fix(ansible): add pip timeout to all install tasks to prevent hangs (#2835)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-native-services.yml
@@ -369,6 +369,9 @@
         virtualenv: /opt/autobot/venv
         virtualenv_python: python3.11
       become_user: autobot-service
+      environment:
+        PIP_DEFAULT_TIMEOUT: "120"
+      timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
 
     - name: Install OpenVINO runtime for NPU Worker
       pip:
@@ -377,6 +380,9 @@
           - openvino-dev[pytorch,tensorflow]
         virtualenv: /opt/autobot/venv
       become_user: autobot-service
+      environment:
+        PIP_DEFAULT_TIMEOUT: "120"
+      timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
 
     - name: Create NPU Worker configuration
       template:
@@ -502,13 +508,19 @@
         source venv/bin/activate
         pip install --upgrade pip setuptools wheel
       become_user: autobot-service
+      environment:
+        PIP_DEFAULT_TIMEOUT: "120"
+      timeout: 120  # Issue #2835: prevent indefinite hang on network issues
 
     - name: Install Python dependencies
       shell: |
         cd /opt/autobot
         source venv/bin/activate
-        pip install -r src/requirements.txt
+        pip install --timeout 120 -r src/requirements.txt
       become_user: autobot-service
+      environment:
+        PIP_DEFAULT_TIMEOUT: "120"
+      timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
 
     - name: Install Ollama
       block:

--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -286,9 +286,12 @@
       command:
         cmd: /opt/autobot/autobot-slm-backend/venv/bin/pip install
              -r /opt/autobot/autobot-slm-backend/requirements.txt
-             --quiet
+             --quiet --timeout 120
       become: true
       become_user: autobot
+      environment:
+        PIP_DEFAULT_TIMEOUT: "120"
+      timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
       when: hostvars['localhost']['python_deps_changed'] | bool
       register: slm_pip_install
       tags: [slm, slm-backend, deps]
@@ -503,9 +506,12 @@
       command:
         cmd: /opt/autobot/autobot-backend/venv/bin/pip install
              -r /opt/autobot/autobot-backend/requirements.txt
-             --quiet
+             --quiet --timeout 120
       become: true
       become_user: autobot
+      environment:
+        PIP_DEFAULT_TIMEOUT: "120"
+      timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
       when:
         - "'01-Backend' in inventory_hostname"
         - hostvars['localhost']['python_deps_changed'] | bool
@@ -674,9 +680,12 @@
       command:
         cmd: /opt/autobot/autobot-npu-worker/venv/bin/pip install
              -r /opt/autobot/autobot-npu-worker/requirements.txt
-             --quiet
+             --quiet --timeout 120
       become: true
       become_user: autobot
+      environment:
+        PIP_DEFAULT_TIMEOUT: "120"
+      timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
       when:
         - >-
           '03-NPU' in inventory_hostname or
@@ -747,9 +756,12 @@
       command:
         cmd: /opt/autobot/autobot-browser-worker/venv/bin/pip install
              -r /opt/autobot/autobot-browser-worker/requirements.txt
-             --quiet
+             --quiet --timeout 120
       become: true
       become_user: autobot
+      environment:
+        PIP_DEFAULT_TIMEOUT: "120"
+      timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
       when:
         - >-
           '05-Browser' in inventory_hostname or

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/openvino.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/openvino.yml
@@ -46,6 +46,9 @@
     name: openvino
     virtualenv: "{{ venv_dir }}"
   become_user: "{{ service_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 300  # Issue #2835: prevent indefinite hang on dependency resolution
 
 - name: Verify OpenVINO installation
   command: "{{ venv_dir }}/bin/python -c 'import openvino; print(openvino.__version__)'"

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/playwright.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/playwright.yml
@@ -28,6 +28,9 @@
     name: playwright
     virtualenv: "{{ venv_dir }}"
   become_user: "{{ service_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 300  # Issue #2835: prevent indefinite hang on dependency resolution
 
 - name: Check if Playwright browsers are installed
   stat:

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/python_deps.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/python_deps.yml
@@ -14,4 +14,7 @@
     requirements: "{{ project_root }}/{{ requirements_file }}"
     virtualenv: "{{ venv_dir }}"
   become_user: "{{ service_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   when: requirements_stat.stat.exists

--- a/autobot-slm-backend/ansible/roles/agent_config/tasks/python_env.yml
+++ b/autobot-slm-backend/ansible/roles/agent_config/tasks/python_env.yml
@@ -22,3 +22,6 @@
     state: latest
     virtualenv: "{{ venv_dir }}"
   become_user: "{{ service_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 120  # Issue #2835: prevent indefinite hang on network issues

--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
@@ -96,6 +96,9 @@
     virtualenv: "{{ ai_install_dir }}/venv"
     state: latest
   become_user: "{{ ai_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 120  # Issue #2835: prevent indefinite hang on network issues
 
 - name: Check if requirements-ai.txt exists
   ansible.builtin.stat:
@@ -109,6 +112,9 @@
     state: present
     extra_args: "--timeout 300"
   become_user: "{{ ai_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "300"
+  timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   when: _ai_requirements_file.stat.exists
 
 - name: Install AI Python packages (fallback list)
@@ -137,6 +143,9 @@
     state: present
     extra_args: "--timeout 300"
   become_user: "{{ ai_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "300"
+  timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   when: not _ai_requirements_file.stat.exists
 
 - name: Deploy AI stack environment file

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -216,6 +216,9 @@
     state: latest
     virtualenv: "{{ backend_code_dir }}/venv"
   become_user: "{{ backend_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 120  # Issue #2835: prevent indefinite hang on network issues
 
 - name: Install autobot-shared as editable package
   ansible.builtin.pip:
@@ -223,6 +226,9 @@
     editable: true
     virtualenv: "{{ backend_code_dir }}/venv"
   become_user: "{{ backend_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 120  # Issue #2835: prevent indefinite hang
   when: backend_install_dir is defined
 
 - name: Create filtered backend requirements file
@@ -236,7 +242,9 @@
     virtualenv: "{{ backend_code_dir }}/venv"
   become_user: "{{ backend_user }}"
   environment:
+    PIP_DEFAULT_TIMEOUT: "120"
     PIP_USE_DEPRECATED: "legacy-resolver"  # Issue #858: Handle complex OpenTelemetry+ChromaDB dependency graph
+  timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   register: pip_install_result
   failed_when: false  # Issue #892: pip module doesn't expose rc, rely on default error handling
   changed_when: pip_install_result.changed
@@ -257,6 +265,9 @@
     state: forcereinstall
     extra_args: "--no-deps"
   become_user: "{{ backend_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 120  # Issue #2835: prevent indefinite hang
   when: backend_install_dir is defined
 
 # ==========================================================

--- a/autobot-slm-backend/ansible/roles/backend_services/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend_services/tasks/main.yml
@@ -27,6 +27,9 @@
     virtualenv: /opt/autobot/venv
     virtualenv_python: python3.12
   become_user: autobot
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
 
 - name: Copy AutoBot application files
   synchronize:

--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -103,6 +103,9 @@
     state: present
     executable: pip3
   become: yes
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 300  # Issue #2835: prevent indefinite hang on dependency resolution
   tags: ['browser', 'packages']
 
 - name: "Browser | Install Playwright browsers"

--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -216,6 +216,9 @@
     state: latest
     executable: pip3
   become: yes
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 120  # Issue #2835: prevent indefinite hang on network issues
   when: _pep668.rc != 0
   tags: ['common', 'python']
 

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml
@@ -100,6 +100,9 @@
     virtualenv: "{{ npu_install_dir }}/venv"
     state: latest
   become_user: "{{ npu_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 120  # Issue #2835: prevent indefinite hang on network issues
 
 - name: Check if OpenVINO is already installed
   ansible.builtin.command:
@@ -117,6 +120,9 @@
     virtualenv: "{{ npu_install_dir }}/venv"
     state: present
   become_user: "{{ npu_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 300  # Issue #2835: prevent indefinite hang on dependency resolution
 
 - name: Install OpenVINO and dependencies
   ansible.builtin.pip:
@@ -131,6 +137,9 @@
     state: present
     extra_args: "--timeout 120"
   become_user: "{{ npu_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   when:
     - npu_install_openvino | default(true)
     - _openvino_check.rc != 0

--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/main.yml
@@ -97,6 +97,9 @@
     executable: pip3
     extra_args: "--break-system-packages"
   become: yes
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 300  # Issue #2835: prevent indefinite hang on dependency resolution
   tags: ['slm_agent', 'packages']
 
 - name: "SLM Agent | Copy agent source - __init__.py (slm package)"

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -222,6 +222,9 @@
   ansible.builtin.command:
     cmd: "{{ slm_backend_dir }}/venv/bin/pip install -e {{ slm_base_dir }}/autobot-shared"
   become_user: "{{ slm_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 120  # Issue #2835: prevent indefinite hang
   when: slm_requirements_stat.stat.exists
   changed_when: true
   tags: ['slm', 'backend']
@@ -232,6 +235,9 @@
     virtualenv: "{{ slm_backend_dir }}/venv"
     state: present
   become_user: "{{ slm_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   when: slm_requirements_stat.stat.exists
   tags: ['slm', 'backend']
 

--- a/autobot-slm-backend/ansible/roles/tts-worker/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/tts-worker/tasks/main.yml
@@ -103,6 +103,9 @@
     virtualenv: "{{ tts_install_dir }}/venv"
     state: latest
   become_user: "{{ tts_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 120  # Issue #2835: prevent indefinite hang on network issues
   tags: ['tts', 'venv']
 
 - name: "TTS Worker | Install FastAPI and server dependencies"
@@ -115,6 +118,9 @@
     virtualenv: "{{ tts_install_dir }}/venv"
     state: present
   become_user: "{{ tts_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "120"
+  timeout: 300  # Issue #2835: prevent indefinite hang on dependency resolution
   tags: ['tts', 'packages']
 
 - name: "TTS Worker | Install torch CPU-only (Pocket TTS requires >=2.5)"
@@ -125,6 +131,9 @@
     state: present
     extra_args: "--index-url https://download.pytorch.org/whl/cpu --timeout 300"
   become_user: "{{ tts_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "300"
+  timeout: 600  # Issue #2835: torch downloads are large, prevent indefinite hang
   tags: ['tts', 'packages']
 
 - name: "TTS Worker | Install pocket-tts and audio dependencies"
@@ -138,6 +147,9 @@
     state: present
     extra_args: "--timeout 300"
   become_user: "{{ tts_user }}"
+  environment:
+    PIP_DEFAULT_TIMEOUT: "300"
+  timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   tags: ['tts', 'packages']
 
 # ============================================================


### PR DESCRIPTION
## Summary
- 15 files, ~30 pip tasks updated with two-layer timeout defense
- `PIP_DEFAULT_TIMEOUT` env var (120-300s per connection)
- Ansible `timeout:` parameter (120-600s per task)
- `--timeout` CLI flag on command-based pip installs
- Prevents indefinite hangs from pip dependency resolution conflicts

## Test plan
- [x] All 15 YAML files valid
- [x] Timeout values appropriate per task type (pip upgrade: 120s, requirements: 600s, torch: 600s)
- [ ] Verify on provisioning: tasks fail cleanly on timeout instead of hanging

Closes #2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)