### PR TITLE
fix(frontend): remove dead loadReview() — GET /review/{id} has no backend storage (#3701)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -276,7 +276,6 @@
             v-for="review in reviewHistory"
             :key="review.id"
             class="history-item"
-            @click="loadReview(review.id)"
           >
             <div class="history-info">
               <span class="history-path">{{ review.path }}</span>
@@ -625,19 +624,6 @@ async function loadHistory() {
   } catch (error) {
     logger.warn('Failed to load review history:', error)
     reviewHistory.value = []
-  }
-}
-
-async function loadReview(reviewId: string) {
-  try {
-    // Issue #701: Added type assertion for response
-    const response = await api.get<ApiDataResponse>(`${getApiBase()}/code-review/review/${reviewId}`)
-    issues.value = (response as ApiDataResponse).issues || (response as ApiDataResponse).data?.issues || []
-    selectedPath.value = (response as ApiDataResponse).path || (response as ApiDataResponse).data?.path || ''
-    hasAnalyzed.value = true
-  } catch (error) {
-    logger.error('Failed to load review:', error)
-    showToast(t('analytics.codeReview.failedToLoadReview'), 'error')
   }
 }
 


### PR DESCRIPTION
## Problem
`CodeReviewDashboard.vue` called `GET /api/code-review/review/{reviewId}` when a user clicked a history entry. This endpoint does not exist in `analytics_code_review.py` — the backend has no storage mechanism for retrieving individual reviews by ID.

## Investigation
Read `analytics_code_review.py` in full. The `GET /history` endpoint returns a list of past reviews, but review records are not stored with retrievable IDs in Redis. There is no storage to back a `GET /review/{id}` endpoint without a larger feature addition.

## Fix (Option B)
Removed `loadReview()` and its `@click` handler from the history list template. The dead code is gone; history items are no longer clickable until proper per-review storage is implemented as a separate feature issue.

**Changed:** `autobot-frontend/src/components/analytics/CodeReviewDashboard.vue` — 14 lines removed, 0 added.

Closes #3701