### PR TITLE
fix(security): add CSRF mitigation middleware and security headers (#2858)

### DIFF
--- a/autobot-slm-backend/api/api_keys.py
+++ b/autobot-slm-backend/api/api_keys.py
@@ -5,6 +5,14 @@
 API Keys API
 
 Endpoints for managing long-lived API keys for programmatic access.
+
+Security note (Issue #2858):
+    All state-changing endpoints (POST, PATCH, DELETE) are protected against
+    CSRF by design: authentication uses HTTPBearer, so tokens are transmitted
+    in the ``Authorization`` header and are never auto-attached by the browser
+    to cross-origin requests.  The SecurityHeadersMiddleware (middleware/)
+    provides an additional enforcement layer that rejects state-changing
+    requests without an ``Authorization`` header.
 """
 
 import logging

--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from middleware import SecurityHeadersMiddleware
 from api import (
     agents_router,
     api_keys_router,
@@ -297,6 +298,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+# Issue #2858 — explicit CSRF mitigation + security headers.
+# Registered after CORSMiddleware so CORS headers are already present.
+app.add_middleware(SecurityHeadersMiddleware)
 
 app.include_router(health_router, prefix="/api")
 app.include_router(browser_router, prefix="/api")

--- a/autobot-slm-backend/middleware/__init__.py
+++ b/autobot-slm-backend/middleware/__init__.py
@@ -1,0 +1,12 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+SLM Backend Middleware Package
+
+Contains reusable ASGI/Starlette middleware for the SLM backend.
+"""
+
+from middleware.security_headers import SecurityHeadersMiddleware
+
+__all__ = ["SecurityHeadersMiddleware"]

--- a/autobot-slm-backend/middleware/security_headers.py
+++ b/autobot-slm-backend/middleware/security_headers.py
@@ -1,0 +1,128 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Security Headers Middleware (Issue #2858)
+
+Adds HTTP security response headers to every response and enforces
+CSRF mitigation for state-changing requests.
+
+CSRF Mitigation Strategy
+------------------------
+This application uses header-based Bearer token authentication exclusively
+(HTTPBearer dependency in services/auth.py — no auth cookies are ever set).
+Browsers do NOT automatically attach custom Authorization headers to
+cross-origin requests, so a malicious third-party page cannot perform
+authenticated state-changing requests on behalf of a logged-in user.
+
+This means the app already has CSRF protection by design.  This middleware
+makes that protection **explicit and auditable** by:
+
+  1. Rejecting state-changing requests (POST/PUT/PATCH/DELETE) that lack an
+     Authorization header entirely — belt-and-suspenders on top of the
+     HTTPBearer dependency.
+  2. Adding standard security response headers to every response so that
+     browsers receive explicit framing, MIME-sniffing, and XSS instructions.
+
+Reference: OWASP CSRF Prevention Cheat Sheet — "Use of Custom Request Headers"
+https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+"""
+
+import logging
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+# HTTP methods that can change server state
+_STATE_CHANGING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Paths exempt from the Authorization header check.
+# These are unauthenticated endpoints where no token exists yet.
+_AUTH_EXEMPT_PREFIXES = (
+    "/api/auth/login",
+    "/api/auth/register",
+    "/api/auth/sso/",
+    "/api/health",
+    "/api/docs",
+    "/api/redoc",
+    "/api/openapi.json",
+    "/api/api-keys/scopes",  # public endpoint — no auth required
+)
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """ASGI middleware that adds security headers and enforces CSRF mitigation.
+
+    Must be registered AFTER CORSMiddleware so CORS headers are already
+    present when this middleware inspects the request.
+
+    Issue #2858 — explicit CSRF protection enforcement.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        """Process request: enforce CSRF check, then add security headers."""
+        if self._is_state_changing(request) and not self._is_exempt(request):
+            if not self._has_authorization_header(request):
+                logger.warning(
+                    "CSRF guard: rejected %s %s — missing Authorization header",
+                    request.method,
+                    request.url.path,
+                )
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "Authorization header required"},
+                )
+
+        response = await call_next(request)
+        _add_security_headers(response)
+        return response
+
+    @staticmethod
+    def _is_state_changing(request: Request) -> bool:
+        return request.method in _STATE_CHANGING_METHODS
+
+    @staticmethod
+    def _is_exempt(request: Request) -> bool:
+        path = request.url.path
+        return any(path.startswith(prefix) for prefix in _AUTH_EXEMPT_PREFIXES)
+
+    @staticmethod
+    def _has_authorization_header(request: Request) -> bool:
+        return "authorization" in request.headers
+
+
+def _add_security_headers(response: Response) -> None:
+    """Attach standard HTTP security headers to an outgoing response.
+
+    Args:
+        response: Starlette/FastAPI response object to mutate in-place.
+    """
+    # Prevent page from being embedded in frames (clickjacking defence)
+    response.headers.setdefault("X-Frame-Options", "DENY")
+
+    # Prevent MIME-type sniffing
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+
+    # Force HTTPS for 1 year (only meaningful when served over TLS)
+    response.headers.setdefault(
+        "Strict-Transport-Security", "max-age=31536000; includeSubDomains"
+    )
+
+    # Disable legacy XSS filter (modern browsers — use CSP instead)
+    response.headers.setdefault("X-XSS-Protection", "0")
+
+    # Restrict Referrer information leaked to third parties
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+
+    # Minimal Content-Security-Policy: API-only backend, no HTML served
+    response.headers.setdefault("Content-Security-Policy", "default-src 'none'")
+
+    # Disable interest-cohort FLoC / Privacy Sandbox APIs
+    response.headers.setdefault("Permissions-Policy", "interest-cohort=()")

--- a/autobot-slm-backend/tests/test_security_headers_middleware.py
+++ b/autobot-slm-backend/tests/test_security_headers_middleware.py
@@ -1,0 +1,140 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for SecurityHeadersMiddleware (Issue #2858).
+
+Verifies that:
+  - State-changing requests without Authorization header are rejected (401).
+  - State-changing requests WITH Authorization header pass through.
+  - Exempt paths (login, health) are not blocked even without a token.
+  - Security response headers are present on all responses.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+# Ensure the slm-backend package is importable
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from middleware.security_headers import SecurityHeadersMiddleware  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Minimal test application
+# ---------------------------------------------------------------------------
+
+
+async def _ok(request: Request) -> JSONResponse:
+    return JSONResponse({"ok": True})
+
+
+_routes = [
+    Route("/api/nodes", _ok, methods=["GET", "POST", "DELETE"]),
+    Route("/api/auth/login", _ok, methods=["POST"]),
+    Route("/api/health", _ok, methods=["GET"]),
+    Route("/api/api-keys/scopes", _ok, methods=["GET"]),
+]
+
+_app = Starlette(routes=_routes)
+_app.add_middleware(SecurityHeadersMiddleware)
+_client = TestClient(_app, raise_server_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# CSRF enforcement tests
+# ---------------------------------------------------------------------------
+
+
+class TestCsrfEnforcement:
+    """POST/PUT/PATCH/DELETE without Authorization header must be rejected."""
+
+    def test_post_without_auth_is_rejected(self):
+        response = _client.post("/api/nodes")
+        assert response.status_code == 401
+        assert "Authorization" in response.json()["detail"]
+
+    def test_delete_without_auth_is_rejected(self):
+        response = _client.delete("/api/nodes")
+        assert response.status_code == 401
+
+    def test_post_with_auth_passes_through(self):
+        response = _client.post(
+            "/api/nodes", headers={"Authorization": "Bearer fake.jwt.token"}
+        )
+        assert response.status_code == 200
+
+    def test_delete_with_auth_passes_through(self):
+        response = _client.delete(
+            "/api/nodes", headers={"Authorization": "Bearer fake.jwt.token"}
+        )
+        assert response.status_code == 200
+
+    def test_get_without_auth_passes_through(self):
+        """GET is read-only — must not be blocked."""
+        response = _client.get("/api/nodes")
+        assert response.status_code == 200
+
+
+class TestExemptPaths:
+    """Unauthenticated paths must never be blocked."""
+
+    def test_login_post_without_auth_passes(self):
+        response = _client.post("/api/auth/login")
+        assert response.status_code == 200
+
+    def test_health_get_passes(self):
+        response = _client.get("/api/health")
+        assert response.status_code == 200
+
+    def test_scopes_get_passes(self):
+        response = _client.get("/api/api-keys/scopes")
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Security header tests
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityHeaders:
+    """All responses must carry the required security headers."""
+
+    def _get_headers(self) -> dict:
+        return _client.get("/api/health").headers
+
+    @pytest.mark.parametrize(
+        "header,expected",
+        [
+            ("x-frame-options", "DENY"),
+            ("x-content-type-options", "nosniff"),
+            ("x-xss-protection", "0"),
+            ("referrer-policy", "strict-origin-when-cross-origin"),
+            ("content-security-policy", "default-src 'none'"),
+        ],
+    )
+    def test_security_header_present(self, header: str, expected: str):
+        headers = self._get_headers()
+        assert header in headers, f"Missing header: {header}"
+        assert headers[header] == expected, (
+            f"Header {header!r}: expected {expected!r}, got {headers[header]!r}"
+        )
+
+    def test_hsts_header_present(self):
+        headers = self._get_headers()
+        assert "strict-transport-security" in headers
+        assert "max-age=31536000" in headers["strict-transport-security"]
+
+    def test_security_headers_on_rejected_request(self):
+        """Rejected CSRF requests must also carry security headers."""
+        response = _client.post("/api/nodes")
+        assert response.status_code == 401
+        assert "x-frame-options" in response.headers
+        assert "x-content-type-options" in response.headers


### PR DESCRIPTION
## Summary
- New `SecurityHeadersMiddleware` in `autobot-slm-backend/middleware/`
- Rejects POST/PUT/PATCH/DELETE without Authorization header (exempt: login, health, SSO, docs)
- Sets 7 security headers: X-Frame-Options, HSTS, CSP, X-Content-Type-Options, etc.
- Auth is header-based (never cookie) — CSRF mitigated by design; this makes it explicit
- Full pytest suite included

Closes #2858

🤖 Generated with [Claude Code](https://claude.com/claude-code)