### PR TITLE
fix(slm-frontend): wire dark mode setting to CSS class

### DIFF
--- a/autobot-slm-frontend/src/App.vue
+++ b/autobot-slm-frontend/src/App.vue
@@ -18,7 +18,7 @@ import UpdateNotification from '@/components/UpdateNotification.vue'
 import { useFleetStore } from '@/stores/fleet'
 import { useAuthStore } from '@/stores/auth'
 import { useSlmWebSocket } from '@/composables/useSlmWebSocket'
-import { useHighContrast } from '@/composables/useAccessibility'
+import { useHighContrast, useDarkMode } from '@/composables/useAccessibility'
 import { ensureTimezone } from '@/composables/useTimezone'
 
 const route = useRoute()
@@ -26,6 +26,7 @@ const fleetStore = useFleetStore()
 const authStore = useAuthStore()
 const ws = useSlmWebSocket()
 const highContrast = useHighContrast()
+const darkMode = useDarkMode()
 
 const isLoginPage = computed(() => route.name === 'login')
 
@@ -65,6 +66,8 @@ async function initializeApp(): Promise<void> {
 onMounted(async () => {
   // Issue #754: Initialize high contrast preference from localStorage
   highContrast.init()
+  // Issue #3305: Initialize dark mode preference from localStorage
+  darkMode.init()
 
   if (authStore.isAuthenticated) {
     await initializeApp()

--- a/autobot-slm-frontend/src/assets/styles/main.css
+++ b/autobot-slm-frontend/src/assets/styles/main.css
@@ -211,6 +211,94 @@
   border-color: var(--a11y-border) !important;
 }
 
+/* ─── Dark Mode (Issue #3305) ───────────────────────────────── */
+
+:root[data-theme='dark'] {
+  --a11y-focus-ring: #38bdf8;
+  --a11y-focus-width: 2px;
+  --a11y-bg: #111827;
+  --a11y-bg-surface: #1f2937;
+  --a11y-bg-muted: #374151;
+  --a11y-text: #f9fafb;
+  --a11y-text-muted: #9ca3af;
+  --a11y-border: #374151;
+  --a11y-sidebar-bg: #030712;
+  --a11y-sidebar-text: #f3f4f6;
+  --a11y-sidebar-active: #38bdf8;
+}
+
+:root[data-theme='dark'] body {
+  background-color: var(--a11y-bg);
+  color: var(--a11y-text);
+}
+
+:root[data-theme='dark'] .card {
+  background-color: var(--a11y-bg-surface);
+  border-color: var(--a11y-border);
+  color: var(--a11y-text);
+}
+
+:root[data-theme='dark'] .bg-gray-100,
+:root[data-theme='dark'] .bg-gray-50 {
+  background-color: var(--a11y-bg) !important;
+}
+
+:root[data-theme='dark'] .bg-white {
+  background-color: var(--a11y-bg-surface) !important;
+}
+
+:root[data-theme='dark'] .bg-gray-200 {
+  background-color: var(--a11y-bg-muted) !important;
+}
+
+:root[data-theme='dark'] .text-gray-900,
+:root[data-theme='dark'] .text-gray-800,
+:root[data-theme='dark'] .text-gray-700 {
+  color: var(--a11y-text) !important;
+}
+
+:root[data-theme='dark'] .text-gray-600,
+:root[data-theme='dark'] .text-gray-500,
+:root[data-theme='dark'] .text-gray-400 {
+  color: var(--a11y-text-muted) !important;
+}
+
+:root[data-theme='dark'] .border-gray-200,
+:root[data-theme='dark'] .border-gray-300,
+:root[data-theme='dark'] .border-gray-100 {
+  border-color: var(--a11y-border) !important;
+}
+
+:root[data-theme='dark'] .btn-secondary {
+  background-color: var(--a11y-bg-muted) !important;
+  color: var(--a11y-text) !important;
+  border-color: var(--a11y-border) !important;
+}
+
+:root[data-theme='dark'] .input {
+  background-color: var(--a11y-bg-surface);
+  border-color: var(--a11y-border);
+  color: var(--a11y-text);
+}
+
+:root[data-theme='dark'] select,
+:root[data-theme='dark'] input,
+:root[data-theme='dark'] textarea {
+  background-color: var(--a11y-bg-surface) !important;
+  border-color: var(--a11y-border) !important;
+  color: var(--a11y-text) !important;
+}
+
+:root[data-theme='dark'] table thead {
+  background-color: var(--a11y-bg-muted) !important;
+}
+
+:root[data-theme='dark'] table th,
+:root[data-theme='dark'] table td {
+  color: var(--a11y-text) !important;
+  border-color: var(--a11y-border) !important;
+}
+
 /* ─── Global Focus Indicators (Issue #754) ───────────────────── */
 
 *:focus-visible {

--- a/autobot-slm-frontend/src/composables/useAccessibility.ts
+++ b/autobot-slm-frontend/src/composables/useAccessibility.ts
@@ -68,6 +68,63 @@ export function useHighContrast() {
 }
 
 
+// ─── Dark Mode ───────────────────────────────────────────────
+
+const DARK_MODE_STORAGE_KEY = 'autobot-dark-mode'
+
+/** Shared reactive state for dark mode across all consumers. */
+const darkModeEnabled = ref(false)
+
+/**
+ * Apply or remove the dark-mode data attribute on the root element.
+ * High-contrast takes priority — dark mode will not override it.
+ */
+function applyDarkMode(enabled: boolean): void {
+  if (enabled) {
+    if (document.documentElement.getAttribute('data-theme') !== 'high-contrast') {
+      document.documentElement.setAttribute('data-theme', 'dark')
+    }
+  } else {
+    if (document.documentElement.getAttribute('data-theme') === 'dark') {
+      document.documentElement.removeAttribute('data-theme')
+    }
+  }
+}
+
+/**
+ * Dark mode composable with localStorage persistence.
+ *
+ * Issue #3305: Wire dark mode setting to CSS class.
+ */
+export function useDarkMode() {
+  function set(enabled: boolean): void {
+    darkModeEnabled.value = enabled
+    localStorage.setItem(DARK_MODE_STORAGE_KEY, String(enabled))
+    applyDarkMode(enabled)
+    logger.info('Dark mode:', enabled ? 'enabled' : 'disabled')
+  }
+
+  function toggle(): void {
+    set(!darkModeEnabled.value)
+  }
+
+  function init(): void {
+    const stored = localStorage.getItem(DARK_MODE_STORAGE_KEY)
+    if (stored === 'true') {
+      darkModeEnabled.value = true
+      applyDarkMode(true)
+    }
+  }
+
+  return {
+    enabled: darkModeEnabled,
+    set,
+    toggle,
+    init,
+  }
+}
+
+
 // ─── Focus Trap ───────────────────────────────────────────────
 
 /** Selector for all focusable elements within a container. */

--- a/autobot-slm-frontend/src/views/settings/GeneralSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/GeneralSettings.vue
@@ -10,9 +10,12 @@
  * NTP sync triggers Ansible time_sync role across all fleet nodes.
  */
 
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
+import { useDarkMode } from '@/composables/useAccessibility'
+
+const darkMode = useDarkMode()
 
 interface Setting {
   key: string
@@ -41,6 +44,11 @@ const settings = ref({
   dark_mode: true,
   auto_refresh: true,
   refresh_interval: '30',
+})
+
+// Issue #3305: Apply dark mode immediately when the toggle changes
+watch(() => settings.value.dark_mode, (enabled: boolean) => {
+  darkMode.set(Boolean(enabled))
 })
 
 const timeConfig = ref<TimeConfig>({


### PR DESCRIPTION
Closes #3305

## Problem
The Dark Mode toggle in Settings > General saved a preference to the backend but never applied any CSS to the UI. There was no `useDarkMode` composable. `SkillsView.vue` appeared dark because it was hardcoded `bg-gray-900` — not because dark mode worked.

## Changes

- **`useAccessibility.ts`**: Added `useDarkMode` composable (mirrors `useHighContrast` pattern). Sets `data-theme='dark'` on `document.documentElement`. Respects high-contrast priority — will not override `data-theme='high-contrast'`.
- **`main.css`**: Added `html[data-theme='dark']` CSS variable overrides for all light Tailwind utility classes (`bg-white`, `bg-gray-100`, `text-gray-900`, borders, inputs, selects, tables). Follows the same pattern as the existing high-contrast block.
- **`App.vue`**: Calls `darkMode.init()` on mount alongside `highContrast.init()` to restore persisted preference from localStorage.
- **`GeneralSettings.vue`**: Watches `settings.dark_mode` and calls `darkMode.set(enabled)` immediately when the toggle changes — no page reload required.

## Testing
1. Open Settings > General
2. Toggle Dark Mode ON → page should immediately switch to dark theme
3. Reload → dark mode should persist (stored in localStorage as `autobot-dark-mode`)
4. Toggle OFF → returns to light theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)