### PR TITLE
chore(frontend): adopt getApiBase() in remaining 7 SecretsApiClient.js paths (#3746)

### DIFF
--- a/autobot-frontend/src/utils/SecretsApiClient.js
+++ b/autobot-frontend/src/utils/SecretsApiClient.js
@@ -36,7 +36,7 @@ class SecretsApiClient {
         }
 
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.get(`/api/secrets/?${params.toString()}`);
+        const response = await this.apiClient.get(`${getApiBase()}/secrets/?${params.toString()}`);
         return response;
     }
 
@@ -51,7 +51,7 @@ class SecretsApiClient {
         }
 
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.get(`/api/secrets/${secretId}?${params.toString()}`);
+        const response = await this.apiClient.get(`${getApiBase()}/secrets/${secretId}?${params.toString()}`);
         return response;
     }
 
@@ -80,7 +80,7 @@ class SecretsApiClient {
         }
 
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.put(`/api/secrets/${secretId}?${params.toString()}`, updateData);
+        const response = await this.apiClient.put(`${getApiBase()}/secrets/${secretId}?${params.toString()}`, updateData);
         return response;
     }
 
@@ -95,7 +95,7 @@ class SecretsApiClient {
         }
 
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.delete(`/api/secrets/${secretId}?${params.toString()}`);
+        const response = await this.apiClient.delete(`${getApiBase()}/secrets/${secretId}?${params.toString()}`);
         return response;
     }
 
@@ -110,7 +110,7 @@ class SecretsApiClient {
         }
 
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.post(`/api/secrets/transfer?${params.toString()}`, transferData);
+        const response = await this.apiClient.post(`${getApiBase()}/secrets/transfer?${params.toString()}`, transferData);
         return response;
     }
 
@@ -119,7 +119,7 @@ class SecretsApiClient {
      */
     async getChatCleanupInfo(chatId) {
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.get(`/api/secrets/chat/${chatId}/cleanup`);
+        const response = await this.apiClient.get(`${getApiBase()}/secrets/chat/${chatId}/cleanup`);
         return response;
     }
 
@@ -134,7 +134,7 @@ class SecretsApiClient {
         }
 
         // Issue #552: Fixed path - removed duplicate /secrets prefix
-        const response = await this.apiClient.delete(`/api/secrets/chat/${chatId}?${params.toString()}`);
+        const response = await this.apiClient.delete(`${getApiBase()}/secrets/chat/${chatId}?${params.toString()}`);
         return response;
     }
 


### PR DESCRIPTION
Closes #3746

## Changes
- Replaced all 7 remaining hardcoded /api/ path strings in SecretsApiClient.js with `${getApiBase()}/`
- getApiBase() was already imported from PR #3729; this completes the migration for this file

## Why
Hardcoded /api/ paths break deployments where the API is served under a different base path (VITE_API_BASE_PATH).

## Test plan
- [ ] No remaining hardcoded /api/ strings in SecretsApiClient.js (verified by grep)
- [ ] All fetch/axios calls use getApiBase() consistently