### PR TITLE
feat(security): add PreToolUse hooks for command blocking, secret scanning, and file protection

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Blocks dangerous shell commands before execution.
+# PreToolUse hook for Bash operations.
+# Exit 2 = block the action. Exit 0 = allow.
+#
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+# Issue: #3021
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"jq is required for command protection hooks but is not installed."}}'
+  exit 2
+fi
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+deny() {
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"$1\"}}"
+  exit 2
+}
+
+# ──────────────────────────────────────────────
+# Git push protections
+# ──────────────────────────────────────────────
+
+if echo "$COMMAND" | grep -qE '(^|[;&|()]+[[:space:]]*)git[[:space:]]+push'; then
+
+  # Block push to main, master, or Dev_new_gui directly
+  if echo "$COMMAND" | grep -qE 'git[[:space:]]+push.*(origin[[:space:]]+|:)(main|master|Dev_new_gui)\b'; then
+    deny "Blocked: cannot push directly to main/master/Dev_new_gui. Use a feature branch and create a PR."
+  fi
+
+  # Block bare git push when on protected branches
+  if echo "$COMMAND" | grep -qE 'git[[:space:]]+push[[:space:]]*($|[;&|])'; then
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+    if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ] || [ "$CURRENT_BRANCH" = "Dev_new_gui" ]; then
+      deny "Blocked: you are on $CURRENT_BRANCH. Use a feature branch and create a PR."
+    fi
+  fi
+
+  # Block force push (allow --force-with-lease)
+  if echo "$COMMAND" | grep -qE 'git[[:space:]]+push.*(-[a-zA-Z]*f|--force)([[:space:]]|$)' && ! echo "$COMMAND" | grep -q '\-\-force-with-lease'; then
+    deny "Blocked: force push is not allowed. Use --force-with-lease if you need to overwrite remote."
+  fi
+fi
+
+# ──────────────────────────────────────────────
+# Git commit protections
+# ──────────────────────────────────────────────
+
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+commit.*--no-verify'; then
+  deny "Blocked: --no-verify bypasses pre-commit hooks. Fix the underlying hook failure instead."
+fi
+
+# ──────────────────────────────────────────────
+# Destructive git operations
+# ──────────────────────────────────────────────
+
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+reset[[:space:]]+--hard'; then
+  deny "Blocked: git reset --hard discards uncommitted changes permanently. Use git stash or git reset --soft instead."
+fi
+
+if echo "$COMMAND" | grep -qE 'git[[:space:]]+clean[[:space:]]+-[a-zA-Z]*f'; then
+  deny "Blocked: git clean -f permanently deletes untracked files. Review with git clean -n first, then run manually if intended."
+fi
+
+# ──────────────────────────────────────────────
+# Destructive filesystem operations
+# ──────────────────────────────────────────────
+
+if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f[[:space:]]+(\/|~|\$HOME|\.\.\/\.\.)'; then
+  deny "Blocked: recursive force-delete on root/home/parent paths. Specify a safe target directory."
+fi
+
+if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*r.*[[:space:]]+(\/[[:space:]]|\/\*|\/$|~\/?\*?[[:space:]]|~\/?\*?$)'; then
+  deny "Blocked: recursive delete targeting root or home directory."
+fi
+
+# ──────────────────────────────────────────────
+# Dangerous database operations
+# ──────────────────────────────────────────────
+
+if echo "$COMMAND" | grep -qiE 'DROP[[:space:]]+(TABLE|DATABASE|SCHEMA)[[:space:]]'; then
+  deny "Blocked: DROP TABLE/DATABASE/SCHEMA detected. This is destructive and irreversible. Run manually if intended."
+fi
+
+if echo "$COMMAND" | grep -qiE 'DELETE[[:space:]]+FROM[[:space:]]+[a-zA-Z_]+[[:space:]]*($|;)' && ! echo "$COMMAND" | grep -qiE 'WHERE'; then
+  deny "Blocked: DELETE FROM without WHERE clause would delete all rows. Add a WHERE clause."
+fi
+
+if echo "$COMMAND" | grep -qiE 'TRUNCATE[[:space:]]+TABLE'; then
+  deny "Blocked: TRUNCATE TABLE detected. This is destructive and irreversible. Run manually if intended."
+fi
+
+# ──────────────────────────────────────────────
+# Dangerous system commands
+# ──────────────────────────────────────────────
+
+if echo "$COMMAND" | grep -qE 'chmod[[:space:]]+777'; then
+  deny "Blocked: chmod 777 gives everyone read/write/execute. Use more restrictive permissions (e.g., 755 or 644)."
+fi
+
+if echo "$COMMAND" | grep -qE '(curl|wget)[[:space:]].*\|[[:space:]]*(bash|sh|zsh|sudo)'; then
+  deny "Blocked: piping downloaded content directly to a shell is dangerous. Download first, inspect, then execute."
+fi
+
+if echo "$COMMAND" | grep -qE '(mkfs|dd[[:space:]]+if=|>[[:space:]]*/dev/)'; then
+  deny "Blocked: destructive disk operation detected. This can cause irreversible data loss."
+fi
+
+# ──────────────────────────────────────────────
+# Accidental package publishing
+# ──────────────────────────────────────────────
+
+if echo "$COMMAND" | grep -qE '(npm|yarn|pnpm|bun)[[:space:]]+publish'; then
+  deny "Blocked: publishing npm packages should be done manually or via CI, not through Claude Code."
+fi
+
+if echo "$COMMAND" | grep -qE 'twine[[:space:]]+upload'; then
+  deny "Blocked: publishing Python packages should be done manually or via CI, not through Claude Code."
+fi
+
+exit 0

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Blocks edits to sensitive or generated files.
+# PreToolUse hook for Edit|Write operations.
+# Exit 2 = block the action. Exit 0 = allow.
+#
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+# Issue: #3026
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"jq is required for file protection hooks but is not installed."}}'
+  exit 2
+fi
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+deny() {
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"$1\"}}"
+  exit 2
+}
+
+ask() {
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"$1\"}}"
+  exit 2
+}
+
+BASENAME=$(basename "$FILE_PATH")
+
+# ──────────────────────────────────────────────
+# Protected file patterns
+# ──────────────────────────────────────────────
+
+PROTECTED_PATTERNS=(
+  "*.pem"
+  "*.key"
+  "*.crt"
+  "*.p12"
+  "*.pfx"
+  "id_rsa"
+  "id_ed25519"
+  "credentials.json"
+  "*.gen.ts"
+  "*.generated.*"
+  "*.min.js"
+  "*.min.css"
+)
+
+for pattern in "${PROTECTED_PATTERNS[@]}"; do
+  case "$BASENAME" in
+    $pattern)
+      deny "Protected file: $BASENAME matches pattern '$pattern'. Cannot edit cryptographic keys, credentials, or generated files."
+      ;;
+  esac
+done
+
+# ──────────────────────────────────────────────
+# Protected directories and paths
+# ──────────────────────────────────────────────
+
+case "$FILE_PATH" in
+  # Git internals
+  .git/*|*/.git/*)
+    deny "Cannot edit files inside .git/"
+    ;;
+  # Secrets directories
+  secrets/*|*/secrets/*)
+    deny "Cannot edit files inside secrets/"
+    ;;
+  # Environment files
+  .env|.env.*|*/.env|*/.env.*)
+    deny "Cannot edit .env files — use SSOT config or Ansible variables instead."
+    ;;
+  # Self-protection: hook scripts
+  .claude/hooks/*|*/.claude/hooks/*)
+    deny "Cannot edit hook scripts — these enforce security boundaries. Edit manually if needed."
+    ;;
+  # Settings files require confirmation
+  .claude/settings.json|*/.claude/settings.json)
+    ask "Editing settings.json — this controls permissions and hooks. Confirm this change."
+    ;;
+  .claude/settings.local.json|*/.claude/settings.local.json)
+    ask "Editing settings.local.json — this controls local permissions. Confirm this change."
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/scan-secrets.sh
+++ b/.claude/hooks/scan-secrets.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Scans file content for accidental secrets before writing.
+# PreToolUse hook for Edit|Write operations.
+# Exit 2 = block (with "ask" decision so user can override). Exit 0 = allow.
+#
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+# Issue: #3022
+
+# Allow if jq is missing (don't block the user)
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Extract the content being written
+if [ "$TOOL_NAME" = "Write" ]; then
+  CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // empty')
+elif [ "$TOOL_NAME" = "Edit" ]; then
+  CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // empty')
+else
+  exit 0
+fi
+
+if [ -z "$CONTENT" ]; then
+  exit 0
+fi
+
+MATCHES=""
+
+# ──────────────────────────────────────────────
+# Cloud provider keys
+# ──────────────────────────────────────────────
+
+# AWS Access Key IDs
+if echo "$CONTENT" | grep -qE 'AKIA[0-9A-Z]{16}'; then
+  MATCHES="$MATCHES AWS access key (AKIA...);"
+fi
+
+# AWS Secret Access Keys
+if echo "$CONTENT" | grep -qiE '(aws_secret_access_key|secret_key)[[:space:]]*[=:][[:space:]]*["\x27]?[A-Za-z0-9/+=]{40}'; then
+  MATCHES="$MATCHES AWS secret key;"
+fi
+
+# ──────────────────────────────────────────────
+# API tokens
+# ──────────────────────────────────────────────
+
+# GitHub tokens (PAT, OAuth, App)
+if echo "$CONTENT" | grep -qE '(ghp_|gho_|ghs_|ghr_|github_pat_)[a-zA-Z0-9_]{20,}'; then
+  MATCHES="$MATCHES GitHub token;"
+fi
+
+# OpenAI / Stripe / Anthropic style keys (sk-...)
+if echo "$CONTENT" | grep -qE 'sk-[a-zA-Z0-9]{20,}'; then
+  MATCHES="$MATCHES API key (sk-...);"
+fi
+
+# Slack tokens
+if echo "$CONTENT" | grep -qE 'xox[bpras]-[0-9a-zA-Z-]{10,}'; then
+  MATCHES="$MATCHES Slack token;"
+fi
+
+# ──────────────────────────────────────────────
+# Cryptographic material
+# ──────────────────────────────────────────────
+
+# Private key blocks
+if echo "$CONTENT" | grep -qE -- '-----BEGIN[[:space:]]+(RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----'; then
+  MATCHES="$MATCHES private key block;"
+fi
+
+# ──────────────────────────────────────────────
+# Connection strings & credentials
+# ──────────────────────────────────────────────
+
+# Connection strings with embedded credentials
+if echo "$CONTENT" | grep -qE '(mongodb|postgres|mysql|redis|amqp|smtp)(\+[a-z]+)?://[^:[:space:]]+:[^@[:space:]]+@'; then
+  MATCHES="$MATCHES connection string with credentials;"
+fi
+
+# Generic password/secret/token assignments with literal values
+# Excludes env var references (process.env, os.environ, getenv, ${...})
+if echo "$CONTENT" | grep -qiE '(password|secret|token|api_key|apikey|api_secret)[[:space:]]*[=:][[:space:]]*["\x27][^"\x27]{8,}["\x27]' && \
+   ! echo "$CONTENT" | grep -qiE '(password|secret|token|api_key|apikey|api_secret)[[:space:]]*[=:][[:space:]]*["\x27]?(process\.env|os\.environ|getenv|\$\{|ENV\[|env\(|config\.)'; then
+  MATCHES="$MATCHES hardcoded credential;"
+fi
+
+# ──────────────────────────────────────────────
+# AutoBot-specific: hardcoded fleet IPs
+# ──────────────────────────────────────────────
+
+# Detect hardcoded IPs in the AutoBot fleet range (except in comments, docs, or config references)
+if echo "$CONTENT" | grep -qE '172\.16\.168\.[0-9]{1,3}' && \
+   ! echo "$CONTENT" | grep -qE '^[[:space:]]*(#|//|/\*|\*|<!--|""").*172\.16\.168\.' && \
+   ! echo "$CONTENT" | grep -qiE '(config\.|ssot_config|AUTOBOT_REFERENCE).*172\.16\.168\.'; then
+  MATCHES="$MATCHES hardcoded AutoBot fleet IP (use SSOT config);"
+fi
+
+if [ -n "$MATCHES" ]; then
+  REASON="Possible secret detected in content:$MATCHES Review carefully before allowing."
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"$REASON\"}}"
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,48 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous-commands.sh",
+            "timeout": 5000,
+            "statusMessage": "Checking command safety..."
+          },
+          {
+            "type": "command",
+            "command": "if [[ \"$TOOL_ARGS\" == *\"git commit\"* ]]; then cd $(git rev-parse --show-toplevel 2>/dev/null || pwd) && echo '\ud83d\udccb Staged files:' && git diff --staged --name-only 2>/dev/null | head -20 && echo '' && echo '\ud83c\udf3f Branch:' $(git branch --show-current 2>/dev/null) '\u2192 Dev_new_gui' && echo ''; fi",
+            "statusMessage": "Verifying git state...",
+            "timeout": 3000
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-files.sh",
+            "timeout": 5000,
+            "statusMessage": "Checking file protections..."
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/scan-secrets.sh",
+            "timeout": 5000,
+            "statusMessage": "Scanning for secrets..."
+          },
+          {
+            "type": "command",
+            "command": "echo 'GITHUB ISSUE REMINDER: Ensure this edit is linked to a GitHub issue. If no issue confirmed yet, search with gh issue list or create with gh issue create before proceeding.'",
+            "statusMessage": "Issue link check...",
+            "timeout": 2000
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit",
@@ -13,7 +55,7 @@
             "type": "command",
             "command": "cd $(git rev-parse --show-toplevel 2>/dev/null || pwd) && FILE=$(echo \"$TOOL_ARGS\" | grep -o '\"file_path\":\"[^\"]*' | cut -d'\"' -f4) && if [[ -n \"$FILE\" ]]; then if [[ \"$FILE\" == *.py ]]; then WAS_STAGED=$(git diff --cached --name-only -- \"$FILE\" 2>/dev/null | grep -q . && echo yes || echo no); echo \"\ud83d\udc0d Auto-formatting $FILE...\"; black --line-length=88 \"$FILE\" 2>&1 | tail -1; isort --profile=black --line-length=88 \"$FILE\" 2>&1 | tail -1; if [[ \"$WAS_STAGED\" == \"yes\" ]]; then git add \"$FILE\" 2>/dev/null; fi; ruff check \"$FILE\" 2>&1 | head -10 || echo \"\u2705 Clean\"; elif [[ \"$FILE\" == *.ts || \"$FILE\" == *.tsx ]]; then echo \"\ud83d\udcd8 Type checking $FILE...\"; if [[ \"$FILE\" == *\"autobot-user-frontend\"* ]]; then cd autobot-user-frontend && npx tsc --noEmit 2>&1 | grep -E \"(error TS|\u2713)\" | head -15 || echo \"\u2705 TypeScript checks passed\"; elif [[ \"$FILE\" == *\"autobot-slm-frontend\"* ]]; then cd autobot-slm-frontend && npx tsc --noEmit 2>&1 | grep -E \"(error TS|\u2713)\" | head -15 || echo \"\u2705 TypeScript checks passed\"; fi; elif [[ \"$FILE\" == *.vue ]]; then echo \"\ud83d\uddbc\ufe0f  Linting Vue component...\"; if [[ \"$FILE\" == *\"autobot-user-frontend\"* ]]; then cd autobot-user-frontend && npm run lint -- \"$FILE\" 2>&1 | head -15 || echo \"\u2705 Vue linting passed\"; elif [[ \"$FILE\" == *\"autobot-slm-frontend\"* ]]; then cd autobot-slm-frontend && npm run lint -- \"$FILE\" 2>&1 | head -15 || echo \"\u2705 Vue linting passed\"; fi; else echo \"\u2713 File type not configured for linting\"; fi; fi",
             "statusMessage": "Running linting checks...",
-            "timeout": 10
+            "timeout": 10000
           }
         ]
       },
@@ -24,7 +66,7 @@
             "type": "command",
             "command": "cd $(git rev-parse --show-toplevel 2>/dev/null || pwd) && FILE=$(echo \"$TOOL_ARGS\" | grep -o '\"file_path\":\"[^\"]*' | cut -d'\"' -f4) && if [[ -n \"$FILE\" ]]; then if [[ \"$FILE\" == *.py ]]; then WAS_STAGED=$(git diff --cached --name-only -- \"$FILE\" 2>/dev/null | grep -q . && echo yes || echo no); echo \"\ud83d\udc0d Auto-formatting new Python file...\"; black --line-length=88 \"$FILE\" 2>&1 | tail -1; isort --profile=black --line-length=88 \"$FILE\" 2>&1 | tail -1; if [[ \"$WAS_STAGED\" == \"yes\" ]]; then git add \"$FILE\" 2>/dev/null; fi; ruff check \"$FILE\" 2>&1 | head -10 || echo \"\u2705 Clean\"; elif [[ \"$FILE\" == *.ts || \"$FILE\" == *.tsx ]]; then echo \"\ud83d\udcd8 Type checking new TypeScript file...\"; if [[ \"$FILE\" == *\"autobot-user-frontend\"* ]]; then cd autobot-user-frontend && npx tsc --noEmit 2>&1 | grep -E \"(error TS|\u2713)\" | head -15 || echo \"\u2705 TypeScript checks passed\"; elif [[ \"$FILE\" == *\"autobot-slm-frontend\"* ]]; then cd autobot-slm-frontend && npx tsc --noEmit 2>&1 | grep -E \"(error TS|\u2713)\" | head -15 || echo \"\u2705 TypeScript checks passed\"; fi; fi; fi",
             "statusMessage": "Running linting checks on new file...",
-            "timeout": 10
+            "timeout": 10000
           }
         ]
       }
@@ -37,31 +79,18 @@
             "type": "command",
             "command": "$(git rev-parse --show-toplevel)/scripts/hooks/session-stop-orphan-check.sh",
             "statusMessage": "Checking for orphaned work...",
-            "timeout": 15
+            "timeout": 15000
           }
         ]
       }
     ],
-    "PreToolUse": [
+    "Notification": [
       {
-        "matcher": "Bash",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "if [[ \"$TOOL_ARGS\" == *\"git commit\"* ]]; then cd $(git rev-parse --show-toplevel 2>/dev/null || pwd) && echo '\ud83d\udccb Staged files:' && git diff --staged --name-only 2>/dev/null | head -20 && echo '' && echo '\ud83c\udf3f Branch:' $(git branch --show-current 2>/dev/null) '\u2192 Dev_new_gui' && echo ''; fi",
-            "statusMessage": "Verifying git state...",
-            "timeout": 3
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'GITHUB ISSUE REMINDER: Ensure this edit is linked to a GitHub issue. If no issue confirmed yet, search with gh issue list or create with gh issue create before proceeding.'",
-            "statusMessage": "Issue link check...",
-            "timeout": 2
+            "command": "which notify-send >/dev/null 2>&1 && notify-send 'Claude Code' 'Claude Code needs your attention' || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add three shell-based PreToolUse hooks that enforce safety at the tool level (cannot be bypassed by model reasoning)
- **block-dangerous-commands.sh**: blocks force-push, push to protected branches, `--no-verify`, destructive git/fs/db ops, package publishing
- **scan-secrets.sh**: detects API keys, tokens, private keys, connection strings, hardcoded credentials, and AutoBot fleet IPs — uses "ask" (not "deny") so users can override for test fixtures
- **protect-files.sh**: blocks edits to `.env`, `.pem`, `.key`, `.git/`, `secrets/`, generated files, and the hook scripts themselves (self-protection)
- Add desktop notification hook (`notify-send`) for when Claude needs attention

Closes #3021, closes #3022, closes #3026

## Test plan
- [x] `block-dangerous-commands.sh` blocks force-push, `--no-verify`, push to Dev_new_gui
- [x] `block-dangerous-commands.sh` allows normal `git push origin <branch>`
- [x] `scan-secrets.sh` detects `sk-*` API keys and hardcoded credentials
- [x] `scan-secrets.sh` allows env var references (`os.environ`, `process.env`)
- [x] `scan-secrets.sh` detects hardcoded AutoBot fleet IPs (172.16.168.*)
- [x] `protect-files.sh` blocks edits to `.env`, hook scripts, `.pem` files
- [x] `protect-files.sh` allows normal file edits
- [x] All hooks verified live — commit message containing blocked patterns was correctly rejected by the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)