### PR TITLE
feat(config): add missing agents to agents.yaml (#2815)

### DIFF
--- a/autobot-infrastructure/shared/config/agents.yaml
+++ b/autobot-infrastructure/shared/config/agents.yaml
@@ -32,6 +32,16 @@ llm:
     # Tier 6: Quality — user-facing chat, research, code
     chat: qwen3.5:9b
     research: qwen3.5:9b
+    code_analysis: qwen3.5:9b
+    web_research_assistant: qwen3.5:9b
+    advanced_web_research: qwen3.5:9b
+    development_speedup: qwen3.5:9b
+    overseer: qwen3.5:9b
+    containerized_librarian: qwen3.5:9b
+    system_knowledge_manager: qwen3.5:9b
+    machine_aware_knowledge_manager: qwen3.5:9b
+    standardized: qwen3.5:9b
+    web_research_integration: qwen3.5:9b
 
 agents:
   chat:
@@ -72,6 +82,85 @@ agents:
     approval_required: true
     enabled: true
     safety_enabled: true
+
+  orchestrator:
+    enabled: true
+
+  knowledge_extraction:
+    enabled: true
+
+  knowledge_retrieval:
+    enabled: true
+    max_results: 10
+
+  code_analysis:
+    enabled: true
+
+  enhanced_system_commands:
+    approval_required: true
+    enabled: true
+    safety_enabled: true
+
+  network_discovery:
+    enabled: true
+    timeout_seconds: 30
+
+  web_research_assistant:
+    enabled: true
+    timeout_seconds: 60
+
+  advanced_web_research:
+    enabled: true
+    timeout_seconds: 120
+
+  development_speedup:
+    enabled: true
+
+  json_formatter:
+    enabled: true
+
+  graph_entity_extractor:
+    enabled: true
+
+  overseer:
+    enabled: true
+
+  step_executor:
+    enabled: true
+
+  npu_code_search:
+    enabled: true
+
+  librarian_assistant:
+    enabled: true
+    timeout_seconds: 60
+
+  containerized_librarian:
+    enabled: true
+    timeout_seconds: 120
+
+  system_knowledge_manager:
+    enabled: true
+
+  machine_aware_knowledge_manager:
+    enabled: true
+
+  man_page_knowledge_integrator:
+    enabled: true
+
+  llm_failsafe:
+    enabled: true
+
+  gemma_classification:
+    enabled: true
+    preferred_model: gemma2:2b
+
+  standardized:
+    enabled: true
+
+  web_research_integration:
+    enabled: true
+    timeout_seconds: 60
 
 knowledge_base:
   enabled: true


### PR DESCRIPTION
## Summary
- Added 21 missing agent entries to agents.yaml from seeder/agent_config
- Includes orchestrator, knowledge_extraction, code_analysis, web_research, and more
- Each entry follows existing YAML format with enabled flag

Closes #2815

## Test Plan
- [ ] Verify YAML is valid: `python3 -c "import yaml; yaml.safe_load(open('agents.yaml'))"`
- [ ] Cross-reference with agent_config.py seeder to confirm all agents present

🤖 Generated with [Claude Code](https://claude.com/claude-code)