### PR TITLE
feat(ansible): auto-register VNC credentials in SLM database (#2926)

### DIFF
--- a/autobot-slm-backend/ansible/roles/vnc/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/defaults/main.yml
@@ -25,3 +25,12 @@ vnc_always_shared: "{{ lookup('env', 'VNC_ALWAYS_SHARED') | default('0', true) }
 # Service management
 vnc_service_name: vnc-server
 websockify_service_name: vnc-websockify
+
+# SLM credential auto-registration (#2926)
+vnc_register_credentials: true
+slm_api_url: "https://{{ hostvars['00-SLM-Manager']['ansible_host'] | default('127.0.0.1') }}"
+slm_admin_user: "admin"
+slm_admin_password: >-
+  {{ hostvars['00-SLM-Manager']['slm_admin_password']
+     | default(lookup('env', 'SLM_ADMIN_PASSWORD'))
+     | default('admin') }}

--- a/autobot-slm-backend/ansible/roles/vnc/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/tasks/main.yml
@@ -172,3 +172,11 @@
     daemon_reload: true
   become: true
   when: websockify_enabled | bool
+
+# --- Auto-register VNC credentials in SLM database (#2926) ---
+- name: Register VNC credentials in SLM
+  ansible.builtin.include_tasks: register-credentials.yml
+  when:
+    - vnc_register_credentials | bool
+    - vnc_password_result.stdout | length > 0
+    - slm_node_id is defined

--- a/autobot-slm-backend/ansible/roles/vnc/tasks/register-credentials.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/tasks/register-credentials.yml
@@ -1,0 +1,61 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# VNC Role - Register VNC credentials in SLM database (#2926)
+#
+# Called at the end of the VNC role to auto-register this node's
+# VNC credentials so they appear in the noVNC tool automatically.
+---
+- name: Authenticate with SLM API for VNC registration
+  ansible.builtin.uri:
+    url: "{{ slm_api_url }}/api/auth/login"
+    method: POST
+    body_format: json
+    body:
+      username: "{{ slm_admin_user }}"
+      password: "{{ slm_admin_password | trim }}"
+    status_code: 200
+    validate_certs: false
+  register: vnc_auth_result
+  retries: 3
+  delay: 5
+  until: vnc_auth_result.status == 200
+
+- name: Check existing VNC credentials for this node
+  ansible.builtin.uri:
+    url: "{{ slm_api_url }}/api/nodes/{{ slm_node_id }}/vnc-credentials"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ vnc_auth_result.json.access_token }}"
+    status_code: [200, 404]
+    validate_certs: false
+  register: existing_vnc_creds
+
+- name: Register VNC credentials in SLM database
+  ansible.builtin.uri:
+    url: "{{ slm_api_url }}/api/nodes/{{ slm_node_id }}/vnc-credentials"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ vnc_auth_result.json.access_token }}"
+    body_format: json
+    body:
+      vnc_type: "desktop"
+      name: "{{ inventory_hostname }} VNC"
+      password: "{{ vnc_password_result.stdout }}"
+      port: "{{ websockify_port | int }}"
+      display_number: "{{ vnc_display | int }}"
+      websockify_enabled: "{{ websockify_enabled | bool }}"
+    status_code: [201]
+    validate_certs: false
+  when:
+    - existing_vnc_creds.status == 200
+    - (existing_vnc_creds.json.credentials | default([])) | length == 0
+  register: vnc_register_result
+
+- name: Log VNC credential registration result
+  ansible.builtin.debug:
+    msg: >-
+      VNC credentials registered for node {{ slm_node_id }}
+      (credential_id: {{ vnc_register_result.json.credential_id | default('skipped') }})
+  when: vnc_register_result is not skipped


### PR DESCRIPTION
## Summary
- Adds automatic VNC credential registration in SLM database after VNC role deployment
- New `register-credentials.yml` task file authenticates with SLM API and creates VNC credentials
- Idempotent: skips registration if credentials already exist for the node
- Controlled by `vnc_register_credentials` variable (default: `true`)
- Requires `slm_node_id` to be defined (from inventory)

Closes #2926

## Test Plan
- [ ] Deploy VNC role on a node and verify credentials appear in SLM DB
- [ ] Run role again — verify no duplicate credentials created
- [ ] Check noVNC tool page shows the deployed VNC endpoint
- [ ] Test with `vnc_register_credentials: false` to verify skip behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)