### PR TITLE
bug(backend): fix ChatHistoryManager create_task race with explicit initialize()

### DIFF
--- a/autobot-backend/chat_history/base.py
+++ b/autobot-backend/chat_history/base.py
@@ -145,6 +145,9 @@ class ChatHistoryBase:
             "ChatHistoryManager ready (Memory Graph will initialize on first async operation)"
         )
 
+    async def initialize(self) -> None:
+        """No-op: history is loaded synchronously in __init__ for the modern implementation."""
+
     def _init_encryption(self):
         """Initialize encryption service if enabled."""
         if self.encryption_enabled:

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -138,6 +138,7 @@ async def _init_chat_history_manager(app: FastAPI) -> None:
     logger.info("✅ [ 30%] Chat History: Initializing chat history manager...")
     try:
         chat_history_manager = ChatHistoryManager()
+        await chat_history_manager.initialize()
         app.state.chat_history_manager = chat_history_manager
         await update_app_state("chat_history_manager", chat_history_manager)
         logger.info("✅ [ 30%] Chat History: Manager initialized successfully")

--- a/autobot-backend/utils/resource_factory.py
+++ b/autobot-backend/utils/resource_factory.py
@@ -119,6 +119,7 @@ class ResourceFactory:
                 redis_host=redis_config.get("host", NetworkConstants.LOCALHOST_NAME),
                 redis_port=redis_config.get("port", NetworkConstants.REDIS_PORT),
             )
+            await chm.initialize()
 
             # Cache in app state if available
             if request is not None:


### PR DESCRIPTION
Closes #3797

Removes the fire-and-forget `loop.create_task(_load_history())` from `ChatHistoryManager.__init__` that could leave `self.history` empty on first access.

**Changes:**
- `chat_history_manager.py`: Drop `create_task` call; add `async def initialize()` for explicit async init
- `chat_history/base.py`: Add no-op `async def initialize()` for uniform call-site pattern
- `initialization/lifespan.py`: `await chat_history_manager.initialize()` after construction
- `utils/resource_factory.py`: `await chm.initialize()` in fallback factory path