### PR TITLE
feat(frontend): add Vue error boundary component (#3375)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -369,7 +369,9 @@
         class="h-full"
       >
         <!-- Use router-view for all content to enable proper sub-routing -->
-        <router-view class="h-full" />
+        <ErrorBoundary>
+          <router-view class="h-full" />
+        </ErrorBoundary>
       </UnifiedLoadingView>
     </main>
   </div>
@@ -401,6 +403,7 @@ import ToastContainer from '@/components/ui/ToastContainer.vue';
 import HostSelectionDialog from '@/components/ui/HostSelectionDialog.vue';
 import UnifiedLoadingView from '@/components/ui/UnifiedLoadingView.vue';
 import ProfileModal from '@/components/profile/ProfileModal.vue';
+import ErrorBoundary from '@/components/common/ErrorBoundary.vue';
 
 const logger = createLogger('App');
 
@@ -414,6 +417,7 @@ export default {
     HostSelectionDialog,
     UnifiedLoadingView,
     ProfileModal,
+    ErrorBoundary,
     DarkModeToggle: defineAsyncComponent(() => import('@/components/ui/DarkModeToggle.vue')),
   },
 


### PR DESCRIPTION
Closes #3375

## Summary

- `ErrorBoundary.vue` already existed in `src/components/common/` with full `onErrorCaptured` implementation, user-friendly fallback UI, retry/reload actions, and structured logging via `createLogger`
- Wires `ErrorBoundary` into `App.vue`: imported, registered in `components`, and wraps `<router-view>` so any unhandled runtime error in any view shows the fallback panel instead of a blank white screen
- No new files created; no duplicate logic introduced

## Test plan

- [ ] Trigger a deliberate throw in any child view component; confirm the error boundary fallback renders with the error message and Try Again / Reload Page buttons
- [ ] Click "Try Again" — confirm the error state resets and the view re-mounts
- [ ] Click "Reload Page" — confirm `window.location.reload()` fires
- [ ] Confirm "Show Details" expands stack trace in the fallback panel
- [ ] Confirm no regression on normal navigation between Chat, KB, Terminal, Agents views

Generated with [Claude Code](https://claude.com/claude-code)