### PR TITLE
fix(backend): use local time in is_business_hours and is_weekend (#3619)

### DIFF
--- a/autobot-backend/context_aware_decision/time_provider.py
+++ b/autobot-backend/context_aware_decision/time_provider.py
@@ -35,24 +35,25 @@ class TimeProvider:
 
     @staticmethod
     def is_business_hours() -> bool:
-        """Check if current time is within business hours (9 AM - 5 PM)."""
-        current_hour = datetime.now(tz=timezone.utc).hour
+        """Check if current time is within business hours (9 AM - 5 PM, local server time)."""
+        current_hour = datetime.now().hour
         return 9 <= current_hour <= 17
 
     @staticmethod
     def is_weekend() -> bool:
-        """Check if current day is weekend."""
-        return datetime.now(tz=timezone.utc).weekday() >= 5
+        """Check if current day is weekend (local server time)."""
+        return datetime.now().weekday() >= 5
 
     @staticmethod
     def get_temporal_context_data() -> Dict[str, Any]:
         """Get comprehensive temporal context data."""
-        current_time = datetime.now(tz=timezone.utc)
+        current_time_utc = datetime.now(tz=timezone.utc)
+        current_time_local = datetime.now()
         return {
             "timestamp": time.time(),
-            "datetime": current_time.isoformat(),
-            "hour": current_time.hour,
-            "day_of_week": current_time.weekday(),
-            "is_business_hours": 9 <= current_time.hour <= 17,
-            "is_weekend": current_time.weekday() >= 5,
+            "datetime": current_time_utc.isoformat(),
+            "hour": current_time_local.hour,
+            "day_of_week": current_time_local.weekday(),
+            "is_business_hours": 9 <= current_time_local.hour <= 17,
+            "is_weekend": current_time_local.weekday() >= 5,
         }


### PR DESCRIPTION
Closes #3619

## Summary
- Revert `is_business_hours()` and `is_weekend()` to use local server time (`datetime.now()`)
- Also fix `get_temporal_context_data()` which had the same bug: `hour`, `day_of_week`, `is_business_hours`, and `is_weekend` fields now reflect local time while `datetime` field remains UTC ISO format
- `current_datetime()` correctly stays UTC-aware as it is a general-purpose utility

## Root cause
PR #3615 bulk-replaced `datetime.now()` → `datetime.now(tz=timezone.utc)` globally across 197 files to fix naive/aware datetime mixing. Business-hours and weekend checks are inherently local-time operations; using UTC causes incorrect results for servers in non-UTC timezones (e.g. UTC+3 at 9:00 local = 06:00 UTC, would be incorrectly classified as outside business hours).

## Test evidence
```
Local hour: 9, UTC hour: 6  ← 3-hour difference confirmed fix is meaningful
Syntax OK
Fix verified: is_business_hours/is_weekend now use local time
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)