### PR TITLE
feat(shared): add feature flag system for optional subsystems (#3017)

### DIFF
--- a/autobot-shared/__init__.py
+++ b/autobot-shared/__init__.py
@@ -28,6 +28,11 @@ __all__ = [
     "deserialize_message",
     "create_reply",
     "get_client_ip",
+    # Feature flags — issue #3017
+    "is_feature_enabled",
+    "get_enabled_features",
+    "require_feature",
+    "FeatureDisabledError",
 ]
 
 # Lazy import map — module attribute → (submodule, name)
@@ -43,6 +48,11 @@ _LAZY_IMPORTS = {
     "deserialize_message": (".models.service_message", "deserialize_message"),
     "create_reply": (".models.service_message", "create_reply"),
     "get_client_ip": (".proxy_utils", "get_client_ip"),
+    # Feature flags — issue #3017
+    "is_feature_enabled": (".feature_flags", "is_feature_enabled"),
+    "get_enabled_features": (".feature_flags", "get_enabled_features"),
+    "require_feature": (".feature_flags", "require_feature"),
+    "FeatureDisabledError": (".feature_flags", "FeatureDisabledError"),
 }
 
 

--- a/autobot-shared/feature_flags.py
+++ b/autobot-shared/feature_flags.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Feature Flag Utilities
+======================
+
+Convenience helpers for checking and enforcing subsystem feature flags.
+All flag values are read from ``FeatureConfig`` (SSOT), which in turn reads
+``AUTOBOT_FEATURE_*`` environment variables.
+
+Subsystem flags (all default ``True``):
+
+* ``npu``              — NPU / OpenVINO acceleration (AUTOBOT_FEATURE_NPU)
+* ``voice``            — TTS / STT processing (AUTOBOT_FEATURE_VOICE)
+* ``browser``          — browser automation via Playwright (AUTOBOT_FEATURE_BROWSER)
+* ``computer_vision``  — CV / image processing (AUTOBOT_FEATURE_COMPUTER_VISION)
+* ``training``         — model training / fine-tuning (AUTOBOT_FEATURE_TRAINING)
+* ``osint``            — OSINT sweep engine (AUTOBOT_FEATURE_OSINT)
+
+Usage::
+
+    from autobot_shared.feature_flags import is_feature_enabled, require_feature
+
+    if is_feature_enabled("npu"):
+        run_npu_inference()
+
+    @require_feature("voice")
+    def synthesize_speech(text: str) -> bytes:
+        ...
+
+Issue: #3017 — No feature flag system for optional subsystems
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Callable, List, TypeVar
+
+logger = logging.getLogger(__name__)
+
+# Mapping of public flag name → FeatureConfig attribute name.
+# Extend this dict whenever a new subsystem flag is added to FeatureConfig.
+_SUBSYSTEM_FLAG_MAP: dict[str, str] = {
+    "npu": "npu_enabled",
+    "voice": "voice_enabled",
+    "browser": "browser_enabled",
+    "computer_vision": "computer_vision_enabled",
+    "training": "training_enabled",
+    "osint": "osint_enabled",
+}
+
+F = TypeVar("F", bound=Callable)
+
+
+class FeatureDisabledError(RuntimeError):
+    """Raised by ``require_feature`` when a subsystem flag is disabled."""
+
+    def __init__(self, feature_name: str) -> None:
+        super().__init__(
+            f"Subsystem '{feature_name}' is disabled on this node. "
+            f"Set AUTOBOT_FEATURE_{feature_name.upper()}=true to enable it."
+        )
+        self.feature_name = feature_name
+
+
+def _get_feature_config():
+    """Return the live FeatureConfig instance.
+
+    Imported lazily to avoid circular imports at module load time.
+    """
+    from autobot_shared.ssot_config import get_config  # noqa: PLC0415
+
+    return get_config().feature
+
+
+def is_feature_enabled(feature_name: str) -> bool:
+    """Return ``True`` when *feature_name* is enabled on this node.
+
+    Args:
+        feature_name: One of the subsystem keys defined in ``_SUBSYSTEM_FLAG_MAP``
+                      (e.g. ``"npu"``, ``"voice"``).
+
+    Returns:
+        Boolean flag value from FeatureConfig.
+
+    Raises:
+        ValueError: If *feature_name* is not a recognised subsystem flag.
+    """
+    attr = _SUBSYSTEM_FLAG_MAP.get(feature_name)
+    if attr is None:
+        known = sorted(_SUBSYSTEM_FLAG_MAP)
+        raise ValueError(
+            f"Unknown feature flag '{feature_name}'. Known flags: {known}"
+        )
+    enabled: bool = getattr(_get_feature_config(), attr)
+    logger.debug("Feature '%s' is %s", feature_name, "enabled" if enabled else "disabled")
+    return enabled
+
+
+def get_enabled_features() -> List[str]:
+    """Return a sorted list of all enabled subsystem feature names.
+
+    Returns:
+        Sorted list of subsystem names that are currently enabled.
+    """
+    feature_cfg = _get_feature_config()
+    enabled = [
+        name
+        for name, attr in _SUBSYSTEM_FLAG_MAP.items()
+        if getattr(feature_cfg, attr)
+    ]
+    result = sorted(enabled)
+    logger.debug("Enabled subsystem features: %s", result)
+    return result
+
+
+def require_feature(feature_name: str) -> Callable[[F], F]:
+    """Decorator — raise ``FeatureDisabledError`` when the subsystem is off.
+
+    Usage::
+
+        @require_feature("browser")
+        def open_browser_session() -> None:
+            ...
+
+    Args:
+        feature_name: Subsystem flag name (e.g. ``"browser"``).
+
+    Returns:
+        Decorator that wraps the target function with a feature gate check.
+
+    Raises:
+        ValueError: At decoration time if *feature_name* is unrecognised.
+        FeatureDisabledError: At call time if the subsystem is disabled.
+    """
+    # Validate the flag name eagerly so typos surface at import time.
+    if feature_name not in _SUBSYSTEM_FLAG_MAP:
+        known = sorted(_SUBSYSTEM_FLAG_MAP)
+        raise ValueError(
+            f"Unknown feature flag '{feature_name}'. Known flags: {known}"
+        )
+
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if not is_feature_enabled(feature_name):
+                raise FeatureDisabledError(feature_name)
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+__all__ = [
+    "FeatureDisabledError",
+    "is_feature_enabled",
+    "get_enabled_features",
+    "require_feature",
+]

--- a/autobot-shared/feature_flags_test.py
+++ b/autobot-shared/feature_flags_test.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit Tests for Feature Flag Utilities
+======================================
+
+Tests env-var reading, defaults, decorator behaviour, and feature listing.
+
+Issue: #3017 — No feature flag system for optional subsystems
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_feature_config(**overrides):
+    """Return a new FeatureConfig instance with isolated env."""
+    from autobot_shared.ssot_config import FeatureConfig
+
+    with patch.dict(os.environ, overrides, clear=True):
+        return FeatureConfig(_env_file=None)
+
+
+# ---------------------------------------------------------------------------
+# FeatureConfig subsystem defaults
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureConfigSubsystemDefaults:
+    """All subsystem flags default to True when no env var is set."""
+
+    def test_npu_enabled_default(self):
+        cfg = _fresh_feature_config()
+        assert cfg.npu_enabled is True
+
+    def test_voice_enabled_default(self):
+        cfg = _fresh_feature_config()
+        assert cfg.voice_enabled is True
+
+    def test_browser_enabled_default(self):
+        cfg = _fresh_feature_config()
+        assert cfg.browser_enabled is True
+
+    def test_computer_vision_enabled_default(self):
+        cfg = _fresh_feature_config()
+        assert cfg.computer_vision_enabled is True
+
+    def test_training_enabled_default(self):
+        cfg = _fresh_feature_config()
+        assert cfg.training_enabled is True
+
+    def test_osint_enabled_default(self):
+        cfg = _fresh_feature_config()
+        assert cfg.osint_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# FeatureConfig env-var overrides
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureConfigEnvVarOverrides:
+    """Subsystem flags can be toggled via AUTOBOT_FEATURE_* env vars."""
+
+    def test_npu_disabled_via_env(self):
+        cfg = _fresh_feature_config(AUTOBOT_FEATURE_NPU="false")
+        assert cfg.npu_enabled is False
+
+    def test_voice_disabled_via_env(self):
+        cfg = _fresh_feature_config(AUTOBOT_FEATURE_VOICE="false")
+        assert cfg.voice_enabled is False
+
+    def test_browser_disabled_via_env(self):
+        cfg = _fresh_feature_config(AUTOBOT_FEATURE_BROWSER="false")
+        assert cfg.browser_enabled is False
+
+    def test_computer_vision_disabled_via_env(self):
+        cfg = _fresh_feature_config(AUTOBOT_FEATURE_COMPUTER_VISION="false")
+        assert cfg.computer_vision_enabled is False
+
+    def test_training_disabled_via_env(self):
+        cfg = _fresh_feature_config(AUTOBOT_FEATURE_TRAINING="false")
+        assert cfg.training_enabled is False
+
+    def test_osint_disabled_via_env(self):
+        cfg = _fresh_feature_config(AUTOBOT_FEATURE_OSINT="false")
+        assert cfg.osint_enabled is False
+
+    def test_explicit_true_still_enabled(self):
+        cfg = _fresh_feature_config(AUTOBOT_FEATURE_NPU="true")
+        assert cfg.npu_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# is_feature_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestIsFeatureEnabled:
+    """is_feature_enabled reads live FeatureConfig through get_config()."""
+
+    def _mock_feature_cfg(self, **kwargs):
+        """Patch get_config().feature with controlled attribute values."""
+        from unittest.mock import MagicMock
+
+        feature_cfg = MagicMock()
+        # Default all flags to True, then apply overrides.
+        defaults = {
+            "npu_enabled": True,
+            "voice_enabled": True,
+            "browser_enabled": True,
+            "computer_vision_enabled": True,
+            "training_enabled": True,
+            "osint_enabled": True,
+        }
+        defaults.update(kwargs)
+        for attr, val in defaults.items():
+            setattr(feature_cfg, attr, val)
+
+        mock_cfg = MagicMock()
+        mock_cfg.feature = feature_cfg
+        return mock_cfg
+
+    def test_returns_true_when_flag_enabled(self):
+        from autobot_shared.feature_flags import is_feature_enabled
+
+        with patch("autobot_shared.feature_flags._get_feature_config") as mock_get:
+            mock_get.return_value = self._mock_feature_cfg().feature
+            assert is_feature_enabled("npu") is True
+
+    def test_returns_false_when_flag_disabled(self):
+        from autobot_shared.feature_flags import is_feature_enabled
+
+        with patch("autobot_shared.feature_flags._get_feature_config") as mock_get:
+            mock_get.return_value = self._mock_feature_cfg(npu_enabled=False).feature
+            assert is_feature_enabled("npu") is False
+
+    def test_raises_for_unknown_flag(self):
+        from autobot_shared.feature_flags import is_feature_enabled
+
+        with pytest.raises(ValueError, match="Unknown feature flag 'nonexistent'"):
+            is_feature_enabled("nonexistent")
+
+    def test_all_known_flags_accepted(self):
+        from autobot_shared.feature_flags import _SUBSYSTEM_FLAG_MAP, is_feature_enabled
+
+        with patch("autobot_shared.feature_flags._get_feature_config") as mock_get:
+            mock_get.return_value = self._mock_feature_cfg().feature
+            for name in _SUBSYSTEM_FLAG_MAP:
+                # Should not raise
+                result = is_feature_enabled(name)
+                assert isinstance(result, bool)
+
+
+# ---------------------------------------------------------------------------
+# get_enabled_features
+# ---------------------------------------------------------------------------
+
+
+class TestGetEnabledFeatures:
+    """get_enabled_features returns a sorted list of enabled subsystem names."""
+
+    def test_all_enabled_returns_all_names(self):
+        from autobot_shared.feature_flags import _SUBSYSTEM_FLAG_MAP, get_enabled_features
+        from unittest.mock import MagicMock
+
+        feature_cfg = MagicMock()
+        for attr in _SUBSYSTEM_FLAG_MAP.values():
+            setattr(feature_cfg, attr, True)
+
+        with patch("autobot_shared.feature_flags._get_feature_config", return_value=feature_cfg):
+            result = get_enabled_features()
+
+        assert result == sorted(_SUBSYSTEM_FLAG_MAP.keys())
+
+    def test_none_enabled_returns_empty_list(self):
+        from autobot_shared.feature_flags import _SUBSYSTEM_FLAG_MAP, get_enabled_features
+        from unittest.mock import MagicMock
+
+        feature_cfg = MagicMock()
+        for attr in _SUBSYSTEM_FLAG_MAP.values():
+            setattr(feature_cfg, attr, False)
+
+        with patch("autobot_shared.feature_flags._get_feature_config", return_value=feature_cfg):
+            result = get_enabled_features()
+
+        assert result == []
+
+    def test_partial_enabled_returns_subset(self):
+        from autobot_shared.feature_flags import _SUBSYSTEM_FLAG_MAP, get_enabled_features
+        from unittest.mock import MagicMock
+
+        feature_cfg = MagicMock()
+        for attr in _SUBSYSTEM_FLAG_MAP.values():
+            setattr(feature_cfg, attr, False)
+        # Enable just npu and voice
+        feature_cfg.npu_enabled = True
+        feature_cfg.voice_enabled = True
+
+        with patch("autobot_shared.feature_flags._get_feature_config", return_value=feature_cfg):
+            result = get_enabled_features()
+
+        assert result == sorted(["npu", "voice"])
+
+    def test_result_is_sorted(self):
+        from autobot_shared.feature_flags import _SUBSYSTEM_FLAG_MAP, get_enabled_features
+        from unittest.mock import MagicMock
+
+        feature_cfg = MagicMock()
+        for attr in _SUBSYSTEM_FLAG_MAP.values():
+            setattr(feature_cfg, attr, True)
+
+        with patch("autobot_shared.feature_flags._get_feature_config", return_value=feature_cfg):
+            result = get_enabled_features()
+
+        assert result == sorted(result)
+
+
+# ---------------------------------------------------------------------------
+# require_feature decorator
+# ---------------------------------------------------------------------------
+
+
+class TestRequireFeatureDecorator:
+    """require_feature raises FeatureDisabledError when subsystem is off."""
+
+    def test_decorated_function_runs_when_enabled(self):
+        from autobot_shared.feature_flags import require_feature
+
+        @require_feature("npu")
+        def _do_npu():
+            return "npu_result"
+
+        with patch("autobot_shared.feature_flags.is_feature_enabled", return_value=True):
+            assert _do_npu() == "npu_result"
+
+    def test_raises_feature_disabled_error_when_off(self):
+        from autobot_shared.feature_flags import FeatureDisabledError, require_feature
+
+        @require_feature("npu")
+        def _do_npu():
+            return "npu_result"
+
+        with patch("autobot_shared.feature_flags.is_feature_enabled", return_value=False):
+            with pytest.raises(FeatureDisabledError) as exc_info:
+                _do_npu()
+
+        assert exc_info.value.feature_name == "npu"
+        assert "npu" in str(exc_info.value).lower()
+
+    def test_error_message_includes_env_var_hint(self):
+        from autobot_shared.feature_flags import FeatureDisabledError, require_feature
+
+        @require_feature("voice")
+        def _speak():
+            pass
+
+        with patch("autobot_shared.feature_flags.is_feature_enabled", return_value=False):
+            with pytest.raises(FeatureDisabledError) as exc_info:
+                _speak()
+
+        assert "AUTOBOT_FEATURE_VOICE" in str(exc_info.value)
+
+    def test_raises_value_error_for_unknown_flag_at_decoration_time(self):
+        from autobot_shared.feature_flags import require_feature
+
+        with pytest.raises(ValueError, match="Unknown feature flag 'bad_flag'"):
+
+            @require_feature("bad_flag")
+            def _noop():
+                pass
+
+    def test_preserves_function_name_and_docstring(self):
+        from autobot_shared.feature_flags import require_feature
+
+        @require_feature("osint")
+        def run_osint_sweep():
+            """Perform an OSINT sweep."""
+            pass
+
+        assert run_osint_sweep.__name__ == "run_osint_sweep"
+        assert run_osint_sweep.__doc__ == "Perform an OSINT sweep."
+
+    def test_passes_args_and_kwargs_through(self):
+        from autobot_shared.feature_flags import require_feature
+
+        @require_feature("training")
+        def train_model(model_id: str, epochs: int = 5) -> dict:
+            return {"model": model_id, "epochs": epochs}
+
+        with patch("autobot_shared.feature_flags.is_feature_enabled", return_value=True):
+            result = train_model("gpt2", epochs=10)
+
+        assert result == {"model": "gpt2", "epochs": 10}
+
+    def test_feature_disabled_error_is_runtime_error(self):
+        from autobot_shared.feature_flags import FeatureDisabledError
+
+        err = FeatureDisabledError("browser")
+        assert isinstance(err, RuntimeError)
+        assert err.feature_name == "browser"

--- a/autobot-shared/ssot_config.py
+++ b/autobot-shared/ssot_config.py
@@ -958,6 +958,15 @@ class FeatureConfig(BaseSettings):
         default=False, alias="AUTOBOT_PERMISSION_SYSTEM_V2"
     )
 
+    # Subsystem feature flags — issue #3017
+    # Set AUTOBOT_FEATURE_<NAME>=false to disable a subsystem on a given node.
+    npu_enabled: bool = Field(default=True, alias="AUTOBOT_FEATURE_NPU")
+    voice_enabled: bool = Field(default=True, alias="AUTOBOT_FEATURE_VOICE")
+    browser_enabled: bool = Field(default=True, alias="AUTOBOT_FEATURE_BROWSER")
+    computer_vision_enabled: bool = Field(default=True, alias="AUTOBOT_FEATURE_COMPUTER_VISION")
+    training_enabled: bool = Field(default=True, alias="AUTOBOT_FEATURE_TRAINING")
+    osint_enabled: bool = Field(default=True, alias="AUTOBOT_FEATURE_OSINT")
+
 
 class AutoBotConfig(BaseSettings):
     """


### PR DESCRIPTION
## Summary
- 6 new subsystem flags in FeatureConfig: NPU, voice, browser, CV, training, OSINT
- Each reads from `AUTOBOT_FEATURE_{NAME}` env var (default: enabled)
- `feature_flags.py`: `is_feature_enabled()`, `get_enabled_features()`, `require_feature()` decorator
- `FeatureDisabledError` with feature name and env var hint
- Opt-out model: all subsystems enabled by default, disable per-node via env

Closes #3017

## Test plan
- [x] Default values (all enabled)
- [x] Env var override disables flag
- [x] is_feature_enabled happy/disabled/unknown paths
- [x] get_enabled_features: all-on, all-off, partial, sorted
- [x] require_feature: passes args, raises FeatureDisabledError, rejects unknown
- [x] flake8 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)