### PR TITLE
fix(tests): correct stale src.tool_discovery patch path in tool_discovery_test (#3722)

### DIFF
--- a/autobot-backend/tools/tool_discovery_test.py
+++ b/autobot-backend/tools/tool_discovery_test.py
@@ -97,7 +97,7 @@ def test_discover_tools_empty_essential_tools(
     """
     Test case with an empty ESSENTIAL_TOOLS list.
     """
-    with patch("src.tool_discovery.ESSENTIAL_TOOLS", []):
+    with patch("tool_discovery.ESSENTIAL_TOOLS", []):
         found_tools = discover_tools()
         assert len(found_tools) == 0
         assert found_tools == {}


### PR DESCRIPTION
Closes #3722

**Root cause:** `@patch('src.tool_discovery.ESSENTIAL_TOOLS', [])` patched a nonexistent attribute — the module lives at `autobot-backend/tool_discovery.py` and is imported without the `src.` namespace prefix. The fix is `@patch('tool_discovery.ESSENTIAL_TOOLS', [])`.

All 5 tests in `tools/tool_discovery_test.py` now pass.