### PR TITLE
fix(security): apply validate_path() to fix path-injection CodeQL alerts

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -1190,18 +1190,19 @@ async def _cleanup_conversation_transcript(session_id: str) -> dict:
         Dict with cleanup result
     """
     import os
-    from pathlib import Path
+
+    from autobot_shared.security.path_validator import validate_relative_path
+    from constants.path_constants import PATH
 
     result = {"transcript_deleted": False, "error": None}
 
     try:
         if "/" in session_id or "\\" in session_id or ".." in session_id:
             raise ValueError("Invalid session ID")
-        from autobot_shared.security.path_validator import validate_relative_path
 
         transcript_path = validate_relative_path(
             f"{session_id}.json",
-            Path("data/conversation_transcripts"),
+            PATH.DATA_DIR / "conversation_transcripts",
         )
 
         if transcript_path.exists():

--- a/autobot-backend/api/logs.py
+++ b/autobot-backend/api/logs.py
@@ -482,8 +482,8 @@ async def get_recent_logs(
 
         most_recent = await _get_most_recent_log_file(log_dir)
         if most_recent:
-            log_path = os.path.join(log_dir, most_recent)
-            recent_entries = await _read_recent_log_lines(log_path, limit)
+            log_path = _validate_log_path(most_recent)
+            recent_entries = await _read_recent_log_lines(str(log_path), limit)
 
         return {
             "entries": recent_entries,


### PR DESCRIPTION
Partial fix for #3164

Fixes path-injection CodeQL alerts in 2 files:

**`api/logs.py`**: `get_recent_logs()` was building a path with `os.path.join(log_dir, most_recent)` where `most_recent` comes from `os.listdir()` — unvalidated filename flowing into `aiofiles.open()`. Now routes through `_validate_log_path()` (same guard used by every other endpoint in the file).

**`api/chat_sessions.py`**: `_cleanup_conversation_transcript()` was calling `validate_relative_path()` with a relative `Path("data/conversation_transcripts")` base. CodeQL flags this because `os.path.realpath` resolves relative bases against CWD (which can shift). Changed to `PATH.DATA_DIR / "conversation_transcripts"` (absolute path from SSOT).

Files already patched (`files.py`, `api/session.py`): audited — all path inputs already guarded at every injection point, no changes needed.