### PR TITLE
fix(tests): update stale mock path in tool_discovery_test.py (#3722)

### DIFF
--- a/autobot-backend/tools/tool_discovery_test.py
+++ b/autobot-backend/tools/tool_discovery_test.py
@@ -97,7 +97,7 @@ def test_discover_tools_empty_essential_tools(
     """
     Test case with an empty ESSENTIAL_TOOLS list.
     """
-    with patch("src.tool_discovery.ESSENTIAL_TOOLS", []):
+    with patch("tool_discovery.ESSENTIAL_TOOLS", []):
         found_tools = discover_tools()
         assert len(found_tools) == 0
         assert found_tools == {}


### PR DESCRIPTION
Closes #3722

Updates the `@patch` decorator in `tools/tool_discovery_test.py` from the stale `src.tool_discovery` path to the correct `tool_discovery` module path after the test co-location refactor (#3712).

## Summary
- `patch("src.tool_discovery.ESSENTIAL_TOOLS", [])` → `patch("tool_discovery.ESSENTIAL_TOOLS", [])` on line 100
- `tool_discovery.py` lives at `autobot-backend/tool_discovery.py` (top-level, no `src` prefix), matching the existing direct import on line 5

## Test plan
- [ ] `cd autobot-backend && python3 -m pytest tools/tool_discovery_test.py -v` — all 5 tests pass (was 4 pass, 1 fail before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)