### PR TITLE
feat(memory-graph): REST endpoints for temporal invalidation

### DIFF
--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -28,7 +28,7 @@ Performance:
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
@@ -133,6 +133,27 @@ class RelationCreateRequest(BaseModel):
         if v not in valid_types:
             raise ValueError(f"relation_type must be one of: {valid_types}")
         return v
+
+
+class InvalidateEntityRequest(BaseModel):
+    """Request model for invalidating an entity (setting valid_to). Issue #3810."""
+
+    ended_at: Optional[str] = Field(
+        default=None,
+        description="ISO-8601 timestamp for valid_to. Defaults to now.",
+    )
+
+
+class InvalidateRelationRequest(BaseModel):
+    """Request model for invalidating a relation (setting valid_to). Issue #3810."""
+
+    from_id: str = Field(..., description="Source entity UUID")
+    relation_type: str = Field(..., description="Type of the relation")
+    to_id: str = Field(..., description="Target entity UUID")
+    ended_at: Optional[str] = Field(
+        default=None,
+        description="ISO-8601 timestamp for valid_to. Defaults to now.",
+    )
 
 
 class EntityResponse(BaseModel):
@@ -1555,3 +1576,212 @@ async def memory_health_check(
                 "timestamp": datetime.utcnow().isoformat(),
             },
         )
+
+
+# ====================================================================
+# Temporal Invalidation Endpoints (Issue #3810)
+# ====================================================================
+
+
+def _build_invalidate_entity_response(
+    request_id: str,
+    entity_id: str,
+    valid_to: str,
+) -> JSONResponse:
+    """Build success response for entity invalidation.
+
+    Args:
+        request_id: Request tracking ID
+        entity_id: Invalidated entity UUID
+        valid_to: ISO-8601 timestamp that was set as valid_to
+
+    Returns:
+        JSONResponse with invalidation confirmation
+    """
+    return JSONResponse(
+        status_code=200,
+        content={
+            "success": True,
+            "data": {
+                "entity_id": entity_id,
+                "valid_to": valid_to,
+                "invalidated": True,
+            },
+            "message": "Entity invalidated successfully",
+            "request_id": request_id,
+        },
+    )
+
+
+def _build_invalidate_relation_response(
+    request_id: str,
+    from_id: str,
+    relation_type: str,
+    to_id: str,
+    valid_to: str,
+) -> JSONResponse:
+    """Build success response for relation invalidation.
+
+    Args:
+        request_id: Request tracking ID
+        from_id: Source entity UUID
+        relation_type: Type of the relation
+        to_id: Target entity UUID
+        valid_to: ISO-8601 timestamp that was set as valid_to
+
+    Returns:
+        JSONResponse with invalidation confirmation
+    """
+    return JSONResponse(
+        status_code=200,
+        content={
+            "success": True,
+            "data": {
+                "from_id": from_id,
+                "relation_type": relation_type,
+                "to_id": to_id,
+                "valid_to": valid_to,
+                "invalidated": True,
+            },
+            "message": "Relation invalidated successfully",
+            "request_id": request_id,
+        },
+    )
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="invalidate_entity",
+    error_code_prefix="MEMORY",
+)
+@router.patch("/entities/{entity_id}/invalidate")
+async def invalidate_entity(
+    entity_id: str = Path(..., description="UUID of the entity to invalidate"),
+    body: InvalidateEntityRequest = Body(default_factory=InvalidateEntityRequest),
+    admin_check: bool = Depends(check_admin_permission),
+    memory_graph: AutoBotMemoryGraph = Depends(get_memory_graph),
+) -> JSONResponse:
+    """Mark an entity as no longer valid by setting valid_to.
+
+    The entity is NOT deleted — history is preserved for temporal queries.
+    Issue #3810.
+
+    Args:
+        entity_id: UUID of the entity to invalidate
+        body: Optional ended_at timestamp (ISO-8601); defaults to now
+        admin_check: Admin permission verification
+        memory_graph: Memory graph instance
+
+    Returns:
+        Invalidation confirmation with the valid_to timestamp applied
+
+    Raises:
+        HTTPException 404: Entity not found
+        HTTPException 500: Internal error
+    """
+    request_id = generate_request_id()
+
+    ended_at = body.ended_at if body else None
+    effective_ended_at = ended_at or datetime.now(timezone.utc).isoformat()
+
+    try:
+        logger.info(
+            "[%s] Invalidating entity %s at %s",
+            request_id,
+            entity_id,
+            effective_ended_at,
+        )
+
+        updated = await memory_graph.invalidate_entity(
+            entity_id=entity_id,
+            ended_at=effective_ended_at,
+        )
+
+        if not updated:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Entity not found: {entity_id}",
+            )
+
+        logger.info("[%s] Entity %s invalidated successfully", request_id, entity_id)
+        return _build_invalidate_entity_response(request_id, entity_id, effective_ended_at)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[%s] Error invalidating entity %s: %s", request_id, entity_id, e)
+        raise HTTPException(status_code=500, detail="Failed to invalidate entity")
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="invalidate_relation",
+    error_code_prefix="MEMORY",
+)
+@router.patch("/relations/invalidate")
+async def invalidate_relation(
+    body: InvalidateRelationRequest = Body(...),
+    admin_check: bool = Depends(check_admin_permission),
+    memory_graph: AutoBotMemoryGraph = Depends(get_memory_graph),
+) -> JSONResponse:
+    """Mark a specific relation as no longer valid by setting valid_to.
+
+    The relation is NOT deleted — history is preserved for temporal queries.
+    Issue #3810.
+
+    Args:
+        body: from_id, relation_type, to_id, and optional ended_at (ISO-8601)
+        admin_check: Admin permission verification
+        memory_graph: Memory graph instance
+
+    Returns:
+        Invalidation confirmation with the valid_to timestamp applied
+
+    Raises:
+        HTTPException 404: No matching relation found
+        HTTPException 500: Internal error
+    """
+    request_id = generate_request_id()
+
+    effective_ended_at = body.ended_at or datetime.now(timezone.utc).isoformat()
+
+    try:
+        logger.info(
+            "[%s] Invalidating relation %s -[%s]-> %s at %s",
+            request_id,
+            body.from_id,
+            body.relation_type,
+            body.to_id,
+            effective_ended_at,
+        )
+
+        updated = await memory_graph.invalidate_relation(
+            from_id=body.from_id,
+            relation_type=body.relation_type,
+            to_id=body.to_id,
+            ended_at=effective_ended_at,
+        )
+
+        if not updated:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"Relation not found: {body.from_id} "
+                    f"-[{body.relation_type}]-> {body.to_id}"
+                ),
+            )
+
+        logger.info("[%s] Relation invalidated successfully", request_id)
+        return _build_invalidate_relation_response(
+            request_id,
+            body.from_id,
+            body.relation_type,
+            body.to_id,
+            effective_ended_at,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("[%s] Error invalidating relation: %s", request_id, e)
+        raise HTTPException(status_code=500, detail="Failed to invalidate relation")

--- a/autobot-backend/tests/memory_graph/test_invalidate_endpoints.py
+++ b/autobot-backend/tests/memory_graph/test_invalidate_endpoints.py
@@ -1,0 +1,273 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for PATCH /memory/entities/{entity_id}/invalidate
+and  PATCH /memory/relations/invalidate REST endpoints.
+
+Issue #3810.
+"""
+
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies so api/memory.py imports without a real Redis
+# ---------------------------------------------------------------------------
+
+def _register_stub(name: str, attrs: dict | None = None) -> types.ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+    if attrs:
+        for k, v in attrs.items():
+            setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+# autobot_shared package stubs
+_autobot_shared = _register_stub("autobot_shared")
+_autobot_shared.__path__ = []
+
+_register_stub(
+    "autobot_shared.redis_client",
+    {"get_redis_client": MagicMock(return_value=None)},
+)
+_redis_mgmt = _register_stub("autobot_shared.redis_management")
+_redis_mgmt.__path__ = []
+_register_stub(
+    "autobot_shared.redis_management.types",
+    {"DATABASE_MAPPING": {"knowledge": 2}},
+)
+_cfg = MagicMock()
+_cfg.vm.redis = "127.0.0.1"
+_register_stub("autobot_shared.ssot_config", {"config": _cfg})
+
+# error_boundaries stub — with_error_handling is a pass-through decorator
+def _with_error_handling(**_kw):
+    def decorator(fn):
+        return fn
+    return decorator
+
+
+_eb_mod = _register_stub(
+    "autobot_shared.error_boundaries",
+    {
+        "with_error_handling": _with_error_handling,
+        "ErrorCategory": MagicMock(SERVER_ERROR="SERVER_ERROR"),
+    },
+)
+
+# auth_middleware stub — always approves
+_auth_mod = _register_stub("auth_middleware", {"check_admin_permission": MagicMock(return_value=True)})
+
+# type_defs.common stub
+_type_defs = _register_stub("type_defs")
+_type_defs.__path__ = []
+_register_stub("type_defs.common", {"Metadata": dict})
+
+# utils.request_utils stub
+_utils = _register_stub("utils")
+_utils.__path__ = []
+_utils_req = _register_stub("utils.request_utils")
+
+_req_counter = 0
+
+
+def _generate_request_id() -> str:
+    global _req_counter
+    _req_counter += 1
+    return f"test-req-{_req_counter:04d}"
+
+
+_utils_req.generate_request_id = _generate_request_id
+
+# autobot_memory_graph stub — provide a minimal AutoBotMemoryGraph class
+_mg_pkg = _register_stub("autobot_memory_graph")
+_mg_pkg.__path__ = []
+
+
+class _FakeMemoryGraph:
+    initialized = True
+    redis_client = MagicMock()
+    knowledge_base = None
+
+
+_mg_pkg.AutoBotMemoryGraph = _FakeMemoryGraph
+
+# ---------------------------------------------------------------------------
+# Import the router under test AFTER stubs are registered
+# ---------------------------------------------------------------------------
+from api.memory import router  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# FastAPI test app
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+app.include_router(router, prefix="/memory")
+
+
+def _make_client(fake_graph: _FakeMemoryGraph) -> TestClient:
+    """Return a TestClient whose app.state.memory_graph is the fake graph."""
+
+    async def override_memory_graph():
+        return fake_graph
+
+    from api.memory import get_memory_graph
+    app.dependency_overrides[get_memory_graph] = override_memory_graph
+
+    # Bypass admin check
+    from auth_middleware import check_admin_permission
+    app.dependency_overrides[check_admin_permission] = lambda: True
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests — PATCH /memory/entities/{entity_id}/invalidate
+# ---------------------------------------------------------------------------
+
+class TestInvalidateEntityEndpoint:
+    def _make_graph(self, invalidate_return: bool) -> _FakeMemoryGraph:
+        graph = _FakeMemoryGraph()
+        graph.invalidate_entity = AsyncMock(return_value=invalidate_return)
+        return graph
+
+    def test_returns_200_when_entity_found(self):
+        graph = self._make_graph(True)
+        client = _make_client(graph)
+        resp = client.patch(
+            "/memory/entities/aaaa-1111-2222-3333/invalidate",
+            json={},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"]["entity_id"] == "aaaa-1111-2222-3333"
+        assert body["data"]["invalidated"] is True
+        assert body["data"]["valid_to"] is not None
+
+    def test_returns_404_when_entity_not_found(self):
+        graph = self._make_graph(False)
+        client = _make_client(graph)
+        resp = client.patch(
+            "/memory/entities/nonexistent-uuid/invalidate",
+            json={},
+        )
+        assert resp.status_code == 404
+
+    def test_custom_ended_at_is_forwarded(self):
+        graph = self._make_graph(True)
+        client = _make_client(graph)
+        custom_ts = "2025-06-01T00:00:00+00:00"
+        resp = client.patch(
+            "/memory/entities/aaaa-1111-2222-3333/invalidate",
+            json={"ended_at": custom_ts},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"]["valid_to"] == custom_ts
+        graph.invalidate_entity.assert_awaited_once_with(
+            entity_id="aaaa-1111-2222-3333",
+            ended_at=custom_ts,
+        )
+
+    def test_default_ended_at_is_utc_now(self):
+        graph = self._make_graph(True)
+        client = _make_client(graph)
+        before = datetime.now(timezone.utc)
+        resp = client.patch(
+            "/memory/entities/aaaa-1111-2222-3333/invalidate",
+            json={},
+        )
+        after = datetime.now(timezone.utc)
+        assert resp.status_code == 200
+        valid_to_str = resp.json()["data"]["valid_to"]
+        valid_to = datetime.fromisoformat(valid_to_str)
+        assert before <= valid_to <= after
+
+    def test_empty_body_is_accepted(self):
+        """Omitting the body entirely should still work (ended_at defaults to now)."""
+        graph = self._make_graph(True)
+        client = _make_client(graph)
+        resp = client.patch("/memory/entities/aaaa-1111/invalidate")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests — PATCH /memory/relations/invalidate
+# ---------------------------------------------------------------------------
+
+class TestInvalidateRelationEndpoint:
+    _VALID_BODY = {
+        "from_id": "from-uuid-1111",
+        "relation_type": "depends_on",
+        "to_id": "to-uuid-2222",
+    }
+
+    def _make_graph(self, invalidate_return: bool) -> _FakeMemoryGraph:
+        graph = _FakeMemoryGraph()
+        graph.invalidate_relation = AsyncMock(return_value=invalidate_return)
+        return graph
+
+    def test_returns_200_when_relation_found(self):
+        graph = self._make_graph(True)
+        client = _make_client(graph)
+        resp = client.patch("/memory/relations/invalidate", json=self._VALID_BODY)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"]["from_id"] == self._VALID_BODY["from_id"]
+        assert body["data"]["relation_type"] == self._VALID_BODY["relation_type"]
+        assert body["data"]["to_id"] == self._VALID_BODY["to_id"]
+        assert body["data"]["invalidated"] is True
+        assert body["data"]["valid_to"] is not None
+
+    def test_returns_404_when_relation_not_found(self):
+        graph = self._make_graph(False)
+        client = _make_client(graph)
+        resp = client.patch("/memory/relations/invalidate", json=self._VALID_BODY)
+        assert resp.status_code == 404
+
+    def test_custom_ended_at_is_forwarded(self):
+        graph = self._make_graph(True)
+        client = _make_client(graph)
+        custom_ts = "2025-07-01T09:00:00+00:00"
+        body = {**self._VALID_BODY, "ended_at": custom_ts}
+        resp = client.patch("/memory/relations/invalidate", json=body)
+        assert resp.status_code == 200
+        assert resp.json()["data"]["valid_to"] == custom_ts
+        graph.invalidate_relation.assert_awaited_once_with(
+            from_id=self._VALID_BODY["from_id"],
+            relation_type=self._VALID_BODY["relation_type"],
+            to_id=self._VALID_BODY["to_id"],
+            ended_at=custom_ts,
+        )
+
+    def test_default_ended_at_is_utc_now(self):
+        graph = self._make_graph(True)
+        client = _make_client(graph)
+        before = datetime.now(timezone.utc)
+        resp = client.patch("/memory/relations/invalidate", json=self._VALID_BODY)
+        after = datetime.now(timezone.utc)
+        assert resp.status_code == 200
+        valid_to_str = resp.json()["data"]["valid_to"]
+        valid_to = datetime.fromisoformat(valid_to_str)
+        assert before <= valid_to <= after
+
+    def test_missing_required_fields_returns_422(self):
+        graph = self._make_graph(True)
+        client = _make_client(graph)
+        resp = client.patch(
+            "/memory/relations/invalidate",
+            json={"from_id": "only-from-id"},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
Closes #3810

## Endpoints added

Both are mounted under `/api/memory` (the existing memory router prefix):

```
PATCH /api/memory/entities/{entity_id}/invalidate
  Body (optional): { "ended_at": "<iso8601>" }  — defaults to now
  Auth: admin required
  200: { entity_id, valid_to, invalidated: true }
  404: entity not found
  500: internal error

PATCH /api/memory/relations/invalidate
  Body (required): { "from_id", "relation_type", "to_id", "ended_at"? }
  Auth: admin required
  200: { from_id, relation_type, to_id, valid_to, invalidated: true }
  404: no matching relation
  500: internal error
```

## Design notes
- Neither endpoint deletes data — stamps `valid_to` only, preserving full temporal history consistent with the underlying `invalidate_entity()` / `invalidate_relation()` mixin methods
- `ended_at` defaults at the REST layer (not delegated to mixin) so the timestamp is echoed back to callers for confirmation
- Entity endpoint accepts empty/omitted body; relation endpoint requires body (all three IDs are mandatory)
- Follows existing `@with_error_handling` + `@router.patch` decorator order throughout `api/memory.py`

## Tests (9)
`tests/memory_graph/test_invalidate_endpoints.py` — 5 entity + 4 relation tests using `FastAPI TestClient` with heavy deps stubbed, matching the pattern of existing `test_temporal_validity.py`.