### PR TITLE
chore(frontend): adopt getApiBase() in stores, models, and components (#3631)

### DIFF
--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -618,25 +618,6 @@ export function getApiBase(): string {
 }
 
 /**
- * Get API base path.
- * Returns the configured API base path, defaulting to '/api'.
- * Override with VITE_API_BASE_PATH environment variable for custom deployments.
- */
-export function getApiBase(): string {
-  return import.meta.env.VITE_API_BASE_PATH || '/api'
-}
-
-/**
- * Get API base path (backward compatibility).
- * Returns the configurable API base path prefix. Defaults to '/api'.
- * Override with VITE_API_BASE_PATH environment variable.
- * Issue: #3631
- */
-export function getApiBase(): string {
-  return import.meta.env.VITE_API_BASE_PATH || '/api'
-}
-
-/**
  * Get WebSocket URL (backward compatibility).
  */
 export function getWebsocketUrl(): string {


### PR DESCRIPTION
Closes #3631

## Summary

- All target files (stores/useKnowledgeStore, usePermissionStore, useUserStore; models/repositories/KnowledgeRepository, ChatRepository, SystemRepository, ApiRepository; components/ChatInterface.ts) already had `getApiBase()` imported and all ~109 hardcoded `/api/` literals replaced from prior development
- Fixed a defect introduced by parallel PRs #3628-#3630: three identical duplicate `getApiBase()` function declarations in `ssot-config.ts` reduced to a single canonical declaration (TypeScript does not allow duplicate function implementations in non-overload contexts)

## Verification

```
grep -rn "'/api/" src/stores/ src/models/ src/components/ChatInterface.ts | grep -v __tests__
# 0 results
```

## Files Changed

- `autobot-frontend/src/config/ssot-config.ts` — removed 2 duplicate `getApiBase()` declarations (19 lines deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)