### PR TITLE
feat(memory): wire WorkingMemory/EssentialStory/AgentDiary into UnifiedMemoryManager

### DIFF
--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -12,8 +12,6 @@ import logging
 import threading
 from typing import Any, Dict, List, Optional
 
-from memory.agent_diary import AgentDiaryService
-
 from autobot_shared.ssot_config import (
     get_agent_endpoint_explicit,
     get_agent_model_explicit,
@@ -24,13 +22,6 @@ from llm_interface import LLMInterface
 
 from .base_agent import AgentRequest
 from .standardized_agent import ActionHandler, StandardizedAgent
-
-try:
-    from memory.working_memory import WorkingMemoryService as _WMS
-    _working_memory_available = True
-except ImportError:
-    _WMS = None
-    _working_memory_available = False
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +44,6 @@ class SentimentAnalysisAgent(StandardizedAgent):
             "opinion_mining",
             "tone_detection",
         ]
-        self._wm = _WMS() if _working_memory_available else None
         self._register_action_handlers()
         logger.info(
             "Sentiment Analysis Agent initialized: provider=%s, model=%s",
@@ -138,7 +128,7 @@ class SentimentAnalysisAgent(StandardizedAgent):
                 f"SESSION:{session_id}|ACTION:sentiment_analysis"
                 f"|OUTCOME:{result['status']}|TOPIC:sentiment"
             )
-            await AgentDiaryService().write(
+            await self.memory_manager.agent_diary.write(
                 self.AGENT_ID, session_id, diary_entry, topic="sentiment"
             )
             return result
@@ -153,30 +143,28 @@ class SentimentAnalysisAgent(StandardizedAgent):
             }
 
     async def _before_process(self, context: dict) -> dict:
-        """Inject cached session sentiment history into context (example override).
-
-        When WorkingMemoryService becomes available (issue #3768) this can load
-        prior session data.  Until then it is a documented no-op that shows the
-        expected override pattern.
-        """
-        if _working_memory_available and self._wm is not None:
-            session_id = context.get("session_id")
-            if session_id:
-                history = await self._wm.get(session_id, "sentiment_history")
-                if history:
-                    context["sentiment_history"] = history
+        """Inject cached session sentiment history into context."""
+        session_id = context.get("session_id")
+        if session_id:
+            history = await self.memory_manager.working_memory.get(
+                session_id, "sentiment_history"
+            )
+            if history:
+                context["sentiment_history"] = history
         return context
 
     async def _after_process(self, context: dict, result: Any) -> None:
-        """Persist the most recent sentiment label to working memory (example override)."""
-        if not (_working_memory_available and result):
+        """Persist the most recent sentiment label to working memory."""
+        if not result:
             return
         session_id = context.get("session_id")
         if not session_id:
             return
         sentiment = result.get("response", "") if isinstance(result, dict) else ""
-        if sentiment and self._wm is not None:
-            await self._wm.store(session_id, "sentiment_history", sentiment)
+        if sentiment:
+            await self.memory_manager.working_memory.store(
+                session_id, "sentiment_history", sentiment
+            )
 
     def _get_system_prompt(self) -> str:
         """Get system prompt for sentiment analysis tasks."""

--- a/autobot-backend/agents/standardized_agent.py
+++ b/autobot-backend/agents/standardized_agent.py
@@ -54,11 +54,9 @@ class StandardizedAgent(BaseAgent):
         super().__init__(agent_type, deployment_mode)
         self.logger = logging.getLogger(f"{__name__}.{agent_type}")
 
-        # Unified memory facade — subsystems accessed via properties:
-        #   self.memory_manager.working_memory  (WorkingMemoryService)
-        #   self.memory_manager.essential_story (EssentialStoryGenerator)
-        #   self.memory_manager.agent_diary     (AgentDiaryService)
-        self.memory_manager: UnifiedMemoryManager = UnifiedMemoryManager()
+        # Lazy memory facade — created on first access so agents that never
+        # use memory don't pay the UnifiedMemoryManager construction cost.
+        self._memory_manager: Optional[UnifiedMemoryManager] = None
 
         # Action handlers mapping - to be configured by subclasses
         self._action_handlers: Dict[str, ActionHandler] = {}
@@ -75,6 +73,15 @@ class StandardizedAgent(BaseAgent):
         # Lock for thread-safe counter access
         # Named differently from BaseAgent._stats_lock (threading.Lock)
         self._async_stats_lock = asyncio.Lock()
+
+    @property
+    def memory_manager(self) -> UnifiedMemoryManager:
+        """Unified memory facade (lazy-init). Subsystems via properties:
+        working_memory, essential_story, agent_diary.
+        """
+        if self._memory_manager is None:
+            self._memory_manager = UnifiedMemoryManager()
+        return self._memory_manager
 
     def register_action_handler(self, action: str, handler: ActionHandler):
         """Register an action handler for this agent"""

--- a/autobot-backend/agents/standardized_agent.py
+++ b/autobot-backend/agents/standardized_agent.py
@@ -54,7 +54,10 @@ class StandardizedAgent(BaseAgent):
         super().__init__(agent_type, deployment_mode)
         self.logger = logging.getLogger(f"{__name__}.{agent_type}")
 
-        # Unified memory facade — subsystems accessed via properties
+        # Unified memory facade — subsystems accessed via properties:
+        #   self.memory_manager.working_memory  (WorkingMemoryService)
+        #   self.memory_manager.essential_story (EssentialStoryGenerator)
+        #   self.memory_manager.agent_diary     (AgentDiaryService)
         self.memory_manager: UnifiedMemoryManager = UnifiedMemoryManager()
 
         # Action handlers mapping - to be configured by subclasses

--- a/autobot-backend/agents/standardized_agent.py
+++ b/autobot-backend/agents/standardized_agent.py
@@ -19,20 +19,10 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
+from memory.manager import UnifiedMemoryManager
 from prompt_manager import get_language_instruction, resolve_language
 
 from .base_agent import AgentRequest, AgentResponse, BaseAgent, DeploymentMode
-
-try:
-    from memory.working_memory import WorkingMemoryService
-    _working_memory_available = True
-except ImportError:
-    logging.getLogger(__name__).warning(
-        "WorkingMemoryService not available (issue #3768 not merged); "
-        "memory lifecycle hooks will use no-op stubs"
-    )
-    WorkingMemoryService = None  # type: ignore[assignment,misc]
-    _working_memory_available = False
 
 
 @dataclass
@@ -63,6 +53,9 @@ class StandardizedAgent(BaseAgent):
         """Initialize standardized agent with action handlers and metrics."""
         super().__init__(agent_type, deployment_mode)
         self.logger = logging.getLogger(f"{__name__}.{agent_type}")
+
+        # Unified memory facade — subsystems accessed via properties
+        self.memory_manager: UnifiedMemoryManager = UnifiedMemoryManager()
 
         # Action handlers mapping - to be configured by subclasses
         self._action_handlers: Dict[str, ActionHandler] = {}
@@ -179,7 +172,7 @@ class StandardizedAgent(BaseAgent):
         """Load working memory into context before request handling.
 
         Override in subclasses to enrich the context with session state
-        or prior conversation history from WorkingMemoryService.
+        or prior conversation history from ``self.memory_manager.working_memory``.
 
         Args:
             context: Mutable context dict forwarded from the request.
@@ -193,7 +186,7 @@ class StandardizedAgent(BaseAgent):
         """Persist key outputs to working memory after request handling.
 
         Override in subclasses to write agent outputs back to
-        WorkingMemoryService so downstream agents can share state.
+        ``self.memory_manager.working_memory`` so downstream agents can share state.
 
         Args:
             context: Context dict as returned by _before_process.

--- a/autobot-backend/memory/__init__.py
+++ b/autobot-backend/memory/__init__.py
@@ -39,7 +39,9 @@ from .enums import MemoryCategory, StorageStrategy, TaskPriority, TaskStatus
 
 # Main Manager
 from .agent_diary import AgentDiaryService
+from .essential_story import EssentialStoryGenerator
 from .manager import UnifiedMemoryManager
+from .working_memory import WorkingMemoryService
 
 # Data Models
 from .models import MemoryEntry, TaskExecutionRecord
@@ -52,8 +54,10 @@ from .protocols import ICacheManager, IGeneralStorage, ITaskStorage
 from .storage import GeneralStorage, TaskStorage
 
 __all__ = [
-    # Agent Diary
+    # Memory subsystems
     "AgentDiaryService",
+    "EssentialStoryGenerator",
+    "WorkingMemoryService",
     # Enums
     "TaskStatus",
     "TaskPriority",

--- a/autobot-backend/memory/__init__.py
+++ b/autobot-backend/memory/__init__.py
@@ -16,15 +16,44 @@ Package Structure:
   - general_storage.py: Category-based memory
 - cache.py: LRU caching implementation
 - monitor.py: System memory monitoring
-- manager.py: Main UnifiedMemoryManager class
+- working_memory.py: Redis-backed session-scoped short-term memory
+- essential_story.py: Always-loaded compact memory summary for LLM prompts
+- agent_diary.py: Per-agent cross-session journal backed by knowledge base
+- manager.py: Main UnifiedMemoryManager class (composes all subsystems)
 - compat.py: Backward compatibility wrappers
+
+All three memory subsystems (WorkingMemoryService, EssentialStoryGenerator,
+AgentDiaryService) are exposed as properties on UnifiedMemoryManager so agents
+access them via ``self.memory_manager.working_memory``, etc., without direct
+subsystem imports.
 
 For backward compatibility, all exports from the original unified_memory_manager.py
 are re-exported here.
 """
 
+# Enums
+from .enums import MemoryCategory, StorageStrategy, TaskPriority, TaskStatus
+
+# Data Models
+from .models import MemoryEntry, TaskExecutionRecord
+
+# Protocols
+from .protocols import ICacheManager, IGeneralStorage, ITaskStorage
+
+# Storage Components
+from .storage import GeneralStorage, TaskStorage
+
 # Cache and Monitor
 from .cache import LRUCacheManager
+from .monitor import MemoryMonitor
+
+# Memory Subsystems (exposed via UnifiedMemoryManager properties)
+from .agent_diary import AgentDiaryService
+from .essential_story import EssentialStoryGenerator
+from .working_memory import WorkingMemoryService
+
+# Main Manager (composes all subsystems above)
+from .manager import UnifiedMemoryManager
 
 # Backward Compatibility Wrappers
 from .compat import (
@@ -33,25 +62,6 @@ from .compat import (
     get_enhanced_memory_manager,
     get_long_term_memory_manager,
 )
-
-# Enums
-from .enums import MemoryCategory, StorageStrategy, TaskPriority, TaskStatus
-
-# Main Manager
-from .agent_diary import AgentDiaryService
-from .essential_story import EssentialStoryGenerator
-from .manager import UnifiedMemoryManager
-from .working_memory import WorkingMemoryService
-
-# Data Models
-from .models import MemoryEntry, TaskExecutionRecord
-from .monitor import MemoryMonitor
-
-# Protocols
-from .protocols import ICacheManager, IGeneralStorage, ITaskStorage
-
-# Storage Components
-from .storage import GeneralStorage, TaskStorage
 
 __all__ = [
     # Memory subsystems

--- a/autobot-backend/memory/manager.py
+++ b/autobot-backend/memory/manager.py
@@ -13,8 +13,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from .agent_diary import AgentDiaryService
 from .cache import LRUCacheManager
 from .enums import MemoryCategory, StorageStrategy, TaskPriority, TaskStatus
+from .essential_story import EssentialStoryGenerator
 from .models import MemoryEntry, TaskExecutionRecord
 from .monitor import MemoryMonitor
 from .protocols import ICacheManager, IGeneralStorage, ITaskStorage
@@ -123,6 +125,10 @@ class UnifiedMemoryManager:
 
         # Session-scoped short-term memory (Redis-backed, eagerly created)
         self._working_memory: WorkingMemoryService = WorkingMemoryService()
+
+        # Lazily-instantiated subsystems
+        self._essential_story: Optional[EssentialStoryGenerator] = None
+        self._agent_diary: Optional[AgentDiaryService] = None
 
         logger.info("Unified Memory Manager created at %s", self.db_path)
 
@@ -558,6 +564,20 @@ class UnifiedMemoryManager:
     def working_memory(self) -> WorkingMemoryService:
         """Return the WorkingMemoryService instance."""
         return self._working_memory
+
+    @property
+    def essential_story(self) -> EssentialStoryGenerator:
+        """Return the EssentialStoryGenerator instance (lazy-init)."""
+        if self._essential_story is None:
+            self._essential_story = EssentialStoryGenerator()
+        return self._essential_story
+
+    @property
+    def agent_diary(self) -> AgentDiaryService:
+        """Return the AgentDiaryService instance (lazy-init)."""
+        if self._agent_diary is None:
+            self._agent_diary = AgentDiaryService()
+        return self._agent_diary
 
     # ========================================================================
     # STATISTICS & MONITORING

--- a/autobot-backend/memory/manager.py
+++ b/autobot-backend/memory/manager.py
@@ -557,24 +557,36 @@ class UnifiedMemoryManager:
             raise ValueError(f"Unknown storage strategy: {strategy}")
 
     # ========================================================================
-    # SESSION-SCOPED WORKING MEMORY (Redis, TTL-backed)
+    # MEMORY SUBSYSTEM PROPERTIES
+    # Agents access all three subsystems via these properties so they
+    # never need to import WorkingMemoryService, EssentialStoryGenerator,
+    # or AgentDiaryService directly.
     # ========================================================================
 
     @property
     def working_memory(self) -> WorkingMemoryService:
-        """Return the WorkingMemoryService instance."""
+        """Redis-backed session-scoped short-term memory (eager, TTL-backed).
+
+        Instantiated at construction time; safe to call immediately.
+        """
         return self._working_memory
 
     @property
     def essential_story(self) -> EssentialStoryGenerator:
-        """Return the EssentialStoryGenerator instance (lazy-init)."""
+        """Always-loaded compact memory summary generator (lazy-init).
+
+        First access constructs the instance; subsequent accesses are free.
+        """
         if self._essential_story is None:
             self._essential_story = EssentialStoryGenerator()
         return self._essential_story
 
     @property
     def agent_diary(self) -> AgentDiaryService:
-        """Return the AgentDiaryService instance (lazy-init)."""
+        """Per-agent cross-session journal backed by the knowledge base (lazy-init).
+
+        First access constructs the instance; subsequent accesses are free.
+        """
         if self._agent_diary is None:
             self._agent_diary = AgentDiaryService()
         return self._agent_diary


### PR DESCRIPTION
## Summary

- Added `essential_story` and `agent_diary` as lazily-instantiated properties on `UnifiedMemoryManager` (`memory/manager.py`), matching the existing `working_memory` property pattern already in place
- Added `self.memory_manager: UnifiedMemoryManager` attribute on `StandardizedAgent` so all agent subclasses get a single, consistent memory facade without direct imports
- Updated `sentiment_analysis_agent.py` to use `self.memory_manager.working_memory` and `self.memory_manager.agent_diary` instead of direct module-level imports + try/except guards
- Exported `EssentialStoryGenerator` and `WorkingMemoryService` from `memory/__init__.py` alongside the existing `AgentDiaryService` export

## Lazy-init pattern

`essential_story` and `agent_diary` follow the same guard pattern used for optional components throughout the manager:

```python
@property
def essential_story(self) -> EssentialStoryGenerator:
    if self._essential_story is None:
        self._essential_story = EssentialStoryGenerator()
    return self._essential_story
```

No service is created until first access — zero cost for agents that never use them.

## Files changed

- `autobot-backend/memory/manager.py` — added imports + two lazy properties
- `autobot-backend/memory/__init__.py` — exported `EssentialStoryGenerator`, `WorkingMemoryService`
- `autobot-backend/agents/standardized_agent.py` — replaced direct import + try/except with `self.memory_manager`
- `autobot-backend/agents/sentiment_analysis_agent.py` — replaced `AgentDiaryService()` / `_WMS()` direct instantiation with `self.memory_manager.agent_diary` / `self.memory_manager.working_memory`

Closes #3809