### PR TITLE
fix(ansible): AUTOBOT_CHROMADB_HOST uses backend_ai_stack_host for WSL2 co-located nodes (#3541)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -62,8 +62,9 @@ backend_llm_model: "qwen3.5:9b"  # Default LLM model
 backend_ai_stack_host: "127.0.0.1"
 backend_ai_stack_port: 8080
 
-# ChromaDB connection (co-located: 127.0.0.1; fleet deployment: ai-stack node IP)
-backend_chromadb_host: "127.0.0.1"
+# ChromaDB connection (co-located: ai-stack node; fleet deployment: ai-stack node IP)
+# Default follows backend_ai_stack_host so WSL2 auto-detection (#3503) propagates here too.
+backend_chromadb_host: "{{ backend_ai_stack_host }}"
 backend_chromadb_port: 8100
 
 # Service Authentication

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -49,6 +49,15 @@
     - backend_ai_stack_host == '127.0.0.1'
   tags: ['backend', 'config']
 
+- name: "Backend | Set backend_chromadb_host=10.255.255.254 on WSL2 hosts (#3541)"
+  ansible.builtin.set_fact:
+    backend_chromadb_host: "10.255.255.254"
+  when:
+    - _proc_version.content is defined
+    - (_proc_version.content | b64decode | lower) is search('microsoft')
+    - backend_chromadb_host == '127.0.0.1'
+  tags: ['backend', 'config']
+
 # ============================================================
 # Per-role env at /etc/autobot/  (#926 Phase 4)
 # ============================================================


### PR DESCRIPTION
Closes #3541

## Root cause
`backend.env.j2` sets `AUTOBOT_CHROMADB_HOST` using `backend_chromadb_host`, whose default was hardcoded to `127.0.0.1`. The WSL2 auto-detection task (PR #3509) updated `backend_ai_stack_host` to `10.255.255.254` on WSL2 nodes but left `backend_chromadb_host` untouched — so the backend tried to connect to ChromaDB on `127.0.0.1`, which is unreachable under WSL2 mirrored networking.

## Fix
Two changes:

1. **`defaults/main.yml`** — `backend_chromadb_host` now defaults to `{{ backend_ai_stack_host }}` so fleet deployments (where `backend_ai_stack_host` points to the AI stack node IP) automatically get the right ChromaDB host without extra config.

2. **`tasks/main.yml`** — Added a `set_fact` task immediately after the existing WSL2 override task to set `backend_chromadb_host: 10.255.255.254` on WSL2 hosts (same `/proc/version` `microsoft` guard, same `== '127.0.0.1'` condition). This is needed because `set_fact` overrides are evaluated at task-run time, after defaults are loaded.

## Test plan
- [x] YAML syntax valid on both files
- [ ] WSL2 co-located: `AUTOBOT_CHROMADB_HOST=10.255.255.254` in rendered `backend.env`
- [ ] Non-WSL2 co-located: `AUTOBOT_CHROMADB_HOST=127.0.0.1`
- [ ] Fleet deployment: `AUTOBOT_CHROMADB_HOST=<ai-stack-node-ip>`