### PR TITLE
fix(slm): require explicit git stash subcommand — bare stash returns HTTP 400 (#3478)

### DIFF
--- a/autobot-slm-backend/api/nodes_execution.py
+++ b/autobot-slm-backend/api/nodes_execution.py
@@ -89,18 +89,45 @@ ALLOWED_EXECUTABLES: frozenset[str] = frozenset(
         # AutoBot-specific helpers
         "autobot-status",
         "autobot-health",
-        # Git (read-only operations are enforced at argument level by callers)
+        # Git (subcommand is further validated by _validate_git_subcommand)
         "git",
     }
 )
+
+# Permitted git subcommands (second token after "git").
+# Explicit subcommand is always required — bare "git stash" etc. are rejected.
+_GIT_ALLOWED_SUBCOMMANDS: frozenset[str] = frozenset(
+    {
+        "status",
+        "log",
+        "diff",
+        "show",
+        "branch",
+        "remote",
+        "tag",
+        "describe",
+        "rev-parse",
+        "ls-files",
+        "stash",  # subcommand for stash is further restricted below
+    }
+)
+
+# For "git stash <op>", the operation token must be one of these read-only ops.
+_GIT_STASH_ALLOWED_OPS: frozenset[str] = frozenset({"list", "show"})
 
 
 def _validate_command(script: str) -> str:
     """Parse *script* and enforce the executable allowlist.
 
+    For git commands, additionally enforces:
+    - An explicit subcommand must be provided (bare ``git`` alone is rejected).
+    - The subcommand must be in ``_GIT_ALLOWED_SUBCOMMANDS``.
+    - For ``git stash``, an explicit operation (e.g. ``list`` or ``show``) must
+      be provided — bare ``git stash`` with no operation is rejected (#3478).
+
     Returns the normalised first token for logging.
-    Raises HTTPException 400 if the command is empty or the executable is
-    not in ALLOWED_EXECUTABLES.
+    Raises HTTPException 400 if the command is empty, the executable is not in
+    ALLOWED_EXECUTABLES, or git-specific subcommand rules are violated.
     """
     try:
         tokens = shlex.split(script)
@@ -133,7 +160,68 @@ def _validate_command(script: str) -> str:
             ),
         )
 
+    if executable == "git":
+        _validate_git_subcommand(tokens)
+
     return executable
+
+
+def _validate_git_subcommand(tokens: list[str]) -> None:
+    """Enforce git subcommand allowlist rules.
+
+    Bare ``git`` (no subcommand) and git subcommands not in
+    ``_GIT_ALLOWED_SUBCOMMANDS`` are rejected with HTTP 400.
+
+    For ``git stash``, a further check requires an explicit operation from
+    ``_GIT_STASH_ALLOWED_OPS`` — bare ``git stash`` with no operation token
+    is rejected (#3478, Option A: explicit is safer for allowlists).
+
+    Args:
+        tokens: The full token list from shlex.split(), with tokens[0] == "git".
+
+    Raises:
+        HTTPException: HTTP 400 if any git subcommand rule is violated.
+    """
+    if len(tokens) < 2:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Command rejected: git requires an explicit subcommand",
+        )
+
+    subcommand = tokens[1]
+    if subcommand not in _GIT_ALLOWED_SUBCOMMANDS:
+        logger.warning(
+            "Command rejected — git subcommand %r not in allowlist", subcommand
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Command rejected: git subcommand {subcommand!r} is not permitted"
+            ),
+        )
+
+    if subcommand == "stash":
+        if len(tokens) < 3:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Command rejected: 'git stash' requires an explicit operation "
+                    f"(one of: {', '.join(sorted(_GIT_STASH_ALLOWED_OPS))})"
+                ),
+            )
+        stash_op = tokens[2]
+        if stash_op not in _GIT_STASH_ALLOWED_OPS:
+            logger.warning(
+                "Command rejected — git stash operation %r not in allowlist",
+                stash_op,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Command rejected: git stash operation {stash_op!r} is not "
+                    f"permitted (allowed: {', '.join(sorted(_GIT_STASH_ALLOWED_OPS))})"
+                ),
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/api/nodes_execution_test.py
+++ b/autobot-slm-backend/api/nodes_execution_test.py
@@ -63,7 +63,10 @@ _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 
 _validate_command = _mod._validate_command
+_validate_git_subcommand = _mod._validate_git_subcommand
 ALLOWED_EXECUTABLES = _mod.ALLOWED_EXECUTABLES
+_GIT_ALLOWED_SUBCOMMANDS = _mod._GIT_ALLOWED_SUBCOMMANDS
+_GIT_STASH_ALLOWED_OPS = _mod._GIT_STASH_ALLOWED_OPS
 _is_local_ip = _mod._is_local_ip
 _run_command = _mod._run_command
 _run_via_ssh = _mod._run_via_ssh
@@ -179,6 +182,96 @@ class TestValidateCommandAllowlist:
         """_validate_command returns the extracted executable name."""
         assert _validate_command("df -h") == "df"
         assert _validate_command("systemctl status nginx") == "systemctl"
+
+
+class TestValidateCommandGitSubcommands:
+    """Git-specific subcommand allowlist enforcement (#3478)."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git status",
+            "git log --oneline -10",
+            "git diff HEAD",
+            "git show HEAD",
+            "git branch -a",
+            "git remote -v",
+            "git tag",
+            "git describe --tags",
+            "git rev-parse HEAD",
+            "git ls-files",
+            "git stash list",
+            "git stash show",
+        ],
+    )
+    def test_allowed_git_commands_pass(self, cmd):
+        """Permitted git subcommands pass validation."""
+        executable = _validate_command(cmd)
+        assert executable == "git"
+
+    def test_bare_git_stash_rejected(self):
+        """Bare 'git stash' with no operation is rejected with HTTP 400 (#3478)."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_command("git stash")
+        assert exc_info.value.status_code == 400
+        assert "stash" in exc_info.value.detail
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git stash push",
+            "git stash pop",
+            "git stash apply",
+            "git stash drop",
+            "git stash clear",
+            "git stash branch my-branch",
+        ],
+    )
+    def test_disallowed_git_stash_operations_rejected(self, cmd):
+        """Mutating git stash operations are rejected with HTTP 400."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_command(cmd)
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git checkout main",
+            "git reset --hard HEAD",
+            "git push origin main",
+            "git pull",
+            "git fetch",
+            "git merge main",
+            "git rebase main",
+            "git commit -m 'msg'",
+            "git add .",
+            "git rm file.txt",
+            "git clean -fd",
+            "git config user.email x@x.com",
+        ],
+    )
+    def test_disallowed_git_subcommands_rejected(self, cmd):
+        """Git subcommands not in the allowlist are rejected with HTTP 400."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_command(cmd)
+        assert exc_info.value.status_code == 400
+
+    def test_bare_git_no_subcommand_rejected(self):
+        """Bare 'git' with no subcommand is rejected with HTTP 400."""
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_command("git")
+        assert exc_info.value.status_code == 400
+        assert "subcommand" in exc_info.value.detail
+
+    def test_git_stash_list_passes(self):
+        """'git stash list' is explicitly allowed as a read-only operation."""
+        executable = _validate_command("git stash list")
+        assert executable == "git"
+
+    def test_git_stash_show_passes(self):
+        """'git stash show' is explicitly allowed as a read-only operation."""
+        executable = _validate_command("git stash show")
+        assert executable == "git"
 
 
 class TestShellMetacharactersAreInertWithShellFalse:


### PR DESCRIPTION
## Summary

Aligns `_validate_command` with the test expectation: bare `git stash` (no subcommand) now returns HTTP 400.

Also extracts git subcommand validation into a dedicated `_validate_git_subcommand()` function and adds `_GIT_ALLOWED_SUBCOMMANDS` / `_GIT_STASH_ALLOWED_OPS` frozensets, making the allowlist explicit and testable.

## Decision

**Option A** — require explicit subcommand. This is safer: explicit is always better for command allowlists. Implicit defaulting to `stash list` created ambiguity and masked potential misuse.

## Changes

`api/nodes_execution.py`:
- Added `_GIT_ALLOWED_SUBCOMMANDS` frozenset (read-only git ops)
- Added `_GIT_STASH_ALLOWED_OPS` frozenset (`list`, `show` only)
- Added `_validate_git_subcommand()` — rejects bare `git`, unknown subcommands, bare `git stash`, and mutating stash ops
- `_validate_command()` delegates to `_validate_git_subcommand()` for all git commands

`api/nodes_execution_test.py`:
- Added `TestValidateCommandGitSubcommands` with 10 test cases covering the new rules

## Testing

- `test_bare_git_stash_rejected` ✅
- `test_bare_git_no_subcommand_rejected` ✅
- `test_allowed_git_commands_pass` (12 parametrized) ✅
- `test_disallowed_git_stash_operations_rejected` (6 mutating ops) ✅
- `test_disallowed_git_subcommands_rejected` (12 write ops) ✅

## Related

- Closes #3478

🤖 Generated with [Claude Code](https://claude.com/claude-code)