### PR TITLE
refactor(backend): remove dead AgentThresholds import and replace magic 0.8 in orchestrator.py (#3607)

### DIFF
--- a/autobot-backend/constants/threshold_constants.py
+++ b/autobot-backend/constants/threshold_constants.py
@@ -39,6 +39,7 @@ class WorkflowThresholds:
 
     SAFETY_THRESHOLD = 0.7  # Minimum safety score required
     QUALITY_THRESHOLD = 0.6  # Minimum quality score required
+    DOC_GENERATION_THRESHOLD = 0.8  # Minimum score to trigger auto-documentation
 
 
 class ComputerVisionThresholds:

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from autobot_shared.logging_manager import get_logger
 from config import config_manager
-from constants.threshold_constants import LLMDefaults, TimingConstants
+from constants.threshold_constants import LLMDefaults, TimingConstants, WorkflowThresholds
 from conversation import ConversationManager
 from llm_interface import LLMInterface
 from memory import LongTermMemoryManager
@@ -237,7 +237,7 @@ class ConsolidatedOrchestrator:
         self.knowledge_base = KnowledgeBase() if KNOWLEDGE_BASE_AVAILABLE else None
 
         self.auto_doc_enabled = True
-        self.doc_generation_threshold = 0.8
+        self.doc_generation_threshold = WorkflowThresholds.DOC_GENERATION_THRESHOLD
         self.knowledge_extraction_enabled = KNOWLEDGE_BASE_AVAILABLE
 
         self.workflow_metrics = {
@@ -970,8 +970,6 @@ class ConsolidatedOrchestrator:
 
         Issue #3393: Merged from enhanced_orchestrator.py into ConsolidatedOrchestrator.
         """
-        from constants.threshold_constants import AgentThresholds
-
         workflow_id = str(uuid.uuid4())
         start_time = time.time()
         context = context or {}


### PR DESCRIPTION
Closes #3607

## Changes
- Removed dead local import `from constants.threshold_constants import AgentThresholds` inside `_execute_enhanced_workflow()` — `AgentThresholds` was imported but never referenced after the PR #3589 consolidation of `enhanced_orchestrator.py`
- Added `DOC_GENERATION_THRESHOLD = 0.8` to `WorkflowThresholds` in `threshold_constants.py` with explanatory comment
- Replaced `self.doc_generation_threshold = 0.8` with `WorkflowThresholds.DOC_GENERATION_THRESHOLD`

## Test plan
- [x] No remaining references to `AgentThresholds` in orchestrator.py
- [x] `WorkflowThresholds.DOC_GENERATION_THRESHOLD` named constant replaces magic number