### PR TITLE
feat(llm): migrate chat completion calls to vLLM optimised API

### DIFF
--- a/autobot-backend/agent_tier_classifier.py
+++ b/autobot-backend/agent_tier_classifier.py
@@ -56,6 +56,14 @@ AGENT_TIER_MAP: Dict[str, AgentTier] = {
     "content-writer": AgentTier.TIER_3_SPECIALIZED,
     "memory-monitor": AgentTier.TIER_3_SPECIALIZED,
     "project-task-planner": AgentTier.TIER_3_SPECIALIZED,
+    # Issue #3389: task agents that call chat_completion_optimized
+    "summarization": AgentTier.TIER_3_SPECIALIZED,
+    "translation": AgentTier.TIER_3_SPECIALIZED,
+    "sentiment-analysis": AgentTier.TIER_3_SPECIALIZED,
+    "code-generation": AgentTier.TIER_3_SPECIALIZED,
+    "audio-processing": AgentTier.TIER_3_SPECIALIZED,
+    "image-analysis": AgentTier.TIER_3_SPECIALIZED,
+    "data-analysis": AgentTier.TIER_3_SPECIALIZED,
     # Tier 4: Orchestrator (Session-Specific)
     "orchestrator": AgentTier.TIER_4_ORCHESTRATOR,
 }

--- a/autobot-backend/agents/audio_processing_agent.py
+++ b/autobot-backend/agents/audio_processing_agent.py
@@ -99,16 +99,16 @@ class AudioProcessingAgent(StandardizedAgent):
     async def process_query(
         self, request_text: str, context: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        """Process an audio processing query using LLM."""
+        """Process an audio processing query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Audio Processing Agent processing: %s...", request_text[:50])
-            messages = [
-                {"role": "system", "content": self._get_localized_system_prompt()},
-                {"role": "user", "content": request_text},
-            ]
-            response = await self.llm_interface.chat_completion(
-                messages=messages,
-                llm_type="chat",
+            session_id = (context or {}).get("session_id", "unknown")
+            response = await self.llm_interface.chat_completion_optimized(
+                agent_type=self.AGENT_ID,
+                user_message=request_text,
+                session_id=session_id,
+                user_name=(context or {}).get("user_name"),
+                user_role=(context or {}).get("user_role"),
                 temperature=0.3,
                 max_tokens=LLMDefaults.SYNTHESIS_MAX_TOKENS,
                 top_p=LLMDefaults.DEFAULT_TOP_P,

--- a/autobot-backend/agents/code_generation_agent.py
+++ b/autobot-backend/agents/code_generation_agent.py
@@ -92,16 +92,16 @@ class CodeGenerationAgent(StandardizedAgent):
     async def process_query(
         self, request_text: str, context: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        """Process a code generation query using LLM."""
+        """Process a code generation query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Code Generation Agent processing: %s...", request_text[:50])
-            messages = [
-                {"role": "system", "content": self._get_localized_system_prompt()},
-                {"role": "user", "content": request_text},
-            ]
-            response = await self.llm_interface.chat_completion(
-                messages=messages,
-                llm_type="chat",
+            session_id = (context or {}).get("session_id", "unknown")
+            response = await self.llm_interface.chat_completion_optimized(
+                agent_type=self.AGENT_ID,
+                user_message=request_text,
+                session_id=session_id,
+                user_name=(context or {}).get("user_name"),
+                user_role=(context or {}).get("user_role"),
                 temperature=0.2,
                 max_tokens=LLMDefaults.EXTENDED_MAX_TOKENS,
                 top_p=LLMDefaults.DEFAULT_TOP_P,

--- a/autobot-backend/agents/data_analysis_agent.py
+++ b/autobot-backend/agents/data_analysis_agent.py
@@ -91,16 +91,16 @@ class DataAnalysisAgent(StandardizedAgent):
     async def process_query(
         self, request_text: str, context: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        """Process a data analysis query using LLM."""
+        """Process a data analysis query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Data Analysis Agent processing: %s...", request_text[:50])
-            messages = [
-                {"role": "system", "content": self._get_localized_system_prompt()},
-                {"role": "user", "content": request_text},
-            ]
-            response = await self.llm_interface.chat_completion(
-                messages=messages,
-                llm_type="chat",
+            session_id = (context or {}).get("session_id", "unknown")
+            response = await self.llm_interface.chat_completion_optimized(
+                agent_type=self.AGENT_ID,
+                user_message=request_text,
+                session_id=session_id,
+                user_name=(context or {}).get("user_name"),
+                user_role=(context or {}).get("user_role"),
                 temperature=0.3,
                 max_tokens=LLMDefaults.SYNTHESIS_MAX_TOKENS,
                 top_p=LLMDefaults.DEFAULT_TOP_P,

--- a/autobot-backend/agents/image_analysis_agent.py
+++ b/autobot-backend/agents/image_analysis_agent.py
@@ -110,16 +110,16 @@ class ImageAnalysisAgent(StandardizedAgent):
     async def process_query(
         self, request_text: str, context: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        """Process an image analysis query using LLM."""
+        """Process an image analysis query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Image Analysis Agent processing: %s...", request_text[:50])
-            messages = [
-                {"role": "system", "content": self._get_localized_system_prompt()},
-                {"role": "user", "content": request_text},
-            ]
-            response = await self.llm_interface.chat_completion(
-                messages=messages,
-                llm_type="chat",
+            session_id = (context or {}).get("session_id", "unknown")
+            response = await self.llm_interface.chat_completion_optimized(
+                agent_type=self.AGENT_ID,
+                user_message=request_text,
+                session_id=session_id,
+                user_name=(context or {}).get("user_name"),
+                user_role=(context or {}).get("user_role"),
                 temperature=0.5,
                 max_tokens=LLMDefaults.SYNTHESIS_MAX_TOKENS,
                 top_p=LLMDefaults.DEFAULT_TOP_P,

--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -108,16 +108,16 @@ class SentimentAnalysisAgent(StandardizedAgent):
     async def process_query(
         self, request_text: str, context: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        """Process a sentiment analysis query using LLM."""
+        """Process a sentiment analysis query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Sentiment Analysis Agent processing: %s...", request_text[:50])
-            messages = [
-                {"role": "system", "content": self._get_localized_system_prompt()},
-                {"role": "user", "content": request_text},
-            ]
-            response = await self.llm_interface.chat_completion(
-                messages=messages,
-                llm_type="chat",
+            session_id = (context or {}).get("session_id", "unknown")
+            response = await self.llm_interface.chat_completion_optimized(
+                agent_type=self.AGENT_ID,
+                user_message=request_text,
+                session_id=session_id,
+                user_name=(context or {}).get("user_name"),
+                user_role=(context or {}).get("user_role"),
                 temperature=0.1,
                 max_tokens=LLMDefaults.CHAT_MAX_TOKENS,
                 top_p=LLMDefaults.DEFAULT_TOP_P,

--- a/autobot-backend/agents/summarization_agent.py
+++ b/autobot-backend/agents/summarization_agent.py
@@ -95,16 +95,16 @@ class SummarizationAgent(StandardizedAgent):
     async def process_query(
         self, request_text: str, context: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        """Process a summarization query using LLM."""
+        """Process a summarization query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Summarization Agent processing: %s...", request_text[:50])
-            messages = [
-                {"role": "system", "content": self._get_localized_system_prompt()},
-                {"role": "user", "content": request_text},
-            ]
-            response = await self.llm_interface.chat_completion(
-                messages=messages,
-                llm_type="chat",
+            session_id = (context or {}).get("session_id", "unknown")
+            response = await self.llm_interface.chat_completion_optimized(
+                agent_type=self.AGENT_ID,
+                user_message=request_text,
+                session_id=session_id,
+                user_name=(context or {}).get("user_name"),
+                user_role=(context or {}).get("user_role"),
                 temperature=0.5,
                 max_tokens=LLMDefaults.SYNTHESIS_MAX_TOKENS,
                 top_p=LLMDefaults.DEFAULT_TOP_P,

--- a/autobot-backend/agents/translation_agent.py
+++ b/autobot-backend/agents/translation_agent.py
@@ -97,16 +97,16 @@ class TranslationAgent(StandardizedAgent):
     async def process_query(
         self, request_text: str, context: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        """Process a translation query using LLM."""
+        """Process a translation query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Translation Agent processing: %s...", request_text[:50])
-            messages = [
-                {"role": "system", "content": self._get_localized_system_prompt()},
-                {"role": "user", "content": request_text},
-            ]
-            response = await self.llm_interface.chat_completion(
-                messages=messages,
-                llm_type="chat",
+            session_id = (context or {}).get("session_id", "unknown")
+            response = await self.llm_interface.chat_completion_optimized(
+                agent_type=self.AGENT_ID,
+                user_message=request_text,
+                session_id=session_id,
+                user_name=(context or {}).get("user_name"),
+                user_role=(context or {}).get("user_role"),
                 temperature=0.3,
                 max_tokens=LLMDefaults.CHAT_MAX_TOKENS,
                 top_p=LLMDefaults.DEFAULT_TOP_P,

--- a/autobot-backend/llm_interface_pkg/interface.py
+++ b/autobot-backend/llm_interface_pkg/interface.py
@@ -987,6 +987,9 @@ class LLMInterface:
                 span.set_attribute("llm.provider", response.provider or "unknown")
                 span.set_attribute("llm.cached", getattr(response, "cached", False))
                 span.set_attribute("llm.error", bool(response.error))
+                # Issue #3389: attach cache hit rate for vLLM prefix-caching visibility
+                if (response.provider or "") == "vllm":
+                    self._calculate_cache_hit_rate(response)
                 return response
             except Exception as e:
                 processing_time = time.time() - start_time
@@ -1375,7 +1378,19 @@ class LLMInterface:
         additional_params: dict | None = None,
         **llm_params,
     ) -> LLMResponse:
-        """Chat completion with vLLM-optimized prompts. Issue #620."""
+        """Chat completion with vLLM-optimized prompts.
+
+        Builds a prefix-cache-friendly prompt (static base + dynamic suffix) and
+        routes the request directly to vLLM, bypassing the provider routing layer.
+        Cache hit rate is attached to response.metadata["cache_hit_rate"].
+
+        Issue #620 (original implementation), Issue #3389 (bug-fix: was incorrectly
+        passing LLMRequest to chat_completion(messages: list) — now calls
+        _execute_with_fallback directly so the pre-built request is honoured).
+        """
+        import time
+        import uuid
+
         from agent_tier_classifier import get_base_prompt_for_agent
         from prompt_manager import get_optimized_prompt
 
@@ -1389,16 +1404,30 @@ class LLMInterface:
             additional_params=additional_params,
         )
 
+        request_id = llm_params.pop("request_id", str(uuid.uuid4()))
+        start_time = time.time()
+
         request = LLMRequest(
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_message},
             ],
             provider="vllm",
+            request_id=request_id,
             **llm_params,
         )
 
-        response = await self.chat_completion(request)
+        response = await self._execute_with_fallback(request, "vllm")
+        response = await self._finalize_response(
+            response,
+            request.messages,
+            request.model_name or "",
+            "vllm",
+            None,
+            request_id,
+            start_time,
+            session_id,
+        )
         self._calculate_cache_hit_rate(response)
         return response
 


### PR DESCRIPTION
Closes #3389

## Summary

- **Bug fix**: `chat_completion_optimized()` was incorrectly passing an `LLMRequest` object as the `messages` argument to `chat_completion(messages: list)`. The method now calls `_execute_with_fallback()` + `_finalize_response()` directly, honouring the pre-built `provider="vllm"` request.
- **Cache hit visibility**: `chat_completion()` now calls `_calculate_cache_hit_rate()` automatically when the resolved provider is `vllm`, so prefix-cache hit rates appear in `response.metadata["cache_hit_rate"]` for all vLLM-routed calls without callers needing to opt in.
- **Tier map expansion**: `AGENT_TIER_MAP` in `agent_tier_classifier.py` gains 7 task-agent entries (`summarization`, `translation`, `sentiment-analysis`, `code-generation`, `audio-processing`, `image-analysis`, `data-analysis`) so `get_base_prompt_for_agent()` resolves them to Tier 3 instead of falling back with a warning.
- **7 agent migrations**: `process_query()` in all 7 single-turn task agents is migrated to `chat_completion_optimized()`, passing `session_id` / `user_name` / `user_role` from the request context. This enables vLLM prefix caching (static base prompt cached; dynamic suffix per request).

## Call sites NOT migrated (intentional)

| Call site | Reason |
|-----------|--------|
| `chat_agent.py` | Carries multi-turn conversation history — flattening to single user message loses context |
| `knowledge_retrieval_agent.py` / `rag_agent.py` | Multi-step prompts with retrieved context; message structure must be preserved |
| `knowledge_extraction_agent.py` | Complex multi-part extraction prompts built dynamically |
| `orchestration/workflow_documentation.py` | Workflow summary uses a custom prompt derived at runtime |
| `judges/__init__.py` | Evaluation prompts differ per invocation |
| `api/chat_knowledge.py` | Session-scoped knowledge summary prompt |
| `services/*` / `async_chat_workflow.py` | Streaming or provider-specific paths already routing correctly |
| `skills/*` / `code_intelligence/*` | Specialised prompts with injected code content |

## Test plan
- [ ] Compile check passes: `python3 -m py_compile llm_interface_pkg/interface.py agent_tier_classifier.py agents/{summarization,translation,sentiment_analysis,code_generation,audio_processing,image_analysis,data_analysis}_agent.py`
- [ ] Unit-test `chat_completion_optimized()` with a mock `_execute_with_fallback` to verify it no longer passes `LLMRequest` to `chat_completion`
- [ ] Verify `response.metadata["cache_hit_rate"]` is populated on vLLM responses after migration
- [ ] On a vLLM-enabled deployment, run back-to-back summarization requests and confirm cache hit rate climbs above 60% by the second request

🤖 Generated with [Claude Code](https://claude.com/claude-code)