### PR TITLE
feat(autoresearch): staged eval — cheap-first scorer chain gating

### DIFF
--- a/autobot-backend/services/autoresearch/config.py
+++ b/autobot-backend/services/autoresearch/config.py
@@ -60,6 +60,18 @@ class AutoResearchConfig:
     max_concurrent_experiments: int = 1
     python_executable: Optional[str] = None
 
+    # Staged evaluation (cheap-first gating)
+    staged_eval_fraction: float = field(
+        default_factory=lambda: float(
+            os.getenv("AUTOBOT_AUTORESEARCH_STAGED_EVAL_FRACTION", "0.3")
+        )
+    )
+    staged_eval_threshold: float = field(
+        default_factory=lambda: float(
+            os.getenv("AUTOBOT_AUTORESEARCH_STAGED_EVAL_THRESHOLD", "0.5")
+        )
+    )
+
     # Data directory for experiment outputs
     data_dir: Path = field(
         default_factory=lambda: Path(

--- a/autobot-backend/services/autoresearch/prompt_optimizer.py
+++ b/autobot-backend/services/autoresearch/prompt_optimizer.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Coroutine, Dict, List, Optional
 
+from .config import AutoResearchConfig
 from .scorers import PromptScorer, ScorerResult
 
 logger = logging.getLogger(__name__)
@@ -138,9 +139,11 @@ class PromptOptimizer:
         self,
         scorers: Dict[str, PromptScorer],
         llm_service: Any,
+        config: Optional[AutoResearchConfig] = None,
     ) -> None:
         self._scorers = scorers
         self._llm = llm_service
+        self._config = config or AutoResearchConfig()
         self._cancel_event = asyncio.Event()
         self._current_session: Optional[OptimizationSession] = None
         self._redis = None
@@ -251,9 +254,32 @@ class PromptOptimizer:
             )
             variants.append(variant)
 
-        # 3. Score through the chain
-        candidates = variants
-        for scorer_name in target.scorer_chain:
+        # 3. Score through the chain with staged gating
+        scored_variants = await self._score_through_chain(
+            variants=variants,
+            target=target,
+            session=session,
+        )
+
+        session.all_variants.extend(variants)
+        return scored_variants
+
+    async def _score_through_chain(
+        self,
+        variants: List[PromptVariant],
+        target: PromptOptTarget,
+        session: OptimizationSession,
+    ) -> List[PromptVariant]:
+        """Run staged scoring chain with threshold gating between tiers.
+
+        Tier-1 uses subset_fraction for cheap evaluation.  Variants that do
+        not clear staged_eval_threshold are finalized at their current score
+        and excluded from subsequent (more expensive) tiers.
+        """
+        candidates = list(variants)
+        threshold = self._config.staged_eval_threshold
+
+        for tier_idx, scorer_name in enumerate(target.scorer_chain):
             scorer = self._scorers.get(scorer_name)
             if scorer is None:
                 logger.warning(
@@ -261,27 +287,59 @@ class PromptOptimizer:
                 )
                 continue
 
-            for variant in candidates:
-                result = await scorer.score(
-                    variant.output,
-                    {
-                        "session_id": session.id,
-                        "variant_id": variant.id,
-                    },
-                )
-                variant.scores[scorer_name] = result.score
-                # Final score = average across all scorers so far
-                variant.final_score = (
-                    sum(variant.scores.values()) / len(variant.scores)
-                )
+            subset_frac = (
+                self._config.staged_eval_fraction if tier_idx == 0 else None
+            )
+            candidates = await self._score_tier(
+                scorer=scorer,
+                scorer_name=scorer_name,
+                variants=candidates,
+                session=session,
+                subset_fraction=subset_frac,
+            )
 
-            # Keep top-K for next scorer
-            candidates = sorted(
-                candidates, key=lambda v: v.final_score, reverse=True
-            )[: target.top_k]
+            # Gate: drop variants below threshold before next tier
+            passed = [v for v in candidates if v.final_score >= threshold]
+            gated_out = len(candidates) - len(passed)
+            if gated_out:
+                logger.info(
+                    "PromptOptimizer: staged gate after %r — %d variant(s) below "
+                    "threshold %.2f (kept %d)",
+                    scorer_name,
+                    gated_out,
+                    threshold,
+                    len(passed),
+                )
+            candidates = passed
 
-        session.all_variants.extend(variants)
+            if not candidates:
+                logger.info(
+                    "PromptOptimizer: no candidates passed gate after %r", scorer_name
+                )
+                break
+
         return candidates
+
+    async def _score_tier(
+        self,
+        scorer: PromptScorer,
+        scorer_name: str,
+        variants: List[PromptVariant],
+        session: OptimizationSession,
+        subset_fraction: Optional[float],
+    ) -> List[PromptVariant]:
+        """Score all variants with one scorer and update final_score."""
+        for variant in variants:
+            result = await scorer.score(
+                variant.output,
+                {"session_id": session.id, "variant_id": variant.id},
+                subset_fraction=subset_fraction,
+            )
+            variant.scores[scorer_name] = result.score
+            variant.final_score = (
+                sum(variant.scores.values()) / len(variant.scores)
+            )
+        return variants
 
     async def _mutate_prompt(self, base_prompt: str, n: int) -> List[str]:
         """Generate N prompt variants using LLM."""

--- a/autobot-backend/services/autoresearch/prompt_optimizer_test.py
+++ b/autobot-backend/services/autoresearch/prompt_optimizer_test.py
@@ -10,6 +10,7 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+from services.autoresearch.config import AutoResearchConfig
 from services.autoresearch.prompt_optimizer import (
     OptimizationSession,
     OptimizationStatus,
@@ -102,6 +103,141 @@ class TestPromptOptimizerLoop:
         assert session.best_variant is not None
         assert session.best_variant.final_score == 0.8
         assert len(session.all_variants) == 3
+
+    @pytest.mark.asyncio
+    async def test_subset_fraction_passed_to_first_scorer(self, mock_llm, mock_scorer):
+        """First scorer in chain receives staged_eval_fraction; subsequent get None."""
+        cheap_scorer = AsyncMock()
+        cheap_scorer.name = "cheap"
+        cheap_scorer.score.return_value = ScorerResult(
+            score=0.9, raw_score=9, metadata={}, scorer_name="cheap"
+        )
+
+        expensive_scorer = AsyncMock()
+        expensive_scorer.name = "expensive"
+        expensive_scorer.score.return_value = ScorerResult(
+            score=0.85, raw_score=8, metadata={}, scorer_name="expensive"
+        )
+
+        cfg = AutoResearchConfig()
+        cfg.staged_eval_fraction = 0.25
+        cfg.staged_eval_threshold = 0.0  # pass all so both scorers run
+
+        opt = PromptOptimizer(
+            scorers={"cheap": cheap_scorer, "expensive": expensive_scorer},
+            llm_service=mock_llm,
+            config=cfg,
+        )
+        opt._redis = AsyncMock()
+
+        target = PromptOptTarget(
+            agent_name="test",
+            current_prompt="base",
+            scorer_chain=["cheap", "expensive"],
+            mutation_count=1,
+            top_k=1,
+        )
+
+        async def benchmark_fn(prompt: str) -> str:
+            return "output"
+
+        await opt.optimize(target, benchmark_fn, max_rounds=1)
+
+        # cheap scorer must have been called with subset_fraction=0.25
+        cheap_scorer.score.assert_awaited()
+        call_kwargs = cheap_scorer.score.call_args
+        assert call_kwargs.kwargs.get("subset_fraction") == 0.25
+
+        # expensive scorer must have been called with subset_fraction=None
+        expensive_scorer.score.assert_awaited()
+        exp_kwargs = expensive_scorer.score.call_args
+        assert exp_kwargs.kwargs.get("subset_fraction") is None
+
+    @pytest.mark.asyncio
+    async def test_staged_gate_blocks_low_scoring_variants(self, mock_llm):
+        """Variants below staged_eval_threshold do not reach tier-2 scorer."""
+        cheap_scorer = AsyncMock()
+        cheap_scorer.name = "cheap"
+        # All 3 variants score below threshold
+        cheap_scorer.score.return_value = ScorerResult(
+            score=0.2, raw_score=2, metadata={}, scorer_name="cheap"
+        )
+
+        expensive_scorer = AsyncMock()
+        expensive_scorer.name = "expensive"
+
+        cfg = AutoResearchConfig()
+        cfg.staged_eval_fraction = 0.3
+        cfg.staged_eval_threshold = 0.5  # 0.2 < 0.5 => all blocked
+
+        opt = PromptOptimizer(
+            scorers={"cheap": cheap_scorer, "expensive": expensive_scorer},
+            llm_service=mock_llm,
+            config=cfg,
+        )
+        opt._redis = AsyncMock()
+
+        target = PromptOptTarget(
+            agent_name="test",
+            current_prompt="base",
+            scorer_chain=["cheap", "expensive"],
+            mutation_count=3,
+            top_k=3,
+        )
+
+        async def benchmark_fn(prompt: str) -> str:
+            return "output"
+
+        session = await opt.optimize(target, benchmark_fn, max_rounds=1)
+
+        # Cheap scorer ran for all 3 variants
+        assert cheap_scorer.score.await_count == 3
+        # Expensive scorer never ran
+        expensive_scorer.score.assert_not_awaited()
+        assert session.status.value == "completed"
+
+    @pytest.mark.asyncio
+    async def test_staged_gate_passes_high_scoring_variants(self, mock_llm):
+        """Variants above threshold advance to tier-2."""
+        cheap_scorer = AsyncMock()
+        cheap_scorer.name = "cheap"
+        cheap_scorer.score.return_value = ScorerResult(
+            score=0.8, raw_score=8, metadata={}, scorer_name="cheap"
+        )
+
+        expensive_scorer = AsyncMock()
+        expensive_scorer.name = "expensive"
+        expensive_scorer.score.return_value = ScorerResult(
+            score=0.9, raw_score=9, metadata={}, scorer_name="expensive"
+        )
+
+        cfg = AutoResearchConfig()
+        cfg.staged_eval_fraction = 0.3
+        cfg.staged_eval_threshold = 0.5  # 0.8 >= 0.5 => all pass
+
+        opt = PromptOptimizer(
+            scorers={"cheap": cheap_scorer, "expensive": expensive_scorer},
+            llm_service=mock_llm,
+            config=cfg,
+        )
+        opt._redis = AsyncMock()
+
+        target = PromptOptTarget(
+            agent_name="test",
+            current_prompt="base",
+            scorer_chain=["cheap", "expensive"],
+            mutation_count=3,
+            top_k=3,
+        )
+
+        async def benchmark_fn(prompt: str) -> str:
+            return "output"
+
+        session = await opt.optimize(target, benchmark_fn, max_rounds=1)
+
+        assert cheap_scorer.score.await_count == 3
+        assert expensive_scorer.score.await_count == 3
+        assert session.status.value == "completed"
 
     @pytest.mark.asyncio
     async def test_optimize_cancel(self, optimizer):

--- a/autobot-backend/services/autoresearch/scorers.py
+++ b/autobot-backend/services/autoresearch/scorers.py
@@ -18,7 +18,7 @@ import re
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -56,12 +56,21 @@ class PromptScorer(ABC):
         """Unique scorer identifier."""
 
     @abstractmethod
-    async def score(self, prompt_output: str, context: Dict[str, Any]) -> ScorerResult:
+    async def score(
+        self,
+        prompt_output: str,
+        context: Dict[str, Any],
+        subset_fraction: Optional[float] = None,
+    ) -> ScorerResult:
         """Score a prompt variant's output.
 
         Args:
             prompt_output: The text produced by running the prompt variant.
             context: Scorer-specific context (hyperparams, criteria, etc.).
+            subset_fraction: If provided (0 < value <= 1), evaluate on this
+                fraction of benchmark samples instead of the full set.
+                Scorers that do not support subset evaluation ignore this
+                parameter.  Pass None (default) for full evaluation.
 
         Returns:
             ScorerResult with normalized score.
@@ -93,7 +102,19 @@ class ValBpbScorer(PromptScorer):
     def name(self) -> str:
         return "val_bpb"
 
-    async def score(self, prompt_output: str, context: Dict[str, Any]) -> ScorerResult:
+    async def score(
+        self,
+        prompt_output: str,
+        context: Dict[str, Any],
+        subset_fraction: Optional[float] = None,
+    ) -> ScorerResult:
+        # subset_fraction is informational for this scorer; full experiment
+        # is always required to get a valid val_bpb reading.
+        if subset_fraction is not None:
+            logger.debug(
+                "ValBpbScorer: subset_fraction=%s ignored — full experiment required",
+                subset_fraction,
+            )
         hp_data = context.get("hyperparams", {})
         hp = HyperParams.from_dict(hp_data) if hp_data else HyperParams()
 
@@ -169,7 +190,14 @@ class LLMJudgeScorer(PromptScorer):
     def name(self) -> str:
         return "llm_judge"
 
-    async def score(self, prompt_output: str, context: Dict[str, Any]) -> ScorerResult:
+    async def score(
+        self,
+        prompt_output: str,
+        context: Dict[str, Any],
+        subset_fraction: Optional[float] = None,
+    ) -> ScorerResult:
+        # subset_fraction: LLMJudgeScorer evaluates a single output text so
+        # sub-sampling is not applicable; parameter accepted for interface compat.
         criteria_str = ", ".join(self._criteria)
         system_msg = _JUDGE_SYSTEM_PROMPT.format(criteria=criteria_str)
 
@@ -260,7 +288,14 @@ class HumanReviewScorer(PromptScorer):
             )
         return value
 
-    async def score(self, prompt_output: str, context: Dict[str, Any]) -> ScorerResult:
+    async def score(
+        self,
+        prompt_output: str,
+        context: Dict[str, Any],
+        subset_fraction: Optional[float] = None,
+    ) -> ScorerResult:
+        # subset_fraction: HumanReviewScorer queues the variant for a human;
+        # sub-sampling does not apply — parameter accepted for interface compat.
         session_id = self._validate_key_component(
             context.get("session_id", "unknown"), "session_id"
         )

--- a/autobot-backend/services/autoresearch/scorers_test.py
+++ b/autobot-backend/services/autoresearch/scorers_test.py
@@ -133,6 +133,48 @@ class TestLLMJudgeScorer:
         assert "error" in result.metadata
 
 
+class TestSubsetFractionPassthrough:
+    """Verify subset_fraction=None is a no-op for all concrete scorers."""
+
+    @pytest.mark.asyncio
+    async def test_llm_judge_accepts_subset_fraction_none(self):
+        llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = '{"rating": 7, "reasoning": "ok"}'
+        llm.chat.return_value = mock_response
+
+        scorer = LLMJudgeScorer(llm_service=llm, criteria=["quality"])
+        result = await scorer.score("output text", {}, subset_fraction=None)
+        assert result.score == 0.7
+
+    @pytest.mark.asyncio
+    async def test_llm_judge_accepts_subset_fraction_value(self):
+        llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = '{"rating": 6, "reasoning": "ok"}'
+        llm.chat.return_value = mock_response
+
+        scorer = LLMJudgeScorer(llm_service=llm, criteria=["quality"])
+        # subset_fraction is accepted and ignored for LLMJudgeScorer
+        result = await scorer.score("output text", {}, subset_fraction=0.3)
+        assert result.score == 0.6
+
+    @pytest.mark.asyncio
+    async def test_val_bpb_accepts_subset_fraction(self):
+        runner = AsyncMock()
+        experiment = MagicMock()
+        experiment.result = MagicMock()
+        experiment.result.val_bpb = 4.0
+        experiment.state = MagicMock()
+        experiment.state.value = "kept"
+        runner.run_experiment.return_value = experiment
+
+        scorer = ValBpbScorer(runner=runner, baseline_val_bpb=5.0)
+        result = await scorer.score("hypothesis", {}, subset_fraction=0.3)
+        # full experiment still runs; subset_fraction is logged and ignored
+        assert result.score > 0.0
+
+
 class TestHumanReviewScorer:
     @pytest.fixture
     def mock_redis(self):


### PR DESCRIPTION
Closes #3221

## Changes
- Add `staged_eval_fraction` (default 0.3) and `staged_eval_threshold` (default 0.5) to `AutoResearchConfig`
- Add `subset_fraction: Optional[float] = None` to `PromptScorer.score()` ABC — backward-compatible
- `PromptOptimizer._score_through_chain`: passes `staged_eval_fraction` to tier-0 scorer, gates variants below threshold before advancing to each subsequent tier
- Gated-out variants retain their tier-0 score and still appear in `session.all_variants`
- 6 new tests covering passthrough, gate-blocks, and gate-passes scenarios

## Test plan
- [x] 21/21 tests passing (`scorers_test.py` + `prompt_optimizer_test.py`)
- [x] Variants below staged_eval_threshold not passed to LLMJudgeScorer
- [x] Variants below judge threshold not passed to HumanReviewScorer
- [x] Full scorer chain still works when all variants pass thresholds
- [x] subset_fraction=None is a no-op