### PR TITLE
fix(backend): add missing websockets dependency (#3098)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -3,6 +3,7 @@
 # Core
 fastapi>=0.135.2                # SECURITY UPDATE - requires starlette >=0.52.1
 uvicorn>=0.42.0
+websockets>=16.0           # Issue #3098: required for WebSocket protocol support (desktop_streaming_manager, slm_client)
 python-dotenv>=1.2.2
 aiofiles>=25.1.0
 pydantic>=2.12.5


### PR DESCRIPTION
## Summary
- Adds `websockets>=16.0` to backend requirements.txt
- Required by `desktop_streaming_manager.py` and `services/slm_client.py` which import websockets directly
- Version pinned to match SLM backend's existing pin

## Test plan
- [ ] `pip install -r requirements.txt` succeeds
- [ ] WebSocket connections work after deployment

Closes #3098

🤖 Generated with [Claude Code](https://claude.com/claude-code)