### PR TITLE
refactor(helpers): cap exponential backoff via TimingConstants (#3565)

### DIFF
--- a/autobot-backend/constants/threshold_constants.py
+++ b/autobot-backend/constants/threshold_constants.py
@@ -149,6 +149,20 @@ class TimingConstants:
     KB_INIT_DELAY = 3.0  # Wait for knowledge base async initialization
 
 
+def exponential_backoff_delay(attempt: int, base: float = 2.0, cap: float = 60.0) -> float:
+    """Return capped exponential backoff delay in seconds.
+
+    Args:
+        attempt: Zero-based attempt index (0 → base**0 = 1 s, 1 → 2 s, …).
+        base: Backoff base (default 2.0).
+        cap: Maximum delay in seconds (default 60.0, matching RetryConfig.BACKOFF_MAX_DELAY).
+
+    Returns:
+        Delay in seconds, never exceeding *cap*.
+    """
+    return min(base**attempt, cap)
+
+
 class RetryConfig:
     """Retry configuration constants."""
 

--- a/autobot-backend/tests/test_exponential_backoff_delay.py
+++ b/autobot-backend/tests/test_exponential_backoff_delay.py
@@ -1,0 +1,57 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for exponential_backoff_delay helper.
+
+Issue #3565: Verify that exponential_backoff_delay applies a cap and produces
+correct base-2 values.
+"""
+
+import pytest
+
+from constants.threshold_constants import RetryConfig, exponential_backoff_delay
+
+
+class TestExponentialBackoffDelay:
+    """Unit tests for exponential_backoff_delay."""
+
+    def test_base_values_with_default_base(self):
+        """attempt=0 → 1s, attempt=1 → 2s, attempt=2 → 4s, attempt=3 → 8s."""
+        assert exponential_backoff_delay(0) == 1.0
+        assert exponential_backoff_delay(1) == 2.0
+        assert exponential_backoff_delay(2) == 4.0
+        assert exponential_backoff_delay(3) == 8.0
+
+    def test_cap_is_applied(self):
+        """High attempt numbers must not exceed the cap."""
+        cap = 60.0
+        # 2**10 = 1024, well above the default cap of 60
+        assert exponential_backoff_delay(10) == cap
+        assert exponential_backoff_delay(30) == cap
+
+    def test_cap_boundary(self):
+        """Value exactly at the cap should be returned unchanged."""
+        # 2**5 = 32 < 60; first attempt to exceed: 2**6 = 64 > 60
+        assert exponential_backoff_delay(5) == 32.0
+        assert exponential_backoff_delay(6) == 60.0  # capped from 64
+
+    def test_custom_cap(self):
+        """Custom cap is respected."""
+        assert exponential_backoff_delay(10, cap=10.0) == 10.0
+        assert exponential_backoff_delay(3, cap=10.0) == 8.0  # 2**3=8 < 10
+
+    def test_custom_base(self):
+        """Custom base is respected."""
+        assert exponential_backoff_delay(3, base=3.0, cap=1000.0) == 27.0
+
+    def test_return_type_is_float(self):
+        """Return value must always be a float."""
+        result = exponential_backoff_delay(0)
+        assert isinstance(result, float)
+
+    def test_default_cap_matches_retry_config(self):
+        """Default cap must match RetryConfig.BACKOFF_MAX_DELAY for consistency."""
+        default_cap = RetryConfig.BACKOFF_MAX_DELAY  # 60.0
+        # At a large attempt the helper must be capped at BACKOFF_MAX_DELAY
+        assert exponential_backoff_delay(100) == default_cap

--- a/autobot-backend/utils/error_boundaries/decorators.py
+++ b/autobot-backend/utils/error_boundaries/decorators.py
@@ -16,7 +16,7 @@ from typing import Callable
 
 from fastapi import HTTPException
 
-from constants.threshold_constants import RetryConfig
+from constants.threshold_constants import RetryConfig, exponential_backoff_delay
 
 from .boundary_manager import get_error_boundary_manager
 from .types import APIErrorResponse, ErrorCategory, ErrorContext, RecoveryStrategy
@@ -57,7 +57,7 @@ async def _handle_async_attempt(
         if attempt == max_retries:
             return (True, await manager.handle_error(e, context))
         if recovery_strategy == RecoveryStrategy.RETRY:
-            await asyncio.sleep(2**attempt)
+            await asyncio.sleep(exponential_backoff_delay(attempt))
             return (False, None)
         return (True, await manager.handle_error(e, context))
 
@@ -95,7 +95,7 @@ def _handle_sync_attempt(
         if attempt == max_retries:
             return (True, asyncio.run(manager.handle_error(e, context)))
         if recovery_strategy == RecoveryStrategy.RETRY:
-            time.sleep(2**attempt)
+            time.sleep(exponential_backoff_delay(attempt))
             return (False, None)
         return (True, asyncio.run(manager.handle_error(e, context)))
 


### PR DESCRIPTION
Closes #3565

## Changes
- Added `exponential_backoff_delay(attempt, base=2.0, cap=60.0)` helper to `threshold_constants.py` — default cap of 60s matches `RetryConfig.BACKOFF_MAX_DELAY`
- Replaced `asyncio.sleep(2**attempt)` in both async and sync retry paths in `decorators.py` with `exponential_backoff_delay(attempt)` — prevents unbounded waits at high retry counts (attempt 10 was 1024s, now capped at 60s)
- Added 7 tests covering: base values, cap enforcement, boundary conditions, custom base/cap, and consistency with `RetryConfig`

## Test plan
- [x] 7 new tests pass
- [x] `2**10` (1024s) now correctly returns 60.0s