### PR TITLE
feat(backend): add Apple Silicon GPU detection (#2014)

### DIFF
--- a/autobot-backend/tests/utils/gpu_optimization/test_gpu_detection.py
+++ b/autobot-backend/tests/utils/gpu_optimization/test_gpu_detection.py
@@ -10,13 +10,16 @@ import pytest
 
 from utils.gpu_optimization.gpu_detection import (
     _check_amd_gpu,
+    _check_apple_gpu,
     _check_intel_gpu,
     _check_nvidia_gpu,
     _check_sysfs_vendor,
     _detect_amd_capabilities,
+    _detect_apple_capabilities,
     _detect_detailed_capabilities,
     _detect_nvidia_capabilities,
     _detect_vendor,
+    _get_macos_system_memory_gb,
     _has_tensor_cores,
     _reset_detection_state,
     check_gpu_availability,
@@ -611,3 +614,166 @@ class TestGetGpuCapabilitiesDict:
         result = get_gpu_capabilities_dict(gpu_available=False)
         assert result["vendor"] == "unknown"
         assert result["memory_gb"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _check_apple_gpu (Issue #2014)
+# ---------------------------------------------------------------------------
+class TestCheckAppleGpu:
+    """Tests for Apple Silicon GPU detection via system_profiler."""
+
+    @patch("utils.gpu_optimization.gpu_detection.platform.system", return_value="Linux")
+    def test_returns_none_on_non_macos(self, _mock):
+        assert _check_apple_gpu() is None
+
+    @patch("utils.gpu_optimization.gpu_detection.subprocess.run")
+    @patch("utils.gpu_optimization.gpu_detection.platform.system", return_value="Darwin")
+    def test_detects_apple_m2(self, _mock_sys, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='{"SPDisplaysDataType": [{"sppci_vendor": "Apple",'
+            '"sppci_model": "Apple M2 Pro",'
+            '"sppci_cores": "19",'
+            '"spdisplays_metal": "spdisplays_metal_supported"}]}',
+        )
+        result = _check_apple_gpu()
+        assert result is not None
+        assert result["name"] == "Apple M2 Pro"
+        assert result["gpu_cores"] == 19
+        assert result["metal_supported"] is True
+
+    @patch("utils.gpu_optimization.gpu_detection.subprocess.run")
+    @patch("utils.gpu_optimization.gpu_detection.platform.system", return_value="Darwin")
+    def test_returns_none_for_non_apple_gpu_on_mac(self, _mock_sys, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='{"SPDisplaysDataType": [{"sppci_vendor": "NVIDIA",'
+            '"sppci_model": "GeForce GTX 1080"}]}',
+        )
+        assert _check_apple_gpu() is None
+
+    @patch("utils.gpu_optimization.gpu_detection.subprocess.run")
+    @patch("utils.gpu_optimization.gpu_detection.platform.system", return_value="Darwin")
+    def test_returns_none_when_system_profiler_fails(self, _mock_sys, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        assert _check_apple_gpu() is None
+
+    @patch("utils.gpu_optimization.gpu_detection.subprocess.run")
+    @patch("utils.gpu_optimization.gpu_detection.platform.system", return_value="Darwin")
+    def test_returns_none_on_timeout(self, _mock_sys, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd="system_profiler", timeout=10
+        )
+        assert _check_apple_gpu() is None
+
+    @patch("utils.gpu_optimization.gpu_detection.subprocess.run")
+    @patch("utils.gpu_optimization.gpu_detection.platform.system", return_value="Darwin")
+    def test_handles_missing_cores_field(self, _mock_sys, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='{"SPDisplaysDataType": [{"sppci_vendor": "Apple",'
+            '"sppci_model": "Apple M1",'
+            '"spdisplays_metal": "spdisplays_metal_supported"}]}',
+        )
+        result = _check_apple_gpu()
+        assert result is not None
+        assert result["gpu_cores"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _detect_apple_capabilities (Issue #2014)
+# ---------------------------------------------------------------------------
+class TestDetectAppleCapabilities:
+    """Tests for Apple Silicon capability population."""
+
+    @patch("utils.gpu_optimization.gpu_detection._get_macos_system_memory_gb", return_value=32.0)
+    def test_populates_from_stashed_info(self, _mock_mem):
+        import utils.gpu_optimization.gpu_detection as mod
+
+        mod._apple_gpu_info = {
+            "name": "Apple M2 Max",
+            "gpu_cores": 38,
+            "metal_supported": True,
+        }
+        caps = GPUCapabilities()
+        result = _detect_apple_capabilities(caps)
+        assert result.vendor == "apple"
+        assert result.name == "Apple M2 Max"
+        assert result.metal_supported is True
+        assert result.unified_memory is True
+        assert result.mixed_precision is True
+        assert result.multiprocessor_count == 38
+        assert result.memory_gb == 32.0
+
+    @patch("utils.gpu_optimization.gpu_detection._get_macos_system_memory_gb", return_value=0.0)
+    def test_fallback_when_no_stashed_info(self, _mock_mem):
+        import utils.gpu_optimization.gpu_detection as mod
+
+        mod._apple_gpu_info = None
+        caps = GPUCapabilities()
+        result = _detect_apple_capabilities(caps)
+        assert result.vendor == "apple"
+        assert result.name == "Apple GPU"
+
+
+# ---------------------------------------------------------------------------
+# _get_macos_system_memory_gb (Issue #2014)
+# ---------------------------------------------------------------------------
+class TestGetMacosSystemMemoryGb:
+    """Tests for macOS system memory detection."""
+
+    @patch("utils.gpu_optimization.gpu_detection.subprocess.run")
+    def test_returns_memory_in_gb(self, mock_run):
+        # 16 GB in bytes
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="17179869184\n"
+        )
+        assert _get_macos_system_memory_gb() == 16.0
+
+    @patch("utils.gpu_optimization.gpu_detection.subprocess.run")
+    def test_returns_zero_on_failure(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        assert _get_macos_system_memory_gb() == 0.0
+
+    @patch("utils.gpu_optimization.gpu_detection.subprocess.run")
+    def test_returns_zero_on_timeout(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="sysctl", timeout=5)
+        assert _get_macos_system_memory_gb() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# detect_gpu_capabilities — Apple path (Issue #2014)
+# ---------------------------------------------------------------------------
+class TestDetectGpuCapabilitiesApple:
+    """Tests for Apple path in detect_gpu_capabilities."""
+
+    @patch("utils.gpu_optimization.gpu_detection._detect_apple_capabilities")
+    @patch("utils.gpu_optimization.gpu_detection._detect_vendor", return_value="apple")
+    def test_apple_path(self, _vendor, mock_detect):
+        expected = GPUCapabilities(vendor="apple", name="Apple M3 Pro")
+        mock_detect.return_value = expected
+        result = detect_gpu_capabilities(gpu_available=True)
+        assert result.vendor == "apple"
+        mock_detect.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _detect_vendor — Apple (Issue #2014)
+# ---------------------------------------------------------------------------
+class TestDetectVendorApple:
+    """Tests for Apple vendor detection in _detect_vendor."""
+
+    @patch("utils.gpu_optimization.gpu_detection._check_apple_gpu")
+    @patch("utils.gpu_optimization.gpu_detection._check_intel_gpu", return_value=False)
+    @patch("utils.gpu_optimization.gpu_detection._check_amd_gpu", return_value=False)
+    @patch("utils.gpu_optimization.gpu_detection._check_nvidia_gpu", return_value=None)
+    def test_apple_detected(self, _nv, _amd, _intel, mock_apple):
+        mock_apple.return_value = {"name": "Apple M2", "gpu_cores": 10, "metal_supported": True}
+        assert _detect_vendor() == "apple"
+
+    @patch("utils.gpu_optimization.gpu_detection._check_apple_gpu", return_value=None)
+    @patch("utils.gpu_optimization.gpu_detection._check_intel_gpu", return_value=False)
+    @patch("utils.gpu_optimization.gpu_detection._check_amd_gpu", return_value=False)
+    @patch("utils.gpu_optimization.gpu_detection._check_nvidia_gpu", return_value=None)
+    def test_no_apple_no_gpu(self, _nv, _amd, _intel, _apple):
+        assert _detect_vendor() is None

--- a/autobot-backend/utils/gpu_optimization/gpu_detection.py
+++ b/autobot-backend/utils/gpu_optimization/gpu_detection.py
@@ -10,7 +10,9 @@ Contains GPU availability checking and capability detection.
 """
 
 import functools
+import json
 import logging
+import platform
 import subprocess
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -21,6 +23,9 @@ logger = logging.getLogger(__name__)
 
 # Stashed GPU name from initial nvidia-smi probe (#2222)
 _nvidia_gpu_name: Optional[str] = None
+
+# Stashed Apple GPU info from initial system_profiler probe (#2014)
+_apple_gpu_info: Optional[Dict[str, Any]] = None
 
 # NVIDIA GPU families known to have tensor cores
 _TENSOR_CORE_FAMILIES = {
@@ -88,6 +93,49 @@ def _check_intel_gpu() -> bool:
     return _check_sysfs_vendor("0x8086")
 
 
+def _check_apple_gpu() -> Optional[Dict[str, Any]]:
+    """Check for Apple Silicon GPU via system_profiler on macOS.
+
+    Issue #2014: Returns a dict with chip name, Metal support, and
+    GPU core count, or None if not on macOS / no Apple GPU found.
+    """
+    if platform.system() != "Darwin":
+        return None
+    try:
+        result = subprocess.run(
+            ["system_profiler", "SPDisplaysDataType", "-json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        displays = data.get("SPDisplaysDataType", [])
+        for gpu in displays:
+            vendor = gpu.get("sppci_vendor", "").lower()
+            chip = gpu.get("sppci_model", "")
+            if "apple" in vendor or chip.startswith("Apple"):
+                cores_str = gpu.get("sppci_cores", "")
+                try:
+                    gpu_cores = int(cores_str)
+                except (ValueError, TypeError):
+                    gpu_cores = 0
+                metal_support = gpu.get("spdisplays_metal", "")
+                return {
+                    "name": chip,
+                    "gpu_cores": gpu_cores,
+                    "metal_supported": "supported" in metal_support.lower()
+                    if metal_support
+                    else False,
+                }
+        return None
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    except (json.JSONDecodeError, KeyError, Exception):
+        return None
+
+
 def _check_sysfs_vendor(vendor_id: str) -> bool:
     """Check sysfs DRM devices for a specific PCI vendor ID."""
     drm_path = Path("/sys/class/drm")
@@ -121,7 +169,7 @@ def _detect_vendor() -> Optional[str]:
     _detect_nvidia_capabilities() can skip its redundant nvidia-smi call.
     Use _detect_vendor.cache_clear() to reset (e.g. in tests).
     """
-    global _nvidia_gpu_name
+    global _nvidia_gpu_name, _apple_gpu_info
     nvidia_name = _check_nvidia_gpu()
     if nvidia_name:
         _nvidia_gpu_name = nvidia_name
@@ -130,13 +178,18 @@ def _detect_vendor() -> Optional[str]:
         return "amd"
     if _check_intel_gpu():
         return "intel"
+    apple_info = _check_apple_gpu()
+    if apple_info:
+        _apple_gpu_info = apple_info
+        return "apple"
     return None
 
 
 def _reset_detection_state() -> None:
     """Reset cached vendor and GPU name state (for test isolation)."""
-    global _nvidia_gpu_name
+    global _nvidia_gpu_name, _apple_gpu_info
     _nvidia_gpu_name = None
+    _apple_gpu_info = None
     _detect_vendor.cache_clear()
 
 
@@ -161,6 +214,8 @@ def detect_gpu_capabilities(gpu_available: bool) -> GPUCapabilities:
     elif vendor == "intel":
         capabilities.vendor = "intel"
         capabilities.name = "Intel GPU (detected via sysfs)"
+    elif vendor == "apple":
+        capabilities = _detect_apple_capabilities(capabilities)
 
     return capabilities
 
@@ -273,6 +328,51 @@ def _detect_detailed_capabilities(
         logger.debug("Failed to get detailed GPU capabilities: %s", e)
 
     return capabilities
+
+
+def _detect_apple_capabilities(
+    capabilities: GPUCapabilities,
+) -> GPUCapabilities:
+    """Detect Apple Silicon GPU capabilities from stashed system_profiler data.
+
+    Issue #2014: Apple Silicon uses unified memory — system RAM is shared
+    with the GPU, so we report total system memory as GPU memory.
+    """
+    capabilities.vendor = "apple"
+    info = _apple_gpu_info
+    if info:
+        capabilities.name = info.get("name", "Apple GPU")
+        capabilities.metal_supported = info.get("metal_supported", False)
+        capabilities.unified_memory = True
+        gpu_cores = info.get("gpu_cores", 0)
+        capabilities.multiprocessor_count = gpu_cores
+        capabilities.mixed_precision = True
+    else:
+        capabilities.name = "Apple GPU"
+    capabilities.memory_gb = _get_macos_system_memory_gb()
+    return capabilities
+
+
+def _get_macos_system_memory_gb() -> float:
+    """Get total system memory on macOS (unified memory = GPU memory).
+
+    Issue #2014: Apple Silicon shares system RAM with GPU.
+    """
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            mem_bytes = int(result.stdout.strip())
+            return round(mem_bytes / (1024**3), 1)
+    except (FileNotFoundError, subprocess.TimeoutExpired, ValueError):
+        pass
+    except Exception:
+        pass
+    return 0.0
 
 
 def get_gpu_capabilities_dict(

--- a/autobot-backend/utils/gpu_optimization/types.py
+++ b/autobot-backend/utils/gpu_optimization/types.py
@@ -97,6 +97,8 @@ class GPUCapabilities:
     memory_gb: float = 0
     max_threads_per_block: int = 0
     multiprocessor_count: int = 0
+    metal_supported: bool = False
+    unified_memory: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
@@ -110,6 +112,8 @@ class GPUCapabilities:
             "memory_gb": self.memory_gb,
             "max_threads_per_block": self.max_threads_per_block,
             "multiprocessor_count": self.multiprocessor_count,
+            "metal_supported": self.metal_supported,
+            "unified_memory": self.unified_memory,
         }
 
     @classmethod
@@ -125,6 +129,8 @@ class GPUCapabilities:
             memory_gb=data.get("memory_gb", 0),
             max_threads_per_block=data.get("max_threads_per_block", 0),
             multiprocessor_count=data.get("multiprocessor_count", 0),
+            metal_supported=data.get("metal_supported", False),
+            unified_memory=data.get("unified_memory", False),
         )
 
 


### PR DESCRIPTION
## Summary
- Add Apple Silicon (M1/M2/M3/M4) GPU detection via `system_profiler SPDisplaysDataType`
- Report Metal support, unified memory, GPU core count
- Uses system RAM as GPU memory for unified memory architectures
- Adds `metal_supported` and `unified_memory` fields to `GPUCapabilities`
- Graceful fallback when system_profiler unavailable or on non-macOS

Closes #2014

## Test plan
- [x] Apple Silicon detection parses system_profiler JSON correctly
- [x] Graceful fallback on non-macOS systems
- [x] No regression for NVIDIA/AMD/Intel detection (existing tests unchanged)
- [x] flake8 passes
- [x] Edge cases: missing cores field, non-Apple GPU on Mac, timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)