### PR TITLE
chore(frontend): adopt getApiBase() in knowledge Vue components (#3682)

### DIFF
--- a/autobot-frontend/src/components/knowledge/BackupManager.vue
+++ b/autobot-frontend/src/components/knowledge/BackupManager.vue
@@ -124,6 +124,7 @@
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { formatFileSize, formatDateTime } from '@/utils/formatHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
@@ -193,7 +194,7 @@ const showStatus = (type: StatusMessage['type'], text: string) => {
 const loadBackups = async () => {
   try {
     isLoadingBackups.value = true
-    const response = await apiClient.get('/api/knowledge-maintenance/backups')
+    const response = await apiClient.get(`${getApiBase()}/knowledge-maintenance/backups`)
     const data = await parseApiResponse(response)
 
     if (data.backups) {
@@ -211,7 +212,7 @@ const createBackup = async () => {
   try {
     isCreatingBackup.value = true
 
-    const response = await apiClient.post('/api/knowledge-maintenance/backup', {
+    const response = await apiClient.post(`${getApiBase()}/knowledge-maintenance/backup`, {
       include_embeddings: backupOptions.value.includeEmbeddings,
       compression: backupOptions.value.compression,
       description: backupOptions.value.description || undefined
@@ -245,7 +246,7 @@ const restoreBackup = async (backupName: string) => {
     isRestoring.value = true
 
     // First, dry run to validate
-    const dryRunResponse = await apiClient.post('/api/knowledge-maintenance/restore', {
+    const dryRunResponse = await apiClient.post(`${getApiBase()}/knowledge-maintenance/restore`, {
       backup_file: backupName,
       dry_run: true
     })
@@ -264,7 +265,7 @@ const restoreBackup = async (backupName: string) => {
     if (!confirmRestore) return
 
     // Actual restore
-    const restoreResponse = await apiClient.post('/api/knowledge-maintenance/restore', {
+    const restoreResponse = await apiClient.post(`${getApiBase()}/knowledge-maintenance/restore`, {
       backup_file: backupName,
       dry_run: false,
       skip_duplicates: true
@@ -295,7 +296,7 @@ const deleteBackup = async (backupName: string) => {
   try {
     isDeletingBackup.value = true
 
-    const response = await apiClient.delete('/api/knowledge-maintenance/backup', {
+    const response = await apiClient.delete(`${getApiBase()}/knowledge-maintenance/backup`, {
       body: JSON.stringify({ backup_file: backupName }),
       headers: { 'Content-Type': 'application/json' }
     } as any)

--- a/autobot-frontend/src/components/knowledge/CleanupStatistics.vue
+++ b/autobot-frontend/src/components/knowledge/CleanupStatistics.vue
@@ -115,6 +115,7 @@
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
@@ -196,7 +197,7 @@ const runDryScan = async () => {
     scanResult.value = null
     statusMessage.value = null
 
-    const response = await apiClient.post('/api/knowledge-maintenance/cleanup', {
+    const response = await apiClient.post(`${getApiBase()}/knowledge-maintenance/cleanup`, {
       remove_empty: options.value.removeEmpty,
       remove_orphaned_tags: options.value.removeOrphanedTags,
       fix_metadata: options.value.fixMetadata,
@@ -241,7 +242,7 @@ const runCleanup = async () => {
   try {
     isCleaning.value = true
 
-    const response = await apiClient.post('/api/knowledge-maintenance/cleanup', {
+    const response = await apiClient.post(`${getApiBase()}/knowledge-maintenance/cleanup`, {
       remove_empty: options.value.removeEmpty,
       remove_orphaned_tags: options.value.removeOrphanedTags,
       fix_metadata: options.value.fixMetadata,

--- a/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
+++ b/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
@@ -188,6 +188,7 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { formatDate } from '@/utils/formatHelpers'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -259,7 +260,7 @@ const scanForIssues = async () => {
   try {
     // Scan for duplicates (dry run)
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const dupResponse = await apiClient.post('/api/knowledge-maintenance/deduplicate?dry_run=true')
+    const dupResponse = await apiClient.post(`${getApiBase()}/knowledge-maintenance/deduplicate?dry_run=true`)
     const dupData = await parseApiResponse(dupResponse)
 
     if (dupData.status === 'success') {
@@ -270,7 +271,7 @@ const scanForIssues = async () => {
 
     // Scan for orphans
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const orphanResponse = await apiClient.get('/api/knowledge-maintenance/orphans')
+    const orphanResponse = await apiClient.get(`${getApiBase()}/knowledge-maintenance/orphans`)
     const orphanData = await parseApiResponse(orphanResponse)
 
     if (orphanData.status === 'success') {
@@ -299,7 +300,7 @@ const cleanupDuplicates = async () => {
 
   try {
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const response = await apiClient.post('/api/knowledge-maintenance/deduplicate?dry_run=false')
+    const response = await apiClient.post(`${getApiBase()}/knowledge-maintenance/deduplicate?dry_run=false`)
     const data = await parseApiResponse(response)
 
     if (data.status === 'success') {
@@ -328,7 +329,7 @@ const cleanupOrphans = async () => {
 
   try {
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const response = await apiClient.delete('/api/knowledge-maintenance/orphans?dry_run=false')
+    const response = await apiClient.delete(`${getApiBase()}/knowledge-maintenance/orphans?dry_run=false`)
     const data = await parseApiResponse(response)
 
     if (data.status === 'success') {

--- a/autobot-frontend/src/components/knowledge/EntityExtractor.vue
+++ b/autobot-frontend/src/components/knowledge/EntityExtractor.vue
@@ -171,6 +171,7 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -286,7 +287,7 @@ async function extractEntities(): Promise<void> {
     const messages = parseMessages(textInput.value)
     logger.info(`Extracting entities from ${messages.length} messages`)
 
-    const response = await apiClient.post('/api/entities/extract', {
+    const response = await apiClient.post(`${getApiBase()}/entities/extract`, {
       conversation_id: conversationId.value.trim(),
       messages
     })

--- a/autobot-frontend/src/components/knowledge/EntityGraphManager.vue
+++ b/autobot-frontend/src/components/knowledge/EntityGraphManager.vue
@@ -197,6 +197,7 @@ import { ref, reactive, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import EntityExtractor from './EntityExtractor.vue'
@@ -294,7 +295,7 @@ async function refreshStats(): Promise<void> {
 
 async function fetchGraphStats(): Promise<void> {
   try {
-    const response = await apiClient.get('/api/knowledge_base/unified/graph?max_facts=0')
+    const response = await apiClient.get(`${getApiBase()}/knowledge_base/unified/graph?max_facts=0`)
     const data = await parseApiResponse(response)
     const graphData = data?.data || data
 
@@ -316,7 +317,7 @@ async function fetchGraphStats(): Promise<void> {
 
 async function fetchExtractionHealth(): Promise<void> {
   try {
-    const response = await apiClient.get('/api/entities/extract/health')
+    const response = await apiClient.get(`${getApiBase()}/entities/extract/health`)
     const data = await parseApiResponse(response)
     const healthData = data?.data || data
 
@@ -331,7 +332,7 @@ async function fetchExtractionHealth(): Promise<void> {
 
 async function fetchGraphRagHealth(): Promise<void> {
   try {
-    const response = await apiClient.get('/api/graph-rag/health')
+    const response = await apiClient.get(`${getApiBase()}/graph-rag/health`)
     const data = await parseApiResponse(response)
     const healthData = data?.data || data
 

--- a/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
+++ b/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
@@ -101,6 +101,7 @@
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { formatDateTime } from '@/utils/formatHelpers'
 import { useAsyncOperation } from '@/composables/useAsyncOperation'
@@ -129,7 +130,7 @@ const { execute: fetchFailedJobs, loading, error } = useAsyncOperation()
 
 // Fetch failed jobs
 const fetchFailedJobsFn = async () => {
-  const response = await apiClient.get('/api/knowledge_base/vectorize_jobs/failed')
+  const response = await apiClient.get(`${getApiBase()}/knowledge_base/vectorize_jobs/failed`)
   const data = await parseApiResponse(response)
 
   if (data.status === 'success') {
@@ -149,7 +150,7 @@ const retryJob = async (jobId: string) => {
   retryingJobs.value.add(jobId)
 
   try {
-    const response = await apiClient.post(`/api/knowledge_base/vectorize_jobs/${jobId}/retry`)
+    const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorize_jobs/${jobId}/retry`)
     const data = await parseApiResponse(response)
 
     if (data.status === 'success') {
@@ -175,7 +176,7 @@ const deleteJob = async (jobId: string) => {
   }
 
   await fetchFailedJobs(async () => {
-    const response = await apiClient.delete(`/api/knowledge_base/vectorize_jobs/${jobId}`)
+    const response = await apiClient.delete(`${getApiBase()}/knowledge_base/vectorize_jobs/${jobId}`)
     const data = await parseApiResponse(response)
 
     if (data.status === 'success') {
@@ -194,7 +195,7 @@ const clearAllFailed = async () => {
   }
 
   await fetchFailedJobs(async () => {
-    const response = await apiClient.delete('/api/knowledge_base/vectorize_jobs/failed/clear')
+    const response = await apiClient.delete(`${getApiBase()}/knowledge_base/vectorize_jobs/failed/clear`)
     const data = await parseApiResponse(response)
 
     if (data.status === 'success') {

--- a/autobot-frontend/src/components/knowledge/GraphRAGQuery.vue
+++ b/autobot-frontend/src/components/knowledge/GraphRAGQuery.vue
@@ -197,6 +197,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -283,7 +284,7 @@ async function executeSearch(): Promise<void> {
   try {
     logger.info(`Executing Graph-RAG search: "${queryText.value.substring(0, 50)}..."`)
 
-    const response = await apiClient.post('/api/graph-rag/search', {
+    const response = await apiClient.post(`${getApiBase()}/graph-rag/search`, {
       query: queryText.value.trim(),
       start_entity: startEntity.value.trim() || null,
       max_depth: maxDepth.value,
@@ -307,7 +308,7 @@ async function checkHealth(): Promise<void> {
   isCheckingHealth.value = true
 
   try {
-    const response = await apiClient.get('/api/graph-rag/health')
+    const response = await apiClient.get(`${getApiBase()}/graph-rag/health`)
     const parsedResponse = await parseApiResponse(response)
     healthStatus.value = parsedResponse?.data || parsedResponse
     logger.info(`Health check: ${healthStatus.value?.status}`)

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -174,6 +174,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import ApiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
@@ -317,7 +318,7 @@ const populateSystemCommands = async () => {
     startProgress(t('knowledge.advanced.progressPopulatingSystemCommands'), 150)
     progressDetails.value = t('knowledge.advanced.progressAddingCommands')
 
-    const apiResponse = await ApiClient.post('/api/knowledge_base/populate_system_commands', {})
+    const apiResponse = await ApiClient.post(`${getApiBase()}/knowledge_base/populate_system_commands`, {})
     const response = await parseApiResponse(apiResponse)
 
     if (response.status === 'success') {
@@ -356,7 +357,7 @@ const populateManPages = async () => {
     startProgress(t('knowledge.advanced.progressPopulatingManPages'), 50)
     progressDetails.value = t('knowledge.advanced.progressAddingManPages')
 
-    const apiResponse = await ApiClient.post('/api/knowledge_base/populate_man_pages', {})
+    const apiResponse = await ApiClient.post(`${getApiBase()}/knowledge_base/populate_man_pages`, {})
     const response = await parseApiResponse(apiResponse)
 
     if (response.status === 'success') {
@@ -395,7 +396,7 @@ const populateAutoBotDocs = async () => {
     startProgress(t('knowledge.advanced.progressPopulatingAutobotDocs'), 30)
     progressDetails.value = t('knowledge.advanced.progressAddingAutobotDocs')
 
-    const apiResponse = await ApiClient.post('/api/knowledge_base/populate_autobot_docs', {})
+    const apiResponse = await ApiClient.post(`${getApiBase()}/knowledge_base/populate_autobot_docs`, {})
     const response = await parseApiResponse(apiResponse)
 
     if (response.status === 'success') {
@@ -449,7 +450,7 @@ const clearAllKnowledge = async () => {
     startProgress(t('knowledge.advanced.progressClearingKB'), 1)
     progressDetails.value = t('knowledge.advanced.progressRemovingEntries')
 
-    const apiResponse = await ApiClient.post('/api/knowledge_base/clear_all', {})
+    const apiResponse = await ApiClient.post(`${getApiBase()}/knowledge_base/clear_all`, {})
     const response = await parseApiResponse(apiResponse)
 
     if (response.status === 'success') {

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -307,6 +307,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 // Create scoped logger for KnowledgeBrowser
@@ -416,7 +417,7 @@ const fetchEntries = async (cursor: string) => {
     limit: '100',
     cursor: cursor || '0'
   })
-  const response = await apiClient.get(`/api/knowledge_base/entries?${params}`)
+  const response = await apiClient.get(`${getApiBase()}/knowledge_base/entries?${params}`)
   const data = await parseApiResponse(response)
 
   // Handle both cursor-based and offset-based formats
@@ -677,7 +678,7 @@ const selectMainCategory = (mainCatId: string) => {
 
 const loadMainCategories = async () => {
   try {
-    const response = await apiClient.get('/api/knowledge_base/categories/main')
+    const response = await apiClient.get(`${getApiBase()}/knowledge_base/categories/main`)
     const data = await parseApiResponse(response)
 
     if (data && data.categories) {
@@ -762,7 +763,7 @@ const refreshVectorizationStatus = async () => {
 // Load main knowledge tree with useAsyncOperation wrapper
 const loadKnowledgeTreeFn = async () => {
   // Load facts from knowledge base by category
-  const response = await apiClient.get('/api/knowledge_base/facts/by_category')
+  const response = await apiClient.get(`${getApiBase()}/knowledge_base/facts/by_category`)
   const data = await parseApiResponse(response)
 
   if (data && data.categories) {
@@ -1038,7 +1039,7 @@ const handlePopulate = async (categoryId: string) => {
 const loadFolderContents = async (folder: TreeNode) => {
   try {
     // Load files for this category
-    const response = await apiClient.post('/api/knowledge_base/search', {
+    const response = await apiClient.post(`${getApiBase()}/knowledge_base/search`, {
       query: '',
       category: folder.category,
       n_results: 100
@@ -1077,7 +1078,7 @@ const loadFileContent = async (file: TreeNode) => {
 
       if (factKey) {
         // Fetch full fact data from backend
-        const apiResponse = await apiClient.get(`/api/knowledge_base/fact/${factKey}`)
+        const apiResponse = await apiClient.get(`${getApiBase()}/knowledge_base/fact/${factKey}`)
         const response = await parseApiResponse(apiResponse)
 
         if (response && response.content) {

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -169,6 +169,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { useKnowledgeBase } from '@/composables/useKnowledgeBase'
 import KnowledgeBrowser from './KnowledgeBrowser.vue'
@@ -252,7 +253,7 @@ const viewCategoryDocuments = async (category: any) => {
   selectedCategoryPath.value = category.path
 
   try {
-    const response = await apiClient.get(`/api/knowledge_base/categories/${encodeURIComponent(category.path)}`)
+    const response = await apiClient.get(`${getApiBase()}/knowledge_base/categories/${encodeURIComponent(category.path)}`)
     const data = await parseApiResponse(response)
     categoryDocuments.value = data?.documents || []
     showCategoryDocuments.value = true
@@ -285,7 +286,7 @@ const loadMainCategories = async () => {
   isLoadingCategories.value = true
   categoriesError.value = null
   try {
-    const response = await apiClient.get('/api/knowledge_base/categories/main')
+    const response = await apiClient.get(`${getApiBase()}/knowledge_base/categories/main`)
     if (response && typeof response === 'object' && 'status' in response) {
       const status = (response as { status: number }).status
       if (status === 401) {

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -370,6 +370,7 @@ import cytoscape, { type Core, type NodeSingular } from 'cytoscape'
 // @ts-expect-error - cytoscape-fcose has no type declarations
 import fcose from 'cytoscape-fcose'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
@@ -868,11 +869,11 @@ async function refreshGraph(): Promise<void> {
 
   try {
     // Fetch from unified knowledge graph endpoint (includes categories + facts)
-    const unifiedResponse = await apiClient.get('/api/knowledge_base/unified/graph?max_facts=100&include_categories=true')
+    const unifiedResponse = await apiClient.get(`${getApiBase()}/knowledge_base/unified/graph?max_facts=100&include_categories=true`)
     const unifiedData = await parseApiResponse(unifiedResponse)
 
     // Also fetch memory entities for backward compatibility
-    const memoryResponse = await apiClient.get('/api/memory/entities/all')
+    const memoryResponse = await apiClient.get(`${getApiBase()}/memory/entities/all`)
     const memoryData = await parseApiResponse(memoryResponse)
 
     // Merge entities from both sources
@@ -933,7 +934,7 @@ async function fetchMemoryRelations(memoryEntities: Entity[]): Promise<void> {
 
   const relationResults = await Promise.allSettled(
     memoryEntities.map(async (entity) => {
-      const response = await apiClient.get(`/api/memory/entities/${entity.id}/relations`)
+      const response = await apiClient.get(`${getApiBase()}/memory/entities/${entity.id}/relations`)
       const parsedResponse = await parseApiResponse(response)
       return { entity, parsedResponse }
     })
@@ -990,7 +991,7 @@ async function createEntity(): Promise<void> {
       .map(o => o.trim())
       .filter(o => o.length > 0)
 
-    const response = await apiClient.post('/api/memory/entities', {
+    const response = await apiClient.post(`${getApiBase()}/memory/entities`, {
       name: newEntity.value.name,
       entity_type: newEntity.value.type,
       observations

--- a/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
@@ -196,6 +196,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { formatFileSize, formatTimeAgo } from '@/utils/formatHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
@@ -246,7 +247,7 @@ const loadHealthDashboard = async () => {
   isLoadingHealth.value = true
 
   try {
-    const response = await apiClient.get('/api/knowledge-maintenance/health/dashboard')
+    const response = await apiClient.get(`${getApiBase()}/knowledge-maintenance/health/dashboard`)
     const data = await parseApiResponse(response)
 
     if (data) {

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
@@ -258,6 +258,7 @@ import { ref, computed, watch, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useToast } from '@/composables/useToast';
 import { apiService } from '@/services/api';
+import { getApiBase } from '@/config/ssot-config';
 import { formatDateTime as formatDate } from '@/utils/formatHelpers';
 import BaseButton from '@/components/base/BaseButton.vue';
 import { createLogger } from '@/utils/debugUtils';
@@ -329,7 +330,7 @@ const loadPendingItems = async () => {
   try {
     loading.value = true;
     // Issue #552: Fixed path to match backend (hyphen instead of underscore)
-    const response = await apiService.get(`/api/chat-knowledge/knowledge/pending/${props.chatId}`);
+    const response = await apiService.get(`${getApiBase()}/chat-knowledge/knowledge/pending/${props.chatId}`);
 
     if (response.success) {
       pendingItems.value = response.pending_items;
@@ -411,7 +412,7 @@ const applyAllDecisions = async () => {
     // Issue #552: Fixed path to match backend (hyphen instead of underscore)
     await Promise.all(
       decisions.map(decision =>
-        apiService.post('/api/chat-knowledge/knowledge/decide', decision)
+        apiService.post(`${getApiBase()}/chat-knowledge/knowledge/decide`, decision)
       )
     );
 
@@ -432,7 +433,7 @@ const compileChat = async () => {
     loading.value = true;
 
     // Issue #552: Fixed path to match backend (hyphen instead of underscore)
-    const response = await apiService.post('/api/chat-knowledge/compile', {
+    const response = await apiService.post(`${getApiBase()}/chat-knowledge/compile`, {
       chat_id: props.chatId,
       title: compileOptions.value.title || null,
       include_system_messages: compileOptions.value.includeSystemMessages

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -18,6 +18,7 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
@@ -147,7 +148,7 @@ async function loadPrompts(): Promise<void> {
   error.value = null
 
   try {
-    const response = await apiClient.get('/api/prompts')
+    const response = await apiClient.get(`${getApiBase()}/prompts`)
     const data = await parseApiResponse(response)
 
     if (data?.prompts) {
@@ -183,7 +184,7 @@ async function savePrompt(): Promise<void> {
 
   try {
     const response = await apiClient.put(
-      `/api/prompts/${encodeURIComponent(selectedPrompt.value.id)}`,
+      `${getApiBase()}/prompts/${encodeURIComponent(selectedPrompt.value.id)}`,
       { content: editedContent.value }
     )
     const data = await parseApiResponse(response)
@@ -222,7 +223,7 @@ async function loadHistory(): Promise<void> {
 
   try {
     const response = await apiClient.get(
-      `/api/prompts/${encodeURIComponent(selectedPrompt.value.id)}/history`
+      `${getApiBase()}/prompts/${encodeURIComponent(selectedPrompt.value.id)}/history`
     )
     const data = await parseApiResponse(response)
 
@@ -248,7 +249,7 @@ async function revertToVersion(version: PromptVersion): Promise<void> {
 
   try {
     const response = await apiClient.post(
-      `/api/prompts/${encodeURIComponent(selectedPrompt.value.id)}/revert`,
+      `${getApiBase()}/prompts/${encodeURIComponent(selectedPrompt.value.id)}/revert`,
       { version: version.version }
     )
     const data = await parseApiResponse(response)

--- a/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
@@ -388,6 +388,7 @@ import { useKnowledgeController } from '@/models/controllers/index'
 import DocumentChangeFeed from '@/components/knowledge/DocumentChangeFeed.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import {
   formatFileSize,
@@ -785,7 +786,7 @@ const refreshVectorStats = async () => {
 
     // Fetch category fact counts (secondary API call - only when needed)
     try {
-      const factsResponse = await apiClient.get('/api/knowledge_base/facts/by_category')
+      const factsResponse = await apiClient.get(`${getApiBase()}/knowledge_base/facts/by_category`)
       const factsData = await parseApiResponse(factsResponse)
 
       if (factsData && factsData.categories) {

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
@@ -19,6 +19,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -105,7 +106,7 @@ async function loadDocCategories(): Promise<void> {
   error.value = null
 
   try {
-    const response = await apiClient.get('/api/knowledge_base/system-docs/categories')
+    const response = await apiClient.get(`${getApiBase()}/knowledge_base/system-docs/categories`)
     const data = await parseApiResponse(response)
 
     if (data?.categories) {
@@ -129,7 +130,7 @@ async function loadCategoryDocs(category: DocCategory): Promise<void> {
 
   try {
     const response = await apiClient.get(
-      `/api/knowledge_base/system-docs/category/${encodeURIComponent(category.path)}`
+      `${getApiBase()}/knowledge_base/system-docs/category/${encodeURIComponent(category.path)}`
     )
     const data = await parseApiResponse(response)
 
@@ -155,7 +156,7 @@ async function loadDocContent(doc: SystemDoc): Promise<void> {
 
   try {
     const response = await apiClient.get(
-      `/api/knowledge_base/system-docs/${encodeURIComponent(doc.id)}`
+      `${getApiBase()}/knowledge_base/system-docs/${encodeURIComponent(doc.id)}`
     )
     const data = await parseApiResponse(response)
 

--- a/autobot-frontend/src/components/knowledge/MemoryOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/MemoryOrphanManager.vue
@@ -116,6 +116,7 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient.ts'
+import { getApiBase } from '@/config/ssot-config'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -184,7 +185,7 @@ const scanOrphans = async () => {
     orphanScanResult.value = null
     statusMessage.value = null
 
-    const response = await apiClient.get('/api/memory/entities/orphans')
+    const response = await apiClient.get(`${getApiBase()}/memory/entities/orphans`)
 
     // Check if we got a valid Response object
     if (!response || typeof response.ok === 'undefined') {
@@ -237,7 +238,7 @@ const cleanupOrphans = async () => {
   try {
     isCleaning.value = true
 
-    const response = await apiClient.delete('/api/memory/entities/orphans?dry_run=false')
+    const response = await apiClient.delete(`${getApiBase()}/memory/entities/orphans?dry_run=false`)
 
     // Check if we got a valid Response object
     if (!response || typeof response.ok === 'undefined') {

--- a/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
@@ -119,6 +119,7 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -185,7 +186,7 @@ const scanSessionOrphans = async () => {
     statusMessage.value = null
 
     // Issue #552: Fixed path to match backend /api/knowledge-maintenance/session-orphans
-    const response = await apiClient.get('/api/knowledge-maintenance/session-orphans')
+    const response = await apiClient.get(`${getApiBase()}/knowledge-maintenance/session-orphans`)
 
     if (!response.ok) {
       const errorText = await response.text()
@@ -230,7 +231,7 @@ const cleanupSessionOrphans = async () => {
     isCleaningOrphans.value = true
 
     // Issue #552: Fixed path to match backend /api/knowledge-maintenance/session-orphans
-    const response = await apiClient.delete('/api/knowledge-maintenance/session-orphans?dry_run=false&preserve_important=true')
+    const response = await apiClient.delete(`${getApiBase()}/knowledge-maintenance/session-orphans?dry_run=false&preserve_important=true`)
 
     if (!response.ok) {
       const errorText = await response.text()

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -118,6 +118,7 @@
 import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { apiService } from '@/services/api'
+import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
@@ -226,7 +227,7 @@ const handleSearch = async () => {
   searchResults.value = []
 
   try {
-    const url = `/api/user-management/users/search?q=${encodeURIComponent(query)}&limit=10`
+    const url = `${getApiBase()}/user-management/users/search?q=${encodeURIComponent(query)}&limit=10`
     const response = await apiService.get<{
       users: ShareEntity[]
       available: boolean

--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -17,6 +17,7 @@ import { ref, computed, watch } from 'vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { useI18n } from 'vue-i18n'
@@ -160,7 +161,7 @@ async function loadFactCount(categoryId: string): Promise<void> {
   isLoadingFactCount.value = true
   try {
     const response = await apiClient.get(
-      `/api/knowledge_base/categories/${encodeURIComponent(categoryId)}/facts?limit=1`
+      `${getApiBase()}/knowledge_base/categories/${encodeURIComponent(categoryId)}/facts?limit=1`
     )
     const data = await parseApiResponse(response)
     factCount.value = data?.total_count ?? 0
@@ -181,7 +182,7 @@ async function saveChanges(): Promise<void> {
 
   try {
     const response = await apiClient.put(
-      `/api/knowledge_base/categories/${encodeURIComponent(props.category.id)}`,
+      `${getApiBase()}/knowledge_base/categories/${encodeURIComponent(props.category.id)}`,
       formData.value
     )
     const data = await parseApiResponse(response)
@@ -213,7 +214,7 @@ async function deleteCategory(): Promise<void> {
 
   try {
     const response = await apiClient.delete(
-      `/api/knowledge_base/categories/${encodeURIComponent(props.category.id)}`
+      `${getApiBase()}/knowledge_base/categories/${encodeURIComponent(props.category.id)}`
     )
     const data = await parseApiResponse(response)
 


### PR DESCRIPTION
Closes #3682

Part of #3680.

Replaced hardcoded `/api/` in 20 knowledge Vue components with `getApiBase()`. 57 path replacements across: BackupManager, CleanupStatistics, DeduplicationManager, EntityExtractor, EntityGraphManager, FailedVectorizationsManager, GraphRAGQuery, KnowledgeAdvanced, KnowledgeBrowser, KnowledgeCategories, KnowledgeGraph, KnowledgeMaintenance, KnowledgePersistenceDialog, KnowledgePromptEditor, KnowledgeStats, KnowledgeSystemDocs, MemoryOrphanManager, SessionOrphanManager, ShareKnowledgeDialog, modals/CategoryEditModal.