### PR TITLE
fix(frontend): remove spurious /analytics prefix from code-review pattern preference URLs (#3699)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -666,7 +666,7 @@ function savePatternPrefs(): void {
 async function applyPatternPrefs(): Promise<void> {
   // Issue #638: Load preferences from backend first, fallback to localStorage
   try {
-    const response = await api.get<ApiDataResponse>(`${getApiBase()}/analytics/code-review/patterns/preferences`);
+    const response = await api.get<ApiDataResponse>(`${getApiBase()}/code-review/patterns/preferences`);
     const prefs = (response as ApiDataResponse).patterns || (response as ApiDataResponse).data?.patterns;
 
     if (prefs) {
@@ -702,7 +702,7 @@ async function togglePattern(pattern: Pattern): Promise<void> {
   const newState = !pattern.enabled;
 
   try {
-    await api.post(`${getApiBase()}/analytics/code-review/patterns/toggle`, {
+    await api.post(`${getApiBase()}/code-review/patterns/toggle`, {
       pattern_id: pattern.id,
       enabled: newState
     });


### PR DESCRIPTION
## Problem
Two API calls in `CodeReviewDashboard.vue` included an extra `/analytics` path segment:

- `applyPatternPrefs()` → `/api/analytics/code-review/patterns/preferences` (404)
- `togglePattern()` → `/api/analytics/code-review/patterns/toggle` (404)

The backend router is mounted at prefix `/code-review`, so the correct paths are `/api/code-review/patterns/preferences` and `/api/code-review/patterns/toggle`. Other calls in the same file were already correct.

The component silently fell back to localStorage on each 404, so pattern preferences were never persisted to the backend.

## Fix
Removed the spurious `/analytics` segment from both URLs. 2 string changes in `CodeReviewDashboard.vue`.

Closes #3699