### PR TITLE
chore(tests): replace hardcoded localhost:8001 URLs in backend tests with config helper

### DIFF
--- a/autobot-backend/api/live_workflow.e2e_test.py
+++ b/autobot-backend/api/live_workflow.e2e_test.py
@@ -5,8 +5,13 @@ Tests the complete system with a running backend
 """
 
 import asyncio
+import sys
+from pathlib import Path
 
 import aiohttp
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from tests.test_helpers import get_test_backend_url
 
 
 async def test_live_workflow_system():
@@ -15,7 +20,7 @@ async def test_live_workflow_system():
     print("🚀 Testing Live AutoBot Workflow Orchestration")  # noqa: print
     print("=" * 60)  # noqa: print
 
-    base_url = "http://localhost:8001"
+    base_url = get_test_backend_url()
 
     async with aiohttp.ClientSession() as session:
         # Step 1: Test basic connectivity
@@ -201,7 +206,7 @@ async def test_chat_integration():
     print("\n5. Testing Chat Integration")  # noqa: print
     print("-" * 40)  # noqa: print
 
-    base_url = "http://localhost:8001"
+    base_url = get_test_backend_url()
 
     async with aiohttp.ClientSession() as session:
         try:

--- a/autobot-backend/api/security_endpoints.e2e_test.py
+++ b/autobot-backend/api/security_endpoints.e2e_test.py
@@ -11,6 +11,11 @@ import sys
 import time
 
 import requests
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from tests.test_helpers import get_test_backend_url
 
 
 async def test_security_endpoints():
@@ -36,7 +41,7 @@ async def test_security_endpoints():
 
         for attempt in range(max_attempts):
             try:
-                response = requests.get("http://localhost:8001/api/hello", timeout=2)
+                response = requests.get(get_test_backend_url() + "/api/hello", timeout=2)
                 if response.status_code == 200:
                     server_ready = True
                     print(
@@ -55,7 +60,7 @@ async def test_security_endpoints():
         print("\n🔍 Testing security status endpoint...")  # noqa: print
         try:
             response = requests.get(
-                "http://localhost:8001/api/security/status", timeout=5
+                get_test_backend_url() + "/api/security/status", timeout=5
             )
             print(f"   Status code: {response.status_code}")  # noqa: print
 
@@ -87,7 +92,7 @@ async def test_security_endpoints():
         print("\n📋 Testing command history endpoint...")  # noqa: print
         try:
             response = requests.get(
-                "http://localhost:8001/api/security/command-history", timeout=5
+                get_test_backend_url() + "/api/security/command-history", timeout=5
             )
             print(f"   Status code: {response.status_code}")  # noqa: print
 
@@ -114,7 +119,7 @@ async def test_security_endpoints():
         print("\n⏳ Testing pending approvals endpoint...")  # noqa: print
         try:
             response = requests.get(
-                "http://localhost:8001/api/security/pending-approvals", timeout=5
+                get_test_backend_url() + "/api/security/pending-approvals", timeout=5
             )
             print(f"   Status code: {response.status_code}")  # noqa: print
 
@@ -135,7 +140,7 @@ async def test_security_endpoints():
         print("\n📜 Testing audit log endpoint...")  # noqa: print
         try:
             response = requests.get(
-                "http://localhost:8001/api/security/audit-log", timeout=5
+                get_test_backend_url() + "/api/security/audit-log", timeout=5
             )
             print(f"   Status code: {response.status_code}")  # noqa: print
 
@@ -158,7 +163,7 @@ async def test_security_endpoints():
             # Just check if the endpoint is available (can't easily test WebSocket here)
             pass
 
-            ws_url = "ws://localhost:8001/api/terminal/ws/secure/test_session"
+            ws_url = get_test_backend_url().replace("http://", "ws://") + "/api/terminal/ws/secure/test_session"
             print(f"   WebSocket URL: {ws_url}")  # noqa: print
             print(  # noqa: print
                 "   ℹ️  WebSocket functionality requires separate testing"

--- a/autobot-backend/api/workflow_api.e2e_test.py
+++ b/autobot-backend/api/workflow_api.e2e_test.py
@@ -5,9 +5,14 @@ Tests all workflow endpoints after backend restart
 """
 
 import asyncio
+import sys
 import time
+from pathlib import Path
 
 import aiohttp
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from tests.test_helpers import get_test_backend_url
 
 
 async def test_workflow_endpoints():
@@ -16,7 +21,7 @@ async def test_workflow_endpoints():
     print("🧪 Testing AutoBot Workflow API Endpoints")  # noqa: print
     print("=" * 60)  # noqa: print
 
-    base_url = "http://localhost:8001/api/workflow"
+    base_url = get_test_backend_url() + "/api/workflow"
 
     async with aiohttp.ClientSession() as session:
         # Test 1: List workflows
@@ -136,7 +141,7 @@ async def test_workflow_endpoints():
 
         try:
             async with session.post(
-                "http://localhost:8001/api/chat", json=chat_request
+                get_test_backend_url() + "/api/chat", json=chat_request
             ) as response:
                 if response.status == 200:
                     result = await response.json()
@@ -198,7 +203,7 @@ async def demonstrate_workflow_orchestration():
         ),
     ]
 
-    base_url = "http://localhost:8001/api/workflow"
+    base_url = get_test_backend_url() + "/api/workflow"
 
     async with aiohttp.ClientSession() as session:
         for i, (request, description) in enumerate(test_requests, 1):

--- a/autobot-backend/computer_vision/phase9_multimodal_ai_test.py
+++ b/autobot-backend/computer_vision/phase9_multimodal_ai_test.py
@@ -16,6 +16,9 @@ from PIL import Image
 
 # Add project root to Python path (must be before src imports)
 sys.path.append(str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tests.test_helpers import get_test_backend_url  # noqa: E402
 
 from computer_vision_system import computer_vision_system  # noqa: E402
 from context_aware_decision_system import (  # noqa: E402
@@ -39,7 +42,7 @@ def test_api_connectivity():
     try:
         import requests
 
-        response = requests.get("http://localhost:8001/api/system/health", timeout=5)
+        response = requests.get(get_test_backend_url() + "/api/system/health", timeout=5)
         if response.status_code == 200:
             health_data = response.json()
             print(  # noqa: print
@@ -51,7 +54,7 @@ def test_api_connectivity():
             return False
     except requests.exceptions.ConnectionError:
         print(  # noqa: print
-            "⚠️ Cannot connect to backend API at http://localhost:8001 "
+            f"⚠️ Cannot connect to backend API at {get_test_backend_url()} "
             "(not required for Phase 9 tests)"
         )
         return False

--- a/autobot-backend/monitoring/monitoring_and_alerts_test.py
+++ b/autobot-backend/monitoring/monitoring_and_alerts_test.py
@@ -37,6 +37,9 @@ import requests
 
 # Add AutoBot paths
 sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tests.test_helpers import get_test_backend_url
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -192,11 +195,11 @@ class MonitoringAndAlertingTester:
         logger.info("🏥 Testing Health Monitoring Endpoints...")
 
         health_endpoints = [
-            ("backend", "http://10.0.0.1:8001/api/health"),
-            ("backend_system", "http://10.0.0.1:8001/api/system/status"),
+            ("backend", get_test_backend_url() + "/api/health"),
+            ("backend_system", get_test_backend_url() + "/api/system/status"),
             (
                 "backend_monitoring",
-                "http://10.0.0.1:8001/api/monitoring/services",
+                get_test_backend_url() + "/api/monitoring/services",
             ),
             ("ollama", "http://127.0.0.1:11434/api/tags"),
         ]
@@ -411,7 +414,7 @@ class MonitoringAndAlertingTester:
         """Simulate a threshold breach and check if alert is triggered"""
         try:
             # Try to send test metric to monitoring endpoint
-            backend_url = "http://10.0.0.1:8001"
+            backend_url = get_test_backend_url()
 
             # Check if there's a test metrics endpoint
             test_endpoints = [
@@ -473,7 +476,7 @@ class MonitoringAndAlertingTester:
         for i in range(5):
             start_time = time.time()
             try:
-                response = requests.get("http://10.0.0.1:8001/api/health", timeout=10)
+                response = requests.get(get_test_backend_url() + "/api/health", timeout=10)
                 response_time = time.time() - start_time
 
                 if response.status_code == 200:
@@ -538,9 +541,9 @@ class MonitoringAndAlertingTester:
 
         # Test main monitoring endpoints that might serve dashboards
         dashboard_urls = [
-            ("System Status", "http://10.0.0.1:8001/api/system/status"),
-            ("Service Health", "http://10.0.0.1:8001/api/monitoring/services"),
-            ("Metrics Summary", "http://10.0.0.1:8001/api/metrics/summary"),
+            ("System Status", get_test_backend_url() + "/api/system/status"),
+            ("Service Health", get_test_backend_url() + "/api/monitoring/services"),
+            ("Metrics Summary", get_test_backend_url() + "/api/metrics/summary"),
             ("Frontend Dashboard", "http://10.0.0.2:5173/dashboard"),
         ]
 
@@ -881,7 +884,7 @@ class MonitoringAndAlertingTester:
         """Simulate an incident scenario"""
         try:
             # Try to trigger incident via test endpoint
-            backend_url = "http://10.0.0.1:8001"
+            backend_url = get_test_backend_url()
 
             incident_endpoints = [
                 "/api/monitoring/incident/simulate",
@@ -921,7 +924,7 @@ class MonitoringAndAlertingTester:
         """Check if incident response was initiated"""
         try:
             # Check for incident response via monitoring endpoint
-            backend_url = "http://10.0.0.1:8001"
+            backend_url = get_test_backend_url()
 
             response_endpoints = [
                 "/api/monitoring/incidents/recent",

--- a/autobot-backend/phase8_control_panel_test.py
+++ b/autobot-backend/phase8_control_panel_test.py
@@ -13,6 +13,8 @@ import requests
 # Add project root to Python path
 sys.path.append(str(Path(__file__).parent))
 
+from tests.test_helpers import get_test_backend_url
+
 from enhanced_memory_manager import TaskPriority
 
 from desktop_streaming_manager import VNCServerManager, desktop_streaming
@@ -26,7 +28,7 @@ def test_api_connectivity():
     try:
         # Test health endpoint
         response = requests.get(
-            "http://localhost:8001/api/control/system/health", timeout=5
+            get_test_backend_url() + "/api/control/system/health", timeout=5
         )
         if response.status_code == 200:
             health_data = response.json()
@@ -39,7 +41,7 @@ def test_api_connectivity():
             return False
     except requests.exceptions.ConnectionError:
         print(
-            "❌ Cannot connect to backend API at http://localhost:8001"
+            f"❌ Cannot connect to backend API at {get_test_backend_url()}"
         )  # noqa: print
         return False
     except Exception as e:
@@ -163,7 +165,7 @@ def test_api_endpoints():
     print("\n🔗 Testing API Endpoints...")  # noqa: print
     print("=" * 50)  # noqa: print
 
-    base_url = "http://localhost:8001/api/control"
+    base_url = get_test_backend_url() + "/api/control"
 
     # Test 1: System health
     print("\n1. Testing System Health Endpoint...")  # noqa: print

--- a/autobot-backend/playwright_integration.e2e_test.py
+++ b/autobot-backend/playwright_integration.e2e_test.py
@@ -5,8 +5,13 @@ Demonstrates the complete workflow with browser automation
 """
 
 import asyncio
+import sys
+from pathlib import Path
 
 import aiohttp
+
+sys.path.insert(0, str(Path(__file__).parent))
+from tests.test_helpers import get_test_backend_url
 
 
 async def test_playwright_service():
@@ -69,7 +74,7 @@ async def test_workflow_with_research():
     print("\n\n🔄 Testing Workflow Orchestration with Web Research")  # noqa: print
     print("=" * 60)  # noqa: print
 
-    base_url = "http://localhost:8001/api/workflow"
+    base_url = get_test_backend_url() + "/api/workflow"
 
     async with aiohttp.ClientSession() as session:
         # Execute a research workflow
@@ -182,7 +187,7 @@ async def test_chat_with_workflow():
         print("-" * 40)  # noqa: print
 
         try:
-            async with session.post("http://localhost:8001/api/chats/new") as response:
+            async with session.post(get_test_backend_url() + "/api/chats/new") as response:
                 if response.status == 200:
                     chat_data = await response.json()
                     chat_id = chat_data.get("chat_id")
@@ -205,7 +210,7 @@ async def test_chat_with_workflow():
 
         try:
             async with session.post(
-                "http://localhost:8001/api/chat", json=chat_request
+                get_test_backend_url() + "/api/chat", json=chat_request
             ) as response:
                 if response.status == 200:
                     result = await response.json()

--- a/autobot-backend/services/settings_debug_test.py
+++ b/autobot-backend/services/settings_debug_test.py
@@ -13,6 +13,8 @@ import requests
 # Add the project root to Python path
 sys.path.insert(0, os.getcwd())
 
+from tests.test_helpers import get_test_backend_url
+
 from config import global_config_manager
 from services.config_service import ConfigService
 
@@ -74,7 +76,7 @@ async def test_api_endpoint():
 
     try:
         start_time = time.time()
-        response = requests.get("http://localhost:8001/api/settings/", timeout=10)
+        response = requests.get(get_test_backend_url() + "/api/settings/", timeout=10)
         end_time = time.time()
 
         if response.status_code == 200:

--- a/autobot-backend/tests/test_helpers.py
+++ b/autobot-backend/tests/test_helpers.py
@@ -1,0 +1,11 @@
+"""Shared helpers for backend e2e/integration tests."""
+import os
+
+
+def get_test_backend_url() -> str:
+    """Return backend base URL for e2e tests.
+
+    Reads AUTOBOT_TEST_BACKEND_URL env var first so CI can override without code changes.
+    Defaults to localhost:8001.
+    """
+    return os.environ.get("AUTOBOT_TEST_BACKEND_URL", "http://localhost:8001")


### PR DESCRIPTION
Closes #3653

## Changes
- Added `autobot-backend/tests/test_helpers.py` with `get_test_backend_url()` — returns `AUTOBOT_TEST_BACKEND_URL` env var or `http://localhost:8001`
- Replaced hardcoded `localhost:8001` and `10.0.0.1:8001` in 8 test files

## Files Changed
- `tests/test_helpers.py` (new)
- `phase8_control_panel_test.py`
- `monitoring/monitoring_and_alerts_test.py`
- `playwright_integration.e2e_test.py`
- `api/security_endpoints.e2e_test.py`
- `api/live_workflow.e2e_test.py`
- `api/workflow_api.e2e_test.py`
- `computer_vision/phase9_multimodal_ai_test.py`
- `services/settings_debug_test.py`

## Note
Post-merge audit found ~14 additional test files with the same pattern not in the original issue scope (e.g. `autobot_demo.e2e_test.py`, `chat_workflow/chat_workflow.e2e_test.py`). Filed as #3654 for a follow-up sweep.

## Verification
- Zero `localhost:8001` literals in all 8 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)