### PR TITLE
chore(frontend): adopt getApiBase() in AppConfig.js and ServiceDiscovery.js

### DIFF
--- a/autobot-frontend/src/config/AppConfig.js
+++ b/autobot-frontend/src/config/AppConfig.js
@@ -8,6 +8,7 @@
 import ServiceDiscovery from './ServiceDiscovery.js';
 import { NetworkConstants } from '../constants/network.ts';
 import { createLogger } from '@/utils/debugUtils';
+import { getApiBase } from '@/config/ssot-config';
 
 const logger = createLogger('AppConfig');
 
@@ -379,7 +380,7 @@ export class AppConfigService {
    */
   async _doLoadRemoteConfig() {
     try {
-      const response = await this.fetchApi('/api/frontend-config', {
+      const response = await this.fetchApi(`${getApiBase()}/frontend-config`, {
         timeout: 5000, // Short timeout for config loading
         cacheBust: false // Don't cache bust config requests
       });
@@ -472,7 +473,7 @@ export class AppConfigService {
    */
   async validateConnection() {
     try {
-      const response = await this.fetchApi('/api/system/health', {
+      const response = await this.fetchApi(`${getApiBase()}/system/health`, {
         method: 'GET',
         timeout: 5000,
         cacheBust: true
@@ -556,7 +557,7 @@ export class AppConfigService {
       }
 
       // Try to fetch from backend API
-      const response = await this.fetchApi('/api/system/frontend-config', {
+      const response = await this.fetchApi(`${getApiBase()}/system/frontend-config`, {
         timeout: 5000,
         cacheBust: false
       });

--- a/autobot-frontend/src/config/ServiceDiscovery.js
+++ b/autobot-frontend/src/config/ServiceDiscovery.js
@@ -12,7 +12,7 @@
  * Author: mrveiss
  */
 
-import { getConfig, getServiceUrl as ssotGetServiceUrl } from './ssot-config';
+import { getConfig, getServiceUrl as ssotGetServiceUrl, getApiBase } from './ssot-config';
 import { buildDefaultServiceUrl, buildDefaultVncUrl } from './defaults.js';
 import { createLogger } from '@/utils/debugUtils';
 
@@ -400,7 +400,7 @@ export default class ServiceDiscovery {
 
       // Handle proxy mode for backend service
       if (serviceName === 'backend' && !url) {
-        const testUrl = '/api/health';
+        const testUrl = `${getApiBase()}/health`;
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), timeout);
 
@@ -426,7 +426,7 @@ export default class ServiceDiscovery {
       const timeoutId = setTimeout(() => controller.abort(), timeout);
 
       // Use different endpoints based on service type
-      let testEndpoint = '/api/system/health';
+      let testEndpoint = `${getApiBase()}/system/health`;
       if (serviceName.startsWith('vnc_')) {
         testEndpoint = '/vnc.html';
       } else if (serviceName === 'redis') {


### PR DESCRIPTION
## Summary

- Replace 5 hardcoded `'/api/'` path literals with `getApiBase()` from `@/config/ssot-config`
- `AppConfig.js`: lines 382, 475, 559 — add `getApiBase` import; update 3 `fetchApi()` calls
- `ServiceDiscovery.js`: lines 403, 429 — extend existing ssot-config import with `getApiBase`; update 2 `fetch()` calls

Closes #3751

🤖 Generated with [Claude Code](https://claude.com/claude-code)