### PR TITLE
fix(backend): default SLM_URL to localhost and deduplicate startup warning (#3655)

### DIFF
--- a/autobot-backend/services/slm_client.py
+++ b/autobot-backend/services/slm_client.py
@@ -38,11 +38,29 @@ from constants.ttl_constants import TTL_5_MINUTES
 
 logger = logging.getLogger(__name__)
 
-# SLM server URL from environment (no hardcoded fallback per SSOT requirements)
-# Set SLM_URL environment variable or SLM client will be unavailable
-DEFAULT_SLM_URL = os.getenv("SLM_URL")
-if not DEFAULT_SLM_URL:
-    logger.warning("SLM_URL not set - SLM client will be unavailable until configured")
+# SLM server URL from environment.  On co-located deployments (backend and SLM
+# share the same host) the env var is often not set, so default to localhost.
+# An explicit env var always wins.
+_COLOCATED_DEFAULT = "http://127.0.0.1:8000"
+DEFAULT_SLM_URL: str = os.getenv("SLM_URL") or _COLOCATED_DEFAULT
+
+# Warn at most once per process — the module is imported by several packages
+# simultaneously, which previously caused the same warning to fire 3×.
+_slm_url_warned: bool = False
+
+
+def _warn_slm_url_once(url: str) -> None:
+    """Emit the SLM_URL diagnostic warning exactly once per process."""
+    global _slm_url_warned
+    if _slm_url_warned:
+        return
+    _slm_url_warned = True
+    if not os.getenv("SLM_URL"):
+        logger.warning(
+            "SLM_URL not set — defaulting to co-located address %s. "
+            "Set SLM_URL explicitly for non-co-located deployments.",
+            url,
+        )
 
 # Ultimate fallback configuration (uses env vars where available)
 ULTIMATE_FALLBACK_CONFIG = {
@@ -627,6 +645,8 @@ async def init_slm_client(
         Initialized SLMClient instance
     """
     global _slm_client
+
+    _warn_slm_url_once(slm_url)
 
     if _slm_client:
         logger.warning("SLM client already initialized, disconnecting old instance")


### PR DESCRIPTION
## Summary

- `SLM_URL` now defaults to `http://127.0.0.1:8000` when the env var is absent, enabling co-located deployments (backend + SLM on the same host) to connect without explicit configuration.
- The startup warning is deferred from module-import time into `init_slm_client()` and gated by a `_slm_url_warned` module-level flag, so it fires **at most once per process** instead of 3× (one per importing package).
- If `SLM_URL` is explicitly set, no warning is emitted at all.

Fixes #3655.

## Test plan

- [ ] Start backend without `SLM_URL` set — confirm exactly **one** warning line in the log, not three
- [ ] Start backend with `SLM_URL=https://remote-slm:8000` — confirm **zero** warning lines
- [ ] Existing `redis_service_manager_slm_test.py` passes (pre-existing failure unrelated to this change — tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)