### PR TITLE
fix(frontend): add missing i18n key auth.login.footer

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -4766,7 +4766,8 @@
       "accountLocked": "Account temporarily locked due to multiple failed attempts",
       "tooManyAttempts": "Too many login attempts. Please try again later.",
       "serverError": "Server error. Please try again later.",
-      "unexpectedError": "حدث خطأ غير متوقع"
+      "unexpectedError": "حدث خطأ غير متوقع",
+      "footer": "© 2026 AutoBot. جميع الحقوق محفوظة."
     }
   },
   "browser": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -4778,7 +4778,8 @@
       "accountLocked": "Konto vorübergehend gesperrt wegen mehrerer fehlgeschlagener Versuche",
       "tooManyAttempts": "Zu viele Anmeldeversuche. Bitte versuchen Sie es später erneut.",
       "serverError": "Serverfehler. Bitte versuchen Sie es später erneut.",
-      "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten"
+      "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten",
+      "footer": "© 2026 AutoBot. Alle Rechte vorbehalten."
     }
   },
   "browser": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -4934,7 +4934,8 @@
       "accountLocked": "Account temporarily locked due to multiple failed attempts",
       "tooManyAttempts": "Too many login attempts. Please try again later.",
       "serverError": "Server error. Please try again later.",
-      "unexpectedError": "An unexpected error occurred"
+      "unexpectedError": "An unexpected error occurred",
+      "footer": "© 2026 AutoBot. All rights reserved."
     }
   },
   "browser": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -4778,7 +4778,8 @@
       "accountLocked": "Cuenta bloqueada temporalmente por múltiples intentos fallidos",
       "tooManyAttempts": "Demasiados intentos de inicio de sesión. Inténtelo más tarde.",
       "serverError": "Error del servidor. Inténtelo de nuevo más tarde.",
-      "unexpectedError": "Se ha producido un error inesperado"
+      "unexpectedError": "Se ha producido un error inesperado",
+      "footer": "© 2026 AutoBot. Todos los derechos reservados."
     }
   },
   "browser": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -4778,7 +4778,8 @@
       "accountLocked": "Compte temporairement verrouillé en raison de tentatives infructueuses",
       "tooManyAttempts": "Trop de tentatives de connexion. Veuillez réessayer plus tard.",
       "serverError": "Erreur du serveur. Veuillez réessayer plus tard.",
-      "unexpectedError": "Une erreur inattendue s'est produite"
+      "unexpectedError": "Une erreur inattendue s'est produite",
+      "footer": "© 2026 AutoBot. Tous droits réservés."
     }
   },
   "browser": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -4778,7 +4778,8 @@
       "accountLocked": "Konts īslaicīgi bloķēts vairāku neveiksmīgu mēģinājumu dēļ",
       "tooManyAttempts": "Pārāk daudz pieteikšanās mēģinājumu. Lūdzu, mēģiniet vēlāk.",
       "serverError": "Servera kļūda. Lūdzu, mēģiniet vēlāk.",
-      "unexpectedError": "Radās neparedzēta kļūda"
+      "unexpectedError": "Radās neparedzēta kļūda",
+      "footer": "© 2026 AutoBot. Visas tiesības aizsargātas."
     }
   },
   "browser": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -4778,7 +4778,8 @@
       "accountLocked": "Konto tymczasowo zablokowane z powodu wielu nieudanych prób",
       "tooManyAttempts": "Zbyt wiele prób logowania. Spróbuj ponownie później.",
       "serverError": "Błąd serwera. Spróbuj ponownie później.",
-      "unexpectedError": "Wystąpił nieoczekiwany błąd"
+      "unexpectedError": "Wystąpił nieoczekiwany błąd",
+      "footer": "© 2026 AutoBot. Wszelkie prawa zastrzeżone."
     }
   },
   "browser": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -4778,7 +4778,8 @@
       "accountLocked": "Conta temporariamente bloqueada devido a múltiplas tentativas falhadas",
       "tooManyAttempts": "Demasiadas tentativas de início de sessão. Tente mais tarde.",
       "serverError": "Erro do servidor. Tente novamente mais tarde.",
-      "unexpectedError": "Ocorreu um erro inesperado"
+      "unexpectedError": "Ocorreu um erro inesperado",
+      "footer": "© 2026 AutoBot. Todos os direitos reservados."
     }
   },
   "browser": {


### PR DESCRIPTION
Closes #3307

## Changes
- Added missing `auth.login.footer` translation key to all 8 locale files (en, de, fr, es, ar, lv, pl, pt)

## Testing
Load the login page — footer should show translated text instead of raw key `auth.login.footer`