### PR TITLE
feat(ansible): add pre-flight code_source sync to deploy playbooks (#3604)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/deploy-aiml.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-aiml.yml
@@ -6,6 +6,14 @@
 # Deploys ChromaDB vector database and AI Stack API (agent router)
 ---
 
+# -------------------------------------------------------------------
+# Pre-flight: Sync code_source from GitHub before roles run (#3604)
+# -------------------------------------------------------------------
+- name: "Pre-flight: Sync code_source"
+  import_playbook: pre-flight-code-sync.yml
+  tags: ['pre-flight']
+
+
 - name: "Deploy AI/ML Infrastructure (ChromaDB + AI Stack API)"
   hosts: aiml
   become: true

--- a/autobot-slm-backend/ansible/playbooks/deploy-backend-local.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-backend-local.yml
@@ -1,4 +1,12 @@
 ---
+
+# -------------------------------------------------------------------
+# Pre-flight: Sync code_source from GitHub before roles run (#3604)
+# -------------------------------------------------------------------
+- name: "Pre-flight: Sync code_source"
+  import_playbook: pre-flight-code-sync.yml
+  tags: ['pre-flight']
+
 # Deploy Backend Services to Main Machine (Localhost)
 # Issue #863: Service management migration
 #

--- a/autobot-slm-backend/ansible/playbooks/deploy-backend-remote.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-backend-remote.yml
@@ -1,4 +1,12 @@
 ---
+
+# -------------------------------------------------------------------
+# Pre-flight: Sync code_source from GitHub before roles run (#3604)
+# -------------------------------------------------------------------
+- name: "Pre-flight: Sync code_source"
+  import_playbook: pre-flight-code-sync.yml
+  tags: ['pre-flight']
+
 # Deploy Backend Services to Main Machine (Remote from SLM)
 # Issue #856: Python 3.12 deployment with pyenv
 #

--- a/autobot-slm-backend/ansible/playbooks/deploy-full.yml
+++ b/autobot-slm-backend/ansible/playbooks/deploy-full.yml
@@ -1,4 +1,12 @@
 ---
+
+# -------------------------------------------------------------------
+# Pre-flight: Sync code_source from GitHub before roles run (#3604)
+# -------------------------------------------------------------------
+- name: "Pre-flight: Sync code_source"
+  import_playbook: pre-flight-code-sync.yml
+  tags: ['pre-flight']
+
 # AutoBot Full Deployment Playbook
 # Orchestrates complete migration from Docker to Hyper-V VMs
 

--- a/autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml
+++ b/autobot-slm-backend/ansible/playbooks/pre-flight-code-sync.yml
@@ -1,0 +1,137 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Pre-flight: sync code_source from GitHub before any deploy playbook runs (#3604)
+#
+# Pulls the latest committed code so that Ansible role files, templates, and
+# defaults are always current when a standalone deploy-*.yml is invoked directly
+# (without going through provision-fleet-roles.yml).
+#
+# Uses ignore_errors: yes so offline / air-gapped SLMs still work — they
+# deploy from whatever code_source is already on disk and get a visible warning.
+# This mirrors the Play 0 block in provision-fleet-roles.yml.
+#
+# Usage (imported by other playbooks — not normally invoked directly):
+#   - name: "Pre-flight: Sync code_source"
+#     import_playbook: pre-flight-code-sync.yml
+#     tags: ['pre-flight']
+---
+- name: "Pre-flight: Sync code_source from GitHub"
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    github_repo: "https://github.com/mrveiss/AutoBot-AI.git"
+    git_repo_root: "/opt/autobot/code_source"
+    deploy_ref: "Dev_new_gui"
+
+  tasks:
+    - name: "[PRE-FLIGHT] Verify code_source exists"
+      ansible.builtin.stat:
+        path: "{{ git_repo_root }}/.git"
+      register: code_source_stat
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Abort if code_source missing"
+      ansible.builtin.fail:
+        msg: >-
+          Code source not found at {{ git_repo_root }}.
+          Initialize with: git clone {{ github_repo }} {{ git_repo_root }}
+      when: not code_source_stat.stat.exists
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Get code_source commit before sync"
+      ansible.builtin.command:
+        cmd: git -C {{ git_repo_root }} log -1 --format='%h %s'
+      register: pre_sync_commit
+      changed_when: false
+      tags: [always]
+
+    # Root-owned files in code_source (e.g. from earlier sudo cp) block
+    # git reset --hard.  Fix ownership before the pull so force: yes works.
+    - name: "[PRE-FLIGHT] Fix code_source ownership so git reset can overwrite"
+      ansible.builtin.file:
+        path: "{{ git_repo_root }}"
+        state: directory
+        owner: "{{ ansible_user_id | default('autobot') }}"
+        group: "{{ ansible_user_id | default('autobot') }}"
+        recurse: true
+      become: true
+      failed_when: false
+      changed_when: false
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Sync latest code from GitHub (if reachable)"
+      ansible.builtin.git:
+        repo: "{{ github_repo }}"
+        dest: "{{ git_repo_root }}"
+        version: "{{ deploy_ref }}"
+        update: yes
+        force: yes
+      ignore_errors: yes
+      register: github_sync
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Warn if GitHub sync skipped"
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: GitHub sync failed (no internet access?).
+          Deploying from existing code_source at {{ git_repo_root }}.
+      when: github_sync is failed
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Show code_source age when sync skipped"
+      ansible.builtin.command:
+        cmd: "git -C {{ git_repo_root }} log -1 --format='Last commit: %h %s (%cr)'"
+      register: code_source_age
+      changed_when: false
+      when: github_sync is failed
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Display code_source age (offline mode)"
+      ansible.builtin.debug:
+        msg: "Offline deployment -- {{ code_source_age.stdout }}"
+      when: github_sync is failed
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Get current deploy commit"
+      ansible.builtin.command:
+        cmd: git -C {{ git_repo_root }} log -1 --format='%h %s'
+      register: deploy_info
+      changed_when: false
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Count commits advanced during sync"
+      ansible.builtin.command:
+        cmd: git -C {{ git_repo_root }} rev-list --count {{ pre_sync_commit.stdout.split()[0] }}..HEAD
+      register: sync_commit_count
+      changed_when: false
+      when: github_sync is not failed
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Display sync delta"
+      ansible.builtin.debug:
+        msg:
+          - "=== Pre-flight Code Sync Summary ==="
+          - "Was at: {{ pre_sync_commit.stdout }}"
+          - "Now at: {{ deploy_info.stdout }}"
+          - "Commits advanced: {{ sync_commit_count.stdout | default('0') }}"
+      when: github_sync is not failed
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] WARN: code_source was significantly behind"
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: code_source advanced {{ sync_commit_count.stdout }} commits during sync.
+          Role behavior may have changed significantly. Review recent changes before proceeding.
+      when:
+        - github_sync is not failed
+        - sync_commit_count.stdout | int > 50
+      tags: [always]
+
+    - name: "[PRE-FLIGHT] Display deployed commit"
+      ansible.builtin.debug:
+        msg: "Deploying from commit: {{ deploy_info.stdout }}"
+      when: github_sync is not failed
+      tags: [always]


### PR DESCRIPTION
## Summary

- Extracts the Play 0 pre-flight block from `provision-fleet-roles.yml` into a shared `pre-flight-code-sync.yml` playbook
- Adds `import_playbook: pre-flight-code-sync.yml` at the top of `deploy-full.yml`, `deploy-aiml.yml`, `deploy-backend-local.yml`, and `deploy-backend-remote.yml`
- `deploy-slm-manager.yml` was already covered (imports `sync-code-source.yml` + `provision-fleet-roles.yml`)
- GitHub sync uses `ignore_errors: yes` — offline/air-gapped SLMs fall back to existing `code_source` with a visible warning and staleness metrics (from PR #3595)

## Test plan

- [ ] Run `python3 -c "import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob('autobot-slm-backend/ansible/playbooks/deploy-*.yml')]"` — all four modified files parse cleanly
- [ ] Invoke `ansible-playbook deploy-aiml.yml --tags pre-flight` on a machine with `/opt/autobot/code_source` — confirms GitHub pull runs and delta is reported
- [ ] Repeat with no network access — confirms warning is printed and play does not abort
- [ ] Invoke `ansible-playbook deploy-aiml.yml --tags pre-flight` with `code_source` 60+ commits behind — confirms >50-commit WARNING fires

Closes #3604

🤖 Generated with [Claude Code](https://claude.com/claude-code)