### PR TITLE
feat(shared): add multi-tier alert cooldown system (#1948)

### DIFF
--- a/autobot-shared/alert_cooldown.py
+++ b/autobot-shared/alert_cooldown.py
@@ -1,0 +1,346 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Multi-tier Alert Cooldown System (Issue #1948)
+==============================================
+
+Prevents notification fatigue through three complementary mechanisms:
+
+1. **Tier-based rate limiting** — each tier has a per-hour send budget.
+2. **Per-alert cooldown** — a successfully sent alert cannot re-fire until
+   its tier-specific cooldown window expires.
+3. **Progressive suppression** — recurring alerts (same semantic fingerprint)
+   experience an exponentially increasing cooldown: 0 h → 6 h → 12 h → 24 h.
+
+Tier overview
+-------------
+- FLASH    (critical)  — 6 sends / hour,  5-minute base cooldown
+- PRIORITY (warning)   — 4 sends / hour, 30-minute base cooldown
+- ROUTINE  (info)      — 2 sends / hour, 60-minute base cooldown
+
+Semantic deduplication
+----------------------
+Alert text is normalised before fingerprinting:
+  - leading/trailing whitespace stripped
+  - numeric tokens replaced with ``<N>``
+  - ISO-8601-like timestamps removed
+  - whitespace collapsed to single space
+
+The resulting string is SHA-256 hashed.  Two alerts that differ only in
+a counter or timestamp therefore share the same fingerprint and are
+treated as identical for cooldown / suppression purposes.
+
+Redis key layout
+----------------
+- ``alerts:cooldown:{tier}:{hash}``  — TTL set to the active cooldown window;
+  value is the recurrence count (used for progressive suppression).
+- ``alerts:rate:{tier}:{window_ts}`` — integer counter for the current
+  one-hour window; expires automatically when the window rolls over.
+
+Usage
+-----
+    from autobot_shared.alert_cooldown import AlertCooldownManager, AlertTier
+
+    mgr = AlertCooldownManager()
+
+    if mgr.should_send("Disk usage at 95% on node-3", AlertTier.FLASH):
+        send_alert(...)
+        mgr.record_sent("Disk usage at 95% on node-3", AlertTier.FLASH)
+"""
+
+import hashlib
+import logging
+import re
+import time
+from enum import Enum
+from autobot_shared.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_RATE_WINDOW_SECONDS = 3600  # 1-hour sliding window for rate limits
+
+# Progressive suppression cooldown schedule (in seconds).
+# Index = recurrence count (0-based); last entry is the cap.
+_PROGRESSIVE_COOLDOWNS = [
+    0,          # 0 h — first recurrence: use tier base cooldown only
+    6 * 3600,   # 6 h
+    12 * 3600,  # 12 h
+    24 * 3600,  # 24 h — cap
+]
+
+
+# ---------------------------------------------------------------------------
+# AlertTier enum
+# ---------------------------------------------------------------------------
+
+
+class AlertTier(Enum):
+    """Alert severity tier with embedded rate-limit and cooldown config.
+
+    Attributes:
+        max_per_hour: Maximum number of sends allowed within a rolling hour.
+        base_cooldown_seconds: Minimum quiet period after the first send.
+    """
+
+    FLASH = ("flash", 6, 5 * 60)       # critical — 6/hr, 5 min cooldown
+    PRIORITY = ("priority", 4, 30 * 60)  # warning  — 4/hr, 30 min cooldown
+    ROUTINE = ("routine", 2, 60 * 60)   # info     — 2/hr, 60 min cooldown
+
+    def __init__(self, tier_name: str, max_per_hour: int, base_cooldown_seconds: int):
+        self.tier_name = tier_name
+        self.max_per_hour = max_per_hour
+        self.base_cooldown_seconds = base_cooldown_seconds
+
+
+# ---------------------------------------------------------------------------
+# AlertCooldownManager
+# ---------------------------------------------------------------------------
+
+
+class AlertCooldownManager:
+    """Manages multi-tier alert cooldown, rate limiting, and progressive suppression.
+
+    All state is persisted in Redis so the manager is stateless across
+    restarts and safe to use from multiple processes simultaneously.
+
+    Args:
+        database: Redis logical database name (default: ``"main"``).
+    """
+
+    def __init__(self, database: str = "main") -> None:
+        self._database = database
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def should_send(self, alert_text: str, tier: AlertTier) -> bool:
+        """Return True if the alert passes all cooldown and rate-limit checks.
+
+        Checks (in order, short-circuiting):
+        1. Per-tier rate limit (hourly budget).
+        2. Per-alert cooldown (is the key still live in Redis?).
+
+        Args:
+            alert_text: Human-readable alert message.
+            tier: The severity tier governing limits.
+
+        Returns:
+            True when the alert should be forwarded; False when suppressed.
+        """
+        fingerprint = _fingerprint(alert_text)
+        redis_client = self._get_client()
+        if redis_client is None:
+            # If Redis is unavailable, allow the alert through (fail-open).
+            logger.warning(
+                "alert_cooldown: Redis unavailable — allowing alert through (fail-open). "
+                "tier=%s fingerprint=%s",
+                tier.tier_name,
+                fingerprint,
+            )
+            return True
+
+        if self._rate_limit_exceeded(redis_client, tier):
+            logger.debug(
+                "alert_cooldown: rate limit exceeded — suppressing. tier=%s fingerprint=%s",
+                tier.tier_name,
+                fingerprint,
+            )
+            return False
+
+        if self._in_cooldown(redis_client, tier, fingerprint):
+            logger.debug(
+                "alert_cooldown: in cooldown — suppressing. tier=%s fingerprint=%s",
+                tier.tier_name,
+                fingerprint,
+            )
+            return False
+
+        return True
+
+    def record_sent(self, alert_text: str, tier: AlertTier) -> None:
+        """Record that an alert was sent, updating rate counters and cooldown keys.
+
+        Must be called immediately after the alert is dispatched so that
+        subsequent calls to :meth:`should_send` reflect the new state.
+
+        Args:
+            alert_text: The same message passed to :meth:`should_send`.
+            tier: The same tier passed to :meth:`should_send`.
+        """
+        fingerprint = _fingerprint(alert_text)
+        redis_client = self._get_client()
+        if redis_client is None:
+            logger.warning(
+                "alert_cooldown: Redis unavailable — cannot record sent alert. "
+                "tier=%s fingerprint=%s",
+                tier.tier_name,
+                fingerprint,
+            )
+            return
+
+        self._increment_rate_counter(redis_client, tier)
+        self._set_cooldown(redis_client, tier, fingerprint)
+        logger.debug(
+            "alert_cooldown: recorded sent alert. tier=%s fingerprint=%s",
+            tier.tier_name,
+            fingerprint,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers — rate limiting
+    # ------------------------------------------------------------------
+
+    def _rate_window_key(self, tier: AlertTier) -> str:
+        """Redis key for the current one-hour rate window."""
+        window_ts = int(time.time()) // _RATE_WINDOW_SECONDS
+        return f"alerts:rate:{tier.tier_name}:{window_ts}"
+
+    def _rate_limit_exceeded(self, redis_client, tier: AlertTier) -> bool:
+        """Return True if the tier's hourly send budget is exhausted."""
+        key = self._rate_window_key(tier)
+        raw = redis_client.get(key)
+        if raw is None:
+            return False
+        return int(raw) >= tier.max_per_hour
+
+    def _increment_rate_counter(self, redis_client, tier: AlertTier) -> None:
+        """Increment the hourly rate counter, setting a TTL on first write."""
+        key = self._rate_window_key(tier)
+        pipe = redis_client.pipeline()
+        pipe.incr(key)
+        # TTL slightly longer than window to handle boundary edge-cases.
+        pipe.expire(key, _RATE_WINDOW_SECONDS + 60)
+        pipe.execute()
+
+    # ------------------------------------------------------------------
+    # Internal helpers — cooldown
+    # ------------------------------------------------------------------
+
+    def _cooldown_key(self, tier: AlertTier, fingerprint: str) -> str:
+        """Redis key for the per-alert cooldown entry."""
+        return f"alerts:cooldown:{tier.tier_name}:{fingerprint}"
+
+    def _in_cooldown(self, redis_client, tier: AlertTier, fingerprint: str) -> bool:
+        """Return True if the cooldown key is still alive in Redis."""
+        key = self._cooldown_key(tier, fingerprint)
+        return redis_client.exists(key) == 1
+
+    def _set_cooldown(self, redis_client, tier: AlertTier, fingerprint: str) -> None:
+        """Write (or refresh) the cooldown key with the appropriate TTL.
+
+        The TTL is the maximum of the tier's base cooldown and the
+        progressive suppression schedule determined by the recurrence count.
+        """
+        key = self._cooldown_key(tier, fingerprint)
+        recurrence = _get_and_increment_recurrence(redis_client, key)
+        ttl = _resolve_cooldown_ttl(tier, recurrence)
+        # Store recurrence count so future calls can escalate the suppression.
+        redis_client.set(key, recurrence + 1, ex=ttl)
+        logger.debug(
+            "alert_cooldown: set cooldown. tier=%s fingerprint=%s recurrence=%d ttl=%ds",
+            tier.tier_name,
+            fingerprint,
+            recurrence,
+            ttl,
+        )
+
+    # ------------------------------------------------------------------
+    # Redis client helper
+    # ------------------------------------------------------------------
+
+    def _get_client(self):
+        """Return a synchronous Redis client, or None on failure."""
+        try:
+            return get_redis_client(async_client=False, database=self._database)
+        except Exception as exc:
+            logger.error("alert_cooldown: failed to obtain Redis client: %s", exc)
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalise(text: str) -> str:
+    """Normalise alert text for semantic fingerprinting.
+
+    Strips timestamps and numeric tokens so that alerts differing only in
+    a counter value or wall-clock time are treated as identical.
+
+    Args:
+        text: Raw alert message.
+
+    Returns:
+        Normalised string suitable for hashing.
+    """
+    # Remove ISO-8601-like timestamps (e.g. 2025-03-31T12:00:00, 2025-03-31 12:00:00)
+    text = re.sub(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?", "", text)
+    # Replace remaining numeric tokens with a placeholder
+    text = re.sub(r"\b\d+(?:\.\d+)?\b", "<N>", text)
+    # Collapse whitespace
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _fingerprint(text: str) -> str:
+    """Return the SHA-256 hex digest of the normalised alert text.
+
+    Args:
+        text: Raw alert message.
+
+    Returns:
+        64-character lowercase hex string.
+    """
+    normalised = _normalise(text)
+    return hashlib.sha256(normalised.encode("utf-8")).hexdigest()
+
+
+def _get_and_increment_recurrence(redis_client, cooldown_key: str) -> int:
+    """Read the existing recurrence count from the cooldown key (0 if absent).
+
+    The value stored in the cooldown key is the recurrence count from the
+    *previous* send.  We read it here before overwriting with the new count
+    in :meth:`AlertCooldownManager._set_cooldown`.
+
+    Args:
+        redis_client: Synchronous Redis client.
+        cooldown_key: The full Redis key for the cooldown entry.
+
+    Returns:
+        Current recurrence count (0 for the very first send).
+    """
+    raw = redis_client.get(cooldown_key)
+    if raw is None:
+        return 0
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return 0
+
+
+def _resolve_cooldown_ttl(tier: AlertTier, recurrence: int) -> int:
+    """Calculate the TTL (seconds) for the cooldown key.
+
+    Combines the tier's base cooldown with the progressive suppression
+    schedule.  The result is the *maximum* of the two so that the base
+    cooldown is always respected even on the first recurrence.
+
+    Args:
+        tier: The alert tier (carries base_cooldown_seconds).
+        recurrence: Zero-based count of how many times this fingerprint
+                    has been sent previously.
+
+    Returns:
+        TTL in seconds (always >= tier.base_cooldown_seconds).
+    """
+    # Clamp recurrence to the last schedule entry.
+    schedule_index = min(recurrence, len(_PROGRESSIVE_COOLDOWNS) - 1)
+    progressive_ttl = _PROGRESSIVE_COOLDOWNS[schedule_index]
+    return max(tier.base_cooldown_seconds, progressive_ttl)

--- a/autobot-shared/alert_cooldown_test.py
+++ b/autobot-shared/alert_cooldown_test.py
@@ -1,0 +1,364 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for the multi-tier alert cooldown system (Issue #1948).
+
+Uses a stub ``autobot_shared.redis_client`` injected before the module under
+test is imported — the same pattern used by ``message_bus_test.py`` — so a
+live Redis connection is never required.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# Install redis_client stub BEFORE importing alert_cooldown
+# ---------------------------------------------------------------------------
+
+
+def _install_redis_stub():
+    """Inject a fake autobot_shared.redis_client into sys.modules."""
+    mod_name = "autobot_shared.redis_client"
+    if mod_name in sys.modules:
+        return
+    stub = types.ModuleType(mod_name)
+    stub.get_redis_client = MagicMock(name="stub_get_redis_client")
+    sys.modules[mod_name] = stub
+
+
+_install_redis_stub()
+
+# Safe to import now
+from autobot_shared.alert_cooldown import (  # noqa: E402
+    AlertCooldownManager,
+    AlertTier,
+    _fingerprint,
+    _normalise,
+    _resolve_cooldown_ttl,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_redis(*, rate_count: int = 0, cooldown_exists: bool = False, stored_recurrence: int = 0):
+    """Return a mock synchronous Redis client with configurable state.
+
+    Args:
+        rate_count: Value returned by ``get()`` for the rate key (0 means
+                    no existing counter, treated as None by the manager).
+        cooldown_exists: Whether ``exists()`` returns 1 for the cooldown key.
+        stored_recurrence: Value returned by ``get()`` for the cooldown key
+                           (used when reading existing recurrence count).
+    """
+    client = MagicMock()
+
+    # pipeline().execute() used by _increment_rate_counter
+    pipe = MagicMock()
+    pipe.incr = MagicMock()
+    pipe.expire = MagicMock()
+    pipe.execute = MagicMock(return_value=[1, True])
+    client.pipeline = MagicMock(return_value=pipe)
+
+    # Rate-counter GET — None means "no sends yet"
+    rate_raw = str(rate_count).encode() if rate_count > 0 else None
+
+    # Cooldown GET — returns recurrence if key exists, else None
+    cooldown_raw = str(stored_recurrence).encode() if cooldown_exists else None
+
+    def _side_effect_get(key):
+        if key.startswith("alerts:rate:"):
+            return rate_raw
+        if key.startswith("alerts:cooldown:"):
+            return cooldown_raw
+        return None
+
+    client.get = MagicMock(side_effect=_side_effect_get)
+    client.exists = MagicMock(return_value=1 if cooldown_exists else 0)
+    client.set = MagicMock(return_value=True)
+
+    return client
+
+
+def _make_manager(redis_client) -> AlertCooldownManager:
+    """Return an AlertCooldownManager whose _get_client() returns the supplied mock."""
+    mgr = AlertCooldownManager()
+    mgr._get_client = MagicMock(return_value=redis_client)
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# Tests — semantic normalisation & fingerprinting
+# ---------------------------------------------------------------------------
+
+
+class TestNormalise:
+    def test_strips_leading_trailing_whitespace(self):
+        assert _normalise("  hello world  ") == "hello world"
+
+    def test_replaces_integers(self):
+        assert _normalise("Disk at 95%") == "Disk at <N>%"
+
+    def test_replaces_floats(self):
+        assert _normalise("Load: 1.23") == "Load: <N>"
+
+    def test_removes_iso_timestamp_with_T(self):
+        result = _normalise("Error at 2025-03-31T12:00:00Z on node-3")
+        assert "2025" not in result
+        assert "12:00" not in result
+
+    def test_removes_iso_timestamp_with_space(self):
+        result = _normalise("Error at 2025-03-31 12:00:00 on host")
+        assert "2025" not in result
+
+    def test_collapses_whitespace(self):
+        assert _normalise("a   b\tc") == "a b c"
+
+    def test_similar_alerts_same_fingerprint(self):
+        """Two alerts differing only in a counter produce the same fingerprint."""
+        fp1 = _fingerprint("Disk usage at 95% on node-3")
+        fp2 = _fingerprint("Disk usage at 96% on node-3")
+        assert fp1 == fp2
+
+    def test_different_alerts_different_fingerprint(self):
+        fp1 = _fingerprint("Disk usage at 95%")
+        fp2 = _fingerprint("CPU usage at 95%")
+        assert fp1 != fp2
+
+    def test_fingerprint_is_64_char_hex(self):
+        fp = _fingerprint("any alert text")
+        assert len(fp) == 64
+        assert all(c in "0123456789abcdef" for c in fp)
+
+    def test_timestamp_alerts_same_fingerprint(self):
+        """Alerts identical except for timestamp share a fingerprint."""
+        fp1 = _fingerprint("Job failed at 2025-01-01T00:00:00Z")
+        fp2 = _fingerprint("Job failed at 2025-06-15T09:30:00Z")
+        assert fp1 == fp2
+
+
+# ---------------------------------------------------------------------------
+# Tests — progressive cooldown TTL resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCooldownTtl:
+    def test_first_send_uses_base_cooldown(self):
+        """Recurrence 0: progressive schedule gives 0 h, so base cooldown wins."""
+        ttl = _resolve_cooldown_ttl(AlertTier.FLASH, recurrence=0)
+        assert ttl == AlertTier.FLASH.base_cooldown_seconds  # 300 s
+
+    def test_second_send_uses_6h(self):
+        """Recurrence 1 → 6 h, which exceeds FLASH base (5 min)."""
+        ttl = _resolve_cooldown_ttl(AlertTier.FLASH, recurrence=1)
+        assert ttl == 6 * 3600
+
+    def test_third_send_uses_12h(self):
+        ttl = _resolve_cooldown_ttl(AlertTier.FLASH, recurrence=2)
+        assert ttl == 12 * 3600
+
+    def test_fourth_and_beyond_capped_at_24h(self):
+        ttl = _resolve_cooldown_ttl(AlertTier.FLASH, recurrence=3)
+        assert ttl == 24 * 3600
+        ttl_high = _resolve_cooldown_ttl(AlertTier.FLASH, recurrence=99)
+        assert ttl_high == 24 * 3600
+
+    def test_routine_base_wins_over_zero_schedule(self):
+        """ROUTINE has a 60-min base; recurrence 0 schedule is 0 → base wins."""
+        ttl = _resolve_cooldown_ttl(AlertTier.ROUTINE, recurrence=0)
+        assert ttl == AlertTier.ROUTINE.base_cooldown_seconds  # 3600 s
+
+
+# ---------------------------------------------------------------------------
+# Tests — AlertTier enum properties
+# ---------------------------------------------------------------------------
+
+
+class TestAlertTierProperties:
+    def test_flash_rate(self):
+        assert AlertTier.FLASH.max_per_hour == 6
+        assert AlertTier.FLASH.base_cooldown_seconds == 5 * 60
+
+    def test_priority_rate(self):
+        assert AlertTier.PRIORITY.max_per_hour == 4
+        assert AlertTier.PRIORITY.base_cooldown_seconds == 30 * 60
+
+    def test_routine_rate(self):
+        assert AlertTier.ROUTINE.max_per_hour == 2
+        assert AlertTier.ROUTINE.base_cooldown_seconds == 60 * 60
+
+    def test_tier_names(self):
+        assert AlertTier.FLASH.tier_name == "flash"
+        assert AlertTier.PRIORITY.tier_name == "priority"
+        assert AlertTier.ROUTINE.tier_name == "routine"
+
+
+# ---------------------------------------------------------------------------
+# Tests — AlertCooldownManager.should_send
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSend:
+    def test_first_alert_always_passes(self):
+        """With no existing rate count and no cooldown key, alert must pass."""
+        client = _make_redis(rate_count=0, cooldown_exists=False)
+        mgr = _make_manager(client)
+        assert mgr.should_send("Service down", AlertTier.FLASH) is True
+
+    def test_suppressed_when_in_cooldown(self):
+        """If the cooldown key exists, the alert must be suppressed."""
+        client = _make_redis(cooldown_exists=True)
+        mgr = _make_manager(client)
+        assert mgr.should_send("Service down", AlertTier.FLASH) is False
+
+    def test_suppressed_when_rate_limit_reached(self):
+        """When the hourly counter equals max_per_hour, suppress the alert."""
+        client = _make_redis(rate_count=AlertTier.FLASH.max_per_hour, cooldown_exists=False)
+        mgr = _make_manager(client)
+        assert mgr.should_send("Any alert", AlertTier.FLASH) is False
+
+    def test_passes_when_rate_below_limit(self):
+        """Counter below max_per_hour and no cooldown — alert should pass."""
+        client = _make_redis(rate_count=AlertTier.FLASH.max_per_hour - 1, cooldown_exists=False)
+        mgr = _make_manager(client)
+        assert mgr.should_send("Any alert", AlertTier.FLASH) is True
+
+    def test_rate_limit_checked_before_cooldown(self):
+        """Rate limit failure short-circuits before checking cooldown."""
+        client = _make_redis(rate_count=AlertTier.PRIORITY.max_per_hour, cooldown_exists=True)
+        mgr = _make_manager(client)
+        # Both limits are hit; rate must be checked first (exists should not be called).
+        result = mgr.should_send("Alert text", AlertTier.PRIORITY)
+        assert result is False
+        client.exists.assert_not_called()
+
+    def test_different_tiers_are_independent(self):
+        """FLASH rate exhaustion must not suppress ROUTINE alerts."""
+        flash_client = _make_redis(rate_count=AlertTier.FLASH.max_per_hour)
+        routine_client = _make_redis(rate_count=0)
+
+        def tier_client(tier):
+            if tier == AlertTier.FLASH:
+                return flash_client
+            return routine_client
+
+        # Use separate manager instances to avoid shared state
+        flash_mgr = _make_manager(flash_client)
+        routine_mgr = _make_manager(routine_client)
+
+        assert flash_mgr.should_send("Disk full", AlertTier.FLASH) is False
+        assert routine_mgr.should_send("Disk full", AlertTier.ROUTINE) is True
+
+    def test_fail_open_when_redis_unavailable(self):
+        """When Redis is None, alert must be allowed through (fail-open)."""
+        mgr = AlertCooldownManager()
+        mgr._get_client = MagicMock(return_value=None)
+        assert mgr.should_send("Alert", AlertTier.FLASH) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests — AlertCooldownManager.record_sent
+# ---------------------------------------------------------------------------
+
+
+class TestRecordSent:
+    def test_increments_rate_counter(self):
+        """record_sent must call pipeline().incr() and pipeline().execute()."""
+        client = _make_redis()
+        mgr = _make_manager(client)
+        mgr.record_sent("Service down", AlertTier.FLASH)
+
+        pipe = client.pipeline.return_value
+        pipe.incr.assert_called_once()
+        pipe.expire.assert_called_once()
+        pipe.execute.assert_called_once()
+
+    def test_sets_cooldown_key(self):
+        """record_sent must call client.set() for the cooldown key."""
+        client = _make_redis()
+        mgr = _make_manager(client)
+        mgr.record_sent("Service down", AlertTier.FLASH)
+
+        assert client.set.called
+        call_args = client.set.call_args
+        key = call_args[0][0]
+        assert "alerts:cooldown:flash:" in key
+
+    def test_cooldown_ttl_matches_base_on_first_send(self):
+        """First send (recurrence 0): TTL must be tier base cooldown (300 s for FLASH)."""
+        client = _make_redis(cooldown_exists=False)
+        mgr = _make_manager(client)
+        mgr.record_sent("Service down", AlertTier.FLASH)
+
+        call_kwargs = client.set.call_args[1]
+        assert call_kwargs.get("ex") == AlertTier.FLASH.base_cooldown_seconds
+
+    def test_cooldown_ttl_escalates_on_recurrence(self):
+        """Second send (stored recurrence=1): TTL must escalate to 6 h."""
+        client = _make_redis(cooldown_exists=True, stored_recurrence=1)
+        mgr = _make_manager(client)
+        mgr.record_sent("Service down", AlertTier.FLASH)
+
+        call_kwargs = client.set.call_args[1]
+        assert call_kwargs.get("ex") == 6 * 3600
+
+    def test_no_op_when_redis_unavailable(self):
+        """record_sent must not raise when Redis is unavailable."""
+        mgr = AlertCooldownManager()
+        mgr._get_client = MagicMock(return_value=None)
+        # Should complete without raising
+        mgr.record_sent("Alert", AlertTier.ROUTINE)
+
+
+# ---------------------------------------------------------------------------
+# Tests — cooldown key namespacing
+# ---------------------------------------------------------------------------
+
+
+class TestKeyNamespacing:
+    def test_cooldown_key_format(self):
+        mgr = AlertCooldownManager()
+        fp = _fingerprint("test alert")
+        key = mgr._cooldown_key(AlertTier.FLASH, fp)
+        assert key == f"alerts:cooldown:flash:{fp}"
+
+    def test_rate_window_key_format(self):
+        import time
+
+        mgr = AlertCooldownManager()
+        key = mgr._rate_window_key(AlertTier.PRIORITY)
+        window_ts = int(time.time()) // 3600
+        assert key == f"alerts:rate:priority:{window_ts}"
+
+    def test_cooldown_keys_differ_across_tiers(self):
+        """Same fingerprint must produce different keys for different tiers."""
+        mgr = AlertCooldownManager()
+        fp = _fingerprint("same alert")
+        key_flash = mgr._cooldown_key(AlertTier.FLASH, fp)
+        key_routine = mgr._cooldown_key(AlertTier.ROUTINE, fp)
+        assert key_flash != key_routine
+
+
+# ---------------------------------------------------------------------------
+# Tests — round-trip (should_send → record_sent → should_send)
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_send_then_blocked(self):
+        """After record_sent, should_send must return False (cooldown active)."""
+        # Simulate: first check passes, then after record_sent the key exists.
+        client_before = _make_redis(rate_count=0, cooldown_exists=False)
+        mgr = _make_manager(client_before)
+
+        assert mgr.should_send("Down", AlertTier.PRIORITY) is True
+        mgr.record_sent("Down", AlertTier.PRIORITY)
+
+        # Simulate state after record_sent: cooldown key now exists.
+        client_after = _make_redis(rate_count=1, cooldown_exists=True)
+        mgr._get_client = MagicMock(return_value=client_after)
+
+        assert mgr.should_send("Down", AlertTier.PRIORITY) is False


### PR DESCRIPTION
## Summary
- Three-tier alert system: FLASH (6/hr, 5min), PRIORITY (4/hr, 30min), ROUTINE (2/hr, 60min)
- Per-alert cooldown with progressive suppression (0h → 6h → 12h → 24h)
- Semantic deduplication: normalize text + SHA-256 hash (strips timestamps/numbers)
- Redis-backed with TTL-based expiry
- Placed in `autobot-shared/` for reuse across components

Closes #1948

## Test plan
- [x] Rate limiting per tier
- [x] Cooldown enforcement
- [x] Semantic dedup (similar alerts hash to same value)
- [x] Progressive suppression escalation
- [x] First alert always sends
- [x] flake8 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)