### PR TITLE
chore(frontend): adopt getApiBase() in composables (Phase 2)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
@@ -19,6 +19,7 @@ import { useBackgroundTask } from '@/composables/useBackgroundTask'
 import { useTaskLoader } from '@/composables/useTaskLoader'
 import { useAnalyticsScanRunner } from '@/composables/useAnalyticsScanRunner'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useAnalyticsDataFetchers')
 
@@ -229,7 +230,7 @@ export function useAnalyticsDataFetchers(
     error: dependencyError,
     load: _loadDependencyTask,
   } = useTaskLoader<DependencyGraph>(
-    '/api/analytics/codebase/analytics/dependencies',
+    `${getApiBase()}/analytics/codebase/analytics/dependencies`,
     (r) => {
       if (r.status === 'success' && r.dependency_data) {
         return r.dependency_data as unknown as DependencyGraph
@@ -244,7 +245,7 @@ export function useAnalyticsDataFetchers(
     error: importTreeError,
     load: _loadImportTreeTask,
   } = useTaskLoader<ImportTreeNode[]>(
-    '/api/analytics/codebase/analytics/import-tree',
+    `${getApiBase()}/analytics/codebase/analytics/import-tree`,
     (r) => {
       if (r.status === 'success' && r.import_tree) {
         return r.import_tree as unknown as ImportTreeNode[]
@@ -256,7 +257,7 @@ export function useAnalyticsDataFetchers(
   )
 
   const dupTask = useBackgroundTask(
-    '/api/analytics/codebase/duplicates',
+    `${getApiBase()}/analytics/codebase/duplicates`,
   )
 
   const scanRunner = useAnalyticsScanRunner()

--- a/autobot-frontend/src/composables/analytics/useAnalyticsDebug.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsDebug.ts
@@ -16,6 +16,7 @@ import { type Ref } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useAnalyticsDebug')
 
@@ -37,11 +38,11 @@ export interface UseAnalyticsDebugDeps {
 
 // Endpoint configs for API health check (#1588)
 const _testEndpointConfigs = [
-  { name: 'Declarations', path: '/api/analytics/codebase/declarations' },
-  { name: 'Duplicates', path: '/api/analytics/codebase/duplicates' },
-  { name: 'Hardcodes', path: '/api/analytics/codebase/hardcodes' },
-  { name: 'NPU', path: '/api/npu/status' },
-  { name: 'Stats', path: '/api/analytics/codebase/stats' },
+  { name: 'Declarations', path: `${getApiBase()}/analytics/codebase/declarations` },
+  { name: 'Duplicates', path: `${getApiBase()}/analytics/codebase/duplicates` },
+  { name: 'Hardcodes', path: `${getApiBase()}/analytics/codebase/hardcodes` },
+  { name: 'NPU', path: `${getApiBase()}/npu/status` },
+  { name: 'Stats', path: `${getApiBase()}/analytics/codebase/stats` },
 ]
 
 export function useAnalyticsDebug(deps: UseAnalyticsDebugDeps) {

--- a/autobot-frontend/src/composables/analytics/useApiEndpointAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useApiEndpointAnalysis.ts
@@ -18,6 +18,7 @@ import type {
   UseCodeIntelAnalysisDeps,
   ApiEndpointAnalysisResult,
 } from './codeIntelTypes'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useApiEndpointAnalysis')
 
@@ -32,7 +33,7 @@ export function useApiEndpointAnalysis(
     error: apiEndpointsError,
     load: _loadApiEndpoints,
   } = useAnalyticsFetch<ApiEndpointAnalysisResult>(
-    '/api/analytics/codebase/endpoint-analysis',
+    `${getApiBase()}/analytics/codebase/endpoint-analysis`,
     (r) => {
       if (r.status === 'success' && r.analysis) {
         return r.analysis as unknown as ApiEndpointAnalysisResult

--- a/autobot-frontend/src/composables/analytics/useBugPrediction.ts
+++ b/autobot-frontend/src/composables/analytics/useBugPrediction.ts
@@ -19,6 +19,7 @@ import type {
   BugPredictionResult,
   TopRiskFactor,
 } from './codeIntelTypes'
+import { getApiBase } from '@/config/ssot-config'
 
 export function useBugPrediction(deps: UseCodeIntelAnalysisDeps) {
   const { t } = deps
@@ -26,7 +27,7 @@ export function useBugPrediction(deps: UseCodeIntelAnalysisDeps) {
   // --- Background task ---
 
   const bugPredictionTask = useBackgroundTask(
-    '/api/analytics/bug-prediction',
+    `${getApiBase()}/analytics/bug-prediction`,
   )
 
   const bugPredictionAnalysis = computed<BugPredictionResult | null>(

--- a/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
@@ -24,6 +24,7 @@ import type {
   PerformanceFindingDetail,
   RedisOptimization,
 } from './codeIntelTypes'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useCodeIntelScores')
 
@@ -38,7 +39,7 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     error: securityScoreError,
     load: _loadSecurityScoreTask,
   } = useTaskLoader<SecurityScoreResult>(
-    '/api/code-intelligence/security/score',
+    `${getApiBase()}/code-intelligence/security/score`,
     (r) => {
       if (r.status === 'success') {
         return {
@@ -68,7 +69,7 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     error: performanceScoreError,
     load: _loadPerformanceScore,
   } = useAnalyticsFetch<PerformanceScoreResult>(
-    '/api/code-intelligence/performance/score',
+    `${getApiBase()}/code-intelligence/performance/score`,
     (r) => {
       if (r.status === 'success') {
         return {
@@ -101,7 +102,7 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     loading: loadingSecurityFindings,
     load: _loadSecurityFindings,
   } = useAnalyticsFetch<SecurityFindingDetail[]>(
-    '/api/code-intelligence/security/analyze',
+    `${getApiBase()}/code-intelligence/security/analyze`,
     (r) =>
       r.status === 'success' && r.findings
         ? (r.findings as unknown as SecurityFindingDetail[])
@@ -115,7 +116,7 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     loading: loadingPerformanceFindings,
     load: _loadPerformanceFindings,
   } = useAnalyticsFetch<PerformanceFindingDetail[]>(
-    '/api/code-intelligence/performance/analyze',
+    `${getApiBase()}/code-intelligence/performance/analyze`,
     (r) =>
       r.status === 'success' && r.findings
         ? (r.findings as unknown as PerformanceFindingDetail[])
@@ -129,7 +130,7 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     loading: loadingRedisOptimizations,
     load: _loadRedisOptimizations,
   } = useAnalyticsFetch<RedisOptimization[]>(
-    '/api/code-intelligence/redis/analyze',
+    `${getApiBase()}/code-intelligence/redis/analyze`,
     (r) =>
       r.status === 'success' && r.findings
         ? (r.findings as unknown as RedisOptimization[])

--- a/autobot-frontend/src/composables/analytics/useConfigDuplicates.ts
+++ b/autobot-frontend/src/composables/analytics/useConfigDuplicates.ts
@@ -14,6 +14,7 @@ import type {
   UseCodeIntelAnalysisDeps,
   ConfigDuplicatesResult,
 } from './codeIntelTypes'
+import { getApiBase } from '@/config/ssot-config'
 
 export function useConfigDuplicates(
   deps: UseCodeIntelAnalysisDeps,
@@ -26,7 +27,7 @@ export function useConfigDuplicates(
     error: configDuplicatesError,
     load: _loadConfigDuplicates,
   } = useAnalyticsFetch<ConfigDuplicatesResult>(
-    '/api/analytics/codebase/config-duplicates',
+    `${getApiBase()}/analytics/codebase/config-duplicates`,
     (r) => {
       if (r.status === 'success') {
         return {

--- a/autobot-frontend/src/composables/analytics/useDashboardLoaders.ts
+++ b/autobot-frontend/src/composables/analytics/useDashboardLoaders.ts
@@ -17,6 +17,7 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { useBackgroundTask } from '@/composables/useBackgroundTask'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useDashboardLoaders')
 
@@ -56,7 +57,7 @@ export interface UseDashboardLoadersDeps {
 }
 
 export function useDashboardLoaders(deps: UseDashboardLoadersDeps) {
-  const dashboardTask = useBackgroundTask('/api/analytics/dashboard/overview')
+  const dashboardTask = useBackgroundTask(`${getApiBase()}/analytics/dashboard/overview`)
 
   const systemOverview = ref<SystemOverviewData | null>(null)
   const communicationPatterns = ref<CommunicationPatternsData | null>(null)

--- a/autobot-frontend/src/composables/analytics/useOwnershipAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useOwnershipAnalysis.ts
@@ -21,6 +21,7 @@ import type {
   KnowledgeGap,
   OwnershipMetrics,
 } from './codeIntelTypes'
+import { getApiBase } from '@/config/ssot-config'
 
 export function useOwnershipAnalysis(
   deps: UseCodeIntelAnalysisDeps,
@@ -33,7 +34,7 @@ export function useOwnershipAnalysis(
     error: ownershipError,
     load: _loadOwnership,
   } = useAnalyticsFetch<OwnershipAnalysisResult>(
-    '/api/analytics/codebase/ownership/analysis',
+    `${getApiBase()}/analytics/codebase/ownership/analysis`,
     (r) => {
       if (r.status === 'success') {
         return {

--- a/autobot-frontend/src/composables/useAgentRegistry.ts
+++ b/autobot-frontend/src/composables/useAgentRegistry.ts
@@ -12,6 +12,7 @@
 import { ref, computed } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useAgentRegistry')
 
@@ -101,7 +102,7 @@ export function useAgentRegistry(options: UseAgentRegistryOptions = {}) {
     isLoading.value = true
     errors.value = []
     try {
-      const data = await ApiClient.get('/api/agent_config/agents/all')
+      const data = await ApiClient.get(`${getApiBase()}/agent_config/agents/all`)
       backendAgents.value = data.agents || []
       specializedAgents.value = data.specialized_agents || []
       summary.value = data.summary || null
@@ -123,7 +124,7 @@ export function useAgentRegistry(options: UseAgentRegistryOptions = {}) {
     isLoadingDetail.value = true
     try {
       const data = await ApiClient.get(
-        `/api/agent_config/agents/specialized/${agentId}`
+        `${getApiBase()}/agent_config/agents/specialized/${agentId}`
       )
       selectedAgent.value = data
     } catch (err: unknown) {

--- a/autobot-frontend/src/composables/useApi.ts
+++ b/autobot-frontend/src/composables/useApi.ts
@@ -9,6 +9,7 @@ import { inject } from 'vue'
 import type { ApiClientType } from '../plugins/api'
 import { showSubtleErrorNotification } from '@/utils/cacheManagement'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 // Create scoped logger for useApi
 const logger = createLogger('useApi')
@@ -200,7 +201,7 @@ export function useChatApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have resetChat(), use direct HTTP call
         async () => {
-          const response = await api.post('/api/chat/reset')
+          const response = await api.post(`${getApiBase()}/chat/reset`)
           return await response.json()
         },
         { errorMessage: 'Failed to reset chat' }
@@ -258,7 +259,7 @@ export function useSettingsApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have getBackendSettings(), use direct HTTP call
         async () => {
-          const response = await api.get('/api/settings/backend')
+          const response = await api.get(`${getApiBase()}/settings/backend`)
           return await response.json()
         },
         {
@@ -275,7 +276,7 @@ export function useSettingsApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have saveBackendSettings(), use direct HTTP call
         async () => {
-          const response = await api.post('/api/settings/backend', settings)
+          const response = await api.post(`${getApiBase()}/settings/backend`, settings)
           return await response.json()
         },
         { errorMessage: 'Failed to update backend settings' }
@@ -298,7 +299,7 @@ export function useKnowledgeApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have searchKnowledge(), use direct HTTP call
         async () => {
-          const response = await api.get(`/api/knowledge/search?query=${encodeURIComponent(query)}&limit=${limit}`)
+          const response = await api.get(`${getApiBase()}/knowledge/search?query=${encodeURIComponent(query)}&limit=${limit}`)
           return await response.json()
         },
         {
@@ -315,7 +316,7 @@ export function useKnowledgeApi() {
       return withErrorHandling(
         // Issue #549 Fix: Use correct path /api/knowledge_base/facts
         async () => {
-          const response = await api.post('/api/knowledge_base/facts', { content: text, title, source })
+          const response = await api.post(`${getApiBase()}/knowledge_base/facts`, { content: text, title, source })
           return await response.json()
         },
         { errorMessage: 'Failed to add text to knowledge base' }
@@ -329,7 +330,7 @@ export function useKnowledgeApi() {
       return withErrorHandling(
         // Issue #549 Fix: Use correct path /api/knowledge_base/url
         async () => {
-          const response = await api.post('/api/knowledge_base/url', { url, method })
+          const response = await api.post(`${getApiBase()}/knowledge_base/url`, { url, method })
           return await response.json()
         },
         { errorMessage: 'Failed to add URL to knowledge base' }
@@ -345,7 +346,7 @@ export function useKnowledgeApi() {
         async () => {
           const formData = new FormData()
           formData.append('file', file)
-          const response = await api.post('/api/knowledge_base/upload', formData)
+          const response = await api.post(`${getApiBase()}/knowledge_base/upload`, formData)
           return await response.json()
         },
         { errorMessage: 'Failed to add file to knowledge base' }
@@ -420,7 +421,7 @@ export function useFileApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have listFiles(), use direct HTTP call
         async () => {
-          const response = await api.get(`/api/files/list?path=${encodeURIComponent(path)}`)
+          const response = await api.get(`${getApiBase()}/files/list?path=${encodeURIComponent(path)}`)
           return await response.json()
         },
         {
@@ -447,7 +448,7 @@ export function useFileApi() {
           formData.append('file', file)
           formData.append('path', path)
           formData.append('overwrite', String(overwrite))
-          const response = await api.post('/api/files/upload', formData)
+          const response = await api.post(`${getApiBase()}/files/upload`, formData)
           return await response.json()
         },
         { errorMessage: 'Failed to upload file' }
@@ -461,7 +462,7 @@ export function useFileApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have viewFile(), use direct HTTP call
         async () => {
-          const response = await api.get(`/api/files/view?path=${encodeURIComponent(path)}`)
+          const response = await api.get(`${getApiBase()}/files/view?path=${encodeURIComponent(path)}`)
           return await response.json()
         },
         { errorMessage: 'Failed to view file' }
@@ -475,7 +476,7 @@ export function useFileApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have deleteFile(), use direct HTTP call
         async () => {
-          const response = await api.delete(`/api/files?path=${encodeURIComponent(path)}`)
+          const response = await api.delete(`${getApiBase()}/files?path=${encodeURIComponent(path)}`)
           return await response.json()
         },
         { errorMessage: 'Failed to delete file' }
@@ -489,7 +490,7 @@ export function useFileApi() {
       return withErrorHandling(
         // Issue #552: Fixed path - backend uses path param /download/{path}, not query param
         async () => {
-          const response = await api.get(`/api/files/download/${encodeURIComponent(path)}`)
+          const response = await api.get(`${getApiBase()}/files/download/${encodeURIComponent(path)}`)
           return await response.blob()
         },
         { errorMessage: 'Failed to download file' }
@@ -506,7 +507,7 @@ export function useFileApi() {
           const formData = new FormData()
           formData.append('path', path)
           formData.append('name', name)
-          const response = await api.post('/api/files/create_directory', formData)
+          const response = await api.post(`${getApiBase()}/files/create_directory`, formData)
           return await response.json()
         },
         { errorMessage: 'Failed to create directory' }
@@ -520,7 +521,7 @@ export function useFileApi() {
       return withErrorHandling(
         // Issue #156 Fix: ApiClient doesn't have getFileStats(), use direct HTTP call
         async () => {
-          const response = await api.get('/api/files/stats')
+          const response = await api.get(`${getApiBase()}/files/stats`)
           return await response.json()
         },
         {

--- a/autobot-frontend/src/composables/useAuditApi.ts
+++ b/autobot-frontend/src/composables/useAuditApi.ts
@@ -23,6 +23,7 @@ import type {
   AuditResult
 } from '@/types/audit'
 import { DEFAULT_AUDIT_FILTER, getDateRangeForFilter } from '@/types/audit'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useAuditApi')
 
@@ -51,7 +52,7 @@ export function useAuditApi() {
           if (params?.offset) searchParams.append('offset', params.offset.toString())
 
           const queryString = searchParams.toString()
-          const url = `/api/audit/logs${queryString ? `?${queryString}` : ''}`
+          const url = `${getApiBase()}/audit/logs${queryString ? `?${queryString}` : ''}`
           const response = await api.get(url)
           return await response.json()
         },
@@ -74,7 +75,7 @@ export function useAuditApi() {
     async getStatistics(): Promise<AuditStatisticsResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get('/api/audit/statistics')
+          const response = await api.get(`${getApiBase()}/audit/statistics`)
           return await response.json()
         },
         {
@@ -90,7 +91,7 @@ export function useAuditApi() {
     async getSessionAuditTrail(sessionId: string): Promise<AuditQueryResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get(`/api/audit/session/${sessionId}`)
+          const response = await api.get(`${getApiBase()}/audit/session/${sessionId}`)
           return await response.json()
         },
         {
@@ -109,7 +110,7 @@ export function useAuditApi() {
     ): Promise<AuditQueryResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get(`/api/audit/user/${userId}?days=${days}`)
+          const response = await api.get(`${getApiBase()}/audit/user/${userId}?days=${days}`)
           return await response.json()
         },
         {
@@ -129,7 +130,7 @@ export function useAuditApi() {
       return withErrorHandling(
         async () => {
           const response = await api.get(
-            `/api/audit/failures?hours=${hours}&result_filter=${resultFilter}`
+            `${getApiBase()}/audit/failures?hours=${hours}&result_filter=${resultFilter}`
           )
           return await response.json()
         },
@@ -146,7 +147,7 @@ export function useAuditApi() {
     async cleanupLogs(request: AuditCleanupRequest): Promise<AuditCleanupResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.post('/api/audit/cleanup', request)
+          const response = await api.post(`${getApiBase()}/audit/cleanup`, request)
           return await response.json()
         },
         {
@@ -161,7 +162,7 @@ export function useAuditApi() {
     async getOperationTypes(): Promise<AuditOperationsResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get('/api/audit/operations')
+          const response = await api.get(`${getApiBase()}/audit/operations`)
           return await response.json()
         },
         {

--- a/autobot-frontend/src/composables/useAutoResearch.ts
+++ b/autobot-frontend/src/composables/useAutoResearch.ts
@@ -7,6 +7,7 @@ import { useApi } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
 import { extractApiErrorMessage } from '@/utils/errorExtract'
 import { showSubtleErrorNotification } from '@/utils/cacheManagement'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useAutoResearch')
 
@@ -120,7 +121,7 @@ export function useAutoResearch() {
       if (params?.limit != null) query.set('limit', String(params.limit))
       if (params?.offset != null) query.set('offset', String(params.offset))
       if (params?.state) query.set('state', params.state)
-      const response = await api.get(`/api/autoresearch/experiments?${query}`)
+      const response = await api.get(`${getApiBase()}/autoresearch/experiments?${query}`)
       experiments.value = response.experiments ?? []
     } catch (err) {
       const msg = extractApiErrorMessage(err, 'Failed to fetch experiments')
@@ -134,7 +135,7 @@ export function useAutoResearch() {
 
   async function fetchStats(): Promise<void> {
     try {
-      const response = await api.get('/api/autoresearch/experiments/stats')
+      const response = await api.get(`${getApiBase()}/autoresearch/experiments/stats`)
       stats.value = response
     } catch (err) {
       const msg = extractApiErrorMessage(err, 'Failed to fetch experiment stats')
@@ -148,7 +149,7 @@ export function useAutoResearch() {
 
   async function fetchOptimizerStatus(): Promise<void> {
     try {
-      const response = await api.get('/api/autoresearch/prompt-optimizer/status')
+      const response = await api.get(`${getApiBase()}/autoresearch/prompt-optimizer/status`)
       optimizerStatus.value = response.session ?? null
     } catch (err) {
       const msg = extractApiErrorMessage(err, 'Failed to fetch optimizer status')
@@ -162,7 +163,7 @@ export function useAutoResearch() {
     agentName: string,
     maxRounds: number = 3,
   ): Promise<void> {
-    await api.post('/api/autoresearch/prompt-optimizer/start', {
+    await api.post(`${getApiBase()}/autoresearch/prompt-optimizer/start`, {
       agent_name: agentName,
       max_rounds: maxRounds,
     })
@@ -170,13 +171,13 @@ export function useAutoResearch() {
   }
 
   async function cancelOptimization(): Promise<void> {
-    await api.post('/api/autoresearch/prompt-optimizer/cancel')
+    await api.post(`${getApiBase()}/autoresearch/prompt-optimizer/cancel`)
     await fetchOptimizerStatus()
   }
 
   async function fetchVariants(sessionId: string): Promise<void> {
     const response = await api.get(
-      `/api/autoresearch/prompt-optimizer/variants/${sessionId}`,
+      `${getApiBase()}/autoresearch/prompt-optimizer/variants/${sessionId}`,
     )
     variants.value = response.variants ?? []
   }
@@ -188,7 +189,7 @@ export function useAutoResearch() {
     comment: string = '',
   ): Promise<void> {
     await api.post(
-      `/api/autoresearch/prompt-optimizer/variants/${variantId}/score?session_id=${sessionId}`,
+      `${getApiBase()}/autoresearch/prompt-optimizer/variants/${variantId}/score?session_id=${sessionId}`,
       { score, comment },
     )
   }
@@ -196,7 +197,7 @@ export function useAutoResearch() {
   // --- Approvals ---
 
   async function fetchPendingApprovals(): Promise<void> {
-    const response = await api.get('/api/autoresearch/approvals/pending')
+    const response = await api.get(`${getApiBase()}/autoresearch/approvals/pending`)
     pendingApprovals.value = response.approvals ?? []
   }
 
@@ -205,7 +206,7 @@ export function useAutoResearch() {
     experimentId: string,
   ): Promise<void> {
     await api.post(
-      `/api/autoresearch/approvals/${sessionId}/${experimentId}`,
+      `${getApiBase()}/autoresearch/approvals/${sessionId}/${experimentId}`,
       { decision: 'approved' },
     )
     await fetchPendingApprovals()
@@ -216,7 +217,7 @@ export function useAutoResearch() {
     experimentId: string,
   ): Promise<void> {
     await api.post(
-      `/api/autoresearch/approvals/${sessionId}/${experimentId}`,
+      `${getApiBase()}/autoresearch/approvals/${sessionId}/${experimentId}`,
       { decision: 'rejected' },
     )
     await fetchPendingApprovals()
@@ -226,14 +227,14 @@ export function useAutoResearch() {
 
   async function fetchInsights(minConfidence: number = 0): Promise<void> {
     const response = await api.get(
-      `/api/autoresearch/insights?min_confidence=${minConfidence}`,
+      `${getApiBase()}/autoresearch/insights?min_confidence=${minConfidence}`,
     )
     insights.value = response.insights ?? []
   }
 
   async function searchInsights(query: string): Promise<void> {
     const response = await api.get(
-      `/api/autoresearch/insights/search?q=${encodeURIComponent(query)}`,
+      `${getApiBase()}/autoresearch/insights/search?q=${encodeURIComponent(query)}`,
     )
     insights.value = response.insights ?? []
   }

--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -27,6 +27,7 @@ import type {
   BatchJobStatus
 } from '@/types/batch-processing'
 import { isTerminalStatus } from '@/types/batch-processing'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useBatchProcessing')
 
@@ -49,7 +50,7 @@ export function useBatchProcessingApi() {
           if (filter?.limit) params.append('limit', filter.limit.toString())
 
           const queryString = params.toString()
-          const url = `/api/batch-jobs${queryString ? `?${queryString}` : ''}`
+          const url = `${getApiBase()}/batch-jobs${queryString ? `?${queryString}` : ''}`
           const response = await api.get(url)
           return await response.json()
         },
@@ -73,7 +74,7 @@ export function useBatchProcessingApi() {
     async getJob(jobId: string): Promise<BatchJob | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get(`/api/batch-jobs/${jobId}`)
+          const response = await api.get(`${getApiBase()}/batch-jobs/${jobId}`)
           return await response.json()
         },
         {
@@ -89,7 +90,7 @@ export function useBatchProcessingApi() {
     async createJob(request: CreateBatchJobRequest): Promise<CreateBatchJobResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.post('/api/batch-jobs', request)
+          const response = await api.post(`${getApiBase()}/batch-jobs`, request)
           return await response.json()
         },
         {
@@ -104,7 +105,7 @@ export function useBatchProcessingApi() {
     async deleteJob(jobId: string): Promise<{ status: string } | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.delete(`/api/batch-jobs/${jobId}`)
+          const response = await api.delete(`${getApiBase()}/batch-jobs/${jobId}`)
           return await response.json()
         },
         {
@@ -119,7 +120,7 @@ export function useBatchProcessingApi() {
     async cancelJob(jobId: string): Promise<{ status: string } | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.post(`/api/batch-jobs/${jobId}/cancel`)
+          const response = await api.post(`${getApiBase()}/batch-jobs/${jobId}/cancel`)
           return await response.json()
         },
         {
@@ -134,7 +135,7 @@ export function useBatchProcessingApi() {
     async getJobLogs(jobId: string): Promise<BatchJobLogsResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get(`/api/batch-jobs/${jobId}/logs`)
+          const response = await api.get(`${getApiBase()}/batch-jobs/${jobId}/logs`)
           return await response.json()
         },
         {
@@ -150,7 +151,7 @@ export function useBatchProcessingApi() {
     async listTemplates(): Promise<BatchTemplatesListResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get('/api/batch-templates')
+          const response = await api.get(`${getApiBase()}/batch-templates`)
           return await response.json()
         },
         {
@@ -166,7 +167,7 @@ export function useBatchProcessingApi() {
     async createTemplate(request: CreateBatchTemplateRequest): Promise<BatchTemplate | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.post('/api/batch-templates', request)
+          const response = await api.post(`${getApiBase()}/batch-templates`, request)
           return await response.json()
         },
         {
@@ -181,7 +182,7 @@ export function useBatchProcessingApi() {
     async deleteTemplate(templateId: string): Promise<{ status: string } | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.delete(`/api/batch-templates/${templateId}`)
+          const response = await api.delete(`${getApiBase()}/batch-templates/${templateId}`)
           return await response.json()
         },
         {
@@ -196,7 +197,7 @@ export function useBatchProcessingApi() {
     async listSchedules(): Promise<BatchSchedulesListResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get('/api/batch-schedules')
+          const response = await api.get(`${getApiBase()}/batch-schedules`)
           return await response.json()
         },
         {
@@ -212,7 +213,7 @@ export function useBatchProcessingApi() {
     async createSchedule(request: CreateBatchScheduleRequest): Promise<BatchSchedule | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.post('/api/batch-schedules', request)
+          const response = await api.post(`${getApiBase()}/batch-schedules`, request)
           return await response.json()
         },
         {
@@ -227,7 +228,7 @@ export function useBatchProcessingApi() {
     async toggleSchedule(scheduleId: string, enabled: boolean): Promise<BatchSchedule | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.patch(`/api/batch-schedules/${scheduleId}`, { enabled })
+          const response = await api.patch(`${getApiBase()}/batch-schedules/${scheduleId}`, { enabled })
           return await response.json()
         },
         {
@@ -242,7 +243,7 @@ export function useBatchProcessingApi() {
     async deleteSchedule(scheduleId: string): Promise<{ status: string } | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.delete(`/api/batch-schedules/${scheduleId}`)
+          const response = await api.delete(`${getApiBase()}/batch-schedules/${scheduleId}`)
           return await response.json()
         },
         {
@@ -257,7 +258,7 @@ export function useBatchProcessingApi() {
     async getHealth(): Promise<BatchHealthResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get('/api/batch-jobs/health')
+          const response = await api.get(`${getApiBase()}/batch-jobs/health`)
           return await response.json()
         },
         {

--- a/autobot-frontend/src/composables/useBrowserAutomation.ts
+++ b/autobot-frontend/src/composables/useBrowserAutomation.ts
@@ -10,6 +10,7 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useBrowserAutomation')
 
@@ -85,7 +86,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   async function fetchWorkerStatus(): Promise<void> {
     try {
-      const data = await ApiClient.get('/api/browser/status')
+      const data = await ApiClient.get(`${getApiBase()}/browser/status`)
       workerStatus.value = data
       logger.debug('Fetched worker status:', data)
     } catch (err) {
@@ -99,7 +100,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/browser/launch', { url: url || 'about:blank' })
+      const data = await ApiClient.post(`${getApiBase()}/browser/launch`, { url: url || 'about:blank' })
       sessions.value.push(data.session)
       currentSession.value = data.session
       logger.debug('Launched browser session:', data.session)
@@ -118,7 +119,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      await ApiClient.post('/api/browser/close', { session_id: sessionId })
+      await ApiClient.post(`${getApiBase()}/browser/close`, { session_id: sessionId })
       sessions.value = sessions.value.filter(s => s.id !== sessionId)
       if (currentSession.value?.id === sessionId) {
         currentSession.value = null
@@ -137,7 +138,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   async function fetchSessions(): Promise<void> {
     try {
-      const data = await ApiClient.get('/api/browser/sessions')
+      const data = await ApiClient.get(`${getApiBase()}/browser/sessions`)
       sessions.value = data.sessions || []
       logger.debug('Fetched sessions:', sessions.value.length)
     } catch (err) {
@@ -149,7 +150,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   async function getSession(sessionId: string): Promise<BrowserSession | null> {
     try {
-      const data = await ApiClient.get(`/api/browser/session/${sessionId}`)
+      const data = await ApiClient.get(`${getApiBase()}/browser/session/${sessionId}`)
       currentSession.value = data
       logger.debug('Fetched session details:', data)
       return data
@@ -165,7 +166,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      await ApiClient.post('/api/browser/navigate', { session_id: sessionId, url })
+      await ApiClient.post(`${getApiBase()}/browser/navigate`, { session_id: sessionId, url })
       logger.debug('Navigated to:', url)
       await fetchSessions()
       return true
@@ -183,7 +184,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      await ApiClient.post('/api/browser/click', { session_id: sessionId, selector })
+      await ApiClient.post(`${getApiBase()}/browser/click`, { session_id: sessionId, selector })
       logger.debug('Clicked element:', selector)
       return true
     } catch (err) {
@@ -200,7 +201,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      await ApiClient.post('/api/browser/type', { session_id: sessionId, selector, text })
+      await ApiClient.post(`${getApiBase()}/browser/type`, { session_id: sessionId, selector, text })
       logger.debug('Typed text into:', selector)
       return true
     } catch (err) {
@@ -217,7 +218,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/browser/screenshot', { session_id: sessionId })
+      const data = await ApiClient.post(`${getApiBase()}/browser/screenshot`, { session_id: sessionId })
       screenshots.value.unshift(data)
       logger.debug('Captured screenshot')
       return data
@@ -235,7 +236,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/browser/execute', { session_id: sessionId, script })
+      const data = await ApiClient.post(`${getApiBase()}/browser/execute`, { session_id: sessionId, script })
       logger.debug('Executed script, result:', data.result)
       return data.result
     } catch (err) {
@@ -252,7 +253,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/browser/automation/run', { script })
+      const data = await ApiClient.post(`${getApiBase()}/browser/automation/run`, { script })
       logger.debug('Automation script completed:', data)
       return data.result
     } catch (err) {
@@ -269,7 +270,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      await ApiClient.delete(`/api/browser/session/${sessionId}`)
+      await ApiClient.delete(`${getApiBase()}/browser/session/${sessionId}`)
       sessions.value = sessions.value.filter(s => s.id !== sessionId)
       logger.debug('Deleted session:', sessionId)
       return true

--- a/autobot-frontend/src/composables/useCodeIntelligence.ts
+++ b/autobot-frontend/src/composables/useCodeIntelligence.ts
@@ -10,6 +10,7 @@
 import { ref, computed, onMounted } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useCodeIntelligence')
 
@@ -169,7 +170,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function analyzeCode(request: CodeAnalysisRequest): Promise<CodeAnalysisResult | null> {
     startLoading()
     try {
-      const data = await ApiClient.post('/api/code-intelligence/analyze', request)
+      const data = await ApiClient.post(`${getApiBase()}/code-intelligence/analyze`, request)
       currentAnalysis.value = data
       logger.debug('Code analysis complete:', data)
       return data
@@ -186,7 +187,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function getAnalysis(analysisId: string): Promise<CodeAnalysisResult | null> {
     startLoading()
     try {
-      const data = await ApiClient.get(`/api/code-intelligence/analysis/${analysisId}`)
+      const data = await ApiClient.get(`${getApiBase()}/code-intelligence/analysis/${analysisId}`)
       currentAnalysis.value = data
       logger.debug('Fetched analysis:', data)
       return data
@@ -203,7 +204,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function getQualityScore(code: string, language?: string): Promise<QualityScore | null> {
     startLoading()
     try {
-      const data = await ApiClient.post('/api/code-intelligence/quality-score', { code, language })
+      const data = await ApiClient.post(`${getApiBase()}/code-intelligence/quality-score`, { code, language })
       qualityScore.value = data
       logger.debug('Quality score:', data)
       return data
@@ -220,7 +221,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function getSuggestions(code: string, language?: string): Promise<void> {
     startLoading()
     try {
-      const data = await ApiClient.post('/api/code-intelligence/suggestions', { code, language })
+      const data = await ApiClient.post(`${getApiBase()}/code-intelligence/suggestions`, { code, language })
       suggestions.value = data.suggestions || []
       logger.debug('Fetched suggestions:', suggestions.value)
     } catch (err) {
@@ -236,8 +237,8 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
     startLoading()
     try {
       const url = path
-        ? `/api/code-intelligence/health-score?path=${encodeURIComponent(path)}`
-        : '/api/code-intelligence/health-score'
+        ? `${getApiBase()}/code-intelligence/health-score?path=${encodeURIComponent(path)}`
+        : `${getApiBase()}/code-intelligence/health-score`
       const data = await ApiClient.get(url)
       healthScore.value = data
       logger.debug('Health score:', healthScore.value)
@@ -253,7 +254,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function getSecurityScoreCached(): Promise<SecurityScoreCached | null> {
     startLoading()
     try {
-      const data = await ApiClient.get('/api/code-intelligence/security/score/cached')
+      const data = await ApiClient.get(`${getApiBase()}/code-intelligence/security/score/cached`)
       securityScoreCached.value = data
       logger.debug('Cached security score:', data)
       return data
@@ -270,7 +271,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function getTrends(days: number = 30): Promise<void> {
     startLoading()
     try {
-      const data = await ApiClient.get(`/api/code-intelligence/trends?days=${days}`)
+      const data = await ApiClient.get(`${getApiBase()}/code-intelligence/trends?days=${days}`)
       trends.value = data.trends || []
       logger.debug('Fetched trends:', trends.value)
     } catch (err) {
@@ -285,7 +286,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function compareCode(file1: string, file2: string): Promise<ComparisonResult | null> {
     startLoading()
     try {
-      const data = await ApiClient.post('/api/code-intelligence/compare', { file1, file2 })
+      const data = await ApiClient.post(`${getApiBase()}/code-intelligence/compare`, { file1, file2 })
       logger.debug('Comparison result:', data)
       return data
     } catch (err) {
@@ -301,7 +302,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function getAnalysisHistory(limit: number = 50): Promise<void> {
     startLoading()
     try {
-      const data = await ApiClient.get(`/api/code-intelligence/history?limit=${limit}`)
+      const data = await ApiClient.get(`${getApiBase()}/code-intelligence/history?limit=${limit}`)
       analysisHistory.value = data.analyses || []
       logger.debug('Fetched analysis history:', analysisHistory.value.length)
     } catch (err) {
@@ -316,7 +317,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function deleteAnalysis(analysisId: string): Promise<boolean> {
     startLoading()
     try {
-      await ApiClient.delete(`/api/code-intelligence/analysis/${analysisId}`)
+      await ApiClient.delete(`${getApiBase()}/code-intelligence/analysis/${analysisId}`)
       analysisHistory.value = analysisHistory.value.filter(a => a.id !== analysisId)
       logger.debug('Deleted analysis:', analysisId)
       return true
@@ -333,7 +334,7 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
   async function batchAnalyze(files: Array<{ code: string; filename: string; language?: string }>): Promise<CodeAnalysisResult[]> {
     startLoading()
     try {
-      const data = await ApiClient.post('/api/code-intelligence/batch-analyze', { files })
+      const data = await ApiClient.post(`${getApiBase()}/code-intelligence/batch-analyze`, { files })
       logger.debug('Batch analysis complete:', data.results?.length)
       return data.results || []
     } catch (err) {

--- a/autobot-frontend/src/composables/useCommandApproval.ts
+++ b/autobot-frontend/src/composables/useCommandApproval.ts
@@ -22,6 +22,7 @@ import { useToast } from '@/composables/useToast'
 import { createLogger } from '@/utils/debugUtils'
 import { useChatStore } from '@/stores/useChatStore'
 import { usePermissionStore } from '@/stores/usePermissionStore'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useCommandApproval')
 
@@ -118,7 +119,7 @@ export function useCommandApproval() {
 
       try {
         const backendUrl = await appConfig.getApiUrl(
-          `/api/agent-terminal/commands/${command_id}`
+          `${getApiBase()}/agent-terminal/commands/${command_id}`
         )
         const response = await fetchWithAuth(backendUrl, { signal })
 
@@ -219,7 +220,7 @@ export function useCommandApproval() {
     try {
       // Get backend URL from appConfig
       const backendUrl = await appConfig.getApiUrl(
-        `/api/agent-terminal/sessions/${terminal_session_id}/approve`
+        `${getApiBase()}/agent-terminal/sessions/${terminal_session_id}/approve`
       )
 
       const response = await fetchWithAuth(backendUrl, {

--- a/autobot-frontend/src/composables/useConversationFiles.ts
+++ b/autobot-frontend/src/composables/useConversationFiles.ts
@@ -9,6 +9,7 @@ import { ref, computed } from 'vue'
 import { useApi } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
 import { extractApiErrorMessage } from '@/utils/errorExtract'
+import { getApiBase } from '@/config/ssot-config'
 
 // Create scoped logger for useConversationFiles
 const logger = createLogger('useConversationFiles')
@@ -95,7 +96,7 @@ export function useConversationFiles(sessionId: string) {
     return result
   })
 
-  const API = `/api/conversation-files/conversation/${sessionId}`
+  const API = `${getApiBase()}/conversation-files/conversation/${sessionId}`
 
   const loadFiles = async (): Promise<void> => {
     if (!sessionId) {
@@ -107,7 +108,7 @@ export function useConversationFiles(sessionId: string) {
     error.value = null
 
     try {
-      const response = await api.get(`/api/conversation-files/conversation/${sessionId}/list`)
+      const response = await api.get(`${getApiBase()}/conversation-files/conversation/${sessionId}/list`)
       // Issue #156 Fix: Call .json() to get data from Response
       const data = await response.json()
 
@@ -152,7 +153,7 @@ export function useConversationFiles(sessionId: string) {
       })
 
       const response = await api.post(
-        `/api/conversation-files/conversation/${sessionId}/upload`,
+        `${getApiBase()}/conversation-files/conversation/${sessionId}/upload`,
         formData,
         {
           headers: {
@@ -202,7 +203,7 @@ export function useConversationFiles(sessionId: string) {
     error.value = null
 
     try {
-      await api.delete(`/api/conversation-files/conversation/${sessionId}/files/${fileId}`)
+      await api.delete(`${getApiBase()}/conversation-files/conversation/${sessionId}/files/${fileId}`)
 
       // Remove file from local state
       files.value = files.value.filter(f => f.file_id !== fileId)
@@ -229,7 +230,7 @@ export function useConversationFiles(sessionId: string) {
 
     try {
       const response = await api.get(
-        `/api/conversation-files/conversation/${sessionId}/download/${fileId}`,
+        `${getApiBase()}/conversation-files/conversation/${sessionId}/download/${fileId}`,
         { responseType: 'blob' }
       )
 
@@ -274,7 +275,7 @@ export function useConversationFiles(sessionId: string) {
 
       // For previewable types, open preview URL
       if (isPreviewable(file.mime_type)) {
-        const previewUrl = `/api/conversation-files/conversation/${sessionId}/preview/${fileId}`
+        const previewUrl = `${getApiBase()}/conversation-files/conversation/${sessionId}/preview/${fileId}`
         window.open(previewUrl, '_blank')
       } else {
         // For non-previewable types, download instead

--- a/autobot-frontend/src/composables/useDevSpeedup.ts
+++ b/autobot-frontend/src/composables/useDevSpeedup.ts
@@ -10,6 +10,7 @@
 import { ref, onMounted } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useDevSpeedup')
 
@@ -92,7 +93,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/dev-speedup/quick-search', { query, type })
+      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/quick-search`, { query, type })
       searchResults.value = data.results || []
       logger.debug('Search results:', searchResults.value.length)
     } catch (err) {
@@ -108,7 +109,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/dev-speedup/snippet-generate', { description, language })
+      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/snippet-generate`, { description, language })
       const snippet = data.snippet
       snippets.value.unshift(snippet)
       logger.debug('Generated snippet:', snippet)
@@ -128,7 +129,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     error.value = null
     try {
       const params = category ? `?category=${category}` : ''
-      const data = await ApiClient.get(`/api/dev-speedup/templates${params}`)
+      const data = await ApiClient.get(`${getApiBase()}/dev-speedup/templates${params}`)
       templates.value = data.templates || []
       logger.debug('Fetched templates:', templates.value.length)
     } catch (err) {
@@ -144,7 +145,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/dev-speedup/refactor-suggest', { code, language })
+      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/refactor-suggest`, { code, language })
       refactorSuggestions.value = data.suggestions || []
       logger.debug('Refactor suggestions:', refactorSuggestions.value.length)
     } catch (err) {
@@ -160,7 +161,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/dev-speedup/boilerplate', { type, ...options })
+      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/boilerplate`, { type, ...options })
       logger.debug('Generated boilerplate')
       return data.code
     } catch (err) {
@@ -177,7 +178,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/dev-speedup/test-generate', { code, language, framework })
+      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/test-generate`, { code, language, framework })
       generatedTests.value = data.tests || []
       logger.debug('Generated tests:', generatedTests.value.length)
     } catch (err) {
@@ -193,7 +194,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/dev-speedup/optimize', { code, language })
+      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/optimize`, { code, language })
       logger.debug('Code optimized')
       return data.optimized_code
     } catch (err) {
@@ -210,7 +211,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/dev-speedup/format', { code, language })
+      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/format`, { code, language })
       logger.debug('Code formatted')
       return data.formatted_code
     } catch (err) {
@@ -227,7 +228,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post('/api/dev-speedup/lint-fix', { code, language })
+      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/lint-fix`, { code, language })
       logger.debug('Linting fixed')
       return data.fixed_code
     } catch (err) {
@@ -242,7 +243,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
 
   async function fetchHistory(): Promise<void> {
     try {
-      const data = await ApiClient.get('/api/dev-speedup/history')
+      const data = await ApiClient.get(`${getApiBase()}/dev-speedup/history`)
       actionHistory.value = data.actions || []
       logger.debug('Fetched action history:', actionHistory.value.length)
     } catch (err) {

--- a/autobot-frontend/src/composables/useDocumentChanges.ts
+++ b/autobot-frontend/src/composables/useDocumentChanges.ts
@@ -15,6 +15,7 @@ import { ref, computed, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 // Create scoped logger for useDocumentChanges
 const logger = createLogger('useDocumentChanges')
@@ -179,7 +180,7 @@ export function useDocumentChanges() {
 
     try {
       // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-      const response = await ApiClient.post('/api/knowledge-maintenance/scan_host_changes', {
+      const response = await ApiClient.post(`${getApiBase()}/knowledge-maintenance/scan_host_changes`, {
         machine_id: machineId.value,
         force,
         scan_type: 'manpages',

--- a/autobot-frontend/src/composables/useEvolution.ts
+++ b/autobot-frontend/src/composables/useEvolution.ts
@@ -11,6 +11,7 @@ import { ref, computed, isRef, type ComputedRef } from 'vue'
 import axios from 'axios'
 import { createLogger } from '@/utils/debugUtils'
 import { extractApiErrorMessage, extractErrorMessage } from '@/utils/errorExtract'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useEvolution')
 
@@ -91,7 +92,7 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
 
   // API client with auth token
   const api = axios.create({
-    baseURL: '/api/analytics/evolution',
+    baseURL: `${getApiBase()}/analytics/evolution`,
     timeout: 120000, // 2 minutes for long-running analysis
     headers: {
       'Content-Type': 'application/json',

--- a/autobot-frontend/src/composables/useKnowledgeBase.ts
+++ b/autobot-frontend/src/composables/useKnowledgeBase.ts
@@ -36,6 +36,7 @@ import type {
   CategorizedFactsResponse,
   CategoryFilterOption
 } from '@/types/knowledgeBase'
+import { getApiBase } from '@/config/ssot-config'
 
 // KnowledgeStats imported from @/types/knowledgeBase (consolidated type definition)
 
@@ -84,7 +85,7 @@ export function useKnowledgeBase() {
    */
   const fetchStats = async (): Promise<KnowledgeStats | null> => {
     try {
-      const response = await apiClient.get('/api/knowledge_base/stats')
+      const response = await apiClient.get(`${getApiBase()}/knowledge_base/stats`)
 
       if (!response) {
         throw new Error('Failed to fetch stats: No response from server');
@@ -105,7 +106,7 @@ export function useKnowledgeBase() {
    */
   const fetchCategories = async (): Promise<KnowledgeCategoryItem[]> => {
     try {
-      const response = await apiClient.get('/api/knowledge_base/categories')
+      const response = await apiClient.get(`${getApiBase()}/knowledge_base/categories`)
 
       if (!response) {
         throw new Error('Failed to fetch categories: No response from server')
@@ -130,7 +131,7 @@ export function useKnowledgeBase() {
    */
   const fetchCategory = async (category: string): Promise<CategoryResponse> => {
     try {
-      const response = await apiClient.get(`/api/knowledge_base/category/${category}`)
+      const response = await apiClient.get(`${getApiBase()}/knowledge_base/category/${category}`)
 
       if (!response) {
         throw new Error('Failed to fetch category: No response from server');
@@ -162,7 +163,7 @@ export function useKnowledgeBase() {
       }
       params.append('limit', String(limit))
 
-      const url = `/api/knowledge_base/facts/by_category?${params.toString()}`
+      const url = `${getApiBase()}/knowledge_base/facts/by_category?${params.toString()}`
       const response = await apiClient.get(url)
 
       if (!response) {
@@ -229,7 +230,7 @@ export function useKnowledgeBase() {
   const searchKnowledge = async (query: string): Promise<SearchResponse> => {
     try {
       // Issue #552: Backend expects POST for search
-      const response = await apiClient.post('/api/knowledge_base/search', { query })
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/search`, { query })
 
       if (!response) {
         throw new Error('Search failed: No response from server');
@@ -270,7 +271,7 @@ export function useKnowledgeBase() {
 
   const advancedSearch = async (options: AdvancedSearchOptions): Promise<SearchResponse> => {
     try {
-      const response = await apiClient.post('/api/knowledge_base/search', options)
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/search`, options)
 
       if (!response) {
         throw new Error('Advanced search failed: No response from server')
@@ -293,7 +294,7 @@ export function useKnowledgeBase() {
     metadata?: Record<string, unknown>
   }): Promise<AddFactResponse> => {
     try {
-      const response = await apiClient.post('/api/knowledge_base/facts', fact)
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/facts`, fact)
 
       if (!response) {
         throw new Error('Failed to add fact: No response from server');
@@ -312,7 +313,7 @@ export function useKnowledgeBase() {
    */
   const uploadKnowledgeFile = async (formData: FormData): Promise<UploadResponse> => {
     try {
-      const url = await appConfig.getApiUrl('/api/knowledge_base/upload')
+      const url = await appConfig.getApiUrl(`${getApiBase()}/knowledge_base/upload`)
 
       const response = await fetchWithAuth(url, {
         method: 'POST',
@@ -340,7 +341,7 @@ export function useKnowledgeBase() {
   const fetchMachineProfiles = async (): Promise<MachineProfile[]> => {
     try {
       // Issue #552: Fixed path - backend uses singular /api/knowledge_base/machine_profile
-      const response = await apiClient.get('/api/knowledge_base/machine_profile')
+      const response = await apiClient.get(`${getApiBase()}/knowledge_base/machine_profile`)
 
       if (!response) {
         throw new Error('Failed to fetch machine profiles: No response from server');
@@ -359,7 +360,7 @@ export function useKnowledgeBase() {
    */
   const fetchManPagesSummary = async (): Promise<ManPagesSummary | null> => {
     try {
-      const response = await apiClient.get('/api/knowledge_base/man_pages/summary')
+      const response = await apiClient.get(`${getApiBase()}/knowledge_base/man_pages/summary`)
 
       if (!response) {
         throw new Error('Failed to fetch man pages summary: No response from server');
@@ -378,7 +379,7 @@ export function useKnowledgeBase() {
    */
   const integrateManPages = async (machineId: string): Promise<IntegrationResponse> => {
     try {
-      const response = await apiClient.post('/api/knowledge_base/man_pages/integrate', {
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/man_pages/integrate`, {
         machine_id: machineId
       })
 
@@ -400,7 +401,7 @@ export function useKnowledgeBase() {
   const getVectorizationStatus = async (): Promise<VectorizationStatusResponse> => {
     try {
       // Issue #552: Fixed path - backend uses /api/knowledge_base/vectorize_facts/status
-      const response = await apiClient.get('/api/knowledge_base/vectorize_facts/status')
+      const response = await apiClient.get(`${getApiBase()}/knowledge_base/vectorize_facts/status`)
 
       if (!response) {
         throw new Error('Failed to get vectorization status: No response from server');
@@ -430,7 +431,7 @@ export function useKnowledgeBase() {
       // Get knowledge-specific timeout (300s for vectorization operations)
       const knowledgeTimeout = appConfig.getTimeout('knowledge')
 
-      const response = await apiClient.post('/api/knowledge_base/vectorize_facts', {
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorize_facts`, {
         batch_size: batchSize,
         batch_delay: batchDelay,
         skip_existing: skipExisting
@@ -470,7 +471,7 @@ export function useKnowledgeBase() {
   const initializeMachineKnowledge = async (machineId: string): Promise<MachineKnowledgeResponse> => {
     try {
 
-      const response = await apiClient.post('/api/knowledge_base/machine_knowledge/initialize', {
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/machine_knowledge/initialize`, {
         machine_id: machineId
       })
 
@@ -501,7 +502,7 @@ export function useKnowledgeBase() {
   const refreshSystemKnowledge = async (): Promise<SystemKnowledgeResponse> => {
     try {
 
-      const response = await apiClient.post('/api/knowledge_base/refresh_system_knowledge', {})
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/refresh_system_knowledge`, {})
 
       logger.debug('[refreshSystemKnowledge] Response received:', {
         ok: response.ok,
@@ -529,7 +530,7 @@ export function useKnowledgeBase() {
    */
   const pollJobStatus = async (taskId: string): Promise<any> => {
     try {
-      const response = await apiClient.get(`/api/knowledge_base/job_status/${taskId}`)
+      const response = await apiClient.get(`${getApiBase()}/knowledge_base/job_status/${taskId}`)
 
       logger.debug('[pollJobStatus] Response received:', {
         ok: response.ok,
@@ -556,7 +557,7 @@ export function useKnowledgeBase() {
   const populateManPages = async (machineId: string): Promise<ManPagesPopulateResponse> => {
     try {
 
-      const response = await apiClient.post('/api/knowledge_base/populate_man_pages', {
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/populate_man_pages`, {
         machine_id: machineId
       })
 
@@ -585,7 +586,7 @@ export function useKnowledgeBase() {
   const populateAutoBotDocs = async (): Promise<AutoBotDocsResponse> => {
     try {
 
-      const response = await apiClient.post('/api/knowledge_base/populate_autobot_docs', {})
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/populate_autobot_docs`, {})
 
       logger.debug('[populateAutoBotDocs] Response received:', {
         ok: response.ok,
@@ -613,7 +614,7 @@ export function useKnowledgeBase() {
     try {
 
       const response = await apiClient.get(
-        `/api/knowledge_base/machine_profile?machine_id=${encodeURIComponent(machineId)}`
+        `${getApiBase()}/knowledge_base/machine_profile?machine_id=${encodeURIComponent(machineId)}`
       )
 
       logger.debug('[fetchMachineProfile] Response received:', {
@@ -641,7 +642,7 @@ export function useKnowledgeBase() {
   const fetchBasicStats = async (): Promise<KnowledgeStats | null> => {
     try {
 
-      const response = await apiClient.get('/api/knowledge_base/stats/basic')
+      const response = await apiClient.get(`${getApiBase()}/knowledge_base/stats/basic`)
 
       logger.debug('[fetchBasicStats] Response received:', {
         ok: response.ok,

--- a/autobot-frontend/src/composables/useKnowledgeGraph.ts
+++ b/autobot-frontend/src/composables/useKnowledgeGraph.ts
@@ -13,6 +13,7 @@
 import { ref, reactive } from 'vue'
 import apiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useKnowledgeGraph')
 
@@ -139,7 +140,7 @@ const stats = reactive({
   summaryCount: 0,
 })
 
-const API_BASE = '/api/knowledge-graph'
+const API_BASE = `${getApiBase()}/knowledge-graph`
 
 // ============================================================================
 // Composable

--- a/autobot-frontend/src/composables/useKnowledgeVectorization.ts
+++ b/autobot-frontend/src/composables/useKnowledgeVectorization.ts
@@ -11,6 +11,7 @@ import apiClient from '@/utils/ApiClient'
 import appConfig from '@/config/AppConfig.js'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 // Create scoped logger for useKnowledgeVectorization
 const logger = createLogger('useKnowledgeVectorization')
@@ -85,7 +86,7 @@ export function useKnowledgeVectorization() {
   const fetchDocumentStatus = async (documentId: string): Promise<VectorizationStatus> => {
     try {
       // Query actual backend status
-      const response = await apiClient.post('/api/knowledge_base/vectorization_status', {
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorization_status`, {
         fact_ids: [documentId],
         use_cache: true
       })
@@ -127,7 +128,7 @@ export function useKnowledgeVectorization() {
       for (let i = 0; i < documentIds.length; i += batchSize) {
         const batch = documentIds.slice(i, i + batchSize)
 
-        const response = await apiClient.post('/api/knowledge_base/vectorization_status', {
+        const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorization_status`, {
           fact_ids: batch,
           use_cache: true
         })
@@ -281,7 +282,7 @@ export function useKnowledgeVectorization() {
 
       // Call backend API to vectorize the fact with proper timeout
       // Issue #648: Use parseApiResponse to handle both Response objects and parsed JSON
-      const response = await apiClient.post(`/api/knowledge_base/vectorize_fact/${documentId}`, undefined, {
+      const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorize_fact/${documentId}`, undefined, {
         timeout: knowledgeTimeout
       })
 
@@ -306,7 +307,7 @@ export function useKnowledgeVectorization() {
 
         // Use knowledge timeout for job status polling as well
         // Issue #648: Use parseApiResponse to handle both Response objects and parsed JSON
-        const jobResponse = await apiClient.get(`/api/knowledge_base/vectorize_job/${jobId}`, {
+        const jobResponse = await apiClient.get(`${getApiBase()}/knowledge_base/vectorize_job/${jobId}`, {
           timeout: knowledgeTimeout
         })
         const jobData = await parseApiResponse(jobResponse)
@@ -354,7 +355,7 @@ export function useKnowledgeVectorization() {
   ): Promise<{ succeeded: string[], failed: string[] }> => {
     const knowledgeTimeout = appConfig.getTimeout('knowledge')
     const batchTimeout = Math.min(knowledgeTimeout * documentIds.length, 300000)
-    const response = await apiClient.post('/api/knowledge_base/vectorize_documents', {
+    const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorize_documents`, {
       document_ids: documentIds
     }, {
       timeout: batchTimeout

--- a/autobot-frontend/src/composables/useOperationsApi.ts
+++ b/autobot-frontend/src/composables/useOperationsApi.ts
@@ -20,6 +20,7 @@ import type {
   OperationStatus
 } from '@/types/operations'
 import { isTerminalStatus } from '@/types/operations'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useOperationsApi')
 
@@ -42,7 +43,7 @@ export function useOperationsApi() {
           if (filter?.limit) params.append('limit', filter.limit.toString())
 
           const queryString = params.toString()
-          const url = `/api/long-running/${queryString ? `?${queryString}` : ''}`
+          const url = `${getApiBase()}/long-running/${queryString ? `?${queryString}` : ''}`
           const response = await api.get(url)
           return await response.json()
         },
@@ -65,7 +66,7 @@ export function useOperationsApi() {
     async getOperation(operationId: string): Promise<Operation | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get(`/api/long-running/${operationId}`)
+          const response = await api.get(`${getApiBase()}/long-running/${operationId}`)
           return await response.json()
         },
         {
@@ -81,7 +82,7 @@ export function useOperationsApi() {
     async cancelOperation(operationId: string): Promise<CancelOperationResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.post(`/api/long-running/${operationId}/cancel`)
+          const response = await api.post(`${getApiBase()}/long-running/${operationId}/cancel`)
           return await response.json()
         },
         {
@@ -96,7 +97,7 @@ export function useOperationsApi() {
     async resumeOperation(operationId: string): Promise<ResumeOperationResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.post(`/api/long-running/${operationId}/resume`)
+          const response = await api.post(`${getApiBase()}/long-running/${operationId}/resume`)
           return await response.json()
         },
         {
@@ -111,7 +112,7 @@ export function useOperationsApi() {
     async getHealth(): Promise<OperationsHealthResponse | null> {
       return withErrorHandling(
         async () => {
-          const response = await api.get('/api/long-running/health')
+          const response = await api.get(`${getApiBase()}/long-running/health`)
           return await response.json()
         },
         {

--- a/autobot-frontend/src/composables/usePatternAnalysis.ts
+++ b/autobot-frontend/src/composables/usePatternAnalysis.ts
@@ -10,7 +10,7 @@
 
 import { ref, reactive, computed } from 'vue'
 import appConfig from '@/config/AppConfig.js'
-import { getConfig } from '@/config/ssot-config'
+import { getConfig, getApiBase } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { extractErrorMessage } from '@/utils/errorExtract'
@@ -155,8 +155,8 @@ export interface AnalysisTaskEntry {
 export function usePatternAnalysis() {
   // Background task for pattern summary (#1332)
   const summaryTask = useBackgroundTask(
-    '/api/analytics/codebase/patterns/summary',
-    '/api/analytics/codebase/patterns/summary/tasks/clear-stuck'
+    `${getApiBase()}/analytics/codebase/patterns/summary`,
+    `${getApiBase()}/analytics/codebase/patterns/summary/tasks/clear-stuck`
   )
 
   // Reactive state

--- a/autobot-frontend/src/composables/usePlugins.ts
+++ b/autobot-frontend/src/composables/usePlugins.ts
@@ -12,6 +12,7 @@
 import { ref } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('usePlugins')
 
@@ -55,7 +56,7 @@ export function usePlugins() {
     loading.value = true
     error.value = null
     try {
-      const data = await ApiClient.get('/api/plugins')
+      const data = await ApiClient.get(`${getApiBase()}/plugins`)
       plugins.value = data.plugins ?? []
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to list plugins'
@@ -70,7 +71,7 @@ export function usePlugins() {
     loading.value = true
     error.value = null
     try {
-      const data = await ApiClient.get('/api/plugins/discover')
+      const data = await ApiClient.get(`${getApiBase()}/plugins/discover`)
       discovered.value = data.discovered ?? []
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Failed to discover plugins'
@@ -84,7 +85,7 @@ export function usePlugins() {
   async function loadPlugin(name: string, config?: Record<string, unknown>): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post(`/api/plugins/${name}/load`, config ? { config } : {})
+      await ApiClient.post(`${getApiBase()}/plugins/${name}/load`, config ? { config } : {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -98,7 +99,7 @@ export function usePlugins() {
   async function unloadPlugin(name: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post(`/api/plugins/${name}/unload`, {})
+      await ApiClient.post(`${getApiBase()}/plugins/${name}/unload`, {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -112,7 +113,7 @@ export function usePlugins() {
   async function reloadPlugin(name: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post(`/api/plugins/${name}/reload`, {})
+      await ApiClient.post(`${getApiBase()}/plugins/${name}/reload`, {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -126,7 +127,7 @@ export function usePlugins() {
   async function enablePlugin(name: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post(`/api/plugins/${name}/enable`, {})
+      await ApiClient.post(`${getApiBase()}/plugins/${name}/enable`, {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -140,7 +141,7 @@ export function usePlugins() {
   async function disablePlugin(name: string): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.post(`/api/plugins/${name}/disable`, {})
+      await ApiClient.post(`${getApiBase()}/plugins/${name}/disable`, {})
       await listPlugins()
       return true
     } catch (err: unknown) {
@@ -153,7 +154,7 @@ export function usePlugins() {
 
   async function getPluginInfo(name: string): Promise<PluginInfo | null> {
     try {
-      return await ApiClient.get(`/api/plugins/${name}`)
+      return await ApiClient.get(`${getApiBase()}/plugins/${name}`)
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : `Failed to get info for plugin ${name}`
       logger.error('getPluginInfo error: %s', msg)
@@ -163,7 +164,7 @@ export function usePlugins() {
 
   async function getPluginConfig(name: string): Promise<Record<string, unknown> | null> {
     try {
-      return await ApiClient.get(`/api/plugins/${name}/config`)
+      return await ApiClient.get(`${getApiBase()}/plugins/${name}/config`)
     } catch {
       logger.warn('getPluginConfig: no config for %s', name)
       return null
@@ -176,7 +177,7 @@ export function usePlugins() {
   ): Promise<boolean> {
     error.value = null
     try {
-      await ApiClient.put(`/api/plugins/${name}/config`, { config })
+      await ApiClient.put(`${getApiBase()}/plugins/${name}/config`, { config })
       return true
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : `Failed to update config for plugin ${name}`

--- a/autobot-frontend/src/composables/usePreferences.ts
+++ b/autobot-frontend/src/composables/usePreferences.ts
@@ -11,6 +11,7 @@ import { ref, watch } from 'vue'
 import { setLocale } from '@/i18n'
 import apiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('usePreferences')
 
@@ -127,10 +128,10 @@ function applyLayoutDensity(density: LayoutDensity): void {
  * Sync language preference to backend personality profile
  */
 function syncLanguageToBackend(code: string): void {
-  apiClient.get('/api/personality/active').then((res) => {
+  apiClient.get(`${getApiBase()}/personality/active`).then((res) => {
     if (res.data && res.data.id) {
       apiClient.put(
-        `/api/personality/profiles/${res.data.id}`,
+        `${getApiBase()}/personality/profiles/${res.data.id}`,
         { language_code: code }
       )
     }

--- a/autobot-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-frontend/src/composables/usePrometheusMetrics.ts
@@ -15,6 +15,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import type { Ref, ComputedRef } from 'vue'
 import { useApi } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 // Create scoped logger
 const logger = createLogger('usePrometheusMetrics')
@@ -295,7 +296,7 @@ export function usePrometheusMetrics(
 
   async function fetchDashboard(): Promise<void> {
     try {
-      const response = await api.get('/api/monitoring/dashboard/overview')
+      const response = await api.get(`${getApiBase()}/monitoring/dashboard/overview`)
       if (response.ok) {
         dashboard.value = await response.json()
         lastUpdate.value = new Date()
@@ -312,7 +313,7 @@ export function usePrometheusMetrics(
 
   async function fetchServices(): Promise<void> {
     try {
-      const response = await api.get('/api/monitoring/services/health')
+      const response = await api.get(`${getApiBase()}/monitoring/services/health`)
       if (response.ok) {
         services.value = await response.json()
         error.value = null
@@ -328,7 +329,7 @@ export function usePrometheusMetrics(
 
   async function fetchAlerts(): Promise<void> {
     try {
-      const response = await api.get('/api/monitoring/alerts/check')
+      const response = await api.get(`${getApiBase()}/monitoring/alerts/check`)
       if (response.ok) {
         alerts.value = await response.json()
         error.value = null
@@ -344,7 +345,7 @@ export function usePrometheusMetrics(
 
   async function fetchRecommendations(): Promise<void> {
     try {
-      const response = await api.get('/api/monitoring/optimization/recommendations')
+      const response = await api.get(`${getApiBase()}/monitoring/optimization/recommendations`)
       if (response.ok) {
         recommendations.value = await response.json()
         error.value = null
@@ -360,7 +361,7 @@ export function usePrometheusMetrics(
 
   async function fetchGPUDetails(): Promise<void> {
     try {
-      const response = await api.get('/api/monitoring/hardware/gpu')
+      const response = await api.get(`${getApiBase()}/monitoring/hardware/gpu`)
       if (response.ok) {
         gpuDetails.value = await response.json()
         error.value = null
@@ -376,7 +377,7 @@ export function usePrometheusMetrics(
 
   async function fetchNPUDetails(): Promise<void> {
     try {
-      const response = await api.get('/api/monitoring/hardware/npu')
+      const response = await api.get(`${getApiBase()}/monitoring/hardware/npu`)
       if (response.ok) {
         npuDetails.value = await response.json()
         error.value = null
@@ -585,7 +586,7 @@ export function useSystemMetrics(pollInterval = 10000) {
   async function fetch() {
     isLoading.value = true
     try {
-      const response = await api.get('/api/monitoring/metrics/current')
+      const response = await api.get(`${getApiBase()}/monitoring/metrics/current`)
       if (response.ok) {
         const data = await response.json()
         metrics.value = data.metrics?.system || null
@@ -646,7 +647,7 @@ export function useServiceHealth(pollInterval = 15000) {
   async function fetch() {
     isLoading.value = true
     try {
-      const response = await api.get('/api/monitoring/services/health')
+      const response = await api.get(`${getApiBase()}/monitoring/services/health`)
       if (response.ok) {
         const data: ServicesSummary = await response.json()
         services.value = data.services || []
@@ -736,7 +737,7 @@ export function useAlerts(pollInterval = 30000) {
   async function fetch() {
     isLoading.value = true
     try {
-      const response = await api.get('/api/monitoring/alerts/check')
+      const response = await api.get(`${getApiBase()}/monitoring/alerts/check`)
       if (response.ok) {
         const data: AlertsSummary = await response.json()
         alerts.value = data.alerts || []

--- a/autobot-frontend/src/composables/useServiceMessages.ts
+++ b/autobot-frontend/src/composables/useServiceMessages.ts
@@ -10,6 +10,7 @@
 import { ref, onUnmounted } from 'vue'
 import { useApiWithState } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useServiceMessages')
 
@@ -78,7 +79,7 @@ export function useServiceMessages() {
           if (params?.receiver) sp.append('receiver', params.receiver)
           if (params?.msg_type) sp.append('msg_type', params.msg_type)
           const qs = sp.toString()
-          const url = `/api/service-messages/latest${qs ? `?${qs}` : ''}`
+          const url = `${getApiBase()}/service-messages/latest${qs ? `?${qs}` : ''}`
           const resp = await api.get(url)
           return (await resp.json()) as LatestMessagesResponse
         },
@@ -105,7 +106,7 @@ export function useServiceMessages() {
   ): Promise<SingleMessageResponse | null> {
     return withErrorHandling(
       async () => {
-        const resp = await api.get(`/api/service-messages/${msgId}`)
+        const resp = await api.get(`${getApiBase()}/service-messages/${msgId}`)
         return (await resp.json()) as SingleMessageResponse
       },
       { errorMessage: 'Failed to fetch service message', fallbackValue: null }
@@ -121,7 +122,7 @@ export function useServiceMessages() {
       const result = await withErrorHandling(
         async () => {
           const resp = await api.get(
-            `/api/service-messages/chain/${correlationId}`
+            `${getApiBase()}/service-messages/chain/${correlationId}`
           )
           return (await resp.json()) as CorrelationChainResponse
         },

--- a/autobot-frontend/src/composables/useSystemStatus.ts
+++ b/autobot-frontend/src/composables/useSystemStatus.ts
@@ -12,6 +12,7 @@
 import { ref, type Ref } from 'vue'
 import apiEndpointMapper from '@/utils/ApiEndpointMapper.js'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 // ---------------------------------------------------------------------------
 // Types & Interfaces
@@ -174,7 +175,7 @@ async function fetchVmStatus(): Promise<[SystemService[], boolean]> {
   try {
     const vmResponse =
       await apiEndpointMapper.fetchWithFallback(
-        '/api/service-monitor/vms/status',
+        `${getApiBase()}/service-monitor/vms/status`,
         { timeout: 5000 },
       ) as FallbackResponse
     const vmData: VmStatusResponse = await vmResponse.json()
@@ -224,7 +225,7 @@ async function fetchServiceStatus(): Promise<[SystemService[], boolean]> {
   try {
     const resp =
       await apiEndpointMapper.fetchWithFallback(
-        '/api/service-monitor/services',
+        `${getApiBase()}/service-monitor/services`,
         { timeout: 5000 },
       ) as FallbackResponse
     const data: ServicesResponse = await resp.json()

--- a/autobot-frontend/src/composables/useTLSCredentials.ts
+++ b/autobot-frontend/src/composables/useTLSCredentials.ts
@@ -12,7 +12,7 @@
  */
 
 import { ref, computed } from 'vue'
-import { getSLMUrl } from '@/config/ssot-config'
+import { getSLMUrl, getApiBase } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { showSubtleErrorNotification } from '@/utils/cacheManagement'
 import { createLogger } from '@/utils/debugUtils'
@@ -192,7 +192,7 @@ async function fetchNodes(): Promise<SLMNode[]> {
   error.value = null
 
   try {
-    const response = await slmFetch('/api/nodes')
+    const response = await slmFetch(`${getApiBase()}/nodes`)
     const data = await response.json()
     nodes.value = data.nodes || []
     return nodes.value
@@ -219,7 +219,7 @@ async function fetchNodeCredentials(nodeId: string): Promise<TLSCredential[]> {
   error.value = null
 
   try {
-    const response = await slmFetch(`/api/nodes/${nodeId}/tls-credentials`)
+    const response = await slmFetch(`${getApiBase()}/nodes/${nodeId}/tls-credentials`)
     const data = await response.json()
     credentials.value = data.credentials || []
     return credentials.value
@@ -245,7 +245,7 @@ async function createCredential(
   error.value = null
 
   try {
-    const response = await slmFetch(`/api/nodes/${nodeId}/tls-credentials`, {
+    const response = await slmFetch(`${getApiBase()}/nodes/${nodeId}/tls-credentials`, {
       method: 'POST',
       body: JSON.stringify(data),
     })
@@ -276,7 +276,7 @@ async function updateCredential(
   error.value = null
 
   try {
-    const response = await slmFetch(`/api/tls/credentials/${credentialId}`, {
+    const response = await slmFetch(`${getApiBase()}/tls/credentials/${credentialId}`, {
       method: 'PATCH',
       body: JSON.stringify(data),
     })
@@ -307,7 +307,7 @@ async function deleteCredential(credentialId: string): Promise<boolean> {
   error.value = null
 
   try {
-    await slmFetch(`/api/tls/credentials/${credentialId}`, {
+    await slmFetch(`${getApiBase()}/tls/credentials/${credentialId}`, {
       method: 'DELETE',
     })
 
@@ -331,7 +331,7 @@ async function deleteCredential(credentialId: string): Promise<boolean> {
  */
 async function getCredential(credentialId: string): Promise<TLSCredential | null> {
   try {
-    const response = await slmFetch(`/api/tls/credentials/${credentialId}`)
+    const response = await slmFetch(`${getApiBase()}/tls/credentials/${credentialId}`)
     return await response.json()
   } catch (err: unknown) {
     logger.error('Error fetching TLS credential:', err)
@@ -351,7 +351,7 @@ async function fetchAllEndpoints(): Promise<TLSEndpoint[]> {
   error.value = null
 
   try {
-    const response = await slmFetch('/api/tls/endpoints')
+    const response = await slmFetch(`${getApiBase()}/tls/endpoints`)
     const data = await response.json()
     endpoints.value = data.endpoints || []
     return endpoints.value
@@ -371,7 +371,7 @@ async function fetchAllEndpoints(): Promise<TLSEndpoint[]> {
  */
 async function fetchExpiringCertificates(days: number = 30): Promise<TLSEndpoint[]> {
   try {
-    const response = await slmFetch(`/api/tls/expiring?days=${days}`)
+    const response = await slmFetch(`${getApiBase()}/tls/expiring?days=${days}`)
     const data = await response.json()
     return data.endpoints || []
   } catch (err: unknown) {

--- a/autobot-frontend/src/composables/useVoiceConversation.ts
+++ b/autobot-frontend/src/composables/useVoiceConversation.ts
@@ -16,7 +16,7 @@ import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
 import { useChatController } from '@/models/controllers'
 import { useChatStore } from '@/stores/useChatStore'
 import { usePreferences } from '@/composables/usePreferences'
-import { getBackendWsUrl } from '@/config/ssot-config'
+import { getBackendWsUrl, getApiBase } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -624,7 +624,7 @@ async function _transcribeAudioWithLanguage(
   form.append('audio', blob, filename)
   const lang = _getShortLanguage()
   if (lang) form.append('language', lang)
-  const res = await fetchWithAuth('/api/voice/transcribe', {
+  const res = await fetchWithAuth(`${getApiBase()}/voice/transcribe`, {
     method: 'POST',
     body: form,
   })

--- a/autobot-frontend/src/composables/useVoiceOutput.ts
+++ b/autobot-frontend/src/composables/useVoiceOutput.ts
@@ -13,7 +13,7 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { useVoiceProfiles } from '@/composables/useVoiceProfiles'
 import { usePreferences } from '@/composables/usePreferences'
-import { getBackendWsUrl } from '@/config/ssot-config'
+import { getBackendWsUrl, getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useVoiceOutput')
 
@@ -259,7 +259,7 @@ export function useVoiceOutput() {
       if (language) {
         formData.append('language', language)
       }
-      const response = await fetchWithAuth('/api/voice/synthesize', {
+      const response = await fetchWithAuth(`${getApiBase()}/voice/synthesize`, {
         method: 'POST',
         body: formData,
       })

--- a/autobot-frontend/src/composables/useVoiceProfiles.ts
+++ b/autobot-frontend/src/composables/useVoiceProfiles.ts
@@ -11,6 +11,7 @@ import { ref, computed } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { usePreferences } from '@/composables/usePreferences'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useVoiceProfiles')
 
@@ -52,7 +53,7 @@ export function useVoiceProfiles() {
     loading.value = true
     error.value = null
     try {
-      const res = await fetchWithAuth('/api/voice/voices')
+      const res = await fetchWithAuth(`${getApiBase()}/voice/voices`)
       if (!res.ok) {
         error.value = `Failed to fetch voices: ${res.status}`
         return
@@ -84,7 +85,7 @@ export function useVoiceProfiles() {
       const formData = new FormData()
       formData.append('name', name)
       formData.append('audio', audioBlob, filename)
-      const res = await fetchWithAuth('/api/voice/voices/create', {
+      const res = await fetchWithAuth(`${getApiBase()}/voice/voices/create`, {
         method: 'POST',
         body: formData,
       })
@@ -108,7 +109,7 @@ export function useVoiceProfiles() {
     loading.value = true
     error.value = null
     try {
-      const res = await fetchWithAuth(`/api/voice/voices/${voiceId}`, {
+      const res = await fetchWithAuth(`${getApiBase()}/voice/voices/${voiceId}`, {
         method: 'DELETE',
       })
       if (!res.ok) {
@@ -136,7 +137,7 @@ export function useVoiceProfiles() {
 
   async function fetchPersonalityVoice(): Promise<void> {
     try {
-      const res = await fetchWithAuth('/api/personality/active')
+      const res = await fetchWithAuth(`${getApiBase()}/personality/active`)
       if (res.ok) {
         const profile = await res.json()
         personalityVoiceId.value = profile?.voice_id ?? ''

--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -13,7 +13,7 @@
  */
 
 import { ref, computed, reactive, onUnmounted, onMounted } from 'vue';
-import { getBackendUrl, getBackendWsUrl } from '@/config/ssot-config';
+import { getBackendUrl, getBackendWsUrl, getApiBase } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
 import { getAuthToken } from '@/utils/fetchWithAuth';
 import type { ApiResponse } from '@/types/api';
@@ -299,7 +299,7 @@ class WorkflowBuilderApiClient {
     context?: Record<string, unknown>,
     maxParallelTasks?: number
   ): Promise<ApiResponse<WorkflowExecutionResult>> {
-    return this.request('/api/orchestrator/workflow/execute', {
+    return this.request(`${getApiBase()}/orchestrator/workflow/execute`, {
       method: 'POST',
       body: JSON.stringify({
         goal,
@@ -315,7 +315,7 @@ class WorkflowBuilderApiClient {
     goal: string,
     context?: Record<string, unknown>
   ): Promise<ApiResponse<{ status: string; plan: WorkflowPlan; task_count: number }>> {
-    return this.request('/api/orchestrator/workflow/plan', {
+    return this.request(`${getApiBase()}/orchestrator/workflow/plan`, {
       method: 'POST',
       body: JSON.stringify({ goal, context }),
     });
@@ -325,14 +325,14 @@ class WorkflowBuilderApiClient {
   async getActiveOrchestrationWorkflows(): Promise<
     ApiResponse<{ status: string; active_count: number; workflows: ActiveWorkflow[] }>
   > {
-    return this.request('/api/orchestrator/workflow/active');
+    return this.request(`${getApiBase()}/orchestrator/workflow/active`);
   }
 
   /** Get agent performance metrics */
   async getAgentPerformance(): Promise<
     ApiResponse<{ status: string; performance_data: Record<string, AgentPerformance> }>
   > {
-    return this.request('/api/orchestrator/agents/performance');
+    return this.request(`${getApiBase()}/orchestrator/agents/performance`);
   }
 
   /** Get agent recommendations */
@@ -348,7 +348,7 @@ class WorkflowBuilderApiClient {
       agent_count: number;
     }>
   > {
-    return this.request('/api/orchestrator/agents/recommend', {
+    return this.request(`${getApiBase()}/orchestrator/agents/recommend`, {
       method: 'POST',
       body: JSON.stringify({
         task_type: taskType,
@@ -361,7 +361,7 @@ class WorkflowBuilderApiClient {
   async getExecutionStrategies(): Promise<
     ApiResponse<{ strategies: Record<string, StrategyInfo>; default: string }>
   > {
-    return this.request('/api/orchestrator/strategies');
+    return this.request(`${getApiBase()}/orchestrator/strategies`);
   }
 
   /** Get agent capabilities */
@@ -372,12 +372,12 @@ class WorkflowBuilderApiClient {
       total_agents: number;
     }>
   > {
-    return this.request('/api/orchestrator/capabilities');
+    return this.request(`${getApiBase()}/orchestrator/capabilities`);
   }
 
   /** Get orchestration system status */
   async getOrchestrationStatus(): Promise<ApiResponse<OrchestrationStatus>> {
-    return this.request('/api/orchestrator/status');
+    return this.request(`${getApiBase()}/orchestrator/status`);
   }
 
   /** Get example workflows */
@@ -387,7 +387,7 @@ class WorkflowBuilderApiClient {
       usage_tips: string[];
     }>
   > {
-    return this.request('/api/orchestrator/examples');
+    return this.request(`${getApiBase()}/orchestrator/examples`);
   }
 
   // ==================================================================================
@@ -402,7 +402,7 @@ class WorkflowBuilderApiClient {
     sessionId: string,
     automationMode: AutomationMode = 'semi_automatic'
   ): Promise<ApiResponse<{ success: boolean; workflow_id: string; message: string }>> {
-    return this.request('/api/workflow-automation/create_workflow', {
+    return this.request(`${getApiBase()}/workflow-automation/create_workflow`, {
       method: 'POST',
       body: JSON.stringify({
         name,
@@ -425,7 +425,7 @@ class WorkflowBuilderApiClient {
   async startWorkflow(
     workflowId: string
   ): Promise<ApiResponse<{ success: boolean; message: string }>> {
-    return this.request(`/api/workflow-automation/start_workflow/${workflowId}`, {
+    return this.request(`${getApiBase()}/workflow-automation/start_workflow/${workflowId}`, {
       method: 'POST',
     });
   }
@@ -437,7 +437,7 @@ class WorkflowBuilderApiClient {
     stepId?: string,
     userInput?: string
   ): Promise<ApiResponse<{ success: boolean; message: string }>> {
-    return this.request('/api/workflow-automation/control_workflow', {
+    return this.request(`${getApiBase()}/workflow-automation/control_workflow`, {
       method: 'POST',
       body: JSON.stringify({
         workflow_id: workflowId,
@@ -452,21 +452,21 @@ class WorkflowBuilderApiClient {
   async getWorkflowStatus(
     workflowId: string
   ): Promise<ApiResponse<{ success: boolean; workflow: ActiveWorkflow }>> {
-    return this.request(`/api/workflow-automation/workflow_status/${workflowId}`);
+    return this.request(`${getApiBase()}/workflow-automation/workflow_status/${workflowId}`);
   }
 
   /** Get all active workflows */
   async getActiveWorkflows(): Promise<
     ApiResponse<{ success: boolean; workflows: ActiveWorkflow[]; count: number }>
   > {
-    return this.request('/api/workflow-automation/active_workflows');
+    return this.request(`${getApiBase()}/workflow-automation/active_workflows`);
   }
 
   /** Get completed workflow history (#1367) */
   async getCompletedWorkflows(): Promise<
     ApiResponse<{ success: boolean; workflows: ActiveWorkflow[]; count: number }>
   > {
-    return this.request('/api/workflow-automation/completed_workflows');
+    return this.request(`${getApiBase()}/workflow-automation/completed_workflows`);
   }
 
   /** Create workflow from natural language */
@@ -485,7 +485,7 @@ class WorkflowBuilderApiClient {
       plan?: PlanApprovalRequest;
     }>
   > {
-    return this.request('/api/workflow-automation/create_from_chat', {
+    return this.request(`${getApiBase()}/workflow-automation/create_from_chat`, {
       method: 'POST',
       body: JSON.stringify({
         user_request: userRequest,
@@ -510,7 +510,7 @@ class WorkflowBuilderApiClient {
       plan: PlanApprovalRequest;
     }>
   > {
-    return this.request(`/api/workflow-automation/present_plan/${workflowId}`, {
+    return this.request(`${getApiBase()}/workflow-automation/present_plan/${workflowId}`, {
       method: 'POST',
       body: JSON.stringify({
         workflow_id: workflowId,
@@ -536,7 +536,7 @@ class WorkflowBuilderApiClient {
       message: string;
     }>
   > {
-    return this.request('/api/workflow-automation/approve_plan', {
+    return this.request(`${getApiBase()}/workflow-automation/approve_plan`, {
       method: 'POST',
       body: JSON.stringify({
         workflow_id: workflowId,
@@ -559,7 +559,7 @@ class WorkflowBuilderApiClient {
       approval: PlanApprovalRequest | null;
     }>
   > {
-    return this.request(`/api/workflow-automation/pending_approval/${workflowId}`);
+    return this.request(`${getApiBase()}/workflow-automation/pending_approval/${workflowId}`);
   }
 }
 

--- a/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
+++ b/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
@@ -9,7 +9,7 @@
  */
 
 import { ref } from 'vue';
-import { getBackendUrl } from '@/config/ssot-config';
+import { getBackendUrl, getApiBase } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
 import { getAuthToken } from '@/utils/fetchWithAuth';
 import type { ApiResponse } from '@/types/api';
@@ -132,7 +132,7 @@ export function useWorkflowNotificationConfig() {
       const res = await apiRequest<{
         success: boolean;
         notification_config: NotificationConfig | null;
-      }>(`/api/workflow-automation/notification_config/${workflowId}`);
+      }>(`${getApiBase()}/workflow-automation/notification_config/${workflowId}`);
 
       if (!res.success || !res.data) {
         configError.value = res.error ?? 'Failed to load config';
@@ -153,7 +153,7 @@ export function useWorkflowNotificationConfig() {
     configError.value = null;
     try {
       const res = await apiRequest<{ success: boolean }>(
-        `/api/workflow-automation/notification_config/${workflowId}`,
+        `${getApiBase()}/workflow-automation/notification_config/${workflowId}`,
         { method: 'PUT', body: JSON.stringify(payload) },
       );
       if (!res.success) {

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -606,6 +606,15 @@ export function getBackendUrl(): string {
 }
 
 /**
+ * Get API base path.
+ * Returns the configured API base path, defaulting to '/api'.
+ * Override with VITE_API_BASE_PATH environment variable for custom deployments.
+ */
+export function getApiBase(): string {
+  return import.meta.env.VITE_API_BASE_PATH || '/api'
+}
+
+/**
  * Get WebSocket URL (backward compatibility).
  */
 export function getWebsocketUrl(): string {


### PR DESCRIPTION
Closes #3630

## Changes

- Added `getApiBase()` to `autobot-frontend/src/config/ssot-config.ts` (prerequisite from #3628)
  - Reads from `VITE_API_BASE_PATH` env var, defaults to `'/api'`
- Replaced ~133 hardcoded `'/api/'` occurrences across 36 composable files
  - All path strings converted to template literals: `` `${getApiBase()}/path` ``
  - Existing ssot-config imports extended with `getApiBase` where applicable
  - New import added where file had no existing ssot-config import

## Files Modified

- `src/config/ssot-config.ts` — added `getApiBase()`
- 8 analytics composables under `src/composables/analytics/`
- 28 composables under `src/composables/`

## Verification

- No remaining `'/api/'` literals in composables/ (excluding test files and JSDoc comments)
- All `getApiBase()` usages have corresponding imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)