### PR TITLE
chore(ansible): move autobot_key to /etc/autobot/ssh/ for multi-user access (#2828)

### DIFF
--- a/autobot-slm-backend/ansible/ansible.cfg
+++ b/autobot-slm-backend/ansible/ansible.cfg
@@ -5,7 +5,7 @@
 inventory = inventory/production.yml
 roles_path = roles
 remote_user = autobot
-private_key_file = ~/.ssh/autobot_key
+private_key_file = /etc/autobot/ssh/autobot_key
 timeout = 30
 forks = 5
 

--- a/autobot-slm-backend/ansible/inventory/hosts-router.yml
+++ b/autobot-slm-backend/ansible/inventory/hosts-router.yml
@@ -4,7 +4,7 @@
 all:
   vars:
     ansible_user: autobot
-    ansible_ssh_private_key_file: ~/.ssh/autobot_key
+    ansible_ssh_private_key_file: /etc/autobot/ssh/autobot_key
     python_interpreter: /usr/bin/python3
 
   children:

--- a/autobot-slm-backend/ansible/inventory/hosts.yml
+++ b/autobot-slm-backend/ansible/inventory/hosts.yml
@@ -2,7 +2,7 @@
 all:
   vars:
     ansible_user: autobot
-    ansible_ssh_private_key_file: ~/.ssh/autobot_key
+    ansible_ssh_private_key_file: /etc/autobot/ssh/autobot_key
     python_interpreter: /usr/bin/python3
 
   children:

--- a/autobot-slm-backend/ansible/inventory/production.yml
+++ b/autobot-slm-backend/ansible/inventory/production.yml
@@ -7,7 +7,7 @@ all:
     # Global SSH and connection settings - UPDATED FOR PROVIDED VMs
     # Issue #700: SSH key authentication (no plaintext passwords)
     ansible_user: autobot
-    ansible_ssh_private_key_file: ~/.ssh/autobot_key
+    ansible_ssh_private_key_file: /etc/autobot/ssh/autobot_key
     ansible_become: yes
     # Become password from vault (only needed if passwordless sudo not configured)
     # To use: ansible-playbook ... --ask-vault-pass

--- a/autobot-slm-backend/ansible/inventory/slm-nodes.yml
+++ b/autobot-slm-backend/ansible/inventory/slm-nodes.yml
@@ -8,7 +8,7 @@
 all:
   vars:
     ansible_user: autobot
-    ansible_ssh_private_key_file: ~/.ssh/autobot_key
+    ansible_ssh_private_key_file: /etc/autobot/ssh/autobot_key
     ansible_python_interpreter: /usr/bin/python3
 
   children:

--- a/autobot-slm-backend/ansible/playbooks/bootstrap-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/bootstrap-node.yml
@@ -27,7 +27,7 @@
 #     --ask-pass --ask-become-pass
 #
 # After bootstrap, verify key auth works:
-#   ssh -i ~/.ssh/autobot_key autobot@<host-ip> whoami
+#   ssh -i /etc/autobot/ssh/autobot_key autobot@<host-ip> whoami
 #
 # Then enroll the node:
 #   ansible-playbook -i inventory/slm-nodes.yml playbooks/enroll-node.yml \
@@ -45,7 +45,8 @@
     autobot_data_dir: "/var/lib/autobot"
     autobot_log_dir: "/var/log/autobot"
     autobot_cert_dir: "/etc/autobot/certs"
-    ssh_pubkey_path: "/home/autobot/.ssh/autobot_key.pub"
+    # Issue #2828: Use shared key path — accessible to any user in autobot group
+    ssh_pubkey_path: "/etc/autobot/ssh/autobot_key.pub"
 
   pre_tasks:
     - name: "Verify target is a Debian/Ubuntu system"
@@ -226,6 +227,6 @@
           - "Firewall: SSH + VNC + websockify allowed"
           - ""
           - "Next steps:"
-          - "  1. Verify: ssh -i ~/.ssh/autobot_key {{ autobot_user }}@{{ ansible_default_ipv4.address }}"
+          - "  1. Verify: ssh -i /etc/autobot/ssh/autobot_key {{ autobot_user }}@{{ ansible_default_ipv4.address }}"
           - "  2. Enroll:  ansible-playbook -i inventory/slm-nodes.yml playbooks/enroll-node.yml --limit {{ inventory_hostname }} -e node_role=vnc"
           - "  3. VNC:     ansible-playbook -i inventory/slm-nodes.yml playbooks/provision-fleet-roles.yml --limit {{ inventory_hostname }} --tags vnc"

--- a/autobot-slm-backend/ansible/playbooks/deploy-base.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-base.yml
@@ -17,7 +17,7 @@
     - name: Display VM information
       debug:
         msg:
-          - "🖥️  Configuring VM: {{ inventory_hostname }}"
+          - "Configuring VM: {{ inventory_hostname }}"
           - "IP Address: {{ ansible_default_ipv4.address }}"
           - "OS: {{ ansible_distribution }} {{ ansible_distribution_version }}"
           - "Role: {{ group_names | join(', ') }}"
@@ -162,10 +162,11 @@
         group: "{{ autobot_group }}"
         mode: '0700'
 
+    # Issue #2828: Use shared key path so any operator can run Ansible
     - name: Set up authorized_keys for autobot user (if public key provided)
       authorized_key:
         user: "{{ autobot_user }}"
-        key: "{{ lookup('file', '~/.ssh/autobot_key.pub') }}"
+        key: "{{ lookup('file', '/etc/autobot/ssh/autobot_key.pub') }}"
         state: present
       ignore_errors: true  # In case key doesn't exist yet
 
@@ -449,12 +450,12 @@
     - name: Display base system deployment summary
       debug:
         msg:
-          - "✅ Base system configuration completed for {{ inventory_hostname }}"
-          - "🔐 Security: UFW firewall enabled, fail2ban configured"
-          - "👤 User: {{ autobot_user }} created with sudo access"
-          - "📊 Monitoring: {{ monitoring.enabled | ternary('Enabled', 'Disabled') }}"
-          - "💾 Backup: {{ backup.enabled | ternary('Enabled', 'Disabled') }}"
-          - "🌐 Network: Internal communication configured"
+          - "Base system configuration completed for {{ inventory_hostname }}"
+          - "Security: UFW firewall enabled, fail2ban configured"
+          - "User: {{ autobot_user }} created with sudo access"
+          - "Monitoring: {{ monitoring.enabled | ternary('Enabled', 'Disabled') }}"
+          - "Backup: {{ backup.enabled | ternary('Enabled', 'Disabled') }}"
+          - "Network: Internal communication configured"
 
     - name: Verify critical services are running
       systemd:

--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -157,11 +157,12 @@
             - "{{ autobot_cert_dir }}"
             - "{{ autobot_home }}/.ssh"
 
+        # Issue #2828: Use shared key path — accessible to any operator
         - name: "Configure SSH authorized keys"
           authorized_key:
             user: "{{ autobot_user }}"
             state: present
-            key: "{{ lookup('file', '~/.ssh/autobot_key.pub') }}"
+            key: "{{ lookup('file', '/etc/autobot/ssh/autobot_key.pub') }}"
           ignore_errors: yes  # Key may not exist during initial enrollment
 
         - name: "Create emergency admin user"

--- a/autobot-slm-backend/ansible/playbooks/rotate-ssh-keys.yml
+++ b/autobot-slm-backend/ansible/playbooks/rotate-ssh-keys.yml
@@ -59,7 +59,7 @@
           - "K2 - Stage new public key alongside old key"
           - "K3 - Verify connectivity with new key"
           - "K4 - Remove old key from authorized_keys"
-          - "K5 - Save new private key to ~/.ssh/autobot_key"
+          - "K5 - Save new private key to /etc/autobot/ssh/autobot_key"
           - "K6 - Remove temp safety-net key"
           - "=========================================================="
 
@@ -212,7 +212,8 @@
   gather_facts: false
 
   vars:
-    _old_key_path: "{{ lookup('env', 'HOME') }}/.ssh/autobot_key"
+    # Issue #2828: Read old key from shared location
+    _old_key_path: "/etc/autobot/ssh/autobot_key"
 
   tasks:
     - name: "SSH K4 | Read current old public key"
@@ -243,27 +244,52 @@
   vars:
     _keys_dir: "{{ lookup('env', 'HOME') }}/.ssh/autobot-rotation"
     _new_key_path: "{{ _keys_dir }}/autobot_key_new"
-    _final_key_path: "{{ lookup('env', 'HOME') }}/.ssh/autobot_key"
+    # Issue #2828: Install to shared location accessible by any operator
+    _final_key_path: "/etc/autobot/ssh/autobot_key"
 
   tasks:
     - name: "SSH K5 | Back up old private key"
       ansible.builtin.copy:
         src: "{{ _final_key_path }}"
         dest: "{{ _final_key_path }}.bak"
-        mode: "0600"
+        mode: "0640"
       failed_when: false
 
     - name: "SSH K5 | Install new private key"
       ansible.builtin.copy:
         src: "{{ _new_key_path }}"
         dest: "{{ _final_key_path }}"
-        mode: "0600"
+        owner: root
+        group: autobot
+        mode: "0640"
+      become: true
 
     - name: "SSH K5 | Install new public key"
       ansible.builtin.copy:
         src: "{{ _new_key_path }}.pub"
         dest: "{{ _final_key_path }}.pub"
+        owner: root
+        group: autobot
         mode: "0644"
+      become: true
+
+    - name: "SSH K5 | Also update autobot user home copy"
+      ansible.builtin.copy:
+        src: "{{ _new_key_path }}"
+        dest: "/home/autobot/.ssh/autobot_key"
+        owner: autobot
+        group: autobot
+        mode: "0600"
+      become: true
+
+    - name: "SSH K5 | Also update autobot user home public key"
+      ansible.builtin.copy:
+        src: "{{ _new_key_path }}.pub"
+        dest: "/home/autobot/.ssh/autobot_key.pub"
+        owner: autobot
+        group: autobot
+        mode: "0644"
+      become: true
 
     - name: "SSH K5 | Confirm installed"
       ansible.builtin.debug:
@@ -315,8 +341,8 @@
           - "AutoBot SSH Key Rotation - COMPLETE"
           - "=========================================================="
           - "All 9 nodes updated with new ED25519 key."
-          - "New key installed at ~/.ssh/autobot_key"
-          - "Old key backed up at ~/.ssh/autobot_key.bak"
+          - "New key installed at /etc/autobot/ssh/autobot_key"
+          - "Old key backed up at /etc/autobot/ssh/autobot_key.bak"
           - ""
-          - "To verify: ssh -i ~/.ssh/autobot_key autobot@{{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }}"
+          - "To verify: ssh -i /etc/autobot/ssh/autobot_key autobot@{{ slm_host | default(hostvars[groups.get('slm_manager', groups.get('slm', ['localhost']))[0]]['ansible_host'] | default('127.0.0.1')) }}"
           - "=========================================================="

--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -91,13 +91,15 @@
   become: yes
   tags: ['common', 'directories']
 
+# Issue #2828: Use shared key path so any user in the autobot group can
+# run Ansible without needing the key in their own ~/.ssh/.
 - name: "Common | Configure SSH key authentication"
   authorized_key:
     user: autobot
-    key: "{{ lookup('file', '~/.ssh/autobot_key.pub') }}"
+    key: "{{ lookup('file', '/etc/autobot/ssh/autobot_key.pub') }}"
     state: present
   become: yes
-  when: lookup('file', '~/.ssh/autobot_key.pub', errors='ignore') is not none
+  when: lookup('file', '/etc/autobot/ssh/autobot_key.pub', errors='ignore') is not none
   tags: ['common', 'ssh']
 
 - name: "Common | Reset UFW to clean state (Issue #895)"

--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -283,7 +283,8 @@ async def _generate_dynamic_inventory(
     inventory = {
         "all": {
             "vars": {
-                "ansible_ssh_private_key_file": "~/.ssh/autobot_key",
+                # Issue #2828: Use shared key path for any-operator access
+                "ansible_ssh_private_key_file": "/etc/autobot/ssh/autobot_key",
                 "ansible_python_interpreter": "/usr/bin/python3",
                 "slm_host": _slm_host,
                 **infra_vars,
@@ -345,13 +346,16 @@ async def _check_node_reachability(inventory_path: Path) -> dict[str, bool]:
     Probes run in parallel; each probe has a 5-second ConnectTimeout plus a
     10-second asyncio timeout as a safety net.
 
-    Returns a dict mapping inventory hostname → reachable (bool).
+    Returns a dict mapping inventory hostname -> reachable (bool).
     """
     raw = yaml.safe_load(inventory_path.read_text(encoding="utf-8"))
     all_vars = raw.get("all", {}).get("vars", {})
     default_key = str(
         Path(
-            all_vars.get("ansible_ssh_private_key_file", "~/.ssh/autobot_key")
+            all_vars.get(
+                "ansible_ssh_private_key_file",
+                "/etc/autobot/ssh/autobot_key",  # Issue #2828
+            )
         ).expanduser()
     )
     default_user = all_vars.get("ansible_user", "autobot")

--- a/install.sh
+++ b/install.sh
@@ -296,7 +296,8 @@ system_setup() {
             "${AUTOBOT_BASE}/nginx/certs" \
             "${AUTOBOT_BASE}/cache" \
             "${LOG_DIR}" \
-            /etc/autobot
+            /etc/autobot \
+            /etc/autobot/ssh
 
     chown -R autobot:autobot "${AUTOBOT_BASE}"
     success "  Directory ownership set"
@@ -307,6 +308,17 @@ system_setup() {
             sudo -u autobot bash -c "mkdir -p /home/autobot/.ssh && ssh-keygen -t ed25519 -f ${ssh_key} -N '' -C 'autobot@slm'"
     else
         success "  SSH key pair already exists"
+    fi
+
+    # Issue #2828: Copy SSH key to shared location so any user in the autobot
+    # group can run Ansible without needing the key in their own ~/.ssh/.
+    if [[ -f "${ssh_key}" ]]; then
+        cp "${ssh_key}" /etc/autobot/ssh/autobot_key
+        cp "${ssh_key}.pub" /etc/autobot/ssh/autobot_key.pub
+        chown root:autobot /etc/autobot/ssh/autobot_key /etc/autobot/ssh/autobot_key.pub
+        chmod 0640 /etc/autobot/ssh/autobot_key
+        chmod 0644 /etc/autobot/ssh/autobot_key.pub
+        success "  SSH key published to /etc/autobot/ssh/ (group-readable)"
     fi
 }
 


### PR DESCRIPTION
## Summary
- Move SSH key to `/etc/autobot/ssh/autobot_key` (root:autobot, 0640) for group-based access
- Updated 12 files: ansible.cfg, 4 inventories, 4 playbooks, common role, wizard, install.sh
- Services running as `autobot` user still use `~autobot/.ssh/` (unchanged)

Closes #2828

🤖 Generated with [Claude Code](https://claude.com/claude-code)