### PR TITLE
fix(frontend): remove duplicate /agent-registry route

### DIFF
--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -509,18 +509,6 @@ const routes: RouteRecordRaw[] = [
       requiresAuth: true
     }
   },
-  // Issue #1794: Agent Registry — browse backend + Claude agents
-  {
-    path: '/agent-registry',
-    name: 'agent-registry',
-    component: () => import('@/views/AgentRegistryView.vue'),
-    meta: {
-      title: 'Agent Registry',
-      icon: 'fas fa-robot',
-      description: 'Browse and monitor all registered agents',
-      requiresAuth: true
-    }
-  },
   // Issue #1521: Agent Heartbeat Panel — real-time agent run status
   {
     path: '/agents/heartbeat',


### PR DESCRIPTION
Closes #3163

Removes duplicate route definition at lines 512-523 that was identical to lines 500-511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)