### PR TITLE
fix(devops): add /slm prefix to agent admin_url for co-located mode (#3096)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/agent-config.yaml.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/agent-config.yaml.j2
@@ -10,7 +10,13 @@
 # Auto-detect if agent runs on same host as SLM backend - use localhost if so (#2955)
 {% set admin_host = slm_admin_url | regex_replace('^https?://([^:/]+).*$', '\\1') %}
 {% if admin_host == ansible_host or admin_host == inventory_hostname or (ansible_connection | default('')) == 'local' %}
+{# Co-located: in single-host mode nginx routes /api/ to user backend,
+   so the agent must use /slm prefix to reach the SLM backend (#3096) #}
+{% if slm_colocated_frontend | default(false) | bool %}
+{% set effective_admin_url = 'https://127.0.0.1/slm' %}
+{% else %}
 {% set effective_admin_url = 'https://127.0.0.1' %}
+{% endif %}
 {% else %}
 {% set effective_admin_url = slm_admin_url %}
 {% endif %}

--- a/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_agent/templates/slm-agent.service.j2
@@ -10,7 +10,13 @@
 # Auto-detect if agent runs on same host as SLM backend - use localhost if so (#2955)
 {% set admin_host = slm_admin_url | regex_replace('^https?://([^:/]+).*$', '\\1') %}
 {% if admin_host == ansible_host or admin_host == inventory_hostname or (ansible_connection | default('')) == 'local' %}
+{# Co-located: in single-host mode nginx routes /api/ to user backend,
+   so the agent must use /slm prefix to reach the SLM backend (#3096) #}
+{% if slm_colocated_frontend | default(false) | bool %}
+{% set effective_admin_url = 'https://127.0.0.1/slm' %}
+{% else %}
 {% set effective_admin_url = 'https://127.0.0.1' %}
+{% endif %}
 {% else %}
 {% set effective_admin_url = slm_admin_url %}
 {% endif %}


### PR DESCRIPTION
## Summary
- When `slm_colocated_frontend` is true (single-host mode), agent `admin_url` now uses `https://127.0.0.1/slm` so heartbeats route through nginx to the SLM backend
- When false (standalone SLM), continues using `https://127.0.0.1` as before
- Applied to both `agent-config.yaml.j2` and `slm-agent.service.j2` templates

## Test plan
- [ ] Deploy with `slm_colocated_frontend: true` — agent heartbeats reach SLM backend via `/slm` prefix
- [ ] Deploy with `slm_colocated_frontend: false` — agent works as before without prefix
- [ ] Render templates with `--check` to verify Jinja2 syntax

Closes #3096

🤖 Generated with [Claude Code](https://claude.com/claude-code)