### PR TITLE
bug: compression_threshold validation + TaskManager eviction

### DIFF
--- a/autobot-backend/a2a/a2a_test.py
+++ b/autobot-backend/a2a/a2a_test.py
@@ -8,6 +8,10 @@ Issue #961: Tests for types, agent_card builder, and task_manager.
 Uses no network connections and no external dependencies.
 """
 
+import asyncio
+
+import pytest
+
 from a2a.agent_card import build_agent_card
 from a2a.task_manager import TaskManager
 from a2a.types import AgentCapabilities, AgentCard, AgentSkill, TaskArtifact, TaskState
@@ -251,3 +255,115 @@ class TestTaskManager:
         task = self.mgr.create_task("Task with context", context=ctx)
         fetched = self.mgr.get_task(task.id)
         assert fetched.context == ctx
+
+
+# ---------------------------------------------------------------------------
+# Issue #3823: Task eviction after TTL
+# ---------------------------------------------------------------------------
+
+
+class TestTaskManagerEviction:
+    """Verify that terminal tasks are evicted from _tasks after the TTL expires."""
+
+    def setup_method(self):
+        self.mgr = TaskManager()
+
+    @pytest.mark.asyncio
+    async def test_completed_task_evicted_after_ttl(self) -> None:
+        """A task that reaches COMPLETED is removed from _tasks after the TTL."""
+        task = self.mgr.create_task("Eviction test")
+        self.mgr.update_state(task.id, TaskState.WORKING)
+        self.mgr.update_state(task.id, TaskState.COMPLETED)
+
+        # Still present immediately after transition
+        assert self.mgr.get_task(task.id) is not None
+
+        # Override TTL to near-zero so the test is fast
+        handle = self.mgr._eviction_handles.get(task.id)
+        assert handle is not None, "Eviction handle must be scheduled"
+
+        # Cancel the real handle and inject a fast one
+        handle.cancel()
+        async def _fast_evict():
+            await asyncio.sleep(0.01)
+            self.mgr._tasks.pop(task.id, None)
+            self.mgr._eviction_handles.pop(task.id, None)
+
+        self.mgr._eviction_handles[task.id] = asyncio.create_task(_fast_evict())
+        await asyncio.sleep(0.05)
+
+        assert self.mgr.get_task(task.id) is None, "Task must be evicted after TTL"
+
+    @pytest.mark.asyncio
+    async def test_failed_task_evicted_after_ttl(self) -> None:
+        """A task that reaches FAILED is removed from _tasks after the TTL."""
+        task = self.mgr.create_task("Failing task")
+        self.mgr.update_state(task.id, TaskState.WORKING)
+        self.mgr.update_state(task.id, TaskState.FAILED, message="timeout")
+
+        handle = self.mgr._eviction_handles.get(task.id)
+        assert handle is not None
+
+        handle.cancel()
+        async def _fast_evict():
+            await asyncio.sleep(0.01)
+            self.mgr._tasks.pop(task.id, None)
+            self.mgr._eviction_handles.pop(task.id, None)
+
+        self.mgr._eviction_handles[task.id] = asyncio.create_task(_fast_evict())
+        await asyncio.sleep(0.05)
+
+        assert self.mgr.get_task(task.id) is None
+
+    @pytest.mark.asyncio
+    async def test_cancelled_task_evicted_after_ttl(self) -> None:
+        """A cancelled task is removed from _tasks after the TTL."""
+        task = self.mgr.create_task("Cancel-eviction test")
+        self.mgr.cancel_task(task.id)
+
+        handle = self.mgr._eviction_handles.get(task.id)
+        assert handle is not None
+
+        handle.cancel()
+        async def _fast_evict():
+            await asyncio.sleep(0.01)
+            self.mgr._tasks.pop(task.id, None)
+            self.mgr._eviction_handles.pop(task.id, None)
+
+        self.mgr._eviction_handles[task.id] = asyncio.create_task(_fast_evict())
+        await asyncio.sleep(0.05)
+
+        assert self.mgr.get_task(task.id) is None
+
+    @pytest.mark.asyncio
+    async def test_task_queryable_before_ttl_expires(self) -> None:
+        """A terminal task must still be queryable immediately after transition."""
+        task = self.mgr.create_task("Query before TTL")
+        self.mgr.update_state(task.id, TaskState.COMPLETED)
+
+        # Cancel eviction so the task stays in store for this assertion
+        handle = self.mgr._eviction_handles.get(task.id)
+        if handle:
+            handle.cancel()
+
+        fetched = self.mgr.get_task(task.id)
+        assert fetched is not None
+        assert fetched.status.state == TaskState.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_duplicate_terminal_transition_resets_eviction_clock(self) -> None:
+        """Calling update_state on an already-terminal task does not create a second handle."""
+        task = self.mgr.create_task("Double terminal")
+        self.mgr.update_state(task.id, TaskState.COMPLETED)
+        first_handle = self.mgr._eviction_handles.get(task.id)
+
+        # update_state on a terminal task is a no-op (returns task, no new eviction)
+        self.mgr.update_state(task.id, TaskState.FAILED)
+        second_handle = self.mgr._eviction_handles.get(task.id)
+
+        # The handle should be unchanged — no new eviction was kicked off
+        # because update_state guards with _TERMINAL_STATES check.
+        assert first_handle is second_handle
+
+        if first_handle:
+            first_handle.cancel()

--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -16,10 +16,13 @@ State machine:
   WORKING   → CANCELLED
 """
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+
+from autobot_shared.ssot_config import config
 
 from .tracing import TraceContext, new_trace_id
 from .types import Task, TaskArtifact, TaskState, TaskStatus
@@ -39,6 +42,7 @@ class TaskManager:
 
     def __init__(self) -> None:
         self._tasks: Dict[str, Task] = {}
+        self._eviction_handles: Dict[str, asyncio.Task] = {}
 
     def create_task(
         self,
@@ -116,6 +120,8 @@ class TaskManager:
                 {"state": state.value, "message": message},
             )
         logger.debug("A2A task %s → %s", task_id, state.value)
+        if state in _TERMINAL_STATES:
+            self._schedule_eviction(task_id)
         return task
 
     def add_artifact(self, task_id: str, artifact: TaskArtifact) -> bool:
@@ -144,7 +150,50 @@ class TaskManager:
         if task.trace_context:
             task.trace_context.record("task.cancelled")
         logger.info("A2A task cancelled: %s", task_id)
+        self._schedule_eviction(task_id)
         return True
+
+    def _schedule_eviction(self, task_id: str) -> None:
+        """Schedule removal of *task_id* from *_tasks* after the configured TTL.
+
+        Issue #3823: Prevents unbounded growth of _tasks by evicting terminal
+        tasks after AUTOBOT_A2A_TASK_TTL_SECONDS (default 60 s).  The task
+        remains queryable during the TTL window so callers can still poll the
+        final status.
+
+        If an eviction is already scheduled for this task_id (e.g. cancel_task
+        called after update_state already triggered it) the earlier handle is
+        cancelled and a new one is started to reset the clock.
+        """
+        ttl = config.timeout.a2a_task_ttl
+
+        # Cancel any pre-existing eviction handle for this task
+        existing = self._eviction_handles.pop(task_id, None)
+        if existing and not existing.done():
+            existing.cancel()
+
+        async def _evict_after_delay() -> None:
+            await asyncio.sleep(ttl)
+            removed = self._tasks.pop(task_id, None)
+            self._eviction_handles.pop(task_id, None)
+            if removed is not None:
+                logger.debug(
+                    "A2A task evicted after TTL %.0fs: %s state=%s",
+                    ttl,
+                    task_id,
+                    removed.status.state.value,
+                )
+
+        try:
+            handle = asyncio.get_running_loop().create_task(_evict_after_delay())
+            self._eviction_handles[task_id] = handle
+        except RuntimeError:
+            # No running event loop (e.g. unit tests using sync calls).
+            # Eviction will not be scheduled — the store still bounds itself
+            # via explicit get_task() returning None after eviction in async use.
+            logger.debug(
+                "A2A task eviction skipped (no event loop): %s", task_id
+            )
 
     def get_audit_log(self, task_id: str) -> Optional[List[Dict[str, Any]]]:
         """Return the full trace event log for a task, or None if not found."""

--- a/autobot-backend/services/memory/compression.py
+++ b/autobot-backend/services/memory/compression.py
@@ -80,10 +80,23 @@ class ContextCompressionService:
             for name, spec in models.items():
                 if not isinstance(spec, dict):
                     continue
-                self._model_thresholds[name] = spec.get(
+                threshold = spec.get(
                     "compression_threshold", _DEFAULT_COMPRESSION_THRESHOLD
                 )
+                context_window = spec.get("context_window_tokens")
+                if context_window is not None and threshold > context_window:
+                    raise ValueError(
+                        f"[#3811] context_windows.yaml: model '{name}' has "
+                        f"compression_threshold={threshold} > "
+                        f"context_window_tokens={context_window}. "
+                        "compression_threshold must not exceed context_window_tokens."
+                    )
+                self._model_thresholds[name] = threshold
             logger.debug("[#3770] Loaded thresholds for %d models", len(self._model_thresholds))
+        except ValueError:
+            # Configuration error — re-raise immediately so startup fails fast
+            # rather than silently running with an invalid threshold.
+            raise
         except Exception as exc:
             logger.warning("[#3770] Could not load thresholds, using default: %s", exc)
 

--- a/autobot-backend/tests/services/test_context_compression.py
+++ b/autobot-backend/tests/services/test_context_compression.py
@@ -238,3 +238,71 @@ class TestLoadThresholds:
 
         svc = ContextCompressionService(config_path=yaml_path)
         assert svc._get_threshold("gpt-4o") > _DEFAULT_COMPRESSION_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Issue #3811: compression_threshold <= context_window_tokens validation
+# ---------------------------------------------------------------------------
+
+
+class TestCompressionThresholdValidation:
+    """Ensure invalid configs (threshold > context_window) fail fast at load time."""
+
+    def _write_yaml(self, tmp_path, models_block: str) -> "Path":
+        from pathlib import Path
+
+        content = f"models:\n{models_block}\ntoken_estimation:\n  chars_per_token: 4\n  safety_margin: 0.9\n"
+        p = tmp_path / "context_windows.yaml"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_threshold_exceeds_context_window_raises(self, tmp_path) -> None:
+        """Loading a YAML where compression_threshold > context_window_tokens must raise ValueError."""
+        yaml_path = self._write_yaml(
+            tmp_path,
+            "  tiny-model:\n    context_window_tokens: 4096\n    max_output_tokens: 2048\n    compression_threshold: 8192\n",
+        )
+        with pytest.raises(ValueError, match="compression_threshold"):
+            ContextCompressionService(config_path=yaml_path)
+
+    def test_threshold_equal_context_window_is_valid(self, tmp_path) -> None:
+        """compression_threshold == context_window_tokens must not raise."""
+        yaml_path = self._write_yaml(
+            tmp_path,
+            "  small-model:\n    context_window_tokens: 4096\n    max_output_tokens: 2048\n    compression_threshold: 4096\n",
+        )
+        svc = ContextCompressionService(config_path=yaml_path)
+        assert svc._get_threshold("small-model") == 4096
+
+    def test_threshold_below_context_window_is_valid(self, tmp_path) -> None:
+        """compression_threshold < context_window_tokens must not raise."""
+        yaml_path = self._write_yaml(
+            tmp_path,
+            "  big-model:\n    context_window_tokens: 128000\n    max_output_tokens: 4096\n    compression_threshold: 32768\n",
+        )
+        svc = ContextCompressionService(config_path=yaml_path)
+        assert svc._get_threshold("big-model") == 32768
+
+    def test_real_yaml_passes_validation(self) -> None:
+        """The committed context_windows.yaml must pass the validator for all models."""
+        from pathlib import Path
+
+        yaml_path = (
+            Path(__file__).parent.parent.parent / "config" / "context_windows.yaml"
+        )
+        if not yaml_path.exists():
+            pytest.skip("context_windows.yaml not found")
+
+        # Must not raise
+        svc = ContextCompressionService(config_path=yaml_path)
+        assert len(svc._model_thresholds) > 0
+
+    def test_missing_context_window_tokens_skips_validation(self, tmp_path) -> None:
+        """A model entry without context_window_tokens must not raise (threshold defaults apply)."""
+        yaml_path = self._write_yaml(
+            tmp_path,
+            "  legacy-model:\n    max_output_tokens: 2048\n    compression_threshold: 99999\n",
+        )
+        # No context_window_tokens key — validation is skipped, no error raised
+        svc = ContextCompressionService(config_path=yaml_path)
+        assert svc._get_threshold("legacy-model") == 99999

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -522,6 +522,14 @@ class TimeoutConfig(BaseSettings):
     background_task: float = Field(default=600.0, alias="AUTOBOT_TIMEOUT_BACKGROUND_TASK")
 
     # ------------------------------------------------------------------ #
+    # A2A task manager (seconds)                                           #
+    # ------------------------------------------------------------------ #
+
+    # How long a terminal A2A task remains queryable before eviction from
+    # the in-memory store (Issue #3823).
+    a2a_task_ttl: float = Field(default=60.0, alias="AUTOBOT_A2A_TASK_TTL_SECONDS")
+
+    # ------------------------------------------------------------------ #
     # Skill / code validation (seconds)                                    #
     # ------------------------------------------------------------------ #
 


### PR DESCRIPTION
Closes #3811
Closes #3823

## #3811 — Validate `compression_threshold <= context_window_tokens`

**Problem:** No validation prevented a YAML edit from setting `compression_threshold > context_window_tokens`, which would silently cause over-compression on small models.

**Fix:** In `services/memory/compression.py::_load_thresholds()`, after extracting `compression_threshold`, a `ValueError` is raised immediately if it exceeds `context_window_tokens`. The `except ValueError: raise` guard before the broad `except Exception` handler ensures the error propagates rather than being swallowed.

**Tests (5):** `TestCompressionThresholdValidation` — threshold-exceeds raises, threshold-equals is valid, threshold-below is valid, real YAML passes, missing-context_window_tokens skips validation.

## #3823 — Evict terminal tasks from `TaskManager` after TTL

**Problem:** `TaskManager._tasks` was an unbounded `Dict[str, Task]`. Terminal tasks (COMPLETED/FAILED/CANCELLED) were never removed, causing OOM in long-running services.

**Fix:**
- `autobot_shared/ssot_config.py` — added `a2a_task_ttl: float` to `TimeoutConfig` (`AUTOBOT_A2A_TASK_TTL_SECONDS`, default 60s)
- `a2a/task_manager.py` — `_schedule_eviction(task_id)` fires when a task reaches a terminal state; uses `asyncio.get_running_loop().create_task()` to sleep then `_tasks.pop()`. Any existing handle for the same task is cancelled before creating a new one. The no-event-loop case (sync tests) is caught with a `RuntimeError` + debug log.
- `self._eviction_handles: Dict[str, asyncio.Task]` tracks pending handles.

**Tests (5):** `TestTaskManagerEviction` — COMPLETED/FAILED/CANCELLED all schedule eviction; task queryable before TTL; no duplicate handle on second terminal transition.

**Note:** Pending eviction tasks produce a cosmetic `Task was destroyed but it is pending!` warning on process shutdown — standard for fire-and-forget async patterns at 60s TTL. A `shutdown()` method to cancel handles can be added as a follow-up.