### PR TITLE
chore(frontend): adopt getApiBase() in ApiClientMonitor.js (#3752)

### DIFF
--- a/autobot-frontend/src/utils/ApiClientMonitor.js
+++ b/autobot-frontend/src/utils/ApiClientMonitor.js
@@ -3,6 +3,7 @@
  */
 
 import rumAgent from './RumAgent.js'
+import { getApiBase } from '@/config/ssot-config'
 
 export function createMonitoredApiClient(originalApiClient) {
   return new Proxy(originalApiClient, {
@@ -80,13 +81,14 @@ function getUrlFromArgs(method, args) {
 
   // Method-specific patterns
   // Issue #552: Fixed paths to match backend endpoints
+  const base = getApiBase()
   const methodUrlMap = {
-    getChatList: '/api/chat/sessions',
-    createNewChat: '/api/chat/sessions',
-    sendMessage: '/api/chat/message',
-    getSystemHealth: '/api/system/health',
-    getSettings: '/api/settings/',
-    executeWorkflow: '/api/workflow/execute'
+    getChatList: `${base}/chat/sessions`,
+    createNewChat: `${base}/chat/sessions`,
+    sendMessage: `${base}/chat/message`,
+    getSystemHealth: `${base}/system/health`,
+    getSettings: `${base}/settings/`,
+    executeWorkflow: `${base}/workflow/execute`
   }
 
   return methodUrlMap[method] || `/${method}`


### PR DESCRIPTION
Closes #3752

## Summary

- Imported `getApiBase` from `@/config/ssot-config`
- Replaced 6 hardcoded `/api/` endpoint constants in `methodUrlMap` with `getApiBase()`-prefixed strings computed lazily at call time
- Ensures correct URL matching in co-located deployment where `getApiBase()` returns `/slm/api`

## Test plan

- [ ] Verify RUM monitoring still tracks API calls in standard deployment (`/api/` prefix)
- [ ] Verify URL matching works in co-located deployment (`/slm/api` prefix)

Generated with [Claude Code](https://claude.com/claude-code)