### PR TITLE
fix(analytics): scope codebase analytics caches and live scans to source_id (#3685)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -39,7 +39,8 @@ router = APIRouter()
 _manager = BackgroundTaskManager(redis_prefix="dup_task:")
 
 # Cache for duplicate analysis (in-memory, refreshed on demand)
-_duplicate_cache: Optional[dict] = None
+# Keyed by source_id (or "" for unscoped) to prevent cross-project leakage (#3685)
+_duplicate_cache: dict[str, dict] = {}
 
 
 def _get_project_root() -> str:
@@ -242,23 +243,25 @@ def _build_detection_error_response(error_msg: str) -> dict:
     }
 
 
-def _process_and_cache_analysis(analysis, project_root: str) -> dict:
+def _process_and_cache_analysis(
+    analysis, project_root: str, source_id: Optional[str] = None
+) -> dict:
     """
     Convert analysis to result dict and log completion.
 
     Issue #620: Extracted from get_duplicate_code to reduce function length.
+    Issue #3685: Keyed by source_id to prevent cross-project cache leakage.
 
     Args:
         analysis: Analysis result object
         project_root: Project root path
+        source_id: Optional source ID for per-project cache scoping
 
     Returns:
         Result dict suitable for JSONResponse
     """
-    global _duplicate_cache
-
     result = _convert_analysis_to_result(analysis, project_root)
-    _duplicate_cache = result
+    _duplicate_cache[source_id or ""] = result
 
     logger.info(
         "Duplicate analysis complete: %d duplicates (%d high, %d medium, %d low)",
@@ -298,24 +301,29 @@ async def _run_duplicate_analysis(
     return analysis
 
 
-def _check_duplicate_cache(refresh: bool) -> Optional[JSONResponse]:
+def _check_duplicate_cache(
+    refresh: bool, source_id: Optional[str] = None
+) -> Optional[JSONResponse]:
     """
     Check if cached results are available and return them.
 
     Issue #620: Extracted from get_duplicate_code to reduce function length.
+    Issue #3685: Keyed by source_id to prevent cross-project cache leakage.
 
     Args:
         refresh: Whether to force fresh analysis
+        source_id: Optional source ID for per-project cache scoping
 
     Returns:
         JSONResponse with cached data, or None if cache miss/refresh requested
     """
-    if _duplicate_cache and not refresh:
+    cached = _duplicate_cache.get(source_id or "")
+    if cached and not refresh:
         logger.info(
             "Returning cached duplicate analysis (%d duplicates)",
-            _duplicate_cache.get("total_count", 0),
+            cached.get("total_count", 0),
         )
-        return JSONResponse(_duplicate_cache)
+        return JSONResponse(cached)
     return None
 
 
@@ -378,12 +386,23 @@ async def get_duplicate_code(
     Returns:
         JSON with duplicates, statistics, and analysis metadata
     """
-    # Check cache first - Issue #620: Use helper
-    cached = _check_duplicate_cache(refresh)
+    # Check cache first - Issue #620, #3685: Scoped by source_id
+    cached = _check_duplicate_cache(refresh, source_id=source_id)
     if cached:
         return cached
 
+    # Issue #3685: Resolve clone_path from source registry so live analysis
+    # runs against the correct project, not always the AutoBot repo.
     project_root = _get_project_root()
+    if source_id:
+        try:
+            from api.codebase_analytics.source_storage import get_source
+
+            source = await get_source(source_id)
+            if source and source.clone_path:
+                project_root = source.clone_path
+        except Exception:
+            logger.debug("Could not resolve clone_path for %s, using default", source_id)
 
     try:
         # Run analysis (semantic or standard) - Issue #620: Use helper
@@ -395,8 +414,8 @@ async def get_duplicate_code(
         if analysis is None:
             return JSONResponse(_build_timeout_response())
 
-        # Convert, cache, and return results - Issue #620: Use helper
-        result = _process_and_cache_analysis(analysis, project_root)
+        # Convert, cache, and return results - Issue #620, #3685: Scoped by source_id
+        result = _process_and_cache_analysis(analysis, project_root, source_id=source_id)
         return JSONResponse(result)
 
     except Exception as e:
@@ -499,20 +518,36 @@ async def detect_config_duplicates_endpoint(
     use_semantic: bool = Query(
         False, description="Enable LLM-based semantic analysis (Issue #554)"
     ),
+    source_id: Optional[str] = Query(
+        None, description="#3685: source_id for per-project scoping"
+    ),
 ):
     """
     Detect configuration value duplicates across codebase (Issue #341).
 
     Issue #554: Enhanced with optional semantic analysis.
     Issue #620: Refactored to use helper functions.
+    Issue #3685: source_id scopes analysis to the correct project clone.
 
     Args:
         use_semantic: Enable semantic duplicate detection via LLM embeddings
+        source_id: Optional source ID to scope analysis to the correct project
 
     Returns:
         JSONResponse with duplicate detection results
     """
     project_root = Path(__file__).resolve().parents[4]
+    if source_id:
+        try:
+            from api.codebase_analytics.source_storage import get_source
+
+            source = await get_source(source_id)
+            if source and source.clone_path:
+                project_root = Path(source.clone_path)
+        except Exception:
+            logger.debug(
+                "Could not resolve clone_path for %s, using default", source_id
+            )
 
     # Issue #620: Use helpers for detection
     result = None

--- a/autobot-backend/api/codebase_analytics/endpoints/ownership.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/ownership.py
@@ -27,7 +27,8 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/ownership", tags=["ownership"])
 
 # Cache for ownership analysis (in-memory, refreshed on demand)
-_ownership_analysis_cache: Optional[dict] = None
+# Keyed by source_id (or "") to prevent cross-project leakage (#3685)
+_ownership_analysis_cache: dict[str, dict] = {}
 _ownership_analysis_cache_lock = asyncio.Lock()
 
 
@@ -274,29 +275,33 @@ def _build_knowledge_gaps_error(message: str) -> dict:
     }
 
 
-async def _check_ownership_cache(refresh: bool) -> Optional[JSONResponse]:
+async def _check_ownership_cache(
+    refresh: bool, source_id: Optional[str] = None
+) -> Optional[JSONResponse]:
     """Check cache for ownership analysis results.
 
     Issue #665: Extracted from get_ownership_analysis to reduce function length.
+    Issue #3685: Keyed by source_id to prevent cross-project cache leakage.
     """
     async with _ownership_analysis_cache_lock:
-        if _ownership_analysis_cache and not refresh:
+        cached = _ownership_analysis_cache.get(source_id or "")
+        if cached and not refresh:
             logger.info(
                 "Returning cached ownership analysis (%d files)",
-                _ownership_analysis_cache.get("summary", {}).get("total_files", 0),
+                cached.get("summary", {}).get("total_files", 0),
             )
-            return JSONResponse(_ownership_analysis_cache)
+            return JSONResponse(cached)
     return None
 
 
-async def _cache_ownership_result(result: dict) -> None:
+async def _cache_ownership_result(result: dict, source_id: Optional[str] = None) -> None:
     """Cache ownership analysis result.
 
     Issue #665: Extracted from get_ownership_analysis to reduce function length.
+    Issue #3685: Keyed by source_id to prevent cross-project cache leakage.
     """
-    global _ownership_analysis_cache
     async with _ownership_analysis_cache_lock:
-        _ownership_analysis_cache = result
+        _ownership_analysis_cache[source_id or ""] = result
 
 
 @router.get("/analysis")
@@ -315,15 +320,27 @@ async def get_ownership_analysis(
     ),
 ):
     """Analyze code ownership (Issue #248). Issue #665: Refactored with helpers."""
-    cached = await _check_ownership_cache(refresh)
+    cached = await _check_ownership_cache(refresh, source_id=source_id)
     if cached:
         return cached
 
     project_root = _get_project_root()
+    # Issue #3685: Use clone_path for the correct project when source_id provided
+    if source_id and not path:
+        try:
+            from api.codebase_analytics.source_storage import get_source
+
+            source = await get_source(source_id)
+            if source and source.clone_path:
+                project_root = source.clone_path
+        except Exception:
+            logger.debug(
+                "Could not resolve clone_path for %s, using default", source_id
+            )
     if not path:
         path = project_root
 
-    error_response = _validate_path_security(path, project_root)
+    error_response = _validate_path_security(path, _get_project_root())
     if error_response:
         return error_response
 
@@ -349,7 +366,7 @@ async def get_ownership_analysis(
             )
 
         result = _build_ownership_result(analysis, path)
-        await _cache_ownership_result(result)
+        await _cache_ownership_result(result, source_id=source_id)
 
         logger.info(
             "Ownership analysis complete: %d files, %d gaps",
@@ -389,12 +406,11 @@ async def get_expertise_scores(
     - Recency of contributions
     - Number of files/directories owned
     """
-    # Check cache first
+    # Check cache first - Issue #3685: Scoped by source_id
     async with _ownership_analysis_cache_lock:
-        if _ownership_analysis_cache and _ownership_analysis_cache.get(
-            "expertise_scores"
-        ):
-            scores = _ownership_analysis_cache["expertise_scores"]
+        cached = _ownership_analysis_cache.get(source_id or "")
+        if cached and cached.get("expertise_scores"):
+            scores = cached["expertise_scores"]
             return JSONResponse(_build_expertise_response(scores, len(scores), "cache"))
 
     # Run fresh analysis if no cache
@@ -452,12 +468,11 @@ async def get_knowledge_gaps(
     - Inactive maintainers
     - High ownership concentration
     """
-    # Check cache first
+    # Check cache first - Issue #3685: Scoped by source_id
     async with _ownership_analysis_cache_lock:
-        if _ownership_analysis_cache and _ownership_analysis_cache.get(
-            "knowledge_gaps"
-        ):
-            gaps = _ownership_analysis_cache["knowledge_gaps"]
+        cached = _ownership_analysis_cache.get(source_id or "")
+        if cached and cached.get("knowledge_gaps"):
+            gaps = cached["knowledge_gaps"]
             if risk_level:
                 gaps = [g for g in gaps if g.get("risk_level") == risk_level]
             return JSONResponse(

--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -119,36 +119,46 @@ def _is_task_stale(task_info: dict) -> bool:
         return False
 
 
-def _get_active_indexing_task() -> Optional[dict]:
+def _get_active_indexing_task(source_id: Optional[str] = None) -> Optional[dict]:
     """
     Check if there's an active indexing task and return its info.
 
     Issue #540: Used to show indexing status in stats endpoint.
     Uses _tasks_sync_lock for thread safety when accessing indexing_tasks.
     Ignores stale tasks that have been running for more than 1 hour.
+    Issue #3685: Filters by source_id to prevent cross-project leakage.
+
+    Args:
+        source_id: When provided, only return a task belonging to this project.
 
     Returns:
-        Task info dict if indexing is in progress, None otherwise.
+        Task info dict if indexing is in progress for this project, None otherwise.
     """
     with _tasks_sync_lock:
         for task_id, task_info in indexing_tasks.items():
-            if task_info.get("status") == "running":
-                # Issue #540: Skip stale tasks (stuck for >1 hour)
-                if _is_task_stale(task_info):
-                    logger.warning(
-                        "Ignoring stale indexing task %s (started: %s)",
-                        task_id,
-                        task_info.get("started_at"),
-                    )
-                    continue
+            if task_info.get("status") != "running":
+                continue
 
-                return {
-                    "task_id": task_id,
-                    "progress": task_info.get("progress", {}),
-                    "phases": task_info.get("phases", {}),
-                    "stats": task_info.get("stats", {}),
-                    "started_at": task_info.get("started_at"),
-                }
+            # Issue #3685: Skip tasks belonging to a different project
+            if source_id is not None and task_info.get("source_id") != source_id:
+                continue
+
+            # Issue #540: Skip stale tasks (stuck for >1 hour)
+            if _is_task_stale(task_info):
+                logger.warning(
+                    "Ignoring stale indexing task %s (started: %s)",
+                    task_id,
+                    task_info.get("started_at"),
+                )
+                continue
+
+            return {
+                "task_id": task_id,
+                "progress": task_info.get("progress", {}),
+                "phases": task_info.get("phases", {}),
+                "stats": task_info.get("stats", {}),
+                "started_at": task_info.get("started_at"),
+            }
     return None
 
 
@@ -196,7 +206,8 @@ async def get_codebase_stats(source_id: Optional[str] = None):
     Issue #1710: source_id filters to per-project stats.
     """
     # Issue #540: Check if indexing is in progress
-    active_task = _get_active_indexing_task()
+    # Issue #3685: Filter by source_id to prevent cross-project leakage
+    active_task = _get_active_indexing_task(source_id=source_id)
 
     code_collection = await asyncio.to_thread(get_code_collection)
 

--- a/autobot-backend/api/codebase_analytics/scanner.py
+++ b/autobot-backend/api/codebase_analytics/scanner.py
@@ -386,7 +386,10 @@ async def do_indexing_with_progress(
         )
 
         async with _tasks_lock:
-            indexing_tasks[task_id] = _create_initial_task_state_bound()
+            state = _create_initial_task_state_bound()
+            # Issue #3685: Store source_id so stats endpoint can filter by project
+            state["source_id"] = source_id
+            indexing_tasks[task_id] = state
             await _save_task_to_redis_bound(task_id)
 
         def update_phase(phase_id, status):


### PR DESCRIPTION
## Summary

Fixes mrveiss/AutoBot-AI#3685 — cross-project data leakage in codebase analytics with 2+ projects.

Five distinct leak vectors corrected:

- **Vector 1** (`duplicates.py:43`): `_duplicate_cache` was a single `Optional[dict]`; now `dict[str, dict]` keyed by `source_id or ""`. `_check_duplicate_cache` and `_process_and_cache_analysis` updated to use the scoped key.
- **Vector 2** (`ownership.py:30`): `_ownership_analysis_cache` same fix. `_check_ownership_cache`, `_cache_ownership_result`, and all three cache-reading endpoints updated.
- **Vector 3** (`duplicates.py:386`): Live `DuplicateCodeDetector` always ran against the AutoBot repo. Now resolves `source.clone_path` from the source registry when `source_id` is provided.
- **Vector 4** (`duplicates.py:498`): `detect_config_duplicates_endpoint` added `source_id` query param with same clone_path resolution.
- **Vector 5** (`stats.py:122`, `scanner.py:389`): `indexing_tasks` entries now store `source_id` at task creation. `_get_active_indexing_task` filters by `source_id` so Project B's stats page no longer shows Project A's indexing progress.

## Test plan

- [ ] Index Project A — verify Project B stats show no indexing activity
- [ ] While Project A is indexing, open Project B stats — confirm no "indexing in progress" banner
- [ ] Run duplicates on Project A — verify Project B duplicates endpoint does not return Project A's cached results
- [ ] Run config-duplicates with `?source_id=<project-b-id>` — verify it scans project B's clone path
- [ ] Ownership analysis on Project A — verify Project B ownership returns no cached result from A

🤖 Generated with [Claude Code](https://claude.com/claude-code)