### PR TITLE
fix(backend): reorder analytics routes to fix /sources/summary 404 (#3107)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/sources.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources.py
@@ -255,6 +255,25 @@ async def create_code_source(request: CodeSourceCreateRequest):
     return JSONResponse(source.model_dump(), status_code=201)
 
 
+@router.get("/sources/summary")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="batch_source_summary",
+    error_code_prefix="CODEBASE",
+)
+async def get_all_source_summaries():
+    """Return summaries for all sources in one request (#1468).
+
+    Replaces N+1 per-source /summary calls from the landing page.
+    Registered before /sources/{source_id} to avoid the literal
+    string "summary" being captured by the {source_id} path parameter (#2654, #3107).
+    """
+    sources = await list_sources()
+    results = await asyncio.gather(*[_build_summary(s) for s in sources])
+    summaries = {r["source_id"]: r for r in results}
+    return JSONResponse({"summaries": summaries})
+
+
 @router.get("/sources/{source_id}")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -311,25 +330,6 @@ async def delete_code_source(source_id: str):
     ok = await delete_source(source_id)
     logger.info("Deleted code source %s", source_id)
     return JSONResponse({"success": ok, "source_id": source_id})
-
-
-@router.get("/sources/summary")
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="batch_source_summary",
-    error_code_prefix="CODEBASE",
-)
-async def get_all_source_summaries():
-    """Return summaries for all sources in one request (#1468).
-
-    Replaces N+1 per-source /summary calls from the landing page.
-    Registered before /sources/{source_id}/summary to avoid the literal
-    string "summary" being captured by the {source_id} path parameter (#2654).
-    """
-    sources = await list_sources()
-    results = await asyncio.gather(*[_build_summary(s) for s in sources])
-    summaries = {r["source_id"]: r for r in results}
-    return JSONResponse({"summaries": summaries})
 
 
 @router.post("/sources/{source_id}/sync")


### PR DESCRIPTION
## Summary
- Moves `get_all_source_summaries()` route handler above `get_code_source()` so FastAPI matches the literal `/sources/summary` path before the parameterized `/sources/{source_id}`
- Root cause: FastAPI matches routes top-to-bottom; `{source_id}` was capturing the literal string "summary"

## Test plan
- [ ] GET /api/analytics/codebase/sources/summary returns 200 with summaries
- [ ] GET /api/analytics/codebase/sources/{actual-id} still returns the correct source

Closes #3107

🤖 Generated with [Claude Code](https://claude.com/claude-code)