### PR TITLE
fix(slm-agent): move get_redis_client to top-level import to fix test patching (#3422)

### DIFF
--- a/autobot-slm-backend/slm/agent/health_collector.py
+++ b/autobot-slm-backend/slm/agent/health_collector.py
@@ -19,6 +19,8 @@ from typing import Dict, List, Optional
 
 import psutil
 
+from autobot_shared.redis_client import get_redis_client
+
 logger = logging.getLogger(__name__)
 
 _STATE_CHANGE_CHANNEL_TEMPLATE = "autobot:services:{service}:state_change"
@@ -314,8 +316,6 @@ class HealthCollector:
         outage must not interrupt health collection (#3404).
         """
         try:
-            from autobot_shared.redis_client import get_redis_client
-
             client = get_redis_client(database="main")
             if client is None:
                 logger.warning(


### PR DESCRIPTION
## Summary
- Moves `get_redis_client` from a deferred import inside `_publish_state_change` to module-level
- `unittest.mock.patch('slm.agent.health_collector.get_redis_client')` was raising `AttributeError` because the name only existed inside the function body, never in the module namespace
- Moving to module level binds the name at import time, making the patch target valid
- No runtime behaviour change — the `try/except` around the call is preserved; Redis unavailability still logs a warning and never propagates

Closes #3422

## Test plan
- [ ] `pytest slm/agent/health_collector_state_change_test.py -v` — all `TestPublishStateChange` tests pass
- [ ] Health collection still functions normally when Redis is available
- [ ] Health collection logs a warning (not exception) when Redis is unavailable