### PR TITLE
fix(frontend): remove duplicate withSourceId() wrap in Redis health URL (#3714)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
@@ -169,9 +169,7 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     redisHealthError.value = ''
     try {
       const backendUrl = await appConfig.getServiceUrl('backend')
-      const url = withSourceId(
-        withSourceId(`${backendUrl}/api/code-intelligence/redis/health-score?path=${encodeURIComponent(rootPath.value)}`),
-      )
+      const url = withSourceId(`${backendUrl}/api/code-intelligence/redis/health-score?path=${encodeURIComponent(rootPath.value)}`)
       const response = await fetchWithAuth(
         url,
         {


### PR DESCRIPTION
## Problem
\`loadRedisHealth()\` in \`useCodeIntelScores.ts\` called \`withSourceId()\` twice on the same URL:

```ts
const url = withSourceId(
  withSourceId(`${backendUrl}/api/code-intelligence/redis/health-score?path=...`),
)
```

\`withSourceId()\` appends \`&source_id=<id>\` — the double call produced a malformed URL with the parameter duplicated: \`...&source_id=abc&source_id=abc\`.

## Fix
Removed the outer wrapper. One call is all that's needed.

**Changed:** `autobot-frontend/src/composables/analytics/useCodeIntelScores.ts` lines 172-174 → 1 line.

Closes #3714