### PR TITLE
fix(frontend): use wss:// on HTTPS for CodeQualityDashboard WebSocket connection (#3702)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -797,7 +797,8 @@ function closeExportMenu(): void {
 
 function connectWebSocket(): void {
   // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
-  const wsUrl = `ws://${window.location.host}/api/quality/ws`;
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = `${protocol}//${window.location.host}/api/quality/ws`;
   ws = new WebSocket(wsUrl);
 
   ws.onopen = () => {


### PR DESCRIPTION
## Problem
`connectWebSocket()` in `CodeQualityDashboard.vue` hardcoded the `ws://` protocol:
```ts
const wsUrl = `ws://${window.location.host}/api/quality/ws`;
```
Browsers block mixed-content `ws://` connections from `https://` pages. The WebSocket always failed silently — live quality metric updates never arrived and the status indicator stayed disconnected.

The backend endpoint (`@router.websocket("/ws")` in `analytics_quality.py`) is correctly implemented; only the frontend protocol was wrong.

## Fix
Derive the protocol from the page:
```ts
const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
const wsUrl = `${protocol}//${window.location.host}/api/quality/ws`;
```

Closes #3702