### PR TITLE
test(slm): fix code_source_test.py collection — add python-multipart stub (#3525)

### DIFF
--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -108,7 +108,7 @@ for _m in [
 # so that code_source_test.py can import code_source.py without the package
 # being installed in the dev environment.  Issue: #3525
 _pm_mod = types.ModuleType("python_multipart")
-_pm_mod.__version__ = "0.0.99"  # type: ignore[attr-defined]
+_pm_mod.__version__ = "9.9.99"  # type: ignore[attr-defined]  # high sentinel — immune to future FastAPI threshold bumps
 sys.modules.setdefault("python_multipart", _pm_mod)
 
 # ── user_management ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `autobot-slm-backend/api/code_source_test.py` could not be collected by pytest because FastAPI's `ensure_multipart_is_installed()` fires at route-registration time when any endpoint uses `UploadFile` or `Form`.
- `code_source_test.py` loads `code_source.py` via `importlib.spec_from_file_location` at module level, triggering this check before `python-multipart` is available in the dev environment.
- Added a `python_multipart` stub (`types.ModuleType` with `__version__ = "0.0.99"`) to `autobot-slm-backend/conftest.py` — the same pattern already used for other missing packages in that file. FastAPI's check imports `python_multipart.__version__` and asserts `> "0.0.12"`, so a stub version satisfies it without any real package.

## Test plan

- [ ] `python3 -m pytest autobot-slm-backend/api/code_source_test.py --collect-only -q` shows `15 tests collected` (was `1 error during collection`)
- [ ] `python3 -m pytest autobot-slm-backend/api/nodes_execution_test.py -q` still shows `149 passed`
- [ ] `python3 -m pytest autobot-slm-backend/api/nodes_execution_test.py autobot-slm-backend/api/code_source_test.py -q` shows `149 passed, 15 collected` (12 pre-existing test-logic failures in code_source_test.py are unrelated to this issue)

Closes #3525

🤖 Generated with [Claude Code](https://claude.com/claude-code)