### PR TITLE
feat(rag): wire staleness propagation into reindexing and reranking (#2547)

### DIFF
--- a/autobot-backend/knowledge/search_components/reranking.py
+++ b/autobot-backend/knowledge/search_components/reranking.py
@@ -250,6 +250,7 @@ class ResultReranker:
         results: List[Dict[str, Any]],
         scores: list,
         weights: Optional[RerankWeights] = None,
+        staleness_map: Optional[Dict[str, float]] = None,
     ) -> None:
         """Apply rerank scores to results.
 
@@ -259,21 +260,75 @@ class ResultReranker:
         similarity score instead of overwriting it.
         Issue #2004: Blend is now driven by compute_blended_score() so
         caller-supplied weights replace the former hardcoded 0.8/0.2 split.
+        Issue #2547: staleness_map supplies pre-fetched per-result staleness
+        scores so the penalty is applied without blocking the event loop.
+
+        Args:
+            results:       Result dicts to score in-place.
+            scores:        Raw cross-encoder logits aligned with results.
+            weights:       Optional blend weights (defaults to RerankWeights()).
+            staleness_map: Optional {chunk_id: staleness_score} pre-fetched by
+                           the async caller.  When None or staleness weight is 0,
+                           the penalty term is skipped.
         """
         effective_weights = weights if weights is not None else RerankWeights()
+        use_staleness = effective_weights.staleness > 0.0 and staleness_map is not None
         for i, result in enumerate(results):
             # Sigmoid: raw logits → 0-1 probability
             normalized = 1.0 / (1.0 + math.exp(-float(scores[i])))
             original_score = result.get("score", 0)
             result["original_score"] = original_score
+
+            penalty = 1.0  # default: no penalty (fresh document)
+            if use_staleness:
+                chunk_id = result.get("chunk_id") or result.get("id", "")
+                raw_staleness = staleness_map.get(chunk_id, 0.0)  # type: ignore[union-attr]
+                penalty = staleness_penalty(raw_staleness)
+
             result["rerank_score"] = compute_blended_score(
                 reranker_score=normalized,
                 vector_score=original_score,
+                staleness_penalty_value=penalty,
                 weights=effective_weights,
             )
         results.sort(key=lambda x: x.get("rerank_score", 0), reverse=True)
         for result in results:
             result["score"] = result.get("rerank_score", 0)
+
+    async def _fetch_staleness_map(
+        self,
+        results: List[Dict[str, Any]],
+        weights: RerankWeights,
+    ) -> Optional[Dict[str, float]]:
+        """Fetch staleness scores from Redis for all result chunk IDs.
+
+        Issue #2547: Pre-fetches scores asynchronously so _apply_rerank_scores()
+        can remain synchronous.  Returns None when staleness weight is disabled
+        (0.0) or when the Redis client is unavailable.
+
+        Args:
+            results: Result dicts; each should have a ``chunk_id`` or ``id`` key.
+            weights: Blend weights; staleness lookup is skipped when weight == 0.
+
+        Returns:
+            Dict mapping chunk_id -> staleness_score, or None.
+        """
+        if weights.staleness == 0.0:
+            return None
+        try:
+            from autobot_shared.redis_client import get_redis_client
+            from services.mesh_brain.staleness_propagator import get_staleness_score
+
+            redis = get_redis_client(async_client=True, database="main")
+            staleness_map: Dict[str, float] = {}
+            for result in results:
+                chunk_id = result.get("chunk_id") or result.get("id", "")
+                if chunk_id and chunk_id not in staleness_map:
+                    staleness_map[chunk_id] = await get_staleness_score(redis, chunk_id)
+            return staleness_map
+        except Exception as exc:
+            logger.warning("Could not fetch staleness scores: %s", exc)
+            return None
 
     async def rerank(
         self,
@@ -288,6 +343,8 @@ class ResultReranker:
         Issue #281 refactor.
         Issue #2004: Optional weights parameter forwards blend configuration
         to _apply_rerank_scores(); defaults to RerankWeights() (0.8/0.2).
+        Issue #2547: When RerankWeights.staleness > 0 a Redis lookup populates
+        the staleness penalty for each result before blending.
 
         Args:
             query:   Search query.
@@ -308,13 +365,20 @@ class ResultReranker:
             if not results:
                 return results
 
+            effective_weights = weights if weights is not None else RerankWeights()
+
+            # Issue #2547: pre-fetch staleness scores asynchronously before the
+            # synchronous scoring loop runs.
+            staleness_map = await self._fetch_staleness_map(results, effective_weights)
+
             cross_encoder = await self._ensure_cross_encoder()
             pairs = [(query, r.get("content", "")) for r in results]
             scores = await asyncio.to_thread(cross_encoder.predict, pairs)
-            self._apply_rerank_scores(results, scores, weights=weights)
+            self._apply_rerank_scores(
+                results, scores, weights=effective_weights, staleness_map=staleness_map
+            )
 
             # Issue #2090: optional MMR diversity pass after cross-encoder scoring
-            effective_weights = weights if weights is not None else RerankWeights()
             if effective_weights.mmr_lambda > 0.0:
                 results = apply_mmr_reorder(results, effective_weights.mmr_lambda)
 

--- a/autobot-backend/services/documentation_watcher.py
+++ b/autobot-backend/services/documentation_watcher.py
@@ -244,6 +244,8 @@ class DocumentationWatcherService:
         Handle a file creation or modification via DocIndexerService.
 
         Issue #1385: Uses ChromaDB-based DocIndexerService instead of Redis KB.
+        Issue #2547: After successful indexing, propagate staleness through the
+        mesh graph and enqueue affected nodes for re-embedding.
 
         Args:
             file_path: Path to the updated file
@@ -262,6 +264,8 @@ class DocumentationWatcherService:
 
             if result.success > 0:
                 logger.info("Reindexed documentation: %s", file_path.name)
+                doc_id = str(file_path.relative_to(PROJECT_ROOT))
+                await self._propagate_staleness_for_doc(doc_id)
             elif result.skipped > 0:
                 logger.debug("File unchanged, skipped: %s", file_path.name)
             else:
@@ -274,6 +278,40 @@ class DocumentationWatcherService:
         except Exception as e:
             logger.error("Error updating documentation %s: %s", file_path, e)
             raise
+
+    async def _propagate_staleness_for_doc(self, doc_id: str) -> None:
+        """Propagate staleness scores from a re-indexed document through the mesh graph.
+
+        Issue #2547: Reads mesh edges from Redis, runs BFS propagation, stores scores,
+        and enqueues strongly-affected nodes for re-embedding.
+
+        Args:
+            doc_id: Relative path used as the node identifier in the mesh graph.
+        """
+        try:
+            from autobot_shared.redis_client import get_redis_client
+            from services.mesh_brain.staleness_propagator import (
+                RedisGraphAdapter,
+                enqueue_for_reembedding,
+                propagate_staleness,
+                store_staleness_scores,
+            )
+
+            redis = get_redis_client(async_client=True, database="main")
+            graph = RedisGraphAdapter(redis)
+            staleness_result = await propagate_staleness(graph, doc_id)
+            stored = await store_staleness_scores(redis, staleness_result.scores)
+            flagged = staleness_result.flagged_for_reembedding()
+            enqueued = await enqueue_for_reembedding(redis, flagged)
+            logger.info(
+                "Staleness propagation for %s: %d scores stored, %d nodes enqueued for re-embedding",
+                doc_id,
+                stored,
+                enqueued,
+            )
+        except Exception as exc:
+            # Staleness propagation is best-effort; a failure must not break indexing.
+            logger.warning("Staleness propagation failed for %s: %s", doc_id, exc)
 
     async def _handle_deletion(self, file_path: Path) -> None:
         """

--- a/autobot-backend/services/documentation_watcher_staleness_test.py
+++ b/autobot-backend/services/documentation_watcher_staleness_test.py
@@ -1,0 +1,168 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for staleness propagation wired into DocumentationWatcherService (#2547).
+
+Covers:
+- _propagate_staleness_for_doc() triggers propagation, store, and enqueue
+- _propagate_staleness_for_doc() swallows errors to avoid breaking indexing
+- _handle_update() calls _propagate_staleness_for_doc() on successful indexing
+- _handle_update() does NOT call _propagate_staleness_for_doc() on skip/failure
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.documentation_watcher import DocumentationWatcherService
+
+
+# =============================================================================
+# _propagate_staleness_for_doc
+# =============================================================================
+
+
+class TestPropagateStalnessForDoc:
+    """Unit tests for _propagate_staleness_for_doc."""
+
+    @pytest.mark.asyncio
+    async def test_propagation_calls_all_three_steps(self):
+        """On success: propagate, store, and enqueue are all called."""
+        watcher = DocumentationWatcherService()
+
+        mock_redis = AsyncMock()
+        mock_graph = MagicMock()
+        mock_staleness_result = MagicMock()
+        mock_staleness_result.scores = {"source": 1.0, "neighbor": 0.6}
+        mock_staleness_result.flagged_for_reembedding = MagicMock(return_value=["neighbor"])
+
+        with (
+            patch("autobot_shared.redis_client.get_redis_client", return_value=mock_redis),
+            patch(
+                "services.mesh_brain.staleness_propagator.RedisGraphAdapter",
+                return_value=mock_graph,
+            ),
+            patch(
+                "services.mesh_brain.staleness_propagator.propagate_staleness",
+                new=AsyncMock(return_value=mock_staleness_result),
+            ),
+            patch(
+                "services.mesh_brain.staleness_propagator.store_staleness_scores",
+                new=AsyncMock(return_value=2),
+            ) as mock_store,
+            patch(
+                "services.mesh_brain.staleness_propagator.enqueue_for_reembedding",
+                new=AsyncMock(return_value=1),
+            ) as mock_enqueue,
+        ):
+            await watcher._propagate_staleness_for_doc("docs/guide.md")
+
+        mock_store.assert_awaited_once()
+        mock_enqueue.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_propagation_swallows_exceptions(self):
+        """Errors in staleness propagation do not propagate to the caller."""
+        watcher = DocumentationWatcherService()
+
+        with patch(
+            "autobot_shared.redis_client.get_redis_client",
+            side_effect=RuntimeError("Redis is down"),
+        ):
+            # Must not raise
+            await watcher._propagate_staleness_for_doc("docs/guide.md")
+
+
+# =============================================================================
+# _handle_update integration
+# =============================================================================
+
+
+class TestHandleUpdateCallsStaleness:
+    """_handle_update triggers staleness propagation only on success."""
+
+    def _make_index_result(self, success=0, skipped=0, failed=0, errors=None):
+        result = MagicMock()
+        result.success = success
+        result.skipped = skipped
+        result.failed = failed
+        result.errors = errors or []
+        return result
+
+    @pytest.mark.asyncio
+    async def test_staleness_called_on_success(self):
+        """Staleness propagation is triggered when index_file returns success > 0."""
+        watcher = DocumentationWatcherService()
+        file_path = Path("/fake/docs/guide.md")
+
+        mock_indexer = AsyncMock()
+        mock_indexer.initialize = AsyncMock(return_value=True)
+        mock_indexer.index_file = AsyncMock(return_value=self._make_index_result(success=1))
+
+        with (
+            patch(
+                "services.documentation_watcher.get_doc_indexer_service",
+                return_value=mock_indexer,
+            ),
+            patch.object(
+                watcher,
+                "_propagate_staleness_for_doc",
+                new=AsyncMock(),
+            ) as mock_propagate,
+        ):
+            await watcher._handle_update(file_path)
+
+        mock_propagate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_staleness_not_called_on_skip(self):
+        """Staleness propagation is NOT triggered when file is skipped."""
+        watcher = DocumentationWatcherService()
+        file_path = Path("/fake/docs/guide.md")
+
+        mock_indexer = AsyncMock()
+        mock_indexer.initialize = AsyncMock(return_value=True)
+        mock_indexer.index_file = AsyncMock(return_value=self._make_index_result(skipped=1))
+
+        with (
+            patch(
+                "services.documentation_watcher.get_doc_indexer_service",
+                return_value=mock_indexer,
+            ),
+            patch.object(
+                watcher,
+                "_propagate_staleness_for_doc",
+                new=AsyncMock(),
+            ) as mock_propagate,
+        ):
+            await watcher._handle_update(file_path)
+
+        mock_propagate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_staleness_not_called_on_failure(self):
+        """Staleness propagation is NOT triggered when indexing fails."""
+        watcher = DocumentationWatcherService()
+        file_path = Path("/fake/docs/guide.md")
+
+        mock_indexer = AsyncMock()
+        mock_indexer.initialize = AsyncMock(return_value=True)
+        mock_indexer.index_file = AsyncMock(
+            return_value=self._make_index_result(failed=1, errors=["some error"])
+        )
+
+        with (
+            patch(
+                "services.documentation_watcher.get_doc_indexer_service",
+                return_value=mock_indexer,
+            ),
+            patch.object(
+                watcher,
+                "_propagate_staleness_for_doc",
+                new=AsyncMock(),
+            ) as mock_propagate,
+        ):
+            await watcher._handle_update(file_path)
+
+        mock_propagate.assert_not_awaited()

--- a/autobot-backend/services/mesh_brain/staleness_integration_test.py
+++ b/autobot-backend/services/mesh_brain/staleness_integration_test.py
@@ -1,0 +1,162 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Integration tests for staleness propagation wiring (#2547).
+
+Covers:
+- RedisGraphAdapter.get_neighbors() reading from Redis sorted sets
+- enqueue_for_reembedding() pushing to mesh:reembed_queue
+- Full propagate → store → enqueue pipeline
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.mesh_brain.staleness_propagator import (
+    RedisGraphAdapter,
+    enqueue_for_reembedding,
+    propagate_staleness,
+    store_staleness_scores,
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_async_redis(zrangebyscore_result=None, rpush_result=None):
+    """Build an async Redis mock wired for staleness tests."""
+    redis = AsyncMock()
+    redis.zrangebyscore = AsyncMock(return_value=zrangebyscore_result or [])
+    redis.rpush = AsyncMock(return_value=rpush_result or 0)
+    pipe = MagicMock()
+    redis.pipeline = lambda: pipe
+    pipe.set = MagicMock()
+    pipe.execute = AsyncMock(return_value=[])
+    return redis
+
+
+# =============================================================================
+# RedisGraphAdapter
+# =============================================================================
+
+
+class TestRedisGraphAdapter:
+    """Unit tests for the Redis-backed MeshGraph adapter."""
+
+    @pytest.mark.asyncio
+    async def test_get_neighbors_decodes_bytes(self):
+        """Members returned as bytes are decoded to strings."""
+        redis = _make_async_redis(zrangebyscore_result=[(b"node-B", 0.9), (b"node-C", 0.5)])
+        adapter = RedisGraphAdapter(redis)
+
+        neighbors = await adapter.get_neighbors("node-A")
+
+        assert neighbors == [("node-B", 0.9), ("node-C", 0.5)]
+        redis.zrangebyscore.assert_awaited_once_with(
+            "mesh:edges:node-A", min=0.0, max="+inf", withscores=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_neighbors_handles_string_members(self):
+        """Members already returned as strings are passed through unchanged."""
+        redis = _make_async_redis(zrangebyscore_result=[("node-B", 0.7)])
+        adapter = RedisGraphAdapter(redis)
+
+        neighbors = await adapter.get_neighbors("node-A")
+
+        assert neighbors == [("node-B", 0.7)]
+
+    @pytest.mark.asyncio
+    async def test_get_neighbors_empty_when_no_edges(self):
+        """An isolated node returns an empty neighbor list."""
+        redis = _make_async_redis(zrangebyscore_result=[])
+        adapter = RedisGraphAdapter(redis)
+
+        neighbors = await adapter.get_neighbors("isolated")
+
+        assert neighbors == []
+
+    @pytest.mark.asyncio
+    async def test_key_format_matches_edge_sync(self):
+        """Key used is mesh:edges:{node_id}, matching MeshEdgeSync layout."""
+        redis = _make_async_redis()
+        adapter = RedisGraphAdapter(redis)
+
+        await adapter.get_neighbors("doc/readme.md")
+
+        call_args = redis.zrangebyscore.call_args
+        assert call_args[0][0] == "mesh:edges:doc/readme.md"
+
+
+# =============================================================================
+# enqueue_for_reembedding
+# =============================================================================
+
+
+class TestEnqueueForReembedding:
+    """Tests for the re-embedding work queue."""
+
+    @pytest.mark.asyncio
+    async def test_enqueues_all_node_ids(self):
+        """All provided node IDs are pushed onto mesh:reembed_queue."""
+        redis = _make_async_redis()
+        node_ids = ["doc/a.md", "doc/b.md", "doc/c.md"]
+
+        count = await enqueue_for_reembedding(redis, node_ids)
+
+        assert count == 3
+        redis.rpush.assert_awaited_once_with("mesh:reembed_queue", *node_ids)
+
+    @pytest.mark.asyncio
+    async def test_empty_list_is_noop(self):
+        """An empty node list makes no Redis calls and returns 0."""
+        redis = _make_async_redis()
+
+        count = await enqueue_for_reembedding(redis, [])
+
+        assert count == 0
+        redis.rpush.assert_not_awaited()
+
+
+# =============================================================================
+# Full pipeline: propagate → store → enqueue
+# =============================================================================
+
+
+class TestFullStalenessIntegrationPipeline:
+    """End-to-end test of the propagate → store → enqueue pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_pipeline_propagates_stores_and_enqueues(self):
+        """BFS runs over the Redis graph, scores are stored, and stale nodes queued."""
+        # Graph: source -> neighbor-B (weight 1.0)
+        # decay=0.7 → neighbor-B gets score 0.7 (above default 0.3 threshold)
+        redis = AsyncMock()
+        redis.zrangebyscore = AsyncMock(
+            side_effect=lambda key, **_: [("neighbor-B", 1.0)] if "source" in key else []
+        )
+        redis.rpush = AsyncMock(return_value=1)
+        pipe = MagicMock()
+        redis.pipeline = lambda: pipe
+        pipe.set = MagicMock()
+        pipe.execute = AsyncMock(return_value=[])
+
+        graph = RedisGraphAdapter(redis)
+        result = await propagate_staleness(graph, "source", max_depth=3, decay=0.7)
+
+        assert "source" in result.scores
+        assert "neighbor-B" in result.scores
+        assert result.scores["neighbor-B"] == pytest.approx(0.7)
+
+        stored = await store_staleness_scores(redis, result.scores)
+        assert stored == len(result.scores)
+
+        flagged = result.flagged_for_reembedding()
+        assert "neighbor-B" in flagged
+        assert "source" not in flagged
+
+        enqueued = await enqueue_for_reembedding(redis, flagged)
+        assert enqueued == len(flagged)
+        redis.rpush.assert_awaited_once_with("mesh:reembed_queue", *flagged)

--- a/autobot-backend/services/mesh_brain/staleness_propagator.py
+++ b/autobot-backend/services/mesh_brain/staleness_propagator.py
@@ -118,3 +118,56 @@ async def get_staleness_score(redis, doc_id: str) -> float:
     """
     value = await redis.get(f"mesh:staleness:{doc_id}")
     return float(value) if value else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Redis-backed MeshGraph adapter
+# ---------------------------------------------------------------------------
+
+_REEMBED_QUEUE_KEY = "mesh:reembed_queue"
+
+
+class RedisGraphAdapter:
+    """MeshGraph adapter that reads edges from the Redis sorted sets written by MeshEdgeSync.
+
+    Issue #2547: Wires propagate_staleness() to the live mesh edge data so that
+    staleness BFS uses the same graph that PPR and retrieval see.
+
+    The Redis key layout mirrors MeshEdgeSync: ``mesh:edges:{node_id}`` is a
+    sorted set where members are neighbour node-IDs and scores are edge weights.
+    """
+
+    def __init__(self, redis) -> None:
+        self._redis = redis
+
+    async def get_neighbors(self, node_id: str) -> list[tuple[str, float]]:
+        """Return [(neighbor_id, edge_weight)] from the Redis sorted set.
+
+        Uses ``zrangebyscore`` with the full weight range and returns results
+        in the same format expected by ``propagate_staleness()``.
+        """
+        key = f"mesh:edges:{node_id}"
+        raw: list[tuple[bytes, float]] = await self._redis.zrangebyscore(
+            key, min=0.0, max="+inf", withscores=True
+        )
+        return [(member.decode() if isinstance(member, bytes) else member, score) for member, score in raw]
+
+
+async def enqueue_for_reembedding(redis, node_ids: list[str]) -> int:
+    """Push node IDs flagged for re-embedding onto the Redis work queue.
+
+    Issue #2547: Background scheduler picks up ``mesh:reembed_queue`` to
+    trigger fresh embeddings for stale nodes.
+
+    Args:
+        redis: Async Redis client.
+        node_ids: Node IDs returned by ``StalenessResult.flagged_for_reembedding()``.
+
+    Returns:
+        Number of IDs enqueued.
+    """
+    if not node_ids:
+        return 0
+    await redis.rpush(_REEMBED_QUEUE_KEY, *node_ids)
+    logger.info("Enqueued %d nodes for re-embedding (key=%s)", len(node_ids), _REEMBED_QUEUE_KEY)
+    return len(node_ids)

--- a/autobot-backend/tests/knowledge/search_components/reranking_staleness_test.py
+++ b/autobot-backend/tests/knowledge/search_components/reranking_staleness_test.py
@@ -1,0 +1,237 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for staleness-aware reranking integration (#2547).
+
+Covers:
+- _apply_rerank_scores() with staleness_map applies the penalty
+- _apply_rerank_scores() without staleness_map (weight=0) is backward-compatible
+- _fetch_staleness_map() returns None when staleness weight is 0
+- rerank() integrates the staleness lookup correctly (mocked Redis)
+"""
+
+import math
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge.search_components.reranking import (
+    RerankWeights,
+    ResultReranker,
+    compute_blended_score,
+    staleness_penalty,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_result(chunk_id: str, score: float = 0.5, content: str = "text") -> dict:
+    return {"chunk_id": chunk_id, "score": score, "content": content}
+
+
+def _sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+# =============================================================================
+# staleness_penalty()
+# =============================================================================
+
+
+class TestStalenessPenalty:
+    """staleness_penalty() converts raw staleness score to a 0-1 factor."""
+
+    def test_fresh_document_no_penalty(self):
+        assert staleness_penalty(0.0) == 1.0
+
+    def test_fully_stale_document_max_penalty(self):
+        assert staleness_penalty(1.0) == 0.0
+
+    def test_midpoint(self):
+        assert staleness_penalty(0.5) == pytest.approx(0.5)
+
+    def test_clamped_at_zero(self):
+        """Scores above 1.0 are clamped to 0 penalty."""
+        assert staleness_penalty(2.0) == 0.0
+
+
+# =============================================================================
+# _apply_rerank_scores() staleness path
+# =============================================================================
+
+
+class TestApplyRerankScoresStaleness:
+    """_apply_rerank_scores applies staleness penalty when weight > 0."""
+
+    def _score_with_map(self, staleness_score: float, staleness_weight: float = 0.5) -> float:
+        """Return rerank_score for a single result with the given staleness."""
+        reranker = ResultReranker()
+        result = _make_result("doc-A", score=0.6)
+        raw_logit = 2.0
+        weights = RerankWeights(reranker=0.5, vector=0.0, staleness=staleness_weight)
+        staleness_map = {"doc-A": staleness_score}
+
+        reranker._apply_rerank_scores([result], [raw_logit], weights=weights, staleness_map=staleness_map)
+        return result["rerank_score"]
+
+    def test_fresh_doc_gets_full_penalty_factor(self):
+        """staleness=0.0 → penalty factor 1.0 → higher score than stale doc."""
+        fresh_score = self._score_with_map(0.0)
+        stale_score = self._score_with_map(1.0)
+        assert fresh_score > stale_score
+
+    def test_fully_stale_doc_reduces_score(self):
+        """staleness=1.0 applies maximum penalty (penalty factor 0.0)."""
+        reranker = ResultReranker()
+        result = _make_result("doc-A", score=0.6)
+        raw_logit = 2.0
+        weights = RerankWeights(reranker=0.5, vector=0.0, staleness=0.5)
+        staleness_map = {"doc-A": 1.0}
+
+        reranker._apply_rerank_scores([result], [raw_logit], weights=weights, staleness_map=staleness_map)
+
+        normalized = _sigmoid(raw_logit)
+        # penalty factor = staleness_penalty(1.0) = 0.0
+        expected = compute_blended_score(
+            reranker_score=normalized,
+            vector_score=0.6,
+            staleness_penalty_value=0.0,
+            weights=weights,
+        )
+        assert result["rerank_score"] == pytest.approx(expected)
+
+    def test_missing_chunk_id_treated_as_fresh(self):
+        """A result with no chunk_id in the map is treated as staleness 0."""
+        reranker = ResultReranker()
+        result = _make_result("unknown-id", score=0.5)
+        raw_logit = 1.0
+        weights = RerankWeights(reranker=0.5, vector=0.5, staleness=0.3)
+        staleness_map = {}  # empty — no entry for unknown-id
+
+        reranker._apply_rerank_scores([result], [raw_logit], weights=weights, staleness_map=staleness_map)
+
+        # Default staleness=0 → penalty factor=1.0
+        normalized = _sigmoid(raw_logit)
+        expected = compute_blended_score(
+            reranker_score=normalized,
+            vector_score=0.5,
+            staleness_penalty_value=1.0,
+            weights=weights,
+        )
+        assert result["rerank_score"] == pytest.approx(expected)
+
+    def test_staleness_weight_zero_skips_lookup(self):
+        """When staleness weight is 0, staleness_map=None is safe (no key error)."""
+        reranker = ResultReranker()
+        result = _make_result("doc-A", score=0.5)
+        raw_logit = 1.0
+        weights = RerankWeights(reranker=0.8, vector=0.2, staleness=0.0)
+
+        # No staleness_map — should not raise
+        reranker._apply_rerank_scores([result], [raw_logit], weights=weights, staleness_map=None)
+
+        assert "rerank_score" in result
+
+    def test_results_sorted_by_rerank_score_descending(self):
+        """Fresh document (lower staleness) should rank above stale one."""
+        reranker = ResultReranker()
+        fresh = _make_result("fresh", score=0.5)
+        stale = _make_result("stale", score=0.5)
+        raw_logits = [2.0, 2.0]  # equal cross-encoder scores
+        weights = RerankWeights(reranker=0.5, vector=0.0, staleness=0.5)
+        staleness_map = {"fresh": 0.0, "stale": 0.9}
+
+        results = [stale, fresh]
+        reranker._apply_rerank_scores(results, raw_logits, weights=weights, staleness_map=staleness_map)
+
+        # fresh should be first after sorting
+        assert results[0]["chunk_id"] == "fresh"
+        assert results[1]["chunk_id"] == "stale"
+
+
+# =============================================================================
+# _fetch_staleness_map()
+# =============================================================================
+
+
+class TestFetchStalenessMap:
+    """_fetch_staleness_map returns None when staleness is disabled."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_weight_zero(self):
+        """No Redis calls when staleness weight is 0."""
+        reranker = ResultReranker()
+        results = [_make_result("doc-A")]
+        weights = RerankWeights(staleness=0.0)
+
+        result = await reranker._fetch_staleness_map(results, weights)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_scores_when_weight_nonzero(self):
+        """Staleness scores are fetched from Redis when weight > 0."""
+        reranker = ResultReranker()
+        results = [_make_result("doc-A"), _make_result("doc-B")]
+        weights = RerankWeights(staleness=0.3)
+
+        mock_redis = AsyncMock()
+
+        # Patch at the source modules because _fetch_staleness_map uses lazy imports
+        with (
+            patch("autobot_shared.redis_client.get_redis_client", return_value=mock_redis),
+            patch(
+                "services.mesh_brain.staleness_propagator.get_staleness_score",
+                new=AsyncMock(side_effect=lambda r, doc_id: 0.7 if doc_id == "doc-A" else 0.0),
+            ),
+        ):
+            staleness_map = await reranker._fetch_staleness_map(results, weights)
+
+        assert staleness_map is not None
+        assert staleness_map["doc-A"] == pytest.approx(0.7)
+        assert staleness_map["doc-B"] == pytest.approx(0.0)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_redis_error(self):
+        """Redis failures degrade gracefully — returns None instead of raising."""
+        reranker = ResultReranker()
+        results = [_make_result("doc-A")]
+        weights = RerankWeights(staleness=0.3)
+
+        with patch(
+            "autobot_shared.redis_client.get_redis_client",
+            side_effect=RuntimeError("Redis unavailable"),
+        ):
+            staleness_map = await reranker._fetch_staleness_map(results, weights)
+
+        assert staleness_map is None
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_chunk_ids(self):
+        """Duplicate chunk_ids trigger only one Redis lookup each."""
+        reranker = ResultReranker()
+        results = [_make_result("doc-A"), _make_result("doc-A")]  # duplicate
+        weights = RerankWeights(staleness=0.3)
+
+        call_count = 0
+
+        async def _fake_get_staleness(redis, doc_id):
+            nonlocal call_count
+            call_count += 1
+            return 0.5
+
+        mock_redis = MagicMock()
+
+        with (
+            patch("autobot_shared.redis_client.get_redis_client", return_value=mock_redis),
+            patch(
+                "services.mesh_brain.staleness_propagator.get_staleness_score",
+                side_effect=_fake_get_staleness,
+            ),
+        ):
+            await reranker._fetch_staleness_map(results, weights)
+
+        assert call_count == 1  # deduplication ensures only one lookup


### PR DESCRIPTION
## Summary
- Hook `propagate_staleness()` into `documentation_watcher` after successful re-indexing
- Wire staleness scores into `ResultReranker` via Redis lookup + `staleness_penalty()`
- Add `RedisGraphAdapter` for live mesh graph traversal during BFS propagation
- Add `enqueue_for_reembedding()` to push flagged nodes to `mesh:reembed_queue`
- Graceful degradation: Redis errors never break indexing or reranking

Closes #2547

## Test plan
- [x] Staleness propagation triggered on doc re-index (not on skip/failure)
- [x] Reranker fetches staleness scores and applies penalty when weight > 0
- [x] Missing chunk IDs treated as fresh (penalty=1.0)
- [x] weight=0 skips Redis lookup entirely
- [x] Redis errors degrade gracefully
- [x] RedisGraphAdapter reads live mesh edges
- [x] enqueue_for_reembedding pushes to Redis list
- [x] flake8 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)