### PR TITLE
feat(hardening): WebSocket auth + WorkflowMemory + register PermissionExtension

### DIFF
--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from auth_middleware import authenticate_websocket
 from type_defs.common import SKIP_WEBSOCKET_PERSISTENCE_TYPES
 
 logger = logging.getLogger(__name__)
@@ -400,6 +401,12 @@ _npu_events_lock = threading.Lock()
 @router.websocket("/ws-test")
 async def websocket_test_endpoint(websocket: WebSocket):
     """Simple test WebSocket endpoint without event manager integration."""
+    # Issue #2818: Authenticate before accepting connection
+    user = await authenticate_websocket(websocket)
+    if user is None:
+        await websocket.close(code=4001, reason="Authentication required")
+        return
+
     try:
         await websocket.accept()
         logger.info("Test WebSocket connected successfully")
@@ -503,7 +510,14 @@ async def websocket_endpoint(websocket: WebSocket):
     WebSocket endpoint for real-time event stream between backend and frontend.
 
     Issue #665: Refactored to use extracted helper methods.
+    Issue #2818: Authenticate before accepting connection.
     """
+    # Issue #2818: Authenticate before accepting connection
+    user = await authenticate_websocket(websocket)
+    if user is None:
+        await websocket.close(code=4001, reason="Authentication required")
+        return
+
     try:
         await websocket.accept()
         logger.info("WebSocket connected from client: %s", websocket.client)
@@ -555,7 +569,15 @@ async def npu_workers_websocket_endpoint(websocket: WebSocket):
     - Worker added/updated/removed events
     - Worker metrics updates
     - Initial worker list on connection
+
+    Issue #2818: Authenticate before accepting connection.
     """
+    # Issue #2818: Authenticate before accepting connection
+    user = await authenticate_websocket(websocket)
+    if user is None:
+        await websocket.close(code=4001, reason="Authentication required")
+        return
+
     try:
         await websocket.accept()
         logger.info("NPU Worker WebSocket connected from client: %s", websocket.client)

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -708,3 +708,54 @@ def check_admin_permission(request: Request) -> bool:
         raise_auth_error("AUTH_0003", "Admin permission required for this operation")
 
     return True
+
+
+async def authenticate_websocket(websocket) -> Optional[dict]:
+    """Authenticate a WebSocket connection.
+
+    Checks for JWT token in query params. Falls back to synthetic admin
+    in single-user mode (mirrors get_user_from_request single-user bypass).
+    Returns None if unauthenticated.
+
+    Issue #2818: Add auth before websocket.accept() to reject unauthenticated
+    connections at the protocol handshake level.
+
+    Args:
+        websocket: FastAPI WebSocket instance.
+
+    Returns:
+        User dict or None if authentication fails.
+    """
+    # Check query param token
+    token = websocket.query_params.get("token")
+    if token:
+        try:
+            auth = AuthenticationMiddleware()
+            token_data = auth.verify_jwt_token(token)
+            if token_data:
+                return {
+                    "username": token_data["username"],
+                    "role": token_data["role"],
+                    "email": token_data.get("email", ""),
+                    "auth_method": "jwt_websocket",
+                }
+        except Exception:
+            logger.warning("WebSocket JWT authentication failed")
+            return None
+
+    # Single-user mode bypass — same logic as get_user_from_request
+    try:
+        from user_management.config import DeploymentMode, get_deployment_config
+
+        deployment_config = get_deployment_config()
+        if deployment_config.mode == DeploymentMode.SINGLE_USER:
+            return {
+                "username": "admin",
+                "role": "admin",
+                "email": "admin@autobot.local",
+                "source": "single_user_mode",
+            }
+    except Exception:
+        logger.debug("Suppressed exception in single-user mode check", exc_info=True)
+
+    return None

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -327,6 +327,34 @@ async def _init_skills(app: FastAPI) -> None:
         )
 
 
+async def _init_builtin_extensions(app: FastAPI) -> None:
+    """Register built-in extensions (permission enforcement, etc.).
+
+    Issue #3009: Wires PermissionEnforcementExtension into the extension
+    manager so all tool executions are subject to role-based permission checks.
+    Non-critical: a failure logs a warning but does not block startup.
+    """
+    try:
+        from extensions.builtin.permission_enforcement import (
+            PermissionEnforcementExtension,
+        )
+        from extensions.manager import ExtensionManager
+
+        manager = getattr(app.state, "extension_manager", None)
+        if manager is None:
+            manager = ExtensionManager()
+            app.state.extension_manager = manager
+
+        manager.register(PermissionEnforcementExtension())
+        logger.info(
+            "Built-in extensions registered (permission_enforcement)"
+        )
+    except Exception as ext_error:
+        logger.warning(
+            "Built-in extension registration failed (non-critical): %s", ext_error
+        )
+
+
 async def initialize_critical_services(app: FastAPI):
     """
     Phase 1: Initialize critical services (BLOCKING).
@@ -386,9 +414,11 @@ async def initialize_critical_services(app: FastAPI):
 
         # --- Tier 3: non-critical services (parallel) ---
         # Issue #743: Register caches with CacheCoordinator for memory optimization
+        # Issue #3009: Register built-in extensions (permission enforcement)
         await asyncio.gather(
             _init_cache_coordinator(),
             _init_skills(app),
+            _init_builtin_extensions(app),
         )
 
         logger.info("✅ [ 60%] PHASE 1 COMPLETE: All critical services operational")

--- a/autobot-backend/orchestration/workflow_executor.py
+++ b/autobot-backend/orchestration/workflow_executor.py
@@ -92,6 +92,7 @@ class WorkflowExecutor:
         release_agent_callback: Callable[[str], None],
         update_performance_callback: Callable[[str, bool, float], None],
         workflow_fetcher: Optional[Callable[[str], Optional[Dict[str, Any]]]] = None,
+        memory: Optional[WorkflowMemory] = None,
     ):
         """
         Initialize the workflow executor.
@@ -106,12 +107,18 @@ class WorkflowExecutor:
                                          used to load child workflows for sub-workflow
                                          composition (Issue #2143).  When None, sub-workflow
                                          steps raise ``ValueError`` at execution time.
+            memory:                      Optional shared WorkflowMemory for multi-agent
+                                         collaboration state (Issue #3009).  When provided,
+                                         parallel step agents can read and write a common
+                                         KV store scoped to this workflow execution.
         """
         self.agent_registry = agent_registry
         self.agent_interactions = agent_interactions
         self._reserve_agent = reserve_agent_callback
         self._release_agent = release_agent_callback
         self._update_performance = update_performance_callback
+        # Issue #3009: shared KV memory for multi-agent collaboration
+        self.memory = memory
         # Issue #2141: variable resolver for ${steps…} piping between steps
         self._variable_resolver = VariableResolver()
         # Issue #2154: checkpoint manager and error handler

--- a/autobot-frontend/src/services/GlobalWebSocketService.ts
+++ b/autobot-frontend/src/services/GlobalWebSocketService.ts
@@ -14,6 +14,7 @@ import { ref, reactive, type Ref } from 'vue'
 import { DEFAULT_CONFIG } from '@/config/defaults.js'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { useUserStore } from '@/stores/useUserStore'
 
 // ---------------------------------------------------------------------------
 // Types & Interfaces
@@ -212,13 +213,22 @@ class GlobalWebSocketService {
       // Health check failed but continue with WebSocket attempt
     })
 
-    const wsUrl = this.state.url
+    // Issue #2818: Append JWT token as query param so backend can authenticate
+    // before accepting the WebSocket handshake.
+    let wsUrl = this.state.url
+    const userStore = useUserStore()
+    const token = userStore.authState.token
+    if (token) {
+      const separator = wsUrl.includes('?') ? '&' : '?'
+      wsUrl = `${wsUrl}${separator}token=${encodeURIComponent(token)}`
+    }
+
     logger.debug(
       'Connecting WebSocket',
-      { attempt: this.reconnectAttempts + 1, url: wsUrl }
+      { attempt: this.reconnectAttempts + 1, url: this.state.url }
     )
     this.trackEvent('connection_attempt', {
-      url: wsUrl,
+      url: this.state.url,
       attempt: this.reconnectAttempts + 1
     })
 

--- a/autobot_shared/workflow_memory.py
+++ b/autobot_shared/workflow_memory.py
@@ -1,0 +1,91 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Shared Workflow Memory — Redis-backed KV store for multi-agent collaboration.
+
+Enables agents working on parallel workflow steps to share findings
+through a lightweight Redis hash scoped to the workflow ID.
+
+Usage::
+
+    from autobot_shared.workflow_memory import WorkflowMemory
+
+    memory = WorkflowMemory("wf-abc123")
+    await memory.write("step1:findings", json.dumps(results))
+    prior = await memory.read("step1:findings")
+    await memory.clear()  # Call when workflow completes
+"""
+
+import logging
+from typing import Dict, Optional
+
+from autobot_shared.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# Auto-expire stuck workflows after 1 hour
+_DEFAULT_TTL_SECONDS = 3600
+
+
+class WorkflowMemory:
+    """Shared KV memory for agents within a single workflow.
+
+    Storage: Redis hash at ``autobot:workflow:{workflow_id}:memory``
+    TTL: 1 hour after last write (auto-expires stuck workflows).
+
+    This is the shared library version backed by an async Redis client.
+    It is distinct from the orchestration-local WorkflowMemory
+    (``autobot-backend/orchestration/workflow_memory.py``) which uses a
+    synchronous client for in-process step coordination.
+    """
+
+    def __init__(self, workflow_id: str) -> None:
+        self.workflow_id = workflow_id
+        self._key = f"autobot:workflow:{workflow_id}:memory"
+
+    async def write(self, key: str, value: str, agent_id: str = "") -> None:
+        """Store a key-value pair in shared workflow memory.
+
+        Args:
+            key: Memory key (convention: ``{step_id}:result`` or ``shared:*``).
+            value: String value (JSON-encode complex data).
+            agent_id: Optional agent identifier for audit logging.
+        """
+        redis = await get_redis_client(async_client=True, database="main")
+        await redis.hset(self._key, key, value)
+        await redis.expire(self._key, _DEFAULT_TTL_SECONDS)
+        if agent_id:
+            logger.debug(
+                "WorkflowMemory[%s] agent=%s wrote key=%s",
+                self.workflow_id,
+                agent_id,
+                key,
+            )
+
+    async def read(self, key: str) -> Optional[str]:
+        """Read a specific key from shared workflow memory.
+
+        Args:
+            key: Memory key to read.
+
+        Returns:
+            Value string or None if not found.
+        """
+        redis = await get_redis_client(async_client=True, database="main")
+        return await redis.hget(self._key, key)
+
+    async def read_all(self) -> Dict[str, str]:
+        """Read all shared memory for this workflow.
+
+        Returns:
+            Dict of all key-value pairs.
+        """
+        redis = await get_redis_client(async_client=True, database="main")
+        return await redis.hgetall(self._key)
+
+    async def clear(self) -> None:
+        """Clean up workflow memory. Call when workflow completes."""
+        redis = await get_redis_client(async_client=True, database="main")
+        await redis.delete(self._key)
+        logger.debug("WorkflowMemory[%s] cleared", self.workflow_id)

--- a/autobot_shared/workflow_memory_test.py
+++ b/autobot_shared/workflow_memory_test.py
@@ -1,0 +1,69 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for WorkflowMemory."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from autobot_shared.workflow_memory import WorkflowMemory
+
+
+class TestWorkflowMemory:
+    def setup_method(self):
+        self.memory = WorkflowMemory("wf-123")
+
+    def test_key_format(self):
+        assert self.memory._key == "autobot:workflow:wf-123:memory"
+
+    @pytest.mark.asyncio
+    @patch("autobot_shared.workflow_memory.get_redis_client")
+    async def test_write(self, mock_get_redis):
+        mock_redis = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+
+        await self.memory.write("step1:result", '{"status": "done"}')
+
+        mock_redis.hset.assert_called_once_with(
+            "autobot:workflow:wf-123:memory", "step1:result", '{"status": "done"}'
+        )
+        mock_redis.expire.assert_called_once_with(
+            "autobot:workflow:wf-123:memory", 3600
+        )
+
+    @pytest.mark.asyncio
+    @patch("autobot_shared.workflow_memory.get_redis_client")
+    async def test_read(self, mock_get_redis):
+        mock_redis = AsyncMock()
+        mock_redis.hget.return_value = '{"status": "done"}'
+        mock_get_redis.return_value = mock_redis
+
+        result = await self.memory.read("step1:result")
+
+        assert result == '{"status": "done"}'
+        mock_redis.hget.assert_called_once_with(
+            "autobot:workflow:wf-123:memory", "step1:result"
+        )
+
+    @pytest.mark.asyncio
+    @patch("autobot_shared.workflow_memory.get_redis_client")
+    async def test_read_all(self, mock_get_redis):
+        mock_redis = AsyncMock()
+        mock_redis.hgetall.return_value = {"k1": "v1", "k2": "v2"}
+        mock_get_redis.return_value = mock_redis
+
+        result = await self.memory.read_all()
+
+        assert result == {"k1": "v1", "k2": "v2"}
+
+    @pytest.mark.asyncio
+    @patch("autobot_shared.workflow_memory.get_redis_client")
+    async def test_clear(self, mock_get_redis):
+        mock_redis = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+
+        await self.memory.clear()
+
+        mock_redis.delete.assert_called_once_with(
+            "autobot:workflow:wf-123:memory"
+        )


### PR DESCRIPTION
Partial: #3009 (tasks 10–12 of 13)
**Depends on:** #3853 (tasks 7–9, provides `PermissionEnforcementExtension`) — merge that first.

## Task 10 — WebSocket Authentication

**`auth_middleware.py`** — added `authenticate_websocket(websocket) -> Optional[dict]`: reads `?token=` query param, verifies via `AuthenticationMiddleware().verify_jwt_token()`, bypasses in `SINGLE_USER` mode (matches existing HTTP auth behaviour).

**`api/websockets.py`** — auth guard added before `websocket.accept()` in all three endpoints (`/ws-test`, `/ws`, `/ws/npu-workers`). Rejects with close code 4001 on auth failure. Note: closing before `accept()` sends an HTTP 403 during the WebSocket upgrade — this is correct handshake-rejection behaviour per Starlette.

**`GlobalWebSocketService.ts`** — reads `userStore.authState.token` in `connect()` and appends `?token=...` to the WebSocket URL before connecting. Token is not logged (URL without token used in log calls).

## Task 11 — Shared Workflow Memory

**`autobot_shared/workflow_memory.py`** (new) — `WorkflowMemory` class: async `write`/`read`/`read_all`/`clear` backed by Redis hash at `autobot:workflow:{workflow_id}:memory`. TTL 3600s refreshed on every write.

**`autobot_shared/workflow_memory_test.py`** (new) — 5 pytest-asyncio tests matching the plan spec, using `AsyncMock` + `patch("autobot_shared.workflow_memory.get_redis_client")`.

**`orchestration/workflow_executor.py`** — added optional `memory: Optional[WorkflowMemory]` param to `__init__` so callers can inject a shared memory instance for cross-agent collaboration.

## Task 12 — Register PermissionEnforcementExtension in Lifespan

**`initialization/lifespan.py`** — added `_init_builtin_extensions(app)` helper that lazy-imports `PermissionEnforcementExtension`, creates or reuses `app.state.extension_manager`, and registers it. Wired into Tier 3 `asyncio.gather()` alongside `_init_cache_coordinator` and `_init_skills`.

`PermissionEnforcementExtension` source is in #3853 — this PR's `lifespan.py` import will resolve once that PR merges.