### PR TITLE
fix(frontend): replace hardcoded IPs in vite.config and ServiceDiscovery (#3052)

### DIFF
--- a/autobot-frontend/src/config/ServiceDiscovery.js
+++ b/autobot-frontend/src/config/ServiceDiscovery.js
@@ -25,7 +25,31 @@ export default class ServiceDiscovery {
     this.config = getConfig();
     this.debugMode = import.meta.env.DEV || this.config.feature.debug;
 
+    // Derive VM subnet prefixes from SSOT config VM IPs (#3052)
+    // instead of hardcoding subnet strings like '172.16.168.'
+    this.vmSubnetPrefixes = this._deriveVmSubnetPrefixes();
+
     this.log('ServiceDiscovery initialized with SSOT config');
+  }
+
+  /**
+   * Derive unique subnet prefixes (first 3 octets) from configured VM IPs.
+   * Returns an array like ['172.16.168.'] derived from actual SSOT VM addresses.
+   */
+  _deriveVmSubnetPrefixes() {
+    const vmIps = Object.values(this.config.vm).filter(
+      (ip) => typeof ip === 'string' && ip.length > 0 && ip !== '127.0.0.1' && ip !== 'localhost'
+    );
+
+    const prefixes = new Set();
+    for (const ip of vmIps) {
+      const parts = ip.split('.');
+      if (parts.length === 4) {
+        prefixes.add(`${parts[0]}.${parts[1]}.${parts[2]}.`);
+      }
+    }
+
+    return Array.from(prefixes);
   }
 
   /**
@@ -232,7 +256,8 @@ export default class ServiceDiscovery {
   }
 
   /**
-   * Detect current deployment environment
+   * Detect current deployment environment.
+   * VM subnet detection uses prefixes derived from SSOT config (#3052).
    */
   _detectEnvironment() {
     const hostname = window.location.hostname;
@@ -243,8 +268,8 @@ export default class ServiceDiscovery {
       return 'development';
     }
 
-    // VM environment (specific IP ranges)
-    if (hostname.startsWith('172.16.168.') || hostname.startsWith('192.168.')) {
+    // VM environment - match subnets derived from SSOT VM IPs
+    if (this.vmSubnetPrefixes.some((prefix) => hostname.startsWith(prefix))) {
       return 'vm';
     }
 

--- a/autobot-frontend/vite.config.ts
+++ b/autobot-frontend/vite.config.ts
@@ -42,9 +42,9 @@ function vadAssetsPlugin(): Plugin {
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const config = {
-    backend: { host: env.VITE_BACKEND_HOST || '172.16.168.20', port: env.VITE_BACKEND_PORT || '8001' },
-    browser: { host: env.VITE_BROWSER_HOST || '172.16.168.25', port: env.VITE_BROWSER_PORT || '3000' },
-    vnc: { host: env.VITE_DESKTOP_VNC_HOST || env.VITE_BACKEND_HOST || '172.16.168.20', port: env.VITE_DESKTOP_VNC_PORT || '6080' },
+    backend: { host: env.VITE_BACKEND_HOST || '127.0.0.1', port: env.VITE_BACKEND_PORT || '8001' },
+    browser: { host: env.VITE_BROWSER_HOST || '127.0.0.1', port: env.VITE_BROWSER_PORT || '3000' },
+    vnc: { host: env.VITE_DESKTOP_VNC_HOST || env.VITE_BACKEND_HOST || '127.0.0.1', port: env.VITE_DESKTOP_VNC_PORT || '6080' },
     protocol: env.VITE_HTTP_PROTOCOL || 'http'
   }
 


### PR DESCRIPTION
## Summary
- `vite.config.ts`: fallback IPs → `127.0.0.1` (safe default when no .env)
- `ServiceDiscovery.js`: derive subnet prefixes from SSOT `config.vm.*` dynamically

Closes #3052

## Test plan
- [ ] Dev server proxies work with VITE_BACKEND_HOST env var
- [ ] ServiceDiscovery detects VM environment from SSOT config
- [ ] No hardcoded fleet IPs remain in either file

🤖 Generated with [Claude Code](https://claude.com/claude-code)