### PR TITLE
fix(setup_wizard): auto-derive backend_chromadb_host from ai_stack_host for fleet deployments

### DIFF
--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -524,6 +524,13 @@ async def _generate_dynamic_inventory(
     if injected_ai_stack and "ai_stack_host" not in infra_vars:
         infra_vars["ai_stack_host"] = "127.0.0.1"
         infra_vars["ai_stack_port"] = 8080
+    # Auto-derive backend_chromadb_host from ai_stack_host for fleet deployments (#3523).
+    # In co-located setups ai_stack_host is 127.0.0.1 (correct); in fleet setups it
+    # is the AI stack node IP (also correct).  backend_chromadb_host in role defaults
+    # is always 127.0.0.1 and has no knowledge of fleet topology.
+    if "ai_stack_host" in infra_vars and "backend_chromadb_host" not in infra_vars:
+        infra_vars["backend_chromadb_host"] = infra_vars["ai_stack_host"]
+        infra_vars["backend_chromadb_port"] = 8100
     inventory = _build_inventory_dict(hosts, children, infra_vars)
 
     fd, path = tempfile.mkstemp(suffix=".yml", prefix="wizard-inventory-")


### PR DESCRIPTION
## Summary

- Fixes #3523: in fleet deployments (dedicated AI stack VM), `backend_chromadb_host` was always `127.0.0.1` (the role default) because the variable was never populated from the AI stack node's IP, causing ChromaDB to be unreachable from the backend node.
- In `_generate_dynamic_inventory`, after `_build_infra_vars()` and the co-located `ai_stack_host` injection block, if `ai_stack_host` is present in `infra_vars` and `backend_chromadb_host` is not already set, auto-populate `backend_chromadb_host` from `ai_stack_host` and set `backend_chromadb_port` to 8100.
- Co-located deployments: `ai_stack_host` is `127.0.0.1` (set by the #3515 fix), so `backend_chromadb_host` becomes `127.0.0.1` — correct.
- Fleet deployments: `ai_stack_host` is the dedicated AI stack VM IP, so `backend_chromadb_host` becomes that IP — correct.

## Test plan

- [ ] Co-located deployment: verify generated inventory has `backend_chromadb_host: 127.0.0.1`
- [ ] Fleet deployment (separate AI stack VM): verify generated inventory has `backend_chromadb_host` equal to the AI stack node IP and `backend_chromadb_port: 8100`
- [ ] Existing `backend_chromadb_host` override (operator-set): verify it is not overwritten (guarded by `not in infra_vars` check)
- [ ] No AI stack node in inventory: verify neither `backend_chromadb_host` nor `backend_chromadb_port` are injected

Generated with [Claude Code](https://claude.com/claude-code)