### PR TITLE
chore(ansible): audit and document clean task single-host guards (#2836)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/cleanup-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/cleanup-nodes.yml
@@ -8,6 +8,13 @@
 # Removes legacy directories, wrong-node role dirs, and stale loose files
 # from all fleet nodes, then reports the resulting /opt/autobot/ layout.
 #
+# WARNING: This playbook is for MULTI-NODE deployments ONLY.
+# Each play targets a specific host group (00-SLM-Manager, 01-Backend, etc.)
+# and deletes directories that should NOT exist on that node. Do NOT run this
+# on a single-host deployment — it will delete co-located role directories.
+# For single-host safety, use the role-level clean.yml tasks which check
+# node_roles before deleting cross-role directories (#2836).
+#
 # Usage:
 #   cd autobot-slm-backend/ansible
 #   ansible-playbook playbooks/cleanup-nodes.yml -i inventory/slm-nodes.yml

--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/clean.yml
@@ -4,6 +4,16 @@
 ---
 # AI Stack role - Phase 1 CLEAN task (#926 Phase 4)
 # Removes legacy and wrong-node directories from .24 (AI stack node).
+#
+# LEGACY directory deletions (ai-stack, npu-worker, browser-service) run
+# unconditionally because NO current role deploys to those paths — they are
+# pre-rename leftovers.
+#
+# Wrong-node deletions of CURRENT canonical dirs (autobot-backend,
+# autobot-frontend, autobot-slm-backend) ONLY run when node_roles is defined
+# (dynamic inventory). When undefined (localhost self-deploy via install.sh),
+# skip ALL cross-role deletions to prevent wiping co-located services on
+# single-host (#2836).
 
 - name: "AI Stack | Clean: legacy ai-stack dir (old name)"
   ansible.builtin.file:

--- a/autobot-slm-backend/ansible/roles/backend/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/clean.yml
@@ -6,6 +6,15 @@
 # Removes legacy and wrong-node directories from .20 (backend node).
 # Run via: ansible-playbook ... --tags clean
 # Safe to run any time; all removes are conditional.
+#
+# LEGACY directory deletions (npu-worker, browser-service, ai-stack,
+# autobot-user-backend, config) run unconditionally because NO current role
+# deploys to those paths — they are pre-rename leftovers.
+#
+# Wrong-node deletions of CURRENT canonical dirs (autobot-slm-frontend,
+# autobot-slm-backend) ONLY run when node_roles is defined (dynamic inventory).
+# When undefined (localhost self-deploy via install.sh), skip ALL cross-role
+# deletions to prevent wiping co-located services on single-host (#2836).
 
 - name: "Backend | Clean: legacy npu-worker dir"
   ansible.builtin.file:

--- a/autobot-slm-backend/ansible/roles/browser/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/clean.yml
@@ -4,6 +4,16 @@
 ---
 # Browser role - Phase 1 CLEAN task (#926 Phase 4)
 # Removes legacy and wrong-node directories from .25 (browser node).
+#
+# LEGACY directory deletions (browser-service, npu-worker, ai-stack) run
+# unconditionally because NO current role deploys to those paths — they are
+# pre-rename leftovers.
+#
+# Wrong-node deletions of CURRENT canonical dirs (autobot-backend,
+# autobot-frontend, autobot-slm-backend) ONLY run when node_roles is defined
+# (dynamic inventory). When undefined (localhost self-deploy via install.sh),
+# skip ALL cross-role deletions to prevent wiping co-located services on
+# single-host (#2836).
 
 - name: "Browser | Clean: legacy browser-service dir (old name)"
   ansible.builtin.file:

--- a/autobot-slm-backend/ansible/roles/frontend/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/frontend/tasks/clean.yml
@@ -4,6 +4,16 @@
 ---
 # Frontend role - Phase 1 CLEAN task (#926 Phase 4)
 # Removes legacy and wrong-node directories from .21 (frontend node).
+#
+# LEGACY directory deletions (autobot-user-frontend, npu-worker,
+# browser-service) run unconditionally because NO current role deploys to
+# those paths — they are pre-rename leftovers.
+#
+# Wrong-node deletions of CURRENT canonical dirs (autobot-slm-frontend,
+# autobot-slm-backend, autobot-backend) ONLY run when node_roles is defined
+# (dynamic inventory). When undefined (localhost self-deploy via install.sh),
+# skip ALL cross-role deletions to prevent wiping co-located services on
+# single-host (#2836).
 
 - name: "Frontend | Clean: legacy autobot-user-frontend dir"
   ansible.builtin.file:

--- a/autobot-slm-backend/ansible/roles/npu-worker/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/tasks/clean.yml
@@ -4,6 +4,16 @@
 ---
 # NPU Worker role - Phase 1 CLEAN task (#926 Phase 4)
 # Removes legacy and wrong-node directories from .22 (NPU node).
+#
+# LEGACY directory deletions (npu-worker, browser-service, ai-stack) run
+# unconditionally because NO current role deploys to those paths — they are
+# pre-rename leftovers.
+#
+# Wrong-node deletions of CURRENT canonical dirs (autobot-backend,
+# autobot-frontend, autobot-slm-backend) ONLY run when node_roles is defined
+# (dynamic inventory). When undefined (localhost self-deploy via install.sh),
+# skip ALL cross-role deletions to prevent wiping co-located services on
+# single-host (#2836).
 
 - name: "NPU Worker | Clean: legacy npu-worker dir (old name)"
   ansible.builtin.file:

--- a/autobot-slm-backend/ansible/roles/slm_agent/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/slm_agent/tasks/clean.yml
@@ -5,6 +5,10 @@
 # SLM Agent role - Phase 1 CLEAN task (#926 Phase 4)
 # Removes stale agent code copied to wrong paths on any node.
 # The legacy autobot-agent.service is already cleaned in main.yml (#917).
+#
+# All deletions target LEGACY agent paths only (agent, slm-agent,
+# /opt/slm-agent). No cross-role directories are touched, so no
+# node_roles guards are needed (#2836).
 
 - name: "SLM Agent | Clean: legacy flat agent dir at /opt/autobot/agent"
   ansible.builtin.file:


### PR DESCRIPTION
## Summary
- Audit confirmed all role clean tasks already have proper co-location guards
- Added documentation comments to 7 clean.yml files explaining safety design
- Added WARNING to `cleanup-nodes.yml` (multi-node only)
- No functional changes — documentation only

Closes #2836

🤖 Generated with [Claude Code](https://claude.com/claude-code)