### PR TITLE
test: replace asyncio.get_event_loop() with asyncio.run() (#3605)

### DIFF
--- a/autobot-backend/chat_workflow/tool_loop_detection_test.py
+++ b/autobot-backend/chat_workflow/tool_loop_detection_test.py
@@ -356,26 +356,26 @@ class TestPrepareLlmResetsLoopState:
         """prepare_llm must return tool_loop_count=0 regardless of prior state."""
         state = self._make_state()
         config = self._make_config()
-        result = asyncio.get_event_loop().run_until_complete(prepare_llm(state, config))
+        result = asyncio.run(prepare_llm(state, config))
         assert result.get("tool_loop_count") == 0
 
     def test_fingerprints_reset_to_empty(self):
         """prepare_llm must return tool_call_fingerprints=[] regardless of prior state."""
         state = self._make_state()
         config = self._make_config()
-        result = asyncio.get_event_loop().run_until_complete(prepare_llm(state, config))
+        result = asyncio.run(prepare_llm(state, config))
         assert result.get("tool_call_fingerprints") == []
 
     def test_loop_warning_reset_to_empty(self):
         """prepare_llm must return tool_loop_warning='' regardless of prior state."""
         state = self._make_state()
         config = self._make_config()
-        result = asyncio.get_event_loop().run_until_complete(prepare_llm(state, config))
+        result = asyncio.run(prepare_llm(state, config))
         assert result.get("tool_loop_warning") == ""
 
     def test_error_state_skips_reset(self):
         """prepare_llm returns {} when error is set — no KeyError on reset fields."""
         state = self._make_state(error="something failed")
         config = self._make_config()
-        result = asyncio.get_event_loop().run_until_complete(prepare_llm(state, config))
+        result = asyncio.run(prepare_llm(state, config))
         assert result == {}


### PR DESCRIPTION
Closes #3605

## Changes
Replaces 4 deprecated `asyncio.get_event_loop().run_until_complete()` calls in `tool_loop_detection_test.py` with the modern `asyncio.run()` equivalent.

`asyncio.get_event_loop()` is deprecated in Python 3.10+ and removed in 3.12. All calls were in standalone test helper functions, so `asyncio.run()` is a direct drop-in replacement.

## Test plan
- [x] 27 tests pass with no deprecation warnings for these calls