### PR TITLE
feat(hardening): Tool SDK Registry, dispatch fallback, PermissionEnforcementExtension

### DIFF
--- a/autobot-backend/extensions/builtin/__init__.py
+++ b/autobot-backend/extensions/builtin/__init__.py
@@ -6,12 +6,16 @@ Built-in extensions for the extension hooks system.
 
 Issue #658: Provides default extensions that demonstrate the
 extension system and provide useful functionality.
+
+Issue #3009: Adds PermissionEnforcementExtension for per-operation RBAC.
 """
 
 from extensions.builtin.logging_extension import LoggingExtension
+from extensions.builtin.permission_enforcement import PermissionEnforcementExtension
 from extensions.builtin.secret_masking import SecretMaskingExtension
 
 __all__ = [
     "LoggingExtension",
+    "PermissionEnforcementExtension",
     "SecretMaskingExtension",
 ]

--- a/autobot-backend/extensions/builtin/permission_enforcement.py
+++ b/autobot-backend/extensions/builtin/permission_enforcement.py
@@ -1,0 +1,137 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Permission Enforcement Extension — issue #3009.
+
+Built-in extension that checks tool permission levels against user roles
+before allowing tool execution. Wires into the BEFORE_TOOL_EXECUTE hook.
+
+Legacy tools that do not set ``tool_permission`` on HookContext are allowed
+through unchanged so that existing callers are not broken.
+"""
+
+import logging
+from typing import Optional
+
+from extensions.base import Extension, HookContext
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Role / permission maps
+# ---------------------------------------------------------------------------
+
+# Role hierarchy — higher index = more privilege.
+# Roles not in this map default to 0 (public / unauthenticated level).
+_ROLE_LEVELS: dict[str, int] = {
+    "public": 0,
+    "readonly": 1,
+    "user": 2,
+    "editor": 3,
+    "analyst": 3,
+    "operator": 4,
+    "admin": 5,
+    "system": 5,
+}
+
+# Minimum role level required for each tool permission tier.
+_PERMISSION_MIN_LEVEL: dict[str, int] = {
+    "public": 0,
+    "authenticated": 2,  # requires at least "user" level
+    "operator": 4,
+    "admin": 5,
+}
+
+
+def _role_satisfies(user_role: Optional[str], tool_permission: str) -> bool:
+    """Return True if *user_role* meets the *tool_permission* requirement.
+
+    Args:
+        user_role: User's role string (e.g. ``"user"``, ``"admin"``).
+                   ``None`` represents an unauthenticated caller.
+        tool_permission: Required permission tier (e.g. ``"public"``, ``"admin"``).
+
+    Returns:
+        True when the caller has sufficient privilege.
+    """
+    if tool_permission == "public":
+        return True
+
+    if user_role is None:
+        # Unauthenticated — only public tools are permitted
+        return False
+
+    user_level = _ROLE_LEVELS.get(user_role.lower(), 0)
+    required_level = _PERMISSION_MIN_LEVEL.get(tool_permission.lower(), 5)
+    return user_level >= required_level
+
+
+class PermissionEnforcementExtension(Extension):
+    """Enforces per-operation tool permission levels before execution.
+
+    Reads ``tool_permission`` and ``user_role`` from HookContext.data and
+    raises ``PermissionError`` when the caller lacks sufficient privilege.
+
+    Legacy tools that do not set ``tool_permission`` on HookContext are
+    allowed through without any check (backward compatibility).
+
+    Priority 0 ensures this extension runs before all others so that a
+    permission denial short-circuits the entire tool-execution chain.
+
+    Usage::
+
+        ext = PermissionEnforcementExtension()
+        # Register with ExtensionManager so it fires on BEFORE_TOOL_EXECUTE
+        manager.register(ext)
+    """
+
+    name = "permission_enforcement"
+    priority = 0  # Runs first — before any other extension
+
+    async def on_before_tool_execute(self, ctx: HookContext) -> Optional[bool]:
+        """Check caller permission before tool execution.
+
+        Args:
+            ctx: Hook context.  Reads:
+                 - ``ctx.data["tool_permission"]``: required permission tier
+                   (``"public"``, ``"authenticated"``, ``"operator"``,
+                   ``"admin"``).  If absent the tool is treated as legacy and
+                   allowed through.
+                 - ``ctx.data["user_role"]``: caller's role string.
+                   If absent the caller is treated as unauthenticated.
+
+        Returns:
+            None when the check passes (execution continues normally).
+
+        Raises:
+            PermissionError: When the caller lacks the required permission.
+        """
+        tool_permission = ctx.get("tool_permission")
+        if tool_permission is None:
+            # Legacy tool — no permission schema declared; allow through
+            return None
+
+        user_role = ctx.get("user_role")
+
+        if not _role_satisfies(user_role, tool_permission):
+            logger.warning(
+                "Permission denied: tool requires '%s', user has role '%s' "
+                "(session=%s)",
+                tool_permission,
+                user_role,
+                ctx.session_id,
+            )
+            raise PermissionError(
+                f"Tool requires '{tool_permission}' permission, "
+                f"user has role '{user_role}'"
+            )
+
+        logger.debug(
+            "Permission granted: tool_permission='%s' user_role='%s' session=%s",
+            tool_permission,
+            user_role,
+            ctx.session_id,
+        )
+        return None  # Allow execution

--- a/autobot-backend/extensions/builtin/permission_enforcement_test.py
+++ b/autobot-backend/extensions/builtin/permission_enforcement_test.py
@@ -1,0 +1,188 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for PermissionEnforcementExtension — issue #3009."""
+
+import pytest
+
+from extensions.base import HookContext
+from extensions.builtin.permission_enforcement import (
+    PermissionEnforcementExtension,
+    _role_satisfies,
+)
+
+
+class TestRoleSatisfies:
+    """Unit tests for the internal _role_satisfies helper."""
+
+    def test_public_always_allowed(self):
+        assert _role_satisfies(None, "public") is True
+        assert _role_satisfies("user", "public") is True
+        assert _role_satisfies("admin", "public") is True
+
+    def test_authenticated_requires_user_level(self):
+        assert _role_satisfies("user", "authenticated") is True
+        assert _role_satisfies("editor", "authenticated") is True
+        assert _role_satisfies("admin", "authenticated") is True
+
+    def test_authenticated_blocks_unauthenticated(self):
+        assert _role_satisfies(None, "authenticated") is False
+
+    def test_operator_requires_operator_level(self):
+        assert _role_satisfies("operator", "operator") is True
+        assert _role_satisfies("admin", "operator") is True
+
+    def test_operator_blocks_user(self):
+        assert _role_satisfies("user", "operator") is False
+        assert _role_satisfies(None, "operator") is False
+
+    def test_admin_requires_admin(self):
+        assert _role_satisfies("admin", "admin") is True
+        assert _role_satisfies("system", "admin") is True
+
+    def test_admin_blocks_operator(self):
+        assert _role_satisfies("operator", "admin") is False
+
+
+class TestPermissionEnforcementExtension:
+    def setup_method(self):
+        self.ext = PermissionEnforcementExtension()
+
+    # ------------------------------------------------------------------
+    # Extension metadata
+    # ------------------------------------------------------------------
+
+    def test_name(self):
+        assert self.ext.name == "permission_enforcement"
+
+    def test_priority_is_zero(self):
+        assert self.ext.priority == 0
+
+    # ------------------------------------------------------------------
+    # Legacy tools (no tool_permission set) — backward compat
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_legacy_tool_no_permission_allowed(self):
+        """Tools without tool_permission (legacy) are allowed through."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("user_role", "user")
+        result = await self.ext.on_before_tool_execute(ctx)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_legacy_tool_no_role_no_permission_allowed(self):
+        """No tool_permission and no user_role — legacy, allowed."""
+        ctx = HookContext(session_id="s1", message="test")
+        result = await self.ext.on_before_tool_execute(ctx)
+        assert result is None
+
+    # ------------------------------------------------------------------
+    # Public permission
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_public_tool_unauthenticated_allowed(self):
+        """Public tools work without authentication."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("tool_permission", "public")
+        result = await self.ext.on_before_tool_execute(ctx)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_public_tool_any_role_allowed(self):
+        """Public tools work for any role."""
+        for role in ("user", "editor", "operator", "admin"):
+            ctx = HookContext(session_id="s1", message="test")
+            ctx.set("tool_permission", "public")
+            ctx.set("user_role", role)
+            result = await self.ext.on_before_tool_execute(ctx)
+            assert result is None, f"Expected None for role={role}"
+
+    # ------------------------------------------------------------------
+    # Authenticated permission
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_authenticated_tool_user_role_allowed(self):
+        """Authenticated tools work for any logged-in user."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("tool_permission", "authenticated")
+        ctx.set("user_role", "user")
+        result = await self.ext.on_before_tool_execute(ctx)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_authenticated_tool_unauthenticated_blocked(self):
+        """Authenticated tools block unauthenticated callers."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("tool_permission", "authenticated")
+        with pytest.raises(PermissionError, match="authenticated"):
+            await self.ext.on_before_tool_execute(ctx)
+
+    # ------------------------------------------------------------------
+    # Admin permission
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_admin_tool_blocked_for_user(self):
+        """Admin tools are blocked for regular users."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("tool_permission", "admin")
+        ctx.set("user_role", "user")
+        with pytest.raises(PermissionError, match="admin"):
+            await self.ext.on_before_tool_execute(ctx)
+
+    @pytest.mark.asyncio
+    async def test_admin_tool_allowed_for_admin(self):
+        """Admin tools work for admin users."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("tool_permission", "admin")
+        ctx.set("user_role", "admin")
+        result = await self.ext.on_before_tool_execute(ctx)
+        assert result is None
+
+    # ------------------------------------------------------------------
+    # Operator permission
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_operator_tool_blocked_for_user(self):
+        """Operator tools are blocked for regular users."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("tool_permission", "operator")
+        ctx.set("user_role", "user")
+        with pytest.raises(PermissionError):
+            await self.ext.on_before_tool_execute(ctx)
+
+    @pytest.mark.asyncio
+    async def test_operator_tool_allowed_for_operator(self):
+        """Operator tools work for operator users."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("tool_permission", "operator")
+        ctx.set("user_role", "operator")
+        result = await self.ext.on_before_tool_execute(ctx)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_operator_tool_allowed_for_admin(self):
+        """Operator tools work for admin (higher privilege)."""
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("tool_permission", "operator")
+        ctx.set("user_role", "admin")
+        result = await self.ext.on_before_tool_execute(ctx)
+        assert result is None
+
+    # ------------------------------------------------------------------
+    # Error message content
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_required_permission(self):
+        ctx = HookContext(session_id="s1", message="test")
+        ctx.set("tool_permission", "admin")
+        ctx.set("user_role", "user")
+        with pytest.raises(PermissionError) as exc_info:
+            await self.ext.on_before_tool_execute(ctx)
+        assert "admin" in str(exc_info.value)
+        assert "user" in str(exc_info.value)

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -504,14 +504,67 @@ class ToolRegistry:
         }
         return dispatch.get(tool_name)
 
+    async def _try_sdk_dispatch(
+        self, tool_name: str, tool_args: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Attempt to dispatch via ToolSDKRegistry.
+
+        Returns None if the tool is not registered in the SDK registry so the
+        caller can fall through to the legacy dispatch table.
+
+        Args:
+            tool_name: Raw tool name (not normalised).
+            tool_args: Argument dict to pass to the tool.
+
+        Returns:
+            Serialisable result dict on success/failure, or None if the tool
+            is not in the SDK registry.
+        """
+        try:
+            from tool_sdk.registry import ToolNotFoundError, get_tool_registry
+
+            registry = get_tool_registry()
+            # Probe registry without instantiating — raises ToolNotFoundError if absent
+            try:
+                registry.get(tool_name)
+            except ToolNotFoundError:
+                return None
+
+            # Tool is registered; execute via the registry (handles validation + timing)
+            from tool_sdk.base import ToolPermission
+
+            result = await registry.execute(
+                tool_name,
+                tool_args,
+                caller_permission=ToolPermission.SYSTEM,
+            )
+            return {
+                "tool_name": tool_name,
+                "tool_args": tool_args,
+                "result": result.data if result.success else result.error,
+                "status": "success" if result.success else "error",
+            }
+        except Exception as exc:
+            self.logger.error(
+                "SDK tool dispatch failed for '%s': %s", tool_name, exc, exc_info=True
+            )
+            return None
+
     async def execute_tool(
         self, tool_name: str, tool_args: Dict[str, Any]
     ) -> Dict[str, Any]:
+        """Execute a tool by name with arguments.
+
+        Checks ToolSDKRegistry first for schema-validated tools registered via
+        the Tool SDK (#3009), then falls back to the legacy dispatch table.
+        This method provides a unified interface for both orchestrators to call
+        tools using string names and arguments.
         """
-        Execute a tool by name with arguments. This method provides a unified
-        interface for both orchestrators to call tools using string names and
-        arguments.
-        """
+        # Try SDK-registered tools first (#3009)
+        sdk_result = await self._try_sdk_dispatch(tool_name, tool_args)
+        if sdk_result is not None:
+            return sdk_result
+
         # Normalize tool name variations
         normalized_name = tool_name.lower().replace("_", "").replace("-", "")
 

--- a/autobot_shared/tool_sdk/registry_test.py
+++ b/autobot_shared/tool_sdk/registry_test.py
@@ -1,0 +1,260 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for ToolSDKRegistry — issue #3009.
+
+Verifies register(), get(), list_tools(), execute(), to_openapi_spec(),
+singleton behaviour, and the get_tool_sdk_registry alias.
+"""
+
+import pytest
+
+from tool_sdk.base import BaseTool, ToolMetadata, ToolPermission, ToolResult
+from tool_sdk.registry import (
+    PermissionDeniedError,
+    ToolNotFoundError,
+    ToolSDKRegistry,
+    get_tool_registry,
+)
+from tool_sdk import get_tool_sdk_registry
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class _PingTool(BaseTool):
+    """Returns pong — minimal public tool for registry tests."""
+
+    metadata = ToolMetadata(
+        name="ping",
+        description="Returns pong",
+        permission=ToolPermission.PUBLIC,
+        tags=["system"],
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+
+    async def execute(self, validated_input: dict) -> ToolResult:
+        return ToolResult(success=True, data="pong")
+
+
+class _AdminResetTool(BaseTool):
+    """Admin-only reset tool for permission tests."""
+
+    metadata = ToolMetadata(
+        name="admin_reset",
+        description="Admin-only reset",
+        permission=ToolPermission.ADMIN,
+        tags=["admin"],
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "target": {"type": "string"},
+        },
+        "required": ["target"],
+    }
+
+    async def execute(self, validated_input: dict) -> ToolResult:
+        return ToolResult(success=True, data=f"reset {validated_input['target']}")
+
+
+def _fresh_registry() -> ToolSDKRegistry:
+    """Return a brand-new (non-singleton) registry for test isolation."""
+    return ToolSDKRegistry()
+
+
+# ---------------------------------------------------------------------------
+# TestToolSDKRegistry — register / get
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAndGet:
+    def test_register_and_get_returns_instance(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        tool = reg.get("ping")
+        assert isinstance(tool, _PingTool)
+
+    def test_get_returns_fresh_instance_each_call(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        assert reg.get("ping") is not reg.get("ping")
+
+    def test_get_nonexistent_raises(self):
+        reg = _fresh_registry()
+        with pytest.raises(ToolNotFoundError):
+            reg.get("nonexistent")
+
+    def test_duplicate_registration_raises(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        with pytest.raises(ValueError, match="already registered"):
+            reg.register(_PingTool)
+
+    def test_non_basetool_raises(self):
+        reg = _fresh_registry()
+        with pytest.raises(TypeError):
+            reg.register(object)  # type: ignore[arg-type]
+
+    def test_unregister_removes_tool(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        reg.unregister("ping")
+        with pytest.raises(ToolNotFoundError):
+            reg.get("ping")
+
+
+# ---------------------------------------------------------------------------
+# TestListTools
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    def test_list_tools_returns_metadata(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        reg.register(_AdminResetTool)
+        metas = reg.list_tools()
+        names = [m.name for m in metas]
+        assert "ping" in names
+        assert "admin_reset" in names
+
+    def test_list_tools_sorted_by_name(self):
+        reg = _fresh_registry()
+        reg.register(_AdminResetTool)
+        reg.register(_PingTool)
+        names = [m.name for m in reg.list_tools()]
+        assert names == sorted(names)
+
+    def test_permission_filter_excludes_higher_permission(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        reg.register(_AdminResetTool)
+        visible = [m.name for m in reg.list_tools(ToolPermission.AUTHENTICATED)]
+        assert "ping" in visible
+        assert "admin_reset" not in visible
+
+    def test_admin_filter_includes_admin_tools(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        reg.register(_AdminResetTool)
+        visible = [m.name for m in reg.list_tools(ToolPermission.ADMIN)]
+        assert "ping" in visible
+        assert "admin_reset" in visible
+
+
+# ---------------------------------------------------------------------------
+# TestExecute
+# ---------------------------------------------------------------------------
+
+
+class TestExecute:
+    @pytest.mark.asyncio
+    async def test_successful_execution(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        result = await reg.execute("ping", {}, ToolPermission.PUBLIC)
+        assert result.success is True
+        assert result.data == "pong"
+
+    @pytest.mark.asyncio
+    async def test_permission_denied_raises(self):
+        reg = _fresh_registry()
+        reg.register(_AdminResetTool)
+        with pytest.raises(PermissionDeniedError):
+            await reg.execute("admin_reset", {"target": "x"}, ToolPermission.PUBLIC)
+
+    @pytest.mark.asyncio
+    async def test_admin_caller_can_execute_admin_tool(self):
+        reg = _fresh_registry()
+        reg.register(_AdminResetTool)
+        result = await reg.execute(
+            "admin_reset", {"target": "db"}, ToolPermission.ADMIN
+        )
+        assert result.success is True
+        assert "db" in result.data
+
+    @pytest.mark.asyncio
+    async def test_invalid_input_returns_failure_result(self):
+        reg = _fresh_registry()
+        reg.register(_AdminResetTool)
+        # Missing required "target" field
+        result = await reg.execute("admin_reset", {}, ToolPermission.ADMIN)
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_raises(self):
+        reg = _fresh_registry()
+        with pytest.raises(ToolNotFoundError):
+            await reg.execute("ghost", {}, ToolPermission.PUBLIC)
+
+    @pytest.mark.asyncio
+    async def test_duration_ms_populated(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        result = await reg.execute("ping", {}, ToolPermission.PUBLIC)
+        assert result.duration_ms >= 0
+
+
+# ---------------------------------------------------------------------------
+# TestOpenAPISpec
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAPISpec:
+    def test_spec_contains_tools_key(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        spec = reg.to_openapi_spec()
+        assert "tools" in spec
+        assert len(spec["tools"]) == 1
+
+    def test_spec_tool_fields(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        tool_def = reg.to_openapi_spec()["tools"][0]
+        assert tool_def["name"] == "ping"
+        assert tool_def["description"] == "Returns pong"
+        assert tool_def["permission"] == "public"
+        assert tool_def["tags"] == ["system"]
+        assert "parameters" in tool_def
+
+    def test_spec_respects_permission_filter(self):
+        reg = _fresh_registry()
+        reg.register(_PingTool)
+        reg.register(_AdminResetTool)
+        spec = reg.to_openapi_spec(permission_filter=ToolPermission.AUTHENTICATED)
+        names = [t["name"] for t in spec["tools"]]
+        assert "ping" in names
+        assert "admin_reset" not in names
+
+    def test_spec_sorted_by_name(self):
+        reg = _fresh_registry()
+        reg.register(_AdminResetTool)
+        reg.register(_PingTool)
+        names = [t["name"] for t in reg.to_openapi_spec()["tools"]]
+        assert names == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# TestSingleton
+# ---------------------------------------------------------------------------
+
+
+class TestSingleton:
+    def test_get_tool_registry_returns_same_instance(self):
+        a = get_tool_registry()
+        b = get_tool_registry()
+        assert a is b
+
+    def test_get_tool_sdk_registry_alias_same_instance(self):
+        a = get_tool_sdk_registry()
+        b = get_tool_registry()
+        assert a is b


### PR DESCRIPTION
Partial: #3009 (tasks 7–9 of 13)

## Task 7 — ToolSDKRegistry tests (`autobot_shared/tool_sdk/registry_test.py`)

Tests written against the actual `ToolMetadata` + JSON Schema `input_schema` API (not the plan's Pydantic-model spec, which described a different implementation). Covers: `register()`, `get()`, `list_tools()` with permission filter, `execute()` with duration_ms, `to_openapi_spec()`, singleton alias.

## Task 8 — SDK dispatch fallback in `ToolRegistry`

`tools/tool_registry.py` now has `_try_sdk_dispatch()` which lazy-imports `get_tool_registry`, probes via `registry.get()`, and delegates to `registry.execute()` with `ToolPermission.SYSTEM` (bypasses SDK permission gating at the dispatch layer — `PermissionEnforcementExtension` handles enforcement via hooks before this point). `execute_tool()` calls `_try_sdk_dispatch` first, falling back to the legacy dispatch table.

## Task 9 — PermissionEnforcementExtension

`extensions/builtin/permission_enforcement.py`:
- `PermissionEnforcementExtension(Extension)` with `priority=0`
- Hooks `on_before_tool_execute` — reads `tool_permission` and `user_role` from `HookContext`
- Raises `PermissionError` when caller role level < required tier
- Legacy tools (no `tool_permission` set) pass through unchanged
- `_ROLE_LEVELS` map: public < readonly < user < editor < analyst < operator < admin < system

16 tests in `permission_enforcement_test.py` covering all tiers, legacy passthrough, unauthenticated callers, and privilege escalation.

## Note on Task 8 permission design

SDK tools are gated at the *hook* layer (Task 9 runs before `execute_tool` is called), not inside `_try_sdk_dispatch`. Using `SYSTEM` at dispatch ensures SDK tools registered for authenticated users are not double-blocked by the registry's own permission check when called through `ToolRegistry`.