### PR TITLE
fix(backend): normalize naive datetime from Redis in knowledge_manager (#3618)

### DIFF
--- a/autobot-backend/agents/machine_aware_system_knowledge_manager.py
+++ b/autobot-backend/agents/machine_aware_system_knowledge_manager.py
@@ -740,6 +740,8 @@ class MachineAwareSystemKnowledgeManager(SystemKnowledgeManager):
             from datetime import datetime, timedelta, timezone
 
             last_updated = datetime.fromisoformat(man_info.last_updated)
+            if last_updated.tzinfo is None:
+                last_updated = last_updated.replace(tzinfo=timezone.utc)
             age_threshold = datetime.now(tz=timezone.utc) - timedelta(hours=max_age_hours)
 
             return last_updated > age_threshold


### PR DESCRIPTION
Closes #3618

## Summary
- Normalize naive datetimes read from Redis by adding UTC tzinfo when tzinfo is None
- Prevents TypeError in naive/aware comparison after #3615 UTC migration

## Root cause
PR #3615 migrated `datetime.now()` to UTC-aware, but pre-migration Redis data stored naive datetime strings. `fromisoformat()` returns naive datetimes which raise `TypeError` on comparison with UTC-aware datetimes. The surrounding `except Exception: return False` caught it silently, treating all pre-migration man page cache entries as expired.

## Fix
Two lines added in `_is_man_page_recent()` after `fromisoformat()`:
```python
if last_updated.tzinfo is None:
    last_updated = last_updated.replace(tzinfo=timezone.utc)
```
This is the standard normalization pattern established in the #3615 migration (also applied in auth_middleware.py and agent_client.py).