### PR TITLE
fix(ansible): make slm_manager role idempotent and remove silent failures (#2857)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/handlers/main.yml
@@ -6,15 +6,20 @@
   ansible.builtin.systemd:
     daemon_reload: true
 
+# Issue #2857: Replace ignore_errors with failed_when to surface restart failures
 - name: restart slm backend
   ansible.builtin.systemd:
     name: "{{ slm_backend_service }}"
     state: restarted
-  ignore_errors: true
+  register: _handler_restart_result
+  failed_when:
+    - _handler_restart_result is failed
+    - "'Could not find the requested service' not in (_handler_restart_result.msg | default(''))"
 
 - name: test nginx config
   ansible.builtin.command:
     cmd: nginx -t
+  changed_when: false
 
 - name: reload nginx
   ansible.builtin.systemd:

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/clean.yml
@@ -28,34 +28,50 @@
     - "'frontend' not in node_roles"
   tags: ['clean']
 
+# Issue #2857: Add node_roles guards to prevent single-host wipe
 - name: "SLM | Clean: wrong-node autobot-user-backend dir"
   ansible.builtin.file:
     path: /opt/autobot/autobot-user-backend
     state: absent
+  when:
+    - node_roles is defined
+    - "'backend' not in node_roles"
   tags: ['clean']
 
 - name: "SLM | Clean: wrong-node autobot-user-frontend dir"
   ansible.builtin.file:
     path: /opt/autobot/autobot-user-frontend
     state: absent
+  when:
+    - node_roles is defined
+    - "'frontend' not in node_roles"
   tags: ['clean']
 
 - name: "SLM | Clean: legacy npu-worker dir"
   ansible.builtin.file:
     path: /opt/autobot/npu-worker
     state: absent
+  when:
+    - node_roles is defined
+    - "'npu-worker' not in node_roles"
   tags: ['clean']
 
 - name: "SLM | Clean: legacy browser-service dir"
   ansible.builtin.file:
     path: /opt/autobot/browser-service
     state: absent
+  when:
+    - node_roles is defined
+    - "'browser' not in node_roles"
   tags: ['clean']
 
 - name: "SLM | Clean: legacy ai-stack dir"
   ansible.builtin.file:
     path: /opt/autobot/ai-stack
     state: absent
+  when:
+    - node_roles is defined
+    - "'ai-stack' not in node_roles"
   tags: ['clean']
 
 - name: "SLM | Clean: wrong-node autobot-npu-worker dir"

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -104,6 +104,7 @@
   when: >-
     not slm_cert_stat.stat.exists
     or (slm_cert_valid.rc | default(1)) != 0
+  changed_when: true
   notify: restart nginx
   tags: ['slm', 'tls']
 
@@ -188,11 +189,21 @@
   when: slm_requirements_stat.stat.exists
   tags: ['slm', 'backend']
 
+# Issue #2857: Check pip existence before bootstrapping
+- name: "SLM | Check if pip is already installed in venv"
+  ansible.builtin.stat:
+    path: "{{ slm_backend_dir }}/venv/bin/pip"
+  register: _venv_pip_stat
+  when: slm_requirements_stat.stat.exists
+  tags: ['slm', 'backend']
+
 - name: "SLM | Bootstrap pip in virtual environment"
   ansible.builtin.command:
     cmd: "{{ slm_backend_dir }}/venv/bin/python3 -m ensurepip --upgrade"
   become_user: "{{ slm_user }}"
-  when: slm_requirements_stat.stat.exists
+  when:
+    - slm_requirements_stat.stat.exists
+    - not (_venv_pip_stat.stat.exists | default(false))
   changed_when: true
   tags: ['slm', 'backend']
 
@@ -218,6 +229,17 @@
     group: "{{ slm_group }}"
   tags: ['slm', 'backend']
 
+# Issue #2857: Check if autobot-shared is already installed before pip install
+- name: "SLM | Check if autobot-shared is installed in venv"
+  ansible.builtin.command:
+    cmd: "{{ slm_backend_dir }}/venv/bin/pip show autobot-shared"
+  become_user: "{{ slm_user }}"
+  register: _shared_installed
+  changed_when: false
+  failed_when: false
+  when: slm_requirements_stat.stat.exists
+  tags: ['slm', 'backend']
+
 - name: "SLM | Install autobot-shared in venv (editable)"
   ansible.builtin.command:
     cmd: "{{ slm_backend_dir }}/venv/bin/pip install -e {{ slm_base_dir }}/autobot-shared"
@@ -225,7 +247,9 @@
   environment:
     PIP_DEFAULT_TIMEOUT: "120"
   timeout: 120  # Issue #2835: prevent indefinite hang
-  when: slm_requirements_stat.stat.exists
+  when:
+    - slm_requirements_stat.stat.exists
+    - _shared_installed.rc != 0
   changed_when: true
   tags: ['slm', 'backend']
 
@@ -317,7 +341,7 @@
   become_user: "{{ slm_user }}"
   when: slm_frontend_build and slm_package_json.stat.exists
   register: slm_frontend_build_result
-  changed_when: slm_frontend_build_result.rc == 0
+  changed_when: true
   environment:
     VITE_API_URL: "{{ '/slm' if (slm_colocated_frontend | default(false) | bool) else '' }}"
   tags: ['slm', 'frontend']
@@ -350,7 +374,7 @@
   when:
     - user_frontend_package_json.stat.exists | default(false)
   register: user_frontend_build_result
-  changed_when: user_frontend_build_result.rc == 0
+  changed_when: true
   tags: ['slm', 'frontend', 'colocated']
 
 # ==========================================================
@@ -429,7 +453,7 @@
   tags: ['slm', 'nginx']
 
 # ==========================================================
-# Firewall
+# Firewall (#2857: replace ignore_errors with failed_when)
 # ==========================================================
 - name: "SLM | Allow HTTP"
   community.general.ufw:
@@ -437,7 +461,16 @@
     port: "80"
     proto: tcp
     comment: "HTTP - AutoBot SLM"
-  ignore_errors: true
+  register: _ufw_http_result
+  failed_when:
+    - _ufw_http_result is failed
+    - "'ufw' not in (_ufw_http_result.msg | default(''))"
+  tags: ['slm', 'firewall']
+
+- name: "SLM | Warn if UFW HTTP rule skipped"
+  ansible.builtin.debug:
+    msg: "WARNING: UFW HTTP rule failed (UFW may not be installed): {{ _ufw_http_result.msg | default('unknown') }}"
+  when: _ufw_http_result is failed
   tags: ['slm', 'firewall']
 
 - name: "SLM | Allow HTTPS"
@@ -446,17 +479,35 @@
     port: "443"
     proto: tcp
     comment: "HTTPS - AutoBot SLM"
-  ignore_errors: true
+  register: _ufw_https_result
+  failed_when:
+    - _ufw_https_result is failed
+    - "'ufw' not in (_ufw_https_result.msg | default(''))"
+  tags: ['slm', 'firewall']
+
+- name: "SLM | Warn if UFW HTTPS rule skipped"
+  ansible.builtin.debug:
+    msg: "WARNING: UFW HTTPS rule failed (UFW may not be installed): {{ _ufw_https_result.msg | default('unknown') }}"
+  when: _ufw_https_result is failed
   tags: ['slm', 'firewall']
 
 # ==========================================================
-# Start services
+# Start services (#2857: replace ignore_errors with proper error handling)
 # ==========================================================
 - name: "SLM | Start backend service"
   ansible.builtin.systemd:
     name: "{{ slm_backend_service }}"
     state: started
-  ignore_errors: true
+  register: _slm_start_result
+  failed_when:
+    - _slm_start_result is failed
+    - "'Could not find the requested service' not in (_slm_start_result.msg | default(''))"
+  tags: ['slm', 'service']
+
+- name: "SLM | Warn if backend service failed to start"
+  ansible.builtin.debug:
+    msg: "WARNING: Backend service {{ slm_backend_service }} failed to start: {{ _slm_start_result.msg | default('unknown') }}"
+  when: _slm_start_result is failed
   tags: ['slm', 'service']
 
 - name: "SLM | Flush handlers to apply pending restarts"


### PR DESCRIPTION
## Summary
- Add stat/when guards for pip bootstrap and autobot-shared install
- Replace `ignore_errors` with specific `failed_when` conditions (UFW, services)
- Add co-location guards to 5 clean tasks
- Add `changed_when` to read-only and always-changed tasks
- Surface silenced errors via debug warning tasks

Closes #2857

🤖 Generated with [Claude Code](https://claude.com/claude-code)