### PR TITLE
fix(slm-frontend): use bg-autobot-bg-tertiary for toggle off-state

### DIFF
--- a/autobot-frontend/src/components/agents/AgentSettingsPanel.vue
+++ b/autobot-frontend/src/components/agents/AgentSettingsPanel.vue
@@ -250,7 +250,7 @@ onMounted(() => {
               type="button"
               :class="[
                 'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-autobot-info focus:ring-offset-2',
-                settings.memory.enabled ? 'bg-autobot-primary' : 'bg-autobot-bg-hover'
+                settings.memory.enabled ? 'bg-autobot-primary' : 'bg-autobot-bg-tertiary'
               ]"
               role="switch"
               :aria-checked="settings.memory.enabled"
@@ -353,7 +353,7 @@ onMounted(() => {
                 type="button"
                 :class="[
                   'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-autobot-info focus:ring-offset-2',
-                  settings.execution.parallelExecution ? 'bg-autobot-primary' : 'bg-autobot-bg-hover'
+                  settings.execution.parallelExecution ? 'bg-autobot-primary' : 'bg-autobot-bg-tertiary'
                 ]"
                 role="switch"
                 :aria-checked="settings.execution.parallelExecution"
@@ -376,7 +376,7 @@ onMounted(() => {
                 type="button"
                 :class="[
                   'relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-autobot-info focus:ring-offset-2',
-                  settings.execution.priorityQueue ? 'bg-autobot-primary' : 'bg-autobot-bg-hover'
+                  settings.execution.priorityQueue ? 'bg-autobot-primary' : 'bg-autobot-bg-tertiary'
                 ]"
                 role="switch"
                 :aria-checked="settings.execution.priorityQueue"


### PR DESCRIPTION
Fixes visual regression introduced in #3322.

`bg-autobot-bg-hover` resolves to `rgba(0,0,0,0.04)` — essentially transparent — making the three toggle switch tracks invisible when in the off state.

Replaced with `bg-autobot-bg-tertiary` (`#f1f5f9` light / `#334155` dark), which provides a visible solid neutral matching the original `bg-gray-300 dark:bg-gray-600` intent.

The reset button's `hover:bg-autobot-bg-hover` is intentionally preserved — hover overlays are the correct use for that token.

Closes #3187