### PR TITLE
fix(slm): move co-location detection before SLM frontend build (#3013)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -298,6 +298,23 @@
   tags: ['slm', 'backend', 'systemd']
 
 # ==========================================================
+# Co-located frontend detection (#3013)
+# Must run BEFORE frontend builds so VITE_API_URL is correct.
+# Auto-detect: if the user frontend code exists on this host,
+# enable co-located mode (SLM at /slm, user frontend at /).
+# ==========================================================
+- name: "SLM | Detect co-located user frontend (#3013)"
+  ansible.builtin.stat:
+    path: "{{ frontend_dist_dir | dirname }}/package.json"
+  register: _colocated_frontend_check
+  tags: ['slm', 'frontend', 'nginx']
+
+- name: "SLM | Set co-located frontend flag (#3013)"
+  ansible.builtin.set_fact:
+    slm_colocated_frontend: "{{ _colocated_frontend_check.stat.exists | default(false) }}"
+  tags: ['slm', 'frontend', 'nginx']
+
+# ==========================================================
 # Frontend build
 # ==========================================================
 - name: "SLM | Check if package.json exists"
@@ -367,20 +384,6 @@
 # ==========================================================
 # Nginx configuration
 # ==========================================================
-# Auto-detect co-located frontend (#2829): if the user frontend
-# code exists on this host, enable co-located mode so nginx
-# serves user frontend at / and SLM at /slm/.
-- name: "SLM | Detect co-located user frontend"
-  ansible.builtin.stat:
-    path: "{{ frontend_dist_dir | dirname }}/package.json"
-  register: _colocated_frontend_check
-  tags: ['slm', 'nginx']
-
-- name: "SLM | Set co-located frontend flag"
-  ansible.builtin.set_fact:
-    slm_colocated_frontend: "{{ _colocated_frontend_check.stat.exists | default(false) }}"
-  tags: ['slm', 'nginx']
-
 - name: "SLM | Deploy nginx configuration"
   ansible.builtin.template:
     src: autobot-slm.conf.j2


### PR DESCRIPTION
## Summary
- Co-location detection tasks were running AFTER the SLM frontend build
- `slm_colocated_frontend` was always `false` at build time → `VITE_API_URL` was empty
- Moved detection before build section so `/slm` base path is set correctly
- Updated tags to include `frontend` since the fact serves both build and nginx

Closes #3013

## Test plan
- [ ] SLM frontend built with `VITE_API_URL=/slm` in co-located mode
- [ ] SLM API calls go to `/slm/api/` not `/api/`
- [ ] Standalone (non-co-located) deployments unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)