### PR TITLE
feat(chat-workflow): content-aware tool-call loop detection in LangGraph (#3254)

### DIFF
--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -22,9 +22,11 @@ Architecture:
     - RLM reflection evaluates response quality before persisting
 """
 
+import hashlib
+import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.redis.aio import AsyncRedisSaver
@@ -33,6 +35,24 @@ from langgraph.types import interrupt
 from typing_extensions import TypedDict
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tool-call loop detection constants (#3254)
+# ---------------------------------------------------------------------------
+
+# Number of identical-fingerprint iterations required to declare a loop.
+_LOOP_DETECTION_WINDOW: int = 3
+
+# Maximum consecutive loop events before the graph halts tool execution.
+_LOOP_ABORT_THRESHOLD: int = 2
+
+# Warning injected into the prompt on first loop detection.
+_LOOP_WARNING_MSG: str = (
+    "You appear to be calling the same tool with identical or near-identical "
+    "arguments repeatedly without making progress. Break the loop: either use "
+    "the 'respond' tool to explain what you have found so far, or try a "
+    "meaningfully different approach."
+)
 
 # Redis connection for checkpointer
 _REDIS_URI = None  # Set lazily from SSOT config
@@ -90,8 +110,88 @@ class ChatState(TypedDict, total=False):
     reflection_history: List[Dict[str, Any]]
     rlm_refinement_hint: str
 
+    # Tool-call loop detection (#3254)
+    # Each entry is a frozenset fingerprint of (tool_name, args_hash) for one iteration.
+    tool_call_fingerprints: List[str]
+    tool_loop_count: int
+    tool_loop_warning: str
+
     # Error tracking
     error: Optional[str]
+
+
+# ---------------------------------------------------------------------------
+# Tool-call loop detection helpers (#3254)
+# ---------------------------------------------------------------------------
+
+
+def _fingerprint_tool_call(tool_call: Dict[str, Any]) -> str:
+    """Return a stable string fingerprint for one tool call.
+
+    The fingerprint is built from the tool name plus a SHA-1 digest of the
+    canonically sorted JSON-serialised params dict.  Using a digest (rather
+    than the raw params string) keeps fingerprints constant-length and avoids
+    false negatives caused by key-ordering differences.
+
+    Issue #3254: content-aware detection — two calls are considered identical
+    when *both* the tool name and the arguments are the same.
+
+    Args:
+        tool_call: A parsed tool-call dict with at least a "name" key and an
+                   optional "params" key (dict or scalar).
+
+    Returns:
+        A short string of the form ``"<name>:<hex_digest>"``.
+    """
+    name = tool_call.get("name", "")
+    params = tool_call.get("params", {})
+    try:
+        canonical = json.dumps(params, sort_keys=True, ensure_ascii=False)
+    except (TypeError, ValueError):
+        canonical = str(params)
+    digest = hashlib.sha1(canonical.encode("utf-8"), usedforsecurity=False).hexdigest()[
+        :12
+    ]
+    return f"{name}:{digest}"
+
+
+def _detect_tool_call_loop(
+    new_fingerprints: List[str],
+    history: List[str],
+    window: int = _LOOP_DETECTION_WINDOW,
+) -> Tuple[bool, List[str]]:
+    """Detect whether the current iteration is a repetition of recent ones.
+
+    A loop is declared when the last ``window - 1`` entries in ``history``
+    are all identical to the current set of fingerprints.  This requires at
+    least ``window`` consecutive identical iterations before triggering.
+
+    Issue #3254: content-aware (not just count-based) — two iterations are
+    considered identical only when they produce *the same tool calls in the
+    same order*.
+
+    Args:
+        new_fingerprints: Fingerprint strings for the current iteration's
+                          tool calls (one entry per tool call).
+        history:          Accumulated per-iteration fingerprint strings from
+                          previous iterations (each entry is one iteration's
+                          comma-joined fingerprints).
+        window:           How many identical consecutive iterations trigger
+                          the loop alarm (default: ``_LOOP_DETECTION_WINDOW``).
+
+    Returns:
+        ``(is_loop, updated_history)`` where ``updated_history`` has the new
+        iteration's fingerprint appended.
+    """
+    current_key = ",".join(new_fingerprints)
+    updated = list(history) + [current_key]
+
+    if len(updated) < window:
+        return False, updated
+
+    recent = updated[-(window):]
+    is_loop = len(set(recent)) == 1 and recent[0] != ""
+    return is_loop, updated
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +229,10 @@ async def initialize_session(state: ChatState, config: RunnableConfig) -> dict:
             "reflection_count": 0,
             "reflection_history": [],
             "rlm_refinement_hint": "",
+            # Tool-call loop detection (#3254)
+            "tool_call_fingerprints": [],
+            "tool_loop_count": 0,
+            "tool_loop_warning": "",
         }
     except Exception as exc:
         logger.error("initialize_session failed: %s", exc, exc_info=True)
@@ -239,7 +343,7 @@ def _inject_mid_conversation_warning(hint: str, initial_prompt: str) -> str:
 
 
 def _build_llm_iteration_context(state: ChatState):
-    """Helper for generate_response. Ref: #1088, #1373, #3260.
+    """Helper for generate_response. Ref: #1088, #1373, #3254, #3260.
 
     Reconstructs an LLMIterationContext from the current graph state so that
     generate_response can delegate to the manager's continuation loop method.
@@ -247,6 +351,9 @@ def _build_llm_iteration_context(state: ChatState):
     When an RLM refinement hint is present (set by reflect_on_response), it
     is appended to the initial prompt so the LLM focuses on the identified
     deficiency in the next pass.
+
+    When a tool-call loop warning is present (#3254), it is similarly appended
+    so the LLM is instructed to break out of the repetitive pattern.
 
     Note (Issue #3260): Corrective/warning content is always merged into
     ``initial_prompt`` via ``_inject_mid_conversation_warning``, never via a
@@ -262,6 +369,12 @@ def _build_llm_iteration_context(state: ChatState):
     hint = state.get("rlm_refinement_hint", "")
     if hint:
         initial_prompt = _inject_mid_conversation_warning(hint, initial_prompt)
+
+    # Inject tool-call loop warning when a repetition loop is detected (#3254).
+    # Same constraint applies: prompt-string injection only, never SystemMessage.
+    loop_warning = state.get("tool_loop_warning", "")
+    if loop_warning:
+        initial_prompt = _inject_mid_conversation_warning(loop_warning, initial_prompt)
 
     return LLMIterationContext(
         ollama_endpoint=state["llm_params"]["ollama_endpoint"],
@@ -353,6 +466,8 @@ async def generate_response(state: ChatState, config: RunnableConfig) -> dict:
         "all_llm_responses": all_responses,
         "tool_calls": parsed_tool_calls,
         "workflow_messages": messages,
+        # Reset loop warning so it is only active for one cycle (#3254).
+        "tool_loop_warning": "",
     }
 
 
@@ -479,6 +594,25 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
             "workflow_messages": messages,
         }
 
+    # Issue #3254: Fingerprint the tool calls about to run and detect loops
+    # *before* execution.  This is the correct place because execute_tools
+    # receives the parsed tool call list from generate_response via state.
+    fingerprint_history = list(state.get("tool_call_fingerprints", []))
+    tool_loop_count = state.get("tool_loop_count", 0)
+    tool_loop_warning = ""
+
+    new_fps = [_fingerprint_tool_call(tc) for tc in tool_calls]
+    is_loop, fingerprint_history = _detect_tool_call_loop(new_fps, fingerprint_history)
+    if is_loop:
+        tool_loop_count += 1
+        tool_loop_warning = _LOOP_WARNING_MSG
+        logger.warning(
+            "Tool-call loop detected (loop_count=%d, session=%s): %s",
+            tool_loop_count,
+            state.get("session_id", "unknown"),
+            new_fps,
+        )
+
     # Execute via existing manager method
     exec_history = list(state.get("execution_history", []))
     break_loop = False
@@ -505,11 +639,30 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
             if isinstance(item, dict) and item.get("type") == "execution_summary":
                 exec_history.append(item)
 
+    # Issue #3254: Emit a user-visible message when the loop abort threshold is
+    # reached so the user understands why the assistant stopped making progress.
+    if tool_loop_count >= _LOOP_ABORT_THRESHOLD:
+        abort_msg = {
+            "type": "response",
+            "content": (
+                "I noticed I was repeating the same action without making progress "
+                "and stopped the loop. Please let me know if you would like me to "
+                "try a different approach."
+            ),
+        }
+        messages.append(abort_msg)
+        if stream_cb:
+            stream_cb(abort_msg)
+
     return {
         "should_continue": not break_loop,
         "execution_history": exec_history,
         "workflow_messages": messages,
         "tool_calls": [],  # Clear after execution
+        # Tool-call loop state (#3254)
+        "tool_call_fingerprints": fingerprint_history,
+        "tool_loop_count": tool_loop_count,
+        "tool_loop_warning": tool_loop_warning,
     }
 
 
@@ -694,9 +847,24 @@ def route_after_reflection(state: ChatState) -> str:
 
 
 def route_after_execution(state: ChatState) -> str:
-    """Route after tool execution — may loop back for continuation."""
+    """Route after tool execution — may loop back for continuation.
+
+    Issue #3254: Aborts to persist_conversation when the tool-call loop
+    detector has fired ``_LOOP_ABORT_THRESHOLD`` or more consecutive times,
+    preventing infinite repetition even when ``should_continue`` is True.
+    """
     if state.get("error"):
         return "persist_conversation"
+
+    # Issue #3254: Abort on persistent tool-call loop.
+    if state.get("tool_loop_count", 0) >= _LOOP_ABORT_THRESHOLD:
+        logger.warning(
+            "Aborting tool-call loop after %d detections (session=%s)",
+            state.get("tool_loop_count", 0),
+            state.get("session_id", "unknown"),
+        )
+        return "persist_conversation"
+
     if state.get("should_continue") and state.get("iteration_count", 0) < 5:
         return "generate_response"
     return "persist_conversation"
@@ -710,8 +878,8 @@ def route_after_execution(state: ChatState) -> str:
 def build_chat_graph() -> StateGraph:
     """Build the chat workflow StateGraph.
 
-    Graph topology (#1718 — agentic search node added between prepare_llm and
-    generate_response; #1373 — RLM reflection loop):
+    Graph topology (#1718 — agentic search node; #1373 — RLM reflection loop;
+    #3254 — content-aware tool-call loop detection):
         START -> initialize_session -> detect_intent
             -> [END if special intent]
             -> prepare_llm -> perform_knowledge_search -> generate_response
@@ -721,8 +889,9 @@ def build_chat_graph() -> StateGraph:
             reflect_on_response
                 -> [generate_response if REFINE and budget remains]
                 -> [persist_conversation if ACCEPT or budget exhausted]
-            execute_tools -> [generate_response if should_continue]
-                          -> [persist_conversation if done]
+            execute_tools
+                -> [generate_response if should_continue AND loop_count < threshold]
+                -> [persist_conversation if done or loop aborted (#3254)]
             persist_conversation -> END
     """
     builder = StateGraph(ChatState)

--- a/autobot-backend/chat_workflow/tool_loop_detection_test.py
+++ b/autobot-backend/chat_workflow/tool_loop_detection_test.py
@@ -1,0 +1,299 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for content-aware tool-call loop detection (Issue #3254).
+
+Tests:
+1. _fingerprint_tool_call produces stable, unique fingerprints.
+2. _detect_tool_call_loop fires only after ``window`` identical iterations.
+3. Different args → no loop triggered.
+4. Different tool names → no loop triggered.
+5. Loop resets when a different call appears in the window.
+6. route_after_execution aborts when tool_loop_count >= _LOOP_ABORT_THRESHOLD.
+7. route_after_execution continues normally when no loop detected.
+8. Loop warning is injected into prompt via _inject_mid_conversation_warning.
+
+This file is self-contained: all runtime dependencies absent from the dev
+Python environment (langchain_core, langgraph, xxhash, redis) are stubbed at
+module level before graph.py is loaded.  The test therefore runs with only
+Python stdlib and pytest installed.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub all missing runtime packages so graph.py can be imported in isolation.
+# (Pattern from graph_inject_warning_test.py)
+# ---------------------------------------------------------------------------
+
+_LANGCHAIN_CORE_MESSAGES = types.ModuleType("langchain_core.messages")
+_LANGCHAIN_CORE_MESSAGES.HumanMessage = MagicMock  # type: ignore[attr-defined]
+_LANGCHAIN_CORE_MESSAGES.SystemMessage = MagicMock  # type: ignore[attr-defined]
+_LANGCHAIN_CORE_MESSAGES.AIMessage = MagicMock  # type: ignore[attr-defined]
+_LANGCHAIN_CORE_MESSAGES.BaseMessage = MagicMock  # type: ignore[attr-defined]
+
+_LANGCHAIN_CORE = types.ModuleType("langchain_core")
+_LANGCHAIN_CORE.messages = _LANGCHAIN_CORE_MESSAGES  # type: ignore[attr-defined]
+
+_LANGCHAIN_CORE_RUNNABLES = types.ModuleType("langchain_core.runnables")
+_LANGCHAIN_CORE_RUNNABLES.RunnableConfig = MagicMock  # type: ignore[attr-defined]
+
+_STUBS: dict = {
+    "langchain_core": _LANGCHAIN_CORE,
+    "langchain_core.messages": _LANGCHAIN_CORE_MESSAGES,
+    "langchain_core.runnables": _LANGCHAIN_CORE_RUNNABLES,
+    "xxhash": types.ModuleType("xxhash"),
+    "redis": types.ModuleType("redis"),
+    "redis.asyncio": types.ModuleType("redis.asyncio"),
+    "langgraph": types.ModuleType("langgraph"),
+    "langgraph.checkpoint": types.ModuleType("langgraph.checkpoint"),
+    "langgraph.checkpoint.redis": types.ModuleType("langgraph.checkpoint.redis"),
+    "langgraph.checkpoint.redis.aio": types.ModuleType(
+        "langgraph.checkpoint.redis.aio"
+    ),
+    "langgraph.graph": types.ModuleType("langgraph.graph"),
+    "langgraph.types": types.ModuleType("langgraph.types"),
+    "typing_extensions": types.ModuleType("typing_extensions"),
+}
+
+for _mod_name, _stub in _STUBS.items():
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = _stub
+
+for _attr in ("END", "START", "StateGraph"):
+    if not hasattr(sys.modules["langgraph.graph"], _attr):
+        setattr(sys.modules["langgraph.graph"], _attr, MagicMock())
+if not hasattr(sys.modules["langgraph.types"], "interrupt"):
+    sys.modules["langgraph.types"].interrupt = MagicMock()  # type: ignore[attr-defined]
+if not hasattr(sys.modules["langgraph.checkpoint.redis.aio"], "AsyncRedisSaver"):
+    sys.modules["langgraph.checkpoint.redis.aio"].AsyncRedisSaver = MagicMock()  # type: ignore[attr-defined]
+
+import typing
+
+if not hasattr(sys.modules["typing_extensions"], "TypedDict"):
+    sys.modules["typing_extensions"].TypedDict = typing.TypedDict  # type: ignore[attr-defined]
+
+# ---------------------------------------------------------------------------
+# Load graph.py as an isolated module.
+# ---------------------------------------------------------------------------
+
+_GRAPH_PATH = Path(__file__).parent / "graph.py"
+_spec = importlib.util.spec_from_file_location("_graph_isolated_loop", _GRAPH_PATH)
+assert _spec is not None and _spec.loader is not None
+_graph_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_graph_module)  # type: ignore[union-attr]
+
+_fingerprint_tool_call = _graph_module._fingerprint_tool_call
+_detect_tool_call_loop = _graph_module._detect_tool_call_loop
+route_after_execution = _graph_module.route_after_execution
+_inject_mid_conversation_warning = _graph_module._inject_mid_conversation_warning
+_LOOP_DETECTION_WINDOW = _graph_module._LOOP_DETECTION_WINDOW
+_LOOP_ABORT_THRESHOLD = _graph_module._LOOP_ABORT_THRESHOLD
+_LOOP_WARNING_MSG = _graph_module._LOOP_WARNING_MSG
+
+
+# ---------------------------------------------------------------------------
+# Tests: _fingerprint_tool_call
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprintToolCall:
+    """Tests for _fingerprint_tool_call."""
+
+    def test_same_call_produces_same_fingerprint(self):
+        """Identical tool call dicts always produce the same fingerprint."""
+        tc = {"name": "execute_command", "params": {"command": "ls -la"}}
+        assert _fingerprint_tool_call(tc) == _fingerprint_tool_call(tc)
+
+    def test_different_args_produce_different_fingerprint(self):
+        """Different param values produce different fingerprints."""
+        tc1 = {"name": "execute_command", "params": {"command": "ls -la"}}
+        tc2 = {"name": "execute_command", "params": {"command": "ls -lah /tmp"}}
+        assert _fingerprint_tool_call(tc1) != _fingerprint_tool_call(tc2)
+
+    def test_different_tool_names_produce_different_fingerprint(self):
+        """Different tool names produce different fingerprints."""
+        tc1 = {"name": "web_search", "params": {"query": "python"}}
+        tc2 = {"name": "execute_command", "params": {"query": "python"}}
+        assert _fingerprint_tool_call(tc1) != _fingerprint_tool_call(tc2)
+
+    def test_param_key_order_does_not_matter(self):
+        """Fingerprint is order-independent for param keys."""
+        tc1 = {"name": "execute_command", "params": {"b": 2, "a": 1}}
+        tc2 = {"name": "execute_command", "params": {"a": 1, "b": 2}}
+        assert _fingerprint_tool_call(tc1) == _fingerprint_tool_call(tc2)
+
+    def test_missing_params_key_handled(self):
+        """Tool call with no 'params' key doesn't raise."""
+        tc = {"name": "respond"}
+        fp = _fingerprint_tool_call(tc)
+        assert fp.startswith("respond:")
+
+    def test_fingerprint_format(self):
+        """Fingerprint is 'name:<hex>' format."""
+        tc = {"name": "execute_command", "params": {"command": "pwd"}}
+        fp = _fingerprint_tool_call(tc)
+        parts = fp.split(":")
+        assert len(parts) == 2
+        assert parts[0] == "execute_command"
+        assert len(parts[1]) == 12  # SHA-1 hex truncated to 12 chars
+
+
+# ---------------------------------------------------------------------------
+# Tests: _detect_tool_call_loop
+# ---------------------------------------------------------------------------
+
+
+class TestDetectToolCallLoop:
+    """Tests for _detect_tool_call_loop."""
+
+    def _make_fp(self, name: str, cmd: str) -> str:
+        return _fingerprint_tool_call({"name": name, "params": {"command": cmd}})
+
+    def test_no_loop_below_window(self):
+        """Loop is NOT triggered when fewer than window identical iterations exist."""
+        fp = self._make_fp("execute_command", "ls")
+        history: list = []
+        for _ in range(_LOOP_DETECTION_WINDOW - 1):
+            is_loop, history = _detect_tool_call_loop([fp], history)
+        assert not is_loop
+
+    def test_loop_triggered_at_window(self):
+        """Loop IS triggered once window identical consecutive iterations accumulate."""
+        fp = self._make_fp("execute_command", "ls")
+        history: list = []
+        for i in range(_LOOP_DETECTION_WINDOW):
+            is_loop, history = _detect_tool_call_loop([fp], history)
+        assert is_loop
+
+    def test_different_args_no_loop(self):
+        """Different args in each iteration never trigger a loop."""
+        history: list = []
+        for i in range(_LOOP_DETECTION_WINDOW + 2):
+            fp = self._make_fp("execute_command", f"ls /path/{i}")
+            is_loop, history = _detect_tool_call_loop([fp], history)
+        assert not is_loop
+
+    def test_loop_reset_by_different_call(self):
+        """A different call in the window prevents loop from triggering."""
+        fp_same = self._make_fp("execute_command", "ls")
+        fp_diff = self._make_fp("execute_command", "pwd")
+        history: list = []
+
+        # Build up window - 1 identical iterations
+        for _ in range(_LOOP_DETECTION_WINDOW - 1):
+            _, history = _detect_tool_call_loop([fp_same], history)
+
+        # Inject one different call — breaks the run
+        _, history = _detect_tool_call_loop([fp_diff], history)
+
+        # Resume identical calls — count restarts from 1, not _LOOP_DETECTION_WINDOW
+        is_loop, _ = _detect_tool_call_loop([fp_same], history)
+        assert not is_loop, "Loop should not fire immediately after a reset call"
+
+    def test_different_tool_names_no_loop(self):
+        """Different tool names in each iteration don't trigger a loop."""
+        history: list = []
+        tools = ["execute_command", "web_search", "respond"]
+        for tool in tools * 3:
+            fp = _fingerprint_tool_call({"name": tool, "params": {}})
+            is_loop, history = _detect_tool_call_loop([fp], history)
+        assert not is_loop
+
+    def test_empty_fingerprints_no_loop(self):
+        """Empty fingerprint list is treated as a distinct non-matching entry."""
+        history: list = []
+        for _ in range(_LOOP_DETECTION_WINDOW + 1):
+            is_loop, history = _detect_tool_call_loop([], history)
+        # Empty list produces "" key — loop should not fire on empty entries
+        assert not is_loop
+
+    def test_updated_history_grows(self):
+        """History list grows by one entry per call."""
+        fp = self._make_fp("execute_command", "ls")
+        history: list = []
+        for i in range(4):
+            _, history = _detect_tool_call_loop([fp], history)
+        assert len(history) == 4
+
+    def test_custom_window(self):
+        """Custom window parameter is respected."""
+        fp = self._make_fp("execute_command", "ls")
+        history: list = []
+        is_loop = False
+        for _ in range(2):
+            is_loop, history = _detect_tool_call_loop([fp], history, window=2)
+        assert is_loop
+
+
+# ---------------------------------------------------------------------------
+# Tests: route_after_execution (loop-abort branch)
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAfterExecutionLoopAbort:
+    """Tests for the loop-abort branch in route_after_execution."""
+
+    def _state(self, **kwargs) -> dict:
+        base = {
+            "error": None,
+            "should_continue": True,
+            "iteration_count": 1,
+            "tool_loop_count": 0,
+            "session_id": "test-session",
+        }
+        base.update(kwargs)
+        return base
+
+    def test_aborts_when_loop_count_meets_threshold(self):
+        state = self._state(tool_loop_count=_LOOP_ABORT_THRESHOLD)
+        assert route_after_execution(state) == "persist_conversation"
+
+    def test_aborts_when_loop_count_exceeds_threshold(self):
+        state = self._state(tool_loop_count=_LOOP_ABORT_THRESHOLD + 5)
+        assert route_after_execution(state) == "persist_conversation"
+
+    def test_continues_when_loop_count_below_threshold(self):
+        state = self._state(tool_loop_count=_LOOP_ABORT_THRESHOLD - 1)
+        assert route_after_execution(state) == "generate_response"
+
+    def test_continues_when_no_loop_count(self):
+        state = self._state(tool_loop_count=0)
+        assert route_after_execution(state) == "generate_response"
+
+    def test_error_always_routes_to_persist(self):
+        state = self._state(error="some error", tool_loop_count=0)
+        assert route_after_execution(state) == "persist_conversation"
+
+    def test_max_iterations_reached_routes_to_persist(self):
+        state = self._state(tool_loop_count=0, iteration_count=10)
+        assert route_after_execution(state) == "persist_conversation"
+
+
+# ---------------------------------------------------------------------------
+# Tests: loop warning injected into prompt
+# ---------------------------------------------------------------------------
+
+
+class TestLoopWarningInjection:
+    """Verify that the loop warning uses _inject_mid_conversation_warning."""
+
+    def test_warning_appended_to_prompt(self):
+        """Loop warning appears in the enriched prompt with [Guidance: ...] wrapper."""
+        prompt = "Describe the process."
+        enriched = _inject_mid_conversation_warning(_LOOP_WARNING_MSG, prompt)
+        assert "[Guidance:" in enriched
+        assert "repeatedly" in enriched
+        assert enriched.startswith(prompt)
+
+    def test_warning_returns_string_not_message_object(self):
+        """Injection returns a plain str — never a LangChain message object."""
+        result = _inject_mid_conversation_warning(_LOOP_WARNING_MSG, "base")
+        assert isinstance(result, str)

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -26,7 +26,7 @@ sys.path.insert(0, str(shared_root))
 
 # Stub optional heavy dependencies that may not be installed in the dev venv.
 # These are only needed at runtime on the target VM; tests use mocks.
-_OPTIONAL_STUBS = ["prometheus_client"]
+_OPTIONAL_STUBS = ["prometheus_client", "xxhash", "torch", "torch.nn", "torch.cuda"]
 for _mod in _OPTIONAL_STUBS:
     if _mod not in sys.modules:
         try:


### PR DESCRIPTION
Closes #3254

## Summary

Adds content-aware tool-call loop detection to the LangGraph chat graph. Rather than simply counting tool calls, the detector fingerprints each call by name + sorted-JSON params and tracks whether consecutive iterations repeat the same pattern.

## Implementation

**New helpers in `chat_workflow/graph.py`:**
- `_fingerprint_tool_call(tool_call)` — stable `"name:<sha1_hex>"` fingerprint from tool name + sorted-JSON params; key-order independent
- `_detect_tool_call_loop(new_fingerprints, history, window)` — compares current iteration's fingerprint key against the last `window-1` entries; loop declared only when all `window` consecutive iterations match

**New `ChatState` fields:**
- `tool_call_fingerprints` — rolling fingerprint history
- `tool_loop_count` — number of loops detected
- `tool_loop_warning` — guidance text injected into the next LLM prompt

**Graph node changes:**
- `initialize_session` — initialises the three new fields
- `execute_tools` — fingerprints incoming tool calls, detects loops, increments counter, sets warning; emits user-facing abort message when `tool_loop_count >= _LOOP_ABORT_THRESHOLD` (2)
- `route_after_execution` — returns `"persist_conversation"` immediately when abort threshold reached
- `generate_response` / `_build_llm_iteration_context` — injects `tool_loop_warning` via `_inject_mid_conversation_warning` (same Anthropic-safe pattern as RLM hints; never a SystemMessage)

**Constants:**
- `_LOOP_DETECTION_WINDOW = 3` — identical consecutive iterations before loop is declared
- `_LOOP_ABORT_THRESHOLD = 2` — loop detections before execution halts

## Tests
22 unit tests covering: fingerprint stability/uniqueness, loop trigger/no-trigger, reset-by-different-call, custom window, `route_after_execution` abort/continue, warning prompt injection.

Also: added `xxhash`, `torch`, `torch.nn`, `torch.cuda` to `conftest.py` optional stubs so chat_workflow tests can collect without the full ML stack.

## Test plan
- [x] 22 unit tests passing
- [ ] LLM calling same tool with same args 3× gets a guidance injection on iteration 4
- [ ] LLM calling same tool with *different* args does not trigger detection
- [ ] After 2 loop detections, graph exits to `persist_conversation`
- [ ] Normal tool use is unaffected