### PR TITLE
fix(backend): normalize naive datetimes from Redis in stats and analytics (#3620)

### DIFF
--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -456,7 +456,7 @@ async def _collect_realtime_metrics_data() -> Dict[str, Any]:
             [
                 call
                 for call in analytics_state["api_call_patterns"]
-                if datetime.fromisoformat(call["timestamp"])
+                if _parse_timestamp(call["timestamp"])
                 > datetime.now(tz=timezone.utc) - timedelta(minutes=1)
             ]
         ),
@@ -537,6 +537,19 @@ async def track_analytics_event(
     }
 
 
+def _parse_timestamp(timestamp_str: str) -> datetime:
+    """Parse an ISO-format timestamp string and ensure it is UTC-aware.
+
+    Pre-#3615 Redis data may store naive datetime strings. After parsing with
+    fromisoformat(), normalize any naive result to UTC so comparisons with
+    UTC-aware datetimes do not raise TypeError.
+    """
+    dt = datetime.fromisoformat(timestamp_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def _parse_historical_calls(api_calls: list, cutoff_time: datetime) -> list:
     """Parse and filter historical API calls. (Issue #315 - extracted)
 
@@ -551,7 +564,7 @@ def _parse_historical_calls(api_calls: list, cutoff_time: datetime) -> list:
     for call_json in api_calls:
         try:
             call_data = json.loads(call_json)
-            call_time = datetime.fromisoformat(call_data["timestamp"])
+            call_time = _parse_timestamp(call_data["timestamp"])
             if call_time > cutoff_time:
                 historical_calls.append(call_data)
         except Exception as e:
@@ -940,7 +953,7 @@ def _get_recent_api_calls(cutoff_seconds: int = 10) -> list:
     return [
         call
         for call in analytics_state["api_call_patterns"]
-        if datetime.fromisoformat(call["timestamp"]) > cutoff
+        if _parse_timestamp(call["timestamp"]) > cutoff
     ]
 
 

--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -111,6 +111,8 @@ def _is_task_stale(task_info: dict) -> bool:
         from datetime import datetime, timezone
 
         start_time = datetime.fromisoformat(started_at)
+        if start_time.tzinfo is None:
+            start_time = start_time.replace(tzinfo=timezone.utc)
         elapsed = (datetime.now(tz=timezone.utc) - start_time).total_seconds()
         return elapsed > _STALE_TASK_TIMEOUT_SECONDS
     except (ValueError, TypeError):

--- a/autobot-backend/knowledge/stats.py
+++ b/autobot-backend/knowledge/stats.py
@@ -778,10 +778,14 @@ class StatsMixin:
             return None
         try:
             if "T" in timestamp_str:
-                return datetime.fromisoformat(
+                dt = datetime.fromisoformat(
                     timestamp_str.replace("Z", "+00:00").split("+")[0]
                 )
-            return datetime.strptime(timestamp_str, "%Y-%m-%d")
+            else:
+                dt = datetime.strptime(timestamp_str, "%Y-%m-%d")
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
         except (ValueError, TypeError):
             return None
 


### PR DESCRIPTION
Closes #3620

## Summary
- Add `_parse_timestamp()` helper in `api/analytics.py` that normalizes naive datetimes to UTC after `fromisoformat()` parsing; used at all 3 comparison sites in that file
- Normalize `start_time` in `api/codebase_analytics/endpoints/stats.py:_is_task_stale()` before subtracting from UTC-aware `datetime.now()`
- Normalize result of `_parse_fact_timestamp()` in `knowledge/stats.py` before it is compared against UTC-aware `now` in `_compute_age_buckets()`

## Root cause
PR #3615 migrated all `datetime.now()` calls to UTC-aware (`tz=timezone.utc`), but Redis data written before that migration stores naive ISO strings. `fromisoformat()` of those strings returns naive datetimes; comparing a naive datetime with an aware datetime raises `TypeError`, which is silently swallowed by the surrounding `except Exception` blocks — causing stale-task detection and age-bucket calculations to silently return wrong results.

## Fix pattern
```python
dt = datetime.fromisoformat(timestamp_str)
if dt.tzinfo is None:
    dt = dt.replace(tzinfo=timezone.utc)
```
Applied consistently at all 5 affected `fromisoformat()` call sites across the 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)