### PR TITLE
fix(tests): evaluate get_test_backend_url() lazily in TakeoverTestClient (#3747)

### DIFF
--- a/autobot-backend/takeover_manager.e2e_test.py
+++ b/autobot-backend/takeover_manager.e2e_test.py
@@ -34,8 +34,8 @@ logger = logging.getLogger(__name__)
 class SessionTakeoverTestSuite:
     """Comprehensive test suite for session takeover functionality"""
 
-    def __init__(self, base_url: str = get_test_backend_url()):
-        self.base_url = base_url
+    def __init__(self, base_url: str | None = None):
+        self.base_url = base_url or get_test_backend_url()
         self.test_session_id = f"test_session_{int(time.time())}"
         self.workflow_manager = None
         self.test_results = []


### PR DESCRIPTION
Fixes #3747

## Changes
- Changed `SessionTakeoverTestSuite.__init__` default arg from eager `get_test_backend_url()` call to `None` sentinel evaluated at call time via `base_url or get_test_backend_url()`

## Why
Python evaluates default arguments at class definition time (module import). Tests using `monkeypatch.setenv` after import would silently use the stale URL.

## Test plan
- [ ] Linting passes
- [ ] Logic: monkeypatch.setenv now correctly overrides URL at test call time