### PR TITLE
fix(frontend): correct useEvolution base URL from /analytics/evolution to /evolution (#3698)

### DIFF
--- a/autobot-frontend/src/composables/useEvolution.ts
+++ b/autobot-frontend/src/composables/useEvolution.ts
@@ -92,7 +92,7 @@ export function useEvolution(sourceId?: string | ComputedRef<string | undefined>
 
   // API client with auth token
   const api = axios.create({
-    baseURL: `${getApiBase()}/analytics/evolution`,
+    baseURL: `${getApiBase()}/evolution`,
     timeout: 120000, // 2 minutes for long-running analysis
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Problem
The `useEvolution` composable built its Axios baseURL as `` `${getApiBase()}/analytics/evolution` `` which resolved to `/api/analytics/evolution/*`. The backend router is mounted at prefix `/evolution` (not `/analytics/evolution`), so every request — timeline, patterns, trends, summary — 404'd. The entire Evolution child tab was silently broken.

## Fix
Removed the spurious `/analytics` segment. baseURL is now `` `${getApiBase()}/evolution` ``.

**Changed:** `autobot-frontend/src/composables/useEvolution.ts` line 95 — 1 character change.

Closes #3698