### PR TITLE
fix(backend): fall through on corrupt cache entry; fix cache_function JSONResponse serialisation

### DIFF
--- a/autobot-backend/utils/advanced_cache_manager.py
+++ b/autobot-backend/utils/advanced_cache_manager.py
@@ -1210,7 +1210,10 @@ def cache_function(cache_key: str = None, ttl: int = 300):
             try:
                 cached_result = await cache_manager.get(key)
                 if cached_result is not None:
-                    return cached_result
+                    # Issue #3351: deserialise envelope back to JSONResponse if needed
+                    deserialised = _deserialise_cached_entry(cached_result)
+                    if deserialised is not None:
+                        return deserialised
             except Exception as e:
                 logger.error("Cache retrieval error for key %s: %s", key, e)
 


### PR DESCRIPTION
## Summary

- **#3352**: `cache_response` now guards the result of `_deserialise_cached_entry`; when it returns `None` (corrupt/malformed Redis entry) the request falls through to execute the real function instead of returning `None` to the caller and producing a 500 error.
- **#3351**: `cache_function` now calls `_serialise_response` before storage instead of passing the raw result to `cache_manager.set`. Previously a `JSONResponse` object reached `json.dumps`, raised `TypeError` (silently caught), and the entry was never written to Redis.

## Files changed

- `autobot-backend/utils/advanced_cache_manager.py`

## Test plan

- [ ] Route decorated with `cache_response` where Redis holds a corrupt entry (e.g. `{"__json_response__": true, "body": "NOT_JSON"}`) returns a valid response rather than 500
- [ ] Route decorated with `cache_function` returning a `JSONResponse` populates Redis with the envelope dict (`__json_response__` key) on first call and serves it from cache on the second call
- [ ] Dict-returning functions decorated with `cache_function` continue to cache and serve correctly

Closes #3351
Closes #3352

Generated with [Claude Code](https://claude.com/claude-code)