### PR TITLE
fix(infra): replace hardcoded IPs in 2 missed test files (#3077)

### DIFF
--- a/autobot-infrastructure/autobot-frontend/tests/gui/frontend_gui_comprehensive.js
+++ b/autobot-infrastructure/autobot-frontend/tests/gui/frontend_gui_comprehensive.js
@@ -5,9 +5,12 @@ const { chromium } = require('playwright');
  * Tests actual UI components and user interactions
  */
 
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://172.16.168.21:5173';
+const BACKEND_URL = process.env.BACKEND_URL || 'http://172.16.168.20:8001';
+
 const CONFIG = {
-    frontendUrl: 'http://172.16.168.21:5173',
-    backendUrl: 'http://172.16.168.20:8001',
+    frontendUrl: FRONTEND_URL,
+    backendUrl: BACKEND_URL,
     timeout: 30000,
     screenshotDir: 'tests/screenshots'
 };

--- a/autobot-infrastructure/autobot-frontend/tests/test_frontend_workflow_integration.js
+++ b/autobot-infrastructure/autobot-frontend/tests/test_frontend_workflow_integration.js
@@ -3,6 +3,8 @@
  * Test the exact frontend workflow integration scenario
  */
 
+const BACKEND_URL = process.env.BACKEND_URL || 'https://172.16.168.20:8443';
+
 async function testFrontendWorkflowIntegration() {
     console.log('🧪 Testing Frontend Workflow Integration');
     console.log('=====================================');
@@ -20,7 +22,7 @@ async function testFrontendWorkflowIntegration() {
 
         try {
             // Exact same call as ChatInterface.vue makes
-            const workflowResponse = await fetch('https://172.16.168.20:8443/api/workflow/execute', {
+            const workflowResponse = await fetch(`${BACKEND_URL}/api/workflow/execute`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -73,7 +75,7 @@ async function testFrontendWorkflowIntegration() {
                     console.log(`   🔄 Checking workflow status...`);
                     await new Promise(resolve => setTimeout(resolve, 2000)); // Wait 2 seconds
 
-                    const statusResponse = await fetch(`https://172.16.168.20:8443/api/workflow/workflow/${workflowResult.workflow_id}/status`);
+                    const statusResponse = await fetch(`${BACKEND_URL}/api/workflow/workflow/${workflowResult.workflow_id}/status`);
                     if (statusResponse.ok) {
                         const statusData = await statusResponse.json();
                         console.log(`   ✅ Workflow status: ${statusData.status}`);


### PR DESCRIPTION
## Summary

- Add `process.env.*` with fallback pattern to 2 test files missed by PR #3062
- `frontend_gui_comprehensive.js`: `FRONTEND_URL` + `BACKEND_URL` env vars
- `test_frontend_workflow_integration.js`: `BACKEND_URL` env var

Closes #3077

## Test plan

- [ ] Both test scripts still work with default IPs (no env vars set)
- [ ] `BACKEND_URL=https://10.0.0.1:8443` override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)