### PR TITLE
fix(ansible): deploy.yml standalone redeploy installs python3.12 prerequisite (#3538)

### DIFF
--- a/autobot-slm-backend/ansible/deploy.yml
+++ b/autobot-slm-backend/ansible/deploy.yml
@@ -51,6 +51,12 @@
       when: "'frontend' in role_list"
 
     # AI/ML Roles
+    # python312 must be present before ai-stack creates its venv (#3538)
+    - name: Install Python 3.12 prerequisite for ai-stack
+      ansible.builtin.include_role:
+        name: python312
+      when: "'ai-stack' in role_list"
+
     - name: Deploy npu-worker role
       ansible.builtin.include_role:
         name: npu-worker


### PR DESCRIPTION
Closes #3538

## Root cause
`deploy.yml` lacked the `python312` prerequisite step that `provision-fleet-roles.yml` has. Fresh hosts without Python 3.12 fail when the `ai-stack` role runs `python3.12 -m venv` (fixed in PR #3536).

## Fix
Added a single task immediately before the AI/ML role block that runs `include_role: name: python312` when `ai-stack` is in the `role_list`. The `python312` role is idempotent — it checks `python3.12 --version` first and skips installation if already present.

## Test plan
- [x] YAML syntax valid
- [ ] Standalone redeploy to a fresh host with only Python 3.10 succeeds (python3.12 installed first)
- [ ] Idempotent: safe to run on hosts that already have Python 3.12
- [ ] Non-ai-stack deploys are unaffected (gated by `when: "'ai-stack' in role_list"`)