### PR TITLE
docs: remove stale passlib references after bcrypt 5.x migration (#2811)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -38,7 +38,7 @@
     # Emergency admin user for fallback access when SSH keys fail
     emergency_admin_user: "autobot_admin"
     # Password hash must be provided via Ansible Vault or --extra-vars.
-    # Generate with: python3 -c "from passlib.hash import sha512_crypt; print(sha512_crypt.hash('YOUR_PASSWORD'))"
+    # Generate with: python3 -c "import bcrypt; print(bcrypt.hashpw(b'YOUR_PASSWORD', bcrypt.gensalt()).decode())"
     # See: inventory/group_vars/vault.yml
     emergency_admin_password_hash: "{{ vault_emergency_admin_password_hash | default(omit) }}"
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -71,7 +71,7 @@ Key packages:
 - redis (5.0+)
 - pydantic (2.5+)
 - PyJWT[crypto]
-- passlib[bcrypt]
+- bcrypt (5.0+)
 - python-multipart
 - aiohttp
 
@@ -330,7 +330,7 @@ python3 -m playwright install webkit
 redis>=5.0.0
 pydantic>=2.5.0
 PyJWT[crypto]>=2.8.0
-passlib[bcrypt]>=1.7.4
+bcrypt>=5.0.0
 ```
 
 ### User Backend
@@ -362,7 +362,7 @@ asyncpg>=0.29.0
 redis>=5.0.0
 pydantic>=2.5.0
 PyJWT[crypto]>=2.8.0
-passlib[bcrypt]>=1.7.4
+bcrypt>=5.0.0
 python-multipart>=0.0.6
 aiohttp>=3.9.0
 ```

--- a/docs/plans/2026-01-15-slm-startup-procedure-design.md
+++ b/docs/plans/2026-01-15-slm-startup-procedure-design.md
@@ -131,7 +131,7 @@ Minimal set (~10 packages):
 - ansible-runner
 - aiofiles
 - python-jose (JWT)
-- passlib (passwords)
+- bcrypt (passwords)
 - websockets
 
 ## Startup Flow


### PR DESCRIPTION
## Summary
- Replace `passlib[bcrypt]` with `bcrypt>=5.0.0` in `DEPENDENCIES.md`
- Update design doc to reference `bcrypt` instead of `passlib`
- Update `enroll-node.yml` comment to show bcrypt API

Closes #2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)