### PR TITLE
fix(backend): update dead /ws exempt path to /api/ws (#3110)

### DIFF
--- a/autobot-backend/middleware/service_auth_enforcement.py
+++ b/autobot-backend/middleware/service_auth_enforcement.py
@@ -70,8 +70,8 @@ EXEMPT_PATHS: List[str] = [
     "/api/monitoring",
     "/api/metrics",
     "/api/analytics",
-    # WebSocket connections
-    "/ws",
+    # WebSocket connections (api.websockets router mounted at /api prefix)
+    "/api/ws",
     # API documentation
     "/docs",
     "/openapi.json",


### PR DESCRIPTION
## Summary
- Updates stale `/ws` exempt path in service_auth_enforcement.py to `/api/ws`
- The websockets router is mounted under the `/api` prefix, so `/ws` never matched any route

## Test plan
- [ ] Service auth no longer exempts dead `/ws` path
- [ ] `/api/ws` WebSocket connections are properly exempted from service auth

Closes #3110

🤖 Generated with [Claude Code](https://claude.com/claude-code)