### PR TITLE
chore(frontend): add getApiBase() to autobot-frontend ssot-config (#3628)

### DIFF
--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -618,25 +618,6 @@ export function getApiBase(): string {
 }
 
 /**
- * Get API base path.
- * Returns the configured API base path, defaulting to '/api'.
- * Override with VITE_API_BASE_PATH environment variable for custom deployments.
- */
-export function getApiBase(): string {
-  return import.meta.env.VITE_API_BASE_PATH || '/api'
-}
-
-/**
- * Get API base path (backward compatibility).
- * Returns the configurable API base path prefix. Defaults to '/api'.
- * Override with VITE_API_BASE_PATH environment variable.
- * Issue: #3631
- */
-export function getApiBase(): string {
-  return import.meta.env.VITE_API_BASE_PATH || '/api'
-}
-
-/**
  * Get WebSocket URL (backward compatibility).
  */
 export function getWebsocketUrl(): string {


### PR DESCRIPTION
Closes #3628

## Changes
`getApiBase()` had been added to `ssot-config.ts` three times by three separate attempts, creating duplicate function declaration errors. This PR removes the two redundant copies and leaves the canonical single definition.

The function reads `VITE_API_BASE_PATH` env var with `/api` fallback — identical behaviour to `getSlmApiBase()` in the SLM frontend.

## Test plan
- [x] Single `getApiBase` declaration in ssot-config.ts
- [x] TypeScript compiler will no longer report duplicate identifier error