### PR TITLE
fix(llm): betas routed via extra_headers + temperature=1 enforced for thinking (#3582)

### DIFF
--- a/autobot-backend/llm_providers/anthropic_provider.py
+++ b/autobot-backend/llm_providers/anthropic_provider.py
@@ -80,7 +80,9 @@ def _build_api_kwargs(
     Handles the three extended-thinking keys that need special treatment:
 
     - ``thinking``      — forwarded directly to the SDK call.
-    - ``betas``         — forwarded directly to the SDK call.
+    - ``betas``         — converted to ``extra_headers["anthropic-beta"]`` as a
+                          comma-joined string; the SDK does not accept a ``betas``
+                          kwarg on ``messages.create()``.
     - ``extra_headers`` — collected separately for the SDK ``extra_headers``
                           keyword argument (not part of the messages payload).
     - ``preserve_reasoning`` — consumed here; not forwarded to the SDK.
@@ -92,7 +94,7 @@ def _build_api_kwargs(
         (merged_kwargs, extra_headers)
     """
     extra_headers: Dict[str, Any] = {}
-    preserved_keys = {"preserve_reasoning", "extra_headers"}
+    preserved_keys = {"preserve_reasoning", "extra_headers", "betas"}
 
     for key, value in api_kwargs.items():
         if key in preserved_keys:
@@ -101,6 +103,15 @@ def _build_api_kwargs(
 
     # Collect extra headers to pass separately.
     extra_headers = dict(api_kwargs.get("extra_headers") or {})
+
+    # ``betas`` must be sent via the ``anthropic-beta`` request header, not as
+    # a kwarg to messages.create().  Merge with any caller-supplied header value.
+    betas: List[str] = api_kwargs.get("betas") or []
+    if betas:
+        existing = extra_headers.get("anthropic-beta", "")
+        merged_betas = [b for b in existing.split(",") if b] + list(betas)
+        extra_headers["anthropic-beta"] = ",".join(merged_betas)
+
     return base, extra_headers
 
 
@@ -219,6 +230,11 @@ class AnthropicProvider(BaseProvider):
         api_kwargs: Dict[str, Any] = request.metadata.get("api_kwargs") or {}
         preserve_reasoning: bool = bool(api_kwargs.get("preserve_reasoning", False))
         kwargs, extra_headers = _build_api_kwargs(kwargs, api_kwargs)
+
+        # The Anthropic API requires temperature=1 when extended thinking is
+        # enabled.  Enforce this regardless of what the caller supplied.
+        if "thinking" in api_kwargs:
+            kwargs["temperature"] = 1
 
         return kwargs, extra_headers, preserve_reasoning
 

--- a/autobot-backend/llm_providers/anthropic_provider_test.py
+++ b/autobot-backend/llm_providers/anthropic_provider_test.py
@@ -106,10 +106,30 @@ class TestBuildApiKwargs:
         assert "preserve_reasoning" not in merged
         assert headers == {}
 
-    def test_betas_forwarded(self):
+    def test_betas_routed_to_extra_headers(self):
         base = {"model": "m"}
-        merged, _ = _build_api_kwargs(base, {"betas": ["output-128k-2025-02-19"]})
-        assert merged["betas"] == ["output-128k-2025-02-19"]
+        merged, headers = _build_api_kwargs(base, {"betas": ["output-128k-2025-02-19"]})
+        assert "betas" not in merged
+        assert headers["anthropic-beta"] == "output-128k-2025-02-19"
+
+    def test_betas_merged_with_existing_extra_headers(self):
+        base = {"model": "m"}
+        api_kwargs = {
+            "betas": ["beta-b"],
+            "extra_headers": {"anthropic-beta": "beta-a"},
+        }
+        merged, headers = _build_api_kwargs(base, api_kwargs)
+        assert "betas" not in merged
+        assert "beta-a" in headers["anthropic-beta"]
+        assert "beta-b" in headers["anthropic-beta"]
+
+    def test_multiple_betas_comma_joined(self):
+        base = {"model": "m"}
+        merged, headers = _build_api_kwargs(
+            base, {"betas": ["beta-a", "beta-b", "beta-c"]}
+        )
+        assert "betas" not in merged
+        assert headers["anthropic-beta"] == "beta-a,beta-b,beta-c"
 
     def test_base_override(self):
         base = {"max_tokens": 4096}
@@ -224,6 +244,50 @@ class TestBuildRequestKwargs:
         )
         _, _, preserve = provider._build_request_kwargs("m", request)
         assert preserve is True
+
+    def test_thinking_enforces_temperature_1(self):
+        provider = self._provider()
+        thinking = {"type": "enabled", "budget_tokens": 8000}
+        request = self._make_request(
+            metadata={
+                "api_kwargs": {
+                    "thinking": thinking,
+                    "max_tokens": 16000,
+                    # Deliberately omit temperature — must be auto-coerced to 1.
+                }
+            }
+        )
+        kwargs, _, _ = provider._build_request_kwargs("claude-sonnet-4-6", request)
+        assert kwargs["temperature"] == 1
+
+    def test_thinking_overrides_explicit_temperature(self):
+        provider = self._provider()
+        thinking = {"type": "enabled", "budget_tokens": 8000}
+        request = self._make_request(
+            metadata={
+                "api_kwargs": {
+                    "thinking": thinking,
+                    "max_tokens": 16000,
+                    "temperature": 0,  # Invalid with thinking — must be coerced to 1.
+                }
+            }
+        )
+        kwargs, _, _ = provider._build_request_kwargs("claude-sonnet-4-6", request)
+        assert kwargs["temperature"] == 1
+
+    def test_betas_routed_to_extra_headers_via_build_request_kwargs(self):
+        provider = self._provider()
+        request = self._make_request(
+            metadata={
+                "api_kwargs": {
+                    "betas": ["output-128k-2025-02-19"],
+                    "max_tokens": 64000,
+                }
+            }
+        )
+        kwargs, headers, _ = provider._build_request_kwargs("claude-sonnet-4-6", request)
+        assert "betas" not in kwargs
+        assert headers.get("anthropic-beta") == "output-128k-2025-02-19"
 
     def test_system_message_extracted(self):
         provider = self._provider()


### PR DESCRIPTION
Closes #3582

## Fixes

### Bug 1 — betas now routed to `extra_headers["anthropic-beta"]`
`"betas"` added to `preserved_keys` in `_build_api_kwargs` so it is no longer merged into the main kwargs dict. After collecting `extra_headers`, any `betas` list from `api_kwargs` is comma-joined and written to `extra_headers["anthropic-beta"]`, merging with any caller-supplied `anthropic-beta` header value.

### Bug 2 — temperature coerced to 1 when thinking is enabled
In `_build_request_kwargs`, after `_build_api_kwargs` returns, if `"thinking"` is present in `api_kwargs`, `kwargs["temperature"]` is unconditionally set to `1` (Anthropic API requirement).

## Tests (30 passing)
- `test_betas_routed_to_extra_headers` — betas not in kwargs, in `extra_headers["anthropic-beta"]`
- `test_betas_merged_with_existing_extra_headers` — betas merge with existing header
- `test_multiple_betas_comma_joined` — multiple betas comma-joined correctly
- `test_thinking_enforces_temperature_1` — temperature coerced when omitted from api_kwargs
- `test_thinking_overrides_explicit_temperature` — temperature coerced even if caller passes 0
- `test_betas_routed_to_extra_headers_via_build_request_kwargs` — end-to-end through `_build_request_kwargs`