### PR TITLE
feat(knowledge): memory graph semantic search — query processor and hybrid scoring (#3384)

### DIFF
--- a/autobot-backend/knowledge/memory_graph/__init__.py
+++ b/autobot-backend/knowledge/memory_graph/__init__.py
@@ -1,26 +1,62 @@
 # Copyright (c) mrveiss. All rights reserved.
-# AutoBot - AI-Powered Automation Platform
 """
-Memory Graph Semantic Search package.
+knowledge.memory_graph — Redis DB 1 (knowledge) memory graph foundation layer.
 
-Issue #3384: Query processor and hybrid scoring for memory graph entities.
+Provides:
+- Semantic search query processor and hybrid scorer (query_processor.py, hybrid_scorer.py)
+- Schema constants and index creation (schema.py)
+- Entity / relation CRUD and BFS traversal (graph_store.py)
 
-Phases implemented here:
-  Phase 1 — Core infrastructure: MemoryGraphQueryProcessor, indexes,
-             entity / relation retrieval.
-  Phase 2 — Search methods: hybrid scoring (semantic + keyword), cosine
-             similarity, BM25 text matching.
+Public API re-exported from this package so callers can write:
+    from knowledge.memory_graph import MemoryGraphQueryProcessor, create_entity
 """
 
-from knowledge.memory_graph.hybrid_scorer import HybridScorer, SearchResult
-from knowledge.memory_graph.query_processor import (
-    MemoryGraphQueryProcessor,
-    QueryIntent,
-)
+from .hybrid_scorer import HybridScorer, SearchResult  # noqa: F401
+from .query_processor import MemoryGraphQueryProcessor, QueryIntent  # noqa: F401
+
+# Graph store symbols — added by PR #3608 / issue-3385
+try:
+    from .graph_store import (  # noqa: F401
+        create_entity,
+        create_relation,
+        get_entity,
+        get_incoming_relations,
+        get_outgoing_relations,
+        traverse_relations,
+    )
+    from .schema import (  # noqa: F401
+        ENTITY_KEY_PREFIX,
+        ENTITY_TYPES,
+        FULLTEXT_INDEX_NAME,
+        PRIMARY_INDEX_NAME,
+        RELATION_TYPES,
+        RELATIONS_IN_PREFIX,
+        RELATIONS_OUT_PREFIX,
+        ensure_indexes,
+    )
+except ImportError:
+    pass  # graph store not yet merged; safe to skip
 
 __all__ = [
+    # query processor / hybrid scorer
     "HybridScorer",
     "MemoryGraphQueryProcessor",
     "QueryIntent",
     "SearchResult",
+    # schema
+    "ENTITY_KEY_PREFIX",
+    "ENTITY_TYPES",
+    "FULLTEXT_INDEX_NAME",
+    "PRIMARY_INDEX_NAME",
+    "RELATION_TYPES",
+    "RELATIONS_IN_PREFIX",
+    "RELATIONS_OUT_PREFIX",
+    "ensure_indexes",
+    # graph_store
+    "create_entity",
+    "create_relation",
+    "get_entity",
+    "get_incoming_relations",
+    "get_outgoing_relations",
+    "traverse_relations",
 ]

--- a/autobot-backend/knowledge/memory_graph/hybrid_scorer.py
+++ b/autobot-backend/knowledge/memory_graph/hybrid_scorer.py
@@ -75,6 +75,21 @@ class HybridScorer:
     entity embeddings from Redis asynchronously.
     """
 
+    def __init__(self, redis_client=None) -> None:
+        """
+        Args:
+            redis_client: Optional async Redis client for embedding lookups.
+                          When None a client is acquired lazily on first use.
+        """
+        self._redis = redis_client
+
+    async def _get_redis(self):
+        """Lazily obtain the async Redis client (cached on self._redis)."""
+        if self._redis is None:
+            from autobot_shared.redis_client import get_redis_client
+            self._redis = await get_redis_client(async_client=True, database="knowledge")
+        return self._redis
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -102,13 +117,14 @@ class HybridScorer:
         """
         keywords = getattr(intent, "keywords", [])
         results: List[SearchResult] = []
+        redis = await self._get_redis()
 
         for entity in candidates:
             entity_text = _entity_to_text(entity)
             entity_id = entity.get("id", "")
 
             # Semantic score
-            entity_embedding = await _fetch_entity_embedding(entity_id)
+            entity_embedding = await _fetch_entity_embedding(entity_id, redis)
             sem_score = (
                 cosine_similarity(query_embedding, entity_embedding)
                 if query_embedding and entity_embedding
@@ -293,23 +309,24 @@ def _build_explanation(
 
 async def _fetch_entity_embedding(
     entity_id: str,
+    redis_client: Any,
 ) -> Optional[List[float]]:
     """
     Retrieve a pre-computed entity embedding from Redis.
 
-    Returns None if the embedding has not yet been indexed (e.g., the
-    entity was created before the indexer ran) so that the caller can
-    degrade gracefully to keyword-only scoring.
+    Returns None if the embedding has not yet been indexed so that the
+    caller can degrade gracefully to keyword-only scoring.
+
+    Args:
+        entity_id:    Entity UUID (without key prefix).
+        redis_client: Async Redis client — caller supplies to avoid N connections.
     """
     if not entity_id:
         return None
 
     try:
-        from autobot_shared.redis_client import get_redis_client
-
-        redis = await get_redis_client(async_client=True, database="knowledge")
         key = f"{_ENTITY_EMBED_KEY_PREFIX}{entity_id}"
-        raw = await redis.get(key)
+        raw = await redis_client.get(key)
         if raw:
             return json.loads(raw)
     except Exception as exc:

--- a/autobot-backend/knowledge/memory_graph/query_processor.py
+++ b/autobot-backend/knowledge/memory_graph/query_processor.py
@@ -24,7 +24,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.redis_client import get_redis_client
@@ -50,36 +50,36 @@ _ENTITY_KEY_PREFIX = "memory:entity:"
 
 # Intent pattern tables
 _TIME_PATTERNS: List[Tuple[str, Any]] = [
-    (r"\btoday\b", lambda: {"start": datetime.now().date()}),
+    (r"\btoday\b", lambda: {"start": datetime.now(tz=timezone.utc).date()}),
     (
         r"\byesterday\b",
-        lambda: {"start": (datetime.now() - timedelta(days=1)).date()},
+        lambda: {"start": (datetime.now(tz=timezone.utc) - timedelta(days=1)).date()},
     ),
     (
         r"\bthis week\b",
         lambda: {
-            "start": (datetime.now() - timedelta(days=datetime.now().weekday())).date()
+            "start": (datetime.now(tz=timezone.utc) - timedelta(days=datetime.now(tz=timezone.utc).weekday())).date()
         },
     ),
     (
         r"\blast (\d+) days?\b",
         lambda m: {
-            "start": (datetime.now() - timedelta(days=int(m.group(1)))).date()
+            "start": (datetime.now(tz=timezone.utc) - timedelta(days=int(m.group(1)))).date()
         },
     ),
     (
         r"\bthis month\b",
-        lambda: {"start": datetime.now().replace(day=1).date()},
+        lambda: {"start": datetime.now(tz=timezone.utc).replace(day=1).date()},
     ),
 ]
 
 _ENTITY_TYPE_PATTERNS: List[Tuple[str, List[str]]] = [
-    (r"\bbugs?\b", ["BUG"]),
-    (r"\bfix(es)?\b", ["BUG"]),
-    (r"\bfeatures?\b", ["FEATURE"]),
-    (r"\bdecisions?\b", ["DECISION"]),
-    (r"\btasks?\b", ["TASK"]),
-    (r"\bconversations?\b", ["CONVERSATION"]),
+    (r"\bbugs?\b", ["bug_fix"]),
+    (r"\bfix(es)?\b", ["bug_fix"]),
+    (r"\bfeatures?\b", ["feature"]),
+    (r"\bdecisions?\b", ["decision"]),
+    (r"\btasks?\b", ["task"]),
+    (r"\bconversations?\b", ["conversation"]),
 ]
 
 _STATUS_PATTERNS: List[Tuple[str, str]] = [
@@ -344,12 +344,18 @@ class MemoryGraphQueryProcessor:
             List of related entity dicts.
         """
         redis = await self._get_redis()
-        rel_key = f"autobot:relations:out:{entity_name}"
+        # Relations are keyed by UUID; resolve name → UUID via FT.SEARCH first
+        # Key prefix matches schema.py RELATIONS_OUT_PREFIX = "memory:relations:out:"
+        source = await self.get_entity_by_name(entity_name)
+        if not source:
+            return []
+        rel_key = f"memory:relations:out:{source['id']}"
         try:
-            raw_json = await redis.get(rel_key)
+            raw_json = await redis.json().get(rel_key)
             if not raw_json:
                 return []
-            relations: List[Dict[str, Any]] = json.loads(raw_json)
+            doc = raw_json if isinstance(raw_json, dict) else {}
+            relations: List[Dict[str, Any]] = doc.get("relations", [])
         except Exception as exc:
             logger.warning(
                 "Failed to read relations for %s: %s", entity_name, exc
@@ -634,11 +640,11 @@ async def _generate_embedding(text: str) -> Optional[List[float]]:
     imported in test environments where the service is mocked.
     """
     try:
+        from autobot_shared.ssot_config import config
         from services.npu_client import generate_embedding_with_fallback
 
-        return await generate_embedding_with_fallback(
-            text, model_name="nomic-embed-text"
-        )
+        model_name = config.get("knowledge.embedding_model", "nomic-embed-text")
+        return await generate_embedding_with_fallback(text, model_name=model_name)
     except Exception as exc:
         logger.warning("Embedding generation failed: %s", exc)
         return None

--- a/autobot-backend/knowledge/memory_graph/query_processor_test.py
+++ b/autobot-backend/knowledge/memory_graph/query_processor_test.py
@@ -258,15 +258,15 @@ class TestIntentExtraction:
 
     def test_bug_keyword_maps_entity_type(self):
         intent = self._extract("show me bug reports")
-        assert "BUG" in intent.entity_types
+        assert "bug_fix" in intent.entity_types
 
     def test_fix_keyword_maps_entity_type(self):
         intent = self._extract("what fixes were deployed?")
-        assert "BUG" in intent.entity_types
+        assert "bug_fix" in intent.entity_types
 
     def test_feature_keyword_maps_entity_type(self):
         intent = self._extract("new features this week")
-        assert "FEATURE" in intent.entity_types
+        assert "feature" in intent.entity_types
 
     def test_completed_keyword_maps_status(self):
         intent = self._extract("tasks we completed")
@@ -620,8 +620,10 @@ class TestEntityRetrieval:
 
     @pytest.mark.asyncio
     async def test_get_related_entities_empty_when_no_key(self):
+        """Returns [] when source entity not found by name."""
         redis_mock = AsyncMock()
-        redis_mock.get = AsyncMock(return_value=None)
+        # get_entity_by_name uses FT.SEARCH — return empty response
+        redis_mock.execute_command = AsyncMock(return_value=[0])
 
         processor = MemoryGraphQueryProcessor(redis_client=redis_mock)
         results = await processor.get_related_entities("NonExistent")
@@ -629,17 +631,22 @@ class TestEntityRetrieval:
 
     @pytest.mark.asyncio
     async def test_get_related_entities_follows_relations(self):
+        source_entity = _make_entity(name="Source Entity")
         related_entity = _make_entity(name="Related Entity")
-        relations = [{"to": "Related Entity", "type": "relates_to"}]
+        relations_doc = {"entity_id": source_entity["id"], "relations": [
+            {"to": "Related Entity", "type": "relates_to"}
+        ]}
 
+        json_mock = AsyncMock()
+        json_mock.get = AsyncMock(return_value=relations_doc)
         redis_mock = AsyncMock()
-        redis_mock.get = AsyncMock(
-            return_value=json.dumps(relations).encode("utf-8")
-        )
-        # get_entity_by_name -> execute_command for FT.SEARCH
-        redis_mock.execute_command = AsyncMock(
-            return_value=_build_raw_ft_response([related_entity])
-        )
+        redis_mock.json = MagicMock(return_value=json_mock)
+
+        # First FT.SEARCH call → source entity; second → related entity
+        redis_mock.execute_command = AsyncMock(side_effect=[
+            _build_raw_ft_response([source_entity]),
+            _build_raw_ft_response([related_entity]),
+        ])
 
         processor = MemoryGraphQueryProcessor(redis_client=redis_mock)
         results = await processor.get_related_entities("Source Entity")


### PR DESCRIPTION
Closes #3384

Implements Phase 1 (core infrastructure) and Phase 2 (hybrid scoring) from `docs/design/MEMORY_GRAPH_SEMANTIC_SEARCH.md`.

## Summary

- **`query_processor.py`** — `MemoryGraphQueryProcessor`: natural language query detection, intent extraction (entity type filters, time range, status), Redis FT.SEARCH query builder, result parsing and ranking
- **`hybrid_scorer.py`** — `HybridScorer`: cosine similarity (embedding-based), BM25 text scoring, configurable weight blend (`semantic_weight` + `keyword_weight`), graceful degradation to keyword-only when embeddings unavailable
- **`__init__.py`** — Package re-exports public API

## Tests

58 unit tests, all passing (`query_processor_test.py`). Redis and embeddings fully mocked.

## Design decisions

- Hybrid score = `semantic_weight × cosine_sim + keyword_weight × bm25` (weights configurable, default 0.7/0.3)
- Natural language detection via heuristics (verb presence, question words, sentence length) — no LLM call required
- Graceful degradation: missing embeddings fall back to keyword-only scoring without errors

## Out of scope (Phases 3–5)

Context integration, caching, query suggestions, and search analytics will be addressed in follow-up issues.