### PR TITLE
fix(backend): allow any authenticated user to GET /review/{id} (#3754)

### DIFF
--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -21,7 +21,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from auth_middleware import check_admin_permission
+from auth_middleware import check_admin_permission, get_current_user
 from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_7_DAYS
 from api.analytics_shared import (
@@ -578,7 +578,7 @@ async def analyze_diff(
 @router.get("/review/{review_id}")
 async def get_review_by_id(
     review_id: str,
-    admin_check: bool = Depends(check_admin_permission),
+    _user: dict = Depends(get_current_user),
     source_id: Optional[str] = Query(None, description="Project source ID (optional, speeds up lookup)"),
 ) -> dict[str, Any]:
     """


### PR DESCRIPTION
Fixes #3754

## Changes
- Added `get_current_user` to imports from `auth_middleware`
- Changed `get_review_by_id` dependency from `check_admin_permission` to `get_current_user`
- All other endpoints (analyze, history, patterns, metrics, etc.) retain admin-only access

## Why
Regular users could see their review history list (`GET /history`) but received 403 when clicking through to details (`GET /review/{id}`). The review result belongs to the authenticated user; no admin gate is needed for read access.

## Test plan
- [ ] Regular user: `GET /api/code-review/review/{id}` returns 200 (not 403)
- [ ] Unauthenticated request: still returns 401
- [ ] Admin user: still gets 200