### PR TITLE
chore(frontend): use getApiBase() instead of getBackendUrl() in notification composables (#3675)

### DIFF
--- a/autobot-frontend/src/composables/useNotificationConfig.ts
+++ b/autobot-frontend/src/composables/useNotificationConfig.ts
@@ -9,7 +9,7 @@
  */
 
 import { ref } from 'vue';
-import { getBackendUrl } from '@/config/ssot-config';
+import { getApiBase } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
 
 const logger = createLogger('NotificationConfig');
@@ -69,8 +69,7 @@ export function useNotificationConfig() {
     loading.value = true;
     error.value = null;
     try {
-      const base = getBackendUrl();
-      const url = `${base}/workflow-automation/notification_config/${workflowId}`;
+      const url = `${getApiBase()}/workflow-automation/notification_config/${workflowId}`;
       const resp = await fetch(url, { headers: getAuthHeaders() });
       if (!resp.ok) {
         throw new Error(`HTTP ${resp.status}`);
@@ -91,8 +90,7 @@ export function useNotificationConfig() {
     saving.value = true;
     error.value = null;
     try {
-      const base = getBackendUrl();
-      const url = `${base}/workflow-automation/notification_config/${workflowId}`;
+      const url = `${getApiBase()}/workflow-automation/notification_config/${workflowId}`;
       const resp = await fetch(url, {
         method: 'PUT',
         headers: getAuthHeaders(),

--- a/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
+++ b/autobot-frontend/src/composables/useWorkflowNotificationConfig.ts
@@ -9,7 +9,7 @@
  */
 
 import { ref } from 'vue';
-import { getBackendUrl, getApiBase } from '@/config/ssot-config';
+import { getApiBase } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
 import { getAuthToken } from '@/utils/fetchWithAuth';
 import type { ApiResponse } from '@/types/api';
@@ -77,7 +77,7 @@ async function apiRequest<T>(
   endpoint: string,
   options: RequestInit = {},
 ): Promise<ApiResponse<T>> {
-  const url = `${getBackendUrl()}${endpoint}`;
+  const url = endpoint;
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 30_000);
 


### PR DESCRIPTION
## Summary

- `useNotificationConfig.ts`: replaced `getBackendUrl()` import with `getApiBase()` and updated URL construction at lines 72 and 94 — URLs now use `/api/workflow-automation/...` instead of `<host>/workflow-automation/...` (missing `/api` prefix)
- `useWorkflowNotificationConfig.ts`: removed `getBackendUrl` import and removed the `getBackendUrl()` prefix from the `apiRequest` helper (line 80) — the endpoint strings passed by callers already contain `getApiBase() + /path`, so prepending `getBackendUrl()` was correct in isolation but the intent is to use path-only URLs consistent with proxy/nginx mode

Closes #3675. Discovered during Phase 3 review of PR #3663.

## Test plan

- [ ] Workflow notification config loads without 404 (path now includes `/api` prefix)
- [ ] Saving notification config via PUT succeeds
- [ ] No TypeScript errors (`vue-tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)