### PR TITLE
refactor(constants): complete error_constants adoption (#3550)

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -17656,7 +17656,7 @@ class TestBatch99SchedulerFINAL(unittest.TestCase):
         self.assertIn("Invalid JSON in variables parameter", source)
         # Should preserve 404 HTTPException for template not found
         self.assertIn("status_code=404", source)
-        self.assertIn("Template not found", source)
+        self.assertIn("ERR_TEMPLATE_NOT_FOUND", source)
         # Should have 1 inner try-catch for JSON parsing
         try_count = source.count("try:")
         self.assertEqual(try_count, 1, "Should have 1 inner try-catch for JSON parsing")

--- a/autobot-backend/api/knowledge_metadata.py
+++ b/autobot-backend/api/knowledge_metadata.py
@@ -16,6 +16,7 @@ Endpoints:
 
 import logging
 
+from constants.error_constants import ERR_TEMPLATE_NOT_FOUND
 from fastapi import APIRouter, Depends, HTTPException
 
 from api.knowledge_models import (
@@ -127,7 +128,7 @@ async def get_metadata_template(template_id: str):
         result = await kb.get_metadata_template(template_id)
 
         if result.get("status") != "success":
-            raise HTTPException(status_code=404, detail="Template not found")
+            raise HTTPException(status_code=404, detail=ERR_TEMPLATE_NOT_FOUND)
 
         return result
 

--- a/autobot-backend/constants/__init__.py
+++ b/autobot-backend/constants/__init__.py
@@ -17,12 +17,10 @@ from .error_constants import (  # Issue #3530: Centralized error message strings
     ERR_INVALID_CREDENTIALS,
     ERR_INVALID_TOKEN,
     ERR_JOB_NOT_FOUND,
-    ERR_NOT_FOUND,
     ERR_PATH_NOT_FOUND,
     ERR_SESSION_NOT_FOUND,
     ERR_TEMPLATE_NOT_FOUND,
     ERR_WORKFLOW_NOT_FOUND,
-    ERR_FAILED_TO,
 )
 from .network_constants import (  # Legacy compatibility exports
     BACKEND_URL,
@@ -140,7 +138,6 @@ __all__ = [
     "CategoryDefaults",
     "ProtocolDefaults",
     # Issue #3530: Error message string constants
-    "ERR_NOT_FOUND",
     "ERR_ASSESSMENT_NOT_FOUND",
     "ERR_SESSION_NOT_FOUND",
     "ERR_FILE_NOT_FOUND",
@@ -153,7 +150,6 @@ __all__ = [
     "ERR_WORKFLOW_NOT_FOUND",
     "ERR_INVALID_CREDENTIALS",
     "ERR_INVALID_TOKEN",
-    "ERR_FAILED_TO",
     # Issue #3531: API path constants
     "PATH_API_HEALTH",
     "PATH_HEALTH",

--- a/autobot-backend/constants/error_constants.py
+++ b/autobot-backend/constants/error_constants.py
@@ -3,9 +3,6 @@
 # Author: mrveiss
 """Shared error message string constants for HTTP responses and logging."""
 
-# Generic resource errors (use as: ERR_NOT_FOUND.format(resource='Workflow')}")
-ERR_NOT_FOUND = "{resource} not found"
-
 # Specific resource errors (pre-formatted for common cases)
 ERR_ASSESSMENT_NOT_FOUND = "Assessment not found"
 ERR_SESSION_NOT_FOUND = "Session not found"
@@ -21,6 +18,3 @@ ERR_WORKFLOW_NOT_FOUND = "Workflow not found"
 # Auth errors
 ERR_INVALID_CREDENTIALS = "Invalid username or password"
 ERR_INVALID_TOKEN = "Invalid token"
-
-# Operation errors — use as f-string prefix at call site
-ERR_FAILED_TO = "Failed to {operation}"

--- a/autobot-backend/services/autoresearch/routes.py
+++ b/autobot-backend/services/autoresearch/routes.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, R
 from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from constants.error_constants import ERR_SESSION_NOT_FOUND
 from constants.ttl_constants import TTL_24_HOURS
 
 from .config import AutoResearchConfig
@@ -339,7 +340,7 @@ async def get_variants(
     key = f"autoresearch:prompt_opt:session:{session_id}"
     raw = await redis.get(key)
     if raw is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+        raise HTTPException(status_code=404, detail=ERR_SESSION_NOT_FOUND)
     data = _json.loads(raw)
     return {"variants": data.get("all_variants", [])}
 


### PR DESCRIPTION
## Summary

Completes the error_constants adoption started in PR #3539, addressing all gaps found in the post-merge code review.

## Changes

- **`services/autoresearch/routes.py`** — wire `ERR_SESSION_NOT_FOUND` (1 site)
- **`api/knowledge_metadata.py`** — wire `ERR_TEMPLATE_NOT_FOUND` (1 site)
- **`constants/error_constants.py`** — remove `ERR_NOT_FOUND` and `ERR_FAILED_TO` (zero call sites; the "Failed to {operation}" pattern is too varied across 30+ sites to adopt uniformly — dead constants violate project rules)
- **`constants/__init__.py`** — remove `ERR_NOT_FOUND` and `ERR_FAILED_TO` from import block and `__all__`
- **`api/api_endpoint_migrations_test.py`** — update `inspect.getsource()` assertion for `schedule_template_workflow` to check for `ERR_TEMPLATE_NOT_FOUND` instead of the literal string

Closes #3550