### PR TITLE
fix(npu): wire worker manager injection, safe failover, error propagation (#2985)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -937,6 +937,33 @@ async def _init_orchestrator(app: FastAPI) -> None:
         app.state.orchestrator = None
 
 
+async def _wire_npu_task_queue() -> None:
+    """Wire NPUWorkerManager into the global TaskQueue for per-worker task tracking (#2985).
+
+    TaskQueue._worker_loop already calls assign_task_to_worker / release_worker_task
+    behind an ``if self.npu_worker_manager is not None:`` guard, but the attribute was
+    never set to an actual instance — making all tracking code dead (#2944).  This helper
+    runs during Phase 2 (non-critical) so that startup is never blocked by NPU issues.
+    """
+    logger.info("[ 98%%] NPU Task Queue: Wiring NPUWorkerManager into TaskQueue...")
+    try:
+        from autobot_shared.redis_client import get_redis_client
+        from services.npu_worker_manager import get_worker_manager
+        from utils.task_queue import get_task_queue
+
+        redis_client = get_redis_client(async_client=True, database="main")
+        worker_manager = await get_worker_manager(redis_client=redis_client)
+        task_queue = get_task_queue()
+        task_queue.npu_worker_manager = worker_manager
+        logger.info(
+            "[ 98%%] NPU Task Queue: NPUWorkerManager wired — per-worker task tracking active"
+        )
+    except Exception as e:
+        logger.warning(
+            "NPU task queue wiring failed (per-worker tracking disabled): %s", e
+        )
+
+
 async def _wire_scheduler_executor() -> None:
     """Wire the orchestration WorkflowExecutor into the global WorkflowScheduler (#2166).
 
@@ -1028,6 +1055,7 @@ async def initialize_background_services(app: FastAPI):
         await _init_process_adapter(app)
         await _init_orchestrator(app)
         await _seed_agent_registry()
+        await _wire_npu_task_queue()
         await _wire_scheduler_executor()
 
         await update_app_state_multi(

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -782,6 +782,10 @@ class NPUWorkerManager:
             logger.error(
                 "Failed to assign task %s to worker %s: %s", task_id, worker_id, e
             )
+            # Re-raise so the caller (_worker_loop) does not process the task
+            # without tracking.  An untracked task would be invisible to failover
+            # and could be silently lost on worker failure (#2985).
+            raise
 
     async def release_worker_task(
         self, queue_name: str, worker_id: str, task_id: str
@@ -834,19 +838,18 @@ class NPUWorkerManager:
 
         task_ids = await self.redis_client.smembers(worker_tasks_key)
         if not task_ids:
-            # Fallback: per-worker SET is empty (callers not yet wired or new
-            # deployment).  Conservatively migrate all tasks still in the global
-            # running ZSET so failover never silently skips migration (#2944).
-            task_ids = await self.redis_client.zrange(running_key, 0, -1)
-            if task_ids:
-                logger.warning(
-                    "Failover: per-worker SET empty for %s; falling back to "
-                    "global running ZSET (%d tasks)",
-                    worker_id,
-                    len(task_ids),
-                )
-            else:
-                logger.info("Failover: dead worker %s had no running tasks", worker_id)
+            # Per-worker SET is empty.  In a multi-worker deployment the global
+            # running ZSET contains tasks from ALL live workers, so migrating it
+            # would incorrectly steal work from healthy workers (#2985).  Instead,
+            # log a WARNING and skip migration — stale running tasks will be
+            # reclaimed by the global retry/timeout mechanism.
+            logger.warning(
+                "Failover: per-worker SET empty for %s — skipping migration to "
+                "avoid stealing tasks from other workers. Stale tasks will be "
+                "reclaimed by the global retry mechanism (#2985).",
+                worker_id,
+            )
+            task_ids = set()
         else:
             logger.info(
                 "Failover: migrating %d tasks from per-worker SET for worker %s",

--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -413,11 +413,31 @@ class TaskQueue:
                     continue
 
                 # Record task assignment in per-worker SET so failover monitor
-                # can migrate only this worker's tasks if it dies (#2944).
+                # can migrate only this worker's tasks if it dies (#2944, #2985).
                 if self.npu_worker_manager is not None:
-                    await self.npu_worker_manager.assign_task_to_worker(
-                        self.queue_name, worker_name, task_id
-                    )
+                    try:
+                        await self.npu_worker_manager.assign_task_to_worker(
+                            self.queue_name, worker_name, task_id
+                        )
+                    except Exception as assign_err:
+                        # Tracking failed: move the task back to pending so
+                        # another worker can pick it up with tracking intact.
+                        # Processing without tracking would make this task
+                        # invisible to failover and silently lost on crash (#2985).
+                        self.logger.error(
+                            "Worker %s: task tracking failed for %s, "
+                            "returning task to pending queue: %s",
+                            worker_name,
+                            task_id,
+                            assign_err,
+                        )
+                        if self.redis:
+                            await self.redis.zrem(self.running_key, task_id)
+                            await self.redis.zadd(
+                                self.pending_key, {task_id: time.time()}
+                            )
+                        await asyncio.sleep(TimingConstants.STANDARD_DELAY)
+                        continue
 
                 try:
                     # Process task


### PR DESCRIPTION
## Summary
Follow-up to PR #2970 based on code review findings:

1. **Wire injection (CRITICAL):** `TaskQueue.npu_worker_manager` was `None` everywhere — added `_wire_npu_task_queue()` in `lifespan.py` Phase 2 startup
2. **Safe failover (HIGH):** Replaced dangerous global ZSET fallback that re-queued ALL workers' tasks — now skips migration when per-worker SET is empty
3. **Error propagation (MEDIUM):** `assign_task_to_worker` re-raises on Redis failure; `_worker_loop` returns untracked tasks to pending queue

Closes #2985

## Test plan
- [ ] `_wire_npu_task_queue()` runs during startup without errors
- [ ] Per-worker SETs are populated when tasks start
- [ ] Failover skips migration when SET is empty (no task stealing)
- [ ] Redis error in assign causes task to return to pending queue
- [ ] Startup continues even if NPU wiring fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)