### PR TITLE
refactor(backend): consolidate terminal API implementations

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -19086,7 +19086,10 @@ class TestBatch109MonitoringCOMPLETE(unittest.TestCase):
 
 
 class TestBatch110TerminalCOMPLETE(unittest.TestCase):
-    """Test batch 110 migration: terminal.py completion (4 endpoints - 3 WebSocket + 1 info - FINAL TO 100%)"""
+    """Test batch 110 migration: terminal.py completion (2 endpoints - 1 WebSocket + 1 info - FINAL TO 100%).
+
+    Issue #3383: /ws/simple and /ws/secure compat aliases removed — use /ws/{session_id}.
+    """
 
     def test_batch_110_terminal_info_simple_pattern(self):
         """Verify terminal_info uses Simple Pattern"""
@@ -19120,48 +19123,34 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         self.assertIn("try:", source)
         self.assertIn("except", source)
 
-    def test_batch_110_simple_compat_websocket_mixed_pattern(self):
-        """Verify simple_terminal_websocket_compat uses Mixed Pattern"""
+    def test_batch_110_compat_aliases_removed(self):
+        """Verify compat aliases are gone — #3383 consolidation complete"""
         from api import terminal
 
-        source = inspect.getsource(terminal.simple_terminal_websocket_compat)
-        # Should have @with_error_handling decorator
-        self.assertIn("@with_error_handling", source)
-        # Should have operation parameter
-        self.assertIn('operation="simple_terminal_websocket_compat"', source)
+        self.assertFalse(
+            hasattr(terminal, "simple_terminal_websocket_compat"),
+            "simple_terminal_websocket_compat should be removed (#3383)",
+        )
+        self.assertFalse(
+            hasattr(terminal, "secure_terminal_websocket_compat"),
+            "secure_terminal_websocket_compat should be removed (#3383)",
+        )
 
-    def test_batch_110_secure_compat_websocket_mixed_pattern(self):
-        """Verify secure_terminal_websocket_compat uses Mixed Pattern"""
+    def test_batch_110_websocket_endpoint_has_decorator(self):
+        """Verify canonical WebSocket endpoint has @with_error_handling decorator"""
         from api import terminal
 
-        source = inspect.getsource(terminal.secure_terminal_websocket_compat)
-        # Should have @with_error_handling decorator
-        self.assertIn("@with_error_handling", source)
-        # Should have operation parameter
-        self.assertIn('operation="secure_terminal_websocket_compat"', source)
-
-    def test_batch_110_all_websocket_endpoints_have_decorator(self):
-        """Verify all 3 WebSocket endpoints have @with_error_handling decorator"""
-        from api import terminal
-
-        websocket_funcs = [
-            terminal.consolidated_terminal_websocket,
-            terminal.simple_terminal_websocket_compat,
-            terminal.secure_terminal_websocket_compat,
-        ]
-
-        for func in websocket_funcs:
-            source = inspect.getsource(func)
-            self.assertIn(
-                "@with_error_handling",
-                source,
-                f"{func.__name__} should have @with_error_handling decorator",
-            )
-            self.assertIn(
-                "@router.websocket",
-                source,
-                f"{func.__name__} should have @router.websocket decorator",
-            )
+        source = inspect.getsource(terminal.consolidated_terminal_websocket)
+        self.assertIn(
+            "@with_error_handling",
+            source,
+            "consolidated_terminal_websocket should have @with_error_handling decorator",
+        )
+        self.assertIn(
+            "@router.websocket",
+            source,
+            "consolidated_terminal_websocket should have @router.websocket decorator",
+        )
 
     def test_batch_110_terminal_100_percent_milestone(self):
         """Verify terminal.py has reached 100% migration (21st file to 100%)"""
@@ -19191,8 +19180,8 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
             if "@with_error_handling" in inspect.getsource(func)
         )
 
-        # terminal.py has 17 total endpoints (including 3 WebSocket endpoints)
-        total_endpoints = 17
+        # terminal.py has 15 total endpoints after #3383 compat alias removal
+        total_endpoints = 15
 
         # Should have migrated all endpoints
         self.assertEqual(
@@ -19217,21 +19206,13 @@ class TestBatch110TerminalCOMPLETE(unittest.TestCase):
         self.assertIn("websocket.accept", source_ws)
         self.assertIn("session_manager", source_ws)
 
-    def test_batch_110_websocket_endpoints_preserve_security_levels(self):
-        """Verify WebSocket endpoints preserve security level management"""
+    def test_batch_110_websocket_endpoint_preserves_security_levels(self):
+        """Verify canonical WebSocket endpoint preserves security level management"""
         from api import terminal
 
-        # Check consolidated endpoint
-        source1 = inspect.getsource(terminal.consolidated_terminal_websocket)
-        self.assertIn("SecurityLevel", source1)
-        self.assertIn("security_level", source1)
-
-        # Check compatibility endpoints
-        source2 = inspect.getsource(terminal.simple_terminal_websocket_compat)
-        self.assertIn("session_manager.session_configs", source2)
-
-        source3 = inspect.getsource(terminal.secure_terminal_websocket_compat)
-        self.assertIn("session_manager.session_configs", source3)
+        source = inspect.getsource(terminal.consolidated_terminal_websocket)
+        self.assertIn("SecurityLevel", source)
+        self.assertIn("security_level", source)
 
     # ==============================================
     # BATCH 111: auth.py - COMPLETE (100%)

--- a/autobot-backend/api/simple_terminal.e2e_test.py
+++ b/autobot-backend/api/simple_terminal.e2e_test.py
@@ -21,7 +21,7 @@ async def test_simple_terminal():
     session_id = f"test_{int(time.time())}"
     print(f"📝 Session ID: {session_id}")  # noqa: print
 
-    uri = get_test_backend_url().replace("https://", "wss://").replace("http://", "ws://") + f"/api/terminal/ws/simple/{session_id}"
+    uri = get_test_backend_url().replace("https://", "wss://").replace("http://", "ws://") + f"/api/terminal/ws/{session_id}"
     print(f"🔗 Connecting to: {uri}")  # noqa: print
 
     try:
@@ -125,7 +125,7 @@ async def test_sessions_api():
 
     try:
         response = requests.get(
-            get_test_backend_url() + "/api/terminal/simple/sessions", timeout=5
+            get_test_backend_url() + "/api/terminal/sessions", timeout=5
         )
         if response.status_code == 200:
             sessions = response.json()
@@ -172,10 +172,10 @@ async def main():
         print("User can now use the simple terminal endpoint:")  # noqa: print
         _base = get_test_backend_url()
         print(  # noqa: print
-            f"  WebSocket: {_base.replace('https://', 'wss://').replace('http://', 'ws://')}/api/terminal/ws/simple/{{session_id}}"
+            f"  WebSocket: {_base.replace('https://', 'wss://').replace('http://', 'ws://')}/api/terminal/ws/{{session_id}}"
         )  # noqa: print
         print(  # noqa: print
-            f"  Sessions:  {_base}/api/terminal/simple/sessions"
+            f"  Sessions:  {_base}/api/terminal/sessions"
         )  # noqa: print
     else:
         print("\n💥 Some tests failed - simple terminal needs fixes")  # noqa: print

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -911,53 +911,6 @@ async def consolidated_terminal_websocket(websocket: WebSocket, session_id: str)
             await terminal.cleanup()
 
 
-# Backward compatibility endpoints
-
-
-@router.websocket("/ws/simple/{session_id}")
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="simple_terminal_websocket_compat",
-    error_code_prefix="TERMINAL",
-)
-async def simple_terminal_websocket_compat(websocket: WebSocket, session_id: str):
-    """Backward compatibility for simple terminal WebSocket"""
-    # Set session to standard security for compatibility
-    if session_id not in session_manager.session_configs:
-        session_manager.session_configs[session_id] = {
-            "session_id": session_id,
-            "security_level": SecurityLevel.STANDARD,
-            "enable_logging": False,
-            "enable_workflow_control": True,
-            "created_at": datetime.now(tz=timezone.utc).isoformat(),
-        }
-
-    # Route to main WebSocket handler
-    await consolidated_terminal_websocket(websocket, session_id)
-
-
-@router.websocket("/ws/secure/{session_id}")
-@with_error_handling(
-    category=ErrorCategory.SERVER_ERROR,
-    operation="secure_terminal_websocket_compat",
-    error_code_prefix="TERMINAL",
-)
-async def secure_terminal_websocket_compat(websocket: WebSocket, session_id: str):
-    """Backward compatibility for secure terminal WebSocket"""
-    # Set session to elevated security for compatibility
-    if session_id not in session_manager.session_configs:
-        session_manager.session_configs[session_id] = {
-            "session_id": session_id,
-            "security_level": SecurityLevel.ELEVATED,
-            "enable_logging": True,
-            "enable_workflow_control": True,
-            "created_at": datetime.now(tz=timezone.utc).isoformat(),
-        }
-
-    # Route to main WebSocket handler
-    await consolidated_terminal_websocket(websocket, session_id)
-
-
 # SSH Terminal WebSocket (Issue #715 - Infrastructure host connections)
 # Issue #729: DEPRECATED - SSH connections to infrastructure hosts moved to slm-server
 # This endpoint now returns a deprecation message and redirects to SLM
@@ -1121,32 +1074,21 @@ async def terminal_info(
     return {
         "name": "Consolidated Terminal API",
         "version": "1.0.0",
-        "description": "Unified terminal API combining all previous implementations",
+        "description": "Single canonical terminal API — all previous implementations consolidated here (#3383)",
         "features": [
             "REST API for session management",
             "WebSocket-based real-time terminal access",
             "Security assessment and command auditing",
             "Workflow automation control integration",
             "Multi-level security controls",
-            "Backward compatibility with existing endpoints",
         ],
         "endpoints": {
             "sessions": "/api/terminal/sessions",
-            "websocket_primary": "/api/terminal/ws/{session_id}",
-            # Issue #3332: /ws/simple and /ws/secure are compat aliases — use /ws/{session_id}
-            "websocket_simple": "/api/terminal/ws/simple/{session_id} (compat alias)",
-            "websocket_secure": "/api/terminal/ws/secure/{session_id} (compat alias)",
+            "websocket": "/api/terminal/ws/{session_id}",
             # Issue #729: SSH to infrastructure hosts moved to slm-server
             "websocket_ssh": "/api/terminal/ws/ssh/{host_id} (deprecated - use SLM)",
         },
         "security_levels": [level.value for level in SecurityLevel],
-        # Issue #3332: simple_terminal_websocket.py, secure_terminal_websocket.py,
-        # and base_terminal.py are deprecated — logic consolidated here.
-        "deprecated_modules": [
-            "api/simple_terminal_websocket.py",
-            "api/secure_terminal_websocket.py",
-            "api/base_terminal.py",
-        ],
         # Issue #729: Layer separation notice
         "notice": "SSH connections to infrastructure hosts have been moved to slm-server. "
         "Use slm-admin or the SLM API for infrastructure terminal access.",


### PR DESCRIPTION
Closes #3383

## Changes

The four competing terminal implementations were:
- `api/terminal.py` — canonical `ConsolidatedTerminalWebSocket` (kept)
- `api/simple_terminal_websocket.py` — already deleted previously
- `api/secure_terminal_websocket.py` — already deleted previously
- `api/base_terminal.py` — already deleted previously

The compat aliases `/ws/simple/{session_id}` and `/ws/secure/{session_id}` that bridged the old modules to the canonical handler are now removed. No frontend code uses these paths (verified by grep).

### Specific changes
- **api/terminal.py**: removed `simple_terminal_websocket_compat` and `secure_terminal_websocket_compat` endpoints; cleaned `terminal_info` response to remove `deprecated_modules` list and compat alias entries
- **api/simple_terminal.e2e_test.py**: updated WebSocket URL `/ws/simple/{id}` → `/ws/{id}`; sessions URL `/terminal/simple/sessions` → `/terminal/sessions`
- **api/api_endpoint_migrations_test.py**: removed tests for deleted compat functions; `total_endpoints` 17 → 15; added assertion that compat aliases are absent