### PR TITLE
refactor(backend): deprecate 3 redundant terminal modules in favour of terminal.py (#3332)

### DIFF
--- a/autobot-backend/api/__init__.py
+++ b/autobot-backend/api/__init__.py
@@ -9,7 +9,8 @@ __all__ = [
     "knowledge",
     "llm",
     "sandbox",
-    "base_terminal",
+    # Issue #567: base_terminal archived — endpoints migrated to terminal.py
+    # Issue #3332: base_terminal removed from public API surface
     "websockets",
     "enhanced_search",  # New NPU-accelerated search API
     "analytics",  # Enhanced backend analytics API

--- a/autobot-backend/api/base_terminal.py
+++ b/autobot-backend/api/base_terminal.py
@@ -1,7 +1,18 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
 """
-Base Terminal WebSocket Handler
-Provides common terminal functionality for websocket handlers including PTY management
-Updated to use improved TerminalWebSocketManager for race condition fixes
+Base Terminal WebSocket Handler — DEPRECATED (Issue #3332)
+
+This module is deprecated. The consolidated terminal implementation lives in:
+    api/terminal.py         — REST API and primary WebSocket (/api/terminal/ws/{session_id})
+    api/terminal_handlers.py — ConsolidatedTerminalWebSocket and ConsolidatedTerminalManager
+
+This file is retained only because api/simple_terminal_websocket.py and
+api/secure_terminal_websocket.py (themselves deprecated) still import
+BaseTerminalWebSocket from here. Once those files are removed, this file
+can be deleted.
+
+Do NOT add new features here or import this module from production code.
 """
 
 import asyncio
@@ -9,10 +20,18 @@ import logging
 import os
 import subprocess  # nosec B404 - required for PTY terminal operations
 import threading
+import warnings
 from abc import ABC, abstractmethod
 from typing import Optional
 
 from utils.terminal_websocket_manager import TerminalWebSocketAdapter
+
+warnings.warn(
+    "api.base_terminal is deprecated (Issue #3332). "
+    "Use api.terminal_handlers.ConsolidatedTerminalWebSocket instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/secure_terminal_websocket.py
+++ b/autobot-backend/api/secure_terminal_websocket.py
@@ -1,16 +1,38 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
 """
-Secure Terminal WebSocket Handler with Command Auditing
-Provides PTY terminal with enhanced security logging and optional sandboxing
+Secure Terminal WebSocket Handler — DEPRECATED (Issue #3332)
+
+This module is deprecated. The consolidated terminal implementation lives in:
+    api/terminal.py   — Primary router with /api/terminal/ws/{session_id}
+    api/terminal_handlers.py — ConsolidatedTerminalWebSocket with security_level support
+
+The /api/terminal/ws/secure/{session_id} WebSocket endpoint in terminal.py
+provides backward-compatible elevated-security access (SecurityLevel.ELEVATED).
+
+SecureTerminalSession and handle_secure_terminal_websocket are kept here only
+for backward compatibility with:
+    api/secure_terminal_websocket_test.py
+    security/security_integration_test.py
+No production code should import from this module.
 """
 
 import json
 import logging
 import time
+import warnings
 from typing import Dict, Optional
 
 from fastapi import WebSocket, WebSocketDisconnect
 
 from .base_terminal import BaseTerminalWebSocket
+
+warnings.warn(
+    "api.secure_terminal_websocket is deprecated (Issue #3332). "
+    "Use api.terminal and /api/terminal/ws/secure/{session_id} instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/api/simple_terminal_websocket.py
+++ b/autobot-backend/api/simple_terminal_websocket.py
@@ -1,15 +1,36 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
 """
-Simplified Terminal WebSocket Handler for AutoBot
-A working alternative to the complex PTY-based system with enhanced security
+Simple Terminal WebSocket Handler — DEPRECATED (Issue #3332)
+
+This module is deprecated. The consolidated terminal implementation lives in:
+    api/terminal.py   — Primary router with /api/terminal/ws/{session_id}
+    api/terminal_handlers.py — ConsolidatedTerminalWebSocket
+
+The /api/terminal/ws/simple/{session_id} WebSocket endpoint in terminal.py
+provides full backward compatibility for any caller that previously used the
+path that this module once served.
+
+SimpleTerminalSession is kept here only for the test in
+takeover_manager.e2e_test.py which imports it inside a try/except block.
+No production code should import from this module.
 """
 
 import json
 import logging
+import warnings
 from typing import Dict
 
 from fastapi import WebSocket, WebSocketDisconnect
 
 from .base_terminal import BaseTerminalWebSocket
+
+warnings.warn(
+    "api.simple_terminal_websocket is deprecated (Issue #3332). "
+    "Use api.terminal and api.terminal_handlers.ConsolidatedTerminalWebSocket instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 def _get_workflow_manager():

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -1003,17 +1003,19 @@ async def terminal_info(
         "endpoints": {
             "sessions": "/api/terminal/sessions",
             "websocket_primary": "/api/terminal/ws/{session_id}",
-            "websocket_simple": "/api/terminal/ws/simple/{session_id}",
-            "websocket_secure": "/api/terminal/ws/secure/{session_id}",
+            # Issue #3332: /ws/simple and /ws/secure are compat aliases — use /ws/{session_id}
+            "websocket_simple": "/api/terminal/ws/simple/{session_id} (compat alias)",
+            "websocket_secure": "/api/terminal/ws/secure/{session_id} (compat alias)",
             # Issue #729: SSH to infrastructure hosts moved to slm-server
             "websocket_ssh": "/api/terminal/ws/ssh/{host_id} (deprecated - use SLM)",
         },
         "security_levels": [level.value for level in SecurityLevel],
-        "consolidated_from": [
-            "terminal.py",
-            "simple_terminal_websocket.py",
-            "secure_terminal_websocket.py",
-            "base_terminal.py",
+        # Issue #3332: simple_terminal_websocket.py, secure_terminal_websocket.py,
+        # and base_terminal.py are deprecated — logic consolidated here.
+        "deprecated_modules": [
+            "api/simple_terminal_websocket.py",
+            "api/secure_terminal_websocket.py",
+            "api/base_terminal.py",
         ],
         # Issue #729: Layer separation notice
         "notice": "SSH connections to infrastructure hosts have been moved to slm-server. "


### PR DESCRIPTION
## Summary
- `terminal.py` is the only registered router — all frontend calls go through it. The other 3 files were never registered.
- Added `DeprecationWarning` at import time to `base_terminal.py`, `simple_terminal_websocket.py`, `secure_terminal_websocket.py`
- Removed `base_terminal` from `api/__init__.__all__` (was marked archived in issue #567)
- Updated `terminal.py` `terminal_info` endpoint to list the deprecated modules

## Why not deleted outright
- `secure_terminal_websocket.py` is directly imported by 2 test files — deletion would break them
- `simple_terminal_websocket.py` is imported (try/except) by an e2e test
- Follow-up: once tests are updated to use `ConsolidatedTerminalWebSocket`, the 3 files can be fully deleted

## Test plan
- [ ] Backend starts without errors
- [ ] `GET /api/terminal/ws/{id}` works (primary endpoint)
- [ ] `GET /api/terminal/sessions` works
- [ ] Importing deprecated modules logs a `DeprecationWarning`

Closes #3332

🤖 Generated with Claude Code