### PR TITLE
test(security): add coverage for domain_security wildcard-to-regex (#3217)

### DIFF
--- a/autobot-backend/security/domain_security_test.py
+++ b/autobot-backend/security/domain_security_test.py
@@ -21,8 +21,6 @@ Test matrix:
 """
 
 import logging
-import re
-from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -315,8 +313,8 @@ class TestCompilePatternsDefaultConfig:
     def test_default_whitelist_wikipedia_subdomain(self):
         assert self.mgr._is_whitelisted("en.wikipedia.org") is True
 
-    def test_default_whitelist_bare_wikipedia_does_not_match_wildcard(self):
-        """wikipedia.org itself is not in the default whitelist via wildcard pattern."""
+    def test_default_whitelist_bare_wikipedia_is_whitelisted(self):
+        """wikipedia.org is a literal entry in the default whitelist."""
         assert self.mgr._is_whitelisted("wikipedia.org") is True
 
     def test_default_blacklist_malware_subdomain(self):


### PR DESCRIPTION
## Summary

- Adds `autobot-backend/security/domain_security_test.py` with 10 test classes covering `DomainSecurityManager._compile_patterns()` wildcard-to-regex conversion
- Tests the fix from PR #3204 (issue #3164) using split-on-wildcard + `re.escape` approach
- Covers: leading wildcard, trailing wildcard, both-ends wildcard, multiple wildcards, mid-string wildcard, literal patterns, regex special chars, adjacent wildcards, empty string, case insensitivity, and default config patterns

## Test plan

- [ ] `pytest autobot-backend/security/domain_security_test.py` — all tests pass

Closes #3217

🤖 Generated with [Claude Code](https://claude.ai/code)