### PR TITLE
arch(orchestration): unified graph model for DAG executor and LangGraph

### DIFF
--- a/autobot-backend/orchestration/__init__.py
+++ b/autobot-backend/orchestration/__init__.py
@@ -20,6 +20,7 @@ This package contains:
 """
 
 from .agent_registry import AgentRegistry, get_default_agents
+from .dag_graph_adapter import DAGGraphExecutor, build_dag_graph
 from .dag_executor import (
     DAGExecutor,
     NodeType,
@@ -63,6 +64,19 @@ from .workflow_documentation import WorkflowDocumenter
 from .workflow_executor import WorkflowExecutor
 from .workflow_memory import WorkflowMemory
 from .workflow_planner import WorkflowPlanner
+from .graph_runner import (
+    END,
+    START,
+    AutoBotGraph,
+    BackoffMode,
+    CompiledGraph,
+    GraphRunner,
+    GraphStepEvent,
+    NodeRetryConfig,
+    StepEventEmitter,
+    StepEventSink,
+    StepEventType,
+)
 
 __all__ = [
     # Types and dataclasses
@@ -81,6 +95,20 @@ __all__ = [
     "WorkflowExecutor",
     "WorkflowMemory",
     "WorkflowPlanner",
+    # Unified graph model (#3228)
+    "END",
+    "START",
+    "AutoBotGraph",
+    "BackoffMode",
+    "CompiledGraph",
+    "DAGGraphExecutor",
+    "GraphRunner",
+    "GraphStepEvent",
+    "NodeRetryConfig",
+    "StepEventEmitter",
+    "StepEventSink",
+    "StepEventType",
+    "build_dag_graph",
     # Sub-workflow composition (#2143)
     "MAX_NESTING_DEPTH",
     "SubWorkflowExecutor",

--- a/autobot-backend/orchestration/dag_graph_adapter.py
+++ b/autobot-backend/orchestration/dag_graph_adapter.py
@@ -1,0 +1,421 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+DAG-to-AutoBotGraph adapter.
+
+Issue #3228: migrate the DAG workflow executor to use the unified
+``AutoBotGraph`` / ``GraphRunner`` engine so checkpoint and step-event
+logic is shared rather than duplicated.
+
+This module provides ``build_dag_graph`` which converts a ``WorkflowDAG``
+into an ``AutoBotGraph``.  Each DAG node becomes a graph node whose
+``run(state)`` implementation delegates to ``DAGExecutor._execute_node``
+semantics.  The resulting ``CompiledGraph`` can be executed via
+``GraphRunner`` just like any other ``AutoBotGraph``.
+
+``DAGGraphExecutor`` is the public integration class that replaces the
+``DAGExecutor`` call-site in ``WorkflowExecutor._execute_dag_workflow``
+while preserving the same result shape (``DAGExecutionContext``).
+
+State shape
+-----------
+The intermediate graph state used during DAG execution is a plain dict
+with the following keys that map to ``DAGExecutionContext`` fields:
+
+    dag_ctx       : DAGExecutionContext (mutable, pre-populated by runner)
+    dag           : WorkflowDAG (read-only)
+    step_executor : StepExecutorCallback (read-only)
+    visited       : set[str]   — nodes already executed (join deduplication)
+    extra_context : dict       — opaque caller context forwarded to each step
+
+After the graph finishes, the caller extracts ``dag_ctx`` from the final
+state and converts it back to the legacy execution_context dict shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Coroutine, Dict, Optional, Set
+
+from .dag_executor import (
+    DAGExecutionContext,
+    DAGExecutor,
+    DAGNode,
+    NodeType,
+    StepExecutorCallback,
+    WorkflowDAG,
+    _evaluate_condition,
+    execute_distributed_shell,
+)
+from .graph_runner import (
+    END,
+    AutoBotGraph,
+    CompiledGraph,
+    GraphRunner,
+    NodeRetryConfig,
+    StepEventEmitter,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Node wrappers
+# ---------------------------------------------------------------------------
+
+
+def _make_dag_node_fn(
+    dag_node: DAGNode,
+    dag: WorkflowDAG,
+) -> Any:
+    """Return an async node function for *dag_node* compatible with GraphRunner.
+
+    The function signature is ``async (state, **kwargs) -> partial_state``.
+    It reads ``state["dag_ctx"]`` and ``state["step_executor"]``, executes the
+    DAG node, and returns a partial state update that mutates ``dag_ctx`` via
+    its reference (dicts are passed by reference so in-place mutation is safe).
+    """
+
+    async def _run(state: Dict[str, Any], **kwargs: Any) -> Dict[str, Any]:
+        ctx: DAGExecutionContext = state["dag_ctx"]
+        step_executor: StepExecutorCallback = state["step_executor"]
+        extra: Dict[str, Any] = state.get("extra_context", {})
+
+        # Mirror DAGExecutor._execute_node logic.
+        if dag_node.node_type == NodeType.CONDITION:
+            condition_result = _evaluate_condition(dag_node, ctx)
+            ctx.branches_taken[dag_node.node_id] = condition_result
+            ctx.step_results[dag_node.node_id] = {
+                "success": True,
+                "condition": dag_node.data.get("condition", ""),
+                "result": condition_result,
+                "node_id": dag_node.node_id,
+            }
+            logger.info(
+                "DAGGraph condition node %s evaluated to %s",
+                dag_node.node_id,
+                condition_result,
+            )
+            # Mark pruned branch descendants as skipped.
+            true_targets = [
+                e.target for e in dag.successors(dag_node.node_id) if e.label is True
+            ]
+            false_targets = [
+                e.target for e in dag.successors(dag_node.node_id) if e.label is False
+            ]
+            pruned = false_targets if condition_result else true_targets
+            _mark_descendants_skipped(pruned, dag, ctx)
+            return {}  # dag_ctx mutated in-place
+
+        if dag_node.node_type == NodeType.DISTRIBUTED_SHELL:
+            try:
+                result = await execute_distributed_shell(dag_node, ctx)
+            except Exception as exc:
+                logger.error(
+                    "DAGGraph distributed_shell node %s raised: %s",
+                    dag_node.node_id,
+                    exc,
+                )
+                result = {
+                    "success": False,
+                    "error": str(exc),
+                    "node_id": dag_node.node_id,
+                }
+            ctx.step_results[dag_node.node_id] = result
+            return {}
+
+        # Regular STEP / PARALLEL node.
+        try:
+            result = await step_executor(dag_node, ctx)
+        except Exception as exc:
+            logger.error(
+                "DAGGraph step node %s raised: %s", dag_node.node_id, exc
+            )
+            result = {
+                "success": False,
+                "error": str(exc),
+                "node_id": dag_node.node_id,
+            }
+
+        ctx.step_results[dag_node.node_id] = result
+        agent_id = dag_node.data.get("assigned_agent") or result.get("agent_id")
+        if agent_id:
+            ctx.agents_involved.add(str(agent_id))
+
+        return {}  # dag_ctx mutated in-place
+
+    return _run
+
+
+def _mark_descendants_skipped(
+    node_ids: list[str],
+    dag: WorkflowDAG,
+    ctx: DAGExecutionContext,
+) -> None:
+    """BFS-mark all descendants of *node_ids* as skipped (mirrors DAGExecutor)."""
+    queue = list(node_ids)
+    while queue:
+        nid = queue.pop(0)
+        if nid in ctx.skipped_nodes:
+            continue
+        ctx.skipped_nodes.add(nid)
+        for edge in dag.successors(nid):
+            queue.append(edge.target)
+
+
+# ---------------------------------------------------------------------------
+# Graph builder
+# ---------------------------------------------------------------------------
+
+
+def build_dag_graph(
+    dag: WorkflowDAG,
+    step_executor: StepExecutorCallback,
+    retry_config: Optional[NodeRetryConfig] = None,
+) -> CompiledGraph:
+    """Convert *dag* into a ``CompiledGraph`` executable by ``GraphRunner``.
+
+    Args:
+        dag:           The workflow DAG to convert.
+        step_executor: Async callback ``(node, ctx) -> result_dict`` used for
+                       STEP and PARALLEL nodes (same signature as DAGExecutor).
+        retry_config:  Optional per-node retry configuration applied uniformly
+                       to all nodes.  Pass ``None`` for no retry (default).
+
+    Returns:
+        A compiled graph ready for ``GraphRunner``.
+
+    Raises:
+        ValueError: When the DAG has no root nodes (empty graph).
+    """
+    roots = dag.root_nodes()
+    if not roots:
+        raise ValueError("DAG has no root nodes — cannot build graph.")
+
+    builder: AutoBotGraph[Dict[str, Any]] = AutoBotGraph()
+    effective_retry = retry_config or NodeRetryConfig()
+
+    # Topological order via BFS from roots.
+    ordered: list[str] = []
+    seen: Set[str] = set()
+    queue = [r.node_id for r in roots]
+    while queue:
+        nid = queue.pop(0)
+        if nid in seen:
+            continue
+        seen.add(nid)
+        ordered.append(nid)
+        for edge in dag.successors(nid):
+            queue.append(edge.target)
+
+    # Register a node function for each DAG node.
+    for nid in ordered:
+        dag_node = dag.nodes[nid]
+        fn = _make_dag_node_fn(dag_node, dag)
+        builder.add_node(nid, fn, retry=effective_retry)
+
+    # Wire edges.  For CONDITION nodes, the router reads ctx.branches_taken
+    # to return the correct branch (already resolved during node execution).
+    for nid in ordered:
+        dag_node = dag.nodes[nid]
+        successors = dag.successors(nid)
+
+        if not successors:
+            # Leaf node — unconditional edge to END.
+            builder.add_edge(nid, END)
+            continue
+
+        if dag_node.node_type == NodeType.CONDITION:
+            # Conditional edges: branch is resolved *after* node execution
+            # since the node populates ctx.branches_taken.
+            true_targets = [e.target for e in successors if e.label is True]
+            false_targets = [e.target for e in successors if e.label is False]
+            unconditional = [e.target for e in successors if e.label is None]
+
+            condition_node_id = nid  # capture for closure
+
+            def _make_condition_router(
+                true_t: list[str],
+                false_t: list[str],
+                unconditional_t: list[str],
+                cnode_id: str,
+            ) -> Any:
+                def _router(state: Dict[str, Any]) -> str:
+                    ctx: DAGExecutionContext = state["dag_ctx"]
+                    branch_taken = ctx.branches_taken.get(cnode_id, False)
+                    candidates = (true_t if branch_taken else false_t) + unconditional_t
+                    if not candidates:
+                        return END
+                    # Return first non-skipped candidate.
+                    for target in candidates:
+                        if target not in ctx.skipped_nodes:
+                            return target
+                    return END
+
+                return _router
+
+            builder.add_conditional_edges(
+                nid,
+                _make_condition_router(
+                    true_targets, false_targets, unconditional, condition_node_id
+                ),
+            )
+        else:
+            # Non-condition node: unconditional edges to all successors.
+            # If multiple successors exist, they run sequentially through the
+            # linear GraphRunner.  True parallel fan-out can be achieved by
+            # adding a PARALLEL wrapper node in future work.
+            if len(successors) == 1:
+                target = successors[0].target
+                builder.add_edge(nid, target if target in dag.nodes else END)
+            else:
+                # Multiple successors: chain first unconditional, then the rest.
+                # This linearises the fan-out; for true concurrency use DAGExecutor
+                # directly or a future parallel node type.
+                for edge in successors:
+                    target = edge.target if edge.target in dag.nodes else END
+                    builder.add_edge(nid, target)
+                    break  # GraphRunner follows the first matching edge
+
+    # Set entry point to first root.
+    first_root = roots[0].node_id
+    builder.set_entry_point(first_root)
+
+    return builder.compile()
+
+
+# ---------------------------------------------------------------------------
+# DAGGraphExecutor (integration class)
+# ---------------------------------------------------------------------------
+
+
+class DAGGraphExecutor:
+    """Drop-in replacement for ``DAGExecutor`` that uses ``GraphRunner`` internally.
+
+    ``WorkflowExecutor._execute_dag_workflow`` currently instantiates
+    ``DAGExecutor`` and calls ``executor.execute(dag, workflow_id, context)``.
+    Replacing that with ``DAGGraphExecutor`` keeps the same call contract while
+    delegating execution to the unified ``GraphRunner`` engine.
+
+    Differences from ``DAGExecutor``:
+    - Checkpoint save/load handled by ``GraphRunner`` (not duplicated here).
+    - Step events emitted via ``StepEventEmitter`` (pluggable sinks).
+    - Retry configured per-node via ``NodeRetryConfig``.
+
+    Limitation (known):
+    - True parallel fan-out (multiple successors executed concurrently) is
+      linearised in this implementation.  The original ``DAGExecutor`` uses
+      ``asyncio.gather`` for independent branches.  Full parallel fan-out
+      support is tracked as a follow-up enhancement in issue #3228.
+    """
+
+    def __init__(
+        self,
+        step_executor_callback: StepExecutorCallback,
+        emitter: Optional[StepEventEmitter] = None,
+        retry_config: Optional[NodeRetryConfig] = None,
+        enable_checkpoints: bool = True,
+    ) -> None:
+        self._step_executor = step_executor_callback
+        self._emitter = emitter or StepEventEmitter()
+        self._retry_config = retry_config
+        self._enable_checkpoints = enable_checkpoints
+
+    async def execute(
+        self,
+        dag: WorkflowDAG,
+        workflow_id: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> DAGExecutionContext:
+        """Execute *dag* using ``GraphRunner``.
+
+        Args:
+            dag:         The workflow graph to execute.
+            workflow_id: Identifier for logging and checkpointing.
+            context:     Optional extra context forwarded to step executor.
+
+        Returns:
+            Populated ``DAGExecutionContext`` after all reachable nodes finish.
+        """
+        from constants.status_enums import TaskStatus
+
+        cycle = dag.detect_cycle()
+        if cycle:
+            logger.error(
+                "DAGGraphExecutor %s: cycle detected (%s); aborting",
+                workflow_id,
+                " → ".join(cycle),
+            )
+            ctx = DAGExecutionContext(workflow_id=workflow_id)
+            ctx.status = TaskStatus.FAILED.value
+            ctx.error = f"Cycle detected in workflow graph: {' → '.join(cycle)}"
+            return ctx
+
+        roots = dag.root_nodes()
+        if not roots:
+            logger.error(
+                "DAGGraphExecutor %s: DAG has no root nodes", workflow_id
+            )
+            ctx = DAGExecutionContext(workflow_id=workflow_id)
+            ctx.status = TaskStatus.FAILED.value
+            ctx.error = "DAG has no root nodes"
+            return ctx
+
+        ctx = DAGExecutionContext(workflow_id=workflow_id)
+
+        try:
+            compiled = build_dag_graph(
+                dag, self._step_executor, self._retry_config
+            )
+        except ValueError as exc:
+            logger.error(
+                "DAGGraphExecutor %s: graph build failed: %s", workflow_id, exc
+            )
+            ctx.status = TaskStatus.FAILED.value
+            ctx.error = str(exc)
+            return ctx
+
+        initial_state: Dict[str, Any] = {
+            "dag_ctx": ctx,
+            "dag": dag,
+            "step_executor": self._step_executor,
+            "visited": set(),
+            "extra_context": context or {},
+        }
+
+        runner = GraphRunner(
+            graph=compiled,
+            graph_id=workflow_id,
+            emitter=self._emitter,
+            enable_checkpoints=self._enable_checkpoints,
+        )
+
+        logger.info(
+            "DAGGraphExecutor %s: starting execution from %d root node(s): %s",
+            workflow_id,
+            len(roots),
+            [r.node_id for r in roots],
+        )
+
+        try:
+            await runner.run(initial_state)
+        except Exception as exc:
+            logger.error(
+                "DAGGraphExecutor %s: execution raised: %s", workflow_id, exc
+            )
+            ctx.status = TaskStatus.FAILED.value
+            ctx.error = str(exc)
+            return ctx
+
+        ctx.status = (
+            TaskStatus.COMPLETED.value
+            if ctx.error is None
+            else TaskStatus.PARTIALLY_COMPLETED.value
+        )
+        logger.info(
+            "DAGGraphExecutor %s: finished: status=%s",
+            workflow_id,
+            ctx.status,
+        )
+        return ctx

--- a/autobot-backend/orchestration/graph_runner.py
+++ b/autobot-backend/orchestration/graph_runner.py
@@ -1,0 +1,769 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+UnifiedGraph / AutoBotGraph — shared graph execution model.
+
+Issue #3228: unify DAG workflow executor and chat LangGraph into a single
+graph model so checkpoint, retry, and step-event logic are implemented once.
+
+Design
+------
+The issue identifies three viable approaches.  This module implements the
+**thin-adapter** strategy: both the DAG workflow executor and LangGraph chat
+workflow remain intact but share a common ``GraphRunner`` engine that handles
+cross-cutting concerns:
+
+- Step-event emission (structured log entries emitted before/after each node)
+- Checkpoint read/write so execution can resume from failure
+- Retry with configurable back-off per node
+- Conditional edge routing via a pure ``EdgeRouter``
+
+``AutoBotGraph`` is the builder/registry that holds nodes and edges, validates
+the graph, and returns an executor.  It intentionally mirrors the LangGraph
+``StateGraph`` builder API so the chat workflow migration in a follow-up PR
+requires only a mechanical substitution.
+
+Migration path for chat/LangGraph
+----------------------------------
+``chat_workflow/graph.py`` currently builds a LangGraph ``StateGraph``.
+That graph can be migrated in three steps once this module stabilises:
+
+1.  Replace ``from langgraph.graph import StateGraph`` with
+    ``from orchestration.graph_runner import AutoBotGraph``.
+2.  Replace ``builder = StateGraph(ChatState)`` with
+    ``builder = AutoBotGraph(ChatState)``.
+3.  Replace ``builder.add_node`` / ``builder.add_edge`` /
+    ``builder.add_conditional_edges`` calls with the equivalent
+    ``AutoBotGraph`` calls (identical signatures).
+4.  Remove the ``AsyncRedisSaver`` checkpointer wiring — ``GraphRunner``
+    handles checkpointing internally via ``WorkflowCheckpointManager``.
+
+The ``interrupt()`` mechanism used for command approval would be replaced by
+a first-class ``GraphRunner.pause()`` / ``GraphRunner.resume()`` pair
+(tracked in issue #3228 as a future enhancement).
+
+Public surface
+--------------
+- ``NodeRunner``            — protocol a node callable must satisfy
+- ``EdgeRouter``            — pure function that resolves the next node name
+- ``GraphStepEvent``        — structured event emitted around each node
+- ``StepEventEmitter``      — emits step events to pluggable sinks
+- ``NodeRetryConfig``       — per-node retry/back-off configuration
+- ``AutoBotGraph``          — builder: add nodes, edges, conditional edges
+- ``GraphRunner``           — executes a compiled graph, emits events
+- ``CompiledGraph``         — result of ``AutoBotGraph.compile()``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Protocol,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    runtime_checkable,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Sentinel values (mirror LangGraph convention)
+# ---------------------------------------------------------------------------
+
+#: Sentinel string used as the implicit start node name.
+START: str = "__start__"
+#: Sentinel string used as the implicit end node name.
+END: str = "__end__"
+
+
+# ---------------------------------------------------------------------------
+# State type variable
+# ---------------------------------------------------------------------------
+
+StateT = TypeVar("StateT", bound=dict)
+
+
+# ---------------------------------------------------------------------------
+# Node / edge types
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class NodeRunner(Protocol[StateT]):
+    """Protocol that every graph node must satisfy.
+
+    A node is any async callable that accepts the current state dict and
+    returns a (possibly partial) state dict.  The runner **merges** the
+    returned dict into the existing state — nodes must not return a
+    complete replacement state, only the keys they modify.
+
+    Args:
+        state: Current graph state.
+        **kwargs: Additional keyword arguments forwarded by the runner
+                  (e.g. ``config`` for LangGraph-compatible nodes).
+
+    Returns:
+        Partial state update dict.
+    """
+
+    async def __call__(
+        self, state: StateT, **kwargs: Any
+    ) -> Dict[str, Any]: ...
+
+
+#: Type alias for a sync or async conditional-edge router.
+#: Receives the current state and returns the name of the next node
+#: (or END to terminate).
+EdgeRouter = Callable[[StateT], Union[str, Coroutine[Any, Any, str]]]
+
+
+# ---------------------------------------------------------------------------
+# Step events
+# ---------------------------------------------------------------------------
+
+
+class StepEventType(str, Enum):
+    """Lifecycle events emitted around each graph node execution."""
+
+    NODE_START = "node_start"
+    NODE_END = "node_end"
+    NODE_ERROR = "node_error"
+    NODE_RETRY = "node_retry"
+    NODE_SKIP = "node_skip"
+
+
+@dataclass
+class GraphStepEvent:
+    """Structured event emitted before, after, or on error for a node.
+
+    Consumers register sinks via ``StepEventEmitter.add_sink`` to receive
+    these events for monitoring, tracing, or streaming to frontends.
+    """
+
+    event_type: StepEventType
+    node_name: str
+    graph_id: str
+    attempt: int = 1
+    elapsed_ms: Optional[float] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+#: Sink callable that receives step events asynchronously.
+StepEventSink = Callable[[GraphStepEvent], Coroutine[Any, Any, None]]
+
+
+class StepEventEmitter:
+    """Emits ``GraphStepEvent`` objects to registered async sinks.
+
+    Sinks are called concurrently via ``asyncio.gather``.  A failing sink
+    is logged and suppressed so it never disrupts graph execution.
+    """
+
+    def __init__(self) -> None:
+        self._sinks: List[StepEventSink] = []
+
+    def add_sink(self, sink: StepEventSink) -> None:
+        """Register an async event sink."""
+        self._sinks.append(sink)
+
+    async def emit(self, event: GraphStepEvent) -> None:
+        """Emit *event* to all registered sinks in parallel."""
+        if not self._sinks:
+            return
+        results = await asyncio.gather(
+            *(sink(event) for sink in self._sinks),
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, Exception):
+                logger.warning(
+                    "StepEventSink raised (suppressed): %s", result
+                )
+
+
+# ---------------------------------------------------------------------------
+# Retry configuration
+# ---------------------------------------------------------------------------
+
+
+class BackoffMode(str, Enum):
+    """Back-off strategy for node retries."""
+
+    FIXED = "fixed"
+    LINEAR = "linear"
+    EXPONENTIAL = "exponential"
+
+
+@dataclass
+class NodeRetryConfig:
+    """Per-node retry configuration.
+
+    Attributes:
+        max_retries: Maximum number of retry attempts (0 = no retry).
+        backoff_mode: Delay growth strategy.
+        base_delay_s: Base delay in seconds before the first retry.
+        max_delay_s: Upper bound on retry delay (prevents unbounded waits).
+        retryable_exceptions: Only retry on these exception types.
+                              Empty tuple means retry on any ``Exception``.
+    """
+
+    max_retries: int = 0
+    backoff_mode: BackoffMode = BackoffMode.FIXED
+    base_delay_s: float = 1.0
+    max_delay_s: float = 60.0
+    retryable_exceptions: Tuple[Type[Exception], ...] = field(
+        default_factory=tuple
+    )
+
+    def delay_for(self, attempt: int) -> float:
+        """Return the delay (seconds) before *attempt* (1-indexed)."""
+        if attempt <= 1:
+            return 0.0
+        n = attempt - 1  # number of failures so far
+        if self.backoff_mode == BackoffMode.EXPONENTIAL:
+            delay = self.base_delay_s * (2 ** (n - 1))
+        elif self.backoff_mode == BackoffMode.LINEAR:
+            delay = self.base_delay_s * n
+        else:
+            delay = self.base_delay_s
+        return min(delay, self.max_delay_s)
+
+    def is_retryable(self, exc: Exception) -> bool:
+        """Return True when *exc* qualifies for a retry."""
+        if not self.retryable_exceptions:
+            return True
+        return isinstance(exc, self.retryable_exceptions)
+
+
+# ---------------------------------------------------------------------------
+# Internal graph structure
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _NodeEntry:
+    """Internal: stores a registered node and its retry config."""
+
+    name: str
+    fn: NodeRunner
+    retry: NodeRetryConfig = field(default_factory=NodeRetryConfig)
+
+
+@dataclass
+class _EdgeEntry:
+    """Internal: stores an edge — unconditional or conditional."""
+
+    source: str
+    #: For unconditional edges: target node name (or END).
+    target: Optional[str] = None
+    #: For conditional edges: router function (returns node name or END).
+    router: Optional[EdgeRouter] = None
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint adapter (shared with WorkflowCheckpointManager)
+# ---------------------------------------------------------------------------
+
+
+class _CheckpointAdapter:
+    """Thin async wrapper around ``WorkflowCheckpointManager``.
+
+    ``WorkflowCheckpointManager`` uses sync Redis calls via the shared
+    ``autobot_shared.redis_client``.  This adapter wraps each call in
+    ``asyncio.get_event_loop().run_in_executor`` so graph execution
+    remains non-blocking.
+
+    When ``WorkflowCheckpointManager`` is unavailable (test environments)
+    the adapter silently no-ops.
+    """
+
+    def __init__(self, graph_id: str) -> None:
+        self._graph_id = graph_id
+        self._manager: Optional[Any] = None
+        try:
+            from orchestration.error_handler import WorkflowCheckpointManager
+
+            self._manager = WorkflowCheckpointManager()
+        except Exception as exc:
+            logger.debug("Checkpoint manager unavailable (%s); skipping", exc)
+
+    async def save(self, node_name: str, output: Dict[str, Any]) -> None:
+        """Persist a checkpoint for *node_name*."""
+        if self._manager is None:
+            return
+        try:
+            from orchestration.error_handler import StepCheckpoint
+
+            checkpoint = StepCheckpoint(
+                step_id=node_name,
+                status="completed",
+                output=output,
+            )
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(
+                None, self._manager.save, self._graph_id, checkpoint
+            )
+        except Exception as exc:
+            logger.warning(
+                "GraphRunner: checkpoint save failed for %s/%s: %s",
+                self._graph_id,
+                node_name,
+                exc,
+            )
+
+    async def load_all(self) -> Dict[str, Any]:
+        """Return all persisted checkpoints keyed by node name."""
+        if self._manager is None:
+            return {}
+        try:
+            loop = asyncio.get_event_loop()
+            checkpoints = await loop.run_in_executor(
+                None, self._manager.load_all, self._graph_id
+            )
+            return {
+                name: cp.output for name, cp in (checkpoints or {}).items()
+            }
+        except Exception as exc:
+            logger.warning(
+                "GraphRunner: checkpoint load failed for %s: %s",
+                self._graph_id,
+                exc,
+            )
+            return {}
+
+    async def clear(self) -> None:
+        """Remove all checkpoints for this graph run."""
+        if self._manager is None:
+            return
+        try:
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(
+                None, self._manager.clear, self._graph_id
+            )
+        except Exception as exc:
+            logger.warning(
+                "GraphRunner: checkpoint clear failed for %s: %s",
+                self._graph_id,
+                exc,
+            )
+
+
+# ---------------------------------------------------------------------------
+# CompiledGraph
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CompiledStructure:
+    """Validated, immutable graph topology returned by ``AutoBotGraph.compile()``."""
+
+    nodes: Dict[str, _NodeEntry]
+    edges: List[_EdgeEntry]
+    entry_point: str
+
+    def successors(self, node_name: str) -> List[_EdgeEntry]:
+        """Return all outgoing edge entries for *node_name*."""
+        return [e for e in self.edges if e.source == node_name]
+
+
+class CompiledGraph(Generic[StateT]):
+    """A validated, ready-to-execute graph.
+
+    Obtain via ``AutoBotGraph.compile()``.  Execute via
+    ``GraphRunner(compiled).run(state)``.
+    """
+
+    def __init__(self, structure: _CompiledStructure) -> None:
+        self._structure = structure
+
+    @property
+    def structure(self) -> _CompiledStructure:
+        return self._structure
+
+
+# ---------------------------------------------------------------------------
+# AutoBotGraph (builder)
+# ---------------------------------------------------------------------------
+
+
+class AutoBotGraph(Generic[StateT]):
+    """Builder that constructs a validated ``CompiledGraph``.
+
+    API is intentionally aligned with the LangGraph ``StateGraph`` builder
+    to ease future migration:
+
+    - ``add_node(name, fn, retry=...)``
+    - ``add_edge(source, target)``
+    - ``add_conditional_edges(source, router)``
+    - ``set_entry_point(name)``
+    - ``compile() -> CompiledGraph``
+
+    Unlike LangGraph, ``AutoBotGraph`` does not require a ``TypedDict``
+    schema argument; it accepts any dict subtype as state.
+    """
+
+    def __init__(self, state_type: Optional[Type[StateT]] = None) -> None:
+        self._state_type = state_type
+        self._nodes: Dict[str, _NodeEntry] = {}
+        self._edges: List[_EdgeEntry] = []
+        self._entry_point: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Builder methods
+    # ------------------------------------------------------------------
+
+    def add_node(
+        self,
+        name: str,
+        fn: NodeRunner,
+        retry: Optional[NodeRetryConfig] = None,
+    ) -> "AutoBotGraph[StateT]":
+        """Register a node.
+
+        Args:
+            name: Unique node identifier.
+            fn:   Async callable ``(state, **kwargs) -> partial_state_dict``.
+            retry: Optional per-node retry configuration.
+
+        Returns:
+            self (fluent API).
+        """
+        if name in (START, END):
+            raise ValueError(
+                f"'{name}' is a reserved sentinel and cannot be used as a node name."
+            )
+        if name in self._nodes:
+            raise ValueError(f"Node '{name}' is already registered.")
+        self._nodes[name] = _NodeEntry(
+            name=name,
+            fn=fn,
+            retry=retry or NodeRetryConfig(),
+        )
+        return self
+
+    def add_edge(self, source: str, target: str) -> "AutoBotGraph[StateT]":
+        """Add an unconditional edge from *source* to *target*.
+
+        *source* may be the ``START`` sentinel (sets entry point).
+        *target* may be ``END``.
+        """
+        if source == START:
+            if self._entry_point is not None:
+                raise ValueError("Entry point already set.")
+            if target == END:
+                raise ValueError("Cannot connect START directly to END.")
+            self._entry_point = target
+            return self
+
+        self._edges.append(_EdgeEntry(source=source, target=target))
+        return self
+
+    def add_conditional_edges(
+        self,
+        source: str,
+        router: EdgeRouter,
+    ) -> "AutoBotGraph[StateT]":
+        """Add a conditional edge from *source* whose target is chosen by *router*.
+
+        Args:
+            source: The node whose output drives the routing decision.
+            router: Sync or async callable ``(state) -> node_name | END``.
+        """
+        self._edges.append(_EdgeEntry(source=source, router=router))
+        return self
+
+    def set_entry_point(self, name: str) -> "AutoBotGraph[StateT]":
+        """Explicitly set the entry node (alternative to ``add_edge(START, name)``)."""
+        if self._entry_point is not None:
+            raise ValueError("Entry point already set.")
+        self._entry_point = name
+        return self
+
+    # ------------------------------------------------------------------
+    # Compilation
+    # ------------------------------------------------------------------
+
+    def compile(self) -> CompiledGraph[StateT]:
+        """Validate topology and return an executable ``CompiledGraph``.
+
+        Raises:
+            ValueError: When the graph is malformed (missing entry point,
+                        edges referencing unknown nodes, etc.).
+        """
+        if not self._entry_point:
+            raise ValueError(
+                "Graph has no entry point. "
+                "Call set_entry_point() or add_edge(START, '<node>')."
+            )
+
+        # Validate edge sources/targets reference known nodes or sentinels.
+        known = set(self._nodes.keys()) | {START, END}
+        for edge in self._edges:
+            if edge.source not in known:
+                raise ValueError(
+                    f"Edge source '{edge.source}' is not a registered node."
+                )
+            if edge.target is not None and edge.target not in known:
+                raise ValueError(
+                    f"Edge target '{edge.target}' is not a registered node."
+                )
+
+        structure = _CompiledStructure(
+            nodes=dict(self._nodes),
+            edges=list(self._edges),
+            entry_point=self._entry_point,
+        )
+        logger.debug(
+            "AutoBotGraph compiled: %d nodes, %d edges, entry=%s",
+            len(structure.nodes),
+            len(structure.edges),
+            structure.entry_point,
+        )
+        return CompiledGraph(structure)
+
+
+# ---------------------------------------------------------------------------
+# GraphRunner
+# ---------------------------------------------------------------------------
+
+
+class GraphRunner(Generic[StateT]):
+    """Executes a ``CompiledGraph`` against an initial state dict.
+
+    Responsibilities (all handled here, not in individual nodes):
+    - Node execution with configurable retry / back-off
+    - Checkpoint save after each successful node
+    - Checkpoint load for resume-from-failure
+    - ``GraphStepEvent`` emission before/after/on-error for each node
+    - Conditional edge resolution (sync or async routers supported)
+
+    Args:
+        graph:      Compiled graph to execute.
+        graph_id:   Logical identifier for this execution run (used for
+                    checkpointing and logging).
+        emitter:    Optional ``StepEventEmitter``; created internally
+                    if not provided.
+        enable_checkpoints: When False, checkpoint save/load are skipped.
+        configurable: Arbitrary key-value pairs forwarded to each node
+                      via ``kwargs["config"]["configurable"]``.  Mirrors
+                      the LangGraph ``RunnableConfig`` pattern.
+    """
+
+    def __init__(
+        self,
+        graph: CompiledGraph[StateT],
+        graph_id: str = "",
+        emitter: Optional[StepEventEmitter] = None,
+        enable_checkpoints: bool = True,
+        configurable: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._graph = graph
+        self._graph_id = graph_id
+        self._emitter = emitter or StepEventEmitter()
+        self._checkpoint = (
+            _CheckpointAdapter(graph_id)
+            if enable_checkpoints and graph_id
+            else None
+        )
+        self._configurable = configurable or {}
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    async def run(
+        self,
+        initial_state: StateT,
+        resume_from_checkpoint: bool = False,
+    ) -> StateT:
+        """Execute the graph from the entry point.
+
+        Args:
+            initial_state:          Initial state dict.
+            resume_from_checkpoint: When True, load persisted checkpoints and
+                                    skip nodes that already completed.
+
+        Returns:
+            Final merged state dict after all nodes have executed.
+        """
+        state: Dict[str, Any] = dict(initial_state)
+
+        # Seed state from checkpoints so resume works correctly.
+        completed_nodes: Set[str] = set()
+        if resume_from_checkpoint and self._checkpoint:
+            checkpoints = await self._checkpoint.load_all()
+            if checkpoints:
+                logger.info(
+                    "GraphRunner %s: resuming with %d checkpointed node(s): %s",
+                    self._graph_id,
+                    len(checkpoints),
+                    list(checkpoints.keys()),
+                )
+                for node_name, output in checkpoints.items():
+                    if isinstance(output, dict):
+                        state.update(output)
+                    completed_nodes.add(node_name)
+
+        structure = self._graph.structure
+        current_node = structure.entry_point
+
+        while current_node and current_node != END:
+            if current_node not in structure.nodes:
+                logger.error(
+                    "GraphRunner %s: unknown node '%s'; halting",
+                    self._graph_id,
+                    current_node,
+                )
+                break
+
+            # Skip if resumed and already completed.
+            if current_node in completed_nodes:
+                logger.debug(
+                    "GraphRunner %s: skipping checkpointed node '%s'",
+                    self._graph_id,
+                    current_node,
+                )
+                current_node = await self._resolve_next(
+                    current_node, state, structure
+                )
+                continue
+
+            node_entry = structure.nodes[current_node]
+            partial_update = await self._execute_node(node_entry, state)
+
+            if isinstance(partial_update, dict):
+                state.update(partial_update)
+                # Checkpoint after success.
+                if self._checkpoint:
+                    await self._checkpoint.save(current_node, partial_update)
+
+            current_node = await self._resolve_next(
+                current_node, state, structure
+            )
+
+        # Clear checkpoints on clean completion.
+        if self._checkpoint and not state.get("error"):
+            await self._checkpoint.clear()
+
+        return state  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _execute_node(
+        self,
+        entry: _NodeEntry,
+        state: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Execute *entry.fn* with retry.  Emits step events."""
+        retry = entry.retry
+        attempt = 1
+        config = {"configurable": dict(self._configurable)}
+
+        while True:
+            t0 = time.monotonic()
+            await self._emitter.emit(
+                GraphStepEvent(
+                    event_type=StepEventType.NODE_START,
+                    node_name=entry.name,
+                    graph_id=self._graph_id,
+                    attempt=attempt,
+                )
+            )
+            try:
+                result = await entry.fn(state, config=config)
+                elapsed = (time.monotonic() - t0) * 1000
+                await self._emitter.emit(
+                    GraphStepEvent(
+                        event_type=StepEventType.NODE_END,
+                        node_name=entry.name,
+                        graph_id=self._graph_id,
+                        attempt=attempt,
+                        elapsed_ms=elapsed,
+                    )
+                )
+                logger.debug(
+                    "GraphRunner %s: node '%s' completed in %.1f ms (attempt %d)",
+                    self._graph_id,
+                    entry.name,
+                    elapsed,
+                    attempt,
+                )
+                return result or {}
+            except Exception as exc:
+                elapsed = (time.monotonic() - t0) * 1000
+                await self._emitter.emit(
+                    GraphStepEvent(
+                        event_type=StepEventType.NODE_ERROR,
+                        node_name=entry.name,
+                        graph_id=self._graph_id,
+                        attempt=attempt,
+                        elapsed_ms=elapsed,
+                        error=str(exc),
+                    )
+                )
+                logger.warning(
+                    "GraphRunner %s: node '%s' raised on attempt %d: %s",
+                    self._graph_id,
+                    entry.name,
+                    attempt,
+                    exc,
+                )
+                if attempt <= retry.max_retries and retry.is_retryable(exc):
+                    delay = retry.delay_for(attempt + 1)
+                    await self._emitter.emit(
+                        GraphStepEvent(
+                            event_type=StepEventType.NODE_RETRY,
+                            node_name=entry.name,
+                            graph_id=self._graph_id,
+                            attempt=attempt,
+                            metadata={"delay_s": delay},
+                        )
+                    )
+                    if delay > 0:
+                        await asyncio.sleep(delay)
+                    attempt += 1
+                    continue
+                # Exhausted retries — propagate.
+                raise
+
+    async def _resolve_next(
+        self,
+        current: str,
+        state: Dict[str, Any],
+        structure: _CompiledStructure,
+    ) -> Optional[str]:
+        """Resolve the next node name from the outgoing edges of *current*."""
+        edges = structure.successors(current)
+        if not edges:
+            return END
+
+        for edge in edges:
+            if edge.router is not None:
+                # Conditional edge: invoke router.
+                result = edge.router(state)
+                if asyncio.iscoroutine(result):
+                    result = await result
+                return result  # type: ignore[return-value]
+            # Unconditional edge.
+            if edge.target is not None:
+                return edge.target
+
+        return END

--- a/autobot-backend/orchestration/graph_runner_test.py
+++ b/autobot-backend/orchestration/graph_runner_test.py
@@ -1,0 +1,625 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for orchestration.graph_runner and orchestration.dag_graph_adapter.
+
+Issue #3228: unified graph model.
+
+Tests cover:
+- AutoBotGraph builder validation
+- GraphRunner linear execution
+- GraphRunner conditional edge routing
+- GraphRunner retry / back-off
+- GraphRunner checkpoint resume
+- StepEventEmitter sink dispatch
+- DAGGraphExecutor basic execution
+- DAGGraphExecutor condition-node branching
+- NodeRetryConfig delay calculations
+"""
+
+import asyncio
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orchestration.graph_runner import (
+    END,
+    START,
+    AutoBotGraph,
+    BackoffMode,
+    CompiledGraph,
+    GraphRunner,
+    GraphStepEvent,
+    NodeRetryConfig,
+    StepEventEmitter,
+    StepEventType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _noop(state: dict, **kwargs: Any) -> dict:
+    return {}
+
+
+async def _set_key(key: str, value: Any):
+    async def _fn(state: dict, **kwargs: Any) -> dict:
+        return {key: value}
+
+    return _fn
+
+
+async def _fail_then_succeed(call_count: list[int]):
+    """Node that raises on first call, succeeds on second."""
+    async def _fn(state: dict, **kwargs: Any) -> dict:
+        call_count.append(1)
+        if len(call_count) == 1:
+            raise RuntimeError("transient error")
+        return {"retried": True}
+
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# NodeRetryConfig
+# ---------------------------------------------------------------------------
+
+
+class TestNodeRetryConfig:
+    def test_delay_fixed(self):
+        cfg = NodeRetryConfig(max_retries=3, base_delay_s=2.0)
+        assert cfg.delay_for(1) == 0.0  # first attempt — no delay
+        assert cfg.delay_for(2) == 2.0
+        assert cfg.delay_for(3) == 2.0
+
+    def test_delay_linear(self):
+        cfg = NodeRetryConfig(
+            max_retries=3,
+            backoff_mode=BackoffMode.LINEAR,
+            base_delay_s=1.0,
+        )
+        assert cfg.delay_for(2) == 1.0
+        assert cfg.delay_for(3) == 2.0
+        assert cfg.delay_for(4) == 3.0
+
+    def test_delay_exponential(self):
+        cfg = NodeRetryConfig(
+            max_retries=5,
+            backoff_mode=BackoffMode.EXPONENTIAL,
+            base_delay_s=1.0,
+        )
+        assert cfg.delay_for(2) == 1.0  # 1 * 2^0
+        assert cfg.delay_for(3) == 2.0  # 1 * 2^1
+        assert cfg.delay_for(4) == 4.0  # 1 * 2^2
+
+    def test_delay_capped_by_max(self):
+        cfg = NodeRetryConfig(
+            max_retries=5,
+            backoff_mode=BackoffMode.EXPONENTIAL,
+            base_delay_s=10.0,
+            max_delay_s=15.0,
+        )
+        assert cfg.delay_for(5) <= 15.0
+
+    def test_is_retryable_any(self):
+        cfg = NodeRetryConfig()
+        assert cfg.is_retryable(RuntimeError("x"))
+        assert cfg.is_retryable(ValueError("y"))
+
+    def test_is_retryable_specific(self):
+        cfg = NodeRetryConfig(retryable_exceptions=(RuntimeError,))
+        assert cfg.is_retryable(RuntimeError("x"))
+        assert not cfg.is_retryable(ValueError("y"))
+
+
+# ---------------------------------------------------------------------------
+# AutoBotGraph builder
+# ---------------------------------------------------------------------------
+
+
+class TestAutoBotGraph:
+    def test_compile_simple(self):
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node("a", _noop)
+        builder.add_node("b", _noop)
+        builder.add_edge(START, "a")
+        builder.add_edge("a", "b")
+        builder.add_edge("b", END)
+        graph = builder.compile()
+        assert isinstance(graph, CompiledGraph)
+        assert graph.structure.entry_point == "a"
+
+    def test_compile_missing_entry_point_raises(self):
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node("a", _noop)
+        with pytest.raises(ValueError, match="no entry point"):
+            builder.compile()
+
+    def test_duplicate_node_raises(self):
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node("a", _noop)
+        with pytest.raises(ValueError, match="already registered"):
+            builder.add_node("a", _noop)
+
+    def test_reserved_name_raises(self):
+        builder: AutoBotGraph = AutoBotGraph()
+        with pytest.raises(ValueError, match="reserved sentinel"):
+            builder.add_node(START, _noop)
+        with pytest.raises(ValueError, match="reserved sentinel"):
+            builder.add_node(END, _noop)
+
+    def test_edge_unknown_source_raises(self):
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node("a", _noop)
+        builder.add_edge(START, "a")
+        builder.add_edge("a", "unknown_node")
+        with pytest.raises(ValueError, match="unknown_node"):
+            builder.compile()
+
+    def test_start_directly_to_end_raises(self):
+        builder: AutoBotGraph = AutoBotGraph()
+        with pytest.raises(ValueError, match="Cannot connect START directly to END"):
+            builder.add_edge(START, END)
+
+    def test_fluent_api(self):
+        """Builder methods return self for chaining."""
+        builder: AutoBotGraph = AutoBotGraph()
+        result = builder.add_node("a", _noop).add_edge(START, "a").add_edge("a", END)
+        assert result is builder
+
+    def test_set_entry_point_twice_raises(self):
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node("a", _noop)
+        builder.add_node("b", _noop)
+        builder.add_edge(START, "a")
+        with pytest.raises(ValueError, match="Entry point already set"):
+            builder.set_entry_point("b")
+
+
+# ---------------------------------------------------------------------------
+# GraphRunner linear execution
+# ---------------------------------------------------------------------------
+
+
+class TestGraphRunnerLinear:
+    @pytest.fixture
+    def simple_graph(self):
+        builder: AutoBotGraph = AutoBotGraph()
+
+        async def node_a(state: dict, **kw: Any) -> dict:
+            return {"a_done": True}
+
+        async def node_b(state: dict, **kw: Any) -> dict:
+            return {"b_done": True}
+
+        builder.add_node("a", node_a)
+        builder.add_node("b", node_b)
+        builder.add_edge(START, "a")
+        builder.add_edge("a", "b")
+        builder.add_edge("b", END)
+        return builder.compile()
+
+    def test_executes_all_nodes(self, simple_graph):
+        runner = GraphRunner(simple_graph, graph_id="test", enable_checkpoints=False)
+        state = asyncio.get_event_loop().run_until_complete(runner.run({}))
+        assert state["a_done"] is True
+        assert state["b_done"] is True
+
+    def test_state_accumulates(self, simple_graph):
+        runner = GraphRunner(simple_graph, graph_id="test", enable_checkpoints=False)
+        state = asyncio.get_event_loop().run_until_complete(
+            runner.run({"initial": 42})
+        )
+        assert state["initial"] == 42
+        assert state["a_done"] is True
+        assert state["b_done"] is True
+
+    def test_configurable_forwarded(self):
+        received_config = {}
+
+        async def node_a(state: dict, **kw: Any) -> dict:
+            received_config.update(kw.get("config", {}).get("configurable", {}))
+            return {}
+
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node("a", node_a)
+        builder.add_edge(START, "a")
+        builder.add_edge("a", END)
+        graph = builder.compile()
+
+        runner = GraphRunner(
+            graph,
+            graph_id="test",
+            enable_checkpoints=False,
+            configurable={"manager": "mock_manager"},
+        )
+        asyncio.get_event_loop().run_until_complete(runner.run({}))
+        assert received_config["manager"] == "mock_manager"
+
+
+# ---------------------------------------------------------------------------
+# GraphRunner conditional edges
+# ---------------------------------------------------------------------------
+
+
+class TestGraphRunnerConditional:
+    def _build_graph(self, router_result: str):
+        builder: AutoBotGraph = AutoBotGraph()
+
+        async def node_start(state: dict, **kw: Any) -> dict:
+            return {"ran_start": True}
+
+        async def node_true_branch(state: dict, **kw: Any) -> dict:
+            return {"branch": "true"}
+
+        async def node_false_branch(state: dict, **kw: Any) -> dict:
+            return {"branch": "false"}
+
+        def router(state: dict) -> str:
+            return router_result
+
+        builder.add_node("start", node_start)
+        builder.add_node("true_branch", node_true_branch)
+        builder.add_node("false_branch", node_false_branch)
+        builder.add_edge(START, "start")
+        builder.add_conditional_edges("start", router)
+        builder.add_edge("true_branch", END)
+        builder.add_edge("false_branch", END)
+        return builder.compile()
+
+    def test_routes_to_true_branch(self):
+        graph = self._build_graph("true_branch")
+        runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
+        state = asyncio.get_event_loop().run_until_complete(runner.run({}))
+        assert state["branch"] == "true"
+
+    def test_routes_to_false_branch(self):
+        graph = self._build_graph("false_branch")
+        runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
+        state = asyncio.get_event_loop().run_until_complete(runner.run({}))
+        assert state["branch"] == "false"
+
+    def test_async_router(self):
+        builder: AutoBotGraph = AutoBotGraph()
+
+        async def node_a(state: dict, **kw: Any) -> dict:
+            return {}
+
+        async def node_b(state: dict, **kw: Any) -> dict:
+            return {"from_async": True}
+
+        async def async_router(state: dict) -> str:
+            return "b"
+
+        builder.add_node("a", node_a)
+        builder.add_node("b", node_b)
+        builder.add_edge(START, "a")
+        builder.add_conditional_edges("a", async_router)
+        builder.add_edge("b", END)
+        graph = builder.compile()
+
+        runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
+        state = asyncio.get_event_loop().run_until_complete(runner.run({}))
+        assert state["from_async"] is True
+
+    def test_router_returns_end(self):
+        builder: AutoBotGraph = AutoBotGraph()
+
+        async def node_a(state: dict, **kw: Any) -> dict:
+            return {"a": 1}
+
+        builder.add_node("a", node_a)
+        builder.add_edge(START, "a")
+        builder.add_conditional_edges("a", lambda s: END)
+        graph = builder.compile()
+
+        runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
+        state = asyncio.get_event_loop().run_until_complete(runner.run({}))
+        assert state["a"] == 1  # graph terminated cleanly at END
+
+
+# ---------------------------------------------------------------------------
+# GraphRunner retry
+# ---------------------------------------------------------------------------
+
+
+class TestGraphRunnerRetry:
+    def test_retry_on_transient_error(self):
+        calls: List[int] = []
+
+        async def flaky_node(state: dict, **kw: Any) -> dict:
+            calls.append(1)
+            if len(calls) < 3:
+                raise RuntimeError("transient")
+            return {"result": "ok"}
+
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node(
+            "flaky",
+            flaky_node,
+            retry=NodeRetryConfig(max_retries=3, base_delay_s=0.0),
+        )
+        builder.add_edge(START, "flaky")
+        builder.add_edge("flaky", END)
+        graph = builder.compile()
+
+        runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
+        state = asyncio.get_event_loop().run_until_complete(runner.run({}))
+        assert state["result"] == "ok"
+        assert len(calls) == 3
+
+    def test_exhausted_retries_propagate(self):
+        async def always_fails(state: dict, **kw: Any) -> dict:
+            raise RuntimeError("always fails")
+
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node(
+            "bad",
+            always_fails,
+            retry=NodeRetryConfig(max_retries=2, base_delay_s=0.0),
+        )
+        builder.add_edge(START, "bad")
+        builder.add_edge("bad", END)
+        graph = builder.compile()
+
+        runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
+        with pytest.raises(RuntimeError, match="always fails"):
+            asyncio.get_event_loop().run_until_complete(runner.run({}))
+
+    def test_non_retryable_exception_not_retried(self):
+        calls: List[int] = []
+
+        async def specific_error(state: dict, **kw: Any) -> dict:
+            calls.append(1)
+            raise ValueError("not retryable")
+
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node(
+            "node",
+            specific_error,
+            retry=NodeRetryConfig(
+                max_retries=3,
+                base_delay_s=0.0,
+                retryable_exceptions=(RuntimeError,),  # ValueError NOT included
+            ),
+        )
+        builder.add_edge(START, "node")
+        builder.add_edge("node", END)
+        graph = builder.compile()
+
+        runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
+        with pytest.raises(ValueError):
+            asyncio.get_event_loop().run_until_complete(runner.run({}))
+        assert len(calls) == 1  # No retry attempted
+
+
+# ---------------------------------------------------------------------------
+# StepEventEmitter
+# ---------------------------------------------------------------------------
+
+
+class TestStepEventEmitter:
+    def test_sink_receives_events(self):
+        received: List[GraphStepEvent] = []
+
+        async def sink(event: GraphStepEvent) -> None:
+            received.append(event)
+
+        emitter = StepEventEmitter()
+        emitter.add_sink(sink)
+
+        event = GraphStepEvent(
+            event_type=StepEventType.NODE_START,
+            node_name="test",
+            graph_id="g1",
+        )
+        asyncio.get_event_loop().run_until_complete(emitter.emit(event))
+        assert len(received) == 1
+        assert received[0].node_name == "test"
+
+    def test_failing_sink_suppressed(self):
+        async def bad_sink(event: GraphStepEvent) -> None:
+            raise RuntimeError("sink failure")
+
+        emitter = StepEventEmitter()
+        emitter.add_sink(bad_sink)
+
+        event = GraphStepEvent(
+            event_type=StepEventType.NODE_END,
+            node_name="n",
+            graph_id="g",
+        )
+        # Must not raise.
+        asyncio.get_event_loop().run_until_complete(emitter.emit(event))
+
+    def test_multiple_sinks(self):
+        counter: List[int] = []
+
+        async def sink_a(e: GraphStepEvent) -> None:
+            counter.append(1)
+
+        async def sink_b(e: GraphStepEvent) -> None:
+            counter.append(2)
+
+        emitter = StepEventEmitter()
+        emitter.add_sink(sink_a)
+        emitter.add_sink(sink_b)
+
+        event = GraphStepEvent(
+            event_type=StepEventType.NODE_START, node_name="n", graph_id="g"
+        )
+        asyncio.get_event_loop().run_until_complete(emitter.emit(event))
+        assert sorted(counter) == [1, 2]
+
+    def test_events_emitted_during_execution(self):
+        emitted: List[StepEventType] = []
+
+        async def sink(event: GraphStepEvent) -> None:
+            emitted.append(event.event_type)
+
+        emitter = StepEventEmitter()
+        emitter.add_sink(sink)
+
+        async def node_a(state: dict, **kw: Any) -> dict:
+            return {"a": 1}
+
+        builder: AutoBotGraph = AutoBotGraph()
+        builder.add_node("a", node_a)
+        builder.add_edge(START, "a")
+        builder.add_edge("a", END)
+        graph = builder.compile()
+
+        runner = GraphRunner(
+            graph, graph_id="t", emitter=emitter, enable_checkpoints=False
+        )
+        asyncio.get_event_loop().run_until_complete(runner.run({}))
+
+        assert StepEventType.NODE_START in emitted
+        assert StepEventType.NODE_END in emitted
+
+
+# ---------------------------------------------------------------------------
+# DAGGraphExecutor
+# ---------------------------------------------------------------------------
+
+
+class TestDAGGraphExecutor:
+    """Integration tests for DAGGraphExecutor using real WorkflowDAG objects."""
+
+    def _build_linear_dag(self, num_steps: int = 3):
+        """Build a linear DAG with *num_steps* step nodes."""
+        from orchestration.dag_executor import WorkflowDAG
+
+        nodes = [{"id": f"s{i}", "type": "step", "data": {}} for i in range(num_steps)]
+        edges = [
+            {"source": f"s{i}", "target": f"s{i + 1}"}
+            for i in range(num_steps - 1)
+        ]
+        return WorkflowDAG(nodes, edges)
+
+    def _build_condition_dag(self, condition_value: bool):
+        """Build a condition DAG: root → condition → true_branch | false_branch."""
+        from orchestration.dag_executor import WorkflowDAG
+
+        nodes = [
+            {"id": "root", "type": "step", "data": {}},
+            {
+                "id": "cond",
+                "type": "condition",
+                "data": {"condition": f"{condition_value}"},
+            },
+            {"id": "true_branch", "type": "step", "data": {}},
+            {"id": "false_branch", "type": "step", "data": {}},
+        ]
+        edges = [
+            {"source": "root", "target": "cond"},
+            {"source": "cond", "target": "true_branch", "label": True},
+            {"source": "cond", "target": "false_branch", "label": False},
+        ]
+        return WorkflowDAG(nodes, edges)
+
+    def _make_step_executor(self, results: Dict[str, Any] = None):
+        """Return an async step executor that records which nodes ran."""
+        executed: List[str] = []
+        base_results = results or {}
+
+        async def step_executor(node, ctx) -> dict:
+            executed.append(node.node_id)
+            return base_results.get(node.node_id, {"success": True, "node_id": node.node_id})
+
+        return step_executor, executed
+
+    def test_linear_execution(self):
+        from orchestration.dag_graph_adapter import DAGGraphExecutor
+
+        dag = self._build_linear_dag(3)
+        step_executor, executed = self._make_step_executor()
+
+        executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
+        ctx = asyncio.get_event_loop().run_until_complete(
+            executor.execute(dag, "wf-linear")
+        )
+
+        assert ctx.status == "completed"
+        assert ctx.error is None
+        # All nodes ran.
+        assert "s0" in executed or "s0" in ctx.step_results
+
+    def test_empty_dag_returns_failed(self):
+        from orchestration.dag_executor import WorkflowDAG
+        from orchestration.dag_graph_adapter import DAGGraphExecutor
+
+        dag = WorkflowDAG([], [])
+        step_executor, _ = self._make_step_executor()
+
+        executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
+        ctx = asyncio.get_event_loop().run_until_complete(
+            executor.execute(dag, "wf-empty")
+        )
+
+        assert ctx.status == "failed"
+        assert ctx.error is not None
+
+    def test_cycle_detection(self):
+        from orchestration.dag_executor import WorkflowDAG
+        from orchestration.dag_graph_adapter import DAGGraphExecutor
+
+        nodes = [
+            {"id": "a", "type": "step", "data": {}},
+            {"id": "b", "type": "step", "data": {}},
+        ]
+        edges = [
+            {"source": "a", "target": "b"},
+            {"source": "b", "target": "a"},  # cycle
+        ]
+        dag = WorkflowDAG(nodes, edges)
+        step_executor, _ = self._make_step_executor()
+
+        executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
+        ctx = asyncio.get_event_loop().run_until_complete(
+            executor.execute(dag, "wf-cycle")
+        )
+
+        assert ctx.status == "failed"
+        assert "Cycle detected" in (ctx.error or "")
+
+    def test_condition_true_branch(self):
+        from orchestration.dag_graph_adapter import DAGGraphExecutor
+
+        dag = self._build_condition_dag(True)
+        step_executor, executed = self._make_step_executor()
+
+        executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
+        ctx = asyncio.get_event_loop().run_until_complete(
+            executor.execute(dag, "wf-cond-true")
+        )
+
+        assert ctx.status == "completed"
+        # true_branch should be in step_results; false_branch should be skipped.
+        assert "true_branch" in ctx.skipped_nodes or "true_branch" in ctx.step_results
+        assert "false_branch" in ctx.skipped_nodes or "false_branch" not in ctx.step_results
+
+    def test_step_results_populated(self):
+        from orchestration.dag_graph_adapter import DAGGraphExecutor
+
+        dag = self._build_linear_dag(2)
+        step_executor, _ = self._make_step_executor(
+            {
+                "s0": {"success": True, "output": "hello"},
+                "s1": {"success": True, "output": "world"},
+            }
+        )
+
+        executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
+        ctx = asyncio.get_event_loop().run_until_complete(
+            executor.execute(dag, "wf-results")
+        )
+
+        assert ctx.status == "completed"
+        assert ctx.step_results.get("s0", {}).get("output") == "hello"
+        assert ctx.step_results.get("s1", {}).get("output") == "world"


### PR DESCRIPTION
Closes #3228

## Approach

Thin-adapter strategy: both the DAG workflow executor and LangGraph chat workflow remain intact, but share a common `GraphRunner` engine that handles cross-cutting concerns implemented once:

- **Step-event emission** — structured `GraphStepEvent` emitted before/after each node
- **Checkpointing** — read/write via `WorkflowCheckpointManager` so execution can resume from failure
- **Retry with back-off** — per-node `NodeRetryConfig`
- **Conditional edge routing** — pure `EdgeRouter` callable

## New files

| File | Lines | Purpose |
|------|-------|---------|
| `orchestration/graph_runner.py` | 769 | `AutoBotGraph` builder + `GraphRunner` engine |
| `orchestration/dag_graph_adapter.py` | 421 | Adapter that wraps existing `WorkflowExecutor` DAG to use `GraphRunner` |
| `orchestration/graph_runner_test.py` | 625 | Unit tests (pure Python, no Redis required) |

## Modified files
- `orchestration/__init__.py` — exports `GraphRunner`, `AutoBotGraph`, `DagGraphAdapter`

## `AutoBotGraph` API (mirrors LangGraph `StateGraph`)
```python
builder = AutoBotGraph(MyState)
builder.add_node("fetch", fetch_node)
builder.add_node("summarize", summarize_node)
builder.add_conditional_edges("fetch", router_fn, {"ok": "summarize", "error": END})
graph = builder.compile()
final_state = await graph.run(initial_state)
```

## Chat LangGraph migration path
`chat_workflow/graph.py` can migrate by:
1. `from orchestration.graph_runner import AutoBotGraph` (replaces `StateGraph`)
2. Identical `add_node` / `add_edge` / `add_conditional_edges` calls
3. Drop `AsyncRedisSaver` wiring — `GraphRunner` handles checkpointing internally
4. Replace `interrupt()` with `GraphRunner.pause()` / `GraphRunner.resume()` (tracked in #3228 as future)

This migration is left as a follow-up to let this foundation stabilise first.