### PR TITLE
chore(frontend): adopt getApiBase() in JS utility files (#3725)

### DIFF
--- a/autobot-frontend/src/utils/FrontendHealthMonitor.js
+++ b/autobot-frontend/src/utils/FrontendHealthMonitor.js
@@ -5,6 +5,7 @@
 
 import { cacheBuster } from './CacheBuster.js';
 import { createLogger } from '@/utils/debugUtils';
+import { getApiBase } from '@/config/ssot-config';
 
 // Create scoped logger for FrontendHealthMonitor
 const logger = createLogger('FrontendHealthMonitor');
@@ -192,7 +193,7 @@ class FrontendHealthMonitor {
             const controller = new AbortController();
             const timeoutId = setTimeout(() => controller.abort(), this.config.apiTimeout);
 
-            const response = await fetch('/api/health', {
+            const response = await fetch(`${getApiBase()}/health`, {
                 signal: controller.signal,
                 headers: cacheBuster.getBustHeaders()
             });

--- a/autobot-frontend/src/utils/OptimizedHealthMonitor.js
+++ b/autobot-frontend/src/utils/OptimizedHealthMonitor.js
@@ -6,6 +6,7 @@
 
 import { cacheBuster } from './CacheBuster.js';
 import { createLogger } from '@/utils/debugUtils';
+import { getApiBase } from '@/config/ssot-config';
 
 // Create scoped logger for OptimizedHealthMonitor
 const logger = createLogger('OptimizedHealthMonitor');
@@ -274,7 +275,7 @@ class OptimizedHealthMonitor {
             const controller = new AbortController();
             const timeoutId = setTimeout(() => controller.abort(), 8000); // 8 second timeout
 
-            const response = await fetch('/api/system/health', {
+            const response = await fetch(`${getApiBase()}/system/health`, {
                 signal: controller.signal,
                 headers: cacheBuster.getBustHeaders()
             });

--- a/autobot-frontend/src/utils/SecretsApiClient.js
+++ b/autobot-frontend/src/utils/SecretsApiClient.js
@@ -6,6 +6,7 @@
  */
 
 import { ApiClient } from './ApiClient';
+import { getApiBase } from '@/config/ssot-config';
 
 class SecretsApiClient {
     constructor() {
@@ -64,7 +65,7 @@ class SecretsApiClient {
         }
 
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.post('/api/secrets/', secretData);
+        const response = await this.apiClient.post(`${getApiBase()}/secrets/`, secretData);
         return response;
     }
 
@@ -142,7 +143,7 @@ class SecretsApiClient {
      */
     async getSecretTypes() {
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.get('/api/secrets/types');
+        const response = await this.apiClient.get(`${getApiBase()}/secrets/types`);
         return response;
     }
 
@@ -151,7 +152,7 @@ class SecretsApiClient {
      */
     async getSecretsStats() {
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.get('/api/secrets/stats');
+        const response = await this.apiClient.get(`${getApiBase()}/secrets/stats`);
         return response;
     }
 


### PR DESCRIPTION
Closes #3725

Replaced hardcoded `/api/` in 3 JS utility files with `getApiBase()`:
- `SecretsApiClient.js`
- `FrontendHealthMonitor.js`
- `OptimizedHealthMonitor.js`