### PR TITLE
refactor(frontend): extract shared escapeHtml utility (#3215)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
@@ -328,6 +328,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
+import { escapeHtml } from '@/utils/sanitize'
 
 const logger = createLogger('CodeGenerationDashboard')
 
@@ -455,17 +456,6 @@ const formatDiff = (diff: string): string => {
       return escapeHtml(line)
     })
     .join('\n')
-}
-
-const escapeHtml = (text: string): string => {
-  const map: Record<string, string> = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#039;'
-  }
-  return text.replace(/[&<>"']/g, m => map[m])
 }
 
 const copyCode = async () => {

--- a/autobot-frontend/src/components/terminal/TerminalOutput.vue
+++ b/autobot-frontend/src/components/terminal/TerminalOutput.vue
@@ -32,6 +32,7 @@
 
 <script setup lang="ts">
 import { ref, nextTick, watch } from 'vue'
+import { escapeHtml } from '@/utils/sanitize'
 
 interface OutputLine {
   content: string
@@ -118,12 +119,11 @@ const formatTerminalLine = (line: OutputLine): string => {
     // Clean up carriage returns and newlines
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '')
-    // HTML escape for safety
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    // Clean up extra whitespace but preserve intentional spacing
-    .replace(/\n+$/, '') // Remove trailing newlines
+    // Remove trailing newlines
+    .replace(/\n+$/, '')
+
+  // HTML escape for safety
+  content = escapeHtml(content)
 
   return content
 }

--- a/autobot-frontend/src/utils/cacheManagement.ts
+++ b/autobot-frontend/src/utils/cacheManagement.ts
@@ -5,10 +5,7 @@
 
 import { createLogger } from '@/utils/debugUtils'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
-
-function escapeHtml(str: string): string {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
-}
+import { escapeHtml } from '@/utils/sanitize'
 
 // Create scoped logger for cacheManagement
 const logger = createLogger('cacheManagement')

--- a/autobot-frontend/src/utils/sanitize.ts
+++ b/autobot-frontend/src/utils/sanitize.ts
@@ -74,3 +74,27 @@ export function sanitizeHtml(
 ): string {
   return DOMPurify.sanitize(html, config ?? CHAT_SANITIZE_CONFIG)
 }
+
+/**
+ * Escape special HTML characters in a plain-text string so it can be safely
+ * embedded in an HTML context without being interpreted as markup.
+ *
+ * Escapes: & < > " '
+ *
+ * Use this when constructing raw HTML strings (e.g. innerHTML / v-html
+ * templates).  For full sanitization of rich HTML, use sanitizeChatHtml or
+ * sanitizeHtml instead.
+ *
+ * @param text - Plain-text string to escape
+ * @returns HTML-safe string
+ */
+export function escapeHtml(text: string): string {
+  const map: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;',
+  }
+  return text.replace(/[&<>"']/g, (m) => map[m])
+}


### PR DESCRIPTION
## Summary

- Adds `escapeHtml(text)` to `autobot-frontend/src/utils/sanitize.ts` as the single shared implementation
- Removes private `escapeHtml` from `CodeGenerationDashboard.vue` and `cacheManagement.ts`
- Rewrites inline `.replace()` chain in `TerminalOutput.vue` to use the shared function

## Test plan

- [ ] `pnpm -C autobot-frontend test` — no regressions

Closes #3215

🤖 Generated with [Claude Code](https://claude.ai/code)