### PR TITLE
fix(security): add auth to browser MCP endpoints (#3451)

### DIFF
--- a/autobot-slm-backend/api/browser.py
+++ b/autobot-slm-backend/api/browser.py
@@ -11,10 +11,13 @@ Related to Issue #1120.
 
 import logging
 import os
+from typing import Annotated
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+
+from services.auth import get_current_user, require_admin
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +31,9 @@ class NavigateRequest(BaseModel):
 
 
 @router.get("/status")
-async def browser_status() -> dict:
+async def browser_status(
+    _: Annotated[dict, Depends(get_current_user)],
+) -> dict:
     """Return status of the persistent browser page."""
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
@@ -43,7 +48,10 @@ async def browser_status() -> dict:
 
 
 @router.post("/navigate")
-async def browser_navigate(body: NavigateRequest) -> dict:
+async def browser_navigate(
+    body: NavigateRequest,
+    _: Annotated[dict, Depends(require_admin)],
+) -> dict:
     """Navigate the persistent browser page to a URL.
 
     Handles javascript: scheme shortcuts used by BrowserTool.vue for
@@ -65,7 +73,9 @@ async def browser_navigate(body: NavigateRequest) -> dict:
 
 
 @router.post("/screenshot")
-async def browser_screenshot() -> dict:
+async def browser_screenshot(
+    _: Annotated[dict, Depends(require_admin)],
+) -> dict:
     """Capture a screenshot of the current browser page as base64 PNG."""
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:


### PR DESCRIPTION
## Summary
- `/browser/mcp/status` — requires `get_current_user` (read-only, any authenticated user)
- `/browser/mcp/navigate` — requires `require_admin` (can navigate to arbitrary URLs)
- `/browser/mcp/screenshot` — requires `require_admin` (captures current page state)

Previously all three endpoints were completely unauthenticated.

## Test plan
- [ ] Unauthenticated requests to all three endpoints return 401
- [ ] Non-admin user on `/navigate` and `/screenshot` returns 403
- [ ] Admin user on all three endpoints succeeds

Closes #3451

🤖 Generated with [Claude Code](https://claude.ai/code)