### PR TITLE
fix(ansible): audit and fix 5 ignore_errors bypasses in playbooks (#2950)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-hybrid-docker.yml
@@ -378,7 +378,8 @@
         - "qwen3.5:9b"            # Quality tier
         - "nomic-embed-text"      # Embeddings
       register: ollama_pull
-      ignore_errors: yes
+      # Individual model pulls may fail due to network or availability (#2950)
+      failed_when: false
 
     - name: Wait for services to be ready
       wait_for:
@@ -499,7 +500,8 @@
             - { url: 'http://localhost:8081/health', name: 'NPU Worker' }
           'autobot-browser':
             - { url: 'http://localhost:3000/health', name: 'Browser Service' }
-      ignore_errors: yes
+      # Endpoint tests are informational; services may still be starting (#2950)
+      failed_when: false
 
     - name: Create service summary
       set_fact:

--- a/autobot-slm-backend/ansible/playbooks/fix-backend-clean-restart.yml
+++ b/autobot-slm-backend/ansible/playbooks/fix-backend-clean-restart.yml
@@ -55,7 +55,6 @@
       loop:
         - /var/run/autobot-backend.pid
         - /tmp/uvicorn.pid
-      ignore_errors: yes
 
     - name: Clear Python bytecode cache
       shell: |
@@ -71,7 +70,8 @@
         if [ -f {{ backend_log_dir }}/backend-error.log ] && [ $(stat -f%z {{ backend_log_dir }}/backend-error.log 2>/dev/null || stat -c%s {{ backend_log_dir }}/backend-error.log) -gt 104857600 ]; then
           mv {{ backend_log_dir }}/backend-error.log {{ backend_log_dir }}/backend-error.log.old
         fi
-      ignore_errors: yes
+      # Log rotation is best-effort; failure must not block restart (#2950)
+      failed_when: false
 
     # ============================================================
     # Phase 3: Verify Configuration
@@ -144,8 +144,8 @@
         url: http://localhost:8443/api/health
         timeout: 5
       register: health_check
+      # Service may still be initializing; result is used in the report below
       failed_when: false
-      ignore_errors: yes
 
     # ============================================================
     # Phase 6: Report Results

--- a/autobot-slm-backend/ansible/playbooks/remove-role.yml
+++ b/autobot-slm-backend/ansible/playbooks/remove-role.yml
@@ -128,7 +128,8 @@
         state: stopped
         enabled: false
       when: _service_file.stat.exists
-      ignore_errors: true
+      # Service may already be stopped or in a failed state during removal (#2950)
+      failed_when: false
 
     - name: "Remove {{ systemd_service }} service file"
       ansible.builtin.file:


### PR DESCRIPTION
## Summary
Follow-up to #2872 (role audit). Audited all 5 remaining `ignore_errors` in playbooks:

- `remove-role.yml`: service stop → `failed_when: false` (service may be degraded)
- `deploy-hybrid-docker.yml` x2: model pull + endpoint test → `failed_when: false` (best-effort)
- `fix-backend-clean-restart.yml`: removed from idempotent file task, converted log rotation to `failed_when: false`, removed redundant coexisting `ignore_errors`

Closes #2950

## Test plan
- [ ] `remove-role.yml` handles stopped/degraded services gracefully
- [ ] `deploy-hybrid-docker.yml` continues on model pull failures
- [ ] `fix-backend-clean-restart.yml` works with missing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)