### PR TITLE
chore(autoresearch): deduplicate _NOTIFY_KEY format string

### DIFF
--- a/autobot-backend/services/autoresearch/routes.py
+++ b/autobot-backend/services/autoresearch/routes.py
@@ -25,6 +25,7 @@ from .knowledge_synthesizer import KnowledgeSynthesizer
 from .models import Experiment, ExperimentState, HyperParams
 from .prompt_optimizer import PromptOptimizer, PromptOptTarget
 from .runner import ExperimentRunner
+from .scorers import _NOTIFY_KEY
 from .store import ExperimentStore
 
 logger = logging.getLogger(__name__)
@@ -369,7 +370,7 @@ async def submit_variant_score(
 
     redis = get_redis_client(async_client=True, database="main")
     key = f"autoresearch:prompt_review:{session_id}:{variant_id}"
-    notify_key = f"autoresearch:prompt_review:notify:{session_id}:{variant_id}"
+    notify_key = _NOTIFY_KEY.format(session_id=session_id, variant_id=variant_id)
     await redis.set(
         key,
         _json.dumps({"score": body.score, "comment": body.comment}),

--- a/autobot-backend/services/autoresearch/scorers.py
+++ b/autobot-backend/services/autoresearch/scorers.py
@@ -253,6 +253,10 @@ class LLMJudgeScorer(PromptScorer):
         return 0
 
 
+# Module-level constant so routes.py can import it directly.
+_NOTIFY_KEY = "autoresearch:prompt_review:notify:{session_id}:{variant_id}"
+
+
 class HumanReviewScorer(PromptScorer):
     """Queue a prompt variant for human review and wait for a score via BLPOP.
 
@@ -266,7 +270,7 @@ class HumanReviewScorer(PromptScorer):
 
     _REVIEW_KEY = "autoresearch:prompt_review:{session_id}:{variant_id}"
     _PENDING_KEY = "autoresearch:prompt_review:pending:{session_id}:{variant_id}"
-    _NOTIFY_KEY = "autoresearch:prompt_review:notify:{session_id}:{variant_id}"
+    _NOTIFY_KEY = _NOTIFY_KEY  # module-level constant; importable by routes.py
     _TTL_SECONDS = TTL_24_HOURS
 
     def __init__(


### PR DESCRIPTION
Closes #3795

Imports `_NOTIFY_KEY` from `scorers.py` into `routes.py` instead of duplicating the format string inline. Single source of truth prevents notify/wait key mismatch.