### PR TITLE
fix(ansible): guard VNC deployment to vnc-role nodes only (#2989)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/production.yml
+++ b/autobot-slm-backend/ansible/inventory/production.yml
@@ -194,7 +194,7 @@ all:
         # AI/ML-specific configuration
         ai_stack_port: 8080
         ollama_port: 11434
-        # TTS Worker (#928, migrated from .22 — #1394)
+        # TTS Worker (#928, migrated from .22 -- #1394)
         tts_worker_port: 8082
         model_cache_size: "10gb"
         inference_threads: 4
@@ -202,7 +202,7 @@ all:
     browser:
       hosts:
         autobot-browser:
-          ansible_host: 172.16.168.25  # Browser VM
+          ansible_host: 172.16.168.25  # Browser VM - headless Playwright worker
           vm_id: "autobot-browser-vm"
           vm_role: "browser"
           vm_hostname: "autobot-browser"
@@ -210,26 +210,23 @@ all:
             ram_mb: 4096     # Test config - dynamic memory
             cpu_cores: 2
             disk_gb: 50      # LVM expansion target
+          # (#2989) .25 is a headless Playwright worker, not a VNC host.
+          # VNC desktop is on .26 (llm node with vnc role).
+          node_roles:
+            - browser
           services:
             - playwright
-            - vnc-server
-            - desktop-environment
             - browser-automation
-          desktop_features:
-            vnc_enabled: true
-            desktop_environment: "xfce4"
       vars:
         # Browser-specific configuration
         playwright_port: 3000
-        vnc_port: 5901
-        vnc_display: ":1"
         browser_timeout: 30
-        headless_mode: false
+        headless_mode: true
 
     llm:
       hosts:
         autobot-llm:
-          ansible_host: 172.16.168.26  # LLM CPU node (#1040) — also VNC desktop (#1525)
+          ansible_host: 172.16.168.26  # LLM CPU node (#1040) -- also VNC desktop (#1525)
           vm_id: "autobot-llm-vm"
           vm_role: "llm"
           vm_hostname: "autobot-llm"
@@ -346,12 +343,12 @@ ai_stack:
   children:
     aiml:
 
-# LLM inference nodes alias — used by provision-fleet-roles.yml (#1040)
+# LLM inference nodes alias -- used by provision-fleet-roles.yml (#1040)
 llm_nodes:
   children:
     llm:
 
-# VNC desktop nodes (#1525, #2407) — nodes with VNC remote desktop access
+# VNC desktop nodes (#1525, #2407) -- nodes with VNC remote desktop access
 vnc_nodes:
   children:
     llm:

--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -52,6 +52,9 @@
 
 # ============================================================
 # VNC + desktop environment (opt-in, default false)  (#1363)
+# Guard: install_vnc must be true AND node must have 'vnc' in
+# node_roles (when defined).  Prevents VNC deployment on headless
+# Playwright workers like .25.  (#2989)
 # ============================================================
 - name: "Browser | Install desktop environment and VNC"
   apt:
@@ -64,7 +67,9 @@
       - xvfb
     state: present
   become: yes
-  when: install_vnc | default(false)
+  when:
+    - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
   tags: ['browser', 'packages', 'vnc']
 
 # ============================================================
@@ -120,7 +125,7 @@
   register: _browser_worker_dir
   tags: ['browser', 'packages']
 
-# (#2872) Replaced failed_when: false with a stat guard — npm install
+# (#2872) Replaced failed_when: false with a stat guard -- npm install
 # failures on a deployed worker directory must surface.
 - name: "Browser | Install Node.js dependencies for browser worker"
   npm:
@@ -138,7 +143,9 @@
     group: autobot
     mode: '0700'
   become: yes
-  when: install_vnc | default(false)
+  when:
+    - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
   tags: ['browser', 'directories', 'vnc']
 
 - name: "Browser | Check if VNC secrets file exists"
@@ -146,7 +153,9 @@
     path: /etc/autobot/vnc-secrets.env
   register: browser_vnc_secrets_stat
   become: yes
-  when: install_vnc | default(false)
+  when:
+    - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
   tags: ['browser', 'vnc']
 
 - name: "Browser | Generate secure VNC password"
@@ -160,6 +169,7 @@
   become: yes
   when:
     - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
     - not (browser_vnc_secrets_stat.stat.exists | default(false))
   tags: ['browser', 'vnc']
 
@@ -170,7 +180,9 @@
   register: browser_vnc_password
   changed_when: false
   become: yes
-  when: install_vnc | default(false)
+  when:
+    - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
   tags: ['browser', 'vnc']
 
 - name: "Browser | Set VNC password file"
@@ -182,6 +194,7 @@
   become: yes
   when:
     - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
     - browser_vnc_password.stdout | default('') | length > 0
   tags: ['browser', 'vnc']
 
@@ -191,7 +204,9 @@
     dest: /etc/systemd/system/autobot-vnc.service
     mode: '0644'
   become: yes
-  when: install_vnc | default(false)
+  when:
+    - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
   notify:
     - reload systemd
     - restart vnc
@@ -216,7 +231,9 @@
     from_ip: "{{ network_subnet }}"
     comment: "VNC Server"
   become: yes
-  when: install_vnc | default(false)
+  when:
+    - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
   notify: reload firewall
   tags: ['browser', 'firewall', 'vnc']
 
@@ -237,7 +254,9 @@
     enabled: yes
     daemon_reload: yes
   become: yes
-  when: install_vnc | default(false)
+  when:
+    - install_vnc | default(false)
+    - node_roles is not defined or 'vnc' in node_roles
   tags: ['browser', 'service', 'vnc']
 
 - name: "Browser | Enable Playwright service"


### PR DESCRIPTION
## Summary
- Added \`node_roles is not defined or 'vnc' in node_roles\` guard to all 9 VNC-specific tasks in browser role
- Updated .25 inventory: removed VNC/desktop vars, set \`headless_mode: true\`, added explicit \`node_roles: [browser]\`
- .26 (VNC host) unaffected — already has \`node_roles: [llm, vnc]\`

Closes #2989

## Test plan
- [ ] .25 no longer gets VNC service deployed
- [ ] .26 still gets VNC service deployed (has 'vnc' in node_roles)
- [ ] Single-host deployments still work (node_roles is not defined fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)