### PR TITLE
fix(install.sh): upsert IP/network keys in preserved secrets to prevent stale values

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -502,10 +502,22 @@ EOF
         network_gateway=$(ip route | awk '/^default/ {print $3}' | head -1)
         [[ -z "$network_subnet" ]] && network_subnet="${local_ip%.*}.0/24"
         [[ -z "$network_gateway" ]] && network_gateway="${local_ip%.*}.1"
-        sed -i "s|^SLM_EXTERNAL_URL=.*|SLM_EXTERNAL_URL=https://${local_ip}|" "${SECRETS_FILE}"
-        sed -i "s|^SLM_HOST=.*|SLM_HOST=${local_ip}|" "${SECRETS_FILE}"
-        sed -i "s|^NETWORK_SUBNET=.*|NETWORK_SUBNET=${network_subnet}|" "${SECRETS_FILE}"
-        sed -i "s|^NETWORK_GATEWAY=.*|NETWORK_GATEWAY=${network_gateway}|" "${SECRETS_FILE}"
+        # Upsert each key: replace the line if it exists, append if missing.
+        # Plain sed s/// silently does nothing when the key is absent — which
+        # causes SLM_HOST / NETWORK_* to stay missing on secrets files written
+        # before those keys were introduced (#3194).
+        _upsert_secrets_key() {
+            local key="$1" value="$2" file="$3"
+            if grep -q "^${key}=" "${file}"; then
+                sed -i "s|^${key}=.*|${key}=${value}|" "${file}"
+            else
+                echo "${key}=${value}" >> "${file}"
+            fi
+        }
+        _upsert_secrets_key "SLM_EXTERNAL_URL" "https://${local_ip}" "${SECRETS_FILE}"
+        _upsert_secrets_key "SLM_HOST"         "${local_ip}"          "${SECRETS_FILE}"
+        _upsert_secrets_key "NETWORK_SUBNET"   "${network_subnet}"    "${SECRETS_FILE}"
+        _upsert_secrets_key "NETWORK_GATEWAY"  "${network_gateway}"   "${SECRETS_FILE}"
         success "  Secrets file preserved (IP/network fields updated to ${local_ip})"
     fi
 


### PR DESCRIPTION
## Summary

- Replaces four bare `sed s///` calls in the preserved-secrets branch of `configure_secrets()` with a local `_upsert_secrets_key` helper
- Helper replaces the line when the key exists and appends it when it is missing
- Ensures `SLM_HOST`, `NETWORK_SUBNET`, and `NETWORK_GATEWAY` are always written to secrets files created before those keys were introduced, preventing divergence after reinstall

## Root Cause

`sed -i "s|^SLM_HOST=.*|SLM_HOST=...|"` silently does nothing when the key is absent. Secrets files written before `SLM_HOST`/`NETWORK_*` were added to the template had no matching line, so the values were never injected on reinstall — leaving `SLM_EXTERNAL_URL` pointing to the old interface.

## Test Plan

- [ ] Fresh install: secrets file written with all keys via heredoc (unchanged path)
- [ ] Reinstall with secrets file containing all keys: all four keys updated in place
- [ ] Reinstall with secrets file missing `SLM_HOST`/`NETWORK_SUBNET`/`NETWORK_GATEWAY`: missing keys appended, existing keys updated
- [ ] `bash -n install.sh` passes with no syntax errors

Closes #3194

🤖 Generated with [Claude Code](https://claude.com/claude-code)