### PR TITLE
fix(ansible): wait for backend health before VNC credential registration (#3592)

### DIFF
--- a/autobot-slm-backend/ansible/roles/vnc/tasks/register-credentials.yml
+++ b/autobot-slm-backend/ansible/roles/vnc/tasks/register-credentials.yml
@@ -7,6 +7,19 @@
 # Called at the end of the VNC role to auto-register this node's
 # VNC credentials so they appear in the noVNC tool automatically.
 ---
+- name: VNC | Wait for SLM backend to be healthy before credential registration
+  ansible.builtin.uri:
+    url: "{{ slm_api_url }}/api/health"
+    method: GET
+    status_code: 200
+    validate_certs: false
+  register: _vnc_slm_health
+  retries: 12
+  delay: 5
+  until: _vnc_slm_health.status == 200
+  ignore_errors: true
+  when: slm_api_url is defined
+
 - name: Authenticate with SLM API for VNC registration
   ansible.builtin.uri:
     url: "{{ slm_api_url }}/api/auth/login"
@@ -18,7 +31,7 @@
     status_code: 200
     validate_certs: false
   register: vnc_auth_result
-  retries: 3
+  retries: 5
   delay: 5
   until: vnc_auth_result.status == 200
 


### PR DESCRIPTION
## Summary

- Adds a backend health wait (12 × 5s = 60s max) before VNC credential registration
- Increases auth retries from 3 to 5 once backend is confirmed healthy
- Existing graceful skip still fires if backend never responds

## Changes

- `roles/vnc/tasks/register-credentials.yml`: new `VNC | Wait for SLM backend to be healthy before credential registration` task as first task; retries on auth bumped to 5

Closes #3592

🤖 Generated with [Claude Code](https://claude.ai/claude-code)