### PR TITLE
feat(workflow): add UI for per-workflow notification config (#3139)

### DIFF
--- a/autobot-backend/services/workflow_automation/models.py
+++ b/autobot-backend/services/workflow_automation/models.py
@@ -204,6 +204,14 @@ class ActiveWorkflow:
     phase: Optional[str] = None
     active_service: Optional[str] = None
 
+    def _serialize_notification_config(self) -> Optional[Metadata]:
+        """Serialize notification_config to a plain dict for API responses."""
+        if self.notification_config is None:
+            return None
+        from dataclasses import asdict
+
+        return asdict(self.notification_config)
+
     def to_status_dict(self) -> Metadata:
         """Convert workflow to status dictionary (Issue #372 - reduces feature envy)."""
         return {
@@ -225,6 +233,7 @@ class ActiveWorkflow:
             ),
             "steps": [step.to_status_dict() for step in self.steps],
             "user_interventions": self.user_interventions,
+            "notification_config": self._serialize_notification_config(),
         }
 
 
@@ -290,3 +299,19 @@ class PlanPresentationRequest(BaseModel):
     approval_mode: str = "full_plan"
     include_risk_assessment: bool = True
     timeout_seconds: int = 300
+
+
+# Issue #3139: Per-workflow notification configuration API model
+class NotificationConfigRequest(BaseModel):
+    """
+    Request model for updating per-workflow notification routing.
+
+    Issue #3139: Maps notification events to delivery channels.
+    """
+
+    enabled: bool = True
+    email_recipients: List[str] = []
+    slack_webhook_url: Optional[str] = None
+    webhook_url: Optional[str] = None
+    channels: Dict[str, List[str]] = {}
+    templates: Dict[str, str] = {}

--- a/autobot-backend/services/workflow_automation/routes.py
+++ b/autobot-backend/services/workflow_automation/routes.py
@@ -10,16 +10,19 @@ FastAPI endpoints for workflow automation.
 import json
 import logging
 import threading
+from dataclasses import asdict
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from services.notification_service import NotificationConfig
 
 from .manager import WorkflowAutomationManager
 from .models import (
     AutomatedWorkflowRequest,
     AutomationMode,
+    NotificationConfigRequest,
     PlanApprovalMode,
     PlanApprovalResponse,
     PlanPresentationRequest,
@@ -461,6 +464,99 @@ async def get_pending_approval(
 
     except Exception as e:
         logger.error("Failed to get pending approval: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# =========================================================================
+# Issue #3139: Per-Workflow Notification Configuration
+# =========================================================================
+
+
+def _find_workflow(workflow_id: str):
+    """Look up a workflow in active or completed stores.
+
+    Returns the ActiveWorkflow dataclass or raises 404.
+    """
+    mgr = get_workflow_manager()
+    wf = mgr.active_workflows.get(workflow_id)
+    if wf is None:
+        wf = mgr.completed_workflows.get(workflow_id)
+    if wf is None:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    return wf
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_notification_config",
+    error_code_prefix="WORKFLOW_AUTOMATION",
+)
+@router.get("/notification_config/{workflow_id}")
+async def get_notification_config(
+    workflow_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Return the notification configuration for a workflow (#3139)."""
+    try:
+        wf = _find_workflow(workflow_id)
+        config_dict = None
+        if wf.notification_config is not None:
+            config_dict = asdict(wf.notification_config)
+        return {
+            "success": True,
+            "workflow_id": workflow_id,
+            "notification_config": config_dict,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to get notification config: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="update_notification_config",
+    error_code_prefix="WORKFLOW_AUTOMATION",
+)
+@router.put("/notification_config/{workflow_id}")
+async def update_notification_config(
+    workflow_id: str,
+    request: NotificationConfigRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Create or update the notification configuration for a workflow (#3139).
+
+    When ``enabled`` is false the config is removed entirely so the
+    executor skips notification delivery.
+    """
+    try:
+        wf = _find_workflow(workflow_id)
+        if not request.enabled:
+            wf.notification_config = None
+        else:
+            wf.notification_config = NotificationConfig(
+                workflow_id=workflow_id,
+                channels=request.channels,
+                templates=request.templates,
+                email_recipients=request.email_recipients,
+                slack_webhook_url=request.slack_webhook_url,
+                webhook_url=request.webhook_url,
+            )
+        config_dict = None
+        if wf.notification_config is not None:
+            config_dict = asdict(wf.notification_config)
+        return {
+            "success": True,
+            "workflow_id": workflow_id,
+            "notification_config": config_dict,
+            "message": "Notification configuration updated",
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to update notification config: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
@@ -1,0 +1,544 @@
+<template>
+  <div class="notification-config">
+    <!-- Workflow Selector -->
+    <div class="config-section">
+      <label class="field-label" for="nc-workflow-select">
+        {{ $t('workflow.notifications.selectWorkflow') }}
+      </label>
+      <select
+        id="nc-workflow-select"
+        class="field-input"
+        :value="selectedWorkflowId"
+        @change="handleWorkflowChange(($event.target as HTMLSelectElement).value)"
+        :disabled="loadingConfig"
+      >
+        <option value="">{{ $t('workflow.notifications.chooseWorkflow') }}</option>
+        <option
+          v-for="wf in workflows"
+          :key="wf.workflow_id"
+          :value="wf.workflow_id"
+        >
+          {{ wf.name }} ({{ wf.workflow_id.slice(0, 8) }})
+        </option>
+      </select>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loadingConfig" class="loading-indicator">
+      <svg class="spinner" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-dasharray="30 70" />
+      </svg>
+      <span>{{ $t('workflow.notifications.loading') }}</span>
+    </div>
+
+    <!-- Error -->
+    <div v-if="configError" class="error-banner" role="alert">
+      <span>{{ configError }}</span>
+    </div>
+
+    <!-- Config Form -->
+    <template v-if="selectedWorkflowId && !loadingConfig">
+      <!-- Enable Toggle -->
+      <div class="config-section toggle-section">
+        <label class="toggle-label">
+          <input
+            type="checkbox"
+            v-model="enabled"
+            class="toggle-input"
+          />
+          <span class="toggle-text">{{ $t('workflow.notifications.enableNotifications') }}</span>
+        </label>
+      </div>
+
+      <fieldset :disabled="!enabled" class="config-fieldset">
+        <!-- Email Recipients -->
+        <div class="config-section">
+          <label class="field-label" for="nc-email-recipients">
+            {{ $t('workflow.notifications.emailRecipients') }}
+          </label>
+          <input
+            id="nc-email-recipients"
+            type="text"
+            class="field-input"
+            v-model="emailRecipientsRaw"
+            :placeholder="$t('workflow.notifications.emailPlaceholder')"
+          />
+          <span class="field-hint">{{ $t('workflow.notifications.emailHint') }}</span>
+        </div>
+
+        <!-- Slack Webhook -->
+        <div class="config-section">
+          <label class="field-label" for="nc-slack-webhook">
+            {{ $t('workflow.notifications.slackWebhookUrl') }}
+          </label>
+          <input
+            id="nc-slack-webhook"
+            type="url"
+            class="field-input"
+            v-model="slackWebhookUrl"
+            placeholder="https://hooks.slack.com/services/..."
+          />
+        </div>
+
+        <!-- Generic Webhook -->
+        <div class="config-section">
+          <label class="field-label" for="nc-webhook-url">
+            {{ $t('workflow.notifications.webhookUrl') }}
+          </label>
+          <input
+            id="nc-webhook-url"
+            type="url"
+            class="field-input"
+            v-model="webhookUrl"
+            placeholder="https://example.com/webhook"
+          />
+        </div>
+
+        <!-- Channel-to-Event Routing Matrix -->
+        <div class="config-section">
+          <h4 class="section-heading">{{ $t('workflow.notifications.eventRouting') }}</h4>
+          <p class="field-hint">{{ $t('workflow.notifications.eventRoutingHint') }}</p>
+
+          <div class="routing-matrix" role="group" :aria-label="$t('workflow.notifications.eventRouting')">
+            <!-- Header row -->
+            <div class="matrix-row matrix-header">
+              <div class="matrix-cell matrix-label-cell"></div>
+              <div
+                v-for="channel in availableChannels"
+                :key="channel"
+                class="matrix-cell matrix-channel-header"
+              >
+                {{ channelLabel(channel) }}
+              </div>
+            </div>
+            <!-- Event rows -->
+            <div
+              v-for="event in allEvents"
+              :key="event"
+              class="matrix-row"
+            >
+              <div class="matrix-cell matrix-label-cell">
+                {{ eventLabel(event) }}
+              </div>
+              <div
+                v-for="channel in availableChannels"
+                :key="`${event}-${channel}`"
+                class="matrix-cell"
+              >
+                <input
+                  type="checkbox"
+                  :checked="isChannelEnabled(event, channel)"
+                  @change="toggleChannel(event, channel)"
+                  :aria-label="`${eventLabel(event)} via ${channelLabel(channel)}`"
+                  class="matrix-checkbox"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <!-- Save Button -->
+      <div class="config-actions">
+        <button
+          class="btn-save"
+          :disabled="saving"
+          @click="handleSave"
+        >
+          <svg v-if="saving" class="spinner btn-spinner" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-dasharray="30 70" />
+          </svg>
+          {{ saving ? $t('workflow.notifications.saving') : $t('workflow.notifications.save') }}
+        </button>
+        <span v-if="saveSuccess" class="save-success">
+          {{ $t('workflow.notifications.saved') }}
+        </span>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { createLogger } from '@/utils/debugUtils';
+import {
+  useWorkflowNotificationConfig,
+  ALL_EVENTS,
+  ALL_CHANNELS,
+  type NotificationEvent,
+  type NotificationChannel,
+  type NotificationConfigPayload,
+} from '@/composables/useWorkflowNotificationConfig';
+
+const logger = createLogger('WorkflowNotificationConfig');
+const { t } = useI18n();
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface WorkflowSummary {
+  workflow_id: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+const props = defineProps<{
+  workflows: WorkflowSummary[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'saved', workflowId: string): void;
+}>();
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+const {
+  saving,
+  loadingConfig,
+  configError,
+  fetchNotificationConfig,
+  saveNotificationConfig,
+} = useWorkflowNotificationConfig();
+
+// ---------------------------------------------------------------------------
+// Local state
+// ---------------------------------------------------------------------------
+
+const selectedWorkflowId = ref('');
+const enabled = ref(false);
+const emailRecipientsRaw = ref('');
+const slackWebhookUrl = ref('');
+const webhookUrl = ref('');
+const channels = ref<Record<string, string[]>>({});
+const saveSuccess = ref(false);
+
+const allEvents = ALL_EVENTS;
+
+/** Only show channels for which the user has provided a target. */
+const availableChannels = computed<NotificationChannel[]>(() => {
+  const result: NotificationChannel[] = [];
+  if (emailRecipientsRaw.value.trim()) result.push('email');
+  if (slackWebhookUrl.value.trim()) result.push('slack');
+  if (webhookUrl.value.trim()) result.push('webhook');
+  result.push('in_app');
+  return result;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function channelLabel(ch: NotificationChannel): string {
+  const map: Record<NotificationChannel, string> = {
+    email: t('workflow.notifications.channelEmail'),
+    slack: t('workflow.notifications.channelSlack'),
+    webhook: t('workflow.notifications.channelWebhook'),
+    in_app: t('workflow.notifications.channelInApp'),
+  };
+  return map[ch] ?? ch;
+}
+
+function eventLabel(ev: NotificationEvent): string {
+  const map: Record<NotificationEvent, string> = {
+    workflow_completed: t('workflow.notifications.eventCompleted'),
+    workflow_failed: t('workflow.notifications.eventFailed'),
+    step_failed: t('workflow.notifications.eventStepFailed'),
+    approval_needed: t('workflow.notifications.eventApprovalNeeded'),
+  };
+  return map[ev] ?? ev;
+}
+
+function isChannelEnabled(event: string, channel: string): boolean {
+  return channels.value[event]?.includes(channel) ?? false;
+}
+
+function toggleChannel(event: string, channel: string): void {
+  if (!channels.value[event]) {
+    channels.value[event] = [];
+  }
+  const idx = channels.value[event].indexOf(channel);
+  if (idx >= 0) {
+    channels.value[event].splice(idx, 1);
+  } else {
+    channels.value[event].push(channel);
+  }
+}
+
+function resetForm(): void {
+  enabled.value = false;
+  emailRecipientsRaw.value = '';
+  slackWebhookUrl.value = '';
+  webhookUrl.value = '';
+  channels.value = {};
+  saveSuccess.value = false;
+}
+
+// ---------------------------------------------------------------------------
+// Load config when workflow selection changes
+// ---------------------------------------------------------------------------
+
+async function handleWorkflowChange(workflowId: string): Promise<void> {
+  selectedWorkflowId.value = workflowId;
+  resetForm();
+  if (!workflowId) return;
+
+  const config = await fetchNotificationConfig(workflowId);
+  if (config) {
+    enabled.value = true;
+    emailRecipientsRaw.value = (config.email_recipients ?? []).join(', ');
+    slackWebhookUrl.value = config.slack_webhook_url ?? '';
+    webhookUrl.value = config.webhook_url ?? '';
+    channels.value = { ...config.channels };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Save
+// ---------------------------------------------------------------------------
+
+async function handleSave(): Promise<void> {
+  if (!selectedWorkflowId.value) return;
+  saveSuccess.value = false;
+
+  const recipients = emailRecipientsRaw.value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const payload: NotificationConfigPayload = {
+    enabled: enabled.value,
+    email_recipients: recipients,
+    slack_webhook_url: slackWebhookUrl.value || null,
+    webhook_url: webhookUrl.value || null,
+    channels: channels.value,
+    templates: {},
+  };
+
+  const ok = await saveNotificationConfig(selectedWorkflowId.value, payload);
+  if (ok) {
+    saveSuccess.value = true;
+    logger.info('Notification config saved for %s', selectedWorkflowId.value);
+    emit('saved', selectedWorkflowId.value);
+  }
+}
+
+// Clear success flash after 3 seconds
+watch(saveSuccess, (val) => {
+  if (val) {
+    setTimeout(() => { saveSuccess.value = false; }, 3000);
+  }
+});
+</script>
+
+<style scoped>
+.notification-config {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 48rem;
+}
+
+.config-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.field-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #e2e8f0);
+}
+
+.field-input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border, #374151);
+  border-radius: 0.375rem;
+  background: var(--color-bg-secondary, #1e293b);
+  color: var(--color-text-primary, #e2e8f0);
+  font-size: 0.875rem;
+  transition: border-color 0.15s;
+}
+.field-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #3b82f6);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+}
+
+.field-hint {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+.toggle-section {
+  flex-direction: row;
+  align-items: center;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-input {
+  width: 1.125rem;
+  height: 1.125rem;
+  accent-color: var(--color-primary, #3b82f6);
+}
+
+.toggle-text {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #e2e8f0);
+}
+
+.config-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.config-fieldset:disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.section-heading {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #e2e8f0);
+  margin: 0;
+}
+
+/* Routing matrix */
+.routing-matrix {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border, #374151);
+  border-radius: 0.375rem;
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+
+.matrix-row {
+  display: flex;
+  align-items: center;
+}
+
+.matrix-row:not(:last-child) {
+  border-bottom: 1px solid var(--color-border, #374151);
+}
+
+.matrix-header {
+  background: var(--color-bg-tertiary, #0f172a);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+.matrix-cell {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+  font-size: 0.8125rem;
+}
+
+.matrix-label-cell {
+  flex: 2;
+  text-align: left;
+  font-weight: 500;
+  color: var(--color-text-primary, #e2e8f0);
+}
+
+.matrix-channel-header {
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+.matrix-checkbox {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--color-primary, #3b82f6);
+  cursor: pointer;
+}
+
+/* Actions */
+.config-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+}
+
+.btn-save {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1.25rem;
+  border: none;
+  border-radius: 0.375rem;
+  background: var(--color-primary, #3b82f6);
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn-save:hover:not(:disabled) {
+  background: var(--color-primary-hover, #2563eb);
+}
+.btn-save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.save-success {
+  font-size: 0.8125rem;
+  color: var(--color-success, #22c55e);
+  font-weight: 500;
+}
+
+/* Loading / Error */
+.loading-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #94a3b8);
+  padding: 0.75rem 0;
+}
+
+.spinner {
+  width: 1.25rem;
+  height: 1.25rem;
+  animation: spin 0.8s linear infinite;
+}
+
+.btn-spinner {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.error-banner {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+  font-size: 0.8125rem;
+}
+</style>

--- a/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
+++ b/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
@@ -1,0 +1,176 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * Workflow Notification Config Composable
+ *
+ * Provides API methods for reading and updating per-workflow
+ * notification configuration (#3139).
+ */
+
+import { ref } from 'vue';
+import { getBackendUrl } from '@/config/ssot-config';
+import { createLogger } from '@/utils/debugUtils';
+import { getAuthToken } from '@/utils/fetchWithAuth';
+import type { ApiResponse } from '@/types/api';
+
+const logger = createLogger('useWorkflowNotificationConfig');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Notification events that can trigger delivery. */
+export type NotificationEvent =
+  | 'workflow_completed'
+  | 'workflow_failed'
+  | 'step_failed'
+  | 'approval_needed';
+
+/** Notification delivery channels. */
+export type NotificationChannel = 'email' | 'slack' | 'webhook' | 'in_app';
+
+/** Shape of the notification config as returned by the backend. */
+export interface NotificationConfig {
+  workflow_id: string;
+  channels: Record<string, string[]>;
+  templates: Record<string, string>;
+  email_recipients: string[];
+  slack_webhook_url: string | null;
+  webhook_url: string | null;
+  user_id: string | null;
+}
+
+/** Payload sent to the PUT endpoint. */
+export interface NotificationConfigPayload {
+  enabled: boolean;
+  email_recipients: string[];
+  slack_webhook_url: string | null;
+  webhook_url: string | null;
+  channels: Record<string, string[]>;
+  templates: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const ALL_EVENTS: NotificationEvent[] = [
+  'workflow_completed',
+  'workflow_failed',
+  'step_failed',
+  'approval_needed',
+];
+
+export const ALL_CHANNELS: NotificationChannel[] = [
+  'email',
+  'slack',
+  'webhook',
+  'in_app',
+];
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function apiRequest<T>(
+  endpoint: string,
+  options: RequestInit = {},
+): Promise<ApiResponse<T>> {
+  const url = `${getBackendUrl()}${endpoint}`;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    const token = getAuthToken();
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...options.headers,
+      },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      return {
+        success: false,
+        error: (err as Record<string, string>).detail || `HTTP ${response.status}`,
+      };
+    }
+
+    const data = await response.json();
+    return { success: true, data };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Notification config API request failed: %s', message);
+    return { success: false, error: message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+export function useWorkflowNotificationConfig() {
+  const saving = ref(false);
+  const loadingConfig = ref(false);
+  const configError = ref<string | null>(null);
+
+  /** Fetch the current notification config for a workflow. */
+  async function fetchNotificationConfig(
+    workflowId: string,
+  ): Promise<NotificationConfig | null> {
+    loadingConfig.value = true;
+    configError.value = null;
+    try {
+      const res = await apiRequest<{
+        success: boolean;
+        notification_config: NotificationConfig | null;
+      }>(`/api/workflow-automation/notification_config/${workflowId}`);
+
+      if (!res.success || !res.data) {
+        configError.value = res.error ?? 'Failed to load config';
+        return null;
+      }
+      return res.data.notification_config;
+    } finally {
+      loadingConfig.value = false;
+    }
+  }
+
+  /** Save notification config for a workflow. */
+  async function saveNotificationConfig(
+    workflowId: string,
+    payload: NotificationConfigPayload,
+  ): Promise<boolean> {
+    saving.value = true;
+    configError.value = null;
+    try {
+      const res = await apiRequest<{ success: boolean }>(
+        `/api/workflow-automation/notification_config/${workflowId}`,
+        { method: 'PUT', body: JSON.stringify(payload) },
+      );
+      if (!res.success) {
+        configError.value = res.error ?? 'Failed to save config';
+        return false;
+      }
+      return true;
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  return {
+    saving,
+    loadingConfig,
+    configError,
+    fetchNotificationConfig,
+    saveNotificationConfig,
+  };
+}

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -3339,6 +3339,33 @@
       "addStepAriaLabel": "Add step",
       "cancel": "Cancel",
       "cancelAriaLabel": "Cancel"
+    },
+    "notifications": {
+      "sidebarLabel": "Notifications",
+      "sectionTitle": "Notification Settings",
+      "sectionDesc": "Configure per-workflow notification routing",
+      "selectWorkflow": "Workflow",
+      "chooseWorkflow": "-- Select a workflow --",
+      "loading": "Loading configuration...",
+      "enableNotifications": "Enable notifications for this workflow",
+      "emailRecipients": "Email Recipients",
+      "emailPlaceholder": "user@example.com, team@example.com",
+      "emailHint": "Comma-separated email addresses",
+      "slackWebhookUrl": "Slack Webhook URL",
+      "webhookUrl": "Generic Webhook URL",
+      "eventRouting": "Event Routing",
+      "eventRoutingHint": "Choose which channels receive each event type",
+      "channelEmail": "Email",
+      "channelSlack": "Slack",
+      "channelWebhook": "Webhook",
+      "channelInApp": "In-App",
+      "eventCompleted": "Workflow Completed",
+      "eventFailed": "Workflow Failed",
+      "eventStepFailed": "Step Failed",
+      "eventApprovalNeeded": "Approval Needed",
+      "save": "Save",
+      "saving": "Saving...",
+      "saved": "Saved successfully"
     }
   },
   "agent": {

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -107,6 +107,22 @@
           <span>{{ $t('workflow.views.history') }}</span>
         </div>
 
+        <!-- Issue #3139: Per-workflow notification configuration -->
+        <button
+          class="category-item"
+          :class="{ active: activeSection === 'notifications' }"
+          @click="activeSection = 'notifications'"
+          role="button"
+          :aria-label="$t('workflow.notifications.sidebarLabel')"
+          tabindex="0"
+        >
+          <svg class="item-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+          </svg>
+          <span>{{ $t('workflow.notifications.sidebarLabel') }}</span>
+        </button>
+
         <button
           class="category-item"
           :class="{ active: activeSection === 'gui-automation' }"
@@ -495,6 +511,14 @@
           />
         </section>
 
+        <!-- Issue #3139: Per-Workflow Notification Configuration -->
+        <section v-if="activeSection === 'notifications'" class="section-notifications">
+          <WorkflowNotificationConfig
+            :workflows="allWorkflowsForNotificationPicker"
+            @saved="handleNotificationConfigSaved"
+          />
+        </section>
+
         <!-- Orchestration Visualizer Section -->
         <section v-if="activeSection === 'orchestration'" class="section-orchestration">
           <OrchestrationVisualizer
@@ -610,6 +634,7 @@ import WorkflowCanvas from '@/components/workflow/WorkflowCanvas.vue';
 import WorkflowTemplateGallery from '@/components/workflow/WorkflowTemplateGallery.vue';
 import WorkflowRunner from '@/components/workflow/WorkflowRunner.vue';
 import WorkflowHistory from '@/components/workflow/WorkflowHistory.vue';
+import WorkflowNotificationConfig from '@/components/workflow/WorkflowNotificationConfig.vue';
 import OrchestrationVisualizer from '@/components/workflow/OrchestrationVisualizer.vue';
 import GUIAutomationControls from '@/components/vision/GUIAutomationControls.vue';
 import ScreenCaptureViewer from '@/components/vision/ScreenCaptureViewer.vue';
@@ -636,6 +661,7 @@ type SectionType =
   | 'natural-language'
   | 'runner'
   | 'history'
+  | 'notifications'
   | 'gui-automation'
   | 'screen-analysis'
   | 'video-processing'
@@ -778,6 +804,7 @@ const sectionTitle = computed(() => {
     'natural-language': t('workflow.views.sectionTitleNaturalLanguage'),
     runner: t('workflow.views.sectionTitleRunner'),
     history: t('workflow.views.sectionTitleHistory'),
+    notifications: t('workflow.notifications.sectionTitle'),
     orchestration: t('workflow.views.sectionTitleOrchestration'),
     agents: t('workflow.views.sectionTitleAgents'),
     'gui-automation': t('workflow.views.sectionTitleGuiAutomation'),
@@ -796,6 +823,7 @@ const sectionDescription = computed(() => {
     'natural-language': t('workflow.views.sectionDescNaturalLanguage'),
     runner: t('workflow.views.sectionDescRunner'),
     history: t('workflow.views.sectionDescHistory'),
+    notifications: t('workflow.notifications.sectionDesc'),
     orchestration: t('workflow.views.sectionDescOrchestration'),
     agents: t('workflow.views.sectionDescAgents'),
     'gui-automation': t('workflow.views.sectionDescGuiAutomation'),
@@ -804,6 +832,21 @@ const sectionDescription = computed(() => {
     'media-gallery': t('workflow.views.sectionDescMediaGallery'),
   };
   return descriptions[activeSection.value] || '';
+});
+
+/** Combine active + completed workflows for the notification config picker (#3139). */
+const allWorkflowsForNotificationPicker = computed(() => {
+  const combined = [
+    ...activeWorkflows.value,
+    ...completedWorkflows.value,
+  ];
+  // Deduplicate by workflow_id
+  const seen = new Set<string>();
+  return combined.filter((wf) => {
+    if (seen.has(wf.workflow_id)) return false;
+    seen.add(wf.workflow_id);
+    return true;
+  });
 });
 
 // Methods
@@ -932,7 +975,7 @@ async function handleSaveWorkflow(name: string, description: string): Promise<vo
 
 async function handleTemplateSelected(template: WorkflowTemplate | WorkflowTemplateSummary): Promise<void> {
   let full = template as WorkflowTemplate;
-  // Issue #1367: API summaries lack steps — fetch full detail
+  // Issue #1367: API summaries lack steps -- fetch full detail
   if (!full.steps?.length) {
     const detail = await fetchTemplateDetail(template.id);
     if (!detail?.steps?.length) {
@@ -1054,6 +1097,12 @@ async function handleReRunWorkflow(workflowId: string): Promise<void> {
   } else {
     showToast('Failed to re-run workflow', 'error');
   }
+}
+
+/** Handle notification config saved event (#3139). */
+function handleNotificationConfigSaved(workflowId: string): void {
+  showToast('Notification settings saved', 'success');
+  logger.info('Notification config saved for workflow %s', workflowId);
 }
 
 // Lifecycle


### PR DESCRIPTION
## Summary
- Adds notification settings UI to the Workflow Builder sidebar
- Users can configure email recipients, Slack webhook, generic webhook per workflow
- Event routing matrix maps workflow events to notification channels
- Backend GET/PUT endpoints for notification_config persistence

## New Files
- `WorkflowNotificationConfig.vue` — form component with event routing matrix
- `useWorkflowNotificationConfig.ts` — composable for notification config API

## Modified Files
- `workflow_automation/models.py` — NotificationConfigRequest model
- `workflow_automation/routes.py` — GET/PUT notification_config endpoints
- `WorkflowBuilderView.vue` — "Notifications" sidebar section
- `en.json` — 25 i18n keys

## Verification
- ✅ Python syntax check passes
- ✅ `vue-tsc --noEmit` passes
- ✅ `npm run build` passes

## Test plan
- [ ] Navigate to Workflow Builder → click Notifications in sidebar
- [ ] Select a workflow from dropdown
- [ ] Configure email/Slack/webhook and save
- [ ] Verify config persists on page reload
- [ ] Run a workflow and verify notifications are sent

Closes #3139

🤖 Generated with [Claude Code](https://claude.com/claude-code)