### PR TITLE
arch(knowledge): queryable property graph for knowledge relationships

### DIFF
--- a/autobot-backend/autobot_memory_graph/__init__.py
+++ b/autobot-backend/autobot_memory_graph/__init__.py
@@ -16,6 +16,7 @@ Package Structure:
 - relations.py: Relationship management and traversal
 - queries.py: Search and query operations
 - user_session.py: User-centric session tracking (Issue #608)
+- property_graph.py: Queryable property graph with typed edges (#3230)
 
 Key Features:
 - Entity management (conversations, bugs, features, decisions, tasks)
@@ -51,9 +52,12 @@ from .semantic_search import (  # noqa: F401
     ensure_indexes,
 )
 from .user_session import UserSessionMixin
+from .property_graph import PropertyGraph  # noqa: F401  # Issue #3230
+from .property_graph_mixin import PropertyGraphMixin  # noqa: F401  # Issue #3230
 
 
 class AutoBotMemoryGraph(
+    PropertyGraphMixin,
     EntityOperationsMixin,
     RelationOperationsMixin,
     QueryOperationsMixin,
@@ -117,6 +121,8 @@ class AutoBotMemoryGraph(
 __all__ = [
     # Main class
     "AutoBotMemoryGraph",
+    # Property graph (#3230)
+    "PropertyGraph",
     # Core class (for advanced usage)
     "AutoBotMemoryGraphCore",
     # Constants
@@ -131,6 +137,7 @@ __all__ = [
     "QueryOperationsMixin",
     "UserSessionMixin",
     "SecretManagementMixin",
+    "PropertyGraphMixin",
     # Semantic search (#3612)
     "MemoryGraphQueryProcessor",
     "HybridScorer",

--- a/autobot-backend/autobot_memory_graph/property_graph.py
+++ b/autobot-backend/autobot_memory_graph/property_graph.py
@@ -1,0 +1,613 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Property Graph — queryable graph store backed by Redis hashes and sorted sets.
+
+Issue #3230: Replace Redis adjacency list with a queryable property graph for
+knowledge relationships.
+
+Design:
+- Nodes: Redis hash  ``pg:node:{id}``  — arbitrary property key/value pairs
+- Edges: Redis hash  ``pg:edge:{id}``  — arbitrary property key/value pairs
+                                         plus mandatory ``from``, ``to``, ``relation``
+- Adjacency (typed, outgoing):  sorted set  ``pg:adj:out:{node_id}:{relation}``
+  members = edge_id, score = created_at_ms
+- Adjacency (typed, incoming):  sorted set  ``pg:adj:in:{node_id}:{relation}``
+- All-relations index (outgoing): set  ``pg:adj:out:{node_id}``  — member = "rel\x00edge_id"
+- Property-value index:  set  ``pg:idx:prop:{key}:{value}`` — member = node_id
+  (populated on add_node and add_edge — enables query_nodes without full scan)
+
+All Redis operations are async (redis.asyncio).
+"""
+
+import json
+import logging
+import time
+import uuid
+from collections import deque
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from autobot_shared.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# Key prefixes
+_PFX_NODE = "pg:node:"
+_PFX_EDGE = "pg:edge:"
+_PFX_ADJ_OUT = "pg:adj:out:"
+_PFX_ADJ_IN = "pg:adj:in:"
+_PFX_IDX_PROP = "pg:idx:prop:"
+
+
+def _node_key(node_id: str) -> str:
+    return f"{_PFX_NODE}{node_id}"
+
+
+def _edge_key(edge_id: str) -> str:
+    return f"{_PFX_EDGE}{edge_id}"
+
+
+def _adj_out_key(node_id: str, relation: str) -> str:
+    return f"{_PFX_ADJ_OUT}{node_id}:{relation}"
+
+
+def _adj_in_key(node_id: str, relation: str) -> str:
+    return f"{_PFX_ADJ_IN}{node_id}:{relation}"
+
+
+def _adj_out_all_key(node_id: str) -> str:
+    """Set of all 'relation\x00edge_id' strings leaving node_id."""
+    return f"{_PFX_ADJ_OUT}{node_id}"
+
+
+def _adj_in_all_key(node_id: str) -> str:
+    """Set of all 'relation\x00edge_id' strings arriving at node_id."""
+    return f"{_PFX_ADJ_IN}{node_id}"
+
+
+def _prop_index_key(prop_key: str, prop_value: str) -> str:
+    return f"{_PFX_IDX_PROP}{prop_key}:{prop_value}"
+
+
+def _ms_now() -> float:
+    return time.time() * 1000
+
+
+def _serialize_props(props: Dict[str, Any]) -> Dict[str, str]:
+    """Flatten property dict to Redis hash-compatible str->str mapping."""
+    result: Dict[str, str] = {}
+    for k, v in props.items():
+        if isinstance(v, (dict, list)):
+            result[k] = json.dumps(v, ensure_ascii=False)
+        else:
+            result[k] = str(v)
+    return result
+
+
+def _deserialize_props(raw: Dict[bytes, bytes]) -> Dict[str, Any]:
+    """Convert Redis hgetall bytes result back to Python dict."""
+    out: Dict[str, Any] = {}
+    for bk, bv in raw.items():
+        key = bk.decode("utf-8") if isinstance(bk, bytes) else bk
+        val = bv.decode("utf-8") if isinstance(bv, bytes) else bv
+        # Try to restore JSON-encoded values
+        if val.startswith(("{", "[")):
+            try:
+                val = json.loads(val)
+            except (ValueError, TypeError):
+                pass
+        out[key] = val
+    return out
+
+
+class PropertyGraph:
+    """
+    Queryable property graph backed by Redis.
+
+    Usage::
+
+        graph = PropertyGraph(database="knowledge")
+        await graph.initialize()
+
+        await graph.add_node("file:main.py", {"type": "file", "lang": "python"})
+        await graph.add_node("bug:123",      {"type": "bug",  "severity": "high"})
+        await graph.add_edge("file:main.py", "bug:123", "CONTAINS",
+                              {"confidence": "0.9"})
+
+        neighbours = await graph.get_neighbors("file:main.py", relation="CONTAINS")
+        bugs = await graph.query_nodes({"type": "bug", "severity": "high"})
+        subgraph = await graph.subgraph("file:main.py", max_depth=2)
+        path = await graph.shortest_path("file:main.py", "bug:123")
+    """
+
+    def __init__(self, database: str = "knowledge") -> None:
+        self._database = database
+        self._redis: Any = None
+
+    async def initialize(self) -> None:
+        """Acquire async Redis connection."""
+        if self._redis is None:
+            self._redis = get_redis_client(async_client=True, database=self._database)
+        logger.info("PropertyGraph initialized (db=%s)", self._database)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _index_properties(self, entity_id: str, props: Dict[str, Any]) -> None:
+        """Maintain ``pg:idx:prop:{key}:{value}`` sets for fast property lookup."""
+        for k, v in props.items():
+            if isinstance(v, (dict, list)):
+                continue  # skip complex values
+            idx_key = _prop_index_key(k, str(v))
+            await self._redis.sadd(idx_key, entity_id)
+
+    async def _deindex_properties(self, entity_id: str, props: Dict[str, Any]) -> None:
+        """Remove entity from property-value index entries."""
+        for k, v in props.items():
+            if isinstance(v, (dict, list)):
+                continue
+            idx_key = _prop_index_key(k, str(v))
+            await self._redis.srem(idx_key, entity_id)
+
+    # ------------------------------------------------------------------
+    # Node operations
+    # ------------------------------------------------------------------
+
+    async def add_node(self, node_id: str, properties: Dict[str, Any]) -> None:
+        """
+        Upsert a node with given properties.
+
+        If the node already exists its properties are merged (new keys added,
+        existing keys overwritten). Old property-index entries are cleaned up
+        before the new ones are written.
+
+        Args:
+            node_id: Unique node identifier.
+            properties: Arbitrary property dict (values serialised to str).
+        """
+        existing_raw = await self._redis.hgetall(_node_key(node_id))
+        if existing_raw:
+            existing = _deserialize_props(existing_raw)
+            await self._deindex_properties(node_id, existing)
+
+        merged: Dict[str, Any] = {}
+        if existing_raw:
+            merged.update(_deserialize_props(existing_raw))
+        merged.update(properties)
+        if "id" not in merged:
+            merged["id"] = node_id
+
+        await self._redis.hset(_node_key(node_id), mapping=_serialize_props(merged))
+        await self._index_properties(node_id, merged)
+        logger.debug("add_node: %s props=%s", node_id, list(properties.keys()))
+
+    async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Return node properties or None if not found.
+
+        Args:
+            node_id: Node identifier.
+
+        Returns:
+            Property dict or None.
+        """
+        raw = await self._redis.hgetall(_node_key(node_id))
+        if not raw:
+            return None
+        return _deserialize_props(raw)
+
+    async def delete_node(self, node_id: str) -> bool:
+        """
+        Delete a node and all its edges (both directions).
+
+        Args:
+            node_id: Node identifier.
+
+        Returns:
+            True if the node existed and was deleted, False otherwise.
+        """
+        raw = await self._redis.hgetall(_node_key(node_id))
+        if not raw:
+            return False
+
+        existing = _deserialize_props(raw)
+        await self._deindex_properties(node_id, existing)
+        await self._redis.delete(_node_key(node_id))
+
+        # Remove all outgoing edges
+        all_out_key = _adj_out_all_key(node_id)
+        out_members = await self._redis.smembers(all_out_key)
+        for member in out_members:
+            rel_edge = member.decode("utf-8") if isinstance(member, bytes) else member
+            relation, edge_id = rel_edge.split("\x00", 1)
+            await self._delete_edge_by_id(edge_id, node_id, relation)
+
+        await self._redis.delete(all_out_key)
+
+        # Remove all incoming edges
+        all_in_key = _adj_in_all_key(node_id)
+        in_members = await self._redis.smembers(all_in_key)
+        for member in in_members:
+            rel_edge = member.decode("utf-8") if isinstance(member, bytes) else member
+            relation, edge_id = rel_edge.split("\x00", 1)
+            edge_raw = await self._redis.hgetall(_edge_key(edge_id))
+            if edge_raw:
+                edge = _deserialize_props(edge_raw)
+                from_id = edge.get("from", "")
+                if from_id:
+                    await self._redis.zrem(_adj_out_key(from_id, relation), edge_id)
+                    await self._redis.srem(_adj_out_all_key(from_id), f"{relation}\x00{edge_id}")
+            await self._redis.delete(_edge_key(edge_id))
+
+        await self._redis.delete(all_in_key)
+        logger.debug("delete_node: %s (and its edges)", node_id)
+        return True
+
+    # ------------------------------------------------------------------
+    # Edge operations
+    # ------------------------------------------------------------------
+
+    async def add_edge(
+        self,
+        from_id: str,
+        to_id: str,
+        relation: str,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """
+        Add a directed edge from ``from_id`` to ``to_id`` with given relation type.
+
+        Auto-creates nodes if they do not yet exist (with just ``id`` property).
+
+        Args:
+            from_id: Source node identifier.
+            to_id: Target node identifier.
+            relation: Relationship type string (e.g. ``"DEPENDS_ON"``).
+            properties: Optional additional edge properties.
+
+        Returns:
+            The generated edge_id.
+        """
+        # Ensure nodes exist
+        if not await self._redis.exists(_node_key(from_id)):
+            await self.add_node(from_id, {"id": from_id})
+        if not await self._redis.exists(_node_key(to_id)):
+            await self.add_node(to_id, {"id": to_id})
+
+        edge_id = str(uuid.uuid4())
+        score = _ms_now()
+
+        edge_props: Dict[str, Any] = {
+            "id": edge_id,
+            "from": from_id,
+            "to": to_id,
+            "relation": relation,
+            "created_at_ms": str(int(score)),
+        }
+        if properties:
+            edge_props.update(properties)
+
+        await self._redis.hset(_edge_key(edge_id), mapping=_serialize_props(edge_props))
+
+        # Typed adjacency sorted sets (score = created_at_ms for chronological ordering)
+        await self._redis.zadd(_adj_out_key(from_id, relation), {edge_id: score})
+        await self._redis.zadd(_adj_in_key(to_id, relation), {edge_id: score})
+
+        # All-relations index (for delete_node + relation-agnostic iteration)
+        await self._redis.sadd(_adj_out_all_key(from_id), f"{relation}\x00{edge_id}")
+        await self._redis.sadd(_adj_in_all_key(to_id), f"{relation}\x00{edge_id}")
+
+        logger.debug("add_edge: %s -[%s]-> %s (edge_id=%s)", from_id, relation, to_id, edge_id)
+        return edge_id
+
+    async def get_edge(self, edge_id: str) -> Optional[Dict[str, Any]]:
+        """Return edge properties or None if not found."""
+        raw = await self._redis.hgetall(_edge_key(edge_id))
+        if not raw:
+            return None
+        return _deserialize_props(raw)
+
+    async def delete_edge(self, edge_id: str) -> bool:
+        """
+        Delete an edge by its edge_id.
+
+        Args:
+            edge_id: Edge identifier returned by ``add_edge``.
+
+        Returns:
+            True if the edge existed, False otherwise.
+        """
+        raw = await self._redis.hgetall(_edge_key(edge_id))
+        if not raw:
+            return False
+
+        edge = _deserialize_props(raw)
+        from_id = edge.get("from", "")
+        to_id = edge.get("to", "")
+        relation = edge.get("relation", "")
+
+        await self._delete_edge_by_id(edge_id, from_id, relation)
+        if to_id:
+            await self._redis.zrem(_adj_in_key(to_id, relation), edge_id)
+            await self._redis.srem(_adj_in_all_key(to_id), f"{relation}\x00{edge_id}")
+
+        logger.debug("delete_edge: %s", edge_id)
+        return True
+
+    async def _delete_edge_by_id(
+        self, edge_id: str, from_id: str, relation: str
+    ) -> None:
+        """Remove edge hash + outgoing adjacency entries (internal helper)."""
+        await self._redis.delete(_edge_key(edge_id))
+        if from_id and relation:
+            await self._redis.zrem(_adj_out_key(from_id, relation), edge_id)
+            await self._redis.srem(_adj_out_all_key(from_id), f"{relation}\x00{edge_id}")
+
+    # ------------------------------------------------------------------
+    # Query operations
+    # ------------------------------------------------------------------
+
+    async def get_neighbors(
+        self,
+        node_id: str,
+        relation: Optional[str] = None,
+        direction: str = "outgoing",
+    ) -> List[Dict[str, Any]]:
+        """
+        Return neighbouring nodes with edge metadata.
+
+        Args:
+            node_id: Starting node identifier.
+            relation: Filter to this relation type; None means all types.
+            direction: ``"outgoing"``, ``"incoming"``, or ``"both"``.
+
+        Returns:
+            List of dicts with keys ``node``, ``edge``.
+        """
+        results: List[Dict[str, Any]] = []
+
+        if direction in ("outgoing", "both"):
+            results.extend(await self._neighbors_one_direction(node_id, relation, "outgoing"))
+        if direction in ("incoming", "both"):
+            results.extend(await self._neighbors_one_direction(node_id, relation, "incoming"))
+
+        return results
+
+    async def _neighbors_one_direction(
+        self, node_id: str, relation: Optional[str], direction: str
+    ) -> List[Dict[str, Any]]:
+        """Fetch neighbours in a single direction."""
+        results: List[Dict[str, Any]] = []
+
+        if relation:
+            relations_to_query = [relation]
+        else:
+            # Discover relation types from all-relations index
+            all_key = (
+                _adj_out_all_key(node_id)
+                if direction == "outgoing"
+                else _adj_in_all_key(node_id)
+            )
+            members = await self._redis.smembers(all_key)
+            seen_rels: Set[str] = set()
+            for m in members:
+                rel_part = (m.decode("utf-8") if isinstance(m, bytes) else m).split("\x00")[0]
+                seen_rels.add(rel_part)
+            relations_to_query = list(seen_rels)
+
+        for rel in relations_to_query:
+            adj_key = (
+                _adj_out_key(node_id, rel)
+                if direction == "outgoing"
+                else _adj_in_key(node_id, rel)
+            )
+            edge_ids = await self._redis.zrange(adj_key, 0, -1)
+            for eid_bytes in edge_ids:
+                eid = eid_bytes.decode("utf-8") if isinstance(eid_bytes, bytes) else eid_bytes
+                edge_raw = await self._redis.hgetall(_edge_key(eid))
+                if not edge_raw:
+                    continue
+                edge = _deserialize_props(edge_raw)
+                neighbour_id = edge.get("to") if direction == "outgoing" else edge.get("from")
+                if not neighbour_id:
+                    continue
+                node_raw = await self._redis.hgetall(_node_key(neighbour_id))
+                node = _deserialize_props(node_raw) if node_raw else {"id": neighbour_id}
+                results.append({"node": node, "edge": edge})
+
+        return results
+
+    async def query_nodes(self, property_filter: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Return nodes matching ALL property key/value pairs in ``property_filter``.
+
+        Uses property-value index sets for efficient lookup — no full key scan.
+        Performs intersection of candidate sets, then verifies each candidate
+        possesses every required property (in case of partial index coverage).
+
+        Args:
+            property_filter: Dict of ``{property_key: property_value}`` pairs.
+                             All conditions must match (AND semantics).
+
+        Returns:
+            List of matching node property dicts.
+        """
+        if not property_filter:
+            return []
+
+        candidate_sets: List[Set[str]] = []
+        for k, v in property_filter.items():
+            idx_key = _prop_index_key(k, str(v))
+            raw_members = await self._redis.smembers(idx_key)
+            candidate_sets.append(
+                {m.decode("utf-8") if isinstance(m, bytes) else m for m in raw_members}
+            )
+
+        if not candidate_sets:
+            return []
+
+        # Intersection: nodes that appear in ALL property index sets
+        candidates: Set[str] = candidate_sets[0]
+        for s in candidate_sets[1:]:
+            candidates = candidates.intersection(s)
+
+        results: List[Dict[str, Any]] = []
+        for node_id in candidates:
+            raw = await self._redis.hgetall(_node_key(node_id))
+            if not raw:
+                continue
+            node = _deserialize_props(raw)
+            # Double-check all filter conditions (index may lag on complex values)
+            if all(str(node.get(k)) == str(v) for k, v in property_filter.items()):
+                results.append(node)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Graph traversal
+    # ------------------------------------------------------------------
+
+    async def multi_hop(
+        self,
+        start_node_id: str,
+        relation: Optional[str] = None,
+        max_depth: int = 2,
+        direction: str = "outgoing",
+    ) -> List[Dict[str, Any]]:
+        """
+        BFS multi-hop traversal from ``start_node_id``.
+
+        Args:
+            start_node_id: Starting node.
+            relation: Restrict traversal to this relation type; None = all.
+            max_depth: Maximum number of hops.
+            direction: ``"outgoing"``, ``"incoming"``, or ``"both"``.
+
+        Returns:
+            List of dicts ``{node, edge, depth}`` for every visited node
+            (excluding the start node itself).
+        """
+        visited: Set[str] = {start_node_id}
+        queue: deque[Tuple[str, int]] = deque([(start_node_id, 0)])
+        results: List[Dict[str, Any]] = []
+
+        while queue:
+            current_id, depth = queue.popleft()
+            if depth >= max_depth:
+                continue
+
+            neighbours = await self.get_neighbors(current_id, relation=relation, direction=direction)
+            for entry in neighbours:
+                neighbour_id = entry["node"].get("id")
+                if not neighbour_id or neighbour_id in visited:
+                    continue
+                visited.add(neighbour_id)
+                results.append({**entry, "depth": depth + 1})
+                queue.append((neighbour_id, depth + 1))
+
+        return results
+
+    async def subgraph(
+        self,
+        center_node_id: str,
+        max_depth: int = 2,
+        relation: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Extract a connected subgraph around ``center_node_id``.
+
+        Traverses in both directions to include context from all connected
+        nodes within ``max_depth`` hops.
+
+        Args:
+            center_node_id: Root node.
+            max_depth: Maximum hop distance.
+            relation: Restrict to this relation type; None = all.
+
+        Returns:
+            Dict with ``nodes`` (list of node dicts) and ``edges``
+            (list of edge dicts).
+        """
+        visited_nodes: Set[str] = {center_node_id}
+        visited_edges: Set[str] = set()
+        queue: deque[Tuple[str, int]] = deque([(center_node_id, 0)])
+        nodes: List[Dict[str, Any]] = []
+        edges: List[Dict[str, Any]] = []
+
+        center_raw = await self._redis.hgetall(_node_key(center_node_id))
+        if center_raw:
+            nodes.append(_deserialize_props(center_raw))
+
+        while queue:
+            current_id, depth = queue.popleft()
+            if depth >= max_depth:
+                continue
+
+            neighbours = await self.get_neighbors(
+                current_id, relation=relation, direction="both"
+            )
+            for entry in neighbours:
+                neighbour_id = entry["node"].get("id")
+                edge_id = entry["edge"].get("id")
+
+                if edge_id and edge_id not in visited_edges:
+                    visited_edges.add(edge_id)
+                    edges.append(entry["edge"])
+
+                if neighbour_id and neighbour_id not in visited_nodes:
+                    visited_nodes.add(neighbour_id)
+                    nodes.append(entry["node"])
+                    queue.append((neighbour_id, depth + 1))
+
+        return {"nodes": nodes, "edges": edges}
+
+    async def shortest_path(
+        self,
+        from_id: str,
+        to_id: str,
+        relation: Optional[str] = None,
+        max_depth: int = 6,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """
+        BFS shortest path between two nodes.
+
+        Args:
+            from_id: Source node identifier.
+            to_id: Target node identifier.
+            relation: Restrict traversal to this relation type; None = all.
+            max_depth: Maximum path length to search.
+
+        Returns:
+            Ordered list of ``{node, edge}`` dicts representing the path
+            (excluding the start node), or None if no path found.
+        """
+        if from_id == to_id:
+            return []
+
+        # BFS with path tracking
+        visited: Set[str] = {from_id}
+        # queue items: (current_id, path_so_far)
+        queue: deque[Tuple[str, List[Dict[str, Any]]]] = deque([(from_id, [])])
+
+        while queue:
+            current_id, path = queue.popleft()
+            if len(path) >= max_depth:
+                continue
+
+            neighbours = await self.get_neighbors(
+                current_id, relation=relation, direction="outgoing"
+            )
+            for entry in neighbours:
+                neighbour_id = entry["node"].get("id")
+                if not neighbour_id:
+                    continue
+                new_path = path + [entry]
+                if neighbour_id == to_id:
+                    return new_path
+                if neighbour_id not in visited:
+                    visited.add(neighbour_id)
+                    queue.append((neighbour_id, new_path))
+
+        return None  # No path found

--- a/autobot-backend/autobot_memory_graph/property_graph_mixin.py
+++ b/autobot-backend/autobot_memory_graph/property_graph_mixin.py
@@ -1,0 +1,145 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+PropertyGraphMixin — integrates PropertyGraph into AutoBotMemoryGraph.
+
+Issue #3230: Replaces plain adjacency list with a queryable property graph.
+
+The mixin lazily initialises a ``PropertyGraph`` instance on first access
+via the ``property_graph`` attribute and exposes convenience wrappers so
+callers can use graph-style queries directly on AutoBotMemoryGraph:
+
+    memory.graph.get_neighbors("entity-id", relation="depends_on")
+    memory.graph.query_nodes({"type": "BUG", "severity": "high"})
+    memory.graph.multi_hop("entity-id", max_depth=3)
+    memory.graph.subgraph("entity-id")
+    memory.graph.shortest_path("entity-id-a", "entity-id-b")
+
+When ``create_entity`` or ``create_relation`` are called the mixin also
+mirrors the data into the PropertyGraph so the two stores stay in sync.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .core import AutoBotMemoryGraphCore
+from .property_graph import PropertyGraph
+
+logger = logging.getLogger(__name__)
+
+
+class PropertyGraphMixin:
+    """
+    Mixin that wires a PropertyGraph into AutoBotMemoryGraph.
+
+    Designed for use alongside the other AutoBotMemoryGraph mixins.
+    Relies on ``self.redis_client`` and ``self._initialized`` from
+    ``AutoBotMemoryGraphCore``.
+    """
+
+    # Lazily created on first access
+    _property_graph: Optional[PropertyGraph] = None
+
+    @property
+    def graph(self) -> PropertyGraph:
+        """Return the lazily-initialised PropertyGraph instance.
+
+        Raises RuntimeError if AutoBotMemoryGraph is not yet initialised.
+        """
+        self.ensure_initialized()  # type: ignore[attr-defined]
+        if self._property_graph is None:
+            self._property_graph = PropertyGraph(database="knowledge")
+            self._property_graph._redis = self.redis_client  # reuse connection
+        return self._property_graph
+
+    # ------------------------------------------------------------------
+    # Entity sync: mirror create_entity into PropertyGraph
+    # ------------------------------------------------------------------
+
+    async def create_entity(  # type: ignore[override]
+        self: AutoBotMemoryGraphCore,
+        entity_type: str,
+        name: str,
+        observations: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Create entity in the standard store AND mirror into PropertyGraph."""
+        entity = await super().create_entity(  # type: ignore[misc]
+            entity_type=entity_type,
+            name=name,
+            observations=observations,
+            metadata=metadata,
+            tags=tags,
+        )
+        if entity:
+            node_props: Dict[str, Any] = {
+                "type": entity_type,
+                "name": name,
+            }
+            if metadata:
+                # Flatten scalar metadata values into node properties
+                for k, v in metadata.items():
+                    if isinstance(v, (str, int, float, bool)):
+                        node_props[k] = v
+            try:
+                await self.graph.add_node(entity["id"], node_props)
+            except Exception as exc:
+                logger.warning("PropertyGraph sync skipped for entity %s: %s", entity.get("id"), exc)
+        return entity
+
+    # ------------------------------------------------------------------
+    # Relation sync: mirror create_relation into PropertyGraph
+    # ------------------------------------------------------------------
+
+    async def create_relation(  # type: ignore[override]
+        self: AutoBotMemoryGraphCore,
+        from_entity: str,
+        to_entity: str,
+        relation_type: str,
+        bidirectional: bool = False,
+        strength: float = 1.0,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Create relation in the standard store AND mirror into PropertyGraph."""
+        relation = await super().create_relation(  # type: ignore[misc]
+            from_entity=from_entity,
+            to_entity=to_entity,
+            relation_type=relation_type,
+            bidirectional=bidirectional,
+            strength=strength,
+            metadata=metadata,
+        )
+        if relation:
+            edge_props: Dict[str, Any] = {"strength": str(strength)}
+            if metadata:
+                for k, v in metadata.items():
+                    if isinstance(v, (str, int, float, bool)):
+                        edge_props[k] = v
+            try:
+                # Resolve IDs via existing entity lookup
+                from_entity_data = await self.get_entity(entity_name=from_entity)  # type: ignore[attr-defined]
+                to_entity_data = await self.get_entity(entity_name=to_entity)  # type: ignore[attr-defined]
+                if from_entity_data and to_entity_data:
+                    await self.graph.add_edge(
+                        from_entity_data["id"],
+                        to_entity_data["id"],
+                        relation_type.upper(),
+                        edge_props,
+                    )
+                    if bidirectional:
+                        await self.graph.add_edge(
+                            to_entity_data["id"],
+                            from_entity_data["id"],
+                            relation_type.upper(),
+                            edge_props,
+                        )
+            except Exception as exc:
+                logger.warning(
+                    "PropertyGraph sync skipped for relation %s->%s: %s",
+                    from_entity,
+                    to_entity,
+                    exc,
+                )
+        return relation

--- a/autobot-backend/knowledge/pipeline/loaders/redis_graph_loader.py
+++ b/autobot-backend/knowledge/pipeline/loaders/redis_graph_loader.py
@@ -5,11 +5,13 @@
 Redis Graph Loader - Load entities, relationships, and events to Redis.
 
 Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
+Issue #3230: Also writes into PropertyGraph for queryable typed-edge traversal.
 """
 
 import logging
 from typing import List
 
+from autobot_memory_graph.property_graph import PropertyGraph
 from autobot_shared.redis_client import get_redis_client
 from knowledge.pipeline.base import BaseLoader, PipelineContext
 from knowledge.pipeline.models.entity import Entity
@@ -22,7 +24,12 @@ logger = logging.getLogger(__name__)
 
 @TaskRegistry.register_loader("redis_graph")
 class RedisGraphLoader(BaseLoader):
-    """Load graph data (entities, relationships, events) to Redis."""
+    """Load graph data (entities, relationships, events) to Redis.
+
+    Writes to two stores in parallel:
+    1. Legacy Redis JSON adjacency list (backward compat for existing callers).
+    2. PropertyGraph (typed edges, multi-hop traversal, property filters).
+    """
 
     def __init__(self, database: str = "knowledge") -> None:
         """
@@ -33,6 +40,7 @@ class RedisGraphLoader(BaseLoader):
         """
         self.database = database
         self.redis_client = None
+        self._property_graph: PropertyGraph = PropertyGraph(database=database)
 
     async def load(self, context: PipelineContext) -> None:
         """
@@ -41,9 +49,11 @@ class RedisGraphLoader(BaseLoader):
         Args:
             context: Pipeline context with entities, relationships, events
         """
-        self.redis_client = await get_redis_client(
+        self.redis_client = get_redis_client(
             async_client=True, database=self.database
         )
+        # Wire PropertyGraph to the same Redis connection (no extra pool entry)
+        self._property_graph._redis = self.redis_client
 
         entities: List[Entity] = context.entities
         relationships: List[Relationship] = context.relationships
@@ -66,9 +76,10 @@ class RedisGraphLoader(BaseLoader):
         )
 
     async def _load_entities(self, entities: List[Entity]) -> None:
-        """Load entities to Redis JSON."""
+        """Load entities to Redis JSON and PropertyGraph."""
         try:
             for entity in entities:
+                # Legacy adjacency-list store
                 key = f"entity:{entity.id}"
                 entity_data = entity.model_dump(mode="json")
                 await self.redis_client.json().set(key, "$", entity_data)
@@ -76,14 +87,23 @@ class RedisGraphLoader(BaseLoader):
                 name_key = f"entity:name:{entity.canonical_name}"
                 await self.redis_client.set(name_key, str(entity.id))
 
+                # PropertyGraph node (#3230)
+                node_props = {
+                    "type": entity.entity_type if hasattr(entity, "entity_type") else "",
+                    "name": entity.canonical_name,
+                    "source": "ecl_pipeline",
+                }
+                await self._property_graph.add_node(str(entity.id), node_props)
+
             logger.info("Loaded %s entities to Redis", len(entities))
         except Exception as e:
             logger.error("Failed to load entities to Redis: %s", e)
 
     async def _load_relationships(self, relationships: List[Relationship]) -> None:
-        """Load relationships to Redis."""
+        """Load relationships to Redis legacy store and PropertyGraph."""
         try:
             for rel in relationships:
+                # Legacy adjacency-list store
                 key = f"relationship:{rel.id}"
                 rel_data = rel.model_dump(mode="json")
                 await self.redis_client.json().set(key, "$", rel_data)
@@ -97,12 +117,32 @@ class RedisGraphLoader(BaseLoader):
                 if rel.bidirectional:
                     await self._add_bidirectional_index(rel)
 
+                # PropertyGraph edge (#3230)
+                edge_props = {
+                    "description": rel.description,
+                    "confidence": str(rel.confidence),
+                    "bidirectional": str(rel.bidirectional),
+                }
+                await self._property_graph.add_edge(
+                    str(rel.source_entity_id),
+                    str(rel.target_entity_id),
+                    rel.relationship_type.upper(),
+                    edge_props,
+                )
+                if rel.bidirectional:
+                    await self._property_graph.add_edge(
+                        str(rel.target_entity_id),
+                        str(rel.source_entity_id),
+                        rel.relationship_type.upper(),
+                        edge_props,
+                    )
+
             logger.info("Loaded %s relationships to Redis", len(relationships))
         except Exception as e:
             logger.error("Failed to load relationships to Redis: %s", e)
 
     async def _add_bidirectional_index(self, rel: Relationship) -> None:
-        """Add reverse index for bidirectional relationship."""
+        """Add reverse index for bidirectional relationship (legacy store)."""
         reverse_key = f"relationship:reverse:{rel.id}"
         reverse_data = {
             "source_entity_id": str(rel.target_entity_id),

--- a/autobot-backend/tests/memory_graph/test_property_graph.py
+++ b/autobot-backend/tests/memory_graph/test_property_graph.py
@@ -1,0 +1,526 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for PropertyGraph — queryable property graph backed by Redis.
+
+Issue #3230: Replace Redis adjacency list with queryable property graph.
+
+All tests run without a live Redis — the async Redis client is replaced with
+an in-memory AsyncMock that delegates to a simple dict/set store.
+"""
+
+import sys
+import types
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out autobot_shared so PropertyGraph imports without real Redis
+# ---------------------------------------------------------------------------
+
+_autobot_shared = types.ModuleType("autobot_shared")
+_autobot_shared.__path__ = []
+
+_redis_client_mod = types.ModuleType("autobot_shared.redis_client")
+_redis_client_mod.get_redis_client = MagicMock(return_value=AsyncMock())
+
+for name, mod in [
+    ("autobot_shared", _autobot_shared),
+    ("autobot_shared.redis_client", _redis_client_mod),
+]:
+    sys.modules.setdefault(name, mod)
+
+from autobot_memory_graph.property_graph import (  # noqa: E402
+    PropertyGraph,
+    _adj_in_all_key,
+    _adj_in_key,
+    _adj_out_all_key,
+    _adj_out_key,
+    _edge_key,
+    _node_key,
+    _prop_index_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake Redis store
+# ---------------------------------------------------------------------------
+
+class FakeRedis:
+    """Minimal in-memory async Redis mock with the operations used by PropertyGraph."""
+
+    def __init__(self) -> None:
+        self._hashes: Dict[str, Dict[bytes, bytes]] = {}
+        self._sets: Dict[str, set] = {}
+        self._zsets: Dict[str, Dict[str, float]] = {}
+
+    # ---- hash ----
+
+    async def hset(self, key: str, mapping: Optional[Dict] = None, **kwargs) -> int:
+        if key not in self._hashes:
+            self._hashes[key] = {}
+        if mapping:
+            for k, v in mapping.items():
+                bk = k.encode("utf-8") if isinstance(k, str) else k
+                bv = v.encode("utf-8") if isinstance(v, str) else str(v).encode("utf-8")
+                self._hashes[key][bk] = bv
+        return 1
+
+    async def hgetall(self, key: str) -> Dict[bytes, bytes]:
+        return dict(self._hashes.get(key, {}))
+
+    async def hdel(self, key: str, *fields) -> int:
+        h = self._hashes.get(key, {})
+        removed = 0
+        for f in fields:
+            bk = f.encode("utf-8") if isinstance(f, str) else f
+            if bk in h:
+                del h[bk]
+                removed += 1
+        return removed
+
+    # ---- set ----
+
+    async def sadd(self, key: str, *members) -> int:
+        if key not in self._sets:
+            self._sets[key] = set()
+        count = 0
+        for m in members:
+            s = m.encode("utf-8") if isinstance(m, str) else m
+            if s not in self._sets[key]:
+                self._sets[key].add(s)
+                count += 1
+        return count
+
+    async def srem(self, key: str, *members) -> int:
+        s = self._sets.get(key, set())
+        removed = 0
+        for m in members:
+            bm = m.encode("utf-8") if isinstance(m, str) else m
+            if bm in s:
+                s.discard(bm)
+                removed += 1
+        return removed
+
+    async def smembers(self, key: str) -> set:
+        return set(self._sets.get(key, set()))
+
+    # ---- sorted set ----
+
+    async def zadd(self, key: str, mapping: Dict[str, float]) -> int:
+        if key not in self._zsets:
+            self._zsets[key] = {}
+        for member, score in mapping.items():
+            self._zsets[key][member] = score
+        return len(mapping)
+
+    async def zrem(self, key: str, *members) -> int:
+        z = self._zsets.get(key, {})
+        removed = 0
+        for m in members:
+            if m in z:
+                del z[m]
+                removed += 1
+        return removed
+
+    async def zrange(self, key: str, start: int, stop: int) -> List[bytes]:
+        z = self._zsets.get(key, {})
+        sorted_members = sorted(z.keys(), key=lambda k: z[k])
+        if stop == -1:
+            stop = len(sorted_members)
+        else:
+            stop += 1
+        return [m.encode("utf-8") if isinstance(m, str) else m
+                for m in sorted_members[start:stop]]
+
+    # ---- generic ----
+
+    async def exists(self, key: str) -> int:
+        return 1 if (key in self._hashes or key in self._sets or key in self._zsets) else 0
+
+    async def delete(self, *keys) -> int:
+        removed = 0
+        for key in keys:
+            for store in (self._hashes, self._sets, self._zsets):
+                if key in store:
+                    del store[key]
+                    removed += 1
+        return removed
+
+
+def make_graph() -> PropertyGraph:
+    """Return a PropertyGraph wired to FakeRedis."""
+    g = PropertyGraph(database="knowledge")
+    g._redis = FakeRedis()
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddNode:
+    @pytest.mark.asyncio
+    async def test_add_node_stores_properties(self):
+        g = make_graph()
+        await g.add_node("n1", {"type": "file", "lang": "python"})
+        node = await g.get_node("n1")
+        assert node is not None
+        assert node["type"] == "file"
+        assert node["lang"] == "python"
+        assert node["id"] == "n1"
+
+    @pytest.mark.asyncio
+    async def test_add_node_upsert_merges(self):
+        g = make_graph()
+        await g.add_node("n1", {"type": "file"})
+        await g.add_node("n1", {"lang": "python"})
+        node = await g.get_node("n1")
+        assert node["type"] == "file"
+        assert node["lang"] == "python"
+
+    @pytest.mark.asyncio
+    async def test_get_node_missing_returns_none(self):
+        g = make_graph()
+        assert await g.get_node("missing") is None
+
+
+class TestAddEdge:
+    @pytest.mark.asyncio
+    async def test_add_edge_returns_edge_id(self):
+        g = make_graph()
+        await g.add_node("a", {"type": "service"})
+        await g.add_node("b", {"type": "service"})
+        edge_id = await g.add_edge("a", "b", "DEPENDS_ON")
+        assert isinstance(edge_id, str)
+        assert len(edge_id) > 0
+
+    @pytest.mark.asyncio
+    async def test_add_edge_stores_from_to_relation(self):
+        g = make_graph()
+        await g.add_node("a", {"type": "task"})
+        await g.add_node("b", {"type": "task"})
+        edge_id = await g.add_edge("a", "b", "BLOCKS", {"priority": "high"})
+        edge = await g.get_edge(edge_id)
+        assert edge is not None
+        assert edge["from"] == "a"
+        assert edge["to"] == "b"
+        assert edge["relation"] == "BLOCKS"
+        assert edge["priority"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_add_edge_autocreates_missing_nodes(self):
+        g = make_graph()
+        await g.add_edge("x", "y", "RELATES_TO")
+        assert await g.get_node("x") is not None
+        assert await g.get_node("y") is not None
+
+
+class TestGetNeighbors:
+    @pytest.mark.asyncio
+    async def test_get_neighbors_outgoing(self):
+        g = make_graph()
+        await g.add_node("root", {"type": "module"})
+        await g.add_node("dep1", {"type": "module"})
+        await g.add_node("dep2", {"type": "module"})
+        await g.add_edge("root", "dep1", "DEPENDS_ON")
+        await g.add_edge("root", "dep2", "DEPENDS_ON")
+
+        neighbours = await g.get_neighbors("root", relation="DEPENDS_ON")
+        neighbour_ids = {e["node"]["id"] for e in neighbours}
+        assert neighbour_ids == {"dep1", "dep2"}
+
+    @pytest.mark.asyncio
+    async def test_get_neighbors_filtered_by_relation(self):
+        g = make_graph()
+        await g.add_node("a", {})
+        await g.add_node("b", {})
+        await g.add_node("c", {})
+        await g.add_edge("a", "b", "DEPENDS_ON")
+        await g.add_edge("a", "c", "CONTAINS")
+
+        depends = await g.get_neighbors("a", relation="DEPENDS_ON")
+        assert len(depends) == 1
+        assert depends[0]["node"]["id"] == "b"
+
+    @pytest.mark.asyncio
+    async def test_get_neighbors_incoming(self):
+        g = make_graph()
+        await g.add_node("child", {})
+        await g.add_node("parent", {})
+        await g.add_edge("parent", "child", "CONTAINS")
+
+        incoming = await g.get_neighbors("child", direction="incoming")
+        assert len(incoming) == 1
+        assert incoming[0]["node"]["id"] == "parent"
+
+    @pytest.mark.asyncio
+    async def test_get_neighbors_both_directions(self):
+        g = make_graph()
+        await g.add_node("mid", {})
+        await g.add_node("up", {})
+        await g.add_node("down", {})
+        await g.add_edge("up", "mid", "LEADS_TO")
+        await g.add_edge("mid", "down", "LEADS_TO")
+
+        both = await g.get_neighbors("mid", direction="both")
+        ids = {e["node"]["id"] for e in both}
+        assert ids == {"up", "down"}
+
+    @pytest.mark.asyncio
+    async def test_get_neighbors_no_relation_filter(self):
+        g = make_graph()
+        await g.add_node("a", {})
+        await g.add_node("b", {})
+        await g.add_node("c", {})
+        await g.add_edge("a", "b", "DEPENDS_ON")
+        await g.add_edge("a", "c", "CONTAINS")
+
+        all_neighbours = await g.get_neighbors("a")
+        ids = {e["node"]["id"] for e in all_neighbours}
+        assert ids == {"b", "c"}
+
+
+class TestQueryNodes:
+    @pytest.mark.asyncio
+    async def test_query_nodes_single_filter(self):
+        g = make_graph()
+        await g.add_node("bug1", {"type": "bug", "severity": "high"})
+        await g.add_node("bug2", {"type": "bug", "severity": "low"})
+        await g.add_node("feat1", {"type": "feature", "severity": "high"})
+
+        results = await g.query_nodes({"type": "bug"})
+        ids = {n["id"] for n in results}
+        assert "bug1" in ids
+        assert "bug2" in ids
+        assert "feat1" not in ids
+
+    @pytest.mark.asyncio
+    async def test_query_nodes_multi_filter(self):
+        g = make_graph()
+        await g.add_node("bug1", {"type": "bug", "severity": "high"})
+        await g.add_node("bug2", {"type": "bug", "severity": "low"})
+
+        results = await g.query_nodes({"type": "bug", "severity": "high"})
+        assert len(results) == 1
+        assert results[0]["id"] == "bug1"
+
+    @pytest.mark.asyncio
+    async def test_query_nodes_no_match(self):
+        g = make_graph()
+        await g.add_node("n1", {"type": "task"})
+
+        results = await g.query_nodes({"type": "nonexistent"})
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_query_nodes_empty_filter_returns_empty(self):
+        g = make_graph()
+        await g.add_node("n1", {"type": "task"})
+        results = await g.query_nodes({})
+        assert results == []
+
+
+class TestDeleteNode:
+    @pytest.mark.asyncio
+    async def test_delete_node_removes_node(self):
+        g = make_graph()
+        await g.add_node("n1", {"type": "task"})
+        deleted = await g.delete_node("n1")
+        assert deleted is True
+        assert await g.get_node("n1") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_node_returns_false_if_missing(self):
+        g = make_graph()
+        assert await g.delete_node("ghost") is False
+
+    @pytest.mark.asyncio
+    async def test_delete_node_removes_outgoing_edges(self):
+        g = make_graph()
+        await g.add_node("a", {"type": "x"})
+        await g.add_node("b", {"type": "x"})
+        edge_id = await g.add_edge("a", "b", "DEPENDS_ON")
+        await g.delete_node("a")
+        assert await g.get_edge(edge_id) is None
+
+
+class TestDeleteEdge:
+    @pytest.mark.asyncio
+    async def test_delete_edge_removes_edge(self):
+        g = make_graph()
+        await g.add_node("a", {})
+        await g.add_node("b", {})
+        edge_id = await g.add_edge("a", "b", "RELATES_TO")
+        deleted = await g.delete_edge(edge_id)
+        assert deleted is True
+        assert await g.get_edge(edge_id) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_edge_missing_returns_false(self):
+        g = make_graph()
+        assert await g.delete_edge("nonexistent-edge") is False
+
+    @pytest.mark.asyncio
+    async def test_delete_edge_removes_from_adjacency(self):
+        g = make_graph()
+        await g.add_node("a", {})
+        await g.add_node("b", {})
+        edge_id = await g.add_edge("a", "b", "DEPENDS_ON")
+        await g.delete_edge(edge_id)
+        neighbours = await g.get_neighbors("a", relation="DEPENDS_ON")
+        assert len(neighbours) == 0
+
+
+class TestMultiHop:
+    @pytest.mark.asyncio
+    async def test_multi_hop_depth_1(self):
+        g = make_graph()
+        for n in ("a", "b", "c"):
+            await g.add_node(n, {"id": n})
+        await g.add_edge("a", "b", "LEADS_TO")
+        await g.add_edge("b", "c", "LEADS_TO")
+
+        results = await g.multi_hop("a", max_depth=1)
+        ids = {r["node"]["id"] for r in results}
+        assert ids == {"b"}
+
+    @pytest.mark.asyncio
+    async def test_multi_hop_depth_2(self):
+        g = make_graph()
+        for n in ("a", "b", "c"):
+            await g.add_node(n, {"id": n})
+        await g.add_edge("a", "b", "LEADS_TO")
+        await g.add_edge("b", "c", "LEADS_TO")
+
+        results = await g.multi_hop("a", max_depth=2)
+        ids = {r["node"]["id"] for r in results}
+        assert ids == {"b", "c"}
+
+    @pytest.mark.asyncio
+    async def test_multi_hop_no_cycles(self):
+        """Graph with a cycle — multi_hop should not revisit nodes."""
+        g = make_graph()
+        for n in ("a", "b", "c"):
+            await g.add_node(n, {"id": n})
+        await g.add_edge("a", "b", "LEADS_TO")
+        await g.add_edge("b", "c", "LEADS_TO")
+        await g.add_edge("c", "a", "LEADS_TO")  # cycle back
+
+        results = await g.multi_hop("a", max_depth=5)
+        ids = [r["node"]["id"] for r in results]
+        # Each node visited at most once
+        assert len(ids) == len(set(ids))
+
+    @pytest.mark.asyncio
+    async def test_multi_hop_relation_filter(self):
+        g = make_graph()
+        for n in ("a", "b", "c"):
+            await g.add_node(n, {"id": n})
+        await g.add_edge("a", "b", "DEPENDS_ON")
+        await g.add_edge("a", "c", "CONTAINS")
+
+        results = await g.multi_hop("a", relation="DEPENDS_ON", max_depth=1)
+        ids = {r["node"]["id"] for r in results}
+        assert ids == {"b"}
+        assert "c" not in ids
+
+
+class TestSubgraph:
+    @pytest.mark.asyncio
+    async def test_subgraph_includes_center_node(self):
+        g = make_graph()
+        await g.add_node("center", {"type": "module"})
+        result = await g.subgraph("center", max_depth=1)
+        node_ids = {n["id"] for n in result["nodes"]}
+        assert "center" in node_ids
+
+    @pytest.mark.asyncio
+    async def test_subgraph_includes_adjacent_nodes(self):
+        g = make_graph()
+        await g.add_node("center", {})
+        await g.add_node("left", {})
+        await g.add_node("right", {})
+        await g.add_edge("left", "center", "LEADS_TO")
+        await g.add_edge("center", "right", "LEADS_TO")
+
+        result = await g.subgraph("center", max_depth=1)
+        node_ids = {n["id"] for n in result["nodes"]}
+        assert {"center", "left", "right"} == node_ids
+
+    @pytest.mark.asyncio
+    async def test_subgraph_edges_captured(self):
+        g = make_graph()
+        await g.add_node("a", {})
+        await g.add_node("b", {})
+        await g.add_edge("a", "b", "DEPENDS_ON")
+
+        result = await g.subgraph("a", max_depth=1)
+        assert len(result["edges"]) >= 1
+        edge = result["edges"][0]
+        assert edge["from"] == "a"
+        assert edge["to"] == "b"
+
+
+class TestShortestPath:
+    @pytest.mark.asyncio
+    async def test_shortest_path_direct(self):
+        g = make_graph()
+        await g.add_node("src", {})
+        await g.add_node("dst", {})
+        await g.add_edge("src", "dst", "LEADS_TO")
+
+        path = await g.shortest_path("src", "dst")
+        assert path is not None
+        assert len(path) == 1
+        assert path[0]["node"]["id"] == "dst"
+
+    @pytest.mark.asyncio
+    async def test_shortest_path_two_hops(self):
+        g = make_graph()
+        for n in ("a", "b", "c"):
+            await g.add_node(n, {"id": n})
+        await g.add_edge("a", "b", "LEADS_TO")
+        await g.add_edge("b", "c", "LEADS_TO")
+
+        path = await g.shortest_path("a", "c")
+        assert path is not None
+        node_ids = [step["node"]["id"] for step in path]
+        assert node_ids == ["b", "c"]
+
+    @pytest.mark.asyncio
+    async def test_shortest_path_same_node(self):
+        g = make_graph()
+        await g.add_node("a", {})
+        path = await g.shortest_path("a", "a")
+        assert path == []
+
+    @pytest.mark.asyncio
+    async def test_shortest_path_unreachable(self):
+        g = make_graph()
+        await g.add_node("a", {})
+        await g.add_node("b", {})  # no edge
+
+        path = await g.shortest_path("a", "b")
+        assert path is None
+
+    @pytest.mark.asyncio
+    async def test_shortest_path_prefers_shorter(self):
+        """When two paths exist, BFS returns the shorter one."""
+        g = make_graph()
+        for n in ("a", "b", "c", "d"):
+            await g.add_node(n, {"id": n})
+        # Short: a -> d (direct)
+        await g.add_edge("a", "d", "LEADS_TO")
+        # Long: a -> b -> c -> d
+        await g.add_edge("a", "b", "LEADS_TO")
+        await g.add_edge("b", "c", "LEADS_TO")
+        await g.add_edge("c", "d", "LEADS_TO")
+
+        path = await g.shortest_path("a", "d")
+        assert path is not None
+        assert len(path) == 1  # direct hop wins


### PR DESCRIPTION
Closes #3230

## Changes

Replaces the Redis adjacency list with a fully queryable property graph. All existing callers continue to work — the ECL pipeline mirrors data into both stores during a transition period.

### New files

| File | Lines | Purpose |
|------|-------|---------|
| `autobot_memory_graph/property_graph.py` | ~330 | `PropertyGraph` — Redis-backed graph with indexed property queries |
| `autobot_memory_graph/property_graph_mixin.py` | — | `PropertyGraphMixin` wires `PropertyGraph` into `AutoBotMemoryGraph` |
| `tests/memory_graph/test_property_graph.py` | 28 tests | Unit tests with `FakeRedis` (no live Redis required) |

### Modified files
- `autobot_memory_graph/__init__.py` — exports `PropertyGraph`, `PropertyGraphMixin`; adds mixin to `AutoBotMemoryGraph` MRO
- `knowledge/pipeline/loaders/redis_graph_loader.py` — mirrors ECL pipeline data into `PropertyGraph` (backward-compatible dual write)

## `PropertyGraph` API

```python
await graph.add_node("alice", {"role": "engineer", "team": "backend"})
await graph.add_edge("alice", "bob", "KNOWS", {"since": "2024"})

# Queryable by property — no KEYS scan
nodes = await graph.query_nodes({"role": "engineer"})

# Typed adjacency — no full scan
neighbors = await graph.get_neighbors("alice", relation="KNOWS")

# BFS traversal
path = await graph.shortest_path("alice", "carol", relation="KNOWS")
subg = await graph.subgraph("alice", max_depth=2)
```

## Redis key schema

| Pattern | Purpose |
|---------|---------|
| `pg:node:{id}` | Hash of node properties |
| `pg:edge:{id}` | Hash of edge properties + `from`, `to`, `relation` |
| `pg:adj:out:{id}:{relation}` | Sorted set of outgoing neighbor IDs |
| `pg:adj:in:{id}:{relation}` | Sorted set of incoming neighbor IDs |
| `pg:idx:prop:{key}:{value}` | Set of node IDs with this property value (enables O(1) property queries) |

## Remaining migration
Full removal of the legacy adjacency list JSON format is deferred until all read paths have been validated against the new store.