### PR TITLE
refactor(helpers): remove duplicate raise_not_found_error in catalog_http_exceptions (#3566)

### DIFF
--- a/autobot-backend/api/system_validation.py
+++ b/autobot-backend/api/system_validation.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
-from utils.catalog_http_exceptions import raise_not_found_error, raise_server_error
+from utils.catalog_http_exceptions import raise_catalog_error_simple, raise_server_error
 from utils.system_validator import get_system_validator
 
 logger = logging.getLogger(__name__)
@@ -195,7 +195,7 @@ async def validate_component(component_name: str):
         }
 
         if component_name.lower() not in component_methods:
-            raise_not_found_error(
+            raise_catalog_error_simple(
                 "API_0002",
                 f"Component '{component_name}' not found. Available: {list(component_methods.keys())}",
             )

--- a/autobot-backend/api/validation_dashboard.py
+++ b/autobot-backend/api/validation_dashboard.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from type_defs.common import Metadata
 from utils.catalog_http_exceptions import (
-    raise_not_found_error,
+    raise_catalog_error_simple,
     raise_server_error,
     raise_service_unavailable,
     raise_validation_error,
@@ -318,7 +318,7 @@ async def get_dashboard_file():
 
     except FileNotFoundError as e:
         logger.error("Dashboard file not found: %s", e)
-        raise_not_found_error("API_0002", "Dashboard file not found")
+        raise_catalog_error_simple("API_0002", "Dashboard file not found")
     except (OSError, IOError) as e:
         logger.error("Error serving dashboard file due to file system error: %s", e)
         raise_server_error("API_0003", "File system error")

--- a/autobot-backend/utils/catalog_http_exceptions.py
+++ b/autobot-backend/utils/catalog_http_exceptions.py
@@ -207,13 +207,6 @@ def raise_validation_error(
     raise_catalog_error_simple(error_code, context)
 
 
-def raise_not_found_error(
-    error_code: str = "API_0002", context: Optional[str] = None
-) -> None:
-    """Raise not found error"""
-    raise_catalog_error_simple(error_code, context)
-
-
 def raise_server_error(
     error_code: str = "API_0003", context: Optional[str] = None
 ) -> None:

--- a/autobot-backend/utils/operation_timeout_integration.py
+++ b/autobot-backend/utils/operation_timeout_integration.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 from constants.network_constants import ServiceURLs
 from constants.threshold_constants import TimingConstants
 from utils.catalog_http_exceptions import (
-    raise_not_found_error,
+    raise_catalog_error_simple,
     raise_server_error,
     raise_validation_error,
 )
@@ -270,7 +270,7 @@ class OperationIntegrationManager:
             # Issue #321: Use helper method to reduce message chains
             checkpoints = await self.list_operation_checkpoints(operation_id)
             if not checkpoints:
-                raise_not_found_error("API_0002", "No checkpoints found for operation")
+                raise_catalog_error_simple("API_0002", "No checkpoints found for operation")
             latest_checkpoint = checkpoints[-1]
             new_operation_id = await self.operation_manager.resume_operation(
                 latest_checkpoint.checkpoint_id
@@ -290,7 +290,7 @@ class OperationIntegrationManager:
         """Handle update progress request."""
         operation = self.operation_manager.get_operation(operation_id)
         if not operation:
-            raise_not_found_error("API_0002", "Operation not found")
+            raise_catalog_error_simple("API_0002", "Operation not found")
         # Issue #321: Use helper method to reduce message chains
         await self.update_operation_progress(
             operation,
@@ -347,7 +347,7 @@ class OperationIntegrationManager:
             """Get operation details by ID."""
             operation = self.operation_manager.get_operation(operation_id)
             if not operation:
-                raise_not_found_error("API_0002", "Operation not found")
+                raise_catalog_error_simple("API_0002", "Operation not found")
             return self._convert_operation_to_response(operation)
 
         @self.router.get("/", response_model=OperationListResponse)
@@ -381,7 +381,7 @@ class OperationIntegrationManager:
         async def cancel_operation(operation_id: str):
             """Cancel a running operation."""
             if not await self.operation_manager.cancel_operation(operation_id):
-                raise_not_found_error("API_0002", "Operation not found")
+                raise_catalog_error_simple("API_0002", "Operation not found")
             return {"status": "cancelled"}
 
         @self.router.post("/{operation_id}/resume")


### PR DESCRIPTION
Closes #3566

## Changes
- Deleted `raise_not_found_error()` from `catalog_http_exceptions.py` (it was a thin wrapper around `raise_catalog_error_simple` with no additional logic)
- Migrated all 6 call sites across 3 files to call `raise_catalog_error_simple()` directly (same signature, same behavior)
- Note: `raise_not_found()` was not used as the migration target because it has a different interface (`resource_type`/`resource_id`) vs the error-code+context pattern used by these callers

## Test plan
- [x] All call sites verified and migrated
- [x] No remaining references to `raise_not_found_error` in codebase