### PR TITLE
fix(frontend): guard loadReview() against undefined reviewId (#3755)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -630,7 +630,10 @@ async function loadHistory() {
 }
 
 async function loadReview(reviewId: string) {
-  if (!reviewId) return
+  if (!reviewId) {
+    showToast(t('analytics.codeReview.reviewNotAvailable'), 'warning')
+    return
+  }
   loading.value = true
   try {
     const params = withSourceIdParams()

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -1658,7 +1658,8 @@
       "failedToUpdate": "Failed to update issue status",
       "markedFalsePositive": "Marked as false positive",
       "failedToLoadReview": "Failed to load review details",
-      "reviewLoaded": "Review loaded from history."
+      "reviewLoaded": "Review loaded from history.",
+      "reviewNotAvailable": "Review details not available — run analysis again to see results."
     },
     "performanceAnalysis": {
       "title": "Performance Analysis",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -1659,7 +1659,8 @@
       "failedToUpdate": "Aktualisierung fehlgeschlagen",
       "markedFalsePositive": "Als falsch-positiv markiert",
       "failedToLoadReview": "Review konnte nicht geladen werden",
-      "reviewLoaded": "Review aus Verlauf geladen."
+      "reviewLoaded": "Review aus Verlauf geladen.",
+      "reviewNotAvailable": "Bewertungsdetails nicht verfügbar — Analyse erneut ausführen, um Ergebnisse zu sehen."
     },
     "performanceAnalysis": {
       "title": "Leistungsanalyse",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -1684,7 +1684,8 @@
       "failedToUpdate": "Failed to update issue status",
       "markedFalsePositive": "Marked as false positive",
       "failedToLoadReview": "Failed to load review details",
-      "reviewLoaded": "Review loaded from history."
+      "reviewLoaded": "Review loaded from history.",
+      "reviewNotAvailable": "Review details not available — run analysis again to see results."
     },
     "performanceAnalysis": {
       "title": "Performance Analysis",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -1659,7 +1659,8 @@
       "failedToUpdate": "Actualización fallida",
       "markedFalsePositive": "Marcado como falso positivo",
       "failedToLoadReview": "No se pudo cargar la revisión",
-      "reviewLoaded": "Revisión cargada desde el historial."
+      "reviewLoaded": "Revisión cargada desde el historial.",
+      "reviewNotAvailable": "Detalles de revisión no disponibles — ejecute el análisis de nuevo para ver los resultados."
     },
     "performanceAnalysis": {
       "title": "Análisis de rendimiento",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -81,7 +81,7 @@
     "knowledge": "دانش",
     "settings": "تنظیمات",
     "system": "سیستم",
-    "desktop": "دسکتاپ",
+    "desktop": "Desktop",
     "research": "تحقیق",
     "workflows": "جریان‌کارها",
     "analytics": "تحلیل",
@@ -102,7 +102,6 @@
     "llmConfig": "LLM Config",
     "browserAutomation": "Browser",
     "devSpeedup": "Dev Tools",
-    "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
   },
@@ -1183,7 +1182,8 @@
       "failedToUpdate": "Failed to update issue status",
       "markedFalsePositive": "Marked as false positive",
       "failedToLoadReview": "Failed to load review details",
-      "reviewLoaded": "Review loaded from history."
+      "reviewLoaded": "Review loaded from history.",
+      "reviewNotAvailable": "Review details not available — run analysis again to see results."
     },
     "performanceAnalysis": {
       "title": "Performance Analysis",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -1659,7 +1659,8 @@
       "failedToUpdate": "Failed to update issue status",
       "markedFalsePositive": "Marked as false positive",
       "failedToLoadReview": "Failed to load review details",
-      "reviewLoaded": "Revue chargée depuis l'historique."
+      "reviewLoaded": "Revue chargée depuis l'historique.",
+      "reviewNotAvailable": "Détails de la revue non disponibles — relancez l'analyse pour voir les résultats."
     },
     "performanceAnalysis": {
       "title": "Performance Analysis",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -81,7 +81,7 @@
     "knowledge": "ידע",
     "settings": "הגדרות",
     "system": "מערכת",
-    "desktop": "שולחן עבודה",
+    "desktop": "Desktop",
     "research": "מחקר",
     "workflows": "תהליכים",
     "analytics": "אנליטיקה",
@@ -102,7 +102,6 @@
     "llmConfig": "LLM Config",
     "browserAutomation": "Browser",
     "devSpeedup": "Dev Tools",
-    "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
   },
@@ -1183,7 +1182,8 @@
       "failedToUpdate": "Failed to update issue status",
       "markedFalsePositive": "Marked as false positive",
       "failedToLoadReview": "Failed to load review details",
-      "reviewLoaded": "Review loaded from history."
+      "reviewLoaded": "Review loaded from history.",
+      "reviewNotAvailable": "Review details not available — run analysis again to see results."
     },
     "performanceAnalysis": {
       "title": "Performance Analysis",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -1659,7 +1659,8 @@
       "failedToUpdate": "Failed to update issue status",
       "markedFalsePositive": "Marked as false positive",
       "failedToLoadReview": "Failed to load review details",
-      "reviewLoaded": "Review loaded from history."
+      "reviewLoaded": "Review loaded from history.",
+      "reviewNotAvailable": "Review details not available — run analysis again to see results."
     },
     "performanceAnalysis": {
       "title": "Performance Analysis",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -1659,7 +1659,8 @@
       "failedToUpdate": "Failed to update issue status",
       "markedFalsePositive": "Marked as false positive",
       "failedToLoadReview": "Failed to load review details",
-      "reviewLoaded": "Review loaded from history."
+      "reviewLoaded": "Review loaded from history.",
+      "reviewNotAvailable": "Review details not available — run analysis again to see results."
     },
     "performanceAnalysis": {
       "title": "Performance Analysis",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -1659,7 +1659,8 @@
       "failedToUpdate": "Failed to update issue status",
       "markedFalsePositive": "Marked as false positive",
       "failedToLoadReview": "Failed to load review details",
-      "reviewLoaded": "Review loaded from history."
+      "reviewLoaded": "Review loaded from history.",
+      "reviewNotAvailable": "Review details not available — run analysis again to see results."
     },
     "performanceAnalysis": {
       "title": "Performance Analysis",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -81,7 +81,7 @@
     "knowledge": "علم",
     "settings": "سیٹنگز",
     "system": "سسٹم",
-    "desktop": "ڈیسک ٹاپ",
+    "desktop": "Desktop",
     "research": "تحقیق",
     "workflows": "ورک فلوز",
     "analytics": "تجزیہ",
@@ -102,7 +102,6 @@
     "llmConfig": "LLM Config",
     "browserAutomation": "Browser",
     "devSpeedup": "Dev Tools",
-    "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
   },
@@ -1183,7 +1182,8 @@
       "failedToUpdate": "Failed to update issue status",
       "markedFalsePositive": "Marked as false positive",
       "failedToLoadReview": "Failed to load review details",
-      "reviewLoaded": "Review loaded from history."
+      "reviewLoaded": "Review loaded from history.",
+      "reviewNotAvailable": "Review details not available — run analysis again to see results."
     },
     "performanceAnalysis": {
       "title": "Performance Analysis",


### PR DESCRIPTION
Fixes #3755

## Changes
- Added early-return guard in `loadReview()` when `reviewId` is undefined/null, replacing the previous silent return with `showToast(t('analytics.codeReview.reviewNotAvailable'), 'warning')`
- Added `reviewNotAvailable` i18n key to all 11 locale files (en, ar, de, es, fa, fr, he, lv, pl, pt, ur) with locale-appropriate translations for de/es/fr and English fallback for the rest

## Why
Pre-existing history entries in Redis (created before PR #3735) have no `id` field. Clicking them called `loadReview(undefined)` → `GET /review/undefined` → HTTP 404, which surfaced as a confusing "Analysis failed" error toast.

## Test plan
- [ ] Clicking a legacy history entry (no `id`) shows friendly warning toast instead of 404 error toast
- [ ] Clicking a new history entry (with `id`) still loads review normally
- [ ] Warning toast text matches `reviewNotAvailable` key in locale file