### PR TITLE
chore(frontend): adopt getApiBase() in chat Vue components (Phase 5b)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -309,6 +309,7 @@ import TranslationShortcutPanel from './TranslationShortcutPanel.vue'
 import { formatFileSize } from '@/utils/formatHelpers'
 import { getFileIconByMimeType } from '@/utils/iconMappings'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 import type { MultiModalResponse } from '@/utils/VisionMultimodalApiClient'
 import { useVoiceOutput } from '@/composables/useVoiceOutput'
 
@@ -845,7 +846,7 @@ const uploadFile = async (upload: any, file: File): Promise<void> => {
 
       // Send request
       const sessionId = store.currentSessionId || 'default'
-      xhr.open('POST', `/api/conversation-files/conversation/${sessionId}/upload`)
+      xhr.open('POST', `${getApiBase()}/conversation-files/conversation/${sessionId}/upload`)
       xhr.send(formData)
     })
   } catch (error) {

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -163,6 +163,7 @@ import ApiClient from '@/utils/ApiClient'
 import batchApiService from '@/services/BatchApiService'
 // MIGRATED: Using AppConfig.js for better configuration management
 import appConfig from '@/config/AppConfig.js'
+import { getApiBase } from '@/config/ssot-config'
 // FIXED: Import NetworkConstants for IP fallback values
 import { NetworkConstants } from '@/constants/network'
 import { createLogger } from '@/utils/debugUtils'
@@ -615,7 +616,7 @@ const onCommandCommented = async (commentData: any) => {
     // This allows the agent to receive the user's alternative approach suggestion
     if (pendingCommand.value.terminalSessionId) {
       const approvalUrl = await appConfig.getApiUrl(
-        `/api/agent-terminal/sessions/${pendingCommand.value.terminalSessionId}/approve`
+        `${getApiBase()}/agent-terminal/sessions/${pendingCommand.value.terminalSessionId}/approve`
       )
 
       const response = await fetchWithAuth(approvalUrl, {

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -520,6 +520,7 @@ import OverseerPlanMessage from '@/components/chat/OverseerPlanMessage.vue'
 import OverseerStepMessage from '@/components/chat/OverseerStepMessage.vue'
 import CitationsDisplay from '@/components/chat/CitationsDisplay.vue'
 import appConfig from '@/config/AppConfig.js'
+import { getApiBase } from '@/config/ssot-config'
 import { formatFileSize, formatTime } from '@/utils/formatHelpers'
 import { useToast } from '@/composables/useToast'
 import { createLogger } from '@/utils/debugUtils'
@@ -1041,7 +1042,7 @@ const pollCommandState = async (command_id: string, callback: (result: any) => v
 
   const poll = async () => {
     try {
-      const backendUrl = await appConfig.getApiUrl(`/api/agent-terminal/commands/${command_id}`)
+      const backendUrl = await appConfig.getApiUrl(`${getApiBase()}/agent-terminal/commands/${command_id}`)
       const response = await fetchWithAuth(backendUrl)
 
       if (!response.ok) {
@@ -1127,7 +1128,7 @@ const approveCommand = async (
 
   try {
     // Get backend URL from appConfig
-    const backendUrl = await appConfig.getApiUrl(`/api/agent-terminal/sessions/${terminal_session_id}/approve`)
+    const backendUrl = await appConfig.getApiUrl(`${getApiBase()}/agent-terminal/sessions/${terminal_session_id}/approve`)
 
     const response = await fetchWithAuth(backendUrl, {
       method: 'POST',

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -297,6 +297,7 @@ import ShareConversationDialog from './ShareConversationDialog.vue'
 import type { FileStats } from '@/composables/useConversationFiles'
 import type { SessionFact } from '@/models/repositories/ChatRepository'
 import ApiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { formatDate } from '@/utils/formatHelpers'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
@@ -463,7 +464,7 @@ const deleteSession = async (sessionId: string) => {
   const [fileStatsResult, kbFactsResult] = await Promise.allSettled([
     // Fetch file stats
     (async () => {
-      const data = await ApiClient.get(`/api/conversation-files/conversation/${sessionId}/list`)
+      const data = await ApiClient.get(`${getApiBase()}/conversation-files/conversation/${sessionId}/list`)
       return data?.stats || null
     })(),
     // Fetch KB facts (Issue #547)
@@ -586,7 +587,7 @@ const reloadSystem = async () => {
 
   try {
     // Call real system reload API
-    const response = await ApiClient.post('/api/system/reload_config')
+    const response = await ApiClient.post(`${getApiBase()}/system/reload_config`)
     const data = await (response as any).json()
 
     if (data && data.success) {

--- a/autobot-frontend/src/components/chat/DocumentationSearchSidebar.vue
+++ b/autobot-frontend/src/components/chat/DocumentationSearchSidebar.vue
@@ -174,6 +174,7 @@ import DocumentationResultCard from './DocumentationResultCard.vue'
 import DocumentationSuggestionChip from './DocumentationSuggestionChip.vue'
 import DocumentationCategoryFilter from './DocumentationCategoryFilter.vue'
 import { useApi } from '@/composables/useApi'
+import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
@@ -294,7 +295,7 @@ const executeSearch = async () => {
   currentPage.value = 1
 
   try {
-    const response = await apiClient.post('/api/knowledge_base/search', {
+    const response = await apiClient.post(`${getApiBase()}/knowledge_base/search`, {
       query: searchQuery.value || '*',
       top_k: 20,
       filters: selectedCategories.value.length > 0
@@ -356,7 +357,7 @@ const loadMore = async () => {
   currentPage.value++
 
   try {
-    const response = await apiClient.post('/api/knowledge_base/docs/browse', {
+    const response = await apiClient.post(`${getApiBase()}/knowledge_base/docs/browse`, {
       search_query: searchQuery.value,
       category: selectedCategories.value[0] || null,
       page: currentPage.value,
@@ -435,7 +436,7 @@ const openRecentDoc = (doc: RecentDoc) => {
 const loadCategories = async () => {
   isLoadingCategories.value = true
   try {
-    const response = await apiClient.get('/api/knowledge_base/docs/categories')
+    const response = await apiClient.get(`${getApiBase()}/knowledge_base/docs/categories`)
     const data = await parseApiResponse(response)
     if (data?.categories) {
       categories.value = data.categories

--- a/autobot-frontend/src/components/chat/ShareConversationDialog.vue
+++ b/autobot-frontend/src/components/chat/ShareConversationDialog.vue
@@ -116,6 +116,7 @@ import { useI18n } from 'vue-i18n'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import ApiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
@@ -181,7 +182,7 @@ const loadFacts = async () => {
   factsLoading.value = true
   try {
     const data = await ApiClient.get(
-      `/api/chat/sessions/${props.sessionId}/share/preview`
+      `${getApiBase()}/chat/sessions/${props.sessionId}/share/preview`
     )
     facts.value = data?.data?.facts || []
     selectedFactIds.value = new Set(facts.value.map(f => f.id))
@@ -228,7 +229,7 @@ const handleShare = async () => {
       body.knowledge_facts = Array.from(selectedFactIds.value)
     }
     const result = await ApiClient.post(
-      `/api/chat/sessions/${props.sessionId}/share`,
+      `${getApiBase()}/chat/sessions/${props.sessionId}/share`,
       body
     )
     emit('shared', result?.data || {})

--- a/autobot-frontend/src/components/chat/TranslationShortcutPanel.vue
+++ b/autobot-frontend/src/components/chat/TranslationShortcutPanel.vue
@@ -94,6 +94,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseButton from '@/components/base/BaseButton.vue'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
@@ -157,7 +158,7 @@ const translateText = async () => {
   translationError.value = ''
 
   try {
-    const result = await apiClient.post('/api/translate', {
+    const result = await apiClient.post(`${getApiBase()}/translate`, {
       text: textToTranslate.value.trim(),
       target_language: targetLanguage.value,
     })
@@ -187,7 +188,7 @@ const detectLanguage = async () => {
   translationError.value = ''
 
   try {
-    const result = await apiClient.post('/api/detect-language', {
+    const result = await apiClient.post(`${getApiBase()}/detect-language`, {
       text: textToTranslate.value.trim(),
     })
 

--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -14,6 +14,7 @@
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ApiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import InteractiveScreenshot from '@/components/browser/InteractiveScreenshot.vue'
 import GUIAutomationControls from '@/components/vision/GUIAutomationControls.vue'
 import {
@@ -64,7 +65,7 @@ function toggleAutomation(): void {
 
 async function checkStatus(): Promise<void> {
   try {
-    const data = await ApiClient.get('/api/playwright/worker-status') as Record<string, unknown>
+    const data = await ApiClient.get(`${getApiBase()}/playwright/worker-status`) as Record<string, unknown>
     isConnected.value = data.status === 'connected' || data.browser_connected === true
   } catch (e) {
     logger.warn('Browser status check failed:', e)
@@ -90,7 +91,7 @@ async function navigate(): Promise<void> {
   url.value = targetUrl
 
   try {
-    const nav = await ApiClient.post('/api/playwright/navigate', { url: targetUrl }) as Record<string, unknown>
+    const nav = await ApiClient.post(`${getApiBase()}/playwright/navigate`, { url: targetUrl }) as Record<string, unknown>
     currentUrl.value = (nav.url as string) || targetUrl
     pageTitle.value = (nav.title as string) || null
     isConnected.value = true
@@ -108,7 +109,7 @@ async function navigate(): Promise<void> {
 
 async function captureScreenshot(): Promise<void> {
   try {
-    const data = await ApiClient.post('/api/playwright/worker-screenshot', {}) as Record<string, unknown>
+    const data = await ApiClient.post(`${getApiBase()}/playwright/worker-screenshot`, {}) as Record<string, unknown>
     screenshot.value = (data.screenshot as string) || null
   } catch (e) {
     logger.warn('Screenshot failed:', e)
@@ -120,7 +121,7 @@ async function goBack(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    const nav = await ApiClient.post('/api/playwright/back', {}) as Record<string, unknown>
+    const nav = await ApiClient.post(`${getApiBase()}/playwright/back`, {}) as Record<string, unknown>
     if (nav.url) { currentUrl.value = nav.url as string; url.value = nav.url as string }
     if (nav.title) pageTitle.value = nav.title as string
     if (nav.screenshot) screenshot.value = nav.screenshot as string
@@ -136,7 +137,7 @@ async function goForward(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    const nav = await ApiClient.post('/api/playwright/forward', {}) as Record<string, unknown>
+    const nav = await ApiClient.post(`${getApiBase()}/playwright/forward`, {}) as Record<string, unknown>
     if (nav.url) { currentUrl.value = nav.url as string; url.value = nav.url as string }
     if (nav.title) pageTitle.value = nav.title as string
     if (nav.screenshot) screenshot.value = nav.screenshot as string
@@ -152,7 +153,7 @@ async function reload(): Promise<void> {
   loading.value = true
   error.value = null
   try {
-    const nav = await ApiClient.post('/api/playwright/reload', {}) as Record<string, unknown>
+    const nav = await ApiClient.post(`${getApiBase()}/playwright/reload`, {}) as Record<string, unknown>
     if (nav.screenshot) screenshot.value = nav.screenshot as string
   } catch (e) {
     error.value = e instanceof Error ? e.message : t('chat.visualBrowser.reloadFailed')
@@ -165,7 +166,7 @@ async function handleInteract(payload: { action: string; params: Record<string, 
   if (!isConnected.value || loading.value) return
   loading.value = true
   try {
-    const result = await ApiClient.post('/api/playwright/interact', {
+    const result = await ApiClient.post(`${getApiBase()}/playwright/interact`, {
       action: payload.action,
       ...payload.params,
     }) as Record<string, unknown>


### PR DESCRIPTION
Closes #3681

Part of #3680.

Replaced hardcoded `/api/` in 8 chat components with `getApiBase()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)