### PR TITLE
fix(backend): replace bare REDIS_HOST with AUTOBOT_REDIS_HOST in chat_history (#3670)

### DIFF
--- a/autobot-backend/chat_history/base.py
+++ b/autobot-backend/chat_history/base.py
@@ -71,7 +71,7 @@ class ChatHistoryBase:
             use_redis if use_redis is not None else redis_config.get("enabled", False)
         )
         self.redis_host = redis_host or redis_config.get(
-            "host", os.getenv("REDIS_HOST", unified_config.get_host("redis"))
+            "host", os.getenv("AUTOBOT_REDIS_HOST", unified_config.get_host("redis"))
         )
         self.redis_port = redis_port or redis_config.get(
             "port",

--- a/autobot-backend/chat_history_manager.py
+++ b/autobot-backend/chat_history_manager.py
@@ -37,7 +37,7 @@ class ChatHistoryManager:
             use_redis if use_redis is not None else redis_config.get("enabled", False)
         )
         self.redis_host = redis_host or redis_config.get(
-            "host", os.getenv("REDIS_HOST", "localhost")
+            "host", os.getenv("AUTOBOT_REDIS_HOST", "localhost")
         )
         self.redis_port = redis_port or redis_config.get("port", 6379)
 


### PR DESCRIPTION
Closes #3670

## Changes
- `chat_history_manager.py` line 40: `os.getenv("REDIS_HOST")` → `os.getenv("AUTOBOT_REDIS_HOST")`
- `chat_history/base.py` line 74: same fix

## Why
All other Redis consumers use `AUTOBOT_REDIS_HOST`. Bare `REDIS_HOST` silently falls back to localhost in deployments where only the canonical env var is set.