### PR TITLE
fix(test): align chat_knowledge e2e test path with router registration

### DIFF
--- a/autobot-backend/knowledge/chat_knowledge_system.e2e_test.py
+++ b/autobot-backend/knowledge/chat_knowledge_system.e2e_test.py
@@ -68,7 +68,7 @@ class ChatKnowledgeSystemTester:
         }
 
         async with self.session.post(
-            f"{BASE_URL}/api/chat_knowledge/context/create", json=context_data
+            f"{BASE_URL}/api/chat-knowledge/context/create", json=context_data
         ) as response:
             if response.status == 200:
                 data = await response.json()
@@ -108,7 +108,7 @@ if __name__ == "__main__":
                 data.add_field("association_type", "upload")
 
                 async with self.session.post(
-                    f"{BASE_URL}/api/chat_knowledge/files/upload/{self.test_chat_id}",
+                    f"{BASE_URL}/api/chat-knowledge/files/upload/{self.test_chat_id}",
                     data=data,
                 ) as response:
                     if response.status == 200:
@@ -151,7 +151,7 @@ if __name__ == "__main__":
             }
 
             async with self.session.post(
-                f"{BASE_URL}/api/chat_knowledge/knowledge/add_temporary",
+                f"{BASE_URL}/api/chat-knowledge/knowledge/add_temporary",
                 json=knowledge_data,
             ) as response:
                 if response.status == 200:
@@ -177,7 +177,7 @@ if __name__ == "__main__":
 
         # Get pending knowledge items
         async with self.session.get(
-            f"{BASE_URL}/api/chat_knowledge/knowledge/pending/{self.test_chat_id}"
+            f"{BASE_URL}/api/chat-knowledge/knowledge/pending/{self.test_chat_id}"
         ) as response:
             if response.status == 200:
                 data = await response.json()
@@ -204,7 +204,7 @@ if __name__ == "__main__":
                             }
 
                             async with self.session.post(
-                                f"{BASE_URL}/api/chat_knowledge/knowledge/decide",
+                                f"{BASE_URL}/api/chat-knowledge/knowledge/decide",
                                 json=decision_data,
                             ) as decision_response:
                                 if decision_response.status == 200:
@@ -253,7 +253,7 @@ if __name__ == "__main__":
             }
 
             async with self.session.post(
-                f"{BASE_URL}/api/chat_knowledge/search", json=search_data
+                f"{BASE_URL}/api/chat-knowledge/search", json=search_data
             ) as response:
                 if response.status == 200:
                     data = await response.json()
@@ -316,7 +316,7 @@ if __name__ == "__main__":
         }
 
         async with self.session.post(
-            f"{BASE_URL}/api/chat_knowledge/compile", json=compile_data
+            f"{BASE_URL}/api/chat-knowledge/compile", json=compile_data
         ) as response:
             if response.status == 200:
                 data = await response.json()
@@ -339,7 +339,7 @@ if __name__ == "__main__":
         logger.info("📋 Test 7: Context Retrieval")
 
         async with self.session.get(
-            f"{BASE_URL}/api/chat_knowledge/context/{self.test_chat_id}"
+            f"{BASE_URL}/api/chat-knowledge/context/{self.test_chat_id}"
         ) as response:
             if response.status == 200:
                 data = await response.json()


### PR DESCRIPTION
## Summary

- Replace all `/api/chat_knowledge/` (underscore) URL paths in `knowledge/chat_knowledge_system.e2e_test.py` with `/api/chat-knowledge/` (hyphen)
- Affected call sites: `context/create`, `files/upload/{id}`, `knowledge/add_temporary`, `knowledge/pending/{id}`, `knowledge/decide`, `search`, `compile`, `context/{id}` — 8 total
- The router prefix in `initialization/router_registry/feature_routers.py` line 289 is `/chat-knowledge` (hyphen); the test was using underscore, causing all paths to return 404 against production

Closes #3349

## Test plan

- [ ] Run `python autobot-backend/knowledge/chat_knowledge_system.e2e_test.py` against a running backend and verify all 7 test cases pass (no 404 responses)
- [ ] Confirm `feature_routers.py` still registers the prefix as `/chat-knowledge` (no changes made to router)

🤖 Generated with [Claude Code](https://claude.com/claude-code)