### PR TITLE
feat(knowledge): duplicate guard on individual fact writes to prevent KB pollution

### DIFF
--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -527,13 +527,63 @@ class FactsMixin:
 
         return None
 
+    async def _find_duplicate(
+        self, content: str, threshold: float = 0.92
+    ) -> Optional[Dict[str, Any]]:
+        """Check ChromaDB for near-duplicate content before inserting.
+
+        Issue #3788: Semantic similarity guard for individual fact writes.
+
+        Queries the vector store for the closest existing fact. ChromaDB
+        returns L2 distances; we convert to cosine similarity via
+        ``1 - distance / 2`` (valid for unit-normalised embeddings).
+
+        Args:
+            content: Candidate fact text to check.
+            threshold: Minimum similarity score to consider a duplicate (0.5-1.0).
+
+        Returns:
+            Metadata dict of the existing fact if a near-duplicate is found,
+            else None.
+        """
+        if not self.vector_store:
+            return None
+        try:
+            embedding = await _generate_embedding_with_npu_fallback(content)
+            chroma_collection = self.vector_store._collection
+            results = await asyncio.to_thread(
+                chroma_collection.query,
+                query_embeddings=[embedding],
+                n_results=3,
+                include=["metadatas", "distances"],
+            )
+            ids = (results.get("ids") or [[]])[0]
+            distances = (results.get("distances") or [[]])[0]
+            metadatas = (results.get("metadatas") or [[]])[0]
+            for i, distance in enumerate(distances):
+                similarity = 1.0 - distance / 2.0
+                if similarity >= threshold:
+                    meta = metadatas[i] if i < len(metadatas) else {}
+                    meta.setdefault("id", ids[i] if i < len(ids) else "?")
+                    logger.debug(
+                        "_find_duplicate: similarity=%.4f >= threshold=%.4f, id=%s",
+                        similarity,
+                        threshold,
+                        meta.get("id"),
+                    )
+                    return meta
+        except Exception as exc:
+            logger.debug("_find_duplicate: query failed, skipping check: %s", exc)
+        return None
+
     async def _check_for_duplicates(
         self, content: str, metadata: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         """
-        Check for duplicate facts by unique_key or content hash.
+        Check for duplicate facts by unique_key, content hash, or semantic similarity.
 
         Issue #281: Extracted helper for duplicate detection.
+        Issue #3788: Added semantic similarity check via ChromaDB.
 
         Args:
             content: Fact content text
@@ -555,7 +605,7 @@ class FactsMixin:
                     "message": "Fact already exists with this unique key",
                 }
 
-        # Check for content duplicates
+        # Check for content duplicates (exact hash match)
         existing_id = await self._find_existing_fact(content, metadata)
         if existing_id:
             logger.info("Duplicate content detected: %s", existing_id)
@@ -563,6 +613,21 @@ class FactsMixin:
                 "status": "duplicate",
                 "fact_id": existing_id,
                 "message": "Fact with identical content already exists",
+            }
+
+        # Issue #3788: Semantic similarity check against ChromaDB
+        from autobot_shared.ssot_config import config as _cfg
+
+        existing_meta = await self._find_duplicate(
+            content, threshold=_cfg.cache.l2.kb_dedup_threshold
+        )
+        if existing_meta:
+            dup_id = existing_meta.get("fact_id") or existing_meta.get("id", "?")
+            logger.info("Near-duplicate fact detected via semantic check: %s", dup_id)
+            return {
+                "status": "duplicate",
+                "fact_id": dup_id,
+                "message": "Near-duplicate fact already exists (semantic similarity)",
             }
 
         return None

--- a/autobot-backend/tests/knowledge/test_facts_dedup.py
+++ b/autobot-backend/tests/knowledge/test_facts_dedup.py
@@ -1,0 +1,338 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for semantic duplicate guard on individual fact writes — Issue #3788.
+
+Verifies that store_fact() skips near-duplicate content above the configured
+threshold, allows content below threshold, and handles edge cases correctly.
+
+Heavy dependencies (llama_index, chromadb, aioredis, redis) are stubbed via
+sys.modules patching so the test suite can run without the full backend stack.
+"""
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out heavy dependencies before importing knowledge.facts
+# ---------------------------------------------------------------------------
+
+_llama_core = types.ModuleType("llama_index.core")
+_llama_core.Document = MagicMock
+_llama_core.Settings = MagicMock()
+_llama_index = types.ModuleType("llama_index")
+
+sys.modules.setdefault("llama_index", _llama_index)
+sys.modules.setdefault("llama_index.core", _llama_core)
+sys.modules.setdefault("llama_index.vector_stores", types.ModuleType("llama_index.vector_stores"))
+sys.modules.setdefault(
+    "llama_index.vector_stores.chroma", types.ModuleType("llama_index.vector_stores.chroma")
+)
+sys.modules.setdefault("chromadb", types.ModuleType("chromadb"))
+sys.modules.setdefault("redis", types.ModuleType("redis"))
+sys.modules.setdefault("aioredis", types.ModuleType("aioredis"))
+
+# knowledge.utils is imported lazily inside _vectorize_fact_in_chromadb
+_knowledge_utils = types.ModuleType("knowledge.utils")
+_knowledge_utils.sanitize_metadata_for_chromadb = lambda m: m
+sys.modules.setdefault("knowledge.utils", _knowledge_utils)
+
+# services.content_fingerprint is imported lazily inside _prepare_fact_metadata
+_svc_fp = types.ModuleType("services.content_fingerprint")
+_svc_fp.compute_fingerprint = lambda c: "fp-test"
+sys.modules.setdefault("services.content_fingerprint", _svc_fp)
+
+# services.npu_client is imported lazily inside _get_npu_client_cached
+_svc_npu = types.ModuleType("services.npu_client")
+_svc_npu.get_npu_client = MagicMock()
+sys.modules.setdefault("services.npu_client", _svc_npu)
+
+import knowledge.facts as facts_module  # noqa: E402 — must follow sys.modules patches
+from knowledge.facts import FactsMixin  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Minimal concrete class that satisfies FactsMixin without a real KB stack
+# ---------------------------------------------------------------------------
+
+_THRESHOLD = 0.92
+
+
+class _FakeKB(FactsMixin):
+    """Minimal KB stub exposing only what FactsMixin needs for these tests."""
+
+    initialized = True
+    embedding_model_name = "test-embed"
+
+    def __init__(self, vector_store=None):
+        self.vector_store = vector_store
+        self.redis_client = MagicMock()
+        self.aioredis_client = AsyncMock()
+
+    def ensure_initialized(self):
+        pass
+
+    async def _increment_stat(self, *_):
+        pass
+
+    def _schedule_bm25_refresh(self):
+        pass
+
+    async def _track_session_fact_relationship(self, *_):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _chroma_result(distance: float, fact_id: str = "existing-001") -> dict:
+    """Build a minimal ChromaDB query result dict with one hit."""
+    return {
+        "ids": [[fact_id]],
+        "distances": [[distance]],
+        "metadatas": [[{"fact_id": fact_id}]],
+    }
+
+
+def _empty_chroma_result() -> dict:
+    return {"ids": [[]], "distances": [[]], "metadatas": [[]]}
+
+
+# ---------------------------------------------------------------------------
+# Tests: _find_duplicate()
+# ---------------------------------------------------------------------------
+
+
+class TestFindDuplicate:
+    """Unit tests for FactsMixin._find_duplicate (#3788)."""
+
+    @pytest.mark.asyncio
+    async def test_above_threshold_returns_metadata(self):
+        """Distance giving similarity >= threshold returns existing metadata."""
+        # similarity = 1 - 0.10/2 = 0.95 >= 0.92
+        chroma_collection = MagicMock()
+        chroma_collection.query = MagicMock(
+            return_value=_chroma_result(distance=0.10, fact_id="dup-42")
+        )
+        vector_store = MagicMock()
+        vector_store._collection = chroma_collection
+        kb = _FakeKB(vector_store=vector_store)
+
+        with patch.object(
+            facts_module,
+            "_generate_embedding_with_npu_fallback",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ), patch("knowledge.facts.asyncio.to_thread", side_effect=lambda f, *a, **k: f(*a, **k)):
+            result = await kb._find_duplicate("duplicate content", threshold=_THRESHOLD)
+
+        assert result is not None
+        assert result.get("fact_id") == "dup-42"
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_returns_none(self):
+        """Distance giving similarity < threshold returns None."""
+        # similarity = 1 - 0.30/2 = 0.85 < 0.92
+        chroma_collection = MagicMock()
+        chroma_collection.query = MagicMock(
+            return_value=_chroma_result(distance=0.30, fact_id="not-dup")
+        )
+        vector_store = MagicMock()
+        vector_store._collection = chroma_collection
+        kb = _FakeKB(vector_store=vector_store)
+
+        with patch.object(
+            facts_module,
+            "_generate_embedding_with_npu_fallback",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ), patch("knowledge.facts.asyncio.to_thread", side_effect=lambda f, *a, **k: f(*a, **k)):
+            result = await kb._find_duplicate("distinct content", threshold=_THRESHOLD)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_vector_store_returns_none(self):
+        """If vector_store is None the guard is skipped and returns None."""
+        kb = _FakeKB(vector_store=None)
+        result = await kb._find_duplicate("some content", threshold=_THRESHOLD)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_chroma_error_returns_none(self):
+        """ChromaDB query failure is swallowed and returns None (graceful degradation)."""
+        chroma_collection = MagicMock()
+        chroma_collection.query = MagicMock(side_effect=RuntimeError("chroma down"))
+        vector_store = MagicMock()
+        vector_store._collection = chroma_collection
+        kb = _FakeKB(vector_store=vector_store)
+
+        with patch.object(
+            facts_module,
+            "_generate_embedding_with_npu_fallback",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ), patch("knowledge.facts.asyncio.to_thread", side_effect=lambda f, *a, **k: f(*a, **k)):
+            result = await kb._find_duplicate("any content", threshold=_THRESHOLD)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_results_returns_none(self):
+        """Empty ChromaDB result set produces no false positive."""
+        chroma_collection = MagicMock()
+        chroma_collection.query = MagicMock(return_value=_empty_chroma_result())
+        vector_store = MagicMock()
+        vector_store._collection = chroma_collection
+        kb = _FakeKB(vector_store=vector_store)
+
+        with patch.object(
+            facts_module,
+            "_generate_embedding_with_npu_fallback",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ), patch("knowledge.facts.asyncio.to_thread", side_effect=lambda f, *a, **k: f(*a, **k)):
+            result = await kb._find_duplicate("brand new content", threshold=_THRESHOLD)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: store_fact() integration
+# ---------------------------------------------------------------------------
+
+
+class TestStoreFact:
+    """Integration tests for store_fact() duplicate guard (#3788)."""
+
+    def _make_config_mock(self):
+        cfg = MagicMock()
+        cfg.cache.l2.kb_dedup_threshold = _THRESHOLD
+        return cfg
+
+    def _make_kb(self, chroma_distance: float, fact_id: str = "existing-001"):
+        chroma_collection = MagicMock()
+        chroma_collection.query = MagicMock(
+            return_value=_chroma_result(distance=chroma_distance, fact_id=fact_id)
+        )
+        vector_store = MagicMock()
+        vector_store._collection = chroma_collection
+        kb = _FakeKB(vector_store=vector_store)
+        kb.redis_client.get = MagicMock(return_value=None)
+        kb.redis_client.exists = MagicMock(return_value=False)
+        kb.redis_client.hset = MagicMock()
+        kb.redis_client.set = MagicMock()
+        kb.redis_client.sadd = MagicMock()
+        kb.aioredis_client.get = AsyncMock(return_value=None)
+        return kb
+
+    @pytest.mark.asyncio
+    async def test_near_duplicate_above_threshold_is_skipped(self):
+        """store_fact with near-duplicate content returns existing ID without writing."""
+        kb = self._make_kb(chroma_distance=0.10)  # sim=0.95 > 0.92
+
+        with patch.object(
+            facts_module,
+            "_generate_embedding_with_npu_fallback",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ), patch(
+            "knowledge.facts.asyncio.to_thread",
+            side_effect=lambda f, *a, **k: f(*a, **k),
+        ), patch(
+            "autobot_shared.ssot_config.config", self._make_config_mock()
+        ):
+            result = await kb.store_fact(
+                "This is a near-duplicate fact", metadata={"category": "test"}
+            )
+
+        assert result["status"] == "duplicate"
+        assert result["fact_id"] == "existing-001"
+
+    @pytest.mark.asyncio
+    async def test_distinct_content_below_threshold_writes_normally(self):
+        """store_fact with distinct content (similarity < threshold) proceeds to write."""
+        kb = self._make_kb(chroma_distance=0.30)  # sim=0.85 < 0.92
+
+        with patch.object(
+            facts_module,
+            "_generate_embedding_with_npu_fallback",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ), patch(
+            "knowledge.facts.asyncio.to_thread",
+            side_effect=lambda f, *a, **k: f(*a, **k),
+        ), patch(
+            "autobot_shared.ssot_config.config", self._make_config_mock()
+        ), patch.object(
+            FactsMixin, "_vectorize_fact_in_chromadb", new=AsyncMock()
+        ), patch.object(
+            FactsMixin, "_store_fact_in_redis", new=AsyncMock()
+        ):
+            result = await kb.store_fact(
+                "Completely different content", metadata={"category": "test"}
+            )
+
+        assert result["status"] == "success"
+        assert "fact_id" in result
+
+    @pytest.mark.asyncio
+    async def test_exact_duplicate_hash_blocked_before_semantic(self):
+        """Exact hash duplicate is caught before the semantic check fires."""
+        # Semantic check would NOT trigger (high distance)
+        kb = self._make_kb(chroma_distance=1.0)
+
+        exact_content = "Exact same content"
+
+        def fake_redis_get(key):
+            if b"content_hash:" in key if isinstance(key, bytes) else "content_hash:" in key:
+                return b"hash-matched-id"
+            return None
+
+        kb.redis_client.get = MagicMock(side_effect=fake_redis_get)
+
+        with patch.object(
+            facts_module,
+            "_generate_embedding_with_npu_fallback",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ), patch(
+            "knowledge.facts.asyncio.to_thread",
+            side_effect=lambda f, *a, **k: f(*a, **k),
+        ), patch(
+            "autobot_shared.ssot_config.config", self._make_config_mock()
+        ):
+            result = await kb.store_fact(exact_content, metadata={})
+
+        assert result["status"] == "duplicate"
+        assert result["fact_id"] == "hash-matched-id"
+
+    @pytest.mark.asyncio
+    async def test_empty_kb_no_false_positive(self):
+        """Empty ChromaDB (no prior facts) does not produce a false duplicate."""
+        chroma_collection = MagicMock()
+        chroma_collection.query = MagicMock(return_value=_empty_chroma_result())
+        vector_store = MagicMock()
+        vector_store._collection = chroma_collection
+        kb = _FakeKB(vector_store=vector_store)
+        kb.redis_client.get = MagicMock(return_value=None)
+        kb.redis_client.hset = MagicMock()
+        kb.redis_client.set = MagicMock()
+        kb.redis_client.sadd = MagicMock()
+        kb.aioredis_client.get = AsyncMock(return_value=None)
+
+        with patch.object(
+            facts_module,
+            "_generate_embedding_with_npu_fallback",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ), patch(
+            "knowledge.facts.asyncio.to_thread",
+            side_effect=lambda f, *a, **k: f(*a, **k),
+        ), patch(
+            "autobot_shared.ssot_config.config", self._make_config_mock()
+        ), patch.object(
+            FactsMixin, "_vectorize_fact_in_chromadb", new=AsyncMock()
+        ), patch.object(
+            FactsMixin, "_store_fact_in_redis", new=AsyncMock()
+        ):
+            result = await kb.store_fact("Brand new fact", metadata={})
+
+        assert result["status"] == "success"

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -693,6 +693,14 @@ class CacheL2Config(BaseSettings):
         alias="AUTOBOT_CACHE_SEMANTIC_THRESHOLD",
         description="Cosine similarity threshold for semantic cache hits (0.5-1.0)",
     )
+    kb_dedup_threshold: float = Field(
+        default=0.92,
+        alias="AUTOBOT_KB_DEDUP_THRESHOLD",
+        description=(
+            "Cosine similarity threshold for KB fact deduplication (0.5-1.0). "
+            "Facts whose nearest ChromaDB neighbour exceeds this score are skipped."
+        ),
+    )
 
 
 class CacheConfig(BaseSettings):


### PR DESCRIPTION
## Summary

- Adds `FactsMixin._find_duplicate()` that queries ChromaDB with a vector embedding before every `store_fact()` insert; facts with cosine similarity >= threshold are silently skipped
- Integrates the semantic check as a third tier in the existing `_check_for_duplicates()` flow (after unique-key and hash checks)
- Adds `kb_dedup_threshold: float = 0.92` to `CacheL2Config` in `ssot_config.py`, overridable via `AUTOBOT_KB_DEDUP_THRESHOLD`

## Test plan

- [x] `test_above_threshold_returns_metadata` — near-duplicate detected, existing metadata returned
- [x] `test_below_threshold_returns_none` — distinct content passes through
- [x] `test_no_vector_store_returns_none` — guard skipped gracefully when vector store is absent
- [x] `test_chroma_error_returns_none` — ChromaDB query failure swallowed, write proceeds
- [x] `test_empty_results_returns_none` — empty KB produces no false positive
- [x] `test_near_duplicate_above_threshold_is_skipped` — store_fact returns existing ID, no new write
- [x] `test_distinct_content_below_threshold_writes_normally` — write proceeds, status=success
- [x] `test_exact_duplicate_hash_blocked_before_semantic` — hash dedup still fires first
- [x] `test_empty_kb_no_false_positive` — first-ever write succeeds

All 9 tests pass. `flake8 --max-line-length=100` clean.

Closes #3788

🤖 Generated with [Claude Code](https://claude.com/claude-code)