### PR TITLE
fix(ansible): AUTOBOT_CHROMADB_HOST fallback uses backend_ai_stack_host (#3541)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -51,7 +51,7 @@ AUTOBOT_AI_STACK_HOST={{ backend_ai_stack_host }}
 AUTOBOT_AI_STACK_PORT={{ backend_ai_stack_port }}
 
 # ChromaDB (remote on AI Stack VM)
-AUTOBOT_CHROMADB_HOST={{ backend_chromadb_host }}
+AUTOBOT_CHROMADB_HOST={{ backend_chromadb_host | default(backend_ai_stack_host | default('127.0.0.1')) }}
 AUTOBOT_CHROMADB_PORT={{ backend_chromadb_port }}
 
 # Deployment / user management mode (Issue #2953)


### PR DESCRIPTION
Closes #3541

Fix the ChromaDB host fallback in `backend.env.j2` to use `backend_ai_stack_host` (set by WSL2 auto-detection) instead of `ai_stack_host` (not set on WSL2 deployments).

On WSL2, the auto-detection logic only populates `backend_ai_stack_host`. The previous template had no fallback at all, which would cause a template rendering error. The corrected fallback chain is:

1. `backend_chromadb_host` (explicitly set for multi-VM deployments)
2. `backend_ai_stack_host` (WSL2 auto-detected value, since ChromaDB runs on the AI Stack VM)
3. `'127.0.0.1'` (single-host / local fallback)