### PR TITLE
fix(backend): log warning in cache metric helpers instead of bare except pass

### DIFF
--- a/autobot-backend/utils/advanced_cache_manager.py
+++ b/autobot-backend/utils/advanced_cache_manager.py
@@ -118,8 +118,8 @@ def _record_cache_hit(key: str) -> None:
         from monitoring.prometheus_metrics import get_metrics_manager
 
         get_metrics_manager().record_llm_response_cache_hit(endpoint=key)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Could not record cache hit metric: %s", e)
 
 
 def _record_cache_miss(key: str) -> None:
@@ -128,8 +128,8 @@ def _record_cache_miss(key: str) -> None:
         from monitoring.prometheus_metrics import get_metrics_manager
 
         get_metrics_manager().record_llm_response_cache_miss(endpoint=key)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Could not record cache miss metric: %s", e)
 
 
 def _generate_cache_key(


### PR DESCRIPTION
## Summary

- Replaces bare `except Exception: pass` in `_record_cache_hit` and `_record_cache_miss` with `except Exception as e: logger.warning(...)` in `autobot-backend/utils/advanced_cache_manager.py`
- The module-level `logger = logging.getLogger(__name__)` at line 22 is already available for use
- A misconfigured or unavailable Prometheus metrics manager will now produce a visible warning in logs instead of failing silently

## Test plan

- [ ] Confirm `_record_cache_hit` and `_record_cache_miss` no longer contain bare `except Exception: pass`
- [ ] Simulate Prometheus unavailability (e.g. import error) and verify `logger.warning` output appears in backend logs
- [ ] Confirm no regressions in cache hit/miss paths during normal operation

Closes #3350

Generated with [Claude Code](https://claude.com/claude-code)