### PR TITLE
fix(ansible): preserve dpkg conffiles during role removal and decommission (#3011)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/decommission-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/decommission-node.yml
@@ -188,13 +188,16 @@
             state: absent
           loop: "{{ _unit_files.stdout_lines | default([]) }}"
 
-        - name: Remove additional managed service files
+        # Issue #3011: Only delete Ansible-managed service files here.
+        # dpkg conffiles (e.g. redis-stack-server.service) are removed by
+        # Phase 5 via 'apt purge' — deleting them manually breaks reinstall
+        # because apt does not restore deleted conffiles without --force-confmiss.
+        - name: Remove Ansible-managed service files (non-dpkg)
           ansible.builtin.file:
             path: "/etc/systemd/system/{{ item }}"
             state: absent
           loop:
             - slm-agent.service
-            - redis-stack-server.service
             - ollama.service
 
         - name: Reload systemd daemon

--- a/autobot-slm-backend/ansible/playbooks/remove-role.yml
+++ b/autobot-slm-backend/ansible/playbooks/remove-role.yml
@@ -131,11 +131,36 @@
       # Service may already be stopped or in a failed state during removal (#2950)
       failed_when: false
 
-    - name: "Remove {{ systemd_service }} service file"
+    # Issue #3011: Do not delete service files owned by dpkg packages.
+    # Deleting a dpkg conffile means `apt install --reinstall` will NOT
+    # restore it — only `apt -o Dpkg::Options::="--force-confmiss" install
+    # --reinstall` will. Let apt purge handle conffile removal instead.
+    - name: "Check if service file is a dpkg conffile"
+      ansible.builtin.shell: >
+        dpkg -S "/etc/systemd/system/{{ systemd_service }}.service" 2>/dev/null
+        && echo dpkg_owned || echo not_dpkg_owned
+      register: _dpkg_check
+      changed_when: false
+      when: _service_file.stat.exists
+
+    - name: "Remove {{ systemd_service }} service file (non-dpkg only)"
       ansible.builtin.file:
         path: "/etc/systemd/system/{{ systemd_service }}.service"
         state: absent
+      when: >
+        _service_file.stat.exists and
+        (_dpkg_check.stdout_lines | default([]) | last | default('')) == 'not_dpkg_owned'
       notify: reload systemd
+
+    - name: "Skip removal of dpkg-managed service file"
+      ansible.builtin.debug:
+        msg: >-
+          Skipping deletion of /etc/systemd/system/{{ systemd_service }}.service —
+          file is owned by a dpkg package. Use 'apt purge {{ systemd_service }}'
+          to remove it properly.
+      when: >
+        _service_file.stat.exists and
+        (_dpkg_check.stdout_lines | default([]) | last | default('')) == 'dpkg_owned'
 
     # =======================================================================
     # DISK CLEANUP
@@ -165,6 +190,7 @@
           Role removal complete: {{ role_name }}
           - Host: {{ ansible_hostname }} ({{ ansible_default_ipv4.address }})
           - Service: {{ 'stopped and removed' if _service_file.stat.exists else 'not present' }}
+          - Service file: {{ 'skipped (dpkg conffile)' if (_dpkg_check.stdout_lines | default([]) | last | default('')) == 'dpkg_owned' else 'removed' }}
           - Disk cleanup: {{ '/opt/autobot/' + role_target_dir + ' removed' if (role_target_dir is defined and role_target_dir | length > 0) else 'skipped (no target dir)' }}
           - Backup: {{ _backup_path | default('none') if (_backup_performed | default(false)) else 'skipped' }}
 

--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -128,13 +128,22 @@
   notify: reload firewall
   tags: ['redis', 'firewall']
 
-- name: "Redis | Ensure base systemd service file exists"
-  ansible.builtin.shell: |
-    if [ ! -f /etc/systemd/system/redis-stack-server.service ]; then
-      apt-get -o Dpkg::Options::="--force-confmiss" install --reinstall redis-stack-server -y
-    fi
+# Issue #3011: Defense-in-depth — restore dpkg conffile if it was deleted
+# by a prior decommission or remove-role run. Plain `apt reinstall` does
+# NOT restore deleted conffiles; --force-confmiss is required.
+- name: "Redis | Check if base systemd service file exists"
+  ansible.builtin.stat:
+    path: /etc/systemd/system/redis-stack-server.service
+  register: _redis_service_file
   become: yes
-  changed_when: false
+  tags: ['redis', 'systemd']
+
+- name: "Redis | Restore missing dpkg conffile (--force-confmiss)"
+  ansible.builtin.shell: >
+    apt-get -o Dpkg::Options::="--force-confmiss"
+    install --reinstall redis-stack-server -y
+  become: yes
+  when: not _redis_service_file.stat.exists
   tags: ['redis', 'systemd']
 
 - name: "Redis | Create systemd override directory"


### PR DESCRIPTION
## Summary
- `remove-role.yml`: Added `dpkg -S` check before deleting service files — skips dpkg conffiles
- `decommission-node.yml`: Removed redis service from Phase 3 deletion — Phase 5 `apt purge` handles it
- Redis role: Proper stat + `--force-confmiss` reinstall as defense-in-depth safety net

Closes #3011

## Test plan
- [ ] `remove-role.yml` skips dpkg-owned service files
- [ ] `decommission-node.yml` Phase 5 purge removes Redis cleanly
- [ ] Redis role reinstalls conffile if missing
- [ ] Non-dpkg service files (ollama, slm-agent) still deleted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)