### PR TITLE
fix(backend): remove total timeout from LLM streaming (#3732)

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -1901,7 +1901,9 @@ before summarizing.
 
         try:
             async with await http_client.post(
-                ollama_endpoint, json=payload, timeout=aiohttp.ClientTimeout(total=TIMEOUT_HTTP_DEFAULT)
+                ollama_endpoint,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=None, connect=TIMEOUT_HTTP_DEFAULT),
             ) as response:
                 logger.info(
                     "[ChatWorkflowManager] Ollama response status: %s", response.status
@@ -3010,10 +3012,14 @@ before summarizing.
                 from .graph import delete_thread_checkpoints
 
                 await delete_thread_checkpoints(session_id)
+            if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+                error_content = "The model is taking too long to respond. Please try again."
+            else:
+                error_content = str(exc) or f"{type(exc).__name__}: unexpected error"
             queue.put_nowait(
                 {
                     "type": "error",
-                    "content": str(exc) or f"{type(exc).__name__}: unexpected error",
+                    "content": error_content,
                 }
             )
         finally:


### PR DESCRIPTION
## Summary

- Replace `ClientTimeout(total=TIMEOUT_HTTP_DEFAULT)` with `ClientTimeout(total=None, connect=TIMEOUT_HTTP_DEFAULT)` in the Ollama streaming POST so the 60s hard cap no longer kills LLM generation on slower hardware
- `connect=TIMEOUT_HTTP_DEFAULT` preserves fast-fail behaviour when Ollama is unreachable
- Improve the user-facing error message for `TimeoutError` from the opaque `"TimeoutError: unexpected error"` to `"The model is taking too long to respond. Please try again."`

## Test plan

- [ ] 168 existing `chat_workflow/` tests pass (`python3 -m pytest chat_workflow/ --ignore=chat_workflow/workflow_plan_approval_test.py`)
- [ ] flake8 shows no new violations on `chat_workflow/manager.py`
- [ ] On a slow GPU/CPU, LLM responses longer than 60s now complete successfully
- [ ] If Ollama is down, the connect timeout still fires within `TIMEOUT_HTTP_DEFAULT` seconds

Closes #3732

🤖 Generated with [Claude Code](https://claude.com/claude-code)