### PR TITLE
fix(security): resolve path-injection CodeQL alerts (#3164)

### DIFF
--- a/autobot-backend/agents/npu_code_search_agent.py
+++ b/autobot-backend/agents/npu_code_search_agent.py
@@ -995,6 +995,7 @@ class NPUCodeSearchAgent(StandardizedAgent):
             return []
 
         try:
+            file_path = str(validate_path(file_path))
             async with aiofiles.open(
                 file_path, "r", encoding="utf-8", errors="ignore"
             ) as f:
@@ -1069,6 +1070,7 @@ class NPUCodeSearchAgent(StandardizedAgent):
             return []
 
         try:
+            file_path = str(validate_path(file_path))
             async with aiofiles.open(
                 file_path, "r", encoding="utf-8", errors="ignore"
             ) as f:
@@ -1177,6 +1179,7 @@ class NPUCodeSearchAgent(StandardizedAgent):
             return []
 
         try:
+            file_path = str(validate_path(file_path))
             async with aiofiles.open(
                 file_path, "r", encoding="utf-8", errors="ignore"
             ) as f:
@@ -1411,6 +1414,7 @@ class NPUCodeSearchAgent(StandardizedAgent):
     ) -> List[str]:
         """Get context lines around a specific line number"""
         try:
+            file_path = str(validate_path(file_path))
             async with aiofiles.open(
                 file_path, "r", encoding="utf-8", errors="ignore"
             ) as f:

--- a/autobot-backend/api/analytics_performance.py
+++ b/autobot-backend/api/analytics_performance.py
@@ -22,6 +22,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from autobot_shared.security.path_validator import validate_path
 
 logger = logging.getLogger(__name__)
 
@@ -542,8 +543,10 @@ async def analyze_path(
     """
     start_time = datetime.now()
 
+    # Validate path stays within allowed roots before analysis (#3164)
+    safe_path = validate_path(path)
     # Issue #398: Use extracted helper
-    files_to_analyze = await _get_files_to_analyze(Path(path))
+    files_to_analyze = await _get_files_to_analyze(safe_path)
 
     # Return no_data response if no files to analyze
     if not files_to_analyze:

--- a/autobot-backend/api/codebase_analytics/endpoints/environment.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/environment.py
@@ -467,8 +467,14 @@ async def get_env_recommendations(
             )
 
     # Run fresh analysis if no cache
+    project_root = _get_project_root()
     if not path:
-        path = str(Path(__file__).resolve().parents[4])
+        path = project_root
+
+    error_response = _validate_env_path_security(path, project_root)
+    if error_response:
+        return error_response
+
     return await _fetch_live_env_recommendations(path)
 
 

--- a/autobot-backend/services/fast_document_scanner.py
+++ b/autobot-backend/services/fast_document_scanner.py
@@ -457,11 +457,21 @@ class FastDocumentScanner:
         Returns:
             ManPageContent with structured sections, or None if failed
         """
+        from autobot_shared.security.path_validator import validate_path
+
         parser = ManPageParser()
 
         try:
+            # Validate path stays within system man directories (#1721)
+            safe_path = validate_path(
+                file_path,
+                allowed_roots=[
+                    "/usr/share/man",
+                    "/usr/local/share/man",
+                ],
+            )
             # Try direct file parsing first (faster)
-            result = parser.parse_man_page(Path(file_path))
+            result = parser.parse_man_page(safe_path)
 
             if result.parse_success:
                 return result


### PR DESCRIPTION
## Summary
- Applied `validate_path()` / `validate_relative_path()` from `autobot_shared.security.path_validator` to all locations where user-controlled paths flow into file system operations
- Part of #3164 (path-injection subset, ~66 alerts)

## Changes

### `autobot-backend/agents/npu_code_search_agent.py` (+4 lines)
Added `validate_path(file_path)` before `aiofiles.open()` in four methods that retrieve file paths from Redis (external data source) and use them to open files:
- `_search_file_exact` — exact-match search reads file content from Redis-stored path
- `_search_file_regex` — regex search reads file content from Redis-stored path
- `_search_file_semantic` — semantic search reads file content from Redis-stored path
- `_get_file_context` — context line lookup reads file content from NPU result metadata path

### `autobot-backend/api/analytics_performance.py` (+5 lines)
Added `validate_path(path)` import and call in `analyze_path` endpoint before passing user-supplied `path` query parameter to `_get_files_to_analyze()`. Uses default allowed roots (`/opt/autobot`, `/tmp`).

### `autobot-backend/api/codebase_analytics/endpoints/environment.py` (+8 lines)
Added path security validation in `get_env_recommendations` endpoint. Previously the user-supplied `path` query param was passed directly to `_fetch_live_env_recommendations()` then `analyzer.analyze_codebase(path)` without validation. Now uses the existing `_validate_env_path_security()` helper (already used by the sibling `analyze_environment` endpoint).

### `autobot-backend/services/fast_document_scanner.py` (+12 lines)
Added `validate_path()` call in `get_parsed_man_page()` before passing `file_path` to `parser.parse_man_page(Path(file_path))`. Restricts allowed roots to system man page directories (`/usr/share/man`, `/usr/local/share/man`) consistent with the existing validation in `read_man_page_content()` in the same file.

## Already Validated (no changes needed)
The following listed files already had complete path validation applied in prior work:
`data_storage.py`, `filesystem_mcp.py`, `git_mcp.py`, `logs.py`, `chat_sessions.py`, `session.py`, `vnc_manager.py`, `prompts.py`, `reports.py`, `ownership.py` (both), `environment.py` (other endpoints), `secure_sandbox_executor.py` (uses tempfile only)

## Test plan
- [ ] Verify no import errors: `python -c "from autobot_shared.security.path_validator import validate_path"`
- [ ] Verify path traversal is blocked: request with `path=../../etc/passwd` returns 4xx
- [ ] Verify legitimate paths within allowed roots still work
- [ ] CodeQL re-scan should show reduction in py/path-injection alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)