### PR TITLE
refactor(http): consolidate HTTP clients onto HTTPClientManager

### DIFF
--- a/autobot-backend/tests/utils/test_service_client_signing.py
+++ b/autobot-backend/tests/utils/test_service_client_signing.py
@@ -1,0 +1,179 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for the shared HMAC-SHA256 signing helper (Issue #3827).
+
+Covers:
+  - ``autobot_shared.http_client.sign_request`` standalone correctness
+  - ``ServiceHTTPClient._sign_request`` delegates to the shared helper
+    (algorithm parity with ``ServiceAuthManager.generate_signature``)
+"""
+
+import hashlib
+import hmac
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autobot_shared.http_client import sign_request
+
+
+class TestSignRequestHelper:
+    """Pure-function tests for autobot_shared.http_client.sign_request."""
+
+    def _expected_signature(
+        self,
+        service_id: str,
+        service_key: str,
+        method: str,
+        path: str,
+        timestamp: int,
+    ) -> str:
+        message = f"{service_id}:{method}:{path}:{timestamp}"
+        return hmac.new(
+            service_key.encode("utf-8"),
+            message.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def test_returns_three_headers(self):
+        headers = sign_request("svc-a", "deadbeef" * 8, "GET", "/api/x", 1700000000)
+        assert set(headers.keys()) == {
+            "X-Service-ID",
+            "X-Service-Signature",
+            "X-Service-Timestamp",
+        }
+
+    def test_service_id_header_value(self):
+        headers = sign_request("main-backend", "key123", "POST", "/infer", 1700000000)
+        assert headers["X-Service-ID"] == "main-backend"
+
+    def test_timestamp_header_is_string(self):
+        ts = 1700000042
+        headers = sign_request("svc", "key", "GET", "/", ts)
+        assert headers["X-Service-Timestamp"] == str(ts)
+
+    def test_signature_matches_manual_hmac(self):
+        service_id = "npu-worker"
+        service_key = "abc123def456" * 4
+        method = "POST"
+        path = "/api/process"
+        timestamp = 1700001234
+
+        headers = sign_request(service_id, service_key, method, path, timestamp)
+        expected = self._expected_signature(
+            service_id, service_key, method, path, timestamp
+        )
+        assert headers["X-Service-Signature"] == expected
+
+    def test_signature_is_hex_string(self):
+        headers = sign_request("svc", "key", "GET", "/", 1700000000)
+        sig = headers["X-Service-Signature"]
+        # SHA-256 hex digest is always 64 lowercase hex characters
+        assert len(sig) == 64
+        assert all(c in "0123456789abcdef" for c in sig)
+
+    def test_different_methods_produce_different_signatures(self):
+        args = ("svc", "key", "/path", 1700000000)
+        get_sig = sign_request(*("svc", "key", "GET", "/path", 1700000000))[
+            "X-Service-Signature"
+        ]
+        post_sig = sign_request(*("svc", "key", "POST", "/path", 1700000000))[
+            "X-Service-Signature"
+        ]
+        assert get_sig != post_sig
+
+    def test_different_timestamps_produce_different_signatures(self):
+        sig1 = sign_request("svc", "key", "GET", "/", 1700000000)["X-Service-Signature"]
+        sig2 = sign_request("svc", "key", "GET", "/", 1700000001)["X-Service-Signature"]
+        assert sig1 != sig2
+
+    def test_different_paths_produce_different_signatures(self):
+        sig1 = sign_request("svc", "key", "GET", "/a", 1700000000)["X-Service-Signature"]
+        sig2 = sign_request("svc", "key", "GET", "/b", 1700000000)["X-Service-Signature"]
+        assert sig1 != sig2
+
+    def test_parity_with_service_auth_manager(self):
+        """sign_request must produce the same digest as ServiceAuthManager.generate_signature."""
+        from security.service_auth import ServiceAuthManager
+
+        service_id = "main-backend"
+        service_key = "cafebabe" * 8
+        method = "DELETE"
+        path = "/api/session/42"
+        timestamp = 1700005000
+
+        auth_mgr = ServiceAuthManager(redis_client=None)
+        expected = auth_mgr.generate_signature(
+            service_id, service_key, method, path, timestamp
+        )
+        actual = sign_request(service_id, service_key, method, path, timestamp)[
+            "X-Service-Signature"
+        ]
+        assert actual == expected
+
+
+class TestServiceHTTPClientSignRequest:
+    """ServiceHTTPClient._sign_request must delegate to the shared helper."""
+
+    def _make_service_client(self) -> "ServiceHTTPClient":
+        from utils.service_client import ServiceHTTPClient
+
+        # Patch get_http_client so ServiceHTTPClient.__init__ doesn't try to
+        # create a real HTTPClientManager (which would need an event loop).
+        with patch("utils.service_client.get_http_client", return_value=MagicMock()):
+            return ServiceHTTPClient(
+                service_id="test-service",
+                service_key="deadcafe" * 8,
+            )
+
+    def test_sign_request_calls_shared_helper(self):
+        client = self._make_service_client()
+        url = "http://10.0.0.5:8080/api/inference"
+
+        with patch(
+            "utils.service_client._sign_request", wraps=sign_request
+        ) as mock_helper:
+            headers = client._sign_request("POST", url)
+
+        mock_helper.assert_called_once()
+        call_args = mock_helper.call_args
+        assert call_args[0][0] == "test-service"
+        assert call_args[0][2] == "POST"
+        assert call_args[0][3] == "/api/inference"
+
+    def test_sign_request_returns_correct_headers(self):
+        client = self._make_service_client()
+        url = "http://10.0.0.5:8080/api/inference"
+
+        headers = client._sign_request("GET", url)
+
+        assert headers["X-Service-ID"] == "test-service"
+        assert "X-Service-Signature" in headers
+        assert "X-Service-Timestamp" in headers
+        assert len(headers["X-Service-Signature"]) == 64
+
+    def test_sign_request_path_only_not_full_url(self):
+        """Only the path component must go into the HMAC — not host or query string."""
+        client = self._make_service_client()
+        url = "http://10.0.0.5:9000/api/process?debug=true"
+
+        headers = client._sign_request("POST", url)
+        timestamp = int(headers["X-Service-Timestamp"])
+
+        # Recompute expected signature using path only
+        expected_headers = sign_request(
+            "test-service", "deadcafe" * 8, "POST", "/api/process", timestamp
+        )
+        assert headers["X-Service-Signature"] == expected_headers["X-Service-Signature"]
+
+    def test_timestamp_is_recent(self):
+        client = self._make_service_client()
+        before = int(time.time())
+        headers = client._sign_request("GET", "http://10.0.0.1/x")
+        after = int(time.time())
+
+        ts = int(headers["X-Service-Timestamp"])
+        assert before <= ts <= after

--- a/autobot-backend/tests/utils/test_traced_http_client.py
+++ b/autobot-backend/tests/utils/test_traced_http_client.py
@@ -1,0 +1,203 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for TracedHttpClient (Issue #3827).
+
+Verifies that TracedHttpClient delegates all HTTP calls to HTTPClientManager
+instead of creating its own raw httpx.AsyncClient.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from utils.traced_http_client import (
+    TracedHttpClient,
+    traced_delete,
+    traced_get,
+    traced_http_client,
+    traced_post,
+    traced_put,
+)
+
+
+def _make_mock_response(status: int = 200) -> MagicMock:
+    """Return a MagicMock that passes as an aiohttp.ClientResponse."""
+    response = MagicMock(spec=aiohttp.ClientResponse)
+    response.status = status
+    return response
+
+
+def _make_mock_http_client(response: MagicMock | None = None) -> MagicMock:
+    """Return a mock HTTPClientManager whose request() is an AsyncMock."""
+    mock = MagicMock()
+    mock.request = AsyncMock(return_value=response or _make_mock_response())
+    return mock
+
+
+class TestTracedHttpClientUsesSharedPool:
+    """TracedHttpClient must delegate requests to HTTPClientManager, not httpx."""
+
+    @pytest.mark.asyncio
+    async def test_get_calls_http_client_manager(self):
+        mock_response = _make_mock_response(200)
+        mock_pool = _make_mock_http_client(mock_response)
+
+        client = TracedHttpClient(http_client=mock_pool)
+        result = await client.get("http://10.0.0.1/api/status")
+
+        mock_pool.request.assert_awaited_once()
+        call_args = mock_pool.request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == "http://10.0.0.1/api/status"
+        assert result is mock_response
+
+    @pytest.mark.asyncio
+    async def test_post_calls_http_client_manager(self):
+        mock_pool = _make_mock_http_client()
+
+        client = TracedHttpClient(http_client=mock_pool)
+        await client.post("http://10.0.0.2/api/infer", json={"prompt": "hello"})
+
+        mock_pool.request.assert_awaited_once()
+        call_args = mock_pool.request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "http://10.0.0.2/api/infer"
+        assert call_args[1].get("json") == {"prompt": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_put_calls_http_client_manager(self):
+        mock_pool = _make_mock_http_client()
+
+        client = TracedHttpClient(http_client=mock_pool)
+        await client.put("http://10.0.0.3/resource/1", json={"key": "val"})
+
+        mock_pool.request.assert_awaited_once()
+        assert mock_pool.request.call_args[0][0] == "PUT"
+
+    @pytest.mark.asyncio
+    async def test_patch_calls_http_client_manager(self):
+        mock_pool = _make_mock_http_client()
+
+        client = TracedHttpClient(http_client=mock_pool)
+        await client.patch("http://10.0.0.3/resource/1", json={"key": "updated"})
+
+        mock_pool.request.assert_awaited_once()
+        assert mock_pool.request.call_args[0][0] == "PATCH"
+
+    @pytest.mark.asyncio
+    async def test_delete_calls_http_client_manager(self):
+        mock_pool = _make_mock_http_client()
+
+        client = TracedHttpClient(http_client=mock_pool)
+        await client.delete("http://10.0.0.4/resource/1")
+
+        mock_pool.request.assert_awaited_once()
+        assert mock_pool.request.call_args[0][0] == "DELETE"
+
+    @pytest.mark.asyncio
+    async def test_no_httpx_client_created(self):
+        """Confirm httpx.AsyncClient is never instantiated during a request."""
+        mock_pool = _make_mock_http_client()
+
+        with patch("httpx.AsyncClient") as mock_httpx:
+            client = TracedHttpClient(http_client=mock_pool)
+            await client.get("http://10.0.0.1/api/status")
+
+        mock_httpx.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_returns_self(self):
+        mock_pool = _make_mock_http_client()
+        client = TracedHttpClient(http_client=mock_pool)
+        async with client as c:
+            assert c is client
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_injected_when_absent(self):
+        """When caller supplies no timeout, the default is forwarded to the pool."""
+        mock_pool = _make_mock_http_client()
+        client = TracedHttpClient(timeout=15.0, http_client=mock_pool)
+        await client.get("http://10.0.0.1/api/status")
+
+        kwargs = mock_pool.request.call_args[1]
+        assert "timeout" in kwargs
+        assert isinstance(kwargs["timeout"], aiohttp.ClientTimeout)
+        assert kwargs["timeout"].total == 15.0
+
+    @pytest.mark.asyncio
+    async def test_caller_provided_timeout_is_not_overridden(self):
+        """When caller supplies a timeout, it must be forwarded unchanged."""
+        mock_pool = _make_mock_http_client()
+        custom_timeout = aiohttp.ClientTimeout(total=99)
+        client = TracedHttpClient(http_client=mock_pool)
+        await client.get("http://10.0.0.1/api/status", timeout=custom_timeout)
+
+        kwargs = mock_pool.request.call_args[1]
+        assert kwargs["timeout"] is custom_timeout
+
+    @pytest.mark.asyncio
+    async def test_exception_from_pool_propagates(self):
+        mock_pool = MagicMock()
+        mock_pool.request = AsyncMock(side_effect=aiohttp.ClientConnectionError("down"))
+
+        client = TracedHttpClient(http_client=mock_pool)
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await client.get("http://10.0.0.1/api/status")
+
+
+class TestTracedHttpClientServiceMapping:
+    """_get_target_service maps known IPs to service names."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_ip_returns_unknown_service(self):
+        mock_pool = _make_mock_http_client()
+        client = TracedHttpClient(http_client=mock_pool)
+        assert client._get_target_service("http://192.168.99.99/x") == "unknown-service"
+
+
+class TestConvenienceFunctions:
+    """Module-level traced_get / traced_post / traced_put / traced_delete helpers."""
+
+    @pytest.mark.asyncio
+    async def test_traced_get_delegates_to_pool(self):
+        mock_pool = _make_mock_http_client()
+        with patch("utils.traced_http_client.get_http_client", return_value=mock_pool):
+            await traced_get("http://10.0.0.1/api/x")
+        mock_pool.request.assert_awaited_once()
+        assert mock_pool.request.call_args[0][0] == "GET"
+
+    @pytest.mark.asyncio
+    async def test_traced_post_delegates_to_pool(self):
+        mock_pool = _make_mock_http_client()
+        with patch("utils.traced_http_client.get_http_client", return_value=mock_pool):
+            await traced_post("http://10.0.0.1/api/x", json={"a": 1})
+        mock_pool.request.assert_awaited_once()
+        assert mock_pool.request.call_args[0][0] == "POST"
+
+    @pytest.mark.asyncio
+    async def test_traced_put_delegates_to_pool(self):
+        mock_pool = _make_mock_http_client()
+        with patch("utils.traced_http_client.get_http_client", return_value=mock_pool):
+            await traced_put("http://10.0.0.1/api/x")
+        mock_pool.request.assert_awaited_once()
+        assert mock_pool.request.call_args[0][0] == "PUT"
+
+    @pytest.mark.asyncio
+    async def test_traced_delete_delegates_to_pool(self):
+        mock_pool = _make_mock_http_client()
+        with patch("utils.traced_http_client.get_http_client", return_value=mock_pool):
+            await traced_delete("http://10.0.0.1/api/x")
+        mock_pool.request.assert_awaited_once()
+        assert mock_pool.request.call_args[0][0] == "DELETE"
+
+    @pytest.mark.asyncio
+    async def test_traced_http_client_context_manager(self):
+        mock_pool = _make_mock_http_client()
+        with patch("utils.traced_http_client.get_http_client", return_value=mock_pool):
+            async with traced_http_client() as client:
+                assert isinstance(client, TracedHttpClient)
+                await client.get("http://10.0.0.1/api/x")
+        mock_pool.request.assert_awaited_once()

--- a/autobot-backend/utils/service_client.py
+++ b/autobot-backend/utils/service_client.py
@@ -20,9 +20,8 @@ from typing import Dict
 import aiohttp
 import structlog
 
-from autobot_shared.http_client import get_http_client
+from autobot_shared.http_client import get_http_client, sign_request as _sign_request
 from autobot_shared.ssot_config import config as _ssot_config
-from security.service_auth import ServiceAuthManager
 
 logger = structlog.get_logger()
 
@@ -59,34 +58,23 @@ class ServiceHTTPClient:
         """
         Generate authentication headers for request.
 
+        Delegates to ``autobot_shared.http_client.sign_request``, the canonical
+        HMAC-SHA256 signing helper, so the algorithm is defined in exactly one
+        place and validated by a single test suite.
+
         Args:
-            method: HTTP method (GET, POST, etc.)
-            url: Full URL of the request
+            method: HTTP method in upper-case (``'GET'``, ``'POST'``, …).
+            url: Full URL of the request — the path component is extracted
+                here before forwarding to the signing helper.
 
         Returns:
-            Dict of authentication headers
+            Dict of authentication headers ready to merge into request kwargs.
         """
-        timestamp = int(time.time())
-
-        # Create auth manager for signing (no Redis needed for signing)
-        auth_manager = ServiceAuthManager(redis_client=None)
-
-        # Extract path from URL for signature
         from urllib.parse import urlparse
 
-        parsed_url = urlparse(url)
-        path = parsed_url.path
-
-        # Generate HMAC signature
-        signature = auth_manager.generate_signature(
-            self.service_id, self.service_key, method, path, timestamp
-        )
-
-        return {
-            "X-Service-ID": self.service_id,
-            "X-Service-Signature": signature,
-            "X-Service-Timestamp": str(timestamp),
-        }
+        timestamp = int(time.time())
+        path = urlparse(url).path
+        return _sign_request(self.service_id, self.service_key, method, path, timestamp)
 
     async def get(self, url: str, **kwargs):
         """

--- a/autobot-backend/utils/traced_http_client.py
+++ b/autobot-backend/utils/traced_http_client.py
@@ -7,6 +7,11 @@ Traced HTTP Client for Cross-VM Communication (Issue #57)
 Provides HTTP client utilities that automatically propagate OpenTelemetry
 trace context across AutoBot's distributed VM infrastructure.
 
+Wraps the shared ``HTTPClientManager`` singleton (aiohttp) rather than
+creating an independent ``httpx.AsyncClient`` per call.  All connections
+go through the managed pool, so tracing is layered on top without
+bypassing connection limits or pool accounting.
+
 Usage:
     from utils.traced_http_client import TracedHttpClient
     from constants.network_constants import ServiceURLs
@@ -20,12 +25,13 @@ Usage:
 
 import logging
 from contextlib import asynccontextmanager
-from typing import Dict, Optional
+from typing import Dict
 
-import httpx
+import aiohttp
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind
 
+from autobot_shared.http_client import HTTPClientManager, get_http_client
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import TimingConstants
 
@@ -36,7 +42,19 @@ class TracedHttpClient:
     """
     HTTP client with automatic OpenTelemetry trace context propagation.
 
-    Ensures distributed traces are connected across AutoBot's 5-VM infrastructure.
+    Wraps the shared ``HTTPClientManager`` pool so that all cross-VM calls
+    participate in connection pooling, dynamic pool sizing, and W3C trace
+    context propagation already implemented in ``HTTPClientManager.request()``.
+
+    The OTel span is opened around the ``HTTPClientManager.request()`` call so
+    that timing captured in the span reflects the full round-trip including
+    pool-wait time, matching the observable latency from the caller's
+    perspective.
+
+    Note: ``HTTPClientManager.request()`` already injects W3C ``traceparent``
+    / ``tracestate`` headers via ``opentelemetry.propagate.inject``.  This
+    class additionally wraps the call in a CLIENT span, giving callers a
+    named span in their trace for each outbound HTTP call.
     """
 
     # AutoBot VM service mapping using NetworkConstants
@@ -53,106 +71,75 @@ class TracedHttpClient:
         self,
         timeout: float = TimingConstants.SHORT_TIMEOUT,
         follow_redirects: bool = True,
+        http_client: HTTPClientManager | None = None,
     ):
         """
         Initialize traced HTTP client.
 
         Args:
-            timeout: Request timeout in seconds
-            follow_redirects: Whether to follow HTTP redirects
+            timeout: Per-request timeout in seconds.  Passed as an
+                ``aiohttp.ClientTimeout(total=timeout)`` kwarg when callers
+                do not supply their own ``timeout`` kwarg.
+            follow_redirects: Unused — kept for API compatibility.
+                ``HTTPClientManager`` uses the session's default redirect
+                behaviour.  Pass ``allow_redirects=False`` in request kwargs
+                to disable for a specific call.
+            http_client: Optional ``HTTPClientManager`` instance to use.
+                Defaults to the process-global singleton from
+                ``get_http_client()``.  Inject an alternative only in tests.
         """
         self._timeout = timeout
         self._follow_redirects = follow_redirects
-        self._client: Optional[httpx.AsyncClient] = None
+        self._http_client: HTTPClientManager = http_client or get_http_client()
 
     async def __aenter__(self) -> "TracedHttpClient":
-        """Create async context manager."""
-        self._client = httpx.AsyncClient(
-            timeout=self._timeout,
-            follow_redirects=self._follow_redirects,
-        )
+        """Return self — pool lifecycle is managed by HTTPClientManager."""
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Clean up async context manager."""
-        if self._client:
-            await self._client.aclose()
-
-    def _get_trace_headers(self) -> Dict[str, str]:
-        """
-        Get current trace context as HTTP headers.
-
-        Returns:
-            Dictionary of trace context headers (traceparent, tracestate, b3, etc.)
-        """
-        try:
-            from opentelemetry.propagate import inject
-
-            headers: Dict[str, str] = {}
-            inject(headers)
-            return headers
-        except Exception as e:
-            logger.debug("Could not extract trace context: %s", e)
-            return {}
+        """No-op — the shared pool is not closed per TracedHttpClient instance."""
 
     def _get_target_service(self, url: str) -> str:
         """
-        Determine target service name from URL.
+        Determine target service name from URL for span labelling.
 
         Args:
-            url: Target URL
+            url: Target URL.
 
         Returns:
-            Service name for span attributes
+            Human-readable service name or ``'unknown-service'``.
         """
         for ip, service in self.VM_SERVICES.items():
             if ip in url:
                 return service
         return "unknown-service"
 
-    def _prepare_request_headers(self, kwargs: dict) -> dict:
+    def _record_response_attributes(
+        self, span: trace.Span, response: aiohttp.ClientResponse
+    ) -> None:
         """
-        Prepare request headers by merging trace headers with existing headers.
+        Record HTTP response attributes on the current span.
 
-        Issue #620.
+        Only ``http.status_code`` is recorded here.  Response body length is
+        intentionally omitted: reading ``response.content`` eagerly would break
+        streaming responses and is not needed for distributed tracing.
 
         Args:
-            kwargs: Original request kwargs
-
-        Returns:
-            Updated kwargs with merged headers
-        """
-        trace_headers = self._get_trace_headers()
-        existing_headers = kwargs.get("headers", {}) or {}
-        kwargs["headers"] = {**existing_headers, **trace_headers}
-        return kwargs
-
-    def _record_response_attributes(self, span, response: httpx.Response) -> None:
-        """
-        Record response attributes on the span.
-
-        Issue #620.
-
-        Args:
-            span: The current trace span
-            response: HTTP response object
+            span: Active OTel span.
+            response: aiohttp response returned by HTTPClientManager.
         """
         if span.is_recording():
-            span.set_attribute("http.status_code", response.status_code)
-            span.set_attribute(
-                "http.response_content_length",
-                len(response.content) if response.content else 0,
-            )
+            span.set_attribute("http.status_code", response.status)
 
-    def _record_exception_attributes(self, span, error: Exception) -> None:
+    def _record_exception_attributes(
+        self, span: trace.Span, error: Exception
+    ) -> None:
         """
-        Record exception attributes on the span.
-
-        Issue #620.
+        Record exception details on the current span.
 
         Args:
-            span: The current trace span
-            error: The exception that occurred
+            span: Active OTel span.
+            error: Exception that caused the request to fail.
         """
         if span.is_recording():
             span.record_exception(error)
@@ -163,24 +150,30 @@ class TracedHttpClient:
         method: str,
         url: str,
         **kwargs,
-    ) -> httpx.Response:
+    ) -> aiohttp.ClientResponse:
         """
-        Execute traced HTTP request.
+        Execute a traced HTTP request via the shared ``HTTPClientManager``.
 
-        Issue #620: Refactored to use extracted helper methods.
+        Opens an OTel CLIENT span around the pooled ``request()`` call.
+        ``HTTPClientManager.request()`` handles W3C trace context injection
+        into outgoing headers, so no duplicate inject is performed here.
 
         Args:
-            method: HTTP method (GET, POST, etc.)
-            url: Target URL
-            **kwargs: Additional httpx request arguments
+            method: HTTP method in upper-case (``'GET'``, ``'POST'``, …).
+            url: Target URL.
+            **kwargs: Additional keyword arguments forwarded verbatim to
+                ``HTTPClientManager.request()``.  If ``timeout`` is not
+                provided, ``aiohttp.ClientTimeout(total=self._timeout)`` is
+                inserted automatically.
 
         Returns:
-            HTTP response
+            ``aiohttp.ClientResponse`` from the shared pool.  The caller is
+            responsible for consuming/closing the response (use as async
+            context manager or call ``response.release()``).
         """
-        if not self._client:
-            raise RuntimeError("TracedHttpClient must be used as async context manager")
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = aiohttp.ClientTimeout(total=self._timeout)
 
-        kwargs = self._prepare_request_headers(kwargs)
         tracer = trace.get_tracer(__name__)
         target_service = self._get_target_service(url)
 
@@ -194,31 +187,31 @@ class TracedHttpClient:
             },
         ) as span:
             try:
-                response = await self._client.request(method, url, **kwargs)
+                response = await self._http_client.request(method, url, **kwargs)
                 self._record_response_attributes(span, response)
                 return response
             except Exception as e:
                 self._record_exception_attributes(span, e)
                 raise
 
-    async def get(self, url: str, **kwargs) -> httpx.Response:
-        """Execute traced GET request."""
+    async def get(self, url: str, **kwargs) -> aiohttp.ClientResponse:
+        """Execute a traced GET request."""
         return await self._request("GET", url, **kwargs)
 
-    async def post(self, url: str, **kwargs) -> httpx.Response:
-        """Execute traced POST request."""
+    async def post(self, url: str, **kwargs) -> aiohttp.ClientResponse:
+        """Execute a traced POST request."""
         return await self._request("POST", url, **kwargs)
 
-    async def put(self, url: str, **kwargs) -> httpx.Response:
-        """Execute traced PUT request."""
+    async def put(self, url: str, **kwargs) -> aiohttp.ClientResponse:
+        """Execute a traced PUT request."""
         return await self._request("PUT", url, **kwargs)
 
-    async def patch(self, url: str, **kwargs) -> httpx.Response:
-        """Execute traced PATCH request."""
+    async def patch(self, url: str, **kwargs) -> aiohttp.ClientResponse:
+        """Execute a traced PATCH request."""
         return await self._request("PATCH", url, **kwargs)
 
-    async def delete(self, url: str, **kwargs) -> httpx.Response:
-        """Execute traced DELETE request."""
+    async def delete(self, url: str, **kwargs) -> aiohttp.ClientResponse:
+        """Execute a traced DELETE request."""
         return await self._request("DELETE", url, **kwargs)
 
 
@@ -237,11 +230,11 @@ async def traced_http_client(
             response = await client.get(f"{ServiceURLs.AI_STACK}/api/status")
 
     Args:
-        timeout: Request timeout in seconds
-        follow_redirects: Whether to follow HTTP redirects
+        timeout: Per-request timeout in seconds.
+        follow_redirects: Kept for API compatibility (see ``TracedHttpClient``).
 
     Yields:
-        TracedHttpClient instance
+        ``TracedHttpClient`` instance backed by the shared pool.
     """
     client = TracedHttpClient(
         timeout=timeout,
@@ -251,26 +244,26 @@ async def traced_http_client(
         yield c
 
 
-# Convenience functions for simple requests
-async def traced_get(url: str, **kwargs) -> httpx.Response:
+# Convenience functions for single-call usage
+async def traced_get(url: str, **kwargs) -> aiohttp.ClientResponse:
     """Execute a single traced GET request."""
     async with traced_http_client() as client:
         return await client.get(url, **kwargs)
 
 
-async def traced_post(url: str, **kwargs) -> httpx.Response:
+async def traced_post(url: str, **kwargs) -> aiohttp.ClientResponse:
     """Execute a single traced POST request."""
     async with traced_http_client() as client:
         return await client.post(url, **kwargs)
 
 
-async def traced_put(url: str, **kwargs) -> httpx.Response:
+async def traced_put(url: str, **kwargs) -> aiohttp.ClientResponse:
     """Execute a single traced PUT request."""
     async with traced_http_client() as client:
         return await client.put(url, **kwargs)
 
 
-async def traced_delete(url: str, **kwargs) -> httpx.Response:
+async def traced_delete(url: str, **kwargs) -> aiohttp.ClientResponse:
     """Execute a single traced DELETE request."""
     async with traced_http_client() as client:
         return await client.delete(url, **kwargs)

--- a/autobot_shared/http_client.py
+++ b/autobot_shared/http_client.py
@@ -7,6 +7,8 @@ Provides efficient aiohttp client session management to prevent resource exhaust
 """
 
 import asyncio
+import hashlib
+import hmac
 import logging
 import time
 from typing import Any, Dict, Optional
@@ -401,6 +403,50 @@ async def close_http_client():
     if _http_client:
         await _http_client.close()
         _http_client = None
+
+
+def sign_request(
+    service_id: str,
+    service_key: str,
+    method: str,
+    path: str,
+    timestamp: int,
+) -> Dict[str, str]:
+    """
+    Generate HMAC-SHA256 authentication headers for service-to-service requests.
+
+    Produces the three headers that ``ServiceAuthManager.validate_signature``
+    expects on the receiving end:
+
+    * ``X-Service-ID``        — caller's service identifier
+    * ``X-Service-Signature`` — HMAC-SHA256 over ``service_id:method:path:timestamp``
+    * ``X-Service-Timestamp`` — Unix epoch seconds as a decimal string
+
+    This is a pure, synchronous function with no I/O — safe to call from any
+    async or sync context.
+
+    Args:
+        service_id: This service's identifier (e.g. ``'main-backend'``).
+        service_key: 256-bit hex-encoded secret shared with the destination.
+        method: HTTP method in upper-case (e.g. ``'GET'``, ``'POST'``).
+        path: URL path component only (e.g. ``'/api/inference'``).
+        timestamp: Unix timestamp (seconds).  Must be within the receiver's
+            replay-attack window (default ±300 s).
+
+    Returns:
+        Dict mapping header name → value, ready to merge into request headers.
+    """
+    message = f"{service_id}:{method}:{path}:{timestamp}"
+    signature = hmac.new(
+        service_key.encode(encoding="utf-8"),
+        message.encode(encoding="utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return {
+        "X-Service-ID": service_id,
+        "X-Service-Signature": signature,
+        "X-Service-Timestamp": str(timestamp),
+    }
 
 
 # Example usage patterns for migration


### PR DESCRIPTION
Closes #3827

## Changes

### `autobot_shared/http_client.py`
Added `sign_request(service_id, service_key, method, path, timestamp) -> Dict[str, str]` — pure HMAC-SHA256 shared signing function, byte-for-byte identical to `ServiceAuthManager.generate_signature`. Produces `X-Service-ID`, `X-Service-Signature`, `X-Service-Timestamp` headers.

### `utils/traced_http_client.py` (full rewrite)
- **Before:** created a raw `httpx.AsyncClient` — bypassed the shared pool entirely
- **After:** wraps `HTTPClientManager` via optional injection (`__init__(http_client=get_http_client())`)
- `_request()` calls `self._http_client.request(method, url, **kwargs)` inside OTel CLIENT span
- `__aenter__`/`__aexit__` are no-ops — pool lifecycle belongs to `HTTPClientManager`
- Return type: `aiohttp.ClientResponse` (was `httpx.Response`)
- `http.response_content_length` attribute removed — reading body eagerly breaks streaming; callers can record it post-consumption

### `utils/service_client.py`
- Replaced 15-line inline HMAC implementation with `sign_request(...)` from `autobot_shared.http_client`
- Removed `ServiceAuthManager` import

## Tests
- `test_traced_http_client.py` (17 tests) — core assertion: `mock_pool.request` called; `httpx.AsyncClient` never instantiated
- `test_service_client_signing.py` (13 tests) — includes `test_parity_with_service_auth_manager` asserting equal digests from both implementations with identical inputs

## Notes
- No external callers of `TracedHttpClient` or the `traced_*` helpers exist — zero caller-migration burden
- `follow_redirects=True` kept in constructor signature for API compat; aiohttp handles at session level