### PR TITLE
fix(voice): replace unsafe 'as string' casts with typed voiceSpeak response (#3197)

### DIFF
--- a/autobot-slm-frontend/src/composables/useAutobotApi.ts
+++ b/autobot-slm-frontend/src/composables/useAutobotApi.ts
@@ -114,6 +114,13 @@ export interface RUMMetrics {
   timestamp: string
 }
 
+export interface VoiceSpeakResponse {
+  response?: string
+  text?: string
+  status?: string
+  error?: string
+}
+
 export function useAutobotApi() {
   const authStore = useAuthStore()
 
@@ -584,11 +591,11 @@ export function useAutobotApi() {
     return response.data
   }
 
-  async function voiceSpeak(text: string, userRole: string = 'admin'): Promise<Record<string, unknown>> {
+  async function voiceSpeak(text: string, userRole: string = 'admin'): Promise<VoiceSpeakResponse> {
     const formData = new FormData()
     formData.append('text', text)
     formData.append('user_role', userRole)
-    const response = await client.post('/voice/speak', formData, {
+    const response = await client.post<VoiceSpeakResponse>('/voice/speak', formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     })
     return response.data

--- a/autobot-slm-frontend/src/views/tools/admin/VoiceTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/VoiceTool.vue
@@ -165,7 +165,10 @@ async function processVoiceInput(): Promise<void> {
     // Send to AI backend - Issue #835
     const response = await api.voiceSpeak(transcript.value)
 
-    aiResponse.value = (response.response as string) || (response.text as string) || 'No response received'
+    const responseText = typeof response.response === 'string' ? response.response
+      : typeof response.text === 'string' ? response.text
+      : 'No response received'
+    aiResponse.value = responseText
 
     // Add AI response to history
     conversationHistory.value.push({


### PR DESCRIPTION
## Summary

- Adds `VoiceSpeakResponse` interface (`response?`, `text?`, `status?`, `error?`) to `useAutobotApi.ts`, replacing the opaque `Record<string, unknown>` return type on `voiceSpeak`
- Updates the `voiceSpeak` function and its axios `client.post` call to use `Promise<VoiceSpeakResponse>`
- Replaces the two unsafe `as string` casts in `VoiceTool.vue` line 168 with `typeof` type guards, so non-string values (objects, numbers, undefined) correctly fall through to the `'No response received'` default instead of producing `[object Object]` or `"0"`

## Test plan

- [ ] TypeScript type check passes (`npx vue-tsc --noEmit`) — only pre-existing `baseUrl` deprecation warning, no new errors
- [ ] Verify `processVoiceInput` in `VoiceTool.vue` sets `aiResponse.value` to the string content of `response.response` or `response.text`, or the fallback string when neither is a string
- [ ] Verify behaviour is unchanged when the backend returns a normal `{ response: "..." }` payload

Closes #3197

🤖 Generated with [Claude Code](https://claude.com/claude-code)