### PR TITLE
chore(slm-frontend): replace hardcoded /api/ with getSlmApiBase() in 3 remaining files

### DIFF
--- a/autobot-slm-frontend/src/composables/useExternalAgents.ts
+++ b/autobot-slm-frontend/src/composables/useExternalAgents.ts
@@ -16,11 +16,10 @@ import type {
   ExternalAgentUpdate,
   ExternalAgentCard,
 } from '@/types/slm'
-
-const API_BASE = ''
+import { getSlmApiBase } from '@/config/ssot-config'
 
 function makeClient() {
-  const client = axios.create({ baseURL: API_BASE })
+  const client = axios.create()
   client.interceptors.request.use((config) => {
     const token = sessionStorage.getItem('slm_access_token')
     if (token) {
@@ -47,7 +46,7 @@ export function useExternalAgents() {
     isLoading.value = true
     error.value = null
     try {
-      const response = await client.get<ExternalAgent[]>('/api/external-agents')
+      const response = await client.get<ExternalAgent[]>(`${getSlmApiBase()}/external-agents`)
       agents.value = response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to fetch external agents')
@@ -58,7 +57,7 @@ export function useExternalAgents() {
 
   async function getAgent(agentId: number): Promise<ExternalAgent | null> {
     try {
-      const response = await client.get<ExternalAgent>(`/api/external-agents/${agentId}`)
+      const response = await client.get<ExternalAgent>(`${getSlmApiBase()}/external-agents/${agentId}`)
       return response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to fetch agent')
@@ -68,7 +67,7 @@ export function useExternalAgents() {
 
   async function createAgent(data: ExternalAgentCreate): Promise<ExternalAgent | null> {
     try {
-      const response = await client.post<ExternalAgent>('/api/external-agents', data)
+      const response = await client.post<ExternalAgent>(`${getSlmApiBase()}/external-agents`, data)
       return response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to register agent')
@@ -81,7 +80,7 @@ export function useExternalAgents() {
     data: ExternalAgentUpdate
   ): Promise<ExternalAgent | null> {
     try {
-      const response = await client.put<ExternalAgent>(`/api/external-agents/${agentId}`, data)
+      const response = await client.put<ExternalAgent>(`${getSlmApiBase()}/external-agents/${agentId}`, data)
       return response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to update agent')
@@ -91,7 +90,7 @@ export function useExternalAgents() {
 
   async function deleteAgent(agentId: number): Promise<boolean> {
     try {
-      await client.delete(`/api/external-agents/${agentId}`)
+      await client.delete(`${getSlmApiBase()}/external-agents/${agentId}`)
       agents.value = agents.value.filter((a) => a.id !== agentId)
       return true
     } catch (e) {
@@ -103,7 +102,7 @@ export function useExternalAgents() {
   async function verifyAgent(agentId: number): Promise<ExternalAgent | null> {
     try {
       const response = await client.post<ExternalAgent & { success: boolean }>(
-        `/api/external-agents/${agentId}/verify`
+        `${getSlmApiBase()}/external-agents/${agentId}/verify`
       )
       return response.data
     } catch (e) {
@@ -114,7 +113,7 @@ export function useExternalAgents() {
 
   async function refreshAgentCard(agentId: number): Promise<boolean> {
     try {
-      await client.post(`/api/external-agents/${agentId}/refresh`)
+      await client.post(`${getSlmApiBase()}/external-agents/${agentId}/refresh`)
       return true
     } catch (e) {
       error.value = _extractError(e, 'Failed to queue card refresh')
@@ -124,7 +123,7 @@ export function useExternalAgents() {
 
   async function fetchCards(): Promise<ExternalAgentCard[]> {
     try {
-      const response = await client.get<ExternalAgentCard[]>('/api/external-agents/cards')
+      const response = await client.get<ExternalAgentCard[]>(`${getSlmApiBase()}/external-agents/cards`)
       return response.data
     } catch (e) {
       error.value = _extractError(e, 'Failed to fetch agent cards')

--- a/autobot-slm-frontend/src/composables/useRoles.ts
+++ b/autobot-slm-frontend/src/composables/useRoles.ts
@@ -10,6 +10,7 @@
 
 import { ref, reactive } from 'vue'
 import axios from 'axios'
+import { getSlmApiBase } from '@/config/ssot-config'
 
 export interface Role {
   name: string
@@ -123,12 +124,8 @@ export function useRoles() {
   const error = ref<string | null>(null)
   const fleetHealth = ref<FleetHealth | null>(null)
 
-  // SLM backend endpoints are at /api/* (proxied by nginx)
-  // NOT /autobot-api/* which goes to the Main AutoBot backend
-  const API_BASE = ''
-
   // Create axios instance with auth
-  const client = axios.create({ baseURL: API_BASE })
+  const client = axios.create()
   client.interceptors.request.use((config) => {
     const token = sessionStorage.getItem('slm_access_token')
     if (token) {
@@ -142,7 +139,7 @@ export function useRoles() {
     error.value = null
 
     try {
-      const response = await client.get<Role[]>('/api/roles')
+      const response = await client.get<Role[]>(`${getSlmApiBase()}/roles`)
       roles.value = response.data
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -155,7 +152,7 @@ export function useRoles() {
   async function getNodeRoles(nodeId: string): Promise<NodeRolesInfo | null> {
     try {
       const response = await client.get<NodeRolesInfo>(
-        `/api/nodes/${nodeId}/detected-roles`
+        `${getSlmApiBase()}/nodes/${nodeId}/detected-roles`
       )
       return response.data
     } catch (e: unknown) {
@@ -172,7 +169,7 @@ export function useRoles() {
   ): Promise<NodeRoleItem | null> {
     try {
       const response = await client.post<NodeRoleItem>(
-        `/api/nodes/${nodeId}/detected-roles`,
+        `${getSlmApiBase()}/nodes/${nodeId}/detected-roles`,
         { role_name: roleName, assignment_type: assignmentType }
       )
       return response.data
@@ -193,7 +190,7 @@ export function useRoles() {
         success: boolean
         message: string
         backup_path?: string
-      }>(`/api/nodes/${nodeId}/detected-roles/${roleName}`, {
+      }>(`${getSlmApiBase()}/nodes/${nodeId}/detected-roles/${roleName}`, {
         params: { backup },
       })
       return response.data
@@ -207,7 +204,7 @@ export function useRoles() {
 
   async function createRole(roleData: Partial<Role>): Promise<Role | null> {
     try {
-      const response = await client.post<Role>('/api/roles', roleData)
+      const response = await client.post<Role>(`${getSlmApiBase()}/roles`, roleData)
       return response.data
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -218,7 +215,7 @@ export function useRoles() {
 
   async function updateRole(roleName: string, roleData: Partial<Role>): Promise<Role | null> {
     try {
-      const response = await client.put<Role>(`/api/roles/${roleName}`, roleData)
+      const response = await client.put<Role>(`${getSlmApiBase()}/roles/${roleName}`, roleData)
       return response.data
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -229,7 +226,7 @@ export function useRoles() {
 
   async function deleteRole(roleName: string): Promise<boolean> {
     try {
-      await client.delete(`/api/roles/${roleName}`)
+      await client.delete(`${getSlmApiBase()}/roles/${roleName}`)
       return true
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -249,7 +246,7 @@ export function useRoles() {
         params.node_ids = nodeIds
       }
       const response = await client.post<SyncResult>(
-        `/api/code-sync/roles/${roleName}/sync`,
+        `${getSlmApiBase()}/code-sync/roles/${roleName}/sync`,
         null,
         { params }
       )
@@ -267,7 +264,7 @@ export function useRoles() {
   async function pullFromSource(): Promise<{ success: boolean; message: string; commit: string | null }> {
     try {
       const response = await client.post<{ success: boolean; message: string; commit: string | null }>(
-        `/api/code-sync/pull`
+        `${getSlmApiBase()}/code-sync/pull`
       )
       return response.data
     } catch (e: unknown) {
@@ -282,7 +279,7 @@ export function useRoles() {
 
   async function fetchFleetHealth(): Promise<void> {
     try {
-      const response = await client.get<FleetHealth>('/api/roles/fleet-health')
+      const response = await client.get<FleetHealth>(`${getSlmApiBase()}/roles/fleet-health`)
       fleetHealth.value = response.data
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } }; message?: string }
@@ -296,7 +293,7 @@ export function useRoles() {
   ): Promise<PlaybookMigrateResult | null> {
     try {
       const response = await client.post<PlaybookMigrateResult>(
-        `/api/roles/${roleName}/migrate`,
+        `${getSlmApiBase()}/roles/${roleName}/migrate`,
         { target_node_id: targetNodeId }
       )
       return response.data
@@ -313,7 +310,7 @@ export function useRoles() {
   ): Promise<NodeActionsResponse | null> {
     try {
       const resp = await client.get<NodeActionsResponse>(
-        `/api/roles/node-actions/${nodeId}`
+        `${getSlmApiBase()}/roles/node-actions/${nodeId}`
       )
       return resp.data
     } catch (e: unknown) {
@@ -336,7 +333,7 @@ export function useRoles() {
   ): Promise<ExecuteActionResult | null> {
     try {
       const resp = await client.post<ExecuteActionResult>(
-        `/api/roles/node-actions/${nodeId}/execute`,
+        `${getSlmApiBase()}/roles/node-actions/${nodeId}/execute`,
         { role_name: roleName, category }
       )
       return resp.data
@@ -359,7 +356,7 @@ export function useRoles() {
   ): Promise<DecommissionPreflight | null> {
     try {
       const resp = await client.get<DecommissionPreflight>(
-        `/api/nodes/${nodeId}/decommission/preflight`
+        `${getSlmApiBase()}/nodes/${nodeId}/decommission/preflight`
       )
       return resp.data
     } catch (e: unknown) {
@@ -386,7 +383,7 @@ export function useRoles() {
         message: string
         deployment_id: string
         output: string
-      }>(`/api/nodes/${nodeId}/decommission`, {
+      }>(`${getSlmApiBase()}/nodes/${nodeId}/decommission`, {
         backup,
         confirm_node_id: confirmNodeId,
       })
@@ -412,7 +409,7 @@ export function useRoles() {
       const resp = await client.post<{
         success: boolean
         message: string
-      }>(`/api/nodes/${nodeId}/reenroll`)
+      }>(`${getSlmApiBase()}/nodes/${nodeId}/reenroll`)
       return resp.data
     } catch (e: unknown) {
       const err = e as {

--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -11,6 +11,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
+import { getSlmApiBase } from '@/config/ssot-config'
 
 // One-time wizard completion check (Issue #1294)
 let wizardCheckDone = false
@@ -506,7 +507,7 @@ router.beforeEach(async (to, _from) => {
     wizardCheckDone = true
     try {
       const token = sessionStorage.getItem('slm_access_token')
-      const { data } = await axios.get('/api/setup/status', {
+      const { data } = await axios.get(`${getSlmApiBase()}/setup/status`, {
         headers: { Authorization: `Bearer ${token}` },
       })
       if (!data.completed) {


### PR DESCRIPTION
Closes #3627

## Changes
- `useRoles.ts`: replaced 16 hardcoded `/api/` with `getSlmApiBase()`; removed redundant `API_BASE` constant and `baseURL` on axios instance
- `useExternalAgents.ts`: replaced 8 hardcoded `/api/` with `getSlmApiBase()`; removed redundant `API_BASE` constant
- `router/index.ts`: replaced 1 occurrence (`'/api/setup/status'`) with `getSlmApiBase()`

## Verification
- `npx vue-tsc --noEmit` passes (only pre-existing tsconfig deprecation warning)
- Zero remaining `'/api/'` literals in all 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)