### PR TITLE
fix(orchestration): resolve status type mismatch NodeHealthCard/ServiceActionButtons (#3195)

### DIFF
--- a/autobot-slm-frontend/src/components/orchestration/NodeHealthCard.vue
+++ b/autobot-slm-frontend/src/components/orchestration/NodeHealthCard.vue
@@ -10,12 +10,13 @@
  * Used across orchestration views for consistent node status display.
  */
 
+import type { NodeStatus } from '@/types/slm'
 
 interface Props {
   nodeId: string
   hostname: string
   ipAddress?: string
-  status: 'online' | 'offline' | 'unknown'
+  status: NodeStatus
   runningCount: number
   stoppedCount: number
   failedCount: number

--- a/autobot-slm-frontend/src/utils/node-status.ts
+++ b/autobot-slm-frontend/src/utils/node-status.ts
@@ -10,7 +10,7 @@
  * Issue #737 Phase 3: Unified data models
  */
 
-import type { NodeStatus, HealthStatus } from '@/types/slm'
+import type { NodeStatus, HealthStatus, ServiceStatus } from '@/types/slm'
 
 /**
  * Status categories for styling purposes.
@@ -155,4 +155,57 @@ export function getMetricBarColor(value: number): string {
   if (value >= 90) return 'bg-red-500'
   if (value >= 70) return 'bg-yellow-500'
   return 'bg-green-500'
+}
+
+/**
+ * Normalize a full NodeStatus value to the three-value display union used by
+ * NodeHealthCard ('online' | 'offline' | 'unknown').
+ *
+ * Mapping rationale:
+ *   online / healthy / degraded                  -> 'online'  (reachable, serving)
+ *   offline / unhealthy / error / decommissioned -> 'offline' (unreachable or broken)
+ *   registered / pending / enrolling / maintenance -> 'unknown' (transitional)
+ *
+ * Issue #3195
+ */
+export function normalizeNodeStatus(status: NodeStatus | string): 'online' | 'offline' | 'unknown' {
+  switch (status) {
+    case 'online':
+    case 'healthy':
+    case 'degraded':
+      return 'online'
+    case 'offline':
+    case 'unhealthy':
+    case 'error':
+    case 'decommissioned':
+      return 'offline'
+    case 'registered':
+    case 'pending':
+    case 'enrolling':
+    case 'maintenance':
+    default:
+      return 'unknown'
+  }
+}
+
+/**
+ * Normalize a service status string to the four-value union used by
+ * ServiceActionButtons ('running' | 'stopped' | 'failed' | 'unknown').
+ *
+ * ServiceStatus is already this union; this helper provides a type-safe
+ * conversion when the value arrives as a plain string from the API.
+ *
+ * Issue #3195
+ */
+export function normalizeServiceStatus(status: ServiceStatus | string): 'running' | 'stopped' | 'failed' | 'unknown' {
+  switch (status) {
+    case 'running':
+      return 'running'
+    case 'stopped':
+      return 'stopped'
+    case 'failed':
+      return 'failed'
+    default:
+      return 'unknown'
+  }
 }

--- a/autobot-slm-frontend/src/views/OrchestrationView.vue
+++ b/autobot-slm-frontend/src/views/OrchestrationView.vue
@@ -31,6 +31,7 @@ import ServiceActionButtons from '@/components/orchestration/ServiceActionButton
 import NodeHealthCard from '@/components/orchestration/NodeHealthCard.vue'
 import RestartConfirmDialog from '@/components/orchestration/RestartConfirmDialog.vue'
 import PostSyncActionBadges from '@/components/orchestration/PostSyncActionBadges.vue'
+import type { NodeStatus, ServiceStatus } from '@/types/slm'
 
 const logger = createLogger('OrchestrationView')
 
@@ -110,11 +111,11 @@ interface NodeServiceGroup {
   nodeId: string
   hostname: string
   ipAddress: string
-  status: string
+  status: NodeStatus
   services: Array<{
     service_name: string
     category: string
-    status: string
+    status: ServiceStatus
     ip_address: string | null
     port: number | null
   }>
@@ -1035,7 +1036,7 @@ onUnmounted(() => {
               :nodeId="node.nodeId"
               :hostname="node.hostname"
               :ipAddress="node.ipAddress"
-              :status="(node.status as 'online' | 'offline' | 'unknown')"
+              :status="node.status"
               :runningCount="node.runningCount"
               :stoppedCount="node.stoppedCount"
               :failedCount="node.failedCount"
@@ -1128,7 +1129,7 @@ onUnmounted(() => {
                       <ServiceActionButtons
                         :serviceName="service.service_name"
                         :nodeId="node.nodeId"
-                        :status="(service.status as 'running' | 'stopped' | 'failed' | 'unknown')"
+                        :status="service.status"
                         :isActionInProgress="orchestration.actionInProgress"
                         :activeAction="orchestration.activeAction"
                         @start="(nId, svc) => handleServiceAction(nId, svc, 'start')"
@@ -1380,7 +1381,7 @@ onUnmounted(() => {
                             <ServiceActionButtons
                               :serviceName="service.service_name"
                               :nodeId="nodeStatus.node_id"
-                              :status="(nodeStatus.status as 'running' | 'stopped' | 'failed' | 'unknown')"
+                              :status="nodeStatus.status"
                               :isActionInProgress="orchestration.actionInProgress"
                               :activeAction="orchestration.activeAction"
                               @start="(nId, svc) => handleServiceAction(nId, svc, 'start')"


### PR DESCRIPTION
## Summary

Closes #3195

- **NodeHealthCard**: widened `status` prop from the narrow `'online' | 'offline' | 'unknown'` union to the full `NodeStatus` type (11 values). The template renders service counts, not status-coloured indicators, so all 11 values are safe to pass.
- **OrchestrationView.vue**: typed `NodeServiceGroup.status` as `NodeStatus` and `NodeServiceGroup.services[].status` as `ServiceStatus` (previously both were `string`), eliminating three `as`-cast lies in the template.
- **node-status.ts**: added `normalizeNodeStatus()` and `normalizeServiceStatus()` helpers for any future call-site that needs to map the full status unions to the narrower display unions, and imported `ServiceStatus` into the utility module.

## Root cause

PR #3180 replaced `as any` casts with typed assertions, revealing that the components declared narrow prop unions that did not cover the full `NodeStatus` values the backend emits (e.g. `'healthy'`, `'degraded'`, `'maintenance'`). The assertions were silently lying to the type system.

## Test plan

- [ ] TypeScript check passes (`npx vue-tsc --noEmit`) with only the pre-existing `baseUrl` deprecation warning
- [ ] Nodes with status `healthy`, `degraded`, `maintenance`, `pending`, `enrolling`, `decommissioned` render correctly in the Orchestration view without falling through to undefined styling
- [ ] Service start/stop/restart buttons continue to show/hide correctly based on `ServiceStatus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)