### PR TITLE
refactor(analytics): extract _resolve_source_or_404 to shared helper

### DIFF
--- a/autobot-backend/api/analytics_code_generation.py
+++ b/autobot-backend/api/analytics_code_generation.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from api.analytics_shared import resolve_source_or_404 as _resolve_source_or_404
 
 # LLM Interface for real code generation
 try:
@@ -46,21 +47,6 @@ except ImportError:
 # Issue #552: Prefix set in router_registry to match frontend calls at /api/code-generation/*
 router = APIRouter(tags=["code-generation", "analytics"])
 logger = logging.getLogger(__name__)
-
-
-async def _resolve_source_or_404(source_id: Optional[str]) -> None:
-    """Raise HTTP 404 if source_id is provided but not found (Issue #3436).
-
-    Uses a lazy import of resolve_source_root to avoid loading the full
-    codebase_analytics package at module import time.
-    """
-    if source_id is None:
-        return
-    from api.codebase_analytics.endpoints.shared import resolve_source_root
-
-    source_root = await resolve_source_root(source_id)
-    if source_root is None:
-        raise HTTPException(status_code=404, detail=f"Source '{source_id}' not found")
 
 # Issue #380: Pre-compiled regex patterns for code analysis and extraction
 _FUNC_DEF_RE = re.compile(r"def\s+(\w+)")  # Extract function name

--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from constants.threshold_constants import TimingConstants
+from api.analytics_shared import resolve_source_or_404 as _resolve_source_or_404
 
 logger = logging.getLogger(__name__)
 
@@ -32,22 +33,6 @@ _VALID_GIT_REF_RE = re.compile(
 )
 
 router = APIRouter(tags=["code-review", "analytics"])  # Prefix set in router_registry
-
-
-async def _resolve_source_or_404(source_id: Optional[str]) -> None:
-    """Raise HTTP 404 if source_id is provided but not found (Issue #3436).
-
-    Uses a lazy import of resolve_source_root to avoid loading the full
-    codebase_analytics package at module import time.
-    """
-    if source_id is None:
-        return
-    from api.codebase_analytics.endpoints.shared import resolve_source_root
-
-    source_root = await resolve_source_root(source_id)
-    if source_root is None:
-        raise HTTPException(status_code=404, detail=f"Source '{source_id}' not found")
-
 
 # Performance optimization: O(1) lookup for reviewable file extensions (Issue #326)
 REVIEWABLE_EXTENSIONS = {".py", ".vue", ".ts", ".js"}

--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -27,26 +27,12 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.security.path_validator import validate_path
+from api.analytics_shared import resolve_source_or_404 as _resolve_source_or_404
 
 logger = logging.getLogger(__name__)
 router = APIRouter(
     tags=["code-evolution", "analytics"]
 )  # Prefix set in router_registry
-
-async def _resolve_source_or_404(source_id: Optional[str]) -> None:
-    """Raise HTTP 404 if source_id is provided but not found (Issue #3436).
-
-    Uses a lazy import of resolve_source_root to avoid loading the full
-    codebase_analytics package at module import time.
-    """
-    if source_id is None:
-        return
-    from api.codebase_analytics.endpoints.shared import resolve_source_root
-    from fastapi import HTTPException
-
-    source_root = await resolve_source_root(source_id)
-    if source_root is None:
-        raise HTTPException(status_code=404, detail=f"Source '{source_id}' not found")
 
 
 # Performance optimization: O(1) lookup for aggregation granularities (Issue #326)

--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -20,26 +20,11 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
+from api.analytics_shared import resolve_source_or_404 as _resolve_source_or_404
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["code-quality", "analytics"])  # Prefix set in router_registry
-
-
-async def _resolve_source_or_404(source_id: Optional[str]) -> None:
-    """Raise HTTP 404 if source_id is provided but not found (Issue #3436).
-
-    Uses a lazy import of resolve_source_root to avoid loading the full
-    codebase_analytics package at module import time.
-    """
-    if source_id is None:
-        return
-    from api.codebase_analytics.endpoints.shared import resolve_source_root
-    from fastapi import HTTPException
-
-    source_root = await resolve_source_root(source_id)
-    if source_root is None:
-        raise HTTPException(status_code=404, detail=f"Source '{source_id}' not found")
 
 
 # ============================================================================

--- a/autobot-backend/api/analytics_shared.py
+++ b/autobot-backend/api/analytics_shared.py
@@ -1,0 +1,30 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Shared helpers for analytics API modules (Issue #3440).
+
+Contains utilities reused across analytics_quality, analytics_evolution,
+analytics_code_review, and analytics_code_generation.
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_source_or_404(source_id: Optional[str]) -> None:
+    """Raise HTTP 404 if source_id is provided but not found.
+
+    Uses lazy imports of resolve_source_root and HTTPException to avoid
+    loading the full codebase_analytics package at module import time.
+    """
+    if source_id is None:
+        return
+    from api.codebase_analytics.endpoints.shared import resolve_source_root
+    from fastapi import HTTPException
+
+    source_root = await resolve_source_root(source_id)
+    if source_root is None:
+        raise HTTPException(status_code=404, detail=f"Source '{source_id}' not found")


### PR DESCRIPTION
Closes #3440

## Changes

Created `autobot-backend/api/analytics_shared.py` with the single canonical `resolve_source_or_404` implementation. Updated 4 analytics modules to import from it:

- `analytics_quality.py` — removed local copy, added import
- `analytics_evolution.py` — removed local copy, added import
- `analytics_code_review.py` — removed local copy, added import
- `analytics_code_generation.py` — removed local copy, added import

**Net: −62 lines, +34 lines** (4 duplicate 14-line functions replaced by 1 shared + 4 one-line imports)

## Notes

- Lazy imports inside the helper (`resolve_source_root`, `HTTPException`) preserved to avoid circular import at module load time
- All existing call sites use `_resolve_source_or_404` as the local alias — unchanged
- 3 pre-existing E501 violations in modified files are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)