### PR TITLE
fix(ansible): rename backend_port to backend_nginx_port in distributed_setup (#3431)

### DIFF
--- a/autobot-slm-backend/ansible/roles/distributed_setup/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/defaults/main.yml
@@ -42,7 +42,7 @@ health_check_enabled: true
 health_check_interval: 60  # seconds
 health_check_endpoints:
   - name: "Backend API"
-    url: "https://{{ coordinator_host }}:8443/api/health"  # Issue #956: HTTPS:8443 since #858/#861
+    url: "https://{{ coordinator_host }}:{{ backend_nginx_port }}/api/health"  # Issue #956: HTTPS:8443 since #858/#861
     expected_status: 200
   - name: "Redis"
     host: "{{ hostvars[groups['redis'][0]]['ansible_host'] }}"
@@ -60,7 +60,11 @@ backup_destinations:
   - local_data
 
 # Service ports (from SSOT)
-backend_port: 8443
+# backend_nginx_port: external HTTPS port exposed by nginx (TLS termination).
+# Do NOT define backend_port here — the backend role owns that variable (8001,
+# plain HTTP, uvicorn bind port).  Defining it here would override the backend
+# role's default when distributed_setup runs after backend in the same play.
+backend_nginx_port: 8443
 frontend_port: 443
 redis_port: 6379
 npu_worker_port: 8081

--- a/autobot-slm-backend/ansible/roles/distributed_setup/templates/check-health.sh.j2
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/templates/check-health.sh.j2
@@ -22,8 +22,8 @@ echo "=========================================="
 echo ""
 
 # Check coordinator
-echo -n "Checking Backend Coordinator ({{ coordinator_host }}:{{ backend_port }})... "
-if curl -s --max-time 5 "http://{{ coordinator_host }}:{{ backend_port }}/api/health" >/dev/null 2>&1; then
+echo -n "Checking Backend Coordinator ({{ coordinator_host }}:{{ backend_nginx_port }})... "
+if curl -s --max-time 5 "https://{{ coordinator_host }}:{{ backend_nginx_port }}/api/health" >/dev/null 2>&1; then
     echo -e "${GREEN}OK${NC}"
 else
     echo -e "${RED}Failed${NC}"
@@ -43,7 +43,7 @@ fi
 
 echo ""
 echo "Service URLs:"
-echo "  Backend API: http://{{ coordinator_host }}:{{ backend_port }}"
+echo "  Backend API: https://{{ coordinator_host }}:{{ backend_nginx_port }}"
 {% for node in fleet_nodes %}
 echo "  {{ node.name }}: http://{{ node.host }}:{{ node.port }}"
 {% endfor %}

--- a/autobot-slm-backend/ansible/roles/distributed_setup/templates/distributed.env.j2
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/templates/distributed.env.j2
@@ -6,7 +6,7 @@ AUTOBOT_DEPLOYMENT_MODE=distributed
 
 # Coordinator configuration
 AUTOBOT_COORDINATOR_HOST={{ coordinator_host }}
-AUTOBOT_BACKEND_PORT={{ backend_port }}
+AUTOBOT_BACKEND_NGINX_PORT={{ backend_nginx_port }}
 
 # Fleet node hostnames (from inventory)
 {% for node in fleet_nodes %}

--- a/autobot-slm-backend/ansible/roles/distributed_setup/templates/fleet_registry.json.j2
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/templates/fleet_registry.json.j2
@@ -2,7 +2,7 @@
   "generated_at": "{{ ansible_date_time.iso8601 }}",
   "coordinator": {
     "host": "{{ coordinator_host }}",
-    "port": {{ backend_port }}
+    "port": {{ backend_nginx_port }}
   },
   "fleet_nodes": [
 {% for node in fleet_nodes %}

--- a/autobot-slm-backend/ansible/roles/distributed_setup/templates/fleet_topology.yml.j2
+++ b/autobot-slm-backend/ansible/roles/distributed_setup/templates/fleet_topology.yml.j2
@@ -7,7 +7,7 @@ generated_at: "{{ ansible_date_time.iso8601 }}"
 coordinator:
   hostname: "{{ coordinator_host }}"
   ip: "{{ coordinator_host }}"
-  port: {{ backend_port }}
+  port: {{ backend_nginx_port }}
   services:
     - backend-api
     - ollama


### PR DESCRIPTION
## Summary
- Renames `backend_port: 8443` → `backend_nginx_port: 8443` in `distributed_setup/defaults/main.yml`
- Removes the conflicting `backend_port` definition so the backend role's `backend_port: 8001` (uvicorn bind port) is no longer shadowed when both roles run in the same play
- Updates all 4 template files (`check-health.sh.j2`, `distributed.env.j2`, `fleet_registry.json.j2`, `fleet_topology.yml.j2`) to use the new `backend_nginx_port` variable
- Also renames the exported env var from `AUTOBOT_BACKEND_PORT=8443` → `AUTOBOT_BACKEND_NGINX_PORT=8443` so uvicorn doesn't try to bind on nginx's TLS port
- Fixes `http://` → `https://` in `check-health.sh.j2` health check URLs (port 8443 is TLS)

Closes #3431

## Test plan
- [ ] `ansible-lint` passes on all changed files
- [ ] Distributed setup playbook deploys without port conflict
- [ ] Backend uvicorn binds to 8001 (not 8443) after deployment
- [ ] Health check script correctly probes `https://<host>:8443/api/health`