### PR TITLE
feat(backend): replace mcp_sync with transport-agnostic MCPClient

### DIFF
--- a/autobot-backend/skills/sync/mcp_sync.py
+++ b/autobot-backend/skills/sync/mcp_sync.py
@@ -3,18 +3,17 @@
 # Author: mrveiss
 """MCP server skill repo sync (Phase 3).
 
-Connects to a remote MCP HTTP server, lists its tools,
-and wraps each as a local skill package.
+Connects to a remote MCP server (stdio, SSE, or HTTP), lists its tools,
+and wraps each as a local skill package.  Delegates to :class:`MCPClient`
+for transport-agnostic communication (#3103).
 """
 
-import asyncio
 import logging
 from typing import Any, Dict, List
 
-import aiohttp
-
 from skills.models import SkillState
 from skills.sync.base_sync import BaseRepoSync
+from skills.sync.mcp_client import MCPClient
 
 logger = logging.getLogger(__name__)
 
@@ -37,40 +36,34 @@ Remote MCP tool from {server_url}.
 
 
 class MCPClientSync(BaseRepoSync):
-    """Sync skills from a remote MCP server by calling tools/list."""
+    """Sync skills from a remote MCP server by calling tools/list.
+
+    Supports all MCP transports (stdio, SSE, HTTP) via :class:`MCPClient`.
+    """
 
     def __init__(self, server_url: str) -> None:
-        """Initialize with the MCP HTTP server URL."""
+        """Initialize with the MCP server URI.
+
+        Args:
+            server_url: Any URI accepted by :func:`create_transport` --
+                ``http://``, ``https://``, ``sse://``, or ``stdio://``.
+        """
         self.server_url = server_url
 
     async def discover(self) -> List[Dict[str, Any]]:
         """Connect to MCP server, list tools, wrap as skill packages."""
         try:
-            tools = await self._fetch_tools()
-        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-            logger.error("MCP sync failed for %s: %s", self.server_url, exc)
+            async with MCPClient(self.server_url) as client:
+                tools = await client.discover_tools()
+        except Exception:
+            logger.exception("MCP sync failed for %s", self.server_url)
             return []
         return [self._tool_to_package(tool) for tool in tools]
 
-    async def _fetch_tools(self) -> List[Dict[str, Any]]:
-        """Fetch tool list from remote MCP server via HTTP RPC."""
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{self.server_url}/rpc",
-                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
-                timeout=aiohttp.ClientTimeout(total=10),
-            ) as resp:
-                if resp.status != 200:
-                    raise aiohttp.ClientResponseError(
-                        resp.request_info, resp.history, status=resp.status
-                    )
-                data = await resp.json()
-                return data.get("result", {}).get("tools", [])
-
-    def _tool_to_package(self, tool: Dict[str, Any]) -> Dict[str, Any]:
-        """Convert a remote MCP tool descriptor to a local skill package dict."""
-        name = tool.get("name", "unknown")
-        desc = tool.get("description", "")
+    def _tool_to_package(self, tool: Any) -> Dict[str, Any]:
+        """Convert an MCPToolDefinition to a local skill package dict."""
+        name = getattr(tool, "name", "unknown")
+        desc = getattr(tool, "description", "")
         # Escape braces so str.format() does not choke on tool names/descriptions
         # that contain literal '{' or '}' characters from MCP server responses.
         safe_name = name.replace("{", "{{").replace("}", "}}")

--- a/autobot-backend/skills/sync/sync_test.py
+++ b/autobot-backend/skills/sync/sync_test.py
@@ -126,34 +126,48 @@ async def test_git_repo_sync_clones_and_delegates(tmp_path, monkeypatch):
 
 @pytest.mark.anyio
 async def test_mcp_client_sync_wraps_tools():
-    """MCPClientSync converts remote tool descriptors into skill packages."""
-    from unittest.mock import AsyncMock, MagicMock, patch
+    """MCPClientSync delegates to MCPClient and wraps tools as skill packages."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, patch
 
-    fake_response_data = {
-        "result": {
-            "tools": [
-                {"name": "echo", "description": "Echo a message"},
-            ]
-        }
-    }
+    fake_tool = SimpleNamespace(name="echo", description="Echo a message")
 
-    mock_resp = AsyncMock()
-    mock_resp.json = AsyncMock(return_value=fake_response_data)
-    mock_resp.status = 200
-    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
-    mock_resp.__aexit__ = AsyncMock(return_value=None)
-
-    mock_session = MagicMock()
-    mock_session.post = MagicMock(return_value=mock_resp)
-    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
-    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_client = AsyncMock()
+    mock_client.discover_tools = AsyncMock(return_value=[fake_tool])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
 
     from skills.sync.mcp_sync import MCPClientSync
 
-    with patch("aiohttp.ClientSession", return_value=mock_session):
+    with patch("skills.sync.mcp_sync.MCPClient", return_value=mock_client):
         sync = MCPClientSync("http://mcp-server.example.com")
         packages = await sync.discover()
 
     assert len(packages) == 1
     assert packages[0]["name"] == "echo"
     assert packages[0]["manifest"]["remote_mcp"] == "http://mcp-server.example.com"
+
+
+@pytest.mark.anyio
+async def test_mcp_client_sync_supports_stdio_uri():
+    """MCPClientSync passes non-HTTP URIs through to MCPClient."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, patch
+
+    fake_tool = SimpleNamespace(name="read_file", description="Read a file")
+
+    mock_client = AsyncMock()
+    mock_client.discover_tools = AsyncMock(return_value=[fake_tool])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    from skills.sync.mcp_sync import MCPClientSync
+
+    stdio_uri = "stdio://npx -y @modelcontextprotocol/server-fs /tmp"
+    with patch("skills.sync.mcp_sync.MCPClient", return_value=mock_client) as mock_cls:
+        sync = MCPClientSync(stdio_uri)
+        packages = await sync.discover()
+
+    mock_cls.assert_called_once_with(stdio_uri)
+    assert len(packages) == 1
+    assert packages[0]["name"] == "read_file"


### PR DESCRIPTION
Closes #3103

## Summary
- Replaced direct aiohttp HTTP-only logic in `MCPClientSync` with delegation to `MCPClient`
- `MCPClientSync` now supports all MCP transports: stdio, SSE, and HTTP via URI scheme detection
- Removed `_fetch_tools()` method — `MCPClient.discover_tools()` handles all transport logic
- Updated `_tool_to_package()` to work with `MCPToolDefinition` objects (via `getattr`)
- Updated tests to mock `MCPClient` instead of `aiohttp.ClientSession`
- Added test for stdio URI passthrough

## Test plan
- [x] Python syntax validated
- [x] Tests updated to use MCPClient mocks
- [x] New test verifies non-HTTP URIs are passed through correctly
- [ ] CI test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)