### PR TITLE
fix(knowledge-graph): remove non-existent _destructor() call (#3420)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
@@ -248,7 +248,6 @@ function disposeGraph(): void {
     renderer.dispose()
   }
 
-  graph.value._destructor()
   graph.value = null
 }
 


### PR DESCRIPTION
## Summary
- Removes call to `_destructor()` on the `3d-force-graph` instance — this method does NOT exist in v1.79.1
- The correct Three.js teardown sequence was already fully in place (lines 224–249): `pauseAnimation()` → scene traverse dispose → `forceContextLoss()` → `renderer.dispose()`
- One-line deletion eliminates the TypeError thrown on every KnowledgeGraph3D unmount

Closes #3420

## Test plan
- [ ] Navigate to Knowledge Graph 3D view
- [ ] Navigate away — confirm no TypeError in browser console
- [ ] Repeat multiple times to confirm no WebGL context leak