### PR TITLE
fix(devops): resolve /var/lib/autobot ownership conflict (#3097)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/group_vars/aiml.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/aiml.yml
@@ -73,9 +73,11 @@ ai_stack:
     log_level: "INFO"
 
   # Model configuration
+  # Issue #3097: ai-stack data under /var/lib/autobot-ai to avoid
+  # ownership conflict with /var/lib/autobot (backend).
   models:
-    base_path: "/var/lib/autobot/models"
-    cache_path: "/var/lib/autobot/models/cache"
+    base_path: "/var/lib/autobot-ai/models"
+    cache_path: "/var/lib/autobot-ai/models/cache"
     temp_path: "/tmp/autobot/models"
 
   # Environment variables
@@ -86,7 +88,7 @@ ai_stack:
     AI_SERVER_WORKERS: 2
     REDIS_HOST: "{{ redis_host }}"
     REDIS_PORT: "{{ redis_port }}"
-    CHROMA_DB_PATH: "/var/lib/autobot/chroma_db"
+    CHROMA_DB_PATH: "/var/lib/autobot-ai/chroma_db"
     DISABLE_EXTERNAL_APIS: "false"  # Enable external APIs in production
     TF_USE_LEGACY_KERAS: 1
     KERAS_BACKEND: "tensorflow"
@@ -282,24 +284,25 @@ hardware:
 
 model_management:
   # Model categories and configurations
+  # Issue #3097: model paths under /var/lib/autobot-ai (ai-stack owned)
   categories:
     language_models:
-      path: "/var/lib/autobot/models/llm"
+      path: "/var/lib/autobot-ai/models/llm"
       formats: ["gguf", "safetensors", "bin"]
       optimization_target: "npu"  # Prefer NPU for language models
 
     embedding_models:
-      path: "/var/lib/autobot/models/embeddings"
+      path: "/var/lib/autobot-ai/models/embeddings"
       formats: ["safetensors", "bin", "onnx"]
       optimization_target: "gpu"  # GPU good for embeddings
 
     vision_models:
-      path: "/var/lib/autobot/models/vision"
+      path: "/var/lib/autobot-ai/models/vision"
       formats: ["onnx", "pb", "tflite"]
       optimization_target: "npu"  # NPU optimized for vision
 
     audio_models:
-      path: "/var/lib/autobot/models/audio"
+      path: "/var/lib/autobot-ai/models/audio"
       formats: ["onnx", "wav2vec2"]
       optimization_target: "cpu"  # CPU fallback for audio
 
@@ -503,7 +506,7 @@ performance:
 
 backup_paths:
   # Model files (large, less frequent backup)
-  - path: "/var/lib/autobot/models"
+  - path: "/var/lib/autobot-ai/models"
     type: "directory"
     frequency: "weekly"
     compress: true

--- a/autobot-slm-backend/ansible/playbooks/data-migration.yml
+++ b/autobot-slm-backend/ansible/playbooks/data-migration.yml
@@ -263,6 +263,7 @@
     migration_backup_dir: "/tmp/autobot-migration-{{ hostvars['localhost']['migration_timestamp'] }}"
 
   tasks:
+    # Issue #3097: model dirs under /var/lib/autobot-ai (ai-stack owned)
     - name: Create model directories
       file:
         path: "{{ item }}"
@@ -271,16 +272,16 @@
         group: "{{ autobot.group }}"
         mode: '0755'
       loop:
-        - "/var/lib/autobot/models"
-        - "/var/lib/autobot/models/cache"
-        - "/var/lib/autobot/models/embeddings"
-        - "/var/lib/autobot/models/llm"
-        - "/var/lib/autobot/models/vision"
+        - "/var/lib/autobot-ai/models"
+        - "/var/lib/autobot-ai/models/cache"
+        - "/var/lib/autobot-ai/models/embeddings"
+        - "/var/lib/autobot-ai/models/llm"
+        - "/var/lib/autobot-ai/models/vision"
 
     - name: Transfer model files to AI/ML VM
       synchronize:
         src: "{{ hostvars['localhost']['migration_backup_dir'] }}/models/"
-        dest: "/var/lib/autobot/models/"
+        dest: "/var/lib/autobot-ai/models/"
         delete: false
         owner: false
         group: false
@@ -289,7 +290,7 @@
 
     - name: Set correct permissions for model files
       file:
-        path: "/var/lib/autobot/models"
+        path: "/var/lib/autobot-ai/models"
         owner: "{{ autobot.user }}"
         group: "{{ autobot.group }}"
         mode: '0755'
@@ -297,7 +298,7 @@
 
     - name: Count migrated model files
       find:
-        paths: "/var/lib/autobot/models"
+        paths: "/var/lib/autobot-ai/models"
         recurse: true
         file_type: file
       register: model_files
@@ -388,7 +389,7 @@
 
     - name: Check model files on AI/ML VM
       find:
-        paths: "/var/lib/autobot/models"
+        paths: "/var/lib/autobot-ai/models"
         patterns: "*"
         file_type: file
       register: migrated_models

--- a/autobot-slm-backend/ansible/playbooks/deploy-full.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-full.yml
@@ -334,7 +334,7 @@
           - ""
           - "3. 💾 Data Verification:"
           - "   - Verify Redis data: redis-cli -h {{ _redis_ip }}"
-          - "   - Check model files: ls -la /var/lib/autobot/models"
+          - "   - Check model files: ls -la /var/lib/autobot-ai/models"
           - "   - Validate knowledge base: API call to /api/knowledge"
           - ""
           - "4. 🔐 Security Review:"

--- a/autobot-slm-backend/ansible/playbooks/remove-role.yml
+++ b/autobot-slm-backend/ansible/playbooks/remove-role.yml
@@ -40,7 +40,8 @@
         - /var/lib/postgresql
       ai-stack:
         - /var/lib/chromadb
-        - /var/lib/autobot/ai-stack
+        # Issue #3097: ai-stack data moved to /var/lib/autobot-ai
+        - /var/lib/autobot-ai
       llm:
         - /usr/share/ollama/.ollama
         - /var/lib/ollama

--- a/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
@@ -8,14 +8,16 @@ ai_user: autobot-ai
 ai_group: autobot-ai
 ai_install_dir: /opt/autobot/autobot-ai-stack
 ai_log_dir: /var/log/autobot
-ai_data_dir: /var/lib/autobot
+# Issue #3097: ai-stack gets its own /var/lib/autobot-ai to avoid ownership
+# conflict with /var/lib/autobot (owned by autobot:autobot for the backend).
+ai_data_dir: /var/lib/autobot-ai
 
 # Server settings
 ai_host: "0.0.0.0"
 ai_port: 8080
 
 # ChromaDB
-chromadb_persist_dir: /var/lib/autobot/chromadb
+chromadb_persist_dir: /var/lib/autobot-ai/chromadb
 chromadb_host: "0.0.0.0"
 chromadb_port: 8100
 

--- a/autobot-slm-backend/ansible/setup-ai-stack.yml
+++ b/autobot-slm-backend/ansible/setup-ai-stack.yml
@@ -24,7 +24,9 @@
     ai_stack_user: autobot
     ai_stack_group: autobot
     chromadb_port: 8100
-    chromadb_data_dir: /var/lib/autobot/chromadb
+    # Issue #3097: ai-stack data under /var/lib/autobot-ai to avoid
+    # ownership conflict with /var/lib/autobot (backend).
+    chromadb_data_dir: /var/lib/autobot-ai/chromadb
     ollama_port: 11434
     enable_ollama: false
 


### PR DESCRIPTION
## Summary
- Moves ai-stack data directory from `/var/lib/autobot` to `/var/lib/autobot-ai` to eliminate ownership conflict with backend
- Updates `ai_data_dir`, `chromadb_persist_dir`, model paths, and all referencing playbooks
- Backend retains `/var/lib/autobot` owned by `autobot:autobot`; ai-stack gets `/var/lib/autobot-ai` owned by `autobot-ai:autobot-ai`

## Test plan
- [ ] `ansible-playbook setup-ai-stack.yml --check` — ai-stack creates `/var/lib/autobot-ai`
- [ ] Backend role — `/var/lib/autobot` remains `autobot:autobot`
- [ ] Backend starts without "Database migration failed" after ai-stack provisioning
- [ ] ChromaDB persists data to `/var/lib/autobot-ai/chromadb`

Closes #3097

🤖 Generated with [Claude Code](https://claude.com/claude-code)