### PR TITLE
fix(backend): correct .ports -> .port typo in chromadb client modules (#3329)

### DIFF
--- a/autobot-backend/utils/async_chromadb_client.py
+++ b/autobot-backend/utils/async_chromadb_client.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 # Issue #3094: Use SSOT config port so the default (8100) matches Ansible deployment.
 # Host remains os.getenv-based: empty string = use local PersistentClient (dev mode).
 _CHROMADB_HOST = os.getenv("AUTOBOT_CHROMADB_HOST", "")
-_CHROMADB_PORT = _ssot_config.ports.chromadb
+_CHROMADB_PORT = _ssot_config.port.chromadb
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/utils/chromadb_client.py
+++ b/autobot-backend/utils/chromadb_client.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 # Issue #3094: Use SSOT config port so the default (8100) matches Ansible deployment.
 # Host remains os.getenv-based: empty string = use local PersistentClient (dev mode).
 _CHROMADB_HOST = os.getenv("AUTOBOT_CHROMADB_HOST", "")
-_CHROMADB_PORT = _ssot_config.ports.chromadb
+_CHROMADB_PORT = _ssot_config.port.chromadb
 
 # Module exports
 __all__ = [


### PR DESCRIPTION
## Summary
- Fix `_ssot_config.ports.chromadb` → `_ssot_config.port.chromadb` in both chromadb client modules
- `AutoBotConfig` has a `port` attribute (singular), not `ports` — the typo caused `AttributeError` on backend startup
- Both `utils/chromadb_client.py` and `utils/async_chromadb_client.py` had the same typo

## Test plan
- [ ] Backend starts without `AttributeError: 'AutoBotConfig' object has no attribute 'ports'`
- [ ] ChromaDB connections succeed at the correct port (8100)

Closes #3329

🤖 Generated with Claude Code