### PR TITLE
fix(frontend): clear auto-save interval on ChatController destroy

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -818,11 +818,6 @@ onMounted(async () => {
   // Load NoVNC URL after initialization
   await loadNovncUrl()
 
-  // Enable auto-save if not disabled
-  if (store.settings.autoSave) {
-    controller.enableAutoSave()
-  }
-
   // Start connection monitoring
   checkConnection()
   startHeartbeat()

--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -54,6 +54,8 @@ export class ChatController {
   } | null = null
   private _streamFlushTimer: ReturnType<typeof setTimeout> | null = null
   private _previewThrottleTimer: ReturnType<typeof setTimeout> | null = null
+  // Issue #3749: stored so disableAutoSave() can clearInterval()
+  private _autoSaveIntervalId: ReturnType<typeof setInterval> | null = null
   private static readonly STREAM_FLUSH_INTERVAL_MS = 80
   private static readonly PREVIEW_THROTTLE_MS = 200
 
@@ -941,7 +943,8 @@ export class ChatController {
 
   // Auto-save functionality with error handling
   enableAutoSave(intervalMs: number = 30000): void {
-    setInterval(() => {
+    this.disableAutoSave()
+    this._autoSaveIntervalId = setInterval(() => {
       if (this.chatStore.settings.autoSave && this.chatStore.currentSessionId) {
         this.saveChatSession().catch(error => {
           logger.warn('Auto-save failed:', error)
@@ -949,6 +952,13 @@ export class ChatController {
         })
       }
     }, intervalMs)
+  }
+
+  disableAutoSave(): void {
+    if (this._autoSaveIntervalId !== null) {
+      clearInterval(this._autoSaveIntervalId)
+      this._autoSaveIntervalId = null
+    }
   }
 
   // Enhanced validation helpers


### PR DESCRIPTION
Closes #3749

## Summary
- Store `setInterval` ID in `ChatController._autoSaveIntervalId`
- Add `disableAutoSave()` that calls `clearInterval()` with the stored ID and nulls it
- Call `disableAutoSave()` at the start of `enableAutoSave()` to prevent double-registration
- Remove redundant `controller.enableAutoSave()` call from `ChatInterface.vue` `onMounted` — the component's own properly-managed auto-save interval (stored in `autoSaveInterval.value`, cleared in `onUnmounted`) already handles this

## Test plan
- [ ] Auto-save interval is cleared when `ChatController` is replaced/reused
- [ ] No interval fires after component is destroyed
- [ ] `disableAutoSave()` is safe to call even if `enableAutoSave()` was never called

🤖 Generated with Claude Code