### PR TITLE
chore(slm-frontend): replace remaining 2 hardcoded /api/ with getSlmApiBase()

### DIFF
--- a/autobot-slm-frontend/src/components/InfrastructureWizard.vue
+++ b/autobot-slm-frontend/src/components/InfrastructureWizard.vue
@@ -220,7 +220,7 @@ async function cancelExecution(): Promise<void> {
 
   try {
     const response = await fetch(
-      `/api/infrastructure/executions/${currentExecution.value.execution_id}/cancel`,
+      `${getSlmApiBase()}/infrastructure/executions/${currentExecution.value.execution_id}/cancel`,
       {
         method: 'POST',
         headers: {

--- a/autobot-slm-frontend/src/views/AgentsView.vue
+++ b/autobot-slm-frontend/src/views/AgentsView.vue
@@ -174,7 +174,7 @@ async function saveAgent() {
       llm_temperature: editForm.value.llm_temperature,
       is_active: editForm.value.is_active,
     }
-    const response = await fetch(`/api/agents/${selectedAgent.value.agent_id}`, {
+    const response = await fetch(`${getSlmApiBase()}/agents/${selectedAgent.value.agent_id}`, {
       method: 'PUT',
       headers: {
         Authorization: `Bearer ${authStore.token}`,


### PR DESCRIPTION
Closes #3726

Final 2 hardcoded `/api/` instances in SLM frontend replaced with `getSlmApiBase()`:
- `AgentsView.vue:177` — fetch call  
- `InfrastructureWizard.vue:223` — cancel URL

SLM frontend now has zero hardcoded `/api/` outside ssot-config.