### PR TITLE
fix(ansible): resolve backend/frontend nginx config conflict on single-host (#2829)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -370,7 +370,22 @@
 # nginx reverse proxy (Issue #957)
 # Holds port backend_nginx_port (8443) permanently so WDF
 # rule is evaluated once for nginx, not on every uvicorn restart.
+#
+# Co-located mode (#2829): When SLM and backend share a host,
+# the SLM nginx proxies directly to uvicorn (port 8001, HTTP).
+# The standalone backend nginx vhost is skipped to avoid a
+# redundant double-proxy (SLM:443 -> backend:8443 -> uvicorn:8001).
 # ==========================================================
+
+# Cleanup: disable standalone backend nginx when co-located with SLM
+- name: "Backend nginx | Disable standalone vhost when co-located with SLM (#2829)"
+  ansible.builtin.file:
+    path: /etc/nginx/sites-enabled/autobot-backend.conf
+    state: absent
+  notify: reload nginx backend
+  when: slm_colocated_frontend | default(false) | bool
+  tags: ['backend', 'nginx']
+
 - name: "Backend nginx | Deploy reverse-proxy vhost config"
   ansible.builtin.template:
     src: nginx-backend.conf.j2
@@ -379,6 +394,7 @@
     owner: root
     group: root
   notify: reload nginx backend
+  when: not (slm_colocated_frontend | default(false) | bool)
   tags: ['backend', 'nginx']
 
 - name: "Backend nginx | Enable vhost (symlink)"
@@ -387,6 +403,7 @@
     dest: /etc/nginx/sites-enabled/autobot-backend.conf
     state: link
   notify: reload nginx backend
+  when: not (slm_colocated_frontend | default(false) | bool)
   tags: ['backend', 'nginx']
 
 - name: "Backend nginx | Disable default vhost"

--- a/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
@@ -44,12 +44,18 @@ slm_nginx_config: autobot-slm
 # When SLM and user frontend share the same host, the SLM
 # nginx config serves the user frontend at / and SLM at /slm/.
 # Set to true + provide paths when deploying single-host.
+#
+# In co-located mode the SLM nginx proxies directly to uvicorn
+# (HTTP on port 8001) instead of through the backend nginx
+# (HTTPS on port 8443), eliminating the double-proxy overhead.
+# The backend role skips its standalone nginx vhost when this
+# flag is true.
 # ==========================================================
 slm_colocated_frontend: false
 frontend_dist_dir: "{{ slm_base_dir }}/autobot-frontend/dist"
 frontend_backend_host: 127.0.0.1
-frontend_backend_port: 8443
-frontend_backend_protocol: https
+frontend_backend_port: 8001
+frontend_backend_protocol: http
 
 # ==========================================================
 # Frontend Build

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm.conf.j2
@@ -3,6 +3,7 @@
 
 {% if slm_colocated_frontend | default(false) | bool %}
 # Co-located user backend upstream (#2829)
+# Proxies directly to uvicorn (HTTP) — no intermediate backend nginx.
 upstream autobot_backend {
     server {{ frontend_backend_host }}:{{ frontend_backend_port }};
 }
@@ -56,6 +57,7 @@ server {
 {% if slm_colocated_frontend | default(false) | bool %}
     # ── Co-located mode (#2829) ───────────────────────────────
     # SLM API under /slm/api/, user backend at /api/, user frontend at /
+    # Backend upstream is plain HTTP to uvicorn — no double-proxy.
 
     # SLM Backend WebSocket (must be before /slm/api/ to take priority)
     location /slm/api/ws/ {
@@ -90,7 +92,7 @@ server {
         proxy_set_header Host $host;
     }
 
-    # User backend WebSocket proxies
+    # User backend WebSocket proxies (HTTP to uvicorn)
     location /api/ws {
         proxy_pass {{ frontend_backend_protocol }}://autobot_backend;
         proxy_http_version 1.1;
@@ -99,7 +101,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_read_timeout 86400;
+{% if frontend_backend_protocol == 'https' %}
         proxy_ssl_verify off;
+{% endif %}
     }
 
     location /api/terminal/ws {
@@ -110,7 +114,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_read_timeout 300s;
+{% if frontend_backend_protocol == 'https' %}
         proxy_ssl_verify off;
+{% endif %}
     }
 
     location /api/voice/stream {
@@ -121,7 +127,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_read_timeout 86400;
+{% if frontend_backend_protocol == 'https' %}
         proxy_ssl_verify off;
+{% endif %}
     }
 
     location /ws {
@@ -131,7 +139,9 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
         proxy_read_timeout 86400;
+{% if frontend_backend_protocol == 'https' %}
         proxy_ssl_verify off;
+{% endif %}
     }
 
     # User backend API proxy
@@ -142,7 +152,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+{% if frontend_backend_protocol == 'https' %}
         proxy_ssl_verify off;
+{% endif %}
         proxy_connect_timeout 60s;
         proxy_send_timeout 300s;
         proxy_read_timeout 300s;

--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/setup", tags=["setup-wizard"])
 
-# ── Wizard Steps ────────────────────────────────────────────────────────────
+# -- Wizard Steps ------------------------------------------------------------
 
 WIZARD_STEPS = [
     "welcome",
@@ -45,7 +45,7 @@ WIZARD_STEPS = [
 ]
 
 
-# ── Schemas ─────────────────────────────────────────────────────────────────
+# -- Schemas -----------------------------------------------------------------
 
 
 class WizardStatus(BaseModel):
@@ -70,7 +70,7 @@ class ProvisionRequest(BaseModel):
     node_ids: Optional[list[str]] = None
 
 
-# ── Settings Helpers ────────────────────────────────────────────────────────
+# -- Settings Helpers --------------------------------------------------------
 
 
 async def _get_setting(key: str, default: str = "") -> str:
@@ -242,7 +242,11 @@ async def _generate_dynamic_inventory(
         # When a node on the SLM host also has the 'frontend' role,
         # set slm_colocated_frontend so the SLM nginx config serves
         # user frontend at / and SLM at /slm/ instead of redirecting.
+        # Also configure the backend upstream to proxy directly to
+        # uvicorn (HTTP on port 8001) instead of through the backend
+        # nginx (HTTPS on port 8443), eliminating the double-proxy.
         _frontend_roles = {"frontend", "autobot-frontend"}
+        _backend_roles = {"backend", "autobot-backend"}
         for node in db_nodes:
             inv_name = node.ansible_target
             if inv_name not in hosts:
@@ -250,6 +254,11 @@ async def _generate_dynamic_inventory(
             roles = set(hosts[inv_name].get("node_roles", []))
             if node.ip_address in local_ips and roles & _frontend_roles:
                 hosts[inv_name]["slm_colocated_frontend"] = True
+                # When backend is also co-located, proxy directly to
+                # uvicorn (HTTP) -- the backend nginx vhost is skipped.
+                if roles & _backend_roles:
+                    hosts[inv_name]["frontend_backend_port"] = 8001
+                    hosts[inv_name]["frontend_backend_protocol"] = "http"
 
         # Fetch ALL active roles for infra var derivation (#1431)
         if node_ids:
@@ -272,7 +281,7 @@ async def _generate_dynamic_inventory(
     # the routable IP that remote nodes should use.  The slm_agent role's
     # default builds slm_admin_url from this value, and the template's
     # auto-detect logic then rewrites it to 127.0.0.1 when the agent is
-    # co-located — but only after slm_host contains the real local IP rather
+    # co-located -- but only after slm_host contains the real local IP rather
     # than the hardcoded multi-node default (172.16.168.19).
     from urllib.parse import urlparse
 
@@ -345,7 +354,7 @@ async def _check_node_reachability(inventory_path: Path) -> dict[str, bool]:
     Probes run in parallel; each probe has a 5-second ConnectTimeout plus a
     10-second asyncio timeout as a safety net.
 
-    Returns a dict mapping inventory hostname → reachable (bool).
+    Returns a dict mapping inventory hostname -> reachable (bool).
     """
     raw = yaml.safe_load(inventory_path.read_text(encoding="utf-8"))
     all_vars = raw.get("all", {}).get("vars", {})
@@ -389,14 +398,14 @@ async def _check_node_reachability(inventory_path: Path) -> dict[str, bool]:
                 else hostname
             )
             logger.warning(
-                "Node %s (%s) is unreachable — skipping (not enrolled?)",
+                "Node %s (%s) is unreachable -- skipping (not enrolled?)",
                 hostname,
                 ip,
             )
     return results
 
 
-# ── Provisioning State (#1384) ──────────────────────────────────────────────
+# -- Provisioning State (#1384) ----------------------------------------------
 
 async def _activate_provisioned_roles(
     node_ids: Optional[list[str]],
@@ -522,7 +531,8 @@ async def _run_provisioning_task(
                     else hostname
                 )
                 msg = (
-                    f"Node {hostname} ({ip}) is unreachable — skipping (not enrolled?)"
+                    f"Node {hostname} ({ip}) is unreachable"
+                    " -- skipping (not enrolled?)"
                 )
                 _write_provision_log(f"WARNING: {msg}")
                 await ws_manager.send_provision_log("warning", msg)
@@ -530,7 +540,8 @@ async def _run_provisioning_task(
         if not reachable:
             _provision_state["status"] = "failed"
             _provision_state["error"] = (
-                "All nodes are unreachable — ensure nodes are enrolled before provisioning"
+                "All nodes are unreachable"
+                " -- ensure nodes are enrolled before provisioning"
             )
             _provision_state["finished_at"] = time.time()
             _write_provision_log("ERROR: All nodes are unreachable")
@@ -538,11 +549,17 @@ async def _run_provisioning_task(
                 "failed",
                 "",
                 0,
-                error="All nodes are unreachable — ensure nodes are enrolled before provisioning",
+                error=(
+                    "All nodes are unreachable"
+                    " -- ensure nodes are enrolled before provisioning"
+                ),
             )
             await ws_manager.send_provision_log(
                 "error",
-                "All nodes are unreachable — ensure nodes are enrolled before provisioning",
+                (
+                    "All nodes are unreachable"
+                    " -- ensure nodes are enrolled before provisioning"
+                ),
             )
             return
 
@@ -609,7 +626,7 @@ async def _run_provisioning_task(
         _write_provision_log(f"EXCEPTION: {exc}")
         logger.exception("Fleet provisioning error: %s", exc)
         elapsed = time.time() - (_provision_state.get("started_at") or time.time())
-        # Sanitize — Ansible exceptions may contain credentials (#2754)
+        # Sanitize -- Ansible exceptions may contain credentials (#2754)
         await ws_manager.send_provision_status(
             "failed", "", elapsed, error="internal error"
         )
@@ -622,7 +639,7 @@ async def _run_provisioning_task(
             temp_inventory_path.unlink(missing_ok=True)
 
 
-# ── Endpoints ───────────────────────────────────────────────────────────────
+# -- Endpoints ---------------------------------------------------------------
 
 
 @router.get("/status", response_model=WizardStatus)


### PR DESCRIPTION
## Summary
- Backend role: skip standalone nginx vhost when co-located with SLM
- SLM defaults: proxy directly to uvicorn (HTTP:8001) instead of backend nginx (HTTPS:8443)
- SLM nginx template: conditional `proxy_ssl_verify` (only when protocol=https)
- Wizard: auto-set `frontend_backend_port`/`protocol` when backend co-located

Eliminates double-proxy chain (SLM nginx → backend nginx → uvicorn) on single-host.

## Test plan
- [x] Python and YAML syntax valid
- [x] Multi-host architecture unchanged (backend nginx still used)
- [ ] Verify single-host: SLM nginx proxies directly to uvicorn on 8001

Closes #2829

🤖 Generated with [Claude Code](https://claude.com/claude-code)