### PR TITLE
fix(chat-workflow): merge context into system prompt to avoid mid-conversation system message

### DIFF
--- a/autobot-backend/agents/enhanced_system_commands_agent.py
+++ b/autobot-backend/agents/enhanced_system_commands_agent.py
@@ -172,10 +172,11 @@ class EnhancedSystemCommandsAgent(StandardizedAgent):
         self, request: str, context: Optional[Dict[str, Any]]
     ) -> List[Dict[str, str]]:
         """Build messages for command generation (Issue #398: extracted)."""
-        messages = [{"role": "system", "content": self._get_system_commands_prompt()}]
+        system_prompt = self._get_system_commands_prompt()
         if context:
             context_str = self._build_context_string(context)
-            messages.append({"role": "system", "content": f"Context: {context_str}"})
+            system_prompt = f"{system_prompt}\n\nContext: {context_str}"
+        messages = [{"role": "system", "content": system_prompt}]
         messages.append({"role": "user", "content": request})
         return messages
 


### PR DESCRIPTION
Closes #3260

## Summary
- `_build_command_messages` in `enhanced_system_commands_agent.py` was appending a second `{"role": "system"}` entry when context was present — Anthropic rejects non-leading system messages and returns a 400 error
- Fix: merge context string into the initial system prompt before building the messages list, so exactly one system message exists at position 0
- All other `{"role": "system"}` uses in the codebase were audited and are correctly first-position only

## Test plan
- [ ] Chat sessions using `EnhancedSystemCommandsAgent` with context no longer produce Anthropic 400 errors
- [ ] Context content is still passed to the LLM (merged into system prompt)
- [ ] flake8 passes (verified: clean)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)