### PR TITLE
feat(slm-frontend): add typed response interfaces for security API endpoints

### DIFF
--- a/autobot-slm-frontend/src/types/slm.ts
+++ b/autobot-slm-frontend/src/types/slm.ts
@@ -653,3 +653,124 @@ export interface ExternalAgentCard {
   base_url: string
   card: Record<string, unknown>
 }
+
+// =============================================================================
+// Security API Response Types (Issue #3184)
+// =============================================================================
+
+export interface SecurityEventResponse {
+  id: number
+  event_id: string
+  timestamp: string
+  event_type: string
+  severity: string
+  category: string | null
+  source_ip: string | null
+  source_user: string | null
+  source_node_id: string | null
+  target_resource: string | null
+  target_node_id: string | null
+  title: string
+  description: string | null
+  threat_indicator: string | null
+  threat_score: number | null
+  mitre_technique: string | null
+  is_acknowledged: boolean
+  acknowledged_by: string | null
+  acknowledged_at: string | null
+  is_resolved: boolean
+  resolved_by: string | null
+  resolved_at: string | null
+  resolution_notes: string | null
+  created_at: string
+}
+
+export interface SecurityOverviewResponse {
+  security_score: number
+  active_threats: number
+  failed_logins_24h: number
+  policy_violations: number
+  total_events_24h: number
+  critical_events: number
+  certificates_expiring: number
+  recent_events: SecurityEventResponse[]
+}
+
+export interface AuditLogResponse {
+  id: number
+  log_id: string
+  timestamp: string
+  user_id: string | null
+  username: string | null
+  ip_address: string | null
+  category: string
+  action: string
+  resource_type: string | null
+  resource_id: string | null
+  description: string | null
+  request_method: string | null
+  request_path: string | null
+  response_status: number | null
+  success: boolean
+  error_message: string | null
+  created_at: string
+}
+
+export interface AuditLogListResponse {
+  logs: AuditLogResponse[]
+  total: number
+  page: number
+  per_page: number
+}
+
+export interface SecurityEventListResponse {
+  events: SecurityEventResponse[]
+  total: number
+  page: number
+  per_page: number
+  unacknowledged_count: number
+  critical_count: number
+}
+
+export interface ThreatSummary {
+  total_threats: number
+  critical: number
+  high: number
+  medium: number
+  low: number
+  acknowledged: number
+  resolved: number
+  by_type: Record<string, number>
+  by_source_ip: Record<string, number>
+  trend_24h: Array<Record<string, unknown>>
+}
+
+export interface SecurityPolicyResponse {
+  id: number
+  policy_id: string
+  name: string
+  description: string | null
+  category: string
+  policy_type: string
+  rules: unknown[]
+  parameters: Record<string, unknown>
+  applies_to_nodes: unknown[]
+  applies_to_roles: unknown[]
+  status: string
+  is_enforced: boolean
+  last_evaluated: string | null
+  compliance_score: number | null
+  violations_count: number
+  version: number
+  created_by: string | null
+  updated_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface SecurityPolicyListResponse {
+  policies: SecurityPolicyResponse[]
+  total: number
+  page: number
+  per_page: number
+}

--- a/autobot-slm-frontend/src/views/SecurityView.vue
+++ b/autobot-slm-frontend/src/views/SecurityView.vue
@@ -21,71 +21,29 @@ import type { TLSEndpointResponse } from '@/types/api-responses'
 import { createLogger } from '@/utils/debugUtils'
 import { formatRelativeTime } from '@/utils/dateUtils'
 import config from '@/config/ssot-config'
+import type {
+  SecurityEventResponse,
+  SecurityOverviewResponse,
+  AuditLogResponse,
+  AuditLogListResponse,
+  SecurityEventListResponse,
+  ThreatSummary as ThreatSummaryType,
+  SecurityPolicyResponse,
+  SecurityPolicyListResponse,
+} from '@/types/slm'
 
 const logger = createLogger('SecurityView')
 const slmApi = useSlmApi()
 const route = useRoute()
 const router = useRouter()
 
-interface SecurityEvent {
-  id: number
-  event_id: string
-  timestamp: string
-  event_type: string
-  severity: string
-  title: string
-  description?: string
-  source_ip?: string
-  source_user?: string
-  is_acknowledged: boolean
-  is_resolved: boolean
-}
+// Type aliases using shared security response interfaces (Issue #3184)
+type SecurityEvent = SecurityEventResponse
+type AuditLog = AuditLogResponse
+type SecurityPolicy = SecurityPolicyResponse
+type SecurityOverview = SecurityOverviewResponse
+type ThreatSummary = ThreatSummaryType
 
-interface AuditLog {
-  id: number
-  log_id: string
-  timestamp: string
-  username?: string
-  ip_address?: string
-  category: string
-  action: string
-  resource_type?: string
-  success: boolean
-}
-
-interface SecurityPolicy {
-  id: number
-  policy_id: string
-  name: string
-  description?: string
-  category: string
-  status: string
-  is_enforced: boolean
-  compliance_score?: number
-  violations_count: number
-}
-
-interface SecurityOverview {
-  security_score: number
-  active_threats: number
-  failed_logins_24h: number
-  policy_violations: number
-  total_events_24h: number
-  critical_events: number
-  certificates_expiring: number
-  recent_events: SecurityEvent[]
-}
-
-interface ThreatSummary {
-  total_threats: number
-  critical: number
-  high: number
-  medium: number
-  low: number
-  acknowledged: number
-  resolved: number
-  by_type: Record<string, number>
-}
 
 interface FleetCert {
   cert_id: string


### PR DESCRIPTION
## Summary

- Moved 8 security response interfaces (`SecurityEventResponse`, `SecurityOverviewResponse`, `AuditLogResponse`, `AuditLogListResponse`, `SecurityEventListResponse`, `ThreatSummary`, `SecurityPolicyResponse`, `SecurityPolicyListResponse`) from private scope inside `useSlmApi.ts` to exported types in `src/types/slm.ts`
- Added matching imports of those types in `useSlmApi.ts`, replacing the local interface definitions
- Replaced 5 duplicated local interface definitions in `SecurityView.vue` (`SecurityEvent`, `AuditLog`, `SecurityPolicy`, `SecurityOverview`, `ThreatSummary`) with type aliases that reference the shared exported types

## Test Plan

- [x] TypeScript compiles without new errors (52 pre-existing router errors remain, none introduced)
- [x] All 9 security API functions retain correct typed signatures
- [x] `SecurityView.vue` uses shared types via aliases, preserving existing local names

Closes #3184

🤖 Generated with [Claude Code](https://claude.com/claude-code)