### PR TITLE
chore(tests): extend get_test_backend_url() to remaining 14 backend test files

### DIFF
--- a/autobot-backend/agents/security_agents.e2e_test.py
+++ b/autobot-backend/agents/security_agents.e2e_test.py
@@ -8,6 +8,8 @@ import sys
 
 sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
 
+from tests.test_helpers import get_test_backend_url
+
 from agents.network_discovery_agent import network_discovery_agent
 from agents.security_scanner_agent import security_scanner_agent
 
@@ -141,7 +143,7 @@ async def test_workflow_integration():
             }
 
             async with session.post(
-                "http://localhost:8001/api/workflow/execute", json=workflow_data
+                get_test_backend_url() + "/api/workflow/execute", json=workflow_data
             ) as response:
                 if response.status == 200:
                     result = await response.json()

--- a/autobot-backend/api/file_upload_comprehensive_test.py
+++ b/autobot-backend/api/file_upload_comprehensive_test.py
@@ -17,11 +17,13 @@ import requests
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from tests.test_helpers import get_test_backend_url
+
 
 class FileUploadAPITests(unittest.TestCase):
     """Test file upload API endpoints"""
 
-    BASE_URL = "http://localhost:8001/api/files"
+    BASE_URL = get_test_backend_url() + "/api/files"
     HEADERS = {"X-User-Role": "admin"}
 
     def setUp(self):

--- a/autobot-backend/api/simple_terminal.e2e_test.py
+++ b/autobot-backend/api/simple_terminal.e2e_test.py
@@ -9,6 +9,8 @@ import time
 
 import websockets
 
+from tests.test_helpers import get_test_backend_url
+
 
 async def test_simple_terminal():
     """Test the simple terminal WebSocket endpoint"""
@@ -19,7 +21,7 @@ async def test_simple_terminal():
     session_id = f"test_{int(time.time())}"
     print(f"📝 Session ID: {session_id}")  # noqa: print
 
-    uri = f"ws://localhost:8001/api/terminal/ws/simple/{session_id}"
+    uri = get_test_backend_url().replace("http://", "ws://") + f"/api/terminal/ws/simple/{session_id}"
     print(f"🔗 Connecting to: {uri}")  # noqa: print
 
     try:
@@ -123,7 +125,7 @@ async def test_sessions_api():
 
     try:
         response = requests.get(
-            "http://localhost:8001/api/terminal/simple/sessions", timeout=5
+            get_test_backend_url() + "/api/terminal/simple/sessions", timeout=5
         )
         if response.status_code == 200:
             sessions = response.json()
@@ -168,11 +170,12 @@ async def main():
     if terminal_success and api_success:
         print("\n🎉 SUCCESS: Simple terminal is a working replacement!")  # noqa: print
         print("User can now use the simple terminal endpoint:")  # noqa: print
+        _base = get_test_backend_url()
         print(  # noqa: print
-            "  WebSocket: ws://localhost:8001/api/terminal/ws/simple/{session_id}"
+            f"  WebSocket: {_base.replace('http://', 'ws://')}/api/terminal/ws/simple/{{session_id}}"
         )  # noqa: print
         print(  # noqa: print
-            "  Sessions:  http://localhost:8001/api/terminal/simple/sessions"
+            f"  Sessions:  {_base}/api/terminal/simple/sessions"
         )  # noqa: print
     else:
         print("\n💥 Some tests failed - simple terminal needs fixes")  # noqa: print

--- a/autobot-backend/autobot_demo.e2e_test.py
+++ b/autobot-backend/autobot_demo.e2e_test.py
@@ -10,11 +10,13 @@ from typing import Any, Dict
 
 import aiohttp
 
+from tests.test_helpers import get_test_backend_url
+
 
 async def create_chat_session() -> str:
     """Create a new chat session and return the chat ID."""
     async with aiohttp.ClientSession() as session:
-        async with session.post("http://localhost:8001/api/chats/new") as response:
+        async with session.post(get_test_backend_url() + "/api/chats/new") as response:
             if response.status == 200:
                 data = await response.json()
                 return data.get("chat_id")
@@ -28,7 +30,7 @@ async def send_chat_message(chat_id: str, message: str) -> Dict[str, Any]:
         chat_request = {"chatId": chat_id, "message": message}
 
         async with session.post(
-            "http://localhost:8001/api/chat", json=chat_request
+            get_test_backend_url() + "/api/chat", json=chat_request
         ) as response:
             if response.status == 200:
                 return await response.json()
@@ -43,7 +45,7 @@ async def execute_workflow(message: str, auto_approve: bool = True) -> Dict[str,
         workflow_request = {"user_message": message, "auto_approve": auto_approve}
 
         async with session.post(
-            "http://localhost:8001/api/workflow/execute", json=workflow_request
+            get_test_backend_url() + "/api/workflow/execute", json=workflow_request
         ) as response:
             if response.status == 200:
                 return await response.json()
@@ -59,7 +61,7 @@ async def monitor_workflow(workflow_id: str, timeout: int = 60):
 
         while time.time() - start_time < timeout:
             async with session.get(
-                f"http://localhost:8001/api/workflow/workflow/{workflow_id}/status"
+                get_test_backend_url() + f"/api/workflow/workflow/{workflow_id}/status"
             ) as response:
                 if response.status == 200:
                     status = await response.json()
@@ -215,7 +217,7 @@ async def demo_workflow_management():
         # Check active workflows
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                "http://localhost:8001/api/workflow/workflows"
+                get_test_backend_url() + "/api/workflow/workflows"
             ) as response:
                 if response.status == 200:
                     data = await response.json()
@@ -256,7 +258,7 @@ async def main():
         async with aiohttp.ClientSession() as session:
             # Check backend health
             async with session.get(
-                "http://localhost:8001/api/system/health"
+                get_test_backend_url() + "/api/system/health"
             ) as response:
                 if response.status == 200:
                     health = await response.json()

--- a/autobot-backend/backend_startup.e2e_test.py
+++ b/autobot-backend/backend_startup.e2e_test.py
@@ -4,6 +4,9 @@ Test backend startup and workflow endpoint registration
 """
 
 
+from tests.test_helpers import get_test_backend_url
+
+
 def test_imports():
     """Test all critical imports."""
     print("🧪 Testing Backend Imports")  # noqa: print
@@ -38,7 +41,7 @@ def test_imports():
             "1. Start the backend: source venv/bin/activate && python main.py"
         )  # noqa: print
         print(  # noqa: print
-            "2. Test workflow endpoint: curl http://localhost:8001/api/workflow/workflows"
+            f"2. Test workflow endpoint: curl {get_test_backend_url()}/api/workflow/workflows"
         )
         print("3. Open frontend and navigate to Workflows tab")  # noqa: print
 

--- a/autobot-backend/chat_workflow/chat_workflow.e2e_test.py
+++ b/autobot-backend/chat_workflow/chat_workflow.e2e_test.py
@@ -8,6 +8,8 @@ import asyncio
 
 import aiohttp
 
+from tests.test_helpers import get_test_backend_url
+
 
 async def test_chat_workflow():
     """Test chat messages that trigger different workflow types."""
@@ -20,7 +22,7 @@ async def test_chat_workflow():
         print("-" * 40)  # noqa: print
 
         try:
-            async with session.post("http://localhost:8001/api/chats/new") as response:
+            async with session.post(get_test_backend_url() + "/api/chats/new") as response:
                 if response.status == 200:
                     chat_data = await response.json()
                     chat_id = chat_data.get("chat_id")
@@ -66,7 +68,7 @@ async def test_chat_workflow():
 
             try:
                 async with session.post(
-                    "http://localhost:8001/api/chat", json=chat_request
+                    get_test_backend_url() + "/api/chat", json=chat_request
                 ) as response:
                     if response.status == 200:
                         result = await response.json()
@@ -123,7 +125,7 @@ async def test_chat_workflow():
 
         try:
             async with session.get(
-                "http://localhost:8001/api/workflow/workflows"
+                get_test_backend_url() + "/api/workflow/workflows"
             ) as response:
                 if response.status == 200:
                     workflows_data = await response.json()
@@ -171,7 +173,7 @@ async def test_direct_workflow_execution():
 
         try:
             async with session.post(
-                "http://localhost:8001/api/workflow/execute", json=workflow_request
+                get_test_backend_url() + "/api/workflow/execute", json=workflow_request
             ) as response:
                 if response.status == 200:
                     result = await response.json()

--- a/autobot-backend/complete_system.e2e_test.py
+++ b/autobot-backend/complete_system.e2e_test.py
@@ -9,6 +9,8 @@ import time
 
 import aiohttp
 
+from tests.test_helpers import get_test_backend_url
+
 
 async def test_workflow_api():
     """Test the workflow API endpoints."""
@@ -30,7 +32,7 @@ async def test_workflow_api():
             }
 
             async with session.post(
-                "http://localhost:8001/api/workflow/execute", json=execution_request
+                get_test_backend_url() + "/api/workflow/execute", json=execution_request
             ) as response:
                 if response.status == 200:
                     result = await response.json()
@@ -47,7 +49,7 @@ async def test_workflow_api():
                         print("-" * 40)  # noqa: print
 
                         async with session.get(
-                            f"http://localhost:8001/api/workflow/workflow/{workflow_id}/status"
+                            get_test_backend_url() + f"/api/workflow/workflow/{workflow_id}/status"
                         ) as status_response:
                             if status_response.status == 200:
                                 status = await status_response.json()
@@ -76,7 +78,7 @@ async def test_workflow_api():
         except aiohttp.ClientError as e:
             print(f"❌ Connection error: {e}")  # noqa: print
             print(  # noqa: print
-                "   Make sure AutoBot backend is running on http://localhost:8001"
+                f"   Make sure AutoBot backend is running on {get_test_backend_url()}"
             )  # noqa: print
 
 

--- a/autobot-backend/knowledge/chat_knowledge_system.e2e_test.py
+++ b/autobot-backend/knowledge/chat_knowledge_system.e2e_test.py
@@ -12,11 +12,13 @@ import time
 
 import aiohttp
 
+from tests.test_helpers import get_test_backend_url
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-BASE_URL = "http://localhost:8001"
+BASE_URL = get_test_backend_url()
 
 
 class ChatKnowledgeSystemTester:
@@ -455,6 +457,6 @@ if __name__ == "__main__":
         success = asyncio.run(main())
         exit(0 if success else 1)
     else:
-        logger.error("❌ Backend is not running at http://localhost:8001")
+        logger.error(f"❌ Backend is not running at {get_test_backend_url()}")
         logger.error("Please start the backend with: ./run_agent.sh")
         exit(1)

--- a/autobot-backend/metrics/metrics_system.e2e_test.py
+++ b/autobot-backend/metrics/metrics_system.e2e_test.py
@@ -8,6 +8,8 @@ import sys
 
 sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
 
+from tests.test_helpers import get_test_backend_url
+
 from metrics.system_monitor import system_monitor
 from metrics.workflow_metrics import workflow_metrics
 
@@ -192,7 +194,7 @@ async def test_metrics_api_integration():
             for endpoint in endpoints_to_test:
                 try:
                     async with session.get(
-                        f"http://localhost:8001{endpoint}"
+                        get_test_backend_url() + endpoint
                     ) as response:
                         if response.status == 200:
                             print(f"✅ {endpoint}: OK")  # noqa: print

--- a/autobot-backend/services/mcp_dispatch_test.py
+++ b/autobot-backend/services/mcp_dispatch_test.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from services.mcp_dispatch import MCPDispatcher, get_mcp_dispatcher
+from tests.test_helpers import get_test_backend_url
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -31,7 +32,7 @@ _SAMPLE_TOOL = {
     "description": "Search the knowledge base",
     "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
     "bridge": "knowledge_mcp",
-    "endpoint": "http://localhost:8001/api/knowledge/mcp/search_knowledge_base",
+    "endpoint": get_test_backend_url() + "/api/knowledge/mcp/search_knowledge_base",
     "features": ["search"],
 }
 
@@ -238,7 +239,7 @@ _ADMIN_TOOL = {
     "description": "List all Redis clients",
     "input_schema": {},
     "bridge": "redis_mcp",
-    "endpoint": "http://localhost:8001/api/redis/mcp/client_list",
+    "endpoint": get_test_backend_url() + "/api/redis/mcp/client_list",
     "features": [],
 }
 

--- a/autobot-backend/takeover_manager.e2e_test.py
+++ b/autobot-backend/takeover_manager.e2e_test.py
@@ -12,6 +12,8 @@ import time
 # Test the workflow automation system
 from unittest.mock import AsyncMock
 
+from tests.test_helpers import get_test_backend_url
+
 # Import system components
 try:
     from api.terminal_handlers import ConsolidatedTerminalWebSocket
@@ -32,7 +34,7 @@ logger = logging.getLogger(__name__)
 class SessionTakeoverTestSuite:
     """Comprehensive test suite for session takeover functionality"""
 
-    def __init__(self, base_url: str = "http://localhost:8001"):
+    def __init__(self, base_url: str = get_test_backend_url()):
         self.base_url = base_url
         self.test_session_id = f"test_session_{int(time.time())}"
         self.workflow_manager = None

--- a/autobot-backend/utils/monitoring_alerts_test.py
+++ b/autobot-backend/utils/monitoring_alerts_test.py
@@ -7,6 +7,8 @@ import asyncio
 import logging
 from datetime import datetime
 
+from tests.test_helpers import get_test_backend_url
+
 # Setup logging
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -226,7 +228,7 @@ async def test_api_integration():
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.get(
-                    "http://localhost:8001/api/alerts/health"
+                    get_test_backend_url() + "/api/alerts/health"
                 ) as response:
                     if response.status == 200:
                         data = await response.json()

--- a/autobot-backend/workflow_scheduler.e2e_test.py
+++ b/autobot-backend/workflow_scheduler.e2e_test.py
@@ -9,6 +9,8 @@ from datetime import datetime, timedelta
 
 sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
 
+from tests.test_helpers import get_test_backend_url
+
 from workflow_scheduler import WorkflowPriority, WorkflowStatus, workflow_scheduler
 
 
@@ -333,7 +335,7 @@ async def test_scheduler_api_integration():
             for endpoint in endpoints_to_test:
                 try:
                     async with session.get(
-                        f"http://localhost:8001{endpoint}"
+                        get_test_backend_url() + endpoint
                     ) as response:
                         if response.status == 200:
                             print(f"✅ {endpoint}: OK")  # noqa: print

--- a/autobot-backend/workflow_templates/workflow_templates.e2e_test.py
+++ b/autobot-backend/workflow_templates/workflow_templates.e2e_test.py
@@ -8,6 +8,8 @@ import sys
 
 sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
 
+from tests.test_helpers import get_test_backend_url
+
 from type_definitions import TaskComplexity
 from workflow_templates import TemplateCategory, workflow_template_manager
 
@@ -269,7 +271,7 @@ async def test_template_api_integration():
             for endpoint in endpoints_to_test:
                 try:
                     async with session.get(
-                        f"http://localhost:8001{endpoint}"
+                        get_test_backend_url() + endpoint
                     ) as response:
                         if response.status == 200:
                             print(f"✅ {endpoint}: OK")  # noqa: print


### PR DESCRIPTION
Closes #3661

## Changes
Replaced hardcoded `localhost:8001` and `10.0.0.1:8001` with `get_test_backend_url()` across 14 additional backend test files missed by #3653.

## Files Changed
- `complete_system.e2e_test.py`
- `takeover_manager.e2e_test.py`
- `autobot_demo.e2e_test.py`
- `workflow_scheduler.e2e_test.py`
- `workflow_templates/workflow_templates.e2e_test.py`
- `chat_workflow/chat_workflow.e2e_test.py`
- `knowledge/chat_knowledge_system.e2e_test.py`
- `api/simple_terminal.e2e_test.py`
- `api/file_upload_comprehensive_test.py`
- `backend_startup.e2e_test.py`
- `metrics/metrics_system.e2e_test.py`
- `utils/monitoring_alerts_test.py`
- `services/mcp_dispatch_test.py`
- `agents/security_agents.e2e_test.py`

## Verification
- Zero `localhost:8001` or `10.0.0.1:8001` literals remaining in all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)