### PR TITLE
refactor(chat): simplify run_in_chat_io_executor callers — review feedback (#2958)

### DIFF
--- a/autobot-backend/chat_history/file_io.py
+++ b/autobot-backend/chat_history/file_io.py
@@ -70,13 +70,13 @@ class FileIOMixin:
     - self._periodic_memory_check(): method
     """
 
-    async def _run_in_io_executor(self, func, *args):
+    async def _run_in_io_executor(self, func, *args, **kwargs):
         """Run a function in the dedicated chat I/O thread pool.
 
         Issue #718: Uses dedicated thread pool to prevent blocking when the
         main asyncio thread pool is saturated by indexing operations.
         """
-        return await run_in_chat_io_executor(func, *args)
+        return await run_in_chat_io_executor(func, *args, **kwargs)
 
     async def _atomic_write(self, file_path: str, content: str) -> None:
         """

--- a/autobot-backend/chat_history/session.py
+++ b/autobot-backend/chat_history/session.py
@@ -12,7 +12,6 @@ Provides session management for chat history:
 - Session listing and updates
 """
 
-import functools
 import json
 import logging
 import os
@@ -448,7 +447,7 @@ class SessionMixin:
         """
         dir_exists = await run_in_chat_io_executor(os.path.exists, chats_directory)
         if not dir_exists:
-            await run_in_chat_io_executor(functools.partial(os.makedirs, chats_directory, exist_ok=True))
+            await run_in_chat_io_executor(os.makedirs, chats_directory, exist_ok=True)
 
     def _build_session_chat_data(
         self,

--- a/autobot-backend/chat_history/session_listing.py
+++ b/autobot-backend/chat_history/session_listing.py
@@ -13,7 +13,6 @@ Issue #718: Uses dedicated thread pool for file I/O to prevent blocking
 when the main asyncio thread pool is saturated by indexing operations.
 """
 
-import functools
 import json
 import logging
 import os
@@ -80,7 +79,7 @@ class SessionListingMixin:
         """
         dir_exists = await run_in_chat_io_executor(os.path.exists, chats_directory)
         if not dir_exists:
-            await run_in_chat_io_executor(functools.partial(os.makedirs, chats_directory, exist_ok=True))
+            await run_in_chat_io_executor(os.makedirs, chats_directory, exist_ok=True)
             return False
         return True
 
@@ -219,9 +218,7 @@ class SessionListingMixin:
             # Ensure chats directory exists
             dir_exists = await run_in_chat_io_executor(os.path.exists, chats_directory)
             if not dir_exists:
-                await run_in_chat_io_executor(
-                    functools.partial(os.makedirs, chats_directory, exist_ok=True)
-                )
+                await run_in_chat_io_executor(os.makedirs, chats_directory, exist_ok=True)
                 return sessions
 
             # Process each chat file


### PR DESCRIPTION
## Summary
Follow-up to PR #2964 based on code review feedback:
- Removed redundant `functools.partial` wrapping from callers — they now pass kwargs directly to `run_in_chat_io_executor()`
- Removed unused `import functools` from `session.py` and `session_listing.py`
- Updated `_run_in_io_executor` to forward `**kwargs` for consistency

Relates to #2958

## Test plan
- [ ] Chat session listing works without errors
- [ ] Chat session saving works
- [ ] No import errors from removed `functools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)