### PR TITLE
fix(tts): extend _check_cache_writable to validate hub/xet subdirs (#3471)

### DIFF
--- a/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
+++ b/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
@@ -68,11 +68,11 @@ TTS_MODEL_ID: str = os.getenv("TTS_MODEL_ID", "liquid-ai/kani-tts-2")
 
 
 def _check_cache_writable(models_dir: Path) -> None:
-    """Validate that the TTS model cache directory is writable before loading.
+    """Validate that the TTS model cache directory and its HF subdirs are writable.
 
     pocket_tts catches PermissionError and re-raises with a misleading
     'accept terms / hf auth login' message. This check surfaces the real
-    cause early so the operator sees the correct fix (#3466).
+    cause early so the operator sees the correct fix (#3466, #3471).
     """
     import getpass
 
@@ -81,17 +81,26 @@ def _check_cache_writable(models_dir: Path) -> None:
     except PermissionError:
         pass  # fall through to the access check below
 
-    if not os.access(models_dir, os.W_OK):
-        user = getpass.getuser()
-        logger.error(
-            "TTS model cache directory %s is not writable by %s. "
-            "Run: sudo chown -R autobot-tts:autobot-tts %s  "
-            "Or re-run setup provisioning to fix automatically. (#3466)",
-            models_dir,
-            user,
-            models_dir,
-        )
-        raise SystemExit(1)
+    # Check root dir plus the HuggingFace Hub cache subdirs where
+    # pocket_tts actually reads/writes model shards (#3471).
+    subdirs_to_check = [models_dir]
+    for subdir_name in ("hub", "xet"):
+        subdir = models_dir / subdir_name
+        if subdir.exists():
+            subdirs_to_check.append(subdir)
+
+    for check_path in subdirs_to_check:
+        if not os.access(check_path, os.W_OK):
+            user = getpass.getuser()
+            logger.error(
+                "TTS model cache directory %s is not writable by %s. "
+                "Run: sudo chown -R autobot-tts:autobot-tts %s  "
+                "Or re-run setup provisioning to fix automatically. (#3466)",
+                check_path,
+                user,
+                models_dir,
+            )
+            raise SystemExit(1)
 
 
 def _is_gated_model(model_id: str) -> bool:


### PR DESCRIPTION
## Summary

- `_check_cache_writable` previously only called `os.access` on the root `models_dir`
- pocket_tts writes model shards into `models_dir/hub/` and `models_dir/xet/`, which may be owned by a different user even when the parent dir is writable
- This caused the permission check to pass but pocket_tts to still fail with a misleading 'accept terms / hf auth login' error
- Fix iterates over `hub/` and `xet/` subdirs (when they exist) and raises `SystemExit(1)` with the correct chown remediation message on the first non-writable path

Closes #3471

## Test plan

- [ ] Deploy tts-worker via Ansible to a host where `models_dir/hub/` exists but is owned by root
- [ ] Confirm the service logs the correct `chown -R autobot-tts:autobot-tts` remediation message and exits with code 1 instead of emitting a misleading auth error
- [ ] Confirm normal startup (all dirs writable) proceeds without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)