### PR TITLE
fix(security): add auth to /events/sync endpoint (#3452)

### DIFF
--- a/autobot-slm-backend/api/events.py
+++ b/autobot-slm-backend/api/events.py
@@ -15,11 +15,16 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import EventSeverity, Node, NodeEvent
+from services.auth import get_current_user
 from services.database import get_db
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/events", tags=["events"])
+router = APIRouter(
+    prefix="/events",
+    tags=["events"],
+    dependencies=[Depends(get_current_user)],
+)
 
 
 class BufferedEvent(BaseModel):


### PR DESCRIPTION
## Summary
- Adds `get_current_user` dependency at `APIRouter` level in `events.py` so every route under `/events` requires a valid bearer token
- The `/events/sync` endpoint was previously unauthenticated, allowing any caller to inject arbitrary events into the database

## Test plan
- [ ] Unauthenticated POST to `/events/sync` now returns 401
- [ ] Authenticated POST with valid token succeeds as before

Closes #3452

🤖 Generated with [Claude Code](https://claude.ai/code)