### PR TITLE
fix(slm-frontend): safe WebSocket URL construction when getBackendUrl() is absolute (#3673)

### DIFF
--- a/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.vue
+++ b/autobot-slm-frontend/src/components/agents/ProcessMonitorTab.vue
@@ -99,14 +99,22 @@ function stopStream() {
   isStreaming.value = false
 }
 
+function buildWsUrl(path: string): string {
+  const base = getBackendUrl()
+  if (!base) {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    return `${proto}//${window.location.host}${path}`
+  }
+  const proto = base.startsWith('https') ? 'wss:' : 'ws:'
+  const wsBase = base.replace(/^https?:\/\//, '').replace(/\/$/, '')
+  return `${proto}//${wsBase}${path}`
+}
+
 function streamLogs(processId: string) {
   stopStream()
   fullLog.value = ''
   isStreaming.value = true
-  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
-  const ws = new WebSocket(
-    `${proto}//${location.host}${getBackendUrl()}/processes/${processId}/stream`,
-  )
+  const ws = new WebSocket(buildWsUrl(`/processes/${processId}/stream`))
   streamSocket.value = ws
   ws.onmessage = (event) => {
     try {


### PR DESCRIPTION
## Summary

- Fixes `ProcessMonitorTab.vue` `streamLogs()` building an invalid WebSocket URL when `getBackendUrl()` returns an absolute URL like `https://172.16.168.20`
- Old code: `` `${proto}//${location.host}${getBackendUrl()}/processes/${id}/stream` `` — concatenates `ws://` + frontend host + absolute backend URL, producing a garbage URL
- New: `buildWsUrl(path)` helper strips the `https?://` scheme from `getBackendUrl()` and replaces it with `ws:` or `wss:` based on the original scheme; falls back to `window.location.host` in proxy mode (empty base URL)

## Test plan

- [ ] `getBackendUrl()` returns `https://172.16.168.20` → `buildWsUrl('/processes/abc/stream')` produces `wss://172.16.168.20/processes/abc/stream`
- [ ] `getBackendUrl()` returns `http://172.16.168.20:8001` → produces `ws://172.16.168.20:8001/processes/abc/stream`
- [ ] `getBackendUrl()` returns `""` (proxy mode) → falls back to `ws(s)://window.location.host/processes/abc/stream`
- [ ] Trailing slash on base URL is stripped correctly

Closes #3673

🤖 Generated with [Claude Code](https://claude.com/claude-code)