### PR TITLE
fix(frontend): replace remaining any types in Vue/TS files (#3167)

### DIFF
--- a/autobot-slm-frontend/src/components/DeploymentWizard.vue
+++ b/autobot-slm-frontend/src/components/DeploymentWizard.vue
@@ -6,7 +6,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useSlmApi } from '@/composables/useSlmApi'
 import { useFleetStore } from '@/stores/fleet'
-import type { SLMNode } from '@/types/slm'
+import type { SLMNode, NodeRole } from '@/types/slm'
 
 interface RoleInfo {
   name: string
@@ -180,7 +180,7 @@ async function deploy(): Promise<void> {
 
     const deployment = await api.createDeployment({
       node_id: nodeId,
-      roles: selectedRoles.value as any,
+      roles: selectedRoles.value as NodeRole[],
     })
 
     emit('deployed', deployment.deployment_id)

--- a/autobot-slm-frontend/src/composables/useSlmApi.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.ts
@@ -1489,26 +1489,26 @@ export function useSlmApi() {
   }
 
   // Security (Issue #813)
-  async function getSecurityOverview(): Promise<any> {
+  async function getSecurityOverview(): Promise<unknown> {
     const response = await client.get('/security/overview')
     return response.data
   }
 
-  async function getAuditLogs(page: number = 1, perPage: number = 50, category?: string): Promise<any> {
+  async function getAuditLogs(page: number = 1, perPage: number = 50, category?: string): Promise<unknown> {
     const params = new URLSearchParams({ page: String(page), per_page: String(perPage) })
     if (category) params.append('category', category)
     const response = await client.get(`/security/audit-logs?${params}`)
     return response.data
   }
 
-  async function getSecurityEvents(page: number = 1, perPage: number = 50, severity?: string): Promise<any> {
+  async function getSecurityEvents(page: number = 1, perPage: number = 50, severity?: string): Promise<unknown> {
     const params = new URLSearchParams({ page: String(page), per_page: String(perPage) })
     if (severity) params.append('severity', severity)
     const response = await client.get(`/security/events?${params}`)
     return response.data
   }
 
-  async function getThreatSummary(hours: number = 24): Promise<any> {
+  async function getThreatSummary(hours: number = 24): Promise<unknown> {
     const response = await client.get(`/security/events/summary?hours=${hours}`)
     return response.data
   }
@@ -1516,7 +1516,7 @@ export function useSlmApi() {
   async function acknowledgeSecurityEvent(
     eventId: string,
     data?: { acknowledged_by?: string; notes?: string }
-  ): Promise<any> {
+  ): Promise<unknown> {
     const response = await client.post(`/security/events/${eventId}/acknowledge`, data || {})
     return response.data
   }
@@ -1524,31 +1524,39 @@ export function useSlmApi() {
   async function resolveSecurityEvent(
     eventId: string,
     data: { resolved_by?: string; resolution_notes: string }
-  ): Promise<any> {
+  ): Promise<unknown> {
     const response = await client.post(`/security/events/${eventId}/resolve`, data)
     return response.data
   }
 
-  async function getSecurityPolicies(page: number = 1, perPage: number = 50): Promise<any> {
+  async function getSecurityPolicies(page: number = 1, perPage: number = 50): Promise<unknown> {
     const params = new URLSearchParams({ page: String(page), per_page: String(perPage) })
     const response = await client.get(`/security/policies?${params}`)
     return response.data
   }
 
-  async function activateSecurityPolicy(policyId: string): Promise<any> {
+  async function activateSecurityPolicy(policyId: string): Promise<unknown> {
     const response = await client.post(`/security/policies/${policyId}/activate`)
     return response.data
   }
 
-  async function deactivateSecurityPolicy(policyId: string): Promise<any> {
+  async function deactivateSecurityPolicy(policyId: string): Promise<unknown> {
     const response = await client.post(`/security/policies/${policyId}/deactivate`)
     return response.data
   }
 
   // Fleet cert expiry (Issue #926 Phase 7)
-  async function getFleetCerts(nodeId?: string): Promise<any[]> {
+  interface FleetCert {
+    node_id: string
+    hostname: string
+    certificate: string
+    expiry: string
+    status: string
+  }
+
+  async function getFleetCerts(nodeId?: string): Promise<FleetCert[]> {
     const params = nodeId ? `?node_id=${nodeId}` : ''
-    const response = await client.get<any[]>(`/security/certificates${params}`)
+    const response = await client.get<FleetCert[]>(`/security/certificates${params}`)
     return response.data
   }
 

--- a/autobot-slm-frontend/src/utils/commitHashUtils.ts
+++ b/autobot-slm-frontend/src/utils/commitHashUtils.ts
@@ -87,10 +87,7 @@ export function isFullHash(hash: string | null | undefined): boolean {
  */
 export function getCommitUrl(hash: string | null | undefined): string | null {
   if (!hash || hash.trim() === '') return null
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const envBase = (import.meta as Record<string, any>).env?.VITE_GITHUB_REPO_URL as
-    | string
-    | undefined
+  const envBase = import.meta.env?.VITE_GITHUB_REPO_URL as string | undefined
   const base = envBase || 'https://github.com/mrveiss/AutoBot-AI'
   return `${base.replace(/\/$/, '')}/commit/${hash.trim()}`
 }

--- a/autobot-slm-frontend/src/views/CodeSyncView.vue
+++ b/autobot-slm-frontend/src/views/CodeSyncView.vue
@@ -898,8 +898,8 @@ onUnmounted(() => {
     <!-- Schedule Modal -->
     <ScheduleModal
       :show="showScheduleModal"
-      :schedule="(editingSchedule as any)"
-      :nodes="(codeSync.pendingNodes.value as any)"
+      :schedule="(editingSchedule as UpdateSchedule | null)"
+      :nodes="(codeSync.pendingNodes.value as PendingNode[])"
       @close="closeScheduleModal"
       @save="handleSaveSchedule"
     />

--- a/autobot-slm-frontend/src/views/FleetOverview.vue
+++ b/autobot-slm-frontend/src/views/FleetOverview.vue
@@ -534,7 +534,7 @@ async function handleReenroll(nodeId: string): Promise<void> {
     <AddNodeModal
       :visible="showAddNodeModal"
       :mode="editingNode ? 'edit' : 'add'"
-      :existing-node="(editingNode as any)"
+      :existing-node="(editingNode as SLMNode | null)"
       @close="closeAddNodeModal"
       @added="handleNodeSaved"
       @updated="handleNodeSaved"

--- a/autobot-slm-frontend/src/views/LoginView.vue
+++ b/autobot-slm-frontend/src/views/LoginView.vue
@@ -13,14 +13,13 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import type { ActiveProvider } from '@/composables/useSsoApi'
+import type { ActiveProvider, useSsoApi } from '@/composables/useSsoApi'
 
 const router = useRouter()
 const authStore = useAuthStore()
 
 // Issue #1016: SSO module lazy-loaded only when providers exist
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let ssoApi: Record<string, any> | null = null
+let ssoApi: ReturnType<typeof useSsoApi> | null = null
 
 const username = ref('')
 const password = ref('')

--- a/autobot-slm-frontend/src/views/OrchestrationView.vue
+++ b/autobot-slm-frontend/src/views/OrchestrationView.vue
@@ -645,7 +645,7 @@ function openCreateRoleForm(): void {
   showRoleForm.value = true
 }
 
-function openEditRoleForm(role: any): void {
+function openEditRoleForm(role: Role): void {
   editingRole.value = role.name
   roleFormData.value = {
     name: role.name,
@@ -1035,7 +1035,7 @@ onUnmounted(() => {
               :nodeId="node.nodeId"
               :hostname="node.hostname"
               :ipAddress="node.ipAddress"
-              :status="node.status as any"
+              :status="(node.status as 'online' | 'offline' | 'unknown')"
               :runningCount="node.runningCount"
               :stoppedCount="node.stoppedCount"
               :failedCount="node.failedCount"
@@ -1122,13 +1122,13 @@ onUnmounted(() => {
                       </span>
                     </td>
                     <td class="px-4 py-2">
-                      <ServiceStatusBadge :status="service.status as any" />
+                      <ServiceStatusBadge :status="service.status" />
                     </td>
                     <td class="px-4 py-2">
                       <ServiceActionButtons
                         :serviceName="service.service_name"
                         :nodeId="node.nodeId"
-                        :status="service.status as any"
+                        :status="(service.status as 'running' | 'stopped' | 'failed' | 'unknown')"
                         :isActionInProgress="orchestration.actionInProgress"
                         :activeAction="orchestration.activeAction"
                         @start="(nId, svc) => handleServiceAction(nId, svc, 'start')"
@@ -1374,13 +1374,13 @@ onUnmounted(() => {
                             <span class="text-xs text-gray-400 ml-1.5 font-mono">{{ nodeStatus.node_id }}</span>
                           </td>
                           <td class="px-4 py-1.5 w-28">
-                            <ServiceStatusBadge :status="nodeStatus.status as any" />
+                            <ServiceStatusBadge :status="nodeStatus.status" />
                           </td>
                           <td class="px-4 py-1.5 text-right">
                             <ServiceActionButtons
                               :serviceName="service.service_name"
                               :nodeId="nodeStatus.node_id"
-                              :status="nodeStatus.status as any"
+                              :status="(nodeStatus.status as 'running' | 'stopped' | 'failed' | 'unknown')"
                               :isActionInProgress="orchestration.actionInProgress"
                               :activeAction="orchestration.activeAction"
                               @start="(nId, svc) => handleServiceAction(nId, svc, 'start')"
@@ -2011,7 +2011,7 @@ onUnmounted(() => {
                 </td>
                 <td class="px-4 py-2 text-sm text-gray-600 font-mono">{{ node.ip_address }}</td>
                 <td class="px-4 py-2">
-                  <ServiceStatusBadge :status="node.status as any" />
+                  <ServiceStatusBadge :status="node.status" />
                 </td>
                 <td class="px-4 py-2 text-sm text-gray-600">
                   {{

--- a/autobot-slm-frontend/src/views/SetupWizardView.vue
+++ b/autobot-slm-frontend/src/views/SetupWizardView.vue
@@ -431,6 +431,7 @@
 import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useSlmApi } from '@/composables/useSlmApi'
+import type { NodeRole } from '@/types/slm'
 import { getConfig } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -792,7 +793,7 @@ async function saveRoles() {
   try {
     for (const node of nodes.value) {
       const roles = nodeRoles.value[node.node_id] || []
-      await updateNodeRoles(node.node_id, roles as any)
+      await updateNodeRoles(node.node_id, roles as NodeRole[])
     }
   } catch (err) {
     logger.error('Failed to save roles:', err)

--- a/autobot-slm-frontend/src/views/ToolsView.vue
+++ b/autobot-slm-frontend/src/views/ToolsView.vue
@@ -169,7 +169,7 @@ async function runHealthCheck(): Promise<void> {
       `Memory: ${data.memory_percent?.toFixed(1) || 'N/A'}%\n` +
       `Disk: ${data.disk_percent?.toFixed(1) || 'N/A'}%\n` +
       `Last Heartbeat: ${data.last_heartbeat || 'N/A'}\n\n` +
-      `Services:\n${(data.services || []).map((s: any) => `  - ${s.name}: ${s.status}`).join('\n') || '  No services found'}`
+      `Services:\n${(data.services || []).map((s: { name: string; status: string }) => `  - ${s.name}: ${s.status}`).join('\n') || '  No services found'}`
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Health check failed'
   } finally {

--- a/autobot-slm-frontend/src/views/monitoring/GrafanaDashboards.vue
+++ b/autobot-slm-frontend/src/views/monitoring/GrafanaDashboards.vue
@@ -157,7 +157,7 @@ function openInGrafana() {
       <div :class="[isFullscreen ? 'flex-1' : 'flex-1 min-h-[600px]']">
         <div class="bg-white rounded-lg shadow-xs border border-gray-200 overflow-hidden h-full">
           <GrafanaDashboard
-            :dashboard="(selectedDashboard as any)"
+            :dashboard="(selectedDashboard as 'overview' | 'system' | 'performance' | 'nodes' | 'redis' | 'api-health')"
             :height="isFullscreen ? 'calc(100vh - 150px)' : 600"
             :showControls="true"
           />

--- a/autobot-slm-frontend/src/views/monitoring/admin/AdminMonitoringView.vue
+++ b/autobot-slm-frontend/src/views/monitoring/admin/AdminMonitoringView.vue
@@ -55,7 +55,15 @@ interface MetricSummary {
 
 const systemHealth = ref<SystemHealth | null>(null)
 const errorStats = ref<ErrorStats | null>(null)
-const recentErrors = ref<any[]>([])
+interface MonitoringError {
+  id: string
+  level: string
+  component: string
+  message: string
+  timestamp: string
+}
+
+const recentErrors = ref<MonitoringError[]>([])
 const metrics = ref<MetricSummary[]>([])
 
 let refreshTimer: ReturnType<typeof setInterval> | null = null

--- a/autobot-slm-frontend/src/views/settings/BackendSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/BackendSettings.vue
@@ -49,9 +49,9 @@ async function fetchSettings(): Promise<void> {
           if (typeof settings.value[key] === 'boolean') {
             (settings.value as unknown as Record<string, boolean>)[key] = s.value === 'true'
           } else if (typeof settings.value[key] === 'number') {
-            (settings.value as Record<string, any>)[key] = parseInt(s.value)
+            (settings.value as Record<string, string | number | boolean>)[key] = parseInt(s.value)
           } else {
-            (settings.value as Record<string, any>)[key] = s.value
+            (settings.value as Record<string, string | number | boolean>)[key] = s.value
           }
         }
       })

--- a/autobot-slm-frontend/src/views/settings/GeneralSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/GeneralSettings.vue
@@ -172,7 +172,7 @@ async function fetchSettings(): Promise<void> {
       const data: Setting[] = await settingsRes.json()
       data.forEach((s) => {
         if (s.value !== null && s.key in settings.value) {
-          (settings.value as Record<string, any>)[s.key] = s.value
+          (settings.value as Record<string, string | number | boolean>)[s.key] = s.value
         }
       })
     }

--- a/autobot-slm-frontend/src/views/settings/MonitoringSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/MonitoringSettings.vue
@@ -41,7 +41,7 @@ async function fetchSettings(): Promise<void> {
       const data = await response.json()
       data.forEach((s: { key: string; value: string | null }) => {
         if (s.value !== null && s.key in settings.value) {
-          (settings.value as Record<string, any>)[s.key] = s.value
+          (settings.value as Record<string, string | number | boolean>)[s.key] = s.value
         }
       })
     }

--- a/autobot-slm-frontend/src/views/settings/NotificationsSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/NotificationsSettings.vue
@@ -46,7 +46,7 @@ async function fetchSettings(): Promise<void> {
           if (typeof notifications.value[key] === 'boolean') {
             (notifications.value as unknown as Record<string, boolean>)[key] = s.value === 'true'
           } else {
-            (notifications.value as Record<string, any>)[key] = s.value
+            (notifications.value as Record<string, string | number | boolean>)[key] = s.value
           }
         }
       })

--- a/autobot-slm-frontend/src/views/tools/admin/VoiceTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/VoiceTool.vue
@@ -42,9 +42,40 @@ const settings = ref<VoiceSettings>({
 const availableVoices = ref<string[]>(['default'])
 const conversationHistory = ref<{ role: 'user' | 'assistant'; text: string; timestamp: Date }[]>([])
 
-// Speech Recognition (using any to avoid missing lib types for SpeechRecognition)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let recognition: any = null
+// Speech Recognition browser API types
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean
+  readonly [index: number]: { readonly transcript: string }
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number
+  readonly [index: number]: SpeechRecognitionResult
+}
+
+interface SpeechRecognitionEvent {
+  readonly resultIndex: number
+  readonly results: SpeechRecognitionResultList
+}
+
+interface SpeechRecognitionErrorEvent {
+  readonly error: string
+}
+
+interface SpeechRecognitionInstance {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  onstart: (() => void) | null
+  onresult: ((event: SpeechRecognitionEvent) => void) | null
+  onend: (() => void) | null
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null
+  start(): void
+  stop(): void
+  abort(): void
+}
+
+let recognition: SpeechRecognitionInstance | null = null
 
 function initSpeechRecognition(): void {
   if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)) {
@@ -52,8 +83,9 @@ function initSpeechRecognition(): void {
     return
   }
 
-  const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
-  recognition = new SpeechRecognition()
+  const SpeechRecognitionCtor = (window as unknown as Record<string, new () => SpeechRecognitionInstance>).SpeechRecognition
+    || (window as unknown as Record<string, new () => SpeechRecognitionInstance>).webkitSpeechRecognition
+  recognition = new SpeechRecognitionCtor()
 
   recognition.continuous = false
   recognition.interimResults = true
@@ -65,8 +97,7 @@ function initSpeechRecognition(): void {
     error.value = null
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  recognition.onresult = (event: any) => {
+  recognition.onresult = (event: SpeechRecognitionEvent) => {
     let interimTranscript = ''
     let finalTranscript = ''
 
@@ -89,8 +120,7 @@ function initSpeechRecognition(): void {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  recognition.onerror = (event: any) => {
+  recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
     isListening.value = false
     error.value = `Speech recognition error: ${event.error}`
   }


### PR DESCRIPTION
## Summary

- Replace 37 `any` type usages across 16 frontend files with proper types
- Add SpeechRecognition type declarations for VoiceTool browser API
- Add `FleetCert` and `MonitoringError` interfaces for previously untyped data
- Use `ReturnType<typeof useSsoApi>` for lazy-loaded SSO module typing
- Replace `Promise<any>` with `Promise<unknown>` for security API endpoints

## Files Changed (16)

| Category | Files | Changes |
|----------|-------|---------|
| API composable | `useSlmApi.ts` | `Promise<any>` → `Promise<unknown>`, add `FleetCert` interface |
| Orchestration | `OrchestrationView.vue` | `role: any` → `Role`, remove/replace `as any` casts |
| Voice tool | `VoiceTool.vue` | Add 5 SpeechRecognition interfaces, remove 3 eslint-disable |
| Settings (4) | `*Settings.vue` | `Record<string, any>` → `Record<string, string \| number \| boolean>` |
| Monitoring (2) | `AdminMonitoringView.vue`, `GrafanaDashboards.vue` | `any[]` → `MonitoringError[]`, typed dashboard cast |
| Other views (5) | Login, CodeSync, Fleet, SetupWizard, Tools | Proper typed assertions |
| Components (1) | `DeploymentWizard.vue` | `as any` → `as NodeRole[]` |
| Utilities (1) | `commitHashUtils.ts` | Use `import.meta.env` directly |

Closes #3167

## Test plan

- [ ] CI type-check passes (`vue-tsc --noEmit`)
- [ ] CI build succeeds
- [ ] Verify orchestration view renders correctly with service status badges
- [ ] Verify voice tool initializes speech recognition
- [ ] Verify settings pages load and save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)