### PR TITLE
fix(ansible): replace changed_when:true chown -R with idempotent file:recurse (#3396)

### DIFF
--- a/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/redis/tasks/main.yml
@@ -75,21 +75,14 @@
   become: yes
   tags: ['redis', 'ownership']
 
-- name: "Redis | Create Redis data directory"
-  file:
-    path: /var/lib/redis-stack
-    state: directory
-    owner: autobot
-    group: autobot
-    mode: '0755'
-  become: yes
-  tags: ['redis', 'directories']
-
 # Issue #3396: Ownership is set to autobot:autobot (not redis:redis) so the
 # autobot service user can read and write the data directory without sudo.
 # The systemd service override (redis-stack-override.conf.j2) runs
 # redis-stack-server as User=autobot Group=autobot to match.
-- name: "Redis | Fix Redis Stack data directory permissions"
+# recurse:yes enforces ownership on all existing files idempotently —
+# the file module only marks changed when it actually modifies something,
+# so it will NOT trigger the restart handler on clean runs.
+- name: "Redis | Create Redis data directory with autobot:autobot ownership"
   file:
     path: /var/lib/redis-stack
     state: directory
@@ -99,14 +92,14 @@
   become: yes
   tags: ['redis', 'ownership']
 
-# Issue #3396: Recursively fix ownership of any existing data files written
-# by a prior redis:redis run so redis-stack-server (now running as autobot)
-# can read and write them without sudo.
 - name: "Redis | Enforce autobot:autobot ownership on Redis data files (recursive)"
-  ansible.builtin.command:
-    cmd: chown -R autobot:autobot /var/lib/redis-stack
+  file:
+    path: /var/lib/redis-stack
+    state: directory
+    owner: autobot
+    group: autobot
+    recurse: yes
   become: yes
-  changed_when: true
   tags: ['redis', 'ownership']
 
 - name: "Redis | Set vm.overcommit_memory for background saves"


### PR DESCRIPTION
## Problem

PR #3696 introduced a `command: chown -R autobot:autobot /var/lib/redis-stack` task with `changed_when: true`. This **always** reports changed and triggers the `restart redis-stack` notify handler on every Ansible play run — causing unnecessary Redis restarts even when no ownership actually changed.

## Fix

Replace with the `ansible.builtin.file` module using `recurse: yes`:

```yaml
- name: "Redis | Enforce autobot:autobot ownership on Redis data files (recursive)"
  file:
    path: /var/lib/redis-stack
    state: directory
    owner: autobot
    group: autobot
    recurse: yes
  become: yes
```

The `file` module only marks the task `changed` when it actually modifies something — so clean runs no longer trigger a Redis restart.

Also removes the duplicate directory-creation task that preceded it (same path, same owner/group, just different mode).

## Test plan

- [ ] Run playbook twice in a row — second run should show no `changed` for the ownership task and NOT restart redis-stack-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)