### PR TITLE
fix(ansible): align slm_tls_cert/key defaults with actual cert paths (#3191)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/defaults/main.yml
@@ -15,7 +15,7 @@ slm_backend_dir: "{{ slm_base_dir }}/autobot-slm-backend"
 slm_frontend_dir: "{{ slm_base_dir }}/autobot-slm-frontend"
 slm_shared_dir: "{{ slm_base_dir }}/autobot_shared"
 slm_log_dir: "{{ slm_base_dir }}/logs"
-slm_certs_dir: "{{ slm_base_dir }}/nginx/certs"
+slm_certs_dir: /etc/autobot/certs
 slm_credentials_dir: /etc/autobot
 slm_credentials_file: slm-secrets.env
 
@@ -29,8 +29,8 @@ slm_backend_port: 8000
 # ==========================================================
 # TLS Configuration
 # ==========================================================
-slm_tls_cert: "{{ slm_certs_dir }}/slm.crt"
-slm_tls_key: "{{ slm_certs_dir }}/slm.key"
+slm_tls_cert: "{{ slm_certs_dir }}/server-cert.pem"
+slm_tls_key: "{{ slm_certs_dir }}/server-key.pem"
 slm_tls_days: 365
 slm_tls_subject: "/C=US/ST=State/L=City/O=AutoBot/CN={{ ansible_host }}"
 


### PR DESCRIPTION
## Summary

The `slm_manager` role was the sole outlier using wrong cert paths — nginx failed to start on fresh deploys because certs are never generated at the paths the role expected.

**Changes in `slm_manager/defaults/main.yml`:**

| Variable | Before | After |
|---|---|---|
| `slm_certs_dir` | `{{ slm_base_dir }}/nginx/certs` → `/opt/autobot/nginx/certs` | `/etc/autobot/certs` |
| `slm_tls_cert` | `{{ slm_certs_dir }}/slm.crt` | `{{ slm_certs_dir }}/server-cert.pem` |
| `slm_tls_key` | `{{ slm_certs_dir }}/slm.key` | `{{ slm_certs_dir }}/server-key.pem` |

All other roles (`backend`, `frontend`, `vnc`, `redis`) and playbooks (`enable-tls.yml`, `rotate-certs.yml`, etc.) consistently use `/etc/autobot/certs/server-cert.pem` and `server-key.pem`. This aligns `slm_manager` with the rest of the system.

Fixes #3191

🤖 Generated with Claude Code