### PR TITLE
fix(slm-frontend): add env var overrides to ssot-config VM IPs and ports (#3049)

### DIFF
--- a/autobot-slm-frontend/src/config/ssot-config.ts
+++ b/autobot-slm-frontend/src/config/ssot-config.ts
@@ -6,6 +6,7 @@
  * Single Source of Truth Configuration for SLM Admin
  *
  * Centralized configuration for all infrastructure endpoints and settings.
+ * All values support VITE_* environment variable overrides (#3049).
  */
 
 export interface SLMConfig {
@@ -44,6 +45,35 @@ export interface SLMConfig {
   }[]
 }
 
+// =============================================================================
+// Environment Variable Helpers
+// =============================================================================
+
+/**
+ * Get string environment variable with fallback.
+ * Matches the pattern used in autobot-frontend ssot-config.ts.
+ */
+function getEnv(key: string, defaultValue: string): string {
+  const value = import.meta.env[key]
+  if (value === undefined || value === null || value === '') {
+    return defaultValue
+  }
+  return String(value)
+}
+
+/**
+ * Get numeric environment variable with fallback.
+ * Matches the pattern used in autobot-frontend ssot-config.ts.
+ */
+function getEnvNumber(key: string, defaultValue: number): number {
+  const value = import.meta.env[key]
+  if (value === undefined || value === null || value === '') {
+    return defaultValue
+  }
+  const parsed = parseInt(String(value), 10)
+  return isNaN(parsed) ? defaultValue : parsed
+}
+
 // Detect protocol from browser context
 const isSecure = typeof window !== 'undefined' && window.location.protocol === 'https:'
 
@@ -56,6 +86,21 @@ function getWsBaseUrl(): string {
   return `${wsProtocol}//${window.location.host}`
 }
 
+// =============================================================================
+// Configuration Builder
+// =============================================================================
+
+// VM IP addresses — env var names match autobot-frontend convention (#3049)
+const vm: SLMConfig['vm'] = {
+  main: getEnv('VITE_BACKEND_HOST', '172.16.168.20'),
+  frontend: getEnv('VITE_FRONTEND_HOST', '172.16.168.21'),
+  npu: getEnv('VITE_NPU_WORKER_HOST', '172.16.168.22'),
+  redis: getEnv('VITE_REDIS_HOST', '172.16.168.23'),
+  ai: getEnv('VITE_AI_STACK_HOST', '172.16.168.24'),
+  browser: getEnv('VITE_BROWSER_HOST', '172.16.168.25'),
+  slm: getEnv('VITE_SLM_HOST', '172.16.168.19'),
+}
+
 const config: SLMConfig = {
   httpProtocol: isSecure ? 'https' : 'http',
   // Use relative path - nginx proxies /api/ to backend
@@ -63,37 +108,30 @@ const config: SLMConfig = {
   wsProtocol: isSecure ? 'wss' : 'ws',
   // Use current host - nginx proxies WebSocket connections
   wsBaseUrl: import.meta.env.VITE_WS_URL || getWsBaseUrl(),
-  vm: {
-    main: '172.16.168.20',
-    frontend: '172.16.168.21',
-    npu: '172.16.168.22',
-    redis: '172.16.168.23',
-    ai: '172.16.168.24',
-    browser: '172.16.168.25',
-    slm: '172.16.168.19',
-  },
+  vm,
   port: {
-    backend: 8001,
-    frontend: 5173,
-    slmApi: 8000,
-    grafana: 3000,
-    prometheus: 9090,
-    redis: 6379,
-    vnc: 6080,
-    ollama: 11434,
-    elasticsearch: 9200,
-    tlsFrontend: 443,
-    tlsBackend: 8443,
-    tlsRedis: 6380,
+    backend: getEnvNumber('VITE_BACKEND_PORT', 8001),
+    frontend: getEnvNumber('VITE_FRONTEND_PORT', 5173),
+    slmApi: getEnvNumber('VITE_SLM_PORT', 8000),
+    grafana: getEnvNumber('VITE_GRAFANA_PORT', 3000),
+    prometheus: getEnvNumber('VITE_PROMETHEUS_PORT', 9090),
+    redis: getEnvNumber('VITE_REDIS_PORT', 6379),
+    vnc: getEnvNumber('VITE_DESKTOP_VNC_PORT', 6080),
+    ollama: getEnvNumber('VITE_OLLAMA_PORT', 11434),
+    elasticsearch: getEnvNumber('VITE_ELASTICSEARCH_PORT', 9200),
+    tlsFrontend: getEnvNumber('VITE_TLS_FRONTEND_PORT', 443),
+    tlsBackend: getEnvNumber('VITE_TLS_BACKEND_PORT', 8443),
+    tlsRedis: getEnvNumber('VITE_TLS_REDIS_PORT', 6380),
   },
+  // Derive IPs from vm object — single source, no duplication (#3049)
   hosts: [
-    { id: 'main', name: 'Main Server', ip: '172.16.168.20', description: 'WSL Backend Server' },
-    { id: 'frontend', name: 'Frontend VM', ip: '172.16.168.21', description: 'Vue.js Frontend' },
-    { id: 'npu', name: 'NPU VM', ip: '172.16.168.22', description: 'NPU Acceleration' },
-    { id: 'redis', name: 'Redis VM', ip: '172.16.168.23', description: 'Redis Stack' },
-    { id: 'ai', name: 'AI VM', ip: '172.16.168.24', description: 'AI Processing' },
-    { id: 'browser', name: 'Browser VM', ip: '172.16.168.25', description: 'Playwright Automation' },
-    { id: 'slm', name: 'SLM Server', ip: '172.16.168.19', description: 'Service Lifecycle Manager' },
+    { id: 'main', name: 'Main Server', ip: vm.main, description: 'WSL Backend Server' },
+    { id: 'frontend', name: 'Frontend VM', ip: vm.frontend, description: 'Vue.js Frontend' },
+    { id: 'npu', name: 'NPU VM', ip: vm.npu, description: 'NPU Acceleration' },
+    { id: 'redis', name: 'Redis VM', ip: vm.redis, description: 'Redis Stack' },
+    { id: 'ai', name: 'AI VM', ip: vm.ai, description: 'AI Processing' },
+    { id: 'browser', name: 'Browser VM', ip: vm.browser, description: 'Playwright Automation' },
+    { id: 'slm', name: 'SLM Server', ip: vm.slm, description: 'Service Lifecycle Manager' },
   ],
 }
 
@@ -104,8 +142,8 @@ export function getConfig(): SLMConfig {
 /**
  * Get the SLM API base path (#2829).
  *
- * Standalone SLM (separate host): VITE_API_URL is empty → returns '/api'
- * Co-located with user frontend:  VITE_API_URL='/slm'  → returns '/slm/api'
+ * Standalone SLM (separate host): VITE_API_URL is empty -> returns '/api'
+ * Co-located with user frontend:  VITE_API_URL='/slm'  -> returns '/slm/api'
  *
  * All SLM composables should use this instead of hardcoding '/api'.
  */
@@ -152,7 +190,7 @@ export function getHosts(): SLMConfig['hosts'] {
 
 /**
  * Get VNC-enabled hosts with port configuration.
- * Returns empty — VNC hosts are discovered dynamically via the SLM API
+ * Returns empty -- VNC hosts are discovered dynamically via the SLM API
  * from nodes that have the 'vnc' role active (#2900).
  */
 export function getVNCHosts(): Array<{ id: string; name: string; host: string; port: number; description: string }> {


### PR DESCRIPTION
## Summary
- Added `getEnv`/`getEnvNumber` helpers matching main frontend
- All 7 VM IPs use `VITE_*_HOST` env var overrides
- All 12 ports use `VITE_*_PORT` env var overrides
- `hosts` array derives from `vm` object (no IP duplication)
- Same env var names as main frontend for single `.env` configuration

Closes #3049

## Test plan
- [ ] SLM frontend builds with default values (no env vars)
- [ ] SLM frontend respects VITE_BACKEND_HOST override
- [ ] Same env var names work in both frontends

🤖 Generated with [Claude Code](https://claude.com/claude-code)