### PR TITLE
fix(ansible): add post-deploy smoke test to backend role (#3687)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-node.yml
@@ -222,6 +222,23 @@
       ansible.builtin.pause:
         seconds: 5
 
+    # Post-restart smoke test (#3687): only runs when autobot-backend was
+    # among the deployed roles to avoid false failures on frontend-only updates.
+    - name: "Backend | Wait for backend to accept connections (#3687)"
+      ansible.builtin.wait_for:
+        host: "{{ hostvars[node_id]['ansible_host'] | default('127.0.0.1') }}"
+        port: 8001
+        timeout: 60
+      when: "'autobot-backend' in (hostvars['localhost']['resolved_role_names'] | default([]))"
+
+    - name: "Backend | Verify /api/health returns 200 (#3687)"
+      ansible.builtin.uri:
+        url: "http://{{ hostvars[node_id]['ansible_host'] | default('127.0.0.1') }}:8001/api/health"
+        status_code: 200
+      retries: 3
+      delay: 5
+      when: "'autobot-backend' in (hostvars['localhost']['resolved_role_names'] | default([]))"
+
     - name: "Mark node as UP_TO_DATE in SLM DB"
       ansible.builtin.uri:
         url: "{{ slm_admin_url }}/api/code-sync/nodes/{{ node_id }}/mark-synced"

--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -77,3 +77,9 @@ service_auth_circuit_breaker_percentage: 100
 service_auth_timestamp_window: 300
 service_auth_rate_limit_window: 300
 service_auth_rate_limit_max_failures: 10
+
+# Post-deploy smoke test (#3687): wait_for probes uvicorn directly on the
+# internal HTTP port; uri verifies /api/health returns 200.  Both values are
+# configurable so staging environments can shorten the timeout.
+backend_health_check_port: 8001
+backend_health_check_timeout: 60

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -557,3 +557,25 @@
     direction: in
   when: _backend_ufw_check.rc == 0
   tags: ['backend', 'ufw']
+
+# ==========================================================
+# Post-deploy smoke test (#3687)
+# systemd reports active (running) even when all uvicorn
+# workers crash-loop because the master process stays alive.
+# Probing the TCP port and /api/health catches that case and
+# fails the play before the deploy is marked complete.
+# ==========================================================
+- name: "Backend | Wait for backend to accept connections (#3687)"
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ backend_health_check_port }}"
+    timeout: "{{ backend_health_check_timeout }}"
+  tags: ['backend', 'smoke-test']
+
+- name: "Backend | Verify /api/health returns 200 (#3687)"
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ backend_health_check_port }}/api/health"
+    status_code: 200
+  retries: 3
+  delay: 5
+  tags: ['backend', 'smoke-test']


### PR DESCRIPTION
## Summary

- Adds `wait_for` (TCP port probe) and `uri` (`/api/health` HTTP 200) tasks at the end of the `backend` role, so every execution of `deploy-backend-local.yml` or `deploy-backend-remote.yml` fails the play immediately if uvicorn workers crash-loop after restart instead of silently leaving a 502 state
- Adds `backend_health_check_port: 8001` and `backend_health_check_timeout: 60` to `roles/backend/defaults/main.yml` so values are overridable per inventory/playbook
- Adds the same two smoke-test tasks to `update-node.yml` Play 3, conditioned on `autobot-backend` being in the deployed role list, covering cache-based node updates

## Root cause

`autobot-backend.service` stays in `active (running)` even when all uvicorn workers crash because the master uvicorn process (the one systemd tracks) remains alive. The service state is not a reliable signal for API readiness. Probing port 8001 directly catches the crash-loop case before the deploy is considered complete.

## Test plan

- [ ] Run `deploy-backend-local.yml` against a host with a known-good backend — play completes without error
- [ ] Introduce an intentional startup crash (e.g. bad env var) — play fails at the `wait_for` step within 60 s
- [ ] Run `update-node.yml` targeting a backend node — health check fires only when `autobot-backend` is in `role_names`
- [ ] Run `update-node.yml` targeting a frontend-only node — health check tasks are skipped

Closes #3687

🤖 Generated with [Claude Code](https://claude.com/claude-code)