### PR TITLE
fix(slm): remove write-capable executables from ALLOWED_EXECUTABLES (#3450)

### DIFF
--- a/autobot-slm-backend/api/nodes_execution.py
+++ b/autobot-slm-backend/api/nodes_execution.py
@@ -84,7 +84,8 @@ ALLOWED_EXECUTABLES: frozenset[str] = frozenset(
         "find",
         "stat",
         "file",
-        # Package management (query-only helpers — apt/yum/dnf/rpm excluded)
+        # Package management (query-only; argument guard in _validate_command
+        # restricts dpkg to -l/-s/-L/-S/--list/--status/--listfiles flags)
         "dpkg",
         # AutoBot-specific helpers
         "autobot-status",
@@ -111,7 +112,9 @@ _GIT_ALLOWED_SUBCOMMANDS: frozenset[str] = frozenset(
         "rev-parse",
         "ls-files",
         "ls-remote",
-        "stash",  # read-only usage: stash list / stash show
+        # stash: only list/show are permitted; sub-subcommand enforced in
+        # _validate_command to block stash pop/drop/clear/push
+        "stash",
     }
 )
 
@@ -124,8 +127,10 @@ def _validate_command(script: str) -> str:
     not in ALLOWED_EXECUTABLES.
 
     Additional per-executable argument guards (#3450):
-    - git: first argument must be in _GIT_ALLOWED_SUBCOMMANDS.
-    - find: -exec flag is rejected.
+    - git: first argument must be in _GIT_ALLOWED_SUBCOMMANDS;
+      'stash' is further restricted to list/show sub-subcommands.
+    - dpkg: first argument must be a read-only query flag.
+    - find: -exec/-execdir flags are rejected.
     """
     try:
         tokens = shlex.split(script)
@@ -173,6 +178,43 @@ def _validate_command(script: str) -> str:
                 detail=(
                     f"Command rejected: git subcommand {subcommand!r} is not "
                     "permitted. Only read-only subcommands are allowed."
+                ),
+            )
+        # git stash: only list and show are read-only; block pop/drop/clear/push.
+        if subcommand == "stash":
+            stash_op = tokens[2] if len(tokens) > 2 else "list"
+            if stash_op not in ("list", "show"):
+                logger.warning(
+                    "Command rejected — git stash %r is not a read-only operation",
+                    stash_op,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Command rejected: git stash {stash_op!r} is not "
+                        "permitted. Only 'stash list' and 'stash show' are allowed."
+                    ),
+                )
+
+    if executable == "dpkg":
+        # Allow only read-only query flags; block install/remove/unpack/configure.
+        _DPKG_READ_FLAGS = {
+            "-l", "--list", "-s", "--status", "-L", "--listfiles",
+            "-S", "--search", "-p", "--print-avail",
+            "--get-selections", "--print-architecture",
+            "--print-foreign-architectures",
+        }
+        flag = tokens[1] if len(tokens) > 1 else ""
+        if flag not in _DPKG_READ_FLAGS:
+            logger.warning(
+                "Command rejected — dpkg flag %r is not a read-only query flag",
+                flag,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Command rejected: dpkg flag {flag!r} is not permitted. "
+                    "Only read-only query flags are allowed."
                 ),
             )
 

--- a/autobot-slm-backend/api/nodes_execution_test.py
+++ b/autobot-slm-backend/api/nodes_execution_test.py
@@ -290,6 +290,92 @@ class TestGitSubcommandGuard:
         assert exc_info.value.status_code == 400
         assert "not permitted" in exc_info.value.detail
 
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git stash list",
+            "git stash show",
+            "git stash show stash@{0}",
+        ],
+    )
+    def test_git_stash_read_only_passes(self, cmd):
+        """git stash list/show are the only permitted stash operations."""
+        executable = _validate_command(cmd)
+        assert executable == "git"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git stash",
+            "git stash push",
+            "git stash pop",
+            "git stash drop",
+            "git stash clear",
+            "git stash apply",
+            "git stash branch newbranch",
+        ],
+    )
+    def test_git_stash_write_ops_rejected(self, cmd):
+        """git stash write operations (pop/drop/clear/push/apply) are rejected."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_command(cmd)
+        assert exc_info.value.status_code == 400
+        assert "not permitted" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# #3450 — dpkg argument guard
+# ---------------------------------------------------------------------------
+
+
+class TestDpkgArgumentGuard:
+    """dpkg is restricted to read-only query flags."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "dpkg -l",
+            "dpkg --list",
+            "dpkg -s nginx",
+            "dpkg --status nginx",
+            "dpkg -L nginx",
+            "dpkg --listfiles nginx",
+            "dpkg -S /usr/bin/python3",
+            "dpkg --search /usr/bin/python3",
+            "dpkg -p nginx",
+            "dpkg --print-avail nginx",
+            "dpkg --get-selections",
+            "dpkg --print-architecture",
+            "dpkg --print-foreign-architectures",
+        ],
+    )
+    def test_dpkg_read_flags_pass(self, cmd):
+        """Read-only dpkg query flags are accepted."""
+        executable = _validate_command(cmd)
+        assert executable == "dpkg"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "dpkg -i evil.deb",
+            "dpkg --install evil.deb",
+            "dpkg -r nginx",
+            "dpkg --remove nginx",
+            "dpkg --purge nginx",
+            "dpkg -P nginx",
+            "dpkg --unpack evil.deb",
+            "dpkg --configure nginx",
+            "dpkg --triggers-only nginx",
+            "dpkg",
+        ],
+    )
+    def test_dpkg_write_flags_rejected(self, cmd):
+        """Write/install/remove dpkg flags are rejected with HTTP 400."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_command(cmd)
+        assert exc_info.value.status_code == 400
+        assert "not permitted" in exc_info.value.detail
+
 
 # ---------------------------------------------------------------------------
 # #3450 — find -exec guard


### PR DESCRIPTION
## Summary

- Removes `apt`, `yum`, `dnf`, `rpm` (package install/remove) from `ALLOWED_EXECUTABLES` entirely — no argument-level enforcement can make these safe enough for an admin API endpoint
- Removes `wget`, `curl` (arbitrary file write, exfiltration, POST to internal services) from `ALLOWED_EXECUTABLES` entirely
- Removes `nmap` (network scanner with `--script exploit` support) from `ALLOWED_EXECUTABLES` entirely
- Adds `_GIT_ALLOWED_SUBCOMMANDS` frozenset; `_validate_command` now enforces read-only git subcommands (`status`, `log`, `diff`, `show`, `branch`, `tag`, `remote`, `describe`, `shortlog`, `rev-parse`, `ls-files`, `ls-remote`, `stash`) — write subcommands (`clone`, `push`, `fetch`, `commit`, `reset`, `clean`, `config`, etc.) return HTTP 400
- `find`: `_validate_command` rejects any command where a token is `-exec` or `-execdir` — prevents arbitrary command chaining through find
- Fixes the false inline comment `# Git (read-only operations are enforced at argument level by callers)` — enforcement is now in `_validate_command` itself

Closes #3450

## Test plan

- [x] `apt install nginx` / `yum install httpd` / `dnf install vim` / `rpm -ivh pkg.rpm` return HTTP 400 (`not permitted`)
- [x] `wget http://example.com/file` / `curl -o /tmp/f http://example.com` / `nmap -sV 10.0.0.1` return HTTP 400 (`not permitted`)
- [x] `git status` / `git log --oneline -10` / `git diff HEAD~1` / `git show HEAD` / `git branch -a` / `git remote -v` pass validation
- [x] `git clone ...` / `git push` / `git pull` / `git commit` / `git reset --hard` / `git config` return HTTP 400 (`not permitted`)
- [x] `git` (no subcommand) returns HTTP 400
- [x] `find /tmp -exec bash {} ;` / `find / -execdir rm {} ;` return HTTP 400 (`not permitted`)
- [x] `find /var/log -name '*.log' -mtime -1` passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)