### PR TITLE
chore(frontend): adopt getApiBase() in analytics Vue components (#3681)

### DIFF
--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
@@ -327,6 +327,7 @@ import BaseButton from '@/components/base/BaseButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import api from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const { t } = useI18n()
 
@@ -412,9 +413,9 @@ const fetchCostData = async () => {
     // Issue #552: Fixed missing /api prefix in analytics endpoints
     // Issue #701: Added type assertions for Promise.all results
     const [summaryRes, trendsRes, modelsRes] = await Promise.all([
-      api.get<ApiDataResponse>('/api/analytics/cost/summary'),
-      api.get<ApiDataResponse>('/api/analytics/cost/trends'),
-      api.get<ApiDataResponse>('/api/analytics/cost/by-model')
+      api.get<ApiDataResponse>(`${getApiBase()}/analytics/cost/summary`),
+      api.get<ApiDataResponse>(`${getApiBase()}/analytics/cost/trends`),
+      api.get<ApiDataResponse>(`${getApiBase()}/analytics/cost/by-model`)
     ])
     costSummary.value = (summaryRes as ApiDataResponse).data
     costTrends.value = (trendsRes as ApiDataResponse).data
@@ -429,8 +430,8 @@ const fetchAgentData = async () => {
     // Issue #552: Fixed missing /api prefix in analytics endpoints
     // Issue #701: Added type assertions for Promise.all results
     const [metricsRes, recsRes] = await Promise.all([
-      api.get<ApiDataResponse>('/api/analytics/agents/performance'),
-      api.get<ApiDataResponse>('/api/analytics/agents/recommendations')
+      api.get<ApiDataResponse>(`${getApiBase()}/analytics/agents/performance`),
+      api.get<ApiDataResponse>(`${getApiBase()}/analytics/agents/recommendations`)
     ])
     agentMetrics.value = (metricsRes as ApiDataResponse).data
     recommendations.value = (recsRes as ApiDataResponse).data
@@ -443,7 +444,7 @@ const fetchExportFormats = async () => {
   try {
     // Issue #552: Fixed missing /api prefix in analytics endpoints
     // Issue #701: Added type assertion for response
-    const res = await api.get<ApiDataResponse>('/api/analytics/export/formats')
+    const res = await api.get<ApiDataResponse>(`${getApiBase()}/analytics/export/formats`)
     exportFormats.value = (res as ApiDataResponse).data?.formats || []
     // Add icons
     exportFormats.value.forEach((f: any) => {
@@ -463,9 +464,9 @@ const fetchBehaviorData = async () => {
     // Issue #552: Fixed missing /api prefix in analytics endpoints
     // Issue #701: Added type assertions for Promise.all results
     const [engagementRes, featuresRes, heatmapRes] = await Promise.all([
-      api.get<ApiDataResponse>('/api/analytics/behavior/engagement'),
-      api.get<ApiDataResponse>('/api/analytics/behavior/features'),
-      api.get<ApiDataResponse>('/api/analytics/behavior/stats/heatmap')
+      api.get<ApiDataResponse>(`${getApiBase()}/analytics/behavior/engagement`),
+      api.get<ApiDataResponse>(`${getApiBase()}/analytics/behavior/features`),
+      api.get<ApiDataResponse>(`${getApiBase()}/analytics/behavior/stats/heatmap`)
     ])
     engagementMetrics.value = (engagementRes as ApiDataResponse).data
     behaviorMetrics.value = (featuresRes as ApiDataResponse).data

--- a/autobot-frontend/src/components/analytics/AgentCostPanel.vue
+++ b/autobot-frontend/src/components/analytics/AgentCostPanel.vue
@@ -150,6 +150,7 @@ import BaseButton from '@/components/base/BaseButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import api from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('AgentCostPanel')
 const { t } = useI18n()
@@ -192,7 +193,7 @@ const formatNumber = (num: number): string => {
 const fetchAgentCosts = async () => {
   loading.value = true
   try {
-    const res = await api.get<{ data: { agents: AgentCost[] } }>('/api/cost/by-agent')
+    const res = await api.get<{ data: { agents: AgentCost[] } }>(`${getApiBase()}/cost/by-agent`)
     agents.value = res.data?.agents || []
   } catch (error) {
     logger.error('Failed to fetch agent costs:', error)
@@ -219,7 +220,7 @@ const saveBudget = async () => {
   budgetDialog.value.saving = true
   try {
     await api.put(
-      `/api/cost/by-agent/${budgetDialog.value.agentId}/budget`,
+      `${getApiBase()}/cost/by-agent/${budgetDialog.value.agentId}/budget`,
       { budget_monthly_usd: budgetDialog.value.amount }
     )
     closeBudgetDialog()

--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
@@ -214,6 +214,7 @@ import { useI18n } from 'vue-i18n'
 import BaseButton from '@/components/ui/BaseButton.vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { useToast } from '@/composables/useToast'
+import { getApiBase } from '@/config/ssot-config'
 
 const { t } = useI18n()
 
@@ -332,9 +333,9 @@ async function fetchTimeline() {
 
     // Issue #552: Fixed path - backend uses /api/evolution/* not /api/analytics/evolution/*
     const [timelineRes, trendsRes, patternsRes] = await Promise.all([
-      fetchWithAuth(`/api/evolution/timeline?${params}`),
-      fetchWithAuth(`/api/evolution/trends?days=${selectedDays.value}`),
-      fetchWithAuth('/api/evolution/patterns')
+      fetchWithAuth(`${getApiBase()}/evolution/timeline?${params}`),
+      fetchWithAuth(`${getApiBase()}/evolution/trends?days=${selectedDays.value}`),
+      fetchWithAuth(`${getApiBase()}/evolution/patterns`)
     ])
 
     if (!timelineRes.ok || !trendsRes.ok) {
@@ -368,7 +369,7 @@ async function exportData() {
 
     // Issue #552: Fixed path - backend uses /api/evolution/* not /api/analytics/evolution/*
     const response = await fetchWithAuth(
-      `/api/evolution/export?format=csv&start_date=${startDate}&end_date=${endDate}`
+      `${getApiBase()}/evolution/export?format=csv&start_date=${startDate}&end_date=${endDate}`
     )
 
     if (!response.ok) throw new Error('Export failed')

--- a/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
@@ -332,6 +332,7 @@ import { useRoute } from 'vue-router'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { escapeHtml } from '@/utils/sanitize'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('CodeGenerationDashboard')
 
@@ -488,7 +489,7 @@ const generateCode = async () => {
   result.value = null
 
   try {
-    const response = await fetchWithAuth('/api/code-generation/generate', {
+    const response = await fetchWithAuth(`${getApiBase()}/code-generation/generate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(generateRequest.value)
@@ -516,7 +517,7 @@ const refactorCode = async () => {
   result.value = null
 
   try {
-    const response = await fetchWithAuth('/api/code-generation/refactor', {
+    const response = await fetchWithAuth(`${getApiBase()}/code-generation/refactor`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(refactorRequest.value)
@@ -541,7 +542,7 @@ const refactorCode = async () => {
 
 const validateCodeSubmit = async () => {
   try {
-    const response = await fetchWithAuth('/api/code-generation/validate', {
+    const response = await fetchWithAuth(`${getApiBase()}/code-generation/validate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -561,7 +562,7 @@ const validateCodeSubmit = async () => {
 const fetchStats = async () => {
   try {
     // Issue #3436: scope to project when sourceId is present
-    const response = await fetchWithAuth(withSourceId('/api/code-generation/stats'))
+    const response = await fetchWithAuth(withSourceId(`${getApiBase()}/code-generation/stats`))
     if (response.ok) {
       const data = await response.json()
       stats.value = data
@@ -573,7 +574,7 @@ const fetchStats = async () => {
 
 const fetchRefactoringTypes = async () => {
   try {
-    const response = await fetchWithAuth('/api/code-generation/refactoring-types')
+    const response = await fetchWithAuth(`${getApiBase()}/code-generation/refactoring-types`)
     if (response.ok) {
       const data = await response.json()
       refactoringTypes.value = data.types

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -424,6 +424,7 @@ import { ref, computed, onMounted, onUnmounted, watch, reactive } from 'vue';
 import { useRoute } from 'vue-router';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { createLogger } from '@/utils/debugUtils';
+import { getApiBase } from '@/config/ssot-config';
 import { getCssVar } from '@/composables/useCssVars'
 
 const logger = createLogger('CodeQualityDashboard');
@@ -648,7 +649,7 @@ async function loadHealthScore(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
     // Issue #3436: scope to project when sourceId is present
-    const response = await fetchWithAuth(withSourceId('/api/quality/health-score'));
+    const response = await fetchWithAuth(withSourceId(`${getApiBase()}/quality/health-score`));
     if (response.ok) {
       healthScore.value = await response.json();
     } else {
@@ -664,7 +665,7 @@ async function loadMetrics(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
     // Issue #3436: scope to project when sourceId is present
-    const response = await fetchWithAuth(withSourceId('/api/quality/metrics'));
+    const response = await fetchWithAuth(withSourceId(`${getApiBase()}/quality/metrics`));
     if (response.ok) {
       metrics.value = await response.json();
     } else {
@@ -681,7 +682,7 @@ async function loadPatterns(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
     // Issue #3436: scope to project when sourceId is present
-    const response = await fetchWithAuth(withSourceId('/api/quality/patterns'));
+    const response = await fetchWithAuth(withSourceId(`${getApiBase()}/quality/patterns`));
     if (response.ok) {
       patterns.value = await response.json();
     } else {
@@ -698,7 +699,7 @@ async function loadComplexity(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
     // Issue #3436: scope to project when sourceId is present
-    const response = await fetchWithAuth(withSourceId('/api/quality/complexity?top_n=5'));
+    const response = await fetchWithAuth(withSourceId(`${getApiBase()}/quality/complexity?top_n=5`));
     if (response.ok) {
       complexity.value = await response.json();
     } else {
@@ -714,7 +715,7 @@ async function loadTrends(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
     // Issue #3436: scope to project when sourceId is present
-    const response = await fetchWithAuth(withSourceId(`/api/quality/trends?period=${selectedPeriod.value}`));
+    const response = await fetchWithAuth(withSourceId(`${getApiBase()}/quality/trends?period=${selectedPeriod.value}`));
     if (response.ok) {
       const data = await response.json();
       trendData.value = data.data_points || [];
@@ -732,7 +733,7 @@ async function loadSnapshot(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
     // Issue #3436: scope to project when sourceId is present
-    const response = await fetchWithAuth(withSourceId('/api/quality/snapshot'));
+    const response = await fetchWithAuth(withSourceId(`${getApiBase()}/quality/snapshot`));
     if (response.ok) {
       const data = await response.json();
       codebaseStats.value = data.codebase_stats || { files: 0, lines: 0, issues: 0 };
@@ -750,7 +751,7 @@ async function drillDown(category: string): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
     // Issue #3436: scope to project when sourceId is present
-    const response = await fetchWithAuth(withSourceId(`/api/quality/drill-down/${category}`));
+    const response = await fetchWithAuth(withSourceId(`${getApiBase()}/quality/drill-down/${category}`));
     if (response.ok) {
       drillDownData.value = await response.json();
     } else {
@@ -767,7 +768,7 @@ async function exportReport(format: string): Promise<void> {
   exportMenuOpen.value = false;
   try {
     // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
-    const response = await fetchWithAuth(`/api/quality/export?format=${format}`);
+    const response = await fetchWithAuth(`${getApiBase()}/quality/export?format=${format}`);
     if (response.ok) {
       const data = await response.json();
       if (format === 'json') {

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -352,6 +352,7 @@ import { useI18n } from 'vue-i18n'
 import { useToast } from '@/composables/useToast'
 import api from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const { t } = useI18n()
 const logger = createLogger('CodeReviewDashboard')
@@ -585,7 +586,7 @@ async function runAnalysis() {
   try {
     // Issue #701: Fixed api.get call to use params option and type assertion
     // Issue #3436: scope to project when sourceId is present
-    const response = await api.get<ApiDataResponse>('/api/code-review/analyze', {
+    const response = await api.get<ApiDataResponse>(`${getApiBase()}/code-review/analyze`, {
       params: withSourceIdParams({
         path: selectedPath.value,
         languages: selectedLanguages.value.join(',')
@@ -617,7 +618,7 @@ async function loadHistory() {
   try {
     // Issue #701: Added type assertion for response
     // Issue #3436: scope to project when sourceId is present
-    const response = await api.get<ApiDataResponse>('/api/code-review/history', {
+    const response = await api.get<ApiDataResponse>(`${getApiBase()}/code-review/history`, {
       params: withSourceIdParams()
     })
     reviewHistory.value = (response as ApiDataResponse).reviews || (response as ApiDataResponse).data?.reviews || []
@@ -630,7 +631,7 @@ async function loadHistory() {
 async function loadReview(reviewId: string) {
   try {
     // Issue #701: Added type assertion for response
-    const response = await api.get<ApiDataResponse>(`/api/code-review/review/${reviewId}`)
+    const response = await api.get<ApiDataResponse>(`${getApiBase()}/code-review/review/${reviewId}`)
     issues.value = (response as ApiDataResponse).issues || (response as ApiDataResponse).data?.issues || []
     selectedPath.value = (response as ApiDataResponse).path || (response as ApiDataResponse).data?.path || ''
     hasAnalyzed.value = true
@@ -644,7 +645,7 @@ async function loadPatterns() {
   showPatterns.value = true
   try {
     // Issue #701: Added type assertion for response
-    const response = await api.get<ApiDataResponse>('/api/code-review/patterns')
+    const response = await api.get<ApiDataResponse>(`${getApiBase()}/code-review/patterns`)
     patterns.value = (response as ApiDataResponse).patterns || (response as ApiDataResponse).data?.patterns || []
     applyPatternPrefs()
   } catch (error) {
@@ -665,7 +666,7 @@ function savePatternPrefs(): void {
 async function applyPatternPrefs(): Promise<void> {
   // Issue #638: Load preferences from backend first, fallback to localStorage
   try {
-    const response = await api.get<ApiDataResponse>('/api/analytics/code-review/patterns/preferences');
+    const response = await api.get<ApiDataResponse>(`${getApiBase()}/analytics/code-review/patterns/preferences`);
     const prefs = (response as ApiDataResponse).patterns || (response as ApiDataResponse).data?.patterns;
 
     if (prefs) {
@@ -701,7 +702,7 @@ async function togglePattern(pattern: Pattern): Promise<void> {
   const newState = !pattern.enabled;
 
   try {
-    await api.post('/api/analytics/code-review/patterns/toggle', {
+    await api.post(`${getApiBase()}/analytics/code-review/patterns/toggle`, {
       pattern_id: pattern.id,
       enabled: newState
     });
@@ -719,7 +720,7 @@ async function togglePattern(pattern: Pattern): Promise<void> {
 
 async function markResolved(issue: ReviewIssue) {
   try {
-    await api.post('/api/code-review/feedback', {
+    await api.post(`${getApiBase()}/code-review/feedback`, {
       issue_id: issue.id,
       feedback: 'resolved'
     })
@@ -734,7 +735,7 @@ async function markResolved(issue: ReviewIssue) {
 
 async function markFalsePositive(issue: ReviewIssue) {
   try {
-    await api.post('/api/code-review/feedback', {
+    await api.post(`${getApiBase()}/code-review/feedback`, {
       issue_id: issue.id,
       feedback: 'false_positive'
     })

--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
@@ -264,6 +264,7 @@
 import { ref, onMounted, computed } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('ConversationFlowDashboard')
 
@@ -333,7 +334,7 @@ const maxHourlyCount = computed(() => {
 const runAnalysis = async () => {
   isLoading.value = true
   try {
-    const response = await fetchWithAuth(`/api/conversation-flow/analyze?hours=${timeRange.value}`)
+    const response = await fetchWithAuth(`${getApiBase()}/conversation-flow/analyze?hours=${timeRange.value}`)
     if (response.ok) {
       analysisResult.value = await response.json()
     }

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -326,6 +326,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const logger = createLogger('LLMPatternDashboard')
 
@@ -480,7 +481,7 @@ const toggleSteps = (type: string) => {
 // API Calls
 const fetchStats = async () => {
   try {
-    const response = await fetchWithAuth('/api/llm-patterns/stats?days=7')
+    const response = await fetchWithAuth(`${getApiBase()}/llm-patterns/stats?days=7`)
     if (response.ok) {
       stats.value = await response.json()
     }
@@ -491,7 +492,7 @@ const fetchStats = async () => {
 
 const fetchRecommendations = async () => {
   try {
-    const response = await fetchWithAuth('/api/llm-patterns/recommendations')
+    const response = await fetchWithAuth(`${getApiBase()}/llm-patterns/recommendations`)
     if (response.ok) {
       const data = await response.json()
       recommendations.value = data.recommendations || []
@@ -503,7 +504,7 @@ const fetchRecommendations = async () => {
 
 const fetchModelComparison = async () => {
   try {
-    const response = await fetchWithAuth('/api/llm-patterns/model-comparison')
+    const response = await fetchWithAuth(`${getApiBase()}/llm-patterns/model-comparison`)
     if (response.ok) {
       const data = await response.json()
       modelComparison.value = data.models || []
@@ -515,7 +516,7 @@ const fetchModelComparison = async () => {
 
 const fetchCategoryDistribution = async () => {
   try {
-    const response = await fetchWithAuth('/api/llm-patterns/category-distribution')
+    const response = await fetchWithAuth(`${getApiBase()}/llm-patterns/category-distribution`)
     if (response.ok) {
       categoryData.value = await response.json()
     }
@@ -526,7 +527,7 @@ const fetchCategoryDistribution = async () => {
 
 const fetchCacheOpportunities = async () => {
   try {
-    const response = await fetchWithAuth('/api/llm-patterns/cache-opportunities')
+    const response = await fetchWithAuth(`${getApiBase()}/llm-patterns/cache-opportunities`)
     if (response.ok) {
       const data = await response.json()
       cacheOpportunities.value = data.opportunities || []
@@ -540,7 +541,7 @@ const runAnalysis = async () => {
   if (!analyzePrompt.value) return
 
   try {
-    const response = await fetchWithAuth('/api/llm-patterns/analyze', {
+    const response = await fetchWithAuth(`${getApiBase()}/llm-patterns/analyze`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
@@ -229,6 +229,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 import { getCssVar } from '@/composables/useCssVars'
 
 const { t } = useI18n()
@@ -333,7 +334,7 @@ const runAnalysis = async () => {
   isAnalyzing.value = true
   try {
     const response = await fetchWithAuth(
-      `/api/log-patterns/mine?hours=${timeRange.value}&include_anomalies=true&include_trends=true`
+      `${getApiBase()}/log-patterns/mine?hours=${timeRange.value}&include_anomalies=true&include_trends=true`
     )
     if (response.ok) {
       miningResult.value = await response.json()
@@ -347,7 +348,7 @@ const runAnalysis = async () => {
 
 const fetchRealtimeData = async () => {
   try {
-    const response = await fetchWithAuth('/api/log-patterns/realtime')
+    const response = await fetchWithAuth(`${getApiBase()}/log-patterns/realtime`)
     if (response.ok) {
       realtimeData.value = await response.json()
     }

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -357,6 +357,7 @@ import { useI18n } from 'vue-i18n'
 import { useToast } from '@/composables/useToast'
 import api from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const { t } = useI18n()
 const logger = createLogger('PerformanceAnalysisDashboard')
@@ -533,7 +534,7 @@ async function runAnalysis() {
   loading.value = true
   try {
     // Issue #701: Fixed api.get call to use params option and type assertion
-    const response = await api.get<ApiDataResponse>('/api/performance/analyze', {
+    const response = await api.get<ApiDataResponse>(`${getApiBase()}/performance/analyze`, {
       params: { path: selectedPath.value }
     })
     // Issue #701: Response is returned directly, handle both response structures
@@ -558,7 +559,7 @@ async function runAnalysis() {
 async function loadPatterns() {
   try {
     // Issue #701: Added type assertion for response
-    const response = await api.get<Pattern[] | ApiDataResponse>('/api/performance/patterns')
+    const response = await api.get<Pattern[] | ApiDataResponse>(`${getApiBase()}/performance/patterns`)
     // Issue #701: Response could be array directly or wrapped in data
     patterns.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data || [])
   } catch (error) {
@@ -570,7 +571,7 @@ async function loadPatterns() {
 async function loadHotspots() {
   try {
     // Issue #701: Added type assertion for response
-    const response = await api.get<Hotspot[] | ApiDataResponse>('/api/performance/hotspots')
+    const response = await api.get<Hotspot[] | ApiDataResponse>(`${getApiBase()}/performance/hotspots`)
     // Issue #701: Response could be array directly or wrapped in data
     hotspots.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data || [])
   } catch (error) {
@@ -583,7 +584,7 @@ async function togglePattern(pattern: Pattern) {
   const newState = !pattern.enabled
   try {
     // Issue #701: Fixed api.post call - data should be second arg, options third
-    await api.post(`/api/performance/patterns/${pattern.id}/toggle`, { enabled: newState })
+    await api.post(`${getApiBase()}/performance/patterns/${pattern.id}/toggle`, { enabled: newState })
     pattern.enabled = newState
   } catch (error) {
     logger.warn('Failed to toggle pattern:', error)

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
@@ -297,6 +297,7 @@ import { useI18n } from 'vue-i18n'
 import { useToast } from '@/composables/useToast'
 import api from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
 
 const { t } = useI18n()
 
@@ -474,7 +475,7 @@ function getIssueBarWidth(count: number): string {
 async function loadStatus() {
   try {
     // Issue #701: Added type assertion for response
-    const response = await api.get<HookStatus | ApiDataResponse>('/api/precommit/status')
+    const response = await api.get<HookStatus | ApiDataResponse>(`${getApiBase()}/precommit/status`)
     // Issue #701: Response could be data directly or wrapped
     hookStatus.value = (response as ApiDataResponse).data || response as HookStatus
   } catch (error) {
@@ -486,7 +487,7 @@ async function loadStatus() {
 async function loadChecks() {
   try {
     // Issue #701: Added type assertion for response
-    const response = await api.get<Check[] | ApiDataResponse>('/api/precommit/checks')
+    const response = await api.get<Check[] | ApiDataResponse>(`${getApiBase()}/precommit/checks`)
     // Issue #701: Response could be array directly or wrapped in data
     checks.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data || [])
   } catch (error) {
@@ -498,7 +499,7 @@ async function loadChecks() {
 async function loadHistory() {
   try {
     // Issue #701: Added type assertion for response
-    const response = await api.get<CommitCheckResult[] | ApiDataResponse>('/api/precommit/history')
+    const response = await api.get<CommitCheckResult[] | ApiDataResponse>(`${getApiBase()}/precommit/history`)
     // Issue #701: Response could be array directly or wrapped in data
     checkHistory.value = Array.isArray(response) ? response : ((response as ApiDataResponse).data || [])
   } catch (error) {
@@ -510,7 +511,7 @@ async function loadHistory() {
 async function loadSummary() {
   try {
     // Issue #701: Added type assertion for response
-    const response = await api.get<Summary | ApiDataResponse>('/api/precommit/summary')
+    const response = await api.get<Summary | ApiDataResponse>(`${getApiBase()}/precommit/summary`)
     // Issue #701: Response could be data directly or wrapped
     summary.value = (response as ApiDataResponse).data || response as Summary
   } catch (error) {
@@ -523,7 +524,7 @@ async function installHooks() {
   installing.value = true
   try {
     // Issue #701: api.post requires data argument
-    await api.post('/api/precommit/install', {})
+    await api.post(`${getApiBase()}/precommit/install`, {})
     await loadStatus()
     showToast(t('analytics.precommit.installSuccess'), 'success')
   } catch (error) {
@@ -538,7 +539,7 @@ async function uninstallHooks() {
   installing.value = true
   try {
     // Issue #701: api.post requires data argument
-    await api.post('/api/precommit/uninstall', {})
+    await api.post(`${getApiBase()}/precommit/uninstall`, {})
     await loadStatus()
     showToast(t('analytics.precommit.uninstallSuccess'), 'info')
   } catch (error) {
@@ -553,7 +554,7 @@ async function runCheck() {
   checking.value = true
   try {
     // Issue #701: Added type assertion for response
-    const response = await api.get<CommitCheckResult | ApiDataResponse>('/api/precommit/check')
+    const response = await api.get<CommitCheckResult | ApiDataResponse>(`${getApiBase()}/precommit/check`)
     // Issue #701: Response could be data directly or wrapped
     lastResult.value = (response as ApiDataResponse).data || response as CommitCheckResult
     await loadHistory()
@@ -577,7 +578,7 @@ async function toggleCheck(check: Check) {
   const newState = !check.enabled
   try {
     // Issue #701: Fixed api.post call - data should be second arg
-    await api.post(`/api/precommit/checks/${check.id}/toggle`, { enabled: newState })
+    await api.post(`${getApiBase()}/precommit/checks/${check.id}/toggle`, { enabled: newState })
     check.enabled = newState
   } catch (error) {
     logger.warn('Failed to toggle check:', error)

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -436,6 +436,7 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { createLogger } from '@/utils/debugUtils';
+import { getApiBase } from '@/config/ssot-config';
 import { getCssVar } from '@/composables/useCssVars'
 
 // Create scoped logger for TechnicalDebtDashboard
@@ -687,7 +688,7 @@ async function loadSummary(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/debt/* not /api/analytics/debt/*
     // Backend returns {status, summary: {...}, top_files: [...], ...}
-    const response = await fetchWithAuth('/api/debt/summary');
+    const response = await fetchWithAuth(`${getApiBase()}/debt/summary`);
     if (response.ok) {
       const result = await response.json();
       // Issue #552: Extract summary from response structure
@@ -707,7 +708,7 @@ async function loadCategoryBreakdown(): Promise<void> {
   try {
     // Issue #552: Fixed - backend uses POST for calculate, GET for summary
     // Backend returns {status, summary: {by_category: {...}, ...}, ...}
-    const response = await fetchWithAuth('/api/debt/summary');
+    const response = await fetchWithAuth(`${getApiBase()}/debt/summary`);
     if (response.ok) {
       const result = await response.json();
       // Issue #552: Extract by_category from nested summary structure
@@ -726,7 +727,7 @@ async function loadRoiPriorities(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/debt/* not /api/analytics/debt/*
     // Backend returns {status, priorities: [...], total_available: N}
-    const response = await fetchWithAuth('/api/debt/roi-priorities?limit=10');
+    const response = await fetchWithAuth(`${getApiBase()}/debt/roi-priorities?limit=10`);
     if (response.ok) {
       const result = await response.json();
       // Issue #552: Extract priorities from response structure
@@ -745,7 +746,7 @@ async function loadDebtItems(): Promise<void> {
   try {
     // Issue #552: Fixed - backend uses POST for /api/debt/calculate
     // Backend returns {status, data: {items, summary, ...}} structure
-    const response = await fetchWithAuth('/api/debt/calculate', { method: 'POST' });
+    const response = await fetchWithAuth(`${getApiBase()}/debt/calculate`, { method: 'POST' });
     if (response.ok) {
       const result = await response.json();
       // Issue #552: Access items from nested data structure
@@ -764,7 +765,7 @@ async function loadTrends(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/debt/* not /api/analytics/debt/*
     // Backend returns {status, trends: [...], data_points: N, change: {...}, direction: "..."}
-    const response = await fetchWithAuth(`/api/debt/trends?period=${selectedPeriod.value}`);
+    const response = await fetchWithAuth(`${getApiBase()}/debt/trends?period=${selectedPeriod.value}`);
     if (response.ok) {
       const result = await response.json();
       // Issue #552: Extract trends from response structure
@@ -783,7 +784,7 @@ async function exportReport(): Promise<void> {
   try {
     // Issue #552: Fixed path - backend uses /api/debt/* not /api/analytics/debt/*
     // Backend returns {status, format, report: "markdown content"} for markdown format
-    const response = await fetchWithAuth('/api/debt/report?format=markdown');
+    const response = await fetchWithAuth(`${getApiBase()}/debt/report?format=markdown`);
     if (response.ok) {
       const result = await response.json();
       // Issue #552: Extract markdown report from JSON response


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `'/api/'` and `` `/api/` `` strings with `getApiBase()` across 12 analytics Vue components
- Adds `import { getApiBase } from '@/config/ssot-config'` to each component's script block
- Covers both `api` (axios) and `fetchWithAuth` call sites, including template-literal URLs with dynamic segments
- `withSourceId()` helper in `CodeQualityDashboard` and `CodeGenerationDashboard` now receives `getApiBase()`-prefixed URLs

Closes #3681

## Files Changed

- `AdvancedAnalytics.vue` — 8 replacements
- `AgentCostPanel.vue` — 2 replacements
- `CodeEvolutionTimeline.vue` — 4 replacements
- `CodeGenerationDashboard.vue` — 5 replacements (incl. `withSourceId`)
- `CodeQualityDashboard.vue` — 8 replacements (incl. `withSourceId`)
- `CodeReviewDashboard.vue` — 8 replacements
- `ConversationFlowDashboard.vue` — 1 replacement
- `LLMPatternDashboard.vue` — 6 replacements
- `LogPatternDashboard.vue` — 2 replacements
- `PerformanceAnalysisDashboard.vue` — 4 replacements
- `PrecommitHookDashboard.vue` — 8 replacements
- `TechnicalDebtDashboard.vue` — 6 replacements

## Test plan

- [ ] Verify zero remaining hardcoded `/api/` strings: `grep -rn "'/api/\|\`/api/" src/components/analytics/` returns no matches
- [ ] TypeScript check passes: `npx vue-tsc --noEmit` exits clean
- [ ] Analytics dashboards load and fetch data correctly against backend at configured URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)