### PR TITLE
chore(analytics): fix flake8 E501 line-length violation (#3724)

### DIFF
--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -816,7 +816,10 @@ def _generate_csv_response(timeline_data: list) -> StreamingResponse:
         iter([csv_content]),
         media_type="text/csv",
         headers={
-            "Content-Disposition": f"attachment; filename=evolution_data_{datetime.now(tz=timezone.utc).strftime('%Y%m%d')}.csv"
+            "Content-Disposition": (
+                "attachment; filename=evolution_data_"
+                f"{datetime.now(tz=timezone.utc).strftime('%Y%m%d')}.csv"
+            )
         },
     )
 


### PR DESCRIPTION
Closes #3724

1 violation fixed in `api/analytics_evolution.py` line 819: `Content-Disposition` f-string header split across lines using implicit string concatenation. `analytics_code_review.py` had zero violations.