### PR TITLE
fix(slm-frontend): replace hardcoded proxy targets with env var overrides (#3076)

### DIFF
--- a/autobot-slm-frontend/vite.config.ts
+++ b/autobot-slm-frontend/vite.config.ts
@@ -2,56 +2,62 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { fileURLToPath, URL } from 'node:url'
 
-export default defineConfig({
-  base: '/slm/',
-  plugins: [vue()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-      '@shared': fileURLToPath(new URL('../autobot-shared', import.meta.url))
-    }
-  },
-  server: {
-    host: '0.0.0.0',
-    port: 5173,
-    proxy: {
-      // SLM Backend API - backend runs on SLM server (.19)
-      '/api': {
-        target: 'https://172.16.168.19',
-        changeOrigin: true,
-        secure: false,
-        ws: true
-      },
-      // Grafana/Prometheus via SLM server nginx proxy
-      '/grafana': {
-        target: 'https://172.16.168.19',
-        changeOrigin: true,
-        secure: false
-      },
-      '/prometheus': {
-        target: 'https://172.16.168.19',
-        changeOrigin: true,
-        secure: false
-      },
-      // Main AutoBot backend for admin functionality (Issue #729)
-      // Issue #1779: inject X-Internal-API-Key for service auth
-      '/autobot-api': {
-        target: 'http://172.16.168.20:8001',
-        changeOrigin: true,
-        ws: true,
-        rewrite: (path) => path.replace(/^\/autobot-api/, '/api'),
-        headers: {
-          'X-Internal-API-Key': process.env.AUTOBOT_INTERNAL_API_KEY || '',
-        },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const slmTarget = env.VITE_SLM_PROXY_TARGET || 'https://172.16.168.19'
+  const autobotTarget = env.VITE_AUTOBOT_PROXY_TARGET || 'http://172.16.168.20:8001'
+
+  return {
+    base: '/slm/',
+    plugins: [vue()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@shared': fileURLToPath(new URL('../autobot-shared', import.meta.url))
       }
+    },
+    server: {
+      host: '0.0.0.0',
+      port: 5173,
+      proxy: {
+        // SLM Backend API - backend runs on SLM server (.19)
+        '/api': {
+          target: slmTarget,
+          changeOrigin: true,
+          secure: false,
+          ws: true
+        },
+        // Grafana/Prometheus via SLM server nginx proxy
+        '/grafana': {
+          target: slmTarget,
+          changeOrigin: true,
+          secure: false
+        },
+        '/prometheus': {
+          target: slmTarget,
+          changeOrigin: true,
+          secure: false
+        },
+        // Main AutoBot backend for admin functionality (Issue #729)
+        // Issue #1779: inject X-Internal-API-Key for service auth
+        '/autobot-api': {
+          target: autobotTarget,
+          changeOrigin: true,
+          ws: true,
+          rewrite: (path) => path.replace(/^\/autobot-api/, '/api'),
+          headers: {
+            'X-Internal-API-Key': process.env.AUTOBOT_INTERNAL_API_KEY || '',
+          },
+        }
+      }
+    },
+    build: {
+      outDir: 'dist',
+      sourcemap: true
     }
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: true
   }
 })


### PR DESCRIPTION
## Summary

- Extract 4 hardcoded proxy IPs in `vite.config.ts` to env vars
- `VITE_SLM_PROXY_TARGET` (default: `https://172.16.168.19`) for /api, /grafana, /prometheus
- `VITE_AUTOBOT_PROXY_TARGET` (default: `http://172.16.168.20:8001`) for /autobot-api
- Uses `loadEnv()` to read env vars at dev server startup

Closes #3076

## Test plan

- [ ] `npm run dev` in `autobot-slm-frontend/` still proxies correctly with defaults
- [ ] Setting `VITE_SLM_PROXY_TARGET=https://10.0.0.1` overrides the SLM proxy
- [ ] `npm run build` succeeds (proxy config is dev-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)