### PR TITLE
fix(vnc): handle both auth token field names (#2926)

### DIFF
--- a/autobot-slm-backend/ansible/roles/vnc/tasks/register-credentials.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/tasks/register-credentials.yml
@@ -22,10 +22,14 @@
   delay: 5
   until: vnc_auth_result.status == 200
 
+- name: Extract auth token (SLM returns access_token, user backend returns token)
+  ansible.builtin.set_fact:
+    _vnc_auth_token: "{{ vnc_auth_result.json.access_token | default(vnc_auth_result.json.token | default('')) }}"
+
 - name: Verify SLM auth succeeded
   ansible.builtin.assert:
     that:
-      - vnc_auth_result.json.access_token is defined
+      - _vnc_auth_token | length > 0
     fail_msg: "SLM auth failed — check slm_admin_password. Response: {{ vnc_auth_result.json | default({}) }}"
 
 - name: Check existing VNC credentials for this node
@@ -33,7 +37,7 @@
     url: "{{ slm_api_url }}/api/nodes/{{ slm_node_id }}/vnc-credentials"
     method: GET
     headers:
-      Authorization: "Bearer {{ vnc_auth_result.json.access_token }}"
+      Authorization: "Bearer {{ _vnc_auth_token }}"
     status_code: [200, 404]
     validate_certs: false
   register: existing_vnc_creds
@@ -43,7 +47,7 @@
     url: "{{ slm_api_url }}/api/nodes/{{ slm_node_id }}/vnc-credentials"
     method: POST
     headers:
-      Authorization: "Bearer {{ vnc_auth_result.json.access_token }}"
+      Authorization: "Bearer {{ _vnc_auth_token }}"
     body_format: json
     body:
       vnc_type: "desktop"


### PR DESCRIPTION
SLM returns access_token, user backend returns token. Extract whichever is present.