### PR TITLE
refactor(agents): declare _get_system_prompt @abstractmethod in StandardizedAgent (#3606)

### DIFF
--- a/autobot-backend/agents/chat_agent.py
+++ b/autobot-backend/agents/chat_agent.py
@@ -76,6 +76,13 @@ class ChatAgent(StandardizedAgent):
         result = await self.process_chat_message(message, context, chat_history)
         return result
 
+    def _get_system_prompt(self) -> str:
+        """Return agent system prompt."""
+        return (
+            "You are a helpful conversational assistant. "
+            "Respond naturally and concisely to user messages, greetings, and simple questions."
+        )
+
     def get_capabilities(self) -> List[str]:
         """Return list of capabilities this agent supports."""
         return self.capabilities.copy()

--- a/autobot-backend/agents/classification_agent.py
+++ b/autobot-backend/agents/classification_agent.py
@@ -108,6 +108,14 @@ class ClassificationAgent(StandardizedAgent):
             "context_analysis": result.context_analysis,
         }
 
+    def _get_system_prompt(self) -> str:
+        """Return agent system prompt."""
+        return (
+            "You are an intelligent workflow classification assistant. "
+            "Analyze user requests to determine intent, complexity, and the appropriate "
+            "agents or workflow steps required to fulfill them."
+        )
+
     def get_capabilities(self) -> List[str]:
         """Return list of capabilities this agent supports."""
         return self.capabilities.copy()

--- a/autobot-backend/agents/enhanced_system_commands_agent.py
+++ b/autobot-backend/agents/enhanced_system_commands_agent.py
@@ -164,6 +164,14 @@ class EnhancedSystemCommandsAgent(StandardizedAgent):
         result = self.validate_command_safety(command)
         return {"is_safe": result, "command": command}
 
+    def _get_system_prompt(self) -> str:
+        """Return agent system prompt."""
+        return (
+            "You are a secure system commands assistant. "
+            "Generate safe, validated shell commands for system operations and administration. "
+            "Always refuse dangerous or destructive commands outside the allowed set."
+        )
+
     def get_capabilities(self) -> List[str]:
         """Return list of capabilities this agent supports."""
         return self.capabilities.copy()

--- a/autobot-backend/agents/gemma_classification_agent.py
+++ b/autobot-backend/agents/gemma_classification_agent.py
@@ -396,6 +396,13 @@ Respond with valid JSON:
         """Return default step count for complexity level."""
         return 1 if complexity == TaskComplexity.SIMPLE else 3
 
+    def _get_system_prompt(self) -> str:
+        """Return agent system prompt."""
+        return (
+            "You are a fast, lightweight classification assistant powered by Gemma. "
+            "Quickly determine workflow complexity and intent from user requests with minimal latency."
+        )
+
     def get_capabilities(self) -> List[str]:
         """Return list of capabilities."""
         return self.capabilities.copy()

--- a/autobot-backend/agents/npu_code_search_agent.py
+++ b/autobot-backend/agents/npu_code_search_agent.py
@@ -298,6 +298,14 @@ class NPUCodeSearchAgent(StandardizedAgent):
         """Handle capabilities request"""
         return {"capabilities": self.capabilities}
 
+    def _get_system_prompt(self) -> str:
+        """Return agent system prompt."""
+        return (
+            "You are an NPU-accelerated code search assistant. "
+            "Search codebases semantically across multiple programming languages "
+            "and return precise, context-aware results."
+        )
+
     def get_capabilities(self) -> List[str]:
         """Return list of capabilities this agent supports"""
         return self.capabilities

--- a/autobot-backend/agents/rag_agent.py
+++ b/autobot-backend/agents/rag_agent.py
@@ -105,6 +105,14 @@ class RAGAgent(StandardizedAgent):
         result = await self.rank_documents(query, documents)
         return {"ranked_documents": result}
 
+    def _get_system_prompt(self) -> str:
+        """Return agent system prompt."""
+        return (
+            "You are a retrieval-augmented generation assistant. "
+            "Synthesize information from retrieved documents, reformulate queries for clarity, "
+            "rank context by relevance, and integrate knowledge base content into accurate responses."
+        )
+
     def get_capabilities(self) -> List[str]:
         """Return list of capabilities this agent supports."""
         return self.capabilities.copy()

--- a/autobot-backend/agents/standardized_agent.py
+++ b/autobot-backend/agents/standardized_agent.py
@@ -361,6 +361,10 @@ class StandardizedAgent(BaseAgent):
         )
 
     @abstractmethod
+    def _get_system_prompt(self) -> str:
+        """Return the system prompt for this agent - must be implemented by subclasses."""
+
+    @abstractmethod
     def get_capabilities(self) -> List[str]:
         """Return list of capabilities - must be implemented by subclasses"""
 
@@ -454,6 +458,10 @@ class ExampleMigratedAgent(StandardizedAgent):
                 ),
             }
         )
+
+    def _get_system_prompt(self) -> str:
+        """Return agent system prompt."""
+        return "You are a helpful assistant."
 
     def get_capabilities(self) -> List[str]:
         """Return list of supported agent capabilities."""


### PR DESCRIPTION
Closes #3606

## Changes
- Added `@abstractmethod` to `_get_system_prompt(self) -> str` in `StandardizedAgent` so subclasses that forget to implement it fail at class-definition time with `TypeError` instead of silently inheriting a default
- Added `_get_system_prompt` implementations to the 6 agents that were missing it: `ChatAgent`, `ClassificationAgent`, `EnhancedSystemCommandsAgent`, `GemmaClassificationAgent`, `NPUCodeSearchAgent`, `RAGAgent`
- Added implementation to `ExampleMigratedAgent` in the same file

## Test plan
- [x] All 7 modified files commit cleanly
- [x] Any future agent subclass missing `_get_system_prompt` will now raise `TypeError` at instantiation