### PR TITLE
fix(ansible): remove default inventory from ansible.cfg to prevent merge (#2837)

### DIFF
--- a/autobot-slm-backend/ansible/ansible.cfg
+++ b/autobot-slm-backend/ansible/ansible.cfg
@@ -2,7 +2,10 @@
 # Ansible Configuration for AutoBot Hyper-V Deployment
 
 # Inventory and Connection Settings
-inventory = inventory/production.yml
+# NOTE: No default inventory is configured. All playbook invocations MUST
+# pass -i <inventory> explicitly. This prevents Ansible from merging a
+# static production.yml with dynamically-generated wizard inventories
+# when both are present (#2837).
 roles_path = roles
 remote_user = autobot
 private_key_file = ~/.ssh/autobot_key


### PR DESCRIPTION
## Summary
- Remove `inventory = inventory/production.yml` from `ansible.cfg`
- Prevents Ansible from merging static production hosts with wizard dynamic inventories
- All invocation paths already pass `-i` explicitly (playbook_executor.py, deploy scripts)
- Completes the root cause fix started in commit 2941809b9

Closes #2837

🤖 Generated with [Claude Code](https://claude.com/claude-code)