### PR TITLE
chore(frontend): adopt getApiBase() in security, visualizations, workflow, and research Vue components (#3684)

### DIFF
--- a/autobot-frontend/src/components/research/CaptchaNotification.vue
+++ b/autobot-frontend/src/components/research/CaptchaNotification.vue
@@ -78,6 +78,7 @@ import { useI18n } from 'vue-i18n'
 // @ts-ignore - JS module without type declarations
 import { useGlobalWebSocket } from '@/composables/useGlobalWebSocket'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
@@ -211,7 +212,7 @@ async function markSolved() {
 
   isSubmitting.value = true
   try {
-    await apiClient.post(`/api/captcha/${activeCaptcha.value.captcha_id}/resolve`)
+    await apiClient.post(`${getApiBase()}/captcha/${activeCaptcha.value.captcha_id}/resolve`)
     activeCaptcha.value = null
     stopTimer()
   } catch (error) {
@@ -226,7 +227,7 @@ async function skipCaptcha() {
 
   isSubmitting.value = true
   try {
-    await apiClient.post(`/api/captcha/${activeCaptcha.value.captcha_id}/skip`)
+    await apiClient.post(`${getApiBase()}/captcha/${activeCaptcha.value.captcha_id}/skip`)
     activeCaptcha.value = null
     stopTimer()
   } catch (error) {

--- a/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.vue
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.vue
@@ -210,6 +210,7 @@ import { ref, onMounted, reactive } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
@@ -255,8 +256,8 @@ async function refreshStatus() {
   loading.value = true
   try {
     const [statusResponse, statsResponse] = await Promise.all([
-      apiClient.get('/api/security/threat-intel/status'),
-      apiClient.get('/api/security/domain-security/stats')
+      apiClient.get(`${getApiBase()}/security/threat-intel/status`),
+      apiClient.get(`${getApiBase()}/security/domain-security/stats`)
     ])
 
     const statusData = (statusResponse as { data?: Record<string, unknown> }).data
@@ -290,7 +291,7 @@ async function checkUrl() {
   checkResult.value = null
 
   try {
-    const response = await apiClient.post('/api/security/threat-intel/check-url', {
+    const response = await apiClient.post(`${getApiBase()}/security/threat-intel/check-url`, {
       url: urlToCheck.value
     })
 

--- a/autobot-frontend/src/components/security/ThreatIntelligenceSettings.vue
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceSettings.vue
@@ -209,6 +209,7 @@ import { ref, reactive, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
 
 const { t } = useI18n()
 const logger = createLogger('ThreatIntelligenceSettings')
@@ -238,8 +239,8 @@ async function refreshStatus() {
   loading.value = true
   try {
     const [statusResponse, statsResponse] = await Promise.all([
-      apiClient.get('/api/security/threat-intel/status'),
-      apiClient.get('/api/security/domain-security/stats')
+      apiClient.get(`${getApiBase()}/security/threat-intel/status`),
+      apiClient.get(`${getApiBase()}/security/domain-security/stats`)
     ])
 
     const statusData = (statusResponse as { data?: Record<string, unknown> }).data

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
@@ -183,6 +183,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
@@ -325,7 +326,7 @@ function pauseAgent(agent: Agent) {
 
 async function fetchAgents() {
   try {
-    const response = await fetchWithAuth('/api/agents/status')
+    const response = await fetchWithAuth(`${getApiBase()}/agents/status`)
     if (response.ok) {
       const data = await response.json()
       if (data.agents) {
@@ -345,7 +346,7 @@ async function fetchEvents() {
   try {
     // Issue #552: Fixed path - backend uses /api/analytics/agents/tasks/recent
     // (analytics_agents.py has prefix="/agents" and is included into analytics.py router)
-    const response = await fetchWithAuth('/api/analytics/agents/tasks/recent?limit=10')
+    const response = await fetchWithAuth(`${getApiBase()}/analytics/agents/tasks/recent?limit=10`)
     if (response.ok) {
       const data = await response.json()
       // Backend returns tasks, not events - adapt response structure

--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
@@ -84,6 +84,7 @@ import VueApexCharts from 'vue3-apexcharts'
 import type { ApexOptions } from 'apexcharts'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const { t } = useI18n()
 
@@ -289,7 +290,7 @@ async function fetchData() {
 
   try {
     // Fetch historical metrics from backend
-    const response = await fetchWithAuth(`/api/monitoring/metrics/history?metric=${selectedMetric.value}&range=${timeRange.value}&machine=${props.machine}`)
+    const response = await fetchWithAuth(`${getApiBase()}/monitoring/metrics/history?metric=${selectedMetric.value}&range=${timeRange.value}&machine=${props.machine}`)
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`)

--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
@@ -513,7 +513,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
-import { getConfig } from '@/config/ssot-config'
+import { getConfig, getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
 
@@ -704,7 +704,7 @@ async function refreshArchitecture() {
 
   try {
     // Issue #552: Fixed path - backend uses /api/monitoring/services/health
-    const healthResponse = await apiClient.get('/api/monitoring/services/health')
+    const healthResponse = await apiClient.get(`${getApiBase()}/monitoring/services/health`)
     const healthData = await parseApiResponse(healthResponse)
 
     // Generate architecture based on known infrastructure

--- a/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.vue
+++ b/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.vue
@@ -142,6 +142,7 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const { t } = useI18n()
 const logger = createLogger('PhaseProgressionIndicator')
@@ -191,7 +192,7 @@ async function loadValidationData(): Promise<void> {
   hasLoadError.value = false
 
   try {
-    const data = await api.get<ValidationReport>('/api/validation-dashboard/report')
+    const data = await api.get<ValidationReport>(`${getApiBase()}/validation-dashboard/report`)
 
     if (data.status === 'success' && data.report) {
       const overview = data.report.system_overview

--- a/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue
@@ -80,6 +80,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import { apiService } from '@/services/api'
+import { getApiBase } from '@/config/ssot-config'
 
 const { t } = useI18n()
 
@@ -127,7 +128,7 @@ const loadWorkflowData = async () => {
   if (!props.workflowId) return
 
   try {
-    const response = await apiService.get(`/api/workflow/workflow/${props.workflowId}`)
+    const response = await apiService.get(`${getApiBase()}/workflow/workflow/${props.workflowId}`)
     activeWorkflow.value = response.workflow
     workflowSteps.value = response.workflow.steps || []
   } catch (error) {
@@ -152,7 +153,7 @@ const cancelWorkflow = async () => {
   if (!confirm(t('workflow.progress.cancelConfirm'))) return
 
   try {
-    await apiService.delete(`/api/workflow/workflow/${props.workflowId}`)
+    await apiService.delete(`${getApiBase()}/workflow/workflow/${props.workflowId}`)
     activeWorkflow.value = null
     emit('workflow-cancelled', props.workflowId)
   } catch (error) {


### PR DESCRIPTION
Closes #3684

Part of #3680.

Replaced hardcoded `/api/` paths in 8 components across 4 directories:
- **security/**: ThreatIntelligenceDashboard.vue, ThreatIntelligenceSettings.vue
- **visualizations/**: AgentActivityVisualization.vue, ResourceHeatmap.vue, SystemArchitectureDiagram.vue
- **workflow/**: PhaseProgressionIndicator.vue, WorkflowProgressWidget.vue
- **research/**: CaptchaNotification.vue