### PR TITLE
fix(npu): wire per-worker task tracking and add failover fallback (#2944)

### DIFF
--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -815,9 +815,11 @@ class NPUWorkerManager:
     ) -> None:
         """Re-queue only the dead worker's tasks and remove it from the registry (#1769, #2496).
 
-        Uses the per-worker task SET ({queue}:worker:{worker_id}:tasks) so that
-        tasks belonging to healthy workers sharing the same queue are never
-        incorrectly re-queued.
+        Primary source: per-worker task SET ({queue}:worker:{worker_id}:tasks),
+        populated by assign_task_to_worker() callers (#2944).  When the SET is
+        empty (e.g. on existing deployments before callers were wired) the method
+        falls back to the global {queue}:running ZSET so that task migration is
+        never silently skipped.
 
         Args:
             worker_id: ID of the dead worker
@@ -832,17 +834,35 @@ class NPUWorkerManager:
 
         task_ids = await self.redis_client.smembers(worker_tasks_key)
         if not task_ids:
-            logger.info("Failover: dead worker %s had no running tasks", worker_id)
-        else:
-            for task_id in task_ids:
-                await self._migrate_running_task(
-                    task_id,
-                    running_key,
-                    pending_key,
-                    failed_key,
-                    tasks_hash,
-                    max_retries,
+            # Fallback: per-worker SET is empty (callers not yet wired or new
+            # deployment).  Conservatively migrate all tasks still in the global
+            # running ZSET so failover never silently skips migration (#2944).
+            task_ids = await self.redis_client.zrange(running_key, 0, -1)
+            if task_ids:
+                logger.warning(
+                    "Failover: per-worker SET empty for %s; falling back to "
+                    "global running ZSET (%d tasks)",
+                    worker_id,
+                    len(task_ids),
                 )
+            else:
+                logger.info("Failover: dead worker %s had no running tasks", worker_id)
+        else:
+            logger.info(
+                "Failover: migrating %d tasks from per-worker SET for worker %s",
+                len(task_ids),
+                worker_id,
+            )
+
+        for task_id in task_ids:
+            await self._migrate_running_task(
+                task_id,
+                running_key,
+                pending_key,
+                failed_key,
+                tasks_hash,
+                max_retries,
+            )
 
         # Remove per-worker task set and worker status/registry
         await self.redis_client.delete(worker_tasks_key)

--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -192,6 +192,10 @@ class TaskQueue:
         self.is_running = False
         self.logger = logging.getLogger(__name__)
 
+        # Optional NPUWorkerManager reference for per-worker task tracking (#2944).
+        # Set externally after construction: queue.npu_worker_manager = manager
+        self.npu_worker_manager = None
+
         # Lock for thread-safe stats access
         self._stats_lock = asyncio.Lock()
 
@@ -408,8 +412,22 @@ class TaskQueue:
                     await asyncio.sleep(TimingConstants.STANDARD_DELAY)
                     continue
 
-                # Process task
-                await self._process_task(task_id, worker_name)
+                # Record task assignment in per-worker SET so failover monitor
+                # can migrate only this worker's tasks if it dies (#2944).
+                if self.npu_worker_manager is not None:
+                    await self.npu_worker_manager.assign_task_to_worker(
+                        self.queue_name, worker_name, task_id
+                    )
+
+                try:
+                    # Process task
+                    await self._process_task(task_id, worker_name)
+                finally:
+                    # Always release regardless of success or exception (#2944).
+                    if self.npu_worker_manager is not None:
+                        await self.npu_worker_manager.release_worker_task(
+                            self.queue_name, worker_name, task_id
+                        )
 
             except asyncio.CancelledError:
                 break


### PR DESCRIPTION
## Summary
- `assign_task_to_worker()` and `release_worker_task()` were added in #2496 but never called
- Per-worker Redis SETs were always empty, making failover silently skip all task migration
- Wired both methods into `TaskQueue._worker_loop()` with `try/finally` for safety
- Added fallback in `_failover_dead_worker()`: if per-worker SET is empty, falls back to global `{queue}:running` ZSET

Closes #2944

## Test plan
- [ ] Per-worker task SETs populated when tasks start
- [ ] Per-worker task SETs cleaned when tasks complete (including on exception)
- [ ] Failover correctly migrates tasks from dead workers
- [ ] Fallback works when per-worker SETs are empty (migration path for existing deployments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)