### PR TITLE
fix(backend): auto-inject WorkflowMemory findings into step prompts (#3099)

### DIFF
--- a/autobot-backend/orchestration/workflow_executor.py
+++ b/autobot-backend/orchestration/workflow_executor.py
@@ -988,12 +988,20 @@ class WorkflowExecutor:
         if agent_id:
             interaction = self._create_agent_interaction(step, execution_context)
 
-        # Issue #3099: Auto-inject prior agent findings from shared memory.
+        # Issue #3099: Auto-inject prior agent findings from shared memory
+        # into both the context dict and the step command/prompt so downstream
+        # agents receive the information without needing to read context explicitly.
         shared_memory = execution_context.get("shared_memory")
         if shared_memory:
             prior_findings = shared_memory.get_all()
             if prior_findings:
                 context["prior_agent_findings"] = prior_findings
+                findings_section = "\n\n## Prior Agent Findings\n"
+                for key, value in prior_findings.items():
+                    findings_section += f"- **{key}**: {value}\n"
+                command = step.get("command", "")
+                if isinstance(command, str) and command:
+                    step["command"] = command + findings_section
 
         try:
             result = await self._simulate_step_execution(step, context)


### PR DESCRIPTION
## Summary
- Prior agent findings from shared WorkflowMemory were stored in `context["prior_agent_findings"]` but never surfaced in the step's command/prompt
- Now formats findings as Markdown and appends to `step["command"]` so downstream agents receive them directly in their prompt
- Preserves existing context dict injection for backward compatibility

## Test plan
- [ ] Multi-step workflow where step 1 stores findings → step 2 sees them in prompt
- [ ] Single-step workflows work normally (no findings = no injection)
- [ ] Empty shared memory doesn't append anything

Closes #3099

🤖 Generated with [Claude Code](https://claude.com/claude-code)