### PR TITLE
refactor(helpers): add extra_data support to TaskResult (#3564)

### DIFF
--- a/autobot-backend/task_handlers/shell_handlers.py
+++ b/autobot-backend/task_handlers/shell_handlers.py
@@ -160,10 +160,11 @@ class ExecuteShellCommandHandler(TaskHandler):
                 "shell_used": use_shell,
             },
         )
-        result = task_error("Command failed.", error=error)
-        result["output"] = output
-        result["returncode"] = returncode
-        return result
+        return task_error(
+            "Command failed.",
+            error=error,
+            extra={"output": output, "returncode": returncode},
+        )
 
     def _build_result_and_log(
         self,

--- a/autobot_shared/models/task_result.py
+++ b/autobot_shared/models/task_result.py
@@ -6,16 +6,20 @@
 Issue #3545: Replaces 2200+ raw result dicts across task handler files with
 typed builder functions that enforce a consistent schema.
 
+Issue #3564: Adds ``extra`` field so callers can merge additional top-level keys
+into the serialised dict without post-hoc dict mutation.
+
 Usage::
 
     from autobot_shared.models.task_result import task_success, task_error, task_pending
 
     return task_success("Command executed securely.", data={"output": output})
     return task_error("Command failed.", error=stderr)
+    return task_error("Command failed.", error=stderr, extra={"output": out, "returncode": rc})
     return task_pending()
 """
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 
@@ -28,57 +32,84 @@ class TaskResult:
         message: Human-readable description of the outcome.
         data:    Optional payload returned to the caller (arbitrary structure).
         error:   Optional error detail string (populated on failure).
+        extra:   Optional mapping of additional top-level keys to merge into the
+                 serialised dict.  Keys in ``extra`` take precedence over the
+                 fixed fields when names collide.
     """
 
     status: str
     message: str
     data: Any = None
     error: str | None = None
+    extra: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
-        """Serialise to a plain dict, omitting keys whose value is None."""
-        return {k: v for k, v in asdict(self).items() if v is not None}
+        """Serialise to a plain dict, omitting fixed-field keys whose value is None.
+
+        ``extra`` keys are merged last so they can extend (but not accidentally
+        overwrite) the standard fields.  The ``extra`` key itself is never
+        included in the output.
+        """
+        base = {
+            k: v
+            for k, v in asdict(self).items()
+            if k != "extra" and v is not None
+        }
+        return {**base, **self.extra}
 
 
-def task_success(message: str, data: Any = None) -> dict:
+def task_success(message: str, data: Any = None, extra: dict | None = None) -> dict:
     """Return a success result dict.
 
     Args:
         message: Description of the successful outcome.
         data:    Optional structured payload to include in the response.
+        extra:   Optional mapping of additional top-level keys to merge into
+                 the serialised dict.
 
     Returns:
         Dict with ``status="success"`` and the supplied fields.
     """
-    return TaskResult("success", message, data=data).to_dict()
+    return TaskResult("success", message, data=data, extra=extra or {}).to_dict()
 
 
-def task_error(message: str, error: str | None = None) -> dict:
+def task_error(
+    message: str,
+    error: str | None = None,
+    extra: dict | None = None,
+) -> dict:
     """Return an error result dict.
 
     Args:
         message: Human-readable description of what went wrong.
         error:   Optional low-level error detail (e.g. stderr, exception text).
+        extra:   Optional mapping of additional top-level keys to merge into
+                 the serialised dict.
 
     Returns:
         Dict with ``status="error"`` and the supplied fields.
     """
-    return TaskResult("error", message, error=error).to_dict()
+    return TaskResult("error", message, error=error, extra=extra or {}).to_dict()
 
 
-def task_pending(message: str = "Task pending approval") -> dict:
+def task_pending(message: str = "Task pending approval", extra: dict | None = None) -> dict:
     """Return a pending result dict.
 
     Args:
         message: Optional override for the default pending message.
+        extra:   Optional mapping of additional top-level keys to merge into
+                 the serialised dict.
 
     Returns:
         Dict with ``status="pending"`` and the supplied message.
     """
-    return TaskResult("pending", message).to_dict()
+    return TaskResult("pending", message, extra=extra or {}).to_dict()
 
 
-def task_pending_approval(message: str = "Task pending approval") -> dict:
+def task_pending_approval(
+    message: str = "Task pending approval",
+    extra: dict | None = None,
+) -> dict:
     """Return a pending-approval result dict.
 
     Used when a task has been queued and is waiting for explicit user
@@ -86,8 +117,10 @@ def task_pending_approval(message: str = "Task pending approval") -> dict:
 
     Args:
         message: Optional override for the default pending-approval message.
+        extra:   Optional mapping of additional top-level keys to merge into
+                 the serialised dict.
 
     Returns:
         Dict with ``status="pending_approval"`` and the supplied message.
     """
-    return TaskResult("pending_approval", message).to_dict()
+    return TaskResult("pending_approval", message, extra=extra or {}).to_dict()

--- a/autobot_shared/models/task_result_test.py
+++ b/autobot_shared/models/task_result_test.py
@@ -179,3 +179,98 @@ def test_returned_dict_is_mutable():
     # Second call is independent
     d2 = task_error("Command failed.", error="stderr")
     assert "output" not in d2
+
+
+# ---------------------------------------------------------------------------
+# extra field — issue #3564
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_merges_extra_keys():
+    """extra keys must appear as top-level entries in the serialised dict."""
+    result = TaskResult(
+        status="error",
+        message="fail",
+        error="stderr",
+        extra={"output": "stdout text", "returncode": 1},
+    )
+    d = result.to_dict()
+    assert d["output"] == "stdout text"
+    assert d["returncode"] == 1
+
+
+def test_to_dict_extra_key_does_not_appear():
+    """The 'extra' key itself must never be present in the output dict."""
+    result = TaskResult(status="success", message="ok", extra={"foo": "bar"})
+    d = result.to_dict()
+    assert "extra" not in d
+
+
+def test_to_dict_none_fixed_field_still_omitted_with_extra():
+    """None-omission for fixed fields must still apply when extra is provided."""
+    result = TaskResult(
+        status="error",
+        message="fail",
+        extra={"returncode": 2},
+    )
+    d = result.to_dict()
+    assert "error" not in d
+    assert "data" not in d
+    assert d["returncode"] == 2
+
+
+def test_to_dict_empty_extra_has_no_effect():
+    result = TaskResult(status="success", message="ok", extra={})
+    d = result.to_dict()
+    assert set(d.keys()) == {"status", "message"}
+
+
+def test_task_error_with_extra():
+    """task_error builder must pass extra through to the serialised dict."""
+    d = task_error(
+        "Command failed.",
+        error="stderr",
+        extra={"output": "stdout", "returncode": 1},
+    )
+    assert d["status"] == "error"
+    assert d["error"] == "stderr"
+    assert d["output"] == "stdout"
+    assert d["returncode"] == 1
+    assert "extra" not in d
+
+
+def test_task_success_with_extra():
+    d = task_success("ok", data={"count": 1}, extra={"elapsed_ms": 42})
+    assert d["status"] == "success"
+    assert d["data"] == {"count": 1}
+    assert d["elapsed_ms"] == 42
+    assert "extra" not in d
+
+
+def test_task_pending_with_extra():
+    d = task_pending("waiting", extra={"queue_position": 3})
+    assert d["status"] == "pending"
+    assert d["queue_position"] == 3
+    assert "extra" not in d
+
+
+def test_task_pending_approval_with_extra():
+    d = task_pending_approval(extra={"approval_id": "abc"})
+    assert d["status"] == "pending_approval"
+    assert d["approval_id"] == "abc"
+    assert "extra" not in d
+
+
+def test_extra_none_is_treated_as_empty():
+    """Passing extra=None must produce the same result as omitting extra."""
+    d1 = task_error("fail", extra=None)
+    d2 = task_error("fail")
+    assert d1 == d2
+
+
+def test_extra_keys_independent_across_calls():
+    """extra dicts from separate calls must not share state."""
+    d1 = task_error("fail", extra={"output": "a"})
+    d2 = task_error("fail", extra={"output": "b"})
+    assert d1["output"] == "a"
+    assert d2["output"] == "b"


### PR DESCRIPTION
Closes #3564

## Changes
- Added `extra: dict = field(default_factory=dict)` field to `TaskResult` dataclass
- `to_dict()` now merges `extra` contents into the output dict (the `extra` key itself is excluded)
- All four builder functions (`task_success`, `task_error`, `task_pending`, `task_pending_approval`) accept an optional `extra: dict | None = None` parameter
- Replaced the fragile 3-line dict mutation in `shell_handlers._build_error_result()` with `task_error(..., extra={"output": output, "returncode": returncode})`

## Test plan
- [x] 34 tests pass (10 new tests for extra-key behavior)
- [x] shell_handlers no longer uses dict mutation workaround