### PR TITLE
fix(ansible): fresh-install issues — SLM frontend rebuild, hostname guard, pg_hba default

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -250,6 +250,23 @@
       register: _slm_nginx_rerendered
       tags: ['frontend', 'slm-nginx', 'provision']
 
+    # Re-build the SLM frontend so VITE_API_URL='/slm' is baked in (#3268).
+    # Without this, the SLM login page calls /api/auth/login which nginx routes
+    # to the user backend (port 8001) → 502 in co-located mode.
+    # Must run BEFORE nginx test/reload so the new assets are served immediately.
+    - name: "SLM | Rebuild SLM frontend with co-located API prefix (#3268)"
+      ansible.builtin.command:
+        cmd: npm run build
+        chdir: "{{ slm_frontend_dir | default('/opt/autobot/autobot-slm-frontend') }}"
+      become_user: "{{ slm_user | default('autobot') }}"
+      environment:
+        VITE_API_URL: "/slm"
+      when:
+        - _is_slm_frontend_colocated | bool
+        - slm_colocated_frontend | default(false) | bool
+      changed_when: true
+      tags: ['frontend', 'slm-nginx', 'provision']
+
     - name: "SLM | Test nginx config after co-location update"
       ansible.builtin.command:
         cmd: nginx -t
@@ -264,22 +281,6 @@
         state: reloaded
       when:
         - _slm_nginx_rerendered is changed
-      tags: ['frontend', 'slm-nginx', 'provision']
-
-    # Re-build the SLM frontend so VITE_API_URL='/slm' is baked in (#3268).
-    # Without this, the SLM login page calls /api/auth/login which nginx routes
-    # to the user backend (port 8001) → 502 in co-located mode.
-    - name: "SLM | Rebuild SLM frontend with co-located API prefix (#3268)"
-      ansible.builtin.command:
-        cmd: npm run build
-        chdir: "{{ slm_frontend_dir | default('/opt/autobot/autobot-slm-frontend') }}"
-      become_user: "{{ slm_user | default('autobot') }}"
-      environment:
-        VITE_API_URL: "/slm"
-      when:
-        - _is_slm_frontend_colocated | bool
-        - slm_colocated_frontend | default(false) | bool
-      changed_when: true
       tags: ['frontend', 'slm-nginx', 'provision']
 
 # -------------------------------------------------------------------

--- a/autobot-slm-backend/ansible/roles/common/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/common/tasks/main.yml
@@ -190,7 +190,9 @@
     regexp: "^{{ ansible_default_ipv4.address }}"
     state: present
   become: yes
-  when: ansible_default_ipv4.address is defined
+  when:
+    - ansible_default_ipv4.address is defined
+    - inventory_hostname != '00-SLM-Manager'
   tags: ['common', 'hostname']
 
 - name: "Common | Configure DNS resolvers"


### PR DESCRIPTION
## Summary

- **Phase 4c SLM frontend rebuild (#3268)**: After nginx co-location update, rebuild the SLM frontend with `VITE_API_URL=/slm` so login page API calls go to `/slm/api/auth/login` instead of `/api/auth/login` → 502. Without this, fresh wizard-provisioned co-located installs show 502 on first login.
- **common role: skip hostname rename on SLM manager (#3265)**: The common role unconditionally renamed the OS hostname to `inventory_hostname`. On a fresh install where the host is named `00-SLM-Manager` in the Ansible inventory, this would rename the machine to literally `00-SLM-Manager`. Guard added to skip hostname change on that node.
- **pg_hba network_subnet default**: `deploy-slm-manager.yml` used `{{ network_subnet }}` in `pg_hba_remote_access.address` which is undefined in single-host installs before secrets are fully populated. Default to `127.0.0.1/32` so PostgreSQL provisioning doesn't fail.

## Test plan

- [ ] Run `provision-fleet-roles.yml` on a co-located (frontend + SLM on same host) fresh install — confirm SLM login works without 502
- [ ] Verify SLM frontend dist was rebuilt with correct `VITE_API_URL=/slm` baked in (`grep VITE_API_URL /opt/autobot/autobot-slm-frontend/dist/assets/*.js`)
- [ ] Run `provision-fleet-roles.yml` on a fresh single-host install — confirm OS hostname is not changed to `00-SLM-Manager`
- [ ] Run `deploy-slm-manager.yml` without `NETWORK_SUBNET` set — confirm PostgreSQL role completes without undefined variable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)