### PR TITLE
fix(workflow): add trigger_payload field to ActiveWorkflow dataclass (#3178)

### DIFF
--- a/autobot-backend/services/workflow_automation/manager.py
+++ b/autobot-backend/services/workflow_automation/manager.py
@@ -171,7 +171,7 @@ class WorkflowAutomationManager:
             return False
 
         workflow = self.active_workflows[workflow_id]
-        if trigger_payload:
+        if trigger_payload is not None:
             workflow.trigger_payload = trigger_payload
         return await self.executor.start_execution(workflow, self.active_workflows)
 

--- a/autobot-backend/services/workflow_automation/models.py
+++ b/autobot-backend/services/workflow_automation/models.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:
     from services.notification_service import NotificationConfig
@@ -190,6 +190,8 @@ class ActiveWorkflow:
     step_results: Dict[str, Metadata] = field(default_factory=dict)
     # Issue #3101: Per-workflow notification routing configuration.
     notification_config: Optional[NotificationConfig] = None
+    # Issue #3178: Trigger payload from the event that fired this workflow.
+    trigger_payload: Optional[Dict[str, Any]] = None
 
     def __post_init__(self):
         """Set default values for created_at and user_interventions."""
@@ -234,6 +236,7 @@ class ActiveWorkflow:
             "steps": [step.to_status_dict() for step in self.steps],
             "user_interventions": self.user_interventions,
             "notification_config": self._serialize_notification_config(),
+            "trigger_payload": self.trigger_payload,
         }
 
 


### PR DESCRIPTION
## Summary

- Declare `trigger_payload: Optional[Dict[str, Any]] = None` as a proper dataclass field on `ActiveWorkflow` instead of setting it as an ad-hoc attribute at runtime, which bypasses type checking and dataclass invariants.
- Include `trigger_payload` in `to_status_dict()` so consumers can observe the value.
- Fix `if trigger_payload:` → `if trigger_payload is not None:` to correctly handle empty-dict payloads (falsy but valid).

## Files Changed

- `autobot-backend/services/workflow_automation/models.py` — added field declaration + serialization
- `autobot-backend/services/workflow_automation/manager.py` — fixed None-check

## Test plan
- [ ] Verify `ActiveWorkflow` can be instantiated without providing `trigger_payload`
- [ ] Verify `trigger_payload={}` (empty dict) is accepted and stored (not dropped by the falsy check)
- [ ] Verify `trigger_payload` appears in `to_status_dict()` output

Closes #3178

🤖 Generated with [Claude Code](https://claude.com/claude-code)