### PR TITLE
bug(backend): fix REDIS_HOST → AUTOBOT_REDIS_HOST in chat history modules

### DIFF
--- a/autobot-backend/chat_history/base.py
+++ b/autobot-backend/chat_history/base.py
@@ -71,7 +71,7 @@ class ChatHistoryBase:
             use_redis if use_redis is not None else redis_config.get("enabled", False)
         )
         self.redis_host = redis_host or redis_config.get(
-            "host", os.getenv("REDIS_HOST", unified_config.get_host("redis"))
+            "host", os.getenv("AUTOBOT_REDIS_HOST", unified_config.get_host("redis"))
         )
         self.redis_port = redis_port or redis_config.get(
             "port",

--- a/autobot-backend/chat_history_manager.py
+++ b/autobot-backend/chat_history_manager.py
@@ -37,7 +37,7 @@ class ChatHistoryManager:
             use_redis if use_redis is not None else redis_config.get("enabled", False)
         )
         self.redis_host = redis_host or redis_config.get(
-            "host", os.getenv("REDIS_HOST", "localhost")
+            "host", os.getenv("AUTOBOT_REDIS_HOST", "localhost")
         )
         self.redis_port = redis_port or redis_config.get("port", 6379)
 


### PR DESCRIPTION
Closes #3671

## Problem
`chat_history_manager.py` and `chat_history/base.py` read `REDIS_HOST` (no prefix) instead of `AUTOBOT_REDIS_HOST`. In distributed deployments where only `AUTOBOT_REDIS_HOST` is set, these files silently fall back to `localhost`, causing chat history reads/writes to fail.

## Changes
- `chat_history_manager.py:40`: `REDIS_HOST` → `AUTOBOT_REDIS_HOST`
- `chat_history/base.py:74`: `REDIS_HOST` → `AUTOBOT_REDIS_HOST`

## Verification
- `grep -rn "os.getenv.*\"REDIS_HOST\"" autobot-backend/ --include="*.py" | grep -v AUTOBOT_REDIS_HOST` → 0 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)