### PR TITLE
feat(slm): add failure_reason column to FleetSyncJobModel (#1980)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -118,6 +118,7 @@ async def reconcile_stale_fleet_sync_jobs() -> int:
         for job in stale_jobs:
             job.status = "failed"
             job.completed_at = datetime.utcnow()
+            job.failure_reason = "reconciled: server restarted while job was running"
             logger.warning(
                 "Reconciled stale fleet sync job %s "
                 "(was 'running', marked 'failed')",
@@ -169,8 +170,9 @@ async def _update_job_status_db(
     *,
     status: Optional[str] = None,
     completed_at: Optional[datetime] = None,
+    failure_reason: Optional[str] = None,
 ) -> None:
-    """Update fleet sync job status in DB (#1707)."""
+    """Update fleet sync job status in DB (#1707, #1980)."""
     from services.database import db_service
 
     async with db_service.session() as db:
@@ -185,6 +187,8 @@ async def _update_job_status_db(
             db_job.status = status
         if completed_at is not None:
             db_job.completed_at = completed_at
+        if failure_reason is not None:
+            db_job.failure_reason = failure_reason[:500]
 
         # Recalculate node counts from node_states
         ns_result = await db.execute(
@@ -262,6 +266,7 @@ async def _load_job_status_from_db(
             total_nodes=db_job.total_nodes,
             completed_nodes=db_job.completed_nodes,
             failed_nodes=db_job.failed_nodes,
+            failure_reason=db_job.failure_reason,
             nodes=[
                 FleetSyncNodeStatus(
                     node_id=ns.node_id,
@@ -1099,6 +1104,7 @@ async def _run_fleet_sync_job(job: FleetSyncJob) -> None:
             slm_self_node.node_id,
         )
 
+    failure_reason: Optional[str] = None
     try:
         await _sync_regular_nodes(executor, job, regular_nodes)
 
@@ -1111,10 +1117,14 @@ async def _run_fleet_sync_job(job: FleetSyncJob) -> None:
     except Exception as e:
         logger.error("Fleet sync job %s failed: %s", job.job_id, e)
         job.status = "failed"
+        failure_reason = str(e)
 
     job.completed_at = datetime.utcnow()
     await _update_job_status_db(
-        job.job_id, status=job.status, completed_at=job.completed_at
+        job.job_id,
+        status=job.status,
+        completed_at=job.completed_at,
+        failure_reason=failure_reason,
     )
     _running_tasks.pop(job.job_id, None)  # Prevent memory leak (#1928)
     logger.info(

--- a/autobot-slm-backend/migrations/add_failure_reason_to_fleet_sync_jobs.py
+++ b/autobot-slm-backend/migrations/add_failure_reason_to_fleet_sync_jobs.py
@@ -1,0 +1,52 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Migration: Add failure_reason column to fleet_sync_jobs table.
+
+Allows callers to distinguish reconciled startup failures
+(server restarted while job was running) from genuine sync errors
+(#1980).
+"""
+
+import logging
+import sys
+
+from migrations.utils import add_column_if_not_exists, get_connection, table_exists
+
+logger = logging.getLogger(__name__)
+
+
+def migrate(db_url: str) -> None:
+    """Add failure_reason VARCHAR(500) to fleet_sync_jobs (#1980)."""
+    conn = get_connection(db_url)
+    cursor = conn.cursor()
+
+    if not table_exists(cursor, "fleet_sync_jobs"):
+        logger.error("fleet_sync_jobs table does not exist — skipping")
+        conn.close()
+        return
+
+    added = add_column_if_not_exists(
+        cursor,
+        "fleet_sync_jobs",
+        "failure_reason",
+        "VARCHAR(500)",
+    )
+
+    conn.commit()
+    conn.close()
+
+    if added:
+        logger.info("Added failure_reason column to fleet_sync_jobs")
+    else:
+        logger.info("failure_reason column already present in fleet_sync_jobs")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    from migrations.runner import get_db_url
+
+    db_url = sys.argv[1] if len(sys.argv) > 1 else get_db_url()
+    logger.info("Migrating database: %s", db_url)
+    migrate(db_url)

--- a/autobot-slm-backend/migrations/runner.py
+++ b/autobot-slm-backend/migrations/runner.py
@@ -58,6 +58,8 @@ MIGRATIONS = [
     "add_node_ansible_name",
     # Issue #2011: add unique constraint on ansible_name
     "add_ansible_name_unique_constraint",
+    # Issue #1980: add failure_reason column to fleet_sync_jobs
+    "add_failure_reason_to_fleet_sync_jobs",
 ]
 
 

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -375,6 +375,7 @@ class FleetSyncJob(Base):
     total_nodes = Column(Integer, default=0)
     completed_nodes = Column(Integer, default=0)
     failed_nodes = Column(Integer, default=0)
+    failure_reason = Column(String(500), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     completed_at = Column(DateTime, nullable=True)
 

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -1639,6 +1639,7 @@ class FleetSyncJobStatus(BaseModel):
     total_nodes: int
     completed_nodes: int
     failed_nodes: int
+    failure_reason: Optional[str] = None
     nodes: List[FleetSyncNodeStatus]
     created_at: datetime
     completed_at: Optional[datetime] = None


### PR DESCRIPTION
## Summary
- Add `failure_reason` VARCHAR(500) column to `fleet_sync_jobs` table
- Populate with `"reconciled: server restarted while job was running"` for stale job cleanup
- Populate with actual error message for genuine sync failures
- Expose in `FleetSyncJobStatus` API schema
- Idempotent migration via `add_column_if_not_exists`

Closes #1980

## Test plan
- [ ] Migration adds column (idempotent, safe to re-run)
- [ ] Reconciled jobs show distinct failure_reason
- [ ] Genuine failures capture error string (truncated to 500 chars)
- [ ] API response includes failure_reason field
- [ ] flake8 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)