### PR TITLE
feat(mesh): add concrete MeshDB/MeshGraph PostgreSQL adapter (#2548)

### DIFF
--- a/autobot-backend/services/mesh_brain/mesh_db_adapter.py
+++ b/autobot-backend/services/mesh_brain/mesh_db_adapter.py
@@ -1,0 +1,124 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Concrete MeshGraph/MeshDB adapter bridging PostgreSQL mesh schema to protocol interfaces (#2548).
+
+The ``mesh_db.py`` module defines ``MeshDB`` — a full-featured async PostgreSQL client
+for the mesh tables introduced in #2055.  That class already satisfies every method
+required by the ``MeshDB`` Protocol in ``edge_learner.py``.
+
+The only gap is the ``MeshGraph`` Protocol defined in ``staleness_propagator.py``:
+
+    async def get_neighbors(self, node_id: str) -> list[tuple[str, float]]: ...
+
+``MeshDB.get_neighbors()`` returns ``list[dict]`` (with ``neighbor_id``, ``weight``, …)
+whereas ``MeshGraph.get_neighbors()`` expects ``list[tuple[str, float]]``.
+
+``MeshDBAdapter`` wraps the concrete ``MeshDB`` instance and:
+
+- Forwards all ``MeshDB`` Protocol calls (``get_edge``, ``update_edge``, ``create_edge``,
+  ``get_co_access_count``, ``update_access_count``) unchanged to the underlying client.
+- Implements ``MeshGraph.get_neighbors()`` by delegating to ``MeshDB.get_neighbors()``
+  and reshaping the result into the ``[(neighbor_id, weight)]`` tuples the BFS
+  propagator expects.
+
+Use ``create_mesh_db_adapter()`` at application startup to get an engine-wired instance.
+"""
+
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from services.mesh_brain.mesh_db import MeshDB
+
+logger = logging.getLogger(__name__)
+
+
+class MeshDBAdapter:
+    """Adapter that satisfies both the ``MeshDB`` and ``MeshGraph`` protocols (#2548).
+
+    Delegates all ``MeshDB`` operations to the wrapped ``MeshDB`` instance.
+    The only transformation applied is in ``get_neighbors()``: the dict rows
+    returned by ``MeshDB.get_neighbors()`` are projected to ``(neighbor_id, weight)``
+    tuples so the result matches the ``MeshGraph`` Protocol signature consumed by
+    ``propagate_staleness()``.
+    """
+
+    def __init__(self, db: MeshDB) -> None:
+        self._db = db
+        logger.debug("MeshDBAdapter initialised wrapping %r", db)
+
+    # ------------------------------------------------------------------
+    # MeshDB protocol — EdgeLearner surface
+    # ------------------------------------------------------------------
+
+    async def get_edge(self, node_a: str, node_b: str) -> dict | None:
+        """Return the first edge between ``node_a`` and ``node_b``, or ``None``."""
+        return await self._db.get_edge(node_a, node_b)
+
+    async def update_edge(self, edge_id: str, **kwargs) -> None:
+        """Partially update an edge's mutable fields."""
+        await self._db.update_edge(edge_id, **kwargs)
+
+    async def create_edge(self, from_node: str, to_node: str, **kwargs) -> None:
+        """Insert a new mesh edge; keyword arguments are forwarded to ``MeshDB.create_edge``."""
+        await self._db.create_edge(from_node, to_node, **kwargs)
+
+    async def get_co_access_count(self, node_a: str, node_b: str) -> int:
+        """Return the co_access_count for the edge between ``node_a`` and ``node_b``."""
+        return await self._db.get_co_access_count(node_a, node_b)
+
+    async def update_access_count(self, node_ids: list[str]) -> None:
+        """Increment access_count and set last_accessed for the given node UUIDs."""
+        await self._db.update_access_count(node_ids)
+
+    # ------------------------------------------------------------------
+    # MeshGraph protocol — StalenessPropagor surface
+    # ------------------------------------------------------------------
+
+    async def get_neighbors(self, node_id: str) -> list[tuple[str, float]]:
+        """Return ``[(neighbor_id, weight)]`` tuples for ``node_id``.
+
+        Delegates to ``MeshDB.get_neighbors()`` (returns ``list[dict]``) and
+        projects each row to the ``(neighbor_id, weight)`` tuple shape required
+        by the ``MeshGraph`` Protocol in ``staleness_propagator.py``.
+        """
+        rows = await self._db.get_neighbors(node_id, min_weight=0.0)
+        result: list[tuple[str, float]] = [
+            (row["neighbor_id"], float(row["weight"])) for row in rows
+        ]
+        logger.debug(
+            "MeshDBAdapter.get_neighbors node=%s found=%d neighbors",
+            node_id,
+            len(result),
+        )
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_mesh_db_adapter(engine: AsyncEngine) -> MeshDBAdapter:
+    """Construct a ``MeshDBAdapter`` wired to ``engine`` (#2548).
+
+    Intended to be called once at application startup, for example::
+
+        from user_management.database import get_async_engine
+        from services.mesh_brain.mesh_db_adapter import create_mesh_db_adapter
+
+        adapter = create_mesh_db_adapter(get_async_engine())
+        edge_learner = EdgeLearner(db=adapter, redis=redis_client)
+
+    Args:
+        engine: An initialised ``AsyncEngine`` for the PostgreSQL mesh database.
+
+    Returns:
+        A ``MeshDBAdapter`` instance that satisfies both ``MeshDB`` and ``MeshGraph``
+        protocols.
+    """
+    db = MeshDB(engine)
+    adapter = MeshDBAdapter(db)
+    logger.info("MeshDBAdapter created with engine %r", engine)
+    return adapter

--- a/autobot-backend/services/mesh_brain/mesh_db_adapter_test.py
+++ b/autobot-backend/services/mesh_brain/mesh_db_adapter_test.py
@@ -1,0 +1,256 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for MeshDBAdapter — concrete MeshGraph/MeshDB adapter (#2548)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.mesh_brain.mesh_db_adapter import MeshDBAdapter, create_mesh_db_adapter
+
+# ---------------------------------------------------------------------------
+# Shared test UUIDs
+# ---------------------------------------------------------------------------
+
+_NODE_A = "aaaaaaaa-0000-0000-0000-000000000001"
+_NODE_B = "bbbbbbbb-0000-0000-0000-000000000002"
+_EDGE_ID = "cccccccc-0000-0000-0000-000000000003"
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a MeshDBAdapter with a fully-mocked inner MeshDB
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(**method_returns) -> tuple["MeshDBAdapter", MagicMock]:
+    """Return ``(adapter, mock_db)`` with each key in ``method_returns`` patched.
+
+    The ``mock_db`` is a ``MagicMock`` whose async methods are ``AsyncMock``
+    instances pre-configured with the supplied return values.
+    """
+    mock_db = MagicMock()
+    for method, return_value in method_returns.items():
+        setattr(mock_db, method, AsyncMock(return_value=return_value))
+    return MeshDBAdapter(mock_db), mock_db
+
+
+# =============================================================================
+# MeshDB protocol surface
+# =============================================================================
+
+
+class TestGetEdge:
+    """MeshDBAdapter.get_edge delegates to inner MeshDB and forwards the result."""
+
+    @pytest.mark.asyncio
+    async def test_returns_dict_when_found(self):
+        edge_row = {
+            "id": _EDGE_ID,
+            "from_node": _NODE_A,
+            "to_node": _NODE_B,
+            "weight": 0.9,
+            "co_access_count": 2,
+        }
+        adapter, mock_db = _make_adapter(get_edge=edge_row)
+
+        result = await adapter.get_edge(_NODE_A, _NODE_B)
+
+        assert result == edge_row
+        mock_db.get_edge.assert_awaited_once_with(_NODE_A, _NODE_B)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_absent(self):
+        adapter, mock_db = _make_adapter(get_edge=None)
+
+        result = await adapter.get_edge(_NODE_A, _NODE_B)
+
+        assert result is None
+        mock_db.get_edge.assert_awaited_once_with(_NODE_A, _NODE_B)
+
+
+class TestUpdateEdge:
+    """MeshDBAdapter.update_edge forwards all keyword arguments to MeshDB."""
+
+    @pytest.mark.asyncio
+    async def test_forwards_kwargs(self):
+        adapter, mock_db = _make_adapter(update_edge=None)
+
+        await adapter.update_edge(_EDGE_ID, weight=0.75, co_access_count=5)
+
+        mock_db.update_edge.assert_awaited_once_with(
+            _EDGE_ID, weight=0.75, co_access_count=5
+        )
+
+
+class TestCreateEdge:
+    """MeshDBAdapter.create_edge forwards positional and keyword arguments to MeshDB."""
+
+    @pytest.mark.asyncio
+    async def test_forwards_all_args(self):
+        adapter, mock_db = _make_adapter(create_edge=_EDGE_ID)
+
+        await adapter.create_edge(
+            _NODE_A,
+            _NODE_B,
+            edge_type="CO_RETRIEVED",
+            weight=0.3,
+            origin="learner",
+        )
+
+        mock_db.create_edge.assert_awaited_once_with(
+            _NODE_A,
+            _NODE_B,
+            edge_type="CO_RETRIEVED",
+            weight=0.3,
+            origin="learner",
+        )
+
+
+class TestGetCoAccessCount:
+    """MeshDBAdapter.get_co_access_count delegates to MeshDB and returns int."""
+
+    @pytest.mark.asyncio
+    async def test_returns_count(self):
+        adapter, mock_db = _make_adapter(get_co_access_count=7)
+
+        result = await adapter.get_co_access_count(_NODE_A, _NODE_B)
+
+        assert result == 7
+        mock_db.get_co_access_count.assert_awaited_once_with(_NODE_A, _NODE_B)
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_edge(self):
+        adapter, mock_db = _make_adapter(get_co_access_count=0)
+
+        result = await adapter.get_co_access_count(_NODE_A, _NODE_B)
+
+        assert result == 0
+
+
+class TestUpdateAccessCount:
+    """MeshDBAdapter.update_access_count delegates the node_ids list to MeshDB."""
+
+    @pytest.mark.asyncio
+    async def test_forwards_node_ids(self):
+        adapter, mock_db = _make_adapter(update_access_count=None)
+
+        await adapter.update_access_count([_NODE_A, _NODE_B])
+
+        mock_db.update_access_count.assert_awaited_once_with([_NODE_A, _NODE_B])
+
+    @pytest.mark.asyncio
+    async def test_empty_list_is_forwarded(self):
+        adapter, mock_db = _make_adapter(update_access_count=None)
+
+        await adapter.update_access_count([])
+
+        mock_db.update_access_count.assert_awaited_once_with([])
+
+
+# =============================================================================
+# MeshGraph protocol surface
+# =============================================================================
+
+
+class TestGetNeighborsMeshGraph:
+    """MeshDBAdapter.get_neighbors satisfies the MeshGraph Protocol.
+
+    MeshDB.get_neighbors returns list[dict] with ``neighbor_id`` and ``weight``
+    keys.  The adapter must project these to list[tuple[str, float]] as required
+    by ``propagate_staleness()``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_projects_dicts_to_tuples(self):
+        db_rows = [
+            {"neighbor_id": _NODE_B, "weight": 0.85, "edge_type": "semantic"},
+            {"neighbor_id": _EDGE_ID, "weight": 0.60, "edge_type": "coref"},
+        ]
+        adapter, mock_db = _make_adapter(get_neighbors=db_rows)
+
+        result = await adapter.get_neighbors(_NODE_A)
+
+        assert result == [(_NODE_B, 0.85), (_EDGE_ID, 0.60)]
+        # Adapter must pass min_weight=0.0 so no edges are discarded
+        mock_db.get_neighbors.assert_awaited_once_with(_NODE_A, min_weight=0.0)
+
+    @pytest.mark.asyncio
+    async def test_empty_neighbors_returns_empty_list(self):
+        adapter, mock_db = _make_adapter(get_neighbors=[])
+
+        result = await adapter.get_neighbors(_NODE_A)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_weight_is_cast_to_float(self):
+        """Weights stored as strings in the DB (e.g. from Redis) are coerced to float."""
+        db_rows = [{"neighbor_id": _NODE_B, "weight": "0.75", "edge_type": "semantic"}]
+        adapter, mock_db = _make_adapter(get_neighbors=db_rows)
+
+        result = await adapter.get_neighbors(_NODE_A)
+
+        assert result == [(_NODE_B, 0.75)]
+        assert isinstance(result[0][1], float)
+
+    @pytest.mark.asyncio
+    async def test_single_neighbor(self):
+        db_rows = [{"neighbor_id": _NODE_B, "weight": 1.0, "edge_type": "strong"}]
+        adapter, mock_db = _make_adapter(get_neighbors=db_rows)
+
+        result = await adapter.get_neighbors(_NODE_A)
+
+        assert len(result) == 1
+        neighbor_id, weight = result[0]
+        assert neighbor_id == _NODE_B
+        assert weight == 1.0
+
+
+# =============================================================================
+# Protocol conformance — structural duck-typing
+# =============================================================================
+
+
+class TestProtocolConformance:
+    """Verify MeshDBAdapter exposes the full method surface of both protocols."""
+
+    def test_has_all_mesh_db_protocol_methods(self):
+        """All methods required by EdgeLearner's MeshDB Protocol are present."""
+        adapter = MeshDBAdapter(MagicMock())
+        for method in (
+            "get_edge",
+            "update_edge",
+            "create_edge",
+            "get_co_access_count",
+            "update_access_count",
+        ):
+            assert callable(getattr(adapter, method, None)), f"Missing method: {method}"
+
+    def test_has_all_mesh_graph_protocol_methods(self):
+        """All methods required by StalenessPropagor's MeshGraph Protocol are present."""
+        adapter = MeshDBAdapter(MagicMock())
+        assert callable(getattr(adapter, "get_neighbors", None))
+
+
+# =============================================================================
+# Factory function
+# =============================================================================
+
+
+class TestCreateMeshDbAdapter:
+    """create_mesh_db_adapter returns a ready MeshDBAdapter."""
+
+    def test_returns_mesh_db_adapter_instance(self):
+        mock_engine = MagicMock()
+        adapter = create_mesh_db_adapter(mock_engine)
+
+        assert isinstance(adapter, MeshDBAdapter)
+
+    def test_inner_db_receives_engine(self):
+        """The wrapped MeshDB instance is constructed with the supplied engine."""
+        mock_engine = MagicMock()
+        adapter = create_mesh_db_adapter(mock_engine)
+
+        # The inner MeshDB must have been given the engine
+        assert adapter._db.engine is mock_engine


### PR DESCRIPTION
## Summary
- `MeshDBAdapter` bridges both `MeshDB` and `MeshGraph` protocols with a single class
- Forwards EdgeLearner methods unchanged to inner `MeshDB`
- Projects `get_neighbors()` dicts to `(node_id, weight)` tuples for StalenessPropagor
- `create_mesh_db_adapter(engine)` factory for startup wiring
- 16 tests covering delegation, projection, protocol conformance

Closes #2548

## Test plan
- [x] All 5 MeshDB protocol methods forwarded correctly
- [x] MeshGraph.get_neighbors() projects dicts to tuples
- [x] Protocol conformance structural checks
- [x] Factory returns correct type with engine threaded through
- [x] flake8 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)