### PR TITLE
refactor(agents): cap exponential backoff in agent_client.py via exponential_backoff_delay (#3658)

### DIFF
--- a/autobot-backend/agents/agent_client.py
+++ b/autobot-backend/agents/agent_client.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 
 from autobot_shared.http_client import get_http_client
+from constants.threshold_constants import exponential_backoff_delay
 from utils.service_registry import get_service_url
 
 from .base_agent import (
@@ -330,14 +331,14 @@ class AgentClient:
 
                 # Wait before retry
                 if attempt < self.config.retry_attempts - 1:
-                    await asyncio.sleep(2**attempt)  # Exponential backoff
+                    await asyncio.sleep(exponential_backoff_delay(attempt))
 
                 last_error = response.error
 
             except Exception as e:
                 last_error = str(e)
                 if attempt < self.config.retry_attempts - 1:
-                    await asyncio.sleep(2**attempt)
+                    await asyncio.sleep(exponential_backoff_delay(attempt))
 
         # All retries failed
         return AgentResponse(


### PR DESCRIPTION
Closes #3658

## Changes
Replaced two uncapped `asyncio.sleep(2**attempt)` calls in `AgentClient._execute_with_retry()` with `exponential_backoff_delay(attempt)` — the shared helper added in PR #3643 (issue #3565) with a 60s cap.

At retry attempt 10, the old code would sleep for 1024 seconds. Both the response-error path and the exception path are fixed.

## Test plan
- [x] Clean diff — only 3 lines changed
- [x] No uncapped `2**attempt` backoff remaining in agent_client.py