### PR TITLE
chore(frontend): Tailwind v4 audit — fix remaining v3 patterns (#3153)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -15,7 +15,7 @@
           <div class="shrink-0 flex items-center">
             <button
               @click="toggleSystemStatus"
-              class="flex items-center space-x-3 hover:bg-autobot-bg-tertiary rounded-md px-2 py-1 transition-all duration-200 focus:outline-hidden focus:ring-2 focus:ring-autobot-primary focus:ring-opacity-50"
+              class="flex items-center space-x-3 hover:bg-autobot-bg-tertiary rounded-md px-2 py-1 transition-all duration-200 focus:outline-hidden focus:ring-2 focus:ring-autobot-primary/50"
               :title="getSystemStatusTooltip()"
             >
               <div class="relative w-8 h-8 bg-white rounded flex items-center justify-center">

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -1422,7 +1422,7 @@ onMounted(async () => {
 /* THOUGHT MESSAGES - Purple theme for AI reasoning */
 .message-wrapper.type-thought {
   @apply bg-purple-900/20 border-purple-500/40 text-purple-200;
-  border-left: 4px solid theme('colors.purple.500');
+  border-left: 4px solid var(--color-purple-500);
 }
 
 .message-wrapper.type-thought .message-avatar {
@@ -1453,7 +1453,7 @@ onMounted(async () => {
 /* PLANNING MESSAGES - Indigo theme for task planning */
 .message-wrapper.type-planning {
   @apply bg-indigo-900/20 border-indigo-500/40 text-indigo-200;
-  border-left: 4px solid theme('colors.indigo.500');
+  border-left: 4px solid var(--color-indigo-500);
 }
 
 .message-wrapper.type-planning .message-avatar {
@@ -1484,7 +1484,7 @@ onMounted(async () => {
 /* DEBUG MESSAGES - Orange/Amber theme for debug output */
 .message-wrapper.type-debug {
   @apply bg-amber-900/20 border-amber-500/40 text-amber-200;
-  border-left: 4px solid theme('colors.amber.500');
+  border-left: 4px solid var(--color-amber-500);
 }
 
 .message-wrapper.type-debug .message-avatar {
@@ -1510,7 +1510,7 @@ onMounted(async () => {
 /* UTILITY MESSAGES - Slate theme for tool/utility output */
 .message-wrapper.type-utility {
   @apply bg-slate-100 border-slate-300 text-slate-800;
-  border-left: 4px solid theme('colors.slate.500');
+  border-left: 4px solid var(--color-slate-500);
 }
 
 .message-wrapper.type-utility .message-avatar {
@@ -1528,7 +1528,7 @@ onMounted(async () => {
 /* SOURCES MESSAGES - Teal theme for source references */
 .message-wrapper.type-sources {
   @apply bg-teal-50 border-teal-300 text-teal-900;
-  border-left: 4px solid theme('colors.teal.500');
+  border-left: 4px solid var(--color-teal-500);
 }
 
 .message-wrapper.type-sources .message-avatar {
@@ -1546,7 +1546,7 @@ onMounted(async () => {
 /* JSON MESSAGES - Cyan theme for structured data */
 .message-wrapper.type-json {
   @apply bg-cyan-50 border-cyan-300 text-cyan-900;
-  border-left: 4px solid theme('colors.cyan.500');
+  border-left: 4px solid var(--color-cyan-500);
 }
 
 .message-wrapper.type-json .message-avatar {
@@ -1560,7 +1560,7 @@ onMounted(async () => {
 /* TERMINAL OUTPUT MESSAGES - Dark theme for terminal output */
 .message-wrapper.type-terminal_output {
   @apply bg-gray-900 border-gray-700 text-gray-100;
-  border-left: 4px solid theme('colors.green.500');
+  border-left: 4px solid var(--color-green-500);
 }
 
 .message-wrapper.type-terminal_output .message-avatar {
@@ -1587,7 +1587,7 @@ onMounted(async () => {
 /* COMMAND APPROVAL REQUEST - Yellow/Warning theme */
 .message-wrapper.type-command_approval_request {
   @apply bg-yellow-900/20 border-yellow-500/40 text-yellow-200;
-  border-left: 4px solid theme('colors.yellow.500');
+  border-left: 4px solid var(--color-yellow-500);
 }
 
 .message-wrapper.type-command_approval_request .message-avatar {

--- a/autobot-frontend/src/components/ui/SystemStatusNotification.vue
+++ b/autobot-frontend/src/components/ui/SystemStatusNotification.vue
@@ -13,7 +13,7 @@
     >
       <div
         v-show="showNotification && notificationLevel === 'toast'"
-        class="fixed bottom-4 right-4 max-w-md w-full bg-autobot-bg-card shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden z-9999"
+        class="fixed bottom-4 right-4 max-w-md w-full bg-autobot-bg-card shadow-lg rounded-lg pointer-events-auto ring-1 ring-black/5 overflow-hidden z-9999"
       >
         <div class="p-4">
           <div class="flex items-start">

--- a/autobot-slm-frontend/src/components/AddNodeModal.vue
+++ b/autobot-slm-frontend/src/components/AddNodeModal.vue
@@ -19,7 +19,7 @@
       >
         <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
           <!-- Background overlay -->
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+          <div class="fixed inset-0 bg-gray-500/75 transition-opacity" aria-hidden="true"></div>
 
           <!-- Modal panel -->
           <div

--- a/autobot-slm-frontend/src/components/DeploymentLogViewer.vue
+++ b/autobot-slm-frontend/src/components/DeploymentLogViewer.vue
@@ -228,7 +228,7 @@ onUnmounted(() => {
 <template>
   <div
     v-if="visible"
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
     @click.self="emit('close')"
     @keydown.escape="emit('close')"
     role="dialog"

--- a/autobot-slm-frontend/src/components/DeploymentWizard.vue
+++ b/autobot-slm-frontend/src/components/DeploymentWizard.vue
@@ -217,7 +217,7 @@ function getCategoryIcon(category: string): string {
 <template>
   <div
     v-if="visible"
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
     @click.self="$emit('close')"
   >
     <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] overflow-hidden flex flex-col">

--- a/autobot-slm-frontend/src/components/InfrastructureWizard.vue
+++ b/autobot-slm-frontend/src/components/InfrastructureWizard.vue
@@ -287,7 +287,7 @@ function getStatusColor(status: string): string {
 <template>
   <div
     v-if="visible"
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
     @click.self="$emit('close')"
   >
     <div class="bg-white rounded-lg shadow-xl w-full max-w-3xl mx-4 max-h-[90vh] overflow-hidden flex flex-col">

--- a/autobot-slm-frontend/src/components/fleet/AssignNPURoleModal.vue
+++ b/autobot-slm-frontend/src/components/fleet/AssignNPURoleModal.vue
@@ -74,7 +74,7 @@ async function assignRole(): Promise<void> {
   <div v-if="visible" class="fixed inset-0 z-50 overflow-y-auto">
     <!-- Backdrop -->
     <div
-      class="fixed inset-0 bg-gray-500 bg-opacity-50 transition-opacity"
+      class="fixed inset-0 bg-gray-500/50 transition-opacity"
       @click="close"
     />
 

--- a/autobot-slm-frontend/src/components/fleet/NPUDetailsPanel.vue
+++ b/autobot-slm-frontend/src/components/fleet/NPUDetailsPanel.vue
@@ -150,7 +150,7 @@ onMounted(async () => {
   <div class="fixed inset-0 z-50 overflow-hidden">
     <!-- Backdrop -->
     <div
-      class="absolute inset-0 bg-gray-500 bg-opacity-50 transition-opacity"
+      class="absolute inset-0 bg-gray-500/50 transition-opacity"
       @click="emit('close')"
     />
 

--- a/autobot-slm-frontend/src/components/orchestration/RestartConfirmDialog.vue
+++ b/autobot-slm-frontend/src/components/orchestration/RestartConfirmDialog.vue
@@ -42,7 +42,7 @@ const emit = defineEmits<{
       <div class="flex items-center justify-center min-h-screen px-4">
         <!-- Backdrop -->
         <div
-          class="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+          class="fixed inset-0 bg-black/50 transition-opacity"
           @click="emit('cancel')"
         ></div>
 

--- a/autobot-slm-frontend/src/views/BackupsView.vue
+++ b/autobot-slm-frontend/src/views/BackupsView.vue
@@ -428,7 +428,7 @@ function getNodeHostname(nodeId: string): string {
     <!-- Create Backup Dialog -->
     <div
       v-if="showCreateBackupDialog"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
       @click.self="showCreateBackupDialog = false"
     >
       <div class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">
@@ -485,7 +485,7 @@ function getNodeHostname(nodeId: string): string {
     <!-- Create Replication Dialog -->
     <div
       v-if="showCreateReplicationDialog"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
       @click.self="showCreateReplicationDialog = false"
     >
       <div class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4">

--- a/autobot-slm-frontend/src/views/DeploymentsView.vue
+++ b/autobot-slm-frontend/src/views/DeploymentsView.vue
@@ -1152,7 +1152,7 @@ function getNodeHostname(nodeId: string): string {
     <!-- Standard Deployment Wizard Dialog -->
     <div
       v-if="showWizard"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
       @click.self="showWizard = false"
     >
       <div class="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto">
@@ -1332,7 +1332,7 @@ function getNodeHostname(nodeId: string): string {
     <!-- Blue-Green Create Dialog -->
     <div
       v-if="showBgCreateDialog"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
       @click.self="showBgCreateDialog = false"
     >
       <div class="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto">
@@ -1509,7 +1509,7 @@ function getNodeHostname(nodeId: string): string {
           v-if="showDetailsModal && selectedDeployment"
           class="fixed inset-0 z-50 flex items-center justify-center p-4"
         >
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="closeDetails"></div>
+          <div class="fixed inset-0 bg-gray-500/75" @click="closeDetails"></div>
           <div class="relative bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
             <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
               <div class="flex items-center gap-3">
@@ -1613,7 +1613,7 @@ function getNodeHostname(nodeId: string): string {
           v-if="showBgDetailsModal && selectedBgDeployment"
           class="fixed inset-0 z-50 flex items-center justify-center p-4"
         >
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="closeBgDetails"></div>
+          <div class="fixed inset-0 bg-gray-500/75" @click="closeBgDetails"></div>
           <div class="relative bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
             <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
               <div class="flex items-center gap-3">

--- a/autobot-slm-frontend/src/views/FleetOverview.vue
+++ b/autobot-slm-frontend/src/views/FleetOverview.vue
@@ -577,7 +577,7 @@ const formatLastSeen = formatRelativeTime
           aria-labelledby="delete-dialog-title"
           @keydown.escape="closeDeleteConfirm"
         >
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="closeDeleteConfirm"></div>
+          <div class="fixed inset-0 bg-gray-500/75" @click="closeDeleteConfirm"></div>
           <div class="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6">
             <div class="flex items-center gap-4 mb-4">
               <div class="shrink-0 w-12 h-12 rounded-full bg-red-100 flex items-center justify-center" aria-hidden="true">
@@ -641,7 +641,7 @@ const formatLastSeen = formatRelativeTime
           aria-label="Connection test result"
           @keydown.escape="closeConnectionTestResult"
         >
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="closeConnectionTestResult"></div>
+          <div class="fixed inset-0 bg-gray-500/75" @click="closeConnectionTestResult"></div>
           <div class="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6">
             <div class="flex items-center gap-4 mb-4">
               <div
@@ -703,7 +703,7 @@ const formatLastSeen = formatRelativeTime
           aria-label="Node details panel"
           @keydown.escape="closeLifecyclePanel"
         >
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="closeLifecyclePanel"></div>
+          <div class="fixed inset-0 bg-gray-500/75" @click="closeLifecyclePanel"></div>
           <div class="fixed inset-y-0 right-0 flex max-w-full pl-10">
             <Transition
               enter-active-class="transform transition duration-300 ease-out"
@@ -799,7 +799,7 @@ const formatLastSeen = formatRelativeTime
           aria-label="Node services panel"
           @keydown.escape="closeServicesPanel"
         >
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="closeServicesPanel"></div>
+          <div class="fixed inset-0 bg-gray-500/75" @click="closeServicesPanel"></div>
           <div class="fixed inset-y-0 right-0 flex max-w-full pl-10">
             <Transition
               enter-active-class="transform transition duration-300 ease-out"

--- a/autobot-slm-frontend/src/views/MaintenanceView.vue
+++ b/autobot-slm-frontend/src/views/MaintenanceView.vue
@@ -632,7 +632,7 @@ function getNodeName(nodeId: string | null): string {
           v-if="showScheduleDialog"
           class="fixed inset-0 z-50 flex items-center justify-center p-4"
         >
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="closeScheduleDialog"></div>
+          <div class="fixed inset-0 bg-gray-500/75" @click="closeScheduleDialog"></div>
           <div class="relative bg-white rounded-lg shadow-xl max-w-lg w-full p-6">
             <div class="flex items-center justify-between mb-4">
               <h3 class="text-lg font-semibold text-gray-900">

--- a/autobot-slm-frontend/src/views/ReplicationView.vue
+++ b/autobot-slm-frontend/src/views/ReplicationView.vue
@@ -462,7 +462,7 @@ function getNodeHostname(nodeId: string): string {
     <!-- Create Dialog -->
     <div
       v-if="showCreateDialog"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
       @click.self="showCreateDialog = false"
     >
       <div class="bg-white rounded-lg shadow-xl max-w-lg w-full mx-4">
@@ -566,7 +566,7 @@ function getNodeHostname(nodeId: string): string {
           v-if="showDetailsModal && selectedReplication"
           class="fixed inset-0 z-50 flex items-center justify-center p-4"
         >
-          <div class="fixed inset-0 bg-gray-500 bg-opacity-75" @click="closeDetails"></div>
+          <div class="fixed inset-0 bg-gray-500/75" @click="closeDetails"></div>
           <div class="relative bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] overflow-hidden">
             <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
               <div class="flex items-center gap-3">

--- a/autobot-slm-frontend/src/views/RolesView.vue
+++ b/autobot-slm-frontend/src/views/RolesView.vue
@@ -459,7 +459,7 @@ onMounted(() => {
 
     <!-- Migrate Role Dialog -->
     <div v-if="showMigrateDialog"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div class="bg-white rounded-lg shadow-xl w-full max-w-lg mx-4">
         <div class="px-6 py-4 border-b flex items-center justify-between">
           <h2 class="text-lg font-semibold text-gray-900">

--- a/autobot-slm-frontend/src/views/ServicesView.vue
+++ b/autobot-slm-frontend/src/views/ServicesView.vue
@@ -871,7 +871,7 @@ onUnmounted(() => {
         <div class="flex items-center justify-center min-h-screen px-4">
           <!-- Backdrop -->
           <div
-            class="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+            class="fixed inset-0 bg-black/50 transition-opacity"
             @click="cancelRestartAll"
           ></div>
 

--- a/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.vue
+++ b/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.vue
@@ -281,11 +281,11 @@ onUnmounted(() => {
             <button
               v-if="!isAcknowledged(index)"
               @click="acknowledgeAlert(index)"
-              class="px-3 py-1 text-xs font-medium bg-white bg-opacity-50 rounded-sm hover:bg-opacity-75 transition-colors"
+              class="px-3 py-1 text-xs font-medium bg-white/50 rounded-sm hover:bg-white/75 transition-colors"
             >
               Acknowledge
             </button>
-            <span v-else class="px-3 py-1 text-xs font-medium bg-white bg-opacity-30 rounded-sm">
+            <span v-else class="px-3 py-1 text-xs font-medium bg-white/30 rounded-sm">
               Acknowledged
             </span>
           </div>

--- a/autobot-slm-frontend/src/views/monitoring/ErrorMonitor.vue
+++ b/autobot-slm-frontend/src/views/monitoring/ErrorMonitor.vue
@@ -516,7 +516,7 @@ onUnmounted(() => {
     <!-- Error Detail Modal -->
     <div
       v-if="selectedError"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       @click.self="closeDetail"
     >
       <div

--- a/autobot-slm-frontend/src/views/performance/AlertRulesView.vue
+++ b/autobot-slm-frontend/src/views/performance/AlertRulesView.vue
@@ -345,7 +345,7 @@ async function handleDelete(): Promise<void> {
         class="fixed inset-0 z-50 flex items-center justify-center"
       >
         <div
-          class="fixed inset-0 bg-black bg-opacity-50"
+          class="fixed inset-0 bg-black/50"
           @click="showCreateModal = false; showEditModal = false"
         ></div>
         <div class="relative bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 p-6">
@@ -481,7 +481,7 @@ async function handleDelete(): Promise<void> {
       leave-to-class="opacity-0"
     >
       <div v-if="showDeleteConfirm" class="fixed inset-0 z-50 flex items-center justify-center">
-        <div class="fixed inset-0 bg-black bg-opacity-50" @click="showDeleteConfirm = false"></div>
+        <div class="fixed inset-0 bg-black/50" @click="showDeleteConfirm = false"></div>
         <div class="relative bg-white rounded-lg shadow-xl w-full max-w-sm mx-4 p-6">
           <h3 class="text-lg font-semibold text-gray-900 mb-2">Delete Alert Rule</h3>
           <p class="text-sm text-gray-600 mb-4">

--- a/autobot-slm-frontend/src/views/performance/SLODashboard.vue
+++ b/autobot-slm-frontend/src/views/performance/SLODashboard.vue
@@ -271,7 +271,7 @@ async function handleDelete(): Promise<void> {
       leave-to-class="opacity-0"
     >
       <div v-if="showCreateModal" class="fixed inset-0 z-50 flex items-center justify-center">
-        <div class="fixed inset-0 bg-black bg-opacity-50" @click="showCreateModal = false"></div>
+        <div class="fixed inset-0 bg-black/50" @click="showCreateModal = false"></div>
         <div class="relative bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 p-6">
           <h3 class="text-lg font-semibold text-gray-900 mb-4">Create SLO</h3>
           <form @submit.prevent="handleCreate" class="space-y-4">
@@ -401,7 +401,7 @@ async function handleDelete(): Promise<void> {
       leave-to-class="opacity-0"
     >
       <div v-if="showDeleteConfirm" class="fixed inset-0 z-50 flex items-center justify-center">
-        <div class="fixed inset-0 bg-black bg-opacity-50" @click="showDeleteConfirm = false"></div>
+        <div class="fixed inset-0 bg-black/50" @click="showDeleteConfirm = false"></div>
         <div class="relative bg-white rounded-lg shadow-xl w-full max-w-sm mx-4 p-6">
           <h3 class="text-lg font-semibold text-gray-900 mb-2">Delete SLO</h3>
           <p class="text-sm text-gray-600 mb-4">

--- a/autobot-slm-frontend/src/views/settings/SecuritySettings.vue
+++ b/autobot-slm-frontend/src/views/settings/SecuritySettings.vue
@@ -469,7 +469,7 @@ onMounted(async () => {
 
     <div
       v-if="showMFASetupModal"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
     >
       <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">
@@ -538,7 +538,7 @@ onMounted(async () => {
 
     <div
       v-if="showBackupCodes"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
     >
       <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">
@@ -583,7 +583,7 @@ onMounted(async () => {
 
     <div
       v-if="showDisableModal"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
     >
       <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">Disable MFA</h3>
@@ -629,7 +629,7 @@ onMounted(async () => {
 
     <div
       v-if="showRegenerateModal"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
     >
       <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">
@@ -680,7 +680,7 @@ onMounted(async () => {
 
     <div
       v-if="showCreateKeyModal"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
     >
       <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">
@@ -774,7 +774,7 @@ onMounted(async () => {
 
     <div
       v-if="showKeyCreatedModal"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
     >
       <div class="bg-white rounded-lg p-6 max-w-md w-full mx-4">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">

--- a/autobot-slm-frontend/src/views/tools/admin/NoVNCTool.vue
+++ b/autobot-slm-frontend/src/views/tools/admin/NoVNCTool.vue
@@ -401,7 +401,7 @@ onUnmounted(() => {
 
     <!-- Screenshot Modal (Issue #74) -->
     <Teleport to="body">
-      <div v-if="showScreenshotModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75" @click="showScreenshotModal = false">
+      <div v-if="showScreenshotModal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/75" @click="showScreenshotModal = false">
         <div class="bg-white rounded-lg shadow-xl max-w-4xl max-h-[90vh] flex flex-col" @click.stop>
           <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
             <h3 class="text-lg font-semibold text-gray-900">Desktop Screenshot</h3>
@@ -422,7 +422,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Type Text Dialog (Issue #74) -->
-      <div v-if="showTypeDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50" @click="showTypeDialog = false">
+      <div v-if="showTypeDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click="showTypeDialog = false">
         <div class="bg-white rounded-lg shadow-xl w-full max-w-md" @click.stop>
           <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
             <h3 class="text-lg font-semibold text-gray-900">Type Text on Desktop</h3>


### PR DESCRIPTION
## Summary

Closes #3153

Full audit of both frontends (`autobot-frontend` and `autobot-slm-frontend`) for remaining Tailwind v3 patterns after the PR #3146 migration. Found and fixed 4 categories of v3 patterns across 23 files.

### Patterns Found and Fixed

**`theme()` function calls** (v3 — replaced by CSS variables in v4)
- `ChatMessages.vue`: 8 occurrences of `theme('colors.X.500')` → `var(--color-X-500)`

**`ring-opacity-*` utilities** (removed in v4 — use `color/opacity` shorthand)
- `App.vue`: `focus:ring-autobot-primary focus:ring-opacity-50` → `focus:ring-autobot-primary/50`
- `SystemStatusNotification.vue`: `ring-black ring-opacity-5` → `ring-black/5`

**`bg-opacity-*` utilities** (removed in v4 — use `color/opacity` shorthand)
- 20 slm-frontend files: `bg-black bg-opacity-50` → `bg-black/50`, `bg-gray-500 bg-opacity-75` → `bg-gray-500/75`, `bg-white bg-opacity-50 hover:bg-opacity-75` → `bg-white/50 hover:bg-white/75`, etc.

### Checklist Items Confirmed Clean

- No `@tailwind base/components/utilities` directives remain (both frontends use `@import 'tailwindcss'`)
- No `@screen` directive usage found
- No `tailwind.config.js` or `tailwind.config.ts` files remain
- No `divide-opacity-*`, `border-opacity-*`, or `text-opacity-*` patterns found
- `blueGray-*` colors are defined as custom CSS variables in `@theme` block — valid in v4
- `outline-none` in `focus:outline-none` contexts: in v4 `outline-none` still sets `outline: 2px solid transparent` — existing `focus:outline-hidden` usages confirmed present where needed
- `placeholder-blueGray-300` and `text-blueGray-*` in `tailwind.css` utilities are valid because `blueGray` is registered in the `@theme` block

## Test plan

- [x] `vue-tsc --noEmit` passes with zero errors on `autobot-frontend`
- [x] All 5 audit search patterns return zero results after fixes
- [x] 23 files changed, all changes are mechanical v3→v4 syntax conversions

🤖 Generated with [Claude Code](https://claude.com/claude-code)