### PR TITLE
docs(frontend): document vitest mockReset gotcha in config

### DIFF
--- a/autobot-frontend/vitest.config.ts
+++ b/autobot-frontend/vitest.config.ts
@@ -66,7 +66,9 @@ export default mergeConfig(
       testTimeout: 10000,
       hookTimeout: 10000,
 
-      // Mock options
+      // Mock options — WARNING (#3070): mockReset wipes vi.mock() factory
+      // implementations between tests.  Always re-apply mocks in beforeEach,
+      // not in the factory.  Use regular functions for constructor mocks.
       clearMocks: true,
       mockReset: true,
       restoreMocks: true,


### PR DESCRIPTION
Closes #3070

## Summary
Added warning comment to `vitest.config.ts` explaining the `mockReset: true` behavior that wipes `vi.mock()` factory implementations between tests.

## Pattern
- Always re-apply mocks in `beforeEach`, not in `vi.mock()` factories
- Use regular functions (not arrows) for constructor mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)