### PR TITLE
feat(backend): wire NotificationService into workflow executor events (#3101)

### DIFF
--- a/autobot-backend/services/workflow_automation/executor.py
+++ b/autobot-backend/services/workflow_automation/executor.py
@@ -37,7 +37,23 @@ from .step_evaluator import WorkflowStepEvaluator
 from .vision_step_handler import VISION_STEP_TYPES, execute_vision_step
 
 if TYPE_CHECKING:
+    from services.notification_service import NotificationService
+
     from .messaging import WorkflowMessenger
+
+# Lazy import to avoid circular dependency at module level.
+_notification_event_mod: Optional[type] = None
+
+
+def _get_notification_event():
+    """Return NotificationEvent enum, importing lazily on first call."""
+    global _notification_event_mod  # noqa: PLW0603
+    if _notification_event_mod is None:
+        from services.notification_service import NotificationEvent
+
+        _notification_event_mod = NotificationEvent
+    return _notification_event_mod
+
 
 logger = logging.getLogger(__name__)
 
@@ -169,9 +185,15 @@ def _resolve_step_references(config: dict, step_results: dict) -> dict:
 class WorkflowExecutor:
     """Handles workflow step execution and processing"""
 
-    def __init__(self, messenger: "WorkflowMessenger"):
+    def __init__(
+        self,
+        messenger: "WorkflowMessenger",
+        notification_service: Optional["NotificationService"] = None,
+    ):
         """Initialize executor with messenger and step evaluator."""
         self.messenger = messenger
+        # Issue #3101: Notification service for workflow lifecycle events.
+        self._notification_service = notification_service
         self.step_evaluator = WorkflowStepEvaluator()
         self.prometheus_metrics = get_metrics_manager()
         # Issue #390: Track pending plan approvals
@@ -185,6 +207,28 @@ class WorkflowExecutor:
         self.limits = WorkflowLimits()
         self.cost_tracker = CostTracker()
         self._timeout_enforcer = StepTimeoutEnforcer()
+
+    async def _notify(
+        self,
+        workflow: ActiveWorkflow,
+        event_name: str,
+        extra: Dict[str, Any],
+    ) -> None:
+        """Fire a notification if the service is wired and workflow has config (#3101)."""
+        if self._notification_service is None:
+            return
+        config = getattr(workflow, "notification_config", None)
+        if config is None:
+            return
+        try:
+            NE = _get_notification_event()
+            event = NE(event_name)
+            payload = {"workflow_id": workflow.workflow_id, **extra}
+            await self._notification_service.send(
+                event, workflow.workflow_id, payload, config
+            )
+        except Exception:
+            logger.exception("Notification delivery failed for %s", event_name)
 
     async def start_execution(
         self, workflow: ActiveWorkflow, workflows: Dict[str, ActiveWorkflow]
@@ -356,6 +400,12 @@ class WorkflowExecutor:
             },
         )
 
+        # Issue #3101: Notify configured channels that approval is needed.
+        if step.requires_confirmation:
+            await self._notify(workflow, "approval_needed", {
+                "step_name": step.step_id,
+            })
+
     def _check_step_dependencies(
         self, workflow: ActiveWorkflow, step: WorkflowStep
     ) -> bool:
@@ -479,6 +529,12 @@ class WorkflowExecutor:
                 "error": str(error),
             },
         )
+
+        # Issue #3101: Notify configured channels on step failure.
+        await self._notify(workflow, "step_failed", {
+            "step_name": step_id,
+            "error": str(error),
+        })
 
     async def approve_and_execute_step(
         self,
@@ -719,6 +775,12 @@ class WorkflowExecutor:
             workflow.session_id, self._build_completion_message(workflow)
         )
 
+        # Issue #3101: Notify configured channels on workflow completion.
+        await self._notify(workflow, "workflow_completed", {
+            "status": "completed",
+            "total_steps": len(workflow.steps),
+        })
+
         # Issue #1367: Archive to completed history
         if self.on_workflow_finished:
             self.on_workflow_finished(workflow.workflow_id)
@@ -775,6 +837,11 @@ class WorkflowExecutor:
             workflow.session_id,
             {"type": "workflow_cancelled", "workflow_id": workflow.workflow_id},
         )
+
+        # Issue #3101: Notify configured channels on workflow cancellation/failure.
+        await self._notify(workflow, "workflow_failed", {
+            "error": "cancelled",
+        })
 
         # Issue #1367: Archive to completed history
         if self.on_workflow_finished:

--- a/autobot-backend/services/workflow_automation/manager.py
+++ b/autobot-backend/services/workflow_automation/manager.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional
 
 from enhanced_orchestrator import get_orchestrator
 from orchestrator import Orchestrator
+from services.notification_service import NotificationService
 from type_defs.common import Metadata
 
 from .controller import WorkflowController
@@ -43,7 +44,11 @@ class WorkflowAutomationManager:
 
         # Composition: delegate to specialized components
         self.messenger = WorkflowMessenger()
-        self.executor = WorkflowExecutor(self.messenger)
+        # Issue #3101: Wire notification service into executor.
+        self._notification_service = NotificationService()
+        self.executor = WorkflowExecutor(
+            self.messenger, notification_service=self._notification_service
+        )
         # Issue #1367: Archive finished workflows to completed history
         self.executor.on_workflow_finished = self.archive_completed_workflow
         self.controller = WorkflowController(self.messenger, self.executor)

--- a/autobot-backend/services/workflow_automation/models.py
+++ b/autobot-backend/services/workflow_automation/models.py
@@ -7,10 +7,15 @@ Workflow Automation Models
 Enums, dataclasses, and Pydantic models for workflow automation.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from services.notification_service import NotificationConfig
 
 from pydantic import BaseModel, Field
 
@@ -183,6 +188,8 @@ class ActiveWorkflow:
     owner_id: Optional[str] = None
     # Issue #2601: Store step execution results keyed by step_id for reference passing.
     step_results: Dict[str, Metadata] = field(default_factory=dict)
+    # Issue #3101: Per-workflow notification routing configuration.
+    notification_config: Optional[NotificationConfig] = None
 
     def __post_init__(self):
         """Set default values for created_at and user_interventions."""


### PR DESCRIPTION
## Summary
- Wires `NotificationService` into `WorkflowExecutor` via constructor injection from `WorkflowAutomationManager`
- Adds `_notify()` helper that dispatches notifications on 4 lifecycle events: `workflow_completed`, `workflow_failed`, `step_failed`, `approval_needed`
- Adds `notification_config` field to `ActiveWorkflow` model (opt-in, defaults to None)
- Notifications silently skipped when no config is set

## Test plan
- [ ] Backend starts without errors (no config = no notifications)
- [ ] Setting `notification_config` on a workflow enables notifications
- [ ] Workflow completion, failure, cancellation, and step failure all fire events

Closes #3101

🤖 Generated with [Claude Code](https://claude.com/claude-code)