### PR TITLE
fix(slm): block find -delete and file-write actions in argument guard (#3474)

### DIFF
--- a/autobot-slm-backend/api/nodes_execution.py
+++ b/autobot-slm-backend/api/nodes_execution.py
@@ -121,14 +121,14 @@ _GIT_STASH_ALLOWED_OPS: frozenset[str] = frozenset({"list", "show"})
 # always lowercase on Linux).
 _FIND_BLOCKED_FLAGS: frozenset[str] = frozenset(
     {
-        "-delete",   # deletes matched files/dirs in-place
-        "-fprint",   # writes matched paths to a named file
+        "-delete",  # deletes matched files/dirs in-place
+        "-fprint",  # writes matched paths to a named file
         "-fprint0",  # same as -fprint but NUL-separated
         "-fprintf",  # formatted write to a named file
-        "-exec",     # executes an arbitrary command per match
+        "-exec",  # executes an arbitrary command per match
         "-execdir",  # like -exec but changes directory first
-        "-ok",       # interactive -exec (still executes commands)
-        "-okdir",    # interactive -execdir
+        "-ok",  # interactive -exec (still executes commands)
+        "-okdir",  # interactive -execdir
     }
 )
 
@@ -198,9 +198,7 @@ def _validate_command(script: str) -> str:
     executable = Path(tokens[0]).name
 
     if executable not in ALLOWED_EXECUTABLES:
-        logger.warning(
-            "Command rejected — executable %r not in allowlist", executable
-        )
+        logger.warning("Command rejected — executable %r not in allowlist", executable)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
@@ -369,7 +367,9 @@ async def _audit_execute_event(
     await db.commit()
 
 
-_SSH_KEY_PATH = os.environ.get("SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key")  # noqa: ssot-path
+_SSH_KEY_PATH = os.environ.get(
+    "SLM_SSH_KEY", "/home/autobot/.ssh/autobot_key"
+)  # noqa: ssot-path
 _SSH_KNOWN_HOSTS_PATH = os.environ.get(
     "SLM_SSH_KNOWN_HOSTS", "/home/autobot/.ssh/known_hosts"
 )
@@ -442,11 +442,16 @@ async def _run_via_ssh(
 
     cmd = [
         "ssh",
-        "-p", str(ssh_port),
-        "-o", f"StrictHostKeyChecking={host_key_checking}",
-        "-o", f"UserKnownHostsFile={known_hosts_file}",
-        "-o", "BatchMode=yes",
-        "-o", f"ConnectTimeout={min(timeout, 30)}",
+        "-p",
+        str(ssh_port),
+        "-o",
+        f"StrictHostKeyChecking={host_key_checking}",
+        "-o",
+        f"UserKnownHostsFile={known_hosts_file}",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        f"ConnectTimeout={min(timeout, 30)}",
     ]
     if Path(_SSH_KEY_PATH).exists():
         cmd.extend(["-i", _SSH_KEY_PATH])

--- a/autobot-slm-backend/api/nodes_execution_test.py
+++ b/autobot-slm-backend/api/nodes_execution_test.py
@@ -344,9 +344,9 @@ class TestValidateCommandFindArgs:
             cmd = f"find /tmp {flag} extra_arg"
             with pytest.raises(HTTPException) as exc_info:
                 _validate_command(cmd)
-            assert exc_info.value.status_code == 400, (
-                f"Expected HTTP 400 for find with flag {flag!r}"
-            )
+            assert (
+                exc_info.value.status_code == 400
+            ), f"Expected HTTP 400 for find with flag {flag!r}"
 
 
 class TestShellMetacharactersAreInertWithShellFalse:
@@ -471,9 +471,9 @@ class TestRunViaSshKnownHosts:
             )
 
         ssh_opts = " ".join(captured_cmd)
-        assert "StrictHostKeyChecking=yes" in ssh_opts, (
-            f"Expected StrictHostKeyChecking=yes in: {ssh_opts}"
-        )
+        assert (
+            "StrictHostKeyChecking=yes" in ssh_opts
+        ), f"Expected StrictHostKeyChecking=yes in: {ssh_opts}"
         assert "StrictHostKeyChecking=no" not in ssh_opts
 
     @pytest.mark.asyncio
@@ -499,15 +499,11 @@ class TestRunViaSshKnownHosts:
             await _run_via_ssh("10.0.0.2", "autobot", 22, ["df", "-h"], 10)
 
         ssh_opts = " ".join(captured_cmd)
-        assert "accept-new" in ssh_opts, (
-            f"Expected accept-new in: {ssh_opts}"
-        )
+        assert "accept-new" in ssh_opts, f"Expected accept-new in: {ssh_opts}"
         assert "StrictHostKeyChecking=no" not in ssh_opts
 
     @pytest.mark.asyncio
-    async def test_tokens_passed_as_individual_args_not_shell_string(
-        self, tmp_path
-    ):
+    async def test_tokens_passed_as_individual_args_not_shell_string(self, tmp_path):
         """SSH receives command tokens as individual arguments (shell=False equivalent).
 
         This verifies that shell injection through SSH arguments is impossible:
@@ -538,9 +534,9 @@ class TestRunViaSshKnownHosts:
         # The individual tokens must appear as separate items in the argument
         # list — NOT as a single concatenated string.
         for token in tokens:
-            assert token in captured_args, (
-                f"Token {token!r} not found as individual arg in: {captured_args}"
-            )
+            assert (
+                token in captured_args
+            ), f"Token {token!r} not found as individual arg in: {captured_args}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extends the \`find\` argument guard in \`nodes_execution.py\` to reject destructive and file-write actions. The prior guard only blocked \`-exec\` and \`-execdir\`, but the comment said "read-only" — this was inaccurate.

Now blocked: \`-delete\`, \`-fprint\`, \`-fprint0\`, \`-fprintf\`, \`-exec\`, \`-execdir\`, \`-ok\`, \`-okdir\`.

## Changes

- \`api/nodes_execution.py\`: \`_FIND_BLOCKED_FLAGS\` frozenset + \`_validate_find_args()\` function + call in \`_validate_command()\`
- \`api/nodes_execution_test.py\`: \`TestValidateCommandFindArgs\` with tests for every blocked flag and allowed read-only commands

## Related

- Closes #3474

🤖 Generated with [Claude Code](https://claude.com/claude-code)