### PR TITLE
refactor(chat): expose public load_full_session API to replace private method access (#3189)

### DIFF
--- a/autobot-backend/chat_history/session.py
+++ b/autobot-backend/chat_history/session.py
@@ -908,6 +908,25 @@ class SessionMixin:
 
         logger.info("Chat session '%s' name updated to '%s'", session_id, name)
 
+    async def load_full_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Load the complete session data dictionary for a given session.
+
+        Returns the full raw data dict (messages, metadata, name, timestamps),
+        or None when the session does not exist.
+
+        This is the public API for callers that need more than just the messages
+        list returned by :meth:`load_session`.  Issue #3189.
+
+        Args:
+            session_id: The session identifier.
+
+        Returns:
+            Full session data dict, or None if the session does not exist.
+        """
+        self._sanitize_session_id(session_id)
+        return await self._load_session_from_file(session_id)
+
     async def get_session_owner(self, session_id: str) -> Optional[str]:
         """
         Get the owner/creator of a specific session.

--- a/autobot-backend/services/conversation_export.py
+++ b/autobot-backend/services/conversation_export.py
@@ -266,35 +266,14 @@ async def _load_full_session_data(
     chat_history_manager, session_id: str
 ) -> Optional[Dict[str, Any]]:
     """
-    Load the full session file data dict (not just the messages list).
+    Load the full session data dict (not just the messages list).
 
+    Delegates to the public :meth:`ChatHistoryManager.load_full_session` API
+    so that this service has no dependency on internal implementation details.
     Returns None when the session does not exist or loading fails.
     """
     try:
-        chats_directory = chat_history_manager._get_chats_directory()
-        import os
-
-        import aiofiles
-
-        from autobot_shared.security.path_validator import validate_relative_path
-
-        for filename_template in (
-            f"{session_id}_chat.json",
-            f"chat_{session_id}.json",
-        ):
-            try:
-                chat_file = str(
-                    validate_relative_path(filename_template, chats_directory)
-                )
-            except ValueError:
-                continue
-            if not os.path.exists(chat_file):
-                continue
-            async with aiofiles.open(chat_file, "r", encoding="utf-8") as fh:
-                raw = await fh.read()
-            return chat_history_manager._decrypt_data(raw)
-        logger.warning("Session file not found for %s", session_id)
-        return None
+        return await chat_history_manager.load_full_session(session_id)
     except Exception as exc:
         logger.error("Error loading full session data for %s: %s", session_id, exc)
         return None


### PR DESCRIPTION
## Summary

- Adds `SessionMixin.load_full_session(session_id)` public method
- Rewrites `conversation_export._load_full_session_data()` to call the new public API instead of accessing private members (`_get_chats_directory`, `_decrypt_data`)
- Removes duplicated file-loading logic from `conversation_export.py`

## Test plan

- [ ] `pytest autobot-backend/` — no regressions

Closes #3189

🤖 Generated with [Claude Code](https://claude.ai/code)