### PR TITLE
chore(ci): enforce Black + isort formatting in pre-commit and CI (#3408)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ target-version = ["py311", "py312"]
 
 [tool.isort]
 profile = "black"
-line_length = 100
+line_length = 120
 src_paths = ["autobot-backend", "autobot_shared", "autobot-slm-backend"]
 known_first_party = ["autobot_shared"]


### PR DESCRIPTION
## Summary

- Closes #3408
- Aligns `pyproject.toml` `[tool.isort]` `line_length` from 100 to 120 to match `[tool.black]` `line-length = 120`
- Resolves config inconsistency: CI runs `isort --settings-path=.` which was reading `line_length = 100` while the explicit CLI arg `--line-length=120` overrode it — now both agree on 120
- Black and isort hooks were already present in `.pre-commit-config.yaml` (auto-format on staged files) and `.github/workflows/code-quality.yml` (`--check` / `--check-only` modes); no redundant steps added

## Test plan

- [ ] Verify `python -m isort --check-only --settings-path=. autobot-backend/ autobot-slm-backend/ autobot_shared/` passes locally
- [ ] Verify `code-quality` CI job passes on this PR
- [ ] Confirm `pyproject.toml` isort `line_length` matches black `line-length` (both 120)

Generated with [Claude Code](https://claude.com/claude-code)