### PR TITLE
chore(slm-frontend): replace hardcoded /api/ with getSlmApiBase() (#3627)

### DIFF
--- a/autobot-slm-frontend/src/components/DeploymentWizard.vue
+++ b/autobot-slm-frontend/src/components/DeploymentWizard.vue
@@ -6,6 +6,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useSlmApi } from '@/composables/useSlmApi'
 import { useFleetStore } from '@/stores/fleet'
+import { getSlmApiBase } from '@/config/ssot-config'
 import type { SLMNode, NodeRole } from '@/types/slm'
 
 interface RoleInfo {
@@ -94,7 +95,7 @@ async function loadData(): Promise<void> {
 async function fetchRoles(): Promise<void> {
   isLoadingRoles.value = true
   try {
-    const response = await fetch('/api/deployments/roles', {
+    const response = await fetch(`${getSlmApiBase()}/deployments/roles`, {
       headers: {
         Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}`,
       },

--- a/autobot-slm-frontend/src/views/InfrastructureView.vue
+++ b/autobot-slm-frontend/src/views/InfrastructureView.vue
@@ -12,6 +12,7 @@
 
 import { ref, computed, onMounted } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
+import { getSlmApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('InfrastructureView')
 import InfrastructureWizard from '@/components/InfrastructureWizard.vue'
@@ -51,7 +52,7 @@ onMounted(() => {
 async function loadPlaybooks(): Promise<void> {
   isLoading.value = true
   try {
-    const response = await fetch('/api/infrastructure/playbooks', {
+    const response = await fetch(`${getSlmApiBase()}/infrastructure/playbooks`, {
       headers: {
         Authorization: `Bearer ${sessionStorage.getItem('slm_access_token')}`,
       },

--- a/autobot-slm-frontend/src/views/RolesView.vue
+++ b/autobot-slm-frontend/src/views/RolesView.vue
@@ -14,6 +14,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { createLogger } from '@/utils/debugUtils'
+import { getSlmApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('RolesView')
 const authStore = useAuthStore()
@@ -110,7 +111,7 @@ const healthClass = computed(() => {
 // API helper
 async function apiFetch<T>(path: string, options?: RequestInit): Promise<T | null> {
   try {
-    const response = await fetch(`${authStore.getApiUrl()}${path}`, {
+    const response = await fetch(`${getSlmApiBase()}${path}`, {
       ...options,
       headers: { 'Content-Type': 'application/json', ...authStore.getAuthHeaders(), ...options?.headers },
     })
@@ -130,20 +131,20 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T | nul
 async function fetchRoles(): Promise<void> {
   isLoading.value = true
   errorMessage.value = null
-  const result = await apiFetch<RoleDefinition[]>('/api/roles')
+  const result = await apiFetch<RoleDefinition[]>('/roles')
   if (result) roles.value = result
   isLoading.value = false
 }
 
 async function fetchFleetHealth(): Promise<void> {
   isLoadingHealth.value = true
-  const result = await apiFetch<FleetHealth>('/api/roles/fleet-health')
+  const result = await apiFetch<FleetHealth>('/roles/fleet-health')
   if (result) fleetHealth.value = result
   isLoadingHealth.value = false
 }
 
 async function fetchNodes(): Promise<void> {
-  const result = await apiFetch<NodeSummary[]>('/api/nodes')
+  const result = await apiFetch<NodeSummary[]>('/nodes')
   if (result) nodes.value = result
 }
 
@@ -205,7 +206,7 @@ async function saveRole(): Promise<void> {
 
   if (editingRole.value) {
     const result = await apiFetch<RoleDefinition>(
-      `/api/roles/${editingRole.value}`,
+      `/roles/${editingRole.value}`,
       { method: 'PUT', body: JSON.stringify(payload) }
     )
     if (result) {
@@ -216,7 +217,7 @@ async function saveRole(): Promise<void> {
     }
   } else {
     const result = await apiFetch<RoleDefinition>(
-      '/api/roles',
+      '/roles',
       { method: 'POST', body: JSON.stringify(payload) }
     )
     if (result) {
@@ -231,7 +232,7 @@ async function saveRole(): Promise<void> {
 async function deleteRole(roleName: string): Promise<void> {
   if (!confirm(`Delete role "${roleName}"? This cannot be undone.`)) return
   const result = await apiFetch<{ message: string }>(
-    `/api/roles/${roleName}`,
+    `/roles/${roleName}`,
     { method: 'DELETE' }
   )
   if (result) {
@@ -256,7 +257,7 @@ async function executeMigrate(): Promise<void> {
   errorMessage.value = null
 
   const result = await apiFetch<{ success: boolean; output: string; playbook: string }>(
-    `/api/roles/${migratingRole.value.name}/migrate`,
+    `/roles/${migratingRole.value.name}/migrate`,
     { method: 'POST', body: JSON.stringify({ target_node_id: targetNodeId.value }) }
   )
 

--- a/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.vue
+++ b/autobot-slm-frontend/src/views/monitoring/AlertsMonitor.vue
@@ -12,6 +12,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { usePrometheusMetrics } from '@/composables/usePrometheusMetrics'
 import { useAuthStore } from '@/stores/auth'
+import { getSlmApiBase } from '@/config/ssot-config'
 
 const {
   alerts,
@@ -129,7 +130,7 @@ async function clearAlerts() {
   try {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' }
     if (authStore.token) headers.Authorization = `Bearer ${authStore.token}`
-    await fetch('/api/monitoring/alerts', { method: 'DELETE', headers })
+    await fetch(`${getSlmApiBase()}/monitoring/alerts`, { method: 'DELETE', headers })
     await refresh()
   } finally {
     isClearing.value = false

--- a/autobot-slm-frontend/src/views/settings/admin/ConfigDefaultsSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/ConfigDefaultsSettings.vue
@@ -15,6 +15,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { createLogger } from '@/utils/debugUtils'
 import { formatDateTime } from '@/composables/useTimezone'
+import { getSlmApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('ConfigDefaultsSettings')
 const authStore = useAuthStore()
@@ -54,7 +55,7 @@ const filteredConfigs = computed(() => {
 // API helper
 async function apiFetch<T>(path: string, options?: RequestInit): Promise<T | null> {
   try {
-    const response = await fetch(`${authStore.getApiUrl()}${path}`, {
+    const response = await fetch(`${getSlmApiBase()}${path}`, {
       ...options,
       headers: { 'Content-Type': 'application/json', ...authStore.getAuthHeaders(), ...options?.headers },
     })
@@ -74,7 +75,7 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T | nul
 async function fetchDefaults(): Promise<void> {
   isLoading.value = true
   errorMessage.value = null
-  const result = await apiFetch<{ configs: ConfigEntry[]; total: number }>('/api/config/defaults')
+  const result = await apiFetch<{ configs: ConfigEntry[]; total: number }>('/config/defaults')
   if (result) configs.value = result.configs
   isLoading.value = false
 }
@@ -101,7 +102,7 @@ async function saveConfig(): Promise<void> {
   if (!key) { errorMessage.value = 'Key is required'; return }
 
   const result = await apiFetch<ConfigEntry>(
-    `/api/config/defaults/${encodeURIComponent(key)}`,
+    `/config/defaults/${encodeURIComponent(key)}`,
     { method: 'PUT', body: JSON.stringify({ value: newValue.value, value_type: newValueType.value }) }
   )
   if (result) {
@@ -115,7 +116,7 @@ async function saveConfig(): Promise<void> {
 async function deleteConfig(key: string): Promise<void> {
   if (!confirm(`Delete global config "${key}"?`)) return
   const result = await apiFetch<{ message: string }>(
-    `/api/config/defaults/${encodeURIComponent(key)}`,
+    `/config/defaults/${encodeURIComponent(key)}`,
     { method: 'DELETE' }
   )
   if (result) {

--- a/autobot-slm-frontend/src/views/settings/admin/PersonalitySettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/PersonalitySettings.vue
@@ -22,6 +22,7 @@ import {
   type PersonalityProfile,
   type ProfileCreate,
 } from '@/composables/usePersonality'
+import { getSlmApiBase } from '@/config/ssot-config'
 
 const {
   profiles,
@@ -54,7 +55,7 @@ const voiceList = ref<{ id: string; name: string; builtin: boolean }[]>([])
 async function fetchVoices() {
   try {
     const token = authStore.token || localStorage.getItem('autobot_access_token') || ''
-    const res = await fetch('/api/voice/voices', {
+    const res = await fetch(`${getSlmApiBase()}/voice/voices`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
     if (res.ok) {


### PR DESCRIPTION
Closes #3627

## Changes
Migrated 9 hardcoded `/api/` occurrences across 6 SLM frontend files to use `getSlmApiBase()`.

Files fixed:
- `views/monitoring/AlertsMonitor.vue` — 1 raw fetch
- `views/settings/admin/ConfigDefaultsSettings.vue` — 2 apiFetch paths
- `views/settings/admin/PersonalitySettings.vue` — 1 raw fetch
- `views/RolesView.vue` — 6 apiFetch paths (local helper updated to use `getSlmApiBase()` as base)
- `views/InfrastructureView.vue` — 1 raw fetch
- `components/DeploymentWizard.vue` — 1 raw fetch

`authStore.getApiUrl()` returns `''` in all standard modes (dev + prod default), so switching local `apiFetch` helpers to `getSlmApiBase()` preserves identical standalone behavior while fixing co-located mode.

## Test plan
- [x] Zero `'/api/` occurrences remain in SLM frontend src/