### PR TITLE
fix(backend): replace hardcoded available_providers with real health checks

### DIFF
--- a/autobot-backend/api/agent_config.py
+++ b/autobot-backend/api/agent_config.py
@@ -109,6 +109,18 @@ async def _get_available_models() -> list:
         return []
 
 
+async def _get_available_providers() -> list:
+    """Return names of LLM providers that are currently reachable."""
+    try:
+        from services.provider_health import ProviderHealthManager
+
+        results = await ProviderHealthManager.check_all_providers(timeout=3.0, use_cache=True)
+        return [name for name, result in results.items() if result.available]
+    except Exception as e:
+        logger.warning("Could not check provider availability: %s", e)
+        return []
+
+
 class AgentConfig(BaseModel):
     """Agent configuration model"""
 
@@ -835,7 +847,7 @@ async def get_agent_config(
         "config_source": config_source,
         "configuration_options": {
             "available_models": await _get_available_models(),
-            "available_providers": ["ollama", "openai", "anthropic"],
+            "available_providers": await _get_available_providers(),
             "configurable_settings": ["model", "provider", "enabled", "priority"],
         },
         "health_check": {


### PR DESCRIPTION
Closes #3276

## Summary
- Added `_get_available_providers()` async helper that calls `ProviderHealthManager.check_all_providers()` with a 3-second timeout and caching enabled
- Replaced the hardcoded `["ollama", "openai", "anthropic"]` list in `get_agent_config` with `await _get_available_providers()`
- Only providers where `available=True` are returned, reflecting real reachability
- Fails open — returns empty list on exception (logs a warning) so the endpoint remains stable

## Test plan
- [ ] Provider reports unavailable when endpoint is unreachable
- [ ] Provider reports available when endpoint responds
- [ ] flake8 passes (verified: clean)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)