### PR TITLE
fix(redis): await get_async_client() coroutine in all callers (#2956)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -94,7 +94,7 @@ async def _get_checkpoint_redis():
     try:
         from autobot_shared.redis_client import get_redis_client
 
-        return get_redis_client(database="analytics", async_client=True)
+        return await get_redis_client(database="analytics", async_client=True)
     except Exception:
         return None
 

--- a/autobot-backend/api/codebase_analytics/source_storage.py
+++ b/autobot-backend/api/codebase_analytics/source_storage.py
@@ -24,7 +24,7 @@ async def _get_redis():
     """Return an async Redis client for the analytics database."""
     from autobot_shared.redis_client import get_redis_client
 
-    return get_redis_client(database="analytics", async_client=True)
+    return await get_redis_client(database="analytics", async_client=True)
 
 
 async def save_source(source: CodeSource) -> bool:

--- a/autobot-backend/api/codebase_analytics/storage.py
+++ b/autobot-backend/api/codebase_analytics/storage.py
@@ -54,7 +54,7 @@ async def get_redis_connection_async():
     """
     from autobot_shared.redis_client import get_redis_client
 
-    redis_client = get_redis_client(database="analytics", async_client=True)
+    redis_client = await get_redis_client(database="analytics", async_client=True)
     if redis_client is None:
         logger.warning("Async Redis client initialization returned None")
         return None

--- a/autobot-backend/services/terminal_history_service.py
+++ b/autobot-backend/services/terminal_history_service.py
@@ -23,8 +23,19 @@ class TerminalHistoryService:
         Args:
             max_entries: Maximum commands to store per user
         """
-        self.redis = get_redis_client(database="main", async_client=True)
+        self._redis = None
         self.max_entries = max_entries
+
+    async def _get_redis(self):
+        """Get async Redis client, initializing lazily on first use.
+
+        Issue #2956: get_async_client is a coroutine so it cannot be called
+        from __init__. Lazy initialization ensures the client is awaited
+        correctly in an async context.
+        """
+        if self._redis is None:
+            self._redis = await get_redis_client(database="main", async_client=True)
+        return self._redis
 
     async def add_command(self, user_id: str, command: str) -> None:
         """Add command to history with current timestamp.
@@ -44,11 +55,15 @@ class TerminalHistoryService:
         timestamp = time.time()
 
         try:
-            await self.redis.zadd(key, {command: timestamp})
+            redis = await self._get_redis()
+            if not redis:
+                logger.error("Redis unavailable; cannot add command to history")
+                return
+            await redis.zadd(key, {command: timestamp})
 
-            count = await self.redis.zcard(key)
+            count = await redis.zcard(key)
             if count > self.max_entries:
-                await self.redis.zremrangebyrank(key, 0, count - self.max_entries - 1)
+                await redis.zremrangebyrank(key, 0, count - self.max_entries - 1)
         except Exception as e:
             logger.error("Failed to add command to history: %s", e)
 
@@ -71,7 +86,10 @@ class TerminalHistoryService:
 
         key = f"terminal:history:{user_id}"
         try:
-            return await self.redis.zrevrange(key, offset, offset + limit - 1)
+            redis = await self._get_redis()
+            if not redis:
+                return []
+            return await redis.zrevrange(key, offset, offset + limit - 1)
         except Exception as e:
             logger.error("Failed to get history: %s", e)
             return []
@@ -113,6 +131,9 @@ class TerminalHistoryService:
 
         key = f"terminal:history:{user_id}"
         try:
-            await self.redis.delete(key)
+            redis = await self._get_redis()
+            if not redis:
+                return
+            await redis.delete(key)
         except Exception as e:
             logger.error("Failed to clear history: %s", e)

--- a/autobot-backend/utils/background_task_manager.py
+++ b/autobot-backend/utils/background_task_manager.py
@@ -69,7 +69,7 @@ class BackgroundTaskManager:
         try:
             from autobot_shared.redis_client import get_redis_client
 
-            return get_redis_client(database="analytics", async_client=True)
+            return await get_redis_client(database="analytics", async_client=True)
         except Exception as exc:
             logger.debug("Redis unavailable (non-fatal): %s", exc)
             return None

--- a/autobot-backend/utils/system_metrics.py
+++ b/autobot-backend/utils/system_metrics.py
@@ -177,9 +177,7 @@ class SystemMetricsCollector:
             1.0 if healthy, 0.0 if unhealthy
         """
         try:
-            redis_client = get_redis_client(database="main", async_client=True)
-            if asyncio.iscoroutine(redis_client):
-                redis_client = await redis_client
+            redis_client = await get_redis_client(database="main", async_client=True)
 
             if not redis_client or not hasattr(redis_client, "ping"):
                 return 0.0
@@ -362,9 +360,7 @@ class SystemMetricsCollector:
         Returns:
             Async Redis client or None if unavailable
         """
-        kb_redis_client = get_redis_client(database="knowledge", async_client=True)
-        if asyncio.iscoroutine(kb_redis_client):
-            kb_redis_client = await kb_redis_client
+        kb_redis_client = await get_redis_client(database="knowledge", async_client=True)
         return kb_redis_client
 
     async def _collect_kb_vector_metrics(

--- a/autobot-infrastructure/shared/scripts/cleanup_redis_metrics.py
+++ b/autobot-infrastructure/shared/scripts/cleanup_redis_metrics.py
@@ -74,9 +74,7 @@ async def _connect_redis_clients(results: dict) -> tuple:
 
     # Connect to Redis (main database)
     try:
-        redis_client = get_redis_client(database="main", async_client=True)
-        if asyncio.iscoroutine(redis_client):
-            redis_client = await redis_client
+        redis_client = await get_redis_client(database="main", async_client=True)
 
         if not redis_client:
             logger.error("Failed to connect to Redis")
@@ -87,9 +85,7 @@ async def _connect_redis_clients(results: dict) -> tuple:
 
     # Also check knowledge database
     try:
-        kb_redis_client = get_redis_client(database="knowledge", async_client=True)
-        if asyncio.iscoroutine(kb_redis_client):
-            kb_redis_client = await kb_redis_client
+        kb_redis_client = await get_redis_client(database="knowledge", async_client=True)
     except Exception:
         kb_redis_client = None
         logger.warning("Knowledge database not available, skipping")

--- a/autobot-infrastructure/shared/scripts/reset_knowledge_base.py
+++ b/autobot-infrastructure/shared/scripts/reset_knowledge_base.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 async def reset_knowledge_base_index():
     """Reset the knowledge base Redis index to use correct embedding dimensions."""
 
-    redis_client = get_redis_client(async_client=True)
+    redis_client = await get_redis_client(async_client=True)
     if not redis_client:
         logger.error("Redis client not available")
         return


### PR DESCRIPTION
## Summary
- `RedisConnectionManager.get_async_client()` is `async def` but several callers were not awaiting the coroutine
- Caused `RuntimeWarning: coroutine never awaited` and Redis connections that silently failed
- Fixed 8 files across `autobot-backend` and `autobot-infrastructure`

## Changes
- `terminal_history_service.py`: replaced unawaited coroutine stored in `__init__` with lazy `async def _get_redis()` helper
- `reset_knowledge_base.py`, `background_task_manager.py`, `source_storage.py`, `pattern_analysis.py`, `storage.py`: added missing `await`
- `system_metrics.py`, `cleanup_redis_metrics.py`: removed fragile `asyncio.iscoroutine()` workarounds, replaced with direct `await`

Closes #2956

## Test plan
- [ ] No more `coroutine 'RedisConnectionManager.get_async_client' was never awaited` warnings
- [ ] Terminal history commands persist correctly
- [ ] Redis operations work across all fixed services
- [ ] Circuit breakers don't trip unnecessarily

🤖 Generated with [Claude Code](https://claude.com/claude-code)