### PR TITLE
feat(config): config management enhancements — startup validation and sync API

### DIFF
--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -2,9 +2,14 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 import datetime
+import json
 import logging
+import os
+import tempfile
 from pathlib import Path
 from typing import Optional
+
+import aiofiles
 
 from celery.result import AsyncResult
 from fastapi import APIRouter, Depends, HTTPException
@@ -778,11 +783,9 @@ async def sync_config(
     caller can display a confirmation to the user.
     """
     import copy
-    import json
-    import os
-    import tempfile
 
     from config.loader import deep_merge
+    from constants.path_constants import PATH
 
     if not request.settings:
         return ConfigSyncResponse(status="skipped", changed={}, unchanged_keys=0)
@@ -792,21 +795,20 @@ async def sync_config(
     # Merge the incoming payload onto the current config.
     merged_config = deep_merge(copy.deepcopy(before_config), request.settings)
 
-    # Persist atomically: write to tmp then rename.
-    from constants.path_constants import PATH
-
+    # Persist atomically: write to tmp then rename (non-blocking write).
     settings_file = PATH.PROJECT_ROOT / "config" / "settings.json"
     settings_file.parent.mkdir(parents=True, exist_ok=True)
 
     tmp_fd, tmp_path = tempfile.mkstemp(
         dir=str(settings_file.parent), suffix=".tmp", prefix="settings_"
     )
+    os.close(tmp_fd)  # aiofiles will reopen by path
     try:
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
-            json.dump(merged_config, fh, indent=2, ensure_ascii=False)
+        async with aiofiles.open(tmp_path, "w", encoding="utf-8") as fh:
+            await fh.write(json.dumps(merged_config, indent=2, ensure_ascii=False))
         os.replace(tmp_path, str(settings_file))
     except Exception:
-        # Clean up tmp file if rename failed.
+        # Clean up tmp file if write or rename failed.
         try:
             os.unlink(tmp_path)
         except OSError:

--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -718,3 +718,127 @@ async def get_update_status(
     except Exception as e:
         logger.error("Error checking update status: %s", str(e))
         raise_server_error("UPDATES_0004", "Error checking update status")
+
+
+# ==================== Config Sync Endpoint (Issue #3398) ====================
+
+
+class ConfigSyncRequest(BaseModel):
+    """Request body for POST /api/settings/sync.
+
+    The *settings* dict is merged into the active settings.json so callers
+    can send partial payloads — only the provided keys are changed.
+    """
+
+    settings: dict
+
+
+class ConfigSyncResponse(BaseModel):
+    """Response body for POST /api/settings/sync."""
+
+    status: str
+    changed: dict  # keys that changed: {key: {"before": old, "after": new}}
+    unchanged_keys: int
+
+
+def _compute_flat_diff(before: dict, after: dict, prefix: str = "") -> dict:
+    """Return a flat dict of keys whose values changed between *before* and *after*.
+
+    Only leaf values are compared; nested dicts are recursed into.
+    """
+    diff: dict = {}
+    all_keys = set(before) | set(after)
+    for key in all_keys:
+        full_key = f"{prefix}.{key}" if prefix else key
+        bval = before.get(key)
+        aval = after.get(key)
+        if isinstance(bval, dict) and isinstance(aval, dict):
+            diff.update(_compute_flat_diff(bval, aval, prefix=full_key))
+        elif bval != aval:
+            diff[full_key] = {"before": bval, "after": aval}
+    return diff
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="sync_config",
+    error_code_prefix="SETTINGS",
+)
+@router.post("/sync", response_model=ConfigSyncResponse)
+async def sync_config(
+    request: ConfigSyncRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: None = Depends(check_admin_permission),
+):
+    """Atomically merge *request.settings* into settings.json (Issue #3398).
+
+    The write is atomic: the new JSON is written to a temp file then renamed
+    over the target, preventing a half-written file from corrupting config.
+    Requires operator/admin permission.  Returns a diff of what changed so the
+    caller can display a confirmation to the user.
+    """
+    import copy
+    import json
+    import os
+    import tempfile
+
+    from config.loader import deep_merge
+
+    if not request.settings:
+        return ConfigSyncResponse(status="skipped", changed={}, unchanged_keys=0)
+
+    before_config: dict = ConfigService.get_full_config()
+
+    # Merge the incoming payload onto the current config.
+    merged_config = deep_merge(copy.deepcopy(before_config), request.settings)
+
+    # Persist atomically: write to tmp then rename.
+    from constants.path_constants import PATH
+
+    settings_file = PATH.PROJECT_ROOT / "config" / "settings.json"
+    settings_file.parent.mkdir(parents=True, exist_ok=True)
+
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        dir=str(settings_file.parent), suffix=".tmp", prefix="settings_"
+    )
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            json.dump(merged_config, fh, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, str(settings_file))
+    except Exception:
+        # Clean up tmp file if rename failed.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    # Invalidate the ConfigService cache so the next read picks up the new file.
+    ConfigService.clear_cache()
+
+    changed = _compute_flat_diff(before_config, merged_config)
+    # Count leaf keys in the incoming payload that were not modified.
+    all_incoming_leaf_count = len(_compute_flat_diff({}, request.settings))
+    unchanged_keys = max(0, all_incoming_leaf_count - len(changed))
+
+    # Audit trail (same pattern as existing save_settings endpoint).
+    await ConfigRevisionService(session).create_revision(
+        entity_type="system",
+        entity_id="settings",
+        before_config=before_config,
+        after_config=merged_config,
+        source="api_sync",
+        created_by="admin",
+    )
+
+    logger.info(
+        "Config sync: %d key(s) changed, %d unchanged",
+        len(changed),
+        unchanged_keys,
+    )
+
+    return ConfigSyncResponse(
+        status="ok",
+        changed=changed,
+        unchanged_keys=unchanged_keys,
+    )

--- a/autobot-backend/config/validation.py
+++ b/autobot-backend/config/validation.py
@@ -4,12 +4,180 @@
 # Author: mrveiss
 """
 Configuration validation for unified config manager.
+
+Issue #3398: enhanced validation — startup warnings, conflict detection,
+             invalid-value fast-fail, and startup summary log.
 """
 
 import logging
-from typing import Any, Dict
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from config.loader import ENV_VAR_MAPPINGS
 
 logger = logging.getLogger(__name__)
+
+# Minimum/maximum valid port range.
+_PORT_MIN = 1
+_PORT_MAX = 65535
+
+# Config keys that must resolve to a non-empty value before serving requests.
+# Each entry is a dot-notation path checked via get_nested().
+_REQUIRED_CONFIG_KEYS: List[str] = [
+    "memory.redis.host",
+    "backend.server_host",
+]
+
+
+@dataclass
+class ConfigValidationResult:
+    """Structured result of startup configuration validation.
+
+    ``valid`` is False when at least one error is present.  Warnings do not
+    cause ``valid`` to be False but are logged at WARNING level.
+    """
+
+    valid: bool = True
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    overrides: Dict[str, Any] = field(default_factory=dict)
+
+    def add_error(self, message: str) -> None:
+        """Record a fatal validation error and mark result as invalid."""
+        self.errors.append(message)
+        self.valid = False
+
+    def add_warning(self, message: str) -> None:
+        """Record a non-fatal validation warning."""
+        self.warnings.append(message)
+
+    def add_override(self, env_var: str, file_value: Any, env_value: Any) -> None:
+        """Record that an env var overrides the file-based value."""
+        self.overrides[env_var] = {"file_value": file_value, "env_value": env_value}
+
+
+def _get_nested_value(config: Dict[str, Any], path: List[str]) -> Any:
+    """Walk ``config`` following ``path`` list; return ``None`` if missing."""
+    current: Any = config
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _validate_port(value: Any, label: str, result: ConfigValidationResult) -> None:
+    """Fail fast when *value* is not a valid TCP port number."""
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        result.add_error(
+            f"Config key '{label}' is not a valid integer (got {value!r})"
+        )
+        return
+    if not (_PORT_MIN <= port <= _PORT_MAX):
+        result.add_error(
+            f"Config key '{label}' has invalid port value {port} "
+            f"(must be {_PORT_MIN}–{_PORT_MAX})"
+        )
+
+
+# Keys whose values must be valid TCP ports.
+_PORT_CONFIG_PATHS: List[tuple] = [
+    (["backend", "server_port"], "backend.server_port"),
+    (["memory", "redis", "port"], "memory.redis.port"),
+]
+
+
+def validate_startup_config(raw_config: Dict[str, Any]) -> ConfigValidationResult:
+    """Validate *raw_config* at startup and return a structured result.
+
+    Checks performed (Issue #3398):
+    1. Required keys are present and non-empty.
+    2. Port values are in the valid TCP range (1–65535).
+    3. Each env var in ``ENV_VAR_MAPPINGS`` that is set is compared against the
+       file-based value; a WARNING is emitted for every override so operators
+       can see at a glance which values were changed by the environment.
+
+    The function never raises; callers decide how to act on the result.
+    """
+    result = ConfigValidationResult()
+
+    # --- 1. Required keys ---
+    for dotted_key in _REQUIRED_CONFIG_KEYS:
+        path = dotted_key.split(".")
+        value = _get_nested_value(raw_config, path)
+        if not value:
+            result.add_error(
+                f"Required config key '{dotted_key}' is missing or empty"
+            )
+
+    # --- 2. Port range validation ---
+    for path, label in _PORT_CONFIG_PATHS:
+        value = _get_nested_value(raw_config, path)
+        if value is not None:
+            _validate_port(value, label, result)
+
+    # --- 3. Env-var override conflict detection ---
+    # Build a snapshot of what the file-based config would look like *without*
+    # applying env overrides so we can compare.
+    for env_var, config_path in ENV_VAR_MAPPINGS.items():
+        env_value_raw = os.getenv(env_var)
+        if env_value_raw is None:
+            continue  # env var not set — no override
+
+        file_value = _get_nested_value(raw_config, config_path)
+        # Convert the raw env string to a comparable Python type.
+        if env_value_raw.lower() in ("true", "false"):
+            env_value: Any = env_value_raw.lower() == "true"
+        elif env_value_raw.isdigit():
+            env_value = int(env_value_raw)
+        else:
+            env_value = env_value_raw
+
+        if file_value is not None and file_value != env_value:
+            key_label = ".".join(config_path)
+            result.add_warning(
+                f"Config override: env var {env_var} overrides file value for "
+                f"'{key_label}' (file={file_value!r}, env={env_value!r})"
+            )
+            result.add_override(env_var, file_value, env_value)
+
+    return result
+
+
+def log_startup_config_summary(raw_config: Dict[str, Any]) -> None:
+    """Emit a concise startup log of active configuration values.
+
+    Logs at INFO level so operators have a single, scannable record of what
+    the backend is actually using (Issue #3398).
+    """
+    redis_host = _get_nested_value(raw_config, ["memory", "redis", "host"])
+    redis_port = _get_nested_value(raw_config, ["memory", "redis", "port"])
+    backend_host = _get_nested_value(raw_config, ["backend", "server_host"])
+    backend_port = _get_nested_value(raw_config, ["backend", "server_port"])
+    ollama_host = _get_nested_value(
+        raw_config,
+        ["backend", "llm", "local", "providers", "ollama", "host"],
+    )
+    selected_model = _get_nested_value(
+        raw_config,
+        ["backend", "llm", "local", "providers", "ollama", "selected_model"],
+    )
+    log_level = _get_nested_value(raw_config, ["logging", "log_level"])
+
+    logger.info(
+        "Config summary — backend=%s:%s  redis=%s:%s  ollama=%s  "
+        "model=%s  log_level=%s",
+        backend_host,
+        backend_port,
+        redis_host,
+        redis_port,
+        ollama_host,
+        selected_model,
+        log_level,
+    )
 
 
 class ValidationMixin:
@@ -46,3 +214,24 @@ class ValidationMixin:
             status["issues"].append("Redis enabled but no host specified")
 
         return status
+
+    def validate_startup(self) -> ConfigValidationResult:
+        """Run full startup validation and log the results.
+
+        Returns the structured result so callers can decide whether to abort.
+        Issue #3398.
+        """
+        raw = self._config if hasattr(self, "_config") else {}
+        result = validate_startup_config(raw)
+
+        # Log override warnings so operators see them at startup.
+        for warning in result.warnings:
+            logger.warning("Config warning: %s", warning)
+
+        if result.errors:
+            for error in result.errors:
+                logger.error("Config error: %s", error)
+        else:
+            log_startup_config_summary(raw)
+
+        return result

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -230,12 +230,26 @@ async def _check_env_drift() -> None:
 
 
 async def _init_config(app: FastAPI) -> None:
-    """Helper for initialize_critical_services. Ref: #1088."""
+    """Helper for initialize_critical_services. Ref: #1088, #3398."""
     logger.info("✅ [ 10%] Config: Loading unified configuration...")
     config = ConfigManager()
     app.state.config = config
     await update_app_state("config", config)
     logger.info("✅ [ 10%] Config: Configuration loaded successfully")
+
+    # Issue #3398: Run startup validation — log override warnings, fail fast on
+    # invalid values (e.g. negative ports, missing required keys).
+    validation_result = config.validate_startup()
+    if not validation_result.valid:
+        error_summary = "; ".join(validation_result.errors)
+        raise RuntimeError(
+            f"Configuration validation failed at startup: {error_summary}"
+        )
+    if validation_result.warnings:
+        logger.warning(
+            "Config: %d override warning(s) detected — review logged warnings above",
+            len(validation_result.warnings),
+        )
 
 
 async def _init_security_layer(app: FastAPI) -> None:


### PR DESCRIPTION
Closes #3398

Implements two of the four planned config management enhancements:

**1. Startup validation with warnings** (`config/validation.py`, `initialization/lifespan.py`):
- `validate_startup_config()` checks required keys, port ranges, and env-var/file conflicts
- `ConfigValidationResult` dataclass tracks errors, warnings, and overrides
- `ValidationMixin.validate_startup()` integrates into `ConfigManager`
- `_init_config()` in lifespan calls `validate_startup()` — raises `RuntimeError` on fatal errors, logs warnings for overrides
- `log_startup_config_summary()` logs a single scannable INFO line of active config

**2. Settings sync API** (`api/settings.py`):
- `POST /api/settings/sync` — atomic write (tempfile + `os.replace`), requires admin, deep-merges partial payload, invalidates ConfigService cache, records audit revision
- Returns diff of changed keys so callers can show confirmation