### PR TITLE
fix(frontend): display JSON error body message instead of [object Object] (#3463)

### DIFF
--- a/autobot-frontend/src/utils/ApiClient.ts
+++ b/autobot-frontend/src/utils/ApiClient.ts
@@ -316,7 +316,11 @@ export class ApiClient {
       const errorData = await response.json();
       return {
         status: response.status,
-        message: errorData.message || errorData.detail || 'Unknown error',
+        message: (() => {
+          const raw = errorData.error || errorData.message || errorData.detail;
+          if (raw == null) return JSON.stringify(errorData) || 'Unknown error';
+          return typeof raw === 'string' ? raw : JSON.stringify(raw);
+        })(),
         details: errorData,
       };
     } catch {


### PR DESCRIPTION
## Summary

Fixes `ApiClient.ts` to extract a human-readable message from structured JSON error responses instead of coercing the object to the string `[object Object]`.

When the backend returns a JSON error body (e.g., `{"error": "Knowledge base unavailable", "message": "...", "code": "KB_INIT_FAILED"}`), the toast and error display now shows `"HTTP 503: Knowledge base unavailable"` instead of `"HTTP 503: [object Object]"`.

## Change

`autobot-frontend/src/utils/ApiClient.ts` — `_extractErrorInfo` message extraction now tries `body.error` first, then `body.message`, then `body.detail`, then falls back to `JSON.stringify(body)`. Each extracted value is also coerced to a string via `JSON.stringify` if it is not already a string, preventing `[object Object]` even for nested object fields.

## Related

- Closes #3463

🤖 Generated with [Claude Code](https://claude.com/claude-code)