### PR TITLE
fix(ansible): add AUTOBOT_AI_STACK_HOST/PORT to backend.env.j2 (#3503)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -55,6 +55,10 @@ backend_llm_provider: "ollama"  # Default LLM provider for all agents
 backend_llm_endpoint: "http://127.0.0.1:11434"  # Default Ollama endpoint
 backend_llm_model: "qwen3.5:9b"  # Default LLM model
 
+# AI Stack connection (co-located: use 127.0.0.1; WSL2: may need 10.255.255.254)
+backend_ai_stack_host: "127.0.0.1"
+backend_ai_stack_port: 8080
+
 # Service Authentication
 service_auth_service_id: "main-backend"
 service_auth_keys_dir: "/etc/autobot/service-keys"

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -44,6 +44,10 @@ AUTOBOT_SLM_TLS_ENABLED=true
 AUTOBOT_TTS_WORKER_HOST={{ tts_host | default('127.0.0.1') }}
 AUTOBOT_TTS_WORKER_PORT={{ tts_port | default(8083) }}
 
+# AI Stack (agent processing service)
+AUTOBOT_AI_STACK_HOST={{ backend_ai_stack_host }}
+AUTOBOT_AI_STACK_PORT={{ backend_ai_stack_port }}
+
 # ChromaDB (remote on AI Stack VM)
 AUTOBOT_CHROMADB_HOST={{ backend_chromadb_host | default(ai_stack_host | default('127.0.0.1')) }}
 AUTOBOT_CHROMADB_PORT={{ backend_chromadb_port | default('8100') }}


### PR DESCRIPTION
Closes #3503

The backend falls back to ssot_config.py's hardcoded default (127.0.0.1) for AI stack host. On WSL2 nodes, 127.0.0.1 returns ECONNREFUSED — the actual loopback IP is 10.255.255.254.

Fix: explicitly set AUTOBOT_AI_STACK_HOST and AUTOBOT_AI_STACK_PORT in backend.env.j2 via Ansible variables so operators can configure the correct address per deployment.