### PR TITLE
feat(backend): auto-inject WorkflowMemory into agent prompt context

### DIFF
--- a/autobot-backend/orchestration/workflow_executor.py
+++ b/autobot-backend/orchestration/workflow_executor.py
@@ -896,6 +896,13 @@ class WorkflowExecutor:
         if agent_id:
             interaction = self._create_agent_interaction(step, execution_context)
 
+        # Issue #3099: Auto-inject prior agent findings from shared memory.
+        shared_memory = execution_context.get("shared_memory")
+        if shared_memory:
+            prior_findings = shared_memory.get_all()
+            if prior_findings:
+                context["prior_agent_findings"] = prior_findings
+
         try:
             result = await self._simulate_step_execution(step, context)
             if interaction:

--- a/autobot-backend/orchestration/workflow_memory_test.py
+++ b/autobot-backend/orchestration/workflow_memory_test.py
@@ -317,3 +317,82 @@ class TestWorkflowMemoryLazyRedis:
             mock_factory.assert_called_once_with(
                 async_client=False, database="workflows"
             )
+
+
+# ---------------------------------------------------------------------------
+# Issue #3099: Auto-injection into agent context
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowMemoryAutoInjection:
+    """Verify that _execute_coordinated_step injects shared_memory findings."""
+
+    def test_prior_findings_injected_into_context(self):
+        """When shared_memory has data, it appears in context['prior_agent_findings']."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from orchestration.workflow_executor import WorkflowExecutor
+
+        executor = WorkflowExecutor.__new__(WorkflowExecutor)
+        executor.logger = MagicMock()
+
+        mock_memory = MagicMock()
+        mock_memory.get_all.return_value = {"step1": "found data"}
+
+        execution_context = {
+            "shared_memory": mock_memory,
+            "agents_involved": set(),
+            "interactions": [],
+        }
+        context: dict = {}
+        step = {"id": "step2", "assigned_agent": None}
+
+        # _simulate_step_execution raises NotImplementedError; we just need
+        # to verify the context was updated before the call.
+        executor._simulate_step_execution = AsyncMock(
+            side_effect=NotImplementedError("stub")
+        )
+        executor._create_agent_interaction = MagicMock(return_value=None)
+
+        import asyncio
+
+        with pytest.raises(NotImplementedError):
+            asyncio.get_event_loop().run_until_complete(
+                executor._execute_coordinated_step(step, execution_context, context)
+            )
+
+        assert context["prior_agent_findings"] == {"step1": "found data"}
+
+    def test_empty_memory_not_injected(self):
+        """When shared_memory is empty, no prior_agent_findings key is added."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from orchestration.workflow_executor import WorkflowExecutor
+
+        executor = WorkflowExecutor.__new__(WorkflowExecutor)
+        executor.logger = MagicMock()
+
+        mock_memory = MagicMock()
+        mock_memory.get_all.return_value = {}
+
+        execution_context = {
+            "shared_memory": mock_memory,
+            "agents_involved": set(),
+            "interactions": [],
+        }
+        context: dict = {}
+        step = {"id": "step2", "assigned_agent": None}
+
+        executor._simulate_step_execution = AsyncMock(
+            side_effect=NotImplementedError("stub")
+        )
+        executor._create_agent_interaction = MagicMock(return_value=None)
+
+        import asyncio
+
+        with pytest.raises(NotImplementedError):
+            asyncio.get_event_loop().run_until_complete(
+                executor._execute_coordinated_step(step, execution_context, context)
+            )
+
+        assert "prior_agent_findings" not in context


### PR DESCRIPTION
Closes #3099

## Summary
- In `_execute_coordinated_step()`, shared memory findings are now auto-injected into `context["prior_agent_findings"]` before agent dispatch
- Agents running later in a workflow automatically see what prior agents wrote to shared memory
- No injection when shared memory is empty (no unnecessary context bloat)

## Changes
- `workflow_executor.py`: 5-line injection block before `_simulate_step_execution()` call
- `workflow_memory_test.py`: 2 new tests verifying injection + no-injection-when-empty

## Test plan
- [x] Python syntax validated
- [x] Test: prior findings injected when memory has data
- [x] Test: no injection when memory is empty
- [ ] CI test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)