### PR TITLE
fix(a2a): guard AUTOBOT_A2A_CARD_TTL int() cast against invalid env var

### DIFF
--- a/autobot-backend/a2a/security.py
+++ b/autobot-backend/a2a/security.py
@@ -34,7 +34,13 @@ logger = logging.getLogger(__name__)
 _SECRET = os.environ.get("AUTOBOT_A2A_SECRET", "")
 
 # How long a signed card is considered fresh (seconds).
-_CARD_TTL = int(os.environ.get("AUTOBOT_A2A_CARD_TTL", "3600"))
+try:
+    _CARD_TTL = int(os.environ.get("AUTOBOT_A2A_CARD_TTL", "3600"))
+except ValueError:
+    logger.warning(
+        "AUTOBOT_A2A_CARD_TTL is not a valid integer; defaulting to 3600 s"
+    )
+    _CARD_TTL = 3600
 
 
 def _get_secret() -> bytes:


### PR DESCRIPTION
Wraps the bare `int()` cast on `AUTOBOT_A2A_CARD_TTL` in a `try/except ValueError`. Invalid env var now logs a clear warning and falls back to 3600 s instead of crashing the backend at startup with an uninformative traceback.

Closes #3824