### PR TITLE
fix(security): exempt agent heartbeat from CSRF middleware

### DIFF
--- a/autobot-slm-backend/middleware/security_headers.py
+++ b/autobot-slm-backend/middleware/security_headers.py
@@ -51,6 +51,7 @@ _AUTH_EXEMPT_PREFIXES = (
     "/api/redoc",
     "/api/openapi.json",
     "/api/api-keys/scopes",  # public endpoint — no auth required
+    "/api/nodes/",  # agent heartbeats — no browser auth, endpoints have own guards
 )
 
 


### PR DESCRIPTION
Agent heartbeats (POST /api/nodes/{id}/heartbeat) were blocked by CSRF middleware requiring Authorization header. Agent uses service-to-service calls without browser auth.