### PR TITLE
chore(frontend): adopt getApiBase() in stores, models, and components (Phase 3)

### DIFF
--- a/autobot-frontend/src/components/ChatInterface.ts
+++ b/autobot-frontend/src/components/ChatInterface.ts
@@ -1,6 +1,7 @@
 // ChatInterface TypeScript definitions and setup
 import { ref, computed, onUnmounted, nextTick } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 // Create scoped logger for ChatInterface
 const logger = createLogger('ChatInterface')
@@ -263,7 +264,7 @@ export function useChatInterface() {
       // Upload files in parallel - eliminates N+1 sequential uploads
       const uploadResults = await Promise.allSettled(
         filesToUpload.map(async (file) => {
-          const result = (await apiClient.uploadFile('/api/files/upload', file)) as unknown as FileUploadResponse
+          const result = (await apiClient.uploadFile(`${getApiBase()}/files/upload`, file)) as unknown as FileUploadResponse
           const filePath = result.path || result.filename || file.name
           await associateFileWithChat(filePath, file.name)
           return filePath

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -606,6 +606,16 @@ export function getBackendUrl(): string {
 }
 
 /**
+ * Get API base path (backward compatibility).
+ * Returns the configurable API base path prefix. Defaults to '/api'.
+ * Override with VITE_API_BASE_PATH environment variable.
+ * Issue: #3631
+ */
+export function getApiBase(): string {
+  return import.meta.env.VITE_API_BASE_PATH || '/api'
+}
+
+/**
  * Get WebSocket URL (backward compatibility).
  */
 export function getWebsocketUrl(): string {

--- a/autobot-frontend/src/models/repositories/ApiRepository.ts
+++ b/autobot-frontend/src/models/repositories/ApiRepository.ts
@@ -1,6 +1,7 @@
 import type { ApiResponse, RequestOptions } from '@/types/models'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { extractErrorMessage } from '@/utils/errorExtract'
+import { getApiBase } from '@/config/ssot-config'
 
 // Note: Window.rum type is defined in @/utils/RumAgent.ts
 
@@ -41,10 +42,10 @@ export class ApiRepository {
       defaultTTL: 5 * 60 * 1000, // 5 minutes
       maxSize: 100,
       endpoints: {
-        '/api/settings/': 10 * 60 * 1000, // 10 minutes
-        '/api/system/health': 30 * 1000,   // 30 seconds
-        '/api/prompts/': 15 * 60 * 1000,   // 15 minutes
-        '/api/chats': 2 * 60 * 1000,       // 2 minutes
+        [`${getApiBase()}/settings/`]: 10 * 60 * 1000, // 10 minutes
+        [`${getApiBase()}/system/health`]: 30 * 1000,   // 30 seconds
+        [`${getApiBase()}/prompts/`]: 15 * 60 * 1000,   // 15 minutes
+        [`${getApiBase()}/chats`]: 2 * 60 * 1000,       // 2 minutes
       }
     }
   }
@@ -294,7 +295,7 @@ export class ApiRepository {
   async testConnection(): Promise<{ connected: boolean; latency?: number; message: string }> {
     try {
       const start = Date.now()
-      await this.get('/api/system/health')
+      await this.get(`${getApiBase()}/system/health`)
       const latency = Date.now() - start
 
       return {

--- a/autobot-frontend/src/models/repositories/ChatRepository.ts
+++ b/autobot-frontend/src/models/repositories/ChatRepository.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import type { AxiosInstance, AxiosResponse, AxiosRequestConfig } from 'axios'
-import { getBackendUrl } from '@/config/ssot-config'
+import { getBackendUrl, getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import type { ChatMessage } from '@/types/api'
 
@@ -226,7 +226,7 @@ export class ChatRepository {
       }
 
       // Use native fetch API for proper SSE streaming support
-      const url = `${this.baseURL}/api/chats/${chatId}/message`
+      const url = `${this.baseURL}${getApiBase()}/chats/${chatId}/message`
       const fetchHeaders: Record<string, string> = { 'Content-Type': 'application/json' }
       const authToken = this._getAuthToken()
       if (authToken) fetchHeaders['Authorization'] = `Bearer ${authToken}`
@@ -274,7 +274,7 @@ export class ChatRepository {
   ): Promise<void> {
     try {
       const response = await this.axios.post(
-        '/api/chat',
+        `${getApiBase()}/chat`,
         {
           message,
           chat_id: chatId,
@@ -321,7 +321,7 @@ export class ChatRepository {
   // Create new chat session
   async createNewChat(title?: string, metadata?: Record<string, unknown>): Promise<ChatSession> {
     try {
-      const response = await this.post('/api/chat/sessions', {
+      const response = await this.post(`${getApiBase()}/chat/sessions`, {
         title: title || 'New Chat',
         metadata: metadata || {}
       })
@@ -340,7 +340,7 @@ export class ChatRepository {
   // Get list of all chat sessions (for compatibility with controller)
   async getChatList(): Promise<ChatSession[]> {
     try {
-      const response = await this.get('/api/chat/sessions')
+      const response = await this.get(`${getApiBase()}/chat/sessions`)
       // Fix: axios wraps response in .data, and API response has { data: { sessions: [...] } }
       const sessions = response.data?.data?.sessions || response.data?.sessions || []
 
@@ -362,7 +362,7 @@ export class ChatRepository {
   // Get single session by ID
   async getSession(sessionId: string): Promise<ChatSession> {
     try {
-      const response = await this.get(`/api/chat/sessions/${sessionId}`)
+      const response = await this.get(`${getApiBase()}/chat/sessions/${sessionId}`)
       return response.data
     } catch (error: unknown) {
       logger.error('Failed to get session:', error)
@@ -374,7 +374,7 @@ export class ChatRepository {
   async getChatMessages(sessionId: string): Promise<ChatMessage[]> {
     try {
       logger.debug(`Fetching messages for session: ${sessionId}`)
-      const response = await this.get(`/api/chat/sessions/${sessionId}`)
+      const response = await this.get(`${getApiBase()}/chat/sessions/${sessionId}`)
       const data = response.data
       logger.debug(`Raw API response:`, JSON.stringify(data).substring(0, 200))
 
@@ -473,7 +473,7 @@ export class ChatRepository {
         params.file_options = JSON.stringify(fileOptions)
       }
 
-      const response = await this.delete(`/api/chat/sessions/${chatId}`, { params })
+      const response = await this.delete(`${getApiBase()}/chat/sessions/${chatId}`, { params })
       return response.data || response
     } catch (error: unknown) {
       logger.error('Failed to delete chat:', error)
@@ -485,7 +485,7 @@ export class ChatRepository {
   // Issue #552: Fixed path - backend uses /api/chat/reset
   async resetChat(): Promise<AxiosResponse> {
     try {
-      const response = await this.post('/api/chat/reset')
+      const response = await this.post(`${getApiBase()}/chat/reset`)
       return response.data || response
     } catch (error: unknown) {
       logger.error('Failed to reset chat:', error)
@@ -497,7 +497,7 @@ export class ChatRepository {
   // Issue #552: Fixed path - backend uses /api/chat/sessions
   async getChatHistory(): Promise<{ messages: ChatMessage[] }> {
     try {
-      const response = await this.get('/api/chat/sessions')
+      const response = await this.get(`${getApiBase()}/chat/sessions`)
       return response.data || response
     } catch (error: unknown) {
       logger.warn('Failed to get chat history (legacy):', error)
@@ -509,7 +509,7 @@ export class ChatRepository {
     try {
       // CRITICAL FIX Issue #259: Wrap messages in 'data' object to match backend expectation
       // Backend expects: { data: { messages: [...], name: "..." } }
-      const response = await this.post(`/api/chats/${params.chatId}/save`, {
+      const response = await this.post(`${getApiBase()}/chats/${params.chatId}/save`, {
         data: {
           messages: params.messages,
           name: params.name || ''
@@ -533,7 +533,7 @@ export class ChatRepository {
   async getSessionFacts(sessionId: string): Promise<SessionFactsResponse> {
     try {
       // Issue #552: Fixed path - backend uses /api/chat-knowledge/chat/sessions/*
-      const response = await this.get(`/api/chat-knowledge/chat/sessions/${sessionId}/facts`)
+      const response = await this.get(`${getApiBase()}/chat-knowledge/chat/sessions/${sessionId}/facts`)
       return response.data || response
     } catch (error: unknown) {
       logger.error('Failed to get session facts:', error)
@@ -552,7 +552,7 @@ export class ChatRepository {
   ): Promise<PreserveFactsResponse> {
     try {
       // Issue #552: Fixed path - backend uses /api/chat-knowledge/chat/sessions/*
-      const response = await this.post(`/api/chat-knowledge/chat/sessions/${sessionId}/facts/preserve`, {
+      const response = await this.post(`${getApiBase()}/chat-knowledge/chat/sessions/${sessionId}/facts/preserve`, {
         fact_ids: factIds,
         preserve
       })

--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -16,6 +16,7 @@ import type {
   ConnectorStatus,
   SyncResult
 } from '@/types/knowledgeBase'
+import { getApiBase } from '@/config/ssot-config'
 
 // Re-export types for convenience
 export type { KnowledgeDocument, SearchResult }
@@ -172,7 +173,7 @@ export class KnowledgeRepository extends ApiRepository {
    * Supports both simple and advanced filtering
    */
   async searchKnowledge(request: SearchKnowledgeRequest): Promise<SearchResult[]> {
-    const response = await this.post('/api/knowledge_base/search', {
+    const response = await this.post(`${getApiBase()}/knowledge_base/search`, {
       query: request.query,
       limit: request.limit || 20,
       category: request.category,
@@ -207,7 +208,7 @@ export class KnowledgeRepository extends ApiRepository {
 
   // RAG-enhanced search using dedicated endpoint
   async ragSearch(request: RagSearchRequest): Promise<RagSearchResponse> {
-    const response = await this.post('/api/knowledge_base/rag_search', {
+    const response = await this.post(`${getApiBase()}/knowledge_base/rag_search`, {
       query: request.query,
       top_k: request.top_k || 10,
       limit: request.limit || 10,
@@ -218,7 +219,7 @@ export class KnowledgeRepository extends ApiRepository {
 
   // Legacy search method for backward compatibility
   async searchKnowledgeBase(query: string, limit: number = 5): Promise<SearchResult[]> {
-    const response = await this.post('/api/knowledge_base/search', {
+    const response = await this.post(`${getApiBase()}/knowledge_base/search`, {
       query,
       n_results: limit
     })
@@ -240,7 +241,7 @@ export class KnowledgeRepository extends ApiRepository {
   }> {
     // Support both 'text' and 'content' fields
     const textContent = request.text || request.content || ''
-    const response = await this.post('/api/knowledge_base/facts', {
+    const response = await this.post(`${getApiBase()}/knowledge_base/facts`, {
       content: textContent,
       title: request.title || '',
       source: request.source || 'Manual Entry',
@@ -253,7 +254,7 @@ export class KnowledgeRepository extends ApiRepository {
   // Legacy add text method
   // Issue #552: Fixed path - backend uses /api/knowledge_base/add_text
   async addKnowledge(content: string, metadata: Record<string, any> = {}): Promise<any> {
-    const response = await this.post('/api/knowledge_base/add_text', {
+    const response = await this.post(`${getApiBase()}/knowledge_base/add_text`, {
       content,
       metadata
     })
@@ -271,7 +272,7 @@ export class KnowledgeRepository extends ApiRepository {
     content?: string
     message?: string
   }> {
-    const response = await this.post('/api/knowledge_base/url', {
+    const response = await this.post(`${getApiBase()}/knowledge_base/url`, {
       url: request.url,
       title: request.title,
       method: request.method || 'fetch',
@@ -308,7 +309,7 @@ export class KnowledgeRepository extends ApiRepository {
       formData.append('tags', JSON.stringify(options.tags))
     }
 
-    const response = await this.post('/api/knowledge_base/upload', formData)
+    const response = await this.post(`${getApiBase()}/knowledge_base/upload`, formData)
     return response.data
   }
 
@@ -317,7 +318,7 @@ export class KnowledgeRepository extends ApiRepository {
    */
   async exportKnowledge(): Promise<Blob> {
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const response = await this.post('/api/knowledge-maintenance/export')
+    const response = await this.post(`${getApiBase()}/knowledge-maintenance/export`)
     return response.data
   }
 
@@ -326,7 +327,7 @@ export class KnowledgeRepository extends ApiRepository {
    */
   async cleanupKnowledge(): Promise<{ success: boolean; message: string; removed_count?: number }> {
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const response = await this.post('/api/knowledge-maintenance/cleanup')
+    const response = await this.post(`${getApiBase()}/knowledge-maintenance/cleanup`)
     return response.data
   }
 
@@ -334,7 +335,7 @@ export class KnowledgeRepository extends ApiRepository {
    * Get basic knowledge base statistics
    */
   async getKnowledgeStats(): Promise<KnowledgeStats> {
-    const response = await this.get('/api/knowledge_base/stats/basic')
+    const response = await this.get(`${getApiBase()}/knowledge_base/stats/basic`)
     return response.data
   }
 
@@ -342,7 +343,7 @@ export class KnowledgeRepository extends ApiRepository {
    * Get detailed knowledge base statistics
    */
   async getDetailedKnowledgeStats(): Promise<DetailedKnowledgeStats> {
-    const response = await this.get('/api/knowledge_base/detailed_stats')
+    const response = await this.get(`${getApiBase()}/knowledge_base/detailed_stats`)
     return response.data
   }
 
@@ -350,7 +351,7 @@ export class KnowledgeRepository extends ApiRepository {
    * Get all categories in knowledge base
    */
   async getCategories(): Promise<string[]> {
-    const response = await this.get('/api/knowledge_base/categories')
+    const response = await this.get(`${getApiBase()}/knowledge_base/categories`)
     return response.data
   }
 
@@ -358,7 +359,7 @@ export class KnowledgeRepository extends ApiRepository {
    * Get documents by category
    */
   async getDocumentsByCategory(category: string): Promise<KnowledgeDocument[]> {
-    const response = await this.get(`/api/knowledge_base/categories/${encodeURIComponent(category)}/documents`)
+    const response = await this.get(`${getApiBase()}/knowledge_base/categories/${encodeURIComponent(category)}/documents`)
     return response.data
   }
 
@@ -366,7 +367,7 @@ export class KnowledgeRepository extends ApiRepository {
    * Get document by ID
    */
   async getDocument(documentId: string): Promise<KnowledgeDocument> {
-    const response = await this.get(`/api/knowledge_base/documents/${documentId}`)
+    const response = await this.get(`${getApiBase()}/knowledge_base/documents/${documentId}`)
     return response.data
   }
 
@@ -375,7 +376,7 @@ export class KnowledgeRepository extends ApiRepository {
    */
   async updateDocument(documentId: string, updates: Partial<KnowledgeDocument>): Promise<KnowledgeDocument> {
     // Use facts endpoint for consistency with backend
-    const response = await this.put(`/api/knowledge_base/facts/${documentId}`, updates)
+    const response = await this.put(`${getApiBase()}/knowledge_base/facts/${documentId}`, updates)
     return response.data
   }
 
@@ -384,7 +385,7 @@ export class KnowledgeRepository extends ApiRepository {
    */
   async deleteDocument(documentId: string): Promise<{ success: boolean; message: string }> {
     // Use facts endpoint for consistency with backend
-    const response = await this.delete(`/api/knowledge_base/facts/${documentId}`)
+    const response = await this.delete(`${getApiBase()}/knowledge_base/facts/${documentId}`)
     return response.data
   }
 
@@ -395,7 +396,7 @@ export class KnowledgeRepository extends ApiRepository {
    * This endpoint may need adjustment based on collection context
    */
   async bulkDeleteDocuments(documentIds: string[], collectionId: string = 'default'): Promise<{ success: boolean; deleted_count: number }> {
-    const response = await this.post(`/api/knowledge_base/collections/${collectionId}/bulk-delete`, {
+    const response = await this.post(`${getApiBase()}/knowledge_base/collections/${collectionId}/bulk-delete`, {
       fact_ids: documentIds
     })
     return response.data
@@ -405,7 +406,7 @@ export class KnowledgeRepository extends ApiRepository {
    * Get similar documents to a given document
    */
   async getSimilarDocuments(documentId: string, limit: number = 5): Promise<SearchResult[]> {
-    const response = await this.get(`/api/knowledge_base/documents/${documentId}/similar?limit=${limit}`)
+    const response = await this.get(`${getApiBase()}/knowledge_base/documents/${documentId}/similar?limit=${limit}`)
 
     // Transform results to match SearchResult format
     const results = response.data.results || response.data || []
@@ -431,7 +432,7 @@ export class KnowledgeRepository extends ApiRepository {
    */
   async getSearchSuggestions(query: string, limit: number = 8): Promise<string[]> {
     try {
-      const response = await this.get(`/api/knowledge_base/suggestions?query=${encodeURIComponent(query)}&limit=${limit}`)
+      const response = await this.get(`${getApiBase()}/knowledge_base/suggestions?query=${encodeURIComponent(query)}&limit=${limit}`)
       return response.data || []
     } catch {
       // Return empty array if suggestions endpoint not available
@@ -445,7 +446,7 @@ export class KnowledgeRepository extends ApiRepository {
    * Consider using vectorize_facts/background for knowledge base specific reindex
    */
   async reindexKnowledgeBase(): Promise<{ success: boolean; message: string }> {
-    const response = await this.post('/api/rebuild_index')
+    const response = await this.post(`${getApiBase()}/rebuild_index`)
     return response.data
   }
 
@@ -453,7 +454,7 @@ export class KnowledgeRepository extends ApiRepository {
    * Check knowledge base health status
    */
   async checkKnowledgeBaseHealth(): Promise<{ healthy: boolean; message: string }> {
-    const response = await this.get('/api/knowledge_base/health')
+    const response = await this.get(`${getApiBase()}/knowledge_base/health`)
     return response.data
   }
 
@@ -469,7 +470,7 @@ export class KnowledgeRepository extends ApiRepository {
     pageSize = 20
   ): Promise<{ sources: PendingSource[]; total: number; page: number }> {
     const response = await this.get(
-      `/api/knowledge_base/verification/pending?page=${page}&page_size=${pageSize}`,
+      `${getApiBase()}/knowledge_base/verification/pending?page=${page}&page_size=${pageSize}`,
       { skipCache: true }
     )
     return response.data
@@ -483,7 +484,7 @@ export class KnowledgeRepository extends ApiRepository {
     user: string
   ): Promise<{ status: string; message: string }> {
     const response = await this.post(
-      `/api/knowledge_base/verification/${encodeURIComponent(factId)}/approve`,
+      `${getApiBase()}/knowledge_base/verification/${encodeURIComponent(factId)}/approve`,
       { user, delete_on_reject: false }
     )
     return response.data
@@ -498,7 +499,7 @@ export class KnowledgeRepository extends ApiRepository {
     deleteOnReject = false
   ): Promise<{ status: string; message: string }> {
     const response = await this.post(
-      `/api/knowledge_base/verification/${encodeURIComponent(factId)}/reject`,
+      `${getApiBase()}/knowledge_base/verification/${encodeURIComponent(factId)}/reject`,
       { user, delete_on_reject: deleteOnReject }
     )
     return response.data
@@ -509,7 +510,7 @@ export class KnowledgeRepository extends ApiRepository {
    */
   async getVerificationConfig(): Promise<VerificationConfig> {
     const response = await this.get(
-      '/api/knowledge_base/verification/config',
+      `${getApiBase()}/knowledge_base/verification/config`,
       { skipCache: true }
     )
     return response.data
@@ -522,7 +523,7 @@ export class KnowledgeRepository extends ApiRepository {
     config: VerificationConfig
   ): Promise<{ status: string; config: VerificationConfig }> {
     const response = await this.put(
-      '/api/knowledge_base/verification/config',
+      `${getApiBase()}/knowledge_base/verification/config`,
       config
     )
     return response.data
@@ -540,7 +541,7 @@ export class KnowledgeRepository extends ApiRepository {
     statuses: Record<string, ConnectorStatus>
   }> {
     const response = await this.get(
-      '/api/knowledge_base/connectors',
+      `${getApiBase()}/knowledge_base/connectors`,
       { skipCache: true }
     )
     return response.data
@@ -553,7 +554,7 @@ export class KnowledgeRepository extends ApiRepository {
     config: Partial<ConnectorConfig>
   ): Promise<ConnectorConfig> {
     const response = await this.post(
-      '/api/knowledge_base/connectors',
+      `${getApiBase()}/knowledge_base/connectors`,
       config
     )
     return response.data
@@ -566,7 +567,7 @@ export class KnowledgeRepository extends ApiRepository {
     id: string
   ): Promise<{ config: ConnectorConfig; status: ConnectorStatus }> {
     const response = await this.get(
-      `/api/knowledge_base/connectors/${encodeURIComponent(id)}`,
+      `${getApiBase()}/knowledge_base/connectors/${encodeURIComponent(id)}`,
       { skipCache: true }
     )
     return response.data
@@ -580,7 +581,7 @@ export class KnowledgeRepository extends ApiRepository {
     updates: Partial<ConnectorConfig>
   ): Promise<ConnectorConfig> {
     const response = await this.put(
-      `/api/knowledge_base/connectors/${encodeURIComponent(id)}`,
+      `${getApiBase()}/knowledge_base/connectors/${encodeURIComponent(id)}`,
       updates
     )
     return response.data
@@ -591,7 +592,7 @@ export class KnowledgeRepository extends ApiRepository {
    */
   async deleteConnector(id: string): Promise<void> {
     await this.delete(
-      `/api/knowledge_base/connectors/${encodeURIComponent(id)}`
+      `${getApiBase()}/knowledge_base/connectors/${encodeURIComponent(id)}`
     )
   }
 
@@ -602,7 +603,7 @@ export class KnowledgeRepository extends ApiRepository {
     id: string
   ): Promise<{ success: boolean; message: string }> {
     const response = await this.post(
-      `/api/knowledge_base/connectors/${encodeURIComponent(id)}/test`
+      `${getApiBase()}/knowledge_base/connectors/${encodeURIComponent(id)}/test`
     )
     return response.data
   }
@@ -615,7 +616,7 @@ export class KnowledgeRepository extends ApiRepository {
     incremental = true
   ): Promise<SyncResult> {
     const response = await this.post(
-      `/api/knowledge_base/connectors/${encodeURIComponent(id)}/sync?incremental=${incremental}`
+      `${getApiBase()}/knowledge_base/connectors/${encodeURIComponent(id)}/sync?incremental=${incremental}`
     )
     return response.data
   }
@@ -628,7 +629,7 @@ export class KnowledgeRepository extends ApiRepository {
     limit = 20
   ): Promise<SyncResult[]> {
     const response = await this.get(
-      `/api/knowledge_base/connectors/${encodeURIComponent(id)}/history?limit=${limit}`,
+      `${getApiBase()}/knowledge_base/connectors/${encodeURIComponent(id)}/history?limit=${limit}`,
       { skipCache: true }
     )
     return response.data
@@ -652,8 +653,8 @@ export class KnowledgeRepository extends ApiRepository {
     total: number
   }> {
     const url = collection
-      ? `/api/knowledge_base/entries?collection=${encodeURIComponent(collection)}`
-      : '/api/knowledge_base/entries'
+      ? `${getApiBase()}/knowledge_base/entries?collection=${encodeURIComponent(collection)}`
+      : `${getApiBase()}/knowledge_base/entries`
     const response = await this.get(url)
 
     // Normalize response format

--- a/autobot-frontend/src/models/repositories/SystemRepository.ts
+++ b/autobot-frontend/src/models/repositories/SystemRepository.ts
@@ -1,5 +1,6 @@
 import { ApiRepository } from './ApiRepository'
 import type { AutoBotSettings, SystemMetrics, DiagnosticsReport } from '@/types/models'
+import { getApiBase } from '@/config/ssot-config'
 
 export interface HealthCheckResponse {
   status: 'healthy' | 'unhealthy' | 'degraded' | 'warning' | 'error'
@@ -50,95 +51,95 @@ export interface CommandExecutionResponse {
 export class SystemRepository extends ApiRepository {
   // Health and status
   async checkHealth(): Promise<HealthCheckResponse> {
-    const response = await this.get('/api/system/health')
+    const response = await this.get(`${getApiBase()}/system/health`)
     return response.data
   }
 
   async getSystemStatus(): Promise<any> {
     // Issue #552: /api/system/status doesn't exist, use /api/system/info instead
-    const response = await this.get('/api/system/info')
+    const response = await this.get(`${getApiBase()}/system/info`)
     return response.data
   }
 
   async getSystemInfo(): Promise<SystemInfoResponse> {
-    const response = await this.get('/api/system/info')
+    const response = await this.get(`${getApiBase()}/system/info`)
     return response.data
   }
 
   async getSystemMetrics(): Promise<SystemMetrics> {
-    const response = await this.get('/api/system/metrics')
+    const response = await this.get(`${getApiBase()}/system/metrics`)
     return response.data
   }
 
   // Settings management
   async getSettings(): Promise<AutoBotSettings> {
-    const response = await this.get('/api/settings/')
+    const response = await this.get(`${getApiBase()}/settings/`)
     return response.data
   }
 
   async updateSettings(settings: Partial<AutoBotSettings>): Promise<AutoBotSettings> {
-    const response = await this.post('/api/settings/', settings)
+    const response = await this.post(`${getApiBase()}/settings/`, settings)
     return response.data
   }
 
   async getBackendSettings(): Promise<any> {
-    const response = await this.get('/api/settings/backend')
+    const response = await this.get(`${getApiBase()}/settings/backend`)
     return response.data
   }
 
   async saveBackendSettings(settings: any): Promise<any> {
-    const response = await this.post('/api/settings/backend', { settings })
+    const response = await this.post(`${getApiBase()}/settings/backend`, { settings })
     return response.data
   }
 
   async getConfigFiles(): Promise<string[]> {
     // Issue #552: Backend uses /api/settings/config for config file operations
-    const response = await this.get('/api/settings/config')
+    const response = await this.get(`${getApiBase()}/settings/config`)
     return response.data
   }
 
   async getConfigFile(filename: string): Promise<string> {
     // Issue #552: Backend uses /api/settings/config with query param
-    const response = await this.get(`/api/settings/config?file=${encodeURIComponent(filename)}`)
+    const response = await this.get(`${getApiBase()}/settings/config?file=${encodeURIComponent(filename)}`)
     return response.data
   }
 
   async updateConfigFile(filename: string, content: string): Promise<any> {
     // Issue #552: Backend uses POST /api/settings/config
-    const response = await this.post('/api/settings/config', { file: filename, content })
+    const response = await this.post(`${getApiBase()}/settings/config`, { file: filename, content })
     return response.data
   }
 
   // Terminal operations
   // Issue #552: Fixed paths - backend uses /api/agent-terminal/* not /api/terminal/*
   async executeCommand(request: ExecuteCommandRequest): Promise<CommandExecutionResponse> {
-    const response = await this.post('/api/agent-terminal/execute', request)
+    const response = await this.post(`${getApiBase()}/agent-terminal/execute`, request)
     return response.data
   }
 
   async interruptProcess(): Promise<any> {
     // Issue #552: Backend requires session_id for interrupt
     // Using execute with interrupt flag as fallback
-    const response = await this.post('/api/agent-terminal/execute', { interrupt: true })
+    const response = await this.post(`${getApiBase()}/agent-terminal/execute`, { interrupt: true })
     return response.data
   }
 
   async killAllProcesses(): Promise<any> {
     // Issue #552: Backend requires session_id for kill
     // Using execute with kill flag as fallback
-    const response = await this.post('/api/agent-terminal/execute', { kill: true })
+    const response = await this.post(`${getApiBase()}/agent-terminal/execute`, { kill: true })
     return response.data
   }
 
   async getTerminalHistory(): Promise<CommandExecutionResponse[]> {
     // Issue #552: Backend uses /api/agent-terminal/sessions for history
-    const response = await this.get('/api/agent-terminal/sessions')
+    const response = await this.get(`${getApiBase()}/agent-terminal/sessions`)
     return response.data
   }
 
   async clearTerminalHistory(): Promise<any> {
     // Issue #552: Backend doesn't have bulk delete - delete sessions individually
-    const response = await this.get('/api/agent-terminal/sessions')
+    const response = await this.get(`${getApiBase()}/agent-terminal/sessions`)
     return response.data
   }
 
@@ -146,37 +147,37 @@ export class SystemRepository extends ApiRepository {
   // Issue #552: These control endpoints don't exist in backend yet - keeping paths for future implementation
   async restartBackend(): Promise<any> {
     // Note: Backend doesn't have /api/system/restart - this is aspirational
-    const response = await this.post('/api/system/restart')
+    const response = await this.post(`${getApiBase()}/system/restart`)
     return response.data
   }
 
   async shutdownSystem(): Promise<any> {
     // Note: Backend doesn't have /api/system/shutdown - this is aspirational
-    const response = await this.post('/api/system/shutdown')
+    const response = await this.post(`${getApiBase()}/system/shutdown`)
     return response.data
   }
 
   async reloadConfiguration(): Promise<any> {
     // Issue #552: Backend uses /api/system/reload_config
-    const response = await this.post('/api/system/reload_config')
+    const response = await this.post(`${getApiBase()}/system/reload_config`)
     return response.data
   }
 
   // Diagnostics
   // Issue #552: Backend uses /api/system-validation/* for diagnostics
   async getDiagnosticsReport(): Promise<DiagnosticsReport> {
-    const response = await this.get('/api/system-validation/validate/status')
+    const response = await this.get(`${getApiBase()}/system-validation/validate/status`)
     return response.data
   }
 
   async runDiagnostics(): Promise<DiagnosticsReport> {
-    const response = await this.post('/api/system-validation/validate/comprehensive')
+    const response = await this.post(`${getApiBase()}/system-validation/validate/comprehensive`)
     return response.data
   }
 
   async fixDiagnosticIssue(issueId: string): Promise<any> {
     // Note: No fix endpoint exists in backend - validation is read-only
-    const response = await this.get(`/api/system-validation/validate/component/${issueId}`)
+    const response = await this.get(`${getApiBase()}/system-validation/validate/component/${issueId}`)
     return response.data
   }
 
@@ -187,19 +188,19 @@ export class SystemRepository extends ApiRepository {
     if (level) params.append('level', level)
     if (limit) params.append('limit', limit.toString())
 
-    const response = await this.get(`/api/logs/recent?${params}`)
+    const response = await this.get(`${getApiBase()}/logs/recent?${params}`)
     return response.data
   }
 
   async clearLogs(): Promise<any> {
     // Issue #552: Backend uses /api/logs/clear/{filename}
-    const response = await this.delete('/api/logs/clear/autobot')
+    const response = await this.delete(`${getApiBase()}/logs/clear/autobot`)
     return response.data
   }
 
   async downloadLogs(): Promise<Blob> {
     // Issue #552: Backend uses /api/logs/read/{filename}
-    const response = await this.get('/api/logs/unified')
+    const response = await this.get(`${getApiBase()}/logs/unified`)
     return response.data
   }
 
@@ -207,72 +208,72 @@ export class SystemRepository extends ApiRepository {
   async getPerformanceMetrics(timeframe?: string): Promise<any> {
     // Issue #552: Backend uses /api/monitoring/metrics/current
     const params = timeframe ? `?timeframe=${timeframe}` : ''
-    const response = await this.get(`/api/monitoring/metrics/current${params}`)
+    const response = await this.get(`${getApiBase()}/monitoring/metrics/current${params}`)
     return response.data
   }
 
   async getResourceUsage(): Promise<any> {
     // Issue #552: Backend uses /api/service-monitor/resources
-    const response = await this.get('/api/service-monitor/resources')
+    const response = await this.get(`${getApiBase()}/service-monitor/resources`)
     return response.data
   }
 
   // Backup and restore
   // Issue #552: These backup endpoints don't exist in backend yet - keeping paths for future implementation
   async createBackup(): Promise<any> {
-    const response = await this.post('/api/system/backup/create')
+    const response = await this.post(`${getApiBase()}/system/backup/create`)
     return response.data
   }
 
   async listBackups(): Promise<any[]> {
-    const response = await this.get('/api/system/backup/list')
+    const response = await this.get(`${getApiBase()}/system/backup/list`)
     return response.data
   }
 
   async restoreBackup(backupId: string): Promise<any> {
-    const response = await this.post(`/api/system/backup/restore/${backupId}`)
+    const response = await this.post(`${getApiBase()}/system/backup/restore/${backupId}`)
     return response.data
   }
 
   async deleteBackup(backupId: string): Promise<any> {
-    const response = await this.delete(`/api/system/backup/${backupId}`)
+    const response = await this.delete(`${getApiBase()}/system/backup/${backupId}`)
     return response.data
   }
 
   // Environment and version info
   async getEnvironmentInfo(): Promise<any> {
     // Issue #552: Backend doesn't have /api/system/environment - use /api/system/info
-    const response = await this.get('/api/system/info')
+    const response = await this.get(`${getApiBase()}/system/info`)
     return response.data
   }
 
   async getVersionInfo(): Promise<any> {
     // Issue #552: Fixed path - backend has /api/services/version
-    const response = await this.get('/api/services/version')
+    const response = await this.get(`${getApiBase()}/services/version`)
     return response.data
   }
 
   async checkForUpdates(): Promise<any> {
     // Note: Backend doesn't have update check - this is aspirational
-    const response = await this.get('/api/system/updates/check')
+    const response = await this.get(`${getApiBase()}/system/updates/check`)
     return response.data
   }
 
   // Security
   // Issue #552: Backend uses /api/security/* for security assessment
   async getSecurityStatus(): Promise<any> {
-    const response = await this.get('/api/security/assessments')
+    const response = await this.get(`${getApiBase()}/security/assessments`)
     return response.data
   }
 
   async runSecurityScan(): Promise<any> {
-    const response = await this.post('/api/security/assessments')
+    const response = await this.post(`${getApiBase()}/security/assessments`)
     return response.data
   }
 
   async getAuditLogs(): Promise<any[]> {
     // Note: Backend doesn't have audit logs endpoint - using assessments
-    const response = await this.get('/api/security/assessments')
+    const response = await this.get(`${getApiBase()}/security/assessments`)
     return response.data
   }
 }

--- a/autobot-frontend/src/stores/useKnowledgeStore.ts
+++ b/autobot-frontend/src/stores/useKnowledgeStore.ts
@@ -9,6 +9,7 @@ import type {
   ConnectorStatus
 } from '@/types/knowledgeBase'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useKnowledgeStore')
 
@@ -310,7 +311,7 @@ export const useKnowledgeStore = defineStore('knowledge', () => {
   async function refreshStats() {
     try {
       isLoading.value = true
-      const response = await ApiClient.get('/api/knowledge_base/stats')
+      const response = await ApiClient.get(`${getApiBase()}/knowledge_base/stats`)
       stats.value = await response.json()
     } catch (error) {
       logger.error('Failed to refresh stats:', error)
@@ -423,7 +424,7 @@ export const useKnowledgeStore = defineStore('knowledge', () => {
   // API-based category update (Issue #747)
   async function updateCategory(id: string, data: Partial<Category>) {
     try {
-      const response = await ApiClient.put(`/api/knowledge_base/categories/${id}`, data)
+      const response = await ApiClient.put(`${getApiBase()}/knowledge_base/categories/${id}`, data)
       const result = await response.json()
       if (result.status === 'success') {
         logger.info('Category updated successfully: %s', id)
@@ -440,7 +441,7 @@ export const useKnowledgeStore = defineStore('knowledge', () => {
   // API-based category delete (Issue #747)
   async function deleteCategory(id: string) {
     try {
-      const response = await ApiClient.delete(`/api/knowledge_base/categories/${id}`)
+      const response = await ApiClient.delete(`${getApiBase()}/knowledge_base/categories/${id}`)
       const result = await response.json()
       if (result.status === 'success') {
         logger.info('Category deleted successfully: %s', id)
@@ -476,7 +477,7 @@ export const useKnowledgeStore = defineStore('knowledge', () => {
     try {
       systemDocsLoading.value = true
       const response = await ApiClient.get(
-        '/api/knowledge_base/entries?collection=autobot-documentation'
+        `${getApiBase()}/knowledge_base/entries?collection=autobot-documentation`
       )
       const result = await response.json()
       systemDocs.value = result.entries || result.documents || []
@@ -497,7 +498,7 @@ export const useKnowledgeStore = defineStore('knowledge', () => {
   async function loadPrompts() {
     try {
       promptsLoading.value = true
-      const response = await ApiClient.get('/api/prompts')
+      const response = await ApiClient.get(`${getApiBase()}/prompts`)
       const result = await response.json()
       prompts.value = result.prompts || []
       logger.info('Loaded %d prompts', prompts.value.length)
@@ -511,7 +512,7 @@ export const useKnowledgeStore = defineStore('knowledge', () => {
 
   async function updatePrompt(id: string, content: string) {
     try {
-      const response = await ApiClient.put(`/api/prompts/${id}`, { content })
+      const response = await ApiClient.put(`${getApiBase()}/prompts/${id}`, { content })
       const result = await response.json()
       // Update the prompt in local state
       const promptIndex = prompts.value.findIndex(p => p.id === id)
@@ -532,7 +533,7 @@ export const useKnowledgeStore = defineStore('knowledge', () => {
 
   async function revertPrompt(id: string) {
     try {
-      const response = await ApiClient.post(`/api/prompts/${id}/revert`, {})
+      const response = await ApiClient.post(`${getApiBase()}/prompts/${id}/revert`, {})
       const result = await response.json()
       // Update the prompt in local state
       const promptIndex = prompts.value.findIndex(p => p.id === id)

--- a/autobot-frontend/src/stores/usePermissionStore.ts
+++ b/autobot-frontend/src/stores/usePermissionStore.ts
@@ -17,6 +17,7 @@ import { defineStore } from 'pinia'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('usePermissionStore')
 
@@ -148,7 +149,7 @@ export const usePermissionStore = defineStore('permission', () => {
     error.value = null
 
     try {
-      const url = await appConfig.getApiUrl('/api/permissions/status')
+      const url = await appConfig.getApiUrl(`${getApiBase()}/permissions/status`)
       const response = await fetchWithAuth(url, { signal: getSignal() })
 
       if (!response.ok) {
@@ -181,7 +182,7 @@ export const usePermissionStore = defineStore('permission', () => {
     error.value = null
 
     try {
-      const url = await appConfig.getApiUrl(`/api/permissions/mode?is_admin=${isAdmin}`)
+      const url = await appConfig.getApiUrl(`${getApiBase()}/permissions/mode?is_admin=${isAdmin}`)
       const response = await fetchWithAuth(url, { signal: getSignal() })
 
       if (!response.ok) {
@@ -213,7 +214,7 @@ export const usePermissionStore = defineStore('permission', () => {
     error.value = null
 
     try {
-      const url = await appConfig.getApiUrl(`/api/permissions/mode?is_admin=${isAdmin}`)
+      const url = await appConfig.getApiUrl(`${getApiBase()}/permissions/mode?is_admin=${isAdmin}`)
       const response = await fetchWithAuth(url, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -250,7 +251,7 @@ export const usePermissionStore = defineStore('permission', () => {
     error.value = null
 
     try {
-      const url = await appConfig.getApiUrl('/api/permissions/rules')
+      const url = await appConfig.getApiUrl(`${getApiBase()}/permissions/rules`)
       const response = await fetchWithAuth(url, { signal: getSignal() })
 
       if (!response.ok) {
@@ -291,7 +292,7 @@ export const usePermissionStore = defineStore('permission', () => {
     error.value = null
 
     try {
-      const url = await appConfig.getApiUrl(`/api/permissions/rules?is_admin=${isAdmin}`)
+      const url = await appConfig.getApiUrl(`${getApiBase()}/permissions/rules?is_admin=${isAdmin}`)
       const response = await fetchWithAuth(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -326,7 +327,7 @@ export const usePermissionStore = defineStore('permission', () => {
     error.value = null
 
     try {
-      const url = await appConfig.getApiUrl('/api/permissions/rules')
+      const url = await appConfig.getApiUrl(`${getApiBase()}/permissions/rules`)
       const response = await fetchWithAuth(url, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
@@ -362,7 +363,7 @@ export const usePermissionStore = defineStore('permission', () => {
     isAdmin = false
   ): Promise<{ result: string; pattern?: string; description?: string } | null> {
     try {
-      const url = await appConfig.getApiUrl(`/api/permissions/check?is_admin=${isAdmin}`)
+      const url = await appConfig.getApiUrl(`${getApiBase()}/permissions/check?is_admin=${isAdmin}`)
       const response = await fetchWithAuth(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -393,7 +394,7 @@ export const usePermissionStore = defineStore('permission', () => {
     try {
       const encodedPath = encodeURIComponent(projectPath)
       const url = await appConfig.getApiUrl(
-        `/api/permissions/memory/${encodedPath}?user_id=${userId}`
+        `${getApiBase()}/permissions/memory/${encodedPath}?user_id=${userId}`
       )
       const response = await fetchWithAuth(url)
 
@@ -443,7 +444,7 @@ export const usePermissionStore = defineStore('permission', () => {
         params.append('comment', comment)
       }
 
-      const url = await appConfig.getApiUrl(`/api/permissions/memory?${params.toString()}`)
+      const url = await appConfig.getApiUrl(`${getApiBase()}/permissions/memory?${params.toString()}`)
       const response = await fetchWithAuth(url, { method: 'POST' })
 
       if (!response.ok) {
@@ -470,7 +471,7 @@ export const usePermissionStore = defineStore('permission', () => {
 
     try {
       const encodedPath = encodeURIComponent(projectPath)
-      let url = await appConfig.getApiUrl(`/api/permissions/memory/${encodedPath}`)
+      let url = await appConfig.getApiUrl(`${getApiBase()}/permissions/memory/${encodedPath}`)
       if (userId) {
         url += `?user_id=${userId}`
       }

--- a/autobot-frontend/src/stores/useUserStore.ts
+++ b/autobot-frontend/src/stores/useUserStore.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('useUserStore')
 
@@ -318,7 +319,7 @@ export const useUserStore = defineStore('user', () => {
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), 5000) // 5s timeout
 
-      const response = await fetch('/api/auth/me', {
+      const response = await fetch(`${getApiBase()}/auth/me`, {
         signal: controller.signal,
         headers: {
           'Accept': 'application/json'
@@ -382,7 +383,7 @@ export const useUserStore = defineStore('user', () => {
         headers['Authorization'] = `Bearer ${authState.value.token}`
       }
 
-      const response = await fetch('/api/auth/change-password', {
+      const response = await fetch(`${getApiBase()}/auth/change-password`, {
         method: 'POST',
         headers,
         body: JSON.stringify({


### PR DESCRIPTION
Closes #3631

## Summary

- Adds `getApiBase()` to `autobot-frontend/src/config/ssot-config.ts` (returns `VITE_API_BASE_PATH` env var, defaults to `'/api'`)
- Replaces all hardcoded `'/api/...'` path literals across 8 files with `` `${getApiBase()}/...` ``
- Files changed: `stores/useKnowledgeStore.ts`, `stores/usePermissionStore.ts`, `stores/useUserStore.ts`, `models/repositories/KnowledgeRepository.ts`, `models/repositories/ChatRepository.ts`, `models/repositories/SystemRepository.ts`, `models/repositories/ApiRepository.ts`, `components/ChatInterface.ts`
- 110 `getApiBase()` call sites replacing ~109 hardcoded literals

## Test plan

- [ ] Verify TypeScript compiles: `npm run type-check` in `autobot-frontend/`
- [ ] Verify no remaining `/api/` string literals in target files
- [ ] Confirm frontend still connects to backend with default `/api` prefix
- [ ] Test with `VITE_API_BASE_PATH=/custom-api` to verify override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)