### PR TITLE
fix(slm): add admin guard to terminal/files/novnc/voice/mcp tool routes (#3490)

### DIFF
--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -414,13 +414,13 @@ const router = createRouter({
           path: 'terminal',
           name: 'tools-terminal',
           component: () => import('@/views/tools/admin/TerminalTool.vue'),
-          meta: { title: 'Terminal', parent: 'tools' }
+          meta: { title: 'Terminal', parent: 'tools', admin: true }
         },
         {
           path: 'files',
           name: 'tools-files',
           component: () => import('@/views/tools/admin/FileBrowserTool.vue'),
-          meta: { title: 'File Browser', parent: 'tools' }
+          meta: { title: 'File Browser', parent: 'tools', admin: true }
         },
         {
           path: 'browser',
@@ -432,19 +432,19 @@ const router = createRouter({
           path: 'novnc',
           name: 'tools-novnc',
           component: () => import('@/views/tools/admin/NoVNCTool.vue'),
-          meta: { title: 'noVNC', parent: 'tools' }
+          meta: { title: 'noVNC', parent: 'tools', admin: true }
         },
         {
           path: 'voice',
           name: 'tools-voice',
           component: () => import('@/views/tools/admin/VoiceTool.vue'),
-          meta: { title: 'Voice', parent: 'tools' }
+          meta: { title: 'Voice', parent: 'tools', admin: true }
         },
         {
           path: 'mcp',
           name: 'tools-mcp',
           component: () => import('@/views/tools/admin/MCPTool.vue'),
-          meta: { title: 'MCP Registry', parent: 'tools' }
+          meta: { title: 'MCP Registry', parent: 'tools', admin: true }
         },
         {
           path: 'agents',


### PR DESCRIPTION
## Summary

Adds \`admin: true\` to the route meta for 5 tool routes under \`views/tools/admin/\` that were missing the admin guard. Non-admin users could previously navigate to these pages and receive 403 on all API calls, resulting in a broken UI. With this fix the router's \`beforeEach\` guard redirects them before the page loads.

## Routes fixed

- \`tools-terminal\`
- \`tools-files\`
- \`tools-novnc\`
- \`tools-voice\`
- \`tools-mcp\`

## Related

- Closes #3490
- Discovered during review of PR #3484 (which fixed \`tools-browser\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)