### PR TITLE
style: apply Black formatting to 89 Python files (#3408)

### DIFF
--- a/autobot-backend/api/conversation_export.py
+++ b/autobot-backend/api/conversation_export.py
@@ -30,8 +30,8 @@ from services.conversation_export import (
     export_conversation_markdown,
     import_conversation,
 )
-from utils.chat_utils import get_chat_history_manager, validate_chat_session_id
 from utils.chat_exceptions import get_exceptions_lazy
+from utils.chat_utils import get_chat_history_manager, validate_chat_session_id
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/llm_interface_pkg/adapters/__init__.py
+++ b/autobot-backend/llm_interface_pkg/adapters/__init__.py
@@ -10,7 +10,6 @@ lookup, fallback behavior, and per-agent configuration.
 
 from .ai_stack_adapter import AIStackAdapter
 from .anthropic_adapter import AnthropicAdapter
-from .layer_inference_adapter import LayerInferenceAdapter
 from .base import (
     AdapterBase,
     AdapterConfig,
@@ -19,6 +18,7 @@ from .base import (
     EnvironmentTestResult,
     SessionCodec,
 )
+from .layer_inference_adapter import LayerInferenceAdapter
 from .ollama_adapter import OllamaAdapter
 from .openai_adapter import OpenAIAdapter
 from .process_adapter import ProcessAdapter

--- a/autobot-backend/llm_interface_pkg/optimization/__init__.py
+++ b/autobot-backend/llm_interface_pkg/optimization/__init__.py
@@ -63,7 +63,6 @@ from .layer_inference import (
     LayerInferenceEngine,
     LayerInferenceStats,
 )
-from .model_inspector import ModelInfo, clear_cache, inspect_model
 from .meta_eviction import (
     EvictionStats,
     MetaDeviceEvictionManager,
@@ -71,6 +70,7 @@ from .meta_eviction import (
     evict_layer_to_meta,
     get_gpu_memory_allocated,
 )
+from .model_inspector import ModelInfo, clear_cache, inspect_model
 from .pipeline import LayerInferencePipeline, PipelineConfig, PreparedPipeline
 from .profiler import INFERENCE_STAGES, LayeredProfiler
 from .prompt_compressor import CompressionConfig, CompressionResult, PromptCompressor

--- a/autobot-backend/llm_interface_pkg/optimization/pipeline.py
+++ b/autobot-backend/llm_interface_pkg/optimization/pipeline.py
@@ -27,9 +27,9 @@ from typing import Any, Dict, Optional
 
 from .attention_backend import (
     AttentionBackendSelector,
-    ModelConfig as AttentionModelConfig,
 )
-from .hf_quantizer import HfQuantizerWrapper, QuantizerConfig, QuantizationType
+from .attention_backend import ModelConfig as AttentionModelConfig
+from .hf_quantizer import HfQuantizerWrapper, QuantizationType, QuantizerConfig
 from .kv_cache import KVCacheConfig, KVCacheManager, LayerKVCache
 from .layer_inference import LayerInferenceConfig, LayerInferenceEngine
 from .meta_eviction import MetaDeviceEvictionManager, clean_memory

--- a/autobot-backend/llm_interface_pkg/optimization/router.py
+++ b/autobot-backend/llm_interface_pkg/optimization/router.py
@@ -266,7 +266,7 @@ class OptimizationRouter:
         if not self.config.quantization_enabled:
             return {}
 
-        from .hf_quantizer import HfQuantizerWrapper, QuantizerConfig, QuantizationType
+        from .hf_quantizer import HfQuantizerWrapper, QuantizationType, QuantizerConfig
 
         quant_type_str = self.config.quantization_type
         type_map = {

--- a/autobot-backend/llm_providers/ollama_provider.py
+++ b/autobot-backend/llm_providers/ollama_provider.py
@@ -65,9 +65,7 @@ class OllamaProvider(BaseProvider):
         if self._delegate is not None:
             return self._delegate
         from llm_interface_pkg.models import LLMSettings
-        from llm_interface_pkg.providers.ollama import (
-            OllamaProvider as _OllamaProvider,
-        )
+        from llm_interface_pkg.providers.ollama import OllamaProvider as _OllamaProvider
         from llm_interface_pkg.streaming import StreamingManager
 
         settings = LLMSettings()

--- a/autobot-backend/services/autoresearch/__init__.py
+++ b/autobot-backend/services/autoresearch/__init__.py
@@ -11,22 +11,7 @@ Issue #2597: Standalone experiment runner + result store.
 Issue #2599: AutoBot-orchestrated loop + web search (M2).
 """
 
-from .knowledge_synthesizer import ExperimentInsight, KnowledgeSynthesizer
-from .prompt_optimizer import (
-    BenchmarkFn,
-    OptimizationSession,
-    OptimizationStatus,
-    PromptOptimizer,
-    PromptOptTarget,
-    PromptVariant,
-)
-from .scorers import (
-    HumanReviewScorer,
-    LLMJudgeScorer,
-    PromptScorer,
-    ScorerResult,
-    ValBpbScorer,
-)
+from .archive import Archive
 from .auto_research_agent import (
     ApprovalGate,
     AutoResearchAgent,
@@ -37,12 +22,16 @@ from .auto_research_agent import (
     SessionStatus,
 )
 from .config import AutoResearchConfig
+from .knowledge_synthesizer import ExperimentInsight, KnowledgeSynthesizer
+from .meta_agent import MetaAgent, MetaPatch
+from .meta_eval_harness import MetaEvalHarness, MetaEvalResult
 from .models import (
     Experiment,
     ExperimentResult,
     ExperimentState,
     ExperimentStats,
     HyperParams,
+    VariantArchiveEntry,
 )
 from .osint_engine import (
     CorrelatedSignal,
@@ -57,13 +46,24 @@ from .osint_engine import (
     build_default_engine,
 )
 from .parser import ExperimentOutputParser
+from .prompt_optimizer import (
+    BenchmarkFn,
+    OptimizationSession,
+    OptimizationStatus,
+    PromptOptimizer,
+    PromptOptTarget,
+    PromptVariant,
+)
 from .routes import router
 from .runner import ExperimentRunner
+from .scorers import (
+    HumanReviewScorer,
+    LLMJudgeScorer,
+    PromptScorer,
+    ScorerResult,
+    ValBpbScorer,
+)
 from .store import ExperimentStore
-from .archive import Archive
-from .models import VariantArchiveEntry
-from .meta_agent import MetaAgent, MetaPatch
-from .meta_eval_harness import MetaEvalHarness, MetaEvalResult
 
 __all__ = [
     # Models

--- a/autobot-backend/services/autoresearch/knowledge_synthesizer_test.py
+++ b/autobot-backend/services/autoresearch/knowledge_synthesizer_test.py
@@ -6,9 +6,9 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from services.autoresearch.knowledge_synthesizer import (
     ExperimentInsight,

--- a/autobot-backend/services/autoresearch/meta_eval_harness_test.py
+++ b/autobot-backend/services/autoresearch/meta_eval_harness_test.py
@@ -7,7 +7,8 @@ Unit tests for MetaEvalHarness (issue #3224).
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch as mock_patch
+from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import patch as mock_patch
 
 import pytest
 

--- a/autobot-backend/services/autoresearch/prompt_optimizer_test.py
+++ b/autobot-backend/services/autoresearch/prompt_optimizer_test.py
@@ -6,9 +6,9 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 
 from services.autoresearch.archive import Archive
 from services.autoresearch.config import AutoResearchConfig

--- a/autobot-backend/services/autoresearch/scorers_test.py
+++ b/autobot-backend/services/autoresearch/scorers_test.py
@@ -6,9 +6,9 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 
 from services.autoresearch.models import Experiment, ExperimentResult, ExperimentState
 from services.autoresearch.scorers import (

--- a/autobot-backend/tests/test_autoresearch_m3.py
+++ b/autobot-backend/tests/test_autoresearch_m3.py
@@ -6,9 +6,9 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 
 from services.autoresearch.knowledge_synthesizer import KnowledgeSynthesizer
 from services.autoresearch.models import (

--- a/autobot-backend/tests/utils/test_cache_response_json_response.py
+++ b/autobot-backend/tests/utils/test_cache_response_json_response.py
@@ -21,12 +21,12 @@ from fastapi.responses import JSONResponse
 
 from utils.advanced_cache_manager import (
     _JSON_RESPONSE_ENVELOPE,
+    SimpleCacheManager,
     _deserialise_cached_entry,
     _record_cache_hit,
     _record_cache_miss,
     _serialise_response,
 )
-from utils.advanced_cache_manager import SimpleCacheManager
 
 # ---------------------------------------------------------------------------
 # _serialise_response


### PR DESCRIPTION
## Summary
- Applied Black auto-formatter to all Python files in `autobot-backend/` and `autobot-slm-backend/`
- 89 files reformatted, 590 insertions / 255 deletions (whitespace/style only)
- No logic changes — pure formatting pass

## Test Plan
- [ ] CI Black check passes
- [ ] No functional test regressions

## Related Issues
Closes #3408