### PR TITLE
refactor(llm): consolidate llm_providers/ with llm_interface_pkg adapters

### DIFF
--- a/autobot-backend/llm_interface_pkg/adapters/anthropic_adapter.py
+++ b/autobot-backend/llm_interface_pkg/adapters/anthropic_adapter.py
@@ -2,9 +2,12 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Anthropic Adapter - Adapter for external Anthropic API.
+Anthropic Adapter - Adapter for external Anthropic API (#1403).
 
-Issue #1403: Provides Claude model access via the Anthropic SDK.
+Delegates execution to ``llm_providers.AnthropicProvider`` which owns the
+canonical Claude implementation (extended thinking, beta headers, think-block
+stripping).  This adapter's sole responsibility is the ``test_environment()``
+diagnostic method used by ``api/adapters.py``.
 """
 
 import logging
@@ -34,88 +37,40 @@ ANTHROPIC_MODELS = [
 
 
 class AnthropicAdapter(AdapterBase):
-    """Adapter for the Anthropic Claude API (#1403)."""
+    """Adapter for the Anthropic Claude API (#1403).
+
+    All inference is delegated to ``llm_providers.AnthropicProvider`` so there
+    is a single implementation of the Anthropic request/response logic.
+    """
 
     def __init__(self, config: Optional[AdapterConfig] = None):
         super().__init__("anthropic_api", config)
-        self._api_key: Optional[str] = None
-        self._client = None
+        self._provider = None
 
-    def _get_api_key(self) -> Optional[str]:
-        """Resolve API key from config or environment."""
-        if self._api_key:
-            return self._api_key
-        self._api_key = self.config.settings.get("api_key") or os.getenv(
-            "ANTHROPIC_API_KEY", ""
-        )
-        return self._api_key
+    def _ensure_provider(self):
+        """Lazily construct the canonical AnthropicProvider."""
+        if self._provider is None:
+            from llm_providers.anthropic_provider import AnthropicProvider
 
-    def _ensure_client(self):
-        """Lazily initialize the Anthropic client."""
-        if self._client is None:
-            import anthropic
-
-            api_key = self._get_api_key()
-            if not api_key:
-                raise ValueError("Anthropic API key not configured")
-            self._client = anthropic.AsyncAnthropic(api_key=api_key)
-        return self._client
+            api_key = self.config.settings.get("api_key") or os.getenv(
+                "ANTHROPIC_API_KEY", ""
+            )
+            self._provider = AnthropicProvider(
+                settings={"api_key": api_key} if api_key else {}
+            )
+        return self._provider
 
     async def execute(self, request: LLMRequest) -> LLMResponse:
-        """Execute LLM call via Anthropic API."""
-        client = self._ensure_client()
-        start = time.time()
-
-        system_msg = ""
-        messages = []
-        for msg in request.messages:
-            if msg.get("role") == "system":
-                system_msg = msg.get("content", "")
-            else:
-                messages.append(
-                    {
-                        "role": msg.get("role", "user"),
-                        "content": msg.get("content", ""),
-                    }
-                )
-
-        kwargs = {
-            "model": request.model_name or ANTHROPIC_CLAUDE_SONNET4_6,
-            "max_tokens": request.max_tokens or 4096,
-            "messages": messages,
-            "temperature": request.temperature,
-        }
-        if system_msg:
-            kwargs["system"] = system_msg
-
-        response = await client.messages.create(**kwargs)
-        elapsed = time.time() - start
-
-        content = ""
-        if response.content:
-            content = response.content[0].text
-
-        return LLMResponse(
-            content=content,
-            model=response.model,
-            provider="anthropic",
-            processing_time=elapsed,
-            request_id=request.request_id,
-            usage={
-                "prompt_tokens": response.usage.input_tokens,
-                "completion_tokens": response.usage.output_tokens,
-                "total_tokens": (
-                    response.usage.input_tokens + response.usage.output_tokens
-                ),
-            },
-        )
+        """Execute LLM call via AnthropicProvider."""
+        provider = self._ensure_provider()
+        return await provider.chat_completion(request)
 
     async def test_environment(self) -> EnvironmentTestResult:
         """Test Anthropic API connectivity."""
         diagnostics: List[DiagnosticMessage] = []
         start = time.time()
 
-        api_key = self._get_api_key()
+        api_key = self.config.settings.get("api_key") or os.getenv("ANTHROPIC_API_KEY", "")
         if not api_key:
             diagnostics.append(
                 DiagnosticMessage(
@@ -138,19 +93,15 @@ class AnthropicAdapter(AdapterBase):
         )
 
         try:
-            client = self._ensure_client()
-            resp = await client.messages.count_tokens(
-                model=ANTHROPIC_CLAUDE_SONNET4_6,
-                messages=[{"role": "user", "content": "test"}],
-            )
+            provider = self._ensure_provider()
+            available = await provider.is_available()
             diagnostics.append(
                 DiagnosticMessage(
-                    level=DiagnosticLevel.INFO,
-                    message="API authentication successful",
-                    details={"input_tokens": resp.input_tokens},
+                    level=DiagnosticLevel.INFO if available else DiagnosticLevel.ERROR,
+                    message="API authentication successful" if available else "API check failed",
                 )
             )
-        except Exception as e:
+        except Exception:
             diagnostics.append(
                 DiagnosticMessage(
                     level=DiagnosticLevel.ERROR,

--- a/autobot-backend/llm_interface_pkg/adapters/ollama_adapter.py
+++ b/autobot-backend/llm_interface_pkg/adapters/ollama_adapter.py
@@ -2,10 +2,12 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Ollama Adapter - Wraps existing OllamaProvider for the adapter registry.
+Ollama Adapter - Adapter wrapping llm_providers.OllamaProvider (#1403).
 
-Issue #1403: Delegates to OllamaProvider for execution, adds
-test_environment and list_models capabilities.
+Delegates execution to ``llm_providers.OllamaProvider`` which owns the
+canonical Ollama implementation (OTel tracing via delegate, circuit breaker,
+streaming).  This adapter's sole responsibility is the ``test_environment()``
+diagnostic method used by ``api/adapters.py``.
 """
 
 import logging
@@ -18,8 +20,7 @@ from autobot_shared.http_client import get_http_client
 from autobot_shared.ssot_config import get_ollama_url
 from constants.api_constants import PATH_OLLAMA_TAGS
 
-from ..models import LLMRequest, LLMResponse, LLMSettings
-from ..streaming import StreamingManager
+from ..models import LLMRequest, LLMResponse
 from .base import (
     AdapterBase,
     AdapterConfig,
@@ -32,20 +33,20 @@ logger = logging.getLogger(__name__)
 
 
 class OllamaAdapter(AdapterBase):
-    """Adapter wrapping the existing OllamaProvider (#1403)."""
+    """Adapter wrapping the canonical OllamaProvider (#1403)."""
 
     def __init__(self, config: Optional[AdapterConfig] = None):
         super().__init__("ollama", config)
         self._provider = None
-        self._settings = LLMSettings()
-        self._streaming_manager = StreamingManager()
 
     def _ensure_provider(self):
-        """Lazily initialize the OllamaProvider."""
+        """Lazily construct the canonical OllamaProvider."""
         if self._provider is None:
-            from ..providers.ollama import OllamaProvider
+            from llm_providers.ollama_provider import OllamaProvider
 
-            self._provider = OllamaProvider(self._settings, self._streaming_manager)
+            base_url = self.config.settings.get("base_url")
+            settings = {"base_url": base_url} if base_url else {}
+            self._provider = OllamaProvider(settings=settings)
         return self._provider
 
     async def execute(self, request: LLMRequest) -> LLMResponse:
@@ -59,7 +60,7 @@ class OllamaAdapter(AdapterBase):
         start = time.time()
         models: List[str] = []
 
-        ollama_url = get_ollama_url()
+        ollama_url = self.config.settings.get("base_url") or get_ollama_url()
         diagnostics.append(
             DiagnosticMessage(
                 level=DiagnosticLevel.INFO,
@@ -89,7 +90,7 @@ class OllamaAdapter(AdapterBase):
                             message=f"HTTP {resp.status} from Ollama",
                         )
                     )
-        except Exception as e:
+        except Exception:
             diagnostics.append(
                 DiagnosticMessage(
                     level=DiagnosticLevel.ERROR,

--- a/autobot-backend/llm_interface_pkg/adapters/openai_adapter.py
+++ b/autobot-backend/llm_interface_pkg/adapters/openai_adapter.py
@@ -2,13 +2,16 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-OpenAI Adapter - Wraps existing OpenAIProvider for the adapter registry.
+OpenAI Adapter - Adapter wrapping llm_providers.OpenAIProvider (#1403).
 
-Issue #1403: Delegates to OpenAIProvider for execution, adds
-test_environment and list_models via the OpenAI API.
+Delegates execution to ``llm_providers.OpenAIProvider`` which owns the
+canonical OpenAI implementation (OTel tracing, circuit breaker, streaming).
+This adapter's sole responsibility is the ``test_environment()`` diagnostic
+method used by ``api/adapters.py``.
 """
 
 import logging
+import os
 import time
 from typing import List, Optional
 
@@ -25,19 +28,24 @@ logger = logging.getLogger(__name__)
 
 
 class OpenAIAdapter(AdapterBase):
-    """Adapter wrapping the existing OpenAIProvider (#1403)."""
+    """Adapter wrapping the canonical OpenAIProvider (#1403)."""
 
     def __init__(self, config: Optional[AdapterConfig] = None):
         super().__init__("openai_api", config)
         self._provider = None
 
-    def _ensure_provider(self):
-        """Lazily initialize the OpenAIProvider."""
-        if self._provider is None:
-            from ..providers.openai_provider import OpenAIProvider
+    def _get_api_key(self) -> Optional[str]:
+        """Resolve OpenAI API key from config or environment."""
+        return self.config.settings.get("api_key") or os.getenv("OPENAI_API_KEY")
 
-            api_key = self.config.settings.get("api_key")
-            self._provider = OpenAIProvider(api_key=api_key)
+    def _ensure_provider(self):
+        """Lazily construct the canonical OpenAIProvider."""
+        if self._provider is None:
+            from llm_providers.openai_provider import OpenAIProvider
+
+            api_key = self._get_api_key()
+            settings = {"api_key": api_key} if api_key else {}
+            self._provider = OpenAIProvider(settings=settings)
         return self._provider
 
     async def execute(self, request: LLMRequest) -> LLMResponse:
@@ -51,8 +59,8 @@ class OpenAIAdapter(AdapterBase):
         start = time.time()
         models: List[str] = []
 
-        provider = self._ensure_provider()
-        if not provider.api_key:
+        api_key = self._get_api_key()
+        if not api_key:
             diagnostics.append(
                 DiagnosticMessage(
                     level=DiagnosticLevel.ERROR,
@@ -74,18 +82,15 @@ class OpenAIAdapter(AdapterBase):
         )
 
         try:
-            import openai
-
-            client = openai.AsyncOpenAI(api_key=provider.api_key)
-            model_list = await client.models.list()
-            models = [m.id for m in model_list.data[:50]]
+            provider = self._ensure_provider()
+            models = await provider.list_models()
             diagnostics.append(
                 DiagnosticMessage(
                     level=DiagnosticLevel.INFO,
                     message=f"Found {len(models)} models",
                 )
             )
-        except Exception as e:
+        except Exception:
             diagnostics.append(
                 DiagnosticMessage(
                     level=DiagnosticLevel.ERROR,
@@ -100,14 +105,14 @@ class OpenAIAdapter(AdapterBase):
             healthy=healthy,
             adapter_type="openai_api",
             diagnostics=diagnostics,
-            models_available=models,
+            models_available=models[:50],
             response_time=elapsed,
         )
 
     async def list_models(self) -> List[str]:
         """Discover available OpenAI models."""
-        result = await self.test_environment()
-        return result.models_available
+        provider = self._ensure_provider()
+        return await provider.list_models()
 
 
 __all__ = ["OpenAIAdapter"]

--- a/autobot-backend/llm_providers/ollama_provider.py
+++ b/autobot-backend/llm_providers/ollama_provider.py
@@ -4,9 +4,10 @@
 """
 Ollama provider for the multi-provider LLM layer (#1806).
 
-Wraps the existing OllamaProvider from llm_interface_pkg.providers.ollama,
-exposing the BaseProvider interface so the ProviderRegistry can treat all
-providers uniformly.
+Delegates chat_completion to ``llm_interface_pkg.providers.ollama.OllamaProvider``
+which carries OpenTelemetry tracing (Issue #697) and circuit breaker protection.
+stream_completion is implemented directly for true incremental chunk delivery
+(the delegate accumulates the full stream before returning).
 
 The base URL is read (in priority order) from:
   1. ``settings["base_url"]``
@@ -80,11 +81,16 @@ class OllamaProvider(BaseProvider):
         return self._delegate
 
     async def chat_completion(self, request: LLMRequest) -> LLMResponse:
-        """Delegate to the existing Ollama provider implementation."""
+        """Delegate to llm_interface_pkg OllamaProvider (carries OTel tracing + circuit breaker).
+
+        The delegate's ``_prepare_chat_request`` calls ``get_host_from_env()``
+        which reads from SSOT config; we override ``ollama_host`` immediately
+        before the call so any settings["base_url"] override is honoured.
+        """
         self._total_requests += 1
         try:
             delegate = self._ensure_delegate()
-            # Ensure the delegate always uses the configured URL
+            # Override host so settings["base_url"] is respected over SSOT env default.
             delegate.ollama_host = self._resolve_base_url()
             response = await delegate.chat_completion(request)
             if response.error:
@@ -93,8 +99,6 @@ class OllamaProvider(BaseProvider):
         except Exception as exc:
             self._total_errors += 1
             logger.error("OllamaProvider delegation error: %s", exc)
-            import time
-
             return LLMResponse(
                 content="",
                 model=request.model_name or "",

--- a/autobot-backend/llm_providers/openai_provider.py
+++ b/autobot-backend/llm_providers/openai_provider.py
@@ -4,9 +4,8 @@
 """
 OpenAI provider for the multi-provider LLM layer (#1806).
 
-Wraps the existing llm_interface_pkg OpenAIProvider, adding streaming support
-and conforming to the BaseProvider interface so the provider registry can
-treat all providers uniformly.
+Supports chat completion and streaming for all GPT/o1 model families.
+OTel tracing spans are emitted for every inference call (Issue #697).
 
 API key is read (in priority order) from:
   1. ``settings["api_key"]``
@@ -23,6 +22,10 @@ import os
 import time
 from typing import Any, AsyncIterator, Dict, List, Optional
 
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
+from circuit_breaker import circuit_breaker_async
 from constants.model_constants import (
     OPENAI_GPT35_TURBO,
     OPENAI_GPT4,
@@ -37,6 +40,9 @@ from llm_interface_pkg.types import ProviderType
 from .base_provider import BaseProvider
 
 logger = logging.getLogger(__name__)
+
+# Issue #697: tracer for LLM operations — mirrors llm_interface_pkg/providers/openai_provider.py
+_tracer = trace.get_tracer("autobot.llm.openai", "2.0.0")
 
 _OPENAI_MODELS = [
     OPENAI_GPT4O,
@@ -103,49 +109,82 @@ class OpenAIProvider(BaseProvider):
         self._client = openai.AsyncOpenAI(**kwargs)
         return self._client
 
+    @circuit_breaker_async("openai_service")
     async def chat_completion(self, request: LLMRequest) -> LLMResponse:
-        """Execute a non-streaming chat completion via OpenAI."""
+        """Execute a non-streaming chat completion via OpenAI.
+
+        Emits an OpenTelemetry span (Issue #697) and is protected by the
+        openai_service circuit breaker.  Errors are returned via
+        ``LLMResponse.error`` so the registry can perform fallback.
+        """
         self._total_requests += 1
         start = time.time()
         model = request.model_name or self._get_setting("default_model", OPENAI_GPT4O_MINI)
-        try:
-            client = self._ensure_client()
-            params: Dict[str, Any] = {
-                "model": model,
-                "messages": request.messages,
-                "temperature": request.temperature,
-                "top_p": request.top_p,
-            }
-            if request.max_tokens:
-                params["max_tokens"] = request.max_tokens
-            if request.stop:
-                params["stop"] = request.stop
-            response = await client.chat.completions.create(**params)
-            choice = response.choices[0]
-            return LLMResponse(
-                content=choice.message.content or "",
-                model=response.model,
-                provider=self.provider_name,
-                processing_time=time.time() - start,
-                request_id=request.request_id,
-                finish_reason=choice.finish_reason,
-                usage={
-                    "prompt_tokens": response.usage.prompt_tokens,
-                    "completion_tokens": response.usage.completion_tokens,
-                    "total_tokens": response.usage.total_tokens,
-                },
-            )
-        except Exception as exc:
-            self._total_errors += 1
-            logger.error("OpenAI chat_completion error: %s", exc)
-            return LLMResponse(
-                content="",
-                model=model,
-                provider=self.provider_name,
-                processing_time=time.time() - start,
-                request_id=request.request_id,
-                error=str(exc),
-            )
+        span_attrs: Dict[str, Any] = {
+            "llm.provider": self.provider_name,
+            "llm.model": model,
+            "llm.request_id": request.request_id,
+            "llm.temperature": request.temperature,
+            "llm.max_tokens": request.max_tokens or 0,
+            "llm.prompt_messages": len(request.messages),
+        }
+        with _tracer.start_as_current_span(
+            "llm.inference", kind=SpanKind.CLIENT, attributes=span_attrs
+        ) as span:
+            try:
+                client = self._ensure_client()
+                params: Dict[str, Any] = {
+                    "model": model,
+                    "messages": request.messages,
+                    "temperature": request.temperature,
+                    "top_p": request.top_p,
+                }
+                if request.max_tokens:
+                    params["max_tokens"] = request.max_tokens
+                if request.stop:
+                    params["stop"] = request.stop
+                response = await client.chat.completions.create(**params)
+                choice = response.choices[0]
+                processing_time = time.time() - start
+                if span.is_recording():
+                    span.set_attribute("llm.duration_ms", processing_time * 1000)
+                    span.set_attribute(
+                        "llm.response_length", len(choice.message.content or "")
+                    )
+                    span.set_attribute("llm.prompt_tokens", response.usage.prompt_tokens)
+                    span.set_attribute(
+                        "llm.completion_tokens", response.usage.completion_tokens
+                    )
+                    span.set_attribute("llm.total_tokens", response.usage.total_tokens)
+                    span.set_status(Status(StatusCode.OK))
+                return LLMResponse(
+                    content=choice.message.content or "",
+                    model=response.model,
+                    provider=self.provider_name,
+                    processing_time=processing_time,
+                    request_id=request.request_id,
+                    finish_reason=choice.finish_reason,
+                    usage={
+                        "prompt_tokens": response.usage.prompt_tokens,
+                        "completion_tokens": response.usage.completion_tokens,
+                        "total_tokens": response.usage.total_tokens,
+                    },
+                )
+            except Exception as exc:
+                self._total_errors += 1
+                logger.error("OpenAI chat_completion error: %s", exc)
+                if span.is_recording():
+                    span.set_status(Status(StatusCode.ERROR, str(exc)))
+                    span.record_exception(exc)
+                    span.set_attribute("llm.error", True)
+                return LLMResponse(
+                    content="",
+                    model=model,
+                    provider=self.provider_name,
+                    processing_time=time.time() - start,
+                    request_id=request.request_id,
+                    error=str(exc),
+                )
 
     async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
         """Stream a chat completion from OpenAI, yielding text chunks."""
@@ -161,11 +200,11 @@ class OpenAIProvider(BaseProvider):
             }
             if request.max_tokens:
                 params["max_tokens"] = request.max_tokens
-            async with await client.chat.completions.create(**params) as stream:
-                async for chunk in stream:
-                    delta = chunk.choices[0].delta.content
-                    if delta:
-                        yield delta
+            stream = await client.chat.completions.create(**params)
+            async for chunk in stream:
+                delta = chunk.choices[0].delta.content
+                if delta:
+                    yield delta
         except Exception as exc:
             self._total_errors += 1
             logger.error("OpenAI stream_completion error: %s", exc)


### PR DESCRIPTION
## Summary
- Adds OpenTelemetry tracing (Issue #697) and circuit breaker to `llm_providers/openai_provider.py` — these were present in the older `llm_interface_pkg/providers/openai_provider.py` but dropped when the `llm_providers/` layer was written
- Rewrites `llm_interface_pkg/adapters/anthropic_adapter.py`, `openai_adapter.py`, and `ollama_adapter.py` to delegate `execute()` to the corresponding `llm_providers/` provider — eliminates ~200 lines of duplicated inference logic
- Fixes a latent bug in `OpenAIAdapter.test_environment()`: it referenced `provider.api_key` which does not exist on `llm_providers.OpenAIProvider`

## Approach

**llm_providers/ is the canonical layer** — used by `services/llm_service.py` (single entry-point for all inference) and 17 other callers. `llm_interface_pkg/adapters/` is older and only used by `api/adapters.py` for diagnostic `test_environment()` endpoints.

The adapters become thin delegation wrappers: each delegates `execute()` to the corresponding `llm_providers/` provider and retains only `test_environment()` (which powers the `/api/adapters/{type}/test` endpoint).

OTel tracing is preserved:
- `openai_provider.py`: tracing added directly (same pattern as `llm_interface_pkg/providers/openai_provider.py`)
- `ollama_provider.py`: delegates `chat_completion` to `llm_interface_pkg/providers/ollama.py` which carries tracing + circuit breaker

## Changes
- `autobot-backend/llm_providers/openai_provider.py` — add OTel tracing + circuit breaker
- `autobot-backend/llm_providers/ollama_provider.py` — clarify delegation docstring; fix stray `import time` inside method body
- `autobot-backend/llm_interface_pkg/adapters/anthropic_adapter.py` — delegate to `AnthropicProvider`
- `autobot-backend/llm_interface_pkg/adapters/openai_adapter.py` — delegate to `OpenAIProvider`; fix broken `provider.api_key` reference
- `autobot-backend/llm_interface_pkg/adapters/ollama_adapter.py` — delegate to `OllamaProvider`

## Tests
Pre-existing test collection error (pydantic_settings env parsing of `LLMSettings`) blocks all llm_providers tests in the local worktree — confirmed pre-existing. All five changed files pass syntax check and `flake8 --max-line-length=100` with zero violations.

Closes #3185