### PR TITLE
fix(slm-frontend): add node summary header to details slide-over panel

### DIFF
--- a/autobot-slm-frontend/src/views/FleetOverview.vue
+++ b/autobot-slm-frontend/src/views/FleetOverview.vue
@@ -366,6 +366,36 @@ async function handleReenroll(nodeId: string): Promise<void> {
     alert(`Failed to re-enroll: ${err instanceof Error ? err.message : 'Unknown error'}`)
   }
 }
+
+// Issue #3306: Node summary helpers for the details slide-over panel
+function nodeStatusBadgeClass(status: string): string {
+  switch (status) {
+    case 'online':
+    case 'healthy':
+      return 'bg-green-100 text-green-800'
+    case 'degraded':
+      return 'bg-yellow-100 text-yellow-800'
+    case 'error':
+    case 'unhealthy':
+      return 'bg-red-100 text-red-800'
+    default:
+      return 'bg-gray-100 text-gray-600'
+  }
+}
+
+function formatLastSeen(ts: string | null | undefined): string {
+  if (!ts) return 'Never'
+  const date = new Date(ts)
+  if (isNaN(date.getTime())) return ts
+  const diffMs = Date.now() - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  if (diffSec < 60) return `${diffSec}s ago`
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  return date.toLocaleDateString()
+}
 </script>
 
 <template>
@@ -708,6 +738,50 @@ async function handleReenroll(nodeId: string): Promise<void> {
                     </button>
                   </div>
                   <div class="flex-1 overflow-y-auto">
+                    <!-- Issue #3306: Node summary section above event log -->
+                    <div v-if="selectedNode" class="border-b border-gray-200 px-6 py-4 bg-white">
+                      <div class="flex items-center justify-between mb-3">
+                        <div>
+                          <p class="text-sm font-medium text-gray-900">{{ selectedNode.hostname }}</p>
+                          <p class="text-xs text-gray-500 mt-0.5">{{ selectedNode.ip_address }}</p>
+                        </div>
+                        <span
+                          class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize"
+                          :class="nodeStatusBadgeClass(selectedNode.status)"
+                        >
+                          {{ selectedNode.status }}
+                        </span>
+                      </div>
+                      <div class="text-xs text-gray-500 mb-3">
+                        Last seen:
+                        <span class="text-gray-700 font-medium">
+                          {{ formatLastSeen(selectedNode.health?.last_heartbeat ?? selectedNode.updated_at) }}
+                        </span>
+                      </div>
+                      <div v-if="selectedNode.health" class="grid grid-cols-3 gap-3 mb-3">
+                        <div class="rounded-md border border-gray-200 px-3 py-2 text-center">
+                          <p class="text-xs text-gray-500">CPU</p>
+                          <p class="text-sm font-semibold text-gray-900">{{ selectedNode.health.cpu_percent.toFixed(1) }}%</p>
+                        </div>
+                        <div class="rounded-md border border-gray-200 px-3 py-2 text-center">
+                          <p class="text-xs text-gray-500">Memory</p>
+                          <p class="text-sm font-semibold text-gray-900">{{ selectedNode.health.memory_percent.toFixed(1) }}%</p>
+                        </div>
+                        <div class="rounded-md border border-gray-200 px-3 py-2 text-center">
+                          <p class="text-xs text-gray-500">Disk</p>
+                          <p class="text-sm font-semibold text-gray-900">{{ selectedNode.health.disk_percent.toFixed(1) }}%</p>
+                        </div>
+                      </div>
+                      <div v-if="selectedNode.roles && selectedNode.roles.length > 0" class="flex flex-wrap gap-1.5">
+                        <span
+                          v-for="role in selectedNode.roles"
+                          :key="role"
+                          class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200"
+                        >
+                          {{ role }}
+                        </span>
+                      </div>
+                    </div>
                     <NodeLifecyclePanel v-if="selectedNode" :node-id="selectedNode.node_id" @close="closeLifecyclePanel" />
                   </div>
                 </div>


### PR DESCRIPTION
Closes #3306

## Problem
Clicking "View details" on a fleet node opened a slide-over panel that jumped directly to the event log. There was no at-a-glance summary showing the node's current state.

## Changes

**`FleetOverview.vue`**:
- Added `nodeStatusBadgeClass(status)` helper — maps `online/healthy → green`, `degraded → yellow`, `error/unhealthy → red`, else gray
- Added `formatLastSeen(ts)` helper — displays relative time (Xs ago / Xm ago / Xh ago / date)
- Inserted a summary section inside the lifecycle panel slide-over, above `<NodeLifecyclePanel>`, showing:
  - Hostname + IP address
  - Status badge (colour-coded)
  - Last seen timestamp (relative)
  - CPU / Memory / Disk % grid (shown when `selectedNode.health` is available)
  - Role badge list (shown when `selectedNode.roles` is non-empty)

## Testing
Fleet Overview → click "View details" on any node → summary section visible above the event log table

🤖 Generated with [Claude Code](https://claude.com/claude-code)