### PR TITLE
fix(backend): pass trigger payload to workflow execution

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -645,10 +645,13 @@ async def _init_trigger_service(app: FastAPI) -> None:
             """Launcher callback invoked by TriggerService when a trigger fires."""
             from services.workflow_automation import get_workflow_manager
 
-            logger.info("Trigger fired for workflow %s", workflow_id)
+            logger.info("Trigger fired for workflow %s with payload keys=%s",
+                        workflow_id, list(payload.keys()) if payload else [])
             mgr = get_workflow_manager()
             if mgr:
-                await mgr.start_workflow_execution(workflow_id)
+                await mgr.start_workflow_execution(
+                    workflow_id, trigger_payload=payload
+                )
 
         await trigger_service.start(launcher=_launch_workflow)
         app.state.trigger_service = trigger_service

--- a/autobot-backend/services/workflow_automation/manager.py
+++ b/autobot-backend/services/workflow_automation/manager.py
@@ -155,13 +155,24 @@ class WorkflowAutomationManager:
         logger.info("Created automated workflow %s: %s", workflow_id, name)
         return workflow_id
 
-    async def start_workflow_execution(self, workflow_id: str) -> bool:
-        """Start executing automated workflow"""
+    async def start_workflow_execution(
+        self, workflow_id: str, trigger_payload: Optional[dict] = None
+    ) -> bool:
+        """Start executing automated workflow.
+
+        Args:
+            workflow_id: ID of the workflow to execute.
+            trigger_payload: Optional event data from the trigger that
+                fired this workflow (#3138). Injected into the workflow's
+                execution context as ``trigger_payload``.
+        """
         if workflow_id not in self.active_workflows:
             logger.error("Workflow %s not found", workflow_id)
             return False
 
         workflow = self.active_workflows[workflow_id]
+        if trigger_payload:
+            workflow.trigger_payload = trigger_payload
         return await self.executor.start_execution(workflow, self.active_workflows)
 
     async def handle_workflow_control(


### PR DESCRIPTION
Closes #3138

## Summary
- `start_workflow_execution()` now accepts optional `trigger_payload` dict
- Launcher callback in `_init_trigger_service()` passes payload through instead of discarding it
- Payload is stored on the workflow object as `trigger_payload` for step executors to access

## Test plan
- [x] Python syntax validated
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)