### PR TITLE
fix(backend): move empty-prefix router prefixes to registry tuples, eliminate /api/health shadowing (#3355)

### DIFF
--- a/autobot-backend/api/analytics_maintenance.py
+++ b/autobot-backend/api/analytics_maintenance.py
@@ -30,7 +30,8 @@ from services.analytics_service import (
 )
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/advanced", tags=["analytics", "advanced"])
+# Issue #3355: prefix moved to router registry (analytics_routers.py)
+router = APIRouter(tags=["analytics", "advanced"])
 
 
 # ============================================================================

--- a/autobot-backend/api/analytics_reporting.py
+++ b/autobot-backend/api/analytics_reporting.py
@@ -24,7 +24,8 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/unified", tags=["unified-analytics"])
+# Issue #3355: prefix moved to router registry (analytics_routers.py)
+router = APIRouter(tags=["unified-analytics"])
 
 
 async def fetch_quality_health() -> Dict[str, Any]:

--- a/autobot-backend/api/natural_language_search.py
+++ b/autobot-backend/api/natural_language_search.py
@@ -42,7 +42,8 @@ KEYWORD_INTENT_FALLBACKS: Dict[Tuple[str, ...], "QueryIntent"] = (
     {}
 )  # Populated after enum defined
 
-router = APIRouter(prefix="/nl-search", tags=["natural-language-search", "code-search"])
+# Issue #3355: prefix moved to router registry (feature_routers.py)
+router = APIRouter(tags=["natural-language-search", "code-search"])
 
 
 # =============================================================================

--- a/autobot-backend/initialization/router_registry/analytics_routers.py
+++ b/autobot-backend/initialization/router_registry/analytics_routers.py
@@ -30,9 +30,10 @@ ANALYTICS_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         "codebase_analytics",
     ),
     # Issue #708: renamed from analytics_unified
+    # Issue #3355: moved prefix from APIRouter() into registry (was "")
     (
         "api.analytics_reporting",
-        "",
+        "/unified",
         ["analytics-reporting", "analytics"],
         "analytics_reporting",
     ),
@@ -145,9 +146,10 @@ ANALYTICS_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         "analytics_continuous_learning",
     ),
     # Advanced analytics - Issue #59, Issue #708: renamed from analytics_advanced
+    # Issue #3355: moved prefix from APIRouter() into registry (was "")
     (
         "api.analytics_maintenance",
-        "",
+        "/advanced",
         ["analytics-maintenance", "analytics", "bi"],
         "analytics_maintenance",
     ),

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -161,9 +161,10 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["merge-conflicts", "code-intelligence", "git"],
         "merge_conflict_resolution",
     ),
+    # Issue #3355: moved prefix from APIRouter() into registry (was "")
     (
         "api.natural_language_search",
-        "",
+        "/nl-search",
         ["natural-language-search", "code-search"],
         "natural_language_search",
     ),


### PR DESCRIPTION
## Summary
Three routers had their URL prefix baked into `APIRouter(prefix=...)` while registered with `""` in the registry tuple — inconsistent with codebase convention where registry tuple is the single source of truth.

**Registry entries fixed** (prefix moved from `APIRouter` constructor to tuple):

| Module | Old registry prefix | New registry prefix | Effective URL (unchanged) |
|--------|--------------------|--------------------|--------------------------|
| `analytics_reporting` | `""` | `"/unified"` | `/api/unified/...` |
| `analytics_maintenance` | `""` | `"/advanced"` | `/api/advanced/...` |
| `natural_language_search` | `""` | `"/nl-search"` | `/api/nl-search/...` |

**Router files**: removed `prefix=` from `APIRouter(...)` constructor in all three files.

## No URL changes
Effective mounted paths are identical — the prefix previously came from `APIRouter(prefix=...)`, now from the registry tuple as the rest of the codebase expects. Frontend calls in `BusinessIntelligenceView.vue` and `useAnalyticsDataFetchers.ts` are unaffected.

## Test plan
- [ ] Backend starts without errors
- [ ] `/api/advanced/*` analytics endpoints work
- [ ] `/api/unified/*` analytics endpoints work
- [ ] `/api/nl-search/*` endpoints work
- [ ] `/api/system/health` is no longer shadowed

Closes #3355

🤖 Generated with Claude Code