### PR TITLE
feat(agent-loop): content-aware repetitive tool-call detection

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -17,6 +17,8 @@ and Think Tool into a cohesive execution system.
 """
 
 import asyncio
+import hashlib
+import json
 import logging
 import time
 import uuid
@@ -418,6 +420,19 @@ class AgentLoop:
         if not tools:
             return {}
 
+        # Issue #3255: Halt before execution if identical call repeated too often
+        repeated_tool = self._check_tool_call_repetition(tools)
+        if repeated_tool is not None:
+            return {
+                repeated_tool: {
+                    "error": (
+                        f"Halted: repetitive tool call detected for '{repeated_tool}' "
+                        f"(exceeded max_identical_tool_calls="
+                        f"{self.config.max_identical_tool_calls})"
+                    )
+                }
+            }
+
         # Check if we need to think before certain tools
         await self._think_before_tools(tools)
 
@@ -602,6 +617,56 @@ Duration: {self._current_context.get_duration_ms():.0f}ms
     # =========================================================================
     # Helper Methods
     # =========================================================================
+
+    # =========================================================================
+    # Repetitive Tool-Call Detection (#3255)
+    # =========================================================================
+
+    @staticmethod
+    def _compute_tool_call_hash(tool: dict[str, Any]) -> str:
+        """Return a stable content hash for a tool call.
+
+        The hash is derived from the tool name and its sorted arguments so that
+        two calls with identical intent produce the same hash regardless of
+        dict-insertion order.
+
+        Issue #3255.
+        """
+        tool_name = tool.get("tool_name", "")
+        args = tool.get("args", tool.get("arguments", tool.get("parameters", {})))
+        if not isinstance(args, dict):
+            args = {}
+        canonical = json.dumps({"n": tool_name, "a": args}, sort_keys=True)
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def _check_tool_call_repetition(
+        self, tools: list[dict[str, Any]]
+    ) -> Optional[str]:
+        """Check whether any pending tool call has been issued too many times.
+
+        Returns the offending tool name if repetition is detected, else None.
+        Records each call regardless so the counter accumulates across iterations.
+
+        Issue #3255.
+        """
+        if not self._current_context:
+            return None
+
+        threshold = self.config.max_identical_tool_calls
+        for tool in tools:
+            call_hash = self._compute_tool_call_hash(tool)
+            count = self._current_context.record_tool_call_hash(call_hash)
+            tool_name = tool.get("tool_name", "unknown")
+            if count > threshold:
+                logger.warning(
+                    "AgentLoop: Detected repetitive tool call: %s called %d times "
+                    "with identical args (threshold=%d)",
+                    tool_name,
+                    count,
+                    threshold,
+                )
+                return tool_name
+        return None
 
     def _should_continue(self) -> bool:
         """Check if the loop should continue."""

--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -657,7 +657,7 @@ Duration: {self._current_context.get_duration_ms():.0f}ms
             call_hash = self._compute_tool_call_hash(tool)
             count = self._current_context.record_tool_call_hash(call_hash)
             tool_name = tool.get("tool_name", "unknown")
-            if count > threshold:
+            if count >= threshold:
                 logger.warning(
                     "AgentLoop: Detected repetitive tool call: %s called %d times "
                     "with identical args (threshold=%d)",

--- a/autobot-backend/agent_loop/types.py
+++ b/autobot-backend/agent_loop/types.py
@@ -180,6 +180,9 @@ class AgentLoopConfig:
     retry_failed_tools: bool = True  # Retry failed tool calls
     max_tool_retries: int = RetryConfig.MIN_RETRIES  # 2 - Max retries per tool
 
+    # Repetitive tool-call detection (#3255)
+    max_identical_tool_calls: int = 3  # Halt when same tool+args seen N times
+
     # Logging
     log_iterations: bool = True  # Log each iteration
     log_tool_results: bool = True  # Log tool execution results
@@ -252,10 +255,21 @@ class TaskContext:
     plan_id: Optional[str] = None
     current_step_id: Optional[str] = None
     metadata: dict = field(default_factory=dict)
+    # Repetitive tool-call detection: maps content-hash -> call count (#3255)
+    tool_call_hashes: dict[str, int] = field(default_factory=dict)
 
     def add_tool(self, tool_name: str) -> None:
         """Record tool execution."""
         self.tools_executed.append(tool_name)
+
+    def record_tool_call_hash(self, call_hash: str) -> int:
+        """Increment call count for a content hash and return the new count.
+
+        Issue #3255: Used by AgentLoop repetition detection.
+        """
+        count = self.tool_call_hashes.get(call_hash, 0) + 1
+        self.tool_call_hashes[call_hash] = count
+        return count
 
     def add_error(self, error: str) -> None:
         """Record an error."""


### PR DESCRIPTION
Closes #3255

Adds per-task content-aware tool-call hash tracking to halt the agent loop when the LLM repeatedly issues identical tool calls that succeed silently.

**Changes:**
- `agent_loop/types.py`: Add `max_identical_tool_calls: int = 3` to `AgentLoopConfig`; add `tool_call_hashes: dict[str, int]` + `record_tool_call_hash()` to `TaskContext`
- `agent_loop/loop.py`: Add `_compute_tool_call_hash()` (stable SHA-256 of tool name + sorted args) and `_check_tool_call_repetition()`; wire check into `_execute_tools` before execution

When any tool+args hash exceeds the threshold, the loop returns an error result for that tool (triggering `_should_continue` to halt) and logs a warning.