### PR TITLE
fix(slm): add admin guard to BrowserTool.vue route (#3470)

### DIFF
--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -426,7 +426,7 @@ const router = createRouter({
           path: 'browser',
           name: 'tools-browser',
           component: () => import('@/views/tools/admin/BrowserTool.vue'),
-          meta: { title: 'Browser', parent: 'tools' }
+          meta: { title: 'Browser', parent: 'tools', admin: true }
         },
         {
           path: 'novnc',


### PR DESCRIPTION
## Summary

Adds `admin: true` to the `/tools/browser` route meta so the router's `beforeEach` guard blocks non-admin users from accessing the Browser MCP page.

Previously, non-admin users could load the page but all API calls (`/navigate`, `/screenshot`) returned 403, resulting in a broken, non-functional UI. With this fix, they are redirected to the fleet dashboard before the page loads.

## Change

`autobot-slm-frontend/src/router/index.ts` — added `admin: true` to the browser route meta:
```ts
meta: { title: 'Browser', parent: 'tools', admin: true }
```

The existing `beforeEach` guard at line 498 already checks `to.meta.admin && !authStore.isAdmin` and redirects non-admin users.

## Related

- Closes #3470
- Related: #3451 (backend auth hardening that exposed this gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)