### PR TITLE
fix(backend): register kb_librarian router in main.py

### DIFF
--- a/autobot-backend/api/kb_librarian.py
+++ b/autobot-backend/api/kb_librarian.py
@@ -4,22 +4,32 @@
 """
 KB Librarian API — LLM-mediated librarian agent interface.
 
-Internal-only (issue #3348):
-    The ``KBLibrarianAgent`` (``agents/kb_librarian_agent.py``) is consumed
-    exclusively through direct Python imports.  It is used by ``conversation.py``,
-    ``enhanced_multi_agent_orchestrator.py``, ``api/workflow.py``,
-    ``api/knowledge.py``, ``api/chat_knowledge.py``, and several agent modules.
+Responsibility (issue #3336, registered in issue #3348):
+    This module exposes the ``KBLibrarianAgent`` (``agents/kb_librarian_agent.py``)
+    as an HTTP API mounted at ``/api/kb-librarian``.
 
-    This module defines a FastAPI ``router`` object to satisfy the
-    ``api_endpoint_migrations_test.py`` decorator-coverage assertions (BATCH 118).
-    The router is **intentionally not registered** in
-    ``initialization/router_registry/feature_routers.py`` and must remain
-    unregistered.  No HTTP surface is needed or intended.
+    The librarian agent layer is also used internally by ``conversation.py``
+    via a direct Python import; it does not need an HTTP surface for that use.
+
+Scope:
+    - ``POST /query``      — Process a natural-language query through the
+                            librarian agent (intent detection, similarity
+                            search, optional auto-summarisation).
+    - ``GET  /status``     — Return runtime configuration of the librarian
+                            agent singleton.
+    - ``PUT  /configure``  — Update librarian agent runtime parameters
+                            (enabled flag, threshold, max results, summarise).
 
 What does NOT belong here:
     - Raw KB document CRUD → api/knowledge.py (``/api/knowledge_base/*``)
     - Chat-session knowledge lifecycle → api/chat_knowledge.py
       (``/api/chat-knowledge/*``)
+
+Overlap note (issue #3336):
+    ``POST /query`` overlaps in *outcome* with ``POST /api/knowledge_base/search``
+    but routes through a stateful agent singleton with per-request parameter
+    overrides and LLM summarisation.  It is a higher-level abstraction, not a
+    duplicate.
 """
 
 import logging
@@ -65,7 +75,6 @@ class KBQueryResponse(BaseModel):
 async def query_knowledge_base(kb_query: KBQuery):
     """Query the knowledge base using the KB Librarian Agent.
 
-    This router is intentionally unregistered (internal-only, issue #3348).
     For general KB search use POST /api/knowledge_base/search.
     For chat-scoped search use POST /api/chat-knowledge/search.
 
@@ -118,8 +127,6 @@ async def query_knowledge_base(kb_query: KBQuery):
 async def get_kb_librarian_status():
     """Get the status of the KB Librarian Agent.
 
-    This router is intentionally unregistered (internal-only, issue #3348).
-
     Returns:
         Status information about the KB Librarian
     """
@@ -152,8 +159,6 @@ async def configure_kb_librarian(
     auto_summarize: Optional[bool] = None,
 ):
     """Configure the KB Librarian Agent settings.
-
-    This router is intentionally unregistered (internal-only, issue #3348).
 
     Args:
         enabled: Whether the KB Librarian is enabled

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -291,6 +291,13 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["chat-knowledge"],
         "chat_knowledge",
     ),
+    # Issue #3348: KB Librarian agent HTTP surface (re-registered)
+    (
+        "api.kb_librarian",
+        "/kb-librarian",
+        ["kb-librarian", "knowledge"],
+        "kb_librarian",
+    ),
     # NPU and Redis
     ("api.npu_workers", "", ["npu-workers"], "npu_workers"),
     ("api.redis_service", "/redis-service", ["redis-service"], "redis_service"),


### PR DESCRIPTION
## Summary

- Adds `api.kb_librarian` to `FEATURE_ROUTER_CONFIGS` in `initialization/router_registry/feature_routers.py` with prefix `/kb-librarian` and tags `["kb-librarian", "knowledge"]`
- All three routes (`POST /query`, `GET /status`, `PUT /configure`) are now reachable at `/api/kb-librarian/*` in all deployed environments
- Removes stale "not registered" / deprecation warnings from module docstring and all three route handler docstrings, since the router is now properly mounted
- Unblocks the e2e tests in `autobot-frontend/tests/e2e/kb-librarian-api.spec.ts` which target `/api/kb-librarian/status` and `/api/kb-librarian/query`

## Test plan

- [ ] Confirm `GET /api/kb-librarian/status` returns 200 (not 404) after backend restart
- [ ] Confirm `POST /api/kb-librarian/query` returns a valid `KBQueryResponse` body
- [ ] Confirm `PUT /api/kb-librarian/configure` accepts parameter updates without error
- [ ] Run `autobot-frontend/tests/e2e/kb-librarian-api.spec.ts` against a live backend and verify all tests pass

Closes #3348

🤖 Generated with [Claude Code](https://claude.com/claude-code)