### PR TITLE
chore(backend): add TimeoutConfig to SSOT and replace magic timeout numbers

### DIFF
--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import io
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
@@ -23,6 +23,7 @@ import numpy as np
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_llm_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_config import config
 from config import cfg
 
 # Import centralized components
@@ -162,7 +163,9 @@ class ProcessingTask:
     input_data: Dict[str, Any]
     complexity: TaskComplexity
     priority: int = 1
-    timeout_seconds: int = 30
+    timeout_seconds: int = field(
+        default_factory=lambda: int(config.timeout.default_request)
+    )
     preferred_device: Optional[HardwareDevice] = None
 
 

--- a/autobot-backend/intelligence/streaming_executor.py
+++ b/autobot-backend/intelligence/streaming_executor.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
+from autobot_shared.ssot_config import config
 from constants.network_constants import NetworkConstants
 from llm_interface import LLMInterface
 from utils.command_validator import CommandValidator
@@ -180,7 +181,7 @@ class StreamingCommandExecutor:
         self,
         command: str,
         user_goal: str,
-        timeout: int = 300,
+        timeout: int = int(config.timeout.sandbox),
         provide_commentary: bool = True,
     ) -> AsyncGenerator[StreamChunk, None]:
         """Issue #665: Refactored to use extracted helpers for reduced line count."""

--- a/autobot-backend/llm_interface_pkg/optimization/connection_pool.py
+++ b/autobot-backend/llm_interface_pkg/optimization/connection_pool.py
@@ -24,6 +24,8 @@ except ImportError:
     HTTPX_AVAILABLE = False
     httpx = None
 
+from autobot_shared.ssot_config import config as _ssot_config
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,9 +37,15 @@ class PoolConfig:
     max_keepalive_connections: int = 20
     keepalive_expiry: float = 5.0  # seconds
     connect_timeout: float = 10.0
-    read_timeout: float = 60.0
-    write_timeout: float = 30.0
-    pool_timeout: float = 30.0
+    read_timeout: float = field(
+        default_factory=lambda: _ssot_config.timeout.connection_pool_read
+    )
+    write_timeout: float = field(
+        default_factory=lambda: _ssot_config.timeout.connection_pool_write
+    )
+    pool_timeout: float = field(
+        default_factory=lambda: _ssot_config.timeout.connection_pool
+    )
     http2: bool = True
     retries: int = 0  # httpx handles retries internally
 

--- a/autobot-backend/llm_multi_provider.py
+++ b/autobot-backend/llm_multi_provider.py
@@ -40,8 +40,6 @@ from dotenv import load_dotenv
 
 from autobot_shared.logging_manager import get_llm_logger
 from autobot_shared.ssot_config import DEFAULT_LLM_MODEL, config as _ssot_config
-
-_DEFAULT_LLM_REQUEST_TIMEOUT: int = int(_ssot_config.timeout.llm_request)
 from constants.model_constants import (
     OPENAI_GPT35_TURBO,
     OPENAI_GPT35_TURBO_16K,
@@ -51,6 +49,8 @@ from constants.model_constants import (
 from constants.threshold_constants import TimingConstants
 
 load_dotenv()
+
+_DEFAULT_LLM_REQUEST_TIMEOUT: int = int(_ssot_config.timeout.llm_request)
 
 # SSOT config for Ollama defaults - Issue #694
 try:

--- a/autobot-backend/llm_multi_provider.py
+++ b/autobot-backend/llm_multi_provider.py
@@ -39,7 +39,9 @@ config_manager = _get_cfg()
 from dotenv import load_dotenv
 
 from autobot_shared.logging_manager import get_llm_logger
-from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL, config as _ssot_config
+
+_DEFAULT_LLM_REQUEST_TIMEOUT: int = int(_ssot_config.timeout.llm_request)
 from constants.model_constants import (
     OPENAI_GPT35_TURBO,
     OPENAI_GPT35_TURBO_16K,
@@ -104,7 +106,7 @@ class LLMRequest:
     stop: Optional[List[str]] = None
     stream: bool = False
     structured_output: bool = False
-    timeout: int = 60
+    timeout: int = field(default_factory=lambda: _DEFAULT_LLM_REQUEST_TIMEOUT)
     retry_count: int = 3
     fallback_enabled: bool = True
     metadata: Dict[str, Any] = field(default_factory=dict)
@@ -138,7 +140,7 @@ class ProviderConfig:
     default_model: str = ""
     available_models: List[str] = field(default_factory=list)
     max_concurrent_requests: int = 10
-    timeout: int = 60
+    timeout: int = field(default_factory=lambda: _DEFAULT_LLM_REQUEST_TIMEOUT)
     retry_count: int = 3
     circuit_breaker_enabled: bool = True
     priority: int = 100  # Lower numbers = higher priority

--- a/autobot-backend/rlm/benchmark.py
+++ b/autobot-backend/rlm/benchmark.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
-from autobot_shared.ssot_config import ROUTING_MODEL
+from autobot_shared.ssot_config import ROUTING_MODEL, config
 from rlm.evaluator import ResponseQualityEvaluator
 from rlm.types import RLMConfig
 
@@ -138,7 +138,7 @@ async def _generate(
     model: str = ROUTING_MODEL,
     temperature: float = 0.5,
     max_tokens: int = 1024,
-    timeout_s: float = 30.0,
+    timeout_s: float = config.timeout.default_request,
 ) -> str:
     """Call Ollama generate and return the raw text."""
     from autobot_shared.ssot_config import get_config

--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -23,6 +23,7 @@ import docker
 from docker.errors import DockerException, ImageNotFound
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_config import config
 from constants.ttl_constants import TTL_1_HOUR
 
 logger = logging.getLogger(__name__)
@@ -784,7 +785,7 @@ secure_sandbox = None  # Will be initialized on first access via get_secure_sand
 async def execute_in_sandbox(
     command: Union[str, List[str]],
     security_level: str = "high",
-    timeout: int = 300,
+    timeout: int = int(config.timeout.sandbox),
     **kwargs,
 ) -> SandboxResult:
     """

--- a/autobot-backend/utils/claude_api_integration.py
+++ b/autobot-backend/utils/claude_api_integration.py
@@ -12,6 +12,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.ssot_config import config
 from constants.threshold_constants import RetryConfig, TimingConstants
 
 from .conversation_rate_limiter import ConversationRateLimiter
@@ -212,7 +213,7 @@ class ClaudeAPIBatchManager:
         content: str,
         priority: RequestPriority = RequestPriority.NORMAL,
         context_type: str = "general",
-        timeout: float = 30.0,
+        timeout: float = config.timeout.default_request,
         metadata: Dict[str, Any] = None,
     ) -> str:
         """Submit a request for processing with batching optimization (thread-safe).

--- a/autobot-backend/utils/request_batcher.py
+++ b/autobot-backend/utils/request_batcher.py
@@ -15,9 +15,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
+from autobot_shared.ssot_config import config
 from constants.threshold_constants import TimingConstants
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_REQUEST_TIMEOUT: float = config.timeout.default_request
 
 
 class BatchingStrategy(Enum):
@@ -49,7 +52,7 @@ class BatchableRequest:
     priority: RequestPriority = RequestPriority.NORMAL
     context_type: str = "general"
     timestamp: float = field(default_factory=time.time)
-    timeout: float = 30.0
+    timeout: float = field(default_factory=lambda: _DEFAULT_REQUEST_TIMEOUT)
     callback: Optional[Callable] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
@@ -746,7 +749,7 @@ async def batch_request(
     content: str,
     priority: RequestPriority = RequestPriority.NORMAL,
     context_type: str = "general",
-    timeout: float = 30.0,
+    timeout: float = config.timeout.default_request,
 ) -> Optional[str]:
     """Submit a request for batching and wait for result"""
     request = BatchableRequest(

--- a/autobot-backend/utils/service_client.py
+++ b/autobot-backend/utils/service_client.py
@@ -21,6 +21,7 @@ import aiohttp
 import structlog
 
 from autobot_shared.http_client import get_http_client
+from autobot_shared.ssot_config import config
 from security.service_auth import ServiceAuthManager
 
 logger = structlog.get_logger()
@@ -34,7 +35,12 @@ class ServiceHTTPClient:
     required authentication headers.
     """
 
-    def __init__(self, service_id: str, service_key: str, timeout: float = 30.0):
+    def __init__(
+        self,
+        service_id: str,
+        service_key: str,
+        timeout: float = config.timeout.default_request,
+    ):
         """
         Initialize authenticated HTTP client.
 

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -441,6 +441,16 @@ class TimeoutConfig(BaseSettings):
 
     Note: Frontend uses milliseconds, backend uses seconds for LLM.
     The config stores values as they appear in .env for consistency.
+
+    Backend timeout constants — all override-able via environment variables:
+      AUTOBOT_REQUEST_TIMEOUT    — general HTTP service-to-service timeout (s)
+      AUTOBOT_LLM_REQUEST_TIMEOUT — LLM inference request timeout (s)
+      AUTOBOT_SANDBOX_TIMEOUT    — sandbox/subprocess execution timeout (s)
+      AUTOBOT_POOL_READ_TIMEOUT  — connection pool read timeout (s)
+      AUTOBOT_POOL_WRITE_TIMEOUT — connection pool write timeout (s)
+      AUTOBOT_POOL_TIMEOUT       — connection pool acquisition timeout (s)
+
+    Issue: #3803
     """
 
     model_config = SettingsConfigDict(
@@ -462,6 +472,24 @@ class TimeoutConfig(BaseSettings):
 
     # WebSocket timeout (seconds)
     websocket: int = Field(default=30, alias="AUTOBOT_WEBSOCKET_TIMEOUT")
+
+    # General service-to-service HTTP request timeout (seconds) — #3803
+    default_request: float = Field(default=30.0, alias="AUTOBOT_REQUEST_TIMEOUT")
+
+    # LLM inference request timeout (seconds) — #3803
+    llm_request: float = Field(default=60.0, alias="AUTOBOT_LLM_REQUEST_TIMEOUT")
+
+    # Sandbox / subprocess execution timeout (seconds) — #3803
+    sandbox: float = Field(default=300.0, alias="AUTOBOT_SANDBOX_TIMEOUT")
+
+    # HTTP connection pool timeouts (seconds) — #3803
+    connection_pool_read: float = Field(
+        default=60.0, alias="AUTOBOT_POOL_READ_TIMEOUT"
+    )
+    connection_pool_write: float = Field(
+        default=30.0, alias="AUTOBOT_POOL_WRITE_TIMEOUT"
+    )
+    connection_pool: float = Field(default=30.0, alias="AUTOBOT_POOL_TIMEOUT")
 
     @property
     def api_seconds(self) -> float:


### PR DESCRIPTION
Closes #3803

Adds 6 named timeout constants to `TimeoutConfig` in `autobot_shared/ssot_config.py`, all configurable via environment variables:
- `default_request` (30s) — `AUTOBOT_REQUEST_TIMEOUT`
- `llm_request` (60s) — `AUTOBOT_LLM_REQUEST_TIMEOUT`
- `sandbox` (300s) — `AUTOBOT_SANDBOX_TIMEOUT`
- `connection_pool_read` (60s) — `AUTOBOT_POOL_READ_TIMEOUT`
- `connection_pool_write` (30s) — `AUTOBOT_POOL_WRITE_TIMEOUT`
- `connection_pool` (30s) — `AUTOBOT_POOL_TIMEOUT`

Replaces 15 magic timeout literals across 10 backend files with `config.timeout.*` constants.