### PR TITLE
chore(frontend): add getApiBase() to ssot-config for configurable API prefix

### DIFF
--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -605,6 +605,18 @@ export function getBackendUrl(): string {
   return getConfig().backendUrl;
 }
 
+
+/**
+ * Get the API base path for the autobot backend.
+ * Returns '/api' by default. Override with VITE_API_BASE_PATH if needed.
+ *
+ * All frontend code should call this instead of hardcoding '/api'.
+ * Consistent with getSlmApiBase() pattern in autobot-slm-frontend.
+ */
+export function getApiBase(): string {
+  return import.meta.env.VITE_API_BASE_PATH || '/api'
+}
+
 /**
  * Get WebSocket URL (backward compatibility).
  */


### PR DESCRIPTION
Closes #3628

## Changes
- Added `getApiBase()` to `autobot-frontend/src/config/ssot-config.ts`
- Returns `VITE_API_BASE_PATH` env var if set, otherwise `'/api'`
- Consistent with `getSlmApiBase()` pattern in the SLM frontend

## Verification
- Function is valid TypeScript; no type-check regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)