### PR TITLE
feat(agents): per-agent cross-session diary — persistent agent journal in KB

### DIFF
--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -12,6 +12,8 @@ import logging
 import threading
 from typing import Any, Dict, List, Optional
 
+from memory.agent_diary import AgentDiaryService
+
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -113,7 +115,7 @@ class SentimentAnalysisAgent(StandardizedAgent):
                 top_p=LLMDefaults.DEFAULT_TOP_P,
             )
             response_text = self._extract_content(response)
-            return {
+            result = {
                 "status": "success",
                 "response": response_text,
                 "response_text": response_text,
@@ -123,6 +125,15 @@ class SentimentAnalysisAgent(StandardizedAgent):
                     response.get("usage", {}) if isinstance(response, dict) else {}
                 ),
             }
+            session_id = (context or {}).get("session_id", "unknown")
+            diary_entry = (
+                f"SESSION:{session_id}|ACTION:sentiment_analysis"
+                f"|OUTCOME:{result['status']}|TOPIC:sentiment"
+            )
+            await AgentDiaryService().write(
+                self.AGENT_ID, session_id, diary_entry, topic="sentiment"
+            )
+            return result
         except Exception as e:
             logger.error("Sentiment Analysis Agent error: %s", e)
             return {

--- a/autobot-backend/memory/__init__.py
+++ b/autobot-backend/memory/__init__.py
@@ -38,6 +38,7 @@ from .compat import (
 from .enums import MemoryCategory, StorageStrategy, TaskPriority, TaskStatus
 
 # Main Manager
+from .agent_diary import AgentDiaryService
 from .manager import UnifiedMemoryManager
 
 # Data Models
@@ -51,6 +52,8 @@ from .protocols import ICacheManager, IGeneralStorage, ITaskStorage
 from .storage import GeneralStorage, TaskStorage
 
 __all__ = [
+    # Agent Diary
+    "AgentDiaryService",
     # Enums
     "TaskStatus",
     "TaskPriority",

--- a/autobot-backend/memory/agent_diary.py
+++ b/autobot-backend/memory/agent_diary.py
@@ -94,26 +94,30 @@ class AgentDiaryService:
     async def read(self, agent_name: str, last_n: int = 10) -> List[Dict[str, Any]]:
         """Return the last *last_n* diary entries for *agent_name*, newest first.
 
+        Uses a metadata-filtered listing (``get_all_facts``) rather than
+        semantic search so that all entries are deterministically retrieved
+        regardless of their semantic similarity to a query string.
+
         Args:
             agent_name: Agent whose entries to retrieve.
             last_n:     Maximum number of entries to return.
 
         Returns:
-            List of result dicts from the KB search (may be empty on error).
+            List of fact dicts sorted newest-first (may be empty on error).
         """
         try:
             kb = await _get_kb()
-            filters = {"source": agent_name, "category": self.CATEGORY}
-            results = await kb.search(
-                query=f"agent diary {agent_name}",
-                top_k=last_n,
-                filters=filters,
-            )
-            results.sort(
+            all_facts = await kb.get_all_facts()
+            entries = [
+                f for f in all_facts
+                if (f.get("metadata") or {}).get("category") == self.CATEGORY
+                and (f.get("metadata") or {}).get("source") == agent_name
+            ]
+            entries.sort(
                 key=lambda r: r.get("metadata", {}).get("diary_timestamp", ""),
                 reverse=True,
             )
-            return results[:last_n]
+            return entries[:last_n]
         except Exception as exc:
             logger.warning(
                 "AgentDiary read failed for agent=%s: %s", agent_name, exc

--- a/autobot-backend/memory/agent_diary.py
+++ b/autobot-backend/memory/agent_diary.py
@@ -1,0 +1,155 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+AgentDiaryService — per-agent cross-session journal stored as KB facts.
+
+Each diary entry is a KB fact whose metadata carries the agent_name,
+session_id, and topic so entries can be retrieved or searched per agent
+without touching any other KB content.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+async def _get_kb():
+    """Module-level thin wrapper so tests can patch ``memory.agent_diary._get_kb``."""
+    from knowledge._composed import get_knowledge_base
+
+    return await get_knowledge_base()
+
+
+class AgentDiaryService:
+    """Persistent per-agent journal backed by the knowledge base.
+
+    Entries are stored as KB facts with category ``AGENT_DIARY`` and
+    ``source`` set to the agent name so they are easily filtered.
+
+    Usage::
+
+        diary = AgentDiaryService()
+        fact_id = await diary.write("my_agent", session_id, "processed X", topic="work")
+        entries  = await diary.read("my_agent", last_n=20)
+        hits     = await diary.search("my_agent", "processed X")
+    """
+
+    CATEGORY = "AGENT_DIARY"
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    async def write(
+        self,
+        agent_name: str,
+        session_id: str,
+        entry: str,
+        topic: str = "general",
+    ) -> str:
+        """Write a journal entry as a KB fact.
+
+        Args:
+            agent_name: Logical name of the agent (used as fact source).
+            session_id:  Current processing session identifier.
+            entry:       Free-text diary content to persist.
+            topic:       Optional topic tag for grouping entries.
+
+        Returns:
+            fact_id of the created (or duplicate) KB fact, or ``""`` on error.
+        """
+        try:
+            kb = await _get_kb()
+            metadata: Dict[str, Any] = {
+                "category": self.CATEGORY,
+                "source": agent_name,
+                "agent_name": agent_name,
+                "session_id": session_id,
+                "topic": topic,
+                "diary_timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            }
+            result = await kb.store_fact(content=entry, metadata=metadata)
+            fact_id: str = result.get("fact_id", "")
+            logger.debug(
+                "AgentDiary write: agent=%s session=%s fact_id=%s status=%s",
+                agent_name,
+                session_id,
+                fact_id,
+                result.get("status"),
+            )
+            return fact_id
+        except Exception as exc:
+            logger.warning(
+                "AgentDiary write failed for agent=%s: %s", agent_name, exc
+            )
+            return ""
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def read(self, agent_name: str, last_n: int = 10) -> List[Dict[str, Any]]:
+        """Return the last *last_n* diary entries for *agent_name*, newest first.
+
+        Args:
+            agent_name: Agent whose entries to retrieve.
+            last_n:     Maximum number of entries to return.
+
+        Returns:
+            List of result dicts from the KB search (may be empty on error).
+        """
+        try:
+            kb = await _get_kb()
+            filters = {"source": agent_name, "category": self.CATEGORY}
+            results = await kb.search(
+                query=f"agent diary {agent_name}",
+                top_k=last_n,
+                filters=filters,
+            )
+            results.sort(
+                key=lambda r: r.get("metadata", {}).get("diary_timestamp", ""),
+                reverse=True,
+            )
+            return results[:last_n]
+        except Exception as exc:
+            logger.warning(
+                "AgentDiary read failed for agent=%s: %s", agent_name, exc
+            )
+            return []
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def search(
+        self, agent_name: str, query: str, n: int = 5
+    ) -> List[Dict[str, Any]]:
+        """Semantic search within one agent's diary.
+
+        Args:
+            agent_name: Agent whose diary to search.
+            query:      Free-text search query.
+            n:          Maximum number of results.
+
+        Returns:
+            List of matching result dicts, or empty list on error.
+        """
+        try:
+            kb = await _get_kb()
+            filters = {"source": agent_name, "category": self.CATEGORY}
+            results = await kb.search(query=query, top_k=n, filters=filters)
+            return results[:n]
+        except Exception as exc:
+            logger.warning(
+                "AgentDiary search failed for agent=%s query=%r: %s",
+                agent_name,
+                query,
+                exc,
+            )
+            return []
+
+
+__all__ = ["AgentDiaryService"]

--- a/autobot-backend/tests/memory/__init__.py
+++ b/autobot-backend/tests/memory/__init__.py
@@ -1,0 +1,3 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss

--- a/autobot-backend/tests/memory/test_agent_diary.py
+++ b/autobot-backend/tests/memory/test_agent_diary.py
@@ -1,0 +1,154 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for AgentDiaryService (issue #3789).
+
+All KB calls are mocked so these tests run without Redis / ChromaDB.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from memory.agent_diary import AgentDiaryService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_kb_mock(store_result=None, search_result=None):
+    """Return an async mock KnowledgeBase stub."""
+    kb = MagicMock()
+    kb.store_fact = AsyncMock(
+        return_value=store_result or {"status": "success", "fact_id": "fact-001"}
+    )
+    kb.search = AsyncMock(return_value=search_result or [])
+    return kb
+
+
+def _result_with_ts(ts: str) -> dict:
+    """Build a minimal KB search result dict."""
+    return {"content": "entry", "metadata": {"diary_timestamp": ts, "source": "a"}}
+
+
+# ---------------------------------------------------------------------------
+# write()
+# ---------------------------------------------------------------------------
+
+class TestWrite:
+    @pytest.mark.asyncio
+    async def test_write_returns_fact_id(self):
+        kb = _make_kb_mock(store_result={"status": "success", "fact_id": "abc-123"})
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            fact_id = await diary.write("agent_a", "sess-1", "did something", topic="work")
+        assert fact_id == "abc-123"
+
+    @pytest.mark.asyncio
+    async def test_write_passes_correct_metadata(self):
+        kb = _make_kb_mock()
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            await diary.write("agent_b", "sess-2", "log entry", topic="ops")
+
+        _, kwargs = kb.store_fact.call_args
+        meta = kwargs["metadata"]
+        assert meta["category"] == AgentDiaryService.CATEGORY
+        assert meta["source"] == "agent_b"
+        assert meta["session_id"] == "sess-2"
+        assert meta["topic"] == "ops"
+        assert "diary_timestamp" in meta
+
+    @pytest.mark.asyncio
+    async def test_write_graceful_on_kb_error(self):
+        kb = MagicMock()
+        kb.store_fact = AsyncMock(side_effect=RuntimeError("KB down"))
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            fact_id = await diary.write("agent_c", "sess-3", "entry")
+        # Must not raise; returns empty string
+        assert fact_id == ""
+
+
+# ---------------------------------------------------------------------------
+# read()
+# ---------------------------------------------------------------------------
+
+class TestRead:
+    @pytest.mark.asyncio
+    async def test_read_returns_newest_first(self):
+        results = [
+            _result_with_ts("2026-01-01T10:00:00+00:00"),
+            _result_with_ts("2026-01-03T10:00:00+00:00"),
+            _result_with_ts("2026-01-02T10:00:00+00:00"),
+        ]
+        kb = _make_kb_mock(search_result=results)
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            entries = await diary.read("agent_a", last_n=3)
+
+        timestamps = [e["metadata"]["diary_timestamp"] for e in entries]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_read_respects_last_n(self):
+        results = [_result_with_ts(f"2026-01-0{i}T00:00:00+00:00") for i in range(1, 6)]
+        kb = _make_kb_mock(search_result=results)
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            entries = await diary.read("agent_a", last_n=2)
+        assert len(entries) == 2
+
+    @pytest.mark.asyncio
+    async def test_read_empty_diary_returns_empty_list(self):
+        kb = _make_kb_mock(search_result=[])
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            entries = await diary.read("agent_x")
+        assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_read_graceful_on_kb_error(self):
+        kb = MagicMock()
+        kb.search = AsyncMock(side_effect=RuntimeError("KB down"))
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            entries = await diary.read("agent_y")
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_passes_correct_filters(self):
+        kb = _make_kb_mock(search_result=[{"content": "match", "metadata": {}}])
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            results = await diary.search("agent_a", "some query", n=3)
+
+        assert len(results) == 1
+        _, kwargs = kb.search.call_args
+        assert kwargs["filters"]["source"] == "agent_a"
+        assert kwargs["filters"]["category"] == AgentDiaryService.CATEGORY
+        assert kwargs["top_k"] == 3
+
+    @pytest.mark.asyncio
+    async def test_search_empty_result(self):
+        kb = _make_kb_mock(search_result=[])
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            results = await diary.search("agent_a", "nothing here")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_graceful_on_kb_error(self):
+        kb = MagicMock()
+        kb.search = AsyncMock(side_effect=RuntimeError("KB down"))
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            results = await diary.search("agent_z", "query")
+        assert results == []

--- a/autobot-backend/tests/memory/test_agent_diary.py
+++ b/autobot-backend/tests/memory/test_agent_diary.py
@@ -17,19 +17,27 @@ from memory.agent_diary import AgentDiaryService
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_kb_mock(store_result=None, search_result=None):
+def _make_kb_mock(store_result=None, search_result=None, all_facts_result=None):
     """Return an async mock KnowledgeBase stub."""
     kb = MagicMock()
     kb.store_fact = AsyncMock(
         return_value=store_result or {"status": "success", "fact_id": "fact-001"}
     )
     kb.search = AsyncMock(return_value=search_result or [])
+    kb.get_all_facts = AsyncMock(return_value=all_facts_result or [])
     return kb
 
 
-def _result_with_ts(ts: str) -> dict:
-    """Build a minimal KB search result dict."""
-    return {"content": "entry", "metadata": {"diary_timestamp": ts, "source": "a"}}
+def _result_with_ts(ts: str, agent: str = "agent_a") -> dict:
+    """Build a minimal KB fact/search result dict."""
+    return {
+        "content": "entry",
+        "metadata": {
+            "diary_timestamp": ts,
+            "source": agent,
+            "category": AgentDiaryService.CATEGORY,
+        },
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -78,12 +86,12 @@ class TestWrite:
 class TestRead:
     @pytest.mark.asyncio
     async def test_read_returns_newest_first(self):
-        results = [
+        all_facts = [
             _result_with_ts("2026-01-01T10:00:00+00:00"),
             _result_with_ts("2026-01-03T10:00:00+00:00"),
             _result_with_ts("2026-01-02T10:00:00+00:00"),
         ]
-        kb = _make_kb_mock(search_result=results)
+        kb = _make_kb_mock(all_facts_result=all_facts)
         with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
             diary = AgentDiaryService()
             entries = await diary.read("agent_a", last_n=3)
@@ -93,16 +101,32 @@ class TestRead:
 
     @pytest.mark.asyncio
     async def test_read_respects_last_n(self):
-        results = [_result_with_ts(f"2026-01-0{i}T00:00:00+00:00") for i in range(1, 6)]
-        kb = _make_kb_mock(search_result=results)
+        all_facts = [_result_with_ts(f"2026-01-0{i}T00:00:00+00:00") for i in range(1, 6)]
+        kb = _make_kb_mock(all_facts_result=all_facts)
         with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
             diary = AgentDiaryService()
             entries = await diary.read("agent_a", last_n=2)
         assert len(entries) == 2
 
     @pytest.mark.asyncio
+    async def test_read_filters_by_agent_and_category(self):
+        """read() must not return entries belonging to a different agent."""
+        all_facts = [
+            _result_with_ts("2026-01-01T10:00:00+00:00", agent="agent_a"),
+            _result_with_ts("2026-01-02T10:00:00+00:00", agent="other_agent"),
+            _result_with_ts("2026-01-03T10:00:00+00:00", agent="agent_a"),
+        ]
+        kb = _make_kb_mock(all_facts_result=all_facts)
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            entries = await diary.read("agent_a", last_n=10)
+
+        assert len(entries) == 2
+        assert all(e["metadata"]["source"] == "agent_a" for e in entries)
+
+    @pytest.mark.asyncio
     async def test_read_empty_diary_returns_empty_list(self):
-        kb = _make_kb_mock(search_result=[])
+        kb = _make_kb_mock(all_facts_result=[])
         with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
             diary = AgentDiaryService()
             entries = await diary.read("agent_x")
@@ -111,11 +135,21 @@ class TestRead:
     @pytest.mark.asyncio
     async def test_read_graceful_on_kb_error(self):
         kb = MagicMock()
-        kb.search = AsyncMock(side_effect=RuntimeError("KB down"))
+        kb.get_all_facts = AsyncMock(side_effect=RuntimeError("KB down"))
         with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
             diary = AgentDiaryService()
             entries = await diary.read("agent_y")
         assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_read_does_not_call_search(self):
+        """read() must use get_all_facts, not kb.search."""
+        kb = _make_kb_mock(all_facts_result=[])
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            await diary.read("agent_a")
+        kb.get_all_facts.assert_awaited_once()
+        kb.search.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `AgentDiaryService` (`memory/agent_diary.py`) with `write()`, `read()`, and `search()` methods backed by the KB facts store (category `AGENT_DIARY`, source=agent_name), providing cross-session persistent memory per agent.
- Exports `AgentDiaryService` from `memory/__init__.py`.
- Demonstrates usage in `SentimentAnalysisAgent.process_query()` — writes a diary entry after each successful analysis.
- Adds 10 unit tests covering write, metadata correctness, newest-first ordering, `last_n` truncation, empty-diary, and graceful KB-error handling for all three methods.

## Test plan

- [x] `flake8 --max-line-length=100` clean on all modified files
- [x] `pytest tests/memory/test_agent_diary.py -v` → 10/10 passed
- [ ] Deploy to dev and confirm KB facts appear with category `AGENT_DIARY` after an agent run

Closes #3789

🤖 Generated with [Claude Code](https://claude.com/claude-code)