### PR TITLE
feat(security): add PreToolUse hook to protect sensitive files (#3026)

### DIFF
--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# PreToolUse hook: protect sensitive files from edits (#3026)
+# Exit 0 = allow, Exit 2 = block (reason on stdout)
+
+input=$(cat)
+
+file_path=$(echo "$input" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)"/\1/')
+
+[ -z "$file_path" ] && exit 0
+
+basename=$(basename "$file_path")
+
+# Block: secrets and credentials
+case "$basename" in
+    .env|.env.*|credentials.json)
+        echo "BLOCKED: $basename is a secrets file — do not edit via Claude" >&2
+        exit 2 ;;
+esac
+
+case "$file_path" in
+    */secrets/*|*/secret/*)
+        echo "BLOCKED: files under secrets/ are protected" >&2
+        exit 2 ;;
+esac
+
+# Block: crypto keys and certificates
+case "$basename" in
+    *.pem|*.key|*.crt|*.p12|*.pfx|id_rsa|id_ed25519)
+        echo "BLOCKED: $basename is a cryptographic key/cert — do not edit via Claude" >&2
+        exit 2 ;;
+esac
+
+# Block: git internals
+case "$file_path" in
+    */.git/*|*.git/*)
+        echo "BLOCKED: .git/ internals are protected" >&2
+        exit 2 ;;
+esac
+
+# Block: self-protection — hook scripts
+case "$file_path" in
+    */.claude/hooks/*)
+        echo "BLOCKED: .claude/hooks/ scripts are self-protected — edit manually" >&2
+        exit 2 ;;
+esac
+
+# Block: lock files
+case "$basename" in
+    package-lock.json|yarn.lock|pnpm-lock.yaml)
+        echo "BLOCKED: $basename is a lock file — do not edit manually" >&2
+        exit 2 ;;
+esac
+
+# Block: generated/minified files
+case "$basename" in
+    *.gen.ts|*.generated.*|*.min.js|*.min.css)
+        echo "BLOCKED: $basename is a generated file — do not edit manually" >&2
+        exit 2 ;;
+esac
+
+# Warn: settings files (allow but notify)
+case "$file_path" in
+    */.claude/settings.json|*/.claude/settings.local.json)
+        echo "WARNING: editing Claude settings file $basename — proceed with caution" >&2
+        exit 0 ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,9 +59,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-files.sh",
+            "timeout": 5000,
+            "statusMessage": "Checking file protections..."
+          },
+          {
+            "type": "command",
             "command": "echo 'GITHUB ISSUE REMINDER: Ensure this edit is linked to a GitHub issue. If no issue confirmed yet, search with gh issue list or create with gh issue create before proceeding.'",
             "statusMessage": "Issue link check...",
-            "timeout": 2
+            "timeout": 2000
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Created `.claude/hooks/protect-files.sh` — blocks edits to secrets, keys, git internals, hooks (self-protection), lock files, and generated files
- Wired as PreToolUse `Edit|Write` matcher in settings.json
- Tested: .env → exit 2, .claude/hooks/* → exit 2, package-lock.json → exit 2, normal .py → exit 0

Closes #3026

## Test plan
- [x] `.env` files blocked (exit 2)
- [x] `.claude/hooks/*` self-protected (exit 2)
- [x] Lock files blocked (exit 2)
- [x] Normal files allowed (exit 0)
- [x] Settings files warn but allow (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)