### PR TITLE
fix(tts): call _check_cache_writable before pocket_tts import (#3480)

### DIFF
--- a/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
+++ b/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
@@ -149,10 +149,9 @@ def _load_model():
     """Load Pocket TTS model. Returns (success, error_msg)."""
     global _model
     try:
+        _check_cache_writable(MODELS_DIR)
         from pocket_tts import TTSModel
 
-        _check_cache_writable(MODELS_DIR)
-        MODELS_DIR.mkdir(parents=True, exist_ok=True)
         VOICES_DIR.mkdir(parents=True, exist_ok=True)
         _configure_hf_token()
         _model = TTSModel.load_model()


### PR DESCRIPTION
## Summary

Moves `_check_cache_writable(MODELS_DIR)` to execute **before** `from pocket_tts import TTSModel` in `_load_model()`. Since `pocket_tts` or its dependencies may perform HuggingFace Hub cache I/O at import time, checking writability first ensures we get a clear diagnostic error rather than a misleading "accept terms / hf auth login" message.

Also removes the redundant `MODELS_DIR.mkdir(parents=True, exist_ok=True)` call that followed the check, since `_check_cache_writable` already calls mkdir internally (added in #3471). `VOICES_DIR.mkdir()` is unchanged.

## Changes

- Reorder: `_check_cache_writable(MODELS_DIR)` moved before `from pocket_tts import TTSModel`
- Remove: redundant `MODELS_DIR.mkdir(parents=True, exist_ok=True)` after the check

## Related

- Closes #3480
- Related: #3466, #3471

🤖 Generated with [Claude Code](https://claude.com/claude-code)