### PR TITLE
fix(security): revert get_current_user on /events/sync — agents have no bearer token (#3452)

### DIFF
--- a/autobot-slm-backend/api/events.py
+++ b/autobot-slm-backend/api/events.py
@@ -15,16 +15,15 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import EventSeverity, Node, NodeEvent
-from services.auth import get_current_user
 from services.database import get_db
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(
-    prefix="/events",
-    tags=["events"],
-    dependencies=[Depends(get_current_user)],
-)
+# This router is intentionally unauthenticated: node agents post to /sync
+# without a bearer token and are identified by node_id validated in the
+# endpoint body against the Node table (#3193).  Network-layer access control
+# (VPN / firewall) provides the perimeter guard.
+router = APIRouter(prefix="/events", tags=["events"])
 
 
 class BufferedEvent(BaseModel):


### PR DESCRIPTION
## Summary

Hotfix for the broken `events.py` merged in #3459.

The router-level `get_current_user` dependency silently breaks all node agent event syncs. Agents call `POST /api/events/sync` with no `Authorization` header — they identify themselves via `node_id` in the request body, validated against the `Node` table. The `security_headers.py` middleware already has an explicit exemption for this endpoint (`#3193`).

Reverts to unauthenticated router and adds a comment documenting the intended security model.

Closes #3452

🤖 Generated with [Claude Code](https://claude.ai/code)