### PR TITLE
refactor(backend): deprecate duplicate settings endpoints, fix stale audit middleware refs (#3334)

### DIFF
--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -81,7 +81,16 @@ async def get_settings():
 )
 @router.get("/settings")
 async def get_settings_explicit():
-    """Get application settings - explicit /settings endpoint for frontend compatibility"""
+    """Get application settings.
+
+    Issue #3334: Deprecated duplicate — use GET /api/settings/ instead.
+    This endpoint remains for backward compatibility but will be removed in a
+    future release.
+    """
+    logger.warning(
+        "Deprecated endpoint called: GET /api/settings/settings. "
+        "Use GET /api/settings/ instead. (#3334)"
+    )
     try:
         return ConfigService.get_full_config()
     except Exception as e:
@@ -133,7 +142,16 @@ async def save_settings_explicit(
     settings_data: dict,
     session: AsyncSession = Depends(get_db_session),
 ):
-    """Save application settings — frontend compat (#1747: audit trail)."""
+    """Save application settings.
+
+    Issue #3334: Deprecated duplicate — use POST /api/settings/ instead.
+    This endpoint remains for backward compatibility but will be removed in a
+    future release.
+    """
+    logger.warning(
+        "Deprecated endpoint called: POST /api/settings/settings. "
+        "Use POST /api/settings/ instead. (#3334)"
+    )
     try:
         if not settings_data:
             logger.warning("Received empty settings data, skipping save")

--- a/autobot-backend/middleware/audit_middleware.py
+++ b/autobot-backend/middleware/audit_middleware.py
@@ -72,12 +72,13 @@ def set_main_event_loop(loop: asyncio.AbstractEventLoop) -> None:
 
 # Issue #380: Module-level frozensets for audit checks
 _MODIFYING_HTTP_METHODS = frozenset({"POST", "PUT", "DELETE", "PATCH"})
+# Issue #3334: /api/config/ replaced by /api/settings/ — updated sensitive prefix list
 _SENSITIVE_PATH_PREFIXES = (
     "/api/auth/",
     "/api/security/",
     "/api/elevation/",
     "/api/files/",
-    "/api/config/",
+    "/api/settings/",
 )
 
 
@@ -99,8 +100,10 @@ AUTO_AUDIT_OPERATIONS = {
     "/api/chat/sessions": "session.create",
     "/api/agent-terminal/sessions": "session.create",
     "/api/terminal/sessions": "session.create",
-    # Configuration
-    "/api/config": "config.update",
+    # Configuration — Issue #3334: consolidated under /api/settings/
+    "/api/settings/": "config.update",
+    "/api/settings/config": "config.update",
+    "/api/settings/backend": "config.update",
 }
 
 


### PR DESCRIPTION
## Summary
- Deprecated `GET /api/settings/settings` and `POST /api/settings/settings` (double-path duplicates of `GET /api/settings/` and `POST /api/settings/`)  — both still functional but now log deprecation warnings
- Fixed `audit_middleware.py`: replaced stale `/api/config` references (no registered endpoint) with correct `/api/settings/`, `/api/settings/config`, `/api/settings/backend`

## What was NOT changed
All domain-scoped `/config` sub-routes (`/api/redis/config`, `/api/llm/config`, etc.) are intentionally kept — they return subsystem-specific config, not system-wide settings, and do not overlap with `/api/settings/`.

## Test plan
- [ ] `GET /api/settings/` returns config (unchanged)
- [ ] `GET /api/settings/settings` still returns config but logs deprecation warning
- [ ] `POST /api/settings/settings` still saves but logs deprecation warning
- [ ] Audit middleware correctly flags `/api/settings/` operations

Closes #3334

🤖 Generated with Claude Code