### PR TITLE
feat(slm): add provision log streaming with heartbeat for long tasks (#3033)

### DIFF
--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -15,6 +15,8 @@ import shutil
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from services.provision_progress import TaskProgressTracker
+
 logger = logging.getLogger(__name__)
 
 
@@ -226,29 +228,60 @@ class PlaybookExecutor:
         progress_callback: Optional[callable],
     ) -> List[str]:
         """
-        Stream and parse playbook output for progress.
+        Stream and parse playbook output for progress (Issue #880, #3033).
 
-        Helper for execute_playbook (Issue #880).
+        Fires progress_callback for each recognized Ansible output line.
+        Between recognized lines — when Ansible is silent during long-running
+        tasks such as ``ollama pull`` or ``npm install`` — a TaskProgressTracker
+        sends periodic heartbeat messages so the UI does not appear stuck.
+
+        A new tracker is started each time a TASK line is detected and the
+        previous one is cancelled, so heartbeats are scoped per task.
         """
         output_lines = []
+        current_tracker: Optional[TaskProgressTracker] = None
+
+        async def _stop_current_tracker() -> None:
+            nonlocal current_tracker
+            if current_tracker is not None:
+                await current_tracker.__aexit__(None, None, None)
+                current_tracker = None
+
+        async def _start_tracker(task_name: str) -> None:
+            nonlocal current_tracker
+            await _stop_current_tracker()
+            if progress_callback is not None:
+                current_tracker = TaskProgressTracker(task_name, progress_callback)
+                await current_tracker.__aenter__()
+
         if process.stdout:
-            while True:
-                line = await process.stdout.readline()
-                if not line:
-                    break
+            try:
+                while True:
+                    line = await process.stdout.readline()
+                    if not line:
+                        break
 
-                line_str = line.decode("utf-8", errors="replace").rstrip()
-                output_lines.append(line_str)
+                    line_str = line.decode("utf-8", errors="replace").rstrip()
+                    output_lines.append(line_str)
 
-                if progress_callback:
-                    progress = self._parse_progress(line_str)
-                    if progress:
-                        try:
-                            await progress_callback(progress)
-                        except Exception as e:
-                            logger.debug(
-                                f"Progress callback error: {e}", exc_info=False
-                            )
+                    if progress_callback:
+                        progress = self._parse_progress(line_str)
+                        if progress:
+                            stage = progress.get("stage", "")
+                            # Start a fresh tracker for every new task boundary
+                            # so heartbeats reflect the task currently executing.
+                            if stage in ("task", "heartbeat") or stage.endswith(
+                                ("_starting", "_syncing", "_restarting", "_waiting")
+                            ):
+                                await _start_tracker(progress.get("message", stage))
+                            try:
+                                await progress_callback(progress)
+                            except Exception as e:
+                                logger.debug(
+                                    "Progress callback error: %s", e, exc_info=False
+                                )
+            finally:
+                await _stop_current_tracker()
 
         return output_lines
 

--- a/autobot-slm-backend/services/provision_progress.py
+++ b/autobot-slm-backend/services/provision_progress.py
@@ -1,0 +1,177 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Provision Progress Tracker (Issue #3033)
+
+Provides heartbeat / elapsed-time messages during long-running Ansible tasks
+(e.g. ``ollama pull``, ``npm install``, ``pip install``) that emit no output
+for extended periods and would otherwise leave the UI appearing stuck.
+
+Usage::
+
+    async with TaskProgressTracker(task_name, progress_callback) as tracker:
+        # ... await long operation ...
+
+The tracker fires a "Still running..." heartbeat via ``progress_callback``
+every ``HEARTBEAT_INTERVAL_SECONDS`` while the ``async with`` block is active.
+"""
+
+import asyncio
+import logging
+import re
+import time
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# How often (in seconds) to emit a heartbeat for a silent task.
+HEARTBEAT_INTERVAL_SECONDS: int = 5
+
+# Known slow task patterns mapped to human-readable duration estimates.
+# Patterns are matched (case-insensitively) against the Ansible task name.
+SLOW_TASK_HINTS: dict[str, str] = {
+    r"ollama\s+pull": "5-15 min per model",
+    r"npm\s+install": "1-3 min",
+    r"npm\s+ci": "1-3 min",
+    r"pip\s+install": "2-5 min",
+    r"pip3\s+install": "2-5 min",
+    r"vite\s+build": "30-60s",
+    r"apt(-get)?\s+(install|upgrade|dist-upgrade)": "1-5 min",
+    r"docker\s+pull": "2-10 min",
+    r"git\s+clone": "30s-5 min",
+}
+
+
+def _get_slow_task_hint(task_name: str) -> Optional[str]:
+    """Return an estimated-duration hint for *task_name*, or ``None``.
+
+    Tries each pattern in ``SLOW_TASK_HINTS`` against the full task name using
+    a case-insensitive substring search.
+
+    Args:
+        task_name: Ansible task name string to match.
+
+    Returns:
+        Human-readable estimate string, e.g. ``"5-15 min per model"``, or
+        ``None`` when no pattern matches.
+    """
+    lower = task_name.lower()
+    for pattern, hint in SLOW_TASK_HINTS.items():
+        if re.search(pattern, lower):
+            return hint
+    return None
+
+
+def format_elapsed(seconds: float) -> str:
+    """Format *seconds* as a human-readable elapsed string.
+
+    Examples::
+
+        format_elapsed(45)    -> "45s"
+        format_elapsed(90)    -> "1m 30s"
+        format_elapsed(3665)  -> "1h 1m 5s"
+
+    Args:
+        seconds: Elapsed time in seconds (may be fractional).
+
+    Returns:
+        Compact human-readable string.
+    """
+    secs = int(seconds)
+    if secs < 60:
+        return f"{secs}s"
+    minutes, secs = divmod(secs, 60)
+    if minutes < 60:
+        return f"{minutes}m {secs}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m {secs}s"
+
+
+class TaskProgressTracker:
+    """Async context manager that sends periodic heartbeats during a task.
+
+    While the ``async with`` block is active a background coroutine wakes up
+    every ``HEARTBEAT_INTERVAL_SECONDS`` and calls *progress_callback* with::
+
+        {
+            "stage": "heartbeat",
+            "message": "Still running... (elapsed: 2m 15s) [npm install — est. 1-3 min]"
+        }
+
+    The hint suffix is omitted when no slow-task pattern matches *task_name*.
+
+    Args:
+        task_name: Ansible task name (used for slow-task hint lookup and logs).
+        progress_callback: Async callable that accepts a ``dict`` with ``stage``
+            and ``message`` keys.  Must not raise — errors are swallowed and
+            logged at DEBUG level to avoid disrupting the calling coroutine.
+        heartbeat_interval: Override the default heartbeat cadence (seconds).
+            Primarily used in tests.
+    """
+
+    def __init__(
+        self,
+        task_name: str,
+        progress_callback: Optional[Callable],
+        *,
+        heartbeat_interval: int = HEARTBEAT_INTERVAL_SECONDS,
+    ) -> None:
+        self._task_name = task_name
+        self._progress_callback = progress_callback
+        self._heartbeat_interval = heartbeat_interval
+        self._start_time: float = 0.0
+        self._heartbeat_task: Optional[asyncio.Task] = None
+
+    async def __aenter__(self) -> "TaskProgressTracker":
+        self._start_time = time.monotonic()
+        if self._progress_callback is not None:
+            self._heartbeat_task = asyncio.ensure_future(self._heartbeat_loop())
+            logger.debug(
+                "TaskProgressTracker started for task: %s", self._task_name
+            )
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            self._heartbeat_task = None
+            logger.debug(
+                "TaskProgressTracker stopped for task: %s (elapsed: %s)",
+                self._task_name,
+                format_elapsed(time.monotonic() - self._start_time),
+            )
+
+    @property
+    def elapsed_seconds(self) -> float:
+        """Seconds since the tracker was entered."""
+        return time.monotonic() - self._start_time
+
+    async def _heartbeat_loop(self) -> None:
+        """Send periodic heartbeat messages until cancelled."""
+        hint = _get_slow_task_hint(self._task_name)
+        try:
+            while True:
+                await asyncio.sleep(self._heartbeat_interval)
+                elapsed_str = format_elapsed(self.elapsed_seconds)
+                if hint:
+                    msg = (
+                        f"Still running... (elapsed: {elapsed_str})"
+                        f" [{self._task_name} — est. {hint}]"
+                    )
+                else:
+                    msg = f"Still running... (elapsed: {elapsed_str})"
+                try:
+                    await self._progress_callback(
+                        {"stage": "heartbeat", "message": msg}
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "TaskProgressTracker: progress_callback error: %s", exc
+                    )
+        except asyncio.CancelledError:
+            pass

--- a/autobot-slm-backend/tests/test_provision_progress.py
+++ b/autobot-slm-backend/tests/test_provision_progress.py
@@ -1,0 +1,264 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for provision_progress module (Issue #3033).
+
+Covers:
+- format_elapsed: boundary formatting (seconds, minutes, hours)
+- _get_slow_task_hint: pattern matching and None for unknown tasks
+- TaskProgressTracker: heartbeat timing, elapsed property, lifecycle
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure autobot-slm-backend is on sys.path for direct test runs.
+_slm_root = Path(__file__).parent.parent
+if str(_slm_root) not in sys.path:
+    sys.path.insert(0, str(_slm_root))
+
+from services.provision_progress import (
+    TaskProgressTracker,
+    _get_slow_task_hint,
+    format_elapsed,
+)
+
+
+# ---------------------------------------------------------------------------
+# format_elapsed
+# ---------------------------------------------------------------------------
+
+
+class TestFormatElapsed:
+    def test_zero_seconds(self):
+        assert format_elapsed(0) == "0s"
+
+    def test_under_one_minute(self):
+        assert format_elapsed(45) == "45s"
+
+    def test_exactly_one_minute(self):
+        assert format_elapsed(60) == "1m 0s"
+
+    def test_minutes_and_seconds(self):
+        assert format_elapsed(90) == "1m 30s"
+
+    def test_exactly_one_hour(self):
+        assert format_elapsed(3600) == "1h 0m 0s"
+
+    def test_hours_minutes_seconds(self):
+        assert format_elapsed(3665) == "1h 1m 5s"
+
+    def test_fractional_seconds_truncated(self):
+        # Fractional part is truncated via int(), not rounded
+        assert format_elapsed(59.9) == "59s"
+
+
+# ---------------------------------------------------------------------------
+# _get_slow_task_hint
+# ---------------------------------------------------------------------------
+
+
+class TestGetSlowTaskHint:
+    def test_ollama_pull_matches(self):
+        hint = _get_slow_task_hint("ollama pull llama3")
+        assert hint is not None
+        assert "min" in hint
+
+    def test_npm_install_matches(self):
+        hint = _get_slow_task_hint("Run npm install for frontend")
+        assert hint is not None
+
+    def test_npm_ci_matches(self):
+        hint = _get_slow_task_hint("npm ci --production")
+        assert hint is not None
+
+    def test_pip_install_matches(self):
+        hint = _get_slow_task_hint("pip install -r requirements.txt")
+        assert hint is not None
+
+    def test_pip3_install_matches(self):
+        hint = _get_slow_task_hint("pip3 install torch")
+        assert hint is not None
+
+    def test_vite_build_matches(self):
+        hint = _get_slow_task_hint("Run vite build")
+        assert hint is not None
+
+    def test_apt_install_matches(self):
+        hint = _get_slow_task_hint("apt-get install -y nginx")
+        assert hint is not None
+
+    def test_docker_pull_matches(self):
+        hint = _get_slow_task_hint("docker pull ubuntu:22.04")
+        assert hint is not None
+
+    def test_git_clone_matches(self):
+        hint = _get_slow_task_hint("git clone https://github.com/example/repo")
+        assert hint is not None
+
+    def test_case_insensitive(self):
+        hint = _get_slow_task_hint("Ollama Pull MyModel")
+        assert hint is not None
+
+    def test_unknown_task_returns_none(self):
+        assert _get_slow_task_hint("Restart autobot-backend service") is None
+
+    def test_empty_string_returns_none(self):
+        assert _get_slow_task_hint("") is None
+
+
+# ---------------------------------------------------------------------------
+# TaskProgressTracker
+# ---------------------------------------------------------------------------
+
+
+class TestTaskProgressTracker:
+    @pytest.mark.asyncio
+    async def test_heartbeat_is_sent_after_interval(self):
+        """Tracker fires callback within 2x the interval."""
+        received: list[dict] = []
+
+        async def callback(progress: dict) -> None:
+            received.append(progress)
+
+        tracker = TaskProgressTracker(
+            "npm install", callback, heartbeat_interval=1
+        )
+        async with tracker:
+            await asyncio.sleep(1.5)  # Wait slightly longer than interval
+
+        assert received, "No heartbeat received"
+        assert received[0]["stage"] == "heartbeat"
+        assert "Still running" in received[0]["message"]
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_message_includes_elapsed(self):
+        """Heartbeat message contains elapsed time."""
+        received: list[dict] = []
+
+        async def callback(progress: dict) -> None:
+            received.append(progress)
+
+        tracker = TaskProgressTracker(
+            "pip install", callback, heartbeat_interval=1
+        )
+        async with tracker:
+            await asyncio.sleep(1.5)
+
+        assert received
+        msg = received[0]["message"]
+        assert "elapsed" in msg
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_includes_slow_task_hint(self):
+        """Heartbeat for a known slow task includes its duration estimate."""
+        received: list[dict] = []
+
+        async def callback(progress: dict) -> None:
+            received.append(progress)
+
+        tracker = TaskProgressTracker(
+            "ollama pull llama3", callback, heartbeat_interval=1
+        )
+        async with tracker:
+            await asyncio.sleep(1.5)
+
+        assert received
+        msg = received[0]["message"]
+        assert "min" in msg  # The ollama hint mentions minutes
+
+    @pytest.mark.asyncio
+    async def test_no_hint_for_unknown_task(self):
+        """Heartbeat for an unknown task does NOT include an estimate bracket."""
+        received: list[dict] = []
+
+        async def callback(progress: dict) -> None:
+            received.append(progress)
+
+        tracker = TaskProgressTracker(
+            "Restart nginx", callback, heartbeat_interval=1
+        )
+        async with tracker:
+            await asyncio.sleep(1.5)
+
+        assert received
+        msg = received[0]["message"]
+        # Square-bracket hint section should be absent
+        assert "[" not in msg
+
+    @pytest.mark.asyncio
+    async def test_no_heartbeat_when_no_callback(self):
+        """Tracker with callback=None does not raise and produces no output."""
+        tracker = TaskProgressTracker("npm install", None, heartbeat_interval=1)
+        async with tracker:
+            await asyncio.sleep(0.1)
+        # If we reach here without exception, the test passes.
+
+    @pytest.mark.asyncio
+    async def test_elapsed_seconds_advances(self):
+        """elapsed_seconds increases while inside the context."""
+        tracker = TaskProgressTracker("pip install", None, heartbeat_interval=60)
+        async with tracker:
+            await asyncio.sleep(0.1)
+            elapsed = tracker.elapsed_seconds
+        assert elapsed >= 0.05
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_stops_on_exit(self):
+        """No heartbeats are emitted after exiting the context manager."""
+        received: list[dict] = []
+
+        async def callback(progress: dict) -> None:
+            received.append(progress)
+
+        tracker = TaskProgressTracker("npm ci", callback, heartbeat_interval=1)
+        async with tracker:
+            await asyncio.sleep(1.5)
+
+        count_on_exit = len(received)
+        await asyncio.sleep(1.5)  # Wait another interval after exit
+
+        assert len(received) == count_on_exit, (
+            "Heartbeats continued after context manager exited"
+        )
+
+    @pytest.mark.asyncio
+    async def test_callback_exception_does_not_crash_tracker(self):
+        """A raising callback is swallowed — tracker continues."""
+        call_count = 0
+
+        async def bad_callback(progress: dict) -> None:
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("simulated callback failure")
+
+        tracker = TaskProgressTracker(
+            "pip install torch", bad_callback, heartbeat_interval=1
+        )
+        async with tracker:
+            await asyncio.sleep(2.5)
+
+        # Should have attempted at least 2 heartbeats without crashing
+        assert call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_multiple_heartbeats_in_interval(self):
+        """Multiple heartbeats fire over a longer wait period."""
+        received: list[dict] = []
+
+        async def callback(progress: dict) -> None:
+            received.append(progress)
+
+        tracker = TaskProgressTracker(
+            "docker pull ubuntu", callback, heartbeat_interval=1
+        )
+        async with tracker:
+            await asyncio.sleep(3.5)
+
+        assert len(received) >= 3, (
+            f"Expected at least 3 heartbeats, got {len(received)}"
+        )


### PR DESCRIPTION
## Summary
- `TaskProgressTracker` async context manager sends heartbeat every 5s during long tasks
- Shows elapsed time and estimated duration for 9 known slow task patterns
- Wired into `_stream_playbook_output` with automatic start/stop per task
- Heartbeat format: "Still running... (elapsed: 2m 15s) [est. 5-15 min per model]"
- 21 tests covering formatting, hint matching, tracker lifecycle

Closes #3033

## Test plan
- [x] format_elapsed: boundary cases (0s, <60s, minutes, hours)
- [x] Slow task hint matching: all 9 patterns, case-insensitive
- [x] Tracker: heartbeat fires, message format, hint inclusion, callback error tolerance
- [x] Tracker cleanup on exit
- [x] flake8 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)