### PR TITLE
refactor(backend): deprecate 9 redundant health endpoints, keep /api/system/health primary (#3333)

### DIFF
--- a/autobot-backend/api/analytics_architecture.py
+++ b/autobot-backend/api/analytics_architecture.py
@@ -1411,10 +1411,19 @@ async def health_check(
     """
     Check the health of the architecture analyzer.
 
+    Deprecated: Use /api/system/health for system-wide health checks.
+    This per-module endpoint will be removed in a future release. (#3333)
+
     Issue #744: Requires admin authentication.
     """
+    logger.warning(
+        "Deprecated health endpoint called: /api/architecture/health — "
+        "use /api/system/health instead (#3333)"
+    )
     return {
         "status": "healthy",
         "available_patterns": len(PatternType),
         "templates_loaded": len(PATTERN_TEMPLATES),
+        "deprecated": True,
+        "use_instead": "/api/system/health",
     }

--- a/autobot-backend/api/analytics_cfg.py
+++ b/autobot-backend/api/analytics_cfg.py
@@ -1452,13 +1452,22 @@ async def cfg_health(
     """
     Health check for CFG analyzer.
 
+    Deprecated: Use /api/system/health for system-wide health checks.
+    This per-module endpoint will be removed in a future release. (#3333)
+
     Issue #744: Requires admin authentication.
     """
+    logger.warning(
+        "Deprecated health endpoint called: /api/cfg-analytics/health — "
+        "use /api/system/health instead (#3333)"
+    )
     return JSONResponse(
         status_code=200,
         content={
             "status": "healthy",
             "service": "cfg_analyzer",
+            "deprecated": True,
+            "use_instead": "/api/system/health",
             "capabilities": [
                 "cfg_construction",
                 "unreachable_code_detection",

--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -948,13 +948,22 @@ def get_code_generation_engine() -> CodeGenerationEngine:
 
 @router.get("/health")
 async def get_health(admin_check: bool = Depends(check_admin_permission)):
-    """Get code generation service health status
+    """Get code generation service health status.
+
+    Deprecated: Use /api/system/health for system-wide health checks.
+    This per-module endpoint will be removed in a future release. (#3333)
 
     Issue #744: Requires admin authentication.
     """
+    logger.warning(
+        "Deprecated health endpoint called: /api/code-generation/health — "
+        "use /api/system/health instead (#3333)"
+    )
     return {
         "status": "healthy",
         "service": "code_generation",
+        "deprecated": True,
+        "use_instead": "/api/system/health",
         "features": [
             "code_generation",
             "refactoring",

--- a/autobot-backend/api/analytics_dfa.py
+++ b/autobot-backend/api/analytics_dfa.py
@@ -1338,11 +1338,20 @@ async def health_check(admin_check: bool = Depends(check_admin_permission)):
     """
     Health check endpoint.
 
+    Deprecated: Use /api/system/health for system-wide health checks.
+    This per-module endpoint will be removed in a future release. (#3333)
+
     Issue #744: Requires admin authentication.
     """
+    logger.warning(
+        "Deprecated health endpoint called: /api/dfa-analytics/health — "
+        "use /api/system/health instead (#3333)"
+    )
     return {
         "status": "healthy",
         "service": "data-flow-analysis",
+        "deprecated": True,
+        "use_instead": "/api/system/health",
         "features": [
             "variable_tracking",
             "def_use_chains",

--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -1023,10 +1023,20 @@ def get_pattern_analyzer() -> LLMPatternAnalyzer:
 
 @router.get("/health")
 async def get_health():
-    """Get LLM pattern analyzer health status"""
+    """Get LLM pattern analyzer health status.
+
+    Deprecated: Use /api/system/health for system-wide health checks.
+    This per-module endpoint will be removed in a future release. (#3333)
+    """
+    logger.warning(
+        "Deprecated health endpoint called: /api/llm-patterns/health — "
+        "use /api/system/health instead (#3333)"
+    )
     return {
         "status": "healthy",
         "service": "llm_pattern_analyzer",
+        "deprecated": True,
+        "use_instead": "/api/system/health",
         "features": [
             "prompt_analysis",
             "usage_tracking",

--- a/autobot-backend/api/mesh_brain.py
+++ b/autobot-backend/api/mesh_brain.py
@@ -32,7 +32,15 @@ async def get_mesh_brain_status() -> dict:
 
 @router.get("/health")
 async def get_mesh_brain_health() -> dict:
-    """Return a concise health summary — healthy when no jobs have last_result='failed'."""
+    """Return a concise health summary — healthy when no jobs have last_result='failed'.
+
+    Deprecated: This router is not registered and will be removed in a future release.
+    Use /api/system/health for system-wide health checks. (#3333)
+    """
+    logger.warning(
+        "Deprecated health endpoint called: /api/mesh/brain/health — "
+        "this router is unregistered and will be removed (#3333)"
+    )
     if _scheduler is None:
         return {"healthy": False, "reason": "not_initialized"}
     return _build_health_response(_scheduler.get_status())

--- a/autobot-backend/api/monitoring_compat.py
+++ b/autobot-backend/api/monitoring_compat.py
@@ -425,7 +425,15 @@ async def get_github_status():
 async def get_monitoring_compat_health():
     """
     Health check for monitoring compatibility layer.
+
+    Deprecated: Use /api/system/health for system-wide health checks.
+    This entire module is deprecated; use Grafana dashboards instead. (#3333)
     """
+    logger.warning(
+        "Deprecated health endpoint called: /api/metrics/health — "
+        "use /api/system/health instead (#3333). %s",
+        DEPRECATION_MSG,
+    )
     # Check Prometheus connectivity
     try:
         cpu = await query_prometheus_instant("autobot_cpu_usage_percent")
@@ -438,5 +446,6 @@ async def get_monitoring_compat_health():
         "prometheus_connected": prometheus_healthy,
         "prometheus_url": PROMETHEUS_URL,
         "deprecation_notice": DEPRECATION_MSG,
+        "use_instead": "/api/system/health",
         "timestamp": datetime.now().isoformat(),
     }

--- a/autobot-backend/api/natural_language_search.py
+++ b/autobot-backend/api/natural_language_search.py
@@ -1293,10 +1293,20 @@ async def list_supported_domains():
 
 @router.get("/health")
 async def health_check():
-    """Health check endpoint."""
+    """Health check endpoint.
+
+    Deprecated: Use /api/system/health for system-wide health checks.
+    This per-module endpoint will be removed in a future release. (#3333)
+    """
+    logger.warning(
+        "Deprecated health endpoint called: /api/health (natural_language_search) — "
+        "use /api/system/health instead (#3333)"
+    )
     return {
         "status": "healthy",
         "service": "natural-language-search",
+        "deprecated": True,
+        "use_instead": "/api/system/health",
         "features": [
             "query_parsing",
             "intent_classification",

--- a/autobot-backend/api/services.py
+++ b/autobot-backend/api/services.py
@@ -227,11 +227,23 @@ async def get_services(admin_check: bool = Depends(check_admin_permission)):
 )
 @router.get("/health")
 async def get_health(admin_check: bool = Depends(check_admin_permission)):
-    """Simple health check endpoint
+    """Simple health check endpoint.
+
+    Deprecated: Use /api/system/health for system-wide health checks.
+    This per-module endpoint will be removed in a future release. (#3333)
 
     Issue #744: Requires admin authentication.
     """
-    return {"status": "healthy", "timestamp": datetime.now()}
+    logger.warning(
+        "Deprecated health endpoint called: /api/services/health — "
+        "use /api/system/health instead (#3333)"
+    )
+    return {
+        "status": "healthy",
+        "timestamp": datetime.now(),
+        "deprecated": True,
+        "use_instead": "/api/system/health",
+    }
 
 
 @with_error_handling(

--- a/docs/api/API_Consolidation_Priority_Plan.md
+++ b/docs/api/API_Consolidation_Priority_Plan.md
@@ -36,10 +36,29 @@ await apiRequest('/api/phases/validation/run')
 - `base_terminal.py` - Base functions
 **Action**: Consolidate to single terminal API
 
-### **4. Health Check Sprawl - 12 IMPLEMENTATIONS**
+### **4. Health Check Sprawl - 37+ IMPLEMENTATIONS** ✅ Partial (Issue #3333)
 **Frontend Usage**: Only calls `/api/system/health` (good!)
-**Backend Reality**: 12 different health endpoints across modules
+**Backend Reality**: 37+ different health endpoints across modules (12 noted originally, audit
+found more)
 **Action**: Deprecate unused health endpoints, keep `/api/system/health` as primary
+**Completed (Issue #3333)**:
+- Audited all health endpoints in `autobot-backend/api/`
+- Primary endpoint `/api/system/health` kept as-is (no changes)
+- Frontend-called endpoints kept as-is: `/api/long-running/health`,
+  `/api/monitoring/services/health`
+- Added deprecation `logger.warning` + `deprecated`/`use_instead` response fields to 9 endpoints
+  with boilerplate static responses or unregistered routers:
+  - `analytics_llm_patterns.py` → `/api/llm-patterns/health`
+  - `analytics_code_generation.py` → `/api/code-generation/health`
+  - `analytics_dfa.py` → `/api/dfa-analytics/health`
+  - `analytics_architecture.py` → `/api/architecture/health`
+  - `analytics_cfg.py` → `/api/cfg-analytics/health`
+  - `services.py` → `/api/services/health`
+  - `mesh_brain.py` → unregistered router (dead module)
+  - `monitoring_compat.py` → unregistered router (already deprecated module)
+  - `natural_language_search.py` → `/api/health` (no-prefix collision risk)
+- Remaining endpoints have legitimate per-service logic (Redis ping, real service checks)
+  and are not called by the frontend
 
 ## 📋 **MEDIUM PRIORITY (Fix This Month)**
 
@@ -96,11 +115,12 @@ await apiRequest('/api/phases/validation/run')
 3. **Deprecate unused terminal APIs**
 4. **Update documentation**
 
-### **Week 3: Health Check Cleanup**
-1. **Audit all 12 health endpoints**
-2. **Keep only `/api/system/health` as primary**
-3. **Add deprecation warnings to others**
-4. **Route internal health checks through system API**
+### **Week 3: Health Check Cleanup** ✅ Phase 1 done (Issue #3333)
+1. ✅ **Audit all health endpoints** — found 37+ (not 12 as originally estimated)
+2. ✅ **Keep `/api/system/health` as primary** — no changes to primary endpoint
+3. ✅ **Add deprecation warnings to boilerplate endpoints** — 9 endpoints updated
+4. **Route internal health checks through system API** — deferred: remaining endpoints
+   have legitimate per-service logic and are not called by the frontend
 
 ### **Week 4: Configuration Consolidation**
 1. **Route all config through `/api/settings/*`**


### PR DESCRIPTION
## Summary
Audit found 37+ health endpoints (not the 12 estimated). Deprecated 9 boilerplate/unreachable ones:

| File | Reason |
|------|--------|
| `analytics_llm_patterns.py` | Static boilerplate — no live checks |
| `analytics_code_generation.py` | Static boilerplate — no live checks |
| `analytics_dfa.py` | Static boilerplate — no live checks |
| `analytics_architecture.py` | Static boilerplate — no live checks |
| `analytics_cfg.py` | Static boilerplate — no live checks |
| `services.py /health` | Returns only `{"status": "healthy"}` — no probe |
| `mesh_brain.py` | Router unregistered — endpoint unreachable |
| `monitoring_compat.py` | Already fully deprecated module, unregistered |
| `natural_language_search.py /health` | Empty-prefix registration causes `/api/health` collision |

## Kept untouched
- `/api/system/health` — primary, checks Redis/config/initialization
- `/api/long-running/health` — called directly by frontend
- `/api/monitoring/services/health` — called directly by frontend
- All endpoints with real service probes (KB, memory graph, Redis, Ollama, Playwright, etc.)

## Deprecation pattern used
Each deprecated endpoint: logs `WARNING`, returns original response + `deprecated: True` + `use_instead: "/api/system/health"` fields.

## Bugs discovered (filing separately)
- `mesh_brain.py` is dead code — router never registered, candidate for full removal
- `monitoring_compat.py` is dead code — same
- 3 modules registered with empty prefix cause `/api/health` route shadowing

Closes #3333

🤖 Generated with Claude Code