### PR TITLE
fix(ansible): co-located ai-stack must run as autobot user (#3501)

### DIFF
--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -351,6 +351,12 @@ def _inject_co_located_ai_stack(
         if _ai_stack_roles & set(roles):
             continue
         hosts[inv_name]["node_roles"] = list(roles) + ["ai-stack"]
+        # Co-located ai-stack shares the backend venv and symlinks owned by
+        # autobot:autobot.  Override the role's default ai_user/ai_group
+        # (autobot-ai) so the systemd service runs with the correct identity
+        # and avoids permission errors on startup (#3501).
+        hosts[inv_name]["ai_user"] = "autobot"
+        hosts[inv_name]["ai_group"] = "autobot"
         logger.info(
             "Auto-injecting ai-stack onto %s (no dedicated AI stack node in fleet; #3461)",
             inv_name,


### PR DESCRIPTION
Closes #3501

## Summary

- In `_inject_co_located_ai_stack()`, when the ai-stack role is auto-injected onto a backend node, set `ai_user: autobot` and `ai_group: autobot` as host vars
- The role defaults (`ai_user: autobot-ai` / `ai_group: autobot-ai`) are correct for dedicated AI stack VMs, but on co-located nodes the service uses the backend venv (`/opt/autobot/autobot-backend/venv/`) and directories owned by `autobot:autobot` — running as `autobot-ai` causes permission errors
- Option A (setup_wizard.py host vars override) chosen over Option B (template conditional) for minimal blast radius — no Ansible template changes required

## Test plan

- [ ] Trigger a co-located setup wizard run (single-host, no dedicated AI stack VM) and confirm inventory generated for the backend node includes `ai_user: autobot` and `ai_group: autobot`
- [ ] Deploy via `deploy-aiml.yml` against the backend node and confirm `autobot-ai-stack.service` shows `User=autobot` / `Group=autobot` in `systemctl cat`
- [ ] Confirm service starts without permission errors in `/var/log/autobot/ai-stack-error.log`
- [ ] Confirm a distributed setup (dedicated AI stack VM) is unaffected — `_inject_co_located_ai_stack` returns early when `fleet_has_ai_stack=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)