### PR TITLE
fix(devops): move NPU worker models dir to /var/lib/autobot-npu (#3120)

### DIFF
--- a/autobot-slm-backend/ansible/roles/npu-worker/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/npu-worker/defaults/main.yml
@@ -8,7 +8,7 @@ npu_user: autobot-npu
 npu_group: autobot-npu
 npu_install_dir: /opt/autobot/autobot-npu-worker
 npu_log_dir: /var/log/autobot
-npu_models_dir: /var/lib/autobot/models
+npu_models_dir: /var/lib/autobot-npu/models
 
 # OpenVINO
 npu_install_openvino: true

--- a/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.py.j2
+++ b/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.py.j2
@@ -23,7 +23,7 @@ logging.basicConfig(
 logger = logging.getLogger("npu-worker")
 
 DEVICE = os.getenv("NPU_DEVICE", "NPU")
-MODELS_DIR = Path(os.getenv("NPU_MODELS_DIR", "/var/lib/autobot/models"))
+MODELS_DIR = Path(os.getenv("NPU_MODELS_DIR", "/var/lib/autobot-npu/models"))
 HOST = os.getenv("NPU_HOST", "0.0.0.0")
 PORT = int(os.getenv("NPU_PORT", "8081"))
 


### PR DESCRIPTION
## Summary
- Moves NPU worker models directory from `/var/lib/autobot/models` to `/var/lib/autobot-npu/models`
- Same pattern as #3097 (ai-stack → /var/lib/autobot-ai) — prevents ownership conflict with backend's `/var/lib/autobot`
- Updates both Ansible default var and Python template fallback

## Test plan
- [ ] `ansible-playbook ... --check` — NPU role creates `/var/lib/autobot-npu/models`
- [ ] NPU worker starts and finds models at new path
- [ ] Backend `/var/lib/autobot` remains `autobot:autobot` owned

Closes #3120

🤖 Generated with [Claude Code](https://claude.com/claude-code)