### PR TITLE
fix(ansible): update deploy-aiml.yml chromadb_port default 8000→8100 (#3462)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-aiml.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-aiml.yml
@@ -28,7 +28,7 @@
     - name: Wait for ChromaDB to be ready
       ansible.builtin.wait_for:
         host: "127.0.0.1"
-        port: "{{ chromadb_port | default(8000) }}"
+        port: "{{ chromadb_port | default(8100) }}"
         timeout: 60
         delay: 5
 
@@ -41,7 +41,7 @@
 
     - name: Verify ChromaDB health
       ansible.builtin.uri:
-        url: "http://127.0.0.1:{{ chromadb_port | default(8000) }}/api/v2/heartbeat"
+        url: "http://127.0.0.1:{{ chromadb_port | default(8100) }}/api/v2/heartbeat"
         return_content: true
       register: chromadb_health
       failed_when: chromadb_health.status != 200
@@ -61,7 +61,7 @@
       ansible.builtin.debug:
         msg:
           - "AI/ML infrastructure deployed successfully"
-          - "ChromaDB: http://{{ ansible_host }}:{{ chromadb_port | default(8000) }}"
+          - "ChromaDB: http://{{ ansible_host }}:{{ chromadb_port | default(8100) }}"
           - "AI Stack API: http://{{ ansible_host }}:{{ ai_port | default(8080) }}"
           - "ChromaDB health: {{ chromadb_health.json | default('OK') }}"
           - "AI Stack health: {{ ai_stack_health.json | default('OK') }}"


### PR DESCRIPTION
## Summary

Fixes the stale `default(8000)` fallback in the `deploy-aiml.yml` post-tasks. ChromaDB was moved to port 8100 in #3094 but the playbook's `wait_for` task, health-check URL, and debug summary message still defaulted to 8000, causing deployment verification to check the wrong port.

## Changes

`autobot-slm-backend/ansible/playbooks/deploy-aiml.yml`:
- `wait_for` port: `default(8000)` → `default(8100)`
- Health check URL port: `default(8000)` → `default(8100)`
- Debug summary URL port: `default(8000)` → `default(8100)`

All three now match `roles/ai-stack/defaults/main.yml` (`chromadb_port: 8100`).

## Related

- Closes #3462

🤖 Generated with [Claude Code](https://claude.com/claude-code)