### PR TITLE
fix(npu-worker): remove hardcoded backend IP fallback (#3084)

### DIFF
--- a/autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py
+++ b/autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py
@@ -1587,8 +1587,10 @@ class WindowsNPUWorker:
             service_config = config.get("service", {})
 
             # Issue #640: Pass our persistent worker_id to prevent duplicates
+            # Issue #3084: Use AUTOBOT_BACKEND_HOST env var; fallback to localhost (no hardcoded IPs)
+            default_backend_host = os.environ.get("AUTOBOT_BACKEND_HOST", "localhost")
             bootstrap = await fetch_bootstrap_config(
-                backend_host=backend_config.get("host", "172.16.168.20"),
+                backend_host=backend_config.get("host") or default_backend_host,
                 backend_port=backend_config.get("port", 8001),
                 worker_port=service_config.get("port", 8082),
                 platform="windows",

--- a/autobot-npu-worker/resources/windows-npu-worker/config/npu_worker.yaml
+++ b/autobot-npu-worker/resources/windows-npu-worker/config/npu_worker.yaml
@@ -1,6 +1,6 @@
 # AutoBot NPU Worker Configuration - Windows Deployment
 # This configuration is for the optional Windows NPU worker installation
-# Separate from the VM-based NPU worker on 172.16.168.22:8081
+# Separate from the VM-based NPU worker on the configured AutoBot network
 
 # Service Configuration
 service:
@@ -19,7 +19,9 @@ service:
 # Backend Integration
 backend:
   # Main AutoBot backend server
-  host: "172.16.168.20"
+  # Set host to null here and provide AUTOBOT_BACKEND_HOST env var at runtime,
+  # or configure via the installer wizard. Do NOT hardcode IPs. (#3084)
+  host: null
   port: 8001
   protocol: "http"
 


### PR DESCRIPTION
## Summary
- Removes hardcoded backend IP (`172.16.168.20`) fallback from `npu_worker.py` `bootstrap_config()`
- Uses `AUTOBOT_BACKEND_HOST` env var with `localhost` as safe default
- Sets `backend.host` to `null` in `npu_worker.yaml` with deployment instructions

## Test plan
- [ ] NPU worker reads backend host from `AUTOBOT_BACKEND_HOST` env var when YAML host is null
- [ ] Falls back to localhost when neither YAML nor env var is set
- [ ] Existing YAML host value still takes precedence over env var when set

Closes #3084

🤖 Generated with [Claude Code](https://claude.com/claude-code)