### PR TITLE
chore(ansible): move _SECRET_TO_ANSIBLE_VAR to shared location

### DIFF
--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from api.websocket import ws_manager
+from services.ansible_secrets import _SECRET_TO_ANSIBLE_VAR
 from services.auth import get_current_user
 from services.database import db_service
 from services.encryption import decrypt_data
@@ -185,17 +186,6 @@ def _build_infra_vars(
             infra_vars[host_var] = resolved
             infra_vars[host_var.replace("_host", "_port")] = port
     return infra_vars
-
-
-# -- Secret key -> Ansible variable name mapping (#3079) --------------------
-
-_SECRET_TO_ANSIBLE_VAR: dict[str, str] = {
-    "hf_token": "tts_hf_token",
-    # Internal API key shared between SLM backend and main backend (#1779, #3512).
-    # Store as "autobot_internal_api_key" in the SLM secrets UI; it is injected
-    # as an Ansible extra_var and rendered into slm-secrets.env and backend.env.
-    "autobot_internal_api_key": "autobot_internal_api_key",
-}
 
 
 async def _fetch_provision_secrets() -> dict[str, str]:

--- a/autobot-slm-backend/services/ansible_secrets.py
+++ b/autobot-slm-backend/services/ansible_secrets.py
@@ -1,0 +1,23 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Ansible secrets mapping shared between setup_wizard and playbook_executor.
+
+Single source of truth for the SLM secret key -> Ansible variable name
+mapping (#3519).  Any caller that needs to inject stored secrets as Ansible
+extra_vars should import _SECRET_TO_ANSIBLE_VAR from here.
+"""
+
+# Maps SLM secrets-store keys to the Ansible extra_var names they become
+# when injected into a playbook run.
+#
+# "hf_token"               -> tts_hf_token  (HuggingFace token for TTS worker)
+# "autobot_internal_api_key" -> autobot_internal_api_key
+#     Internal API key shared between SLM backend and main backend (#1779,
+#     #3512).  Stored via the SLM secrets UI; injected as an Ansible extra_var
+#     and rendered into slm-secrets.env and backend.env.
+_SECRET_TO_ANSIBLE_VAR: dict[str, str] = {
+    "hf_token": "tts_hf_token",
+    "autobot_internal_api_key": "autobot_internal_api_key",
+}

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -15,16 +15,10 @@ import shutil
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from services.ansible_secrets import _SECRET_TO_ANSIBLE_VAR
 from services.provision_progress import TaskProgressTracker
 
 logger = logging.getLogger(__name__)
-
-# Secret key -> Ansible variable name mapping (#3519).
-# Must stay in sync with setup_wizard._SECRET_TO_ANSIBLE_VAR.
-_SECRET_TO_ANSIBLE_VAR: dict[str, str] = {
-    "hf_token": "tts_hf_token",
-    "autobot_internal_api_key": "autobot_internal_api_key",
-}
 
 
 async def fetch_deploy_secrets() -> dict[str, str]:


### PR DESCRIPTION
## Summary

- Extracts the duplicated `_SECRET_TO_ANSIBLE_VAR` dict from `setup_wizard.py` and `playbook_executor.py` into a new shared module `services/ansible_secrets.py`.
- Previously the dict was defined identically in both callers (added in the #3519 fix), with a comment in `playbook_executor.py` warning it must stay in sync. Both callers now import from the single source of truth.

Closes #3778

## Test Plan
- [ ] `python3 -c "from services.ansible_secrets import _SECRET_TO_ANSIBLE_VAR; print(len(_SECRET_TO_ANSIBLE_VAR))"` prints `2`
- [ ] No import errors in `setup_wizard.py` or `playbook_executor.py`