### PR TITLE
fix(tts): move _check_cache_writable before pocket_tts import, remove redundant mkdir (#3480)

### DIFF
--- a/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
+++ b/autobot-slm-backend/ansible/roles/tts-worker/templates/tts-worker.py.j2
@@ -149,10 +149,9 @@ def _load_model():
     """Load Pocket TTS model. Returns (success, error_msg)."""
     global _model
     try:
+        _check_cache_writable(MODELS_DIR)
         from pocket_tts import TTSModel
 
-        _check_cache_writable(MODELS_DIR)
-        MODELS_DIR.mkdir(parents=True, exist_ok=True)
         VOICES_DIR.mkdir(parents=True, exist_ok=True)
         _configure_hf_token()
         _model = TTSModel.load_model()


### PR DESCRIPTION
## Summary
- Moves `_check_cache_writable()` call to before `from pocket_tts import TTSModel` so cache writability is validated before the import (which triggers HuggingFace cache access)
- Removes redundant `mkdir` call that followed the check
- Prevents misleading "accept terms / hf auth login" errors when the real problem is a permissions issue on the cache directory

## Test plan
- [ ] Deploy TTS worker with a read-only HF cache directory
- [ ] Confirm the worker exits with a clear permissions error before attempting to load the model
- [ ] Confirm normal startup still works when cache is writable

Closes #3480

🤖 Generated with [Claude Code](https://claude.com/claude-code)