### PR TITLE
chore(slm-frontend): replace hardcoded /autobot-api/ with getBackendUrl() (#3652)

### DIFF
--- a/autobot-slm-frontend/src/components/agents/ConfigHistoryTab.vue
+++ b/autobot-slm-frontend/src/components/agents/ConfigHistoryTab.vue
@@ -11,6 +11,7 @@
 
 import { computed, ref, watch } from 'vue'
 import { useAuthStore } from '@/stores/auth'
+import { getBackendUrl } from '@/config/ssot-config'
 
 interface Revision {
   id: string
@@ -54,7 +55,7 @@ async function fetchRevisions() {
   selectedRevision.value = null
   try {
     const res = await fetch(
-      `/autobot-api/config-revisions/${entityType.value}/${entityId.value}?limit=50`,
+      `${getBackendUrl()}/config-revisions/${entityType.value}/${entityId.value}?limit=50`,
       { headers: headers.value },
     )
     if (!res.ok) throw new Error(`Failed to load revisions: ${res.status}`)
@@ -71,7 +72,7 @@ async function rollback(revisionId: string) {
   rollbackLoading.value = true
   try {
     const res = await fetch(
-      `/autobot-api/config-revisions/${entityType.value}/${entityId.value}/${revisionId}/rollback`,
+      `${getBackendUrl()}/config-revisions/${entityType.value}/${entityId.value}/${revisionId}/rollback`,
       { method: 'POST', headers: headers.value },
     )
     if (!res.ok) {

--- a/autobot-slm-frontend/src/components/agents/OrgChartTab.vue
+++ b/autobot-slm-frontend/src/components/agents/OrgChartTab.vue
@@ -11,6 +11,7 @@
 
 import { computed, onMounted, ref } from 'vue'
 import { useAuthStore } from '@/stores/auth'
+import { getBackendUrl } from '@/config/ssot-config'
 import OrgTreeNode from './OrgTreeNode.vue'
 
 interface OrgNode {
@@ -60,7 +61,7 @@ async function fetchTree() {
   loading.value = true
   error.value = null
   try {
-    const res = await fetch('/autobot-api/agents/org', { headers: headers.value })
+    const res = await fetch(`${getBackendUrl()}/agents/org`, { headers: headers.value })
     if (!res.ok) throw new Error(`Failed to load org tree: ${res.status}`)
     tree.value = await res.json()
   } catch (err) {
@@ -76,9 +77,9 @@ async function selectNode(node: OrgNode) {
   delegateError.value = null
   try {
     const [reportsRes, activityRes, delegationsRes] = await Promise.all([
-      fetch(`/autobot-api/agents/${node.agent_id}/reports`, { headers: headers.value }),
-      fetch(`/autobot-api/agents/${node.agent_id}/activity`, { headers: headers.value }),
-      fetch(`/autobot-api/agents/${node.agent_id}/delegations?role=delegator&limit=10`, {
+      fetch(`${getBackendUrl()}/agents/${node.agent_id}/reports`, { headers: headers.value }),
+      fetch(`${getBackendUrl()}/agents/${node.agent_id}/activity`, { headers: headers.value }),
+      fetch(`${getBackendUrl()}/agents/${node.agent_id}/delegations?role=delegator&limit=10`, {
         headers: headers.value,
       }),
     ])
@@ -97,7 +98,7 @@ async function submitDelegation() {
   delegateError.value = null
   try {
     const res = await fetch(
-      `/autobot-api/agents/${selectedNode.value.agent_id}/delegate`,
+      `${getBackendUrl()}/agents/${selectedNode.value.agent_id}/delegate`,
       {
         method: 'POST',
         headers: headers.value,

--- a/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.vue
+++ b/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.vue
@@ -11,6 +11,7 @@
 
 import { computed, ref } from 'vue'
 import { useAuthStore } from '@/stores/auth'
+import { getBackendUrl } from '@/config/ssot-config'
 
 interface ProcessRun {
   id: string
@@ -62,7 +63,7 @@ async function fetchProcesses() {
   selectedProcess.value = null
   fullLog.value = null
   try {
-    let url = `/autobot-api/agents/${agentId.value}/processes?limit=50`
+    let url = `${getBackendUrl()}/agents/${agentId.value}/processes?limit=50`
     if (statusFilter.value) url += `&status=${statusFilter.value}`
     const res = await fetch(url, { headers: headers.value })
     if (!res.ok) throw new Error(`Failed to load processes: ${res.status}`)
@@ -79,7 +80,7 @@ async function fetchProcesses() {
 async function fetchFullLog(processId: string) {
   fullLogLoading.value = true
   try {
-    const res = await fetch(`/autobot-api/processes/${processId}/logs`, {
+    const res = await fetch(`${getBackendUrl()}/processes/${processId}/logs`, {
       headers: headers.value,
     })
     fullLog.value = res.ok ? await res.text() : 'Failed to load log'
@@ -104,7 +105,7 @@ function streamLogs(processId: string) {
   isStreaming.value = true
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
   const ws = new WebSocket(
-    `${proto}//${location.host}/autobot-api/processes/${processId}/stream`,
+    `${proto}//${location.host}${getBackendUrl()}/processes/${processId}/stream`,
   )
   streamSocket.value = ws
   ws.onmessage = (event) => {
@@ -129,7 +130,7 @@ function streamLogs(processId: string) {
 
 async function signalProcess(processId: string, sig: string) {
   try {
-    const res = await fetch(`/autobot-api/processes/${processId}/signal`, {
+    const res = await fetch(`${getBackendUrl()}/processes/${processId}/signal`, {
       method: 'POST',
       headers: headers.value,
       body: JSON.stringify({ signal: sig }),
@@ -156,7 +157,7 @@ async function spawnProcess() {
         : [],
       timeout_seconds: spawnForm.value.timeout_seconds,
     }
-    const res = await fetch('/autobot-api/processes/spawn', {
+    const res = await fetch(`${getBackendUrl()}/processes/spawn`, {
       method: 'POST',
       headers: headers.value,
       body: JSON.stringify(payload),

--- a/autobot-slm-frontend/src/composables/useAutobotApi.ts
+++ b/autobot-slm-frontend/src/composables/useAutobotApi.ts
@@ -12,9 +12,7 @@
 
 import axios, { type AxiosInstance, type AxiosRequestConfig } from 'axios'
 import { useAuthStore } from '@/stores/auth'
-
-// AutoBot backend is proxied via nginx at /autobot-api/
-const API_BASE = '/autobot-api'
+import { getBackendUrl } from '@/config/ssot-config'
 
 // Type definitions for AutoBot API responses
 
@@ -125,7 +123,7 @@ export function useAutobotApi() {
   const authStore = useAuthStore()
 
   const client: AxiosInstance = axios.create({
-    baseURL: API_BASE,
+    baseURL: getBackendUrl(),
     headers: {
       'Content-Type': 'application/json',
     },

--- a/autobot-slm-frontend/src/composables/useSkills.ts
+++ b/autobot-slm-frontend/src/composables/useSkills.ts
@@ -12,9 +12,7 @@
 import { ref, computed, readonly, onUnmounted } from 'vue'
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
-
-// Skills API is on the main AutoBot backend, proxied via nginx
-const API_BASE = '/autobot-api/skills/'
+import { getBackendUrl } from '@/config/ssot-config'
 
 // =============================================================================
 // Type Definitions
@@ -84,7 +82,7 @@ export function useSkills() {
   const initialized = ref(false)
 
   const api = axios.create({
-    baseURL: API_BASE,
+    baseURL: `${getBackendUrl()}/skills/`,
     timeout: 15000,
   })
 
@@ -281,10 +279,6 @@ export interface GovernanceConfig {
   default_trust_level: string
 }
 
-// Governance API base — hits main backend via SLM nginx proxy
-const SKILLS_REPOS_BASE = '/autobot-api/skills/repos'
-const SKILLS_GOV_BASE = '/autobot-api/skills/governance'
-
 // =============================================================================
 // useSkillGovernance Composable
 // =============================================================================
@@ -312,7 +306,7 @@ export function useSkillGovernance() {
   async function fetchRepos(): Promise<void> {
     loading.value = true
     try {
-      const { data } = await api.get<SkillRepo[]>(SKILLS_REPOS_BASE)
+      const { data } = await api.get<SkillRepo[]>(`${getBackendUrl()}/skills/repos`)
       repos.value = data
     } catch (e: unknown) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch repos'
@@ -325,7 +319,7 @@ export function useSkillGovernance() {
     payload: Omit<SkillRepo, 'id' | 'skill_count' | 'status' | 'last_synced'>,
   ): Promise<unknown> {
     try {
-      const { data } = await api.post(SKILLS_REPOS_BASE, payload)
+      const { data } = await api.post(`${getBackendUrl()}/skills/repos`, payload)
       await fetchRepos()
       return data
     } catch (e: unknown) {
@@ -336,7 +330,7 @@ export function useSkillGovernance() {
 
   async function syncRepo(repoId: string): Promise<unknown> {
     try {
-      const { data } = await api.post(`${SKILLS_REPOS_BASE}/${repoId}/sync`)
+      const { data } = await api.post(`${getBackendUrl()}/skills/repos/${repoId}/sync`)
       await fetchRepos()
       return data
     } catch (e: unknown) {
@@ -347,7 +341,7 @@ export function useSkillGovernance() {
 
   async function fetchApprovals(): Promise<void> {
     try {
-      const { data } = await api.get<SkillApproval[]>(`${SKILLS_GOV_BASE}/approvals`)
+      const { data } = await api.get<SkillApproval[]>(`${getBackendUrl()}/skills/governance/approvals`)
       approvals.value = data
     } catch (e: unknown) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch approvals'
@@ -361,7 +355,7 @@ export function useSkillGovernance() {
     notes = '',
   ): Promise<void> {
     try {
-      await api.post(`${SKILLS_GOV_BASE}/approvals/${approvalId}`, {
+      await api.post(`${getBackendUrl()}/skills/governance/approvals/${approvalId}`, {
         approved,
         notes,
         trust_level: trustLevel,
@@ -374,7 +368,7 @@ export function useSkillGovernance() {
 
   async function fetchDrafts(): Promise<void> {
     try {
-      const { data } = await api.get<Record<string, unknown>[]>(`${SKILLS_GOV_BASE}/drafts`)
+      const { data } = await api.get<Record<string, unknown>[]>(`${getBackendUrl()}/skills/governance/drafts`)
       drafts.value = Array.isArray(data) ? data : []
     } catch (e: unknown) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch drafts'
@@ -383,7 +377,7 @@ export function useSkillGovernance() {
 
   async function testDraft(skillId: string): Promise<unknown> {
     try {
-      const { data } = await api.post(`${SKILLS_GOV_BASE}/drafts/${skillId}/test`)
+      const { data } = await api.post(`${getBackendUrl()}/skills/governance/drafts/${skillId}/test`)
       return data
     } catch (e: unknown) {
       error.value = e instanceof Error ? e.message : 'Test draft failed'
@@ -393,7 +387,7 @@ export function useSkillGovernance() {
 
   async function promoteDraft(skillId: string): Promise<unknown> {
     try {
-      const { data } = await api.post(`${SKILLS_GOV_BASE}/drafts/${skillId}/promote`)
+      const { data } = await api.post(`${getBackendUrl()}/skills/governance/drafts/${skillId}/promote`)
       await fetchDrafts()
       return data
     } catch (e: unknown) {
@@ -404,7 +398,7 @@ export function useSkillGovernance() {
 
   async function fetchGovernance(): Promise<void> {
     try {
-      const { data } = await api.get<GovernanceConfig>(`${SKILLS_GOV_BASE}/`)
+      const { data } = await api.get<GovernanceConfig>(`${getBackendUrl()}/skills/governance/`)
       governanceConfig.value = data
     } catch (e: unknown) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch governance config'
@@ -413,7 +407,7 @@ export function useSkillGovernance() {
 
   async function setGovernanceMode(mode: GovernanceConfig['mode']): Promise<void> {
     try {
-      await api.put(`${SKILLS_GOV_BASE}/`, { mode })
+      await api.put(`${getBackendUrl()}/skills/governance/`, { mode })
       await fetchGovernance()
     } catch (e: unknown) {
       error.value = e instanceof Error ? e.message : 'Failed to update governance mode'

--- a/autobot-slm-frontend/src/views/settings/admin/CacheSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/CacheSettings.vue
@@ -13,6 +13,7 @@
 import { ref, reactive, computed, onMounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useAutobotApi, type CacheConfig, type CacheStats } from '@/composables/useAutobotApi'
+import { getBackendUrl } from '@/config/ssot-config'
 
 const authStore = useAuthStore()
 const api = useAutobotApi()
@@ -136,7 +137,7 @@ async function clearRedisCache(database: string): Promise<void> {
   error.value = null
 
   try {
-    await fetch(`/autobot-api/cache/redis/clear/${database}`, {
+    await fetch(`${getBackendUrl()}/cache/redis/clear/${database}`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${authStore.token}`,

--- a/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
+++ b/autobot-slm-frontend/src/views/settings/admin/UserManagementSettings.vue
@@ -14,7 +14,7 @@
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { formatDateTime } from '@/composables/useTimezone'
 import { useAuthStore } from '@/stores/auth'
-import { getSlmApiBase } from '@/config/ssot-config'
+import { getSlmApiBase, getBackendUrl } from '@/config/ssot-config'
 import { useAutobotApi, type UserResponse } from '@/composables/useAutobotApi'
 import {
   useSlmUserApi,
@@ -341,7 +341,7 @@ async function checkRbacStatus(): Promise<void> {
   if (!isAdmin.value) return
 
   try {
-    const response = await fetch('/autobot-api/settings/rbac/status', {
+    const response = await fetch(`${getBackendUrl()}/settings/rbac/status`, {
       headers: { Authorization: `Bearer ${authStore.token}` },
     })
 
@@ -360,7 +360,7 @@ async function initializeRbac(): Promise<void> {
   error.value = null
 
   try {
-    const response = await fetch('/autobot-api/settings/rbac/initialize', {
+    const response = await fetch(`${getBackendUrl()}/settings/rbac/initialize`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Closes #3652

## Changes
- 7 files in `autobot-slm-frontend/`: migrated 34 hardcoded `/autobot-api/` occurrences to `getBackendUrl()` from ssot-config
- Files: `ConfigHistoryTab.vue`, `OrgChartTab.vue`, `ProcessMonitorTab.vue`, `useAutobotApi.ts`, `useSkills.ts`, `CacheSettings.vue`, `UserManagementSettings.vue`