### PR TITLE
fix(slm-frontend): wire i18n keys in WorkflowLiveDashboard status/connection labels

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -155,6 +155,7 @@
 
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
 import { useLiveEvents, type LiveEvent } from '@/composables/useLiveEvents';
 import AgentObservabilityPanel from './AgentObservabilityPanel.vue';
@@ -165,6 +166,7 @@ import type {
 } from '@/composables/useWorkflowBuilder';
 
 const logger = createLogger('WorkflowLiveDashboard');
+const { t } = useI18n();
 
 const props = defineProps<{
   activeWorkflows: ActiveWorkflow[];
@@ -200,9 +202,9 @@ const connectionIcon = computed(() => {
 });
 
 const connectionLabel = computed(() => {
-  if (liveConnected.value) return 'Live';
-  if (connectionState.value === 'connecting') return 'Connecting...';
-  return 'Disconnected';
+  if (liveConnected.value) return t('workflow.liveDashboard.connectionLive');
+  if (connectionState.value === 'connecting') return t('workflow.liveDashboard.connectionConnecting');
+  return t('workflow.liveDashboard.connectionDisconnected');
 });
 
 async function reconnectLiveEvents(): Promise<void> {
@@ -263,12 +265,12 @@ function getStatusIcon(wf: ActiveWorkflow): string {
 }
 
 function getStatusLabel(wf: ActiveWorkflow): string {
-  if (wf.is_cancelled) return 'Cancelled';
-  if (wf.is_paused) return 'Paused';
-  if (wf.completed_at) return 'Completed';
-  if (wf.steps.some(s => s.status === 'failed')) return 'Failed';
-  if (wf.steps.some(s => s.status === 'executing')) return 'Running';
-  return 'Pending';
+  if (wf.is_cancelled) return t('workflow.liveDashboard.cancelled');
+  if (wf.is_paused) return t('workflow.liveDashboard.paused');
+  if (wf.completed_at) return t('workflow.liveDashboard.completedRecent');
+  if (wf.steps.some(s => s.status === 'failed')) return t('workflow.liveDashboard.failed');
+  if (wf.steps.some(s => s.status === 'executing')) return t('workflow.liveDashboard.running');
+  return t('workflow.liveDashboard.pending');
 }
 
 function getProgressPercent(wf: ActiveWorkflow): number {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -3407,7 +3407,12 @@
       "noActiveDescription": "Start a workflow to see live execution progress here.",
       "loading": "Loading workflows...",
       "stepOf": "Step {current} of {total}",
-      "stepN": "Step {n}"
+      "stepN": "Step {n}",
+      "cancelled": "Cancelled",
+      "pending": "Pending",
+      "connectionLive": "Live",
+      "connectionConnecting": "Connecting...",
+      "connectionDisconnected": "Disconnected"
     },
     "agentObservability": {
       "title": "Agent Observability",


### PR DESCRIPTION
## Summary
- Replaces hardcoded English strings in `getStatusLabel()` and `connectionLabel` with `t()` calls
- Uses pre-existing i18n keys from `en.json` (`workflow.liveDashboard.*`) where available
- Adds 5 new keys to `en.json` for values that were missing: `cancelled`, `pending`, `connectionLive`, `connectionConnecting`, `connectionDisconnected`
- No functional changes — purely i18n wiring

Closes #3188

🤖 Generated with [Claude Code](https://claude.ai/code)