### PR TITLE
feat(frontend): add HeartbeatPanel route at /agents/heartbeat

### DIFF
--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -521,6 +521,18 @@ const routes: RouteRecordRaw[] = [
       requiresAuth: true
     }
   },
+  // Issue #1521: Agent Heartbeat Panel — real-time agent run status
+  {
+    path: '/agents/heartbeat',
+    name: 'agent-heartbeat',
+    component: () => import('@/components/agents/HeartbeatPanel.vue'),
+    meta: {
+      title: 'Agent Heartbeat',
+      icon: 'fas fa-heartbeat',
+      description: 'Monitor agent heartbeat and real-time run status',
+      requiresAuth: true
+    }
+  },
   // Issue #899: Code Intelligence — merged into /analytics/codebase
   {
     path: '/code-intelligence',


### PR DESCRIPTION
Closes #1521

## Summary
- Added route `/agents/heartbeat` pointing to existing `HeartbeatPanel.vue` component
- Route has auth guard, title, icon, and description metadata

## Context
`HeartbeatPanel.vue` was created in #1407 but no route was ever added, making it unreachable.

## Test plan
- [x] Route added to router config
- [ ] Navigation to /agents/heartbeat renders HeartbeatPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)