### PR TITLE
fix(redis): RDB persistence permissions and vm.overcommit (#2954)

### DIFF
--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -74,6 +74,26 @@
   become: yes
   tags: ['redis', 'directories']
 
+- name: "Redis | Fix Redis Stack data directory permissions"
+  file:
+    path: /var/lib/redis-stack
+    state: directory
+    owner: redis
+    group: redis
+    mode: '0750'
+  become: yes
+  tags: ['redis', 'configuration']
+
+- name: "Redis | Set vm.overcommit_memory for background saves"
+  ansible.builtin.sysctl:
+    name: vm.overcommit_memory
+    value: '1'
+    state: present
+    sysctl_set: true
+    reload: true
+  become: yes
+  tags: ['redis', 'configuration']
+
 - name: "Redis | Configure Redis Stack"
   template:
     src: redis-stack.conf.j2

--- a/autobot-slm-backend/ansible/roles/redis/templates/redis-stack.conf.j2
+++ b/autobot-slm-backend/ansible/roles/redis/templates/redis-stack.conf.j2
@@ -26,7 +26,7 @@ requirepass {{ redis_password }}
 save 900 1
 save 300 10
 save 60 10000
-stop-writes-on-bgsave-error yes
+stop-writes-on-bgsave-error no
 rdbcompression yes
 rdbchecksum yes
 dbfilename dump.rdb


### PR DESCRIPTION
## Summary
- Fix /var/lib/redis-stack ownership to redis:redis (was root, causing permission denied)
- Set vm.overcommit_memory=1 via sysctl (required for background saves)
- Change stop-writes-on-bgsave-error to no (prevents cascading write failures)

Closes #2954