### PR TITLE
fix(ansible): guard groups['database'] lookup in deploy-backend-local.yml (#3651)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-backend-local.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-backend-local.yml
@@ -31,7 +31,7 @@
     celery_max_tasks_per_child: 1000
 
     # Redis connection
-    backend_redis_host: "{{ hostvars[groups['database'][0]]['ansible_host'] | default('127.0.0.1') }}"
+    backend_redis_host: "{{ hostvars[groups['database'][0]]['ansible_host'] | default('127.0.0.1') if 'database' in groups and groups['database'] | length > 0 else '127.0.0.1' }}"
     backend_redis_port: 6379
 
     # Deployment settings


### PR DESCRIPTION
## Summary

- Fixes `AnsibleUndefinedVariable` crash when the `database` inventory group is absent or empty in `deploy-backend-local.yml`
- Replaces the bare `groups['database'][0]` index access with an inline Jinja2 guard: evaluates the `hostvars` lookup only when `'database' in groups and groups['database'] | length > 0`, otherwise falls back to `127.0.0.1`
- No other `groups['X'][0]` patterns exist in this file

## Test plan

- [ ] Run `python3 -c "import yaml; yaml.safe_load(open('autobot-slm-backend/ansible/playbooks/deploy-backend-local.yml'))"` — exits 0
- [ ] Run `ansible-playbook --syntax-check autobot-slm-backend/ansible/playbooks/deploy-backend-local.yml` with an inventory that has no `database` group — no `AnsibleUndefinedVariable` error
- [ ] Run with a normal inventory that has a `database` group — `backend_redis_host` resolves to the VM's `ansible_host` value as before

Closes #3651

🤖 Generated with [Claude Code](https://claude.com/claude-code)