### PR TITLE
feat(slm): serve SLM at /slm subroute for single-host (#2716)

### DIFF
--- a/autobot-slm-backend/main.py
+++ b/autobot-slm-backend/main.py
@@ -9,6 +9,7 @@ Main FastAPI application entry point.
 
 import asyncio
 import logging
+import os
 import sys
 from contextlib import asynccontextmanager
 
@@ -287,6 +288,7 @@ app = FastAPI(
     description="Service Lifecycle Manager for AutoBot",
     version="1.0.0",
     lifespan=lifespan,
+    root_path=os.getenv("SLM_ROOT_PATH", ""),
     docs_url="/api/docs" if settings.debug else None,
     redoc_url="/api/redoc" if settings.debug else None,
 )


### PR DESCRIPTION
## Summary
- Add `root_path` to FastAPI constructor via `SLM_ROOT_PATH` env var
- Nginx config already has `/slm/api/` proxy and `/slm/` frontend blocks
- Vite config already sets `base: '/slm/'`
- Vue Router already uses `import.meta.env.BASE_URL`
- This PR completes the missing FastAPI side for OpenAPI/redirect URL correctness

Closes #2716

## Test plan
- [ ] Set `SLM_ROOT_PATH=/slm` and verify `/slm/api/docs` loads correctly
- [ ] API health check works at `/slm/api/health`
- [ ] Frontend loads at `/slm/` with working router navigation
- [ ] No regression on standalone deployment (empty root_path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)