### PR TITLE
fix(ansible): add pre-flight git pull to provision-fleet-roles.yml

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
+++ b/autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml
@@ -21,6 +21,69 @@
 ---
 
 # -------------------------------------------------------------------
+# Play 0: Pre-flight — sync code_source from GitHub (#3561)
+#
+# Pulls the latest committed code before any role runs so that
+# Ansible role files, templates, and defaults are always current.
+# Uses ignore_errors: yes so offline / air-gapped SLMs still work
+# (they deploy from whatever code_source is already on disk and get
+# a visible warning).  Mirrors the pattern in update-all-nodes.yml.
+# -------------------------------------------------------------------
+- name: "Play 0 - Pre-flight: Sync code_source from GitHub"
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    github_repo: "https://github.com/mrveiss/AutoBot-AI.git"
+    git_repo_root: "/opt/autobot/code_source"
+    deploy_ref: "Dev_new_gui"
+
+  tasks:
+    - name: "[PRE-FLIGHT] Verify code_source exists"
+      ansible.builtin.stat:
+        path: "{{ git_repo_root }}/.git"
+      register: code_source_stat
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Abort if code_source missing"
+      ansible.builtin.fail:
+        msg: >-
+          Code source not found at {{ git_repo_root }}.
+          Initialize with: git clone {{ github_repo }} {{ git_repo_root }}
+      when: not code_source_stat.stat.exists
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Sync latest code from GitHub (if reachable)"
+      ansible.builtin.git:
+        repo: "{{ github_repo }}"
+        dest: "{{ git_repo_root }}"
+        version: "{{ deploy_ref }}"
+        update: yes
+      ignore_errors: yes
+      register: github_sync
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Warn if GitHub sync skipped"
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: GitHub sync failed (no internet access?).
+          Deploying from existing code_source at {{ git_repo_root }}.
+      when: github_sync is failed
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Get current deploy commit"
+      ansible.builtin.command: >-
+        git -C {{ git_repo_root }} log -1 --format='%h %s'
+      register: deploy_info
+      changed_when: false
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Display deployed commit"
+      ansible.builtin.debug:
+        msg: "Deploying from commit: {{ deploy_info.stdout }}"
+      tags: [always]
+
+# -------------------------------------------------------------------
 # Phase 0: Shared Dependencies (nginx, python312, nodejs)
 # Resolved from ROLE_DEPENDENCIES map via node_dependencies host var.
 # -------------------------------------------------------------------


### PR DESCRIPTION
Closes #3561

## Changes

Added Play 0 pre-flight block to `provision-fleet-roles.yml` (playbooks/ version) that mirrors the exact pattern from `update-all-nodes.yml` lines 47-99:

1. `stat` check — aborts if `code_source/.git` is missing (same fail-fast as update-all-nodes)
2. `ansible.builtin.git` pull from `Dev_new_gui` with `ignore_errors: yes` — offline/air-gapped SLMs skip the pull and get a warning rather than a hard failure
3. Warning debug task when sync fails (GitHub unreachable)
4. Displays deployed commit SHA + subject so operators can confirm what version is running

## Why

Observed 2026-04-06: PR #3536 (stale-venv detection for ai-stack) was merged but `code_source` on the SLM manager wasn't updated. Old ai-stack role ran → Python 3.10 venv persisted → `numpy>=2.4.3` install failed (requires Python ≥3.11). The only clue was a task name discrepancy in the verbose output.

## No changes to callers

`api/setup_wizard.py` and `api/nodes.py` invoke the playbook by name — no modification needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)