### PR TITLE
fix(backend): add authentication to Docker deployment API endpoints (#3423)

### DIFF
--- a/autobot-backend/api/slm/deployments.py
+++ b/autobot-backend/api/slm/deployments.py
@@ -28,6 +28,7 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
+from auth_middleware import get_current_user
 from models.infrastructure import (
     DeploymentActionResponse,
     DeploymentCreateRequest,
@@ -46,7 +47,11 @@ from services.slm_client import get_slm_client
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/slm/deployments", tags=["slm-deployments"])
+router = APIRouter(
+    prefix="/slm/deployments",
+    tags=["slm-deployments"],
+    dependencies=[Depends(get_current_user)],
+)
 
 _VALID_STRATEGIES = {s.value for s in DeploymentStrategy}
 


### PR DESCRIPTION
## Summary
- Adds router-level `dependencies=[Depends(get_current_user)]` to cover all 7 SLM deployment endpoints at once
- Unauthenticated callers can no longer trigger, cancel, or roll back Docker deployments
- Reuses existing `get_current_user` from `auth_middleware` — no new auth code introduced

Closes #3423

## Security
All endpoints under `/slm/deployments` were publicly accessible without credentials. Router-level dependency enforcement is the same JWT-based pattern every other sensitive API in the codebase uses.

## Test plan
- [ ] Unauthenticated request to any `/slm/deployments/*` endpoint returns HTTP 401
- [ ] Authenticated request (valid JWT) succeeds as before
- [ ] Run existing backend test suite — all pass