### PR TITLE
fix(devops): replace hardcoded backend IP in nginx configs

### DIFF
--- a/autobot-infrastructure/shared/config/nginx/slm-site.conf
+++ b/autobot-infrastructure/shared/config/nginx/slm-site.conf
@@ -64,10 +64,10 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # AutoBot Backend API (main backend at 172.16.168.20:8001)
+    # AutoBot Backend API (main backend at ${AUTOBOT_BACKEND_HOST}:8001)
     # Issue #729 - Proxy for migrated admin functionality
     location /autobot-api/ {
-        proxy_pass http://172.16.168.20:8001/api/;
+        proxy_pass http://${AUTOBOT_BACKEND_HOST}:8001/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -82,7 +82,7 @@ server {
 
     # AutoBot Backend WebSocket (terminal, etc.)
     location /autobot-api/ws/ {
-        proxy_pass http://172.16.168.20:8001/api/ws/;
+        proxy_pass http://${AUTOBOT_BACKEND_HOST}:8001/api/ws/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/autobot-infrastructure/shared/scripts/install-slm.sh
+++ b/autobot-infrastructure/shared/scripts/install-slm.sh
@@ -504,10 +504,10 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # AutoBot Backend API (main backend at 172.16.168.20:8001)
+    # AutoBot Backend API (main backend at ${DEV_HOST}:8001)
     # Issue #729 - Proxy for migrated admin functionality
     location /autobot-api/ {
-        proxy_pass http://172.16.168.20:8001/api/;
+        proxy_pass http://${DEV_HOST}:8001/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -522,7 +522,7 @@ server {
 
     # AutoBot Backend WebSocket (terminal, etc.)
     location /autobot-api/ws/ {
-        proxy_pass http://172.16.168.20:8001/api/ws/;
+        proxy_pass http://${DEV_HOST}:8001/api/ws/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Closes #3137

## Summary
- `install-slm.sh`: replaced `172.16.168.20` with `${DEV_HOST}` in nginx heredoc (already sourced from `AUTOBOT_BACKEND_HOST` env var)
- `slm-site.conf`: replaced hardcoded IP with `${AUTOBOT_BACKEND_HOST}` placeholder

## Test plan
- [x] No hardcoded `172.16.168.20` remains in either file
- [ ] `install-slm.sh` generates correct nginx config with custom host

🤖 Generated with [Claude Code](https://claude.com/claude-code)