### PR TITLE
feat(mesh): persist EWC++ weights and importance to Redis (#2546)

### DIFF
--- a/autobot-backend/services/mesh_brain/edge_learner.py
+++ b/autobot-backend/services/mesh_brain/edge_learner.py
@@ -41,10 +41,18 @@ class EdgeLearner:
     retrieval feedback from overwriting high-confidence learned edge weights.
     Per-edge importance (Fisher proxy) grows with successful co-retrievals
     and dampens updates proportionally. Disabled when ewc_lambda=0.
+
+    EWC state persistence (#2546): reference weights and importance scores
+    are persisted to Redis hashes so that EWC protection survives restarts.
+    update_importance() is called automatically on every successful edge
+    reinforcement so that importance scores accumulate correctly over time.
     """
 
     # Redis hash key for persisting stream cursors across restarts (#2210).
     CURSOR_HASH_KEY = "rag:cursors:edge_learner"
+    # Redis hash keys for persisting EWC++ state across restarts (#2546).
+    EWC_REFERENCE_WEIGHTS_KEY = "mesh:ewc:reference_weights"
+    EWC_IMPORTANCE_KEY = "mesh:ewc:importance"
 
     def __init__(
         self,
@@ -74,6 +82,8 @@ class EdgeLearner:
         # Loaded from Redis on first access (#2210).
         self._cursors: dict[str, str] = {}
         self._cursors_loaded = False
+        # EWC++ state is loaded lazily from Redis on first consume call (#2546).
+        self._ewc_state_loaded = False
 
     async def _load_cursors(self) -> None:
         """Load persisted cursors from Redis hash on first call (#2210)."""
@@ -97,6 +107,51 @@ class EdgeLearner:
             await self.redis.hset(self.CURSOR_HASH_KEY, stream_key, cursor)
         except Exception:
             logger.warning("EdgeLearner: failed to persist cursor for %s", stream_key)
+
+    async def _load_ewc_state(self) -> None:
+        """Load persisted EWC++ reference weights and importance from Redis on first call (#2546)."""
+        if self._ewc_state_loaded:
+            return
+        try:
+            raw_weights = await self.redis.hgetall(self.EWC_REFERENCE_WEIGHTS_KEY)
+            if raw_weights:
+                self._reference_weights.update({k: float(v) for k, v in raw_weights.items()})
+                logger.info(
+                    "EdgeLearner: loaded %d persisted EWC reference weights from Redis",
+                    len(raw_weights),
+                )
+        except Exception:
+            logger.warning("EdgeLearner: failed to load EWC reference weights, starting empty")
+        try:
+            raw_importance = await self.redis.hgetall(self.EWC_IMPORTANCE_KEY)
+            if raw_importance:
+                self._importance.update({k: float(v) for k, v in raw_importance.items()})
+                logger.info(
+                    "EdgeLearner: loaded %d persisted EWC importance scores from Redis",
+                    len(raw_importance),
+                )
+        except Exception:
+            logger.warning("EdgeLearner: failed to load EWC importance scores, starting empty")
+        self._ewc_state_loaded = True
+
+    async def _save_ewc_state(self) -> None:
+        """Persist EWC++ reference weights and importance scores to Redis (#2546)."""
+        if self._reference_weights:
+            try:
+                await self.redis.hset(
+                    self.EWC_REFERENCE_WEIGHTS_KEY,
+                    mapping={k: str(v) for k, v in self._reference_weights.items()},
+                )
+            except Exception:
+                logger.warning("EdgeLearner: failed to persist EWC reference weights")
+        if self._importance:
+            try:
+                await self.redis.hset(
+                    self.EWC_IMPORTANCE_KEY,
+                    mapping={k: str(v) for k, v in self._importance.items()},
+                )
+            except Exception:
+                logger.warning("EdgeLearner: failed to persist EWC importance scores")
 
     async def on_retrieval(self, event: dict) -> None:
         """Process a single retrieval feedback event.
@@ -169,19 +224,21 @@ class EdgeLearner:
             self._importance[edge_id] = current * 0.95
 
     async def consolidate_weights(self) -> None:
-        """Snapshot current weights as EWC reference points (#2097).
+        """Snapshot current EWC state to Redis as reference points (#2097, #2546).
 
         Called automatically every ewc_consolidation_interval updates.
-        The reference dict is already kept current during _update_existing_edge,
-        so this method serves as a hook for logging and future persistence.
+        Persists both reference weights and importance scores so that EWC
+        protection survives EdgeLearner restarts.
         """
+        await self._save_ewc_state()
         logger.info(
-            "EdgeLearner: consolidated %d reference weights",
+            "EdgeLearner: consolidated %d reference weights and %d importance scores to Redis",
             len(self._reference_weights),
+            len(self._importance),
         )
 
     async def _update_existing_edge(self, edge: dict) -> None:
-        """Apply EMA weight update with EWC++ dampening and increment co_access_count (#2097)."""
+        """Apply EMA weight update with EWC++ dampening and increment co_access_count (#2097, #2546)."""
         proposed_weight = edge["weight"] * self.ema_decay + 1.0 * (1 - self.ema_decay)
         final_weight = self._apply_ewc_dampening(
             edge["id"], edge["weight"], proposed_weight
@@ -193,6 +250,8 @@ class EdgeLearner:
         )
         # Track reference weight for future EWC penalty computations.
         self._reference_weights[edge["id"]] = final_weight
+        # Record successful co-retrieval so importance accumulates over time (#2546).
+        self.update_importance(edge["id"], success=True)
         self._update_count += 1
         if self._update_count % self.ewc_consolidation_interval == 0:
             await self.consolidate_weights()
@@ -232,8 +291,9 @@ class EdgeLearner:
             date_key = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
 
         stream_key = f"rag:feedback:{date_key}"
-        # Load persisted cursors from Redis on first call (#2210).
+        # Load persisted cursors and EWC state from Redis on first call (#2210, #2546).
         await self._load_cursors()
+        await self._load_ewc_state()
         # Resume from exclusive lower bound. "0-0" reads from the start.
         # After processing entry "T-S", we store "T-(S+1)" so the next
         # xrange call excludes the already-processed entry.

--- a/autobot-backend/services/mesh_brain/edge_learner_test.py
+++ b/autobot-backend/services/mesh_brain/edge_learner_test.py
@@ -405,3 +405,175 @@ class TestEWCPrevention:
         stored = learner._reference_weights["edge-1"]
         call_kwargs = db.update_edge.call_args.kwargs
         assert stored == pytest.approx(call_kwargs["weight"])
+
+    @pytest.mark.asyncio
+    async def test_update_importance_called_on_reinforcement(self):
+        """update_importance(success=True) is called for each reinforced edge (#2546)."""
+        db = _make_db_mock()
+        edge = _existing_edge(weight=0.6, co_access_count=2)
+        db.get_edge = AsyncMock(return_value=edge)
+
+        learner = _make_ewc_learner(db, _make_redis_mock())
+        assert learner._importance.get("edge-1", 0.0) == 0.0
+
+        await learner.on_retrieval({"final_ranked_ids": ["A", "B"]})
+
+        # Importance must have grown after the successful reinforcement.
+        assert learner._importance.get("edge-1", 0.0) > 0.0
+
+
+# =============================================================================
+# EWC++ Redis persistence tests (#2546)
+# =============================================================================
+
+
+class TestEWCRedisPersistence:
+    """Tests for EWC++ state load/save via Redis (#2546)."""
+
+    @pytest.mark.asyncio
+    async def test_load_ewc_state_restores_reference_weights(self):
+        """_load_ewc_state() populates _reference_weights from Redis hash."""
+        db = _make_db_mock()
+        redis = _make_redis_mock()
+        redis.hgetall = AsyncMock(
+            side_effect=[
+                {},  # CURSOR_HASH_KEY → no cursors
+                {"edge-1": "0.75", "edge-2": "0.5"},  # EWC_REFERENCE_WEIGHTS_KEY
+                {},  # EWC_IMPORTANCE_KEY → empty
+            ]
+        )
+
+        learner = _make_ewc_learner(db, redis)
+        await learner.consume_feedback_stream(date_key="2026-03-23")
+
+        assert learner._reference_weights == {"edge-1": pytest.approx(0.75), "edge-2": pytest.approx(0.5)}
+
+    @pytest.mark.asyncio
+    async def test_load_ewc_state_restores_importance(self):
+        """_load_ewc_state() populates _importance from Redis hash."""
+        db = _make_db_mock()
+        redis = _make_redis_mock()
+        redis.hgetall = AsyncMock(
+            side_effect=[
+                {},  # CURSOR_HASH_KEY
+                {},  # EWC_REFERENCE_WEIGHTS_KEY
+                {"edge-1": "0.3", "edge-3": "0.8"},  # EWC_IMPORTANCE_KEY
+            ]
+        )
+
+        learner = _make_ewc_learner(db, redis)
+        await learner.consume_feedback_stream(date_key="2026-03-23")
+
+        assert learner._importance == {"edge-1": pytest.approx(0.3), "edge-3": pytest.approx(0.8)}
+
+    @pytest.mark.asyncio
+    async def test_load_ewc_state_called_only_once(self):
+        """_load_ewc_state() is idempotent — Redis is not queried on subsequent calls."""
+        db = _make_db_mock()
+        redis = _make_redis_mock()
+        # hgetall called 3 times on first consume: cursor + 2 EWC hashes.
+        redis.hgetall = AsyncMock(return_value={})
+
+        learner = _make_ewc_learner(db, redis)
+        await learner.consume_feedback_stream(date_key="2026-03-23")
+        first_call_count = redis.hgetall.await_count  # 3 (cursors + weights + importance)
+
+        await learner.consume_feedback_stream(date_key="2026-03-23")
+        # No additional hgetall calls on second consume — state already loaded.
+        assert redis.hgetall.await_count == first_call_count
+
+    @pytest.mark.asyncio
+    async def test_save_ewc_state_persists_reference_weights(self):
+        """_save_ewc_state() writes reference weights to Redis hash via hset mapping."""
+        db = _make_db_mock()
+        redis = _make_redis_mock()
+
+        learner = _make_ewc_learner(db, redis)
+        learner._reference_weights = {"edge-1": 0.75}
+        learner._importance = {}
+
+        await learner._save_ewc_state()
+
+        redis.hset.assert_any_await(
+            EdgeLearner.EWC_REFERENCE_WEIGHTS_KEY,
+            mapping={"edge-1": "0.75"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_save_ewc_state_persists_importance(self):
+        """_save_ewc_state() writes importance scores to Redis hash via hset mapping."""
+        db = _make_db_mock()
+        redis = _make_redis_mock()
+
+        learner = _make_ewc_learner(db, redis)
+        learner._reference_weights = {}
+        learner._importance = {"edge-2": 0.5}
+
+        await learner._save_ewc_state()
+
+        redis.hset.assert_any_await(
+            EdgeLearner.EWC_IMPORTANCE_KEY,
+            mapping={"edge-2": "0.5"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_consolidate_weights_calls_save_ewc_state(self):
+        """consolidate_weights() triggers _save_ewc_state() — persisting to Redis (#2546)."""
+        db = _make_db_mock()
+        redis = _make_redis_mock()
+
+        learner = _make_ewc_learner(db, redis)
+        learner._reference_weights = {"edge-x": 0.6}
+        learner._importance = {"edge-x": 0.4}
+
+        await learner.consolidate_weights()
+
+        # hset must have been called for both EWC hashes.
+        hset_keys = [call.args[0] for call in redis.hset.call_args_list]
+        assert EdgeLearner.EWC_REFERENCE_WEIGHTS_KEY in hset_keys
+        assert EdgeLearner.EWC_IMPORTANCE_KEY in hset_keys
+
+    @pytest.mark.asyncio
+    async def test_load_ewc_state_tolerates_redis_failure_on_weights(self):
+        """Redis failure loading reference weights is logged and does not raise (#2546)."""
+        db = _make_db_mock()
+        redis = _make_redis_mock()
+        # First hgetall (cursors) succeeds; second (EWC weights) raises; third (importance) ok.
+        redis.hgetall = AsyncMock(side_effect=[{}, RuntimeError("redis down"), {}])
+
+        learner = _make_ewc_learner(db, redis)
+        # Must not raise.
+        await learner._load_ewc_state()
+
+        assert learner._reference_weights == {}
+        assert learner._ewc_state_loaded is True
+
+    @pytest.mark.asyncio
+    async def test_load_ewc_state_tolerates_redis_failure_on_importance(self):
+        """Redis failure loading importance is logged and does not raise (#2546)."""
+        db = _make_db_mock()
+        redis = _make_redis_mock()
+        redis.hgetall = AsyncMock(side_effect=[{"edge-1": "0.5"}, RuntimeError("redis down")])
+
+        learner = _make_ewc_learner(db, redis)
+        # Bypass cursor load so only 2 hgetall calls needed.
+        learner._cursors_loaded = True
+        await learner._load_ewc_state()
+
+        assert learner._reference_weights == {"edge-1": pytest.approx(0.5)}
+        assert learner._importance == {}
+        assert learner._ewc_state_loaded is True
+
+    @pytest.mark.asyncio
+    async def test_save_ewc_state_tolerates_redis_failure(self):
+        """Redis failure during save is logged and does not raise (#2546)."""
+        db = _make_db_mock()
+        redis = _make_redis_mock()
+        redis.hset = AsyncMock(side_effect=RuntimeError("write failed"))
+
+        learner = _make_ewc_learner(db, redis)
+        learner._reference_weights = {"edge-1": 0.6}
+        learner._importance = {"edge-1": 0.3}
+
+        # Must not raise.
+        await learner._save_ewc_state()


### PR DESCRIPTION
## Summary
- Persist EWC++ reference weights to Redis hash `mesh:ewc:reference_weights`
- Persist importance scores to Redis hash `mesh:ewc:importance`
- Load persisted state on EdgeLearner startup (lazy, fault-tolerant)
- Wire `update_importance()` into edge reinforcement feedback loop
- EWC protection is no longer a no-op — importance accumulates from real usage

Closes #2546

## Test plan
- [x] `test_update_importance_called_on_reinforcement` — wiring verified
- [x] `TestEWCRedisPersistence` — 8 tests covering load/save/consolidation/fault tolerance
- [x] flake8 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)