### PR TITLE
fix(ansible): add backend_chromadb_host/port defaults to backend role

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -59,6 +59,10 @@ backend_llm_model: "qwen3.5:9b"  # Default LLM model
 backend_ai_stack_host: "127.0.0.1"
 backend_ai_stack_port: 8080
 
+# ChromaDB connection (co-located: 127.0.0.1; fleet deployment: ai-stack node IP)
+backend_chromadb_host: "127.0.0.1"
+backend_chromadb_port: 8100
+
 # Service Authentication
 service_auth_service_id: "main-backend"
 service_auth_keys_dir: "/etc/autobot/service-keys"

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -49,8 +49,8 @@ AUTOBOT_AI_STACK_HOST={{ backend_ai_stack_host }}
 AUTOBOT_AI_STACK_PORT={{ backend_ai_stack_port }}
 
 # ChromaDB (remote on AI Stack VM)
-AUTOBOT_CHROMADB_HOST={{ backend_chromadb_host | default(ai_stack_host | default('127.0.0.1')) }}
-AUTOBOT_CHROMADB_PORT={{ backend_chromadb_port | default('8100') }}
+AUTOBOT_CHROMADB_HOST={{ backend_chromadb_host }}
+AUTOBOT_CHROMADB_PORT={{ backend_chromadb_port }}
 
 # Deployment / user management mode (Issue #2953)
 AUTOBOT_USER_MODE={{ backend_user_mode | default('single_user') }}


### PR DESCRIPTION
Closes #3514

Adds `backend_chromadb_host` and `backend_chromadb_port` to `backend/defaults/main.yml`, removing the fragile Jinja2 fallback chains (`| default(ai_stack_host | default('127.0.0.1'))`) from `backend.env.j2`.

This mirrors the pattern introduced for `AUTOBOT_AI_STACK_HOST` in #3503. Operators can now override both ChromaDB and AI Stack hosts in a single consistent place (e.g. setting `backend_chromadb_host: "10.255.255.254"` for WSL2 co-located deployments).