### PR TITLE
fix(ansible): create src/ directory before backend module symlinks (#3500)

### DIFF
--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
@@ -171,6 +171,15 @@
   notify: restart ai-stack
   tags: ['ai', 'deploy']
 
+- name: "AI Stack | Create src/ directory for backend module symlinks"
+  ansible.builtin.file:
+    path: "{{ ai_install_dir }}/src"
+    state: directory
+    mode: "0755"
+    owner: "{{ ai_user }}"
+    group: "{{ ai_group }}"
+  tags: ['ai', 'deploy']
+
 - name: Create src/ symlinks to backend modules (co-located deployment)
   ansible.builtin.file:
     src: "{{ backend_install_dir }}/{{ item }}"


### PR DESCRIPTION
Closes #3500

The `Create src/ symlinks` task in `ai-stack/tasks/main.yml` assumes `{{ ai_install_dir }}/src/` already exists. On a fresh deployment the directory doesn't exist and the symlink task fails.

Fix: add a directory-creation task immediately before the symlink task.