### PR TITLE
chore(dev): add structlog and aiosqlite to requirements-dev.txt (#3723)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+# Dev venv requirements — use: pip install -r requirements-dev.txt
+# Pulls full backend dependency chain plus explicit dev-only extras.
+# Issue #3723: security/ and memory/ test packages failed collection with
+# ModuleNotFoundError because these two packages were missing from the venv.
+
+-r autobot-backend/requirements.txt
+
+# Explicit re-declaration ensures both packages are present in the dev venv
+# even when pip resolves the -r chain in unexpected order.
+structlog>=25.4.0    # service_auth_enforcement, service_auth_logging, service_client
+aiosqlite>=0.21.0   # memory/storage/general_storage, memory/storage/task_storage, utils/async_database_pool


### PR DESCRIPTION
Closes #3723

## Summary
- Creates `requirements-dev.txt` at repo root that chains `autobot-backend/requirements.txt` (which already includes the full runtime dep chain via `-r ../requirements.txt`)
- Explicitly re-declares `structlog>=25.4.0` and `aiosqlite>=0.21.0` so dev venvs always have both packages present, preventing `ModuleNotFoundError` during pytest collection of `security/` and `memory/` test packages

## Test plan
- [ ] `pip install -r requirements-dev.txt` in a fresh venv succeeds
- [ ] `pytest autobot-backend/security/ autobot-backend/memory/` collects without `ModuleNotFoundError`