### PR TITLE
refactor(backend): remove dead doc_generation_threshold attribute (#3656)

### DIFF
--- a/autobot-backend/constants/threshold_constants.py
+++ b/autobot-backend/constants/threshold_constants.py
@@ -39,7 +39,6 @@ class WorkflowThresholds:
 
     SAFETY_THRESHOLD = 0.7  # Minimum safety score required
     QUALITY_THRESHOLD = 0.6  # Minimum quality score required
-    DOC_GENERATION_THRESHOLD = 0.8  # Minimum score to trigger auto-documentation
 
 
 class ComputerVisionThresholds:

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from autobot_shared.logging_manager import get_logger
 from config import config_manager
-from constants.threshold_constants import LLMDefaults, TimingConstants, WorkflowThresholds
+from constants.threshold_constants import LLMDefaults, TimingConstants
 from conversation import ConversationManager
 from llm_interface import LLMInterface
 from memory import LongTermMemoryManager
@@ -237,7 +237,6 @@ class ConsolidatedOrchestrator:
         self.knowledge_base = KnowledgeBase() if KNOWLEDGE_BASE_AVAILABLE else None
 
         self.auto_doc_enabled = True
-        self.doc_generation_threshold = WorkflowThresholds.DOC_GENERATION_THRESHOLD
         self.knowledge_extraction_enabled = KNOWLEDGE_BASE_AVAILABLE
 
         self.workflow_metrics = {


### PR DESCRIPTION
Closes #3656

## Changes
- Removed `self.doc_generation_threshold` from `ConsolidatedOrchestrator.__init__` — it was set but never read; the auto-doc path is gated on the boolean `auto_document` parameter, not a quality score
- Removed `WorkflowThresholds.DOC_GENERATION_THRESHOLD` constant (added in #3607) since it had no usage
- Removed `WorkflowThresholds` from the orchestrator import line

## Test plan
- [x] No references to `doc_generation_threshold` or `DOC_GENERATION_THRESHOLD` remain