### PR TITLE
fix(chat-workflow): route system prompt via Ollama system field; raise num_ctx to 8192 (#3761)

### DIFF
--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -323,19 +323,20 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
         conversation_context: str,
         message: str,
     ) -> str:
-        """Build full prompt with optional knowledge context."""
+        """Build full prompt with optional knowledge context.
+
+        system_prompt is sent via the Ollama ``system`` field — not embedded here
+        to avoid double-injection and context-window waste.
+        """
         if knowledge_context:
             return (
-                system_prompt
-                + "\n\n"
-                + knowledge_context
+                knowledge_context
                 + "\n"
                 + conversation_context
                 + f"\n**Current user message:** {message}\n\nAssistant:"
             )
         return (
-            system_prompt
-            + conversation_context
+            conversation_context
             + f"\n**Current user message:** {message}\n\nAssistant:"
         )
 
@@ -435,7 +436,7 @@ Do NOT conclude the task or provide a final summary - just explain this specific
 
     def _get_interpretation_llm_options(self) -> Dict[str, Any]:
         """Get LLM options for command interpretation."""
-        return {"temperature": 0.7, "top_p": 0.9, "num_ctx": 2048}
+        return {"temperature": 0.7, "top_p": 0.9, "num_ctx": ModelConstants.DEFAULT_NUM_CTX}
 
     async def _interpret_non_streaming(
         self,

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -22,6 +22,7 @@ from async_chat_workflow import WorkflowMessage
 from autobot_shared.error_boundaries import error_boundary, get_error_boundary_manager
 from autobot_shared.redis_client import get_redis_client as get_redis_manager
 from constants.ttl_constants import TIMEOUT_HTTP_DEFAULT, TTL_24_HOURS
+from constants.model_constants import ModelConstants
 from slash_command_handler import get_slash_command_handler
 
 from .conversation import ConversationHandlerMixin
@@ -1799,15 +1800,22 @@ before summarizing.
 {instructions}"""
 
     def _get_llm_request_payload(
-        self, selected_model: str, current_prompt: str
+        self, selected_model: str, current_prompt: str, system_prompt: str = ""
     ) -> dict:
         """Build LLM request payload."""
-        return {
+        payload = {
             "model": selected_model,
             "prompt": current_prompt,
             "stream": True,
-            "options": {"temperature": 0.7, "top_p": 0.9, "num_ctx": 2048},
+            "options": {
+                "temperature": 0.7,
+                "top_p": 0.9,
+                "num_ctx": ModelConstants.CHAT_NUM_CTX,
+            },
         }
+        if system_prompt:
+            payload["system"] = system_prompt
+        return payload
 
     def _log_and_parse_tool_calls(
         self, llm_response: str, iteration: int
@@ -1892,11 +1900,12 @@ before summarizing.
         used_knowledge: bool,
         rag_citations: List[Dict[str, Any]],
         iteration: int,
+        system_prompt: str = "",
     ):
         """Process a single LLM iteration. Yields chunks, then (llm_response, tool_calls). Issue #620."""
         import aiohttp
 
-        payload = self._get_llm_request_payload(selected_model, current_prompt)
+        payload = self._get_llm_request_payload(selected_model, current_prompt, system_prompt)
         llm_response = ""
 
         try:
@@ -2115,6 +2124,7 @@ before summarizing.
             ctx.used_knowledge,
             ctx.rag_citations,
             iteration,
+            system_prompt=ctx.system_prompt or "",
         ):
             if isinstance(item, tuple):
                 llm_response, tool_calls = item

--- a/autobot-backend/constants/model_constants.py
+++ b/autobot-backend/constants/model_constants.py
@@ -371,6 +371,7 @@ class ModelConfig:
     DEFAULT_REPEAT_PENALTY: float = 1.1
     DEFAULT_MAX_TOKENS: int = 2048
     DEFAULT_NUM_CTX: int = 4096  # Ollama context window
+    CHAT_NUM_CTX: int = 8192  # Chat workflow: larger window for system prompt (~3k tokens)
 
     # Timeouts (in seconds)
     # Issue #763: Was ConfigRegistry.get("timeout.llm", "30").


### PR DESCRIPTION
Closes #3761

## Changes
- `ModelConstants.CHAT_NUM_CTX = 8192` — chat workflow context window (was hardcoded 2048, less than system prompt alone)
- `_get_llm_request_payload`: sends `system_prompt` via Ollama `system` field; uses `CHAT_NUM_CTX`
- `_process_single_llm_iteration` / `_collect_llm_iteration_response`: thread `ctx.system_prompt` through call chain
- `_build_full_prompt`: removes system_prompt from concatenated prompt string (no double-injection)
- `_get_interpretation_llm_options`: `num_ctx: 2048` → `ModelConstants.DEFAULT_NUM_CTX`

## Root cause
`system_prompt_simple.md` is ~3 010 tokens. With `num_ctx=2048`, Ollama truncated the prompt from the beginning, dropping the entire Tool Syntax section (chars 2 578–4 028). The model never received `execute_command` or `web_search` TOOL_CALL syntax.