### PR TITLE
chore(autoresearch): deduplicate _NOTIFY_KEY format string

### DIFF
--- a/autobot-backend/services/autoresearch/routes.py
+++ b/autobot-backend/services/autoresearch/routes.py
@@ -25,6 +25,7 @@ from .knowledge_synthesizer import KnowledgeSynthesizer
 from .models import Experiment, ExperimentState, HyperParams
 from .prompt_optimizer import PromptOptimizer, PromptOptTarget
 from .runner import ExperimentRunner
+from .scorers import HUMAN_REVIEW_NOTIFY_KEY
 from .store import ExperimentStore
 
 logger = logging.getLogger(__name__)
@@ -369,7 +370,7 @@ async def submit_variant_score(
 
     redis = get_redis_client(async_client=True, database="main")
     key = f"autoresearch:prompt_review:{session_id}:{variant_id}"
-    notify_key = f"autoresearch:prompt_review:notify:{session_id}:{variant_id}"
+    notify_key = HUMAN_REVIEW_NOTIFY_KEY.format(session_id=session_id, variant_id=variant_id)
     await redis.set(
         key,
         _json.dumps({"score": body.score, "comment": body.comment}),

--- a/autobot-backend/services/autoresearch/scorers.py
+++ b/autobot-backend/services/autoresearch/scorers.py
@@ -26,6 +26,11 @@ logger = logging.getLogger(__name__)
 # Validation pattern for Redis key components — alphanumeric, hyphens, underscores
 _KEY_COMPONENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
+# Shared Redis key format strings for human-review scoring.
+# routes.py imports HUMAN_REVIEW_NOTIFY_KEY so both sides of the BLPOP
+# protocol always reference the same key pattern.
+HUMAN_REVIEW_NOTIFY_KEY = "autoresearch:prompt_review:notify:{session_id}:{variant_id}"
+
 
 @dataclass
 class ScorerResult:
@@ -266,7 +271,7 @@ class HumanReviewScorer(PromptScorer):
 
     _REVIEW_KEY = "autoresearch:prompt_review:{session_id}:{variant_id}"
     _PENDING_KEY = "autoresearch:prompt_review:pending:{session_id}:{variant_id}"
-    _NOTIFY_KEY = "autoresearch:prompt_review:notify:{session_id}:{variant_id}"
+    _NOTIFY_KEY = HUMAN_REVIEW_NOTIFY_KEY
     _TTL_SECONDS = TTL_24_HOURS
 
     def __init__(


### PR DESCRIPTION
Extracts the BLPOP key pattern into a single `HUMAN_REVIEW_NOTIFY_KEY` constant in `scorers.py`, imported by `routes.py`. Eliminates the silent key mismatch risk where the writer and reader could drift apart.

Closes #3795