### PR TITLE
fix(docs): replace hardcoded 172.16.168.x IPs with VM role placeholders

### DIFF
--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -164,7 +164,7 @@ Key packages:
 - @heroicons/vue
 
 ### Nginx Configuration
-- Proxy to backend: https://172.16.168.20:8443
+- Proxy to backend: https://<backend-ip>:8443
 - WebSocket support for /ws endpoint
 - TLS certificates: `/etc/ssl/certs/autobot.{crt,key}`
 
@@ -426,8 +426,8 @@ All VMs must be able to reach:
 ### Environment Variables
 - `AUTOBOT_BASE_DIR` - Base directory (default: `/opt/autobot`)
 - `SLM_ANSIBLE_DIR` - Ansible directory (default: `/opt/autobot/autobot-slm-backend/ansible`)
-- `REDIS_HOST` - Redis server IP (172.16.168.23)
-- `POSTGRES_HOST` - PostgreSQL server IP (172.16.168.19 for SLM)
+- `REDIS_HOST` - Redis server IP (<database-ip>)
+- `POSTGRES_HOST` - PostgreSQL server IP (<slm-manager-ip> for SLM)
 
 ---
 

--- a/docs/GETTING_STARTED_COMPLETE.md
+++ b/docs/GETTING_STARTED_COMPLETE.md
@@ -80,18 +80,18 @@ ansible-playbook playbooks/deploy-full.yml
 ./run_agent.sh
 
 # 3. Access AutoBot
-# Production frontend: https://172.16.168.21 (Frontend VM)
-# Backend API: https://172.16.168.20:8443
-# SLM Admin: https://172.16.168.19
+# Production frontend: https://<frontend-ip> (Frontend VM)
+# Backend API: https://<backend-ip>:8443
+# SLM Admin: https://<slm-manager-ip>
 ```
 
 ### **Verification**
 ```bash
 # Verify backend health (from another VM due to WSL2 loopback)
-ssh autobot@172.16.168.19 'curl --insecure https://172.16.168.20:8443/api/health'
+ssh autobot@<slm-manager-ip> 'curl --insecure https://<backend-ip>:8443/api/health'
 
 # Verify Redis
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 
 # Check service status
 ansible all -m ping

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -13,7 +13,7 @@ A document that captures an important architectural decision along with its cont
 An autonomous AI component that can perform specific tasks. AutoBot uses multiple specialized agents including KB Librarian, RAG Agent, and Task Agents.
 
 ### API Gateway
-The central entry point for all API requests, handling routing, authentication, and rate limiting. Located at `172.16.168.20:8443` (HTTPS).
+The central entry point for all API requests, handling routing, authentication, and rate limiting. Located at `<backend-ip>:8443` (HTTPS).
 
 ### Async Client
 A non-blocking Redis or HTTP client that allows concurrent operations. Used for high-performance data access.
@@ -26,7 +26,7 @@ A non-blocking Redis or HTTP client that allows concurrent operations. Used for 
 The FastAPI-based REST API service running on the main machine. Handles all business logic, LLM orchestration, and data management.
 
 ### Browser VM
-VM5 (`172.16.168.25:3000`) dedicated to Playwright browser automation. Isolated for security and stability.
+VM5 (`<browser-ip>:3000`) dedicated to Playwright browser automation. Isolated for security and stability.
 
 ---
 
@@ -75,7 +75,7 @@ The Python web framework used for the backend API. Provides async support, autom
 A code smell where a method accesses data from another object more than its own. Indicates misplaced logic.
 
 ### Frontend VM
-VM1 (`172.16.168.21:5173`) - the **only** machine allowed to run the Vite frontend server.
+VM1 (`<frontend-ip>:5173`) - the **only** machine allowed to run the Vite frontend server.
 
 ---
 
@@ -145,7 +145,7 @@ AI capabilities that span multiple modalities: text, image, voice, and desktop i
 Redis database accessed by logical name (e.g., "knowledge") rather than number (e.g., db=1). See [ADR-002](adr/002-redis-database-separation.md).
 
 ### NPU Worker
-VM2 (`172.16.168.22:8081`) - dedicated service for Intel NPU-accelerated AI inference.
+VM2 (`<npu-ip>:8081`) - dedicated service for Intel NPU-accelerated AI inference.
 
 ---
 

--- a/docs/QUICK_START_BROWSER_VNC.md
+++ b/docs/QUICK_START_BROWSER_VNC.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](architecture/VM_ROLES.md) for role definitions.
+
 # Quick Start: Browser VNC Real-Time Viewing
 
 ## TL;DR - Using the System
@@ -14,26 +16,26 @@
 
 ```bash
 # Check system status
-ssh autobot@172.16.168.25 'sudo systemctl status browser-*.service'
+ssh autobot@<browser-ip> 'sudo systemctl status browser-*.service'
 
 # View Playwright logs
-ssh autobot@172.16.168.25 'sudo journalctl -u browser-playwright -f'
+ssh autobot@<browser-ip> 'sudo journalctl -u browser-playwright -f'
 
 # Test navigation
-curl -X POST http://172.16.168.25:3000/navigate \
+curl -X POST http://<browser-ip>:3000/navigate \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
 
 # Restart all services
-ssh autobot@172.16.168.25 'sudo systemctl restart browser-*.service'
+ssh autobot@<browser-ip> 'sudo systemctl restart browser-*.service'
 ```
 
 ## Access Points
 
 | Service | URL | Purpose |
 |---------|-----|---------|
-| **noVNC Web** | http://172.16.168.25:6080/vnc.html | Direct VNC access |
-| **Playwright API** | http://172.16.168.25:3000 | Browser automation |
+| **noVNC Web** | http://<browser-ip>:6080/vnc.html | Direct VNC access |
+| **Playwright API** | http://<browser-ip>:3000 | Browser automation |
 | **Frontend** | Browser tab in AutoBot | Integrated experience |
 
 ## Architecture
@@ -41,7 +43,7 @@ ssh autobot@172.16.168.25 'sudo systemctl restart browser-*.service'
 ```
 User/Agent → Frontend Browser Tab
                     ↓ (noVNC iframe)
-           Browser VM (172.16.168.25)
+           Browser VM (<browser-ip>)
                     ↓
            ┌────────┴────────┐
            │                  │
@@ -66,7 +68,7 @@ User/Agent → Frontend Browser Tab
 
 ```bash
 # Quick health check
-ssh autobot@172.16.168.25 "
+ssh autobot@<browser-ip> "
   sudo systemctl is-active browser-vnc browser-vnc-websockify browser-playwright &&
   ss -tuln | grep -E ':(5901|6080|3000)'
 "
@@ -91,7 +93,7 @@ ssh autobot@172.16.168.25 "
 
 **Via API:**
 ```bash
-curl -X POST http://172.16.168.25:3000/navigate \
+curl -X POST http://<browser-ip>:3000/navigate \
   -H "Content-Type: application/json" \
   -d '{"url": "https://github.com"}'
 ```
@@ -99,7 +101,7 @@ curl -X POST http://172.16.168.25:3000/navigate \
 ### Reload Page
 
 ```bash
-curl -X POST http://172.16.168.25:3000/reload \
+curl -X POST http://<browser-ip>:3000/reload \
   -H "Content-Type: application/json" \
   -d '{"wait_until": "networkidle"}'
 ```
@@ -110,17 +112,17 @@ curl -X POST http://172.16.168.25:3000/reload \
 
 ```bash
 # Check VNC service
-ssh autobot@172.16.168.25 'sudo systemctl status browser-vnc'
+ssh autobot@<browser-ip> 'sudo systemctl status browser-vnc'
 
 # Restart if needed
-ssh autobot@172.16.168.25 'sudo systemctl restart browser-vnc'
+ssh autobot@<browser-ip> 'sudo systemctl restart browser-vnc'
 ```
 
 ### Browser Not Visible in VNC
 
 ```bash
 # Check Playwright is in headed mode
-ssh autobot@172.16.168.25 'sudo journalctl -u browser-playwright | grep mode'
+ssh autobot@<browser-ip> 'sudo journalctl -u browser-playwright | grep mode'
 
 # Should show: "headless":false,"mode":"headed"
 ```
@@ -129,7 +131,7 @@ ssh autobot@172.16.168.25 'sudo journalctl -u browser-playwright | grep mode'
 
 ```bash
 # Check service logs
-ssh autobot@172.16.168.25 'sudo journalctl -xe'
+ssh autobot@<browser-ip> 'sudo journalctl -xe'
 
 # Redeploy all services
 ./scripts/infrastructure/deploy_browser_vnc_services.sh

--- a/docs/ROADMAP_2025.md
+++ b/docs/ROADMAP_2025.md
@@ -429,7 +429,7 @@ AUTOBOT_REASONING_MODEL=qwen3.5:9b
 
 | Task | Planned | Actual | Status |
 |------|---------|--------|--------|
-| Redis server | ✓ | Dedicated VM (172.16.168.23) | ✅ |
+| Redis server | ✓ | Dedicated VM (<database-ip>) | ✅ |
 | Python redis-py | ✓ | Async support | ✅ |
 | Agent memory | ✓ | ChatHistoryManager | ✅ |
 | Task queue | ✓ | Distributed | ✅ |
@@ -550,12 +550,12 @@ AUTOBOT_REASONING_MODEL=qwen3.5:9b
 
 | VM | IP | Purpose | Status |
 |----|-----|---------|--------|
-| Main (WSL) | 172.16.168.20 | Backend API + VNC | ✅ |
-| VM1 Frontend | 172.16.168.21 | Web UI | ✅ |
-| VM2 NPU Worker | 172.16.168.22 | Hardware AI | ✅ |
-| VM3 Redis | 172.16.168.23 | Data layer | ✅ |
-| VM4 AI Stack | 172.16.168.24 | AI processing | ✅ |
-| VM5 Browser | 172.16.168.25 | Playwright | ✅ |
+| Main (WSL) | <backend-ip> | Backend API + VNC | ✅ |
+| VM1 Frontend | <frontend-ip> | Web UI | ✅ |
+| VM2 NPU Worker | <npu-ip> | Hardware AI | ✅ |
+| VM3 Redis | <database-ip> | Data layer | ✅ |
+| VM4 AI Stack | <aiml-ip> | AI processing | ✅ |
+| VM5 Browser | <browser-ip> | Playwright | ✅ |
 
 ---
 
@@ -586,7 +586,7 @@ AUTOBOT_REASONING_MODEL=qwen3.5:9b
 
 ### ✅ PHASE 18: Browser Automation (COMPLETE)
 
-- ✅ Playwright on Browser VM (172.16.168.25)
+- ✅ Playwright on Browser VM (<browser-ip>)
 - ✅ Screenshot capture, element interaction
 - ✅ Form automation, navigation control
 - ✅ Multi-browser support (Chromium, Firefox, WebKit)

--- a/docs/adr/001-distributed-vm-architecture.md
+++ b/docs/adr/001-distributed-vm-architecture.md
@@ -31,12 +31,12 @@ We adopt a distributed 6-VM architecture where each VM serves a specific purpose
 
 | VM | IP Address | Port | Purpose |
 |----|------------|------|---------|
-| **Main (WSL)** | 172.16.168.20 | 8001, 6080 | Backend API + VNC Desktop |
-| **VM1 Frontend** | 172.16.168.21 | 5173 | Web interface (Vite dev server) |
-| **VM2 NPU Worker** | 172.16.168.22 | 8081 | Hardware AI acceleration |
-| **VM3 Redis** | 172.16.168.23 | 6379 | Data layer (Redis Stack) |
-| **VM4 AI Stack** | 172.16.168.24 | 8080 | AI processing (Ollama, LLM) |
-| **VM5 Browser** | 172.16.168.25 | 3000 | Web automation (Playwright) |
+| **Main (WSL)** | <backend-ip> | 8001, 6080 | Backend API + VNC Desktop |
+| **VM1 Frontend** | <frontend-ip> | 5173 | Web interface (Vite dev server) |
+| **VM2 NPU Worker** | <npu-ip> | 8081 | Hardware AI acceleration |
+| **VM3 Redis** | <database-ip> | 6379 | Data layer (Redis Stack) |
+| **VM4 AI Stack** | <aiml-ip> | 8080 | AI processing (Ollama, LLM) |
+| **VM5 Browser** | <browser-ip> | 3000 | Web automation (Playwright) |
 
 ### Alternatives Considered
 
@@ -89,11 +89,11 @@ We adopt a distributed 6-VM architecture where each VM serves a specific purpose
 
 ### Network Configuration
 
-All VMs are on the same subnet (172.16.168.0/24) for low-latency communication.
+All VMs are on the same subnet (<network-subnet>) for low-latency communication.
 
 ```bash
 # SSH access pattern
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip>
 
 # Sync files to VM
 ./scripts/utilities/sync-to-vm.sh frontend autobot-frontend/src/ /home/autobot/autobot-frontend/src/
@@ -106,10 +106,10 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.21
 curl http://localhost:8001/api/health
 
 # Redis
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 
 # Frontend (from main machine)
-curl http://172.16.168.21:5173
+curl http://<frontend-ip>:5173
 ```
 
 ### Critical Rules

--- a/docs/adr/002-redis-database-separation.md
+++ b/docs/adr/002-redis-database-separation.md
@@ -117,7 +117,7 @@ async_redis = await get_redis_client(async_client=True, database="knowledge")
 
 # FORBIDDEN - Never instantiate directly
 import redis
-client = redis.Redis(host="172.16.168.23", db=0)  # DON'T DO THIS
+client = redis.Redis(host="<database-ip>", db=0)  # DON'T DO THIS
 ```
 
 ### Migration Script
@@ -134,15 +134,15 @@ python scripts/migrate_redis_databases.py --from 0 --to 1 --pattern "llama_index
 
 ```bash
 # Backup specific database
-redis-cli -h 172.16.168.23 -n 1 --rdb knowledge_backup.rdb
+redis-cli -h <database-ip> -n 1 --rdb knowledge_backup.rdb
 
 # Backup all databases
-redis-cli -h 172.16.168.23 BGSAVE
+redis-cli -h <database-ip> BGSAVE
 ```
 
 ## Related ADRs
 
-- [ADR-001](001-distributed-vm-architecture.md) - Redis runs on VM3 (172.16.168.23)
+- [ADR-001](001-distributed-vm-architecture.md) - Redis runs on VM3 (<database-ip>)
 
 ---
 

--- a/docs/adr/003-npu-integration-strategy.md
+++ b/docs/adr/003-npu-integration-strategy.md
@@ -29,7 +29,7 @@ Intel NPUs (Neural Processing Units) offer an alternative:
 
 ## Decision
 
-We create a dedicated NPU Worker VM (VM2: 172.16.168.22) that:
+We create a dedicated NPU Worker VM (VM2: <npu-ip>) that:
 1. Has direct hardware passthrough to the Intel NPU
 2. Runs OpenVINO for model optimization
 3. Exposes an HTTP API for AI inference requests
@@ -90,7 +90,7 @@ The main backend routes appropriate workloads to the NPU worker.
 ```
 ┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
 │  Backend API    │────▶│   NPU Worker     │────▶│  Intel NPU      │
-│  (172.16.168.20)│     │  (172.16.168.22) │     │  Hardware       │
+│  (<backend-ip>)│     │  (<npu-ip>) │     │  Hardware       │
 └─────────────────┘     └──────────────────┘     └─────────────────┘
          │
          ▼ (fallback)
@@ -104,17 +104,17 @@ The main backend routes appropriate workloads to the NPU worker.
 
 ```python
 # Health check
-GET http://172.16.168.22:8081/health
+GET http://<npu-ip>:8081/health
 
 # Embedding generation
-POST http://172.16.168.22:8081/embeddings
+POST http://<npu-ip>:8081/embeddings
 {
     "texts": ["text to embed"],
     "model": "bge-small-en"
 }
 
 # Inference
-POST http://172.16.168.22:8081/inference
+POST http://<npu-ip>:8081/inference
 {
     "prompt": "...",
     "model": "llama-7b-openvino"

--- a/docs/adr/005-single-frontend-mandate.md
+++ b/docs/adr/005-single-frontend-mandate.md
@@ -22,14 +22,14 @@ Developers would accidentally start frontend servers locally while the VM was al
 
 ## Decision
 
-**Only VM1 (172.16.168.21:5173) may run the frontend server.**
+**Only VM1 (<frontend-ip>:5173) may run the frontend server.**
 
 This is an absolute mandate with zero exceptions:
 
 | Machine | Frontend Server | Status |
 |---------|-----------------|--------|
-| Main (172.16.168.20) | **FORBIDDEN** | Never start Vite here |
-| VM1 (172.16.168.21) | **REQUIRED** | Only frontend server |
+| Main (<backend-ip>) | **FORBIDDEN** | Never start Vite here |
+| VM1 (<frontend-ip>) | **REQUIRED** | Only frontend server |
 | All other VMs | **FORBIDDEN** | No frontend capability |
 
 ### Development Workflow
@@ -37,7 +37,7 @@ This is an absolute mandate with zero exceptions:
 1. **Edit locally** in `autobot-frontend/`
 2. **Sync to VM1** using `./sync-frontend.sh` or sync scripts
 3. **VM1 serves** the frontend (dev or production mode)
-4. **Access** via `http://172.16.168.21:5173`
+4. **Access** via `http://<frontend-ip>:5173`
 
 ### Alternatives Considered
 
@@ -84,7 +84,7 @@ This is an absolute mandate with zero exceptions:
 
 ### Forbidden Commands
 
-**NEVER run these on the main machine (172.16.168.20):**
+**NEVER run these on the main machine (<backend-ip>):**
 
 ```bash
 # ALL FORBIDDEN - Will cause conflicts
@@ -108,7 +108,7 @@ vim autobot-frontend/src/components/MyComponent.vue
 ./scripts/utilities/sync-to-vm.sh frontend autobot-frontend/ /home/autobot/autobot-frontend/
 
 # 3. Access in browser
-firefox http://172.16.168.21:5173
+firefox http://<frontend-ip>:5173
 ```
 
 ### Enforcement
@@ -127,7 +127,7 @@ The systemd service configuration enforces this by:
 # Warn if Vite process running locally
 if pgrep -f "vite" > /dev/null; then
     echo "WARNING: Vite is running locally. This violates ADR-005."
-    echo "Only VM1 (172.16.168.21) should run the frontend."
+    echo "Only VM1 (<frontend-ip>) should run the frontend."
     exit 1
 fi
 ```
@@ -138,7 +138,7 @@ fi
 **Solution**: Run sync script, then hard refresh (Ctrl+Shift+R)
 
 **Symptom**: WebSocket connection failed
-**Solution**: Ensure connecting to 172.16.168.21:5173, not localhost
+**Solution**: Ensure connecting to <frontend-ip>:5173, not localhost
 
 **Symptom**: Port 5173 already in use on main machine
 **Solution**: Kill local process: `pkill -f vite`

--- a/docs/api/AGENT_TERMINAL_API.md
+++ b/docs/api/AGENT_TERMINAL_API.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 ## Agent Terminal API Documentation
 
 **API Version:** 1.0.0
@@ -64,12 +66,12 @@ Create a new terminal session for an AI agent.
 - `admin_agent` - Administrative agents (highest privilege)
 
 **Available Hosts:**
-- `main` - Main machine (172.16.168.20)
-- `frontend` - Frontend VM (172.16.168.21)
-- `npu-worker` - NPU Worker VM (172.16.168.22)
-- `redis` - Redis VM (172.16.168.23)
-- `ai-stack` - AI Stack VM (172.16.168.24)
-- `browser` - Browser VM (172.16.168.25)
+- `main` - Main machine (<backend-ip>)
+- `frontend` - Frontend VM (<frontend-ip>)
+- `npu-worker` - NPU Worker VM (<npu-ip>)
+- `redis` - Redis VM (<database-ip>)
+- `ai-stack` - AI Stack VM (<aiml-ip>)
+- `browser` - Browser VM (<browser-ip>)
 
 #### Response (201 Created)
 
@@ -89,7 +91,7 @@ Create a new terminal session for an AI agent.
 #### Example
 
 ```bash
-curl -X POST https://172.16.168.20:8443/api/agent-terminal/sessions \
+curl -X POST https://<backend-ip>:8443/api/agent-terminal/sessions \
   -H "Content-Type: application/json" \
   -d '{
     "agent_id": "chat_agent_1",
@@ -138,13 +140,13 @@ List agent terminal sessions with optional filtering.
 
 ```bash
 # List all sessions
-curl https://172.16.168.20:8443/api/agent-terminal/sessions
+curl https://<backend-ip>:8443/api/agent-terminal/sessions
 
 # List sessions for specific agent
-curl https://172.16.168.20:8443/api/agent-terminal/sessions?agent_id=chat_agent_1
+curl https://<backend-ip>:8443/api/agent-terminal/sessions?agent_id=chat_agent_1
 
 # List sessions for specific conversation
-curl https://172.16.168.20:8443/api/agent-terminal/sessions?conversation_id=conv_abc123
+curl https://<backend-ip>:8443/api/agent-terminal/sessions?conversation_id=conv_abc123
 ```
 
 ---
@@ -183,7 +185,7 @@ Get detailed information about a specific agent terminal session.
 #### Example
 
 ```bash
-curl https://172.16.168.20:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000
+curl https://<backend-ip>:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000
 ```
 
 ---
@@ -206,7 +208,7 @@ Close and delete an agent terminal session.
 #### Example
 
 ```bash
-curl -X DELETE https://172.16.168.20:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000
+curl -X DELETE https://<backend-ip>:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000
 ```
 
 ---
@@ -279,7 +281,7 @@ Execute a command in an agent terminal session with security controls.
 
 ```bash
 # Execute safe command (auto-approved)
-curl -X POST "https://172.16.168.20:8443/api/agent-terminal/execute?session_id=550e8400-e29b-41d4-a716-446655440000" \
+curl -X POST "https://<backend-ip>:8443/api/agent-terminal/execute?session_id=550e8400-e29b-41d4-a716-446655440000" \
   -H "Content-Type: application/json" \
   -d '{
     "command": "echo \"Hello World\"",
@@ -287,7 +289,7 @@ curl -X POST "https://172.16.168.20:8443/api/agent-terminal/execute?session_id=5
   }'
 
 # Execute moderate command (requires approval)
-curl -X POST "https://172.16.168.20:8443/api/agent-terminal/execute?session_id=550e8400-e29b-41d4-a716-446655440000" \
+curl -X POST "https://<backend-ip>:8443/api/agent-terminal/execute?session_id=550e8400-e29b-41d4-a716-446655440000" \
   -H "Content-Type: application/json" \
   -d '{
     "command": "mkdir /tmp/test_dir",
@@ -340,7 +342,7 @@ Approve or deny a pending agent command.
 
 ```bash
 # Approve command
-curl -X POST https://172.16.168.20:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000/approve \
+curl -X POST https://<backend-ip>:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000/approve \
   -H "Content-Type: application/json" \
   -d '{
     "approved": true,
@@ -348,7 +350,7 @@ curl -X POST https://172.16.168.20:8443/api/agent-terminal/sessions/550e8400-e29
   }'
 
 # Deny command
-curl -X POST https://172.16.168.20:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000/approve \
+curl -X POST https://<backend-ip>:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000/approve \
   -H "Content-Type: application/json" \
   -d '{
     "approved": false,
@@ -390,7 +392,7 @@ User interrupts agent and takes control of the terminal session.
 #### Example
 
 ```bash
-curl -X POST https://172.16.168.20:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000/interrupt \
+curl -X POST https://<backend-ip>:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000/interrupt \
   -H "Content-Type: application/json" \
   -d '{
     "user_id": "user_123"
@@ -418,7 +420,7 @@ Resume agent control after user interrupt.
 #### Example
 
 ```bash
-curl -X POST https://172.16.168.20:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000/resume
+curl -X POST https://<backend-ip>:8443/api/agent-terminal/sessions/550e8400-e29b-41d4-a716-446655440000/resume
 ```
 
 ---
@@ -512,7 +514,7 @@ import httpx
 async def create_agent_session():
     async with httpx.AsyncClient() as client:
         response = await client.post(
-            "https://172.16.168.20:8443/api/agent-terminal/sessions",
+            "https://<backend-ip>:8443/api/agent-terminal/sessions",
             json={
                 "agent_id": "chat_agent_1",
                 "agent_role": "chat_agent",
@@ -525,7 +527,7 @@ async def create_agent_session():
 async def execute_command(session_id, command):
     async with httpx.AsyncClient() as client:
         response = await client.post(
-            f"https://172.16.168.20:8443/api/agent-terminal/execute?session_id={session_id}",
+            f"https://<backend-ip>:8443/api/agent-terminal/execute?session_id={session_id}",
             json={
                 "command": command,
                 "description": "Agent command"

--- a/docs/api/CODE_VECTORIZATION_API.md
+++ b/docs/api/CODE_VECTORIZATION_API.md
@@ -1,7 +1,9 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # Code Vectorization API Specification
 **Version**: 1.0
 **Date**: 2025-10-25
-**Base URL**: `https://172.16.168.20:8443/api/analytics/code`
+**Base URL**: `https://<backend-ip>:8443/api/analytics/code`
 
 ---
 
@@ -64,7 +66,7 @@ Trigger code vectorization for the codebase.
         "status": "in_progress",
         "estimated_time_seconds": 120,
         "total_files": 450,
-        "websocket_url": "wss://172.16.168.20:8443/ws/vectorization/550e8400-e29b-41d4-a716-446655440000"
+        "websocket_url": "wss://<backend-ip>:8443/ws/vectorization/550e8400-e29b-41d4-a716-446655440000"
     }
 }
 ```
@@ -563,7 +565,7 @@ Get cache statistics.
 
 ### Vectorization Progress
 
-**Endpoint:** `wss://172.16.168.20:8443/ws/vectorization/{job_id}`
+**Endpoint:** `wss://<backend-ip>:8443/ws/vectorization/{job_id}`
 
 **Message Types:**
 

--- a/docs/api/COMPREHENSIVE_API_DOCUMENTATION.md
+++ b/docs/api/COMPREHENSIVE_API_DOCUMENTATION.md
@@ -17,11 +17,11 @@ AutoBot's Phase 5 architecture exposes a comprehensive REST API with 518+ endpoi
 
 ### Service Distribution
 - **Main Backend**: 127.0.0.1:8443 - Core API and system management
-- **Frontend**: 172.16.168.21:5173 - Vue.js web interface
-- **NPU Worker**: 172.16.168.22:8081 - Hardware AI acceleration
-- **Redis**: 172.16.168.23:6379 - Data persistence layer
-- **AI Stack**: 172.16.168.24:8080 - AI model processing
-- **Browser Service**: 172.16.168.25:3000 - Web automation via Playwright
+- **Frontend**: <frontend-ip>:5173 - Vue.js web interface
+- **NPU Worker**: <npu-ip>:8081 - Hardware AI acceleration
+- **Redis**: <database-ip>:6379 - Data persistence layer
+- **AI Stack**: <aiml-ip>:8080 - AI model processing
+- **Browser Service**: <browser-ip>:3000 - Web automation via Playwright
 
 ## Core API Categories
 
@@ -243,26 +243,26 @@ AutoBot's Phase 5 architecture exposes a comprehensive REST API with 518+ endpoi
         "memory_usage": "245MB / 1GB",
         "connected_clients": 12,
         "operations_per_sec": 150,
-        "host": "172.16.168.23:6379"
+        "host": "<database-ip>:6379"
       },
       "npu_worker": {
         "status": "healthy",
         "gpu_utilization": 0.23,
         "model_loading_time": 1.8,
         "queue_size": 3,
-        "host": "172.16.168.22:8081"
+        "host": "<npu-ip>:8081"
       },
       "ai_stack": {
         "status": "healthy",
         "active_models": ["gpt-4-turbo", "claude-3-sonnet"],
         "avg_inference_time": 2.1,
-        "host": "172.16.168.24:8080"
+        "host": "<aiml-ip>:8080"
       },
       "browser_service": {
         "status": "healthy",
         "active_sessions": 2,
         "available_browsers": ["chromium", "firefox"],
-        "host": "172.16.168.25:3000"
+        "host": "<browser-ip>:3000"
       },
       "knowledge_base": {
         "status": "healthy",

--- a/docs/api/FRONTEND_INTEGRATION_API_SPECS.md
+++ b/docs/api/FRONTEND_INTEGRATION_API_SPECS.md
@@ -1,18 +1,18 @@
 # AutoBot Frontend Integration API Specifications
 
 ## Overview
-This document provides complete API specifications for frontend integration with the AutoBot backend system. The backend runs on `https://172.16.168.20:8443/` and provides 285+ documented endpoints across multiple service modules.
+This document provides complete API specifications for frontend integration with the AutoBot backend system. The backend runs on `https://<backend-ip>:8443/` and provides 285+ documented endpoints across multiple service modules.
 
 ## Base Configuration
 
 ### Backend API Base URL
 ```
-https://172.16.168.20:8443/
+https://<backend-ip>:8443/
 ```
 
 ### OpenAPI Documentation
-- **Swagger UI**: `https://172.16.168.20:8443/docs`
-- **OpenAPI JSON**: `https://172.16.168.20:8443/openapi.json`
+- **Swagger UI**: `https://<backend-ip>:8443/docs`
+- **OpenAPI JSON**: `https://<backend-ip>:8443/openapi.json`
 
 ## Core API Endpoints
 
@@ -273,12 +273,12 @@ Content-Type: application/json
 
 #### Main WebSocket Connection
 ```javascript
-const ws = new WebSocket('ws://172.16.168.20:8443/ws');
+const ws = new WebSocket('ws://<backend-ip>:8443/ws');
 ```
 
 #### Test WebSocket Connection
 ```javascript
-const ws = new WebSocket('ws://172.16.168.20:8443/ws-test');
+const ws = new WebSocket('ws://<backend-ip>:8443/ws-test');
 ```
 
 #### WebSocket Message Types
@@ -403,11 +403,11 @@ GET /api/system/frontend-config
         "embedding_endpoint": "http://127.0.0.1:11434/api/embeddings"
       },
       "playwright": {
-        "vnc_url": "http://172.16.168.25:6080",
-        "api_url": "http://172.16.168.25:3000"
+        "vnc_url": "http://<browser-ip>:6080",
+        "api_url": "http://<browser-ip>:3000"
       },
       "redis": {
-        "host": "172.16.168.23",
+        "host": "<database-ip>",
         "port": 6379,
         "enabled": true
       }
@@ -590,7 +590,7 @@ Content-Type: application/json
 #### React/TypeScript Example
 ```typescript
 // API client configuration
-const API_BASE = 'https://172.16.168.20:8443';
+const API_BASE = 'https://<backend-ip>:8443';
 
 interface ChatMessage {
   message: string;
@@ -647,7 +647,7 @@ async function sendChatMessage(
 
 // WebSocket connection
 function connectWebSocket(onMessage: (data: any) => void) {
-  const ws = new WebSocket(`ws://172.16.168.20:8443/ws`);
+  const ws = new WebSocket(`ws://<backend-ip>:8443/ws`);
 
   ws.onopen = () => {
     console.log('WebSocket connected');
@@ -709,7 +709,7 @@ export function useChatAPI() {
   };
 
   const connectWebSocket = () => {
-    ws.value = new WebSocket('ws://172.16.168.20:8443/ws');
+    ws.value = new WebSocket('ws://<backend-ip>:8443/ws');
 
     ws.value.onopen = () => {
       isConnected.value = true;

--- a/docs/api/IP_ADDRESSING_SCHEME.md
+++ b/docs/api/IP_ADDRESSING_SCHEME.md
@@ -106,7 +106,7 @@ PLAYWRIGHT_VNC_URL: 'http://127.0.0.4:6080/vnc.html'
 
 1. **No hardcoded IPs anywhere in code or docs.** Reference Ansible vars, ssot_config, or environment variables.
 2. **No `localhost` / `127.0.0.1`.** Use role aliases in co-located mode, or `ssot_config` values in distributed mode.
-3. **Document by role, not by IP.** When writing docs or error messages, say "backend VM" not "172.16.168.20".
+3. **Document by role, not by IP.** When writing docs or error messages, say "backend VM" not "<backend-ip>".
 4. **IPs in docs are examples only.** Any specific IP shown in documentation reflects one test deployment and is not canonical.
 
 ---

--- a/docs/api/REDIS_SERVICE_MANAGEMENT_API.md
+++ b/docs/api/REDIS_SERVICE_MANAGEMENT_API.md
@@ -21,7 +21,7 @@
 
 ## Overview
 
-The Redis Service Management API provides comprehensive control over the Redis service running on VM3 (172.16.168.23:6379) within AutoBot's distributed infrastructure. This API enables:
+The Redis Service Management API provides comprehensive control over the Redis service running on VM3 (<database-ip>:6379) within AutoBot's distributed infrastructure. This API enables:
 
 - **Service Control**: Start, stop, restart Redis service
 - **Health Monitoring**: Real-time health checks and status reporting
@@ -32,7 +32,7 @@ The Redis Service Management API provides comprehensive control over the Redis s
 ### Base URL
 
 ```
-https://172.16.168.20:8443/api/services/redis
+https://<backend-ip>:8443/api/services/redis
 ```
 
 ### API Versioning
@@ -107,7 +107,7 @@ Operations are restricted based on user roles:
 
 ```bash
 curl -X POST \
-  https://172.16.168.20:8443/api/services/redis/start \
+  https://<backend-ip>:8443/api/services/redis/start \
   -H "Authorization: Bearer YOUR_JWT_TOKEN"
 ```
 
@@ -182,7 +182,7 @@ curl -X POST \
 
 ```bash
 curl -X POST \
-  https://172.16.168.20:8443/api/services/redis/stop \
+  https://<backend-ip>:8443/api/services/redis/stop \
   -H "Authorization: Bearer YOUR_JWT_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"confirmation": true}'
@@ -252,7 +252,7 @@ curl -X POST \
 
 ```bash
 curl -X POST \
-  https://172.16.168.20:8443/api/services/redis/restart \
+  https://<backend-ip>:8443/api/services/redis/restart \
   -H "Authorization: Bearer YOUR_JWT_TOKEN"
 ```
 
@@ -314,7 +314,7 @@ curl -X POST \
 
 ```bash
 curl -X GET \
-  https://172.16.168.20:8443/api/services/redis/status
+  https://<backend-ip>:8443/api/services/redis/status
 ```
 
 **Example Response (Running):**
@@ -329,7 +329,7 @@ curl -X GET \
   "commands_processed": 1000000,
   "last_check": "2025-10-10T14:30:00Z",
   "vm_info": {
-    "host": "172.16.168.23",
+    "host": "<database-ip>",
     "name": "Redis VM",
     "ssh_accessible": true
   }
@@ -347,7 +347,7 @@ curl -X GET \
   "connections": null,
   "last_check": "2025-10-10T14:30:00Z",
   "vm_info": {
-    "host": "172.16.168.23",
+    "host": "<database-ip>",
     "name": "Redis VM",
     "ssh_accessible": true
   }
@@ -424,7 +424,7 @@ curl -X GET \
 
 ```bash
 curl -X GET \
-  https://172.16.168.20:8443/api/services/redis/health
+  https://<backend-ip>:8443/api/services/redis/health
 ```
 
 **Example Response (Healthy):**
@@ -560,7 +560,7 @@ curl -X GET \
 
 ```bash
 curl -X GET \
-  "https://172.16.168.20:8443/api/services/redis/logs?lines=20&level=error" \
+  "https://<backend-ip>:8443/api/services/redis/logs?lines=20&level=error" \
   -H "Authorization: Bearer YOUR_JWT_TOKEN"
 ```
 
@@ -587,7 +587,7 @@ curl -X GET \
   ],
   "total_lines": 20,
   "service": "redis-server",
-  "vm": "172.16.168.23"
+  "vm": "<database-ip>"
 }
 ```
 
@@ -602,7 +602,7 @@ curl -X GET \
 ```bash
 # Start Redis service as operator
 curl -X POST \
-  https://172.16.168.20:8443/api/services/redis/start \
+  https://<backend-ip>:8443/api/services/redis/start \
   -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \
   -H "Content-Type: application/json"
 ```
@@ -612,7 +612,7 @@ curl -X POST \
 ```bash
 # Stop Redis service with confirmation
 curl -X POST \
-  https://172.16.168.20:8443/api/services/redis/stop \
+  https://<backend-ip>:8443/api/services/redis/stop \
   -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -625,7 +625,7 @@ curl -X POST \
 ```bash
 # Restart Redis service
 curl -X POST \
-  https://172.16.168.20:8443/api/services/redis/restart \
+  https://<backend-ip>:8443/api/services/redis/restart \
   -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \
   -H "Content-Type: application/json"
 ```
@@ -635,7 +635,7 @@ curl -X POST \
 ```bash
 # Get current status (no authentication required)
 curl -X GET \
-  https://172.16.168.20:8443/api/services/redis/status
+  https://<backend-ip>:8443/api/services/redis/status
 ```
 
 #### Get Health (Public)
@@ -643,7 +643,7 @@ curl -X GET \
 ```bash
 # Get detailed health status
 curl -X GET \
-  https://172.16.168.20:8443/api/services/redis/health
+  https://<backend-ip>:8443/api/services/redis/health
 ```
 
 #### Get Logs (Admin)
@@ -651,7 +651,7 @@ curl -X GET \
 ```bash
 # Get last 100 error logs
 curl -X GET \
-  "https://172.16.168.20:8443/api/services/redis/logs?lines=100&level=error" \
+  "https://<backend-ip>:8443/api/services/redis/logs?lines=100&level=error" \
   -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 ```
 
@@ -732,7 +732,7 @@ class RedisServiceClient:
 
 # Usage example
 client = RedisServiceClient(
-    base_url='https://172.16.168.20:8443',
+    base_url='https://<backend-ip>:8443',
     api_token='your_jwt_token_here'
 )
 
@@ -841,7 +841,7 @@ All API errors follow this consistent format:
   "error": "Redis VM unreachable",
   "message": "Cannot establish SSH connection to Redis VM",
   "details": {
-    "host": "172.16.168.23",
+    "host": "<database-ip>",
     "error": "Connection timeout after 10 seconds"
   },
   "timestamp": "2025-10-10T14:30:00Z"
@@ -896,7 +896,7 @@ X-RateLimit-Reset: 1696950000
 
 ### WebSocket Connection
 
-**Endpoint:** `ws://172.16.168.20:8443/ws/services/redis/status`
+**Endpoint:** `ws://<backend-ip>:8443/ws/services/redis/status`
 
 **Authentication:** Required (JWT token in URL parameter or header)
 
@@ -906,7 +906,7 @@ X-RateLimit-Reset: 1696950000
 // JavaScript WebSocket connection
 const token = 'your_jwt_token_here';
 const ws = new WebSocket(
-  `ws://172.16.168.20:8443/ws/services/redis/status?token=${token}`
+  `ws://<backend-ip>:8443/ws/services/redis/status?token=${token}`
 );
 
 ws.onopen = () => {
@@ -1017,7 +1017,7 @@ function useRedisServiceStatus(token) {
 
   useEffect(() => {
     const ws = new WebSocket(
-      `ws://172.16.168.20:8443/ws/services/redis/status?token=${token}`
+      `ws://<backend-ip>:8443/ws/services/redis/status?token=${token}`
     );
 
     ws.onopen = () => {

--- a/docs/api/WEBSOCKET_INTEGRATION_GUIDE.md
+++ b/docs/api/WEBSOCKET_INTEGRATION_GUIDE.md
@@ -6,9 +6,9 @@ This guide provides comprehensive WebSocket integration patterns for real-time c
 ## WebSocket Endpoints
 
 ### Primary Endpoints
-- **Main WebSocket**: `wss://172.16.168.20:8443/ws`
-- **Test WebSocket**: `wss://172.16.168.20:8443/ws-test`
-- **Health Check**: `wss://172.16.168.20:8443/ws/health`
+- **Main WebSocket**: `wss://<backend-ip>:8443/ws`
+- **Test WebSocket**: `wss://<backend-ip>:8443/ws-test`
+- **Health Check**: `wss://<backend-ip>:8443/ws/health`
 
 ## Message Formats
 
@@ -900,7 +900,7 @@ describe('AutoBot WebSocket Integration', () => {
   let ws: WebSocket;
 
   beforeEach(() => {
-    ws = new WebSocket('wss://172.16.168.20:8443/ws-test');
+    ws = new WebSocket('wss://<backend-ip>:8443/ws-test');
   });
 
   afterEach(() => {

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -18,7 +18,7 @@ AutoBot supports comprehensive configuration through environment variables with 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AUTOBOT_DEFAULT_LLM_MODEL` | `qwen3.5:9b` | **Quality tier** - Default LLM model for complex tasks (chat, research, code) |
-| `AUTOBOT_OLLAMA_HOST` | `172.16.168.24` | Ollama server host (AI Stack VM) |
+| `AUTOBOT_OLLAMA_HOST` | `<aiml-ip>` | Ollama server host (AI Stack VM) |
 | `AUTOBOT_OLLAMA_PORT` | `11434` | Ollama server port |
 | `AUTOBOT_OLLAMA_ENDPOINT` | `http://${HOST}:${PORT}/api/generate` | Ollama API endpoint |
 | `AUTOBOT_LLM_PROVIDER_TYPE` | `local` | LLM provider type (local/cloud) |

--- a/docs/api/npu-worker-pool.md
+++ b/docs/api/npu-worker-pool.md
@@ -29,14 +29,14 @@ NPUTaskQueue → NPUWorkerPool → NPUWorkerClient instances
 npu:
   workers:
     - id: npu-worker-vm2
-      host: 172.16.168.22
+      host: <npu-ip>
       port: 8081
       priority: 10
       enabled: true
       max_concurrent_tasks: 4
 
     - id: windows-npu-worker
-      host: 172.16.168.20
+      host: <backend-ip>
       port: 8082
       priority: 5
       enabled: true
@@ -83,7 +83,7 @@ Get per-worker health states.
   "workers": [
     {
       "id": "npu-worker-vm2",
-      "url": "http://172.16.168.22:8081",
+      "url": "http://<npu-ip>:8081",
       "priority": 10,
       "enabled": true,
       "healthy": true,

--- a/docs/api/redis-documentation.md
+++ b/docs/api/redis-documentation.md
@@ -60,13 +60,13 @@ AutoBot uses dedicated Redis databases for different data types, enabling indivi
 
 ```bash
 # Check all database sizes
-for db in {0..15}; do echo -n "DB$db: "; redis-cli -h 172.16.168.23 -p 6379 -n $db DBSIZE; done
+for db in {0..15}; do echo -n "DB$db: "; redis-cli -h <database-ip> -p 6379 -n $db DBSIZE; done
 
 # Clear a specific database (example: temp data in DB 9)
-redis-cli -h 172.16.168.23 -p 6379 -n 9 FLUSHDB
+redis-cli -h <database-ip> -p 6379 -n 9 FLUSHDB
 
 # Backup a specific database
-redis-cli -h 172.16.168.23 -p 6379 -n 0 --rdb main_backup.rdb
+redis-cli -h <database-ip> -p 6379 -n 0 --rdb main_backup.rdb
 ```
 
 ### Legacy schema (Docker-based deployment)

--- a/docs/architecture/AUTOBOT_MEMORY_GRAPH_ARCHITECTURE.md
+++ b/docs/architecture/AUTOBOT_MEMORY_GRAPH_ARCHITECTURE.md
@@ -50,7 +50,7 @@ The AutoBot Memory Graph is an enhanced memory system that provides graph-based 
 │                                                                   │
 └───────────────────────────────────────────────────────────────────┘
                                 │
-                                │ Redis Stack (172.16.168.23:6379)
+                                │ Redis Stack (<database-ip>:6379)
                                 ▼
                 ┌────────────────────────────────┐
                 │  Redis Stack Modules           │
@@ -63,7 +63,7 @@ The AutoBot Memory Graph is an enhanced memory system that provides graph-based 
 
 ### 1.2 Technology Stack
 
-- **Storage Backend**: Redis Stack 7.4 on VM3 (172.16.168.23:6379)
+- **Storage Backend**: Redis Stack 7.4 on VM3 (<database-ip>:6379)
 - **Database**: DB 9 (dedicated for Memory Graph)
 - **Redis Modules**:
   - **RedisGraph**: Native graph operations for entity relationships
@@ -212,7 +212,7 @@ class AutoBotMemoryGraph:
 
     def __init__(
         self,
-        redis_host: str = "172.16.168.23",
+        redis_host: str = "<database-ip>",
         redis_port: int = 6379,
         database: int = 9,
         chat_history_manager: Optional[ChatHistoryManager] = None
@@ -679,7 +679,7 @@ The system maintains full backward compatibility:
 1. Create `AutoBotMemoryGraph` class in `src/autobot_memory_graph.py`
 2. Initialize Redis DB 9 with RedisGraph, RedisJSON, RediSearch indexes
 3. Create RediSearch index for entity search
-4. Deploy configuration to Redis VM (172.16.168.23)
+4. Deploy configuration to Redis VM (<database-ip>)
 5. Unit tests for all API operations
 
 **Validation**:
@@ -822,7 +822,7 @@ async def process_chat_message(message, ...):
    ```python
    # Redis connection pool (50 connections, 10 I/O threads)
    pool = redis.ConnectionPool(
-       host="172.16.168.23",
+       host="<database-ip>",
        port=6379,
        db=9,
        max_connections=50,
@@ -879,7 +879,7 @@ Total:                      = 33 MB
 ### 7.1 Access Control
 
 1. **Network Security**:
-   - Redis VM on internal network only (172.16.168.0/24)
+   - Redis VM on internal network only (<network-subnet>)
    - No external access to Redis port
    - Protected mode disabled (internal network trust)
 

--- a/docs/architecture/BACKEND_CRITICAL_ISSUES_ARCHITECTURAL_ANALYSIS.md
+++ b/docs/architecture/BACKEND_CRITICAL_ISSUES_ARCHITECTURAL_ANALYSIS.md
@@ -27,12 +27,12 @@ This architectural analysis examines how 6 critical backend issues identified in
 AutoBot operates as a sophisticated distributed system across 6 virtual machines:
 
 ```
-VM0 (Main Host WSL): Backend API (172.16.168.20:8443) + Ollama + VNC Desktop
-VM1 (Frontend): Vue.js web interface (172.16.168.21:5173)
-VM2 (NPU Worker): Intel NPU + GPU acceleration (172.16.168.22:8081)
-VM3 (Redis Stack): Centralized data layer (172.16.168.23:6379) - 11 specialized databases
-VM4 (AI Stack): Multi-provider AI orchestration (172.16.168.24:8080)
-VM5 (Browser): Playwright automation (172.16.168.25:3000)
+VM0 (Main Host WSL): Backend API (<backend-ip>:8443) + Ollama + VNC Desktop
+VM1 (Frontend): Vue.js web interface (<frontend-ip>:5173)
+VM2 (NPU Worker): Intel NPU + GPU acceleration (<npu-ip>:8081)
+VM3 (Redis Stack): Centralized data layer (<database-ip>:6379) - 11 specialized databases
+VM4 (AI Stack): Multi-provider AI orchestration (<aiml-ip>:8080)
+VM5 (Browser): Playwright automation (<browser-ip>:3000)
 ```
 
 The backend API on VM0 serves as the central orchestrator coordinating all services. Any critical backend issues directly impact the entire distributed system's reliability, security, and performance.
@@ -260,7 +260,7 @@ class ConversationFileManager:
 ### Distributed System Impact
 
 **Redis Blocking Across Network:**
-- Every synchronous `redis_client.get(key)` call to VM3 (172.16.168.23) blocks VM0's entire event loop
+- Every synchronous `redis_client.get(key)` call to VM3 (<database-ip>) blocks VM0's entire event loop
 - Network round-trip time (2-5ms) becomes complete event loop freeze
 - All concurrent requests queue waiting for single Redis operation to complete
 
@@ -397,7 +397,7 @@ Context window in `autobot-backend/api/chat_enhanced.py` increased 50x (10→500
 ### Distributed System Impact
 
 **AI Stack Overload:**
-- chat_enhanced.py sends 200 messages to AI Stack VM (172.16.168.24:8080)
+- chat_enhanced.py sends 200 messages to AI Stack VM (<aiml-ip>:8080)
 - AI Stack routes to Ollama on VM0 (127.0.0.1:11434)
 - Round-trip: VM0→VM4→VM0 with massive context payload
 
@@ -618,7 +618,7 @@ class TestDistributedFileOperations:
     async def test_file_upload_from_frontend_vm(self):
         """Test file upload flow: Frontend VM → Backend → Redis → Storage."""
         # Simulate frontend VM uploading file
-        client = AsyncTestClient(backend_url="https://172.16.168.20:8443")
+        client = AsyncTestClient(backend_url="https://<backend-ip>:8443")
 
         file_content = b"test content"
         response = await client.post(
@@ -640,7 +640,7 @@ class TestDistributedFileOperations:
         assert cursor.fetchone() is not None
 
         # Verify cache in Redis on VM3
-        redis_client = await get_async_redis_client(host="172.16.168.23")
+        redis_client = await get_async_redis_client(host="<database-ip>")
         cached_metadata = await redis_client.get(f"file:{file_id}")
         assert cached_metadata is not None
 
@@ -725,7 +725,7 @@ class TestDistributedFailureScenarios:
     async def test_redis_vm_unreachable(self):
         """Test graceful degradation when Redis VM fails."""
         # Block network to Redis VM
-        await block_network("172.16.168.23")
+        await block_network("<database-ip>")
 
         try:
             # File upload should still work (degraded mode)
@@ -739,7 +739,7 @@ class TestDistributedFailureScenarios:
             assert "cache_unavailable" in response.json().get("warnings", [])
 
         finally:
-            await restore_network("172.16.168.23")
+            await restore_network("<database-ip>")
 ```
 
 **Required Test Categories:**
@@ -1915,9 +1915,9 @@ class AutoBotConfig(BaseSettings):
     """Centralized configuration with validation."""
 
     # Service endpoints
-    backend_host: str = "172.16.168.20"
+    backend_host: str = "<backend-ip>"
     backend_port: int = 8001
-    redis_host: str = "172.16.168.23"
+    redis_host: str = "<database-ip>"
     redis_port: int = 6379
 
     # File management
@@ -2070,7 +2070,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 # Initialize tracer
 tracer_provider = TracerProvider()
 jaeger_exporter = JaegerExporter(
-    agent_host_name="172.16.168.20",
+    agent_host_name="<backend-ip>",
     agent_port=6831
 )
 tracer_provider.add_span_processor(

--- a/docs/architecture/BACKGROUND_VECTORIZATION.md
+++ b/docs/architecture/BACKGROUND_VECTORIZATION.md
@@ -262,7 +262,7 @@ const checkStatus = async () => {
 tail -f logs/backend.log | grep -i error
 
 # Verify knowledge base initialized
-curl https://172.16.168.20:8443/api/knowledge_base/stats
+curl https://<backend-ip>:8443/api/knowledge_base/stats
 ```
 
 **Issue**: Slow vectorization
@@ -271,7 +271,7 @@ curl https://172.16.168.20:8443/api/knowledge_base/stats
 redis-cli CONFIG GET io-threads  # Should be 10
 
 # Check batch size
-curl https://172.16.168.20:8443/api/knowledge_base/vectorize_facts/status
+curl https://<backend-ip>:8443/api/knowledge_base/vectorize_facts/status
 ```
 
 **Issue**: High resource usage

--- a/docs/architecture/CHAT_INFRASTRUCTURE_ACCESS_DESIGN.md
+++ b/docs/architecture/CHAT_INFRASTRUCTURE_ACCESS_DESIGN.md
@@ -42,7 +42,7 @@ Refactor the Chat Terminal and VNC tabs to use user-configured external hosts vi
 │  Chat Terminal ──────────► Local PTY (AutoBot host)             │
 │                            └─ SECURITY RISK: Direct access      │
 │                                                                  │
-│  Chat VNC ───────────────► Main Machine VNC (172.16.168.20)     │
+│  Chat VNC ───────────────► Main Machine VNC (<backend-ip>)     │
 │                            └─ Checked on startup                 │
 │                            └─ SECURITY RISK: Exposes desktop    │
 │                                                                  │
@@ -160,7 +160,7 @@ Refactor the Chat Terminal and VNC tabs to use user-configured external hosts vi
 │                           │     │    ┌──────────────────┐      │
 │  ┌──────────────────┐     │     │    │ db-server        │      │
 │  │ Redis Stack      │     ✗     │    │ 192.168.1.20    │      │
-│  │ 172.16.168.23    │◄────┼─────┼───►│ SSH only        │      │
+│  │ <database-ip>    │◄────┼─────┼───►│ SSH only        │      │
 │  └──────────────────┘     │     │    └──────────────────┘      │
 │                           │     │                              │
 │          NO ACCESS ───────┘     │    User connects via         │

--- a/docs/architecture/CODE_VECTORIZATION_ARCHITECTURE.md
+++ b/docs/architecture/CODE_VECTORIZATION_ARCHITECTURE.md
@@ -162,7 +162,7 @@ This document outlines the architecture for a comprehensive code vectorization a
         "job_id": "uuid-v4",
         "estimated_time": 120,  # seconds
         "total_files": 450,
-        "websocket_channel": "wss://172.16.168.20:8443/ws/vectorization/{job_id}"
+        "websocket_channel": "wss://<backend-ip>:8443/ws/vectorization/{job_id}"
     }
 }
 

--- a/docs/architecture/CONFIG_MIGRATION_IMPLEMENTATION.md
+++ b/docs/architecture/CONFIG_MIGRATION_IMPLEMENTATION.md
@@ -19,7 +19,7 @@ python scripts/validate_timeout_config.py
 
 # 4. Verify no regression
 scripts/start-services.sh start
-curl http://172.16.168.21:5173  # Frontend accessible?
+curl http://<frontend-ip>:5173  # Frontend accessible?
 ```
 
 ## Implementation Steps
@@ -406,11 +406,11 @@ python scripts/validate_timeout_config.py
 curl http://localhost:8001/api/health
 
 # 4. Frontend connectivity (CRITICAL!)
-curl http://172.16.168.21:5173
+curl http://<frontend-ip>:5173
 
 # 5. Full system test
 scripts/start-services.sh start
-# Open browser to http://172.16.168.21:5173
+# Open browser to http://<frontend-ip>:5173
 # Test model selection in GUI
 ```
 

--- a/docs/architecture/DISTRIBUTED_6VM_ARCHITECTURE.md
+++ b/docs/architecture/DISTRIBUTED_6VM_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## ✅ DISTRIBUTED ARCHITECTURE SUCCESSFULLY CONFIGURED
 
-AutoBot is now properly configured for the **6-VM distributed architecture** with the main WSL machine (172.16.168.20) serving as the **Backend API Coordinator**.
+AutoBot is now properly configured for the **6-VM distributed architecture** with the main WSL machine (<backend-ip>) serving as the **Backend API Coordinator**.
 
 ---
 
@@ -12,12 +12,12 @@ AutoBot is now properly configured for the **6-VM distributed architecture** wit
 
 | Role | VM | IP Address | Port | Status | Description |
 |------|----|-----------|----|--------|-------------|
-| **Coordinator** | Main WSL | 172.16.168.20 | 8002 | ✅ **RUNNING** | Backend API + Ollama + VNC |
-| **Frontend** | Frontend VM | 172.16.168.21 | 5173 | ✅ Connected | Vue.js Web Interface |
-| **NPU Worker** | NPU VM | 172.16.168.22 | 8081 | ✅ Connected | Intel OpenVINO + Hardware Acceleration |
-| **Data Layer** | Redis VM | 172.16.168.23 | 6379 | ✅ Connected | Redis Stack + Vector Storage |
-| **AI Processing** | AI Stack VM | 172.16.168.24 | 8080 | ✅ Connected | Multimodal AI Services |
-| **Browser Automation** | Browser VM | 172.16.168.25 | 3000 | ✅ Connected | Playwright Automation |
+| **Coordinator** | Main WSL | <backend-ip> | 8002 | ✅ **RUNNING** | Backend API + Ollama + VNC |
+| **Frontend** | Frontend VM | <frontend-ip> | 5173 | ✅ Connected | Vue.js Web Interface |
+| **NPU Worker** | NPU VM | <npu-ip> | 8081 | ✅ Connected | Intel OpenVINO + Hardware Acceleration |
+| **Data Layer** | Redis VM | <database-ip> | 6379 | ✅ Connected | Redis Stack + Vector Storage |
+| **AI Processing** | AI Stack VM | <aiml-ip> | 8080 | ✅ Connected | Multimodal AI Services |
+| **Browser Automation** | Browser VM | <browser-ip> | 3000 | ✅ Connected | Playwright Automation |
 
 ---
 
@@ -25,12 +25,12 @@ AutoBot is now properly configured for the **6-VM distributed architecture** wit
 
 ### ✅ **All Services Online and Connected**
 
-- **Backend API Coordinator**: `http://172.16.168.20:8002` ✅ 
-- **Frontend Interface**: `http://172.16.168.21:5173` ✅
-- **Redis Stack + Insight**: `http://172.16.168.23:6379` + `http://172.16.168.23:8002` ✅
-- **NPU Worker**: `http://172.16.168.22:8081` ✅
-- **AI Stack**: `http://172.16.168.24:8080` ✅
-- **Browser Service**: `http://172.16.168.25:3000` ✅
+- **Backend API Coordinator**: `http://<backend-ip>:8002` ✅ 
+- **Frontend Interface**: `http://<frontend-ip>:5173` ✅
+- **Redis Stack + Insight**: `http://<database-ip>:6379` + `http://<database-ip>:8002` ✅
+- **NPU Worker**: `http://<npu-ip>:8081` ✅
+- **AI Stack**: `http://<aiml-ip>:8080` ✅
+- **Browser Service**: `http://<browser-ip>:3000` ✅
 - **Ollama LLM**: `http://127.0.0.1:11434` ✅
 - **VNC Desktop**: `http://127.0.0.1:6080` ✅
 
@@ -41,7 +41,7 @@ AutoBot is now properly configured for the **6-VM distributed architecture** wit
 ### **1. Distributed Redis Client**
 - **File**: `src/utils/distributed_redis_client.py`
 - **Features**: 
-  - Remote Redis VM connection (172.16.168.23:6379)
+  - Remote Redis VM connection (<database-ip>:6379)
   - Connection pooling and retry logic
   - Non-blocking with graceful fallbacks
   - Optimized for distributed architecture
@@ -101,9 +101,9 @@ bash scripts/distributed/collect-backups.sh
 python src/utils/distributed_redis_client.py
 
 # Test individual service endpoints
-curl http://172.16.168.20:8002/api/health
-curl http://172.16.168.22:8081/health
-curl http://172.16.168.24:8080/health
+curl http://<backend-ip>:8002/api/health
+curl http://<npu-ip>:8081/health
+curl http://<aiml-ip>:8080/health
 ```
 
 ---
@@ -111,16 +111,16 @@ curl http://172.16.168.24:8080/health
 ## 🔗 Service Access URLs
 
 ### **User Interfaces**
-- **Main AutoBot Frontend**: http://172.16.168.21:5173
-- **Backend API Documentation**: http://172.16.168.20:8002/docs
-- **Redis Insight Dashboard**: http://172.16.168.23:8002
+- **Main AutoBot Frontend**: http://<frontend-ip>:5173
+- **Backend API Documentation**: http://<backend-ip>:8002/docs
+- **Redis Insight Dashboard**: http://<database-ip>:8002
 - **VNC Desktop Access**: http://127.0.0.1:6080
 
 ### **Service APIs** 
-- **Backend Coordinator API**: http://172.16.168.20:8002/api/
-- **NPU Worker API**: http://172.16.168.22:8081/
-- **AI Stack API**: http://172.16.168.24:8080/
-- **Browser Automation API**: http://172.16.168.25:3000/
+- **Backend Coordinator API**: http://<backend-ip>:8002/api/
+- **NPU Worker API**: http://<npu-ip>:8081/
+- **AI Stack API**: http://<aiml-ip>:8080/
+- **Browser Automation API**: http://<browser-ip>:3000/
 - **Ollama LLM API**: http://127.0.0.1:11434/api/
 
 ---
@@ -128,7 +128,7 @@ curl http://172.16.168.24:8080/health
 ## 🔒 Security Configuration
 
 ### **Network Security**
-- **Subnet**: 172.16.168.0/24
+- **Subnet**: <network-subnet>
 - **Firewall**: Enabled on all VMs
 - **SSH Keys**: `~/.ssh/autobot_distributed` for passwordless access
 - **Access Control**: Only AutoBot subnet and localhost allowed
@@ -143,18 +143,18 @@ curl http://172.16.168.24:8080/health
 
 ## 🔧 Hardware Optimization
 
-### **Main WSL Coordinator (172.16.168.20)**
+### **Main WSL Coordinator (<backend-ip>)**
 - **CPU**: Intel Ultra 9 185H (22 cores) - Backend API processing
 - **GPU**: RTX 4070 - Semantic chunking and embeddings
 - **RAM**: 32GB+ - In-memory caching and processing
 - **Role**: API coordination, local LLM, VNC desktop
 
-### **NPU Worker VM (172.16.168.22)** 
+### **NPU Worker VM (<npu-ip>)** 
 - **NPU**: Intel AI Boost (NPU) - Hardware AI acceleration
 - **GPU**: Intel Arc (if available) - Additional GPU processing
 - **Role**: OpenVINO acceleration, inference optimization
 
-### **Redis VM (172.16.168.23)**
+### **Redis VM (<database-ip>)**
 - **RAM**: High memory configuration - Vector storage
 - **Storage**: SSD recommended - Persistent data layer
 - **Role**: High-performance Redis Stack with RedisInsight
@@ -208,7 +208,7 @@ curl http://172.16.168.24:8080/health
 
 ### **Performance**
 - **Hardware Specialization**: NPU for AI, RTX 4070 for graphics, dedicated Redis
-- **Network Optimization**: Local subnet communication (172.16.168.0/24)
+- **Network Optimization**: Local subnet communication (<network-subnet>)
 - **Connection Pooling**: Efficient resource utilization across VMs
 
 ---

--- a/docs/architecture/DISTRIBUTED_ARCHITECTURE.md
+++ b/docs/architecture/DISTRIBUTED_ARCHITECTURE.md
@@ -22,33 +22,33 @@ AutoBot Phase 5 implements a sophisticated distributed architecture across 6 ded
 ```mermaid
 graph TB
     subgraph "Physical Host (WSL2 - Ubuntu 22.04)"
-        MainHost[Main Host<br/>172.16.168.20<br/>Backend API + Desktop Access]
+        MainHost[Main Host<br/><backend-ip><br/>Backend API + Desktop Access]
         OllamaLocal[Ollama LLM Server<br/>127.0.0.1:11434<br/>Local AI Processing]
         VNC[VNC Desktop<br/>127.0.0.1:6080<br/>noVNC + kex]
     end
 
-    subgraph "VM1 - Frontend (172.16.168.21)"
+    subgraph "VM1 - Frontend (<frontend-ip>)"
         Vue3[Vue 3 + TypeScript<br/>Port 5173<br/>Nginx + Hot Reload]
         Vite[Vite Dev Server<br/>HMR + Proxy Config]
     end
 
-    subgraph "VM2 - NPU Worker (172.16.168.22)"
+    subgraph "VM2 - NPU Worker (<npu-ip>)"
         NPUService[Intel NPU Service<br/>Port 8081<br/>OpenVINO + NPU Acceleration]
         GPUProcess[GPU Acceleration<br/>CUDA/OpenCL<br/>Computer Vision Tasks]
     end
 
-    subgraph "VM3 - Redis Stack (172.16.168.23)"
+    subgraph "VM3 - Redis Stack (<database-ip>)"
         RedisStack[Redis Stack 7.4.0<br/>Port 6379<br/>11 Specialized Databases]
         RedisInsight[RedisInsight<br/>Port 8002<br/>Visual Management]
         VectorDB[Vector Storage<br/>13,383 Embeddings<br/>Knowledge Vectors]
     end
 
-    subgraph "VM4 - AI Stack (172.16.168.24)"
+    subgraph "VM4 - AI Stack (<aiml-ip>)"
         AIOrchestrator[AI Model Orchestrator<br/>Port 8080<br/>Multi-Provider Support]
         ModelCache[Model Cache<br/>GPU Memory Management<br/>Inference Optimization]
     end
 
-    subgraph "VM5 - Browser Service (172.16.168.25)"
+    subgraph "VM5 - Browser Service (<browser-ip>)"
         Playwright[Playwright Automation<br/>Port 3000<br/>Multi-Browser Support]
         WebDrivers[Chrome + Firefox<br/>Headless/Headed Modes<br/>Screenshot + Interaction]
     end
@@ -70,7 +70,7 @@ graph TB
 
 ## Detailed Component Architecture
 
-### Main Host (WSL2) - 172.16.168.20
+### Main Host (WSL2) - <backend-ip>
 **Role**: Core API server, system integration, and desktop access
 
 **Specifications**:
@@ -99,7 +99,7 @@ backend/
 # Core Configuration
 BACKEND_HOST=0.0.0.0
 BACKEND_PORT=8001
-REDIS_HOST=172.16.168.23
+REDIS_HOST=<database-ip>
 OLLAMA_HOST=127.0.0.1
 
 # Multi-Modal AI Configuration
@@ -113,7 +113,7 @@ VNC_PASSWORD=autobot_secure
 DISPLAY=:99
 ```
 
-### VM1 - Frontend Service (172.16.168.21)
+### VM1 - Frontend Service (<frontend-ip>)
 **Role**: Modern web interface with real-time capabilities
 
 **Specifications**:
@@ -146,7 +146,7 @@ autobot-frontend/
 ```nginx
 server {
     listen 80;
-    server_name 172.16.168.21;
+    server_name <frontend-ip>;
 
     # Frontend static files
     location / {
@@ -156,7 +156,7 @@ server {
 
     # API proxy to main host
     location /api/ {
-        proxy_pass https://172.16.168.20:8443/api/;
+        proxy_pass https://<backend-ip>:8443/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -166,7 +166,7 @@ server {
 
     # WebSocket proxy
     location /ws/ {
-        proxy_pass https://172.16.168.20:8443/ws/;
+        proxy_pass https://<backend-ip>:8443/ws/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
@@ -174,7 +174,7 @@ server {
 }
 ```
 
-### VM2 - NPU Worker (172.16.168.22)  
+### VM2 - NPU Worker (<npu-ip>)  
 **Role**: Hardware-accelerated AI processing and computer vision
 
 **Specifications**:
@@ -224,7 +224,7 @@ models:
     fallback: "sentence_transformer_gpu.onnx"
 ```
 
-### VM3 - Redis Stack (172.16.168.23)
+### VM3 - Redis Stack (<database-ip>)
 **Role**: Centralized data persistence and caching
 
 **Specifications**:
@@ -285,7 +285,7 @@ loadmodule /opt/redis-stack/lib/redisearch.so
 loadmodule /opt/redis-stack/lib/rejson.so
 ```
 
-### VM4 - AI Stack (172.16.168.24)
+### VM4 - AI Stack (<aiml-ip>)
 **Role**: Multi-provider AI model orchestration and inference
 
 **Specifications**:
@@ -343,7 +343,7 @@ providers:
 
   ollama:
     enabled: true
-    base_url: "http://172.16.168.20:11434"
+    base_url: "http://<backend-ip>:11434"
     models: ["tinyllama", "phi", "llama2", "codellama"]
     health_check_interval: 30
 
@@ -359,7 +359,7 @@ routing_rules:
     model: "claude-3-opus-20240229"
 ```
 
-### VM5 - Browser Service (172.16.168.25)
+### VM5 - Browser Service (<browser-ip>)
 **Role**: Web automation and browser-based task execution
 
 **Specifications**:
@@ -426,31 +426,31 @@ GET /api/sessions/{session_id}/screenshot
 
 ### Network Topology
 ```
-Physical Host (172.16.168.20)
-├── Frontend VM (172.16.168.21)     # DMZ - Public facing
-├── NPU Worker (172.16.168.22)      # Compute tier - Internal only  
-├── Redis Stack (172.16.168.23)     # Data tier - Internal only
-├── AI Stack (172.16.168.24)        # Service tier - Internal only
-└── Browser Service (172.16.168.25) # Automation tier - Controlled access
+Physical Host (<backend-ip>)
+├── Frontend VM (<frontend-ip>)     # DMZ - Public facing
+├── NPU Worker (<npu-ip>)      # Compute tier - Internal only  
+├── Redis Stack (<database-ip>)     # Data tier - Internal only
+├── AI Stack (<aiml-ip>)        # Service tier - Internal only
+└── Browser Service (<browser-ip>) # Automation tier - Controlled access
 ```
 
 **Firewall Rules**:
 ```bash
 # External access (from internet)
-ALLOW 172.16.168.21:80,443         # Frontend web interface
-ALLOW 172.16.168.20:6080           # VNC desktop (admin only)
+ALLOW <frontend-ip>:80,443         # Frontend web interface
+ALLOW <backend-ip>:6080           # VNC desktop (admin only)
 
 # Inter-service communication (internal network)  
-ALLOW 172.16.168.20 -> 172.16.168.21:5173    # Backend to Frontend
-ALLOW 172.16.168.20 -> 172.16.168.22:8081    # Backend to NPU
-ALLOW 172.16.168.20 -> 172.16.168.23:6379    # Backend to Redis
-ALLOW 172.16.168.20 -> 172.16.168.24:8080    # Backend to AI Stack  
-ALLOW 172.16.168.20 -> 172.16.168.25:3000    # Backend to Browser
+ALLOW <backend-ip> -> <frontend-ip>:5173    # Backend to Frontend
+ALLOW <backend-ip> -> <npu-ip>:8081    # Backend to NPU
+ALLOW <backend-ip> -> <database-ip>:6379    # Backend to Redis
+ALLOW <backend-ip> -> <aiml-ip>:8080    # Backend to AI Stack  
+ALLOW <backend-ip> -> <browser-ip>:3000    # Backend to Browser
 
 # Service-to-service communication
-ALLOW 172.16.168.22 -> 172.16.168.23:6379    # NPU to Redis
-ALLOW 172.16.168.24 -> 172.16.168.23:6379    # AI Stack to Redis
-ALLOW 172.16.168.25 -> 172.16.168.23:6379    # Browser to Redis
+ALLOW <npu-ip> -> <database-ip>:6379    # NPU to Redis
+ALLOW <aiml-ip> -> <database-ip>:6379    # AI Stack to Redis
+ALLOW <browser-ip> -> <database-ip>:6379    # Browser to Redis
 
 # Deny all other traffic
 DENY ALL OTHER
@@ -559,29 +559,29 @@ sudo systemctl enable autobot-browser.service
 # Comprehensive health check system
 health_checks = {
     "main_host": {
-        "backend_api": "https://172.16.168.20:8443/api/health",
+        "backend_api": "https://<backend-ip>:8443/api/health",
         "ollama_service": "http://127.0.0.1:11434/api/tags",
         "vnc_desktop": "tcp://127.0.0.1:5900"
     },
     "vm1_frontend": {
-        "nginx": "http://172.16.168.21:80/health",
-        "vue_dev": "http://172.16.168.21:5173"
+        "nginx": "http://<frontend-ip>:80/health",
+        "vue_dev": "http://<frontend-ip>:5173"
     },
     "vm2_npu": {
-        "npu_service": "http://172.16.168.22:8081/health",
+        "npu_service": "http://<npu-ip>:8081/health",
         "gpu_status": "nvidia-smi"
     },
     "vm3_redis": {
-        "redis_server": "tcp://172.16.168.23:6379",
-        "redisinsight": "http://172.16.168.23:8002"
+        "redis_server": "tcp://<database-ip>:6379",
+        "redisinsight": "http://<database-ip>:8002"
     },
     "vm4_ai": {
-        "orchestrator": "http://172.16.168.24:8080/health",
-        "model_status": "http://172.16.168.24:8080/models/status"
+        "orchestrator": "http://<aiml-ip>:8080/health",
+        "model_status": "http://<aiml-ip>:8080/models/status"
     },
     "vm5_browser": {
-        "playwright": "http://172.16.168.25:3000/health",
-        "browser_pools": "http://172.16.168.25:3000/sessions/stats"
+        "playwright": "http://<browser-ip>:3000/health",
+        "browser_pools": "http://<browser-ip>:3000/sessions/stats"
     }
 }
 ```
@@ -753,11 +753,11 @@ python3 scripts/health_check_all_vms.py
 
 # 2. Update knowledge base indices  
 echo "Optimizing knowledge base..."
-curl -X POST https://172.16.168.20:8443/api/knowledge_base/optimize
+curl -X POST https://<backend-ip>:8443/api/knowledge_base/optimize
 
 # 3. Clear expired cache entries
 echo "Cleaning Redis cache..."
-redis-cli -h 172.16.168.23 -p 6379 FLUSHDB 3
+redis-cli -h <database-ip> -p 6379 FLUSHDB 3
 
 # 4. Rotate logs
 echo "Rotating logs..."
@@ -784,7 +784,7 @@ echo "Maintenance completed successfully"
 - [Troubleshooting Guide](../troubleshooting/COMPREHENSIVE_TROUBLESHOOTING.md)
 
 **Support & Monitoring**:
-- System Health Dashboard: `http://172.16.168.21/health`
-- Redis Insight: `http://172.16.168.23:8002`
+- System Health Dashboard: `http://<frontend-ip>/health`
+- Redis Insight: `http://<database-ip>:8002`
 - VNC Desktop Access: `http://127.0.0.1:6080`
-- API Documentation: `https://172.16.168.20:8443/docs`
+- API Documentation: `https://<backend-ip>:8443/docs`

--- a/docs/architecture/MEMORY_GRAPH_CHAT_INTEGRATION.md
+++ b/docs/architecture/MEMORY_GRAPH_CHAT_INTEGRATION.md
@@ -376,7 +376,7 @@ Entity not found, creating new entity for session: {session_id}
 
 **Symptom**: Warning logged during session creation
 **Solution**:
-1. Check Redis connection (VM3: 172.16.168.23:6379)
+1. Check Redis connection (VM3: <database-ip>:6379)
 2. Verify Redis DB 9 is accessible
 3. Check logs for specific initialization error
 4. System continues with JSON files only

--- a/docs/architecture/MONITORING_ARCHITECTURE.md
+++ b/docs/architecture/MONITORING_ARCHITECTURE.md
@@ -25,7 +25,7 @@ AutoBot uses a unified Prometheus/Grafana monitoring stack for comprehensive obs
 +--------+-----------------------+-----------------------+---------+
 |                                                                   |
 |                         Prometheus                                |
-|                         (VM3: 172.16.168.23:9090)                |
+|                         (VM3: <database-ip>:9090)                |
 |                                                                   |
 |   - Scrapes all /metrics endpoints every 15s                    |
 |   - Stores time-series data (30 day retention)                  |
@@ -76,7 +76,7 @@ Location: `src/monitoring/`
 
 ### 2. Prometheus Server
 
-**Location**: VM3 (172.16.168.23:9090)
+**Location**: VM3 (<database-ip>:9090)
 
 **Configuration**: `config/prometheus/prometheus.yml`
 
@@ -88,12 +88,12 @@ global:
 scrape_configs:
   - job_name: 'autobot-backend'
     static_configs:
-      - targets: ['172.16.168.20:8443']
+      - targets: ['<backend-ip>:8443']
     metrics_path: '/api/monitoring/metrics'
 
   - job_name: 'npu-worker'
     static_configs:
-      - targets: ['172.16.168.22:8081']
+      - targets: ['<npu-ip>:8081']
     metrics_path: '/metrics'
 ```
 
@@ -101,7 +101,7 @@ scrape_configs:
 
 ### 3. Grafana Dashboards
 
-**Location**: VM3 (172.16.168.23:3000)
+**Location**: VM3 (<database-ip>:3000)
 
 **Datasource UID**: `PBFA97CFB590B2093`
 
@@ -386,17 +386,17 @@ type DashboardType =
 
 1. Check backend metrics endpoint:
    ```bash
-   curl https://172.16.168.20:8443/api/monitoring/metrics | head
+   curl https://<backend-ip>:8443/api/monitoring/metrics | head
    ```
 
 2. Check Prometheus targets:
    ```bash
-   curl http://172.16.168.23:9090/api/v1/targets | jq '.data.activeTargets'
+   curl http://<database-ip>:9090/api/v1/targets | jq '.data.activeTargets'
    ```
 
 3. Verify Grafana datasource:
    ```bash
-   curl http://172.16.168.23:3000/api/datasources
+   curl http://<database-ip>:3000/api/datasources
    ```
 
 ### Missing New Metrics
@@ -405,7 +405,7 @@ After adding new metrics recorders:
 
 1. Restart backend to register new metrics
 2. Wait 15 seconds for Prometheus scrape
-3. Verify in Prometheus: `http://172.16.168.23:9090/graph`
+3. Verify in Prometheus: `http://<database-ip>:9090/graph`
 4. Refresh Grafana dashboard
 
 ### High Cardinality Warnings

--- a/docs/architecture/NETWORK_TOPOLOGY.md
+++ b/docs/architecture/NETWORK_TOPOLOGY.md
@@ -1,7 +1,7 @@
 # AutoBot Network Topology
 
 > **Status:** Active — defined in Phase 1-2 of [#926](https://github.com/mrveiss/AutoBot-AI/issues/926)
-> **Subnet:** `172.16.168.0/24` (all fleet nodes)
+> **Subnet:** `<network-subnet>` (all fleet nodes)
 
 ---
 
@@ -9,16 +9,16 @@
 
 | Node | IP | OS | Roles |
 |------|----|----|-------|
-| SLM Server | `172.16.168.19` | Ubuntu 22.04 | slm-backend, slm-frontend, slm-database, monitoring, slm-agent |
-| Backend (WSL) | `172.16.168.20` | Kali Rolling | backend, ollama, slm-agent |
-| Frontend VM | `172.16.168.21` | Ubuntu 22.04 | frontend, slm-agent |
-| NPU VM | `172.16.168.22` | Ubuntu 22.04 | npu-worker, slm-agent |
-| Database VM | `172.16.168.23` | Ubuntu 22.04 | database, slm-agent |
-| AI Stack VM | `172.16.168.24` | Ubuntu 22.04 | ai-stack, slm-agent |
-| Browser VM | `172.16.168.25` | Ubuntu 22.04 | browser-worker, slm-agent |
-| Reserved (.26) | `172.16.168.26` | Ubuntu 22.04 | slm-agent |
-| Reserved (.27) | `172.16.168.27` | Ubuntu 22.04 | slm-agent |
-| Dev Machine | `172.16.168.20` ¹ | Kali Rolling (WSL2) | git, Ansible control |
+| SLM Server | `<slm-manager-ip>` | Ubuntu 22.04 | slm-backend, slm-frontend, slm-database, monitoring, slm-agent |
+| Backend (WSL) | `<backend-ip>` | Kali Rolling | backend, ollama, slm-agent |
+| Frontend VM | `<frontend-ip>` | Ubuntu 22.04 | frontend, slm-agent |
+| NPU VM | `<npu-ip>` | Ubuntu 22.04 | npu-worker, slm-agent |
+| Database VM | `<database-ip>` | Ubuntu 22.04 | database, slm-agent |
+| AI Stack VM | `<aiml-ip>` | Ubuntu 22.04 | ai-stack, slm-agent |
+| Browser VM | `<browser-ip>` | Ubuntu 22.04 | browser-worker, slm-agent |
+| Reserved (.26) | `<reserved-ip>` | Ubuntu 22.04 | slm-agent |
+| Reserved (.27) | `<reserved-ip>` | Ubuntu 22.04 | slm-agent |
+| Dev Machine | `<backend-ip>` ¹ | Kali Rolling (WSL2) | git, Ansible control |
 
 ¹ Dev machine is the WSL2 host at `.20`. Backend also runs here.
 
@@ -135,13 +135,13 @@ All inter-service HTTPS uses internal CA-signed certs issued by `setup-internal-
 
 | Node | Cert Path | Subject CN | Signed By |
 |------|-----------|------------|-----------|
-| `.19` | `/etc/autobot/certs/autobot-slm-backend.crt` | `172.16.168.19` | AutoBot Internal CA |
-| `.20` | `/etc/autobot/certs/autobot-backend.crt` | `172.16.168.20` | AutoBot Internal CA |
-| `.21` | `/etc/autobot/certs/autobot-frontend.crt` | `172.16.168.21` | AutoBot Internal CA |
-| `.22` | `/etc/autobot/certs/autobot-npu-worker.crt` | `172.16.168.22` | AutoBot Internal CA |
-| `.23` | `/etc/autobot/certs/autobot-database.crt` | `172.16.168.23` | AutoBot Internal CA |
-| `.24` | `/etc/autobot/certs/autobot-ai-stack.crt` | `172.16.168.24` | AutoBot Internal CA |
-| `.25` | `/etc/autobot/certs/autobot-browser-worker.crt` | `172.16.168.25` | AutoBot Internal CA |
+| `.19` | `/etc/autobot/certs/autobot-slm-backend.crt` | `<slm-manager-ip>` | AutoBot Internal CA |
+| `.20` | `/etc/autobot/certs/autobot-backend.crt` | `<backend-ip>` | AutoBot Internal CA |
+| `.21` | `/etc/autobot/certs/autobot-frontend.crt` | `<frontend-ip>` | AutoBot Internal CA |
+| `.22` | `/etc/autobot/certs/autobot-npu-worker.crt` | `<npu-ip>` | AutoBot Internal CA |
+| `.23` | `/etc/autobot/certs/autobot-database.crt` | `<database-ip>` | AutoBot Internal CA |
+| `.24` | `/etc/autobot/certs/autobot-ai-stack.crt` | `<aiml-ip>` | AutoBot Internal CA |
+| `.25` | `/etc/autobot/certs/autobot-browser-worker.crt` | `<browser-ip>` | AutoBot Internal CA |
 
 CA root cert: `/etc/autobot/ca/ca-cert.pem` on `.19`.
 All nodes receive the CA cert at `/etc/autobot/certs/ca-cert.pem`.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -22,25 +22,25 @@ AutoBot is an AI-powered automation platform built on a distributed 6-VM archite
 
 ```mermaid
 graph TB
-    User[User Browser] --> Frontend[VM1: Frontend<br/>172.16.168.21:5173]
-    Frontend --> Backend[Main: Backend API<br/>172.16.168.20:8443]
-    Backend --> Redis[VM3: Redis Stack<br/>172.16.168.23:6379]
-    Backend --> AI[VM4: AI Stack<br/>172.16.168.24:8080]
-    Backend --> NPU[VM2: NPU Worker<br/>172.16.168.22:8081]
-    Backend --> Browser[VM5: Browser Automation<br/>172.16.168.25:3000]
-    Backend --> Desktop[Main: VNC Desktop<br/>172.16.168.20:6080]
+    User[User Browser] --> Frontend[VM1: Frontend<br/><frontend-ip>:5173]
+    Frontend --> Backend[Main: Backend API<br/><backend-ip>:8443]
+    Backend --> Redis[VM3: Redis Stack<br/><database-ip>:6379]
+    Backend --> AI[VM4: AI Stack<br/><aiml-ip>:8080]
+    Backend --> NPU[VM2: NPU Worker<br/><npu-ip>:8081]
+    Backend --> Browser[VM5: Browser Automation<br/><browser-ip>:3000]
+    Backend --> Desktop[Main: VNC Desktop<br/><backend-ip>:6080]
 ```
 
 ### Service Responsibilities
 
 | VM | IP Address | Services | Purpose |
 |----|------------|----------|---------|
-| **Main (WSL)** | 172.16.168.20 | Backend API (8001), VNC (6080) | Core API, desktop automation |
-| **VM1 Frontend** | 172.16.168.21 | Vite (5173) | Web interface (single source) |
-| **VM2 NPU Worker** | 172.16.168.22 | NPU API (8081) | Hardware-accelerated AI |
-| **VM3 Redis** | 172.16.168.23 | Redis Stack (6379) | Data persistence, caching |
-| **VM4 AI Stack** | 172.16.168.24 | Ollama (8080) | LLM inference, embeddings |
-| **VM5 Browser** | 172.16.168.25 | Playwright (3000) | Web automation |
+| **Main (WSL)** | <backend-ip> | Backend API (8001), VNC (6080) | Core API, desktop automation |
+| **VM1 Frontend** | <frontend-ip> | Vite (5173) | Web interface (single source) |
+| **VM2 NPU Worker** | <npu-ip> | NPU API (8081) | Hardware-accelerated AI |
+| **VM3 Redis** | <database-ip> | Redis Stack (6379) | Data persistence, caching |
+| **VM4 AI Stack** | <aiml-ip> | Ollama (8080) | LLM inference, embeddings |
+| **VM5 Browser** | <browser-ip> | Playwright (3000) | Web automation |
 
 ---
 
@@ -137,13 +137,13 @@ Key architectural decisions are documented in ADRs. See [docs/adr/](../adr/READM
 curl http://localhost:8001/api/health
 
 # Frontend
-curl http://172.16.168.21:5173
+curl http://<frontend-ip>:5173
 
 # Redis
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 
 # Ollama
-curl http://172.16.168.24:8080/api/tags
+curl http://<aiml-ip>:8080/api/tags
 ```
 
 ### Key Configuration Files

--- a/docs/architecture/REDIS_SERVICE_MANAGEMENT_ARCHITECTURE.md
+++ b/docs/architecture/REDIS_SERVICE_MANAGEMENT_ARCHITECTURE.md
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-This document defines the architecture for Redis service management features in AutoBot's distributed VM infrastructure. The design enables frontend UI controls and backend auto-detection/auto-start capabilities for the Redis service running on VM3 (172.16.168.23), while maintaining security, auditability, and alignment with AutoBot's "No Temporary Fixes" policy.
+This document defines the architecture for Redis service management features in AutoBot's distributed VM infrastructure. The design enables frontend UI controls and backend auto-detection/auto-start capabilities for the Redis service running on VM3 (<database-ip>), while maintaining security, auditability, and alignment with AutoBot's "No Temporary Fixes" policy.
 
 ---
 
@@ -33,7 +33,7 @@ This document defines the architecture for Redis service management features in 
 ### 1.1 Current State
 
 **Infrastructure:**
-- Redis service runs on VM3 (172.16.168.23:6379)
+- Redis service runs on VM3 (<database-ip>:6379)
 - SSH key-based authentication configured (~/.ssh/autobot_key)
 - Existing SSHManager handles remote command execution
 - ConsolidatedHealthService aggregates component health
@@ -70,7 +70,7 @@ This document defines the architecture for Redis service management features in 
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                         Frontend (VM1: 172.16.168.21)               │
+│                         Frontend (VM1: <frontend-ip>)               │
 │  ┌───────────────────────────────────────────────────────────────┐  │
 │  │  RedisServiceControl.vue                                      │  │
 │  │  - Service status display                                     │  │
@@ -84,7 +84,7 @@ This document defines the architecture for Redis service management features in 
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│                    Backend API (Main: 172.16.168.20:8443)           │
+│                    Backend API (Main: <backend-ip>:8443)           │
 │  ┌───────────────────────────────────────────────────────────────┐  │
 │  │  /api/services/redis (ServiceManagementRouter)                │  │
 │  │  ┌─────────────────────────────────────────────────────────┐  │  │
@@ -122,7 +122,7 @@ This document defines the architecture for Redis service management features in 
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│                    Redis VM (VM3: 172.16.168.23)                    │
+│                    Redis VM (VM3: <database-ip>)                    │
 │  ┌───────────────────────────────────────────────────────────────┐  │
 │  │  systemd (redis-server.service)                               │  │
 │  │  ┌─────────────────────────────────────────────────────────┐  │  │
@@ -133,7 +133,7 @@ This document defines the architecture for Redis service management features in 
 │  │  └─────────────────────────────────────────────────────────┘  │  │
 │  └───────────────────────────────────────────────────────────────┘  │
 │                                                                       │
-│  Redis Process: 172.16.168.23:6379                                   │
+│  Redis Process: <database-ip>:6379                                   │
 └─────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -683,7 +683,7 @@ async def auto_recover(self) -> RecoveryResult:
   "commands_processed": 1000000,
   "last_check": "2025-10-10T14:30:00Z",
   "vm_info": {
-    "host": "172.16.168.23",
+    "host": "<database-ip>",
     "name": "Redis VM",
     "ssh_accessible": true
   }
@@ -700,7 +700,7 @@ async def auto_recover(self) -> RecoveryResult:
   "connections": null,
   "last_check": "2025-10-10T14:30:00Z",
   "vm_info": {
-    "host": "172.16.168.23",
+    "host": "<database-ip>",
     "name": "Redis VM",
     "ssh_accessible": true
   }
@@ -880,7 +880,7 @@ async def auto_recover(self) -> RecoveryResult:
   ],
   "total_lines": 50,
   "service": "redis-server",
-  "vm": "172.16.168.23"
+  "vm": "<database-ip>"
 }
 ```
 
@@ -888,7 +888,7 @@ async def auto_recover(self) -> RecoveryResult:
 
 ### 4.2 WebSocket Real-Time Updates
 
-**Endpoint:** `wss://172.16.168.20:8443/ws/services/redis/status`
+**Endpoint:** `wss://<backend-ip>:8443/ws/services/redis/status`
 
 **Authentication:** Required (token in URL or header)
 
@@ -1651,7 +1651,7 @@ autobot ALL=(ALL) NOPASSWD: /bin/journalctl -u redis-server *
     "email": "admin@autobot.local",
     "role": "admin"
   },
-  "source_ip": "172.16.168.20",
+  "source_ip": "<backend-ip>",
   "result": {
     "success": true,
     "duration_seconds": 15.7,
@@ -2323,7 +2323,7 @@ async def test_full_restart_flow(client: AsyncClient, admin_token: str):
 ```javascript
 test('Admin can restart Redis service from UI', async ({ page }) => {
   // Login as admin
-  await page.goto('http://172.16.168.21:5173/login');
+  await page.goto('http://<frontend-ip>:5173/login');
   await page.fill('[name="email"]', 'admin@autobot.local');
   await page.fill('[name="password"]', 'admin-password');
   await page.click('button[type="submit"]');
@@ -2372,7 +2372,7 @@ from httpx import AsyncClient
 async def load_test_status_endpoint(duration_seconds: int = 60):
     """Load test status endpoint for sustained period"""
 
-    client = AsyncClient(base_url="https://172.16.168.20:8443")
+    client = AsyncClient(base_url="https://<backend-ip>:8443")
 
     request_count = 0
     error_count = 0
@@ -2430,7 +2430,7 @@ redis_service_management:
     name: "redis-server"
     systemd_unit: "redis-server.service"
     host: "redis"  # Reference to SSH host config
-    ip: "172.16.168.23"
+    ip: "<database-ip>"
     port: 6379
 
   # Health Monitoring
@@ -2443,7 +2443,7 @@ redis_service_management:
     checks:
       connectivity:
         enabled: true
-        command: "redis-cli -h 172.16.168.23 PING"
+        command: "redis-cli -h <database-ip> PING"
         expected_output: "PONG"
 
       systemd:

--- a/docs/architecture/ROLE_ARCHITECTURE.md
+++ b/docs/architecture/ROLE_ARCHITECTURE.md
@@ -22,17 +22,17 @@ The `manifest.yml` in each infrastructure directory is the **single source of tr
 
 | Role | Directory | Target Node | IP |
 |------|-----------|-------------|-----|
-| `autobot-backend` | `autobot-backend/` | backend (.20) | 172.16.168.20 |
-| `autobot-frontend` | `autobot-frontend/` | frontend (.21) | 172.16.168.21 |
-| `autobot-ollama` | `autobot-ollama/` | backend (.20) | 172.16.168.20 |
-| `autobot-slm-backend` | `autobot-slm-backend/` | slm (.19) | 172.16.168.19 |
-| `autobot-slm-frontend` | `autobot-slm-frontend/` | slm (.19) | 172.16.168.19 |
-| `autobot-slm-database` | `autobot-slm-database/` | slm (.19) | 172.16.168.19 |
-| `autobot-monitoring` | `autobot-monitoring/` | slm (.19) | 172.16.168.19 |
-| `autobot-npu-worker` | `autobot-npu-worker/` | npu (.22) | 172.16.168.22 |
-| `autobot-browser-worker` | `autobot-browser-worker/` | browser (.25) | 172.16.168.25 |
-| `autobot-ai-stack` | `autobot-ai-stack/` | ai-stack (.24) | 172.16.168.24 |
-| `autobot-database` | `autobot-database/` | database (.23) | 172.16.168.23 |
+| `autobot-backend` | `autobot-backend/` | backend (.20) | <backend-ip> |
+| `autobot-frontend` | `autobot-frontend/` | frontend (.21) | <frontend-ip> |
+| `autobot-ollama` | `autobot-ollama/` | backend (.20) | <backend-ip> |
+| `autobot-slm-backend` | `autobot-slm-backend/` | slm (.19) | <slm-manager-ip> |
+| `autobot-slm-frontend` | `autobot-slm-frontend/` | slm (.19) | <slm-manager-ip> |
+| `autobot-slm-database` | `autobot-slm-database/` | slm (.19) | <slm-manager-ip> |
+| `autobot-monitoring` | `autobot-monitoring/` | slm (.19) | <slm-manager-ip> |
+| `autobot-npu-worker` | `autobot-npu-worker/` | npu (.22) | <npu-ip> |
+| `autobot-browser-worker` | `autobot-browser-worker/` | browser (.25) | <browser-ip> |
+| `autobot-ai-stack` | `autobot-ai-stack/` | ai-stack (.24) | <aiml-ip> |
+| `autobot-database` | `autobot-database/` | database (.23) | <database-ip> |
 | `autobot-slm-agent` | `autobot-slm-agent/` | **all nodes** | all |
 | `autobot_shared` | `autobot_shared/` | all backend nodes | all |
 
@@ -44,15 +44,15 @@ Each node gets **only** its assigned role directories + `autobot_shared/` + `aut
 
 | Node | IP | Roles |
 |------|----|-------|
-| SLM (.19) | 172.16.168.19 | slm-backend + slm-frontend + slm-database + monitoring + slm-agent |
-| Backend (.20) | 172.16.168.20 | backend + ollama + slm-agent |
-| Frontend (.21) | 172.16.168.21 | frontend + slm-agent |
-| NPU (.22) | 172.16.168.22 | npu-worker + slm-agent |
-| Database (.23) | 172.16.168.23 | database + slm-agent |
-| AI Stack (.24) | 172.16.168.24 | ai-stack + slm-agent |
-| Browser (.25) | 172.16.168.25 | browser-worker + slm-agent |
-| Reserved (.26) | 172.16.168.26 | slm-agent |
-| Reserved (.27) | 172.16.168.27 | slm-agent |
+| SLM (.19) | <slm-manager-ip> | slm-backend + slm-frontend + slm-database + monitoring + slm-agent |
+| Backend (.20) | <backend-ip> | backend + ollama + slm-agent |
+| Frontend (.21) | <frontend-ip> | frontend + slm-agent |
+| NPU (.22) | <npu-ip> | npu-worker + slm-agent |
+| Database (.23) | <database-ip> | database + slm-agent |
+| AI Stack (.24) | <aiml-ip> | ai-stack + slm-agent |
+| Browser (.25) | <browser-ip> | browser-worker + slm-agent |
+| Reserved (.26) | <reserved-ip> | slm-agent |
+| Reserved (.27) | <reserved-ip> | slm-agent |
 
 Expected `/opt/autobot/` content on each node:
 

--- a/docs/architecture/SSOT_CONFIGURATION_ARCHITECTURE.md
+++ b/docs/architecture/SSOT_CONFIGURATION_ARCHITECTURE.md
@@ -201,9 +201,9 @@ class AutoBotConfigSchema(BaseModel):
 ```
 Layer 1: .env (Required Configuration)
 -----------------------------------------
-AUTOBOT_MAIN_MACHINE_IP=172.16.168.20
-AUTOBOT_FRONTEND_VM_IP=172.16.168.21
-AUTOBOT_REDIS_VM_IP=172.16.168.23
+AUTOBOT_MAIN_MACHINE_IP=<backend-ip>
+AUTOBOT_FRONTEND_VM_IP=<frontend-ip>
+AUTOBOT_REDIS_VM_IP=<database-ip>
 AUTOBOT_BACKEND_PORT=8001
 AUTOBOT_DEFAULT_LLM_MODEL=qwen3.5:9b
 
@@ -279,22 +279,22 @@ The canonical `.env` structure with all configuration values:
 # -----------------------------------------------------------------------------
 
 # Main Machine (WSL) - Backend API + VNC Desktop
-AUTOBOT_VM_MAIN_IP=172.16.168.20
+AUTOBOT_VM_MAIN_IP=<backend-ip>
 
 # VM1 Frontend - Web interface (SINGLE FRONTEND SERVER)
-AUTOBOT_VM_FRONTEND_IP=172.16.168.21
+AUTOBOT_VM_FRONTEND_IP=<frontend-ip>
 
 # VM2 NPU Worker - Hardware AI acceleration
-AUTOBOT_VM_NPU_IP=172.16.168.22
+AUTOBOT_VM_NPU_IP=<npu-ip>
 
 # VM3 Redis - Data layer
-AUTOBOT_VM_REDIS_IP=172.16.168.23
+AUTOBOT_VM_REDIS_IP=<database-ip>
 
 # VM4 AI Stack - AI processing
-AUTOBOT_VM_AISTACK_IP=172.16.168.24
+AUTOBOT_VM_AISTACK_IP=<aiml-ip>
 
 # VM5 Browser - Web automation (Playwright)
-AUTOBOT_VM_BROWSER_IP=172.16.168.25
+AUTOBOT_VM_BROWSER_IP=<browser-ip>
 
 # -----------------------------------------------------------------------------
 # SERVICE PORTS
@@ -389,12 +389,12 @@ from pydantic_settings import BaseSettings
 
 class VMConfig(BaseSettings):
     """VM IP addresses"""
-    main: str = Field(alias="AUTOBOT_VM_MAIN_IP", default="172.16.168.20")
-    frontend: str = Field(alias="AUTOBOT_VM_FRONTEND_IP", default="172.16.168.21")
-    npu: str = Field(alias="AUTOBOT_VM_NPU_IP", default="172.16.168.22")
-    redis: str = Field(alias="AUTOBOT_VM_REDIS_IP", default="172.16.168.23")
-    aistack: str = Field(alias="AUTOBOT_VM_AISTACK_IP", default="172.16.168.24")
-    browser: str = Field(alias="AUTOBOT_VM_BROWSER_IP", default="172.16.168.25")
+    main: str = Field(alias="AUTOBOT_VM_MAIN_IP", default="<backend-ip>")
+    frontend: str = Field(alias="AUTOBOT_VM_FRONTEND_IP", default="<frontend-ip>")
+    npu: str = Field(alias="AUTOBOT_VM_NPU_IP", default="<npu-ip>")
+    redis: str = Field(alias="AUTOBOT_VM_REDIS_IP", default="<database-ip>")
+    aistack: str = Field(alias="AUTOBOT_VM_AISTACK_IP", default="<aiml-ip>")
+    browser: str = Field(alias="AUTOBOT_VM_BROWSER_IP", default="<browser-ip>")
 
 
 class PortConfig(BaseSettings):
@@ -569,12 +569,12 @@ export function getConfig(): AutoBotConfig {
   if (_config) return _config;
 
   const vm: VMConfig = {
-    main: getEnv('VITE_VM_MAIN_IP', '172.16.168.20'),
-    frontend: getEnv('VITE_VM_FRONTEND_IP', '172.16.168.21'),
-    npu: getEnv('VITE_VM_NPU_IP', '172.16.168.22'),
-    redis: getEnv('VITE_VM_REDIS_IP', '172.16.168.23'),
-    aistack: getEnv('VITE_VM_AISTACK_IP', '172.16.168.24'),
-    browser: getEnv('VITE_VM_BROWSER_IP', '172.16.168.25'),
+    main: getEnv('VITE_VM_MAIN_IP', '<backend-ip>'),
+    frontend: getEnv('VITE_VM_FRONTEND_IP', '<frontend-ip>'),
+    npu: getEnv('VITE_VM_NPU_IP', '<npu-ip>'),
+    redis: getEnv('VITE_VM_REDIS_IP', '<database-ip>'),
+    aistack: getEnv('VITE_VM_AISTACK_IP', '<aiml-ip>'),
+    browser: getEnv('VITE_VM_BROWSER_IP', '<browser-ip>'),
   };
 
   const port: PortConfig = {

--- a/docs/architecture/TERMINAL_ARCHITECTURE_DISTRIBUTED.md
+++ b/docs/architecture/TERMINAL_ARCHITECTURE_DISTRIBUTED.md
@@ -3,10 +3,10 @@
 ## Current Architecture (Co-located with Backend)
 
 ### Overview
-Currently, the terminal functionality runs on the main machine (`172.16.168.20`) alongside the backend API. This provides optimal performance and minimal latency for terminal operations.
+Currently, the terminal functionality runs on the main machine (`<backend-ip>`) alongside the backend API. This provides optimal performance and minimal latency for terminal operations.
 
 ### Current Setup
-- **Location**: Main machine (WSL) at `172.16.168.20`
+- **Location**: Main machine (WSL) at `<backend-ip>`
 - **Backend API**: Port 8001
 - **Terminal Endpoints**: `/api/terminal/*`
 - **WebSocket Endpoints**: `/ws/terminal/*`, `/ws/simple/*`, `/ws/secure/*`
@@ -65,14 +65,14 @@ POST   /api/terminal/{id}/control/return # Return to agent
 ### Proposed Distributed Architecture
 
 ```
-Main Backend Machine (172.16.168.20)
+Main Backend Machine (<backend-ip>)
 ├── FastAPI Backend (Port 8001)
 ├── Terminal Proxy API
 └── WebSocket Proxy
 
 ↓ Network Communication ↓
 
-Terminal Machine (172.16.168.26) [Future]
+Terminal Machine (<reserved-ip>) [Future]
 ├── Terminal Service (Port 8002)
 ├── PTY Manager
 ├── Security Auditor
@@ -128,7 +128,7 @@ WS     /api/terminal/ws/{id}          # WebSocket proxy
 terminal:
   mode: "local"  # or "remote"
   remote:
-    host: "172.16.168.26"
+    host: "<reserved-ip>"
     port: 8002
     auth:
       method: "ssh_key"
@@ -200,7 +200,7 @@ async def terminal_websocket_proxy(websocket: WebSocket, session_id: str):
 ```bash
 # Terminal configuration
 AUTOBOT_TERMINAL_MODE=remote
-AUTOBOT_TERMINAL_HOST=172.16.168.26
+AUTOBOT_TERMINAL_HOST=<reserved-ip>
 AUTOBOT_TERMINAL_PORT=8002
 AUTOBOT_TERMINAL_AUTH_KEY=/home/autobot/.ssh/terminal_key
 ```
@@ -245,7 +245,7 @@ class TerminalServiceDiscovery:
 ```python
 @pytest.mark.asyncio
 async def test_remote_terminal_command_execution():
-    client = RemoteTerminalClient("172.16.168.26:8002")
+    client = RemoteTerminalClient("<reserved-ip>:8002")
     session = await client.create_session()
     result = await client.execute_command(session.id, "pwd")
     assert result.exit_code == 0

--- a/docs/architecture/TERMINAL_INTEGRATION_ARCHITECTURE_VALIDATION.md
+++ b/docs/architecture/TERMINAL_INTEGRATION_ARCHITECTURE_VALIDATION.md
@@ -25,7 +25,7 @@ This document provides a comprehensive validation of the terminal integration ar
 
 ### 1.1 Existing Components
 
-#### Frontend Layer (`172.16.168.21`)
+#### Frontend Layer (`<frontend-ip>`)
 ```
 ┌─────────────────────────────────────────────────────────┐
 │  Terminal.vue (Custom Rendering)                        │
@@ -46,7 +46,7 @@ This document provides a comprehensive validation of the terminal integration ar
 │  │ • Session management (create/connect/close)      │   │
 │  └─────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────┘
-                           ▼ WebSocket (wss://172.16.168.20:8443)
+                           ▼ WebSocket (wss://<backend-ip>:8443)
 ┌─────────────────────────────────────────────────────────┐
 │  Backend API (terminal.py) - Main Machine                │
 │  ┌─────────────────────────────────────────────────┐   │
@@ -223,7 +223,7 @@ async def get_session_audit_log(
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│  AutoBot Frontend (172.16.168.21)                                   │
+│  AutoBot Frontend (<frontend-ip>)                                   │
 │                                                                       │
 │  ┌────────────────────────────┐  ┌────────────────────────────┐   │
 │  │  Chat Terminal              │  │  Tools Terminal             │   │
@@ -251,7 +251,7 @@ async def get_session_audit_log(
 └───────────────────────────────┬─────────────────────────────────────┘
                                  ▼ WebSocket
 ┌─────────────────────────────────────────────────────────────────────┐
-│  Backend API (172.16.168.20:8443)                                   │
+│  Backend API (<backend-ip>:8443)                                   │
 │                                                                       │
 │  ┌─────────────────────────────────────────────────────────────┐   │
 │  │  EnhancedTerminalOrchestrator (NEW)                          │   │
@@ -275,7 +275,7 @@ async def get_session_audit_log(
                     ▼                           ▼
            ┌────────────────┐        ┌──────────────────────────┐
            │  Local PTY     │        │  SSH to Remote VMs       │
-           │  bash/zsh      │        │  (172.16.168.21-25)      │
+           │  bash/zsh      │        │  (<frontend-ip>-25)      │
            │  (Main VM)     │        └──────────────────────────┘
            └────────────────┘
 ```
@@ -332,7 +332,7 @@ interface ChatTerminalState {
 **Props:**
 ```typescript
 interface ToolsTerminalProps {
-  hostTarget: string;                // VM IP (172.16.168.20-25)
+  hostTarget: string;                // VM IP (<backend-ip>-25)
   sshConfig?: SSHConfig;             // SSH credentials and settings
   initialDirectory?: string;         // Starting working directory
   multiSession?: boolean;            // Allow multiple tabs
@@ -482,7 +482,7 @@ class EnhancedTerminalOrchestrator:
 **Features:**
 - **Connection Pooling**: Reuse SSH connections for performance
 - **PTY Forwarding**: Forward PTY over SSH for interactive sessions
-- **Host Selection**: Support all 5 VMs (172.16.168.20-25)
+- **Host Selection**: Support all 5 VMs (<backend-ip>-25)
 - **SSH Key Authentication**: Use autobot_key for passwordless access
 - **Error Recovery**: Reconnect on connection loss
 
@@ -497,11 +497,11 @@ class MultiMachineSSHAdapter:
         self.connections = {}  # host -> paramiko.SSHClient
         self.ssh_key_path = "$HOME/.ssh/autobot_key"
         self.host_mapping = {
-            "frontend": "172.16.168.21",
-            "npu-worker": "172.16.168.22",
-            "redis": "172.16.168.23",
-            "ai-stack": "172.16.168.24",
-            "browser": "172.16.168.25",
+            "frontend": "<frontend-ip>",
+            "npu-worker": "<npu-ip>",
+            "redis": "<database-ip>",
+            "ai-stack": "<aiml-ip>",
+            "browser": "<browser-ip>",
         }
 
     async def create_ssh_session(
@@ -555,11 +555,11 @@ class MultiMachineSSHAdapter:
 ### 3.1 SSH Integration Architecture
 
 **Target Machines:**
-- **VM1 Frontend** (`172.16.168.21`): Web interface operations
-- **VM2 NPU Worker** (`172.16.168.22`): AI hardware commands
-- **VM3 Redis** (`172.16.168.23`): Database operations
-- **VM4 AI Stack** (`172.16.168.24`): AI model operations
-- **VM5 Browser** (`172.16.168.25`): Browser automation
+- **VM1 Frontend** (`<frontend-ip>`): Web interface operations
+- **VM2 NPU Worker** (`<npu-ip>`): AI hardware commands
+- **VM3 Redis** (`<database-ip>`): Database operations
+- **VM4 AI Stack** (`<aiml-ip>`): AI model operations
+- **VM5 Browser** (`<browser-ip>`): Browser automation
 
 **SSH Connection Flow:**
 ```
@@ -575,7 +575,7 @@ class MultiMachineSSHAdapter:
          ▼ WebSocket message
 ┌──────────────────────────────────────────┐
 │  Backend: EnhancedTerminalOrchestrator   │
-│  route_to_ssh_adapter("172.16.168.24")   │
+│  route_to_ssh_adapter("<aiml-ip>")   │
 └────────┬─────────────────────────────────┘
          ▼
 ┌──────────────────────────────────────────┐
@@ -586,7 +586,7 @@ class MultiMachineSSHAdapter:
 └────────┬─────────────────────────────────┘
          ▼ SSH (port 22, key auth)
 ┌──────────────────────────────────────────┐
-│  Remote VM (172.16.168.24)                │
+│  Remote VM (<aiml-ip>)                │
 │  bash/zsh session as autobot user         │
 └───────────────────────────────────────────┘
 ```
@@ -600,11 +600,11 @@ class MultiMachineSSHAdapter:
     <label>Target Machine:</label>
     <select v-model="selectedHost" @change="switchHost">
       <option value="local">Main VM (Local)</option>
-      <option value="frontend">Frontend VM (172.16.168.21)</option>
-      <option value="npu-worker">NPU Worker (172.16.168.22)</option>
-      <option value="redis">Redis VM (172.16.168.23)</option>
-      <option value="ai-stack">AI Stack (172.16.168.24)</option>
-      <option value="browser">Browser VM (172.16.168.25)</option>
+      <option value="frontend">Frontend VM (<frontend-ip>)</option>
+      <option value="npu-worker">NPU Worker (<npu-ip>)</option>
+      <option value="redis">Redis VM (<database-ip>)</option>
+      <option value="ai-stack">AI Stack (<aiml-ip>)</option>
+      <option value="browser">Browser VM (<browser-ip>)</option>
     </select>
 
     <div class="connection-status">

--- a/docs/architecture/TIMEOUT_CONFIGURATION_PROMETHEUS_METRICS_DESIGN.md
+++ b/docs/architecture/TIMEOUT_CONFIGURATION_PROMETHEUS_METRICS_DESIGN.md
@@ -841,7 +841,7 @@ global:
 scrape_configs:
   - job_name: 'autobot-backend'
     static_configs:
-      - targets: ['172.16.168.20:8443']  # Main machine backend
+      - targets: ['<backend-ip>:8443']  # Main machine backend
         labels:
           service: 'autobot'
           component: 'backend'
@@ -854,7 +854,7 @@ scrape_configs:
 
   - job_name: 'redis-exporter'
     static_configs:
-      - targets: ['172.16.168.23:9121']  # Redis exporter (if deployed)
+      - targets: ['<database-ip>:9121']  # Redis exporter (if deployed)
         labels:
           service: 'redis'
           environment: 'production'
@@ -863,7 +863,7 @@ scrape_configs:
 alerting:
   alertmanagers:
     - static_configs:
-        - targets: ['172.16.168.20:9093']  # Alertmanager address
+        - targets: ['<backend-ip>:9093']  # Alertmanager address
 
 # Rule files for alerting
 rule_files:
@@ -1257,18 +1257,18 @@ async def test_metrics_collection_overhead():
 ### 4.3 Monitoring Dashboard Access
 
 **Prometheus:**
-- URL: `http://172.16.168.20:9090`
+- URL: `http://<backend-ip>:9090`
 - Query examples:
   - Timeout rate: `rate(autobot_timeout_total{status="timeout"}[5m])`
   - Circuit breaker state: `autobot_circuit_breaker_state`
 
 **Grafana:**
-- URL: `http://172.16.168.20:3001`
+- URL: `http://<backend-ip>:3001`
 - Default credentials: admin/admin
 - Dashboard: "AutoBot Timeout & Performance Monitoring"
 
 **Metrics Endpoint:**
-- URL: `https://172.16.168.20:8443/monitoring/metrics`
+- URL: `https://<backend-ip>:8443/monitoring/metrics`
 - Format: Prometheus text format
 - Refresh: Real-time
 
@@ -1312,13 +1312,13 @@ prom/alertmanager:latest  (optional)
 
 ### 5.3 Infrastructure Requirements
 
-**Main Machine (172.16.168.20):**
+**Main Machine (<backend-ip>):**
 - FastAPI backend with `/monitoring/metrics` endpoint
 - Prometheus server (port 9090)
 - Grafana server (port 3001)
 - Alertmanager (port 9093, optional)
 
-**Redis VM (172.16.168.23):**
+**Redis VM (<database-ip>):**
 - Redis server accessible for connection pool metrics
 - Optional: Redis exporter for native Redis metrics
 

--- a/docs/architecture/UPDATE_FLOWS.md
+++ b/docs/architecture/UPDATE_FLOWS.md
@@ -72,7 +72,7 @@ git push
 
 ```bash
 # scripts/hooks/slm-post-commit
-curl -sk -X POST https://172.16.168.19/api/code-source/notify \
+curl -sk -X POST https://<slm-manager-ip>/api/code-source/notify \
   -H "Authorization: Bearer ${SLM_API_TOKEN}" \
   -d '{"commit": "abc123", "changed_roles": ["autobot-backend"]}'
 ```

--- a/docs/architecture/VECTOR_STORE_MIGRATION.md
+++ b/docs/architecture/VECTOR_STORE_MIGRATION.md
@@ -320,7 +320,7 @@ for doc_id in sample_ids:
 
 ```bash
 # Remove vector data from Redis (keep cache/state)
-redis-cli -h 172.16.168.23 DEL llama_index:*
+redis-cli -h <database-ip> DEL llama_index:*
 
 # Verify Redis size reduced
 redis-cli INFO memory | grep used_memory_human

--- a/docs/architecture/data-flows.md
+++ b/docs/architecture/data-flows.md
@@ -15,12 +15,12 @@ flowchart TB
         Browser[Web Browser]
     end
 
-    subgraph Frontend["VM1: Frontend (172.16.168.21)"]
+    subgraph Frontend["VM1: Frontend (<frontend-ip>)"]
         Vue[Vue 3 Application]
         WS_Client[WebSocket Client]
     end
 
-    subgraph Backend["Main: Backend (172.16.168.20)"]
+    subgraph Backend["Main: Backend (<backend-ip>)"]
         API[FastAPI Server]
         WS_Server[WebSocket Server]
         Orchestrator[Enhanced Orchestrator]
@@ -28,19 +28,19 @@ flowchart TB
         KB_Manager[Knowledge Base Manager]
     end
 
-    subgraph Redis["VM3: Redis (172.16.168.23)"]
+    subgraph Redis["VM3: Redis (<database-ip>)"]
         DB0[(DB0: Main)]
         DB1[(DB1: Knowledge)]
         DB2[(DB2: Prompts)]
         DB3[(DB3: Analytics)]
     end
 
-    subgraph AI["VM4: AI Stack (172.16.168.24)"]
+    subgraph AI["VM4: AI Stack (<aiml-ip>)"]
         Ollama[Ollama Server]
         Models[LLM Models]
     end
 
-    subgraph NPU["VM2: NPU Worker (172.16.168.22)"]
+    subgraph NPU["VM2: NPU Worker (<npu-ip>)"]
         NPU_API[NPU API]
         OpenVINO[OpenVINO Runtime]
     end
@@ -269,7 +269,7 @@ flowchart LR
         Browser_Client[Browser Client]
     end
 
-    subgraph Browser_VM["VM5: Browser (172.16.168.25)"]
+    subgraph Browser_VM["VM5: Browser (<browser-ip>)"]
         Playwright[Playwright Server]
         Chromium[Chromium Browser]
         Context[Browser Context]
@@ -318,7 +318,7 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-    subgraph Main["Main Machine (172.16.168.20)"]
+    subgraph Main["Main Machine (<backend-ip>)"]
         Xvfb[Xvfb Display]
         x11vnc[x11vnc Server]
         noVNC[noVNC WebSocket]
@@ -354,7 +354,7 @@ flowchart LR
 
 ```mermaid
 flowchart TB
-    subgraph Redis["VM3: Redis Stack (172.16.168.23:6379)"]
+    subgraph Redis["VM3: Redis Stack (<database-ip>:6379)"]
         subgraph DB0["Database 0: Main"]
             Sessions[Sessions]
             Cache[API Cache]

--- a/docs/architecture/redis-schema.md
+++ b/docs/architecture/redis-schema.md
@@ -10,7 +10,7 @@ This document describes the data structures and key patterns used in AutoBot's R
 
 ## Database Overview
 
-AutoBot uses Redis Stack on VM3 (`172.16.168.23:6379`) with named database abstraction:
+AutoBot uses Redis Stack on VM3 (`<database-ip>:6379`) with named database abstraction:
 
 | Database | Name | Purpose | Key Count (Typical) |
 |----------|------|---------|---------------------|
@@ -388,33 +388,33 @@ redis.rpush("conversation:conv_001:messages", json.dumps(message))
 
 ```bash
 # Full backup
-redis-cli -h 172.16.168.23 BGSAVE
+redis-cli -h <database-ip> BGSAVE
 
 # Database-specific backup
-redis-cli -h 172.16.168.23 -n 1 --rdb knowledge_backup.rdb
+redis-cli -h <database-ip> -n 1 --rdb knowledge_backup.rdb
 ```
 
 ### Key Analysis
 
 ```bash
 # Count keys by pattern
-redis-cli -h 172.16.168.23 -n 0 KEYS "session:*" | wc -l
+redis-cli -h <database-ip> -n 0 KEYS "session:*" | wc -l
 
 # Memory usage
-redis-cli -h 172.16.168.23 INFO memory
+redis-cli -h <database-ip> INFO memory
 
 # Key distribution
-redis-cli -h 172.16.168.23 DBSIZE
+redis-cli -h <database-ip> DBSIZE
 ```
 
 ### Cleanup
 
 ```bash
 # Flush cache only (DB 0 cache keys)
-redis-cli -h 172.16.168.23 -n 0 KEYS "cache:*" | xargs redis-cli -h 172.16.168.23 -n 0 DEL
+redis-cli -h <database-ip> -n 0 KEYS "cache:*" | xargs redis-cli -h <database-ip> -n 0 DEL
 
 # Expire old analytics
-redis-cli -h 172.16.168.23 -n 3 KEYS "metrics:*:2024-*" | xargs redis-cli -h 172.16.168.23 -n 3 DEL
+redis-cli -h <database-ip> -n 3 KEYS "metrics:*:2024-*" | xargs redis-cli -h <database-ip> -n 3 DEL
 ```
 
 ---

--- a/docs/database/MEMORY_GRAPH_QUICK_REFERENCE.md
+++ b/docs/database/MEMORY_GRAPH_QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # Redis Memory Graph Quick Reference
 
-**Database:** DB 0 @ 172.16.168.23:6379
+**Database:** DB 0 @ <database-ip>:6379
 **Key Prefixes:** `memory:graph:entity:*`, `memory:graph:relations:*`
 **Indexes:** `memory_graph_entity_idx`, `memory_graph_fulltext_idx`
 
@@ -33,19 +33,19 @@ python scripts/utilities/init_memory_graph_redis.py --rollback
 
 ```bash
 # Count entities
-redis-cli -h 172.16.168.23 KEYS "memory:graph:entity:*" | wc -l
+redis-cli -h <database-ip> KEYS "memory:graph:entity:*" | wc -l
 
 # Count relations
-redis-cli -h 172.16.168.23 KEYS "memory:graph:relations:*" | wc -l
+redis-cli -h <database-ip> KEYS "memory:graph:relations:*" | wc -l
 
 # Index statistics
-redis-cli -h 172.16.168.23 FT.INFO memory_graph_entity_idx | grep -E "num_docs|num_records"
+redis-cli -h <database-ip> FT.INFO memory_graph_entity_idx | grep -E "num_docs|num_records"
 
 # Memory usage
-redis-cli -h 172.16.168.23 INFO memory | grep used_memory_human
+redis-cli -h <database-ip> INFO memory | grep used_memory_human
 
 # List all indexes
-redis-cli -h 172.16.168.23 FT._LIST
+redis-cli -h <database-ip> FT._LIST
 ```
 
 ---
@@ -56,21 +56,21 @@ redis-cli -h 172.16.168.23 FT._LIST
 
 ```bash
 # All conversations
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "@type:{conversation}" LIMIT 0 10
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "@type:{conversation}" LIMIT 0 10
 
 # All bug fixes
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "@type:{bug_fix}" LIMIT 0 10
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "@type:{bug_fix}" LIMIT 0 10
 ```
 
 ### By Status & Priority
 
 ```bash
 # Active high-priority items
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx \
   "@status:{active} @priority:{high}" LIMIT 0 10
 
 # Archived conversations
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx \
   "@type:{conversation} @status:{archived}" LIMIT 0 10
 ```
 
@@ -78,20 +78,20 @@ redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
 
 ```bash
 # Entities about Redis
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "@tags:{redis}" LIMIT 0 10
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "@tags:{redis}" LIMIT 0 10
 
 # Multiple tags (OR)
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "@tags:{redis|database}" LIMIT 0 10
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "@tags:{redis|database}" LIMIT 0 10
 ```
 
 ### Full-Text Search
 
 ```bash
 # Search in names and observations
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "memory graph optimization" LIMIT 0 10
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "memory graph optimization" LIMIT 0 10
 
 # Phonetic search (typo-tolerant)
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_fulltext_idx "performans" LIMIT 0 10
+redis-cli -h <database-ip> FT.SEARCH memory_graph_fulltext_idx "performans" LIMIT 0 10
 ```
 
 ### Date Range
@@ -99,13 +99,13 @@ redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_fulltext_idx "performans" LIMI
 ```bash
 # Last 7 days
 TIMESTAMP=$(date -d '7 days ago' +%s)000
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx \
   "@created_at:[$TIMESTAMP +inf]" SORTBY created_at DESC LIMIT 0 10
 
 # Specific date range
 START=1728000000000  # Unix timestamp ms
 END=1728086400000
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx \
   "@created_at:[$START $END]" LIMIT 0 10
 ```
 
@@ -113,10 +113,10 @@ redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
 
 ```bash
 # Count by type (fast)
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "@type:{conversation}" LIMIT 0 0
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "@type:{conversation}" LIMIT 0 0
 
 # Count active tasks
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx \
   "@type:{task} @status:{active}" LIMIT 0 0
 ```
 
@@ -130,7 +130,7 @@ redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
 import redis
 import time
 
-r = redis.Redis(host='172.16.168.23', port=6379, db=0)
+r = redis.Redis(host='<database-ip>', port=6379, db=0)
 
 entity = {
     "id": "new-entity-uuid",
@@ -153,10 +153,10 @@ r.json().set(f"memory:graph:entity:{entity['id']}", '$', entity)
 
 ```bash
 # Get complete entity
-redis-cli -h 172.16.168.23 JSON.GET "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4"
+redis-cli -h <database-ip> JSON.GET "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4"
 
 # Get specific fields
-redis-cli -h 172.16.168.23 JSON.GET "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4" \
+redis-cli -h <database-ip> JSON.GET "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4" \
   $.name $.type $.metadata.topics
 ```
 
@@ -164,15 +164,15 @@ redis-cli -h 172.16.168.23 JSON.GET "memory:graph:entity:267ab75b-8c44-46bb-b038
 
 ```bash
 # Update status
-redis-cli -h 172.16.168.23 JSON.SET "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4" \
+redis-cli -h <database-ip> JSON.SET "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4" \
   '$.metadata.status' '"completed"'
 
 # Add observation
-redis-cli -h 172.16.168.23 JSON.ARRAPPEND "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4" \
+redis-cli -h <database-ip> JSON.ARRAPPEND "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4" \
   '$.observations' '"New observation added"'
 
 # Update timestamp
-redis-cli -h 172.16.168.23 JSON.SET "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4" \
+redis-cli -h <database-ip> JSON.SET "memory:graph:entity:267ab75b-8c44-46bb-b038-e5ee72096de4" \
   '$.updated_at' $(date +%s)000
 ```
 
@@ -180,9 +180,9 @@ redis-cli -h 172.16.168.23 JSON.SET "memory:graph:entity:267ab75b-8c44-46bb-b038
 
 ```bash
 # Delete entity (also delete relations!)
-redis-cli -h 172.16.168.23 DEL "memory:graph:entity:entity-uuid"
-redis-cli -h 172.16.168.23 DEL "memory:graph:relations:out:entity-uuid"
-redis-cli -h 172.16.168.23 DEL "memory:graph:relations:in:entity-uuid"
+redis-cli -h <database-ip> DEL "memory:graph:entity:entity-uuid"
+redis-cli -h <database-ip> DEL "memory:graph:relations:out:entity-uuid"
+redis-cli -h <database-ip> DEL "memory:graph:relations:in:entity-uuid"
 ```
 
 ---
@@ -194,7 +194,7 @@ redis-cli -h 172.16.168.23 DEL "memory:graph:relations:in:entity-uuid"
 ```python
 import redis
 
-r = redis.Redis(host='172.16.168.23', port=6379, db=0)
+r = redis.Redis(host='<database-ip>', port=6379, db=0)
 
 relation = {
     "to": "target-entity-uuid",
@@ -219,10 +219,10 @@ r.json().arrappend(in_key, '$.relations', reverse_rel)
 
 ```bash
 # Get outgoing relations
-redis-cli -h 172.16.168.23 JSON.GET "memory:graph:relations:out:267ab75b-8c44-46bb-b038-e5ee72096de4"
+redis-cli -h <database-ip> JSON.GET "memory:graph:relations:out:267ab75b-8c44-46bb-b038-e5ee72096de4"
 
 # Get incoming relations
-redis-cli -h 172.16.168.23 JSON.GET "memory:graph:relations:in:267ab75b-8c44-46bb-b038-e5ee72096de4"
+redis-cli -h <database-ip> JSON.GET "memory:graph:relations:in:267ab75b-8c44-46bb-b038-e5ee72096de4"
 ```
 
 ### Traverse Graph
@@ -230,7 +230,7 @@ redis-cli -h 172.16.168.23 JSON.GET "memory:graph:relations:in:267ab75b-8c44-46b
 ```python
 def traverse_relations(entity_id, relation_type="relates_to", max_depth=3):
     """BFS traversal of entity graph"""
-    r = redis.Redis(host='172.16.168.23', port=6379, db=0)
+    r = redis.Redis(host='<database-ip>', port=6379, db=0)
 
     visited = set()
     queue = [(entity_id, 0)]
@@ -270,14 +270,14 @@ print(f"Found {len(related)} related entities")
 ### Check Connection
 
 ```bash
-redis-cli -h 172.16.168.23 -p 6379 PING
+redis-cli -h <database-ip> -p 6379 PING
 # Expected: PONG
 ```
 
 ### Verify Modules
 
 ```bash
-redis-cli -h 172.16.168.23 MODULE LIST
+redis-cli -h <database-ip> MODULE LIST
 # Must include: search, ReJSON
 ```
 
@@ -285,10 +285,10 @@ redis-cli -h 172.16.168.23 MODULE LIST
 
 ```bash
 # List indexes
-redis-cli -h 172.16.168.23 FT._LIST
+redis-cli -h <database-ip> FT._LIST
 
 # Get detailed index info
-redis-cli -h 172.16.168.23 FT.INFO memory_graph_entity_idx
+redis-cli -h <database-ip> FT.INFO memory_graph_entity_idx
 ```
 
 ### View Logs
@@ -308,8 +308,8 @@ grep -i error logs/database/memory_graph_init.log
 
 ```bash
 # Drop indexes (keeps data)
-redis-cli -h 172.16.168.23 FT.DROPINDEX memory_graph_entity_idx
-redis-cli -h 172.16.168.23 FT.DROPINDEX memory_graph_fulltext_idx
+redis-cli -h <database-ip> FT.DROPINDEX memory_graph_entity_idx
+redis-cli -h <database-ip> FT.DROPINDEX memory_graph_fulltext_idx
 
 # Recreate
 python scripts/utilities/init_memory_graph_redis.py
@@ -323,7 +323,7 @@ python scripts/utilities/init_memory_graph_redis.py
 
 ```bash
 # Last 20 updates
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "*" \
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "*" \
   SORTBY updated_at DESC LIMIT 0 20 \
   RETURN 4 $.name $.type $.updated_at $.metadata.status
 ```
@@ -332,7 +332,7 @@ redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "*" \
 
 ```bash
 # Active high-priority tasks
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx \
   "@type:{task} @status:{active} @priority:{high}" \
   SORTBY created_at DESC LIMIT 0 10
 ```
@@ -341,9 +341,9 @@ redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx \
 
 ```bash
 # Group by topic (manual aggregation needed)
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "@tags:{redis}" LIMIT 0 0
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "@tags:{database}" LIMIT 0 0
-redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "@tags:{frontend}" LIMIT 0 0
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "@tags:{redis}" LIMIT 0 0
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "@tags:{database}" LIMIT 0 0
+redis-cli -h <database-ip> FT.SEARCH memory_graph_entity_idx "@tags:{frontend}" LIMIT 0 0
 ```
 
 ---
@@ -354,8 +354,8 @@ redis-cli -h 172.16.168.23 FT.SEARCH memory_graph_entity_idx "@tags:{frontend}" 
 
 ```bash
 # Export all Memory Graph data
-redis-cli -h 172.16.168.23 --scan --pattern "memory:graph:*" | \
-  xargs redis-cli -h 172.16.168.23 DUMP | \
+redis-cli -h <database-ip> --scan --pattern "memory:graph:*" | \
+  xargs redis-cli -h <database-ip> DUMP | \
   gzip > memory_graph_backup_$(date +%Y%m%d).json.gz
 ```
 

--- a/docs/database/REDIS_MEMORY_GRAPH_SPECIFICATION.md
+++ b/docs/database/REDIS_MEMORY_GRAPH_SPECIFICATION.md
@@ -3,7 +3,7 @@
 **Version:** 1.0
 **Date:** 2025-10-03
 **Status:** Design Complete - Ready for Implementation
-**Database:** Redis Stack DB 2 (172.16.168.23:6379)
+**Database:** Redis Stack DB 2 (<database-ip>:6379)
 
 ---
 
@@ -267,7 +267,7 @@ import redis
 from redis.commands.json.path import Path
 
 # Connect to DB 2
-r = redis.Redis(host='172.16.168.23', port=6379, db=2)
+r = redis.Redis(host='<database-ip>', port=6379, db=2)
 
 # Step 1: Get conversation entity
 conversation = r.json().get('memory:entity:267ab75b-8c44-46bb-b038-e5ee72096de4')
@@ -309,7 +309,7 @@ def traverse_relations(entity_id, relation_type, max_depth=3):
     Returns:
         List of entities in traversal order
     """
-    r = redis.Redis(host='172.16.168.23', port=6379, db=2)
+    r = redis.Redis(host='<database-ip>', port=6379, db=2)
 
     visited = set()
     queue = [(entity_id, 0)]  # (id, depth)
@@ -377,7 +377,7 @@ def get_entity_with_cache(entity_id):
 
     Hot entities cached for 1 hour to reduce DB load.
     """
-    r = redis.Redis(host='172.16.168.23', port=6379, db=2)
+    r = redis.Redis(host='<database-ip>', port=6379, db=2)
     cache_key = f"memory:cache:hot:{entity_id}"
 
     # Try cache first
@@ -411,7 +411,7 @@ def create_entities_batch(entities):
 
     Reduces round-trips from N to 1.
     """
-    r = redis.Redis(host='172.16.168.23', port=6379, db=2)
+    r = redis.Redis(host='<database-ip>', port=6379, db=2)
     pipeline = r.pipeline()
 
     for entity in entities:
@@ -468,7 +468,7 @@ def search_entities_paginated(query, page=1, page_size=20):
     Returns:
         Dict with results and pagination metadata
     """
-    r = redis.Redis(host='172.16.168.23', port=6379, db=2)
+    r = redis.Redis(host='<database-ip>', port=6379, db=2)
     offset = (page - 1) * page_size
 
     result = r.ft('memory_entity_idx').search(
@@ -704,7 +704,7 @@ def migrate_conversations_to_memory_graph():
     3. Batch write to Redis DB 2
     """
     # Connect to Redis DB 2
-    r = redis.Redis(host='172.16.168.23', port=6379, db=2)
+    r = redis.Redis(host='<database-ip>', port=6379, db=2)
 
     # Get all transcript files
     transcript_dir = Path('data/conversation_transcripts')

--- a/docs/deployment/CODE_SYNC_UI_GUIDE.md
+++ b/docs/deployment/CODE_SYNC_UI_GUIDE.md
@@ -1,7 +1,7 @@
 # Code Sync UI Guide
 ## Visual Walkthrough of SLM Code Deployment Interface
 
-> **Access:** https://172.16.168.19/code-sync
+> **Access:** https://<slm-manager-ip>/code-sync
 
 ---
 

--- a/docs/deployment/FRONTEND_CACHE_CLEARING.md
+++ b/docs/deployment/FRONTEND_CACHE_CLEARING.md
@@ -179,7 +179,7 @@ This ensures:
 
 ### 2. Verify Deployment on Server
 ```bash
-ssh autobot@172.16.168.21
+ssh autobot@<frontend-ip>
 ls -lh /opt/autobot/autobot-frontend/dist/
 cat /opt/autobot/autobot-frontend/dist/index.html
 ```

--- a/docs/deployment/FRONTEND_DEPLOYMENT_CHECKLIST.md
+++ b/docs/deployment/FRONTEND_DEPLOYMENT_CHECKLIST.md
@@ -1,7 +1,7 @@
 # Frontend Deployment Checklist
 ## Quick Reference for AutoBot Code Deployments
 
-> **SLM Interface:** https://172.16.168.19/code-sync
+> **SLM Interface:** https://<slm-manager-ip>/code-sync
 
 ---
 
@@ -19,7 +19,7 @@
   ls -la ~/.ssh/autobot_key
 
   # Test SSH to frontend
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "echo success"
+  ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "echo success"
   ```
 
 - [ ] **Git Hook Installed**
@@ -64,7 +64,7 @@
 ### Phase 2: SLM Deployment
 
 - [ ] **Access SLM**
-  - Browser: https://172.16.168.19
+  - Browser: https://<slm-manager-ip>
   - Login with admin credentials
   - Navigate to "Code Sync" in sidebar
 
@@ -97,14 +97,14 @@
 - [ ] **Test Frontend Access**
   ```bash
   # Check homepage loads
-  curl -Ik https://172.16.168.21
+  curl -Ik https://<frontend-ip>
 
   # Check your new feature (Phase 2 example)
-  curl -Ik https://172.16.168.21/analytics/evolution
+  curl -Ik https://<frontend-ip>/analytics/evolution
   ```
 
 - [ ] **Browser Testing**
-  - Open: https://172.16.168.21
+  - Open: https://<frontend-ip>
   - Hard refresh: Ctrl+F5 (clear cache)
   - Check console: F12 → Console (no red errors)
   - Navigate to your feature
@@ -124,10 +124,10 @@ cd autobot-frontend && npm run build && cd ..
 git add <files> && git commit -m "feat: change" && git push
 
 # 2. Deploy via SLM
-# https://172.16.168.19/code-sync → Sync Now
+# https://<slm-manager-ip>/code-sync → Sync Now
 
 # 3. Verify
-curl -Ik https://172.16.168.21
+curl -Ik https://<frontend-ip>
 ```
 
 **Expected Time:** 3-7 minutes total
@@ -140,14 +140,14 @@ curl -Ik https://172.16.168.21
 
 ```bash
 # Check SLM logs
-ssh autobot@172.16.168.19
+ssh autobot@<slm-manager-ip>
 journalctl -u autobot-slm-backend -n 100 --no-pager
 
 # Check SSH connectivity
-ssh autobot@172.16.168.21 "echo test"
+ssh autobot@<frontend-ip> "echo test"
 
 # Verify disk space
-ssh autobot@172.16.168.21 "df -h"
+ssh autobot@<frontend-ip> "df -h"
 ```
 
 ### Changes Not Visible
@@ -160,23 +160,23 @@ Ctrl + F5  (or Cmd + Shift + R on Mac)
 F12 → Application → Clear Storage → Clear site data
 
 # Check nginx serving correct files
-ssh autobot@172.16.168.21 "ls -lt /var/www/autobot-frontend/ | head -10"
+ssh autobot@<frontend-ip> "ls -lt /var/www/autobot-frontend/ | head -10"
 
 # Check file timestamp
-ssh autobot@172.16.168.21 "stat /var/www/autobot-frontend/index.html"
+ssh autobot@<frontend-ip> "stat /var/www/autobot-frontend/index.html"
 ```
 
 ### Build Fails on VM
 
 ```bash
 # Check node version (need 16+)
-ssh autobot@172.16.168.21 "node --version"
+ssh autobot@<frontend-ip> "node --version"
 
 # Check npm install errors
-ssh autobot@172.16.168.21 "cd /opt/autobot/autobot-frontend && npm install"
+ssh autobot@<frontend-ip> "cd /opt/autobot/autobot-frontend && npm install"
 
 # Check build errors
-ssh autobot@172.16.168.21 "cd /opt/autobot/autobot-frontend && npm run build"
+ssh autobot@<frontend-ip> "cd /opt/autobot/autobot-frontend && npm run build"
 ```
 
 ### Rollback to Previous Version
@@ -193,7 +193,7 @@ git push --force-with-lease origin Dev_new_gui
 bash scripts/hooks/slm-post-commit
 
 # 4. Re-sync in SLM interface
-# https://172.16.168.19/code-sync → Sync Now
+# https://<slm-manager-ip>/code-sync → Sync Now
 ```
 
 ---
@@ -214,10 +214,10 @@ bash scripts/hooks/slm-post-commit
 
 | Resource | URL |
 |----------|-----|
-| SLM Admin | https://172.16.168.19 |
-| Code Sync | https://172.16.168.19/code-sync |
-| User Frontend | https://172.16.168.21 |
-| Backend Docs | https://172.16.168.20:8443/docs |
+| SLM Admin | https://<slm-manager-ip> |
+| Code Sync | https://<slm-manager-ip>/code-sync |
+| User Frontend | https://<frontend-ip> |
+| Backend Docs | https://<backend-ip>:8443/docs |
 | GitHub Issues | https://github.com/mrveiss/AutoBot-AI/issues |
 
 ---
@@ -235,10 +235,10 @@ bash scripts/hooks/slm-post-commit
 journalctl -u autobot-slm-backend -f
 
 # Frontend VM Nginx
-ssh autobot@172.16.168.21 "journalctl -u nginx -f"
+ssh autobot@<frontend-ip> "journalctl -u nginx -f"
 
 # Frontend VM System
-ssh autobot@172.16.168.21 "tail -f /var/log/syslog"
+ssh autobot@<frontend-ip> "tail -f /var/log/syslog"
 ```
 
 ---

--- a/docs/deployment/FRONTEND_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/FRONTEND_DEPLOYMENT_GUIDE.md
@@ -1,7 +1,7 @@
 # Frontend Deployment Guide
 ## Using SLM Code Sync Interface
 
-> **Quick Link:** https://172.16.168.19/code-sync
+> **Quick Link:** https://<slm-manager-ip>/code-sync
 
 ---
 
@@ -15,7 +15,7 @@ AutoBot uses a **pull-based deployment system** managed through the SLM (Service
 
 ### Step 1: Access SLM Admin Interface
 
-1. **Open Browser**: Navigate to `https://172.16.168.19`
+1. **Open Browser**: Navigate to `https://<slm-manager-ip>`
 2. **Login**: Use your SLM admin credentials
    - Default: `admin` / (check `/etc/autobot/slm-secrets.env` on SLM server)
    - Browser will warn about self-signed certificate - this is expected, click "Advanced" → "Proceed"
@@ -48,7 +48,7 @@ AutoBot uses a **pull-based deployment system** managed through the SLM (Service
 
 1. **Click "Configure"** button in Code Source card
 2. **Select Source Node**: Choose "01-Backend" or whichever node has git access
-   - Typically the Main server (172.16.168.20) or development machine
+   - Typically the Main server (<backend-ip>) or development machine
 3. **Repository Path**: `/opt/autobot` (or `/opt/autobot` if different)
 4. **Branch**: `Dev_new_gui` (or `main` for production)
 5. **Click "Save"**
@@ -137,7 +137,7 @@ The Code Source card will now show:
 
 1. **Check Status Banner**: "Outdated Nodes" should show `0 / 9`
 2. **Green Badge**: "All Up To Date" appears
-3. **Test Frontend**: Open `https://172.16.168.21/analytics/evolution`
+3. **Test Frontend**: Open `https://<frontend-ip>/analytics/evolution`
    - New Evolution Dashboard should be visible in Analytics menu
    - Charts and UI should match Phase 2 implementation
 
@@ -170,7 +170,7 @@ The Code Source card will now show:
 **Post-Commit Hook Flow:**
 1. Developer commits to git on Main server (.20)
 2. `.git/hooks/post-commit` executes `scripts/hooks/slm-post-commit`
-3. Hook calls `POST https://172.16.168.19/api/code-source/notify`
+3. Hook calls `POST https://<slm-manager-ip>/api/code-source/notify`
 4. SLM updates `CodeSource` table with new commit hash
 5. SLM marks all fleet nodes as `CodeStatus.OUTDATED`
 6. Nodes appear in Code Sync "Pending Updates" table
@@ -252,7 +252,7 @@ NodeRole (
 **Environment Variables (SLM Server):**
 ```bash
 # /etc/autobot/slm-secrets.env
-AUTOBOT_SLM_HOST=172.16.168.19
+AUTOBOT_SLM_HOST=<slm-manager-ip>
 AUTOBOT_CODE_SOURCE_NODE=01-Backend
 SLM_REPO_PATH=/opt/autobot
 SLM_SSH_KEY=/home/autobot/.ssh/autobot_key
@@ -290,7 +290,7 @@ SLM_SSH_KEY=/home/autobot/.ssh/autobot_key
 ### Deployment Execution Checklist
 
 **Step-by-Step:**
-- [ ] 1. Access SLM interface at https://172.16.168.19/code-sync
+- [ ] 1. Access SLM interface at https://<slm-manager-ip>/code-sync
 - [ ] 2. Verify "Latest Version" shows your commit hash (745e45ee for Phase 2)
 - [ ] 3. Confirm "Outdated Nodes" count > 0 (should show Frontend VM)
 - [ ] 4. Check "Pending Updates" table lists Frontend node
@@ -311,7 +311,7 @@ SLM_SSH_KEY=/home/autobot/.ssh/autobot_key
 - [ ] `last_sync_at` timestamp is recent (within last 5 minutes)
 
 **Manual Testing:**
-- [ ] Open frontend: https://172.16.168.21
+- [ ] Open frontend: https://<frontend-ip>
 - [ ] Check browser console for errors (F12 → Console)
 - [ ] Navigate to new feature: `/analytics/evolution` (Phase 2)
 - [ ] Verify UI renders correctly (no missing components)
@@ -335,7 +335,7 @@ SLM_SSH_KEY=/home/autobot/.ssh/autobot_key
 
 **If sync fails:**
 - [ ] Check SLM backend logs: `journalctl -u autobot-slm-backend -n 100`
-- [ ] Verify SSH connectivity: `ssh autobot@172.16.168.21 "echo test"`
+- [ ] Verify SSH connectivity: `ssh autobot@<frontend-ip> "echo test"`
 - [ ] Check disk space on Frontend VM: `df -h` (need >1GB free)
 - [ ] Verify git repository accessible: `ls -la .git`
 - [ ] Check npm/node versions on Frontend VM: `node --version` (need 16+)
@@ -350,7 +350,7 @@ SLM_SSH_KEY=/home/autobot/.ssh/autobot_key
 **If progress hangs:**
 - [ ] Check WebSocket connection in browser (F12 → Network → WS)
 - [ ] Verify SLM backend not crashed: `systemctl status autobot-slm-backend`
-- [ ] Check node SSH connection still alive: `ssh autobot@172.16.168.21`
+- [ ] Check node SSH connection still alive: `ssh autobot@<frontend-ip>`
 - [ ] Review sync timeout settings (default: 10 minutes)
 
 ---
@@ -366,22 +366,22 @@ SLM_SSH_KEY=/home/autobot/.ssh/autobot_key
 git add . && git commit -m "feat: your change" && git push
 
 # 2. Access SLM
-https://172.16.168.19/code-sync
+https://<slm-manager-ip>/code-sync
 
 # 3. Click "Sync Now" for outdated nodes
 
 # 4. Verify
-https://172.16.168.21  # Check your changes live
+https://<frontend-ip>  # Check your changes live
 ```
 
 ### 🔧 Configuration Quick Access
 
 | Item | Location |
 |------|----------|
-| SLM Admin UI | https://172.16.168.19 |
-| Code Sync Page | https://172.16.168.19/code-sync |
-| User Frontend | https://172.16.168.21 |
-| Backend API | https://172.16.168.20:8443/docs |
+| SLM Admin UI | https://<slm-manager-ip> |
+| Code Sync Page | https://<slm-manager-ip>/code-sync |
+| User Frontend | https://<frontend-ip> |
+| Backend API | https://<backend-ip>:8443/docs |
 | SLM Backend Logs | `journalctl -u autobot-slm-backend -f` |
 | Post-Commit Hook | `.git/hooks/post-commit` |
 

--- a/docs/deployment/ISSUE_898_DEPLOYMENT.md
+++ b/docs/deployment/ISSUE_898_DEPLOYMENT.md
@@ -45,7 +45,7 @@ cd autobot-slm-backend/ansible
 ansible-playbook playbooks/deploy-full.yml --tags backend
 
 # Verify backend restarts successfully
-ssh autobot@172.16.168.20 "systemctl status autobot-backend"
+ssh autobot@<backend-ip> "systemctl status autobot-backend"
 ```
 
 ### Option 2: Manual Sync
@@ -55,7 +55,7 @@ ssh autobot@172.16.168.20 "systemctl status autobot-backend"
 ./infrastructure/shared/scripts/sync-to-vm.sh main autobot-backend/
 
 # SSH to server and restart backend
-ssh autobot@172.16.168.20
+ssh autobot@<backend-ip>
 cd /opt/autobot
 sudo systemctl restart autobot-backend
 
@@ -70,7 +70,7 @@ journalctl -u autobot-backend -n 100 --no-pager | grep -i "nameerror\|list"
 ### 1. Check Backend Startup (No NameError)
 
 ```bash
-ssh autobot@172.16.168.20 "journalctl -u autobot-backend -n 50 --no-pager"
+ssh autobot@<backend-ip> "journalctl -u autobot-backend -n 50 --no-pager"
 ```
 
 **Expected:** No `NameError: name 'List' is not defined` errors
@@ -78,7 +78,7 @@ ssh autobot@172.16.168.20 "journalctl -u autobot-backend -n 50 --no-pager"
 ### 2. Test Backend Health
 
 ```bash
-curl -sk https://172.16.168.20:8443/api/health | jq
+curl -sk https://<backend-ip>:8443/api/health | jq
 ```
 
 **Expected:** `{"status": "healthy"}` or similar
@@ -86,7 +86,7 @@ curl -sk https://172.16.168.20:8443/api/health | jq
 ### 3. Test Login (Returns JWT Token)
 
 ```bash
-curl -sk https://172.16.168.20:8443/api/auth/login \
+curl -sk https://<backend-ip>:8443/api/auth/login \
   -X POST \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"admin"}' \
@@ -99,11 +99,11 @@ curl -sk https://172.16.168.20:8443/api/auth/login \
 
 ```bash
 # Check frontend can reach backend
-curl -Ik https://172.16.168.21
+curl -Ik https://<frontend-ip>
 
 # Test from frontend to backend
-ssh autobot@172.16.168.21 \
-  "curl -s http://172.16.168.20:8443/api/health | jq"
+ssh autobot@<frontend-ip> \
+  "curl -s http://<backend-ip>:8443/api/health | jq"
 ```
 
 ---
@@ -119,7 +119,7 @@ ssh autobot@172.16.168.21 \
 **Fix:**
 ```bash
 # Verify file on server has List import
-ssh autobot@172.16.168.20 \
+ssh autobot@<backend-ip> \
   "head -20 /opt/autobot/autobot-backend/api/vnc_manager.py | grep 'from typing'"
 ```
 
@@ -128,8 +128,8 @@ Expected output should include: `from typing import Dict, List`
 If not, manually copy the file:
 ```bash
 scp autobot-backend/api/vnc_manager.py \
-  autobot@172.16.168.20:/opt/autobot/autobot-backend/api/vnc_manager.py
-ssh autobot@172.16.168.20 "sudo systemctl restart autobot-backend"
+  autobot@<backend-ip>:/opt/autobot/autobot-backend/api/vnc_manager.py
+ssh autobot@<backend-ip> "sudo systemctl restart autobot-backend"
 ```
 
 ### Login Returns "Could not determine join condition"
@@ -140,7 +140,7 @@ ssh autobot@172.16.168.20 "sudo systemctl restart autobot-backend"
 
 **Fix:** Verify commits e9abf21a and 852518e1 are deployed:
 ```bash
-ssh autobot@172.16.168.20 \
+ssh autobot@<backend-ip> \
   "cd /opt/autobot && git log --oneline -10 | grep -E 'e9abf21a|852518e1'"
 ```
 

--- a/docs/design/MEMORY_GRAPH_SEARCH_ARCHITECTURE.md
+++ b/docs/design/MEMORY_GRAPH_SEARCH_ARCHITECTURE.md
@@ -142,7 +142,7 @@ User Query: "What bugs did we fix today?"
 │ Observations:                                                │
 │   - Fixed incorrect endpoint /api/system/status             │
 │   - Updated API calls in frontend components                │
-│   - Deployed to Frontend VM (172.16.168.21)                 │
+│   - Deployed to Frontend VM (<frontend-ip>)                 │
 │ Created: 2025-10-03 09:15                                    │
 │ Relations: [relates_to: API Documentation Update]           │
 └─────────────────────────────────────────────────────────────┘
@@ -524,7 +524,7 @@ MemoryGraphSearch
     │       │       └─► Ollama Server (localhost:11434)
     │       │
     │       └─► RedisVectorStore (llama-index)
-    │               └─► Redis Server (172.16.168.23:6379)
+    │               └─► Redis Server (<database-ip>:6379)
     │
     ├─► EntityIndexManager
     │       │

--- a/docs/design/MEMORY_GRAPH_SEMANTIC_SEARCH.md
+++ b/docs/design/MEMORY_GRAPH_SEMANTIC_SEARCH.md
@@ -702,7 +702,7 @@ The System Status Bug Fix addressed an incorrect API endpoint. Here's what I fou
 **Details:**
 - Fixed endpoint from /api/status to /api/system/status
 - Updated API calls in frontend components
-- Deployed to Frontend VM (172.16.168.21)
+- Deployed to Frontend VM (<frontend-ip>)
 
 **Related entities:**
 - API Documentation Update (documentation)

--- a/docs/developer/ANSIBLE_CREDENTIAL_SECURITY.md
+++ b/docs/developer/ANSIBLE_CREDENTIAL_SECURITY.md
@@ -36,7 +36,7 @@ SSH key authentication should already be configured. Verify with:
 
 ```bash
 # Test SSH connection to a VM
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip>
 
 # Test Ansible connectivity
 cd ansible
@@ -89,8 +89,8 @@ Host *
     PubkeyAuthentication yes
     PasswordAuthentication no
 
-Host autobot-frontend 172.16.168.21
-    HostName 172.16.168.21
+Host autobot-frontend <frontend-ip>
+    HostName <frontend-ip>
     User autobot
     IdentityFile ~/.ssh/autobot_key
 ```
@@ -182,7 +182,7 @@ ansible-vault rekey inventory/group_vars/vault.yml
 
 The passwordless sudo configuration is secure because:
 
-- VMs are on an isolated internal network (172.16.168.0/24)
+- VMs are on an isolated internal network (<network-subnet>)
 - SSH is the only remote access method
 - SSH only accepts key-based authentication
 - Firewall rules restrict access to the internal network
@@ -199,7 +199,7 @@ Force password auth from the client:
 
 ```bash
 # Emergency SSH with password
-ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no autobot@172.16.168.21
+ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no autobot@<frontend-ip>
 
 # For Ansible operations
 ansible all -i inventory/production.yml -m ping \
@@ -220,7 +220,7 @@ If network access is completely lost:
 
 ```bash
 # From WSL, re-copy the SSH key
-ssh-copy-id -i ~/.ssh/autobot_key.pub -o PreferredAuthentications=password autobot@172.16.168.21
+ssh-copy-id -i ~/.ssh/autobot_key.pub -o PreferredAuthentications=password autobot@<frontend-ip>
 ```
 
 ### Preventing Lockouts
@@ -240,11 +240,11 @@ ls -la ~/.ssh/autobot_key
 chmod 600 ~/.ssh/autobot_key
 
 # Test key authentication
-ssh -v autobot@172.16.168.21
+ssh -v autobot@<frontend-ip>
 
 # Regenerate key if corrupted
 ssh-keygen -t rsa -b 4096 -f ~/.ssh/autobot_key -N ''
-ssh-copy-id -i ~/.ssh/autobot_key.pub autobot@172.16.168.21
+ssh-copy-id -i ~/.ssh/autobot_key.pub autobot@<frontend-ip>
 ```
 
 ## Troubleshooting
@@ -257,7 +257,7 @@ ls -la ~/.ssh/autobot_key
 # Should be: -rw------- (600)
 
 # Test SSH manually
-ssh -vvv -i ~/.ssh/autobot_key autobot@172.16.168.21
+ssh -vvv -i ~/.ssh/autobot_key autobot@<frontend-ip>
 ```
 
 ### Permission Denied (sudo)

--- a/docs/developer/ARCHITECTURE_COMPLIANCE_IMPLEMENTATION_REPORT.md
+++ b/docs/developer/ARCHITECTURE_COMPLIANCE_IMPLEMENTATION_REPORT.md
@@ -16,7 +16,7 @@ Successfully replaced **manual architecture fix scripts** with **automated compl
 - `workflow_orchestration_fix.py` - Analysis document (not really a fix script)
 
 **Problems**:
-1. ❌ **Hardcoded IP addresses** - `172.16.168.23` hardcoded in scripts
+1. ❌ **Hardcoded IP addresses** - `<database-ip>` hardcoded in scripts
 2. ❌ **Hardcoded paths** - `/opt/autobot` hardcoded
 3. ❌ **Manual execution** - Developers had to remember to run them
 4. ❌ **Reactive approach** - Fixed issues after they occurred
@@ -33,7 +33,7 @@ Successfully replaced **manual architecture fix scripts** with **automated compl
 ```python
 # BEFORE (created by fix_critical_redis_timeouts.py with hardcodes)
 def get_redis_connection(
-    host: str = "172.16.168.23",  # ❌ Hardcoded
+    host: str = "<database-ip>",  # ❌ Hardcoded
     port: int = 6379,
     ...
 )
@@ -74,12 +74,12 @@ def get_redis_connection(
 
 #### TestServiceDistribution
 Validates that each service runs on its designated VM:
-- ✅ `test_redis_on_vm3_only()` - Redis must be on 172.16.168.23
-- ✅ `test_backend_on_main_machine()` - Backend on 172.16.168.20
-- ✅ `test_frontend_on_vm1()` - Frontend on 172.16.168.21
-- ✅ `test_npu_worker_on_vm2()` - NPU worker on 172.16.168.22
-- ✅ `test_ai_stack_on_vm4()` - AI stack on 172.16.168.24
-- ✅ `test_browser_service_on_vm5()` - Browser service on 172.16.168.25
+- ✅ `test_redis_on_vm3_only()` - Redis must be on <database-ip>
+- ✅ `test_backend_on_main_machine()` - Backend on <backend-ip>
+- ✅ `test_frontend_on_vm1()` - Frontend on <frontend-ip>
+- ✅ `test_npu_worker_on_vm2()` - NPU worker on <npu-ip>
+- ✅ `test_ai_stack_on_vm4()` - AI stack on <aiml-ip>
+- ✅ `test_browser_service_on_vm5()` - Browser service on <browser-ip>
 
 #### TestNetworkConfiguration
 Validates network configuration compliance:
@@ -182,7 +182,7 @@ Tests automatically run on:
 
 ```python
 # Old way (hardcoded - DON'T DO THIS)
-redis_client = redis.Redis(host="172.16.168.23", port=6379)
+redis_client = redis.Redis(host="<database-ip>", port=6379)
 
 # New way (configuration-driven - CORRECT)
 from src.utils.redis_helper import get_redis_connection

--- a/docs/developer/AUTOBOT_REFERENCE.md
+++ b/docs/developer/AUTOBOT_REFERENCE.md
@@ -37,26 +37,26 @@ cd autobot-slm-backend/ansible && ansible-playbook playbooks/<playbook>.yml --sy
 
 | Service | IP:Port | Component | Purpose |
 |---------|---------|-----------|---------|
-| SLM Server | 172.16.168.19:443 | `autobot-slm-backend/` + `autobot-slm-frontend/` | SLM backend + admin UI (nginx+SSL) |
-| Main (WSL) | 172.16.168.20:8443 | `autobot-backend/` | Backend API + VNC (6080) |
-| Frontend VM | 172.16.168.21:443 | `autobot-frontend/` | User frontend (nginx+SSL, production build) |
-| NPU VM | 172.16.168.22:8081 | `autobot-npu-worker/` | Hardware AI acceleration |
-| Redis VM | 172.16.168.23:6379 | - | Data layer (Redis Stack) |
-| AI Stack VM | 172.16.168.24:8080 | - | AI processing |
-| Browser VM | 172.16.168.25:3000 | `autobot-browser-worker/` | Playwright automation |
-| LLM CPU | 172.16.168.26 | - | LLM CPU node (05-LLM-CPU, role: llm-cpu) |
-| Reserved | 172.16.168.27 | - | (Unassigned) |
+| SLM Server | <slm-manager-ip>:443 | `autobot-slm-backend/` + `autobot-slm-frontend/` | SLM backend + admin UI (nginx+SSL) |
+| Main (WSL) | <backend-ip>:8443 | `autobot-backend/` | Backend API + VNC (6080) |
+| Frontend VM | <frontend-ip>:443 | `autobot-frontend/` | User frontend (nginx+SSL, production build) |
+| NPU VM | <npu-ip>:8081 | `autobot-npu-worker/` | Hardware AI acceleration |
+| Redis VM | <database-ip>:6379 | - | Data layer (Redis Stack) |
+| AI Stack VM | <aiml-ip>:8080 | - | AI processing |
+| Browser VM | <browser-ip>:3000 | `autobot-browser-worker/` | Playwright automation |
+| LLM CPU | <reserved-ip> | - | LLM CPU node (05-LLM-CPU, role: llm-cpu) |
+| Reserved | <reserved-ip> | - | (Unassigned) |
 
 ### Component Architecture
 
 | Directory | Deploys To | Description |
 |-----------|------------|-------------|
-| `autobot-backend/` | 172.16.168.20 (Main) | Core AutoBot backend - AI agents, chat, tools |
-| `autobot-frontend/` | 172.16.168.21 (Frontend VM) | User chat interface (Vue 3, nginx+SSL) |
-| `autobot-slm-backend/` | 172.16.168.19 (SLM) | SLM backend - Fleet management, monitoring |
-| `autobot-slm-frontend/` | 172.16.168.19 (SLM) | SLM admin dashboard - Vue 3 UI (nginx+SSL) |
-| `autobot-npu-worker/` | 172.16.168.22 (NPU) | NPU acceleration worker |
-| `autobot-browser-worker/` | 172.16.168.25 (Browser) | Playwright automation worker |
+| `autobot-backend/` | <backend-ip> (Main) | Core AutoBot backend - AI agents, chat, tools |
+| `autobot-frontend/` | <frontend-ip> (Frontend VM) | User chat interface (Vue 3, nginx+SSL) |
+| `autobot-slm-backend/` | <slm-manager-ip> (SLM) | SLM backend - Fleet management, monitoring |
+| `autobot-slm-frontend/` | <slm-manager-ip> (SLM) | SLM admin dashboard - Vue 3 UI (nginx+SSL) |
+| `autobot-npu-worker/` | <npu-ip> (NPU) | NPU acceleration worker |
+| `autobot-browser-worker/` | <browser-ip> (Browser) | Playwright automation worker |
 | `autobot_shared/` | All backends | Common utilities (redis, config, logging) |
 | `autobot-infrastructure/` | Dev machine | Per-role infrastructure (not deployed) |
 
@@ -182,8 +182,8 @@ Workflow: Edit Ansible templates locally → commit → deploy via Ansible → v
 ```bash
 # Health checks
 # NOTE: .20 must be tested from another VM (WSL2 loopback limitation)
-ssh autobot@172.16.168.19 'curl --insecure https://172.16.168.20:8443/api/health'
-redis-cli -h 172.16.168.23 ping
+ssh autobot@<slm-manager-ip> 'curl --insecure https://<backend-ip>:8443/api/health'
+redis-cli -h <database-ip> ping
 
 # Ansible Deployment
 cd autobot-slm-backend/ansible

--- a/docs/developer/BACKEND_DEBUGGING.md
+++ b/docs/developer/BACKEND_DEBUGGING.md
@@ -164,14 +164,14 @@ ss -tlnp | grep PORT
 curl -s --max-time 5 http://127.0.0.1:8001/api/health
 
 # From another host
-curl -s --max-time 5 https://172.16.168.20:8443/api/health
+curl -s --max-time 5 https://<backend-ip>:8443/api/health
 ```
 
 ### 4. Network path check
 
 ```bash
 # Can you reach the port at all?
-telnet 172.16.168.20 8001
+telnet <backend-ip> 8001
 
 # Packet-level view
 sudo tcpdump -i any port 8001 -n

--- a/docs/developer/CHROMADB_INDEXING_OPTIMIZATION.md
+++ b/docs/developer/CHROMADB_INDEXING_OPTIMIZATION.md
@@ -154,7 +154,7 @@ To force a full re-index when incremental indexing is enabled:
 
 ```bash
 # Clear all file hashes from Redis
-redis-cli -h 172.16.168.23 -n 11 KEYS "codebase:file_hash:*" | xargs redis-cli -h 172.16.168.23 -n 11 DEL
+redis-cli -h <database-ip> -n 11 KEYS "codebase:file_hash:*" | xargs redis-cli -h <database-ip> -n 11 DEL
 ```
 
 Or temporarily disable incremental indexing:

--- a/docs/developer/CLAUDE_MD_OPTIMIZATION_PLAN.md
+++ b/docs/developer/CLAUDE_MD_OPTIMIZATION_PLAN.md
@@ -93,7 +93,7 @@ client = redis.Redis(host="...", port=...)
 ```
 
 **🚨 MANDATORY: Local-Only Development**
-- ❌ **NEVER edit code on remote VMs (172.16.168.21-25)**
+- ❌ **NEVER edit code on remote VMs (<frontend-ip>-25)**
 - ✅ **Edit locally** in `/opt/autobot`
 - ✅ **Sync immediately** using sync scripts
 
@@ -165,12 +165,12 @@ Each subtask should be:
 
 | Service | IP:Port | Purpose |
 |---------|---------|---------|
-| **Main Machine (WSL)** | 172.16.168.20:8443 | Backend API + VNC Desktop (6080) |
-| **VM1 Frontend** | 172.16.168.21:5173 | Web interface (SINGLE FRONTEND) |
-| **VM2 NPU Worker** | 172.16.168.22:8081 | Hardware AI acceleration |
-| **VM3 Redis** | 172.16.168.23:6379 | Data layer |
-| **VM4 AI Stack** | 172.16.168.24:8080 | AI processing |
-| **VM5 Browser** | 172.16.168.25:3000 | Web automation (Playwright) |
+| **Main Machine (WSL)** | <backend-ip>:8443 | Backend API + VNC Desktop (6080) |
+| **VM1 Frontend** | <frontend-ip>:5173 | Web interface (SINGLE FRONTEND) |
+| **VM2 NPU Worker** | <npu-ip>:8081 | Hardware AI acceleration |
+| **VM3 Redis** | <database-ip>:6379 | Data layer |
+| **VM4 AI Stack** | <aiml-ip>:8080 | AI processing |
+| **VM5 Browser** | <browser-ip>:3000 | Web automation (Playwright) |
 ```
 
 **REMOVED from CLAUDE.md** (redundant):

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -41,7 +41,7 @@ If you find existing work, USE IT — don't reimplement from scratch.
 ```python
 from autobot_shared.redis_client import get_redis_client
 redis_client = get_redis_client(async_client=False, database="main")
-# NEVER: redis.Redis(host="172.16.168.23", ...)
+# NEVER: redis.Redis(host="<database-ip>", ...)
 ```
 
 Databases: `main`, `knowledge`, `prompts`, `analytics`
@@ -63,7 +63,7 @@ Pre-commit hook enforces this. Guide: [`HARDCODING_PREVENTION.md`](HARDCODING_PR
 
 Always check existing config files for correct network ranges. Use environment variables or SSOT config.
 
-> Violation: Writing a new Redis helper when `autobot_shared.redis_client.get_redis_client` already exists, or hardcoding `172.16.168.23`.
+> Violation: Writing a new Redis helper when `autobot_shared.redis_client.get_redis_client` already exists, or hardcoding `<database-ip>`.
 
 ---
 

--- a/docs/developer/CONFIG_MIGRATION_CHECKLIST.md
+++ b/docs/developer/CONFIG_MIGRATION_CHECKLIST.md
@@ -35,9 +35,9 @@ from src.config.ssot_config import config
 
 | Pattern | Replace With |
 |---------|--------------|
-| `"172.16.168.20"` | `config.backend.host` |
-| `"172.16.168.21"` | `config.frontend.host` |
-| `"172.16.168.23"` | `config.redis.host` |
+| `"<backend-ip>"` | `config.backend.host` |
+| `"<frontend-ip>"` | `config.frontend.host` |
+| `"<database-ip>"` | `config.redis.host` |
 | `8001` (backend port) | `config.backend.port` |
 | `6379` (redis port) | `config.redis.port` |
 | `"qwen3.5:9b"` | `config.llm.default_model` |
@@ -86,8 +86,8 @@ import { getConfig, getBackendUrl } from '@/config/ssot-config'
 
 | Pattern | Replace With |
 |---------|--------------|
-| `"https://172.16.168.20:8443"` | `getBackendUrl()` |
-| `"172.16.168.20"` | `getConfig().backend.host` |
+| `"https://<backend-ip>:8443"` | `getBackendUrl()` |
+| `"<backend-ip>"` | `getConfig().backend.host` |
 | `8001` | `getConfig().backend.port` |
 
 - [ ] All hardcoded URLs replaced
@@ -130,12 +130,12 @@ fi
 
 | Pattern | Replace With |
 |---------|--------------|
-| `172.16.168.20` | `${AUTOBOT_BACKEND_HOST:-172.16.168.20}` |
-| `172.16.168.21` | `${AUTOBOT_FRONTEND_HOST:-172.16.168.21}` |
-| `172.16.168.22` | `${AUTOBOT_NPU_WORKER_HOST:-172.16.168.22}` |
-| `172.16.168.23` | `${AUTOBOT_REDIS_HOST:-172.16.168.23}` |
-| `172.16.168.24` | `${AUTOBOT_AI_STACK_HOST:-172.16.168.24}` |
-| `172.16.168.25` | `${AUTOBOT_BROWSER_SERVICE_HOST:-172.16.168.25}` |
+| `<backend-ip>` | `${AUTOBOT_BACKEND_HOST:-<backend-ip>}` |
+| `<frontend-ip>` | `${AUTOBOT_FRONTEND_HOST:-<frontend-ip>}` |
+| `<npu-ip>` | `${AUTOBOT_NPU_WORKER_HOST:-<npu-ip>}` |
+| `<database-ip>` | `${AUTOBOT_REDIS_HOST:-<database-ip>}` |
+| `<aiml-ip>` | `${AUTOBOT_AI_STACK_HOST:-<aiml-ip>}` |
+| `<browser-ip>` | `${AUTOBOT_BROWSER_SERVICE_HOST:-<browser-ip>}` |
 | `8001` (backend) | `${AUTOBOT_BACKEND_PORT:-8001}` |
 | `5173` (frontend) | `${AUTOBOT_FRONTEND_PORT:-5173}` |
 | `6379` (redis) | `${AUTOBOT_REDIS_PORT:-6379}` |

--- a/docs/developer/DEVELOPER_SETUP.md
+++ b/docs/developer/DEVELOPER_SETUP.md
@@ -23,9 +23,9 @@ docker compose up -d --build
 # Optional profiles: --profile ollama, --profile monitoring
 
 # 3. Access development interface
-# SLM Orchestration: https://172.16.168.19/orchestration
-# User Frontend: https://172.16.168.21
-# Backend API: https://172.16.168.20:8443/docs
+# SLM Orchestration: https://<slm-manager-ip>/orchestration
+# User Frontend: https://<frontend-ip>
+# Backend API: https://<backend-ip>:8443/docs
 # VNC Desktop: http://127.0.0.1:6080
 ```
 
@@ -136,7 +136,7 @@ AutoBot supports three deployment methods:
 sudo ./install.sh
 # - Installs system packages and Python 3.12 venv
 # - Configures systemd services (autobot-backend, autobot-celery, etc.)
-# - Sets up networking for the 172.16.168.0/24 fleet
+# - Sets up networking for the <network-subnet> fleet
 # - Generates SSH keys for inter-VM communication
 # - Launches the Setup Wizard at https://<server-ip>
 #   (complete remaining configuration — AI models, API keys — via the wizard)
@@ -161,7 +161,7 @@ docker compose --profile ollama --profile monitoring up -d --build
 #### Path C: Fleet Deployment via Ansible (from SLM Manager .19)
 
 ```bash
-# On the SLM Manager (172.16.168.19)
+# On the SLM Manager (<slm-manager-ip>)
 cd autobot-slm-backend/ansible
 
 # Deploy or update the full fleet
@@ -193,7 +193,7 @@ Phase 2 — Dependency Installation (~5 min)
   - SSH server and key generation
 
 Phase 3 — Fleet Infrastructure Setup (~8 min)
-  - Configure VM network (172.16.168.0/24)
+  - Configure VM network (<network-subnet>)
   - Generate SSH keys for inter-VM communication
   - Set up firewall rules and VM-to-VM networking
   - Install VM-specific dependencies
@@ -255,16 +255,16 @@ systemctl status ollama
 
 # Or use SLM GUI
 scripts/start-services.sh gui
-# Visit: https://172.16.168.19/orchestration
+# Visit: https://<slm-manager-ip>/orchestration
 
 # Expected services:
-✓ Main Backend API      (https://172.16.168.20:8443)
+✓ Main Backend API      (https://<backend-ip>:8443)
 ✓ Celery Worker         (Background tasks)
-✓ Frontend Service      (https://172.16.168.21)
-✓ NPU Worker           (http://172.16.168.22:8081)
-✓ Redis Stack          (tcp://172.16.168.23:6379)
-✓ AI Orchestrator      (http://172.16.168.24:8080)
-✓ Browser Service      (http://172.16.168.25:3000)
+✓ Frontend Service      (https://<frontend-ip>)
+✓ NPU Worker           (http://<npu-ip>:8081)
+✓ Redis Stack          (tcp://<database-ip>:6379)
+✓ AI Orchestrator      (http://<aiml-ip>:8080)
+✓ Browser Service      (http://<browser-ip>:3000)
 ✓ Ollama LLM           (http://127.0.0.1:11434)
 
 System Status: ALL SERVICES HEALTHY ✓
@@ -307,7 +307,7 @@ journalctl -u autobot-backend -f
 **Alternative: SLM GUI (Best for operations)**
 ```bash
 scripts/start-services.sh gui
-# Or visit: https://172.16.168.19/orchestration
+# Or visit: https://<slm-manager-ip>/orchestration
 ```
 
 See [Service Management Guide](SERVICE_MANAGEMENT.md) for complete documentation.
@@ -318,21 +318,21 @@ Once services are started, these URLs will be available:
 
 ```yaml
 # Primary interfaces
-SLM_Orchestration: "https://172.16.168.19/orchestration"  # Service management GUI
-Frontend_UI: "https://172.16.168.21"                      # User interface (production)
-Frontend_Dev: "http://172.16.168.21:5173"                 # Development server (if running)
-Backend_API: "https://172.16.168.20:8443"                 # FastAPI backend (TLS)
-API_Docs: "https://172.16.168.20:8443/docs"               # Interactive API documentation
+SLM_Orchestration: "https://<slm-manager-ip>/orchestration"  # Service management GUI
+Frontend_UI: "https://<frontend-ip>"                      # User interface (production)
+Frontend_Dev: "http://<frontend-ip>:5173"                 # Development server (if running)
+Backend_API: "https://<backend-ip>:8443"                 # FastAPI backend (TLS)
+API_Docs: "https://<backend-ip>:8443/docs"               # Interactive API documentation
 
 # Administrative interfaces
 VNC_Desktop: "http://127.0.0.1:6080"          # Full desktop access
-Redis_Insight: "http://172.16.168.23:8002"   # Database management
-System_Health: "https://172.16.168.21/health" # System monitoring
+Redis_Insight: "http://<database-ip>:8002"   # Database management
+System_Health: "https://<frontend-ip>/health" # System monitoring
 
 # Development tools (backend endpoints)
-WebSocket_Test: "https://172.16.168.20:8443/ws-test"  # WebSocket testing
-File_Manager: "https://172.16.168.20:8443/files"      # File browser
-Log_Viewer: "https://172.16.168.20:8443/logs"         # Real-time logs
+WebSocket_Test: "https://<backend-ip>:8443/ws-test"  # WebSocket testing
+File_Manager: "https://<backend-ip>:8443/files"      # File browser
+Log_Viewer: "https://<backend-ip>:8443/logs"         # Real-time logs
 ```
 
 ### Hot Reload Development
@@ -405,7 +405,7 @@ flake8 src/ backend/         # Check code style
 **Database Development**:
 ```bash
 # Connect to Redis for debugging
-redis-cli -h 172.16.168.23 -p 6379
+redis-cli -h <database-ip> -p 6379
 
 # Browse databases
 SELECT 0  # Main application data
@@ -414,7 +414,7 @@ SELECT 8  # Vector embeddings
 FT.INFO knowledge_idx  # Vector database info
 
 # Redis Insight GUI
-# Visit: http://172.16.168.23:8002
+# Visit: http://<database-ip>:8002
 ```
 
 ## Configuration Management
@@ -436,7 +436,7 @@ AutoBot uses a hierarchical configuration system:
 # Core services
 BACKEND_HOST=0.0.0.0
 BACKEND_PORT=8001
-REDIS_HOST=172.16.168.23
+REDIS_HOST=<database-ip>
 REDIS_PORT=6379
 
 # AI Configuration  
@@ -462,29 +462,29 @@ ENABLE_HOT_RELOAD=true
 ```yaml
 vms:
   frontend:
-    host: "172.16.168.21"
+    host: "<frontend-ip>"
     services: ["nginx", "vue-dev-server"]
     ports: [80, 443, 5173]
 
   npu_worker:  
-    host: "172.16.168.22"
+    host: "<npu-ip>"
     services: ["npu-service", "gpu-fallback"]
     ports: [8081, 8082]
     hardware: ["intel_npu", "nvidia_gpu"]
 
   redis_stack:
-    host: "172.16.168.23"
+    host: "<database-ip>"
     services: ["redis-server", "redisinsight"]
     ports: [6379, 8002]
     databases: 11
 
   ai_orchestrator:
-    host: "172.16.168.24"
+    host: "<aiml-ip>"
     services: ["model-orchestrator", "inference-cache"]
     ports: [8080, 8083, 8084]
 
   browser_service:
-    host: "172.16.168.25"
+    host: "<browser-ip>"
     services: ["playwright-api", "browser-pool"]  
     ports: [3000, 3001, 3002]
 ```
@@ -505,7 +505,7 @@ sudo usermod -aG docker $USER
 ```bash
 # Check Redis service status
 docker ps | grep redis
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 
 # If not responding, restart Redis
 docker restart autobot-redis
@@ -514,7 +514,7 @@ docker restart autobot-redis
 **Problem: Frontend shows "Network Error" for API calls**
 ```bash
 # Check backend is running
-curl -k https://172.16.168.20:8443/api/health
+curl -k https://<backend-ip>:8443/api/health
 
 # Check systemd service status
 systemctl status autobot-backend
@@ -588,7 +588,7 @@ journalctl -u autobot-backend -u autobot-celery -u redis-stack-server -f
 **Debug WebSocket Connections**:
 ```javascript
 // Test WebSocket connection in browser console
-const ws = new WebSocket('wss://172.16.168.20:8443/ws/test');
+const ws = new WebSocket('wss://<backend-ip>:8443/ws/test');
 ws.onopen = () => console.log('WebSocket connected');
 ws.onmessage = (event) => console.log('Received:', event.data);
 ws.onerror = (error) => console.log('WebSocket error:', error);
@@ -597,7 +597,7 @@ ws.onerror = (error) => console.log('WebSocket error:', error);
 **Debug Multi-modal AI Processing**:
 ```bash
 # Test AI processing pipeline
-curl -k -X POST https://172.16.168.20:8443/api/multimodal/process \
+curl -k -X POST https://<backend-ip>:8443/api/multimodal/process \
   -H "Content-Type: application/json" \
   -d '{
     "inputs": {
@@ -806,16 +806,16 @@ scripts/start-services.sh status
 **2. Database Optimization**:
 ```bash
 # Clear development cache for fresh start
-redis-cli -h 172.16.168.23 FLUSHDB 3
+redis-cli -h <database-ip> FLUSHDB 3
 
 # Optimize knowledge base index
-curl -k -X POST https://172.16.168.20:8443/api/knowledge_base/optimize
+curl -k -X POST https://<backend-ip>:8443/api/knowledge_base/optimize
 ```
 
 **3. AI Model Caching**:
 ```bash
 # Pre-load models for faster development
-curl -X POST http://172.16.168.24:8080/models/preload \
+curl -X POST http://<aiml-ip>:8080/models/preload \
   -H "Content-Type: application/json" \
   -d '{"models": ["gpt-3.5-turbo", "claude-3-sonnet"]}'
 ```
@@ -842,7 +842,7 @@ cd autobot-slm-backend/ansible
 ansible-playbook playbooks/deploy-native-services.yml
 
 # 6. Verify deployment via SLM GUI
-# Visit: https://172.16.168.19/orchestration
+# Visit: https://<slm-manager-ip>/orchestration
 ```
 
 ## Getting Help
@@ -850,7 +850,7 @@ ansible-playbook playbooks/deploy-native-services.yml
 ### Documentation Resources
 
 - **Service Management**: `docs/developer/SERVICE_MANAGEMENT.md` - Complete service management guide
-- **API Documentation**: https://172.16.168.20:8443/docs (when running)
+- **API Documentation**: https://<backend-ip>:8443/docs (when running)
 - **Architecture Guide**: `docs/architecture/DISTRIBUTED_ARCHITECTURE.md`
 - **Troubleshooting**: `docs/troubleshooting/COMPREHENSIVE_TROUBLESHOOTING.md`
 - **Security Guide**: `docs/security/SECURITY_IMPLEMENTATION.md`
@@ -886,7 +886,7 @@ ansible-playbook playbooks/deploy-native-services.yml
 
 **Internal Support**:
 - Check logs: `journalctl -u autobot-backend -f` or `scripts/start-services.sh logs backend`
-- Health check: `curl -k https://172.16.168.20:8443/api/health`
+- Health check: `curl -k https://<backend-ip>:8443/api/health`
 - System status: `scripts/start-services.sh status` or visit SLM GUI
 
 **Community Resources**:

--- a/docs/developer/DISTRIBUTED_TRACING.md
+++ b/docs/developer/DISTRIBUTED_TRACING.md
@@ -46,7 +46,7 @@ Add to `.env` or `.env.example`:
 
 ```bash
 # Jaeger OTLP endpoint (default: Redis VM)
-AUTOBOT_JAEGER_ENDPOINT=http://172.16.168.23:4317
+AUTOBOT_JAEGER_ENDPOINT=http://<database-ip>:4317
 
 # Trace sampling rate (0.0-1.0)
 # 1.0 = trace everything (development)
@@ -127,7 +127,7 @@ Examples:
 #### SSH Spans
 ```python
 "ssh.target_vm": "frontend",
-"ssh.target_ip": "172.16.168.21",
+"ssh.target_ip": "<frontend-ip>",
 "ssh.user": "autobot",
 "ssh.files_copied": 3,
 "pki.operation": "distribute",
@@ -228,7 +228,7 @@ async with TracedHttpClient() as client:
      jaegertracing/all-in-one:1.50
    ```
 
-2. Access Jaeger UI: http://172.16.168.23:16686
+2. Access Jaeger UI: http://<database-ip>:16686
 
 ### Example Trace Queries
 
@@ -258,7 +258,7 @@ async def _init_distributed_tracing(app: FastAPI, update_status_fn):
 
 1. **Check Jaeger is running:**
    ```bash
-   curl http://172.16.168.23:4317/health
+   curl http://<database-ip>:4317/health
    ```
 
 2. **Enable console export for debugging:**

--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -14,7 +14,7 @@ The following values must NEVER be hardcoded in source files:
 
 | Type | Examples | Correct Alternative |
 |------|----------|---------------------|
-| **IP Addresses** | `"172.16.168.20"`, `"192.168.1.100"` | `config.backend.host` (Python) or SSOT env vars |
+| **IP Addresses** | `"<backend-ip>"`, `"192.168.1.100"` | `config.backend.host` (Python) or SSOT env vars |
 | **Port Numbers** | `8001`, `6379`, `5173` | `config.backend.port` (Python) or SSOT env vars |
 | **LLM Model Names** | `"qwen3.5:9b"`, `"mistral:7b-instruct"` | `config.llm.default_model` or `AUTOBOT_DEFAULT_LLM_MODEL` |
 | **URLs** | `"http://example.com/api"` | `getBackendUrl()` (TypeScript) or SSOT config |
@@ -80,7 +80,7 @@ redis_host = ConfigRegistry.get("vm.redis")
 npu_port = ConfigRegistry.get("port.npu")
 
 # BAD -- redundant hardcoded fallback (will trigger detection script)
-redis_host = ConfigRegistry.get("vm.redis", "172.16.168.23")
+redis_host = ConfigRegistry.get("vm.redis", "<database-ip>")
 ```
 
 For model names and embedding models, use the SSOT constants:
@@ -107,8 +107,8 @@ embedding = "nomic-embed-text:latest"
 
 ```python
 # BAD - Hardcoded values
-url = "https://172.16.168.20:8443/api/chat"
-redis_host = "172.16.168.23"
+url = "https://<backend-ip>:8443/api/chat"
+redis_host = "<database-ip>"
 redis_port = 6379
 
 # GOOD - Use SSOT config
@@ -123,7 +123,7 @@ redis_port = config.redis.port
 
 ```typescript
 // BAD - Hardcoded values
-const url = "https://172.16.168.20:8443/api/chat"
+const url = "https://<backend-ip>:8443/api/chat"
 
 // GOOD - Use SSOT config
 import { getBackendUrl } from '@/config/ssot-config'
@@ -142,10 +142,10 @@ if [ -f "$PROJECT_ROOT/.env" ]; then
 fi
 
 # BAD - Hardcoded
-BACKEND_HOST="172.16.168.20"
+BACKEND_HOST="<backend-ip>"
 
 # GOOD - SSOT env var with fallback
-BACKEND_HOST="${AUTOBOT_BACKEND_HOST:-172.16.168.20}"
+BACKEND_HOST="${AUTOBOT_BACKEND_HOST:-<backend-ip>}"
 ```
 
 ### 2. For LLM Model Names
@@ -251,7 +251,7 @@ autobot-infrastructure/shared/scripts/detect-hardcoded-values.sh
 
 **IP Address Patterns**:
 
-- IPv4: `172.16.168.20`, `192.168.1.1`, etc.
+- IPv4: `<backend-ip>`, `192.168.1.1`, etc.
 - IPv6: Full and compressed formats
 - Excludes: Comments, documentation, test files
 

--- a/docs/developer/INFRASTRUCTURE_DEPLOYMENT.md
+++ b/docs/developer/INFRASTRUCTURE_DEPLOYMENT.md
@@ -16,11 +16,11 @@ This guide provides detailed instructions for AutoBot's distributed VM infrastru
 
 **Configured for all 5 VMs**:
 
-- `frontend` (172.16.168.21)
-- `npu-worker` (172.16.168.22)
-- `redis` (172.16.168.23)
-- `ai-stack` (172.16.168.24)
-- `browser` (172.16.168.25)
+- `frontend` (<frontend-ip>)
+- `npu-worker` (<npu-ip>)
+- `redis` (<database-ip>)
+- `ai-stack` (<aiml-ip>)
+- `browser` (<browser-ip>)
 
 ### Verify SSH Access
 
@@ -28,11 +28,11 @@ This guide provides detailed instructions for AutoBot's distributed VM infrastru
 # Test connection to all VMs
 for vm in frontend npu-worker redis ai-stack browser; do
     echo "Testing $vm..."
-    ssh -i ~/.ssh/autobot_key autobot@172.16.168.{21..25} "hostname" 2>/dev/null
+    ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> through <browser-ip> "hostname" 2>/dev/null
 done
 
 # Test specific VM
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "echo 'Frontend VM connected'"
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "echo 'Frontend VM connected'"
 ```
 
 ### SSH Configuration
@@ -42,31 +42,31 @@ Add to `~/.ssh/config` for easier access:
 ```ssh-config
 # AutoBot VMs
 Host autobot-frontend
-    HostName 172.16.168.21
+    HostName <frontend-ip>
     User autobot
     IdentityFile ~/.ssh/autobot_key
     StrictHostKeyChecking accept-new
 
 Host autobot-npu
-    HostName 172.16.168.22
+    HostName <npu-ip>
     User autobot
     IdentityFile ~/.ssh/autobot_key
     StrictHostKeyChecking accept-new
 
 Host autobot-redis
-    HostName 172.16.168.23
+    HostName <database-ip>
     User autobot
     IdentityFile ~/.ssh/autobot_key
     StrictHostKeyChecking accept-new
 
 Host autobot-ai
-    HostName 172.16.168.24
+    HostName <aiml-ip>
     User autobot
     IdentityFile ~/.ssh/autobot_key
     StrictHostKeyChecking accept-new
 
 Host autobot-browser
-    HostName 172.16.168.25
+    HostName <browser-ip>
     User autobot
     IdentityFile ~/.ssh/autobot_key
     StrictHostKeyChecking accept-new
@@ -178,7 +178,7 @@ ssh autobot-redis
 
 ### The Rule
 
-**NEVER edit code directly on remote VMs (172.16.168.21-25) - ZERO TOLERANCE**
+**NEVER edit code directly on remote VMs (<frontend-ip>-25) - ZERO TOLERANCE**
 
 ### Required Workflow
 
@@ -215,7 +215,7 @@ git commit -m "Update chat API"
 
 ```bash
 # NEVER DO THIS - Direct editing on VM
-ssh autobot@172.16.168.21
+ssh autobot@<frontend-ip>
 vim /home/autobot/autobot-user-autobot-backend/api/chat.py  # PERMANENT WORK LOSS RISK!
 ```
 
@@ -254,27 +254,27 @@ vite --host localhost --port 5173
 
 ### Service Access Patterns
 
-**Backend on Main Machine** (172.16.168.20):
+**Backend on Main Machine** (<backend-ip>):
 
 ```python
 # Binds to all interfaces
 uvicorn main:app --host 0.0.0.0 --port 8001
 
 # Accessed from frontend VM:
-# https://172.16.168.20:8443/api/chat
+# https://<backend-ip>:8443/api/chat
 ```
 
-**Frontend on VM1** (172.16.168.21):
+**Frontend on VM1** (<frontend-ip>):
 
 ```bash
 # Binds to all interfaces
 npm run dev -- --host 0.0.0.0 --port 5173
 
 # Accessed from browser:
-# http://172.16.168.21:5173
+# http://<frontend-ip>:5173
 ```
 
-**Redis on VM3** (172.16.168.23):
+**Redis on VM3** (<database-ip>):
 
 ```bash
 # Configure Redis to bind to all interfaces
@@ -282,7 +282,7 @@ npm run dev -- --host 0.0.0.0 --port 5173
 bind 0.0.0.0
 
 # Accessed from any VM:
-# redis-cli -h 172.16.168.23 -p 6379
+# redis-cli -h <database-ip> -p 6379
 ```
 
 ### Inter-VM Communication
@@ -294,10 +294,10 @@ bind 0.0.0.0
 from autobot_shared.network_constants import NetworkConstants
 
 backend_url = f"http://{NetworkConstants.MAIN_MACHINE_IP}:{NetworkConstants.BACKEND_PORT}/api/chat"
-# Result: https://172.16.168.20:8443/api/chat
+# Result: https://<backend-ip>:8443/api/chat
 
 redis_host = NetworkConstants.REDIS_VM_IP
-# Result: 172.16.168.23
+# Result: <database-ip>
 
 # WRONG - Using localhost (won't work from remote VMs)
 backend_url = "http://localhost:8001/api/chat"
@@ -310,13 +310,13 @@ redis_host = "localhost"
 
 ```bash
 # From main machine, test backend accessibility
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 
 # From frontend VM, test backend accessibility
-ssh autobot@172.16.168.21 "curl https://172.16.168.20:8443/api/health"
+ssh autobot@<frontend-ip> "curl https://<backend-ip>:8443/api/health"
 
 # From any VM, test Redis
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 # Should return: PONG
 
 # Test all VMs from main machine
@@ -336,7 +336,7 @@ done
 
 AutoBot infrastructure requires specific firewall rules to function correctly:
 
-1. **Infrastructure subnet must be allowed** (`172.16.168.0/24`) - VMs cannot communicate without this
+1. **Infrastructure subnet must be allowed** (`<network-subnet>`) - VMs cannot communicate without this
 2. **SSH must be allowed** (port 22) - Critical to prevent lockout
 3. **Service-specific ports** - Backend API, Redis, Frontend, etc.
 
@@ -354,7 +354,7 @@ cd autobot-slm-backend/ansible
 ansible-playbook playbooks/provision-fleet-roles.yml --tags common,firewall
 
 # Deploy to specific VM
-ansible-playbook playbooks/provision-fleet-roles.yml --limit 172.16.168.20 --tags common,firewall
+ansible-playbook playbooks/provision-fleet-roles.yml --limit <backend-ip> --tags common,firewall
 ```
 
 **Firewall rules are defined in**: `ansible/inventory/group_vars/all.yml` under `security.firewall_rules`
@@ -385,38 +385,38 @@ sudo ./infrastructure/shared/config/ufw-defaults.sh status
 ### Default Firewall Rules
 
 **Base rules (applied to ALL VMs):**
-- SSH from gateway (port 22, source: 172.16.168.1)
+- SSH from gateway (port 22, source: <network-gateway>)
 
 **Role-specific rules (defined in `inventory/group_vars/<role>.yml`):**
 
-**Frontend VM (172.16.168.21):**
+**Frontend VM (<frontend-ip>):**
 - 443/tcp (any) - HTTPS public access
 - 80/tcp (any) - HTTP public access
 - 5173/tcp (infrastructure only) - Vue dev server
 - 8001/tcp (infrastructure only) - Backend API connectivity
 - 8443/tcp (infrastructure only) - Backend API HTTPS connectivity
 
-**Backend VM (172.16.168.20):**
+**Backend VM (<backend-ip>):**
 - 8443/tcp (infrastructure only) - Backend API HTTPS
 - 8001/tcp (infrastructure only) - Backend API HTTP
 - 6080/tcp (infrastructure only) - noVNC web console
 - 5900/tcp (infrastructure only) - VNC
 
-**Redis VM (172.16.168.23):**
+**Redis VM (<database-ip>):**
 - 6379/tcp (infrastructure only) - Redis Stack
 - 5432/tcp (infrastructure only) - PostgreSQL
 - 8001/tcp (infrastructure only) - Redis Insight UI
 
-**AI/ML VMs (172.16.168.22, 172.16.168.24):**
+**AI/ML VMs (<npu-ip>, <aiml-ip>):**
 - 8080/tcp (infrastructure only) - AI Stack API
 - 8081/tcp (infrastructure only) - NPU Worker API
 - 11434/tcp (infrastructure only) - Ollama API
 
-**Browser VM (172.16.168.25):**
+**Browser VM (<browser-ip>):**
 - 3000/tcp (infrastructure only) - Browser Worker API
 - 3001/tcp (infrastructure only) - Playwright Debug
 
-**SLM Server (172.16.168.19):**
+**SLM Server (<slm-manager-ip>):**
 - 443/tcp (any) - SLM Frontend HTTPS
 - 80/tcp (any) - SLM Frontend HTTP
 - 8000/tcp (infrastructure only) - SLM Backend API
@@ -451,7 +451,7 @@ sudo dmesg | grep UFW | tail -20
 sudo ufw status verbose
 
 # Check specific rule exists
-sudo ufw status | grep "172.16.168.0/24"
+sudo ufw status | grep "<network-subnet>"
 sudo ufw status | grep "8443"
 
 # Check recent UFW blocks
@@ -486,7 +486,7 @@ security:
     - rule: allow
       port: 9999
       proto: tcp
-      src: "172.16.168.0/24"
+      src: "<network-subnet>"
       comment: "Custom service port"
 ```
 
@@ -501,7 +501,7 @@ ansible-playbook playbooks/provision-fleet-roles.yml --tags common,firewall
 
 ```bash
 # Allow specific port from infrastructure subnet
-sudo ufw allow from 172.16.168.0/24 to any port 9999 proto tcp comment 'Custom service'
+sudo ufw allow from <network-subnet> to any port 9999 proto tcp comment 'Custom service'
 
 # Allow specific port from any source
 sudo ufw allow 9999/tcp comment 'Public service'
@@ -521,7 +521,7 @@ After deploying firewall configuration, verify:
 sudo ufw status | grep "Status: active"
 
 # 2. Infrastructure subnet rule exists
-sudo ufw status | grep "172.16.168.0/24"
+sudo ufw status | grep "<network-subnet>"
 
 # 3. SSH rule exists (CRITICAL)
 sudo ufw status | grep "22/tcp"
@@ -532,9 +532,9 @@ sudo ufw status | grep "6379/tcp"  # Redis
 sudo ufw status | grep "443/tcp"   # Frontend
 
 # 5. Test actual connectivity
-curl http://172.16.168.20:8443/api/health  # Backend
-redis-cli -h 172.16.168.23 ping            # Redis
-curl https://172.16.168.21                 # Frontend
+curl http://<backend-ip>:8443/api/health  # Backend
+redis-cli -h <database-ip> ping            # Redis
+curl https://<frontend-ip>                 # Frontend
 ```
 
 ---
@@ -545,20 +545,20 @@ curl https://172.16.168.21                 # Frontend
 
 | VM | IP:Port | Service | Purpose |
 |----|---------|---------|---------|
-| **Main (WSL)** | 172.16.168.20:8443 | Backend API | FastAPI backend, business logic |
-| **Main (WSL)** | 172.16.168.20:6080 | VNC Desktop | noVNC web-based terminal |
-| **VM1 Frontend** | 172.16.168.21:5173 | Web UI | Vue.js frontend (SINGLE SERVER) |
-| **VM2 NPU Worker** | 172.16.168.22:8081 | AI Acceleration | Hardware NPU for AI tasks |
-| **VM3 Redis** | 172.16.168.23:6379 | Data Layer | Redis database, cache, queues |
-| **VM4 AI Stack** | 172.16.168.24:8080 | AI Processing | LLM inference, AI services |
-| **VM5 Browser** | 172.16.168.25:3000 | Web Automation | Playwright browser automation |
+| **Main (WSL)** | <backend-ip>:8443 | Backend API | FastAPI backend, business logic |
+| **Main (WSL)** | <backend-ip>:6080 | VNC Desktop | noVNC web-based terminal |
+| **VM1 Frontend** | <frontend-ip>:5173 | Web UI | Vue.js frontend (SINGLE SERVER) |
+| **VM2 NPU Worker** | <npu-ip>:8081 | AI Acceleration | Hardware NPU for AI tasks |
+| **VM3 Redis** | <database-ip>:6379 | Data Layer | Redis database, cache, queues |
+| **VM4 AI Stack** | <aiml-ip>:8080 | AI Processing | LLM inference, AI services |
+| **VM5 Browser** | <browser-ip>:3000 | Web Automation | Playwright browser automation |
 
 ### Architecture Diagram
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
 │                     Main Machine (WSL)                       │
-│                    172.16.168.20                             │
+│                    <backend-ip>                             │
 │  ┌──────────────┐  ┌──────────────┐                         │
 │  │ Backend API  │  │ VNC Desktop  │                         │
 │  │   :8001      │  │   :6080      │                         │
@@ -569,13 +569,13 @@ curl https://172.16.168.21                 # Frontend
         │                   │                   │
 ┌───────▼─────────┐ ┌──────▼──────────┐ ┌─────▼──────────┐
 │  VM1: Frontend  │ │  VM3: Redis     │ │  VM4: AI Stack │
-│  172.16.168.21  │ │  172.16.168.23  │ │  172.16.168.24 │
+│  <frontend-ip>  │ │  <database-ip>  │ │  <aiml-ip> │
 │  Port: 5173     │ │  Port: 6379     │ │  Port: 8080    │
 └─────────────────┘ └─────────────────┘ └────────────────┘
         │                   │                   │
 ┌───────▼─────────┐ ┌──────▼──────────┐
 │ VM2: NPU Worker │ │ VM5: Browser    │
-│ 172.16.168.22   │ │ 172.16.168.25   │
+│ <npu-ip>   │ │ <browser-ip>   │
 │ Port: 8081      │ │ Port: 3000      │
 └─────────────────┘ └─────────────────┘
 ```
@@ -628,11 +628,11 @@ cd autobot-slm-backend/ansible
 ansible-playbook playbooks/deploy-native-services.yml
 
 # 4. Verify health checks
-curl -k https://172.16.168.20:8443/api/health
-curl https://172.16.168.21
+curl -k https://<backend-ip>:8443/api/health
+curl https://<frontend-ip>
 
 # 5. Monitor via SLM GUI
-# Visit: https://172.16.168.19/orchestration
+# Visit: https://<slm-manager-ip>/orchestration
 ```
 
 **See**: [Service Management Guide](SERVICE_MANAGEMENT.md) for Ansible deployment details.
@@ -644,16 +644,16 @@ curl https://172.16.168.21
 ```bash
 # Update specific node via Ansible
 cd autobot-slm-backend/ansible
-ansible-playbook playbooks/deploy-native-services.yml --limit 172.16.168.21 --tags frontend
+ansible-playbook playbooks/deploy-native-services.yml --limit <frontend-ip> --tags frontend
 
 # Wait for health check
-curl https://172.16.168.21
+curl https://<frontend-ip>
 
 # Update NPU Worker VM
-ansible-playbook playbooks/deploy-native-services.yml --limit 172.16.168.22 --tags npu
+ansible-playbook playbooks/deploy-native-services.yml --limit <npu-ip> --tags npu
 
 # Or use SLM GUI for rolling updates
-# Visit: https://172.16.168.19/orchestration
+# Visit: https://<slm-manager-ip>/orchestration
 # Select node → Deploy → Monitor progress
 ```
 
@@ -662,7 +662,7 @@ ansible-playbook playbooks/deploy-native-services.yml --limit 172.16.168.22 --ta
 ```bash
 # Update Frontend VM
 ./infrastructure/shared/scripts/sync-to-vm.sh frontend autobot-slm-frontend/ /opt/autobot/autobot-slm-frontend/
-ssh autobot@172.16.168.21 "sudo systemctl restart autobot-frontend"
+ssh autobot@<frontend-ip> "sudo systemctl restart autobot-frontend"
 ```
 
 ---
@@ -679,8 +679,8 @@ for ip in 20 21 22 23 24 25; do
 done
 
 # Check services on each VM
-ssh autobot@172.16.168.21 "systemctl status frontend"
-ssh autobot@172.16.168.23 "systemctl status redis"
+ssh autobot@<frontend-ip> "systemctl status frontend"
+ssh autobot@<database-ip> "systemctl status redis"
 ```
 
 ### Restart Services
@@ -695,11 +695,11 @@ sudo systemctl restart autobot-backend
 sudo systemctl restart autobot-celery
 
 # Remote VM services (via SSH)
-ssh autobot@172.16.168.21 "sudo systemctl restart autobot-frontend"
-ssh autobot@172.16.168.23 "sudo systemctl restart redis-stack-server"
+ssh autobot@<frontend-ip> "sudo systemctl restart autobot-frontend"
+ssh autobot@<database-ip> "sudo systemctl restart redis-stack-server"
 
 # Or use SLM Orchestration GUI
-# Visit: https://172.16.168.19/orchestration
+# Visit: https://<slm-manager-ip>/orchestration
 ```
 
 ### View Logs
@@ -713,13 +713,13 @@ scripts/start-services.sh logs backend
 journalctl -u autobot-celery -f
 
 # Remote VMs - Frontend logs
-ssh autobot@172.16.168.21 "journalctl -u autobot-frontend -f"
+ssh autobot@<frontend-ip> "journalctl -u autobot-frontend -f"
 
 # Remote VMs - Redis logs
-ssh autobot@172.16.168.23 "journalctl -u redis-stack-server -f"
+ssh autobot@<database-ip> "journalctl -u redis-stack-server -f"
 
 # Or use SLM GUI for log viewing
-# Visit: https://172.16.168.19/orchestration → Select service → Logs
+# Visit: https://<slm-manager-ip>/orchestration → Select service → Logs
 ```
 
 ---
@@ -765,7 +765,7 @@ chmod +x infrastructure/shared/scripts/sync-to-vm.sh
 chmod 600 ~/.ssh/autobot_key
 
 # Test SSH connection
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "echo 'Connected'"
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "echo 'Connected'"
 ```
 
 ### Services Not Accessible
@@ -776,14 +776,14 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "echo 'Connected'"
 
 ```bash
 # 1. Verify service is running
-ssh autobot@172.16.168.21 "ps aux | grep node"  # Frontend
+ssh autobot@<frontend-ip> "ps aux | grep node"  # Frontend
 ps aux | grep uvicorn  # Backend (main machine)
 
 # 2. Verify service is binding to 0.0.0.0
 netstat -tulpn | grep 8001  # Should show 0.0.0.0:8001
 
 # 3. Test from source VM
-ssh autobot@172.16.168.21 "curl https://172.16.168.20:8443/api/health"
+ssh autobot@<frontend-ip> "curl https://<backend-ip>:8443/api/health"
 ```
 
 ### VM Out of Sync
@@ -802,7 +802,7 @@ ansible-playbook playbooks/deploy-native-services.yml
 sudo systemctl restart autobot-backend
 
 # Verify sync
-ssh autobot@172.16.168.20 "md5sum /opt/autobot/autobot-backend/api/chat.py"
+ssh autobot@<backend-ip> "md5sum /opt/autobot/autobot-backend/api/chat.py"
 md5sum autobot-backend/api/chat.py
 # Hashes should match
 ```
@@ -839,7 +839,7 @@ md5sum autobot-backend/api/chat.py
 
 **Avoid**:
 
-- [ ] No direct edits on remote VMs (172.16.168.21-25)
+- [ ] No direct edits on remote VMs (<frontend-ip>-25)
 - [ ] No binding to localhost/127.0.0.1
 - [ ] No hardcoded IPs/ports in code
 - [ ] No skipping sync after changes

--- a/docs/developer/LANGCHAIN_MCP_INTEGRATION.md
+++ b/docs/developer/LANGCHAIN_MCP_INTEGRATION.md
@@ -44,7 +44,7 @@ from langchain.tools import Tool, StructuredTool
 from langchain_anthropic import ChatAnthropic
 
 # AutoBot backend configuration
-AUTOBOT_BACKEND_URL = "https://172.16.168.20:8443"
+AUTOBOT_BACKEND_URL = "https://<backend-ip>:8443"
 
 
 async def call_mcp_tool(

--- a/docs/developer/MCP_MANAGEMENT_GUIDE.md
+++ b/docs/developer/MCP_MANAGEMENT_GUIDE.md
@@ -520,7 +520,7 @@ async def list_all_mcp_tools():
     """Get all MCP tools from registry"""
     async with aiohttp.ClientSession() as session:
         async with session.get(
-            "https://172.16.168.20:8443/api/mcp/tools"
+            "https://<backend-ip>:8443/api/mcp/tools"
         ) as response:
             data = await response.json()
             return data["tools"]
@@ -529,7 +529,7 @@ async def check_mcp_health():
     """Check health of all MCP bridges"""
     async with aiohttp.ClientSession() as session:
         async with session.get(
-            "https://172.16.168.20:8443/api/mcp/health"
+            "https://<backend-ip>:8443/api/mcp/health"
         ) as response:
             data = await response.json()
             return data["status"] == "healthy"

--- a/docs/developer/PROMETHEUS_METRICS_USAGE.md
+++ b/docs/developer/PROMETHEUS_METRICS_USAGE.md
@@ -295,7 +295,7 @@ scrape_configs:
     scrape_interval: 15s
     metrics_path: '/api/monitoring/metrics'
     static_configs:
-      - targets: ['172.16.168.20:8443']
+      - targets: ['<backend-ip>:8443']
 ```
 
 ### Alert Rules

--- a/docs/developer/REDIS_CLIENT_USAGE.md
+++ b/docs/developer/REDIS_CLIENT_USAGE.md
@@ -49,15 +49,15 @@ async_redis = await get_redis_client(async_client=True, database="knowledge")
 ```python
 # ❌ WRONG - Direct instantiation (67 files still violate this!)
 import redis
-client = redis.Redis(host="172.16.168.23", port=6379, db=0)
+client = redis.Redis(host="<database-ip>", port=6379, db=0)
 
 # ❌ WRONG - Custom connection pooling
-pool = redis.ConnectionPool(host="172.16.168.23", port=6379, max_connections=10)
+pool = redis.ConnectionPool(host="<database-ip>", port=6379, max_connections=10)
 client = redis.Redis(connection_pool=pool)
 
 # ❌ WRONG - Direct StrictRedis
 from redis import StrictRedis
-client = StrictRedis(host="172.16.168.23", port=6379)
+client = StrictRedis(host="<database-ip>", port=6379)
 ```
 
 ### Deprecated Utilities
@@ -92,9 +92,9 @@ analytics_db = get_redis_client(database="analytics")  # Analytics data
 
 # ❌ WRONG - Database numbers (unclear purpose)
 import redis
-db0 = redis.Redis(host="172.16.168.23", db=0)  # What is this for?
-db1 = redis.Redis(host="172.16.168.23", db=1)  # What is this for?
-db2 = redis.Redis(host="172.16.168.23", db=2)  # What is this for?
+db0 = redis.Redis(host="<database-ip>", db=0)  # What is this for?
+db1 = redis.Redis(host="<database-ip>", db=1)  # What is this for?
+db2 = redis.Redis(host="<database-ip>", db=2)  # What is this for?
 ```
 
 ### Standard Database Names
@@ -212,7 +212,7 @@ def safe_redis_operation():
          │ Manages connection pools
          ▼
 ┌─────────────────┐
-│  Redis Server   │ (172.16.168.23:6379)
+│  Redis Server   │ (<database-ip>:6379)
 └─────────────────┘
 ```
 
@@ -225,7 +225,7 @@ The canonical utility uses `NetworkConstants` internally:
 from src.constants.network_constants import NetworkConstants
 
 # Automatic - no hardcoded IPs!
-redis_host = NetworkConstants.REDIS_VM_IP  # 172.16.168.23
+redis_host = NetworkConstants.REDIS_VM_IP  # <database-ip>
 redis_port = NetworkConstants.REDIS_PORT    # 6379
 ```
 
@@ -267,7 +267,7 @@ import redis
 
 class MyService:
     def __init__(self):
-        self.redis = redis.Redis(host="172.16.168.23", port=6379, db=0)
+        self.redis = redis.Redis(host="<database-ip>", port=6379, db=0)
 
     def cache_data(self, key, value):
         self.redis.set(key, value)
@@ -382,10 +382,10 @@ result = redis_client.get(key)  # What if connection fails?
 **Solution**:
 ```bash
 # Check Redis VM is running
-ssh autobot@172.16.168.23 "systemctl status redis"
+ssh autobot@<database-ip> "systemctl status redis"
 
 # Check Redis is listening
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 # Should return: PONG
 
 # Verify NetworkConstants
@@ -399,14 +399,14 @@ python3 -c "from src.constants.network_constants import NetworkConstants; print(
 **Solution**:
 ```bash
 # Check network connectivity
-ping 172.16.168.23
+ping <database-ip>
 
 # Check Redis configuration
-ssh autobot@172.16.168.23 "cat /etc/redis/redis.conf | grep bind"
-# Should bind to 0.0.0.0 or 172.16.168.23
+ssh autobot@<database-ip> "cat /etc/redis/redis.conf | grep bind"
+# Should bind to 0.0.0.0 or <database-ip>
 
 # Check timeout settings
-ssh autobot@172.16.168.23 "cat /etc/redis/redis.conf | grep timeout"
+ssh autobot@<database-ip> "cat /etc/redis/redis.conf | grep timeout"
 ```
 
 ### Database Number Confusion

--- a/docs/developer/REDIS_CONSOLIDATION_MIGRATION_GUIDE.md
+++ b/docs/developer/REDIS_CONSOLIDATION_MIGRATION_GUIDE.md
@@ -107,7 +107,7 @@ async with client.pipeline() as pipe:
 \`\`\`python
 from src.utils.async_redis_manager import AsyncRedisManager
 
-manager = AsyncRedisManager(host="172.16.168.23", port=6379)
+manager = AsyncRedisManager(host="<database-ip>", port=6379)
 await manager.connect()
 client = manager.client
 \`\`\`
@@ -119,7 +119,7 @@ from src.utils.redis_client import get_redis_client
 client = await get_redis_client(
     async_client=True,
     database="main",  # or whichever database you need
-    host="172.16.168.23",  # optional - uses NetworkConstants.REDIS_VM_IP by default
+    host="<database-ip>",  # optional - uses NetworkConstants.REDIS_VM_IP by default
     port=6379  # optional - uses default
 )
 \`\`\`

--- a/docs/developer/REDIS_PERFORMANCE_OPTIMIZATION.md
+++ b/docs/developer/REDIS_PERFORMANCE_OPTIMIZATION.md
@@ -1,6 +1,6 @@
 # Redis Performance Optimization Plan for AutoBot
 
-## Current Redis Status (172.16.168.23:6379)
+## Current Redis Status (<database-ip>:6379)
 
 ### Configuration Analysis
 - **Version**: Redis 7.4.5 (latest stable) ✅
@@ -38,10 +38,10 @@
 #### Set Memory Limits
 ```bash
 # Recommended: 8GB limit (leaves headroom for OS)
-redis-cli -h 172.16.168.23 CONFIG SET maxmemory 8gb
+redis-cli -h <database-ip> CONFIG SET maxmemory 8gb
 
 # Change eviction policy to LRU for vectorization jobs
-redis-cli -h 172.16.168.23 CONFIG SET maxmemory-policy allkeys-lru
+redis-cli -h <database-ip> CONFIG SET maxmemory-policy allkeys-lru
 ```
 
 **Rationale**:
@@ -63,7 +63,7 @@ maxmemory-samples 10  # Higher = better LRU accuracy (default: 5)
 ```bash
 # Current: save 3600 1 300 100 60 10000 (very aggressive)
 # Recommended: Less frequent snapshots
-redis-cli -h 172.16.168.23 CONFIG SET save "3600 1 7200 10000"
+redis-cli -h <database-ip> CONFIG SET save "3600 1 7200 10000"
 ```
 
 **Rationale**:
@@ -73,8 +73,8 @@ redis-cli -h 172.16.168.23 CONFIG SET save "3600 1 7200 10000"
 
 #### Option B: Enable AOF for Better Durability
 ```bash
-redis-cli -h 172.16.168.23 CONFIG SET appendonly yes
-redis-cli -h 172.16.168.23 CONFIG SET appendfsync everysec
+redis-cli -h <database-ip> CONFIG SET appendonly yes
+redis-cli -h <database-ip> CONFIG SET appendfsync everysec
 ```
 
 **Rationale**:
@@ -90,7 +90,7 @@ redis-cli -h 172.16.168.23 CONFIG SET appendfsync everysec
 Current implementation needs review. Recommended settings:
 ```python
 redis_pool = redis.ConnectionPool(
-    host='172.16.168.23',
+    host='<database-ip>',
     port=6379,
     decode_responses=True,
     max_connections=50,        # Increase from default 10
@@ -192,11 +192,11 @@ async def redis_metrics(req: Request):
 #### Monitor Slow Commands
 ```bash
 # Enable slow log (commands taking > 10ms)
-redis-cli -h 172.16.168.23 CONFIG SET slowlog-log-slower-than 10000
-redis-cli -h 172.16.168.23 CONFIG SET slowlog-max-len 128
+redis-cli -h <database-ip> CONFIG SET slowlog-log-slower-than 10000
+redis-cli -h <database-ip> CONFIG SET slowlog-max-len 128
 
 # Check slow log
-redis-cli -h 172.16.168.23 SLOWLOG GET 10
+redis-cli -h <database-ip> SLOWLOG GET 10
 ```
 
 ### 7. Scaling Considerations (FUTURE)
@@ -286,7 +286,7 @@ redis-cli -h 172.16.168.23 SLOWLOG GET 10
 ## Configuration File Template
 
 ```conf
-# /etc/redis/redis.conf on VM3 (172.16.168.23)
+# /etc/redis/redis.conf on VM3 (<database-ip>)
 
 # Network
 bind 0.0.0.0

--- a/docs/developer/ROLES.md
+++ b/docs/developer/ROLES.md
@@ -578,7 +578,7 @@ optional roles:
 └──────────────────┘    └──────────────────┘    └────────────────────────────────┘
 
   ─── Required service boundary     ···  Optional / degraded-without
-  ══  External HTTPS                 ──  Internal subnet 172.16.168.0/24
+  ══  External HTTPS                 ──  Internal subnet <network-subnet>
 ```
 
 ---

--- a/docs/developer/SERVICE_MANAGEMENT.md
+++ b/docs/developer/SERVICE_MANAGEMENT.md
@@ -21,7 +21,7 @@ AutoBot uses **SLM (System Lifecycle Manager) orchestration** and **systemd** fo
 
 **Best for:** Visual monitoring, fleet-wide operations, production management
 
-**Access:** https://172.16.168.19/orchestration
+**Access:** https://<slm-manager-ip>/orchestration
 
 **Features:**
 - Start/stop/restart all services
@@ -31,9 +31,9 @@ AutoBot uses **SLM (System Lifecycle Manager) orchestration** and **systemd** fo
 - Service dependency visualization
 
 **Usage:**
-1. Open https://172.16.168.19/orchestration in browser
+1. Open https://<slm-manager-ip>/orchestration in browser
 2. Navigate to "Services" tab
-3. Select node (e.g., "Main - 172.16.168.20")
+3. Select node (e.g., "Main - <backend-ip>")
 4. Click service action buttons (Start/Stop/Restart)
 5. View logs by clicking "Logs" button
 
@@ -238,7 +238,7 @@ python backend/main.py
 systemctl status redis-stack-server
 
 # Check network connectivity
-curl -k https://172.16.168.20:8443/api/health
+curl -k https://<backend-ip>:8443/api/health
 ```
 
 ### Restarting Services After Configuration Changes
@@ -308,7 +308,7 @@ AUTOBOT_BACKEND_PORT=8443
 AUTOBOT_BACKEND_TLS_ENABLED=true
 
 # Redis
-AUTOBOT_REDIS_HOST=172.16.168.23
+AUTOBOT_REDIS_HOST=<database-ip>
 AUTOBOT_REDIS_PORT=6379
 
 # AI Services
@@ -344,7 +344,7 @@ ansible-playbook playbooks/deploy-native-services.yml
 **Deploy to specific node:**
 ```bash
 # Deploy to frontend VM
-ansible-playbook playbooks/deploy-native-services.yml --limit 172.16.168.21
+ansible-playbook playbooks/deploy-native-services.yml --limit <frontend-ip>
 
 # Deploy NPU worker
 ansible-playbook playbooks/deploy-native-services.yml --tags npu
@@ -364,7 +364,7 @@ ansible-playbook playbooks/deploy-native-services.yml --tags npu
 ./infrastructure/shared/scripts/sync-to-vm.sh main autobot-backend/
 
 # SSH to node and restart
-ssh autobot@172.16.168.20
+ssh autobot@<backend-ip>
 sudo systemctl restart autobot-backend
 ```
 
@@ -519,7 +519,7 @@ scripts/start-services.sh start backend
 sudo systemctl start autobot-backend
 
 # Or SLM GUI
-# Open https://172.16.168.19/orchestration
+# Open https://<slm-manager-ip>/orchestration
 ```
 
 **4. Update your workflow:**
@@ -586,7 +586,7 @@ journalctl -u autobot-backend -n 50
 
 ## Additional Resources
 
-- **SLM Orchestration:** https://172.16.168.19/orchestration
+- **SLM Orchestration:** https://<slm-manager-ip>/orchestration
 - **Systemd Documentation:** `man systemd`, `man journalctl`
 - **Ansible Playbooks:** `autobot-slm-backend/ansible/playbooks/`
 - **Service Templates:** `autobot-slm-backend/ansible/roles/*/templates/*.service.j2`
@@ -599,7 +599,7 @@ journalctl -u autobot-backend -n 50
 **Common Issues:**
 1. Service won't start → Check logs: `journalctl -u autobot-backend -n 50`
 2. Configuration not loading → Restart: `sudo systemctl restart autobot-backend`
-3. Can't access GUI → Check network: `ping 172.16.168.19`
+3. Can't access GUI → Check network: `ping <slm-manager-ip>`
 4. Port in use → Find process: `lsof -i :8443`
 
 **Need more help?**

--- a/docs/developer/SSOT_CONFIG_GUIDE.md
+++ b/docs/developer/SSOT_CONFIG_GUIDE.md
@@ -13,9 +13,9 @@ AutoBot uses a **Single Source of Truth (SSOT)** configuration pattern where all
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                     .env (Master SSOT)                          │
-│  AUTOBOT_BACKEND_HOST=172.16.168.20                            │
-│  AUTOBOT_FRONTEND_HOST=172.16.168.21                           │
-│  AUTOBOT_REDIS_HOST=172.16.168.23                              │
+│  AUTOBOT_BACKEND_HOST=<backend-ip>                            │
+│  AUTOBOT_FRONTEND_HOST=<frontend-ip>                           │
+│  AUTOBOT_REDIS_HOST=<database-ip>                              │
 │  ...                                                            │
 └─────────────────────────────────────────────────────────────────┘
                               │
@@ -35,12 +35,12 @@ AutoBot uses a **Single Source of Truth (SSOT)** configuration pattern where all
 from autobot_shared.ssot_config import config
 
 # Access configuration values
-backend_host = config.backend.host        # "172.16.168.20"
+backend_host = config.backend.host        # "<backend-ip>"
 redis_url = config.redis.url              # Full connection URL
 llm_model = config.llm.default_model      # "qwen3.5:9b"
 
 # Get full URL for a service
-api_url = config.backend.url              # "https://172.16.168.20:8443"
+api_url = config.backend.url              # "https://<backend-ip>:8443"
 ```
 
 ### TypeScript (Frontend)
@@ -50,10 +50,10 @@ import { getConfig, getBackendUrl, getRedisUrl } from '@/config/ssot-config'
 
 // Access configuration
 const config = getConfig()
-const backendHost = config.backend.host   // "172.16.168.20"
+const backendHost = config.backend.host   // "<backend-ip>"
 
 // Get full URLs
-const apiUrl = getBackendUrl()            // "https://172.16.168.20:8443"
+const apiUrl = getBackendUrl()            // "https://<backend-ip>:8443"
 const redisUrl = getRedisUrl()            // Full Redis connection URL
 ```
 
@@ -71,7 +71,7 @@ if [ -f "$PROJECT_ROOT/.env" ]; then
 fi
 
 # Use variables with fallbacks
-BACKEND_HOST="${AUTOBOT_BACKEND_HOST:-172.16.168.20}"
+BACKEND_HOST="${AUTOBOT_BACKEND_HOST:-<backend-ip>}"
 REDIS_PORT="${AUTOBOT_REDIS_PORT:-6379}"
 ```
 
@@ -83,17 +83,17 @@ All SSOT variables use the `AUTOBOT_` prefix. Here's the complete list:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AUTOBOT_BACKEND_HOST` | `172.16.168.20` | Backend API server IP |
+| `AUTOBOT_BACKEND_HOST` | `<backend-ip>` | Backend API server IP |
 | `AUTOBOT_BACKEND_PORT` | `8001` | Backend API port |
-| `AUTOBOT_FRONTEND_HOST` | `172.16.168.21` | Frontend server IP |
+| `AUTOBOT_FRONTEND_HOST` | `<frontend-ip>` | Frontend server IP |
 | `AUTOBOT_FRONTEND_PORT` | `5173` | Frontend dev server port |
-| `AUTOBOT_REDIS_HOST` | `172.16.168.23` | Redis server IP |
+| `AUTOBOT_REDIS_HOST` | `<database-ip>` | Redis server IP |
 | `AUTOBOT_REDIS_PORT` | `6379` | Redis port |
-| `AUTOBOT_NPU_WORKER_HOST` | `172.16.168.22` | NPU Worker IP |
+| `AUTOBOT_NPU_WORKER_HOST` | `<npu-ip>` | NPU Worker IP |
 | `AUTOBOT_NPU_WORKER_PORT` | `8081` | NPU Worker port |
-| `AUTOBOT_AI_STACK_HOST` | `172.16.168.24` | AI Stack IP |
+| `AUTOBOT_AI_STACK_HOST` | `<aiml-ip>` | AI Stack IP |
 | `AUTOBOT_AI_STACK_PORT` | `8080` | AI Stack port |
-| `AUTOBOT_BROWSER_SERVICE_HOST` | `172.16.168.25` | Browser service IP |
+| `AUTOBOT_BROWSER_SERVICE_HOST` | `<browser-ip>` | Browser service IP |
 | `AUTOBOT_BROWSER_SERVICE_PORT` | `3000` | Browser service port |
 
 ### LLM Configuration
@@ -143,7 +143,7 @@ This means `ConfigRegistry.get()` callers **no longer need hardcoded fallbacks**
 redis_host = ConfigRegistry.get("vm.redis")
 
 # ❌ WRONG — redundant hardcoded fallback
-redis_host = ConfigRegistry.get("vm.redis", "172.16.168.23")
+redis_host = ConfigRegistry.get("vm.redis", "<database-ip>")
 ```
 
 ## Best Practices
@@ -165,14 +165,14 @@ const redisHost = getConfig().redis.host
 ```bash
 # ✅ CORRECT - Shell
 source "$PROJECT_ROOT/.env"
-REDIS_HOST="${AUTOBOT_REDIS_HOST:-172.16.168.23}"
+REDIS_HOST="${AUTOBOT_REDIS_HOST:-<database-ip>}"
 ```
 
 ### DON'T: Hardcode Values
 
 ```python
 # ❌ WRONG - Hardcoded IP
-redis_host = "172.16.168.23"
+redis_host = "<database-ip>"
 
 # ❌ WRONG - Direct os.getenv without SSOT
 redis_host = os.getenv("REDIS_HOST", "localhost")
@@ -180,12 +180,12 @@ redis_host = os.getenv("REDIS_HOST", "localhost")
 
 ```typescript
 // ❌ WRONG - Hardcoded
-const redisHost = "172.16.168.23"
+const redisHost = "<database-ip>"
 ```
 
 ```bash
 # ❌ WRONG - Hardcoded in script
-REDIS_HOST="172.16.168.23"
+REDIS_HOST="<database-ip>"
 ```
 
 ### DO: Use Fallbacks in Shell Scripts
@@ -230,7 +230,7 @@ fi
 **Before (hardcoded):**
 ```python
 import redis
-client = redis.Redis(host="172.16.168.23", port=6379, db=0)
+client = redis.Redis(host="<database-ip>", port=6379, db=0)
 ```
 
 **After (SSOT):**
@@ -249,7 +249,7 @@ client = redis.Redis(
 
 **Before (hardcoded):**
 ```typescript
-const API_URL = "https://172.16.168.20:8443"
+const API_URL = "https://<backend-ip>:8443"
 ```
 
 **After (SSOT):**
@@ -262,14 +262,14 @@ const API_URL = getBackendUrl()
 
 **Before (hardcoded):**
 ```bash
-REMOTE_HOST="172.16.168.21"
+REMOTE_HOST="<frontend-ip>"
 ssh autobot@$REMOTE_HOST "command"
 ```
 
 **After (SSOT):**
 ```bash
 # Load .env first (see template above)
-REMOTE_HOST="${AUTOBOT_FRONTEND_HOST:-172.16.168.21}"
+REMOTE_HOST="${AUTOBOT_FRONTEND_HOST:-<frontend-ip>}"
 ssh autobot@$REMOTE_HOST "command"
 ```
 
@@ -337,7 +337,7 @@ The `src/config/ssot_mappings.py` module provides programmatic access to SSOT ma
 from src.config.ssot_mappings import get_mapping_for_value, get_ssot_suggestion
 
 # Check if a value has an SSOT equivalent
-mapping = get_mapping_for_value("172.16.168.23")
+mapping = get_mapping_for_value("<database-ip>")
 if mapping:
     print(f"Use {mapping.python_config} instead")
     # Output: Use config.vm.redis instead
@@ -369,7 +369,7 @@ Each hardcoded value now includes SSOT mapping info:
 {
   "file": "src/example.py",
   "line": 42,
-  "value": "172.16.168.23",
+  "value": "<database-ip>",
   "ssot_mapping": {
     "has_ssot_equivalent": true,
     "python_config": "config.vm.redis",
@@ -445,8 +445,8 @@ All infrastructure configuration (IPs, ports, hosts) is in `.env`:
 
 ```bash
 # Infrastructure - managed by SSOT
-AUTOBOT_BACKEND_HOST=172.16.168.20
-AUTOBOT_REDIS_HOST=172.16.168.23
+AUTOBOT_BACKEND_HOST=<backend-ip>
+AUTOBOT_REDIS_HOST=<database-ip>
 AUTOBOT_OLLAMA_HOST=127.0.0.1
 AUTOBOT_DEFAULT_LLM_MODEL=qwen3.5:9b
 ```

--- a/docs/developer/THINKING_TOOLS_CONFIGURATION.md
+++ b/docs/developer/THINKING_TOOLS_CONFIGURATION.md
@@ -162,10 +162,10 @@ autobot-backend/api/structured_thinking_mcp.py
 **Check Tool Registration**:
 ```bash
 # Test sequential thinking endpoint
-curl https://172.16.168.20:8443/api/mcp/sequential-thinking/tools
+curl https://<backend-ip>:8443/api/mcp/sequential-thinking/tools
 
 # Test structured thinking endpoint
-curl https://172.16.168.20:8443/api/mcp/structured-thinking/tools
+curl https://<backend-ip>:8443/api/mcp/structured-thinking/tools
 ```
 
 ### Step 3: Ensure Tools Are Available to LLM
@@ -343,8 +343,8 @@ Here's the implementation plan...
 **Check MCP Server Status**:
 ```bash
 # Test endpoints
-curl https://172.16.168.20:8443/api/mcp/sequential-thinking/tools
-curl https://172.16.168.20:8443/api/mcp/structured-thinking/tools
+curl https://<backend-ip>:8443/api/mcp/sequential-thinking/tools
+curl https://<backend-ip>:8443/api/mcp/structured-thinking/tools
 ```
 
 **Check Backend Logs**:

--- a/docs/developer/VNC_MCP_ARCHITECTURE.md
+++ b/docs/developer/VNC_MCP_ARCHITECTURE.md
@@ -23,7 +23,7 @@ AutoBot now provides complete VNC observation capabilities through the **Model C
        │ VNC requests
        ↓
 ┌──────────────────────────────────────────────────┐
-│          Backend (172.16.168.20:8443)            │
+│          Backend (<backend-ip>:8443)            │
 │                                                  │
 │  ┌────────────────────┐  ┌────────────────────┐ │
 │  │  VNC Proxy         │  │  VNC MCP Bridge    │ │
@@ -40,7 +40,7 @@ AutoBot now provides complete VNC observation capabilities through the **Model C
     ┌──────────────┐        ┌──────────────┐
     │  Browser VM  │        │ AutoBot LLM  │
     │  VNC Server  │        │    Agents    │
-    │ (172.16.168  │        │              │
+    │ <network-subnet>  │        │              │
     │    .25:6080) │        │ • Human loop │
     └──────────────┘        │ • Approvals  │
                             └──────────────┘
@@ -61,8 +61,8 @@ AutoBot now provides complete VNC observation capabilities through the **Model C
 - `GET  /api/vnc-proxy/{type}/status` - Check VNC availability
 
 **VNC Types**:
-- `desktop` - Main machine desktop VNC (172.16.168.20:6080)
-- `browser` - Browser VM Playwright VNC (172.16.168.25:6080)
+- `desktop` - Main machine desktop VNC (<backend-ip>:6080)
+- `browser` - Browser VM Playwright VNC (<browser-ip>:6080)
 
 **Observation Recording**:
 ```python
@@ -106,10 +106,10 @@ await record_observation(vnc_type, "disconnection", {"status": "closed"})
 
 ```javascript
 // Before (BROKEN):
-http://172.16.168.25:6080/vnc.html/vnc.html  // ❌ duplicate
+http://<browser-ip>:6080/vnc.html/vnc.html  // ❌ duplicate
 
 // After (FIXED):
-https://172.16.168.20:8443/api/vnc-proxy/browser/vnc.html  // ✅ via backend
+https://<backend-ip>:8443/api/vnc-proxy/browser/vnc.html  // ✅ via backend
 ```
 
 ---
@@ -177,7 +177,7 @@ Response:
 {
   "success": true,
   "accessible": true,
-  "endpoint": "http://172.16.168.25:6080",
+  "endpoint": "http://<browser-ip>:6080",
   "message": "VNC browser is accessible"
 }
 ```
@@ -303,24 +303,24 @@ VNC proxy records: All WebSocket frames to MCP
 ### Test VNC Proxy
 ```bash
 # Check browser VNC status
-curl https://172.16.168.20:8443/api/vnc-proxy/browser/status
+curl https://<backend-ip>:8443/api/vnc-proxy/browser/status
 
 # Access noVNC client
-curl https://172.16.168.20:8443/api/vnc-proxy/browser/vnc.html
+curl https://<backend-ip>:8443/api/vnc-proxy/browser/vnc.html
 ```
 
 ### Test MCP Tools
 ```bash
 # List available VNC MCP tools
-curl https://172.16.168.20:8443/api/vnc/mcp/tools
+curl https://<backend-ip>:8443/api/vnc/mcp/tools
 
 # Check VNC status via MCP
-curl -X POST https://172.16.168.20:8443/api/vnc/mcp/check_vnc_status \
+curl -X POST https://<backend-ip>:8443/api/vnc/mcp/check_vnc_status \
   -H "Content-Type: application/json" \
   -d '{"vnc_type": "browser"}'
 
 # Get browser VNC context
-curl -X POST https://172.16.168.20:8443/api/vnc/mcp/get_browser_vnc_context
+curl -X POST https://<backend-ip>:8443/api/vnc/mcp/get_browser_vnc_context
 ```
 
 ---

--- a/docs/developer/WSL2_NETWORKING.md
+++ b/docs/developer/WSL2_NETWORKING.md
@@ -1,14 +1,14 @@
 # WSL2 Networking — Known Limitations
 
-**TL;DR**: The backend at `172.16.168.20:8443` **cannot be reached from within .20 itself**.
+**TL;DR**: The backend at `<backend-ip>:8443` **cannot be reached from within .20 itself**.
 Always test backend connectivity **from another VM** (e.g., .19 or .21).
 
 ---
 
 ## The Problem
 
-When running `curl` or any TCP connection to `127.0.0.1:8443` or `172.16.168.20:8443`
-from **within** the WSL2 host (172.16.168.20), you get immediate `ECONNREFUSED` even though
+When running `curl` or any TCP connection to `127.0.0.1:8443` or `<backend-ip>:8443`
+from **within** the WSL2 host (<backend-ip>), you get immediate `ECONNREFUSED` even though
 `ss -tlnp` shows the uvicorn socket in `LISTEN` state.
 
 ## Root Cause
@@ -27,7 +27,7 @@ interface where uvicorn actually listens.
 
 Since Windows has no listener on port 8443, the connection is immediately refused.
 
-The same applies to the machine's own external IP (`172.16.168.20`): WSL2's routing
+The same applies to the machine's own external IP (`<backend-ip>`): WSL2's routing
 intercepts the connection before it reaches the Linux socket.
 
 ## Evidence
@@ -44,7 +44,7 @@ intercepts the connection before it reaches the Linux socket.
 
 | Scenario | Status |
 |----------|--------|
-| Connect from within .20 (127.0.0.1 or 172.16.168.20) | ❌ Connection refused |
+| Connect from within .20 (127.0.0.1 or <backend-ip>) | ❌ Connection refused |
 | Connect from .19, .21, or any other VM | ✅ Works normally |
 | Frontend (.21) → Backend (.20) API calls | ✅ Works normally |
 | Production use | ✅ Unaffected |
@@ -53,17 +53,17 @@ intercepts the connection before it reaches the Linux socket.
 
 ```bash
 # Health check
-ssh autobot@172.16.168.19 'curl --insecure https://172.16.168.20:8443/api/health'
+ssh autobot@<slm-manager-ip> 'curl --insecure https://<backend-ip>:8443/api/health'
 
 # Authenticated endpoint
-TOKEN=$(ssh autobot@172.16.168.19 'curl --insecure -s -X POST \
-  https://172.16.168.20:8443/api/auth/login \
+TOKEN=$(ssh autobot@<slm-manager-ip> 'curl --insecure -s -X POST \
+  https://<backend-ip>:8443/api/auth/login \
   -H "Content-Type: application/json" \
   -d "{\"username\":\"admin\",\"password\":\"admin\"}" \
   | python3 -c "import sys,json; print(json.load(sys.stdin)[\"token\"])"')
 
-ssh autobot@172.16.168.19 "curl --insecure -s \
-  https://172.16.168.20:8443/api/knowledge_base/categories/main \
+ssh autobot@<slm-manager-ip> "curl --insecure -s \
+  https://<backend-ip>:8443/api/knowledge_base/categories/main \
   -H 'Authorization: Bearer $TOKEN'"
 ```
 
@@ -75,7 +75,7 @@ Change the Ansible backend role to bind only to the eth2 interface:
 
 ```yaml
 # autobot-slm-backend/ansible/roles/backend/defaults/main.yml
-backend_host: "172.16.168.20"  # eth2 only, instead of 0.0.0.0
+backend_host: "<backend-ip>"  # eth2 only, instead of 0.0.0.0
 ```
 
 This makes local-loopback tests impossible but has no production impact since all
@@ -107,9 +107,9 @@ ansible-playbook playbooks/deploy-full.yml --tags backend,nginx --limit main_bac
 **Verify:**
 ```bash
 # From another VM:
-ssh autobot@172.16.168.19 'curl -sk https://172.16.168.20:8443/api/health'
+ssh autobot@<slm-manager-ip> 'curl -sk https://<backend-ip>:8443/api/health'
 # nginx status on .20:
-ssh autobot@172.16.168.20 'sudo systemctl status nginx'
+ssh autobot@<backend-ip> 'sudo systemctl status nginx'
 ```
 
 ### Option 3: Disable WSL2 mirrored networking

--- a/docs/examples/mcp_agent_workflows/README.md
+++ b/docs/examples/mcp_agent_workflows/README.md
@@ -65,7 +65,7 @@ AUTOBOT_BACKEND_URL = f"http://{NetworkConstants.MAIN_MACHINE_IP}:{NetworkConsta
 Set `AUTOBOT_BACKEND_URL` for standalone usage:
 
 ```bash
-export AUTOBOT_BACKEND_URL="https://172.16.168.20:8443"
+export AUTOBOT_BACKEND_URL="https://<backend-ip>:8443"
 python -m examples.mcp_agent_workflows.research_workflow
 ```
 

--- a/docs/features/ADVANCED_ANALYTICS.md
+++ b/docs/features/ADVANCED_ANALYTICS.md
@@ -278,7 +278,7 @@ Add to your Prometheus configuration:
 scrape_configs:
   - job_name: 'autobot'
     static_configs:
-      - targets: ['172.16.168.20:8443']
+      - targets: ['<backend-ip>:8443']
     metrics_path: '/api/analytics/export/prometheus'
     scrape_interval: 30s
 ```

--- a/docs/features/KNOWLEDGE_GRAPH.md
+++ b/docs/features/KNOWLEDGE_GRAPH.md
@@ -208,7 +208,7 @@ curl -X POST https://localhost:8443/api/memory/entities \
     "entity_type": "implementation",
     "observations": [
       "Uses Redis Stack for data persistence",
-      "Configured on 172.16.168.23:6379"
+      "Configured on <database-ip>:6379"
     ]
   }'
 ```
@@ -263,7 +263,7 @@ Potential future improvements:
 ### Graph Not Loading
 
 1. Check backend is running: `curl https://localhost:8443/api/memory/health`
-2. Verify Redis connection: `redis-cli -h 172.16.168.23 ping`
+2. Verify Redis connection: `redis-cli -h <database-ip> ping`
 3. Check browser console for API errors
 
 ### Entity Creation Fails

--- a/docs/features/LOG_FORWARDING.md
+++ b/docs/features/LOG_FORWARDING.md
@@ -167,12 +167,12 @@ Scope: Global
 ```
 
 Hosts included:
-- autobot-main (172.16.168.20) - Backend API
-- autobot-frontend (172.16.168.21) - Web interface
-- autobot-npu-worker (172.16.168.22) - NPU acceleration
-- autobot-redis (172.16.168.23) - Redis data layer
-- autobot-ai-stack (172.16.168.24) - AI processing
-- autobot-browser (172.16.168.25) - Browser automation
+- autobot-main (<backend-ip>) - Backend API
+- autobot-frontend (<frontend-ip>) - Web interface
+- autobot-npu-worker (<npu-ip>) - NPU acceleration
+- autobot-redis (<database-ip>) - Redis data layer
+- autobot-ai-stack (<aiml-ip>) - AI processing
+- autobot-browser (<browser-ip>) - Browser automation
 
 ### Per-Host Scope
 

--- a/docs/fixes/CONVERSATION_TERMINATION_REPORT.md
+++ b/docs/fixes/CONVERSATION_TERMINATION_REPORT.md
@@ -234,7 +234,7 @@ python -m pytest tests/test_conversation_handling_fix.py::TestRegressionPreventi
 - Prompt file changes hot-reload automatically via PromptManager
 
 ### Production Deployment Steps
-1. Sync `src/chat_workflow_manager.py` to AI Stack VM (172.16.168.24)
+1. Sync `src/chat_workflow_manager.py` to AI Stack VM (<aiml-ip>)
 2. Sync `autobot-backend/resources/prompts/chat/` directory to AI Stack VM
 3. Sync `tests/` directory for validation
 4. Run test suite on production

--- a/docs/fixes/SESSION_ID_VALIDATION_REPORT.md
+++ b/docs/fixes/SESSION_ID_VALIDATION_REPORT.md
@@ -151,7 +151,7 @@ Findings stored in Memory MCP:
 python tests/test_session_validation.py
 
 # Test with actual backend (if running)
-curl -X DELETE http://172.16.168.20:8443/api/chat/sessions/test_conv
+curl -X DELETE http://<backend-ip>:8443/api/chat/sessions/test_conv
 
 # Expected: Success (session deleted)
 # Previous: 500 error "Invalid session ID format"

--- a/docs/frontend/DESIGN_SYSTEM_COMPLETE.md
+++ b/docs/frontend/DESIGN_SYSTEM_COMPLETE.md
@@ -334,4 +334,4 @@ AutoBot now has a **production-ready, professional design system** with:
 - Global scrollbar styling
 
 **Status:** ✅ **FUNCTIONAL**
-**Deployment:** All changes synced to [http://172.16.168.21:5173](http://172.16.168.21:5173)
+**Deployment:** All changes synced to [http://<frontend-ip>:5173](http://<frontend-ip>:5173)

--- a/docs/guides/ANSIBLE_PLAYBOOK_REFERENCE.md
+++ b/docs/guides/ANSIBLE_PLAYBOOK_REFERENCE.md
@@ -17,7 +17,7 @@ ansible-playbook -i ansible/inventory/production.yml ansible/playbooks/deploy-fu
 ansible-playbook -i ansible/inventory/production.yml ansible/playbooks/deploy-development-services.yml
 ```
 **Purpose**: Development environment with hot reload and development workflow
-**Components**: Vite dev server on VM1 (172.16.168.21:5173) with live reload
+**Components**: Vite dev server on VM1 (<frontend-ip>:5173) with live reload
 **Use Case**: Daily development work with automatic code refresh
 
 ### 3. **Health Check and Validation**
@@ -40,7 +40,7 @@ ansible-playbook -i ansible/inventory/production.yml ansible/playbooks/deploy-ba
 ```bash
 ansible-playbook -i ansible/inventory/production.yml ansible/playbooks/deploy-database.yml
 ```
-**Purpose**: Redis Stack, data persistence, model storage on VM3 (172.16.168.23)
+**Purpose**: Redis Stack, data persistence, model storage on VM3 (<database-ip>)
 
 #### Data Migration
 ```bash
@@ -64,11 +64,11 @@ ansible-playbook -i ansible/inventory/production.yml ansible/playbooks/deploy-na
 
 | VM | IP Address | Role | Ansible Group | Primary Services |
 |---|---|---|---|---|
-| VM1 | 172.16.168.21 | Frontend | `frontend` | nginx, Vue.js, development server |
-| VM2 | 172.16.168.22 | NPU Worker | `aiml` | NPU acceleration, Intel OpenVINO |
-| VM3 | 172.16.168.23 | Database | `database` | Redis Stack, RedisInsight |
-| VM4 | 172.16.168.24 | AI Stack | `aiml` | AI processing, backend ML |
-| VM5 | 172.16.168.25 | Browser | `browser` | Playwright, VNC, desktop environment |
+| VM1 | <frontend-ip> | Frontend | `frontend` | nginx, Vue.js, development server |
+| VM2 | <npu-ip> | NPU Worker | `aiml` | NPU acceleration, Intel OpenVINO |
+| VM3 | <database-ip> | Database | `database` | Redis Stack, RedisInsight |
+| VM4 | <aiml-ip> | AI Stack | `aiml` | AI processing, backend ML |
+| VM5 | <browser-ip> | Browser | `browser` | Playwright, VNC, desktop environment |
 
 ## Service-Specific Deployment Commands
 
@@ -141,7 +141,7 @@ ansible all -i ansible/inventory/production.yml -m shell -a "uptime && free -h |
 ansible all -i ansible/inventory/production.yml -m shell -a "systemctl status autobot-* --no-pager -l"
 
 # Network connectivity test
-ansible all -i ansible/inventory/production.yml -m shell -a "ping -c 3 172.16.168.20 && curl -s https://172.16.168.20:8443/api/health || echo 'Connection failed'"
+ansible all -i ansible/inventory/production.yml -m shell -a "ping -c 3 <backend-ip> && curl -s https://<backend-ip>:8443/api/health || echo 'Connection failed'"
 ```
 
 ## Troubleshooting Commands
@@ -199,7 +199,7 @@ sudo systemctl start autobot-backend
 ansible-playbook playbooks/update-all-nodes.yml
 
 # Health check
-curl -sk https://172.16.168.20:8443/api/health | jq
+curl -sk https://<backend-ip>:8443/api/health | jq
 ```
 
 ## Best Practices

--- a/docs/guides/chat-ollama-configuration.md
+++ b/docs/guides/chat-ollama-configuration.md
@@ -176,7 +176,7 @@ backend:
       endpoint: http://127.0.0.1:11434
       # GPU endpoint for model-to-endpoint routing (#1070)
       # When set, models in gpu_models are routed here instead of the default.
-      # gpu_endpoint: http://172.16.168.20:11434
+      # gpu_endpoint: http://<backend-ip>:11434
       # gpu_models:
       #   - "qwen3.5:9b"
       #   - "mistral:7b-instruct"
@@ -283,7 +283,7 @@ first successful result is used.
 [1] SLM service discovery (_discover_ollama_from_slm)
      |  Calls: services/slm_client.py -> discover_service("ollama")
      |  Cached: 60s TTL
-     |  Returns: base URL like "http://172.16.168.20:11434"
+     |  Returns: base URL like "http://<backend-ip>:11434"
      |
      +-- If found -> append /api/generate -> DONE
      |
@@ -1015,7 +1015,7 @@ backend:
   llm:
     ollama:
       endpoint: http://127.0.0.1:11434           # CPU endpoint (default)
-      gpu_endpoint: http://172.16.168.20:11434    # GPU-accelerated endpoint
+      gpu_endpoint: http://<backend-ip>:11434    # GPU-accelerated endpoint
       gpu_models:
         - "qwen3.5:9b"
         - "mistral:7b-instruct"
@@ -1058,7 +1058,7 @@ journalctl -u autobot-backend --since "30 seconds ago" \
 Expected output:
 
 ```
-[ChatWorkflowManager] Making Ollama request to: http://172.16.168.20:11434/api/generate
+[ChatWorkflowManager] Making Ollama request to: http://<backend-ip>:11434/api/generate
 [ChatWorkflowManager] Using model: qwen3.5:9b
 ```
 
@@ -1108,7 +1108,7 @@ fallback chain:
 ### Configuring SLM URL
 
 ```bash
-export SLM_URL=https://172.16.168.19:8443
+export SLM_URL=https://<slm-manager-ip>:8443
 ```
 
 Without `SLM_URL`, the SLM client is unavailable and discovery silently returns
@@ -1164,7 +1164,7 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 OLLAMA_BASE_URL = "http://127.0.0.1:11434"
-BACKEND_URL = "https://172.16.168.20:8443"
+BACKEND_URL = "https://<backend-ip>:8443"
 
 
 async def check_ollama() -> list[str]:
@@ -1489,10 +1489,10 @@ done
 
 ```bash
 # Check Redis connectivity
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 
 # Check for conversation keys
-redis-cli -h 172.16.168.23 keys "chat:conversation:*" | head -5
+redis-cli -h <database-ip> keys "chat:conversation:*" | head -5
 
 # Check file transcripts
 ls -la autobot-backend/data/conversation_transcripts/ | head -5
@@ -1519,7 +1519,7 @@ ls -la autobot-backend/data/conversation_transcripts/ | head -5
 | LLM timeout | -- | `AUTOBOT_LLM_TIMEOUT` | `30` (seconds) |
 | LLM temperature | -- | `AUTOBOT_LLM_TEMPERATURE` | `0.7` |
 | SLM URL | -- | `SLM_URL` | (none) |
-| Redis host | -- | `AUTOBOT_REDIS_HOST` | `172.16.168.23` |
+| Redis host | -- | `AUTOBOT_REDIS_HOST` | `<database-ip>` |
 
 ---
 

--- a/docs/guides/codebase-analytics-api.md
+++ b/docs/guides/codebase-analytics-api.md
@@ -107,7 +107,7 @@ For the full endpoint reference, report generation, and SDK client, see
 ---
 
 
-> **Base URL:** `https://172.16.168.20:8443`
+> **Base URL:** `https://<backend-ip>:8443`
 > **API Prefix:** `/api/analytics/codebase`
 > **Auth:** All endpoints require admin permission (`check_admin_permission` dependency)
 > **Source code:** `autobot-backend/api/codebase_analytics/`
@@ -437,21 +437,21 @@ print(json.dumps(report, indent=2))
 
 ```bash
 # Index a project
-curl -sk -X POST "https://172.16.168.20:8443/api/analytics/codebase/index" \
+curl -sk -X POST "https://<backend-ip>:8443/api/analytics/codebase/index" \
   -H "Content-Type: application/json" \
   -d '{"root_path": "/opt/autobot/autobot-backend"}' | jq .
 
 # Check indexing status
-curl -sk "https://172.16.168.20:8443/api/analytics/codebase/index/status/<task_id>" | jq .
+curl -sk "https://<backend-ip>:8443/api/analytics/codebase/index/status/<task_id>" | jq .
 
 # Get API coverage report
-curl -sk "https://172.16.168.20:8443/api/analytics/codebase/endpoint-coverage" | jq .
+curl -sk "https://<backend-ip>:8443/api/analytics/codebase/endpoint-coverage" | jq .
 
 # Get codebase statistics
-curl -sk "https://172.16.168.20:8443/api/analytics/codebase/stats" | jq .
+curl -sk "https://<backend-ip>:8443/api/analytics/codebase/stats" | jq .
 
 # Get full endpoint analysis with details
-curl -sk "https://172.16.168.20:8443/api/analytics/codebase/endpoint-analysis" | jq .
+curl -sk "https://<backend-ip>:8443/api/analytics/codebase/endpoint-analysis" | jq .
 ```
 
 ---
@@ -734,8 +734,8 @@ Find hardcoded values in the codebase (IPs, credentials, magic numbers).
       "file_path": "api/redis.py",
       "line": 42,
       "type": "ip_address",
-      "value": "172.16.168.23",
-      "context": "redis_host = '172.16.168.23'"
+      "value": "<database-ip>",
+      "context": "redis_host = '<database-ip>'"
     }
   ],
   "total_count": 15,
@@ -1654,13 +1654,13 @@ class CodebaseAnalyticsClient:
     """Async Python client for the Codebase Analytics API.
 
     Args:
-        base_url: Backend base URL (default: https://172.16.168.20:8443).
+        base_url: Backend base URL (default: https://<backend-ip>:8443).
         verify_ssl: Whether to verify SSL certificates.
     """
 
     def __init__(
         self,
-        base_url: str = "https://172.16.168.20:8443",
+        base_url: str = "https://<backend-ip>:8443",
         verify_ssl: bool = False,
     ):
         """Initialize the client with backend URL."""
@@ -2228,8 +2228,8 @@ ls -la /opt/autobot/data/chromadb/
 mkdir -p /opt/autobot/data/chromadb/
 
 # If corrupted, clear and re-index
-curl -sk -X DELETE "https://172.16.168.20:8443/api/analytics/codebase/cache"
-curl -sk -X POST "https://172.16.168.20:8443/api/analytics/codebase/index"
+curl -sk -X DELETE "https://<backend-ip>:8443/api/analytics/codebase/cache"
+curl -sk -X POST "https://<backend-ip>:8443/api/analytics/codebase/index"
 ```
 
 ### Redis connection failed (using in-memory storage)
@@ -2239,10 +2239,10 @@ curl -sk -X POST "https://172.16.168.20:8443/api/analytics/codebase/index"
 **Fix:**
 ```bash
 # Check Redis connectivity from backend host
-redis-cli -h 172.16.168.23 -p 6379 -n 11 ping
+redis-cli -h <database-ip> -p 6379 -n 11 ping
 
 # Check Redis service on .23
-ssh autobot@172.16.168.23 "sudo systemctl status redis"
+ssh autobot@<database-ip> "sudo systemctl status redis"
 ```
 
 The system falls back to in-memory storage, but data is lost on restart.

--- a/docs/guides/distributed-task-failover-redis.md
+++ b/docs/guides/distributed-task-failover-redis.md
@@ -1161,11 +1161,11 @@ All endpoints require admin authentication and are prefixed with `/api`.
 ### Pairing a Worker
 
 ```bash
-curl -sk -X POST https://172.16.168.20:8443/api/npu/workers/pair \
+curl -sk -X POST https://<backend-ip>:8443/api/npu/workers/pair \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{
-        "url": "http://172.16.168.22:8081",
+        "url": "http://<npu-ip>:8081",
         "name": "NPU Worker VM22",
         "platform": "linux",
         "max_concurrent_tasks": 4,
@@ -1281,7 +1281,7 @@ All endpoints are under `/api/scheduler` and require admin authentication.
 ### Scheduling a Workflow
 
 ```bash
-curl -sk -X POST https://172.16.168.20:8443/api/scheduler/schedule \
+curl -sk -X POST https://<backend-ip>:8443/api/scheduler/schedule \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{
@@ -1300,19 +1300,19 @@ curl -sk -X POST https://172.16.168.20:8443/api/scheduler/schedule \
 
 ```bash
 # Pause the queue
-curl -sk -X POST https://172.16.168.20:8443/api/scheduler/queue/control \
+curl -sk -X POST https://<backend-ip>:8443/api/scheduler/queue/control \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"action": "pause"}'
 
 # Resume the queue
-curl -sk -X POST https://172.16.168.20:8443/api/scheduler/queue/control \
+curl -sk -X POST https://<backend-ip>:8443/api/scheduler/queue/control \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"action": "resume"}'
 
 # Set maximum concurrent workflows
-curl -sk -X POST https://172.16.168.20:8443/api/scheduler/queue/control \
+curl -sk -X POST https://<backend-ip>:8443/api/scheduler/queue/control \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"action": "set_max_concurrent", "value": 5}'
@@ -1381,7 +1381,7 @@ All endpoints are under `/api/operations`.
 ### Starting a Long-Running Operation
 
 ```bash
-curl -sk -X POST https://172.16.168.20:8443/api/operations/codebase/index \
+curl -sk -X POST https://<backend-ip>:8443/api/operations/codebase/index \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{
@@ -1407,7 +1407,7 @@ Response:
 
 ```javascript
 const ws = new WebSocket(
-    `wss://172.16.168.20:8443/api/operations/${operationId}/progress`
+    `wss://<backend-ip>:8443/api/operations/${operationId}/progress`
 );
 
 ws.onmessage = (event) => {
@@ -1426,7 +1426,7 @@ interrupted, it can be resumed from the most recent checkpoint:
 ```bash
 # Resume an interrupted operation
 curl -sk -X POST \
-    https://172.16.168.20:8443/api/operations/${OPERATION_ID}/resume \
+    https://<backend-ip>:8443/api/operations/${OPERATION_ID}/resume \
     -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -2028,7 +2028,7 @@ redis = get_redis_client(async_client=False, database="main")
 ```python
 # WRONG -- bypasses all protections, violates CLAUDE.md Rule 2
 import redis
-r = redis.Redis(host="172.16.168.23", port=6379, db=0)
+r = redis.Redis(host="<database-ip>", port=6379, db=0)
 ```
 
 ### Use the Correct Database
@@ -2115,7 +2115,7 @@ at 500 entries). Query it directly:
 
 ```bash
 # Last 10 failover events
-redis-cli -h 172.16.168.23 -n 0 LRANGE failover:log 0 9
+redis-cli -h <database-ip> -n 0 LRANGE failover:log 0 9
 ```
 
 Or programmatically:
@@ -2136,36 +2136,36 @@ for event in events:
 
 ```bash
 # List all registered workers
-redis-cli -h 172.16.168.23 -n 0 SMEMBERS workers:registered
+redis-cli -h <database-ip> -n 0 SMEMBERS workers:registered
 
 # Check a specific worker's heartbeat
-redis-cli -h 172.16.168.23 -n 0 GET worker:npu-worker-1:heartbeat
+redis-cli -h <database-ip> -n 0 GET worker:npu-worker-1:heartbeat
 
 # Check heartbeat TTL (seconds remaining)
-redis-cli -h 172.16.168.23 -n 0 TTL worker:npu-worker-1:heartbeat
+redis-cli -h <database-ip> -n 0 TTL worker:npu-worker-1:heartbeat
 
 # Count tasks assigned to a worker
-redis-cli -h 172.16.168.23 -n 0 SCARD worker:npu-worker-1:tasks
+redis-cli -h <database-ip> -n 0 SCARD worker:npu-worker-1:tasks
 
 # List tasks assigned to a worker
-redis-cli -h 172.16.168.23 -n 0 SMEMBERS worker:npu-worker-1:tasks
+redis-cli -h <database-ip> -n 0 SMEMBERS worker:npu-worker-1:tasks
 
 # Inspect a specific task
-redis-cli -h 172.16.168.23 -n 0 HGETALL task:<task-id>
+redis-cli -h <database-ip> -n 0 HGETALL task:<task-id>
 ```
 
 ### Queue Depth Monitoring
 
 ```bash
 # Check queue depth
-redis-cli -h 172.16.168.23 -n 0 LLEN queue:npu_tasks
+redis-cli -h <database-ip> -n 0 LLEN queue:npu_tasks
 
 # Check processing list depth (tasks being worked on)
-redis-cli -h 172.16.168.23 -n 0 LLEN queue:npu_tasks:processing
+redis-cli -h <database-ip> -n 0 LLEN queue:npu_tasks:processing
 
 # Check priority queue depths
 for p in critical high normal low; do
-    echo "$p: $(redis-cli -h 172.16.168.23 -n 0 LLEN queue:${p}:npu_inference)"
+    echo "$p: $(redis-cli -h <database-ip> -n 0 LLEN queue:${p}:npu_inference)"
 done
 ```
 
@@ -2195,13 +2195,13 @@ actually alive.
 **Resolution:**
 ```bash
 # Check network connectivity from worker to Redis
-ping -c 3 172.16.168.23
+ping -c 3 <database-ip>
 
 # Check Redis latency
-redis-cli -h 172.16.168.23 --latency
+redis-cli -h <database-ip> --latency
 
 # Check if worker process is running
-ssh autobot@172.16.168.22 "ps aux | grep npu_worker"
+ssh autobot@<npu-ip> "ps aux | grep npu_worker"
 ```
 
 ### Tasks Stuck in Processing List
@@ -2215,12 +2215,12 @@ workers, but unregistered workers or edge cases can leave orphans.
 **Resolution:**
 ```bash
 # List stuck tasks
-redis-cli -h 172.16.168.23 -n 0 LRANGE queue:npu_tasks:processing 0 -1
+redis-cli -h <database-ip> -n 0 LRANGE queue:npu_tasks:processing 0 -1
 
 # Manually re-queue a stuck task
-redis-cli -h 172.16.168.23 -n 0 LREM queue:npu_tasks:processing 1 "<task_id>"
-redis-cli -h 172.16.168.23 -n 0 HSET task:<task_id> status queued worker_id ""
-redis-cli -h 172.16.168.23 -n 0 LPUSH queue:npu_tasks "<task_id>"
+redis-cli -h <database-ip> -n 0 LREM queue:npu_tasks:processing 1 "<task_id>"
+redis-cli -h <database-ip> -n 0 HSET task:<task_id> status queued worker_id ""
+redis-cli -h <database-ip> -n 0 LPUSH queue:npu_tasks "<task_id>"
 ```
 
 ### Circuit Breaker Open
@@ -2233,10 +2233,10 @@ redis-cli -h 172.16.168.23 -n 0 LPUSH queue:npu_tasks "<task_id>"
 **Resolution:**
 ```bash
 # Check Redis is running
-ssh autobot@172.16.168.23 "systemctl status redis-stack-server"
+ssh autobot@<database-ip> "systemctl status redis-stack-server"
 
 # Check Redis memory usage
-redis-cli -h 172.16.168.23 INFO memory | grep used_memory_human
+redis-cli -h <database-ip> INFO memory | grep used_memory_human
 
 # The circuit breaker auto-resets after 60 seconds of the last failure.
 # If Redis is back up, wait 60 seconds and retry.
@@ -2255,10 +2255,10 @@ If the task payload itself is causing crashes, fix the root cause. To
 retry a permanently failed task, reset its state manually:
 
 ```bash
-redis-cli -h 172.16.168.23 -n 0 HSET task:<task_id> status queued
-redis-cli -h 172.16.168.23 -n 0 HSET task:<task_id> retry_count 0
-redis-cli -h 172.16.168.23 -n 0 HSET task:<task_id> worker_id ""
-redis-cli -h 172.16.168.23 -n 0 LPUSH queue:<task_type> "<task_id>"
+redis-cli -h <database-ip> -n 0 HSET task:<task_id> status queued
+redis-cli -h <database-ip> -n 0 HSET task:<task_id> retry_count 0
+redis-cli -h <database-ip> -n 0 HSET task:<task_id> worker_id ""
+redis-cli -h <database-ip> -n 0 LPUSH queue:<task_type> "<task_id>"
 ```
 
 ---

--- a/docs/guides/llm-middleware-telemetry.md
+++ b/docs/guides/llm-middleware-telemetry.md
@@ -108,9 +108,9 @@ def get_chat_workflow_manager():
 **Seed test telemetry and verify:**
 
 ```bash
-redis-cli -h 172.16.168.23 SET metrics:cpu:current 45
-redis-cli -h 172.16.168.23 SET metrics:memory:current 62
-redis-cli -h 172.16.168.23 HSET service:backend:health status healthy
+redis-cli -h <database-ip> SET metrics:cpu:current 45
+redis-cli -h <database-ip> SET metrics:memory:current 62
+redis-cli -h <database-ip> HSET service:backend:health status healthy
 curl -sk https://localhost:8443/api/chat/message \
   -H "Content-Type: application/json" \
   -d '{"message": "What is the current system status?", "session_id": "test"}'
@@ -1051,7 +1051,7 @@ backend:
     ollama:
       endpoint: http://127.0.0.1:11434
       # GPU endpoint for model-to-endpoint routing (#1070)
-      # gpu_endpoint: http://172.16.168.20:11434
+      # gpu_endpoint: http://<backend-ip>:11434
       # gpu_models:
       #   - "qwen3.5:9b"
       #   - "mistral:7b-instruct"
@@ -1085,8 +1085,8 @@ infrastructure:
 from autobot_shared.ssot_config import config
 
 # Access fleet node IPs
-redis_host = config.redis.host      # -> "172.16.168.23"
-ai_stack_host = config.ai_stack.host # -> "172.16.168.24"
+redis_host = config.redis.host      # -> "<database-ip>"
+ai_stack_host = config.ai_stack.host # -> "<aiml-ip>"
 
 # Access Redis properly
 from autobot_shared.redis_client import get_redis_client
@@ -1650,11 +1650,11 @@ def get_chat_workflow_manager() -> ChatWorkflowManager:
 
 ```bash
 # Example: set test telemetry values
-redis-cli -h 172.16.168.23 SET metrics:cpu:current 45
-redis-cli -h 172.16.168.23 SET metrics:memory:current 62
-redis-cli -h 172.16.168.23 SET metrics:disk:current 38
-redis-cli -h 172.16.168.23 HSET service:backend:health status healthy
-redis-cli -h 172.16.168.23 HSET service:frontend:health status healthy
+redis-cli -h <database-ip> SET metrics:cpu:current 45
+redis-cli -h <database-ip> SET metrics:memory:current 62
+redis-cli -h <database-ip> SET metrics:disk:current 38
+redis-cli -h <database-ip> HSET service:backend:health status healthy
+redis-cli -h <database-ip> HSET service:frontend:health status healthy
 ```
 
 **Step 4.** Restart the backend and verify:

--- a/docs/guides/rag-pdf-workflow.md
+++ b/docs/guides/rag-pdf-workflow.md
@@ -214,9 +214,9 @@ ChromaDB Storage       Cross-Encoder Reranking
 
 | Store | Location | Purpose |
 |-------|----------|---------|
-| **ChromaDB** | AI Stack VM (172.16.168.24) via `data/chromadb` path | Vector embeddings with HNSW index (cosine, construction_ef=300, search_ef=100, M=32) |
-| **Redis DB 1** | Redis VM (172.16.168.23) | Document metadata, fact storage (`knowledge_base:facts` hash), category caches, vectorization status |
-| **NPU Worker** | NPU VM (172.16.168.22) | Hardware-accelerated embedding generation with cached availability checks (30s TTL) |
+| **ChromaDB** | AI Stack VM (<aiml-ip>) via `data/chromadb` path | Vector embeddings with HNSW index (cosine, construction_ef=300, search_ef=100, M=32) |
+| **Redis DB 1** | Redis VM (<database-ip>) | Document metadata, fact storage (`knowledge_base:facts` hash), category caches, vectorization status |
+| **NPU Worker** | NPU VM (<npu-ip>) | Hardware-accelerated embedding generation with cached availability checks (30s TTL) |
 
 ### Embedding Pipeline
 
@@ -1738,15 +1738,15 @@ aligned this across 6 locations). Adjust this to control result quality:
 
 ```bash
 # Check knowledge base health
-curl -sk https://172.16.168.20:8443/api/knowledge_base/health \
+curl -sk https://<backend-ip>:8443/api/knowledge_base/health \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 
 # Check total facts and vectors
-curl -sk https://172.16.168.20:8443/api/knowledge_base/stats \
+curl -sk https://<backend-ip>:8443/api/knowledge_base/stats \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 
 # Verify NPU availability for embeddings
-curl -sk https://172.16.168.20:8443/api/enhanced-search/hardware/status \
+curl -sk https://<backend-ip>:8443/api/enhanced-search/hardware/status \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 ```
 
@@ -1755,7 +1755,7 @@ curl -sk https://172.16.168.20:8443/api/enhanced-search/hardware/status \
 - If `total_vectors` is much lower than `total_facts`, background vectorization is incomplete.
   Wait or trigger manual vectorization.
 - If `rag_status` is `"error"`, the RAG Agent failed to initialize. Check AI Stack availability
-  on 172.16.168.24.
+  on <aiml-ip>.
 - Lower the `score_threshold` / `min_score` parameter to 0.1 to see if content exists but
   scores below threshold.
 - Switch to `mode: "hybrid"` -- pure semantic search may miss keyword-heavy content.
@@ -1768,7 +1768,7 @@ curl -sk https://172.16.168.20:8443/api/enhanced-search/hardware/status \
 
 ```bash
 # List recent entries to verify the upload is stored
-curl -sk "https://172.16.168.20:8443/api/knowledge_base/entries?limit=5" \
+curl -sk "https://<backend-ip>:8443/api/knowledge_base/entries?limit=5" \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 ```
 
@@ -1789,20 +1789,20 @@ curl -sk "https://172.16.168.20:8443/api/knowledge_base/entries?limit=5" \
 
 ```bash
 # Run a benchmark
-curl -sk https://172.16.168.20:8443/api/enhanced-search/benchmark \
+curl -sk https://<backend-ip>:8443/api/enhanced-search/benchmark \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '{"test_queries": ["test query"], "iterations": 3}' | python3 -m json.tool
 
 # Check performance analytics
-curl -sk https://172.16.168.20:8443/api/enhanced-search/performance/analytics \
+curl -sk https://<backend-ip>:8443/api/enhanced-search/performance/analytics \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 ```
 
 **Fixes:**
 
 - If `device_used` is `"cpu"`, NPU and GPU are unavailable. Check NPU Worker on
-  172.16.168.22 and GPU drivers.
+  <npu-ip> and GPU drivers.
 - If `cache_size` is 0, the search cache is cold. Performance improves after repeated queries.
 - If `embedding_generation_time_ms` is high, the embedding model may need warming up.
   The backend runs `warmup_npu_connection()` at startup (Issue #165).
@@ -1825,7 +1825,7 @@ tail -100 /var/log/autobot/backend.log | grep -i "knowledge\|init"
 
 **Fixes:**
 
-- Verify Redis is accessible on 172.16.168.23:6379. The knowledge base uses DB 1.
+- Verify Redis is accessible on <database-ip>:6379. The knowledge base uses DB 1.
 - Verify ChromaDB data directory exists and is writable: `ls -la data/chromadb/`.
 - Check if Ollama is running (needed for LlamaIndex embedding configuration):
   `curl http://127.0.0.1:11434/api/tags`.

--- a/docs/guides/realtime-monitoring-notifications.md
+++ b/docs/guides/realtime-monitoring-notifications.md
@@ -83,8 +83,8 @@ if __name__ == "__main__":
 **Verify it works:**
 
 ```bash
-curl -sk https://172.16.168.20:8443/api/system/health | python3 -m json.tool
-redis-cli -h 172.16.168.23 subscribe system_alerts
+curl -sk https://<backend-ip>:8443/api/system/health | python3 -m json.tool
+redis-cli -h <database-ip> subscribe system_alerts
 ```
 
 For the full implementation with SQLite storage, Prometheus metrics, auto-recovery,
@@ -257,7 +257,7 @@ collector = HealthCollector(
     services=["nginx", "autobot-backend", "redis-server"],
     ports=[
         {"host": "localhost", "port": 8443},
-        {"host": "172.16.168.23", "port": 6379},
+        {"host": "<database-ip>", "port": 6379},
     ],
     discover_services=True,
 )
@@ -280,7 +280,7 @@ health = collector.collect()
 #     },
 #     "ports": {
 #         "localhost:8443": true,
-#         "172.16.168.23:6379": true
+#         "<database-ip>:6379": true
 #     },
 #     "discovered_services": [
 #         {
@@ -403,7 +403,7 @@ asyncio.run(run_continuous())
 ## 3. API Endpoints for Monitoring
 
 All backend endpoints are served over HTTPS on port 8443. The base URL is
-`https://172.16.168.20:8443` (configured via `autobot_shared.ssot_config`).
+`https://<backend-ip>:8443` (configured via `autobot_shared.ssot_config`).
 
 ### System Health Endpoints
 
@@ -415,7 +415,7 @@ frontend health monitors before login.
 **Request:**
 
 ```bash
-curl -sk https://172.16.168.20:8443/api/system/health | python3 -m json.tool
+curl -sk https://<backend-ip>:8443/api/system/health | python3 -m json.tool
 ```
 
 **Response (200 OK):**
@@ -450,7 +450,7 @@ LLM, knowledge base, system resources, and per-service status.
 
 ```bash
 curl -sk -H "Authorization: Bearer $TOKEN" \
-    https://172.16.168.20:8443/api/system/health/detailed | python3 -m json.tool
+    https://<backend-ip>:8443/api/system/health/detailed | python3 -m json.tool
 ```
 
 **Response (200 OK):**
@@ -497,7 +497,7 @@ memory, disk, and cache statistics.
 
 ```bash
 curl -sk -H "Authorization: Bearer $TOKEN" \
-    https://172.16.168.20:8443/api/system/metrics | python3 -m json.tool
+    https://<backend-ip>:8443/api/system/metrics | python3 -m json.tool
 ```
 
 **Response (200 OK):**
@@ -542,7 +542,7 @@ All error monitoring endpoints are mounted under `/api/error-monitoring/`.
 Returns system-wide error statistics aggregated from the error boundary system.
 
 ```bash
-curl -sk https://172.16.168.20:8443/api/error-monitoring/statistics | python3 -m json.tool
+curl -sk https://<backend-ip>:8443/api/error-monitoring/statistics | python3 -m json.tool
 ```
 
 ```json
@@ -576,7 +576,7 @@ curl -sk https://172.16.168.20:8443/api/error-monitoring/statistics | python3 -m
 Returns the most recent error reports stored in Redis (max 100).
 
 ```bash
-curl -sk "https://172.16.168.20:8443/api/error-monitoring/recent?limit=5" | python3 -m json.tool
+curl -sk "https://<backend-ip>:8443/api/error-monitoring/recent?limit=5" | python3 -m json.tool
 ```
 
 ```json
@@ -603,7 +603,7 @@ curl -sk "https://172.16.168.20:8443/api/error-monitoring/recent?limit=5" | pyth
 Returns the error system's own health assessment with a 0-100 score.
 
 ```bash
-curl -sk https://172.16.168.20:8443/api/error-monitoring/health | python3 -m json.tool
+curl -sk https://<backend-ip>:8443/api/error-monitoring/health | python3 -m json.tool
 ```
 
 ```json
@@ -660,7 +660,7 @@ Set custom alert thresholds per component:
 curl -sk -X POST \
     -H "Content-Type: application/json" \
     -d '{"component": "redis", "threshold": 5}' \
-    https://172.16.168.20:8443/api/error-monitoring/metrics/alert-threshold
+    https://<backend-ip>:8443/api/error-monitoring/metrics/alert-threshold
 ```
 
 #### `POST /api/error-monitoring/metrics/resolve/{trace_id}`
@@ -678,7 +678,7 @@ The SLM admin server on `.19` provides fleet-wide health:
 #### `GET /api/health`
 
 ```bash
-curl -sk https://172.16.168.19:8000/api/health | python3 -m json.tool
+curl -sk https://<slm-manager-ip>:8000/api/health | python3 -m json.tool
 ```
 
 ```json
@@ -830,7 +830,7 @@ async def set_custom_threshold(component: str, threshold: int):
     """Set a custom alert threshold for a component."""
     async with aiohttp.ClientSession() as session:
         await session.post(
-            "https://172.16.168.20:8443/api/error-monitoring/metrics/alert-threshold",
+            "https://<backend-ip>:8443/api/error-monitoring/metrics/alert-threshold",
             json={
                 "component": component,
                 "error_code": None,  # any error in component
@@ -879,7 +879,7 @@ sent_count = await publish_live_event(
         "severity": "CRITICAL",
         "message": "Service nginx has entered failed state",
         "timestamp": "2026-03-15T10:30:00",
-        "node": "172.16.168.21",
+        "node": "<frontend-ip>",
     },
 )
 # sent_count = number of WebSocket clients that received the event
@@ -956,7 +956,7 @@ Prometheus scrapes autobot_service_status metric
         "description": "Backend API is not responding",
         "recommendation": "Check backend service logs and restart if necessary"
     },
-    "externalURL": "http://172.16.168.20:9093",
+    "externalURL": "http://<backend-ip>:9093",
     "alerts": [
         {
             "status": "firing",
@@ -973,7 +973,7 @@ Prometheus scrapes autobot_service_status metric
             },
             "startsAt": "2026-03-15T10:30:00.000Z",
             "endsAt": null,
-            "generatorURL": "http://172.16.168.20:9090/graph?...",
+            "generatorURL": "http://<backend-ip>:9090/graph?...",
             "fingerprint": "abc123def456"
         }
     ]
@@ -1677,7 +1677,7 @@ WebSocket endpoint is at `/ws/live` and requires JWT authentication.
         "severity": "CRITICAL",
         "message": "Service nginx has entered failed state",
         "timestamp": "2026-03-15T10:30:00",
-        "node": "172.16.168.21"
+        "node": "<frontend-ip>"
     }
 }
 ```
@@ -1687,7 +1687,7 @@ WebSocket endpoint is at `/ws/live` and requires JWT authentication.
 ```javascript
 // Connect to the live events WebSocket
 const token = localStorage.getItem('auth_token');
-const ws = new WebSocket(`wss://172.16.168.20:8443/ws/live?token=${token}`);
+const ws = new WebSocket(`wss://<backend-ip>:8443/ws/live?token=${token}`);
 
 ws.onopen = () => {
     console.log('Connected to live events');
@@ -1766,7 +1766,7 @@ The dedicated monitoring dashboard WebSocket at `/ws/monitoring` automatically
 broadcasts performance updates:
 
 ```javascript
-const monitoringWs = new WebSocket('wss://172.16.168.20:8443/ws/monitoring');
+const monitoringWs = new WebSocket('wss://<backend-ip>:8443/ws/monitoring');
 
 monitoringWs.onmessage = (event) => {
     const data = JSON.parse(event.data);
@@ -1933,19 +1933,19 @@ scrape_configs:
     tls_config:
       insecure_skip_verify: true
     static_configs:
-      - targets: ['172.16.168.20:8443']
+      - targets: ['<backend-ip>:8443']
     metrics_path: '/metrics'
     scrape_interval: 15s
 
   - job_name: 'node'
     static_configs:
       - targets:
-        - '172.16.168.20:9100'
-        - '172.16.168.21:9100'
-        - '172.16.168.22:9100'
-        - '172.16.168.23:9100'
-        - '172.16.168.24:9100'
-        - '172.16.168.25:9100'
+        - '<backend-ip>:9100'
+        - '<frontend-ip>:9100'
+        - '<npu-ip>:9100'
+        - '<database-ip>:9100'
+        - '<aiml-ip>:9100'
+        - '<browser-ip>:9100'
 ```
 
 ### AlertManager Configuration
@@ -1969,7 +1969,7 @@ route:
 receivers:
   - name: 'autobot-webhook'
     webhook_configs:
-      - url: 'https://172.16.168.20:8443/api/webhook/alertmanager'
+      - url: 'https://<backend-ip>:8443/api/webhook/alertmanager'
         tls_config:
           insecure_skip_verify: true
         send_resolved: true
@@ -1985,35 +1985,35 @@ curl -sk -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{}' \
-    https://172.16.168.20:8443/api/prometheus/mcp/get_system_metrics
+    https://<backend-ip>:8443/api/prometheus/mcp/get_system_metrics
 
 # Query a specific metric
 curl -sk -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"query": "autobot_service_health_score"}' \
-    https://172.16.168.20:8443/api/prometheus/mcp/query_metric
+    https://<backend-ip>:8443/api/prometheus/mcp/query_metric
 
 # Get service health status
 curl -sk -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{}' \
-    https://172.16.168.20:8443/api/prometheus/mcp/get_service_health
+    https://<backend-ip>:8443/api/prometheus/mcp/get_service_health
 
 # Get metrics for a specific VM
 curl -sk -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
-    -d '{"vm_ip": "172.16.168.23"}' \
-    https://172.16.168.20:8443/api/prometheus/mcp/get_vm_metrics
+    -d '{"vm_ip": "<database-ip>"}' \
+    https://<backend-ip>:8443/api/prometheus/mcp/get_vm_metrics
 
 # List all available metrics
 curl -sk -X POST \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"filter": "autobot_service"}' \
-    https://172.16.168.20:8443/api/prometheus/mcp/list_available_metrics
+    https://<backend-ip>:8443/api/prometheus/mcp/list_available_metrics
 ```
 
 ### Grafana Dashboard Integration
@@ -2057,7 +2057,7 @@ Error Rate Panel:
 ```bash
 # Check detailed health to identify which component is degraded
 curl -sk -H "Authorization: Bearer $TOKEN" \
-    https://172.16.168.20:8443/api/system/health/detailed | python3 -m json.tool
+    https://<backend-ip>:8443/api/system/health/detailed | python3 -m json.tool
 
 # Look for components with "error" in their status
 ```
@@ -2079,13 +2079,13 @@ curl -sk -H "Authorization: Bearer $TOKEN" \
 ```bash
 # Get a fresh token
 TOKEN=$(curl -sk -X POST \
-    https://172.16.168.20:8443/api/auth/login \
+    https://<backend-ip>:8443/api/auth/login \
     -H "Content-Type: application/json" \
     -d '{"username": "admin", "password": "..."}' \
     | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 
 # Use the token in the WebSocket URL
-wscat -c "wss://172.16.168.20:8443/ws/live?token=$TOKEN" --no-check
+wscat -c "wss://<backend-ip>:8443/ws/live?token=$TOKEN" --no-check
 ```
 
 #### 3. Alerts not appearing in the monitoring dashboard
@@ -2094,14 +2094,14 @@ wscat -c "wss://172.16.168.20:8443/ws/live?token=$TOKEN" --no-check
 
 ```bash
 # 1. Check if Prometheus is scraping the backend
-curl -s http://172.16.168.20:9090/api/v1/targets \
+curl -s http://<backend-ip>:9090/api/v1/targets \
     | python3 -m json.tool | grep autobot
 
 # 2. Check if AlertManager is receiving alerts
-curl -s http://172.16.168.20:9093/api/v2/alerts | python3 -m json.tool
+curl -s http://<backend-ip>:9093/api/v2/alerts | python3 -m json.tool
 
 # 3. Check the webhook endpoint health
-curl -sk https://172.16.168.20:8443/api/webhook/alertmanager/health
+curl -sk https://<backend-ip>:8443/api/webhook/alertmanager/health
 
 # 4. Check if WebSocket manager has connected clients
 # (visible in backend logs)
@@ -2153,13 +2153,13 @@ SystemMonitor().cleanup_old_metrics()
 
 ```bash
 # Check Redis connectivity
-redis-cli -h 172.16.168.23 -p 6379 ping
+redis-cli -h <database-ip> -p 6379 ping
 
 # Monitor the alert channel in real time
-redis-cli -h 172.16.168.23 subscribe system_alerts
+redis-cli -h <database-ip> subscribe system_alerts
 
 # From another terminal, publish a test alert
-redis-cli -h 172.16.168.23 publish system_alerts '{"type":"test","message":"ping"}'
+redis-cli -h <database-ip> publish system_alerts '{"type":"test","message":"ping"}'
 ```
 
 **Common causes:**
@@ -2173,13 +2173,13 @@ redis-cli -h 172.16.168.23 publish system_alerts '{"type":"test","message":"ping
 
 ```bash
 # Check if metrics endpoint is responding
-curl -sk https://172.16.168.20:8443/metrics | head -20
+curl -sk https://<backend-ip>:8443/metrics | head -20
 
 # Check for autobot-specific metrics
-curl -sk https://172.16.168.20:8443/metrics | grep autobot_service
+curl -sk https://<backend-ip>:8443/metrics | grep autobot_service
 
 # Verify Prometheus can reach the backend
-curl -s http://172.16.168.20:9090/api/v1/targets \
+curl -s http://<backend-ip>:9090/api/v1/targets \
     | python3 -c "
 import sys, json
 targets = json.load(sys.stdin)['data']['activeTargets']
@@ -2223,7 +2223,7 @@ initialize. During this time, health checks may return `degraded` or `unhealthy`
 
 ```bash
 # Watch health status until it becomes "healthy"
-watch -n 5 'curl -sk https://172.16.168.20:8443/api/system/health 2>/dev/null \
+watch -n 5 'curl -sk https://<backend-ip>:8443/api/system/health 2>/dev/null \
     | python3 -m json.tool 2>/dev/null || echo "Not ready yet"'
 ```
 
@@ -2234,21 +2234,21 @@ watch -n 5 'curl -sk https://172.16.168.20:8443/api/system/health 2>/dev/null \
 systemctl list-units --type=service --state=failed --no-pager
 
 # Check backend health
-curl -sk https://172.16.168.20:8443/api/system/health | python3 -m json.tool
+curl -sk https://<backend-ip>:8443/api/system/health | python3 -m json.tool
 
 # Check SLM fleet health (requires auth)
 curl -sk -H "Authorization: Bearer $SLM_TOKEN" \
-    https://172.16.168.19:8000/api/roles/fleet-health | python3 -m json.tool
+    https://<slm-manager-ip>:8000/api/roles/fleet-health | python3 -m json.tool
 
 # Check recent errors
-curl -sk "https://172.16.168.20:8443/api/error-monitoring/recent?limit=5" \
+curl -sk "https://<backend-ip>:8443/api/error-monitoring/recent?limit=5" \
     | python3 -m json.tool
 
 # Check Prometheus alert rules
-curl -s http://172.16.168.20:9090/api/v1/rules | python3 -m json.tool
+curl -s http://<backend-ip>:9090/api/v1/rules | python3 -m json.tool
 
 # Check firing alerts
-curl -s http://172.16.168.20:9093/api/v2/alerts | python3 -m json.tool
+curl -s http://<backend-ip>:9093/api/v2/alerts | python3 -m json.tool
 
 # Monitor backend logs for alerts in real time
 journalctl -u autobot-backend -f | grep -i "alert\|CRITICAL\|failed"

--- a/docs/guides/slm-bash-execution.md
+++ b/docs/guides/slm-bash-execution.md
@@ -19,7 +19,7 @@ import ssl
 
 import aiohttp
 
-SLM_URL = "https://172.16.168.19"
+SLM_URL = "https://<slm-manager-ip>"
 
 
 def _ssl_ctx() -> ssl.SSLContext:
@@ -84,12 +84,12 @@ if __name__ == "__main__":
 **curl equivalent:**
 
 ```bash
-TOKEN=$(curl -sk https://172.16.168.19/api/auth/login \
+TOKEN=$(curl -sk https://<slm-manager-ip>/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"your_password"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 
-curl -sk -X POST https://172.16.168.19/api/infrastructure/execute \
+curl -sk -X POST https://<slm-manager-ip>/api/infrastructure/execute \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"playbook":"run-command.yml","extra_vars":{"target_hosts":"frontend","shell_command":"systemctl status nginx"}}'
@@ -123,7 +123,7 @@ Execute bash commands on target groups of Linux nodes using the AutoBot Service 
 
 ## 1. SLM Overview
 
-The Service Lifecycle Manager (SLM) is the central control plane for the AutoBot fleet. It runs on `172.16.168.19` and provides:
+The Service Lifecycle Manager (SLM) is the central control plane for the AutoBot fleet. It runs on `<slm-manager-ip>` and provides:
 
 - **FastAPI backend** (`autobot-slm-backend/`) -- RESTful API with JWT authentication for fleet operations
 - **Vue 3 admin dashboard** (`autobot-slm-frontend/`) -- web UI served via nginx with TLS on port 443
@@ -156,8 +156,8 @@ The Service Lifecycle Manager (SLM) is the central control plane for the AutoBot
 The SLM backend listens on port 8000 internally, proxied through nginx on port 443 with TLS. All API routes are prefixed with `/api`.
 
 ```
-Internal:  http://172.16.168.19:8000/api/...
-External:  https://172.16.168.19:443/api/...  (self-signed TLS)
+Internal:  http://<slm-manager-ip>:8000/api/...
+External:  https://<slm-manager-ip>:443/api/...  (self-signed TLS)
 ```
 
 ---
@@ -170,15 +170,15 @@ The SLM Ansible inventory (`autobot-slm-backend/ansible/inventory/slm-nodes.yml`
 
 | Node ID | IP Address | Role | Monitored Services |
 |---------|------------|------|--------------------|
-| `00-SLM-Manager` | 172.16.168.19 | SLM Server | autobot-slm-backend, slm-admin-ui, nginx, postgresql |
-| `01-Backend` | 172.16.168.20 | Main Backend | autobot-backend, ollama, nginx |
-| `02-Frontend` | 172.16.168.21 | Frontend VM | nginx |
-| `npu-worker` | 172.16.168.22 | NPU Worker | autobot-npu-worker, nginx |
-| `04-Databases` | 172.16.168.23 | Redis/Database | redis-stack-server, redis_exporter, nginx |
-| `03-AI-Stack` | 172.16.168.24 | AI Processing | autobot-ai-stack, autobot-chromadb, autobot-tts-worker, nginx |
-| `browser-automation` | 172.16.168.25 | Browser | autobot-playwright, nginx |
-| `05-LLM-CPU` | 172.16.168.26 | LLM CPU Node | ollama |
-| `06-Node-27` | 172.16.168.27 | Reserved | (none) |
+| `00-SLM-Manager` | <slm-manager-ip> | SLM Server | autobot-slm-backend, slm-admin-ui, nginx, postgresql |
+| `01-Backend` | <backend-ip> | Main Backend | autobot-backend, ollama, nginx |
+| `02-Frontend` | <frontend-ip> | Frontend VM | nginx |
+| `npu-worker` | <npu-ip> | NPU Worker | autobot-npu-worker, nginx |
+| `04-Databases` | <database-ip> | Redis/Database | redis-stack-server, redis_exporter, nginx |
+| `03-AI-Stack` | <aiml-ip> | AI Processing | autobot-ai-stack, autobot-chromadb, autobot-tts-worker, nginx |
+| `browser-automation` | <browser-ip> | Browser | autobot-playwright, nginx |
+| `05-LLM-CPU` | <reserved-ip> | LLM CPU Node | ollama |
+| `06-Node-27` | <reserved-ip> | Reserved | (none) |
 
 ### Ansible Inventory Groups
 
@@ -249,7 +249,7 @@ import ssl
 
 import aiohttp
 
-SLM_URL = "https://172.16.168.19"
+SLM_URL = "https://<slm-manager-ip>"
 
 
 def _create_permissive_ssl() -> ssl.SSLContext:
@@ -304,13 +304,13 @@ if __name__ == "__main__":
 
 ```bash
 # Obtain JWT token
-TOKEN=$(curl -sk https://172.16.168.19/api/auth/login \
+TOKEN=$(curl -sk https://<slm-manager-ip>/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"your_password"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 
 # Verify token works
-curl -sk https://172.16.168.19/api/auth/me \
+curl -sk https://<slm-manager-ip>/api/auth/me \
   -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 ```
 
@@ -359,7 +359,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-SLM_URL = "https://172.16.168.19"
+SLM_URL = "https://<slm-manager-ip>"
 
 # Valid Ansible inventory groups from slm-nodes.yml
 VALID_GROUPS = {
@@ -675,11 +675,11 @@ if __name__ == "__main__":
 
 ### 4.2 Alternative: Direct Ansible Execution from SLM Host
 
-If you have SSH access to the SLM server (172.16.168.19), you can run Ansible ad-hoc commands directly:
+If you have SSH access to the SLM server (<slm-manager-ip>), you can run Ansible ad-hoc commands directly:
 
 ```bash
 # SSH to SLM server
-ssh autobot@172.16.168.19
+ssh autobot@<slm-manager-ip>
 
 # Run ad-hoc command on all infrastructure nodes
 cd /opt/autobot/autobot-slm-backend/ansible
@@ -934,7 +934,7 @@ Response 200:
     "success": true,
     "message": "Restart successful",
     "node_id": "02-Frontend",
-    "host": "172.16.168.21"
+    "host": "<frontend-ip>"
 }
 ```
 
@@ -1157,7 +1157,7 @@ import aiohttp
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-SLM_URL = "https://172.16.168.19"
+SLM_URL = "https://<slm-manager-ip>"
 
 
 def _create_ssl_context() -> ssl.SSLContext:
@@ -1315,47 +1315,47 @@ if __name__ == "__main__":
 
 ```bash
 # Authenticate and store token
-TOKEN=$(curl -sk https://172.16.168.19/api/auth/login \
+TOKEN=$(curl -sk https://<slm-manager-ip>/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"your_password"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 
 # Check fleet health
-curl -sk https://172.16.168.19/api/roles/fleet-health \
+curl -sk https://<slm-manager-ip>/api/roles/fleet-health \
   -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 
 # List all registered playbooks
-curl -sk https://172.16.168.19/api/infrastructure/playbooks \
+curl -sk https://<slm-manager-ip>/api/infrastructure/playbooks \
   -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 
 # Execute update-all-nodes playbook
-curl -sk https://172.16.168.19/api/infrastructure/execute \
+curl -sk https://<slm-manager-ip>/api/infrastructure/execute \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"playbook_id":"update-all-nodes","variables":{}}' \
   | python3 -m json.tool
 
 # Restart nginx on frontend node
-curl -sk -X POST https://172.16.168.19/api/orchestration/services/nginx/restart \
+curl -sk -X POST https://<slm-manager-ip>/api/orchestration/services/nginx/restart \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"node_id":"02-Frontend"}' \
   | python3 -m json.tool
 
 # Restart nginx across ALL nodes that have it
-curl -sk -X POST https://172.16.168.19/api/orchestration/fleet/services/nginx/restart \
+curl -sk -X POST https://<slm-manager-ip>/api/orchestration/fleet/services/nginx/restart \
   -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 
 # Get services running on backend node
-curl -sk https://172.16.168.19/api/nodes/01-Backend/services \
+curl -sk https://<slm-manager-ip>/api/nodes/01-Backend/services \
   -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 
 # Get service logs from a node
-curl -sk "https://172.16.168.19/api/nodes/01-Backend/services/autobot-backend/logs?lines=50" \
+curl -sk "https://<slm-manager-ip>/api/nodes/01-Backend/services/autobot-backend/logs?lines=50" \
   -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 
 # Start all services in dependency order
-curl -sk -X POST https://172.16.168.19/api/orchestration/start-all \
+curl -sk -X POST https://<slm-manager-ip>/api/orchestration/start-all \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"exclude":[]}' \
@@ -1369,7 +1369,7 @@ curl -sk -X POST https://172.16.168.19/api/orchestration/start-all \
 The SLM admin dashboard provides a graphical interface for fleet management. Access it at:
 
 ```
-https://172.16.168.19/
+https://<slm-manager-ip>/
 ```
 
 ### Dashboard Panels
@@ -1434,7 +1434,7 @@ import aiohttp
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-SLM_URL = "https://172.16.168.19"
+SLM_URL = "https://<slm-manager-ip>"
 
 
 def _create_ssl_context() -> ssl.SSLContext:
@@ -1563,17 +1563,17 @@ if __name__ == "__main__":
 
 ```bash
 # Authenticate
-TOKEN=$(curl -sk https://172.16.168.19/api/auth/login \
+TOKEN=$(curl -sk https://<slm-manager-ip>/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"your_password"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 
 # Step 1: Pull latest code
-curl -sk -X POST https://172.16.168.19/api/code-sync/pull \
+curl -sk -X POST https://<slm-manager-ip>/api/code-sync/pull \
   -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 
 # Step 2: Sync to fleet (batch_size=1 to avoid index.lock races)
-curl -sk -X POST https://172.16.168.19/api/code-sync/fleet/sync \
+curl -sk -X POST https://<slm-manager-ip>/api/code-sync/fleet/sync \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"strategy":"rolling","batch_size":1,"restart":true}' \
@@ -1609,7 +1609,7 @@ ansible-playbook -i inventory/slm-nodes.yml playbooks/update-all-nodes.yml --lim
 - **SSH key-based authentication** -- all fleet nodes use the `autobot` user with `~/.ssh/autobot_key`
 - **TLS encryption** -- nginx reverse proxy with certificates on all nodes
 - **Internal CA** -- self-signed certificates managed via the `rotate-certs.yml` playbook
-- **Firewall rules** -- SLM API port 8000 restricted to `172.16.168.0/24` subnet (Issue #894)
+- **Firewall rules** -- SLM API port 8000 restricted to `<network-subnet>` subnet (Issue #894)
 
 ### Command Execution Safety
 
@@ -1660,7 +1660,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-SLM_URL = "https://172.16.168.19"
+SLM_URL = "https://<slm-manager-ip>"
 
 
 def _create_ssl_context() -> ssl.SSLContext:
@@ -1814,7 +1814,7 @@ if __name__ == "__main__":
 
 ```bash
 # From any machine on the network
-curl -sk https://172.16.168.19/api/health | python3 -m json.tool
+curl -sk https://<slm-manager-ip>/api/health | python3 -m json.tool
 
 # Expected: {"status": "healthy", ...}
 ```
@@ -1822,13 +1822,13 @@ curl -sk https://172.16.168.19/api/health | python3 -m json.tool
 #### 2. Verify SSH Connectivity to Fleet Nodes
 
 ```bash
-# From SLM server (172.16.168.19)
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.20 hostname
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 hostname
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.22 hostname
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 hostname
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.24 hostname
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.25 hostname
+# From SLM server (<slm-manager-ip>)
+ssh -i ~/.ssh/autobot_key autobot@<backend-ip> hostname
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> hostname
+ssh -i ~/.ssh/autobot_key autobot@<npu-ip> hostname
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> hostname
+ssh -i ~/.ssh/autobot_key autobot@<aiml-ip> hostname
+ssh -i ~/.ssh/autobot_key autobot@<browser-ip> hostname
 ```
 
 #### 3. Verify Ansible Connectivity
@@ -1850,12 +1850,12 @@ journalctl -u autobot-slm-backend -n 100 --no-pager
 
 ```bash
 # Via SLM API
-TOKEN=$(curl -sk https://172.16.168.19/api/auth/login \
+TOKEN=$(curl -sk https://<slm-manager-ip>/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"your_password"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 
-curl -sk https://172.16.168.19/api/nodes/01-Backend/services \
+curl -sk https://<slm-manager-ip>/api/nodes/01-Backend/services \
   -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 ```
 
@@ -1910,7 +1910,7 @@ When a fleet sync reports `partial` status, some nodes succeeded while others fa
 
 ```bash
 # Check which nodes failed
-curl -sk "https://172.16.168.19/api/code-sync/fleet/sync/$JOB_ID" \
+curl -sk "https://<slm-manager-ip>/api/code-sync/fleet/sync/$JOB_ID" \
   -H "Authorization: Bearer $TOKEN" \
   | python3 -c "
 import sys, json
@@ -1921,7 +1921,7 @@ for node in data.get('node_states', []):
 "
 
 # Retry sync for specific failed node
-curl -sk -X POST https://172.16.168.19/api/code-sync/fleet/sync \
+curl -sk -X POST https://<slm-manager-ip>/api/code-sync/fleet/sync \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"strategy":"rolling","batch_size":1,"restart":true,"node_filter":["02-Frontend"]}' \

--- a/docs/guides/slm-docker-ansible-deployment.md
+++ b/docs/guides/slm-docker-ansible-deployment.md
@@ -13,7 +13,7 @@ complete end-to-end example:
 **1. Authenticate with the SLM:**
 
 ```bash
-SLM_TOKEN=$(curl -sk -X POST https://172.16.168.19/api/auth/login \
+SLM_TOKEN=$(curl -sk -X POST https://<slm-manager-ip>/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username": "admin", "password": "your_password"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
@@ -74,7 +74,7 @@ import asyncio
 
 async def deploy_docker_via_slm():
     """Deploy a Docker container to a fleet node using the SLM API."""
-    slm_url = "https://172.16.168.19"
+    slm_url = "https://<slm-manager-ip>"
 
     async with aiohttp.ClientSession() as session:
         # Authenticate
@@ -128,8 +128,8 @@ asyncio.run(deploy_docker_via_slm())
 
 ```bash
 curl -sk -H "Authorization: Bearer $SLM_TOKEN" \
-  https://172.16.168.19/api/nodes | python3 -m json.tool
-ssh autobot@172.16.168.24 "docker ps --filter name=my-web-app"
+  https://<slm-manager-ip>/api/nodes | python3 -m json.tool
+ssh autobot@<aiml-ip> "docker ps --filter name=my-web-app"
 ```
 
 For rolling deployments, inventory configuration, and node lifecycle management,
@@ -164,13 +164,13 @@ AutoBot's primary deployment model uses systemd services managed via Ansible. Ho
 
 ## 1. SLM Architecture for Deployment
 
-The Service Lifecycle Manager (SLM) is AutoBot's centralized fleet management system. It runs on the admin machine (172.16.168.19) and orchestrates all infrastructure operations --- including Docker container deployments --- across the fleet via Ansible.
+The Service Lifecycle Manager (SLM) is AutoBot's centralized fleet management system. It runs on the admin machine (<slm-manager-ip>) and orchestrates all infrastructure operations --- including Docker container deployments --- across the fleet via Ansible.
 
 ### Architectural Overview
 
 ```
 +---------------------------------------------------------------+
-|                   SLM Server (172.16.168.19)                   |
+|                   SLM Server (<slm-manager-ip>)                   |
 |                                                                |
 |  +-------------------+    +-------------------+               |
 |  | FastAPI Backend    |    | Vue.js Admin UI   |               |
@@ -213,7 +213,7 @@ The SLM enforces a strict separation between management and runtime:
 
 | Aspect | Management Plane (SLM) | Runtime Plane (Fleet Nodes) |
 |--------|------------------------|----------------------------|
-| **Location** | 172.16.168.19 | 172.16.168.20-27 |
+| **Location** | <slm-manager-ip> | <backend-ip>-27 |
 | **Purpose** | Orchestration, monitoring, deployment | Application workloads |
 | **Access** | Admin credentials, JWT tokens | SSH key-based (passwordless) |
 | **State** | PostgreSQL (persistent) | Stateless (agent heartbeat only) |
@@ -404,7 +404,7 @@ Provides async helper functions for authenticating with the SLM
 backend API and obtaining JWT Bearer tokens for subsequent requests.
 
 The SLM backend runs behind nginx with self-signed TLS on the
-internal 172.16.168.0/24 network. All examples use ssl=False
+internal <network-subnet> network. All examples use ssl=False
 for self-signed certificate handling.
 """
 
@@ -418,7 +418,7 @@ logger = logging.getLogger(__name__)
 
 # SLM backend is behind nginx reverse proxy with TLS on port 443.
 # Uvicorn binds to port 8000 internally (not exposed to LAN).
-SLM_BASE_URL = "https://172.16.168.19"
+SLM_BASE_URL = "https://<slm-manager-ip>"
 
 
 async def authenticate(
@@ -545,7 +545,7 @@ async def refresh_token(
 
 ### Security Notes
 
-- The SLM uses self-signed TLS certificates on the internal 172.16.168.0/24 network. Pass `ssl=False` (aiohttp) or `verify=False` (requests) when making API calls.
+- The SLM uses self-signed TLS certificates on the internal <network-subnet> network. Pass `ssl=False` (aiohttp) or `verify=False` (requests) when making API calls.
 - The admin password is managed via the `SLM_ADMIN_PASSWORD` environment variable. When set, the SLM backend syncs the admin password on every startup (in `_ensure_admin_user()`), making the env var the single source of truth.
 - Tokens expire after 24 hours (`access_token_expire_minutes = 60 * 24` in Settings).
 - All authentication events (success and failure) are recorded in the `audit_logs` table with IP address, username, and timestamp.
@@ -555,7 +555,7 @@ async def refresh_token(
 
 ## 4. Creating an Ansible Playbook for Docker Deployment
 
-Ansible playbooks for Docker deployment should be placed in the SLM Ansible directory at `/opt/autobot/autobot-slm-backend/ansible/` on the SLM server (172.16.168.19). The `PlaybookExecutor` resolves playbook names relative to this directory.
+Ansible playbooks for Docker deployment should be placed in the SLM Ansible directory at `/opt/autobot/autobot-slm-backend/ansible/` on the SLM server (<slm-manager-ip>). The `PlaybookExecutor` resolves playbook names relative to this directory.
 
 ### Playbook: deploy-container.yml
 
@@ -792,7 +792,7 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
-SLM_BASE_URL = "https://172.16.168.19"
+SLM_BASE_URL = "https://<slm-manager-ip>"
 
 
 async def deploy_docker_container(
@@ -969,7 +969,7 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
-SLM_BASE_URL = "https://172.16.168.19"
+SLM_BASE_URL = "https://<slm-manager-ip>"
 
 
 async def deploy_via_deployment_api(
@@ -1107,7 +1107,7 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
-SLM_BASE_URL = "https://172.16.168.19"
+SLM_BASE_URL = "https://<slm-manager-ip>"
 
 
 async def migrate_role_to_node(
@@ -1275,28 +1275,28 @@ all:
     slm_nodes:
       hosts:
         00-SLM-Manager:
-          ansible_host: 172.16.168.19
+          ansible_host: <slm-manager-ip>
           slm_node_id: "00-SLM-Manager"
         01-Backend:
-          ansible_host: 172.16.168.20
+          ansible_host: <backend-ip>
           slm_node_id: "01-Backend"
         02-Frontend:
-          ansible_host: 172.16.168.21
+          ansible_host: <frontend-ip>
           slm_node_id: "02-Frontend"
         npu-worker:
-          ansible_host: 172.16.168.22
+          ansible_host: <npu-ip>
           slm_node_id: "npu-worker"
         03-AI-Stack:
-          ansible_host: 172.16.168.24
+          ansible_host: <aiml-ip>
           slm_node_id: "03-AI-Stack"
         04-Databases:
-          ansible_host: 172.16.168.23
+          ansible_host: <database-ip>
           slm_node_id: "04-Databases"
         browser-automation:
-          ansible_host: 172.16.168.25
+          ansible_host: <browser-ip>
           slm_node_id: "browser-automation"
         05-LLM-CPU:
-          ansible_host: 172.16.168.26
+          ansible_host: <reserved-ip>
           slm_node_id: "05-LLM-CPU"
 
     # Role-based groups for targeted deployments
@@ -1367,14 +1367,14 @@ ansible-playbook \
 
 | Inventory Host | IP Address | SLM Node ID | Role | Group(s) |
 |----------------|------------|-------------|------|----------|
-| `00-SLM-Manager` | 172.16.168.19 | `00-SLM-Manager` | SLM admin | `slm_server` |
-| `01-Backend` | 172.16.168.20 | `01-Backend` | Main backend | `main` |
-| `02-Frontend` | 172.16.168.21 | `02-Frontend` | User frontend | `frontend` |
-| `npu-worker` | 172.16.168.22 | `npu-worker` | NPU acceleration | `npu_worker` |
-| `04-Databases` | 172.16.168.23 | `04-Databases` | Redis Stack | `redis` |
-| `03-AI-Stack` | 172.16.168.24 | `03-AI-Stack` | AI processing | `ai_stack` |
-| `browser-automation` | 172.16.168.25 | `browser-automation` | Playwright | `browser_worker` |
-| `05-LLM-CPU` | 172.16.168.26 | `05-LLM-CPU` | LLM inference | `llm_nodes` |
+| `00-SLM-Manager` | <slm-manager-ip> | `00-SLM-Manager` | SLM admin | `slm_server` |
+| `01-Backend` | <backend-ip> | `01-Backend` | Main backend | `main` |
+| `02-Frontend` | <frontend-ip> | `02-Frontend` | User frontend | `frontend` |
+| `npu-worker` | <npu-ip> | `npu-worker` | NPU acceleration | `npu_worker` |
+| `04-Databases` | <database-ip> | `04-Databases` | Redis Stack | `redis` |
+| `03-AI-Stack` | <aiml-ip> | `03-AI-Stack` | AI processing | `ai_stack` |
+| `browser-automation` | <browser-ip> | `browser-automation` | Playwright | `browser_worker` |
+| `05-LLM-CPU` | <reserved-ip> | `05-LLM-CPU` | LLM inference | `llm_nodes` |
 
 ### Inventory Variables
 
@@ -1411,7 +1411,7 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
-SLM_BASE_URL = "https://172.16.168.19"
+SLM_BASE_URL = "https://<slm-manager-ip>"
 
 
 async def rolling_deploy_fleet_sync(
@@ -1640,16 +1640,16 @@ The `PlaybookExecutor` uses only `slm-nodes.yml` by default. If your playbook ne
 
 ### All Builds Run FROM .19
 
-The SLM server (172.16.168.19) is the Ansible controller. All `ansible-playbook` commands execute from .19. Never run Ansible from fleet nodes:
+The SLM server (<slm-manager-ip>) is the Ansible controller. All `ansible-playbook` commands execute from .19. Never run Ansible from fleet nodes:
 
 ```bash
 # CORRECT - run from SLM server
-ssh autobot@172.16.168.19
+ssh autobot@<slm-manager-ip>
 cd /opt/autobot/autobot-slm-backend/ansible
 ansible-playbook -i inventory/slm-nodes.yml deploy-container.yml
 
 # WRONG - running Ansible from a fleet node
-ssh autobot@172.16.168.24
+ssh autobot@<aiml-ip>
 ansible-playbook deploy-container.yml  # No inventory, no SSH keys
 ```
 
@@ -1672,11 +1672,11 @@ ansible-playbook deploy-container.yml  # No inventory, no SSH keys
 ```bash
 # CORRECT
 rsync -avz --exclude='venv' autobot-slm-backend/ \
-  autobot@172.16.168.19:/opt/autobot/autobot-slm-backend/
+  autobot@<slm-manager-ip>:/opt/autobot/autobot-slm-backend/
 
 # WRONG - overwrites production venv
 rsync -avz autobot-slm-backend/ \
-  autobot@172.16.168.19:/opt/autobot/autobot-slm-backend/
+  autobot@<slm-manager-ip>:/opt/autobot/autobot-slm-backend/
 ```
 
 ### File Ownership After become: true
@@ -1729,7 +1729,7 @@ vim autobot-slm-backend/ansible/deploy-container.yml
 ansible-playbook ansible/playbooks/deploy-infrastructure.yml
 
 # WRONG - direct editing on VM
-ssh autobot@172.16.168.19 "vim /opt/autobot/.../deploy-container.yml"
+ssh autobot@<slm-manager-ip> "vim /opt/autobot/.../deploy-container.yml"
 ```
 
 ### SLM Backend Startup Time
@@ -1800,7 +1800,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger("deploy-container")
 
-SLM_BASE_URL = "https://172.16.168.19"
+SLM_BASE_URL = "https://<slm-manager-ip>"
 
 
 async def authenticate(
@@ -2171,7 +2171,7 @@ curl -s http://<target_ip>:<host_port>/health
 # Expected: HTTP 200 with healthy response body
 
 # 6. Fleet health via SLM API
-curl -sk https://172.16.168.19/api/roles/fleet-health \
+curl -sk https://<slm-manager-ip>/api/roles/fleet-health \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 # Expected: "health": "healthy" or "degraded" (not "critical")
 ```
@@ -2180,22 +2180,22 @@ curl -sk https://172.16.168.19/api/roles/fleet-health \
 
 ```bash
 # 7. Deployment recorded and completed
-curl -sk "https://172.16.168.19/api/deployments?node_id=<node_id>" \
+curl -sk "https://<slm-manager-ip>/api/deployments?node_id=<node_id>" \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 # Expected: Latest deployment shows "status": "completed"
 
 # 8. Node still online with recent heartbeat
-curl -sk "https://172.16.168.19/api/nodes/<node_id>" \
+curl -sk "https://<slm-manager-ip>/api/nodes/<node_id>" \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 # Expected: "status": "online", "last_heartbeat" within 60 seconds
 
 # 9. Infrastructure execution log
-curl -sk "https://172.16.168.19/api/infrastructure/executions/<execution_id>" \
+curl -sk "https://<slm-manager-ip>/api/infrastructure/executions/<execution_id>" \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 # Expected: "status": "completed", output shows all tasks succeeded
 
 # 10. No recent error events for the node
-curl -sk "https://172.16.168.19/api/nodes/<node_id>/events" \
+curl -sk "https://<slm-manager-ip>/api/nodes/<node_id>/events" \
   -H "Authorization: Bearer <token>" | python3 -m json.tool
 # Expected: No error or critical severity events in recent history
 ```

--- a/docs/guides/vision-vnc-ui-testing.md
+++ b/docs/guides/vision-vnc-ui-testing.md
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 BACKEND_URL = f"https://{config.vm.main}:{config.port.backend}"
 
 
-async def run_vnc_ui_test(token: str, target_host: str = "172.16.168.25"):
+async def run_vnc_ui_test(token: str, target_host: str = "<browser-ip>"):
     """Capture a VNC desktop, detect UI elements, click a button, and verify.
 
     Args:
@@ -909,7 +909,7 @@ Authorization: Bearer <token>
 ```json
 {
     "vnc_type": "browser",
-    "endpoint": "http://172.16.168.25:6080",
+    "endpoint": "http://<browser-ip>:6080",
     "accessible": true,
     "status": 200
 }
@@ -1066,7 +1066,7 @@ logger = logging.getLogger("vision_ui_test")
 # ---------------------------------------------------------------------------
 
 # Backend runs HTTPS on port 8443. Adjust if your deployment differs.
-DEFAULT_BACKEND_URL = "https://172.16.168.20:8443"
+DEFAULT_BACKEND_URL = "https://<backend-ip>:8443"
 
 # Self-signed certificate -- disable verification for internal network.
 # In production, supply a proper CA bundle instead.
@@ -1784,7 +1784,7 @@ asyncio.run(custom_test())
 ## 5. Playwright Integration
 
 For browser-based UI testing (as opposed to desktop VNC testing), AutoBot
-provides a Playwright API that runs on the Browser VM (172.16.168.25, port 3000).
+provides a Playwright API that runs on the Browser VM (<browser-ip>, port 3000).
 
 The Playwright API is mounted at `/api/playwright` and requires admin
 authentication.
@@ -1901,7 +1901,7 @@ import ssl
 
 import aiohttp
 
-BACKEND_URL = "https://172.16.168.20:8443"
+BACKEND_URL = "https://<backend-ip>:8443"
 
 SSL_CTX = ssl.create_default_context()
 SSL_CTX.check_hostname = False
@@ -2351,14 +2351,14 @@ sudo apt-get install scrot
 1. Check that the VNC screenshot is capturing correctly:
 
     ```bash
-    curl -sk https://172.16.168.20:8443/api/vnc/screenshot \
+    curl -sk https://<backend-ip>:8443/api/vnc/screenshot \
         -H "Authorization: Bearer <token>" | jq '.status'
     ```
 
 2. Verify the Vision service is healthy:
 
     ```bash
-    curl -sk https://172.16.168.20:8443/api/vision/health \
+    curl -sk https://<backend-ip>:8443/api/vision/health \
         -H "Authorization: Bearer <token>" | jq '.'
     ```
 

--- a/docs/guides/visual-workflow-parallel-execution.md
+++ b/docs/guides/visual-workflow-parallel-execution.md
@@ -925,15 +925,15 @@ executor = ParallelToolExecutor(
 # Create tool calls for parallel execution
 calls = [
     ToolCall(tool_name="execute_shell", arguments={
-        "host": "172.16.168.21",
+        "host": "<frontend-ip>",
         "command": "/opt/autobot/scripts/audit/check_permissions.sh",
     }),
     ToolCall(tool_name="execute_shell", arguments={
-        "host": "172.16.168.22",
+        "host": "<npu-ip>",
         "command": "/opt/autobot/scripts/audit/check_services.sh",
     }),
     ToolCall(tool_name="execute_shell", arguments={
-        "host": "172.16.168.24",
+        "host": "<aiml-ip>",
         "command": "/opt/autobot/scripts/audit/check_network.sh",
     }),
 ]
@@ -997,12 +997,12 @@ async def execute_step_on_target(
 
 | IP | Role | Typical Audit Scripts |
 |----|------|-----------------------|
-| 172.16.168.21 | Frontend VM | `check_permissions.sh`, `check_nginx.sh` |
-| 172.16.168.22 | NPU VM | `check_services.sh`, `check_npu_health.sh` |
-| 172.16.168.23 | Redis VM | `check_redis.sh`, `check_memory.sh` |
-| 172.16.168.24 | AI Stack VM | `check_network.sh`, `check_gpu.sh` |
-| 172.16.168.25 | Browser VM | `check_playwright.sh`, `check_vnc.sh` |
-| 172.16.168.19 | SLM Server | `check_slm.sh`, `check_celery.sh` |
+| <frontend-ip> | Frontend VM | `check_permissions.sh`, `check_nginx.sh` |
+| <npu-ip> | NPU VM | `check_services.sh`, `check_npu_health.sh` |
+| <database-ip> | Redis VM | `check_redis.sh`, `check_memory.sh` |
+| <aiml-ip> | AI Stack VM | `check_network.sh`, `check_gpu.sh` |
+| <browser-ip> | Browser VM | `check_playwright.sh`, `check_vnc.sh` |
+| <slm-manager-ip> | SLM Server | `check_slm.sh`, `check_celery.sh` |
 
 ---
 
@@ -1318,21 +1318,21 @@ fleet_update_template = WorkflowTemplate(
             agent_type="system_commands",
             action="apt update on frontend node",
             description="System_Commands: apt update (.21)",
-            inputs={"target_host": "172.16.168.21", "cmd": "sudo apt update"},
+            inputs={"target_host": "<frontend-ip>", "cmd": "sudo apt update"},
         ),
         WorkflowStep(
             id="update_npu",
             agent_type="system_commands",
             action="apt update on NPU node",
             description="System_Commands: apt update (.22)",
-            inputs={"target_host": "172.16.168.22", "cmd": "sudo apt update"},
+            inputs={"target_host": "<npu-ip>", "cmd": "sudo apt update"},
         ),
         WorkflowStep(
             id="update_ai_stack",
             agent_type="system_commands",
             action="apt update on AI Stack node",
             description="System_Commands: apt update (.24)",
-            inputs={"target_host": "172.16.168.24", "cmd": "sudo apt update"},
+            inputs={"target_host": "<aiml-ip>", "cmd": "sudo apt update"},
         ),
         # Phase 2: Upgrade packages (parallel, depends on update phase)
         WorkflowStep(
@@ -1342,7 +1342,7 @@ fleet_update_template = WorkflowTemplate(
             description="System_Commands: apt upgrade (.21)",
             dependencies=["update_frontend"],
             requires_approval=True,
-            inputs={"target_host": "172.16.168.21", "cmd": "sudo apt upgrade -y"},
+            inputs={"target_host": "<frontend-ip>", "cmd": "sudo apt upgrade -y"},
         ),
         WorkflowStep(
             id="upgrade_npu",
@@ -1351,7 +1351,7 @@ fleet_update_template = WorkflowTemplate(
             description="System_Commands: apt upgrade (.22)",
             dependencies=["update_npu"],
             requires_approval=True,
-            inputs={"target_host": "172.16.168.22", "cmd": "sudo apt upgrade -y"},
+            inputs={"target_host": "<npu-ip>", "cmd": "sudo apt upgrade -y"},
         ),
         WorkflowStep(
             id="upgrade_ai_stack",
@@ -1360,7 +1360,7 @@ fleet_update_template = WorkflowTemplate(
             description="System_Commands: apt upgrade (.24)",
             dependencies=["update_ai_stack"],
             requires_approval=True,
-            inputs={"target_host": "172.16.168.24", "cmd": "sudo apt upgrade -y"},
+            inputs={"target_host": "<aiml-ip>", "cmd": "sudo apt upgrade -y"},
         ),
         # Phase 3: Verify services (after all upgrades)
         WorkflowStep(
@@ -1726,7 +1726,7 @@ workflow = {
                 "parallel_group": "audit_wave_1",
                 "timeout": 300,
                 "inputs": {
-                    "target_host": "172.16.168.21",
+                    "target_host": "<frontend-ip>",
                     "script": "/opt/autobot/scripts/audit/check_permissions.sh",
                 },
             },
@@ -1737,7 +1737,7 @@ workflow = {
                 "parallel_group": "audit_wave_1",
                 "timeout": 300,
                 "inputs": {
-                    "target_host": "172.16.168.22",
+                    "target_host": "<npu-ip>",
                     "script": "/opt/autobot/scripts/audit/check_services.sh",
                 },
             },
@@ -1748,7 +1748,7 @@ workflow = {
                 "parallel_group": "audit_wave_1",
                 "timeout": 300,
                 "inputs": {
-                    "target_host": "172.16.168.24",
+                    "target_host": "<aiml-ip>",
                     "script": "/opt/autobot/scripts/audit/check_network.sh",
                 },
             },

--- a/docs/implementation/ISSUE_753_FINAL_REPORT.md
+++ b/docs/implementation/ISSUE_753_FINAL_REPORT.md
@@ -353,7 +353,7 @@ Screen Reader (announce change)
 
 ### Live Deployment
 
-**URL**: http://172.16.168.21:5173/preferences
+**URL**: http://<frontend-ip>:5173/preferences
 **Status**: ✅ Deployed and Accessible
 **Last Sync**: 2026-02-05
 
@@ -521,7 +521,7 @@ d306c6d4 - Preferences UI + accessibility
 - Phase 2 (Preferences UI): 10/10
 - Full WCAG 2.1 AA compliance
 - All commits: 733c0f04, 2b6722c7, 69f5289a, 946cc818, ed9e442e, d306c6d4, 93c05a36
-- Live at: http://172.16.168.21:5173/preferences
+- Live at: http://<frontend-ip>:5173/preferences
 
 ---
 

--- a/docs/infrastructure/BROWSER_VNC_SETUP.md
+++ b/docs/infrastructure/BROWSER_VNC_SETUP.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-Real-time collaborative browser viewing system for AutoBot - enables both users and AI agents to observe and control the same browser instance through VNC on Browser VM (172.16.168.25).
+Real-time collaborative browser viewing system for AutoBot - enables both users and AI agents to observe and control the same browser instance through VNC on Browser VM (<browser-ip>).
 
 ## Architecture
 
 ```
-Frontend (172.16.168.21:5173)
+Frontend (<frontend-ip>:5173)
     ↓
 Browser Tab Component (PopoutChromiumBrowser.vue)
     ↓
-noVNC iframe → Browser VM (172.16.168.25:6080/vnc.html)
+noVNC iframe → Browser VM (<browser-ip>:6080/vnc.html)
     ↓
 websockify (port 6080) → VNC Server (port 5901)
     ↓
@@ -60,10 +60,10 @@ If needed, deploy manually:
 
 ```bash
 # Copy service files
-scp scripts/infrastructure/browser-*.service autobot@172.16.168.25:/tmp/
+scp scripts/infrastructure/browser-*.service autobot@<browser-ip>:/tmp/
 
 # Install on Browser VM
-ssh autobot@172.16.168.25
+ssh autobot@<browser-ip>
 sudo mv /tmp/browser-*.service /etc/systemd/system/
 sudo chmod 644 /etc/systemd/system/browser-*.service
 sudo systemctl daemon-reload
@@ -76,40 +76,40 @@ sudo systemctl start browser-vnc browser-vnc-websockify browser-playwright
 ### Check Status
 
 ```bash
-ssh autobot@172.16.168.25 'sudo systemctl status browser-vnc browser-vnc-websockify browser-playwright'
+ssh autobot@<browser-ip> 'sudo systemctl status browser-vnc browser-vnc-websockify browser-playwright'
 ```
 
 ### View Logs
 
 ```bash
 # Playwright logs (includes browser activity)
-ssh autobot@172.16.168.25 'sudo journalctl -u browser-playwright -f'
+ssh autobot@<browser-ip> 'sudo journalctl -u browser-playwright -f'
 
 # VNC server logs
-ssh autobot@172.16.168.25 'sudo journalctl -u browser-vnc -f'
+ssh autobot@<browser-ip> 'sudo journalctl -u browser-vnc -f'
 
 # websockify logs
-ssh autobot@172.16.168.25 'sudo journalctl -u browser-vnc-websockify -f'
+ssh autobot@<browser-ip> 'sudo journalctl -u browser-vnc-websockify -f'
 ```
 
 ### Restart Services
 
 ```bash
 # Restart all browser services
-ssh autobot@172.16.168.25 'sudo systemctl restart browser-*.service'
+ssh autobot@<browser-ip> 'sudo systemctl restart browser-*.service'
 
 # Restart individual service
-ssh autobot@172.16.168.25 'sudo systemctl restart browser-playwright'
+ssh autobot@<browser-ip> 'sudo systemctl restart browser-playwright'
 ```
 
 ### Stop/Start Services
 
 ```bash
 # Stop all
-ssh autobot@172.16.168.25 'sudo systemctl stop browser-*.service'
+ssh autobot@<browser-ip> 'sudo systemctl stop browser-*.service'
 
 # Start all
-ssh autobot@172.16.168.25 'sudo systemctl start browser-vnc browser-vnc-websockify browser-playwright'
+ssh autobot@<browser-ip> 'sudo systemctl start browser-vnc browser-vnc-websockify browser-playwright'
 ```
 
 ## Configuration
@@ -170,8 +170,8 @@ vncUrl.value = await appConfig.getVncUrl('playwright', {
 
 ### Direct VNC Access
 
-- **noVNC Web**: http://172.16.168.25:6080/vnc.html
-- **VNC Protocol**: vnc://172.16.168.25:5901
+- **noVNC Web**: http://<browser-ip>:6080/vnc.html
+- **VNC Protocol**: vnc://<browser-ip>:5901
 
 ### Frontend Browser Tab
 
@@ -187,7 +187,7 @@ Navigate to Browser tab in AutoBot interface:
 
 ```bash
 # Check all ports listening
-ssh autobot@172.16.168.25 "ss -tuln | grep -E ':(5901|6080|3000)'"
+ssh autobot@<browser-ip> "ss -tuln | grep -E ':(5901|6080|3000)'"
 
 # Should show:
 # - Port 5901 (VNC)
@@ -197,7 +197,7 @@ ssh autobot@172.16.168.25 "ss -tuln | grep -E ':(5901|6080|3000)'"
 
 ### Test VNC Connection
 
-1. Open http://172.16.168.25:6080/vnc.html
+1. Open http://<browser-ip>:6080/vnc.html
 2. Click "Connect"
 3. Should see XFCE desktop
 
@@ -205,7 +205,7 @@ ssh autobot@172.16.168.25 "ss -tuln | grep -E ':(5901|6080|3000)'"
 
 ```bash
 # Navigate to a page via API
-curl -X POST http://172.16.168.25:3000/navigate \
+curl -X POST http://<browser-ip>:3000/navigate \
   -H "Content-Type: application/json" \
   -d '{"url": "https://example.com"}'
 
@@ -246,30 +246,30 @@ curl -X POST http://172.16.168.25:3000/navigate \
 
 ```bash
 # Check VNC server
-ssh autobot@172.16.168.25 'ps aux | grep Xtigervnc'
+ssh autobot@<browser-ip> 'ps aux | grep Xtigervnc'
 
 # Restart if needed
-ssh autobot@172.16.168.25 'sudo systemctl restart browser-vnc'
+ssh autobot@<browser-ip> 'sudo systemctl restart browser-vnc'
 ```
 
 ### websockify Not Working
 
 ```bash
 # Check logs
-ssh autobot@172.16.168.25 'sudo journalctl -u browser-vnc-websockify -n 50'
+ssh autobot@<browser-ip> 'sudo journalctl -u browser-vnc-websockify -n 50'
 
 # Verify noVNC installed
-ssh autobot@172.16.168.25 'dpkg -l | grep novnc'
+ssh autobot@<browser-ip> 'dpkg -l | grep novnc'
 
 # Install if missing
-ssh autobot@172.16.168.25 'sudo apt-get install -y novnc'
+ssh autobot@<browser-ip> 'sudo apt-get install -y novnc'
 ```
 
 ### Playwright Still Headless
 
 ```bash
 # Check environment variables
-ssh autobot@172.16.168.25 'sudo systemctl show browser-playwright | grep Environment'
+ssh autobot@<browser-ip> 'sudo systemctl show browser-playwright | grep Environment'
 
 # Should show:
 # Environment=HEADLESS=false DISPLAY=:1
@@ -279,13 +279,13 @@ ssh autobot@172.16.168.25 'sudo systemctl show browser-playwright | grep Environ
 
 ```bash
 # Check DISPLAY variable
-ssh autobot@172.16.168.25 'echo $DISPLAY'
+ssh autobot@<browser-ip> 'echo $DISPLAY'
 
 # Check X server
-ssh autobot@172.16.168.25 'ps aux | grep Xtigervnc'
+ssh autobot@<browser-ip> 'ps aux | grep Xtigervnc'
 
 # Restart Playwright with correct DISPLAY
-ssh autobot@172.16.168.25 'sudo systemctl restart browser-playwright'
+ssh autobot@<browser-ip> 'sudo systemctl restart browser-playwright'
 ```
 
 ## Maintenance
@@ -300,10 +300,10 @@ ssh autobot@172.16.168.25 'sudo systemctl restart browser-playwright'
 
 ```bash
 # Check system resources
-ssh autobot@172.16.168.25 'top -b -n 1 | head -20'
+ssh autobot@<browser-ip> 'top -b -n 1 | head -20'
 
 # Check service memory usage
-ssh autobot@172.16.168.25 'systemctl status browser-playwright --no-pager | grep Memory'
+ssh autobot@<browser-ip> 'systemctl status browser-playwright --no-pager | grep Memory'
 ```
 
 ## Security Notes

--- a/docs/infrastructure/GRAFANA_EXTERNAL_HOST_SETUP.md
+++ b/docs/infrastructure/GRAFANA_EXTERNAL_HOST_SETUP.md
@@ -5,11 +5,11 @@
 > **⚠️ IMPORTANT NOTE:**
 >
 > **Current Production Configuration (Issue #859):**
-> - Grafana is deployed on **SLM Server (172.16.168.19)** via Ansible playbooks (`slm_manager` role)
-> - Prometheus and AlertManager also run on SLM Server (172.16.168.19)
-> - Redis VM (172.16.168.23) runs only Redis Stack
+> - Grafana is deployed on **SLM Server (<slm-manager-ip>)** via Ansible playbooks (`slm_manager` role)
+> - Prometheus and AlertManager also run on SLM Server (<slm-manager-ip>)
+> - Redis VM (<database-ip>) runs only Redis Stack
 >
-> **This document covers OPTIONAL external deployment** for advanced use cases requiring dedicated monitoring infrastructure. For standard deployments, Grafana remains colocated with the SLM backend on 172.16.168.19.
+> **This document covers OPTIONAL external deployment** for advanced use cases requiring dedicated monitoring infrastructure. For standard deployments, Grafana remains colocated with the SLM backend on <slm-manager-ip>.
 
 This document describes how to deploy Grafana on a dedicated external host for AutoBot SLM monitoring, instead of running it locally on the SLM server.
 
@@ -33,7 +33,7 @@ This document describes how to deploy Grafana on a dedicated external host for A
 ### Current Architecture (Local Grafana)
 
 ```
-SLM Server (172.16.168.19)
+SLM Server (<slm-manager-ip>)
 ├── Grafana :3000 (localhost only)
 ├── Prometheus :9090 (localhost only)
 ├── Nginx :443
@@ -52,16 +52,16 @@ SLM Server (172.16.168.19)
 ### External Architecture (Dedicated Monitoring VM)
 
 ```
-SLM Server (172.16.168.19)
+SLM Server (<slm-manager-ip>)
 ├── Prometheus :9090 (exposed to monitoring VM)
 ├── Nginx :443
-│   ├── /grafana/ → http://172.16.168.28:3000/grafana/
+│   ├── /grafana/ → http://<reserved-ip>:3000/grafana/
 │   └── Frontend served from /
 └── AutoBot SLM Backend :8000
 
-Monitoring VM (172.16.168.28)
+Monitoring VM (<reserved-ip>)
 └── Grafana :3000
-    └── Data Source → http://172.16.168.19:9090 (Prometheus)
+    └── Data Source → http://<slm-manager-ip>:9090 (Prometheus)
 ```
 
 **Characteristics:**
@@ -124,7 +124,7 @@ Monitoring VM (172.16.168.28)
 1. **Target VM prepared:**
    ```bash
    # Ubuntu 22.04 with SSH access
-   ssh autobot@172.16.168.28 "uname -a"
+   ssh autobot@<reserved-ip> "uname -a"
    ```
 
 2. **Ansible inventory configured:**
@@ -152,10 +152,10 @@ ansible-playbook migrate-grafana-to-vm.yml \
   -i inventory-migration.ini
 
 # Step 2: Verify migration
-curl -k https://172.16.168.19/grafana/api/health
+curl -k https://<slm-manager-ip>/grafana/api/health
 
 # Step 3: Test dashboard access
-curl -k -I https://172.16.168.19/grafana/d/autobot-system?kiosk=tv
+curl -k -I https://<slm-manager-ip>/grafana/d/autobot-system?kiosk=tv
 
 # Step 4: (Optional) Remove Grafana from SLM server
 ansible-playbook migrate-grafana-to-vm.yml \
@@ -168,18 +168,18 @@ ansible-playbook migrate-grafana-to-vm.yml \
 
 1. **Direct Grafana access:**
    ```bash
-   curl http://172.16.168.28:3000/grafana/api/health
+   curl http://<reserved-ip>:3000/grafana/api/health
    # Expected: {"database":"ok","version":"12.3.2"}
    ```
 
 2. **Proxied access via SLM:**
    ```bash
-   curl -k https://172.16.168.19/grafana/api/health
+   curl -k https://<slm-manager-ip>/grafana/api/health
    # Expected: {"database":"ok","version":"12.3.2"}
    ```
 
 3. **Dashboard access:**
-   - Open browser: https://172.16.168.19/monitoring/system
+   - Open browser: https://<slm-manager-ip>/monitoring/system
    - Verify all 6 dashboard types load
    - Check Prometheus data is displayed
 
@@ -190,7 +190,7 @@ ansible-playbook migrate-grafana-to-vm.yml \
 ### Phase 1: Install Grafana on External Host
 
 ```bash
-# On monitoring VM (172.16.168.28)
+# On monitoring VM (<reserved-ip>)
 sudo apt-get update
 
 # Add Grafana APT repository
@@ -217,10 +217,10 @@ http_addr = 0.0.0.0
 http_port = 3000
 
 # Domain should be the SLM server (nginx proxy)
-domain = 172.16.168.19
+domain = <slm-manager-ip>
 
 # Root URL includes the proxy path
-root_url = https://172.16.168.19/grafana/
+root_url = https://<slm-manager-ip>/grafana/
 
 # Enable subpath serving
 serve_from_sub_path = true
@@ -247,7 +247,7 @@ sudo chown root:grafana /var/lib/grafana/dashboards
 sudo chmod 755 /var/lib/grafana/dashboards
 
 # Copy dashboards from SLM server
-scp -r autobot@172.16.168.19:/var/lib/grafana/dashboards/*.json \
+scp -r autobot@<slm-manager-ip>:/var/lib/grafana/dashboards/*.json \
   /tmp/
 
 sudo mv /tmp/*.json /var/lib/grafana/dashboards/
@@ -280,7 +280,7 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-    url: http://172.16.168.19:9090
+    url: http://<slm-manager-ip>:9090
     isDefault: true
     editable: false
     jsonData:
@@ -305,11 +305,11 @@ curl http://localhost:3000/api/health
 
 ```bash
 # On monitoring VM - allow incoming from SLM server
-sudo ufw allow from 172.16.168.19 to any port 3000 proto tcp \
+sudo ufw allow from <slm-manager-ip> to any port 3000 proto tcp \
   comment "Nginx to Grafana"
 
 # On SLM server - allow incoming from monitoring VM
-sudo ufw allow from 172.16.168.28 to any port 9090 proto tcp \
+sudo ufw allow from <reserved-ip> to any port 9090 proto tcp \
   comment "Grafana to Prometheus"
 
 sudo ufw status numbered
@@ -323,7 +323,7 @@ Edit `/etc/nginx/sites-available/autobot-slm`:
 # Update Grafana proxy location
 location /grafana/ {
     # Point to external Grafana host
-    proxy_pass http://172.16.168.28:3000/grafana/;
+    proxy_pass http://<reserved-ip>:3000/grafana/;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -331,7 +331,7 @@ location /grafana/ {
     proxy_set_header X-Forwarded-Proto $scheme;
 
     # Add CORS headers for iframe embedding
-    add_header Access-Control-Allow-Origin "https://172.16.168.19" always;
+    add_header Access-Control-Allow-Origin "https://<slm-manager-ip>" always;
     add_header Access-Control-Allow-Credentials "true" always;
 }
 ```
@@ -346,12 +346,12 @@ sudo systemctl reload nginx
 
 ```bash
 # Test all components
-curl http://172.16.168.28:3000/grafana/api/health  # Direct Grafana
-curl -k https://172.16.168.19/grafana/api/health   # Proxied via nginx
-curl -k -I https://172.16.168.19/grafana/d/autobot-system?kiosk=tv  # Dashboard
+curl http://<reserved-ip>:3000/grafana/api/health  # Direct Grafana
+curl -k https://<slm-manager-ip>/grafana/api/health   # Proxied via nginx
+curl -k -I https://<slm-manager-ip>/grafana/d/autobot-system?kiosk=tv  # Dashboard
 
 # Open in browser
-xdg-open https://172.16.168.19/monitoring/system
+xdg-open https://<slm-manager-ip>/monitoring/system
 ```
 
 ---
@@ -369,7 +369,7 @@ To use external Grafana with the `slm_manager` role:
 grafana_mode: external
 
 # Specify external Grafana host
-grafana_external_host: 172.16.168.28
+grafana_external_host: <reserved-ip>
 
 # Grafana port (default: 3000)
 grafana_port: 3000
@@ -383,10 +383,10 @@ grafana_deploy_dashboards: false  # Set to true if deploying from Ansible
 
 # Enable CORS for external access
 grafana_enable_cors: true
-grafana_cors_origin: "https://172.16.168.19"
+grafana_cors_origin: "https://<slm-manager-ip>"
 
 # Prometheus must be accessible from external Grafana
-prometheus_host: 172.16.168.19  # Expose on all interfaces or specific IP
+prometheus_host: <slm-manager-ip>  # Expose on all interfaces or specific IP
 prometheus_port: 9090
 ```
 
@@ -394,15 +394,15 @@ prometheus_port: 9090
 
 ```ini
 [slm_server]
-172.16.168.19 ansible_user=autobot
+<slm-manager-ip> ansible_user=autobot
 
 [slm_server:vars]
 grafana_mode=external
-grafana_external_host=172.16.168.28
+grafana_external_host=<reserved-ip>
 grafana_install=false
 grafana_configure=false
 grafana_enable_cors=true
-prometheus_host=172.16.168.19
+prometheus_host=<slm-manager-ip>
 ```
 
 Run deployment:
@@ -423,10 +423,10 @@ ansible-playbook deploy-slm-manager.yml -i inventory.ini
 **Diagnosis:**
 ```bash
 # Check Prometheus accessibility from Grafana VM
-ssh autobot@172.16.168.28 "curl -s http://172.16.168.19:9090/api/v1/query?query=up | jq"
+ssh autobot@<reserved-ip> "curl -s http://<slm-manager-ip>:9090/api/v1/query?query=up | jq"
 
 # Check Grafana data source configuration
-curl -s -u admin:admin http://172.16.168.28:3000/api/datasources | jq
+curl -s -u admin:admin http://<reserved-ip>:3000/api/datasources | jq
 ```
 
 **Solution:**
@@ -454,14 +454,14 @@ curl -s -u admin:admin http://172.16.168.28:3000/api/datasources | jq
 
 **Symptoms:**
 ```
-Access to XMLHttpRequest at 'https://172.16.168.19/grafana/...' from origin
-'https://172.16.168.28:3000' has been blocked by CORS policy
+Access to XMLHttpRequest at 'https://<slm-manager-ip>/grafana/...' from origin
+'https://<reserved-ip>:3000' has been blocked by CORS policy
 ```
 
 **Solution:**
 1. Verify nginx CORS headers:
    ```bash
-   curl -k -I https://172.16.168.19/grafana/api/health | grep Access-Control
+   curl -k -I https://<slm-manager-ip>/grafana/api/health | grep Access-Control
    ```
 
 2. Check Grafana cookie settings:
@@ -480,13 +480,13 @@ Access to XMLHttpRequest at 'https://172.16.168.19/grafana/...' from origin
 **Diagnosis:**
 ```bash
 # Check Grafana is running
-ssh autobot@172.16.168.28 "systemctl status grafana-server"
+ssh autobot@<reserved-ip> "systemctl status grafana-server"
 
 # Check Grafana is listening
-ssh autobot@172.16.168.28 "netstat -tlnp | grep 3000"
+ssh autobot@<reserved-ip> "netstat -tlnp | grep 3000"
 
 # Test direct access
-ssh autobot@172.16.168.28 "curl -I http://localhost:3000/grafana/api/health"
+ssh autobot@<reserved-ip> "curl -I http://localhost:3000/grafana/api/health"
 ```
 
 **Solution:**
@@ -513,12 +513,12 @@ ssh autobot@172.16.168.28 "curl -I http://localhost:3000/grafana/api/health"
 
 2. Check `root_url` includes the subpath:
    ```ini
-   root_url = https://172.16.168.19/grafana/
+   root_url = https://<slm-manager-ip>/grafana/
    ```
 
 3. Ensure nginx proxy_pass keeps the prefix:
    ```nginx
-   proxy_pass http://172.16.168.28:3000/grafana/;  # NOT /
+   proxy_pass http://<reserved-ip>:3000/grafana/;  # NOT /
    ```
 
 ### Issue: Authentication Required
@@ -557,7 +557,7 @@ ssh autobot@172.16.168.28 "curl -I http://localhost:3000/grafana/api/health"
    ```bash
    # On monitoring VM
    sudo ufw deny 3000
-   sudo ufw allow from 172.16.168.19 to any port 3000
+   sudo ufw allow from <slm-manager-ip> to any port 3000
    ```
 
 3. **VPN/Private Network:**
@@ -650,10 +650,10 @@ sudo systemctl enable grafana-server
 
 # 3. Verify
 curl http://localhost:3000/api/health
-curl -k https://172.16.168.19/grafana/api/health
+curl -k https://<slm-manager-ip>/grafana/api/health
 
 # 4. Test dashboards
-xdg-open https://172.16.168.19/monitoring/system
+xdg-open https://<slm-manager-ip>/monitoring/system
 ```
 
 ### Ansible Rollback

--- a/docs/infrastructure/GRAFANA_QUICK_REFERENCE.md
+++ b/docs/infrastructure/GRAFANA_QUICK_REFERENCE.md
@@ -13,11 +13,11 @@ curl http://localhost:3000/api/health
 systemctl status grafana-server
 
 # External Grafana (monitoring VM)
-curl http://172.16.168.28:3000/api/health
-ssh autobot@172.16.168.28 "systemctl status grafana-server"
+curl http://<reserved-ip>:3000/api/health
+ssh autobot@<reserved-ip> "systemctl status grafana-server"
 
 # Via nginx proxy
-curl -k https://172.16.168.19/grafana/api/health
+curl -k https://<slm-manager-ip>/grafana/api/health
 ```
 
 ### Test Dashboard Access
@@ -25,7 +25,7 @@ curl -k https://172.16.168.19/grafana/api/health
 # All dashboard types
 for dash in autobot-system autobot-overview autobot-performance autobot-multi-machine autobot-redis autobot-api-health; do
   echo -n "$dash: "
-  curl -k -s -o /dev/null -w "%{http_code}\n" "https://172.16.168.19/grafana/d/$dash?kiosk=tv"
+  curl -k -s -o /dev/null -w "%{http_code}\n" "https://<slm-manager-ip>/grafana/d/$dash?kiosk=tv"
 done
 ```
 
@@ -35,14 +35,14 @@ done
 sudo journalctl -u grafana-server -f
 
 # External
-ssh autobot@172.16.168.28 "sudo journalctl -u grafana-server -f"
+ssh autobot@<reserved-ip> "sudo journalctl -u grafana-server -f"
 ```
 
 ---
 
 ## 📁 Important File Locations
 
-### SLM Server (172.16.168.19)
+### SLM Server (<slm-manager-ip>)
 ```
 /etc/grafana/grafana.ini                    - Grafana configuration
 /var/lib/grafana/dashboards/                - Dashboard JSON files
@@ -80,7 +80,7 @@ docs/infrastructure/
 sudo systemctl restart grafana-server
 
 # External
-ssh autobot@172.16.168.28 "sudo systemctl restart grafana-server"
+ssh autobot@<reserved-ip> "sudo systemctl restart grafana-server"
 ```
 
 ### Reload Nginx (after config change)
@@ -96,7 +96,7 @@ curl -s http://localhost:3000/api/search | jq -r '.[] | "\(.title) - \(.uid)"'
 ### Check Prometheus Connection
 ```bash
 # From Grafana VM
-curl -s http://172.16.168.19:9090/api/v1/query?query=up | jq
+curl -s http://<slm-manager-ip>:9090/api/v1/query?query=up | jq
 ```
 
 ---
@@ -111,25 +111,25 @@ grafana_mode: local
 
 **URLs:**
 - Direct: http://localhost:3000
-- Proxied: https://172.16.168.19/grafana/
+- Proxied: https://<slm-manager-ip>/grafana/
 
 ### Mode 2: External Grafana (Dedicated VM)
 ```yaml
 grafana_mode: external
-grafana_external_host: 172.16.168.28
+grafana_external_host: <reserved-ip>
 grafana_enable_cors: true
 ```
 
 **URLs:**
-- Direct: http://172.16.168.28:3000
-- Proxied: https://172.16.168.19/grafana/
+- Direct: http://<reserved-ip>:3000
+- Proxied: https://<slm-manager-ip>/grafana/
 
 ### Mode 3: External Grafana (Cloud/Remote)
 ```yaml
 grafana_mode: external
 grafana_external_host: grafana.example.com
 grafana_enable_cors: true
-prometheus_host: 172.16.168.19  # Public IP
+prometheus_host: <slm-manager-ip>  # Public IP
 ```
 
 ---
@@ -155,7 +155,7 @@ ansible -i inventory-migration.ini monitoring_vm -m ping
 ansible-playbook migrate-grafana-to-vm.yml -i inventory-migration.ini
 
 # 4. Verify
-curl -k https://172.16.168.19/grafana/api/health
+curl -k https://<slm-manager-ip>/grafana/api/health
 ```
 
 ### Rollback to Local
@@ -171,7 +171,7 @@ ansible-playbook deploy-slm-manager.yml -i inventory.ini \
 ### Problem: No Data in Dashboards
 ```bash
 # Check Prometheus
-curl http://172.16.168.19:9090/api/v1/query?query=up
+curl http://<slm-manager-ip>:9090/api/v1/query?query=up
 
 # Check firewall
 sudo ufw status | grep 9090
@@ -196,7 +196,7 @@ cat /etc/nginx/sites-enabled/autobot-slm | grep grafana -A 5
 ### Problem: CORS Errors
 ```bash
 # Check nginx CORS headers
-curl -k -I https://172.16.168.19/grafana/api/health | grep Access-Control
+curl -k -I https://<slm-manager-ip>/grafana/api/health | grep Access-Control
 
 # Check Grafana settings
 grep -E "allow_embedding|cookie_samesite" /etc/grafana/grafana.ini | grep -v '^;'
@@ -230,17 +230,17 @@ grep -A 2 "location /grafana/" /etc/nginx/sites-enabled/autobot-slm
 
 ### Direct Access (Kiosk Mode)
 ```
-https://172.16.168.19/grafana/d/autobot-system?kiosk=tv
-https://172.16.168.19/grafana/d/autobot-overview?kiosk=tv
-https://172.16.168.19/grafana/d/autobot-performance?kiosk=tv
-https://172.16.168.19/grafana/d/autobot-multi-machine?kiosk=tv
-https://172.16.168.19/grafana/d/autobot-redis?kiosk=tv
-https://172.16.168.19/grafana/d/autobot-api-health?kiosk=tv
+https://<slm-manager-ip>/grafana/d/autobot-system?kiosk=tv
+https://<slm-manager-ip>/grafana/d/autobot-overview?kiosk=tv
+https://<slm-manager-ip>/grafana/d/autobot-performance?kiosk=tv
+https://<slm-manager-ip>/grafana/d/autobot-multi-machine?kiosk=tv
+https://<slm-manager-ip>/grafana/d/autobot-redis?kiosk=tv
+https://<slm-manager-ip>/grafana/d/autobot-api-health?kiosk=tv
 ```
 
 ### SLM Frontend Integration
 ```
-https://172.16.168.19/monitoring/system
+https://<slm-manager-ip>/monitoring/system
 ```
 
 ---
@@ -250,10 +250,10 @@ https://172.16.168.19/monitoring/system
 ### Minimum Required Access
 ```bash
 # SLM Server firewall
-sudo ufw allow from 172.16.168.28 to any port 9090 comment "Grafana to Prometheus"
+sudo ufw allow from <reserved-ip> to any port 9090 comment "Grafana to Prometheus"
 
 # Monitoring VM firewall
-sudo ufw allow from 172.16.168.19 to any port 3000 comment "Nginx to Grafana"
+sudo ufw allow from <slm-manager-ip> to any port 3000 comment "Nginx to Grafana"
 ```
 
 ### Production Hardening
@@ -318,7 +318,7 @@ Save as `check-grafana-health.sh`:
 #!/bin/bash
 # AutoBot Grafana Health Check
 
-GRAFANA_HOST="${1:-172.16.168.19}"
+GRAFANA_HOST="${1:-<slm-manager-ip>}"
 GRAFANA_PORT="${2:-3000}"
 
 echo "=== Grafana Health Check ==="
@@ -364,7 +364,7 @@ Usage:
 ```bash
 chmod +x check-grafana-health.sh
 ./check-grafana-health.sh                    # Local
-./check-grafana-health.sh 172.16.168.28      # External
+./check-grafana-health.sh <reserved-ip>      # External
 ```
 
 ---

--- a/docs/infrastructure/GRAFANA_ROLE_CONSISTENCY.md
+++ b/docs/infrastructure/GRAFANA_ROLE_CONSISTENCY.md
@@ -8,7 +8,7 @@
 
 AutoBot has two Ansible roles that can deploy Grafana:
 
-1. **`slm_manager`** - Deploys Grafana on SLM server (172.16.168.19)
+1. **`slm_manager`** - Deploys Grafana on SLM server (<slm-manager-ip>)
 2. **`monitoring`** - Deploys Grafana on any node (dedicated monitoring VMs)
 
 Both roles now ensure **repeatable, consistent configuration** regardless of where Grafana is deployed.
@@ -72,7 +72,7 @@ Both roles deploy the same 14 AutoBot dashboards:
 grafana_mode: local
 grafana_install: true
 ```
-**Result:** Grafana installed and configured on 172.16.168.19
+**Result:** Grafana installed and configured on <slm-manager-ip>
 
 ### Scenario 2: External Grafana on Dedicated VM
 ```yaml
@@ -80,13 +80,13 @@ grafana_install: true
 monitoring_install_grafana: true
 grafana_allow_anonymous: true
 ```
-**Result:** Grafana installed on monitoring VM (e.g., 172.16.168.28)
+**Result:** Grafana installed on monitoring VM (e.g., <reserved-ip>)
 
 ### Scenario 3: Proxied External Grafana
 ```yaml
 # slm_manager points to external host
 grafana_mode: external
-grafana_external_host: 172.16.168.28
+grafana_external_host: <reserved-ip>
 grafana_enable_cors: true
 ```
 **Result:** SLM server proxies requests to external Grafana
@@ -128,7 +128,7 @@ grep -E "serve_from_sub_path|allow_embedding|cookie_samesite" /etc/grafana/grafa
 for dash in autobot-system autobot-overview autobot-performance \
             autobot-multi-machine autobot-redis autobot-api-health; do
   curl -k -s -o /dev/null -w "$dash: %{http_code}\n" \
-    "https://172.16.168.19/grafana/d/${dash}?kiosk=tv"
+    "https://<slm-manager-ip>/grafana/d/${dash}?kiosk=tv"
 done
 ```
 
@@ -158,7 +158,7 @@ cd autobot-slm-backend/ansible
 ansible-playbook playbooks/deploy-slm-manager.yml -i inventory.ini --tags grafana
 
 # Verify settings
-ssh autobot@172.16.168.19 "grep -E 'serve_from_sub_path|allow_embedding' /etc/grafana/grafana.ini"
+ssh autobot@<slm-manager-ip> "grep -E 'serve_from_sub_path|allow_embedding' /etc/grafana/grafana.ini"
 ```
 
 ---

--- a/docs/monitoring/DISTRIBUTED_TRACING.md
+++ b/docs/monitoring/DISTRIBUTED_TRACING.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
@@ -12,12 +14,12 @@ AutoBot uses OpenTelemetry for distributed tracing across its 5-VM infrastructur
 
 | VM | IP Address | Service Name | Role |
 |----|------------|--------------|------|
-| Main Machine | 172.16.168.20 | autobot-backend | Backend API |
-| VM1 Frontend | 172.16.168.21 | autobot-frontend | Web interface |
-| VM2 NPU Worker | 172.16.168.22 | autobot-npu-worker | Hardware AI acceleration |
-| VM3 Redis | 172.16.168.23 | autobot-redis | Data layer + Jaeger |
-| VM4 AI Stack | 172.16.168.24 | autobot-ai-stack | AI processing |
-| VM5 Browser | 172.16.168.25 | autobot-browser | Web automation |
+| Main Machine | <backend-ip> | autobot-backend | Backend API |
+| VM1 Frontend | <frontend-ip> | autobot-frontend | Web interface |
+| VM2 NPU Worker | <npu-ip> | autobot-npu-worker | Hardware AI acceleration |
+| VM3 Redis | <database-ip> | autobot-redis | Data layer + Jaeger |
+| VM4 AI Stack | <aiml-ip> | autobot-ai-stack | AI processing |
+| VM5 Browser | <browser-ip> | autobot-browser | Web automation |
 
 ## Architecture
 
@@ -99,7 +101,7 @@ opentelemetry-exporter-otlp
 opentelemetry-propagator-b3
 ```
 
-### Jaeger Setup (VM3 Redis - 172.16.168.23)
+### Jaeger Setup (VM3 Redis - <database-ip>)
 
 Since AutoBot doesn't use Docker, Jaeger runs as a native binary on the Redis VM.
 
@@ -107,7 +109,7 @@ Since AutoBot doesn't use Docker, Jaeger runs as a native binary on the Redis VM
 
 ```bash
 # SSH to Redis VM
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23
+ssh -i ~/.ssh/autobot_key autobot@<database-ip>
 
 # Download Jaeger (latest version)
 JAEGER_VERSION="1.53.0"
@@ -152,11 +154,11 @@ sudo systemctl start jaeger
 sudo systemctl status jaeger
 
 # Test OTLP endpoint
-curl http://172.16.168.23:4317  # gRPC (connection refused is OK)
-curl http://172.16.168.23:4318  # HTTP
+curl http://<database-ip>:4317  # gRPC (connection refused is OK)
+curl http://<database-ip>:4318  # HTTP
 
 # Access Jaeger UI
-# Open in browser: http://172.16.168.23:16686
+# Open in browser: http://<database-ip>:16686
 ```
 
 ## Configuration
@@ -165,7 +167,7 @@ curl http://172.16.168.23:4318  # HTTP
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AUTOBOT_JAEGER_ENDPOINT` | `http://172.16.168.23:4317` | OTLP gRPC endpoint |
+| `AUTOBOT_JAEGER_ENDPOINT` | `http://<database-ip>:4317` | OTLP gRPC endpoint |
 | `AUTOBOT_TRACE_CONSOLE` | `false` | Enable console span export |
 | `AUTOBOT_ENV` | `development` | Deployment environment tag |
 
@@ -179,7 +181,7 @@ tracing = get_tracing_service()
 tracing.initialize(
     service_name="autobot-backend",
     service_version="2.0.0",
-    jaeger_endpoint="http://172.16.168.23:4317",
+    jaeger_endpoint="http://<database-ip>:4317",
 )
 tracing.instrument_fastapi(app)
 ```
@@ -242,7 +244,7 @@ http_client = get_traced_http_client()
 async def call_ai_stack(payload: dict):
     # Trace context is automatically propagated via headers
     response = await http_client.post(
-        "http://172.16.168.24:8080/api/process",
+        "http://<aiml-ip>:8080/api/process",
         payload=payload,
     )
     return response
@@ -280,7 +282,7 @@ async def call_ai_stack(payload: dict):
 
     async with httpx.AsyncClient() as client:
         response = await client.post(
-            "http://172.16.168.24:8080/api/process",
+            "http://<aiml-ip>:8080/api/process",
             json=payload,
             headers=headers,  # Propagate trace context
         )
@@ -320,7 +322,7 @@ The following paths are excluded from detailed tracing to reduce noise:
 
 ### Jaeger UI
 
-Access the Jaeger UI at: `http://172.16.168.23:16686`
+Access the Jaeger UI at: `http://<database-ip>:16686`
 
 Features:
 - Search traces by service, operation, tags
@@ -333,7 +335,7 @@ Features:
 Tracing status is included in the backend health check:
 
 ```bash
-curl https://172.16.168.20:8443/api/health | jq '.services.distributed_tracing'
+curl https://<backend-ip>:8443/api/health | jq '.services.distributed_tracing'
 # Returns: "ready" or "pending" or "failed"
 ```
 
@@ -343,12 +345,12 @@ curl https://172.16.168.20:8443/api/health | jq '.services.distributed_tracing'
 
 1. **Check Jaeger is running:**
    ```bash
-   ssh autobot@172.16.168.23 "sudo systemctl status jaeger"
+   ssh autobot@<database-ip> "sudo systemctl status jaeger"
    ```
 
 2. **Verify OTLP endpoint:**
    ```bash
-   curl -v http://172.16.168.23:4318/v1/traces
+   curl -v http://<database-ip>:4318/v1/traces
    ```
 
 3. **Enable console export for debugging:**
@@ -381,7 +383,7 @@ sudo systemctl restart jaeger
 
 ## VM-Specific Setup
 
-### NPU Worker (VM2 - 172.16.168.22)
+### NPU Worker (VM2 - <npu-ip>)
 
 ```python
 # In NPU worker initialization
@@ -390,27 +392,27 @@ from backend.services.tracing_service import get_tracing_service
 tracing = get_tracing_service()
 tracing.initialize(
     service_name="autobot-npu-worker",
-    jaeger_endpoint="http://172.16.168.23:4317",
+    jaeger_endpoint="http://<database-ip>:4317",
 )
 ```
 
-### AI Stack (VM4 - 172.16.168.24)
+### AI Stack (VM4 - <aiml-ip>)
 
 ```python
 # In AI stack initialization
 tracing.initialize(
     service_name="autobot-ai-stack",
-    jaeger_endpoint="http://172.16.168.23:4317",
+    jaeger_endpoint="http://<database-ip>:4317",
 )
 ```
 
-### Browser Automation (VM5 - 172.16.168.25)
+### Browser Automation (VM5 - <browser-ip>)
 
 ```python
 # In browser automation service
 tracing.initialize(
     service_name="autobot-browser",
-    jaeger_endpoint="http://172.16.168.23:4317",
+    jaeger_endpoint="http://<database-ip>:4317",
 )
 ```
 

--- a/docs/monitoring/EPIC_80_COMPLETION.md
+++ b/docs/monitoring/EPIC_80_COMPLETION.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # Epic #80: Consolidate All Monitoring Systems - COMPLETE ✅
 
 **Status**: ✅ **COMPLETE**
@@ -31,35 +33,35 @@
 
 | Component | Location | Port | Purpose |
 |-----------|----------|------|---------|
-| **Prometheus** | SLM Server (172.16.168.19) | 9090 | Metrics collection & storage |
-| **Grafana** | SLM Server (172.16.168.19) | 3000 | Dashboard visualization |
-| **AlertManager** | SLM Server (172.16.168.19) | 9093 | Alert routing & notifications |
-| **Backend Metrics** | Main (172.16.168.20) | 8001 | `/api/monitoring/metrics` endpoint |
+| **Prometheus** | SLM Server (<slm-manager-ip>) | 9090 | Metrics collection & storage |
+| **Grafana** | SLM Server (<slm-manager-ip>) | 3000 | Dashboard visualization |
+| **AlertManager** | SLM Server (<slm-manager-ip>) | 9093 | Alert routing & notifications |
+| **Backend Metrics** | Main (<backend-ip>) | 8001 | `/api/monitoring/metrics` endpoint |
 
 **Note:** Monitoring stack is deployed via Ansible playbooks (`slm_manager` role), not manually.
 
 ### Data Flow
 
 ```
-AutoBot Backend (172.16.168.20:8443)
+AutoBot Backend (<backend-ip>:8443)
     ↓
     Exposes /api/monitoring/metrics (Prometheus format)
     ↓
-Prometheus (172.16.168.19:9090)
+Prometheus (<slm-manager-ip>:9090)
     ↓
     Scrapes metrics every 15s
     ↓
     Stores time-series data (30-day retention)
     ↓
-Grafana (172.16.168.19:3000)
+Grafana (<slm-manager-ip>:3000)
     ↓
     Queries Prometheus for dashboard data
     ↓
-AutoBot Frontend (172.16.168.21:5173)
+AutoBot Frontend (<frontend-ip>:5173)
     ↓
     Embeds Grafana dashboards via iframe
     ↓
-Users access at: http://172.16.168.21:5173/monitoring/dashboards
+Users access at: http://<frontend-ip>:5173/monitoring/dashboards
 ```
 
 ---
@@ -125,7 +127,7 @@ async def metrics_endpoint():
     return Response(content=metrics_data, media_type=CONTENT_TYPE_LATEST)
 ```
 
-**Endpoint**: `https://172.16.168.20:8443/api/monitoring/metrics`
+**Endpoint**: `https://<backend-ip>:8443/api/monitoring/metrics`
 
 **Registered in**: `backend/app_factory_enhanced.py`
 
@@ -137,7 +139,7 @@ async def metrics_endpoint():
 scrape_configs:
   - job_name: 'autobot-backend'
     static_configs:
-      - targets: ['172.16.168.20:8443']
+      - targets: ['<backend-ip>:8443']
         labels:
           instance: 'autobot-main'
           service: 'backend-api'
@@ -168,7 +170,7 @@ org_name = Main Org.
 org_role = Viewer
 
 [cors]
-allow_origins = http://172.16.168.21:5173
+allow_origins = http://<frontend-ip>:5173
 ```
 
 **Dashboards Imported**:
@@ -234,7 +236,7 @@ All monitoring services run as **systemd services** on SLM Server (deployed via 
 
 ```bash
 # Check status
-ssh autobot@172.16.168.19 'systemctl status prometheus grafana-server alertmanager'
+ssh autobot@<slm-manager-ip> 'systemctl status prometheus grafana-server alertmanager'
 
 # All services are enabled for auto-start on boot
 systemctl is-enabled prometheus      # enabled
@@ -246,14 +248,14 @@ systemctl is-enabled alertmanager    # enabled
 
 ```bash
 # Restart all monitoring services
-ssh autobot@172.16.168.19 'sudo systemctl restart prometheus alertmanager grafana-server'
+ssh autobot@<slm-manager-ip> 'sudo systemctl restart prometheus alertmanager grafana-server'
 
 # Stop services
-ssh autobot@172.16.168.19 'sudo systemctl stop prometheus alertmanager grafana-server'
+ssh autobot@<slm-manager-ip> 'sudo systemctl stop prometheus alertmanager grafana-server'
 
 # View logs
-ssh autobot@172.16.168.19 'sudo journalctl -u prometheus -f'
-ssh autobot@172.16.168.19 'sudo journalctl -u grafana-server -f'
+ssh autobot@<slm-manager-ip> 'sudo journalctl -u prometheus -f'
+ssh autobot@<slm-manager-ip> 'sudo journalctl -u grafana-server -f'
 ```
 
 ### Startup Procedure Integration
@@ -322,21 +324,21 @@ The backend exposes the following metrics at `/api/monitoring/metrics`:
 
 | Service | URL | Credentials |
 |---------|-----|-------------|
-| **AutoBot UI** | http://172.16.168.21:5173/monitoring/dashboards | N/A |
-| **Grafana Direct** | http://172.16.168.19:3000 | admin / autobot |
-| **Prometheus** | http://172.16.168.19:9090 | N/A (no auth) |
-| **AlertManager** | http://172.16.168.19:9093 | N/A (no auth) |
-| **Backend Metrics** | https://172.16.168.20:8443/api/monitoring/metrics | N/A |
+| **AutoBot UI** | http://<frontend-ip>:5173/monitoring/dashboards | N/A |
+| **Grafana Direct** | http://<slm-manager-ip>:3000 | admin / autobot |
+| **Prometheus** | http://<slm-manager-ip>:9090 | N/A (no auth) |
+| **AlertManager** | http://<slm-manager-ip>:9093 | N/A (no auth) |
+| **Backend Metrics** | https://<backend-ip>:8443/api/monitoring/metrics | N/A |
 
 ### Recommended Access Method
 
-**✅ Primary**: http://172.16.168.21:5173/monitoring/dashboards
+**✅ Primary**: http://<frontend-ip>:5173/monitoring/dashboards
 - Integrated into AutoBot UI
 - No login required
 - All dashboards in one place
 - Consistent theme and navigation
 
-**⚙️ Advanced**: http://172.16.168.19:3000
+**⚙️ Advanced**: http://<slm-manager-ip>:3000
 - Direct Grafana access (on SLM Server)
 - Dashboard editing capabilities
 - Query explorer
@@ -404,16 +406,16 @@ The backend exposes the following metrics at `/api/monitoring/metrics`:
 
 ```bash
 # Check all services
-curl http://172.16.168.19:9090/-/healthy  # Prometheus
-curl http://172.16.168.19:3000/api/health # Grafana
-curl http://172.16.168.19:9093/-/healthy  # AlertManager
-curl https://172.16.168.20:8443/api/monitoring/metrics | head # Backend
+curl http://<slm-manager-ip>:9090/-/healthy  # Prometheus
+curl http://<slm-manager-ip>:3000/api/health # Grafana
+curl http://<slm-manager-ip>:9093/-/healthy  # AlertManager
+curl https://<backend-ip>:8443/api/monitoring/metrics | head # Backend
 
 # Check targets
-curl http://172.16.168.19:9090/api/v1/targets
+curl http://<slm-manager-ip>:9090/api/v1/targets
 
 # Query metrics
-curl "http://172.16.168.19:9090/api/v1/query?query=up{job='autobot-backend'}"
+curl "http://<slm-manager-ip>:9090/api/v1/query?query=up{job='autobot-backend'}"
 ```
 
 ### Current Status (as of 2025-12-05)
@@ -475,28 +477,28 @@ Targets monitored: 9
 **Problem**: No data in dashboards
 ```bash
 # Check backend metrics endpoint
-curl https://172.16.168.20:8443/api/monitoring/metrics
+curl https://<backend-ip>:8443/api/monitoring/metrics
 
 # Check Prometheus targets
-curl http://172.16.168.19:9090/api/v1/targets
+curl http://<slm-manager-ip>:9090/api/v1/targets
 
 # Check Prometheus logs
-ssh autobot@172.16.168.19 'sudo journalctl -u prometheus -n 100'
+ssh autobot@<slm-manager-ip> 'sudo journalctl -u prometheus -n 100'
 ```
 
 **Problem**: Grafana not loading
 ```bash
 # Check Grafana status
-ssh autobot@172.16.168.19 'sudo systemctl status grafana-server'
+ssh autobot@<slm-manager-ip> 'sudo systemctl status grafana-server'
 
 # Restart Grafana
-ssh autobot@172.16.168.19 'sudo systemctl restart grafana-server'
+ssh autobot@<slm-manager-ip> 'sudo systemctl restart grafana-server'
 ```
 
 **Problem**: High memory usage on Prometheus
 ```bash
 # Check current data size
-ssh autobot@172.16.168.19 'du -sh /var/lib/prometheus/'
+ssh autobot@<slm-manager-ip> 'du -sh /var/lib/prometheus/'
 
 # Reduce retention if needed (edit prometheus.service)
 # Change: --storage.tsdb.retention.time=30d
@@ -526,7 +528,7 @@ ssh autobot@172.16.168.19 'du -sh /var/lib/prometheus/'
 
 All monitoring systems have been successfully consolidated into a unified Prometheus + Grafana stack. Users can now access all dashboards "under one roof" at:
 
-**http://172.16.168.21:5173/monitoring/dashboards**
+**http://<frontend-ip>:5173/monitoring/dashboards**
 
 The system is:
 - ✅ Production-ready

--- a/docs/monitoring/QUICK_REFERENCE.md
+++ b/docs/monitoring/QUICK_REFERENCE.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # Monitoring Quick Reference Guide
 
 **Author**: mrveiss
@@ -9,16 +11,16 @@
 
 ### Primary Dashboard Access
 ```
-http://172.16.168.21:5173/monitoring/dashboards
+http://<frontend-ip>:5173/monitoring/dashboards
 ```
 Navigate: **AutoBot UI → Monitoring → Dashboards**
 
 ### Direct Service Access
 | Service | URL | Credentials |
 |---------|-----|-------------|
-| Grafana | http://172.16.168.19:3000 | admin / autobot |
-| Prometheus | http://172.16.168.19:9090 | (no auth) |
-| AlertManager | http://172.16.168.19:9093 | (no auth) |
+| Grafana | http://<slm-manager-ip>:3000 | admin / autobot |
+| Prometheus | http://<slm-manager-ip>:9090 | (no auth) |
+| AlertManager | http://<slm-manager-ip>:9093 | (no auth) |
 
 **Note:** Monitoring stack is deployed on SLM Server via Ansible playbooks (`slm_manager` role).
 
@@ -58,43 +60,43 @@ Navigate: **AutoBot UI → Monitoring → Dashboards**
 ### Check Service Status
 ```bash
 # All monitoring services
-ssh autobot@172.16.168.19 'systemctl status prometheus grafana-server alertmanager'
+ssh autobot@<slm-manager-ip> 'systemctl status prometheus grafana-server alertmanager'
 
 # Backend metrics endpoint
-curl https://172.16.168.20:8443/api/monitoring/metrics | head
+curl https://<backend-ip>:8443/api/monitoring/metrics | head
 ```
 
 ### Restart Services
 ```bash
 # Restart all monitoring services
-ssh autobot@172.16.168.19 'sudo systemctl restart prometheus alertmanager grafana-server'
+ssh autobot@<slm-manager-ip> 'sudo systemctl restart prometheus alertmanager grafana-server'
 
 # Restart individual service
-ssh autobot@172.16.168.19 'sudo systemctl restart grafana-server'
+ssh autobot@<slm-manager-ip> 'sudo systemctl restart grafana-server'
 ```
 
 ### View Logs
 ```bash
 # Prometheus logs
-ssh autobot@172.16.168.19 'sudo journalctl -u prometheus -f'
+ssh autobot@<slm-manager-ip> 'sudo journalctl -u prometheus -f'
 
 # Grafana logs
-ssh autobot@172.16.168.19 'sudo journalctl -u grafana-server -f'
+ssh autobot@<slm-manager-ip> 'sudo journalctl -u grafana-server -f'
 
 # AlertManager logs
-ssh autobot@172.16.168.19 'sudo journalctl -u alertmanager -f'
+ssh autobot@<slm-manager-ip> 'sudo journalctl -u alertmanager -f'
 ```
 
 ### Check Metrics
 ```bash
 # Test backend metrics endpoint
-curl https://172.16.168.20:8443/api/monitoring/metrics
+curl https://<backend-ip>:8443/api/monitoring/metrics
 
 # Check Prometheus targets
-curl http://172.16.168.19:9090/api/v1/targets | python3 -m json.tool
+curl http://<slm-manager-ip>:9090/api/v1/targets | python3 -m json.tool
 
 # Query specific metric
-curl "http://172.16.168.19:9090/api/v1/query?query=autobot_cpu_usage_percent"
+curl "http://<slm-manager-ip>:9090/api/v1/query?query=autobot_cpu_usage_percent"
 ```
 
 ---
@@ -104,16 +106,16 @@ curl "http://172.16.168.19:9090/api/v1/query?query=autobot_cpu_usage_percent"
 ### Quick Health Check
 ```bash
 # One-liner to check all services
-echo "Backend:"; curl -s https://172.16.168.20:8443/api/health > /dev/null && echo "✅ UP" || echo "❌ DOWN"; \
-echo "Prometheus:"; curl -s http://172.16.168.19:9090/-/healthy > /dev/null && echo "✅ UP" || echo "❌ DOWN"; \
-echo "Grafana:"; curl -s http://172.16.168.19:3000/api/health > /dev/null && echo "✅ UP" || echo "❌ DOWN"; \
-echo "AlertManager:"; curl -s http://172.16.168.19:9093/-/healthy > /dev/null && echo "✅ UP" || echo "❌ DOWN"
+echo "Backend:"; curl -s https://<backend-ip>:8443/api/health > /dev/null && echo "✅ UP" || echo "❌ DOWN"; \
+echo "Prometheus:"; curl -s http://<slm-manager-ip>:9090/-/healthy > /dev/null && echo "✅ UP" || echo "❌ DOWN"; \
+echo "Grafana:"; curl -s http://<slm-manager-ip>:3000/api/health > /dev/null && echo "✅ UP" || echo "❌ DOWN"; \
+echo "AlertManager:"; curl -s http://<slm-manager-ip>:9093/-/healthy > /dev/null && echo "✅ UP" || echo "❌ DOWN"
 ```
 
 ### Detailed Status
 ```bash
 # Check scraping status
-curl -s http://172.16.168.19:9090/api/v1/targets | \
+curl -s http://<slm-manager-ip>:9090/api/v1/targets | \
   python3 -c "import sys, json; data = json.load(sys.stdin); \
   [print(f\"{r['labels']['job']}: {'✅ UP' if r['health'] == 'up' else '❌ DOWN'}\") \
   for r in data['data']['activeTargets']]"
@@ -127,19 +129,19 @@ curl -s http://172.16.168.19:9090/api/v1/targets | \
 
 **Check 1**: Backend metrics endpoint
 ```bash
-curl https://172.16.168.20:8443/api/monitoring/metrics
+curl https://<backend-ip>:8443/api/monitoring/metrics
 # Should return Prometheus-format metrics
 ```
 
 **Check 2**: Prometheus scraping
 ```bash
-curl http://172.16.168.19:9090/api/v1/targets | grep autobot-backend -A 10
+curl http://<slm-manager-ip>:9090/api/v1/targets | grep autobot-backend -A 10
 # Look for "health": "up"
 ```
 
 **Check 3**: Grafana datasource
 ```bash
-curl http://172.16.168.19:3000/api/datasources
+curl http://<slm-manager-ip>:3000/api/datasources
 # Should show Prometheus datasource
 ```
 
@@ -152,30 +154,30 @@ sudo systemctl restart autobot-backend
 
 **Check**: Service status
 ```bash
-ssh autobot@172.16.168.19 'sudo systemctl status grafana-server'
+ssh autobot@<slm-manager-ip> 'sudo systemctl status grafana-server'
 ```
 
 **Fix**: Restart Grafana
 ```bash
-ssh autobot@172.16.168.19 'sudo systemctl restart grafana-server'
+ssh autobot@<slm-manager-ip> 'sudo systemctl restart grafana-server'
 ```
 
 ### High Prometheus Memory
 
 **Check**: Data size
 ```bash
-ssh autobot@172.16.168.19 'du -sh /var/lib/prometheus/'
+ssh autobot@<slm-manager-ip> 'du -sh /var/lib/prometheus/'
 ```
 
 **Fix**: Reduce retention (if > 5GB)
 ```bash
 # Edit prometheus service
-ssh autobot@172.16.168.19 'sudo nano /etc/systemd/system/prometheus.service'
+ssh autobot@<slm-manager-ip> 'sudo nano /etc/systemd/system/prometheus.service'
 # Change: --storage.tsdb.retention.time=30d
 # To:     --storage.tsdb.retention.time=15d
 
 # Reload and restart
-ssh autobot@172.16.168.19 'sudo systemctl daemon-reload && sudo systemctl restart prometheus'
+ssh autobot@<slm-manager-ip> 'sudo systemctl daemon-reload && sudo systemctl restart prometheus'
 ```
 
 ---

--- a/docs/operations/ACCESS_CONTROL_ROLLOUT_RUNBOOK.md
+++ b/docs/operations/ACCESS_CONTROL_ROLLOUT_RUNBOOK.md
@@ -20,9 +20,9 @@ Deploy access control enforcement to eliminate CVSS 9.1 vulnerability: **Broken 
 
 ### Environment Verification
 
-- [ ] All 6 VMs accessible (172.16.168.21-25)
-- [ ] Redis healthy (172.16.168.23:6379)
-- [ ] Backend API responding (172.16.168.20:8443)
+- [ ] All 6 VMs accessible (<frontend-ip>-25)
+- [ ] Redis healthy (<database-ip>:6379)
+- [ ] Backend API responding (<backend-ip>:8443)
 - [ ] SSH keys configured (`~/.ssh/autobot_key`)
 - [ ] Python virtual environment activated
 - [ ] No ongoing deployments or maintenance
@@ -122,7 +122,7 @@ python3 scripts/security/backfill_session_ownership.py --verify-only
 **Issue:** Backfill fails partway through
 ```bash
 # Check Redis connectivity
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 
 # Check specific session
 python3 -c "
@@ -190,7 +190,7 @@ asyncio.run(main())
 **Performance Validation:**
 ```bash
 # Backend API response times should be < +10ms
-curl -w "@curl-format.txt" -o /dev/null -s "https://172.16.168.20:8443/api/health"
+curl -w "@curl-format.txt" -o /dev/null -s "https://<backend-ip>:8443/api/health"
 ```
 
 **Rollback:** Disable audit middleware (requires backend restart)
@@ -417,7 +417,7 @@ asyncio.run(main())
 **Test 1: Cross-User Access Attempt**
 ```bash
 # Attempt to access another user's session (should fail)
-curl -X GET "https://172.16.168.20:8443/api/chat/sessions/OTHER_USER_SESSION_ID" \
+curl -X GET "https://<backend-ip>:8443/api/chat/sessions/OTHER_USER_SESSION_ID" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -w "\nHTTP Status: %{http_code}\n"
 ```
@@ -426,7 +426,7 @@ curl -X GET "https://172.16.168.20:8443/api/chat/sessions/OTHER_USER_SESSION_ID"
 **Test 2: Unauthenticated Access**
 ```bash
 # Attempt without authentication (should fail)
-curl -X GET "https://172.16.168.20:8443/api/chat/sessions/SESSION_ID" \
+curl -X GET "https://<backend-ip>:8443/api/chat/sessions/SESSION_ID" \
   -w "\nHTTP Status: %{http_code}\n"
 ```
 **Expected:** HTTP 401 Unauthorized
@@ -613,7 +613,7 @@ python3 scripts/security/backfill_session_ownership.py --default-owner admin --f
 **Diagnosis:**
 ```bash
 # Check Redis DB 10 connectivity
-redis-cli -h 172.16.168.23 -p 6379 -n 10 ping
+redis-cli -h <database-ip> -p 6379 -n 10 ping
 
 # Check audit logger statistics
 python3 -c "
@@ -651,7 +651,7 @@ sudo systemctl restart autobot-backend
 ./scripts/deployment/validate_access_control.sh --performance-only
 
 # Check Redis latency
-redis-cli -h 172.16.168.23 -p 6379 --latency
+redis-cli -h <database-ip> -p 6379 --latency
 ```
 
 **Resolution:**
@@ -660,8 +660,8 @@ redis-cli -h 172.16.168.23 -p 6379 --latency
 ./scripts/deployment/rollback_access_control.sh --reason "Performance degradation"
 
 # Investigate Redis performance
-redis-cli -h 172.16.168.23 -p 6379 INFO stats
-redis-cli -h 172.16.168.23 -p 6379 SLOWLOG GET 10
+redis-cli -h <database-ip> -p 6379 INFO stats
+redis-cli -h <database-ip> -p 6379 SLOWLOG GET 10
 ```
 
 ---

--- a/docs/operations/CLAUDE_MD_REINDEX_QUICKSTART.md
+++ b/docs/operations/CLAUDE_MD_REINDEX_QUICKSTART.md
@@ -25,10 +25,10 @@ bash scripts/database/reindex_claude_md.sh
 ## ✅ Verification
 ```bash
 # Check stats
-curl https://172.16.168.20:8443/api/knowledge_base/stats | jq
+curl https://<backend-ip>:8443/api/knowledge_base/stats | jq
 
 # Test search for new content
-curl "https://172.16.168.20:8443/api/knowledge_base/search?q=MANDATORY+WORKFLOW&limit=1"
+curl "https://<backend-ip>:8443/api/knowledge_base/search?q=MANDATORY+WORKFLOW&limit=1"
 ```
 
 ## 📚 Full Documentation

--- a/docs/operations/REDIS_SERVICE_RUNBOOK.md
+++ b/docs/operations/REDIS_SERVICE_RUNBOOK.md
@@ -38,7 +38,7 @@ This runbook provides operational procedures for managing the Redis service with
 
 **Service Details:**
 - **Service Name:** redis-server
-- **Host:** VM3 (172.16.168.23)
+- **Host:** VM3 (<database-ip>)
 - **Port:** 6379
 - **systemd Unit:** redis-server.service
 - **User:** redis
@@ -69,7 +69,7 @@ This runbook provides operational procedures for managing the Redis service with
 ```
 ┌─────────────────────────────────────────────────────────┐
 │                   Main Machine (WSL)                     │
-│              172.16.168.20:8443                         │
+│              <backend-ip>:8443                         │
 │                                                         │
 │  ┌─────────────────────────────────────────────────┐  │
 │  │  RedisServiceManager                            │  │
@@ -84,7 +84,7 @@ This runbook provides operational procedures for managing the Redis service with
                  ▼
 ┌─────────────────────────────────────────────────────────┐
 │                 Redis VM (VM3)                           │
-│              172.16.168.23:6379                         │
+│              <database-ip>:6379                         │
 │                                                         │
 │  ┌─────────────────────────────────────────────────┐  │
 │  │  systemd (redis-server.service)                 │  │
@@ -138,7 +138,7 @@ This runbook provides operational procedures for managing the Redis service with
 
 **Command:**
 ```bash
-redis-cli -h 172.16.168.23 -p 6379 PING
+redis-cli -h <database-ip> -p 6379 PING
 ```
 
 **Expected Response:** `PONG`
@@ -163,7 +163,7 @@ redis-cli -h 172.16.168.23 -p 6379 PING
 
 **Command:**
 ```bash
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "systemctl is-active redis-server"
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> "systemctl is-active redis-server"
 ```
 
 **Expected Response:** `active`
@@ -193,7 +193,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "systemctl is-active redis-serve
 
 1. **Memory Usage:**
    ```bash
-   redis-cli -h 172.16.168.23 INFO memory | grep used_memory_human
+   redis-cli -h <database-ip> INFO memory | grep used_memory_human
    ```
    - **Normal:** <3072 MB
    - **Warning:** 3072-4000 MB
@@ -201,7 +201,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "systemctl is-active redis-serve
 
 2. **Connection Count:**
    ```bash
-   redis-cli -h 172.16.168.23 INFO clients | grep connected_clients
+   redis-cli -h <database-ip> INFO clients | grep connected_clients
    ```
    - **Normal:** <8000
    - **Warning:** 8000-9500
@@ -209,7 +209,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "systemctl is-active redis-serve
 
 3. **Commands Per Second:**
    ```bash
-   redis-cli -h 172.16.168.23 INFO stats | grep instantaneous_ops_per_sec
+   redis-cli -h <database-ip> INFO stats | grep instantaneous_ops_per_sec
    ```
    - **Normal:** <10000
    - **Warning:** 10000-50000
@@ -232,13 +232,13 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "systemctl is-active redis-serve
 Operators can view health status in multiple places:
 
 1. **Web Interface:**
-   - URL: `http://172.16.168.21:5173/services/redis`
+   - URL: `http://<frontend-ip>:5173/services/redis`
    - Real-time updates via WebSocket
    - Visual health indicators
 
 2. **API Endpoint:**
    ```bash
-   curl https://172.16.168.20:8443/api/services/redis/health
+   curl https://<backend-ip>:8443/api/services/redis/health
    ```
 
 3. **Command Line:**
@@ -340,7 +340,7 @@ Operators can view health status in multiple places:
 **Actions:**
 ```bash
 # Send SIGHUP to reload configuration
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
   "sudo systemctl reload redis-server"
 ```
 
@@ -368,7 +368,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
 **Actions:**
 ```bash
 # Start the service
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
   "sudo systemctl start redis-server"
 ```
 
@@ -398,7 +398,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
 **Actions:**
 ```bash
 # Force restart the service
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
   "sudo systemctl restart redis-server"
 ```
 
@@ -430,7 +430,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
 **Manual Reset Procedure:**
 ```bash
 # After fixing root cause, reset circuit breaker
-curl -X POST https://172.16.168.20:8443/api/services/redis/reset-circuit-breaker \
+curl -X POST https://<backend-ip>:8443/api/services/redis/reset-circuit-breaker \
   -H "Authorization: Bearer $ADMIN_TOKEN"
 ```
 
@@ -488,7 +488,7 @@ Before performing manual operations:
 
 1. **SSH to Redis VM:**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip>
    ```
 
 2. **Check service status:**
@@ -534,7 +534,7 @@ Before performing manual operations:
 
 1. **Check current state:**
    ```bash
-   redis-cli -h 172.16.168.23 INFO | grep -E "uptime|memory|clients"
+   redis-cli -h <database-ip> INFO | grep -E "uptime|memory|clients"
    ```
 
 2. **Notify users** (if connection count >50):
@@ -544,14 +544,14 @@ Before performing manual operations:
 
 3. **Graceful restart:**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
      "sudo systemctl restart redis-server"
    ```
 
 4. **Monitor startup:**
    ```bash
    # Watch service come back online
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
      "sudo journalctl -u redis-server -f"
    ```
    - Wait for "Ready to accept connections" message
@@ -559,7 +559,7 @@ Before performing manual operations:
 
 5. **Verify health:**
    ```bash
-   curl https://172.16.168.20:8443/api/services/redis/health
+   curl https://<backend-ip>:8443/api/services/redis/health
    ```
 
 6. **Confirm dependent services recovered:**
@@ -577,13 +577,13 @@ Before performing manual operations:
 
 1. **Backup current configuration:**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
      "sudo cp /etc/redis/redis.conf /etc/redis/redis.conf.backup.$(date +%Y%m%d_%H%M%S)"
    ```
 
 2. **Edit configuration:**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip>
    sudo vim /etc/redis/redis.conf
    ```
 
@@ -641,14 +641,14 @@ Before performing manual operations:
 2. **Notify immediately:**
    ```bash
    # Send emergency notification
-   curl -X POST https://172.16.168.20:8443/api/notifications/emergency \
+   curl -X POST https://<backend-ip>:8443/api/notifications/emergency \
      -H "Authorization: Bearer $ADMIN_TOKEN" \
      -d '{"message": "Redis emergency stop initiated", "reason": "..."}'
    ```
 
 3. **Stop service:**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
      "sudo systemctl stop redis-server"
    ```
 
@@ -709,7 +709,7 @@ sudo journalctl -u redis-server --since "1 hour ago"
     "email": "admin@autobot.local",
     "role": "admin"
   },
-  "source_ip": "172.16.168.20",
+  "source_ip": "<backend-ip>",
   "result": {
     "success": true,
     "duration_seconds": 15.7,
@@ -857,12 +857,12 @@ chmod 600 ~/.ssh/autobot_key
 
 2. **Deploy new key to Redis VM:**
    ```bash
-   ssh-copy-id -i ~/.ssh/autobot_key_new autobot@172.16.168.23
+   ssh-copy-id -i ~/.ssh/autobot_key_new autobot@<database-ip>
    ```
 
 3. **Test new key:**
    ```bash
-   ssh -i ~/.ssh/autobot_key_new autobot@172.16.168.23 "echo 'Key works'"
+   ssh -i ~/.ssh/autobot_key_new autobot@<database-ip> "echo 'Key works'"
    ```
 
 4. **Update AutoBot configuration:**
@@ -879,7 +879,7 @@ chmod 600 ~/.ssh/autobot_key
 
 6. **Remove old key from VM after 24 hours:**
    ```bash
-   ssh autobot@172.16.168.23 "sed -i '/old_key_fingerprint/d' ~/.ssh/authorized_keys"
+   ssh autobot@<database-ip> "sed -i '/old_key_fingerprint/d' ~/.ssh/authorized_keys"
    ```
 
 ### Sudo Permissions
@@ -903,7 +903,7 @@ autobot ALL=(ALL) NOPASSWD: /bin/journalctl -u redis-server *
 **Verify Permissions:**
 ```bash
 # Test sudo access
-ssh autobot@172.16.168.23 "sudo -l"
+ssh autobot@<database-ip> "sudo -l"
 ```
 
 ### Command Validation
@@ -975,7 +975,7 @@ redis-check-rdb backups/redis/daily/latest/dump.rdb
 
 ```bash
 # Create on-demand backup
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 << 'EOF'
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> << 'EOF'
   # Trigger save
   redis-cli BGSAVE
 
@@ -990,7 +990,7 @@ EOF
 
 # Download backup
 scp -i ~/.ssh/autobot_key \
-  autobot@172.16.168.23:/tmp/dump-*.rdb \
+  autobot@<database-ip>:/tmp/dump-*.rdb \
   backups/redis/manual/
 ```
 
@@ -1007,13 +1007,13 @@ scp -i ~/.ssh/autobot_key \
 
 1. **Stop Redis service:**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
      "sudo systemctl stop redis-server"
    ```
 
 2. **Backup corrupted data:**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
      "sudo cp /var/lib/redis/dump.rdb /var/lib/redis/dump.rdb.corrupted"
    ```
 
@@ -1022,10 +1022,10 @@ scp -i ~/.ssh/autobot_key \
    # Copy backup to Redis VM
    scp -i ~/.ssh/autobot_key \
      backups/redis/daily/latest/dump.rdb \
-     autobot@172.16.168.23:/tmp/
+     autobot@<database-ip>:/tmp/
 
    # Replace corrupted file
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 << 'EOF'
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip> << 'EOF'
      sudo mv /tmp/dump.rdb /var/lib/redis/dump.rdb
      sudo chown redis:redis /var/lib/redis/dump.rdb
      sudo chmod 640 /var/lib/redis/dump.rdb
@@ -1034,14 +1034,14 @@ scp -i ~/.ssh/autobot_key \
 
 4. **Start Redis:**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 \
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip> \
      "sudo systemctl start redis-server"
    ```
 
 5. **Verify data integrity:**
    ```bash
-   redis-cli -h 172.16.168.23 DBSIZE
-   redis-cli -h 172.16.168.23 INFO persistence
+   redis-cli -h <database-ip> DBSIZE
+   redis-cli -h <database-ip> INFO persistence
    ```
 
 6. **Test functionality:**
@@ -1079,7 +1079,7 @@ scp -i ~/.ssh/autobot_key \
    - Restore latest data backup
 
    **Option B: Deploy new Redis VM**
-   - Provision new VM at 172.16.168.23
+   - Provision new VM at <database-ip>
    - Install Redis
    - Configure service
    - Restore data from backup
@@ -1089,10 +1089,10 @@ scp -i ~/.ssh/autobot_key \
 4. **Verify full system recovery:**
    ```bash
    # Test all health checks
-   curl https://172.16.168.20:8443/api/services/redis/health
+   curl https://<backend-ip>:8443/api/services/redis/health
 
    # Test from backend
-   redis-cli -h 172.16.168.23 PING
+   redis-cli -h <database-ip> PING
    ```
 
 **RTO (Recovery Time Objective):** 30 minutes (VM restore) or 2 hours (new VM)
@@ -1188,16 +1188,16 @@ scp -i ~/.ssh/autobot_key \
 1. **Backup everything:**
    ```bash
    # Data backup
-   ssh autobot@172.16.168.23 "redis-cli BGSAVE"
+   ssh autobot@<database-ip> "redis-cli BGSAVE"
 
    # Config backup
-   ssh autobot@172.16.168.23 \
+   ssh autobot@<database-ip> \
      "sudo cp /etc/redis/redis.conf /etc/redis/redis.conf.pre-upgrade"
    ```
 
 2. **Update Redis:**
    ```bash
-   ssh autobot@172.16.168.23 << 'EOF'
+   ssh autobot@<database-ip> << 'EOF'
      # Stop service
      sudo systemctl stop redis-server
 
@@ -1216,14 +1216,14 @@ scp -i ~/.ssh/autobot_key \
 3. **Verify update:**
    ```bash
    # Check version
-   redis-cli -h 172.16.168.23 INFO server | grep redis_version
+   redis-cli -h <database-ip> INFO server | grep redis_version
 
    # Run health checks
-   curl https://172.16.168.20:8443/api/services/redis/health
+   curl https://<backend-ip>:8443/api/services/redis/health
 
    # Test functionality
-   redis-cli -h 172.16.168.23 SET test "upgrade-success"
-   redis-cli -h 172.16.168.23 GET test
+   redis-cli -h <database-ip> SET test "upgrade-success"
+   redis-cli -h <database-ip> GET test
    ```
 
 4. **Monitor post-upgrade:**
@@ -1234,7 +1234,7 @@ scp -i ~/.ssh/autobot_key \
 **Rollback (if needed):**
 
 ```bash
-ssh autobot@172.16.168.23 << 'EOF'
+ssh autobot@<database-ip> << 'EOF'
   # Stop current version
   sudo systemctl stop redis-server
 
@@ -1598,61 +1598,61 @@ Auto-recovery fails
 
 ```bash
 # Quick health check
-redis-cli -h 172.16.168.23 PING
+redis-cli -h <database-ip> PING
 
 # Service status
-ssh autobot@172.16.168.23 "systemctl status redis-server"
+ssh autobot@<database-ip> "systemctl status redis-server"
 
 # Full health via API
-curl https://172.16.168.20:8443/api/services/redis/health
+curl https://<backend-ip>:8443/api/services/redis/health
 
 # Memory usage
-redis-cli -h 172.16.168.23 INFO memory | grep used_memory_human
+redis-cli -h <database-ip> INFO memory | grep used_memory_human
 
 # Connection count
-redis-cli -h 172.16.168.23 INFO clients | grep connected_clients
+redis-cli -h <database-ip> INFO clients | grep connected_clients
 ```
 
 ### Service Control
 
 ```bash
 # Start
-ssh autobot@172.16.168.23 "sudo systemctl start redis-server"
+ssh autobot@<database-ip> "sudo systemctl start redis-server"
 
 # Stop
-ssh autobot@172.16.168.23 "sudo systemctl stop redis-server"
+ssh autobot@<database-ip> "sudo systemctl stop redis-server"
 
 # Restart
-ssh autobot@172.16.168.23 "sudo systemctl restart redis-server"
+ssh autobot@<database-ip> "sudo systemctl restart redis-server"
 
 # Reload config
-ssh autobot@172.16.168.23 "sudo systemctl reload redis-server"
+ssh autobot@<database-ip> "sudo systemctl reload redis-server"
 ```
 
 ### Logs
 
 ```bash
 # Recent logs
-ssh autobot@172.16.168.23 "sudo journalctl -u redis-server -n 50"
+ssh autobot@<database-ip> "sudo journalctl -u redis-server -n 50"
 
 # Follow logs
-ssh autobot@172.16.168.23 "sudo journalctl -u redis-server -f"
+ssh autobot@<database-ip> "sudo journalctl -u redis-server -f"
 
 # Errors only
-ssh autobot@172.16.168.23 "sudo journalctl -u redis-server -p err"
+ssh autobot@<database-ip> "sudo journalctl -u redis-server -p err"
 ```
 
 ### Performance
 
 ```bash
 # Full INFO
-redis-cli -h 172.16.168.23 INFO
+redis-cli -h <database-ip> INFO
 
 # Slow queries
-redis-cli -h 172.16.168.23 SLOWLOG GET 10
+redis-cli -h <database-ip> SLOWLOG GET 10
 
 # Key statistics
-redis-cli -h 172.16.168.23 --bigkeys
+redis-cli -h <database-ip> --bigkeys
 ```
 
 ---

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -19,7 +19,7 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 ## Failure Scenarios
 
-### Scenario 1: Main Backend Failure (172.16.168.20)
+### Scenario 1: Main Backend Failure (<backend-ip>)
 
 **Impact**: Complete API outage, no chat functionality
 
@@ -61,12 +61,12 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 ---
 
-### Scenario 2: Frontend VM Failure (172.16.168.21)
+### Scenario 2: Frontend VM Failure (<frontend-ip>)
 
 **Impact**: No web interface, API still functional
 
 **Symptoms**:
-- Cannot access `http://172.16.168.21:5173`
+- Cannot access `http://<frontend-ip>:5173`
 - SSH to VM1 fails or shows issues
 
 **Recovery Steps**:
@@ -84,7 +84,7 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 3. **SSH and restart service**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.21
+   ssh -i ~/.ssh/autobot_key autobot@<frontend-ip>
 
    # On VM1:
    cd /opt/autobot/autobot-slm-frontend
@@ -100,20 +100,20 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 ---
 
-### Scenario 3: Redis Failure (172.16.168.23)
+### Scenario 3: Redis Failure (<database-ip>)
 
 **Impact**: Session loss, knowledge base unavailable, cache miss
 
 **Symptoms**:
 - Connection errors in backend logs
-- `redis-cli -h 172.16.168.23 ping` fails
+- `redis-cli -h <database-ip> ping` fails
 - Chat responses very slow or fail
 
 **Recovery Steps**:
 
 1. **Check Redis status**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.23
+   ssh -i ~/.ssh/autobot_key autobot@<database-ip>
    sudo systemctl status redis-stack-server
    ```
 
@@ -124,8 +124,8 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 3. **Verify connectivity**
    ```bash
-   redis-cli -h 172.16.168.23 ping
-   redis-cli -h 172.16.168.23 INFO
+   redis-cli -h <database-ip> ping
+   redis-cli -h <database-ip> INFO
    ```
 
 4. **Restore from backup if data lost**
@@ -145,20 +145,20 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 ---
 
-### Scenario 4: AI Stack Failure (172.16.168.24)
+### Scenario 4: AI Stack Failure (<aiml-ip>)
 
 **Impact**: LLM responses fail, embeddings unavailable
 
 **Symptoms**:
 - Chat responses timeout
-- `curl http://172.16.168.24:8080/api/tags` fails
+- `curl http://<aiml-ip>:8080/api/tags` fails
 - Backend logs show Ollama connection errors
 
 **Recovery Steps**:
 
 1. **Check Ollama status**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.24
+   ssh -i ~/.ssh/autobot_key autobot@<aiml-ip>
    sudo systemctl status ollama
    ```
 
@@ -169,7 +169,7 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 3. **Verify models are loaded**
    ```bash
-   curl http://172.16.168.24:8080/api/tags
+   curl http://<aiml-ip>:8080/api/tags
    ```
 
 4. **Pull models if missing**
@@ -184,7 +184,7 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 ---
 
-### Scenario 5: NPU Worker Failure (172.16.168.22)
+### Scenario 5: NPU Worker Failure (<npu-ip>)
 
 **Impact**: Slower embeddings (falls back to cloud/CPU)
 
@@ -196,7 +196,7 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 1. **Check NPU worker status**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.22
+   ssh -i ~/.ssh/autobot_key autobot@<npu-ip>
    sudo systemctl status npu-worker
    ```
 
@@ -216,7 +216,7 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 ---
 
-### Scenario 6: Browser VM Failure (172.16.168.25)
+### Scenario 6: Browser VM Failure (<browser-ip>)
 
 **Impact**: Browser automation unavailable
 
@@ -228,7 +228,7 @@ This document provides disaster recovery procedures for AutoBot's distributed in
 
 1. **Check VM and Playwright**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.25
+   ssh -i ~/.ssh/autobot_key autobot@<browser-ip>
    sudo systemctl status playwright-server
    ```
 
@@ -291,16 +291,16 @@ BACKUP_DIR="/backups/autobot/$(date +%Y-%m-%d)"
 mkdir -p "$BACKUP_DIR"
 
 # Redis backup
-ssh autobot@172.16.168.23 "redis-cli BGSAVE"
+ssh autobot@<database-ip> "redis-cli BGSAVE"
 sleep 10
-scp autobot@172.16.168.23:/var/lib/redis-stack/dump.rdb "$BACKUP_DIR/"
+scp autobot@<database-ip>:/var/lib/redis-stack/dump.rdb "$BACKUP_DIR/"
 
 # Configuration backup
 cp -r .env "$BACKUP_DIR/"
 cp -r backend/core/config.py "$BACKUP_DIR/"
 
 # Knowledge base metadata
-redis-cli -h 172.16.168.23 -n 1 KEYS "doc:*" > "$BACKUP_DIR/kb_keys.txt"
+redis-cli -h <database-ip> -n 1 KEYS "doc:*" > "$BACKUP_DIR/kb_keys.txt"
 
 echo "Backup completed: $BACKUP_DIR"
 ```
@@ -330,11 +330,11 @@ check_service() {
 }
 
 check_service "http://localhost:8001/api/health" "Backend API"
-check_service "http://172.16.168.21:5173" "Frontend"
-check_service "http://172.16.168.24:8080/api/tags" "Ollama"
+check_service "http://<frontend-ip>:5173" "Frontend"
+check_service "http://<aiml-ip>:8080/api/tags" "Ollama"
 
 # Redis check
-if ! redis-cli -h 172.16.168.23 ping > /dev/null 2>&1; then
+if ! redis-cli -h <database-ip> ping > /dev/null 2>&1; then
     echo "ALERT: Redis is DOWN at $(date)" | mail -s "AutoBot Alert: Redis" admin@example.com
 fi
 ```

--- a/docs/operations/scaling-strategy.md
+++ b/docs/operations/scaling-strategy.md
@@ -20,12 +20,12 @@ AutoBot's 6-VM architecture enables independent scaling of each component. This 
 
 | VM | IP | vCPUs | RAM | Storage | Purpose |
 |----|-----|-------|-----|---------|---------|
-| Main (WSL) | 172.16.168.20 | 4 | 8 GB | 50 GB | Backend API + VNC |
-| VM1 Frontend | 172.16.168.21 | 2 | 4 GB | 20 GB | Web interface |
-| VM2 NPU Worker | 172.16.168.22 | 4 | 8 GB | 30 GB | Hardware AI |
-| VM3 Redis | 172.16.168.23 | 2 | 8 GB | 50 GB | Data layer |
-| VM4 AI Stack | 172.16.168.24 | 4 | 16 GB | 100 GB | LLM models |
-| VM5 Browser | 172.16.168.25 | 2 | 4 GB | 20 GB | Playwright |
+| Main (WSL) | <backend-ip> | 4 | 8 GB | 50 GB | Backend API + VNC |
+| VM1 Frontend | <frontend-ip> | 2 | 4 GB | 20 GB | Web interface |
+| VM2 NPU Worker | <npu-ip> | 4 | 8 GB | 30 GB | Hardware AI |
+| VM3 Redis | <database-ip> | 2 | 8 GB | 50 GB | Data layer |
+| VM4 AI Stack | <aiml-ip> | 4 | 16 GB | 100 GB | LLM models |
+| VM5 Browser | <browser-ip> | 2 | 4 GB | 20 GB | Playwright |
 
 ---
 
@@ -68,7 +68,7 @@ Start-VM -Name "AutoBot-Frontend"
 
 **Post-scaling verification**:
 ```bash
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip>
 free -h  # Verify RAM
 nproc    # Verify CPUs
 ```
@@ -88,7 +88,7 @@ nproc    # Verify CPUs
            │                 │                 │
     ┌──────▼──────┐   ┌──────▼──────┐   ┌──────▼──────┐
     │ Frontend A  │   │ Frontend B  │   │ Frontend C  │
-    │ 172.16.168.21│   │ 172.16.168.26│   │ 172.16.168.27│
+    │ <frontend-ip>│   │ <reserved-ip>│   │ <reserved-ip>│
     └─────────────┘   └─────────────┘   └─────────────┘
 ```
 
@@ -105,7 +105,7 @@ nproc    # Verify CPUs
 
 2. **Configure new VM**
    ```bash
-   # Set new static IP (e.g., 172.16.168.26)
+   # Set new static IP (e.g., <reserved-ip>)
    sudo nano /etc/netplan/00-installer-config.yaml
    sudo netplan apply
    ```
@@ -115,8 +115,8 @@ nproc    # Verify CPUs
    # /etc/nginx/conf.d/frontend-lb.conf
    upstream frontend_pool {
        least_conn;
-       server 172.16.168.21:5173;
-       server 172.16.168.26:5173;
+       server <frontend-ip>:5173;
+       server <reserved-ip>:5173;
    }
 
    server {
@@ -168,7 +168,7 @@ python3 -c "from openvino.runtime import Core; print(Core().available_devices)"
            │                 │                 │
     ┌──────▼──────┐   ┌──────▼──────┐   ┌──────▼──────┐
     │ NPU Worker A│   │ NPU Worker B│   │ Cloud API   │
-    │ 172.16.168.22│   │ 172.16.168.28│   │ (Fallback)  │
+    │ <npu-ip>│   │ <reserved-ip>│   │ (Fallback)  │
     └─────────────┘   └─────────────┘   └─────────────┘
 ```
 
@@ -176,8 +176,8 @@ python3 -c "from openvino.runtime import Core; print(Core().available_devices)"
 ```python
 # In backend/core/config.py
 NPU_WORKERS = [
-    "http://172.16.168.22:8081",
-    "http://172.16.168.28:8081",
+    "http://<npu-ip>:8081",
+    "http://<reserved-ip>:8081",
 ]
 
 # Round-robin or least-connections load balancing
@@ -204,7 +204,7 @@ Start-VM -Name "AutoBot-Redis"
 
 **Configure Redis for new memory**:
 ```bash
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23
+ssh -i ~/.ssh/autobot_key autobot@<database-ip>
 
 # Update Redis config
 sudo nano /etc/redis-stack.conf
@@ -246,8 +246,8 @@ sudo systemctl restart redis-stack-server
 3. **Initialize cluster**:
    ```bash
    redis-cli --cluster create \
-     172.16.168.23:6379 172.16.168.29:6379 172.16.168.30:6379 \
-     172.16.168.31:6379 172.16.168.32:6379 172.16.168.33:6379 \
+     <database-ip>:6379 <reserved-ip>:6379 <example-ip>:6379 \
+     <example-ip>:6379 <example-ip>:6379 <example-ip>:6379 \
      --cluster-replicas 1
    ```
 
@@ -256,7 +256,7 @@ sudo systemctl restart redis-stack-server
    from redis.cluster import RedisCluster
 
    redis = RedisCluster(
-       host="172.16.168.23",
+       host="<database-ip>",
        port=6379,
        decode_responses=True
    )
@@ -303,7 +303,7 @@ Set-VMGpuPartitionAdapter -VMName "AutoBot-AI" -MinPartitionVRAM 2GB
            │                 │                 │
     ┌──────▼──────┐   ┌──────▼──────┐   ┌──────▼──────┐
     │ Ollama A    │   │ Ollama B    │   │ Cloud LLM   │
-    │ 172.16.168.24│   │ 172.16.168.34│   │ (Overflow)  │
+    │ <aiml-ip>│   │ <example-ip>│   │ (Overflow)  │
     └─────────────┘   └─────────────┘   └─────────────┘
 ```
 
@@ -311,8 +311,8 @@ Set-VMGpuPartitionAdapter -VMName "AutoBot-AI" -MinPartitionVRAM 2GB
 ```python
 # In LLM interface
 OLLAMA_ENDPOINTS = [
-    "http://172.16.168.24:8080",
-    "http://172.16.168.34:8080",
+    "http://<aiml-ip>:8080",
+    "http://<example-ip>:8080",
 ]
 
 async def get_available_ollama():
@@ -357,16 +357,16 @@ Start-VM -Name "AutoBot-Browser"
            │                 │                 │
     ┌──────▼──────┐   ┌──────▼──────┐   ┌──────▼──────┐
     │ Browser A   │   │ Browser B   │   │ Browser C   │
-    │ 172.16.168.25│   │ 172.16.168.35│   │ 172.16.168.36│
+    │ <browser-ip>│   │ <example-ip>│   │ <new-node-ip>│
     └─────────────┘   └─────────────┘   └─────────────┘
 ```
 
 **Pool Manager**:
 ```python
 BROWSER_POOL = [
-    "http://172.16.168.25:3000",
-    "http://172.16.168.35:3000",
-    "http://172.16.168.36:3000",
+    "http://<browser-ip>:3000",
+    "http://<example-ip>:3000",
+    "http://<new-node-ip>:3000",
 ]
 
 async def get_browser_session():
@@ -426,14 +426,14 @@ Deploy multiple backend instances behind load balancer. Requires:
 curl -w "%{time_total}\n" -o /dev/null -s http://localhost:8001/api/health
 
 # Redis Memory
-redis-cli -h 172.16.168.23 INFO memory | grep used_memory_human
+redis-cli -h <database-ip> INFO memory | grep used_memory_human
 
 # Ollama Queue
-curl -s http://172.16.168.24:8080/api/ps | jq '.models | length'
+curl -s http://<aiml-ip>:8080/api/ps | jq '.models | length'
 
 # VM CPU Usage
-ssh autobot@172.16.168.21 "top -bn1 | grep 'Cpu(s)'"
-ssh autobot@172.16.168.24 "top -bn1 | grep 'Cpu(s)'"
+ssh autobot@<frontend-ip> "top -bn1 | grep 'Cpu(s)'"
+ssh autobot@<aiml-ip> "top -bn1 | grep 'Cpu(s)'"
 ```
 
 ### Alerting Thresholds

--- a/docs/operations/vm-service-states.md
+++ b/docs/operations/vm-service-states.md
@@ -23,8 +23,8 @@ offline services through circuit breakers and intelligent log suppression.
 
 | Service | VM | IP:Port | Description |
 |---------|-----|---------|-------------|
-| **Backend API** | Main (WSL) | 172.16.168.20:8443 | Core backend - must always be running |
-| **Redis** | VM3 | 172.16.168.23:6379 | Data layer - required for caching, sessions, queues |
+| **Backend API** | Main (WSL) | <backend-ip>:8443 | Core backend - must always be running |
+| **Redis** | VM3 | <database-ip>:6379 | Data layer - required for caching, sessions, queues |
 
 **If these are offline**: System will not function properly. Immediate attention required.
 
@@ -32,11 +32,11 @@ offline services through circuit breakers and intelligent log suppression.
 
 | Service | VM | IP:Port | Description | When Offline |
 |---------|-----|---------|-------------|--------------|
-| **Frontend** | VM1 | 172.16.168.21:5173 | Web interface | Use backend API directly |
-| **NPU Worker** | VM2 | 172.16.168.22:8081 | Hardware AI acceleration | Falls back to CPU inference |
-| **AI Stack** | VM4 | 172.16.168.24:8080 | AI processing stack | Limited AI features |
-| **Ollama** | VM4 | 172.16.168.24:11434 | Local LLM inference | Uses fallback LLM providers |
-| **Browser Automation** | VM5 | 172.16.168.25:3000 | Playwright automation | Web scraping unavailable |
+| **Frontend** | VM1 | <frontend-ip>:5173 | Web interface | Use backend API directly |
+| **NPU Worker** | VM2 | <npu-ip>:8081 | Hardware AI acceleration | Falls back to CPU inference |
+| **AI Stack** | VM4 | <aiml-ip>:8080 | AI processing stack | Limited AI features |
+| **Ollama** | VM4 | <aiml-ip>:11434 | Local LLM inference | Uses fallback LLM providers |
+| **Browser Automation** | VM5 | <browser-ip>:3000 | Playwright automation | Web scraping unavailable |
 
 **If these are offline**: System continues with reduced functionality. Non-urgent.
 
@@ -95,21 +95,21 @@ intelligent log suppression:
 
 ```
 # First failure
-WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to 172.16.168.22:8081
+WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to <npu-ip>:8081
 
 # Second failure
-WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to 172.16.168.22:8081
+WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to <npu-ip>:8081
 
 # Third failure
-WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to 172.16.168.22:8081
+WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to <npu-ip>:8081
 
 # Fourth failure (suppression begins)
-WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to 172.16.168.22:8081
+WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to <npu-ip>:8081
 
 # Next 60 seconds of failures: no logs
 
 # After 60 seconds
-WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to 172.16.168.22:8081 (47 similar errors suppressed)
+WARNING: VM service NPU Worker (npu_worker) is offline: Cannot connect to <npu-ip>:8081 (47 similar errors suppressed)
 ```
 
 ---

--- a/docs/planning/BACKEND_ROOT_CAUSE_IMPLEMENTATION_PLAN.md
+++ b/docs/planning/BACKEND_ROOT_CAUSE_IMPLEMENTATION_PLAN.md
@@ -18,7 +18,7 @@ This plan addresses 4 root causes identified in AutoBot's backend with full "No 
 **Key Metrics**:
 - **Total Tasks**: 47 granular implementation tasks
 - **Agents Required**: 6 specialized agents working in parallel
-- **VMs Affected**: All 6 VMs (172.16.168.20-25)
+- **VMs Affected**: All 6 VMs (<backend-ip>-25)
 - **Code Changes**: 15 files modified, 5 files created
 - **Tests Required**: 28 test cases across unit/integration/security
 
@@ -363,7 +363,7 @@ ansible-playbook -i ansible/inventory ansible/playbooks/deploy-service-auth.yml 
 ansible all -i ansible/inventory -m shell -a "ls -la /etc/autobot/service-keys/"
 
 # Verify correct middleware file deployed
-ssh autobot@172.16.168.20 "grep -l 'ServiceAuthLoggingMiddleware' /home/autobot/backend/app.py"
+ssh autobot@<backend-ip> "grep -l 'ServiceAuthLoggingMiddleware' /home/autobot/backend/app.py"
 ```
 
 **What Ansible Does**:
@@ -407,11 +407,11 @@ ansible-playbook -i ansible/inventory ansible/playbooks/deploy-service-auth.yml 
   --extra-vars "middleware_file=service_auth_enforcement.py"
 
 # Verify enforcement active
-curl http://172.16.168.22:8081/api/process
+curl http://<npu-ip>:8081/api/process
 # Should return: 401 Unauthorized (no signature)
 
 # Verify correct middleware deployed
-ssh autobot@172.16.168.20 "grep -l 'ServiceAuthEnforcementMiddleware' /home/autobot/backend/app.py"
+ssh autobot@<backend-ip> "grep -l 'ServiceAuthEnforcementMiddleware' /home/autobot/backend/app.py"
 ```
 
 **What Ansible Does**:
@@ -457,7 +457,7 @@ user browser-service on >password ~sessions:* +get +set +del +expire
 ansible-playbook -i ansible/inventory ansible/playbooks/deploy-redis-acl.yml
 
 # Restart Redis with ACL enabled
-ssh autobot@172.16.168.23 "sudo systemctl restart redis-stack-server"
+ssh autobot@<database-ip> "sudo systemctl restart redis-stack-server"
 ```
 
 **Task 3.14: Update All Redis Clients with Auth (2 hours)**
@@ -626,17 +626,17 @@ If agents must work sequentially:
 After each deployment:
 ```bash
 # Backend health
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 
 # Redis connectivity
-redis-cli -h 172.16.168.23 --user main-backend --pass <password> ping
+redis-cli -h <database-ip> --user main-backend --pass <password> ping
 
 # Service auth verification
-curl -H "X-Service-ID: test" http://172.16.168.22:8081/api/process
+curl -H "X-Service-ID: test" http://<npu-ip>:8081/api/process
 # Should return 401 (no valid signature)
 
 # Chat functionality
-curl -X POST https://172.16.168.20:8443/api/chat/stream \
+curl -X POST https://<backend-ip>:8443/api/chat/stream \
   -H "Content-Type: application/json" \
   -d '{"message": "test", "session_id": "test"}'
 ```

--- a/docs/planning/CONFIGURATION_MANAGEMENT_IMPLEMENTATION_PLAN.md
+++ b/docs/planning/CONFIGURATION_MANAGEMENT_IMPLEMENTATION_PLAN.md
@@ -1172,10 +1172,10 @@ VM_HOSTNAME=vm1-frontend                  # VM identifier for distributed reload
 4. **Verify Deployment:**
    ```bash
    # Check validation endpoint
-   curl https://172.16.168.20:8443/api/config/validate
+   curl https://<backend-ip>:8443/api/config/validate
 
    # Check sync status
-   curl https://172.16.168.20:8443/api/settings/sync-status
+   curl https://<backend-ip>:8443/api/settings/sync-status
    ```
 
 5. **Enable Hot Reload:**

--- a/docs/planning/DAY_3_IMPLEMENTATION_PLAN.md
+++ b/docs/planning/DAY_3_IMPLEMENTATION_PLAN.md
@@ -12,7 +12,7 @@
 Day 3 focuses on distributing the 6 pre-generated service API keys to their respective VMs and configuring each service to use HMAC-SHA256 authentication for service-to-service calls. This is a **configuration deployment only** - no code changes required.
 
 **Current Status**:
-- ✅ All 6 service keys generated and stored in Redis (172.16.168.23:6379)
+- ✅ All 6 service keys generated and stored in Redis (<database-ip>:6379)
 - ✅ Ansible playbook created and ready
 - ✅ Logging middleware deployed and collecting data
 - ⏳ Service keys NOT YET distributed to VMs
@@ -41,7 +41,7 @@ Day 3 focuses on distributing the 6 pre-generated service API keys to their resp
 7. `/api/settings/*` - 11 requests (settings)
 
 **Request Sources**:
-- 100% from Frontend VM (172.16.168.21) - browser/user requests
+- 100% from Frontend VM (<frontend-ip>) - browser/user requests
 - 0% service-to-service calls (services not configured yet)
 
 **Authentication Pattern**:
@@ -62,16 +62,16 @@ Unknown Service: 0%
 
 ## Service Key Inventory
 
-All 6 service keys generated and stored in Redis at `172.16.168.23:6379`:
+All 6 service keys generated and stored in Redis at `<database-ip>:6379`:
 
 | Service ID | VM | IP Address | Key Location | Purpose |
 |------------|-----|-----------|-------------|---------|
-| **main-backend** | Main (WSL) | 172.16.168.20 | `service:key:main-backend` | Backend API calls to other services |
-| **frontend** | VM1 | 172.16.168.21 | `service:key:frontend` | Frontend server-side API calls |
-| **npu-worker** | VM2 | 172.16.168.22 | `service:key:npu-worker` | NPU worker calls to backend |
-| **redis-stack** | VM3 | 172.16.168.23 | `service:key:redis-stack` | Redis Stack admin operations |
-| **ai-stack** | VM4 | 172.16.168.24 | `service:key:ai-stack` | AI/ML service API calls |
-| **browser-service** | VM5 | 172.16.168.25 | `service:key:browser-service` | Browser automation API calls |
+| **main-backend** | Main (WSL) | <backend-ip> | `service:key:main-backend` | Backend API calls to other services |
+| **frontend** | VM1 | <frontend-ip> | `service:key:frontend` | Frontend server-side API calls |
+| **npu-worker** | VM2 | <npu-ip> | `service:key:npu-worker` | NPU worker calls to backend |
+| **redis-stack** | VM3 | <database-ip> | `service:key:redis-stack` | Redis Stack admin operations |
+| **ai-stack** | VM4 | <aiml-ip> | `service:key:ai-stack` | AI/ML service API calls |
+| **browser-service** | VM5 | <browser-ip> | `service:key:browser-service` | Browser automation API calls |
 
 **Key Properties**:
 - **Format**: 256-bit (64 hex characters)
@@ -88,7 +88,7 @@ All 6 service keys generated and stored in Redis at `172.16.168.23:6379`:
 **Task 3.1: Verify Service Keys in Redis**
 ```bash
 # Connect to Redis and verify all 6 keys exist
-redis-cli -h 172.16.168.23 -p 6379
+redis-cli -h <database-ip> -p 6379
 
 # Check each service key
 EXISTS service:key:main-backend
@@ -162,7 +162,7 @@ This creates:
 
 SERVICE_ID=main-backend
 SERVICE_KEY=<256-bit hex key>
-REDIS_HOST=172.16.168.23
+REDIS_HOST=<database-ip>
 REDIS_PORT=6379
 AUTH_TIMESTAMP_WINDOW=300
 ```
@@ -204,7 +204,7 @@ ansible all -i ansible/inventory/production.yml \
 
 Each service needs to load authentication credentials on startup.
 
-**Main Backend** (172.16.168.20):
+**Main Backend** (<backend-ip>):
 ```bash
 # Edit backend startup to load service keys
 cat >> /home/autobot/backend/.env << 'EOF'
@@ -215,7 +215,7 @@ SERVICE_KEY_FILE=/etc/autobot/service-keys/main-backend.env
 EOF
 ```
 
-**Frontend** (172.16.168.21):
+**Frontend** (<frontend-ip>):
 ```bash
 # Frontend needs to send auth headers for server-side API calls
 cat >> /home/autobot/autobot-frontend/.env << 'EOF'
@@ -226,7 +226,7 @@ VITE_SERVICE_KEY_FILE=/etc/autobot/service-keys/frontend.env
 EOF
 ```
 
-**NPU Worker** (172.16.168.22):
+**NPU Worker** (<npu-ip>):
 ```bash
 cat >> /home/autobot/npu-worker/.env << 'EOF'
 
@@ -236,7 +236,7 @@ SERVICE_KEY_FILE=/etc/autobot/service-keys/npu-worker.env
 EOF
 ```
 
-**AI Stack** (172.16.168.24):
+**AI Stack** (<aiml-ip>):
 ```bash
 cat >> /home/autobot/ai-stack/.env << 'EOF'
 
@@ -246,7 +246,7 @@ SERVICE_KEY_FILE=/etc/autobot/service-keys/ai-stack.env
 EOF
 ```
 
-**Browser Service** (172.16.168.25):
+**Browser Service** (<browser-ip>):
 ```bash
 cat >> /home/autobot/browser-service/.env << 'EOF'
 
@@ -279,7 +279,7 @@ ansible-playbook -i ansible/inventory/production.yml \
 # 3. Frontend, NPU, Browser, AI (in parallel)
 
 # Restart backend
-ssh autobot@172.16.168.20 "sudo systemctl restart autobot-backend"
+ssh autobot@<backend-ip> "sudo systemctl restart autobot-backend"
 
 # Wait 30 seconds for backend to be ready
 sleep 30
@@ -293,7 +293,7 @@ ansible frontend,npu-worker,ai-stack,browser-service \
 **Task 3.10: Verify Services Loaded Credentials**
 ```bash
 # Check backend logs for service auth initialization
-ssh autobot@172.16.168.20 \
+ssh autobot@<backend-ip> \
   "grep 'Service credentials loaded' /home/autobot/logs/backend.log"
 
 # Check all services loaded their keys
@@ -306,7 +306,7 @@ ansible all -i ansible/inventory/production.yml \
 **Test 1: Backend → Redis Health Check**
 ```bash
 # Backend should now send auth headers to Redis API
-curl -v https://172.16.168.20:8443/api/redis/health
+curl -v https://<backend-ip>:8443/api/redis/health
 ```
 
 **Expected Log** (backend.log):
@@ -317,8 +317,8 @@ curl -v https://172.16.168.20:8443/api/redis/health
 **Test 2: NPU Worker → Backend Registration**
 ```bash
 # NPU worker should authenticate when registering
-ssh autobot@172.16.168.22 \
-  "curl -X POST https://172.16.168.20:8443/api/npu/register"
+ssh autobot@<npu-ip> \
+  "curl -X POST https://<backend-ip>:8443/api/npu/register"
 ```
 
 **Expected Log** (backend.log):
@@ -329,7 +329,7 @@ ssh autobot@172.16.168.22 \
 **Test 3: Frontend SSR → Backend API**
 ```bash
 # Frontend server-side rendering should authenticate
-curl http://172.16.168.21:5173/
+curl http://<frontend-ip>:5173/
 # This triggers frontend → backend API call with auth
 ```
 
@@ -428,10 +428,10 @@ ansible all -i ansible/inventory/production.yml \
 ansible all -i ansible/inventory/production.yml -m shell -a "systemctl status autobot-*"
 
 # Check frontend accessible
-curl http://172.16.168.21:5173
+curl http://<frontend-ip>:5173
 
 # Check backend accessible
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 ```
 
 ---
@@ -582,7 +582,7 @@ headers = {
 **Diagnosis**:
 ```bash
 # Check service key matches Redis
-redis-cli -h 172.16.168.23 -p 6379 GET service:key:main-backend
+redis-cli -h <database-ip> -p 6379 GET service:key:main-backend
 cat /etc/autobot/service-keys/main-backend.env | grep SERVICE_KEY
 ```
 

--- a/docs/planning/READY_TO_IMPLEMENT.md
+++ b/docs/planning/READY_TO_IMPLEMENT.md
@@ -50,9 +50,9 @@
 
 ### System Health ✅
 
-- ✅ Backend running: https://172.16.168.20:8443
-- ✅ Frontend running: http://172.16.168.21:5173
-- ✅ Redis running: 172.16.168.23:6379
+- ✅ Backend running: https://<backend-ip>:8443
+- ✅ Frontend running: http://<frontend-ip>:5173
+- ✅ Redis running: <database-ip>:6379
 - ✅ All 6 VMs operational
 - ✅ All distributed services healthy
 
@@ -199,19 +199,19 @@ Create custom prompts for each agent based on their task sections
 
 ### Backend Status
 ```
-✅ Running: https://172.16.168.20:8443
+✅ Running: https://<backend-ip>:8443
 ✅ Health: All services operational
 ✅ Redis: Connected and healthy
 ```
 
 ### VM Status
 ```
-✅ Frontend (VM1):   172.16.168.21:5173
-✅ NPU Worker (VM2): 172.16.168.22:8081
-✅ Redis (VM3):      172.16.168.23:6379
-✅ AI Stack (VM4):   172.16.168.24:8080
-✅ Browser (VM5):    172.16.168.25:3000
-✅ Main (VM0):       172.16.168.20:8443
+✅ Frontend (VM1):   <frontend-ip>:5173
+✅ NPU Worker (VM2): <npu-ip>:8081
+✅ Redis (VM3):      <database-ip>:6379
+✅ AI Stack (VM4):   <aiml-ip>:8080
+✅ Browser (VM5):    <browser-ip>:3000
+✅ Main (VM0):       <backend-ip>:8443
 ```
 
 ### Documentation Status

--- a/docs/planning/WEEK_1_FINAL_STATUS.md
+++ b/docs/planning/WEEK_1_FINAL_STATUS.md
@@ -12,8 +12,8 @@
 
 **Single Environment Architecture:**
 - **Dev/Production:** Same environment (no separate staging)
-- **Backend:** https://172.16.168.20:8443 ✅ RUNNING
-- **Frontend:** http://172.16.168.21:5173 ✅ RUNNING
+- **Backend:** https://<backend-ip>:8443 ✅ RUNNING
+- **Frontend:** http://<frontend-ip>:5173 ✅ RUNNING
 - **Database:** `data/conversation_files.db` ✅ EXISTS (96KB)
 - **All 6 VMs:** ✅ OPERATIONAL
 
@@ -194,7 +194,7 @@ All 5 critical bugs are now FIXED in production:
 ## 📞 Production Support
 
 ### Monitoring
-- **Health Check:** https://172.16.168.20:8443/api/health
+- **Health Check:** https://<backend-ip>:8443/api/health
 - **Database:** `data/conversation_files.db`
 - **Logs:** Check backend logs for initialization messages
 

--- a/docs/planning/WEEK_1_QUICK_START.md
+++ b/docs/planning/WEEK_1_QUICK_START.md
@@ -7,9 +7,9 @@
 ## ✅ Pre-Flight Checklist
 
 ### System Status
-- [x] Backend running: https://172.16.168.20:8443
-- [x] Frontend running: http://172.16.168.21:5173
-- [x] Redis running: 172.16.168.23:6379
+- [x] Backend running: https://<backend-ip>:8443
+- [x] Frontend running: http://<frontend-ip>:5173
+- [x] Redis running: <database-ip>:6379
 - [x] All VMs accessible
 - [x] Implementation guide created: `planning/tasks/week-1-database-initialization-detailed-guide.md`
 - [x] Memory MCP entities created
@@ -228,7 +228,7 @@ After implementation, verify these criteria:
 - [ ] Fresh deployment scenario tested
 - [ ] Existing deployment scenario tested
 - [ ] All 6 VMs can perform file operations
-- [ ] Health check accessible: `curl https://172.16.168.20:8443/api/health`
+- [ ] Health check accessible: `curl https://<backend-ip>:8443/api/health`
 
 ---
 
@@ -251,7 +251,7 @@ sqlite3 data/conversation_files.db "SELECT * FROM schema_version;"
 # Should show: 1.0.0
 
 # 4. Test health check
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 # Should show database status as "healthy"
 
 # 5. Run unit tests
@@ -261,7 +261,7 @@ pytest tests/unit/test_conversation_file_manager.py -v --cov=src.conversation_fi
 pytest tests/distributed/test_db_initialization.py -v -m integration
 
 # 7. Test file upload (end-to-end)
-curl -X POST https://172.16.168.20:8443/api/files/conversation/upload \
+curl -X POST https://<backend-ip>:8443/api/files/conversation/upload \
   -F "file=@test.txt" \
   -F "session_id=test-session"
 ```

--- a/docs/planning/WEEK_3_ENFORCEMENT_MODE_DEPLOYMENT_PLAN.md
+++ b/docs/planning/WEEK_3_ENFORCEMENT_MODE_DEPLOYMENT_PLAN.md
@@ -42,9 +42,9 @@
 **Objective**: Deploy ServiceHTTPClient to all remote services
 
 **Services to Update**:
-1. NPU Worker (172.16.168.22:8081)
-2. AI Stack (172.16.168.24:8080)
-3. Browser Service (172.16.168.25:3000)
+1. NPU Worker (<npu-ip>:8081)
+2. AI Stack (<aiml-ip>:8080)
+3. Browser Service (<browser-ip>:3000)
 
 **Tasks**:
 - Add ServiceHTTPClient to service codebase
@@ -87,7 +87,7 @@
 
 ## Phase 1: Remote Service Updates
 
-### 1.1 NPU Worker Service (172.16.168.22:8081)
+### 1.1 NPU Worker Service (<npu-ip>:8081)
 
 #### Current State
 
@@ -118,7 +118,7 @@ def get_backend_client():
 async def send_inference_result(task_id: str, result: dict):
     """Send inference result to backend with authentication."""
     client = get_backend_client()
-    backend_url = os.getenv("BACKEND_HOST", "172.16.168.20")
+    backend_url = os.getenv("BACKEND_HOST", "<backend-ip>")
     backend_port = os.getenv("BACKEND_PORT", "8001")
 
     response = await client.post(
@@ -139,7 +139,7 @@ async def send_inference_result(task_id: str, result: dict):
 4. Test authenticated request to backend
 5. Restart NPU worker service
 
-### 1.2 AI Stack Service (172.16.168.24:8080)
+### 1.2 AI Stack Service (<aiml-ip>:8080)
 
 #### Current State
 
@@ -169,7 +169,7 @@ def get_backend_client():
 async def report_status(status: dict):
     """Report AI stack status to backend with authentication."""
     client = get_backend_client()
-    backend_url = os.getenv("BACKEND_HOST", "172.16.168.20")
+    backend_url = os.getenv("BACKEND_HOST", "<backend-ip>")
     backend_port = os.getenv("BACKEND_PORT", "8001")
 
     response = await client.post(
@@ -183,7 +183,7 @@ async def report_status(status: dict):
 - `/etc/autobot/.env` has `SERVICE_ID=ai-stack`
 - `/etc/autobot/service-keys/ai-stack.env` has service key
 
-### 1.3 Browser Service (172.16.168.25:3000)
+### 1.3 Browser Service (<browser-ip>:3000)
 
 #### Current State
 
@@ -213,7 +213,7 @@ def get_backend_client():
 async def send_automation_result(task_id: str, result: dict):
     """Send automation result to backend with authentication."""
     client = get_backend_client()
-    backend_url = os.getenv("BACKEND_HOST", "172.16.168.20")
+    backend_url = os.getenv("BACKEND_HOST", "<backend-ip>")
     backend_port = os.getenv("BACKEND_PORT", "8001")
 
     response = await client.post(
@@ -225,7 +225,7 @@ async def send_automation_result(task_id: str, result: dict):
 async def upload_screenshot(screenshot_data: bytes):
     """Upload screenshot to backend with authentication."""
     client = get_backend_client()
-    backend_url = os.getenv("BACKEND_HOST", "172.16.168.20")
+    backend_url = os.getenv("BACKEND_HOST", "<backend-ip>")
     backend_port = os.getenv("BACKEND_PORT", "8001")
 
     response = await client.post(
@@ -371,9 +371,9 @@ grep "Service auth failed" logs/backend.log | tail -50
 grep "401" logs/backend.log | grep -v "logging only" | tail -20
 
 # Verify services still functioning
-curl http://172.16.168.22:8081/health  # NPU Worker
-curl http://172.16.168.24:8080/health  # AI Stack
-curl http://172.16.168.25:3000/health  # Browser
+curl http://<npu-ip>:8081/health  # NPU Worker
+curl http://<aiml-ip>:8080/health  # AI Stack
+curl http://<browser-ip>:3000/health  # Browser
 ```
 
 ### 3.2 Enforcement Activation
@@ -395,7 +395,7 @@ sudo systemctl restart autobot-backend
 tail -f logs/backend.log | grep "service"
 
 # Check enforcement working
-curl -X POST https://172.16.168.20:8443/api/npu/test
+curl -X POST https://<backend-ip>:8443/api/npu/test
 # Should return 401 Unauthorized (no auth headers)
 ```
 

--- a/docs/planning/issue-55-complete-summary.md
+++ b/docs/planning/issue-55-complete-summary.md
@@ -287,10 +287,10 @@ entity_extractor = GraphEntityExtractor(
 sudo systemctl restart autobot-backend
 
 # 2. Verify endpoints available
-curl https://172.16.168.20:8443/api/entities/extract/health
+curl https://<backend-ip>:8443/api/entities/extract/health
 
 # 3. Test extraction
-curl -X POST https://172.16.168.20:8443/api/entities/extract \
+curl -X POST https://<backend-ip>:8443/api/entities/extract \
   -H "Content-Type: application/json" \
   -d '{
     "conversation_id": "test-123",

--- a/docs/planning/issue-55-phase2-completion-summary.md
+++ b/docs/planning/issue-55-phase2-completion-summary.md
@@ -400,7 +400,7 @@ The following issues were discovered and fixed during test execution:
 ### Basic Entity Extraction
 
 ```bash
-curl -X POST https://172.16.168.20:8443/api/entities/extract \
+curl -X POST https://<backend-ip>:8443/api/entities/extract \
   -H "Content-Type: application/json" \
   -d '{
     "conversation_id": "conv-123",
@@ -414,7 +414,7 @@ curl -X POST https://172.16.168.20:8443/api/entities/extract \
 ### Batch Extraction
 
 ```bash
-curl -X POST https://172.16.168.20:8443/api/entities/extract-batch \
+curl -X POST https://<backend-ip>:8443/api/entities/extract-batch \
   -H "Content-Type: application/json" \
   -d '{
     "conversations": [
@@ -433,7 +433,7 @@ curl -X POST https://172.16.168.20:8443/api/entities/extract-batch \
 ### Health Check
 
 ```bash
-curl https://172.16.168.20:8443/api/entities/extract/health
+curl https://<backend-ip>:8443/api/entities/extract/health
 ```
 
 ---

--- a/docs/planning/issue-55-phase2-deployment.md
+++ b/docs/planning/issue-55-phase2-deployment.md
@@ -31,7 +31,7 @@ sudo systemctl restart autobot-backend
 # ✅ [ 88%] Entity Extractor: Entity extractor initialized successfully
 
 # 4. Verify new endpoints are available
-curl https://172.16.168.20:8443/api/entities/extract/health
+curl https://<backend-ip>:8443/api/entities/extract/health
 
 # Expected response:
 # {
@@ -49,7 +49,7 @@ curl https://172.16.168.20:8443/api/entities/extract/health
 
 ```bash
 # Test entity extraction with sample conversation
-curl -X POST https://172.16.168.20:8443/api/entities/extract \
+curl -X POST https://<backend-ip>:8443/api/entities/extract \
   -H "Content-Type: application/json" \
   -d '{
     "conversation_id": "test-123",
@@ -115,7 +115,7 @@ git revert HEAD  # Or specific commit
 sudo systemctl start autobot-backend
 
 # 4. Verify core services still working
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 ```
 
 The new routers are optional - if they fail to load, backend continues with core functionality.

--- a/docs/planning/redis-ownership-standardization-plan.md
+++ b/docs/planning/redis-ownership-standardization-plan.md
@@ -20,7 +20,7 @@
 
 **Scope:**
 - **Files Affected:** 5 configuration and script files
-- **Directories Affected:** 2 Redis directories on VM3 (172.16.168.23)
+- **Directories Affected:** 2 Redis directories on VM3 (<database-ip>)
 - **Infrastructure:** Distributed VM setup (main + 5 VMs)
 
 ---
@@ -35,9 +35,9 @@
 - **Time:** 5 minutes
 - **Commands:**
   ```bash
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo chown -R autobot:autobot /var/lib/redis-stack"
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo chown -R autobot:autobot /var/log/redis-stack"
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo systemctl restart redis-stack-server"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "sudo chown -R autobot:autobot /var/lib/redis-stack"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "sudo chown -R autobot:autobot /var/log/redis-stack"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "sudo systemctl restart redis-stack-server"
   ```
 - **Success Criteria:** Redis service starts successfully, no permission errors in logs
 - **Risk:** Medium - Service restart required (but quick recovery)
@@ -48,9 +48,9 @@
 - **Time:** 3 minutes
 - **Commands:**
   ```bash
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "systemctl status redis-stack-server"
-  redis-cli -h 172.16.168.23 ping
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "ls -la /var/lib/redis-stack /var/log/redis-stack"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "systemctl status redis-stack-server"
+  redis-cli -h <database-ip> ping
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "ls -la /var/lib/redis-stack /var/log/redis-stack"
   ```
 - **Success Criteria:** Service active, PONG response, `autobot:autobot` ownership confirmed
 - **Dependencies:** Task 1.1 complete
@@ -141,11 +141,11 @@
   # Add new function after line 200 (in verification section)
   verify_redis_ownership() {
       echo "Verifying Redis ownership..."
-      local owner=$(ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "stat -c '%U:%G' /var/lib/redis-stack" 2>/dev/null)
+      local owner=$(ssh -i ~/.ssh/autobot_key autobot@<database-ip> "stat -c '%U:%G' /var/lib/redis-stack" 2>/dev/null)
       if [[ "$owner" != "autobot:autobot" ]]; then
           echo "WARNING: Redis ownership mismatch detected: $owner (expected autobot:autobot)"
           echo "Fixing ownership..."
-          ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo chown -R autobot:autobot /var/lib/redis-stack /var/log/redis-stack"
+          ssh -i ~/.ssh/autobot_key autobot@<database-ip> "sudo chown -R autobot:autobot /var/lib/redis-stack /var/log/redis-stack"
           echo "Ownership corrected."
       else
           echo "Redis ownership verified: autobot:autobot"
@@ -199,18 +199,18 @@
   sudo systemctl start autobot-backend
 
   # Test 2: Ownership auto-correction
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo chown -R redis:redis /var/lib/redis-stack"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "sudo chown -R redis:redis /var/lib/redis-stack"
   sudo systemctl restart autobot-backend
 
   # Test 3: Service restart
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo systemctl restart redis-stack-server"
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "stat -c '%U:%G' /var/lib/redis-stack"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "sudo systemctl restart redis-stack-server"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "stat -c '%U:%G' /var/lib/redis-stack"
 
   # Test 4: Ansible deployment
   ansible-playbook -i ansible/inventory ansible/playbooks/deploy-database.yml
 
   # Test 5 & 6: File/directory verification
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "find /var/lib/redis-stack /var/log/redis-stack -not -user autobot -o -not -group autobot"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "find /var/lib/redis-stack /var/log/redis-stack -not -user autobot -o -not -group autobot"
   ```
 - **Success Criteria:** All tests pass, ownership always `autobot:autobot`, no permission errors
 - **Dependencies:** Task 4.1 complete
@@ -237,8 +237,8 @@
 - **Time:** 3 minutes
 - **Commands:**
   ```bash
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo chown -R redis:redis /var/lib/redis-stack /var/log/redis-stack"
-  ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "sudo systemctl restart redis-stack-server"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "sudo chown -R redis:redis /var/lib/redis-stack /var/log/redis-stack"
+  ssh -i ~/.ssh/autobot_key autobot@<database-ip> "sudo systemctl restart redis-stack-server"
   ```
 
 #### Phase 2 Rollback (if Ansible playbook breaks)

--- a/docs/planning/tasks/backend-vulnerabilities-implementation-plan.md
+++ b/docs/planning/tasks/backend-vulnerabilities-implementation-plan.md
@@ -422,7 +422,7 @@ USE_ASYNC_REDIS = os.getenv("USE_ASYNC_REDIS", "false").lower() == "true"
     "session_id": "abc123",
     "user_id": "user_b",
     "owner_id": "user_a",
-    "ip_address": "172.16.168.21",
+    "ip_address": "<frontend-ip>",
     "vm_source": "frontend"
   }
   ```
@@ -1145,7 +1145,7 @@ USE_DISTRIBUTED_LOCKS = os.getenv("USE_DISTRIBUTED_LOCKS", "false") == "true"
 **3. Rollback Procedures**
 ```bash
 # Quick rollback (disable feature flag)
-curl -X POST https://172.16.168.20:8443/api/admin/feature-flags \
+curl -X POST https://<backend-ip>:8443/api/admin/feature-flags \
   -d '{"USE_ASYNC_REDIS": false}'
 
 # Full rollback (revert deployment)
@@ -1511,7 +1511,7 @@ await memory_graph.create_relation(
 **Level 1: Feature Flag Disable (30 seconds)**
 ```bash
 # Instant rollback via API
-curl -X POST https://172.16.168.20:8443/api/admin/feature-flags \
+curl -X POST https://<backend-ip>:8443/api/admin/feature-flags \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -d '{
     "USE_ASYNC_REDIS": false,

--- a/docs/planning/tasks/redis-service-management-implementation-tasks.md
+++ b/docs/planning/tasks/redis-service-management-implementation-tasks.md
@@ -140,7 +140,7 @@ result = await self.ssh_manager.execute_command(
 # Commands to execute:
 # 1. systemctl is-active redis-server
 # 2. systemctl status redis-server
-# 3. redis-cli -h 172.16.168.23 PING
+# 3. redis-cli -h <database-ip> PING
 ```
 
 ---
@@ -271,7 +271,7 @@ redis_service_management:
     name: "redis-server"
     systemd_unit: "redis-server.service"
     host: "redis"
-    ip: "172.16.168.23"
+    ip: "<database-ip>"
     port: 6379
 
   health_check:
@@ -501,7 +501,7 @@ async def test_full_service_restart_flow(test_client, admin_auth_token):
 
 **Acceptance Criteria:**
 - [ ] ConnectionHealthChecker class with async check method
-- [ ] Executes `redis-cli -h 172.16.168.23 PING` via SSH
+- [ ] Executes `redis-cli -h <database-ip> PING` via SSH
 - [ ] Measures response time in milliseconds
 - [ ] Returns HealthCheckResult (status, layer, response_time, error)
 - [ ] Timeout handling (5 seconds max)
@@ -515,7 +515,7 @@ class ConnectionHealthChecker:
         try:
             result = await ssh_manager.execute_command(
                 host='redis',
-                command='redis-cli -h 172.16.168.23 PING',
+                command='redis-cli -h <database-ip> PING',
                 timeout=5
             )
             response_time = (time.time() - start_time) * 1000
@@ -1269,7 +1269,7 @@ export default {
 **Priority:** P0 (Critical - Real-Time Updates)
 
 **Acceptance Criteria:**
-- [ ] WebSocket endpoint: `wss://172.16.168.20:8443/ws/services/redis/status`
+- [ ] WebSocket endpoint: `wss://<backend-ip>:8443/ws/services/redis/status`
 - [ ] Authentication via token (URL parameter or header)
 - [ ] Broadcast service status changes to all subscribed clients
 - [ ] Message types: service_status, service_event, auto_recovery
@@ -1463,7 +1463,7 @@ const subscribeToStatusUpdates = (callback) => {
 **E2E Test Example:**
 ```javascript
 test('Admin can restart Redis service from UI', async ({ page }) => {
-  await page.goto('http://172.16.168.21:5173/login');
+  await page.goto('http://<frontend-ip>:5173/login');
   await page.fill('[name="email"]', 'admin@autobot.local');
   await page.fill('[name="password"]', 'admin-password');
   await page.click('button[type="submit"]');
@@ -1700,7 +1700,7 @@ ansible redis -i ansible/inventory -m shell -a "sudo systemctl status redis-serv
     "email": "admin@autobot.local",
     "role": "admin"
   },
-  "source_ip": "172.16.168.20",
+  "source_ip": "<backend-ip>",
   "result": {
     "success": true,
     "duration_seconds": 15.7,
@@ -1854,7 +1854,7 @@ import time
 from httpx import AsyncClient
 
 async def load_test_status_endpoint(duration_seconds: int = 60):
-    client = AsyncClient(base_url="https://172.16.168.20:8443")
+    client = AsyncClient(base_url="https://<backend-ip>:8443")
 
     request_count = 0
     error_count = 0
@@ -2348,8 +2348,8 @@ REDIS-5.4.1 + REDIS-5.4.2 (Final Testing)
 
 **Development Environment:**
 - Local development on `/opt/autobot`
-- Backend testing against Redis VM (172.16.168.23)
-- Frontend testing on VM1 (172.16.168.21:5173)
+- Backend testing against Redis VM (<database-ip>)
+- Frontend testing on VM1 (<frontend-ip>:5173)
 - SSH key: `~/.ssh/autobot_key`
 
 **Deployment Strategy:**

--- a/docs/project/CONFIG_REMEDIATION_PLAN.md
+++ b/docs/project/CONFIG_REMEDIATION_PLAN.md
@@ -114,8 +114,8 @@ This project plan addresses **147 hardcoded configuration violations** identifie
 **Issue:**
 - Lines 15-16: Hardcoded Redis URLs with specific database numbers
 ```python
-broker=os.environ.get("CELERY_BROKER_URL", "redis://172.16.168.23:6379/1"),
-backend=os.environ.get("CELERY_RESULT_BACKEND", "redis://172.16.168.23:6379/2"),
+broker=os.environ.get("CELERY_BROKER_URL", "redis://<database-ip>:6379/1"),
+backend=os.environ.get("CELERY_RESULT_BACKEND", "redis://<database-ip>:6379/2"),
 ```
 
 **Should Be:**
@@ -226,13 +226,13 @@ ollama_endpoint = config.get(
 **Issue:**
 - Lines 233-239: Hardcoded IPs as defaults in the config manager itself
 ```python
-"backend": "172.16.168.20",
-"frontend": "172.16.168.21",
-"redis": "172.16.168.23",
-"ollama": "172.16.168.20",
-"ai_stack": "172.16.168.24",
-"npu_worker": "172.16.168.22",
-"browser_service": "172.16.168.25",
+"backend": "<backend-ip>",
+"frontend": "<frontend-ip>",
+"redis": "<database-ip>",
+"ollama": "<backend-ip>",
+"ai_stack": "<aiml-ip>",
+"npu_worker": "<npu-ip>",
+"browser_service": "<browser-ip>",
 ```
 
 **Should Be:** Read from `config/complete.yaml` infrastructure section, with NO hardcoded fallbacks
@@ -279,11 +279,11 @@ allow_origins = [
     "http://127.0.0.1:5173",
     "http://localhost:3000",
     "http://127.0.0.1:3000",
-    "http://172.16.168.20:5173",
-    "http://172.16.168.21:5173",
-    "http://172.16.168.20:3000",
-    "http://172.16.168.21:3000",
-    "http://172.16.168.25:3000",
+    "http://<backend-ip>:5173",
+    "http://<frontend-ip>:5173",
+    "http://<backend-ip>:3000",
+    "http://<frontend-ip>:3000",
+    "http://<browser-ip>:3000",
 ]
 ```
 
@@ -343,7 +343,7 @@ security:
 - Line 63: Hardcoded fallback to VM IP
 ```python
 self.redis_host = redis_host or redis_config.get(
-    "host", os.getenv("REDIS_HOST", "172.16.168.23")  # HARDCODED IP
+    "host", os.getenv("REDIS_HOST", "<database-ip>")  # HARDCODED IP
 )
 ```
 
@@ -386,7 +386,7 @@ self.redis_host = redis_host or redis_config.get(
 **Issue:**
 - Line 557: Hardcoded Ollama endpoint fallback
 ```python
-.get("endpoint", "http://172.16.168.20:11434"),  # HARDCODED
+.get("endpoint", "http://<backend-ip>:11434"),  # HARDCODED
 ```
 
 **Should Be:**
@@ -606,8 +606,8 @@ redis:
 **Issue:**
 - Lines 30-37: Hardcoded VM IPs as class constants
 ```python
-MAIN_MACHINE_IP: str = "172.16.168.20"
-FRONTEND_VM_IP: str = "172.16.168.21"
+MAIN_MACHINE_IP: str = "<backend-ip>"
+FRONTEND_VM_IP: str = "<frontend-ip>"
 # ... etc
 ```
 
@@ -1315,7 +1315,7 @@ timeouts:
 ```python
 def test_get_host_from_config():
     """Test host retrieval from config"""
-    assert config.get_host("redis") == "172.16.168.23"
+    assert config.get_host("redis") == "<database-ip>"
 
 def test_get_host_with_env_override():
     """Test environment variable override"""
@@ -1325,7 +1325,7 @@ def test_get_host_with_env_override():
 def test_get_cors_origins():
     """Test CORS origin generation"""
     origins = config.get_cors_origins()
-    assert "http://172.16.168.21:5173" in origins
+    assert "http://<frontend-ip>:5173" in origins
     assert "http://localhost:5173" in origins
 ```
 
@@ -2468,7 +2468,7 @@ backend:
 
 # 1. Add to config/complete.yaml
 new_service:
-  host: "172.16.168.30"
+  host: "<example-ip>"
   port: 9000
   timeout: 5.0
 
@@ -2481,7 +2481,7 @@ timeout = config.get("new_service.timeout", 5.0)
 
 # 3. Add tests
 def test_new_service_config():
-    assert config.get_host("new_service") == "172.16.168.30"
+    assert config.get_host("new_service") == "<example-ip>"
 ```
 
 ---

--- a/docs/research/INTEL_NPU_WINDOWS_DEPLOYMENT_ANALYSIS.md
+++ b/docs/research/INTEL_NPU_WINDOWS_DEPLOYMENT_ANALYSIS.md
@@ -242,7 +242,7 @@ pip install numpy>=1.24.0
 
 2. **Network Architecture:**
    ```
-   WSL2 Backend (172.16.168.20:8443)
+   WSL2 Backend (<backend-ip>:8443)
        ↓ HTTP
    Windows NPU Worker (Windows Host:8082)
        ↓ OpenVINO/NPU
@@ -323,12 +323,12 @@ pip install numpy>=1.24.0
 
 **Current Architecture:**
 ```
-WSL2 Main (172.16.168.20)
-  ├── VM1 Frontend (172.16.168.21)
-  ├── VM2 NPU Worker (172.16.168.22)  ← Currently in VM
-  ├── VM3 Redis (172.16.168.23)
-  ├── VM4 AI Stack (172.16.168.24)
-  └── VM5 Browser (172.16.168.25)
+WSL2 Main (<backend-ip>)
+  ├── VM1 Frontend (<frontend-ip>)
+  ├── VM2 NPU Worker (<npu-ip>)  ← Currently in VM
+  ├── VM3 Redis (<database-ip>)
+  ├── VM4 AI Stack (<aiml-ip>)
+  └── VM5 Browser (<browser-ip>)
 ```
 
 **Required Architecture with Windows NPU:**
@@ -336,11 +336,11 @@ WSL2 Main (172.16.168.20)
 Windows Host (192.168.x.x or localhost)
   └── NPU Worker Native (Port 8082)
         ↑ HTTP
-WSL2 Main (172.16.168.20)
-  ├── VM1 Frontend (172.16.168.21)
-  ├── VM3 Redis (172.16.168.23)
-  ├── VM4 AI Stack (172.16.168.24)
-  └── VM5 Browser (172.16.168.25)
+WSL2 Main (<backend-ip>)
+  ├── VM1 Frontend (<frontend-ip>)
+  ├── VM3 Redis (<database-ip>)
+  ├── VM4 AI Stack (<aiml-ip>)
+  └── VM5 Browser (<browser-ip>)
 ```
 
 **Changes Required:**
@@ -372,8 +372,8 @@ WSL2 Main (172.16.168.20)
 │  ┌────────────────────────────────┐    │
 │  │ WSL2 Ubuntu                    │    │
 │  │                                │    │
-│  │  Backend API (172.16.168.20)   │    │
-│  │  Remote VMs (172.16.168.21-25) │    │
+│  │  Backend API (<backend-ip>)   │    │
+│  │  Remote VMs (<frontend-ip>-25) │    │
 │  └────────────────────────────────┘    │
 └─────────────────────────────────────────┘
 ```
@@ -642,7 +642,7 @@ profiling_info = infer_request.get_profiling_info()
 ### 8.5 Rollback Plan
 
 **If migration fails:**
-1. Keep VM2 NPU worker (172.16.168.22) as CPU-only fallback
+1. Keep VM2 NPU worker (<npu-ip>) as CPU-only fallback
 2. Backend can detect NPU unavailability and fall back to CPU
 3. No data loss risk (stateless worker)
 

--- a/docs/research/REDIS_OWNERSHIP_CONFLICT_RESEARCH_REPORT.md
+++ b/docs/research/REDIS_OWNERSHIP_CONFLICT_RESEARCH_REPORT.md
@@ -29,7 +29,7 @@ A three-way configuration conflict has been identified in the Redis Stack deploy
 | **Ansible Playbook** | `redis-stack` | `redis-stack` | INTENDED | What deployment expects |
 | **Start Script** | `redis` | `redis` | EXECUTED | What manual script sets |
 
-### User/Group Existence on Redis VM (172.16.168.23)
+### User/Group Existence on Redis VM (<database-ip>)
 
 ```bash
 # Users that EXIST:
@@ -306,7 +306,7 @@ sudo chown redis:redis /var/lib/redis-stack /var/log/redis-stack
 
 This is already correct and matches the recommended solution.
 
-### 5. Update Systemd Service on Redis VM (172.16.168.23)
+### 5. Update Systemd Service on Redis VM (<database-ip>)
 
 **File on VM**: `/etc/systemd/system/redis-stack-server.service`
 
@@ -339,7 +339,7 @@ Group=redis
 - [ ] Commit all configuration changes
 
 ### Phase 3: Fix Directory Ownership (Redis VM)
-- [ ] SSH to Redis VM: `ssh -i ~/.ssh/autobot_key autobot@172.16.168.23`
+- [ ] SSH to Redis VM: `ssh -i ~/.ssh/autobot_key autobot@<database-ip>`
 - [ ] Stop Redis service: `sudo systemctl stop redis-stack-server`
 - [ ] Fix directory ownership: `sudo chown -R redis:redis /var/lib/redis-stack`
 - [ ] Fix log ownership: `sudo chown -R redis:redis /var/log/redis-stack`
@@ -347,19 +347,19 @@ Group=redis
 
 ### Phase 4: Deploy Updated Configuration (Ansible)
 - [ ] Deploy systemd service: `ansible-playbook -i ansible/inventory/production.yml ansible/playbooks/deploy-database.yml --tags systemd`
-- [ ] Verify service file deployed: `ssh autobot@172.16.168.23 "cat /etc/systemd/system/redis-stack-server.service | grep User="`
-- [ ] Reload systemd: `ssh autobot@172.16.168.23 "sudo systemctl daemon-reload"`
+- [ ] Verify service file deployed: `ssh autobot@<database-ip> "cat /etc/systemd/system/redis-stack-server.service | grep User="`
+- [ ] Reload systemd: `ssh autobot@<database-ip> "sudo systemctl daemon-reload"`
 
 ### Phase 5: Restart and Verify
-- [ ] Start Redis service: `ssh autobot@172.16.168.23 "sudo systemctl start redis-stack-server"`
-- [ ] Check service status: `ssh autobot@172.16.168.23 "sudo systemctl status redis-stack-server"`
-- [ ] Verify no permission errors: `ssh autobot@172.16.168.23 "sudo journalctl -u redis-stack-server -n 50 --no-pager | grep -i permission"`
-- [ ] Test Redis connectivity: `redis-cli -h 172.16.168.23 ping`
-- [ ] Verify RDB save works: `redis-cli -h 172.16.168.23 BGSAVE` (wait 10s) `redis-cli -h 172.16.168.23 LASTSAVE`
-- [ ] Check file ownership after save: `ssh autobot@172.16.168.23 "ls -la /var/lib/redis-stack/dump.rdb"`
+- [ ] Start Redis service: `ssh autobot@<database-ip> "sudo systemctl start redis-stack-server"`
+- [ ] Check service status: `ssh autobot@<database-ip> "sudo systemctl status redis-stack-server"`
+- [ ] Verify no permission errors: `ssh autobot@<database-ip> "sudo journalctl -u redis-stack-server -n 50 --no-pager | grep -i permission"`
+- [ ] Test Redis connectivity: `redis-cli -h <database-ip> ping`
+- [ ] Verify RDB save works: `redis-cli -h <database-ip> BGSAVE` (wait 10s) `redis-cli -h <database-ip> LASTSAVE`
+- [ ] Check file ownership after save: `ssh autobot@<database-ip> "ls -la /var/lib/redis-stack/dump.rdb"`
 
 ### Phase 6: Monitor and Validate
-- [ ] Monitor logs for 1 hour: `ssh autobot@172.16.168.23 "sudo journalctl -u redis-stack-server -f"`
+- [ ] Monitor logs for 1 hour: `ssh autobot@<database-ip> "sudo journalctl -u redis-stack-server -f"`
 - [ ] Verify RDB saves succeed at scheduled intervals
 - [ ] Confirm no permission denied errors
 - [ ] Validate backup system can access data files
@@ -431,17 +431,17 @@ If issues occur after implementation:
 
 ```bash
 # Check systemd service configuration
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "cat /etc/systemd/system/redis-stack-server.service"
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> "cat /etc/systemd/system/redis-stack-server.service"
 
 # Check directory ownership
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "ls -la /var/lib/redis-stack/"
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> "ls -la /var/lib/redis-stack/"
 
 # Check user existence
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "getent passwd redis; getent passwd redis-stack; getent passwd autobot"
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> "getent passwd redis; getent passwd redis-stack; getent passwd autobot"
 
 # Check service status and errors
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "systemctl status redis-stack-server"
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.23 "journalctl -u redis-stack-server | grep -i permission"
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> "systemctl status redis-stack-server"
+ssh -i ~/.ssh/autobot_key autobot@<database-ip> "journalctl -u redis-stack-server | grep -i permission"
 ```
 
 ---

--- a/docs/runbooks/ASSIGN_ROLE.md
+++ b/docs/runbooks/ASSIGN_ROLE.md
@@ -27,7 +27,7 @@ Before assigning, verify the role can coexist with existing roles on the node.
 
 ```bash
 # Check what roles are currently on the node
-curl -sk https://172.16.168.19/api/nodes/<node-id> \
+curl -sk https://<slm-manager-ip>/api/nodes/<node-id> \
   -H "Authorization: Bearer ${SLM_TOKEN}" \
   | jq '.roles'
 
@@ -55,7 +55,7 @@ Edit `autobot-slm-backend/ansible/inventory/slm-nodes.yml` to add the new role:
 
 ```yaml
 04-Database:
-  ansible_host: 172.16.168.23
+  ansible_host: <database-ip>
   ansible_user: autobot
   node_roles:
     - autobot-database
@@ -70,7 +70,7 @@ Edit `autobot-slm-backend/ansible/inventory/slm-nodes.yml` to add the new role:
 Register the new role assignment in SLM:
 
 ```bash
-curl -sk -X POST https://172.16.168.19/api/nodes/<node-id>/roles \
+curl -sk -X POST https://<slm-manager-ip>/api/nodes/<node-id>/roles \
   -H "Authorization: Bearer ${SLM_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{"role": "autobot-monitoring"}'
@@ -133,13 +133,13 @@ ansible-playbook playbooks/provision-fleet-roles.yml \
 
 ```bash
 # Check new role service is running
-ssh autobot@172.16.168.23 "systemctl status autobot-monitoring"
+ssh autobot@<database-ip> "systemctl status autobot-monitoring"
 
 # Check health endpoint
-curl -sk https://172.16.168.23/metrics    # Prometheus example
+curl -sk https://<database-ip>/metrics    # Prometheus example
 
 # Check SLM shows the new role
-curl -sk https://172.16.168.19/api/nodes/04-Database \
+curl -sk https://<slm-manager-ip>/api/nodes/04-Database \
   -H "Authorization: Bearer ${SLM_TOKEN}" \
   | jq '.roles'
 ```
@@ -165,7 +165,7 @@ ansible 04-Database -i inventory/slm-nodes.yml -m file \
 # Edit inventory/slm-nodes.yml: remove 'autobot-monitoring' from node_roles
 
 # 4. Update SLM DB
-curl -sk -X DELETE https://172.16.168.19/api/nodes/04-Database/roles/autobot-monitoring \
+curl -sk -X DELETE https://<slm-manager-ip>/api/nodes/04-Database/roles/autobot-monitoring \
   -H "Authorization: Bearer ${SLM_TOKEN}"
 ```
 

--- a/docs/runbooks/CODE_UPDATE.md
+++ b/docs/runbooks/CODE_UPDATE.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # Runbook: Deploy a Code Update
 
 **Issue #926 Phase 8** | Last updated: 2026-02-18
@@ -29,7 +31,7 @@ git push
 # → hook detects changed role, notifies SLM, SLM marks nodes OUTDATED
 
 # Trigger update from SLM GUI
-# https://172.16.168.19 → Code Sync → "Update All Nodes"
+# https://<slm-manager-ip> → Code Sync → "Update All Nodes"
 
 # Manual trigger via Ansible
 cd autobot-slm-backend/ansible
@@ -80,7 +82,7 @@ scripts/hooks/slm-post-commit
 ### 3. Trigger Fleet Update
 
 Via SLM GUI (recommended):
-1. Navigate to `https://172.16.168.19` → **Code Sync**
+1. Navigate to `https://<slm-manager-ip>` → **Code Sync**
 2. Review which nodes are `OUTDATED` and which commit they're on
 3. Click **"Update All"** or select individual nodes
 
@@ -99,7 +101,7 @@ CLI:
 
 ```bash
 # Watch node status
-watch -n 5 "curl -sk https://172.16.168.19/api/nodes \
+watch -n 5 "curl -sk https://<slm-manager-ip>/api/nodes \
   -H 'Authorization: Bearer ${SLM_TOKEN}' \
   | jq '.[] | {node_id, code_status}'"
 ```
@@ -108,16 +110,16 @@ watch -n 5 "curl -sk https://172.16.168.19/api/nodes \
 
 ```bash
 # Check all nodes are UP_TO_DATE
-curl -sk https://172.16.168.19/api/nodes \
+curl -sk https://<slm-manager-ip>/api/nodes \
   -H "Authorization: Bearer ${SLM_TOKEN}" \
   | jq '.[] | select(.code_status != "UP_TO_DATE") | {node_id, code_status}'
 # Expected: empty array
 
 # Check backend health
-ssh autobot@172.16.168.19 'curl --insecure https://172.16.168.20:8443/api/health'
+ssh autobot@<slm-manager-ip> 'curl --insecure https://<backend-ip>:8443/api/health'
 
 # Check frontend
-curl -sk https://172.16.168.21/api/health
+curl -sk https://<frontend-ip>/api/health
 ```
 
 ---
@@ -172,7 +174,7 @@ git checkout <old-commit-hash>
 # 2. Rsync to SLM cache manually
 rsync -av --exclude='node_modules' --exclude='venv' \
   autobot-backend/ \
-  autobot@172.16.168.19:/opt/autobot/cache/autobot-backend/
+  autobot@<slm-manager-ip>:/opt/autobot/cache/autobot-backend/
 
 # 3. Trigger update
 cd autobot-slm-backend/ansible
@@ -203,9 +205,9 @@ git stash pop
 ## Post-Update Verification Checklist
 
 - [ ] All nodes show `code_status: UP_TO_DATE` in SLM
-- [ ] Backend health check returns 200: `curl -sk https://172.16.168.19 'curl --insecure https://172.16.168.20:8443/api/health'`
-- [ ] Frontend serves updated build: `curl -sk https://172.16.168.21/ | grep <version-or-feature>`
-- [ ] No error spikes in logs: `ssh autobot@172.16.168.20 "tail -50 /var/log/autobot/backend.log" | grep -i error`
+- [ ] Backend health check returns 200: `curl -sk https://<slm-manager-ip> 'curl --insecure https://<backend-ip>:8443/api/health'`
+- [ ] Frontend serves updated build: `curl -sk https://<frontend-ip>/ | grep <version-or-feature>`
+- [ ] No error spikes in logs: `ssh autobot@<backend-ip> "tail -50 /var/log/autobot/backend.log" | grep -i error`
 
 ---
 

--- a/docs/runbooks/DEPLOY_NEW_NODE.md
+++ b/docs/runbooks/DEPLOY_NEW_NODE.md
@@ -12,7 +12,7 @@ This runbook describes how to bring a new Ubuntu 22.04 VM into the AutoBot fleet
 
 ## Prerequisites
 
-- Ubuntu 22.04 VM with network access to `172.16.168.0/24`
+- Ubuntu 22.04 VM with network access to `<network-subnet>`
 - VM is reachable from dev machine via SSH (password or initial key)
 - `autobot-slm-backend/ansible/` is the working directory
 - SLM server (`.19`) is running and healthy
@@ -25,15 +25,15 @@ Pick the next available IP from the fleet subnet. Currently assigned:
 
 | IP | Role |
 |----|------|
-| `172.16.168.19` | SLM Server |
-| `172.16.168.20` | Backend |
-| `172.16.168.21` | Frontend |
-| `172.16.168.22` | NPU |
-| `172.16.168.23` | Database |
-| `172.16.168.24` | AI Stack |
-| `172.16.168.25` | Browser |
-| `172.16.168.26` | Reserved |
-| `172.16.168.27` | Reserved |
+| `<slm-manager-ip>` | SLM Server |
+| `<backend-ip>` | Backend |
+| `<frontend-ip>` | Frontend |
+| `<npu-ip>` | NPU |
+| `<database-ip>` | Database |
+| `<aiml-ip>` | AI Stack |
+| `<browser-ip>` | Browser |
+| `<reserved-ip>` | Reserved |
+| `<reserved-ip>` | Reserved |
 
 Configure static IP on the new VM (via `/etc/netplan/` or your hypervisor's DHCP reservation).
 
@@ -101,7 +101,7 @@ Add the node to the SLM database. Either via SLM API or seed script:
 
 ```bash
 # Via API
-curl -sk -X POST https://172.16.168.19/api/nodes \
+curl -sk -X POST https://<slm-manager-ip>/api/nodes \
   -H "Authorization: Bearer ${SLM_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -152,7 +152,7 @@ This generates a CA-signed cert and reports it to SLM's `security/certificates` 
 
 ```bash
 # Check node appears in SLM dashboard
-curl -sk https://172.16.168.19/api/nodes | jq '.[] | select(.node_id=="08-NewRole")'
+curl -sk https://<slm-manager-ip>/api/nodes | jq '.[] | select(.node_id=="08-NewRole")'
 
 # Test role health endpoint
 curl -sk https://172.16.168.XX:<port>/health

--- a/docs/runbooks/EMERGENCY_RECOVERY.md
+++ b/docs/runbooks/EMERGENCY_RECOVERY.md
@@ -34,8 +34,8 @@ If `autobot_ed25519` and `autobot_admin_temp_ed25519` both fail, you need consol
 
 ```bash
 # Test each key explicitly
-ssh -i ~/.ssh/autobot_ed25519 -o BatchMode=yes autobot@172.16.168.19 "echo ok" 2>&1
-ssh -i ~/.ssh/autobot_admin_temp_ed25519 -o BatchMode=yes autobot@172.16.168.19 "echo ok" 2>&1
+ssh -i ~/.ssh/autobot_ed25519 -o BatchMode=yes autobot@<slm-manager-ip> "echo ok" 2>&1
+ssh -i ~/.ssh/autobot_admin_temp_ed25519 -o BatchMode=yes autobot@<slm-manager-ip> "echo ok" 2>&1
 ```
 
 **Step 2: Use VM console (Hyper-V / VMware / KVM)**
@@ -68,32 +68,32 @@ ansible-playbook playbooks/rotate-ssh-keys.yml -i inventory/slm-nodes.yml
 
 ## SLM Recovery
 
-### Scenario: SLM server unreachable (172.16.168.19)
+### Scenario: SLM server unreachable (<slm-manager-ip>)
 
 **Step 1: Check SLM service status via SSH**
 
 ```bash
-ssh autobot@172.16.168.19 "sudo systemctl status autobot-slm-backend"
+ssh autobot@<slm-manager-ip> "sudo systemctl status autobot-slm-backend"
 ```
 
 **Step 2: Check logs**
 
 ```bash
-ssh autobot@172.16.168.19 "sudo journalctl -u autobot-slm-backend -n 100 --no-pager"
+ssh autobot@<slm-manager-ip> "sudo journalctl -u autobot-slm-backend -n 100 --no-pager"
 ```
 
 **Step 3: Restart SLM services**
 
 ```bash
-ssh autobot@172.16.168.19 "sudo systemctl restart autobot-slm-backend nginx"
+ssh autobot@<slm-manager-ip> "sudo systemctl restart autobot-slm-backend nginx"
 ```
 
 **Step 4: If DB is corrupt, recover from backup**
 
 ```bash
-ssh autobot@172.16.168.19 "sudo systemctl stop autobot-slm-backend"
-ssh autobot@172.16.168.19 "sudo -u postgres pg_restore -d autobot_slm /opt/autobot/data/backups/latest.dump"
-ssh autobot@172.16.168.19 "sudo systemctl start autobot-slm-backend"
+ssh autobot@<slm-manager-ip> "sudo systemctl stop autobot-slm-backend"
+ssh autobot@<slm-manager-ip> "sudo -u postgres pg_restore -d autobot_slm /opt/autobot/data/backups/latest.dump"
+ssh autobot@<slm-manager-ip> "sudo systemctl start autobot-slm-backend"
 ```
 
 **Step 5: If full redeploy needed**
@@ -113,20 +113,20 @@ ansible-playbook playbooks/deploy-slm-manager.yml -i inventory/slm-nodes.yml --l
 **Step 1: Ping check**
 
 ```bash
-ping -c 3 172.16.168.<node-ip>
+ping -c 3 <new-node-ip>
 ```
 
 **Step 2: Check if service is running (via another reachable node)**
 
 ```bash
 # From SLM server
-ssh autobot@172.16.168.19 "curl -sk https://172.16.168.<node-ip>:8443/api/health"
+ssh autobot@<slm-manager-ip> "curl -sk https://<new-node-ip>:8443/api/health"
 ```
 
 **Step 3: If node OS is up but service is down**
 
 ```bash
-ssh autobot@172.16.168.<node-ip> "sudo systemctl restart autobot-<role>"
+ssh autobot@<new-node-ip> "sudo systemctl restart autobot-<role>"
 ```
 
 **Step 4: Reprovision the node**
@@ -176,7 +176,7 @@ The SLM backend sets the admin password from `/etc/autobot/slm-secrets.env` on s
 **Step 1: Read current password from secrets file**
 
 ```bash
-ssh autobot@172.16.168.19 "sudo cat /etc/autobot/slm-secrets.env | grep ADMIN_PASSWORD"
+ssh autobot@<slm-manager-ip> "sudo cat /etc/autobot/slm-secrets.env | grep ADMIN_PASSWORD"
 ```
 
 **Step 2: If file is missing, regenerate via Ansible**
@@ -190,7 +190,7 @@ ansible-playbook playbooks/deploy-slm-manager.yml --tags secrets -i inventory/sl
 **Step 3: Reset password directly in DB (last resort)**
 
 ```bash
-ssh autobot@172.16.168.19
+ssh autobot@<slm-manager-ip>
 # Generate hash:
 python3 -c "import bcrypt; print(bcrypt.hashpw(b'NEW_PASSWORD', bcrypt.gensalt()).decode())"
 # Update DB:
@@ -214,7 +214,7 @@ reconstruct the break-glass credentials.
 
 ```bash
 # Fetch Part A from SLM
-ssh autobot@172.16.168.19 "sudo cat /etc/autobot/keys/break-glass-a.enc"
+ssh autobot@<slm-manager-ip> "sudo cat /etc/autobot/keys/break-glass-a.enc"
 
 # Decrypt using Parts B and C (GPG)
 gpg --decrypt break-glass.enc

--- a/docs/runbooks/ROTATE_CERTS.md
+++ b/docs/runbooks/ROTATE_CERTS.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # Runbook: Rotate TLS Certificates
 
 **Issue #926 Phase 7** | Last updated: 2026-02-18
@@ -75,9 +77,9 @@ Expected output per node:
 ansible-playbook playbooks/rotate-certs.yml --tags check
 
 # Verify HTTPS connectivity
-curl --insecure -v https://172.16.168.19/ 2>&1 | grep "expire date"
-curl --insecure -v https://172.16.168.21/ 2>&1 | grep "expire date"
-ssh autobot@172.16.168.19 "curl --insecure -v https://172.16.168.20:8443/api/health 2>&1 | grep 'expire date'"
+curl --insecure -v https://<slm-manager-ip>/ 2>&1 | grep "expire date"
+curl --insecure -v https://<frontend-ip>/ 2>&1 | grep "expire date"
+ssh autobot@<slm-manager-ip> "curl --insecure -v https://<backend-ip>:8443/api/health 2>&1 | grep 'expire date'"
 ```
 
 ### 5. Update SLM Cert Records (optional)
@@ -115,7 +117,7 @@ If the new cert causes issues, restore the backup:
 
 ```bash
 # On a specific node (example: SLM server)
-ssh autobot@172.16.168.19 "sudo cp /etc/autobot/certs/server-cert.pem.bak /etc/autobot/certs/server-cert.pem && sudo systemctl reload nginx"
+ssh autobot@<slm-manager-ip> "sudo cp /etc/autobot/certs/server-cert.pem.bak /etc/autobot/certs/server-cert.pem && sudo systemctl reload nginx"
 ```
 
 Or via Ansible:

--- a/docs/runbooks/ROTATE_SSH_KEYS.md
+++ b/docs/runbooks/ROTATE_SSH_KEYS.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # Runbook: Rotate SSH Keys
 
 **Issue #926 Phase 7** | Last updated: 2026-02-18
@@ -94,9 +96,9 @@ are not rolled back (they are safe to leave in place).
 
 ```bash
 # Test direct SSH with new key
-ssh -i ~/.ssh/autobot_ed25519 autobot@172.16.168.19 "hostname"
-ssh -i ~/.ssh/autobot_ed25519 autobot@172.16.168.20 "hostname"
-ssh -i ~/.ssh/autobot_ed25519 autobot@172.16.168.21 "hostname"
+ssh -i ~/.ssh/autobot_ed25519 autobot@<slm-manager-ip> "hostname"
+ssh -i ~/.ssh/autobot_ed25519 autobot@<backend-ip> "hostname"
+ssh -i ~/.ssh/autobot_ed25519 autobot@<frontend-ip> "hostname"
 
 # Test Ansible connectivity
 ansible all -i inventory/slm-nodes.yml -m ping
@@ -136,14 +138,14 @@ If you've rotated to a broken key but the safety-net key is still present:
 
 ```bash
 # SSH in with safety-net key
-ssh -i ~/.ssh/autobot_admin_temp_ed25519 autobot@172.16.168.19
+ssh -i ~/.ssh/autobot_admin_temp_ed25519 autobot@<slm-manager-ip>
 
 # Restore old key (from backup)
 cat ~/.ssh/autobot_ed25519.bak >> ~/.ssh/authorized_keys
 
 # Remove broken new key
 # (identify fingerprint from: ssh-keygen -l -f ~/.ssh/autobot_ed25519_new.pub)
-ssh-keygen -R 172.16.168.19
+ssh-keygen -R <slm-manager-ip>
 ```
 
 ---

--- a/docs/runbooks/SYSTEM_UPDATE.md
+++ b/docs/runbooks/SYSTEM_UPDATE.md
@@ -140,8 +140,8 @@ ansible 01-Backend -i inventory/slm-nodes.yml -m reboot --become
 ansible-playbook playbooks/system-update.yml --tags check -i inventory/slm-nodes.yml
 
 # Check services are healthy
-ssh autobot@172.16.168.19 "systemctl is-active autobot-slm-backend"
-ssh autobot@172.16.168.19 'curl --insecure https://172.16.168.20:8443/api/health | jq .status'
+ssh autobot@<slm-manager-ip> "systemctl is-active autobot-slm-backend"
+ssh autobot@<slm-manager-ip> 'curl --insecure https://<backend-ip>:8443/api/health | jq .status'
 ```
 
 ---
@@ -154,7 +154,7 @@ Kernel updates require a reboot to take effect. Use the same reboot procedure ab
 - Reboot `.23` (database/Redis) only during scheduled maintenance — all backends will lose Redis connection temporarily
 
 After rebooting `.19`:
-1. Wait for SLM health check: `curl -sk https://172.16.168.19/api/health`
+1. Wait for SLM health check: `curl -sk https://<slm-manager-ip>/api/health`
 2. Verify SLM agents reconnect: SLM GUI → Fleet Overview → all nodes reconnect within 60s
 
 ---

--- a/docs/security/ACCESS_CONTROL_SAFE_ROLLOUT_GUIDE.md
+++ b/docs/security/ACCESS_CONTROL_SAFE_ROLLOUT_GUIDE.md
@@ -132,7 +132,7 @@ python -m uvicorn backend.app_factory:app --host 0.0.0.0 --port 8001 --reload
 ### Step 2: Verify Backend Running
 
 ```bash
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 # Expected: {"status": "healthy", ...}
 ```
 
@@ -155,7 +155,7 @@ python -m pytest tests/security/test_access_control_penetration.py -v
 
 ```bash
 # Check that unauthorized access attempts are being logged
-redis-cli -h 172.16.168.23 -p 6379 -n 10
+redis-cli -h <database-ip> -p 6379 -n 10
 > KEYS audit:*
 > ZRANGE audit:log:2025-10-06 0 -1 WITHSCORES
 ```
@@ -175,12 +175,12 @@ Expected audit entries for denied access:
 
 ```bash
 # Test 1: Authorized access (should succeed)
-curl -X GET https://172.16.168.20:8443/api/chat/sessions/YOUR_SESSION_ID \
+curl -X GET https://<backend-ip>:8443/api/chat/sessions/YOUR_SESSION_ID \
   -H "X-Username: admin"
 # Expected: 200 OK with messages
 
 # Test 2: Unauthorized access (should be blocked)
-curl -X GET https://172.16.168.20:8443/api/chat/sessions/SOMEONE_ELSES_SESSION \
+curl -X GET https://<backend-ip>:8443/api/chat/sessions/SOMEONE_ELSES_SESSION \
   -H "X-Username: attacker"
 # Expected: 403 Forbidden {"detail": "You do not have permission to access this conversation"}
 ```
@@ -238,7 +238,7 @@ pytest tests/security/test_access_control_penetration.py -v
 ```bash
 # Ownership validation should add < 10ms overhead
 curl -w "@curl-format.txt" -o /dev/null -s \
-  https://172.16.168.20:8443/api/chat/sessions/YOUR_SESSION
+  https://<backend-ip>:8443/api/chat/sessions/YOUR_SESSION
 # time_total should be < previous_time + 10ms
 ```
 
@@ -261,7 +261,7 @@ pkill -f "uvicorn.*backend"
 python -m uvicorn backend.app_factory:app --host 0.0.0.0 --port 8001 --reload
 
 # 3. Verify rollback
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 ```
 
 ### Full Rollback with Git

--- a/docs/security/BACKFILL_EXEC_SUMMARY.md
+++ b/docs/security/BACKFILL_EXEC_SUMMARY.md
@@ -56,11 +56,11 @@ python3 scripts/security/backfill_conversation_ownership.py --dry-run
 ### Phase 3: Production (30 minutes)
 ```bash
 # Backup Redis
-redis-cli -h 172.16.168.23 BGSAVE
+redis-cli -h <database-ip> BGSAVE
 
 # Execute backfill
 python3 scripts/security/backfill_conversation_ownership.py \
-    --redis-host 172.16.168.23 \
+    --redis-host <database-ip> \
     --default-owner admin \
     --ttl-days 90
 ```
@@ -71,7 +71,7 @@ python3 scripts/security/backfill_conversation_ownership.py \
 python3 scripts/security/verify_ownership_backfill.py
 
 # Check Redis
-redis-cli -h 172.16.168.23 -n 0 KEYS "chat_session_owner:*" | wc -l
+redis-cli -h <database-ip> -n 0 KEYS "chat_session_owner:*" | wc -l
 # Expected: 54
 ```
 

--- a/docs/security/ENFORCEMENT_ACTIVATION_READY.md
+++ b/docs/security/ENFORCEMENT_ACTIVATION_READY.md
@@ -13,13 +13,13 @@
 ```
 Status: healthy
 Uptime: Operational
-API Endpoint: https://172.16.168.20:8443
+API Endpoint: https://<backend-ip>:8443
 ```
 
 **Frontend Accessibility**: ✅ Accessible
 ```
 Status Code: 200 OK
-Frontend URL: http://172.16.168.21:5173
+Frontend URL: http://<frontend-ip>:5173
 ```
 
 **Authentication Failures**: ✅ ZERO
@@ -61,10 +61,10 @@ Error patterns: None detected
 
 **Deployed and Verified**:
 - ✅ main-backend: `/etc/autobot/service-keys/main-backend.env`
-- ✅ npu-worker: Deployed to VM 22 (172.16.168.22)
-- ✅ ai-stack: Deployed to VM 24 (172.16.168.24)
-- ✅ browser-service: Deployed to VM 25 (172.16.168.25)
-- ✅ frontend: Deployed to VM 21 (172.16.168.21)
+- ✅ npu-worker: Deployed to VM 22 (<npu-ip>)
+- ✅ ai-stack: Deployed to VM 24 (<aiml-ip>)
+- ✅ browser-service: Deployed to VM 25 (<browser-ip>)
+- ✅ frontend: Deployed to VM 21 (<frontend-ip>)
 
 ---
 
@@ -77,10 +77,10 @@ Error patterns: None detected
 
 **Service Communication Pattern**:
 ```
-Backend (172.16.168.20:8443)
-    ├─> NPU Worker (172.16.168.22:8081)      [passive receiver]
-    ├─> AI Stack (172.16.168.24:8080)        [passive receiver]
-    └─> Browser Service (172.16.168.25:3000) [passive receiver]
+Backend (<backend-ip>:8443)
+    ├─> NPU Worker (<npu-ip>:8081)      [passive receiver]
+    ├─> AI Stack (<aiml-ip>:8080)        [passive receiver]
+    └─> Browser Service (<browser-ip>:3000) [passive receiver]
 ```
 
 **Remote Service Backend Calls**:
@@ -139,8 +139,8 @@ Backend (172.16.168.20:8443)
 **Attack Vector**:
 ```bash
 # Currently succeeds (vulnerability exploitable)
-curl -X POST https://172.16.168.20:8443/api/npu/heartbeat
-curl -X POST https://172.16.168.20:8443/api/ai-stack/results
+curl -X POST https://<backend-ip>:8443/api/npu/heartbeat
+curl -X POST https://<backend-ip>:8443/api/ai-stack/results
 ```
 
 ### Post-Enforcement State
@@ -153,7 +153,7 @@ curl -X POST https://172.16.168.20:8443/api/ai-stack/results
 **Attack Prevention**:
 ```bash
 # Will return 401 Unauthorized
-curl -X POST https://172.16.168.20:8443/api/npu/heartbeat
+curl -X POST https://<backend-ip>:8443/api/npu/heartbeat
 # Response: {"detail": "Missing authentication headers", "authenticated": false}
 ```
 
@@ -182,7 +182,7 @@ export SERVICE_AUTH_ENFORCEMENT_MODE=false
 sudo systemctl restart autobot-backend
 
 # Verify rollback
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 ```
 
 **Recovery Time**: < 2 minutes

--- a/docs/security/FILE_PERMISSIONS_SECURITY_ARCHITECTURE.md
+++ b/docs/security/FILE_PERMISSIONS_SECURITY_ARCHITECTURE.md
@@ -1092,7 +1092,7 @@ class TestFileAuthE2E:
         page = browser_page
 
         # Navigate to login page
-        page.goto("http://172.16.168.21:5173/login")
+        page.goto("http://<frontend-ip>:5173/login")
 
         # Fill login form
         page.fill('input[type="text"]', "developer")
@@ -1118,7 +1118,7 @@ class TestFileAuthE2E:
         page = browser_page
 
         # Try to access protected page without authentication
-        page.goto("http://172.16.168.21:5173/files")
+        page.goto("http://<frontend-ip>:5173/files")
 
         # Should redirect to login
         page.wait_for_url("**/login", timeout=5000)
@@ -1131,14 +1131,14 @@ class TestFileAuthE2E:
         page = browser_page
 
         # Login first
-        page.goto("http://172.16.168.21:5173/login")
+        page.goto("http://<frontend-ip>:5173/login")
         page.fill('input[type="text"]', "developer")
         page.fill('input[type="password"]', "dev123secure")
         page.click('button[type="submit"]')
         page.wait_for_url("**/dashboard", timeout=5000)
 
         # Navigate to files page
-        page.goto("http://172.16.168.21:5173/files")
+        page.goto("http://<frontend-ip>:5173/files")
 
         # Monitor network requests
         requests_with_auth = []
@@ -1161,7 +1161,7 @@ class TestFileAuthE2E:
         page = browser_page
 
         # Login
-        page.goto("http://172.16.168.21:5173/login")
+        page.goto("http://<frontend-ip>:5173/login")
         page.fill('input[type="text"]', "developer")
         page.fill('input[type="password"]', "dev123secure")
         page.click('button[type="submit"]')
@@ -1227,10 +1227,10 @@ grep "enable_auth: true" config/config.yaml
 pip list | grep -E "fastapi|pydantic|jwt"
 
 # 3. Verify backend running
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 
 # 4. Verify frontend accessible
-curl http://172.16.168.21:5173
+curl http://<frontend-ip>:5173
 ```
 
 **Backup Critical Files**:
@@ -1273,7 +1273,7 @@ sudo systemctl restart autobot-backend
 ./scripts/utilities/sync-to-vm.sh ai-stack autobot-backend/api/files.py /home/autobot/autobot-backend/api/
 
 # Step 2.5: Restart backend
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.24 "supervisorctl restart autobot-backend"
+ssh -i ~/.ssh/autobot_key autobot@<aiml-ip> "supervisorctl restart autobot-backend"
 ```
 
 **Phase 3: Backend Testing** (15 minutes)
@@ -1286,14 +1286,14 @@ pytest tests/integration/test_file_auth_integration.py -v
 
 # Step 3.3: Manual API testing
 # Try to access file endpoint without auth (should fail with 401)
-curl https://172.16.168.20:8443/api/files/view?path=test.txt
+curl https://<backend-ip>:8443/api/files/view?path=test.txt
 
 # Try with valid token (should succeed)
-TOKEN=$(curl -X POST https://172.16.168.20:8443/api/auth/login \
+TOKEN=$(curl -X POST https://<backend-ip>:8443/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"developer","password":"dev123secure"}' | jq -r .token)
 
-curl https://172.16.168.20:8443/api/files/view?path=test.txt \
+curl https://<backend-ip>:8443/api/files/view?path=test.txt \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -1319,10 +1319,10 @@ curl https://172.16.168.20:8443/api/files/view?path=test.txt \
 ./scripts/utilities/sync-to-vm.sh frontend autobot-frontend/src/ /home/autobot/autobot-frontend/src/
 
 # Step 4.6: Rebuild frontend
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "cd /home/autobot/autobot-vue && npm run build"
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "cd /home/autobot/autobot-vue && npm run build"
 
 # Step 4.7: Restart frontend
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "supervisorctl restart autobot-frontend"
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "supervisorctl restart autobot-frontend"
 ```
 
 **Phase 5: End-to-End Testing** (30 minutes)
@@ -1331,7 +1331,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "supervisorctl restart autobot-f
 pytest tests/e2e/test_file_auth_e2e.py -v
 
 # Step 5.2: Manual browser testing
-# Open http://172.16.168.21:5173
+# Open http://<frontend-ip>:5173
 # Try to access /files without login (should redirect to /login)
 # Login with credentials
 # Access /files (should work)
@@ -1366,21 +1366,21 @@ tail -f logs/backend.log | grep ERROR
 # Step 1: Restore backend files
 cp autobot-backend/api/files.py.backup.* autobot-backend/api/files.py
 ./scripts/utilities/sync-to-vm.sh ai-stack autobot-backend/api/files.py /home/autobot/autobot-backend/api/
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.24 "supervisorctl restart autobot-backend"
+ssh -i ~/.ssh/autobot_key autobot@<aiml-ip> "supervisorctl restart autobot-backend"
 
 # Step 2: Restore frontend files
 cp autobot-frontend/autobot-backend/utils/ApiClient.ts.backup.* autobot-frontend/autobot-backend/utils/ApiClient.ts
 ./scripts/utilities/sync-to-vm.sh frontend autobot-frontend/src/ /home/autobot/autobot-frontend/src/
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "cd /home/autobot/autobot-vue && npm run build"
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "supervisorctl restart autobot-frontend"
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "cd /home/autobot/autobot-vue && npm run build"
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "supervisorctl restart autobot-frontend"
 
 # Step 3: Disable auth temporarily (emergency only)
 # Edit config/config.yaml and set enable_auth: false
 sudo systemctl restart autobot-backend
 
 # Step 4: Verify system operational
-curl https://172.16.168.20:8443/api/health
-curl http://172.16.168.21:5173
+curl https://<backend-ip>:8443/api/health
+curl http://<frontend-ip>:5173
 ```
 
 ### 5.4 Post-Deployment Validation
@@ -1390,7 +1390,7 @@ curl http://172.16.168.21:5173
 # 1. All file endpoints return 401 without auth
 for endpoint in view upload delete download create list; do
   echo "Testing /api/files/$endpoint"
-  response=$(curl -s -o /dev/null -w "%{http_code}" https://172.16.168.20:8443/api/files/$endpoint)
+  response=$(curl -s -o /dev/null -w "%{http_code}" https://<backend-ip>:8443/api/files/$endpoint)
   if [ "$response" = "401" ]; then
     echo "✓ $endpoint requires auth"
   else
@@ -1399,7 +1399,7 @@ for endpoint in view upload delete download create list; do
 done
 
 # 2. Authenticated requests work correctly
-TOKEN=$(curl -X POST https://172.16.168.20:8443/api/auth/login \
+TOKEN=$(curl -X POST https://<backend-ip>:8443/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"developer","password":"dev123secure"}' | jq -r .token)
 
@@ -1407,7 +1407,7 @@ for endpoint in view list; do
   echo "Testing authenticated /api/files/$endpoint"
   response=$(curl -s -o /dev/null -w "%{http_code}" \
     -H "Authorization: Bearer $TOKEN" \
-    "https://172.16.168.20:8443/api/files/$endpoint?path=.")
+    "https://<backend-ip>:8443/api/files/$endpoint?path=.")
   if [ "$response" = "200" ]; then
     echo "✓ $endpoint works with auth"
   else
@@ -1541,14 +1541,14 @@ Authorization: Bearer {jwt_token}
 
 **Getting a Token**:
 ```bash
-curl -X POST https://172.16.168.20:8443/api/auth/login \
+curl -X POST https://<backend-ip>:8443/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"your_username","password":"your_password"}'
 ```
 
 **Example Authenticated Request**:
 ```bash
-curl -X GET https://172.16.168.20:8443/api/files/view?path=test.txt \
+curl -X GET https://<backend-ip>:8443/api/files/view?path=test.txt \
   -H "Authorization: Bearer {your_token}"
 ```
 
@@ -1653,7 +1653,7 @@ vim autobot-backend/api/files.py
 ./scripts/utilities/sync-to-vm.sh ai-stack autobot-backend/api/files.py /home/autobot/autobot-backend/api/
 
 # Restart backend
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.24 "supervisorctl restart autobot-backend"
+ssh -i ~/.ssh/autobot_key autobot@<aiml-ip> "supervisorctl restart autobot-backend"
 ```
 
 **Frontend Deployment**:
@@ -1665,7 +1665,7 @@ vim autobot-frontend/autobot-backend/utils/ApiClient.ts
 ./scripts/utilities/sync-to-vm.sh frontend autobot-frontend/src/ /home/autobot/autobot-frontend/src/
 
 # Rebuild and restart
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "cd /home/autobot/autobot-vue && npm run build && supervisorctl restart autobot-frontend"
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "cd /home/autobot/autobot-vue && npm run build && supervisorctl restart autobot-frontend"
 ```
 
 **Testing**:

--- a/docs/security/OWNERSHIP_BACKFILL_ANALYSIS.md
+++ b/docs/security/OWNERSHIP_BACKFILL_ANALYSIS.md
@@ -60,7 +60,7 @@ AutoBot uses **TWO SEPARATE** conversation storage systems:
 - **Session ID Format**: UUID, `session_{number}`, `test-session-{id}`, or custom
 
 #### System C: Session Ownership (Security Layer)
-- **Location**: Redis DB 0 (172.16.168.23:6379)
+- **Location**: Redis DB 0 (<database-ip>:6379)
 - **Manager**: `backend/security/session_ownership.py`
 - **Schema**:
   ```
@@ -349,8 +349,8 @@ CREATE INDEX idx_ownership_backfilled ON conversation_ownership(is_backfilled);
 1. **Stop backfill script** (if still running)
 2. **Delete all ownership keys**:
    ```bash
-   redis-cli -h 172.16.168.23 -p 6379 -n 0 DEL chat_session_owner:*
-   redis-cli -h 172.16.168.23 -p 6379 -n 0 DEL user_chat_sessions:*
+   redis-cli -h <database-ip> -p 6379 -n 0 DEL chat_session_owner:*
+   redis-cli -h <database-ip> -p 6379 -n 0 DEL user_chat_sessions:*
    ```
 3. **Re-run backfill** with corrected logic
 4. **Verify** ownership assignment
@@ -387,10 +387,10 @@ CREATE INDEX idx_ownership_backfilled ON conversation_ownership(is_backfilled);
 **Step 1: Environment Preparation**
 ```bash
 # Backup Redis DB 0
-redis-cli -h 172.16.168.23 -p 6379 BGSAVE
+redis-cli -h <database-ip> -p 6379 BGSAVE
 
 # Verify backup completed
-redis-cli -h 172.16.168.23 -p 6379 LASTSAVE
+redis-cli -h <database-ip> -p 6379 LASTSAVE
 
 # Copy backup to safe location
 docker cp autobot-redis-stack:/data/dump.rdb backups/redis_pre_backfill_$(date +%Y%m%d_%H%M%S).rdb
@@ -400,7 +400,7 @@ docker cp autobot-redis-stack:/data/dump.rdb backups/redis_pre_backfill_$(date +
 ```bash
 # Execute backfill (async, non-blocking)
 python3 scripts/security/backfill_conversation_ownership.py \
-    --redis-host 172.16.168.23 \
+    --redis-host <database-ip> \
     --redis-port 6379 \
     --redis-db 0 \
     --default-owner admin \
@@ -409,7 +409,7 @@ python3 scripts/security/backfill_conversation_ownership.py \
 
 # After dry-run validation, run for real
 python3 scripts/security/backfill_conversation_ownership.py \
-    --redis-host 172.16.168.23 \
+    --redis-host <database-ip> \
     --redis-port 6379 \
     --redis-db 0 \
     --default-owner admin \
@@ -419,27 +419,27 @@ python3 scripts/security/backfill_conversation_ownership.py \
 **Step 3: Verification**
 ```bash
 # Count ownership keys created
-redis-cli -h 172.16.168.23 -p 6379 -n 0 KEYS "chat_session_owner:*" | wc -l
+redis-cli -h <database-ip> -p 6379 -n 0 KEYS "chat_session_owner:*" | wc -l
 # Expected: 54
 
 # Verify admin user session set
-redis-cli -h 172.16.168.23 -p 6379 -n 0 SMEMBERS "user_chat_sessions:admin" | wc -l
+redis-cli -h <database-ip> -p 6379 -n 0 SMEMBERS "user_chat_sessions:admin" | wc -l
 # Expected: 54
 
 # Check sample ownership
-redis-cli -h 172.16.168.23 -p 6379 -n 0 GET "chat_session_owner:d40d0c19-2d76-4af7-98dd-d1c6a07619ac"
+redis-cli -h <database-ip> -p 6379 -n 0 GET "chat_session_owner:d40d0c19-2d76-4af7-98dd-d1c6a07619ac"
 # Expected: "admin"
 ```
 
 **Step 4: Functional Testing**
 ```bash
 # Test ownership validation API
-curl -X POST https://172.16.168.20:8443/api/chat/sessions/d40d0c19-2d76-4af7-98dd-d1c6a07619ac/validate \
+curl -X POST https://<backend-ip>:8443/api/chat/sessions/d40d0c19-2d76-4af7-98dd-d1c6a07619ac/validate \
     -H "Authorization: Bearer <admin_token>"
 # Expected: 200 OK with authorized=true
 
 # Test unauthorized access (should fail after auth enabled)
-curl -X GET https://172.16.168.20:8443/api/chat/sessions/d40d0c19-2d76-4af7-98dd-d1c6a07619ac \
+curl -X GET https://<backend-ip>:8443/api/chat/sessions/d40d0c19-2d76-4af7-98dd-d1c6a07619ac \
     -H "Authorization: Bearer <different_user_token>"
 # Expected: 403 Forbidden (when auth enabled)
 ```
@@ -544,7 +544,7 @@ class ConversationOwnershipBackfill:
 
     def __init__(
         self,
-        redis_host: str = "172.16.168.23",
+        redis_host: str = "<database-ip>",
         redis_port: int = 6379,
         redis_db: int = 0,
         default_owner: str = "admin",
@@ -774,7 +774,7 @@ async def main():
     )
     parser.add_argument(
         "--redis-host",
-        default="172.16.168.23",
+        default="<database-ip>",
         help="Redis host address"
     )
     parser.add_argument(

--- a/docs/security/SECURITY_FRAMEWORK.md
+++ b/docs/security/SECURITY_FRAMEWORK.md
@@ -264,37 +264,37 @@ iptables -A INPUT -i lo -j ACCEPT
 # Allow established connections
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
-# Main Host (172.16.168.20) - Backend API
-iptables -A INPUT -s 172.16.168.21 -p tcp --dport 8001 -j ACCEPT  # Frontend → Backend
-iptables -A INPUT -s 172.16.168.22 -p tcp --dport 8001 -j ACCEPT  # NPU → Backend
-iptables -A INPUT -s 172.16.168.24 -p tcp --dport 8001 -j ACCEPT  # AI Stack → Backend
-iptables -A INPUT -s 172.16.168.25 -p tcp --dport 8001 -j ACCEPT  # Browser → Backend
+# Main Host (<backend-ip>) - Backend API
+iptables -A INPUT -s <frontend-ip> -p tcp --dport 8001 -j ACCEPT  # Frontend → Backend
+iptables -A INPUT -s <npu-ip> -p tcp --dport 8001 -j ACCEPT  # NPU → Backend
+iptables -A INPUT -s <aiml-ip> -p tcp --dport 8001 -j ACCEPT  # AI Stack → Backend
+iptables -A INPUT -s <browser-ip> -p tcp --dport 8001 -j ACCEPT  # Browser → Backend
 
 # VNC Access (admin only, with IP restriction)
 iptables -A INPUT -s 192.168.1.0/24 -p tcp --dport 6080 -j ACCEPT  # Admin network only
 
-# VM1 - Frontend (172.16.168.21) 
+# VM1 - Frontend (<frontend-ip>) 
 iptables -A INPUT -p tcp --dport 80 -j ACCEPT   # HTTP (redirect to HTTPS)
 iptables -A INPUT -p tcp --dport 443 -j ACCEPT  # HTTPS
-iptables -A INPUT -s 172.16.168.20 -p tcp --dport 5173 -j ACCEPT  # Dev server
+iptables -A INPUT -s <backend-ip> -p tcp --dport 5173 -j ACCEPT  # Dev server
 
-# VM2 - NPU Worker (172.16.168.22) - Internal only
-iptables -A INPUT -s 172.16.168.20 -p tcp --dport 8081 -j ACCEPT  # Backend → NPU
+# VM2 - NPU Worker (<npu-ip>) - Internal only
+iptables -A INPUT -s <backend-ip> -p tcp --dport 8081 -j ACCEPT  # Backend → NPU
 
-# VM3 - Redis Stack (172.16.168.23) - Internal only
-iptables -A INPUT -s 172.16.168.20 -p tcp --dport 6379 -j ACCEPT  # Backend → Redis
-iptables -A INPUT -s 172.16.168.22 -p tcp --dport 6379 -j ACCEPT  # NPU → Redis
-iptables -A INPUT -s 172.16.168.24 -p tcp --dport 6379 -j ACCEPT  # AI Stack → Redis
-iptables -A INPUT -s 172.16.168.25 -p tcp --dport 6379 -j ACCEPT  # Browser → Redis
+# VM3 - Redis Stack (<database-ip>) - Internal only
+iptables -A INPUT -s <backend-ip> -p tcp --dport 6379 -j ACCEPT  # Backend → Redis
+iptables -A INPUT -s <npu-ip> -p tcp --dport 6379 -j ACCEPT  # NPU → Redis
+iptables -A INPUT -s <aiml-ip> -p tcp --dport 6379 -j ACCEPT  # AI Stack → Redis
+iptables -A INPUT -s <browser-ip> -p tcp --dport 6379 -j ACCEPT  # Browser → Redis
 
 # RedisInsight (admin access only)
 iptables -A INPUT -s 192.168.1.0/24 -p tcp --dport 8002 -j ACCEPT
 
-# VM4 - AI Stack (172.16.168.24) - Internal only  
-iptables -A INPUT -s 172.16.168.20 -p tcp --dport 8080 -j ACCEPT  # Backend → AI Stack
+# VM4 - AI Stack (<aiml-ip>) - Internal only  
+iptables -A INPUT -s <backend-ip> -p tcp --dport 8080 -j ACCEPT  # Backend → AI Stack
 
-# VM5 - Browser Service (172.16.168.25) - Internal only
-iptables -A INPUT -s 172.16.168.20 -p tcp --dport 3000 -j ACCEPT  # Backend → Browser
+# VM5 - Browser Service (<browser-ip>) - Internal only
+iptables -A INPUT -s <backend-ip> -p tcp --dport 3000 -j ACCEPT  # Backend → Browser
 
 # SSH access (key-based only)
 iptables -A INPUT -s 192.168.1.0/24 -p tcp --dport 22 -j ACCEPT

--- a/docs/security/SERVICE_AUTH_DAY3_DEPLOYMENT_COMPLETE.md
+++ b/docs/security/SERVICE_AUTH_DAY3_DEPLOYMENT_COMPLETE.md
@@ -214,7 +214,7 @@ client = create_service_client_from_env()
 ### Test 3: Authenticated HTTP Request ✅
 
 ```python
-response = await client.get("https://172.16.168.20:8443/api/system/health")
+response = await client.get("https://<backend-ip>:8443/api/system/health")
 # Returns: 200 OK with auth headers
 ```
 
@@ -300,7 +300,7 @@ response = await client.get("https://172.16.168.20:8443/api/system/health")
 **Monitoring Commands**:
 ```bash
 # Quick health check (run every 4 hours)
-curl -s https://172.16.168.20:8443/api/health | jq -r '.status'
+curl -s https://<backend-ip>:8443/api/health | jq -r '.status'
 
 # Authentication warnings (last hour)
 grep "Service auth failed" logs/backend.log | tail -100

--- a/docs/security/SERVICE_AUTH_ENFORCEMENT_ACTIVATION_CHECKLIST.md
+++ b/docs/security/SERVICE_AUTH_ENFORCEMENT_ACTIVATION_CHECKLIST.md
@@ -65,13 +65,13 @@
 **Commands**:
 ```bash
 # Verify backend is running
-curl -s https://172.16.168.20:8443/api/health | jq
+curl -s https://<backend-ip>:8443/api/health | jq
 
 # Check recent authentication failures (should be 0)
 tail -100 logs/backend.log | grep -c "Service auth failed"
 
 # Verify frontend accessible
-curl -s http://172.16.168.21:5173 | head -5
+curl -s http://<frontend-ip>:5173 | head -5
 
 # Run monitoring dashboard
 bash scripts/monitoring/service_auth_monitor.sh
@@ -133,19 +133,19 @@ Service-only paths: ['/api/npu/results', '/api/npu/heartbeat', ...]
 
 ```bash
 # Health check
-curl -s https://172.16.168.20:8443/api/health
+curl -s https://<backend-ip>:8443/api/health
 
 # Frontend config
-curl -s https://172.16.168.20:8443/api/frontend-config
+curl -s https://<backend-ip>:8443/api/frontend-config
 
 # Chat list
-curl -s https://172.16.168.20:8443/api/chats
+curl -s https://<backend-ip>:8443/api/chats
 
 # NPU workers (frontend Settings panel)
-curl -s https://172.16.168.20:8443/api/npu/workers
+curl -s https://<backend-ip>:8443/api/npu/workers
 
 # Cache stats
-curl -s https://172.16.168.20:8443/api/cache/stats
+curl -s https://<backend-ip>:8443/api/cache/stats
 ```
 
 **Expected**: All requests return 200 OK (no authentication required)
@@ -154,9 +154,9 @@ curl -s https://172.16.168.20:8443/api/cache/stats
 
 ```bash
 # These should return 401 Unauthorized without service authentication
-curl -s -w "\nHTTP Status: %{http_code}\n" https://172.16.168.20:8443/api/npu/heartbeat
-curl -s -w "\nHTTP Status: %{http_code}\n" https://172.16.168.20:8443/api/ai-stack/results
-curl -s -w "\nHTTP Status: %{http_code}\n" https://172.16.168.20:8443/api/browser/internal
+curl -s -w "\nHTTP Status: %{http_code}\n" https://<backend-ip>:8443/api/npu/heartbeat
+curl -s -w "\nHTTP Status: %{http_code}\n" https://<backend-ip>:8443/api/ai-stack/results
+curl -s -w "\nHTTP Status: %{http_code}\n" https://<backend-ip>:8443/api/browser/internal
 ```
 
 **Expected**: All return 401 with `{"detail": "...", "authenticated": false}`
@@ -180,7 +180,7 @@ tail -f logs/backend.log | grep -E "(Service auth|BLOCKED|exempt)"
 
 ### Step 6: Frontend Functional Testing (15 minutes)
 
-**Test via Browser** (http://172.16.168.21:5173):
+**Test via Browser** (http://<frontend-ip>:5173):
 
 1. **Chat Functionality**:
    - [ ] Can view chat list
@@ -223,7 +223,7 @@ bash scripts/monitoring/service_auth_monitor.sh
 tail -100 logs/backend.log | grep -i error
 
 # Frontend accessibility
-curl -s http://172.16.168.21:5173 | head -5
+curl -s http://<frontend-ip>:5173 | head -5
 ```
 
 **Alert Thresholds**:
@@ -279,8 +279,8 @@ tail -50 logs/backend.log | grep "Service Authentication"
 # Should see: "Service Authentication in LOGGING MODE (enforcement disabled)"
 
 # Test frontend
-curl https://172.16.168.20:8443/api/health
-curl http://172.16.168.21:5173
+curl https://<backend-ip>:8443/api/health
+curl http://<frontend-ip>:5173
 ```
 
 **Post-Rollback**:

--- a/docs/security/SERVICE_AUTH_ENFORCEMENT_ACTIVATION_COMPLETE.md
+++ b/docs/security/SERVICE_AUTH_ENFORCEMENT_ACTIVATION_COMPLETE.md
@@ -43,7 +43,7 @@ Service authentication enforcement has been **successfully activated** and is no
 2025-10-09 15:15:50 [error] Service authentication FAILED - request BLOCKED
                            error='Missing authentication headers'
                            status_code=401
-INFO: 172.16.168.20:45814 - "GET /api/npu/heartbeat HTTP/1.1" 401 Unauthorized
+INFO: <backend-ip>:45814 - "GET /api/npu/heartbeat HTTP/1.1" 401 Unauthorized
 ```
 
 ---
@@ -77,7 +77,7 @@ INFO: 172.16.168.20:45814 - "GET /api/npu/heartbeat HTTP/1.1" 401 Unauthorized
 
 **Attack Prevention**:
 ```bash
-curl https://172.16.168.20:8443/api/npu/heartbeat
+curl https://<backend-ip>:8443/api/npu/heartbeat
 # Returns: 401 Unauthorized - Attack BLOCKED ✅
 ```
 

--- a/docs/security/SERVICE_AUTH_ENFORCEMENT_ROLLOUT_PLAN.md
+++ b/docs/security/SERVICE_AUTH_ENFORCEMENT_ROLLOUT_PLAN.md
@@ -215,11 +215,11 @@ SERVICE_ONLY_PATHS = [
 ```python
 # Method 1: Create from environment
 client = create_service_client_from_env()
-response = await client.get("http://172.16.168.24:8080/api/inference")
+response = await client.get("http://<aiml-ip>:8080/api/inference")
 
 # Method 2: Explicit credentials
 client = ServiceHTTPClient(service_id="main-backend", service_key="...")
-response = await client.post("http://172.16.168.22:8081/api/process", json={...})
+response = await client.post("http://<npu-ip>:8081/api/process", json={...})
 ```
 
 **Current Deployment:**
@@ -323,11 +323,11 @@ echo "Current time: $(date)"
 echo "Hours elapsed: (calculate)"
 
 # Verify system stability
-curl -s https://172.16.168.20:8443/api/health | jq -r '.status'
+curl -s https://<backend-ip>:8443/api/health | jq -r '.status'
 # Expected: "healthy"
 
 # Check service keys still present
-redis-cli -h 172.16.168.23 -a "$REDIS_PASSWORD" KEYS "service:key:*" | wc -l
+redis-cli -h <database-ip> -a "$REDIS_PASSWORD" KEYS "service:key:*" | wc -l
 # Expected: 6
 
 # Review authentication logs
@@ -347,7 +347,7 @@ grep "Service auth failed" logs/backend.log | tail -50
 #### Step 1.2: Update NPU Worker Configuration
 
 **Duration:** 30-45 minutes
-**Target:** VM 22 (172.16.168.22)
+**Target:** VM 22 (<npu-ip>)
 
 **Actions:**
 
@@ -356,8 +356,8 @@ grep "Service auth failed" logs/backend.log | tail -50
    Identify where NPU Worker makes backend API calls:
    ```bash
    # On NPU Worker (VM 22), find backend API calls
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.22
-   grep -r "https://172.16.168.20:8443" /home/autobot/npu-worker/
+   ssh -i ~/.ssh/autobot_key autobot@<npu-ip>
+   grep -r "https://<backend-ip>:8443" /home/autobot/npu-worker/
    ```
 
    Example locations to update:
@@ -373,7 +373,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    scp -i ~/.ssh/autobot_key \
      backend/utils/service_client.py \
      backend/security/service_auth.py \
-     autobot@172.16.168.22:/home/autobot/npu-worker/utils/
+     autobot@<npu-ip>:/home/autobot/npu-worker/utils/
    ```
 
    Option B: Create shared library package (better long-term)
@@ -389,7 +389,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    SERVICE_ID=npu-worker
    SERVICE_KEY_FILE=/etc/autobot/service-keys/npu-worker.env
    AUTH_TIMESTAMP_WINDOW=300
-   BACKEND_HOST=172.16.168.20
+   BACKEND_HOST=<backend-ip>
    BACKEND_PORT=8001
    ```
 
@@ -402,7 +402,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    async def send_results(results):
        async with httpx.AsyncClient() as client:
            response = await client.post(
-               "https://172.16.168.20:8443/api/npu/results",
+               "https://<backend-ip>:8443/api/npu/results",
                json=results
            )
    ```
@@ -414,7 +414,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    async def send_results(results):
        client = create_service_client_from_env()
        response = await client.post(
-           "https://172.16.168.20:8443/api/npu/results",
+           "https://<backend-ip>:8443/api/npu/results",
            json=results
        )
        await client.close()
@@ -423,7 +423,7 @@ grep "Service auth failed" logs/backend.log | tail -50
 5. **Restart NPU Worker service**
 
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.22
+   ssh -i ~/.ssh/autobot_key autobot@<npu-ip>
    sudo systemctl restart npu-worker
    # OR
    pkill -f npu_worker && python -m npu_worker &
@@ -457,14 +457,14 @@ grep "Service auth failed" logs/backend.log | tail -50
 #### Step 1.3: Update AI Stack Configuration
 
 **Duration:** 30-45 minutes
-**Target:** VM 24 (172.16.168.24)
+**Target:** VM 24 (<aiml-ip>)
 
 **Actions:** (Similar to Step 1.2)
 
 1. **Identify backend API call locations in AI Stack**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.24
-   grep -r "https://172.16.168.20:8443" /home/autobot/ai-stack/
+   ssh -i ~/.ssh/autobot_key autobot@<aiml-ip>
+   grep -r "https://<backend-ip>:8443" /home/autobot/ai-stack/
    ```
 
 2. **Deploy ServiceHTTPClient to AI Stack**
@@ -472,7 +472,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    scp -i ~/.ssh/autobot_key \
      backend/utils/service_client.py \
      backend/security/service_auth.py \
-     autobot@172.16.168.24:/home/autobot/ai-stack/utils/
+     autobot@<aiml-ip>:/home/autobot/ai-stack/utils/
    ```
 
 3. **Verify .env configuration on VM 24**
@@ -480,7 +480,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    SERVICE_ID=ai-stack
    SERVICE_KEY_FILE=/etc/autobot/service-keys/ai-stack.env
    AUTH_TIMESTAMP_WINDOW=300
-   BACKEND_HOST=172.16.168.20
+   BACKEND_HOST=<backend-ip>
    BACKEND_PORT=8001
    ```
 
@@ -488,7 +488,7 @@ grep "Service auth failed" logs/backend.log | tail -50
 
 5. **Restart AI Stack services**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.24
+   ssh -i ~/.ssh/autobot_key autobot@<aiml-ip>
    sudo systemctl restart ai-stack
    ```
 
@@ -509,14 +509,14 @@ grep "Service auth failed" logs/backend.log | tail -50
 #### Step 1.4: Update Browser Service Configuration
 
 **Duration:** 30-45 minutes
-**Target:** VM 25 (172.16.168.25)
+**Target:** VM 25 (<browser-ip>)
 
 **Actions:** (Similar to Steps 1.2 and 1.3)
 
 1. **Identify backend API call locations in Browser Service**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.25
-   grep -r "https://172.16.168.20:8443" /home/autobot/browser-service/
+   ssh -i ~/.ssh/autobot_key autobot@<browser-ip>
+   grep -r "https://<backend-ip>:8443" /home/autobot/browser-service/
    ```
 
 2. **Deploy ServiceHTTPClient to Browser Service**
@@ -524,7 +524,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    scp -i ~/.ssh/autobot_key \
      backend/utils/service_client.py \
      backend/security/service_auth.py \
-     autobot@172.16.168.25:/home/autobot/browser-service/utils/
+     autobot@<browser-ip>:/home/autobot/browser-service/utils/
    ```
 
 3. **Verify .env configuration on VM 25**
@@ -532,7 +532,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    SERVICE_ID=browser-service
    SERVICE_KEY_FILE=/etc/autobot/service-keys/browser-service.env
    AUTH_TIMESTAMP_WINDOW=300
-   BACKEND_HOST=172.16.168.20
+   BACKEND_HOST=<backend-ip>
    BACKEND_PORT=8001
    ```
 
@@ -540,7 +540,7 @@ grep "Service auth failed" logs/backend.log | tail -50
 
 5. **Restart Browser Service**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.25
+   ssh -i ~/.ssh/autobot_key autobot@<browser-ip>
    sudo systemctl restart browser-service
    ```
 
@@ -561,14 +561,14 @@ grep "Service auth failed" logs/backend.log | tail -50
 #### Step 1.5: Evaluate Frontend Service Authentication Need
 
 **Duration:** 15-30 minutes
-**Target:** VM 21 (172.16.168.21)
+**Target:** VM 21 (<frontend-ip>)
 
 **Evaluation Questions:**
 
 1. **Does Frontend VM make server-side API calls to backend?**
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.21
-   grep -r "https://172.16.168.20:8443" /home/autobot/autobot-frontend/
+   ssh -i ~/.ssh/autobot_key autobot@<frontend-ip>
+   grep -r "https://<backend-ip>:8443" /home/autobot/autobot-frontend/
    ```
 
 2. **Are these calls from browser or from server-side code?**
@@ -625,7 +625,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    # End-to-end workflow tests
 
    # Test 1: Chat with AI (involves AI Stack)
-   curl -X POST https://172.16.168.20:8443/api/chat \
+   curl -X POST https://<backend-ip>:8443/api/chat \
      -H "Content-Type: application/json" \
      -d '{"message": "Hello", "session_id": "test"}'
 
@@ -641,7 +641,7 @@ grep "Service auth failed" logs/backend.log | tail -50
    # Verify authentication overhead is minimal (< 10ms)
    # Compare pre-auth vs post-auth response times
 
-   ab -n 100 -c 10 https://172.16.168.20:8443/api/health
+   ab -n 100 -c 10 https://<backend-ip>:8443/api/health
    # Note: Average response time
 
    # Should be similar to pre-authentication baseline
@@ -668,7 +668,7 @@ grep "Service auth failed" logs/backend.log | tail -50
 
 ```bash
 # Example: Rollback NPU Worker
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.22
+ssh -i ~/.ssh/autobot_key autobot@<npu-ip>
 
 # Revert code to previous version
 cd /home/autobot/npu-worker
@@ -678,7 +678,7 @@ git checkout HEAD~1  # Or specific commit
 sudo systemctl restart npu-worker
 
 # Verify functionality restored
-curl http://172.16.168.22:8081/health
+curl http://<npu-ip>:8081/health
 ```
 
 **Service continues working with unauthenticated calls** (logging mode allows this)
@@ -790,7 +790,7 @@ curl http://172.16.168.22:8081/health
 
        # Service health
        echo "Service Health:"
-       curl -s https://172.16.168.20:8443/api/health | jq -r '.status' 2>/dev/null || echo "ERROR"
+       curl -s https://<backend-ip>:8443/api/health | jq -r '.status' 2>/dev/null || echo "ERROR"
 
        sleep 10
    done
@@ -826,7 +826,7 @@ curl http://172.16.168.22:8081/health
 
    # Verify rollback
    sleep 5
-   status=$(curl -s https://172.16.168.20:8443/api/health | jq -r '.status')
+   status=$(curl -s https://<backend-ip>:8443/api/health | jq -r '.status')
 
    if [ "$status" = "healthy" ]; then
        echo "✅ Rollback successful - Enforcement mode disabled"
@@ -874,15 +874,15 @@ curl http://172.16.168.22:8081/health
 
    ```bash
    # Backend health check
-   curl -s https://172.16.168.20:8443/api/health | jq
+   curl -s https://<backend-ip>:8443/api/health | jq
    # Expected: {"status": "healthy", ...}
 
    # Frontend accessibility test (should still work)
-   curl -s https://172.16.168.20:8443/api/settings | jq
+   curl -s https://<backend-ip>:8443/api/settings | jq
    # Expected: 200 OK (exempt path)
 
    # Service-only path test (should require auth)
-   curl -s https://172.16.168.20:8443/api/npu/internal
+   curl -s https://<backend-ip>:8443/api/npu/internal
    # Expected: 401 Unauthorized (if called without auth)
    ```
 
@@ -909,7 +909,7 @@ curl http://172.16.168.22:8081/health
 
 ```bash
 # 1. Backend health
-curl -s https://172.16.168.20:8443/api/health | jq -r '.status'
+curl -s https://<backend-ip>:8443/api/health | jq -r '.status'
 
 # 2. Authentication metrics (last hour)
 cutoff=$(date -d '1 hour ago' '+%Y-%m-%d %H:%M')
@@ -929,7 +929,7 @@ echo "Auth Success: $success | Failed: $failed | Blocked: $blocked"
 # - Trigger browser automation → Verify completion
 
 # 4. Frontend accessibility
-curl -s https://172.16.168.20:8443/api/settings > /dev/null
+curl -s https://<backend-ip>:8443/api/settings > /dev/null
 echo "Frontend access: $?"  # Should be 0 (success)
 ```
 
@@ -987,7 +987,7 @@ echo "Frontend access: $?"  # Should be 0 (success)
    for path in "/api/chat" "/api/settings" "/api/knowledge" "/api/terminal"; do
        echo "Testing: $path"
        status=$(curl -s -o /dev/null -w '%{http_code}' \
-                "https://172.16.168.20:8443$path")
+                "https://<backend-ip>:8443$path")
 
        if [ "$status" != "200" ] && [ "$status" != "404" ]; then
            echo "❌ FAILED: $path returned $status (expected 200 or 404)"
@@ -1005,7 +1005,7 @@ echo "Frontend access: $?"  # Should be 0 (success)
    for path in "/api/npu/internal" "/api/ai-stack/internal" "/api/browser/internal"; do
        echo "Testing: $path (should be blocked)"
        status=$(curl -s -o /dev/null -w '%{http_code}' \
-                "https://172.16.168.20:8443$path")
+                "https://<backend-ip>:8443$path")
 
        if [ "$status" = "401" ] || [ "$status" = "403" ]; then
            echo "✅ PASSED: $path properly blocked ($status)"
@@ -1020,7 +1020,7 @@ echo "Frontend access: $?"  # Should be 0 (success)
    ```bash
    # Test emergency override mechanism
 
-   curl -X GET "https://172.16.168.20:8443/api/npu/internal" \
+   curl -X GET "https://<backend-ip>:8443/api/npu/internal" \
         -H "X-Override-Token: YOUR_OVERRIDE_TOKEN" \
         -v
 
@@ -1061,7 +1061,7 @@ sed -i 's/SERVICE_AUTH_ENFORCEMENT_MODE=true/SERVICE_AUTH_ENFORCEMENT_MODE=false
 sudo systemctl restart autobot-backend
 
 # Verify rollback
-curl -s https://172.16.168.20:8443/api/health | jq -r '.status'
+curl -s https://<backend-ip>:8443/api/health | jq -r '.status'
 # Expected: "healthy"
 
 # Confirm enforcement disabled
@@ -1192,7 +1192,7 @@ grep SERVICE_AUTH_ENFORCEMENT_MODE .env
 
        # Verify backend healthy
        sleep 5
-       status=$(curl -s https://172.16.168.20:8443/api/health | jq -r '.status')
+       status=$(curl -s https://<backend-ip>:8443/api/health | jq -r '.status')
 
        if [ "$status" != "healthy" ]; then
            echo "❌ Backend health check failed at ${pct}% - Rolling back"
@@ -1272,7 +1272,7 @@ grep SERVICE_AUTH_ENFORCEMENT_MODE .env
 
        echo
        echo "Service Health:"
-       curl -s https://172.16.168.20:8443/api/health | jq -r '.status' 2>/dev/null || echo "ERROR"
+       curl -s https://<backend-ip>:8443/api/health | jq -r '.status' 2>/dev/null || echo "ERROR"
 
        sleep 10
    done
@@ -1293,7 +1293,7 @@ grep SERVICE_AUTH_ENFORCEMENT_MODE .env
    echo "Current time: $(date)"
 
    # Verify all services still healthy
-   curl -s https://172.16.168.20:8443/api/health | jq
+   curl -s https://<backend-ip>:8443/api/health | jq
 
    # Review recent authentication logs
    grep "Service authenticated successfully" logs/backend.log | tail -20
@@ -1371,7 +1371,7 @@ grep SERVICE_AUTH_ENFORCEMENT_MODE .env
 
    ```bash
    # Load testing with authentication
-   ab -n 1000 -c 50 https://172.16.168.20:8443/api/health
+   ab -n 1000 -c 50 https://<backend-ip>:8443/api/health
 
    # Compare to baseline (from Phase 2)
    # Authentication overhead should still be < 10ms
@@ -1383,7 +1383,7 @@ grep SERVICE_AUTH_ENFORCEMENT_MODE .env
    # Attempt unauthenticated access to service-only paths
    for path in "/api/npu/internal" "/api/ai-stack/internal" "/api/browser/internal"; do
        status=$(curl -s -o /dev/null -w '%{http_code}' \
-                "https://172.16.168.20:8443$path")
+                "https://<backend-ip>:8443$path")
 
        if [ "$status" = "401" ] || [ "$status" = "403" ]; then
            echo "✅ $path properly secured"
@@ -1422,7 +1422,7 @@ System automatically executes rollback script - no manual intervention needed.
 bash scripts/rollback-enforcement.sh
 
 # Verify system restored
-curl -s https://172.16.168.20:8443/api/health | jq
+curl -s https://<backend-ip>:8443/api/health | jq
 
 # Review logs to identify issue
 grep "ERROR\|FAILED" logs/backend.log | tail -50
@@ -1473,7 +1473,7 @@ grep "ERROR\|FAILED" logs/backend.log | tail -50
    sudo systemctl restart autobot-backend
 
    # Verify configuration
-   curl -s https://172.16.168.20:8443/api/health | jq
+   curl -s https://<backend-ip>:8443/api/health | jq
    ```
 
 #### Step 4.2: Production Hardening
@@ -1716,7 +1716,7 @@ grep "ERROR\|FAILED" logs/backend.log | tail -50
    # Service key status
    echo "Service Key Status:"
    for key in main-backend frontend npu-worker redis-stack ai-stack browser-service; do
-       ttl=$(redis-cli -h 172.16.168.23 -a "$REDIS_PASSWORD" TTL "service:key:$key" 2>/dev/null)
+       ttl=$(redis-cli -h <database-ip> -a "$REDIS_PASSWORD" TTL "service:key:$key" 2>/dev/null)
        days=$((ttl / 86400))
        echo "  $key: $days days remaining"
    done
@@ -1724,7 +1724,7 @@ grep "ERROR\|FAILED" logs/backend.log | tail -50
 
    # System health
    echo "Backend Health:"
-   curl -s https://172.16.168.20:8443/api/health | jq -r '.status'
+   curl -s https://<backend-ip>:8443/api/health | jq -r '.status'
 
    echo
    echo "=== Report Complete ==="
@@ -1777,7 +1777,7 @@ nohup python -m uvicorn backend.app_factory:app --host 0.0.0.0 --port 8001 > log
 sleep 5
 
 # Step 4: Verify rollback
-status=$(curl -s https://172.16.168.20:8443/api/health | jq -r '.status' 2>/dev/null)
+status=$(curl -s https://<backend-ip>:8443/api/health | jq -r '.status' 2>/dev/null)
 
 if [ "$status" = "healthy" ]; then
     echo "✅ EMERGENCY ROLLBACK SUCCESSFUL"
@@ -1837,7 +1837,7 @@ sudo systemctl restart autobot-backend
 sleep 10
 
 # Backend health
-health=$(curl -s https://172.16.168.20:8443/api/health | jq -r '.status')
+health=$(curl -s https://<backend-ip>:8443/api/health | jq -r '.status')
 echo "Backend health: $health"
 
 # Service connectivity
@@ -1848,7 +1848,7 @@ done
 
 # Frontend accessibility
 for path in "/api/chat" "/api/settings" "/api/knowledge"; do
-    status=$(curl -s -o /dev/null -w '%{http_code}' "https://172.16.168.20:8443$path")
+    status=$(curl -s -o /dev/null -w '%{http_code}' "https://<backend-ip>:8443$path")
     echo "Frontend path $path: $status"
 done
 
@@ -1957,7 +1957,7 @@ echo "System restored to logging-only mode"
 
 **Quick Health Check:**
 ```bash
-curl -s https://172.16.168.20:8443/api/health | jq
+curl -s https://<backend-ip>:8443/api/health | jq
 ```
 
 **Authentication Metrics (Last Hour):**
@@ -1980,7 +1980,7 @@ grep "Service authenticated successfully" logs/backend.log | \
 **Service Key Status:**
 ```bash
 for key in main-backend frontend npu-worker redis-stack ai-stack browser-service; do
-  ttl=$(redis-cli -h 172.16.168.23 -a "$REDIS_PASSWORD" TTL "service:key:$key" 2>/dev/null)
+  ttl=$(redis-cli -h <database-ip> -a "$REDIS_PASSWORD" TTL "service:key:$key" 2>/dev/null)
   days=$((ttl / 86400))
   echo "$key: $days days"
 done
@@ -2008,7 +2008,7 @@ echo
 
 # Test 1: Backend Health
 echo "[Test 1] Backend Health Check"
-health=$(curl -s https://172.16.168.20:8443/api/health | jq -r '.status')
+health=$(curl -s https://<backend-ip>:8443/api/health | jq -r '.status')
 if [ "$health" = "healthy" ]; then
     echo "✅ PASSED: Backend is healthy"
 else
@@ -2022,7 +2022,7 @@ passed=0
 failed=0
 
 for path in "/api/chat" "/api/settings" "/api/knowledge" "/api/terminal"; do
-    status=$(curl -s -o /dev/null -w '%{http_code}' "https://172.16.168.20:8443$path")
+    status=$(curl -s -o /dev/null -w '%{http_code}' "https://<backend-ip>:8443$path")
     if [ "$status" = "200" ] || [ "$status" = "404" ]; then
         echo "✅ $path: $status"
         ((passed++))
@@ -2041,7 +2041,7 @@ passed=0
 failed=0
 
 for path in "/api/npu/internal" "/api/ai-stack/internal" "/api/browser/internal"; do
-    status=$(curl -s -o /dev/null -w '%{http_code}' "https://172.16.168.20:8443$path")
+    status=$(curl -s -o /dev/null -w '%{http_code}' "https://<backend-ip>:8443$path")
     if [ "$status" = "401" ] || [ "$status" = "403" ]; then
         echo "✅ $path: Blocked ($status)"
         ((passed++))
@@ -2075,7 +2075,7 @@ echo "[Test 5] Service Key Status"
 
 all_keys_ok=true
 for key in main-backend frontend npu-worker redis-stack ai-stack browser-service; do
-    ttl=$(redis-cli -h 172.16.168.23 -a "$REDIS_PASSWORD" TTL "service:key:$key" 2>/dev/null)
+    ttl=$(redis-cli -h <database-ip> -a "$REDIS_PASSWORD" TTL "service:key:$key" 2>/dev/null)
 
     if [ "$ttl" -gt 2592000 ]; then  # > 30 days
         days=$((ttl / 86400))
@@ -2397,7 +2397,7 @@ See "Endpoint Categorization" section for complete list.
 SERVICE_ID=npu-worker
 SERVICE_KEY_FILE=/etc/autobot/service-keys/npu-worker.env
 AUTH_TIMESTAMP_WINDOW=300
-BACKEND_HOST=172.16.168.20
+BACKEND_HOST=<backend-ip>
 BACKEND_PORT=8001
 ```
 
@@ -2424,19 +2424,19 @@ grep "Service authenticated successfully" logs/backend.log | \
 **Service Key Management:**
 ```bash
 # Check service key TTL
-redis-cli -h 172.16.168.23 -a "$REDIS_PASSWORD" TTL "service:key:main-backend"
+redis-cli -h <database-ip> -a "$REDIS_PASSWORD" TTL "service:key:main-backend"
 
 # List all service keys
-redis-cli -h 172.16.168.23 -a "$REDIS_PASSWORD" KEYS "service:key:*"
+redis-cli -h <database-ip> -a "$REDIS_PASSWORD" KEYS "service:key:*"
 
 # View service key value (for verification only)
-redis-cli -h 172.16.168.23 -a "$REDIS_PASSWORD" GET "service:key:main-backend"
+redis-cli -h <database-ip> -a "$REDIS_PASSWORD" GET "service:key:main-backend"
 ```
 
 **Clock Synchronization:**
 ```bash
 # Force NTP sync on VM
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.22 "sudo ntpdate -u pool.ntp.org"
+ssh -i ~/.ssh/autobot_key autobot@<npu-ip> "sudo ntpdate -u pool.ntp.org"
 
 # Check time across all VMs
 for vm in 20 21 22 23 24 25; do

--- a/docs/security/TLS_CERTIFICATE_MANAGEMENT.md
+++ b/docs/security/TLS_CERTIFICATE_MANAGEMENT.md
@@ -25,12 +25,12 @@ AutoBot Internal CA (Root)
 ├── ca-cert.pem (CA Certificate)
 ├── ca-key.pem (CA Private Key - CRITICAL)
 └── Service Certificates
-    ├── main-host (172.16.168.20) - Backend API
-    ├── frontend (172.16.168.21) - Web Interface
-    ├── npu-worker (172.16.168.22) - NPU Acceleration
-    ├── redis (172.16.168.23) - Data Layer
-    ├── ai-stack (172.16.168.24) - AI Processing
-    └── browser (172.16.168.25) - Web Automation
+    ├── main-host (<backend-ip>) - Backend API
+    ├── frontend (<frontend-ip>) - Web Interface
+    ├── npu-worker (<npu-ip>) - NPU Acceleration
+    ├── redis (<database-ip>) - Data Layer
+    ├── ai-stack (<aiml-ip>) - AI Processing
+    └── browser (<browser-ip>) - Web Automation
 ```
 
 ### Certificate Specifications
@@ -123,7 +123,7 @@ If you need to generate a certificate for a new service:
 ```bash
 # Define service details
 SERVICE_NAME="new-service"
-IP_ADDRESS="172.16.168.26"
+IP_ADDRESS="<reserved-ip>"
 COMMON_NAME="autobot-new-service"
 
 # Create service directory
@@ -234,7 +234,7 @@ If automated distribution fails, distribute manually:
 
 ```bash
 SERVICE="frontend"
-IP="172.16.168.21"
+IP="<frontend-ip>"
 SSH_KEY="$HOME/.ssh/autobot_key"
 
 # Create directory on remote VM
@@ -454,12 +454,12 @@ openssl verify -CAfile certs/ca/ca-cert.pem certs/frontend/server-cert.pem
 
 1. **Verify VM is running**:
    ```bash
-   ping -c 3 172.16.168.21
+   ping -c 3 <frontend-ip>
    ```
 
 2. **Check SSH connectivity**:
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "echo 'Connection OK'"
+   ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "echo 'Connection OK'"
    ```
 
 3. **Verify SSH key permissions**:
@@ -469,7 +469,7 @@ openssl verify -CAfile certs/ca/ca-cert.pem certs/frontend/server-cert.pem
 
 4. **Check SSH authorized_keys on VM**:
    ```bash
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "cat ~/.ssh/authorized_keys"
+   ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "cat ~/.ssh/authorized_keys"
    ```
 
 ### Certificate Expiration
@@ -496,7 +496,7 @@ openssl verify -CAfile certs/ca/ca-cert.pem certs/frontend/server-cert.pem
 3. **Restart affected services**:
    ```bash
    # Example for frontend
-   ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "sudo systemctl restart nginx"
+   ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "sudo systemctl restart nginx"
    ```
 
 ### Wrong SAN Entries
@@ -708,12 +708,12 @@ openssl s_client -connect <IP>:443 -CAfile certs/ca/ca-cert.pem
 
 | VM Name | IP Address | Service Name | Certificate Location |
 |---------|------------|--------------|---------------------|
-| main-host | 172.16.168.20 | autobot-backend | `/etc/autobot/certs/` |
-| frontend | 172.16.168.21 | nginx | `/etc/autobot/certs/` |
-| npu-worker | 172.16.168.22 | npu-worker | `/etc/autobot/certs/` |
-| redis | 172.16.168.23 | redis-stack-server | `/etc/autobot/certs/` |
-| ai-stack | 172.16.168.24 | backend | `/etc/autobot/certs/` |
-| browser | 172.16.168.25 | playwright | `/etc/autobot/certs/` |
+| main-host | <backend-ip> | autobot-backend | `/etc/autobot/certs/` |
+| frontend | <frontend-ip> | nginx | `/etc/autobot/certs/` |
+| npu-worker | <npu-ip> | npu-worker | `/etc/autobot/certs/` |
+| redis | <database-ip> | redis-stack-server | `/etc/autobot/certs/` |
+| ai-stack | <aiml-ip> | backend | `/etc/autobot/certs/` |
+| browser | <browser-ip> | playwright | `/etc/autobot/certs/` |
 
 ### Support Contacts
 

--- a/docs/superpowers/specs/2026-03-29-shared-dependency-roles-design.md
+++ b/docs/superpowers/specs/2026-03-29-shared-dependency-roles-design.md
@@ -122,7 +122,7 @@ Add a new phase at the start of `provision-fleet-roles.yml`:
 The `node_dependencies` variable is computed by `setup_wizard.py` in the dynamic inventory — it resolves `ROLE_DEPENDENCIES` for all roles assigned to each node, deduplicates, and sets it as a host var:
 
 ```yaml
-172.16.168.20:
+<backend-ip>:
   node_roles: [backend, frontend, redis, ai-stack, ...]
   node_dependencies: [nginx, python312, nodejs]
   pending_dep_removals: []

--- a/docs/system-state.md
+++ b/docs/system-state.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](architecture/VM_ROLES.md) for role definitions.
+
 # AutoBot System State & Updates
 
 This document tracks all system fixes, improvements, and status updates for the AutoBot platform.
@@ -86,8 +88,8 @@ python scripts/security/mtls-migrate.py --phase disable-password
 
 After analysis, it was determined that the main frontend and SLM should **coexist** with complementary purposes:
 
-- **Main Frontend (172.16.168.21)** - User-oriented application features (Chat, UI, Workflows, User Tools)
-- **SLM Admin (172.16.168.19)** - Infrastructure administration (Fleet, Nodes, Services, System Settings)
+- **Main Frontend (<frontend-ip>)** - User-oriented application features (Chat, UI, Workflows, User Tools)
+- **SLM Admin (<slm-manager-ip>)** - Infrastructure administration (Fleet, Nodes, Services, System Settings)
 
 **SLM Admin Implementation:**
 
@@ -115,8 +117,8 @@ After analysis, it was determined that the main frontend and SLM should **coexis
 **Access:**
 
 ```
-SLM Admin: http://172.16.168.19:5174
-API Base:  http://172.16.168.19:8000/api
+SLM Admin: http://<slm-manager-ip>:5174
+API Base:  http://<slm-manager-ip>:8000/api
 ```
 
 **Code Quality Fixes (Code Review):**
@@ -204,15 +206,15 @@ API Base:  http://172.16.168.19:8000/api
 
 **Access:**
 ```
-Primary: http://172.16.168.21:5173/monitoring/dashboards
+Primary: http://<frontend-ip>:5173/monitoring/dashboards
 Navigate: AutoBot UI → Monitoring → Dashboards
 ```
 
 **Components:**
-- **Prometheus** (172.16.168.19:9090) - Metrics collection & storage (30-day retention)
-- **Grafana** (172.16.168.19:3000) - Dashboard visualization (admin/autobot)
-- **AlertManager** (172.16.168.19:9093) - Alert routing & notifications
-- **Backend Metrics** (172.16.168.20:8443) - `/api/monitoring/metrics` endpoint
+- **Prometheus** (<slm-manager-ip>:9090) - Metrics collection & storage (30-day retention)
+- **Grafana** (<slm-manager-ip>:3000) - Dashboard visualization (admin/autobot)
+- **AlertManager** (<slm-manager-ip>:9093) - Alert routing & notifications
+- **Backend Metrics** (<backend-ip>:8443) - `/api/monitoring/metrics` endpoint
 
 **Note:** Monitoring stack (Prometheus, Grafana, AlertManager) is deployed on SLM Server via Ansible playbooks (`slm_manager` role), not manually or via scripts.
 
@@ -765,7 +767,7 @@ export class KnowledgeController {
 ```python
 {
     "machine_id": "mv-stealth",
-    "machine_ip": "172.16.168.20",
+    "machine_ip": "<backend-ip>",
     "os_name": "Kali",
     "os_version": "2025.2",
     "os_type": "Linux",
@@ -788,7 +790,7 @@ export class KnowledgeController {
 
 **Status:** ✅ Complete
 
-**Changes Applied** (VM3: 172.16.168.23):
+**Changes Applied** (VM3: <database-ip>):
 
 1. **Memory Management:**
    - Set `maxmemory 8gb` (prevents OOM kills)
@@ -1110,7 +1112,7 @@ scripts/start-services.sh start
 
 # Or: SLM Orchestration GUI
 scripts/start-services.sh gui
-# Visit: https://172.16.168.19/orchestration
+# Visit: https://<slm-manager-ip>/orchestration
 
 # Or: Direct systemctl
 sudo systemctl start autobot-backend
@@ -1411,7 +1413,7 @@ scripts/start-services.sh --help
 scripts/start-services.sh gui
 
 # Or visit directly:
-# https://172.16.168.19/orchestration
+# https://<slm-manager-ip>/orchestration
 ```
 - Visual service management
 - Real-time health monitoring
@@ -1454,7 +1456,7 @@ cd autobot-slm-backend/ansible
 ansible-playbook playbooks/deploy-native-services.yml
 
 # Monitor via SLM GUI
-# https://172.16.168.19/orchestration
+# https://<slm-manager-ip>/orchestration
 ```
 - Automated deployment
 - Service orchestration
@@ -1474,19 +1476,19 @@ Desktop access is **enabled by default** on all modes:
 ### Service Layout - Distributed VM Infrastructure
 
 **Infrastructure Overview:**
-- 📡 **Main Machine (WSL)**: `172.16.168.20` - Backend API (port 8443) + Desktop/Terminal VNC (port 6080)
+- 📡 **Main Machine (WSL)**: `<backend-ip>` - Backend API (port 8443) + Desktop/Terminal VNC (port 6080)
 - 🌐 **Remote VMs:**
-  - **VM1 Frontend**: `172.16.168.21:5173` - Web interface (SINGLE FRONTEND SERVER)
-  - **VM2 NPU Worker**: `172.16.168.22:8081` - Hardware AI acceleration
-  - **VM3 Redis**: `172.16.168.23:6379` - Data layer
-  - **VM4 AI Stack**: `172.16.168.24:8080` - AI processing
-  - **VM5 Browser**: `172.16.168.25:3000` - Web automation (Playwright)
+  - **VM1 Frontend**: `<frontend-ip>:5173` - Web interface (SINGLE FRONTEND SERVER)
+  - **VM2 NPU Worker**: `<npu-ip>:8081` - Hardware AI acceleration
+  - **VM3 Redis**: `<database-ip>:6379` - Data layer
+  - **VM4 AI Stack**: `<aiml-ip>:8080` - AI processing
+  - **VM5 Browser**: `<browser-ip>:3000` - Web automation (Playwright)
 
 **Service Distribution:**
-- **Backend API**: `172.16.168.20:8443` - Main machine
-- **Desktop VNC**: `172.16.168.20:6080` - Main machine
-- **Terminal VNC**: `172.16.168.20:6080` - Main machine
-- **Browser Automation**: `172.16.168.25:3000` - Browser VM
+- **Backend API**: `<backend-ip>:8443` - Main machine
+- **Desktop VNC**: `<backend-ip>:6080` - Main machine
+- **Terminal VNC**: `<backend-ip>:6080` - Main machine
+- **Browser Automation**: `<browser-ip>:3000` - Browser VM
 - **Ollama LLM**: `127.0.0.1:11434` - Local LLM processing
 
 ## ⚠️ **CRITICAL: Single Frontend Server Architecture**
@@ -1494,8 +1496,8 @@ Desktop access is **enabled by default** on all modes:
 **MANDATORY FRONTEND SERVER RULES:**
 
 ### **✅ CORRECT: Single Frontend Server**
-- **ONLY** `172.16.168.21:5173` runs the frontend (Frontend VM)
-- **NO** frontend servers on main machine (`172.16.168.20`)
+- **ONLY** `<frontend-ip>:5173` runs the frontend (Frontend VM)
+- **NO** frontend servers on main machine (`<backend-ip>`)
 - **NO** local development servers (`localhost:5173`)
 - **NO** multiple frontend instances permitted
 
@@ -1510,7 +1512,7 @@ Desktop access is **enabled by default** on all modes:
 - **SSH Key Authentication**: Uses `~/.ssh/autobot_key` (no passwords)
 
 ### **❌ STRICTLY FORBIDDEN (CAUSES SYSTEM CONFLICTS):**
-- Starting frontend servers on main machine (`172.16.168.20`)
+- Starting frontend servers on main machine (`<backend-ip>`)
 - Running `npm run dev` locally
 - Running `yarn dev` locally
 - Running `vite dev` locally
@@ -1558,7 +1560,7 @@ All major issues have been resolved:
 The application is now fully functional with:
 
 - Backend responding on port 8443 (main machine) — **Note**: test from .19/.21, not from within .20 (WSL2 loopback limitation, see [WSL2_NETWORKING.md](developer/WSL2_NETWORKING.md))
-- **Single Frontend VM** running on 172.16.168.21:5173 with proxy to backend
+- **Single Frontend VM** running on <frontend-ip>:5173 with proxy to backend
 - **VNC desktop access on port 6080 (enabled by default)**
 - All VM services healthy
 - Chat save operations working
@@ -1702,7 +1704,7 @@ All services now start cleanly and maintain stable operations.
 ### **Safe Database Operations:**
 ```bash
 # Safe to drop any database - data can be regenerated
-redis-cli -h 172.16.168.23 FLUSHDB
+redis-cli -h <database-ip> FLUSHDB
 
 # Repopulate knowledge base after dropping
 curl -X POST https://localhost:8443/api/knowledge_base/rebuild
@@ -1741,7 +1743,7 @@ curl -X POST https://localhost:8443/api/knowledge_base/rebuild
 **This rule MUST NEVER BE BROKEN under any circumstances:**
 
 - **ALL code edits MUST be made locally** and then synced to remote hosts
-- **NEVER use SSH to edit files directly** on remote VMs (172.16.168.21-25)
+- **NEVER use SSH to edit files directly** on remote VMs (<frontend-ip>-25)
 - **NEVER use remote text editors** (vim, nano, etc.) on remote hosts
 - **NEVER use vi, vim, nano, emacs** or any editor on remote machines
 - **Configuration changes MUST be made locally** and deployed via sync scripts
@@ -1767,7 +1769,7 @@ curl -X POST https://localhost:8443/api/knowledge_base/rebuild
 ./scripts/utilities/setup-ssh-keys.sh
 
 # Verify key deployment
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "hostname"
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "hostname"
 ```
 
 #### Sync Files to Remote VMs:
@@ -1818,7 +1820,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "hostname"
 
 **Sync Methods**:
 - **Frontend production build**: `./sync-frontend.sh` (builds and deploys to /var/www/html/)
-- **Frontend source code**: `tar czf /tmp/frontend-src.tar.gz --exclude=node_modules --exclude=dist --exclude=.git -C autobot-vue . && sshpass -p "autobot" scp -o StrictHostKeyChecking=no /tmp/frontend-src.tar.gz autobot@172.16.168.21:/tmp/ && sshpass -p "autobot" ssh -o StrictHostKeyChecking=no autobot@172.16.168.21 "cd /home/autobot/autobot-vue && tar xzf /tmp/frontend-src.tar.gz"`
+- **Frontend source code**: `tar czf /tmp/frontend-src.tar.gz --exclude=node_modules --exclude=dist --exclude=.git -C autobot-vue . && sshpass -p "autobot" scp -o StrictHostKeyChecking=no /tmp/frontend-src.tar.gz autobot@<frontend-ip>:/tmp/ && sshpass -p "autobot" ssh -o StrictHostKeyChecking=no autobot@<frontend-ip> "cd /home/autobot/autobot-vue && tar xzf /tmp/frontend-src.tar.gz"`
 - **Backend/other services**: Use ansible playbooks or custom sync scripts
 
 **🎯 WHY THIS RULE MUST NEVER BE BROKEN:**
@@ -1842,7 +1844,7 @@ ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "hostname"
 - **Backup protection** - code is preserved and can be restored
 
 **🚨 ZERO TOLERANCE POLICY:**
-Direct editing on remote machines (172.16.168.21-25) **GUARANTEES WORK LOSS** when machines are reinstalled. We cannot track remote changes and cannot recover lost work.
+Direct editing on remote machines (<frontend-ip>-25) **GUARANTEES WORK LOSS** when machines are reinstalled. We cannot track remote changes and cannot recover lost work.
 
 ## Fixes Applied During This Session
 
@@ -2036,7 +2038,7 @@ These fixes address the **root architectural causes** rather than symptoms, maki
 curl https://localhost:8443/api/health
 
 # Redis connection
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 
 # View logs
 tail -f logs/backend.log
@@ -2340,7 +2342,7 @@ Fragmentation Ratio: 0.98 (excellent)
 - Request throughput: ⬆️ 30% (with connection pool optimization)
 
 ### Configuration Persisted
-Changes saved to `/etc/redis-stack.conf` on VM3 (172.16.168.23)
+Changes saved to `/etc/redis-stack.conf` on VM3 (<database-ip>)
 
 ### Why Redis Uses Only 1 Core
 Redis is architecturally **single-threaded** for command processing by design:

--- a/docs/tasks/security/tls-implementation.md
+++ b/docs/tasks/security/tls-implementation.md
@@ -127,12 +127,12 @@ CA Certificate:
 - Location: certs/ca/
 
 Service Certificates (6):
-1. main-host (172.16.168.20) - autobot-backend
-2. frontend (172.16.168.21) - autobot-frontend
-3. npu-worker (172.16.168.22) - autobot-npu-worker
-4. redis (172.16.168.23) - autobot-redis
-5. ai-stack (172.16.168.24) - autobot-ai-stack
-6. browser (172.16.168.25) - autobot-browser
+1. main-host (<backend-ip>) - autobot-backend
+2. frontend (<frontend-ip>) - autobot-frontend
+3. npu-worker (<npu-ip>) - autobot-npu-worker
+4. redis (<database-ip>) - autobot-redis
+5. ai-stack (<aiml-ip>) - autobot-ai-stack
+6. browser (<browser-ip>) - autobot-browser
 
 All certificates include:
 - DNS: Common Name, Service Name, localhost

--- a/docs/testing/PREFERENCES_TESTING_GUIDE.md
+++ b/docs/testing/PREFERENCES_TESTING_GUIDE.md
@@ -11,7 +11,7 @@
 
 This guide provides comprehensive testing procedures for the AutoBot Preferences System, including dark/light mode, font size scaling, accent colors, and layout density preferences.
 
-**Test URL**: http://172.16.168.21:5173/preferences
+**Test URL**: http://<frontend-ip>:5173/preferences
 
 ---
 
@@ -31,14 +31,14 @@ This guide provides comprehensive testing procedures for the AutoBot Preferences
 ## Quick Start Testing
 
 ### Prerequisites
-- AutoBot frontend running at http://172.16.168.21:5173
+- AutoBot frontend running at http://<frontend-ip>:5173
 - Modern web browser (Chrome, Firefox, Safari, or Edge)
 - Screen reader (optional, for accessibility testing)
 
 ### Basic Smoke Test (5 minutes)
 
 1. **Navigate to Preferences**
-   - Go to http://172.16.168.21:5173
+   - Go to http://<frontend-ip>:5173
    - Click "Preferences" in the header
    - Verify page loads successfully
 
@@ -669,7 +669,7 @@ This guide provides comprehensive testing procedures for the AutoBot Preferences
 ## Test Execution Checklist
 
 ### Before Testing
-- [ ] Frontend server running (http://172.16.168.21:5173)
+- [ ] Frontend server running (http://<frontend-ip>:5173)
 - [ ] Clear browser cache
 - [ ] Clear localStorage
 - [ ] Browser DevTools open

--- a/docs/troubleshooting/COMPREHENSIVE_TROUBLESHOOTING_GUIDE.md
+++ b/docs/troubleshooting/COMPREHENSIVE_TROUBLESHOOTING_GUIDE.md
@@ -20,15 +20,15 @@ python3 scripts/health_check_comprehensive.py
 tail -f logs/autobot.log | grep -i error
 
 # 4. Check VM network connectivity
-ping -c 3 172.16.168.21  # Frontend
-ping -c 3 172.16.168.22  # NPU Worker  
-ping -c 3 172.16.168.23  # Redis
-ping -c 3 172.16.168.24  # AI Stack
-ping -c 3 172.16.168.25  # Browser Service
+ping -c 3 <frontend-ip>  # Frontend
+ping -c 3 <npu-ip>  # NPU Worker  
+ping -c 3 <database-ip>  # Redis
+ping -c 3 <aiml-ip>  # AI Stack
+ping -c 3 <browser-ip>  # Browser Service
 
 # 5. Verify critical services
 curl -s http://127.0.0.1:8001/api/health | jq .
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
 ```
 
@@ -75,7 +75,7 @@ docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
 ```bash
 # Check if Redis is running
 docker ps | grep redis
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 
 # If Redis is down, restart it
 docker restart autobot-redis
@@ -137,14 +137,14 @@ for vm in 21 22 23 24 25; do
 done
 
 # Check firewall rules
-sudo iptables -L -n | grep 172.16.168
+sudo iptables -L -n | grep "<network-subnet>"
 
 # Test specific service ports
-nc -zv 172.16.168.21 5173  # Frontend dev server
-nc -zv 172.16.168.22 8081  # NPU Worker
-nc -zv 172.16.168.23 6379  # Redis
-nc -zv 172.16.168.24 8080  # AI Stack
-nc -zv 172.16.168.25 3000  # Browser Service
+nc -zv <frontend-ip> 5173  # Frontend dev server
+nc -zv <npu-ip> 8081  # NPU Worker
+nc -zv <database-ip> 6379  # Redis
+nc -zv <aiml-ip> 8080  # AI Stack
+nc -zv <browser-ip> 3000  # Browser Service
 ```
 
 **Solutions**:
@@ -160,7 +160,7 @@ for vm in 21 22 23 24 25; do
 done
 
 # Test SSH connectivity
-ssh -i ~/.ssh/autobot_key autobot@172.16.168.21 "echo 'VM1 accessible'"
+ssh -i ~/.ssh/autobot_key autobot@<frontend-ip> "echo 'VM1 accessible'"
 ```
 
 #### B. Network Configuration Issues
@@ -170,7 +170,7 @@ ip addr show
 ip route show
 
 # Verify VM network is properly configured
-ping -c 3 172.16.168.1  # Network gateway
+ping -c 3 <network-gateway>  # Network gateway
 
 # Reset network if needed (WSL2)
 wsl --shutdown
@@ -191,13 +191,13 @@ docker ps | grep redis
 docker logs autobot-redis --tail=50
 
 # 2. Test Redis connectivity from different VMs
-redis-cli -h 172.16.168.23 -p 6379 ping
+redis-cli -h <database-ip> -p 6379 ping
 
 # 3. Check Redis memory usage
-redis-cli -h 172.16.168.23 info memory
+redis-cli -h <database-ip> info memory
 
 # 4. Check database configuration
-redis-cli -h 172.16.168.23 config get databases
+redis-cli -h <database-ip> config get databases
 ```
 
 **Solutions**:
@@ -212,7 +212,7 @@ docker rm autobot-redis
 docker run -d \
   --name autobot-redis \
   --network autobot \
-  --ip 172.16.168.23 \
+  --ip <database-ip> \
   -p 6379:6379 \
   -v redis_data:/data \
   redis/redis-stack:7.4.0-v1
@@ -221,10 +221,10 @@ docker run -d \
 #### B. Redis Memory Issues
 ```bash
 # Check available memory
-redis-cli -h 172.16.168.23 info memory | grep used_memory_human
+redis-cli -h <database-ip> info memory | grep used_memory_human
 
 # If Redis is out of memory, clear unnecessary data
-redis-cli -h 172.16.168.23
+redis-cli -h <database-ip>
 SELECT 3  # Cache database
 FLUSHDB  # Clear cache only
 
@@ -235,7 +235,7 @@ docker restart autobot-redis
 #### C. Database Configuration Issues
 ```bash
 # Verify Redis database separation
-redis-cli -h 172.16.168.23
+redis-cli -h <database-ip>
 INFO keyspace  # Should show multiple databases
 
 # If databases are mixed up, run database migration
@@ -256,7 +256,7 @@ python3 scripts/migrate_redis_databases.py --fix-separation
 **Diagnostic Commands**:
 ```bash
 # 1. Check NPU Worker status
-curl -s http://172.16.168.22:8081/health | jq .
+curl -s http://<npu-ip>:8081/health | jq .
 
 # 2. Verify GPU availability
 nvidia-smi
@@ -266,7 +266,7 @@ python3 -c "import torch; print(f'CUDA available: {torch.cuda.is_available()}')"
 python3 -c "from openvino.runtime import Core; print(f'NPU available: {\"NPU\" in Core().available_devices}')"
 
 # 4. Test AI Stack orchestrator
-curl -s http://172.16.168.24:8080/health | jq .
+curl -s http://<aiml-ip>:8080/health | jq .
 ```
 
 **Solutions**:
@@ -274,13 +274,13 @@ curl -s http://172.16.168.24:8080/health | jq .
 #### A. NPU Worker Issues
 ```bash
 # Check NPU service logs
-ssh autobot@172.16.168.22 'sudo journalctl -u autobot-npu-worker -f'
+ssh autobot@<npu-ip> 'sudo journalctl -u autobot-npu-worker -f'
 
 # Restart NPU service
-ssh autobot@172.16.168.22 'sudo systemctl restart autobot-npu-worker'
+ssh autobot@<npu-ip> 'sudo systemctl restart autobot-npu-worker'
 
 # If NPU not detected, fallback to GPU
-curl -X POST http://172.16.168.22:8081/config \
+curl -X POST http://<npu-ip>:8081/config \
   -H "Content-Type: application/json" \
   -d '{"fallback_to_gpu": true, "primary_device": "GPU"}'
 ```
@@ -324,12 +324,12 @@ python3 scripts/download_ai_models.py --force-refresh
 curl -s http://127.0.0.1:8001/api/knowledge_base/stats/comprehensive | jq .
 
 # 2. Test direct Redis vector search
-redis-cli -h 172.16.168.23
+redis-cli -h <database-ip>
 SELECT 8  # Vector database
 FT.INFO knowledge_idx
 
 # 3. Check embedding service
-curl -s http://172.16.168.22:8081/embeddings/health | jq .
+curl -s http://<npu-ip>:8081/embeddings/health | jq .
 ```
 
 **Solutions**:
@@ -340,7 +340,7 @@ curl -s http://172.16.168.22:8081/embeddings/health | jq .
 curl -X POST http://127.0.0.1:8001/api/knowledge_base/rebuild_index
 
 # Or manually rebuild
-redis-cli -h 172.16.168.23
+redis-cli -h <database-ip>
 SELECT 8
 FT.DROPINDEX knowledge_idx
 # Index will be rebuilt automatically on next search
@@ -349,10 +349,10 @@ FT.DROPINDEX knowledge_idx
 #### B. Embedding Service Issues
 ```bash
 # Restart embedding service on NPU worker
-ssh autobot@172.16.168.22 'sudo systemctl restart autobot-embedding-service'
+ssh autobot@<npu-ip> 'sudo systemctl restart autobot-embedding-service'
 
 # Test embedding generation
-curl -X POST http://172.16.168.22:8081/embeddings/generate \
+curl -X POST http://<npu-ip>:8081/embeddings/generate \
   -H "Content-Type: application/json" \
   -d '{"text": "test embedding generation"}'
 ```
@@ -360,10 +360,10 @@ curl -X POST http://172.16.168.22:8081/embeddings/generate \
 #### C. Database Corruption
 ```bash
 # Check Redis database integrity
-redis-cli -h 172.16.168.23 --latency-history -i 1
+redis-cli -h <database-ip> --latency-history -i 1
 
 # If corrupted, restore from backup
-redis-cli -h 172.16.168.23 --rdb backup/dump.rdb
+redis-cli -h <database-ip> --rdb backup/dump.rdb
 
 # Or rebuild knowledge base from source
 python3 scripts/rebuild_knowledge_base.py --from-source
@@ -379,10 +379,10 @@ python3 scripts/rebuild_knowledge_base.py --from-source
 **Diagnostic Commands**:
 ```bash
 # 1. Check frontend service
-curl -s http://172.16.168.21:5173/ | head -10
+curl -s http://<frontend-ip>:5173/ | head -10
 
 # 2. Test API proxy
-curl -s http://172.16.168.21:5173/api/health
+curl -s http://<frontend-ip>:5173/api/health
 
 # 3. Check WebSocket connection
 wscat -c ws://127.0.0.1:8001/ws/test
@@ -399,7 +399,7 @@ cat vite.config.ts | grep -A 10 proxy
 # Expected proxy configuration:
 # proxy: {
 #   '/api': {
-#     target: 'https://172.16.168.20:8443',
+#     target: 'https://<backend-ip>:8443',
 #     changeOrigin: true
 #   }
 # }
@@ -411,7 +411,7 @@ npm run dev
 #### B. CORS Issues
 ```bash
 # Check CORS headers
-curl -H "Origin: http://172.16.168.21:5173" \
+curl -H "Origin: http://<frontend-ip>:5173" \
      -H "Access-Control-Request-Method: POST" \
      -H "Access-Control-Request-Headers: Content-Type" \
      -X OPTIONS \
@@ -432,7 +432,7 @@ curl --include \
      http://127.0.0.1:8001/ws/test
 
 # Test WebSocket proxy through Nginx
-curl -I http://172.16.168.21:5173/ws/test
+curl -I http://<frontend-ip>:5173/ws/test
 ```
 
 ---
@@ -489,7 +489,7 @@ ps aux | grep -i terminal | grep -v grep
 pkill -f "terminal_session"
 
 # Clear session storage
-redis-cli -h 172.16.168.23
+redis-cli -h <database-ip>
 SELECT 2  # Session database
 KEYS "terminal_session:*"
 DEL terminal_session:*  # Clear all terminal sessions
@@ -505,13 +505,13 @@ DEL terminal_session:*  # Clear all terminal sessions
 **Diagnostic Commands**:
 ```bash
 # 1. Check browser service status
-curl -s http://172.16.168.25:3000/health | jq .
+curl -s http://<browser-ip>:3000/health | jq .
 
 # 2. Check available browsers
-curl -s http://172.16.168.25:3000/browsers | jq .
+curl -s http://<browser-ip>:3000/browsers | jq .
 
 # 3. List active sessions
-curl -s http://172.16.168.25:3000/sessions | jq .
+curl -s http://<browser-ip>:3000/sessions | jq .
 ```
 
 **Solutions**:
@@ -519,35 +519,35 @@ curl -s http://172.16.168.25:3000/sessions | jq .
 #### A. Browser Pool Exhaustion
 ```bash
 # Check active sessions
-curl -s http://172.16.168.25:3000/sessions/stats | jq .
+curl -s http://<browser-ip>:3000/sessions/stats | jq .
 
 # Close idle sessions
-curl -X DELETE http://172.16.168.25:3000/sessions/cleanup
+curl -X DELETE http://<browser-ip>:3000/sessions/cleanup
 
 # Increase browser pool size
-ssh autobot@172.16.168.25 'echo "MAX_BROWSER_SESSIONS=20" >> /opt/autobot/browser/.env'
-ssh autobot@172.16.168.25 'sudo systemctl restart autobot-browser-service'
+ssh autobot@<browser-ip> 'echo "MAX_BROWSER_SESSIONS=20" >> /opt/autobot/browser/.env'
+ssh autobot@<browser-ip> 'sudo systemctl restart autobot-browser-service'
 ```
 
 #### B. Playwright Installation Issues
 ```bash
 # Reinstall Playwright browsers
-ssh autobot@172.16.168.25 'cd /opt/autobot/browser && npx playwright install --with-deps'
+ssh autobot@<browser-ip> 'cd /opt/autobot/browser && npx playwright install --with-deps'
 
 # Check browser installation
-ssh autobot@172.16.168.25 'npx playwright install --dry-run'
+ssh autobot@<browser-ip> 'npx playwright install --dry-run'
 ```
 
 #### C. Display/X11 Issues
 ```bash
 # Check X11 forwarding
-ssh autobot@172.16.168.25 'echo $DISPLAY'
+ssh autobot@<browser-ip> 'echo $DISPLAY'
 
 # Start virtual display if needed
-ssh autobot@172.16.168.25 'sudo systemctl start xvfb'
+ssh autobot@<browser-ip> 'sudo systemctl start xvfb'
 
 # Test browser launch
-ssh autobot@172.16.168.25 'timeout 10s chromium-browser --headless --dump-dom http://example.com'
+ssh autobot@<browser-ip> 'timeout 10s chromium-browser --headless --dump-dom http://example.com'
 ```
 
 ### 9. File Upload & Management Issues
@@ -627,7 +627,7 @@ iostat 1 5
 free -m
 
 # 3. Check cache hit rates
-redis-cli -h 172.16.168.23 info stats | grep cache
+redis-cli -h <database-ip> info stats | grep cache
 
 # 4. Profile application
 python3 -m cProfile -o profile.stats backend/main.py
@@ -638,13 +638,13 @@ python3 -m cProfile -o profile.stats backend/main.py
 #### A. Database Query Optimization
 ```bash
 # Check slow Redis queries
-redis-cli -h 172.16.168.23 SLOWLOG GET 10
+redis-cli -h <database-ip> SLOWLOG GET 10
 
 # Optimize knowledge base index
 curl -X POST http://127.0.0.1:8001/api/knowledge_base/optimize_index
 
 # Clear query cache if needed
-redis-cli -h 172.16.168.23
+redis-cli -h <database-ip>
 SELECT 3  # Cache database
 FLUSHDB
 ```
@@ -706,11 +706,11 @@ fi
 
 # 4. Database Health
 echo "=== Database Health ==="
-redis_ping=$(redis-cli -h 172.16.168.23 ping 2>/dev/null || echo "FAILED")
+redis_ping=$(redis-cli -h <database-ip> ping 2>/dev/null || echo "FAILED")
 echo "Redis: $redis_ping"
 
 if [ "$redis_ping" = "PONG" ]; then
-    kb_count=$(redis-cli -h 172.16.168.23 -n 8 DBSIZE 2>/dev/null || echo 0)
+    kb_count=$(redis-cli -h <database-ip> -n 8 DBSIZE 2>/dev/null || echo 0)
     echo "Knowledge base vectors: $kb_count"
 fi
 
@@ -747,7 +747,7 @@ find /data/autobot/temp/ -type f -mtime +7 -delete
 
 # 3. Database Optimization
 echo "Optimizing databases..."
-redis-cli -h 172.16.168.23 BGREWRITEAOF
+redis-cli -h <database-ip> BGREWRITEAOF
 curl -X POST http://127.0.0.1:8001/api/knowledge_base/optimize
 
 # 4. Update System Packages

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -172,16 +172,16 @@ python3 scripts/health_check_comprehensive.py
 tail -f logs/autobot.log | grep -i error
 
 # 4. VM network
-ping -c 3 172.16.168.19  # SLM
-ping -c 3 172.16.168.21  # Frontend
-ping -c 3 172.16.168.22  # NPU
-ping -c 3 172.16.168.23  # Redis
-ping -c 3 172.16.168.24  # AI Stack
-ping -c 3 172.16.168.25  # Browser
+ping -c 3 <slm-manager-ip>  # SLM
+ping -c 3 <frontend-ip>  # Frontend
+ping -c 3 <npu-ip>  # NPU
+ping -c 3 <database-ip>  # Redis
+ping -c 3 <aiml-ip>  # AI Stack
+ping -c 3 <browser-ip>  # Browser
 
 # 5. Critical services
 curl -s http://127.0.0.1:8001/api/health | jq .
-redis-cli -h 172.16.168.23 ping
+redis-cli -h <database-ip> ping
 ```
 
 ---

--- a/docs/troubleshooting/guides/ansible-role-deployment-failures.md
+++ b/docs/troubleshooting/guides/ansible-role-deployment-failures.md
@@ -78,7 +78,7 @@ rm -rf ansible/roles/old_location/my_role
 # After OS upgrade (Ubuntu 20.04→22.04), playbook uses old facts
 
 # Clear cache for specific host
-rm /tmp/ansible_fact_cache/172.16.168.22
+rm /tmp/ansible_fact_cache/<npu-ip>
 
 # Or clear all
 rm -rf /tmp/ansible_fact_cache/*

--- a/docs/troubleshooting/guides/frontend-api-calls-404-401-errors.md
+++ b/docs/troubleshooting/guides/frontend-api-calls-404-401-errors.md
@@ -29,13 +29,13 @@
 
 ```bash
 # 1. Check if backend is running and accessible
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 
 # 2. Check CORS configuration
 grep -r "get_cors_origins" autobot-backend/
 
 # 3. Verify API routes are registered
-curl https://172.16.168.20:8443/docs | grep -i "advanced-control"
+curl https://<backend-ip>:8443/docs | grep -i "advanced-control"
 
 # 4. Check frontend API client configuration
 grep -r "ApiClient" autobot-frontend/src/ | grep import
@@ -91,7 +91,7 @@ def get_cors_origins():
     return origins
 ```
 
-Ensure this includes `172.16.168.21` (Frontend VM).
+Ensure this includes `<frontend-ip>` (Frontend VM).
 
 ### Step 4: Remove Duplicate JS/TS Files
 
@@ -150,19 +150,19 @@ async post<T>(endpoint: string, data: any): Promise<T> {
 
 ```bash
 # 1. Check API health
-curl https://172.16.168.20:8443/api/health
+curl https://<backend-ip>:8443/api/health
 
 # 2. Test specific endpoints
-curl https://172.16.168.20:8443/api/advanced-control/status
+curl https://<backend-ip>:8443/api/advanced-control/status
 
 # 3. Check CORS headers
-curl -H "Origin: http://172.16.168.21" -I https://172.16.168.20:8443/api/health
+curl -H "Origin: http://<frontend-ip>" -I https://<backend-ip>:8443/api/health
 
 # Should include:
-# Access-Control-Allow-Origin: http://172.16.168.21
+# Access-Control-Allow-Origin: http://<frontend-ip>
 
 # 4. Verify routes in OpenAPI docs
-curl https://172.16.168.20:8443/docs
+curl https://<backend-ip>:8443/docs
 ```
 
 **Success Indicators**:

--- a/docs/troubleshooting/guides/npu-worker-port-not-accessible.md
+++ b/docs/troubleshooting/guides/npu-worker-port-not-accessible.md
@@ -26,23 +26,23 @@ The NPU worker deployed via Ansible was a **placeholder implementation**:
 
 ```bash
 # Check if NPU worker has FastAPI installed
-ssh autobot@172.16.168.22 "pip list | grep fastapi"
+ssh autobot@<npu-ip> "pip list | grep fastapi"
 
 # If missing, install dependencies
-ssh autobot@172.16.168.22 "cd /opt/autobot/npu-worker && ./venv/bin/pip install 'fastapi>=0.100.0' 'uvicorn[standard]>=0.20.0'"
+ssh autobot@<npu-ip> "cd /opt/autobot/npu-worker && ./venv/bin/pip install 'fastapi>=0.100.0' 'uvicorn[standard]>=0.20.0'"
 
 # Restart service
-ssh autobot@172.16.168.22 "sudo systemctl restart autobot-npu-worker"
+ssh autobot@<npu-ip> "sudo systemctl restart autobot-npu-worker"
 
 # Verify port is accessible
-curl http://172.16.168.22:8081/health
+curl http://<npu-ip>:8081/health
 ```
 
 ## Detailed Resolution Steps
 
 ### Step 1: Verify Service Status
 ```bash
-ssh autobot@172.16.168.22 "sudo systemctl status autobot-npu-worker"
+ssh autobot@<npu-ip> "sudo systemctl status autobot-npu-worker"
 ```
 **Expected Output**:
 ```
@@ -52,7 +52,7 @@ ssh autobot@172.16.168.22 "sudo systemctl status autobot-npu-worker"
 
 ### Step 2: Check Port Binding
 ```bash
-ssh autobot@172.16.168.22 "sudo netstat -tlnp | grep 8081"
+ssh autobot@<npu-ip> "sudo netstat -tlnp | grep 8081"
 ```
 **Expected Output** (if broken):
 ```
@@ -61,7 +61,7 @@ ssh autobot@172.16.168.22 "sudo netstat -tlnp | grep 8081"
 
 ### Step 3: Review NPU Worker Code
 ```bash
-ssh autobot@172.16.168.22 "head -30 /opt/autobot/npu-worker/npu-worker.py"
+ssh autobot@<npu-ip> "head -30 /opt/autobot/npu-worker/npu-worker.py"
 ```
 Look for:
 - FastAPI imports
@@ -77,12 +77,12 @@ cd autobot-slm-backend/ansible
 ansible-playbook -i inventory.yml setup-npu-worker.yml --limit vm2
 
 # Or manually copy updated npu-worker.py template
-scp roles/npu-worker/templates/npu-worker.py.j2 autobot@172.16.168.22:/opt/autobot/npu-worker/npu-worker.py
+scp roles/npu-worker/templates/npu-worker.py.j2 autobot@<npu-ip>:/opt/autobot/npu-worker/npu-worker.py
 ```
 
 ### Step 5: Install Dependencies
 ```bash
-ssh autobot@172.16.168.22 "cd /opt/autobot/npu-worker && sudo -u autobot ./venv/bin/pip install 'fastapi>=0.100.0' 'uvicorn[standard]>=0.20.0'"
+ssh autobot@<npu-ip> "cd /opt/autobot/npu-worker && sudo -u autobot ./venv/bin/pip install 'fastapi>=0.100.0' 'uvicorn[standard]>=0.20.0'"
 ```
 **Expected Output**:
 ```
@@ -91,21 +91,21 @@ Successfully installed fastapi-0.129.0 uvicorn-0.40.0 [...]
 
 ### Step 6: Configure Firewall
 ```bash
-ssh autobot@172.16.168.22 "sudo ufw allow 8081/tcp comment 'NPU Worker API'"
+ssh autobot@<npu-ip> "sudo ufw allow 8081/tcp comment 'NPU Worker API'"
 ```
 
 ### Step 7: Restart Service
 ```bash
-ssh autobot@172.16.168.22 "sudo systemctl restart autobot-npu-worker"
+ssh autobot@<npu-ip> "sudo systemctl restart autobot-npu-worker"
 sleep 3
-ssh autobot@172.16.168.22 "sudo systemctl status autobot-npu-worker"
+ssh autobot@<npu-ip> "sudo systemctl status autobot-npu-worker"
 ```
 
 ## Verification
 
 ```bash
 # Test health endpoint from main server
-curl http://172.16.168.22:8081/health
+curl http://<npu-ip>:8081/health
 
 # Expected response:
 # {
@@ -119,7 +119,7 @@ curl http://172.16.168.22:8081/health
 # }
 
 # Check logs for startup messages
-ssh autobot@172.16.168.22 "tail -20 /var/log/autobot/npu-worker.log"
+ssh autobot@<npu-ip> "tail -20 /var/log/autobot/npu-worker.log"
 
 # Should show:
 # INFO:     Uvicorn running on http://0.0.0.0:8081
@@ -136,7 +136,7 @@ ssh autobot@172.16.168.22 "tail -20 /var/log/autobot/npu-worker.log"
 1. **Always deploy using Ansible roles** instead of manual file copies
 2. **Test endpoints after deployment**:
    ```bash
-   curl http://172.16.168.22:8081/health
+   curl http://<npu-ip>:8081/health
    ```
 3. **Monitor startup logs** during service restart:
    ```bash

--- a/docs/user-guide/05-preferences.md
+++ b/docs/user-guide/05-preferences.md
@@ -10,7 +10,7 @@
 
 1. **From Desktop**: Click **"Preferences"** in the top navigation bar
 2. **From Mobile**: Tap the menu icon → Select **"Preferences"**
-3. **Direct Link**: Navigate to http://172.16.168.21:5173/preferences
+3. **Direct Link**: Navigate to http://<frontend-ip>:5173/preferences
 
 ---
 

--- a/docs/user-guide/06-redis-management.md
+++ b/docs/user-guide/06-redis-management.md
@@ -46,7 +46,7 @@ Redis is a critical component of AutoBot that provides:
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                    Frontend UI (VM1)                         │
-│              http://172.16.168.21:5173                       │
+│              http://<frontend-ip>:5173                       │
 │                                                              │
 │  [Redis Service Controls]                                   │
 │   - Service Status Display                                  │
@@ -59,7 +59,7 @@ Redis is a critical component of AutoBot that provides:
                        ▼
 ┌─────────────────────────────────────────────────────────────┐
 │              Backend API (Main Machine)                      │
-│           https://172.16.168.20:8443                         │
+│           https://<backend-ip>:8443                         │
 │                                                              │
 │  [Redis Service Manager]                                    │
 │   - Service Control Logic                                   │
@@ -71,7 +71,7 @@ Redis is a critical component of AutoBot that provides:
                        ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                Redis VM (VM3)                                │
-│           172.16.168.23:6379                                │
+│           <database-ip>:6379                                │
 │                                                              │
 │  [Redis Service]                                            │
 │   - Redis Server Process                                    │
@@ -85,7 +85,7 @@ Redis is a critical component of AutoBot that provides:
 
 ### Step 1: Login to AutoBot
 
-1. Navigate to AutoBot frontend: `http://172.16.168.21:5173`
+1. Navigate to AutoBot frontend: `http://<frontend-ip>:5173`
 2. Login with your credentials
 3. Ensure you have appropriate role permissions (see [Role-Based Access](#role-based-access))
 


### PR DESCRIPTION
Closes #3311

## Changes
- Replace all 172.16.168.x IPs in 159 active docs files with VM role placeholders
- Role mapping applied: `<slm-manager-ip>`, `<backend-ip>`, `<frontend-ip>`, `<npu-ip>`, `<database-ip>`, `<aiml-ip>`, `<browser-ip>`
- Subnet references → `<network-subnet>`, gateway → `<network-gateway>`
- Add IP disclaimer callout to 10 highest-density files linking to VM_ROLES.md
- Remaining instances are shell variables (`$ip`, `$vm`), existing placeholders (`XX`), or bash ranges — all appropriate
- Files in `docs/archives/` intentionally left unchanged (historical records)

## Role mapping
| IP | Role | Placeholder |
|---|---|---|
| 172.16.168.19 | SLM Manager | `<slm-manager-ip>` |
| 172.16.168.20 | Backend | `<backend-ip>` |
| 172.16.168.21 | Frontend | `<frontend-ip>` |
| 172.16.168.22 | NPU Worker | `<npu-ip>` |
| 172.16.168.23 | Database | `<database-ip>` |
| 172.16.168.24 | AI/ML | `<aiml-ip>` |
| 172.16.168.25 | Browser | `<browser-ip>` |