### PR TITLE
chore(chat-workflow): remove orphaned system_prompt param from _build_full_prompt (#3794)

### DIFF
--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -318,7 +318,6 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
 
     def _build_full_prompt(
         self,
-        system_prompt: str,
         knowledge_context: str,
         conversation_context: str,
         message: str,
@@ -431,7 +430,7 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
             session.metadata["used_knowledge"] = False
 
         full_prompt = self._build_full_prompt(
-            system_prompt, knowledge_context, conversation_context, message
+            knowledge_context, conversation_context, message
         )
         full_prompt = await _emit_full_prompt_ready(
             full_prompt,


### PR DESCRIPTION
Closes #3794

Follow-up to #3765. The fix commit that removed `system_prompt` from the signature/call-site was pushed to the branch after the squash merge and was never included. This completes that cleanup.