### PR TITLE
fix(frontend,backend): add status polling for code source cards (#3092)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/sources.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources.py
@@ -67,8 +67,15 @@ def _build_clone_url(repo: str, token: Optional[str]) -> str:
     return f"https://github.com/{repo}"
 
 
+_GIT_TIMEOUT_SECONDS = 120
+
+
 async def _run_git_clone(url: str, dest: str, branch: str) -> str:
-    """Clone a repo shallowly. Returns stderr on failure."""
+    """Clone a repo shallowly. Returns stderr on failure.
+
+    A 120-second timeout prevents the background task from hanging
+    indefinitely on large repos or network issues (#3092).
+    """
     proc = await asyncio.create_subprocess_exec(
         "git",
         "clone",
@@ -79,14 +86,23 @@ async def _run_git_clone(url: str, dest: str, branch: str) -> str:
         dest,
         stderr=asyncio.subprocess.PIPE,
     )
-    _, stderr = await proc.communicate()
+    try:
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=_GIT_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return f"git clone timed out after {_GIT_TIMEOUT_SECONDS}s"
     if proc.returncode != 0:
         return stderr.decode("utf-8", errors="replace")
     return ""
 
 
 async def _run_git_pull(clone_path: str) -> str:
-    """Pull latest changes in an existing clone. Returns stderr on failure."""
+    """Pull latest changes in an existing clone. Returns stderr on failure.
+
+    A 120-second timeout prevents the background task from hanging
+    indefinitely on network issues (#3092).
+    """
     proc = await asyncio.create_subprocess_exec(
         "git",
         "-C",
@@ -95,7 +111,12 @@ async def _run_git_pull(clone_path: str) -> str:
         "--ff-only",
         stderr=asyncio.subprocess.PIPE,
     )
-    _, stderr = await proc.communicate()
+    try:
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=_GIT_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return f"git pull timed out after {_GIT_TIMEOUT_SECONDS}s"
     if proc.returncode != 0:
         return stderr.decode("utf-8", errors="replace")
     return ""

--- a/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
@@ -174,7 +174,7 @@
  * Issue #1458
  */
 
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
@@ -209,6 +209,12 @@ const loading = ref(false)
 const showAddModal = ref(false)
 const syncingId = ref<string | null>(null)
 const deletingId = ref<string | null>(null)
+
+// Polling state for syncing cards (#3092)
+const _pollTimer = ref<ReturnType<typeof setInterval> | null>(null)
+const _pollDeadline = ref<number>(0)
+const POLL_INTERVAL_MS = 4000
+const POLL_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
 // ---- API helpers ----------------------------------------------------------
 
@@ -353,17 +359,75 @@ async function deleteSource(source: CodeSource) {
   }
 }
 
+// ---- Polling (#3092) -------------------------------------------------------
+
+function _hasSyncingSource(): boolean {
+  return sources.value.some((s) => s.status === 'syncing')
+}
+
+function _stopPolling(): void {
+  if (_pollTimer.value !== null) {
+    clearInterval(_pollTimer.value)
+    _pollTimer.value = null
+    logger.info('Status polling stopped')
+  }
+}
+
+async function _pollTick(): Promise<void> {
+  if (Date.now() > _pollDeadline.value) {
+    logger.warn('Status polling timed out after 5 minutes — stopping')
+    _stopPolling()
+    return
+  }
+  try {
+    const backendUrl = await getBackendUrl()
+    const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/sources`)
+    if (!response.ok) {
+      logger.warn('Poll request failed, HTTP %d', response.status)
+      return
+    }
+    const data = await response.json()
+    sources.value = data.sources ?? []
+    if (!_hasSyncingSource()) {
+      _stopPolling()
+      await loadSummaries()
+      logger.info('All sources resolved — polling complete')
+    }
+  } catch (err: unknown) {
+    logger.error('Poll error:', err instanceof Error ? err.message : String(err))
+  }
+}
+
+function _startPolling(): void {
+  _stopPolling()
+  _pollDeadline.value = Date.now() + POLL_TIMEOUT_MS
+  _pollTimer.value = setInterval(_pollTick, POLL_INTERVAL_MS)
+  logger.info('Status polling started (interval %dms, timeout 5min)', POLL_INTERVAL_MS)
+}
+
 // ---- Modal Handlers -------------------------------------------------------
 
 function handleSourceSaved() {
   showAddModal.value = false
-  loadSources()
+  loadSources().then(() => {
+    if (_hasSyncingSource()) {
+      _startPolling()
+    }
+  })
 }
 
 // ---- Lifecycle ------------------------------------------------------------
 
 onMounted(() => {
-  loadSources()
+  loadSources().then(() => {
+    if (_hasSyncingSource()) {
+      _startPolling()
+    }
+  })
+})
+
+onUnmounted(() => {
+  _stopPolling()
 })
 </script>
 


### PR DESCRIPTION
## Summary
- **Backend:** Wraps git clone/pull in `asyncio.wait_for` with 120s timeout so sync tasks fail cleanly instead of hanging forever
- **Frontend:** Polls `/api/analytics/codebase/sources` every 4s while any source has `status === 'syncing'`, updates cards in place, stops when all complete or after 5min timeout
- Cleans up polling interval on unmount to prevent memory leaks

## Test plan
- [ ] Add a code source — spinner appears during sync
- [ ] After processing completes — spinner resolves, card shows final status
- [ ] If processing fails or times out — error status displayed
- [ ] Page refresh with syncing source resumes polling
- [ ] Navigating away stops polling (no memory leak)

Closes #3092

🤖 Generated with [Claude Code](https://claude.com/claude-code)