### PR TITLE
fix(knowledge-graph): teardown, i18n, shallowRef typing, nextTick, RAF leak

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -38,10 +38,10 @@
           @click="toggleViewMode"
           class="action-btn view-mode-btn"
           :class="{ active: viewMode === '3d' }"
-          :title="viewMode === '2d' ? 'Switch to 3D view' : 'Switch to 2D view'"
+          :title="viewMode === '2d' ? $t('knowledge.graph.switchTo3d') : $t('knowledge.graph.switchTo2d')"
         >
           <i :class="viewMode === '2d' ? 'fas fa-cube' : 'fas fa-project-diagram'"></i>
-          {{ viewMode === '2d' ? '3D' : '2D' }}
+          {{ viewMode === '2d' ? $t('knowledge.graph.label3d') : $t('knowledge.graph.label2d') }}
         </button>
         <button
           @click="showCleanupPanel = !showCleanupPanel"
@@ -1162,8 +1162,15 @@ function toggleLayout(): void {
  * Issue #3330: 3D force-graph view toggle
  */
 function toggleViewMode(): void {
-  viewMode.value = viewMode.value === '2d' ? '3d' : '2d'
   if (viewMode.value === '2d') {
+    // Destroy Cytoscape to stop its RAF loop before switching to 3D (Issue #3363)
+    if (cy.value) {
+      cy.value.destroy()
+      cy.value = null
+    }
+    viewMode.value = '3d'
+  } else {
+    viewMode.value = '2d'
     nextTick(() => {
       if (!cy.value && cytoscapeContainer.value) {
         initCytoscape()

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
@@ -2,7 +2,7 @@
   <div ref="container" class="graph3d-container">
     <div v-if="isEmpty" class="graph3d-empty">
       <i class="fas fa-project-diagram"></i>
-      <p>No entities to display</p>
+      <p>{{ $t('knowledge.graph.noEntities3D') }}</p>
     </div>
   </div>
 </template>
@@ -17,18 +17,20 @@
  *
  * @see KnowledgeGraph.vue - Parent component that owns data fetching and controls
  * @see Issue #3330 - 3D graph view toggle feature
+ * @see Issue #3363 - WebGL teardown, i18n, shallowRef typing, nextTick fixes
  *
  * @author mrveiss
- * @copyright (c) 2025 mrveiss
+ * @copyright (c) 2026 mrveiss
  */
 
 // AutoBot - AI-Powered Automation Platform
-// Copyright (c) 2025 mrveiss
+// Copyright (c) 2026 mrveiss
 // Author: mrveiss
 
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
-import ForceGraph3D from '3d-force-graph'
+import { ref, shallowRef, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import ForceGraph3D, { type ForceGraph3DInstance } from '3d-force-graph'
 import SpriteText from 'three-spritetext'
+import * as THREE from 'three'
 import { getCssVar } from '@/composables/useCssVars'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -87,13 +89,16 @@ const emit = defineEmits<{
 // ============================================================================
 
 const container = ref<HTMLElement | null>(null)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let graph: any = null
+// shallowRef prevents Vue from deeply observing the heavy Three.js instance.
+// Issue #704 pattern: same rationale as KnowledgeGraph.vue shallowRef<Core>
+// Issue #3363: typed with ForceGraph3DInstance instead of any
+const graph = shallowRef<ForceGraph3DInstance | null>(null)
 
 const isEmpty = computed(() => props.entities.length === 0)
 
 // ============================================================================
 // Color Mapping (mirrors KnowledgeGraph.vue palette)
+// Issue #704: All colors use CSS custom properties for theming support
 // ============================================================================
 
 function getNodeColor(type: string): string {
@@ -143,13 +148,14 @@ function buildGraphData(): { nodes: GraphNode[]; links: GraphLink[] } {
 function initGraph(): void {
   if (!container.value) return
 
-  const width = container.value.clientWidth
-  const height = container.value.clientHeight
+  const width = container.value.clientWidth || container.value.offsetWidth
+  const height = container.value.clientHeight || container.value.offsetHeight || 500
 
-  graph = ForceGraph3D({ antialias: true, alpha: true })(container.value)
+  // new ForceGraph3D(element, config) per IForceGraph3D constructor signature
+  graph.value = new ForceGraph3D(container.value, { antialias: true, alpha: true })
     .width(width)
     .height(height)
-    .backgroundColor('#0f172a')
+    .backgroundColor(getCssVar('--bg-primary', '#0f172a'))
     .graphData(buildGraphData())
     // Nodes: colored sphere + floating sprite text label
     .nodeColor((node: object) => getNodeColor((node as GraphNode).type))
@@ -158,16 +164,17 @@ function initGraph(): void {
     .nodeThreeObject((node: object) => {
       const n = node as GraphNode
       const sprite = new SpriteText(n.name)
-      sprite.color = '#e2e8f0'
+      sprite.color = getCssVar('--text-primary', '#e2e8f0')
       sprite.textHeight = 5
       sprite.backgroundColor = 'rgba(15, 23, 42, 0.75)'
       sprite.padding = 2
       sprite.borderRadius = 3
-      sprite.position.y = 12
+      // SpriteText extends THREE.Sprite — position is inherited from Object3D
+      ;(sprite as unknown as THREE.Sprite).position.y = 12
       return sprite
     })
     // Links
-    .linkColor(() => '#475569')
+    .linkColor(() => getCssVar('--border-default', '#475569'))
     .linkOpacity(0.5)
     .linkWidth(1)
     .linkDirectionalArrowLength(4)
@@ -187,34 +194,65 @@ function initGraph(): void {
   logger.debug('3D graph initialized', { nodes: props.entities.length, links: props.edges.length })
 }
 
+/**
+ * Fully disposes all Three.js GPU resources to prevent memory leaks.
+ * Issue #3363: renderer.dispose() alone does not release geometry/material buffers.
+ */
+function disposeGraph(): void {
+  if (!graph.value) return
+
+  graph.value.pauseAnimation()
+
+  const scene = graph.value.scene()
+  if (scene) {
+    scene.traverse((obj: THREE.Object3D) => {
+      const mesh = obj as THREE.Mesh
+      mesh.geometry?.dispose()
+      const materials = Array.isArray(mesh.material) ? mesh.material : mesh.material ? [mesh.material] : []
+      materials.forEach((m: THREE.Material) => m.dispose())
+    })
+  }
+
+  const renderer = graph.value.renderer()
+  if (renderer) {
+    renderer.forceContextLoss()
+    renderer.dispose()
+  }
+
+  graph.value._destructor()
+  graph.value = null
+}
+
 // ============================================================================
 // Lifecycle
 // ============================================================================
 
 onMounted(() => {
+  // nextTick ensures the container has non-zero dimensions before initGraph reads them.
+  // Issue #3363: fixes 0×0 canvas on initial mount of conditionally-rendered component.
   if (!isEmpty.value) {
-    initGraph()
+    nextTick(() => initGraph())
   }
 })
 
 onUnmounted(() => {
-  if (graph) {
-    // Pause animation and release renderer resources
-    graph.pauseAnimation()
-    graph.renderer()?.dispose()
-    graph = null
-  }
+  disposeGraph()
 })
 
-// Rebuild graph data when filtered entities/edges change
+// Rebuild graph data when filtered entities/edges change.
+// nextTick in the init path ensures DOM has laid out before dimensions are read.
+// Issue #3363: fixes invisible graph when data arrives before DOM layout.
 watch(
   () => [props.entities, props.edges] as const,
-  () => {
-    if (!graph) {
-      if (!isEmpty.value) initGraph()
+  async () => {
+    if (!graph.value) {
+      if (!isEmpty.value) {
+        await nextTick()
+        initGraph()
+      }
       return
     }
-    graph.graphData(buildGraphData())
+    graph.value.graphData(buildGraphData())
   },
   { deep: true }
 )
@@ -228,7 +266,7 @@ watch(
   position: relative;
   border-radius: var(--radius-lg);
   overflow: hidden;
-  background: #0f172a;
+  background: var(--bg-primary);
 }
 
 .graph3d-empty {

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -2542,6 +2542,10 @@
       "zoomIn": "Zoom in",
       "zoomOut": "Zoom out",
       "fitToView": "Fit to view",
+      "switchTo3d": "التبديل إلى عرض ثلاثي الأبعاد",
+      "switchTo2d": "التبديل إلى عرض ثنائي الأبعاد",
+      "label3d": "3D",
+      "label2d": "2D",
       "fullscreen": "Fullscreen",
       "exitFullscreen": "Exit fullscreen",
       "typeLabel": "Type:",
@@ -2601,7 +2605,8 @@
         "searching": "Searching entities...",
         "noResults": "No entities found matching your search",
         "sourcesCount": "{count} sources"
-      }
+      },
+      "noEntities3D": "لا توجد كيانات للعرض"
     },
     "connectors": {
       "title": "Source Connectors",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -2555,6 +2555,10 @@
       "zoomIn": "Vergrößern",
       "zoomOut": "Verkleinern",
       "fitToView": "In Ansicht einpassen",
+      "switchTo3d": "Zur 3D-Ansicht wechseln",
+      "switchTo2d": "Zur 2D-Ansicht wechseln",
+      "label3d": "3D",
+      "label2d": "2D",
       "fullscreen": "Vollbild",
       "exitFullscreen": "Vollbild beenden",
       "typeLabel": "Typ:",
@@ -2614,7 +2618,8 @@
         "searching": "Entitäten werden gesucht...",
         "noResults": "Keine Entitäten zu Ihrer Suche gefunden",
         "sourcesCount": "{count} Quellen"
-      }
+      },
+      "noEntities3D": "Keine Entitäten zum Anzeigen"
     },
     "connectors": {
       "title": "Quell-Konnektoren",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2580,6 +2580,10 @@
       "zoomIn": "Zoom in",
       "zoomOut": "Zoom out",
       "fitToView": "Fit to view",
+      "switchTo3d": "Switch to 3D view",
+      "switchTo2d": "Switch to 2D view",
+      "label3d": "3D",
+      "label2d": "2D",
       "fullscreen": "Fullscreen",
       "exitFullscreen": "Exit fullscreen",
       "typeLabel": "Type:",
@@ -2639,7 +2643,8 @@
         "searching": "Searching entities...",
         "noResults": "No entities found matching your search",
         "sourcesCount": "{count} sources"
-      }
+      },
+      "noEntities3D": "No entities to display"
     },
     "connectors": {
       "title": "Source Connectors",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -2555,6 +2555,10 @@
       "zoomIn": "Acercar",
       "zoomOut": "Alejar",
       "fitToView": "Ajustar a la vista",
+      "switchTo3d": "Cambiar a vista 3D",
+      "switchTo2d": "Cambiar a vista 2D",
+      "label3d": "3D",
+      "label2d": "2D",
       "fullscreen": "Pantalla completa",
       "exitFullscreen": "Salir de pantalla completa",
       "typeLabel": "Tipo:",
@@ -2614,7 +2618,8 @@
         "searching": "Buscando entidades...",
         "noResults": "No se encontraron entidades que coincidan con su búsqueda",
         "sourcesCount": "{count} fuentes"
-      }
+      },
+      "noEntities3D": "No hay entidades para mostrar"
     },
     "connectors": {
       "title": "Conectores de fuentes",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -1589,5 +1589,14 @@
         "scanFile": "Scan File"
       }
     }
+  },
+  "knowledge": {
+    "graph": {
+      "switchTo3d": "تغییر به نمای سه‌بعدی",
+      "switchTo2d": "تغییر به نمای دوبعدی",
+      "label3d": "3D",
+      "label2d": "2D",
+      "noEntities3D": "هیچ موجودیتی برای نمایش وجود ندارد"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -2555,6 +2555,10 @@
       "zoomIn": "Zoom avant",
       "zoomOut": "Zoom arrière",
       "fitToView": "Ajuster à la vue",
+      "switchTo3d": "Passer en vue 3D",
+      "switchTo2d": "Passer en vue 2D",
+      "label3d": "3D",
+      "label2d": "2D",
       "fullscreen": "Plein écran",
       "exitFullscreen": "Quitter le plein écran",
       "typeLabel": "Type :",
@@ -2614,7 +2618,8 @@
         "searching": "Recherche d'entités...",
         "noResults": "Aucune entité correspondant à votre recherche",
         "sourcesCount": "{count} sources"
-      }
+      },
+      "noEntities3D": "Aucune entité à afficher"
     },
     "connectors": {
       "title": "Connecteurs source",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -1589,5 +1589,14 @@
         "scanFile": "Scan File"
       }
     }
+  },
+  "knowledge": {
+    "graph": {
+      "switchTo3d": "עבור לתצוגה תלת-ממדית",
+      "switchTo2d": "עבור לתצוגה דו-ממדית",
+      "label3d": "3D",
+      "label2d": "2D",
+      "noEntities3D": "אין ישויות להצגה"
+    }
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -2555,6 +2555,10 @@
       "zoomIn": "Tuvināt",
       "zoomOut": "Tālināt",
       "fitToView": "Pielāgot skatam",
+      "switchTo3d": "Pārslēgties uz 3D skatu",
+      "switchTo2d": "Pārslēgties uz 2D skatu",
+      "label3d": "3D",
+      "label2d": "2D",
       "fullscreen": "Pilnekrāns",
       "exitFullscreen": "Iziet no pilnekrāna",
       "typeLabel": "Tips:",
@@ -2614,7 +2618,8 @@
         "searching": "Meklē entītījas...",
         "noResults": "Nav atrasta neviena entītīja, kas atbilst jūsu meklējumam",
         "sourcesCount": "{count} avoti"
-      }
+      },
+      "noEntities3D": "Nav entītiju, ko parādīt"
     },
     "connectors": {
       "title": "Avotu savienotāji",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -2555,6 +2555,10 @@
       "zoomIn": "Powiększ",
       "zoomOut": "Pomniejsz",
       "fitToView": "Dopasuj do widoku",
+      "switchTo3d": "Przełącz na widok 3D",
+      "switchTo2d": "Przełącz na widok 2D",
+      "label3d": "3D",
+      "label2d": "2D",
       "fullscreen": "Pełny ekran",
       "exitFullscreen": "Zamknij pełny ekran",
       "typeLabel": "Typ:",
@@ -2614,7 +2618,8 @@
         "searching": "Wyszukiwanie encji...",
         "noResults": "Nie znaleziono encji pasujących do wyszukiwania",
         "sourcesCount": "{count} źródeł"
-      }
+      },
+      "noEntities3D": "Brak encji do wyświetlenia"
     },
     "connectors": {
       "title": "Konektory źródeł",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -2555,6 +2555,10 @@
       "zoomIn": "Aumentar zoom",
       "zoomOut": "Diminuir zoom",
       "fitToView": "Ajustar à tela",
+      "switchTo3d": "Mudar para vista 3D",
+      "switchTo2d": "Mudar para vista 2D",
+      "label3d": "3D",
+      "label2d": "2D",
       "fullscreen": "Tela cheia",
       "exitFullscreen": "Sair da tela cheia",
       "typeLabel": "Tipo:",
@@ -2614,7 +2618,8 @@
         "searching": "Pesquisando entidades...",
         "noResults": "Nenhuma entidade encontrada para sua pesquisa",
         "sourcesCount": "{count} fontes"
-      }
+      },
+      "noEntities3D": "Nenhuma entidade para exibir"
     },
     "connectors": {
       "title": "Conectores de fontes",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -1589,5 +1589,14 @@
         "scanFile": "Scan File"
       }
     }
+  },
+  "knowledge": {
+    "graph": {
+      "switchTo3d": "3D منظر پر جائیں",
+      "switchTo2d": "2D منظر پر جائیں",
+      "label3d": "3D",
+      "label2d": "2D",
+      "noEntities3D": "دکھانے کے لیے کوئی ہستی نہیں"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3330 — addresses all 5 review issues from PR #3359.

- **GPU memory leak**: `disposeGraph()` now traverses the Three.js scene tree, calling `.geometry.dispose()` / `.material.dispose()` on all objects, then `forceContextLoss()` + `renderer.dispose()` + `_destructor()` — no more leak on 2D↔3D toggle
- **Cytoscape RAF loop**: `toggleViewMode()` calls `cy.value.destroy(); cy.value = null` before switching to 3D, stopping the detached animation loop
- **0×0 canvas bug**: `initGraph()` now wrapped in `nextTick()` both in `onMounted` and in the `watch` path — container has non-zero dimensions before dimensions are read
- **i18n regression**: toggle button title/label now use `$t('knowledge.graph.switchTo3d')` / `$t('knowledge.graph.label3d')` keys, added to all 11 locale files
- **Typing**: `graph` changed from `let graph: any` + eslint-disable to `shallowRef<ForceGraph3DInstance | null>` — matches the `shallowRef<Core>` pattern in the parent

## Test Plan
- [ ] Repeatedly toggle 2D↔3D — GPU memory in devtools stays stable
- [ ] Switch to 3D, verify Cytoscape is destroyed (no RAF in performance trace)
- [ ] Load page with slow data fetch — 3D graph renders at correct size
- [ ] Toggle button shows translated string in all supported locales
- [ ] `vue-tsc --noEmit` passes with zero errors

Closes #3363

🤖 Generated with Claude Code