### PR TITLE
chore(backend): expand hardcoding prevention beyond IPs/ports (#3397)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,7 +120,7 @@ repos:
         types: [python, ts, vue]
         pass_filenames: false
         stages: [pre-commit]
-        description: "Blocks commits with hardcoded IPs, ports, magic numbers, and role strings"
+        description: "Blocks commits with hardcoded IPs, ports, magic numbers, role strings, AutoBot file paths, and model name literals (#3397)"
 
   # Function length enforcement (Issue #620)
   - repo: local

--- a/autobot-backend/agent_loop/think_tool.py
+++ b/autobot-backend/agent_loop/think_tool.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 from agent_loop.types import ThinkCategory, ThinkResult
+from autobot_shared.ssot_config import ROUTING_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +147,7 @@ class ThinkToolConfig:
     """Configuration for the Think Tool."""
 
     # LLM settings
-    model: str = "llama3.2:latest"
+    model: str = ROUTING_MODEL
     temperature: float = 0.3  # Lower temperature for reasoning
     max_tokens: int = 1000
 

--- a/autobot-backend/mcp_manual_integration.py
+++ b/autobot-backend/mcp_manual_integration.py
@@ -731,10 +731,11 @@ class MCPManualService:
         sources = []
 
         # Common documentation directories
+        _base_dir = os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot")
         common_doc_dirs = [
             "/usr/share/doc",
             "/usr/local/share/doc",
-            "/opt/autobot/docs",
+            f"{_base_dir}/docs",
             f"{PATH.PROJECT_ROOT}/docs",
             "/usr/share/man",
             "/usr/local/share/man",

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import with_error_handling
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_config import config
 from plugin_sdk.base import PluginRegistry
 from plugin_sdk.loader import PluginLoader
 
@@ -35,10 +36,11 @@ def get_plugin_loader() -> PluginLoader:
     """Get or create plugin loader instance."""
     global _plugin_loader
     if _plugin_loader is None:
-        # Define plugin directories
+        # Define plugin directories using SSOT config (#3397)
+        plugins_root = config.path.plugins_path
         plugin_dirs = [
-            Path("/opt/autobot/plugins/core-plugins"),
-            Path("/opt/autobot/plugins/community-plugins"),
+            plugins_root / "core-plugins",
+            plugins_root / "community-plugins",
             # Development fallback
             Path("plugins/core-plugins"),
             Path("plugins/community-plugins"),

--- a/autobot-backend/rlm/benchmark.py
+++ b/autobot-backend/rlm/benchmark.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+from autobot_shared.ssot_config import ROUTING_MODEL
 from rlm.evaluator import ResponseQualityEvaluator
 from rlm.types import RLMConfig
 
@@ -134,7 +135,7 @@ class BenchmarkSummary:
 
 async def _generate(
     prompt: str,
-    model: str = "llama3.2:latest",
+    model: str = ROUTING_MODEL,
     temperature: float = 0.5,
     max_tokens: int = 1024,
     timeout_s: float = 30.0,
@@ -246,7 +247,7 @@ async def _run_rlm_pass(
 
 async def run_benchmark(
     queries: Optional[List[Dict[str, Any]]] = None,
-    model: str = "llama3.2:latest",
+    model: str = ROUTING_MODEL,
     rlm_config: Optional[RLMConfig] = None,
     max_queries: int = 0,
 ) -> Dict[str, Any]:
@@ -353,7 +354,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--model",
-        default="llama3.2:latest",
+        default=ROUTING_MODEL,
         help="Ollama model",
     )
     parser.add_argument(

--- a/autobot-backend/rlm/types.py
+++ b/autobot-backend/rlm/types.py
@@ -16,6 +16,8 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Any, Dict
 
+from autobot_shared.ssot_config import ROUTING_MODEL
+
 
 class ReflectionVerdict(Enum):
     """Outcome of a self-reflection evaluation."""
@@ -76,7 +78,7 @@ class RLMConfig:
     max_reflections: int = 3
     quality_threshold: float = 0.7
     complexity_gate: float = 0.7
-    model: str = "llama3.2:latest"
+    model: str = ROUTING_MODEL
     temperature: float = 0.2
     max_eval_tokens: int = 512
     timeout_ms: int = 10000

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values
@@ -37,6 +37,7 @@ get_staged_files() {
         grep -v -E '(__pycache__|node_modules|\.venv|venv|archive|temp)' | \
         grep -v -E '(test_|_test\.py|\.test\.ts|\.spec\.ts)' | \
         grep -v -E '(ssot_config\.py|ssot-config\.ts|threshold_constants\.py)' | \
+        grep -v -E '(path_constants\.py|network_constants\.py|security_constants\.py)' | \
         grep -v -E '(constants/|config\.py$|\.env)' || true
 }
 
@@ -230,6 +231,91 @@ check_hardcoded_roles() {
     done < "$file"
 }
 
+# Check for hardcoded AutoBot file paths (#3397)
+# Catches /opt/autobot, /tmp/autobot, /var/lib/autobot used as bare string
+# literals instead of going through SSOT config.path or AUTOBOT_BASE_DIR env var.
+check_hardcoded_paths() {
+    local file="$1"
+    local line_num=0
+
+    while IFS= read -r line; do
+        ((line_num++))
+
+        # Skip comments
+        if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]] || [[ "$line" =~ ^[[:space:]]*\* ]]; then
+            continue
+        fi
+
+        # Skip if already using env var or SSOT config
+        if echo "$line" | grep -qE '(AUTOBOT_BASE_DIR|os\.environ\.get|getenv|config\.path)'; then
+            continue
+        fi
+
+        # Skip string assignments in ssot_config / path_constants (these ARE the SSOT)
+        if echo "$line" | grep -qE '(PathConfig|PathConstants|default=.*opt/autobot|Field\()'; then
+            continue
+        fi
+
+        # Skip shell-style ${VAR:-/opt/autobot} expansions — those use the env var
+        if echo "$line" | grep -qE '\$\{[A-Z_]+:-/opt/autobot'; then
+            continue
+        fi
+
+        # Detect bare /opt/autobot, /tmp/autobot, /var/lib/autobot path literals
+        if echo "$line" | grep -qE '"(/opt/autobot|/tmp/autobot|/var/lib/autobot)'; then
+            local path_val
+            path_val=$(echo "$line" | grep -oE '"(/opt/autobot|/tmp/autobot|/var/lib/autobot)[^"]*"' | head -1)
+            echo -e "${RED}VIOLATION${NC} $file:$line_num"
+            echo "  Hardcoded AutoBot file path: $path_val"
+            echo -e "  ${CYAN}Fix: Use config.path.base_dir from ssot_config or os.environ.get('AUTOBOT_BASE_DIR', '/opt/autobot')${NC}"
+            echo "  Line: ${line:0:80}"
+            echo ""
+            ((VIOLATIONS++))
+        fi
+    done < "$file"
+}
+
+# Check for hardcoded model name strings outside SSOT constants (#3397)
+# Catches model name literals that should come from ssot_config constants.
+check_hardcoded_model_names() {
+    local file="$1"
+    local line_num=0
+
+    # Model name patterns that have SSOT equivalents
+    local model_pattern="llama3\.2:latest|llama3\.2:1b|qwen3\.5:9b|nomic-embed-text:latest|gemma2:2b|phi3:mini|mistral:7b-instruct|dolphin-llama3:8b"
+
+    while IFS= read -r line; do
+        ((line_num++))
+
+        # Skip comments
+        if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*// ]]; then
+            continue
+        fi
+
+        # Skip if using SSOT constants or config
+        if echo "$line" | grep -qE '(ROUTING_MODEL|CLASSIFICATION_MODEL|LIGHT_PROCESSING_MODEL|INSTRUCTION_MODEL|SYSTEM_MODEL|QUALITY_MODEL|DEFAULT_LLM_MODEL|DEFAULT_EMBEDDING_MODEL|config\.llm\.)'; then
+            continue
+        fi
+
+        # Skip assignments in ssot_config itself (these define the constants)
+        if echo "$line" | grep -qE '^(ROUTING_MODEL|CLASSIFICATION_MODEL|LIGHT_PROCESSING_MODEL|INSTRUCTION_MODEL|SYSTEM_MODEL|QUALITY_MODEL|DEFAULT_LLM_MODEL|DEFAULT_EMBEDDING_MODEL)\s*='; then
+            continue
+        fi
+
+        # Detect bare model name string literals
+        if echo "$line" | grep -qE "\"(${model_pattern})\""; then
+            local model_val
+            model_val=$(echo "$line" | grep -oE "\"(${model_pattern})\"" | head -1)
+            echo -e "${RED}VIOLATION${NC} $file:$line_num"
+            echo "  Hardcoded model name: $model_val"
+            echo -e "  ${CYAN}Fix: Import ROUTING_MODEL/DEFAULT_LLM_MODEL/etc from autobot_shared.ssot_config${NC}"
+            echo "  Line: ${line:0:80}"
+            echo ""
+            ((VIOLATIONS++))
+        fi
+    done < "$file"
+}
+
 # Check for hardcoded category strings
 check_hardcoded_categories() {
     local file="$1"
@@ -289,6 +375,8 @@ main() {
             check_magic_numbers "$file"
             check_hardcoded_roles "$file"
             check_hardcoded_categories "$file"
+            check_hardcoded_paths "$file"
+            check_hardcoded_model_names "$file"
         fi
     done
 

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -944,6 +944,67 @@ class DatabasePoolConfig(BaseSettings):
     )
 
 
+class PathConfig(BaseSettings):
+    """
+    File-system path configuration.
+
+    Provides a single source of truth for well-known AutoBot directories so
+    production code never needs to hard-code paths like /opt/autobot.
+
+    Override any value via environment variable (e.g. AUTOBOT_BASE_DIR=/srv/autobot).
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=str(PROJECT_ROOT / ".env"),
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    # Installation root — all derived paths use this as their base.
+    # Default matches the standard Ansible deployment target.
+    base_dir: str = Field(default="/opt/autobot", alias="AUTOBOT_BASE_DIR")
+
+    # Well-known sub-directories (all relative to base_dir unless absolute).
+    # Override individual paths via AUTOBOT_PLUGINS_DIR etc. when needed.
+    plugins_dir: str = Field(default="plugins", alias="AUTOBOT_PLUGINS_DIR")
+    data_dir: str = Field(default="data", alias="AUTOBOT_DATA_DIR")
+    logs_dir: str = Field(default="logs", alias="AUTOBOT_LOG_DIR")
+    models_dir: str = Field(default="models", alias="AUTOBOT_MODELS_DIR")
+    docs_dir: str = Field(default="docs", alias="AUTOBOT_DOCS_DIR")
+
+    def resolve(self, relative: str) -> Path:
+        """Resolve a path relative to base_dir."""
+        p = Path(relative)
+        if p.is_absolute():
+            return p
+        return Path(self.base_dir) / p
+
+    @property
+    def plugins_path(self) -> Path:
+        """Absolute path to the plugins directory."""
+        return self.resolve(self.plugins_dir)
+
+    @property
+    def data_path(self) -> Path:
+        """Absolute path to the data directory."""
+        return self.resolve(self.data_dir)
+
+    @property
+    def logs_path(self) -> Path:
+        """Absolute path to the logs directory."""
+        return self.resolve(self.logs_dir)
+
+    @property
+    def models_path(self) -> Path:
+        """Absolute path to the models directory."""
+        return self.resolve(self.models_dir)
+
+    @property
+    def docs_path(self) -> Path:
+        """Absolute path to the docs directory."""
+        return self.resolve(self.docs_dir)
+
+
 class FeatureConfig(BaseSettings):
     """Feature flags configuration."""
 
@@ -1011,6 +1072,7 @@ class AutoBotConfig(BaseSettings):
     feature: FeatureConfig = Field(default_factory=FeatureConfig)
     permission: PermissionConfig = Field(default_factory=PermissionConfig)
     database_pool: DatabasePoolConfig = Field(default_factory=DatabasePoolConfig)
+    path: PathConfig = Field(default_factory=PathConfig)  # Issue #3397
 
     # Top-level settings
     deployment_mode: str = Field(default="distributed", alias="AUTOBOT_DEPLOYMENT_MODE")


### PR DESCRIPTION
## Summary

Expands the hardcoding prevention pre-commit hook (from #3253) to detect additional categories beyond RFC 1918 IPs:

- **New `PathConfig` in SSOT**: Adds `config.path.base_dir`, `config.path.plugins_path`, `config.path.data_path` etc., all backed by `AUTOBOT_BASE_DIR` / `AUTOBOT_PLUGINS_DIR` env vars. Default is `/opt/autobot` matching the standard Ansible deployment target.
- **`plugin_manager.py`**: Replaces `Path("/opt/autobot/plugins/core-plugins")` with `config.path.plugins_path / "core-plugins"` via SSOT config.
- **`mcp_manual_integration.py`**: Replaces `"/opt/autobot/docs"` literal with `os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot")` pattern.
- **`rlm/types.py`, `agent_loop/think_tool.py`, `rlm/benchmark.py`**: Replace `"llama3.2:latest"` string literals with `ROUTING_MODEL` constant imported from `autobot_shared.ssot_config`.
- **Pre-commit hook enhanced**: Added `check_hardcoded_paths()` (detects `/opt/autobot`, `/tmp/autobot`, `/var/lib/autobot` literals) and `check_hardcoded_model_names()` (detects known model name strings not using SSOT constants). Both run on every staged `.py`/`.ts`/`.vue` file.

**Intentionally skipped (documented):**
- Database connection URLs — already env-var driven via `AUTOBOT_REDIS_HOST` etc.
- API base URLs — swept in #3253 getApiBase() migration
- Test fixtures with model names — test files excluded from hook scanning
- `ssot_config.py` itself — excluded from hook (defines the constants)

Closes #3397

## Test Plan
- [ ] `python3 -c "from autobot_shared.ssot_config import config, ROUTING_MODEL; print(config.path.plugins_path, ROUTING_MODEL)"` succeeds
- [ ] Pre-commit hook blocks a staged file containing `"/opt/autobot/foo"` bare string literal
- [ ] Pre-commit hook blocks a staged file containing `"llama3.2:latest"` bare string literal
- [ ] `os.environ.get("AUTOBOT_BASE_DIR", "/opt/autobot")` pattern is allowed by hook
- [ ] `ROUTING_MODEL` usage is allowed by hook