### PR TITLE
feat(hardening): tasks 3-6 + perf(memory): fix O(n) KB scan

### DIFF
--- a/autobot-backend/llm_interface_pkg/optimization/flash_attention.py
+++ b/autobot-backend/llm_interface_pkg/optimization/flash_attention.py
@@ -11,15 +11,33 @@ GQA expansion. Graceful fallback: Flash Attn -> SDPA -> vanilla.
 
 Issue #1955: Flash Attention v2 with variable-length sequence optimization.
 """
+# Issue #3009: from __future__ import annotations defers annotation evaluation
+# so torch types in dataclass fields / function signatures are strings at runtime.
+from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
-import torch
+if TYPE_CHECKING:
+    import torch as _torch_type  # noqa: F401
 
 logger = logging.getLogger(__name__)
+
+# Issue #3009: Lazy-load torch on first use so importing this module does not
+# require torch to be installed (NPU/GPU subsystem is feature-flagged).
+_torch: Any = None
+
+
+def _get_torch() -> Any:
+    """Return the torch module, importing it on first call."""
+    global _torch  # noqa: PLW0603
+    if _torch is None:
+        import torch
+
+        _torch = torch
+    return _torch
 
 # Lazy imports for optional dependencies
 _flash_attn_available: Optional[bool] = None
@@ -124,7 +142,7 @@ def _try_load_fused_rope() -> None:
 
 def _has_sdpa() -> bool:
     """Check if PyTorch scaled_dot_product_attention is available."""
-    return hasattr(torch.nn.functional, "scaled_dot_product_attention")
+    return hasattr(_get_torch().nn.functional, "scaled_dot_product_attention")
 
 
 def detect_backend() -> AttentionBackend:
@@ -144,7 +162,9 @@ def _build_repeat_kv_fn():
     """Build a JIT-compiled repeat_kv function for GQA expansion.
 
     Issue #1955: JIT compilation avoids Python overhead on repeated calls.
+    Issue #3009: torch imported lazily — only called after torch is available.
     """
+    import torch  # noqa: PLC0415 — lazy import, torch is a heavy optional dep
 
     @torch.jit.script
     def repeat_kv(kv: torch.Tensor, n_rep: int) -> torch.Tensor:
@@ -166,8 +186,17 @@ def _build_repeat_kv_fn():
     return repeat_kv
 
 
-# Module-level JIT-compiled function
-repeat_kv = _build_repeat_kv_fn()
+# Issue #3009: repeat_kv is built lazily on first use so that importing this
+# module does not trigger a torch import at startup.
+_repeat_kv_fn = None
+
+
+def repeat_kv(kv: Any, n_rep: int) -> Any:
+    """Expand KV heads for GQA — thin wrapper around the JIT-compiled version."""
+    global _repeat_kv_fn  # noqa: PLW0603
+    if _repeat_kv_fn is None:
+        _repeat_kv_fn = _build_repeat_kv_fn()
+    return _repeat_kv_fn(kv, n_rep)
 
 
 class GrowingKVCache:
@@ -186,13 +215,14 @@ class GrowingKVCache:
         self,
         chunk_size: int = 256,
         device: Optional[torch.device] = None,
-        dtype: torch.dtype = torch.float16,
+        dtype: torch.dtype = None,
     ):
+        _t = _get_torch()
         self.chunk_size = chunk_size
-        self.device = device or torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = device or _t.device(
+            "cuda" if _t.cuda.is_available() else "cpu"
         )
-        self.dtype = dtype
+        self.dtype = dtype if dtype is not None else _t.float16
         self._state = KVCacheState(chunk_size=chunk_size)
 
     @property
@@ -224,7 +254,7 @@ class GrowingKVCache:
         """Allocate the initial cache with chunk-aligned capacity."""
         batch, _, kv_pair, num_heads, head_dim = new_kv.shape
         initial_len = self.chunk_size
-        return torch.zeros(
+        return _get_torch().zeros(
             batch,
             initial_len,
             kv_pair,
@@ -243,7 +273,8 @@ class GrowingKVCache:
         extra_chunks = ((needed - current_capacity - 1) // self.chunk_size) + 1
         extra_len = extra_chunks * self.chunk_size
         batch, _, kv_pair, num_heads, head_dim = new_kv.shape
-        extension = torch.zeros(
+        _t = _get_torch()
+        extension = _t.zeros(
             batch,
             extra_len,
             kv_pair,
@@ -252,7 +283,7 @@ class GrowingKVCache:
             device=self.device,
             dtype=self.dtype,
         )
-        self._state.cache = torch.cat([self._state.cache, extension], dim=1)
+        self._state.cache = _t.cat([self._state.cache, extension], dim=1)
         logger.debug(
             "KV cache grown by %d positions to %d total",
             extra_len,
@@ -330,7 +361,7 @@ class FlashAttentionV2:
         n_rep = num_q_heads // num_kv_heads
         k = repeat_kv(kv[:, :, 0], n_rep)
         v = repeat_kv(kv[:, :, 1], n_rep)
-        return torch.stack([k, v], dim=2)
+        return _get_torch().stack([k, v], dim=2)
 
     def _forward_flash(
         self,
@@ -423,7 +454,7 @@ class FlashAttentionV2:
 
         attn_mask = self._build_sdpa_mask(key_padding_mask, q.shape[1], q.device)
 
-        output = torch.nn.functional.scaled_dot_product_attention(
+        output = _get_torch().nn.functional.scaled_dot_product_attention(
             q_t,
             k_t,
             v_t,
@@ -448,8 +479,9 @@ class FlashAttentionV2:
 
         mask = None
         if self.config.causal and key_padding_mask is not None:
-            causal = torch.tril(
-                torch.ones(seq_len, seq_len, device=device, dtype=torch.bool)
+            _t = _get_torch()
+            causal = _t.tril(
+                _t.ones(seq_len, seq_len, device=device, dtype=_t.bool)
             )
             pad_mask = key_padding_mask[:, None, None, :]
             mask = causal[None, None, :, :] & pad_mask
@@ -477,13 +509,14 @@ class FlashAttentionV2:
         k_t = k.transpose(1, 2)
         v_t = v.transpose(1, 2)
 
-        scores = torch.matmul(q_t, k_t.transpose(-2, -1)) * scale
+        _t = _get_torch()
+        scores = _t.matmul(q_t, k_t.transpose(-2, -1)) * scale
         scores = self._apply_masks_to_scores(
             scores, key_padding_mask, q.shape[1], q.device
         )
-        weights = torch.softmax(scores, dim=-1)
+        weights = _t.softmax(scores, dim=-1)
 
-        output = torch.matmul(weights, v_t)
+        output = _t.matmul(weights, v_t)
         return AttentionOutput(
             output=output.transpose(1, 2),
             backend_used=AttentionBackend.VANILLA,
@@ -498,8 +531,9 @@ class FlashAttentionV2:
     ) -> torch.Tensor:
         """Apply causal and padding masks to attention scores."""
         if self.config.causal:
-            causal_mask = torch.triu(
-                torch.ones(seq_len, seq_len, device=device, dtype=torch.bool),
+            _t = _get_torch()
+            causal_mask = _t.triu(
+                _t.ones(seq_len, seq_len, device=device, dtype=_t.bool),
                 diagonal=1,
             )
             scores = scores.masked_fill(causal_mask[None, None, :, :], float("-inf"))
@@ -549,7 +583,7 @@ class FlashAttentionV2:
         sin: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Apply RoPE using the fused flash_attn kernel."""
-        freqs = torch.stack([cos, sin], dim=-1)
+        freqs = _get_torch().stack([cos, sin], dim=-1)
         q_rot = fused_fn(q, freqs)
         k_rot = fused_fn(k, freqs)
         return q_rot, k_rot
@@ -588,7 +622,7 @@ def _rotate_half_apply(
     """
     half = x.shape[-1] // 2
     x1, x2 = x[..., :half], x[..., half:]
-    rotated = torch.cat([-x2, x1], dim=-1)
+    rotated = _get_torch().cat([-x2, x1], dim=-1)
     return x * cos + rotated * sin
 
 

--- a/autobot-backend/memory/agent_diary.py
+++ b/autobot-backend/memory/agent_diary.py
@@ -107,7 +107,12 @@ class AgentDiaryService:
         """
         try:
             kb = await _get_kb()
-            all_facts = await kb.get_all_facts()
+            # Issue #3808: pass limit to avoid a full O(n) KB scan.
+            # We fetch a generous window (500) so that filtering by category+source
+            # still yields enough entries even on large KBs.  The result is then
+            # sorted and capped to last_n.
+            _FETCH_LIMIT = 500
+            all_facts = await kb.get_all_facts(limit=_FETCH_LIMIT)
             entries = [
                 f for f in all_facts
                 if (f.get("metadata") or {}).get("category") == self.CATEGORY

--- a/autobot-backend/memory/essential_story.py
+++ b/autobot-backend/memory/essential_story.py
@@ -82,7 +82,10 @@ class EssentialStoryGenerator:
         from knowledge._composed import get_knowledge_base
 
         kb = await get_knowledge_base()
-        all_facts = await kb.get_all_facts()
+        # Issue #3808: limit the Redis scan to 200 facts so we never do a full
+        # O(n) scan.  200 provides enough headroom to find the top-quality facts
+        # for any model's token budget (max 800 tokens) after sorting.
+        all_facts = await kb.get_all_facts(limit=200)
 
         def _quality(fact: Dict[str, Any]) -> float:
             meta = fact.get("metadata") or {}
@@ -91,9 +94,7 @@ class EssentialStoryGenerator:
             except (TypeError, ValueError):
                 return 0.0
 
-        # Cap at 50 highest-quality facts — sufficient for any token budget (max 800 tokens)
-        # and avoids a full KB scan on large collections.
-        sorted_facts = sorted(all_facts, key=_quality, reverse=True)[:50]
+        sorted_facts = sorted(all_facts, key=_quality, reverse=True)
 
         selected: List[Dict[str, Any]] = []
         used_tokens = 0

--- a/autobot-backend/tests/memory/test_agent_diary.py
+++ b/autobot-backend/tests/memory/test_agent_diary.py
@@ -151,6 +151,15 @@ class TestRead:
         kb.get_all_facts.assert_awaited_once()
         kb.search.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_read_passes_limit_to_get_all_facts(self):
+        """Issue #3808: get_all_facts must be called with limit=500 to avoid O(n) scan."""
+        kb = _make_kb_mock(all_facts_result=[])
+        with patch("memory.agent_diary._get_kb", AsyncMock(return_value=kb)):
+            diary = AgentDiaryService()
+            await diary.read("agent_a")
+        kb.get_all_facts.assert_awaited_once_with(limit=500)
+
 
 # ---------------------------------------------------------------------------
 # search()

--- a/autobot-backend/tests/memory/test_essential_story.py
+++ b/autobot-backend/tests/memory/test_essential_story.py
@@ -202,8 +202,8 @@ class TestFetchTopFacts:
         assert len(result) <= 3
 
     @pytest.mark.asyncio
-    async def test_caps_at_50_facts_before_token_loop(self):
-        """Even with a huge token budget, at most 50 facts are ever processed."""
+    async def test_passes_limit_to_get_all_facts(self):
+        """Issue #3808: get_all_facts must be called with limit=200, not unbounded."""
         facts = _make_facts(200, quality_step=0.005)
         mock_kb = AsyncMock()
         mock_kb.get_all_facts = AsyncMock(return_value=facts)
@@ -212,9 +212,9 @@ class TestFetchTopFacts:
         )
 
         gen = EssentialStoryGenerator()
-        result = await gen._fetch_top_facts(max_tokens=100_000)
+        await gen._fetch_top_facts(max_tokens=100_000)
 
-        assert len(result) <= 50
+        mock_kb.get_all_facts.assert_awaited_once_with(limit=200)
 
     @pytest.mark.asyncio
     async def test_empty_kb_returns_empty_list(self):

--- a/autobot-frontend/src/shims-vue.d.ts
+++ b/autobot-frontend/src/shims-vue.d.ts
@@ -15,3 +15,8 @@ declare module 'vue' {
 }
 
 export {};
+
+// Compile-time feature flag defines injected by Vite (#3009)
+declare const __FEATURE_VOICE__: boolean
+declare const __FEATURE_VNC__: boolean
+declare const __FEATURE_BROWSER__: boolean

--- a/autobot-frontend/vite.config.ts
+++ b/autobot-frontend/vite.config.ts
@@ -49,6 +49,11 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
+    define: {
+      __FEATURE_VOICE__: JSON.stringify(env.VITE_FEATURE_VOICE !== 'false'),
+      __FEATURE_VNC__: JSON.stringify(env.VITE_FEATURE_VNC !== 'false'),
+      __FEATURE_BROWSER__: JSON.stringify(env.VITE_FEATURE_BROWSER !== 'false'),
+    },
     plugins: [vue(), vueDevTools(), vadAssetsPlugin()],
     optimizeDeps: {
       include: ['@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-web-links', '@heroicons/vue/24/outline', '@heroicons/vue/24/solid'],

--- a/autobot_shared/feature_flags_test.py
+++ b/autobot_shared/feature_flags_test.py
@@ -340,3 +340,35 @@ class TestRequireFeatureDecorator:
         err = FeatureDisabledError("browser")
         assert isinstance(err, RuntimeError)
         assert err.feature_name == "browser"
+
+
+# ---------------------------------------------------------------------------
+# FeatureConfig plan short-name fields — issue #3009
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureConfigPlanFields:
+    """Verify the short-name subsystem fields added in issue #3009."""
+
+    def test_default_flags_exist(self):
+        cfg = _fresh_feature_config()
+        assert hasattr(cfg, "npu")
+        assert hasattr(cfg, "voice")
+        assert hasattr(cfg, "browser_automation")
+        assert hasattr(cfg, "computer_vision")
+        assert hasattr(cfg, "training")
+        assert hasattr(cfg, "graph_rag")
+        assert hasattr(cfg, "mcp")
+
+    def test_heavy_features_off_by_default(self):
+        cfg = _fresh_feature_config()
+        assert cfg.computer_vision is False
+        assert cfg.training is False
+
+    def test_standard_features_on_by_default(self):
+        cfg = _fresh_feature_config()
+        assert cfg.npu is True
+        assert cfg.voice is True
+        assert cfg.browser_automation is True
+        assert cfg.graph_rag is True
+        assert cfg.mcp is True

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1042,6 +1042,21 @@ class FeatureConfig(BaseSettings):
     training_enabled: bool = Field(default=True, alias="AUTOBOT_FEATURE_TRAINING")
     osint_enabled: bool = Field(default=True, alias="AUTOBOT_FEATURE_OSINT")
 
+    # Subsystem feature flags — issue #3009 (plan short-name fields)
+    # These complement the *_enabled fields above with concise names.
+    # Heavy optional subsystems (computer_vision, training) default to False.
+    npu: bool = Field(default=True, alias="AUTOBOT_FEATURE_NPU_2")
+    voice: bool = Field(default=True, alias="AUTOBOT_FEATURE_VOICE_2")
+    browser_automation: bool = Field(
+        default=True, alias="AUTOBOT_FEATURE_BROWSER_AUTOMATION"
+    )
+    computer_vision: bool = Field(
+        default=False, alias="AUTOBOT_FEATURE_COMPUTER_VISION_CV"
+    )
+    training: bool = Field(default=False, alias="AUTOBOT_FEATURE_TRAINING_TR")
+    graph_rag: bool = Field(default=True, alias="AUTOBOT_FEATURE_GRAPH_RAG")
+    mcp: bool = Field(default=True, alias="AUTOBOT_FEATURE_MCP")
+
 
 class AutoBotConfig(BaseSettings):
     """

--- a/autobot_shared/tool_sdk/__init__.py
+++ b/autobot_shared/tool_sdk/__init__.py
@@ -38,6 +38,9 @@ from tool_sdk.registry import (
     get_tool_registry,
 )
 
+# Alias for plan-specified name (#3009)
+get_tool_sdk_registry = get_tool_registry
+
 __all__ = [
     "BaseTool",
     "ToolInputError",
@@ -48,4 +51,5 @@ __all__ = [
     "ToolNotFoundError",
     "ToolSDKRegistry",
     "get_tool_registry",
+    "get_tool_sdk_registry",
 ]

--- a/autobot_shared/tool_sdk/base_test.py
+++ b/autobot_shared/tool_sdk/base_test.py
@@ -1,0 +1,84 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for tool SDK base classes — issue #3009.
+
+Verifies BaseTool contract, ToolPermission levels, and ToolResult structure
+using the canonical API (ToolMetadata + JSON Schema input_schema).
+"""
+
+import pytest
+
+from tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
+
+
+class _EchoTool(BaseTool):
+    metadata = ToolMetadata(
+        name="echo",
+        description="Echoes input back",
+        permission=ToolPermission.PUBLIC,
+        tags=["test"],
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {"message": {"type": "string"}},
+        "required": ["message"],
+        "additionalProperties": False,
+    }
+
+    async def execute(self, validated_input: dict) -> ToolResult:
+        return ToolResult(success=True, data=validated_input["message"])
+
+
+class TestToolPermission:
+    def test_permission_values(self):
+        assert ToolPermission.PUBLIC == "public"
+        assert ToolPermission.AUTHENTICATED == "authenticated"
+        assert ToolPermission.ADMIN == "admin"
+
+    def test_permission_ordering(self):
+        assert ToolPermission.PUBLIC.allows(ToolPermission.PUBLIC)
+        assert ToolPermission.AUTHENTICATED.allows(ToolPermission.PUBLIC)
+        assert not ToolPermission.PUBLIC.allows(ToolPermission.AUTHENTICATED)
+        assert ToolPermission.ADMIN.allows(ToolPermission.AUTHENTICATED)
+
+
+class TestToolResult:
+    def test_success_result(self):
+        result = ToolResult(success=True, data={"key": "value"})
+        assert result.success is True
+        assert result.data == {"key": "value"}
+        assert result.error is None
+
+    def test_error_result(self):
+        result = ToolResult(success=False, error="Something failed")
+        assert result.success is False
+        assert result.error == "Something failed"
+        assert result.data is None
+
+    def test_duration_ms_default(self):
+        result = ToolResult(success=True)
+        assert result.duration_ms == 0.0
+
+
+class TestBaseTool:
+    @pytest.mark.asyncio
+    async def test_echo_tool_execute(self):
+        tool = _EchoTool()
+        result = await tool.execute({"message": "hello"})
+        assert result.success is True
+        assert result.data == "hello"
+
+    def test_tool_attributes(self):
+        tool = _EchoTool()
+        assert tool.metadata.name == "echo"
+        assert tool.metadata.description == "Echoes input back"
+        assert tool.metadata.permission == ToolPermission.PUBLIC
+        assert tool.input_schema["properties"]["message"]["type"] == "string"
+
+    def test_input_validation_rejects_missing_field(self):
+        from tool_sdk.base import ToolInputError
+
+        tool = _EchoTool()
+        with pytest.raises(ToolInputError):
+            tool.validate_input({})


### PR DESCRIPTION
Closes #3808
Partial: #3009 (tasks 3–6 of 13)

## Changes

### Task 3 — Feature flags: frontend Vite defines
- `autobot-frontend/vite.config.ts` — `define` block with `__FEATURE_VOICE__`, `__FEATURE_VNC__`, `__FEATURE_BROWSER__`
- `autobot-frontend/src/shims-vue.d.ts` — TypeScript declarations for the three globals

### Task 4 — Lazy torch imports
- `llm_interface_pkg/optimization/flash_attention.py` — `_get_torch()` lazy helper, `from __future__ import annotations`, deferred all `torch.*` usage to function bodies

### Task 5 — Lazy chromadb/PIL/cv2
- No changes needed — all target files already deferred via `TYPE_CHECKING` guards

### Task 6 — Tool SDK base classes
- `autobot_shared/tool_sdk/__init__.py` — added `get_tool_sdk_registry` convenience alias
- `autobot_shared/tool_sdk/base_test.py` — new tests for `BaseTool`, `ToolPermission`, `ToolResult`
- `autobot_shared/ssot_config.py` — added 7 short-name `FeatureConfig` fields (`npu`, `voice`, `browser_automation`, `computer_vision`, `training`, `graph_rag`, `mcp`)
- `autobot_shared/feature_flags_test.py` — `TestFeatureConfigPlanFields` tests

### #3808 — Fix O(n) KB scan in memory reads
- `memory/agent_diary.py` — pass `limit=500` to `get_all_facts()`
- `memory/essential_story.py` — pass `limit=200` to `get_all_facts()`, remove post-slice `[:50]`
- `tests/memory/test_agent_diary.py` — `test_read_passes_limit_to_get_all_facts`
- `tests/memory/test_essential_story.py` — updated to assert limit is passed (not just post-filtered)

## Remaining hardening tasks
Tasks 1–2 (parallel startup init, FeatureConfig backend flags) and tasks 7–13 (Tool SDK registry, integration, permission hooks, WebSocket auth, workflow memory, lifespan registration) are tracked against #3009.