### PR TITLE
feat(frontend): KB vectorization status UI components

### DIFF
--- a/autobot-frontend/src/components/knowledge/BatchSelectionToolbar.vue
+++ b/autobot-frontend/src/components/knowledge/BatchSelectionToolbar.vue
@@ -1,0 +1,252 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+
+<template>
+  <transition name="slide-down">
+    <div v-if="selectedCount > 0" class="batch-selection-toolbar">
+      <div class="toolbar-inner">
+        <!-- Selection summary -->
+        <div class="selection-summary">
+          <i class="fas fa-check-square selection-icon"></i>
+          <span class="selection-label">
+            {{ t('knowledge.batchSelection.selected', { count: selectedCount }) }}
+          </span>
+          <span v-if="eligibleCount < selectedCount" class="eligible-note">
+            ({{ t('knowledge.batchSelection.eligible', { count: eligibleCount }) }})
+          </span>
+        </div>
+
+        <!-- Actions -->
+        <div class="toolbar-actions">
+          <button
+            class="action-btn vectorize-btn"
+            :disabled="eligibleCount === 0 || isVectorizing"
+            :title="vectorizeBtnTooltip"
+            @click="handleVectorize"
+          >
+            <i v-if="isVectorizing" class="fas fa-spinner fa-spin"></i>
+            <i v-else class="fas fa-cubes"></i>
+            <span>{{ vectorizeBtnLabel }}</span>
+          </button>
+
+          <button
+            class="action-btn clear-btn"
+            :title="t('knowledge.batchSelection.clearSelectionTitle')"
+            @click="emit('deselect-all')"
+          >
+            <i class="fas fa-times"></i>
+            <span>{{ t('knowledge.batchSelection.clearSelection') }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup lang="ts">
+/**
+ * BatchSelectionToolbar Component (Issue #3388)
+ *
+ * Appears when one or more KB documents are selected, offering a "Vectorize
+ * selected" bulk action.  Counts only non-vectorized documents as eligible so
+ * the button copy is accurate.
+ *
+ * Does NOT duplicate KnowledgeBatchToolbar.vue (tree-browser sticky header) or
+ * BulkActionsToolbar.vue (export/delete/tags for entry list).  This toolbar is
+ * the vectorization-specific selection bar for general KB views.
+ */
+
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { createLogger } from '@/utils/debugUtils'
+import type { VectorizationStatus } from '@/composables/useKnowledgeVectorization'
+
+const { t } = useI18n()
+const logger = createLogger('BatchSelectionToolbar')
+
+// =============================================================================
+// Props & Emits
+// =============================================================================
+
+interface SelectedDocumentInfo {
+  id: string
+  status: VectorizationStatus
+}
+
+interface Props {
+  /** Documents currently selected by the user */
+  selectedDocuments: SelectedDocumentInfo[]
+  /** True while a batch vectorization job is in flight */
+  isVectorizing?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  isVectorizing: false
+})
+
+const emit = defineEmits<{
+  /** Request batch vectorization for the provided document IDs */
+  (e: 'vectorize', documentIds: string[]): void
+  /** Request clearing the current selection */
+  (e: 'deselect-all'): void
+}>()
+
+// =============================================================================
+// Computed
+// =============================================================================
+
+const selectedCount = computed(() => props.selectedDocuments.length)
+
+/**
+ * Documents that are not yet vectorized and not already pending.
+ * Vectorized documents are skipped so the count is honest.
+ */
+const eligibleDocuments = computed(() =>
+  props.selectedDocuments.filter(d => d.status !== 'vectorized' && d.status !== 'pending')
+)
+
+const eligibleCount = computed(() => eligibleDocuments.value.length)
+
+const vectorizeBtnLabel = computed(() => {
+  if (props.isVectorizing) return t('knowledge.batchSelection.vectorizing')
+  if (eligibleCount.value === 0) return t('knowledge.batchSelection.noneEligible')
+  return t('knowledge.batchSelection.vectorizeSelected', { count: eligibleCount.value })
+})
+
+const vectorizeBtnTooltip = computed(() => {
+  if (props.isVectorizing) return t('knowledge.batchSelection.vectorizingTooltip')
+  if (eligibleCount.value === 0) return t('knowledge.batchSelection.noneEligibleTooltip')
+  return t('knowledge.batchSelection.vectorizeSelectedTooltip', { count: eligibleCount.value })
+})
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+function handleVectorize(): void {
+  if (eligibleCount.value === 0 || props.isVectorizing) return
+  const ids = eligibleDocuments.value.map(d => d.id)
+  logger.debug('Batch vectorize requested for %d documents', ids.length)
+  emit('vectorize', ids)
+}
+</script>
+
+<style scoped>
+/* Issue #3388: Batch selection toolbar */
+.batch-selection-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: var(--color-primary);
+  color: var(--text-on-primary);
+  padding: var(--spacing-3) var(--spacing-6);
+  box-shadow: var(--shadow-lg);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  margin: 0 var(--spacing-4) var(--spacing-4) var(--spacing-4);
+}
+
+.toolbar-inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* Selection summary */
+.selection-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-weight: var(--font-medium);
+}
+
+.selection-icon {
+  font-size: 1.125rem;
+}
+
+.selection-label {
+  font-size: var(--text-sm);
+}
+
+.eligible-note {
+  font-size: var(--text-xs);
+  opacity: 0.8;
+}
+
+/* Actions */
+.toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  border: none;
+  cursor: pointer;
+  transition: all var(--duration-200) var(--ease-in-out);
+}
+
+.vectorize-btn {
+  background: var(--bg-primary);
+  color: var(--color-primary-active);
+}
+
+.vectorize-btn:hover:not(:disabled) {
+  background: var(--color-primary-bg);
+  transform: translateY(-1px);
+}
+
+.vectorize-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.clear-btn {
+  background: var(--bg-primary-transparent);
+  color: var(--text-on-primary);
+  border: 1px solid var(--bg-primary-transparent-hover);
+}
+
+.clear-btn:hover {
+  background: var(--bg-primary-transparent-hover);
+}
+
+/* Slide-down transition */
+.slide-down-enter-active,
+.slide-down-leave-active {
+  transition: all var(--duration-300) var(--ease-in-out);
+}
+
+.slide-down-enter-from,
+.slide-down-leave-to {
+  opacity: 0;
+  transform: translateY(-100%);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .toolbar-inner {
+    flex-direction: column;
+    gap: var(--spacing-3);
+  }
+
+  .toolbar-actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .action-btn {
+    flex: 1;
+    justify-content: center;
+  }
+}
+</style>

--- a/autobot-frontend/src/components/knowledge/VectorizationActionButton.vue
+++ b/autobot-frontend/src/components/knowledge/VectorizationActionButton.vue
@@ -1,0 +1,169 @@
+<!-- AutoBot - AI-Powered Automation Platform -->
+<!-- Copyright (c) 2025 mrveiss -->
+<!-- Author: mrveiss -->
+
+<template>
+  <button
+    class="vectorization-action-btn"
+    :class="buttonClass"
+    :disabled="isDisabled"
+    :title="tooltipText"
+    @click.stop="handleClick"
+  >
+    <i :class="iconClass"></i>
+    <span v-if="showLabel" class="btn-label">{{ labelText }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+/**
+ * VectorizationActionButton Component (Issue #3388)
+ *
+ * Action button to trigger vectorization for a single knowledge base document.
+ * Disabled when the document is already vectorized or has a pending job in flight.
+ */
+
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { createLogger } from '@/utils/debugUtils'
+import type { VectorizationStatus } from '@/composables/useKnowledgeVectorization'
+
+const { t } = useI18n()
+const logger = createLogger('VectorizationActionButton')
+
+// =============================================================================
+// Props & Emits
+// =============================================================================
+
+interface Props {
+  documentId: string
+  status: VectorizationStatus
+  /** Show text label next to the icon (default: false — icon-only) */
+  showLabel?: boolean
+  /** Compact icon-only variant (smaller padding) */
+  compact?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  showLabel: false,
+  compact: false
+})
+
+const emit = defineEmits<{
+  /** Emitted when the user requests vectorization for documentId */
+  (e: 'vectorize', documentId: string): void
+}>()
+
+// =============================================================================
+// Computed
+// =============================================================================
+
+const isDisabled = computed(() => {
+  return props.status === 'vectorized' || props.status === 'pending'
+})
+
+const isRetry = computed(() => props.status === 'failed')
+
+const buttonClass = computed(() => {
+  const classes: string[] = []
+
+  if (props.compact) classes.push('compact')
+
+  if (isDisabled.value) {
+    classes.push('is-disabled')
+  } else if (isRetry.value) {
+    classes.push('is-retry')
+  } else {
+    classes.push('is-vectorize')
+  }
+
+  return classes.join(' ')
+})
+
+const iconClass = computed(() => {
+  if (props.status === 'pending') return 'fas fa-spinner fa-spin'
+  if (isRetry.value) return 'fas fa-redo'
+  return 'fas fa-cube'
+})
+
+const labelText = computed(() => {
+  if (props.status === 'vectorized') return t('knowledge.vectorization.actionAlreadyDone')
+  if (props.status === 'pending') return t('knowledge.vectorization.actionInProgress')
+  if (isRetry.value) return t('knowledge.vectorization.actionRetry')
+  return t('knowledge.vectorization.actionVectorize')
+})
+
+const tooltipText = computed(() => {
+  if (props.status === 'vectorized') return t('knowledge.vectorization.tooltipAlreadyDone')
+  if (props.status === 'pending') return t('knowledge.vectorization.tooltipInProgress')
+  if (isRetry.value) return t('knowledge.vectorization.tooltipRetry')
+  return t('knowledge.vectorization.tooltipVectorize')
+})
+
+// =============================================================================
+// Handlers
+// =============================================================================
+
+function handleClick(): void {
+  if (isDisabled.value) return
+  logger.debug('Vectorize requested for document: %s', props.documentId)
+  emit('vectorize', props.documentId)
+}
+</script>
+
+<style scoped>
+/* Issue #3388: Vectorization action button */
+.vectorization-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1-5);
+  padding: var(--spacing-1-5) var(--spacing-3);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: all var(--duration-200) var(--ease-in-out);
+  white-space: nowrap;
+}
+
+.vectorization-action-btn.compact {
+  padding: var(--spacing-1) var(--spacing-2);
+}
+
+/* Vectorize (default) */
+.vectorization-action-btn.is-vectorize {
+  background: var(--color-primary);
+  color: var(--text-on-primary);
+}
+
+.vectorization-action-btn.is-vectorize:hover {
+  background: var(--color-primary-hover);
+  transform: scale(1.05);
+  box-shadow: var(--shadow-primary);
+}
+
+/* Retry (failed) */
+.vectorization-action-btn.is-retry {
+  background: var(--color-error);
+  color: var(--text-on-primary);
+}
+
+.vectorization-action-btn.is-retry:hover {
+  background: var(--color-error-hover);
+  transform: scale(1.05);
+}
+
+/* Disabled (vectorized or pending) */
+.vectorization-action-btn.is-disabled,
+.vectorization-action-btn:disabled {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.btn-label {
+  white-space: nowrap;
+}
+</style>


### PR DESCRIPTION
Closes #3388

## Summary
Adds two new KB vectorization UI components (two others were already implemented):

**New:**
- `VectorizationActionButton.vue` — per-document vectorize/retry button; disabled when `vectorized` or `pending`; shows retry variant on `failed`
- `BatchSelectionToolbar.vue` — sticky toolbar shown when ≥1 KB nodes are selected; "Vectorize selected" bulk action with eligible-count filter (excludes already-vectorized/pending docs)

**Already existed (no changes):**
- `VectorizationStatusBadge.vue` — colour-coded badge for all four statuses
- `VectorizationProgressModal.vue` — real-time per-document progress + cancel action

## Technical notes
- Vue 3 `<script setup lang="ts">` + Composition API throughout
- Imports `VectorizationStatus` type from existing `useKnowledgeVectorization` composable
- `createLogger` from `@/utils/debugUtils` — no `console.*`
- `BatchSelectionToolbar` uses slide-down transition matching `KnowledgeBatchToolbar.vue`

## Test plan
- [ ] `VectorizationActionButton` renders in vectorize/retry/disabled states correctly
- [ ] `BatchSelectionToolbar` appears on selection, hides on deselect-all, shows correct eligible count
- [ ] No TypeScript errors on build

🤖 Generated with Claude Code