### PR TITLE
fix(ansible): ai-stack role uses python3.12 for venv + fix pip cache (#3534)

### DIFF
--- a/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml
@@ -77,9 +77,24 @@
     - "{{ ai_data_dir }}"
     - "{{ ai_data_dir }}/chromadb"
 
-- name: Create Python virtual environment
+- name: Check existing venv Python version (#3534)
   ansible.builtin.command:
-    cmd: python3 -m venv {{ ai_install_dir }}/venv
+    cmd: "{{ ai_install_dir }}/venv/bin/python --version"
+  register: _ai_venv_python_version
+  changed_when: false
+  failed_when: false
+
+- name: Remove stale venv if not Python 3.12 (#3534)
+  ansible.builtin.file:
+    path: "{{ ai_install_dir }}/venv"
+    state: absent
+  when:
+    - _ai_venv_python_version.rc == 0
+    - "'Python 3.12' not in _ai_venv_python_version.stdout"
+
+- name: Create Python virtual environment (#3534)
+  ansible.builtin.command:
+    cmd: python3.12 -m venv {{ ai_install_dir }}/venv
     creates: "{{ ai_install_dir }}/venv/bin/python"
 
 - name: Fix venv ownership
@@ -90,6 +105,14 @@
     group: "{{ ai_group }}"
     recurse: true
 
+- name: Create pip cache directory for ai user (#3535)
+  ansible.builtin.file:
+    path: "{{ ai_data_dir }}/.cache/pip"
+    state: directory
+    owner: "{{ ai_user }}"
+    group: "{{ ai_group }}"
+    mode: "0755"
+
 - name: Upgrade pip in venv
   ansible.builtin.pip:
     name: pip
@@ -98,6 +121,7 @@
   become_user: "{{ ai_user }}"
   environment:
     PIP_DEFAULT_TIMEOUT: "120"
+    HOME: "{{ ai_data_dir }}"
   timeout: 120  # Issue #2835: prevent indefinite hang on network issues
 
 - name: Check if requirements-ai.txt exists
@@ -114,6 +138,7 @@
   become_user: "{{ ai_user }}"
   environment:
     PIP_DEFAULT_TIMEOUT: "300"
+    HOME: "{{ ai_data_dir }}"
   timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   when: _ai_requirements_file.stat.exists
 
@@ -145,6 +170,7 @@
   become_user: "{{ ai_user }}"
   environment:
     PIP_DEFAULT_TIMEOUT: "300"
+    HOME: "{{ ai_data_dir }}"
   timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
   when: not _ai_requirements_file.stat.exists
 


### PR DESCRIPTION
## Summary

- **Root cause:** `ai-stack` Ansible role created the venv with `python3` (resolves to Python 3.10 on target hosts), but `requirements-ai.txt` requires `numpy>=2.4.3` which only exists for Python 3.11+. The backend role correctly uses `python3.12`; the ai-stack role did not.
- **Stale venv guard:** Added version check before creation so a pre-existing Python 3.10 venv is removed rather than silently reused (the `creates:` guard would otherwise skip re-creation).
- **Pip cache:** `autobot-ai` service account has `create_home: false` so `~/.cache/pip` never exists. Added pip cache dir under `ai_data_dir` and set `HOME` env var on all pip tasks to suppress the warning and enable caching. Closes #3535.

## Changes

`autobot-slm-backend/ansible/roles/ai-stack/tasks/main.yml`:
- Add "Check existing venv Python version" — `failed_when: false` so it's a no-op on first deploy
- Add "Remove stale venv if not Python 3.12" — removes 3.10 venv before re-creation
- `python3 -m venv` → `python3.12 -m venv`
- Add "Create pip cache directory for ai user" under `ai_data_dir/.cache/pip`
- Add `HOME: "{{ ai_data_dir }}"` to all three `pip` tasks (upgrade pip, install from requirements, fallback install)

## Test plan

- [ ] Re-run fleet provisioning against a node with `ai-stack` role — Phase 5a should succeed
- [ ] Verify venv is at `.../venv/lib/python3.12/site-packages` on target host
- [ ] Verify no pip cache warning in provisioning output
- [ ] Re-run against a host with a pre-existing Python 3.10 venv — stale venv is detected and removed

Closes #3534
Closes #3535

🤖 Generated with [Claude Code](https://claude.com/claude-code)