### PR TITLE
fix(tests): handle https→wss protocol upgrade in simple_terminal.e2e_test.py

### DIFF
--- a/autobot-backend/api/simple_terminal.e2e_test.py
+++ b/autobot-backend/api/simple_terminal.e2e_test.py
@@ -21,7 +21,7 @@ async def test_simple_terminal():
     session_id = f"test_{int(time.time())}"
     print(f"📝 Session ID: {session_id}")  # noqa: print
 
-    uri = get_test_backend_url().replace("http://", "ws://") + f"/api/terminal/ws/simple/{session_id}"
+    uri = get_test_backend_url().replace("https://", "wss://").replace("http://", "ws://") + f"/api/terminal/ws/simple/{session_id}"
     print(f"🔗 Connecting to: {uri}")  # noqa: print
 
     try:
@@ -172,7 +172,7 @@ async def main():
         print("User can now use the simple terminal endpoint:")  # noqa: print
         _base = get_test_backend_url()
         print(  # noqa: print
-            f"  WebSocket: {_base.replace('http://', 'ws://')}/api/terminal/ws/simple/{{session_id}}"
+            f"  WebSocket: {_base.replace('https://', 'wss://').replace('http://', 'ws://')}/api/terminal/ws/simple/{{session_id}}"
         )  # noqa: print
         print(  # noqa: print
             f"  Sessions:  {_base}/api/terminal/simple/sessions"


### PR DESCRIPTION
Fixes #3748

## Summary
- Replace single `http://` → `ws://` substitution with chained `.replace("https://", "wss://").replace("http://", "ws://")` in both WebSocket URL construction sites
- Line 24: live test URL used by `websockets.connect()`
- Line 175: summary printout shown on test success

## Test plan
- [ ] WebSocket URL construction correctly upgrades `https://` base URLs to `wss://`
- [ ] `http://` base URLs still upgrade to `ws://`

🤖 Generated with Claude Code