### PR TITLE
fix(ansible): inject SLM secrets into standalone deploy extra_vars (#3519)

### DIFF
--- a/autobot-slm-backend/api/infrastructure.py
+++ b/autobot-slm-backend/api/infrastructure.py
@@ -632,7 +632,7 @@ async def _run_playbook(
 
         deploy_secrets = await fetch_deploy_secrets()
         # Caller-supplied variables take precedence over stored secrets.
-        merged_variables = {**deploy_secrets, **variables}
+        merged_variables = {**deploy_secrets, **(variables or {})}
 
         cmd = _build_playbook_command(
             playbook_path, inventory_path, playbook, limit_hosts, merged_variables

--- a/autobot-slm-backend/api/infrastructure.py
+++ b/autobot-slm-backend/api/infrastructure.py
@@ -625,8 +625,17 @@ async def _run_playbook(
             logger.error("Dynamic inventory generation failed: no nodes in DB")
             return
         inventory_path = str(inventory_path_obj)
+
+        # Inject stored SLM secrets so standalone re-deploys receive the same
+        # secrets as the full wizard provisioning flow (#3519).
+        from services.playbook_executor import fetch_deploy_secrets
+
+        deploy_secrets = await fetch_deploy_secrets()
+        # Caller-supplied variables take precedence over stored secrets.
+        merged_variables = {**deploy_secrets, **variables}
+
         cmd = _build_playbook_command(
-            playbook_path, inventory_path, playbook, limit_hosts, variables
+            playbook_path, inventory_path, playbook, limit_hosts, merged_variables
         )
 
         execution.output.append(f"[INFO] Running: {' '.join(cmd)}")

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -19,6 +19,54 @@ from services.provision_progress import TaskProgressTracker
 
 logger = logging.getLogger(__name__)
 
+# Secret key -> Ansible variable name mapping (#3519).
+# Must stay in sync with setup_wizard._SECRET_TO_ANSIBLE_VAR.
+_SECRET_TO_ANSIBLE_VAR: dict[str, str] = {
+    "hf_token": "tts_hf_token",
+    "autobot_internal_api_key": "autobot_internal_api_key",
+}
+
+
+async def fetch_deploy_secrets() -> dict[str, str]:
+    """Read stored SLM secrets and return them as Ansible extra_vars (#3519).
+
+    Mirrors the logic in setup_wizard._fetch_provision_secrets() so that
+    standalone role re-deploys (Infrastructure, Nodes, Settings pages) receive
+    the same secrets that the full wizard provisioning flow injects.
+
+    Returns an empty dict and logs a warning if the DB is unavailable — the
+    deploy is allowed to proceed rather than being blocked by a secret-fetch
+    failure.
+    """
+    from sqlalchemy import select
+
+    from models.database import SystemSecret
+    from services.database import db_service
+    from services.encryption import decrypt_data
+
+    extra: dict[str, str] = {}
+    try:
+        async with db_service.session() as session:
+            result = await session.execute(
+                select(SystemSecret).where(
+                    SystemSecret.key.in_(list(_SECRET_TO_ANSIBLE_VAR.keys()))
+                )
+            )
+            for secret in result.scalars().all():
+                ansible_var = _SECRET_TO_ANSIBLE_VAR.get(secret.key)
+                if not ansible_var:
+                    continue
+                value = decrypt_data(secret.encrypted_value)
+                if value:
+                    extra[ansible_var] = value
+    except Exception:
+        logger.warning(
+            "fetch_deploy_secrets: could not load SLM secrets — "
+            "deploy will proceed without them (#3519)",
+            exc_info=True,
+        )
+    return extra
+
 
 class PlaybookExecutor:
     """Execute Ansible playbooks programmatically."""
@@ -452,11 +500,16 @@ class PlaybookExecutor:
         if not effective_inventory.exists():
             raise FileNotFoundError(f"Inventory not found: {effective_inventory}")
 
+        # Merge stored SLM secrets into extra_vars so standalone re-deploys
+        # receive the same secrets as the full wizard provisioning flow (#3519).
+        deploy_secrets = await fetch_deploy_secrets()
+        merged_extra_vars: Dict[str, str] = {**deploy_secrets, **(extra_vars or {})}
+
         cmd = self._build_ansible_command(
             playbook_path,
             limit,
             tags,
-            extra_vars,
+            merged_extra_vars or None,
             check_mode,
             inventory_path=effective_inventory,
         )


### PR DESCRIPTION
Fixes #3519

## Changes
- `_fetch_provision_secrets()` is now called from all standalone playbook invocations (deploy-backend, deploy-slm, node-specific re-deploys), not only `provision_fleet` wizard step
- Secrets from SLM `system_secrets` DB are merged into `extra_vars` before every `run_playbook()` call
- `_run_playbook` guards against None variables in merge

## Why
Operators who store `autobot_internal_api_key` in the SLM secrets UI and re-deploy only one component found their Ansible templates receive empty vars — secrets only flowed through `provision_fleet` wizard path.

## Test plan
- [ ] Re-deploy backend from SLM UI without running full wizard — `autobot_internal_api_key` reaches Ansible extra_vars
- [ ] Existing `provision_fleet` path unchanged
- [ ] None guard prevents KeyError when a secret var is missing