### PR TITLE
fix(config): replace hardcoded IPs in comments to fix SSOT CI check (#3042)

### DIFF
--- a/autobot-shared/network_utils.py
+++ b/autobot-shared/network_utils.py
@@ -102,7 +102,7 @@ def is_local_host(hostname_or_url: str) -> bool:
 
     Args:
         hostname_or_url: A bare IP / hostname, or a URL such as
-            ``https://172.16.168.19:8443``.
+            ``https://<slm-host>:8443``.
 
     Returns:
         True when the extracted host is one of the local addresses.

--- a/autobot-slm-frontend/src/composables/useSlmWebSocket.ts
+++ b/autobot-slm-frontend/src/composables/useSlmWebSocket.ts
@@ -20,7 +20,7 @@ const logger = createLogger('SlmWebSocket')
 
 // Use WebSocket URL from SSOT config
 // Issue #2489: Prefix with apiBaseUrl when it's a relative path (Docker: /slm)
-// but skip when it's a full URL (fleet: http://172.16.168.19:8000)
+// but skip when it's a full URL (fleet: http://<slm-host>:8000)
 const config = getConfig()
 const apiPrefix = config.apiBaseUrl.startsWith('/') ? config.apiBaseUrl : ''
 const WS_URL = `${config.wsBaseUrl}${apiPrefix}/api/ws/events`


### PR DESCRIPTION
## Summary
- Replaced 2 hardcoded IPs in comments/docstrings with `<slm-host>` placeholders
- Fixes SSOT CI check that was failing on every PR

Closes #3042

## Test plan
- [ ] SSOT CI check passes with 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)