### PR TITLE
fix(config): replace hardcoded IPs in standalone script and model schema (#2983)

### DIFF
--- a/autobot-backend/models/npu_models.py
+++ b/autobot-backend/models/npu_models.py
@@ -334,7 +334,7 @@ class WorkerHeartbeat(BaseModel):
                 "worker_id": "windows_npu_worker_abc123",
                 "status": "online",
                 "platform": "windows",
-                "url": "http://192.168.168.21:8082",
+                "url": "http://127.0.0.1:8082",
                 "current_load": 1,
                 "total_tasks_completed": 42,
                 "total_tasks_failed": 2,

--- a/autobot-infrastructure/shared/scripts/slm-agent-standalone.py
+++ b/autobot-infrastructure/shared/scripts/slm-agent-standalone.py
@@ -50,7 +50,7 @@ class SLMAgent:
                 return yaml.safe_load(f)
         return {
             "node_id": os.environ.get("SLM_NODE_ID", "unknown"),
-            "admin_url": os.environ.get("SLM_ADMIN_URL", "http://172.16.168.19:8000"),
+            "admin_url": os.environ.get("SLM_ADMIN_URL", f"http://{os.environ.get('SLM_HOST', '127.0.0.1')}:8000"),
             "heartbeat_interval": int(os.environ.get("SLM_HEARTBEAT_INTERVAL", "30")),
         }
 


### PR DESCRIPTION
## Summary
- `slm-agent-standalone.py`: replaced hardcoded `172.16.168.19` fallback with `SLM_HOST` env var + `127.0.0.1` default
- `npu_models.py`: replaced `192.168.168.21` in json_schema_extra example with `127.0.0.1`

Closes #2983

## Test plan
- [ ] Standalone agent uses SLM_HOST env var when SLM_ADMIN_URL is unset
- [ ] Falls back to 127.0.0.1 safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)