### PR TITLE
chore(ansible): move _SECRET_TO_ANSIBLE_VAR to shared location

### DIFF
--- a/autobot-slm-backend/api/infrastructure.py
+++ b/autobot-slm-backend/api/infrastructure.py
@@ -627,8 +627,8 @@ async def _run_playbook(
         inventory_path = str(inventory_path_obj)
 
         # Inject stored SLM secrets so standalone re-deploys receive the same
-        # secrets as the full wizard provisioning flow (#3519).
-        from services.playbook_executor import fetch_deploy_secrets
+        # secrets as the full wizard provisioning flow (#3519, #3778).
+        from services.ansible_secrets import fetch_deploy_secrets
 
         deploy_secrets = await fetch_deploy_secrets()
         # Caller-supplied variables take precedence over stored secrets.

--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -25,10 +25,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from api.websocket import ws_manager
-from services.ansible_secrets import _SECRET_TO_ANSIBLE_VAR
+from services.ansible_secrets import fetch_deploy_secrets
 from services.auth import get_current_user
 from services.database import db_service
-from services.encryption import decrypt_data
 from services.playbook_executor import get_playbook_executor
 
 logger = logging.getLogger(__name__)
@@ -187,31 +186,6 @@ def _build_infra_vars(
             infra_vars[host_var.replace("_host", "_port")] = port
     return infra_vars
 
-
-async def _fetch_provision_secrets() -> dict[str, str]:
-    """Read stored secrets and map them to Ansible extra_vars (#3079)."""
-    from sqlalchemy import select
-
-    from models.database import SystemSecret
-
-    extra: dict[str, str] = {}
-    try:
-        async with db_service.session() as session:
-            result = await session.execute(
-                select(SystemSecret).where(
-                    SystemSecret.key.in_(list(_SECRET_TO_ANSIBLE_VAR.keys()))
-                )
-            )
-            for secret in result.scalars().all():
-                ansible_var = _SECRET_TO_ANSIBLE_VAR.get(secret.key)
-                if not ansible_var:
-                    continue
-                value = decrypt_data(secret.encrypted_value)
-                if value:
-                    extra[ansible_var] = value
-    except Exception:
-        logger.exception("Failed to load provision secrets")
-    return extra
 
 
 def _build_host_entries(
@@ -944,8 +918,8 @@ async def _run_provisioning_task(
                 )
                 await ws_manager.send_provision_status("running", stage, elapsed)
 
-        # Issue #3079: Pass stored secrets as Ansible extra_vars
-        extra_vars = await _fetch_provision_secrets()
+        # Issue #3079: Pass stored secrets as Ansible extra_vars (#3778)
+        extra_vars = await fetch_deploy_secrets()
 
         result = await executor.execute_playbook(
             playbook_name="playbooks/provision-fleet-roles.yml",

--- a/autobot-slm-backend/services/ansible_secrets.py
+++ b/autobot-slm-backend/services/ansible_secrets.py
@@ -6,8 +6,13 @@ Ansible secrets mapping shared between setup_wizard and playbook_executor.
 
 Single source of truth for the SLM secret key -> Ansible variable name
 mapping (#3519).  Any caller that needs to inject stored secrets as Ansible
-extra_vars should import _SECRET_TO_ANSIBLE_VAR from here.
+extra_vars should import _SECRET_TO_ANSIBLE_VAR and fetch_deploy_secrets
+from here.
 """
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Maps SLM secrets-store keys to the Ansible extra_var names they become
 # when injected into a playbook run.
@@ -21,3 +26,44 @@ _SECRET_TO_ANSIBLE_VAR: dict[str, str] = {
     "hf_token": "tts_hf_token",
     "autobot_internal_api_key": "autobot_internal_api_key",
 }
+
+
+async def fetch_deploy_secrets() -> dict[str, str]:
+    """Read stored SLM secrets and return them as Ansible extra_vars (#3519, #3778).
+
+    Single source of truth used by setup_wizard, playbook_executor, and
+    infrastructure — any deploy path that needs to inject stored secrets as
+    Ansible extra_vars should call this function.
+
+    Returns an empty dict and logs a warning if the DB is unavailable — the
+    deploy is allowed to proceed rather than being blocked by a secret-fetch
+    failure.
+    """
+    from sqlalchemy import select
+
+    from models.database import SystemSecret
+    from services.database import db_service
+    from services.encryption import decrypt_data
+
+    extra: dict[str, str] = {}
+    try:
+        async with db_service.session() as session:
+            result = await session.execute(
+                select(SystemSecret).where(
+                    SystemSecret.key.in_(list(_SECRET_TO_ANSIBLE_VAR.keys()))
+                )
+            )
+            for secret in result.scalars().all():
+                ansible_var = _SECRET_TO_ANSIBLE_VAR.get(secret.key)
+                if not ansible_var:
+                    continue
+                value = decrypt_data(secret.encrypted_value)
+                if value:
+                    extra[ansible_var] = value
+    except Exception:
+        logger.warning(
+            "fetch_deploy_secrets: could not load SLM secrets — "
+            "deploy will proceed without them (#3519)",
+            exc_info=True,
+        )
+    return extra

--- a/autobot-slm-backend/services/playbook_executor.py
+++ b/autobot-slm-backend/services/playbook_executor.py
@@ -15,51 +15,10 @@ import shutil
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from services.ansible_secrets import _SECRET_TO_ANSIBLE_VAR
+from services.ansible_secrets import fetch_deploy_secrets
 from services.provision_progress import TaskProgressTracker
 
 logger = logging.getLogger(__name__)
-
-
-async def fetch_deploy_secrets() -> dict[str, str]:
-    """Read stored SLM secrets and return them as Ansible extra_vars (#3519).
-
-    Mirrors the logic in setup_wizard._fetch_provision_secrets() so that
-    standalone role re-deploys (Infrastructure, Nodes, Settings pages) receive
-    the same secrets that the full wizard provisioning flow injects.
-
-    Returns an empty dict and logs a warning if the DB is unavailable — the
-    deploy is allowed to proceed rather than being blocked by a secret-fetch
-    failure.
-    """
-    from sqlalchemy import select
-
-    from models.database import SystemSecret
-    from services.database import db_service
-    from services.encryption import decrypt_data
-
-    extra: dict[str, str] = {}
-    try:
-        async with db_service.session() as session:
-            result = await session.execute(
-                select(SystemSecret).where(
-                    SystemSecret.key.in_(list(_SECRET_TO_ANSIBLE_VAR.keys()))
-                )
-            )
-            for secret in result.scalars().all():
-                ansible_var = _SECRET_TO_ANSIBLE_VAR.get(secret.key)
-                if not ansible_var:
-                    continue
-                value = decrypt_data(secret.encrypted_value)
-                if value:
-                    extra[ansible_var] = value
-    except Exception:
-        logger.warning(
-            "fetch_deploy_secrets: could not load SLM secrets — "
-            "deploy will proceed without them (#3519)",
-            exc_info=True,
-        )
-    return extra
 
 
 class PlaybookExecutor:


### PR DESCRIPTION
Consolidates `fetch_deploy_secrets()` into `ansible_secrets.py` as the single source of truth. Removes duplicate implementations from `playbook_executor.py` (39 lines) and `setup_wizard.py` (24 lines). All three deploy paths now import from the same location.

Closes #3778