### PR TITLE
fix(frontend): extract error message from JSON error bodies instead of [object Object] (#3463)

### DIFF
--- a/autobot-frontend/src/utils/ApiClient.ts
+++ b/autobot-frontend/src/utils/ApiClient.ts
@@ -316,7 +316,11 @@ export class ApiClient {
       const errorData = await response.json();
       return {
         status: response.status,
-        message: errorData.message || errorData.detail || 'Unknown error',
+        message: (() => {
+          const raw = errorData.error || errorData.message || errorData.detail;
+          if (raw == null) return JSON.stringify(errorData) || 'Unknown error';
+          return typeof raw === 'string' ? raw : JSON.stringify(raw);
+        })(),
         details: errorData,
       };
     } catch {


### PR DESCRIPTION
## Summary
- Extracts `.error`, `.message`, or `.detail` fields from JSON error response bodies before displaying to the user
- Prevents `[object Object]` from appearing in error toasts and messages
- Falls back to raw text if the response body is not JSON

## Test plan
- [ ] Trigger a backend API error with a JSON body (e.g. `{"error": "Something failed"}`)
- [ ] Confirm the error toast shows the string, not `[object Object]`
- [ ] Verify non-JSON error bodies (plain text, HTML) still display correctly

Closes #3463

🤖 Generated with [Claude Code](https://claude.com/claude-code)