### PR TITLE
fix(ansible): sync standalone autobot_shared on backend deploy (#3649)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -8,6 +8,7 @@ backend_user: autobot
 backend_group: autobot
 backend_install_dir: /opt/autobot/autobot-backend
 backend_code_dir: "{{ backend_install_dir }}"  # Actual code location (can be overridden by playbook)
+backend_shared_standalone_dir: /opt/autobot/autobot_shared  # Standalone PYTHONPATH copy used by workers (#3649)
 backend_log_dir: /var/log/autobot
 backend_data_dir: /var/lib/autobot
 

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -200,6 +200,33 @@
     - restart celery
   tags: ['backend', 'deploy']
 
+# Issue #3649: Also sync to the standalone /opt/autobot/autobot_shared/ that workers
+# resolve via PYTHONPATH. The backend venv editable-install points at backend_install_dir
+# but Celery workers and other services import from the standalone copy — skipping this
+# sync caused ModuleNotFoundError when new modules were added (pagination.py, task_result.py).
+- name: "Backend | Sync autobot_shared to standalone PYTHONPATH dir (#3649)"
+  ansible.posix.synchronize:
+    src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/autobot_shared/"
+    dest: "{{ backend_shared_standalone_dir }}/"
+    rsync_opts:
+      - "--exclude=__pycache__"
+      - "--exclude=*.pyc"
+      - "--exclude=*.egg-info"
+      - "--exclude=.git"
+      - "--delete"
+  notify:
+    - restart backend
+    - restart celery
+  tags: ['backend', 'deploy']
+
+- name: "Backend | Fix ownership of standalone autobot_shared (#3649)"
+  ansible.builtin.file:
+    path: "{{ backend_shared_standalone_dir }}"
+    owner: "{{ backend_user }}"
+    group: "{{ backend_group }}"
+    recurse: true
+  tags: ['backend', 'deploy']
+
 - name: Create backend symlink for imports
   ansible.builtin.file:
     src: "{{ backend_code_dir }}"


### PR DESCRIPTION
## Summary

- The backend Ansible role only synced `code_source/autobot_shared/` into `backend_install_dir/autobot_shared/` (the in-backend copy used by the venv editable install)
- `/opt/autobot/autobot_shared/` (the standalone PYTHONPATH copy resolved by Celery workers and other co-located services) was never updated on deploy
- Workers crashed with `ModuleNotFoundError` when new modules were added to `autobot_shared` (pagination.py, task_result.py, error_boundaries.py, alert_cooldown.py from sessions 43-45)

## Changes

- **`roles/backend/tasks/main.yml`**: Add `synchronize` task after the existing backend-dir sync that pushes `code_source/autobot_shared/` → `backend_shared_standalone_dir` with `--delete` to remove stale files; add `file` task to fix ownership to `autobot:autobot`
- **`roles/backend/defaults/main.yml`**: Add `backend_shared_standalone_dir: /opt/autobot/autobot_shared` default so the path is a named variable, not a hardcoded literal

## Test plan

- [ ] Run `provision-fleet-roles.yml` against VM4 (backend host) and confirm `/opt/autobot/autobot_shared/` is updated to match `code_source/autobot_shared/`
- [ ] Confirm `from autobot_shared.pagination import PaginationParams` succeeds in a Celery worker shell after deploy
- [ ] Confirm ownership is `autobot:autobot` on `/opt/autobot/autobot_shared/` after deploy

Fixes #3649

🤖 Generated with [Claude Code](https://claude.com/claude-code)