### PR TITLE
fix(security): fix stack-trace-exposure CodeQL alerts (#1733)

### DIFF
--- a/autobot-backend/api/database_mcp.py
+++ b/autobot-backend/api/database_mcp.py
@@ -956,7 +956,7 @@ async def database_describe_schema_mcp(request: SchemaRequest) -> Metadata:
 
     except ValueError as e:
         logger.warning("Invalid table identifier in describe_schema request: %s", e)
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Invalid table identifier")
     except sqlite3.Error as e:
         logger.error("SQLite error describing schema: %s", e)
         raise HTTPException(status_code=500, detail="Error describing schema")

--- a/autobot-backend/api/intelligent_agent.py
+++ b/autobot-backend/api/intelligent_agent.py
@@ -353,7 +353,7 @@ async def websocket_stream(websocket: WebSocket):
             except Exception as e:
                 logger.error("Error processing WebSocket goal: %s", e)
                 await websocket.send_json(
-                    {"type": "error", "content": f"Error processing goal: {str(e)}"}
+                    {"type": "error", "content": "Error processing goal"}
                 )
     except WebSocketDisconnect:
         logger.info("WebSocket connection closed")
@@ -361,7 +361,7 @@ async def websocket_stream(websocket: WebSocket):
         logger.error("WebSocket error: %s", e)
         try:
             await websocket.send_json(
-                {"type": "error", "content": f"WebSocket error: {str(e)}"}
+                {"type": "error", "content": "WebSocket error"}
             )
         except Exception as conn_error:
             logger.debug("Connection error: %s", conn_error)  # Connection closed

--- a/autobot-backend/api/multimodal.py
+++ b/autobot-backend/api/multimodal.py
@@ -190,7 +190,7 @@ async def process_image(
             processing_time=processing_time,
             confidence=0.0,
             result_data={},
-            error_message=str(e),
+            error_message="Image processing failed",
         )
 
 
@@ -262,7 +262,7 @@ async def process_audio(
             processing_time=processing_time,
             confidence=0.0,
             result_data={},
-            error_message=str(e),
+            error_message="Audio processing failed",
         )
 
 
@@ -321,7 +321,7 @@ async def process_text(
             processing_time=processing_time,
             confidence=0.0,
             result_data={},
-            error_message=str(e),
+            error_message="Text processing failed",
         )
 
 

--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -71,7 +71,7 @@ async def get_settings():
         return ConfigService.get_full_config()
     except Exception as e:
         logger.error("Error getting settings: %s", str(e))
-        raise_server_error("API_0003", f"Error getting settings: {str(e)}")
+        raise_server_error("API_0003", "Error getting settings")
 
 
 @with_error_handling(
@@ -86,7 +86,7 @@ async def get_settings_explicit():
         return ConfigService.get_full_config()
     except Exception as e:
         logger.error("Error getting settings: %s", str(e))
-        raise_server_error("API_0003", f"Error getting settings: {str(e)}")
+        raise_server_error("API_0003", "Error getting settings")
 
 
 @with_error_handling(
@@ -120,7 +120,7 @@ async def save_settings(
         return result
     except Exception as e:
         logger.error("Error saving settings: %s", str(e))
-        raise_server_error("API_0003", f"Error saving settings: {str(e)}")
+        raise_server_error("API_0003", "Error saving settings")
 
 
 @with_error_handling(
@@ -153,7 +153,7 @@ async def save_settings_explicit(
         return result
     except Exception as e:
         logger.error("Error saving settings: %s", str(e))
-        raise_server_error("API_0003", f"Error saving settings: {str(e)}")
+        raise_server_error("API_0003", "Error saving settings")
 
 
 @with_error_handling(
@@ -168,7 +168,7 @@ async def get_backend_settings():
         return ConfigService.get_backend_settings()
     except Exception as e:
         logger.error("Error getting backend settings: %s", str(e))
-        raise_server_error("API_0003", f"Error getting backend settings: {str(e)}")
+        raise_server_error("API_0003", "Error getting backend settings")
 
 
 @with_error_handling(
@@ -197,7 +197,7 @@ async def save_backend_settings(
         return result
     except Exception as e:
         logger.error("Error saving backend settings: %s", str(e))
-        raise_server_error("API_0003", f"Error saving backend settings: {str(e)}")
+        raise_server_error("API_0003", "Error saving backend settings")
 
 
 @with_error_handling(
@@ -212,7 +212,7 @@ async def get_full_config():
         return ConfigService.get_full_config()
     except Exception as e:
         logger.error("Error getting full config: %s", str(e))
-        raise_server_error("API_0003", f"Error getting full config: {str(e)}")
+        raise_server_error("API_0003", "Error getting full config")
 
 
 @with_error_handling(
@@ -241,7 +241,7 @@ async def save_full_config(
         return result
     except Exception as e:
         logger.error("Error saving full config: %s", str(e))
-        raise_server_error("API_0003", f"Error saving full config: {str(e)}")
+        raise_server_error("API_0003", "Error saving full config")
 
 
 @with_error_handling(
@@ -271,7 +271,7 @@ async def clear_cache():
         }
     except Exception as e:
         logger.error("Error in clear-cache endpoint: %s", str(e))
-        raise_server_error("API_0003", f"Error in clear-cache endpoint: {str(e)}")
+        raise_server_error("API_0003", "Error clearing cache")
 
 
 # ==================== RBAC Management Endpoints (Issue #687) ====================
@@ -323,7 +323,7 @@ async def initialize_rbac_endpoint(
 
     except Exception as e:
         logger.error("Error queuing RBAC initialization: %s", str(e))
-        raise_server_error("RBAC_0001", f"Error queuing RBAC initialization: {str(e)}")
+        raise_server_error("RBAC_0001", "Error queuing RBAC initialization")
 
 
 @with_error_handling(
@@ -370,7 +370,7 @@ async def get_rbac_task_status(
 
     except Exception as e:
         logger.error("Error getting RBAC task status: %s", str(e))
-        raise_server_error("RBAC_0002", f"Error getting task status: {str(e)}")
+        raise_server_error("RBAC_0002", "Error getting task status")
 
 
 @with_error_handling(
@@ -406,7 +406,7 @@ async def get_rbac_status(
 
     except Exception as e:
         logger.error("Error checking RBAC status: %s", str(e))
-        raise_server_error("RBAC_0003", f"Error checking RBAC status: {str(e)}")
+        raise_server_error("RBAC_0003", "Error checking RBAC status")
 
 
 # ==================== System Updates Endpoints (Issue #544) ====================
@@ -494,7 +494,7 @@ async def run_system_update_endpoint(
         raise
     except Exception as e:
         logger.error("Error queuing system update: %s", str(e))
-        raise_server_error("UPDATES_0001", f"Error queuing system update: {str(e)}")
+        raise_server_error("UPDATES_0001", "Error queuing system update")
 
 
 @with_error_handling(
@@ -541,7 +541,7 @@ async def get_update_task_status(
 
     except Exception as e:
         logger.error("Error getting update task status: %s", str(e))
-        raise_server_error("UPDATES_0002", f"Error getting task status: {str(e)}")
+        raise_server_error("UPDATES_0002", "Error getting task status")
 
 
 def _check_celery_worker_available() -> tuple[bool, str]:
@@ -658,7 +658,7 @@ async def check_updates_endpoint(
         raise
     except Exception as e:
         logger.error("Error queuing update check: %s", str(e))
-        raise_server_error("UPDATES_0003", f"Error queuing update check: {str(e)}")
+        raise_server_error("UPDATES_0003", "Error queuing update check")
 
 
 @with_error_handling(
@@ -699,4 +699,4 @@ async def get_update_status(
 
     except Exception as e:
         logger.error("Error checking update status: %s", str(e))
-        raise_server_error("UPDATES_0004", f"Error checking update status: {str(e)}")
+        raise_server_error("UPDATES_0004", "Error checking update status")

--- a/autobot-backend/api/system_validation.py
+++ b/autobot-backend/api/system_validation.py
@@ -63,7 +63,7 @@ async def validation_health():
         }
     except Exception as e:
         logger.error("Validation health check failed: %s", e)
-        raise_server_error("API_0003", f"Health check failed: {str(e)}")
+        raise_server_error("API_0003", "Health check failed")
 
 
 @with_error_handling(
@@ -83,9 +83,7 @@ async def run_comprehensive_validation(
         result = await validator.run_comprehensive_validation()
 
         if not result["success"]:
-            raise_server_error(
-                "API_0003", f"Validation failed: {result.get('error', 'Unknown error')}"
-            )
+            raise_server_error("API_0003", "Validation failed")
 
         # Format response
         validation_result = ValidationResult(
@@ -103,7 +101,7 @@ async def run_comprehensive_validation(
 
     except Exception as e:
         logger.error("Comprehensive validation failed: %s", e)
-        raise_server_error("API_0003", f"Validation error: {str(e)}")
+        raise_server_error("API_0003", "Validation error")
 
 
 @with_error_handling(
@@ -170,7 +168,7 @@ async def run_quick_validation():
 
     except Exception as e:
         logger.error("Quick validation failed: %s", e)
-        raise_server_error("API_0003", f"Quick validation error: {str(e)}")
+        raise_server_error("API_0003", "Quick validation error")
 
 
 @with_error_handling(
@@ -218,7 +216,7 @@ async def validate_component(component_name: str):
         raise
     except Exception as e:
         logger.error("Component validation failed for %s: %s", component_name, e)
-        raise_server_error("API_0003", f"Component validation error: {str(e)}")
+        raise_server_error("API_0003", "Component validation error")
 
 
 @with_error_handling(
@@ -283,7 +281,7 @@ async def get_optimization_recommendations():
 
     except Exception as e:
         logger.error("Failed to get recommendations: %s", e)
-        raise_server_error("API_0003", f"Recommendations error: {str(e)}")
+        raise_server_error("API_0003", "Recommendations error")
 
 
 @with_error_handling(
@@ -315,7 +313,7 @@ async def get_validation_status():
 
     except Exception as e:
         logger.error("Failed to get validation status: %s", e)
-        raise_server_error("API_0003", f"Status error: {str(e)}")
+        raise_server_error("API_0003", "Status error")
 
 
 @with_error_handling(
@@ -363,4 +361,4 @@ async def run_performance_benchmark():
 
     except Exception as e:
         logger.error("Performance benchmark failed: %s", e)
-        raise_server_error("API_0003", f"Benchmark error: {str(e)}")
+        raise_server_error("API_0003", "Benchmark error")

--- a/autobot-backend/api/terminal_websocket.py
+++ b/autobot-backend/api/terminal_websocket.py
@@ -67,7 +67,7 @@ class TerminalWebSocketHandler:
                 {
                     "type": "error",
                     "message": "Failed to initialize terminal session",
-                    "details": str(e),
+                    "details": "Terminal session initialization failed",
                 },
             )
 
@@ -120,11 +120,12 @@ class TerminalWebSocketHandler:
                 except WebSocketDisconnect:
                     break
                 except json.JSONDecodeError as e:
-                    await self._send_error(websocket, f"Invalid JSON: {str(e)}")
+                    logger.warning("Invalid JSON received in WebSocket message: %s", e)
+                    await self._send_error(websocket, "Invalid JSON")
                 except Exception as e:
                     logger.error(f"Error handling WebSocket message: {e}")
                     await self._send_error(
-                        websocket, f"Error processing message: {str(e)}"
+                        websocket, "Error processing message"
                     )
 
         except Exception as e:
@@ -162,7 +163,8 @@ class TerminalWebSocketHandler:
                     history_service.add_command(chat_id, user_input.strip())
                 )
         except ValueError as e:
-            await self._send_error_to_chat(chat_id, str(e))
+            logger.warning("Input error for chat %s: %s", chat_id, e)
+            await self._send_error_to_chat(chat_id, "Invalid input request")
 
     async def _handle_control_action(self, chat_id: str, action: str) -> None:
         """Handle take_control or return_control messages. Issue #620."""
@@ -172,7 +174,8 @@ class TerminalWebSocketHandler:
             else:
                 await system_command_agent.return_control_of_session(chat_id)
         except ValueError as e:
-            await self._send_error_to_chat(chat_id, str(e))
+            logger.warning("Control action error for chat %s: %s", chat_id, e)
+            await self._send_error_to_chat(chat_id, "Control action failed")
 
     async def _handle_signal(self, chat_id: str, data: Dict[str, Any]) -> None:
         """Handle signal message. Issue #620."""
@@ -180,7 +183,8 @@ class TerminalWebSocketHandler:
         try:
             await system_command_agent.send_signal_to_session(chat_id, signal_type)
         except ValueError as e:
-            await self._send_error_to_chat(chat_id, str(e))
+            logger.warning("Signal error for chat %s: %s", chat_id, e)
+            await self._send_error_to_chat(chat_id, "Signal failed")
 
     async def _handle_resize(self, chat_id: str, data: Dict[str, Any]) -> None:
         """Handle resize message. Issue #620."""

--- a/autobot-backend/api/workflow.py
+++ b/autobot-backend/api/workflow.py
@@ -1007,7 +1007,8 @@ async def execute_single_step(workflow_id: str, step: Metadata, orchestrator):
             await _handle_fallback_step(ctx, agent_type)
 
     except Exception as e:
-        step["result"] = f"Error executing step: {str(e)}"
+        logger.error("Error executing step %s: %s", step_id, e)
+        step["result"] = "Error executing step"
         step["status"] = "failed"
 
         # End step timing with failure

--- a/autobot-backend/security/service_auth.py
+++ b/autobot-backend/security/service_auth.py
@@ -253,4 +253,4 @@ async def validate_service_auth(request: Request) -> Dict:
         logger.error(
             "Service auth validation error", error=str(e), path=request.url.path
         )
-        raise_server_error("API_0003", f"Authentication service error: {str(e)}")
+        raise_server_error("API_0003", "Authentication service error")

--- a/autobot-backend/startup_validator.py
+++ b/autobot-backend/startup_validator.py
@@ -28,7 +28,6 @@ import asyncio
 import importlib
 import logging
 import sys
-import traceback
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -164,9 +163,10 @@ class StartupValidator:
                 importlib.import_module(module_name)
                 logger.debug("✅ Critical import: %s", module_name)
             except ImportError as e:
+                logger.error("Critical import failed: %s: %s", module_name, e)
                 self.result.add_error(
                     f"Critical import failed: {module_name}",
-                    {"error": str(e), "traceback": traceback.format_exc()},
+                    {"error": type(e).__name__},
                 )
 
     def _validate_autobot_modules(self):
@@ -178,15 +178,17 @@ class StartupValidator:
                 importlib.import_module(module_name)
                 logger.debug("✅ AutoBot module: %s", module_name)
             except ImportError as e:
+                logger.error("AutoBot module import failed: %s: %s", module_name, e)
                 self.result.add_error(
                     f"AutoBot module import failed: {module_name}",
-                    {"error": str(e), "traceback": traceback.format_exc()},
+                    {"error": type(e).__name__},
                 )
             except Exception as e:
                 # Module imported but failed to initialize
+                logger.error("AutoBot module initialization failed: %s: %s", module_name, e)
                 self.result.add_error(
                     f"AutoBot module initialization failed: {module_name}",
-                    {"error": str(e), "traceback": traceback.format_exc()},
+                    {"error": type(e).__name__},
                 )
 
     def _validate_optional_modules(self):
@@ -198,13 +200,15 @@ class StartupValidator:
                 importlib.import_module(module_name)
                 logger.debug("✅ Optional module: %s", module_name)
             except ImportError as e:
+                logger.debug("Optional module not available: %s: %s", module_name, e)
                 self.result.add_warning(
-                    f"Optional module not available: {module_name}", {"error": str(e)}
+                    f"Optional module not available: {module_name}", {"error": type(e).__name__}
                 )
             except Exception as e:
+                logger.debug("Optional module initialization failed: %s: %s", module_name, e)
                 self.result.add_warning(
                     f"Optional module initialization failed: {module_name}",
-                    {"error": str(e)},
+                    {"error": type(e).__name__},
                 )
 
     async def _validate_configuration(self):
@@ -231,9 +235,10 @@ class StartupValidator:
             logger.debug("✅ Configuration validation passed")
 
         except Exception as e:
+            logger.error("Configuration system failed: %s", e)
             self.result.add_error(
                 "Configuration system failed",
-                {"error": str(e), "traceback": traceback.format_exc()},
+                {"error": type(e).__name__},
             )
 
     async def _validate_service_connectivity(self):

--- a/autobot-backend/utils/operation_timeout_integration.py
+++ b/autobot-backend/utils/operation_timeout_integration.py
@@ -174,7 +174,8 @@ class OperationIntegrationManager:
             )
             return {"operation_id": operation_id, "status": "created"}
         except ValueError as e:
-            raise_validation_error("API_0001", str(e))
+            logger.warning("Operation creation validation error: %s", e)
+            raise_validation_error("API_0001", "Invalid operation parameters")
         except Exception as e:
             logger.error("Failed to create operation: %s", e)
             raise_server_error("API_0003", "Internal server error")
@@ -281,7 +282,7 @@ class OperationIntegrationManager:
             }
         except Exception as e:
             logger.error("Failed to resume operation: %s", e)
-            raise_server_error("API_0003", str(e))
+            raise_server_error("API_0003", "Failed to resume operation")
 
     async def _handle_update_progress(
         self, operation_id: str, request: ProgressUpdateRequest
@@ -312,7 +313,7 @@ class OperationIntegrationManager:
             return {"operation_id": operation_id, "status": "started"}
         except Exception as e:
             logger.error("Failed to start codebase indexing: %s", e)
-            raise_server_error("API_0003", str(e))
+            raise_server_error("API_0003", "Failed to start codebase indexing")
 
     async def _handle_start_testing(
         self, test_suite_path: str, test_patterns: Optional[List[str]] = None
@@ -325,7 +326,7 @@ class OperationIntegrationManager:
             return {"operation_id": operation_id, "status": "started"}
         except Exception as e:
             logger.error("Failed to start comprehensive testing: %s", e)
-            raise_server_error("API_0003", str(e))
+            raise_server_error("API_0003", "Failed to start comprehensive testing")
 
     def _setup_routes(self):
         """Setup FastAPI routes for operation management. Issue #620."""

--- a/autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py
+++ b/autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py
@@ -1257,7 +1257,7 @@ class WindowsNPUWorker:
 
         except Exception as e:
             logger.error(f"Pairing failed: {e}")
-            raise HTTPException(status_code=500, detail=str(e))
+            raise HTTPException(status_code=500, detail="Pairing failed")
 
     def _handle_pairing_status(self) -> Dict[str, Any]:
         """Return current pairing status for GET /pairing-status (Issue #641)."""
@@ -1296,7 +1296,7 @@ class WindowsNPUWorker:
 
         except Exception as e:
             logger.error(f"Unpair failed: {e}")
-            raise HTTPException(status_code=500, detail=str(e))
+            raise HTTPException(status_code=500, detail="Unpair failed")
 
     def _register_device_routes(self):
         """Register /device-info route (Issue #640)."""
@@ -1452,7 +1452,7 @@ class WindowsNPUWorker:
             }
         except Exception as e:
             logger.error(f"Embedding generation failed: {e}")
-            raise HTTPException(status_code=500, detail=str(e))
+            raise HTTPException(status_code=500, detail="Embedding generation failed")
 
     async def _handle_semantic_search(
         self,
@@ -1484,7 +1484,7 @@ class WindowsNPUWorker:
             }
         except Exception as e:
             logger.error(f"Semantic search failed: {e}")
-            raise HTTPException(status_code=500, detail=str(e))
+            raise HTTPException(status_code=500, detail="Semantic search failed")
 
     def _register_model_routes(self):
         """Register /model/optimize and /performance/benchmark routes."""
@@ -1502,7 +1502,7 @@ class WindowsNPUWorker:
                 }
             except Exception as e:
                 logger.error(f"Model optimization failed: {e}")
-                raise HTTPException(status_code=500, detail=str(e))
+                raise HTTPException(status_code=500, detail="Model optimization failed")
 
         @self.app.get("/performance/benchmark")
         async def benchmark():
@@ -1515,7 +1515,7 @@ class WindowsNPUWorker:
                 }
             except Exception as e:
                 logger.error(f"Benchmark failed: {e}")
-                raise HTTPException(status_code=500, detail=str(e))
+                raise HTTPException(status_code=500, detail="Benchmark failed")
 
     async def initialize(self):
         """

--- a/autobot-slm-agent/agent.py
+++ b/autobot-slm-agent/agent.py
@@ -471,7 +471,7 @@ class SLMAgent:
             return web.json_response({"error": "invalid JSON"}, status=400)
         except Exception as e:
             logger.error("Error handling code change: %s", e)
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _notify_code_change(self, commit: str) -> None:
         """Send immediate notification to SLM server about code change."""

--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py
@@ -508,7 +508,7 @@ class SLMAgent:
             return web.json_response({"error": "invalid JSON"}, status=400)
         except Exception as e:
             logger.error("Error handling code change: %s", e)
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _notify_code_change(self, commit: str) -> None:
         """Send immediate notification to SLM server about code change."""

--- a/autobot-slm-backend/api/infrastructure.py
+++ b/autobot-slm-backend/api/infrastructure.py
@@ -653,7 +653,7 @@ async def _run_playbook(
     except Exception as e:
         execution.status = PlaybookStatus.FAILED
         execution.error = "Internal server error"
-        execution.output.append(f"[ERROR] {str(e)}")
+        execution.output.append("[ERROR] Playbook execution failed")
         logger.exception("Playbook execution failed: %s", execution_id)
 
     finally:

--- a/autobot-slm-backend/api/orchestration.py
+++ b/autobot-slm-backend/api/orchestration.py
@@ -631,7 +631,7 @@ async def _run_ssh_service_action(
             action,
             str(e),
         )
-        return False, f"Error: {str(e)[:200]}"
+        return False, "Service action failed"
 
 
 @fleet_router.get("/services", response_model=FleetServicesResponse)

--- a/autobot-slm-backend/api/services.py
+++ b/autobot-slm-backend/api/services.py
@@ -112,7 +112,7 @@ async def _run_ansible_service_action(
         return False, f"Timeout waiting for {action} to complete"
     except Exception as e:
         logger.exception("Service action error: %s", e)
-        return False, f"Error: {str(e)[:200]}"
+        return False, "Service action failed"
 
 
 # Port mapping for services that bind to specific ports
@@ -175,7 +175,7 @@ async def _kill_orphan_on_port(node: Node, port: int) -> Tuple[bool, str]:
 
     except Exception as e:
         logger.warning("Could not kill orphan on port %d: %s", port, e)
-        return False, str(e)
+        return False, f"Could not kill orphan on port {port}"
 
 
 async def _run_ansible_get_logs(
@@ -238,7 +238,7 @@ async def _run_ansible_get_logs(
         return False, "Timeout fetching logs"
     except Exception as e:
         logger.exception("Get logs error: %s", e)
-        return False, f"Error: {str(e)[:200]}"
+        return False, "Failed to fetch logs"
 
 
 def _build_scan_failure_response(node_id: str, message: str) -> ServiceScanResponse:
@@ -424,7 +424,7 @@ async def scan_node_services(
 
     except Exception as e:
         logger.exception("Service scan error on %s: %s", node.hostname, e)
-        return _build_scan_failure_response(node_id, f"Error: {str(e)[:200]}")
+        return _build_scan_failure_response(node_id, "Service scan failed")
 
 
 async def _upsert_service(

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -283,7 +283,7 @@ async def _run_update_job(job_id: str, node_id: str, update_ids: List[str]) -> N
             job.error = "Internal server error"
             job.completed_at = datetime.utcnow()
             await db.commit()
-            await _broadcast_job_update(job_id, "failed", job.progress, str(e))
+            await _broadcast_job_update(job_id, "failed", job.progress, "Update job failed")
 
 
 def _parse_discover_output(output: str) -> List[dict]:
@@ -636,9 +636,9 @@ async def _run_discover_job(
     except Exception as e:
         logger.exception("Discover job failed: %s", job_id)
         job["status"] = "failed"
-        job["message"] = str(e)
+        job["message"] = "Discover job failed"
         job["completed_at"] = datetime.utcnow().isoformat()
-        await _broadcast_job_update(job_id, "failed", job.get("progress", 0), str(e))
+        await _broadcast_job_update(job_id, "failed", job.get("progress", 0), "Discover job failed")
 
 
 @router.post("/discover", response_model=UpdateDiscoverResponse)

--- a/autobot-slm-backend/monitoring/advanced_apm_system.py
+++ b/autobot-slm-backend/monitoring/advanced_apm_system.py
@@ -793,7 +793,7 @@ class AdvancedAPMSystem:
 
         except Exception as e:
             self.logger.error(f"Error generating performance summary: {e}")
-            return {"error": str(e)}
+            return {"error": "Failed to generate performance summary"}
 
     async def generate_apm_report(self) -> Dict[str, Any]:
         """Generate comprehensive APM report."""
@@ -826,7 +826,7 @@ class AdvancedAPMSystem:
 
         except Exception as e:
             self.logger.error(f"Error generating APM report: {e}")
-            return {"error": str(e)}
+            return {"error": "Failed to generate APM report"}
 
     async def _store_apm_report(self, report: Dict[str, Any]):
         """Store APM report."""

--- a/autobot-slm-backend/monitoring/ai_performance_analytics.py
+++ b/autobot-slm-backend/monitoring/ai_performance_analytics.py
@@ -826,7 +826,7 @@ else:
             self.logger.error(f"Error generating AI performance report: {e}")
             self.logger.error(traceback.format_exc())
             return {
-                "error": str(e),
+                "error": "Failed to generate AI performance report",
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
 

--- a/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
+++ b/autobot-slm-backend/monitoring/business_intelligence_dashboard.py
@@ -905,7 +905,7 @@ class BusinessIntelligenceDashboard:
         except Exception as e:
             self.logger.error(f"Error generating dashboard report: {e}")
             return {
-                "error": str(e),
+                "error": "Failed to generate dashboard report",
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
 

--- a/autobot-slm-backend/monitoring/comprehensive_monitoring_controller.py
+++ b/autobot-slm-backend/monitoring/comprehensive_monitoring_controller.py
@@ -560,7 +560,7 @@ class ComprehensiveMonitoringController:
         except Exception as e:
             self.logger.error(f"Error generating instant report: {e}")
             return {
-                "error": str(e),
+                "error": "Failed to generate instant report",
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
 

--- a/autobot-slm-backend/monitoring/monitor_control.py
+++ b/autobot-slm-backend/monitoring/monitor_control.py
@@ -484,7 +484,7 @@ class MonitorControl:
             self.logger.error(f"Error getting current status: {e}")
             return {
                 "timestamp": datetime.now().isoformat(),
-                "error": str(e),
+                "error": "Failed to get monitoring status",
                 "monitoring": {"running": self.running},
             }
 

--- a/autobot-slm-backend/monitoring/performance_dashboard.py
+++ b/autobot-slm-backend/monitoring/performance_dashboard.py
@@ -536,7 +536,8 @@ class PerformanceDashboard:
                 metrics, dumps=lambda obj: json.dumps(obj, default=str)
             )
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("Error getting current metrics: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def get_metrics_history(self, request):
         """Get historical performance metrics."""
@@ -566,7 +567,8 @@ class PerformanceDashboard:
             return web.json_response(parsed_history)
 
         except Exception as e:
-            return web.json_response({"error": str(e), "history": []}, status=500)
+            logger.error("Error getting metrics history: %s", e)
+            return web.json_response({"error": "Internal server error", "history": []}, status=500)
 
     async def get_system_status(self, request):
         """Get overall system status summary."""
@@ -605,7 +607,8 @@ class PerformanceDashboard:
             return web.json_response(status_summary)
 
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("Error getting system status: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def get_alerts(self, request):
         """Get current performance alerts."""
@@ -627,7 +630,8 @@ class PerformanceDashboard:
             )
 
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("Error getting alerts: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def websocket_handler(self, request):
         """Handle WebSocket connections for real-time updates."""

--- a/autobot-slm-backend/services/database.py
+++ b/autobot-slm-backend/services/database.py
@@ -188,7 +188,7 @@ class DatabaseService:
             return {"status": "healthy", "database": "postgresql"}
         except Exception as e:
             logger.error("Database health check failed: %s", e)
-            return {"status": "unhealthy", "error": str(e)}
+            return {"status": "unhealthy", "error": "Health check failed"}
 
     @asynccontextmanager
     async def session(self) -> AsyncGenerator[AsyncSession, None]:

--- a/autobot-slm-backend/slm/agent/agent.py
+++ b/autobot-slm-backend/slm/agent/agent.py
@@ -508,7 +508,7 @@ class SLMAgent:
             return web.json_response({"error": "invalid JSON"}, status=400)
         except Exception as e:
             logger.error("Error handling code change: %s", e)
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _notify_code_change(self, commit: str) -> None:
         """Send immediate notification to SLM server about code change."""

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -149,7 +149,7 @@ class SSOService(BaseService):
             return {"success": True, "message": "LDAP connection successful"}
         except Exception as e:
             logger.error("LDAP connection test failed: %s", e)
-            return {"success": False, "message": str(e)}
+            return {"success": False, "message": "LDAP connection test failed"}
 
     def _generate_oauth_state(self, provider_id: uuid.UUID) -> str:
         """Generate OAuth2 state token and store provider mapping."""


### PR DESCRIPTION
## Summary
- Fixes ~65 `py/stack-trace-exposure` CodeQL alerts across 26 files
- Replaces `str(e)` in HTTP responses with generic error messages
- Server-side logging preserved for debugging
- Covers autobot-backend, autobot-slm-backend, and autobot-npu-worker

## Key Changes
- **api/settings.py**: 13 fixes across all settings endpoints
- **api/system_validation.py**: 8 fixes across validation endpoints  
- **api/terminal_websocket.py**: 6 fixes in WebSocket error messages
- **monitoring/*.py**: 10 fixes across 5 monitoring modules
- **npu_worker.py**: 6 fixes in NPU worker endpoints

## Remaining Work (follow-up PRs)
- ~155 remaining `py/stack-trace-exposure` alerts in internal/non-API code
- 70 `py/path-injection` alerts (shared `validate_path` utility exists)
- 55 `py/clear-text-logging` alerts (inspection found no actual secrets logged)
- 40 warning-severity alerts (Actions permissions already set)

## Verification
- ✅ All changed files pass `python -m py_compile`

## Test plan
- [ ] Verify API error responses return generic messages (not stack traces)
- [ ] Verify server logs still contain full exception details
- [ ] Test settings, validation, monitoring, and WebSocket endpoints

Closes #1733

🤖 Generated with [Claude Code](https://claude.com/claude-code)