### PR TITLE
refactor(backend): document KB API boundaries, deprecate unregistered kb_librarian routes (#3336)

### DIFF
--- a/autobot-backend/api/chat_knowledge.py
+++ b/autobot-backend/api/chat_knowledge.py
@@ -3,8 +3,35 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Chat Knowledge Management API
-Handles chat-specific file associations, knowledge context, and compilation
+Chat Knowledge API — session-scoped knowledge lifecycle management.
+
+Responsibility (issue #3336):
+    This module owns all knowledge operations that are **scoped to a chat
+    session**.  It is mounted at ``/api/chat-knowledge/*``.
+
+Scope:
+    - Creating and updating per-session knowledge contexts (topic, keywords,
+      user ownership).
+    - Associating or uploading files to a specific chat session.
+    - Adding *temporary* knowledge facts that live only for the duration of
+      a session.
+    - Presenting pending-decision facts to the user and applying
+      add-to-KB / keep-temporary / delete decisions.
+    - Compiling an entire chat conversation into a permanent KB entry.
+    - Session-fact preservation before conversation deletion (issue #547).
+
+What does NOT belong here:
+    - General KB document management (ingestion, tagging, categories) →
+      api/knowledge.py  (mounted at ``/api/knowledge_base/*``)
+    - LLM-mediated librarian queries → api/kb_librarian.py
+
+Overlap note (issue #3336):
+    The ``POST /search`` endpoint in this module delegates to
+    ``KnowledgeBase.search()`` *and* additionally searches in-memory
+    temporary facts for the requesting session.  It is NOT a duplicate of
+    ``POST /api/knowledge_base/search``: it adds session-scoped temporary
+    results that the global endpoint cannot see.  Keep both; they serve
+    different consumers.
 """
 
 import asyncio

--- a/autobot-backend/api/kb_librarian.py
+++ b/autobot-backend/api/kb_librarian.py
@@ -1,7 +1,44 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""KB Librarian API endpoints."""
+"""
+KB Librarian API — LLM-mediated librarian agent interface.
+
+Responsibility (issue #3336):
+    This module exposes the ``KBLibrarianAgent`` (``agents/kb_librarian_agent.py``)
+    as an HTTP API.  Its routes are **NOT currently registered** in any router
+    loader (``initialization/router_registry/``).  All routes therefore return
+    404 in every deployed environment.
+
+    The librarian agent layer is also used internally by ``conversation.py``
+    via a direct Python import; it does not need an HTTP surface for that use.
+
+Scope (intended, if re-registered):
+    - ``POST /query``      — Process a natural-language query through the
+                            librarian agent (intent detection, similarity
+                            search, optional auto-summarisation).
+    - ``GET  /status``     — Return runtime configuration of the librarian
+                            agent singleton.
+    - ``PUT  /configure``  — Update librarian agent runtime parameters
+                            (enabled flag, threshold, max results, summarise).
+
+What does NOT belong here:
+    - Raw KB document CRUD → api/knowledge.py (``/api/knowledge_base/*``)
+    - Chat-session knowledge lifecycle → api/chat_knowledge.py
+      (``/api/chat-knowledge/*``)
+
+Overlap note (issue #3336):
+    ``POST /query`` overlaps in *outcome* with ``POST /api/knowledge_base/search``
+    but routes through a stateful agent singleton with per-request parameter
+    overrides and LLM summarisation.  It is a higher-level abstraction, not a
+    duplicate.  If this router is re-registered, its mount point should be
+    ``/api/kb-librarian`` and the e2e tests in
+    ``autobot-frontend/tests/e2e/kb-librarian-api.spec.ts`` can be enabled.
+
+DEPRECATION WARNING:
+    All routes in this module emit a WARNING-level log on every invocation
+    until the router is formally re-registered or removed.  See issue #3336.
+"""
 
 import logging
 from typing import List, Optional
@@ -46,12 +83,22 @@ class KBQueryResponse(BaseModel):
 async def query_knowledge_base(kb_query: KBQuery):
     """Query the knowledge base using the KB Librarian Agent.
 
+    .. deprecated::
+        This router is not registered in any router loader (issue #3336).
+        This endpoint is unreachable in all deployed environments.
+        For general KB search use POST /api/knowledge_base/search.
+        For chat-scoped search use POST /api/chat-knowledge/search.
+
     Args:
         kb_query: The query parameters
 
     Returns:
         KBQueryResponse with search results
     """
+    logger.warning(
+        "DEPRECATED: kb_librarian /query called but this router is not registered "
+        "(issue #3336). Use /api/knowledge_base/search for general KB search."
+    )
     try:
         kb_librarian = get_kb_librarian()
 
@@ -95,9 +142,17 @@ async def query_knowledge_base(kb_query: KBQuery):
 async def get_kb_librarian_status():
     """Get the status of the KB Librarian Agent.
 
+    .. deprecated::
+        This router is not registered in any router loader (issue #3336).
+        This endpoint is unreachable in all deployed environments.
+
     Returns:
         Status information about the KB Librarian
     """
+    logger.warning(
+        "DEPRECATED: kb_librarian /status called but this router is not registered "
+        "(issue #3336)."
+    )
     try:
         kb_librarian = get_kb_librarian()
 
@@ -128,6 +183,10 @@ async def configure_kb_librarian(
 ):
     """Configure the KB Librarian Agent settings.
 
+    .. deprecated::
+        This router is not registered in any router loader (issue #3336).
+        This endpoint is unreachable in all deployed environments.
+
     Args:
         enabled: Whether the KB Librarian is enabled
         similarity_threshold: Minimum similarity score (0.0-1.0)
@@ -137,6 +196,10 @@ async def configure_kb_librarian(
     Returns:
         Updated configuration
     """
+    logger.warning(
+        "DEPRECATED: kb_librarian /configure called but this router is not "
+        "registered (issue #3336)."
+    )
     try:
         kb_librarian = get_kb_librarian()
 

--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -1,7 +1,34 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Knowledge Base API endpoints for content management and search with RAG integration."""
+"""
+Knowledge Base API — primary document management and general search.
+
+Responsibility (issue #3336):
+    This module is the **canonical owner** of all knowledge-base document
+    lifecycle operations.  It is mounted at ``/api/knowledge_base/*``.
+
+Scope:
+    - Ingesting content: text facts, URLs, file uploads, man-pages,
+      machine profiles, and AutoBot documentation.
+    - General-purpose semantic search (vector + keyword) across the
+      entire knowledge base.
+    - Category, tag, collection, and metadata management.
+    - Import/export job status and statistics.
+    - Admin health and clear-all operations.
+
+What does NOT belong here:
+    - Chat-session-scoped operations (temporary facts, file associations,
+      session compilation, session-fact preservation) → api/chat_knowledge.py
+    - LLM-mediated librarian queries (intent detection, auto-summarise,
+      per-request parameter overrides) → api/kb_librarian.py
+
+Related modules:
+    - ``api/chat_knowledge.py``  — chat-session knowledge lifecycle
+    - ``api/kb_librarian.py``    — librarian agent (unregistered, internal use)
+    - ``api/knowledge_search.py``  — search sub-router (included here)
+    - ``api/knowledge_tags.py``, ``api/knowledge_categories.py``, etc.
+"""
 
 import asyncio
 import json


### PR DESCRIPTION
## Summary
- Added module-level docstrings defining the responsibility boundary of each of the 3 KB APIs
- `kb_librarian.py`: router is **not registered** in any router loader — all routes return 404 in production. Added `WARNING` log to each route if ever called, pointing to canonical alternatives.
- `chat_knowledge.py`: documents session-scoped KB ops (distinct from general-purpose `knowledge.py`)
- `knowledge.py`: documents as canonical owner of all persistent KB document lifecycle ops

## Overlaps clarified (not duplicates)
- `/search` in `chat_knowledge.py` also scans in-memory session facts — not a duplicate of `knowledge.py /search`
- `/health` endpoints in both files cover different services

## Bugs discovered (filed separately)
- `kb_librarian.py` router is unregistered — `autobot-frontend/tests/e2e/kb-librarian-api.spec.ts` always fails against real backend
- `knowledge/chat_knowledge_system.e2e_test.py` uses `api/chat_knowledge/` (underscore) but registration is `api/chat-knowledge/` (hyphen) — all paths 404

## Test plan
- [ ] Backend starts without errors
- [ ] `/api/knowledge_base/*` endpoints work
- [ ] `/api/chat-knowledge/*` endpoints work
- [ ] No `kb_librarian` routes are reachable (unregistered)

Closes #3336

🤖 Generated with Claude Code