### PR TITLE
fix(infra): replace hardcoded IPs in utility scripts with env var overrides (#3051)

### DIFF
--- a/autobot-infrastructure/shared/scripts/infrastructure/playwright-server.js
+++ b/autobot-infrastructure/shared/scripts/infrastructure/playwright-server.js
@@ -7,6 +7,9 @@ const express = require('express');
 const winston = require('winston');
 const app = express();
 
+// Configuration from environment variables with safe localhost defaults
+const FRONTEND_URL = process.env.AUTOBOT_FRONTEND_URL || 'http://127.0.0.1:5173';
+
 // Configure Winston logger
 const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
@@ -315,7 +318,7 @@ app.post('/send-test-message', async (req, res) => {
     message: req.body.message
   });
   try {
-    const { frontend_url = 'http://172.16.168.21:5173', message = 'what network scanning tools do we have available?' } = req.body;
+    const { frontend_url = FRONTEND_URL, message = 'what network scanning tools do we have available?' } = req.body;
 
     const browser = await initBrowser();
     const page = await browser.newPage();
@@ -534,7 +537,7 @@ app.post('/test-frontend', async (req, res) => {
     frontend_url: req.body.frontend_url
   });
   try {
-    const { frontend_url = 'http://172.16.168.21:5173' } = req.body;
+    const { frontend_url = FRONTEND_URL } = req.body;
 
     const browser = await initBrowser();
     const page = await browser.newPage();
@@ -1016,7 +1019,7 @@ app.post('/reload', async (req, res) => {
 
 // Health check endpoint with frontend connectivity test
 app.get('/test-frontend-connectivity', async (req, res) => {
-  const frontendUrl = req.query.url || 'http://172.16.168.21:5173';
+  const frontendUrl = req.query.url || FRONTEND_URL;
 
   logger.info('Testing frontend connectivity', {
     endpoint: '/test-frontend-connectivity',
@@ -1060,7 +1063,7 @@ app.get('/test-frontend-connectivity', async (req, res) => {
       frontend_url: frontendUrl,
       error: error.message,
       navigation_config: NAVIGATION_CONFIG,
-      recommendation: 'Check if frontend is running on VM1 (172.16.168.21:5173)',
+      recommendation: `Check if frontend is running at ${FRONTEND_URL}`,
       timestamp: new Date().toISOString()
     });
   }

--- a/autobot-infrastructure/shared/scripts/utilities/capture_console_logs.js
+++ b/autobot-infrastructure/shared/scripts/utilities/capture_console_logs.js
@@ -1,9 +1,15 @@
 /**
  * Console log capture script for Browser VM
  * Captures browser console warnings and errors from chat view
+ *
+ * Environment variables:
+ *   AUTOBOT_FRONTEND_URL  - Frontend base URL (default: http://127.0.0.1:5173)
  */
 
 const puppeteer = require('puppeteer');
+
+// Configuration from environment variables with safe localhost defaults
+const FRONTEND_URL = process.env.AUTOBOT_FRONTEND_URL || 'http://127.0.0.1:5173';
 
 async function captureConsoleLogs() {
     let browser;
@@ -59,8 +65,9 @@ async function captureConsoleLogs() {
         });
 
         // Navigate to chat view
-        console.log('Navigating to chat view...');
-        await page.goto('http://172.16.168.21:5173/chat', {
+        const chatUrl = `${FRONTEND_URL}/chat`;
+        console.log(`Navigating to chat view at ${chatUrl}...`);
+        await page.goto(chatUrl, {
             waitUntil: 'networkidle2',
             timeout: 30000
         });
@@ -93,9 +100,9 @@ async function captureConsoleLogs() {
         // Output results
         console.log('\n=== CONSOLE ANALYSIS RESULTS ===');
         if (consoleMessages.length === 0) {
-            console.log('✅ No console warnings or errors detected');
+            console.log('No console warnings or errors detected');
         } else {
-            console.log(`❌ Found ${consoleMessages.length} console issues:`);
+            console.log(`Found ${consoleMessages.length} console issues:`);
             consoleMessages.forEach((msg, index) => {
                 console.log(`\n${index + 1}. [${msg.type.toUpperCase()}] ${msg.text}`);
                 if (msg.location && msg.location.url) {
@@ -112,7 +119,7 @@ async function captureConsoleLogs() {
         const resultsPath = '/tmp/console_analysis_results.json';
         fs.writeFileSync(resultsPath, JSON.stringify({
             timestamp: new Date().toISOString(),
-            url: 'http://172.16.168.21:5173/chat',
+            url: chatUrl,
             totalIssues: consoleMessages.length,
             messages: consoleMessages
         }, null, 2));

--- a/autobot-infrastructure/shared/scripts/utilities/test_console_using_browser_vm.js
+++ b/autobot-infrastructure/shared/scripts/utilities/test_console_using_browser_vm.js
@@ -1,15 +1,25 @@
 /**
  * Test console warnings and errors using AutoBot's Browser VM
- * This script uses AutoBot's dedicated Browser VM (172.16.168.25:3000) for browser automation
+ * This script uses AutoBot's dedicated Browser VM for browser automation
  * instead of installing Playwright locally on Kali Linux (which is incompatible)
+ *
+ * Environment variables:
+ *   AUTOBOT_BROWSER_HOST  - Browser VM hostname (default: 127.0.0.1)
+ *   AUTOBOT_BROWSER_PORT  - Browser VM port (default: 3000)
+ *   AUTOBOT_FRONTEND_URL  - Frontend base URL (default: http://127.0.0.1:5173)
  */
 
 const http = require('http');
 const https = require('https');
 const querystring = require('querystring');
 
+// Configuration from environment variables with safe localhost defaults
+const BROWSER_VM_HOST = process.env.AUTOBOT_BROWSER_HOST || '127.0.0.1';
+const BROWSER_VM_PORT = parseInt(process.env.AUTOBOT_BROWSER_PORT || '3000', 10);
+const FRONTEND_URL = process.env.AUTOBOT_FRONTEND_URL || 'http://127.0.0.1:5173';
+
 class BrowserVMClient {
-    constructor(browserVMHost = '172.16.168.25', browserVMPort = 3000) {
+    constructor(browserVMHost = BROWSER_VM_HOST, browserVMPort = BROWSER_VM_PORT) {
         this.browserVMHost = browserVMHost;
         this.browserVMPort = browserVMPort;
         this.baseUrl = `http://${browserVMHost}:${browserVMPort}`;
@@ -69,16 +79,16 @@ class BrowserVMClient {
      */
     async startBrowserSession() {
         try {
-            console.log('🌐 Starting browser session on Browser VM...');
+            console.log('Starting browser session on Browser VM...');
             const response = await this.sendRequest('/api/browser/start', 'POST', {
                 headless: false,
                 viewport: { width: 1920, height: 1080 }
             });
 
-            console.log('✅ Browser session started:', response);
+            console.log('Browser session started:', response);
             return response.sessionId;
         } catch (error) {
-            console.error('❌ Failed to start browser session:', error.message);
+            console.error('Failed to start browser session:', error.message);
             throw error;
         }
     }
@@ -88,7 +98,7 @@ class BrowserVMClient {
      */
     async navigateAndCaptureConsole(sessionId, url) {
         try {
-            console.log(`🔍 Navigating to ${url} and capturing console messages...`);
+            console.log(`Navigating to ${url} and capturing console messages...`);
 
             // Navigate to the URL
             await this.sendRequest('/api/browser/navigate', 'POST', {
@@ -108,7 +118,7 @@ class BrowserVMClient {
 
             return consoleMessages;
         } catch (error) {
-            console.error('❌ Failed to navigate and capture console:', error.message);
+            console.error('Failed to navigate and capture console:', error.message);
             throw error;
         }
     }
@@ -119,9 +129,9 @@ class BrowserVMClient {
     async closeBrowserSession(sessionId) {
         try {
             await this.sendRequest('/api/browser/close', 'POST', { sessionId });
-            console.log('✅ Browser session closed');
+            console.log('Browser session closed');
         } catch (error) {
-            console.error('⚠️  Failed to close browser session:', error.message);
+            console.error('Failed to close browser session:', error.message);
         }
     }
 }
@@ -135,18 +145,18 @@ async function testChatViewConsole() {
         sessionId = await browserClient.startBrowserSession();
 
         // Test chat view console
-        const chatUrl = 'http://172.16.168.21:5173/chat';
-        console.log(`🔍 Testing chat view console at: ${chatUrl}`);
+        const chatUrl = `${FRONTEND_URL}/chat`;
+        console.log(`Testing chat view console at: ${chatUrl}`);
 
         const consoleMessages = await browserClient.navigateAndCaptureConsole(sessionId, chatUrl);
 
         // Analyze results
         console.log('\n=== CONSOLE ANALYSIS RESULTS ===');
         if (!consoleMessages || !consoleMessages.messages || consoleMessages.messages.length === 0) {
-            console.log('✅ No console warnings or errors detected in chat view!');
-            console.log('🎉 Console warnings and errors have been successfully eliminated!');
+            console.log('No console warnings or errors detected in chat view!');
+            console.log('Console warnings and errors have been successfully eliminated!');
         } else {
-            console.log(`❌ Found ${consoleMessages.messages.length} console issues:`);
+            console.log(`Found ${consoleMessages.messages.length} console issues:`);
             consoleMessages.messages.forEach((msg, index) => {
                 console.log(`\n${index + 1}. [${msg.type.toUpperCase()}] ${msg.text}`);
                 if (msg.location && msg.location.url) {
@@ -167,30 +177,30 @@ async function testChatViewConsole() {
         const fs = require('fs');
         const resultsPath = '/tmp/console_test_results.json';
         fs.writeFileSync(resultsPath, JSON.stringify(results, null, 2));
-        console.log(`\n💾 Results saved to: ${resultsPath}`);
+        console.log(`\nResults saved to: ${resultsPath}`);
 
         return results;
 
     } catch (error) {
-        console.error('❌ Browser VM automation failed:', error);
+        console.error('Browser VM automation failed:', error);
 
         // Fallback: Try simple HTTP check
-        console.log('\n🔄 Falling back to simple HTTP check...');
+        console.log('\nFalling back to simple HTTP check...');
         try {
             const http = require('http');
-            const testReq = http.get('http://172.16.168.21:5173/', (res) => {
-                console.log(`✅ Frontend is accessible (HTTP ${res.statusCode})`);
-                console.log('💡 Frontend and backend are now properly connected');
-                console.log('🎯 Previous console warnings were likely due to backend module import failures');
-                console.log('✅ Backend is now running with correct Python path, eliminating import errors');
+            const testReq = http.get(`${FRONTEND_URL}/`, (res) => {
+                console.log(`Frontend is accessible (HTTP ${res.statusCode})`);
+                console.log('Frontend and backend are now properly connected');
+                console.log('Previous console warnings were likely due to backend module import failures');
+                console.log('Backend is now running with correct Python path, eliminating import errors');
             });
 
             testReq.on('error', (err) => {
-                console.error('❌ Frontend accessibility test failed:', err.message);
+                console.error('Frontend accessibility test failed:', err.message);
             });
 
         } catch (fallbackError) {
-            console.error('❌ Fallback test also failed:', fallbackError.message);
+            console.error('Fallback test also failed:', fallbackError.message);
         }
 
     } finally {
@@ -202,11 +212,12 @@ async function testChatViewConsole() {
 }
 
 // Run the test
-console.log('🚀 Starting console test using AutoBot Browser VM...');
-console.log('📋 This uses the dedicated Browser VM (172.16.168.25:3000) instead of local Playwright');
-console.log('🔧 Following CLAUDE.md guidelines for Kali Linux compatibility\n');
+console.log('Starting console test using AutoBot Browser VM...');
+console.log(`Browser VM: ${BROWSER_VM_HOST}:${BROWSER_VM_PORT}`);
+console.log(`Frontend URL: ${FRONTEND_URL}`);
+console.log('Following CLAUDE.md guidelines for Kali Linux compatibility\n');
 
 testChatViewConsole().catch(error => {
-    console.error('💥 Test execution failed:', error);
+    console.error('Test execution failed:', error);
     process.exit(1);
 });


### PR DESCRIPTION
## Summary

- Add `process.env.*` with fallback pattern to infrastructure utility/test scripts
- Replace all hardcoded `172.16.168.*` IPs with configurable env var constants
- Matches existing `test-validation-comprehensive-fixed.js` pattern

### Files changed:
- `autobot-infrastructure/shared/scripts/utilities/test_console_using_browser_vm.js`
- `autobot-infrastructure/shared/scripts/utilities/capture_console_logs.js`
- `autobot-infrastructure/shared/scripts/infrastructure/playwright-server.js`

Closes #3051

## Test plan

- [ ] Scripts still work with default IPs (no env vars set)
- [ ] `FRONTEND_URL=http://10.0.0.1:5173` override works for each script
- [ ] `BROWSER_VM_HOST` override works for browser VM scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)