### PR TITLE
feat(agents): enforce memory read/write via pipeline lifecycle hooks

### DIFF
--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -24,7 +24,7 @@ from .base_agent import AgentRequest
 from .standardized_agent import ActionHandler, StandardizedAgent
 
 try:
-    from autobot_backend.memory.working_memory import WorkingMemoryService as _WMS
+    from memory.working_memory import WorkingMemoryService as _WMS
     _working_memory_available = True
 except ImportError:
     _WMS = None

--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -21,7 +21,7 @@ from constants.threshold_constants import LLMDefaults
 from llm_interface import LLMInterface
 
 from .base_agent import AgentRequest
-from .standardized_agent import ActionHandler, StandardizedAgent
+from .standardized_agent import ActionHandler, StandardizedAgent, _working_memory_available
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +132,36 @@ class SentimentAnalysisAgent(StandardizedAgent):
                 "agent_type": "sentiment_analysis",
                 "model_used": self.model_name,
             }
+
+    async def _before_process(self, context: dict) -> dict:
+        """Inject cached session sentiment history into context (example override).
+
+        When WorkingMemoryService becomes available (issue #3768) this can load
+        prior session data.  Until then it is a documented no-op that shows the
+        expected override pattern.
+        """
+        if _working_memory_available:
+            session_id = context.get("session_id")
+            if session_id:
+                from autobot_backend.memory.working_memory import WorkingMemoryService
+                history = await WorkingMemoryService.load(session_id, key="sentiment_history")
+                if history:
+                    context["sentiment_history"] = history
+        return context
+
+    async def _after_process(self, context: dict, result: Any) -> None:
+        """Persist the most recent sentiment label to working memory (example override)."""
+        if not (_working_memory_available and result):
+            return
+        session_id = context.get("session_id")
+        if not session_id:
+            return
+        sentiment = result.get("response", "") if isinstance(result, dict) else ""
+        if sentiment:
+            from autobot_backend.memory.working_memory import WorkingMemoryService
+            await WorkingMemoryService.save(
+                session_id, key="sentiment_history", value=sentiment
+            )
 
     def _get_system_prompt(self) -> str:
         """Get system prompt for sentiment analysis tasks."""

--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -21,7 +21,14 @@ from constants.threshold_constants import LLMDefaults
 from llm_interface import LLMInterface
 
 from .base_agent import AgentRequest
-from .standardized_agent import ActionHandler, StandardizedAgent, _working_memory_available
+from .standardized_agent import ActionHandler, StandardizedAgent
+
+try:
+    from autobot_backend.memory.working_memory import WorkingMemoryService as _WMS
+    _working_memory_available = True
+except ImportError:
+    _WMS = None
+    _working_memory_available = False
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +51,7 @@ class SentimentAnalysisAgent(StandardizedAgent):
             "opinion_mining",
             "tone_detection",
         ]
+        self._wm = _WMS() if _working_memory_available else None
         self._register_action_handlers()
         logger.info(
             "Sentiment Analysis Agent initialized: provider=%s, model=%s",
@@ -140,11 +148,10 @@ class SentimentAnalysisAgent(StandardizedAgent):
         prior session data.  Until then it is a documented no-op that shows the
         expected override pattern.
         """
-        if _working_memory_available:
+        if _working_memory_available and self._wm is not None:
             session_id = context.get("session_id")
             if session_id:
-                from autobot_backend.memory.working_memory import WorkingMemoryService
-                history = await WorkingMemoryService.load(session_id, key="sentiment_history")
+                history = await self._wm.get(session_id, "sentiment_history")
                 if history:
                     context["sentiment_history"] = history
         return context
@@ -157,11 +164,8 @@ class SentimentAnalysisAgent(StandardizedAgent):
         if not session_id:
             return
         sentiment = result.get("response", "") if isinstance(result, dict) else ""
-        if sentiment:
-            from autobot_backend.memory.working_memory import WorkingMemoryService
-            await WorkingMemoryService.save(
-                session_id, key="sentiment_history", value=sentiment
-            )
+        if sentiment and self._wm is not None:
+            await self._wm.store(session_id, "sentiment_history", sentiment)
 
     def _get_system_prompt(self) -> str:
         """Get system prompt for sentiment analysis tasks."""

--- a/autobot-backend/agents/standardized_agent.py
+++ b/autobot-backend/agents/standardized_agent.py
@@ -77,7 +77,8 @@ class StandardizedAgent(BaseAgent):
         self._last_error = None
 
         # Lock for thread-safe counter access
-        self._async_stats_lock = asyncio.Lock()  # Named differently from BaseAgent._stats_lock (threading.Lock)
+        # Named differently from BaseAgent._stats_lock (threading.Lock)
+        self._async_stats_lock = asyncio.Lock()
 
     def register_action_handler(self, action: str, handler: ActionHandler):
         """Register an action handler for this agent"""
@@ -97,7 +98,8 @@ class StandardizedAgent(BaseAgent):
         """Validate action and get handler method (Issue #398: extracted).
 
         Returns:
-            (error_response, handler_config, handler_method) - error_response is set if validation fails
+            (error_response, handler_config, handler_method) - error_response is set
+            if validation fails.
         """
         if not request.action:
             return (
@@ -113,7 +115,8 @@ class StandardizedAgent(BaseAgent):
             return (
                 self._create_error_response(
                     request,
-                    f"Unsupported action '{request.action}'. Supported actions: {supported_actions}",
+                    f"Unsupported action '{request.action}'. "
+                    f"Supported actions: {supported_actions}",
                     "unsupported_action",
                 ),
                 None,
@@ -196,6 +199,7 @@ class StandardizedAgent(BaseAgent):
             context: Context dict as returned by _before_process.
             result:  The handler return value (may be None on error).
         """
+        pass
 
     async def process_request(self, request: AgentRequest) -> AgentResponse:
         """Standardized request processing (Issue #398: refactored to use helpers)."""
@@ -228,6 +232,10 @@ class StandardizedAgent(BaseAgent):
                     request.request_id,
                     hook_exc,
                 )
+
+            # Note: enriched context is available to _after_process.
+            # Handlers access request.payload directly; context carries
+            # cross-hook state (session_id, working memory entries, etc.).
 
             # Validate and get handler (Issue #398: extracted)
             (

--- a/autobot-backend/agents/standardized_agent.py
+++ b/autobot-backend/agents/standardized_agent.py
@@ -23,6 +23,17 @@ from prompt_manager import get_language_instruction, resolve_language
 
 from .base_agent import AgentRequest, AgentResponse, BaseAgent, DeploymentMode
 
+try:
+    from autobot_backend.memory.working_memory import WorkingMemoryService
+    _working_memory_available = True
+except ImportError:
+    logging.getLogger(__name__).warning(
+        "WorkingMemoryService not available (issue #3768 not merged); "
+        "memory lifecycle hooks will use no-op stubs"
+    )
+    WorkingMemoryService = None  # type: ignore[assignment,misc]
+    _working_memory_available = False
+
 
 @dataclass
 class ActionHandler:
@@ -161,6 +172,31 @@ class StandardizedAgent(BaseAgent):
             },
         )
 
+    async def _before_process(self, context: dict) -> dict:
+        """Load working memory into context before request handling.
+
+        Override in subclasses to enrich the context with session state
+        or prior conversation history from WorkingMemoryService.
+
+        Args:
+            context: Mutable context dict forwarded from the request.
+
+        Returns:
+            Enriched context dict (may be the same object or a new one).
+        """
+        return context
+
+    async def _after_process(self, context: dict, result: Any) -> None:
+        """Persist key outputs to working memory after request handling.
+
+        Override in subclasses to write agent outputs back to
+        WorkingMemoryService so downstream agents can share state.
+
+        Args:
+            context: Context dict as returned by _before_process.
+            result:  The handler return value (may be None on error).
+        """
+
     async def process_request(self, request: AgentRequest) -> AgentResponse:
         """Standardized request processing (Issue #398: refactored to use helpers)."""
         start_time = time.time()
@@ -176,6 +212,23 @@ class StandardizedAgent(BaseAgent):
                 request.action,
             )
 
+            # --- memory lifecycle: before ---
+            context = dict(request.context or {})
+            try:
+                t0 = time.time()
+                context = await self._before_process(context)
+                self.logger.debug(
+                    "_before_process for %s took %.3fs",
+                    request.request_id,
+                    time.time() - t0,
+                )
+            except Exception as hook_exc:
+                self.logger.warning(
+                    "_before_process hook failed for %s (ignored): %s",
+                    request.request_id,
+                    hook_exc,
+                )
+
             # Validate and get handler (Issue #398: extracted)
             (
                 error_response,
@@ -186,6 +239,22 @@ class StandardizedAgent(BaseAgent):
                 return error_response
 
             result = await self._call_handler_safely(handler_method, request)
+
+            # --- memory lifecycle: after ---
+            try:
+                t0 = time.time()
+                await self._after_process(context, result)
+                self.logger.debug(
+                    "_after_process for %s took %.3fs",
+                    request.request_id,
+                    time.time() - t0,
+                )
+            except Exception as hook_exc:
+                self.logger.warning(
+                    "_after_process hook failed for %s (ignored): %s",
+                    request.request_id,
+                    hook_exc,
+                )
 
             processing_time = time.time() - start_time
             async with self._async_stats_lock:

--- a/autobot-backend/agents/standardized_agent.py
+++ b/autobot-backend/agents/standardized_agent.py
@@ -24,7 +24,7 @@ from prompt_manager import get_language_instruction, resolve_language
 from .base_agent import AgentRequest, AgentResponse, BaseAgent, DeploymentMode
 
 try:
-    from autobot_backend.memory.working_memory import WorkingMemoryService
+    from memory.working_memory import WorkingMemoryService
     _working_memory_available = True
 except ImportError:
     logging.getLogger(__name__).warning(

--- a/autobot-backend/tests/agents/test_memory_hooks.py
+++ b/autobot-backend/tests/agents/test_memory_hooks.py
@@ -1,0 +1,240 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for _before_process / _after_process memory lifecycle hooks (#3771).
+
+Verifies:
+- hook call order (before -> handler -> after)
+- hook failures are isolated and never crash the agent
+- default no-op hooks do not alter existing agent behaviour
+"""
+
+import sys
+import types
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-populate sys.modules with a hollow 'agents' package so that
+# agents/standardized_agent.py's relative imports work without executing
+# agents/__init__.py (which pulls in llama_index and other unavailable libs).
+# Pattern documented in CLAUDE.md key discoveries:
+#   "pytest conftest.py hollow-api pattern: pre-populate sys.modules['api']
+#    with types.ModuleType(__path__=[api_dir])"
+# ---------------------------------------------------------------------------
+_AGENTS_DIR = Path(__file__).resolve().parents[2] / "agents"
+
+if "agents" not in sys.modules:
+    _agents_pkg = types.ModuleType("agents")
+    _agents_pkg.__path__ = [str(_AGENTS_DIR)]  # type: ignore[assignment]
+    _agents_pkg.__package__ = "agents"
+    sys.modules["agents"] = _agents_pkg
+
+# Now the regular package imports work because 'agents' is already registered.
+from agents.base_agent import AgentRequest  # noqa: E402
+from agents.standardized_agent import ActionHandler, StandardizedAgent  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete agent for testing
+# ---------------------------------------------------------------------------
+
+class _MinimalAgent(StandardizedAgent):
+    """Minimal StandardizedAgent subclass used in unit tests."""
+
+    def __init__(self):
+        super().__init__("test_agent")
+        self.register_action_handler(
+            "echo",
+            ActionHandler(
+                handler_method="handle_echo",
+                required_params=["text"],
+            ),
+        )
+
+    def _get_system_prompt(self) -> str:
+        return "test"
+
+    def get_capabilities(self) -> List[str]:
+        return ["echo"]
+
+    async def handle_echo(self, request: AgentRequest) -> Dict[str, Any]:
+        return {"echoed": request.payload["text"]}
+
+
+def _make_request(action: str = "echo", payload: dict = None, context: dict = None) -> AgentRequest:
+    return AgentRequest(
+        request_id=str(uuid.uuid4()),
+        agent_type="test_agent",
+        action=action,
+        payload=payload or {"text": "hello"},
+        context=context or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hook call-order tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_before_process_called_before_handler():
+    """_before_process must be awaited before the action handler fires."""
+    agent = _MinimalAgent()
+    call_order = []
+
+    original_before = agent._before_process
+    original_handler = agent.handle_echo
+
+    async def spy_before(ctx):
+        call_order.append("before")
+        return await original_before(ctx)
+
+    async def spy_handler(req):
+        call_order.append("handler")
+        return await original_handler(req)
+
+    agent._before_process = spy_before
+    agent.handle_echo = spy_handler
+
+    await agent.process_request(_make_request())
+
+    assert call_order.index("before") < call_order.index("handler")
+
+
+@pytest.mark.asyncio
+async def test_after_process_called_after_handler():
+    """_after_process must be awaited after the action handler completes."""
+    agent = _MinimalAgent()
+    call_order = []
+
+    original_after = agent._after_process
+    original_handler = agent.handle_echo
+
+    async def spy_after(ctx, result):
+        call_order.append("after")
+        return await original_after(ctx, result)
+
+    async def spy_handler(req):
+        call_order.append("handler")
+        return await original_handler(req)
+
+    agent._after_process = spy_after
+    agent.handle_echo = spy_handler
+
+    await agent.process_request(_make_request())
+
+    assert call_order.index("handler") < call_order.index("after")
+
+
+@pytest.mark.asyncio
+async def test_full_hook_order():
+    """Full order must be: before -> handler -> after."""
+    agent = _MinimalAgent()
+    call_order = []
+
+    agent._before_process = AsyncMock(side_effect=lambda ctx: (call_order.append("before"), ctx)[1])
+    agent._after_process = AsyncMock(side_effect=lambda ctx, r: call_order.append("after"))
+    original_handler = agent.handle_echo
+
+    async def spy_handler(req):
+        call_order.append("handler")
+        return await original_handler(req)
+
+    agent.handle_echo = spy_handler
+
+    response = await agent.process_request(_make_request())
+
+    assert response.status == "success"
+    assert call_order == ["before", "handler", "after"]
+
+
+# ---------------------------------------------------------------------------
+# Hook failure isolation tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_before_process_failure_does_not_crash_agent():
+    """A raised exception in _before_process must not prevent handler from running."""
+    agent = _MinimalAgent()
+
+    async def failing_before(ctx):
+        raise RuntimeError("simulated before-hook failure")
+
+    agent._before_process = failing_before
+
+    response = await agent.process_request(_make_request())
+
+    assert response.status == "success"
+    assert response.result["echoed"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_after_process_failure_does_not_crash_agent():
+    """A raised exception in _after_process must not prevent a success response."""
+    agent = _MinimalAgent()
+
+    async def failing_after(ctx, result):
+        raise RuntimeError("simulated after-hook failure")
+
+    agent._after_process = failing_after
+
+    response = await agent.process_request(_make_request())
+
+    assert response.status == "success"
+    assert response.result["echoed"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_both_hooks_failing_does_not_crash_agent():
+    """Both hooks may fail independently — agent must still succeed."""
+    agent = _MinimalAgent()
+
+    async def failing_before(ctx):
+        raise ValueError("before error")
+
+    async def failing_after(ctx, result):
+        raise ValueError("after error")
+
+    agent._before_process = failing_before
+    agent._after_process = failing_after
+
+    response = await agent.process_request(_make_request())
+
+    assert response.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# Default no-op hook behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_default_before_process_returns_context_unchanged():
+    """Default _before_process must return the same context dict."""
+    agent = _MinimalAgent()
+    ctx = {"session_id": "abc", "user": "alice"}
+    result = await agent._before_process(ctx)
+    assert result is ctx
+
+
+@pytest.mark.asyncio
+async def test_default_after_process_returns_none():
+    """Default _after_process must be a coroutine returning None."""
+    agent = _MinimalAgent()
+    result = await agent._after_process({"session_id": "abc"}, {"data": 1})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_no_op_hooks_preserve_existing_behaviour():
+    """With default hooks, process_request must behave identically to pre-hook code."""
+    agent = _MinimalAgent()
+    response = await agent.process_request(_make_request(payload={"text": "world"}))
+
+    assert response.status == "success"
+    assert response.result["echoed"] == "world"
+    assert response.agent_type == "test_agent"


### PR DESCRIPTION
Closes #3771

Depends on #3768

## Changes

- Add `_before_process(context)` and `_after_process(context, result)` async hooks to `StandardizedAgent.process_request()`
- Both hooks have no-op default implementations — all 24+ existing agent subclasses are unaffected
- Hook exceptions are caught and logged at `WARNING`; never re-raised, never crash the agent
- Hook timing is logged at `DEBUG` level
- `WorkingMemoryService` imported with `try/except ImportError` fallback; a warning is logged if issue #3768 is not merged yet
- `SentimentAnalysisAgent` overrides both hooks as a documented, runnable example of the pattern
- New `tests/agents/` package with 9 unit tests verifying call order and failure isolation

## Test results

```
9 passed in 1.10s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)