### PR TITLE
chore(types): rename 3 competing TaskComplexity enums to distinct names

### DIFF
--- a/autobot-backend/ai_hardware_accelerator.py
+++ b/autobot-backend/ai_hardware_accelerator.py
@@ -134,7 +134,7 @@ class HardwareDevice(Enum):
     CPU = "cpu"  # CPU fallback
 
 
-class TaskComplexity(Enum):
+class ProcessingLoad(Enum):
     """Task complexity levels for hardware routing."""
 
     LIGHTWEIGHT = "lightweight"  # < 1s, small models
@@ -161,7 +161,7 @@ class ProcessingTask:
     task_id: str
     task_type: str
     input_data: Dict[str, Any]
-    complexity: TaskComplexity
+    complexity: ProcessingLoad
     priority: int = 1
     timeout_seconds: int = int(_ssot_config.timeout.default_request)
     preferred_device: Optional[HardwareDevice] = None
@@ -369,15 +369,15 @@ class AIHardwareAccelerator:
 
     def _classify_by_threshold(
         self, value: int, light_threshold: int, mod_threshold: int
-    ) -> TaskComplexity:
+    ) -> ProcessingLoad:
         """Classify by value thresholds (Issue #315 - extracted helper)."""
         if value < light_threshold:
-            return TaskComplexity.LIGHTWEIGHT
+            return ProcessingLoad.LIGHTWEIGHT
         if value < mod_threshold:
-            return TaskComplexity.MODERATE
-        return TaskComplexity.HEAVY
+            return ProcessingLoad.MODERATE
+        return ProcessingLoad.HEAVY
 
-    def _classify_task_complexity(self, task: ProcessingTask) -> TaskComplexity:
+    def _classify_task_complexity(self, task: ProcessingTask) -> ProcessingLoad:
         """Classify task complexity for optimal device routing (Issue #315 - refactored)."""
         task_type = task.task_type
         input_data = task.input_data
@@ -408,7 +408,7 @@ class AIHardwareAccelerator:
                 model_config.MODEL_SIZE_MODERATE_THRESHOLD_MB,
             )
 
-        return TaskComplexity.MODERATE  # Conservative default
+        return ProcessingLoad.MODERATE  # Conservative default
 
     def _is_device_under_threshold(
         self, device: HardwareDevice, threshold: float
@@ -489,9 +489,9 @@ class AIHardwareAccelerator:
             return task.preferred_device
 
         # Intelligent routing based on complexity and availability
-        if complexity == TaskComplexity.LIGHTWEIGHT:
+        if complexity == ProcessingLoad.LIGHTWEIGHT:
             return self._route_lightweight_task()
-        elif complexity == TaskComplexity.MODERATE:
+        elif complexity == ProcessingLoad.MODERATE:
             return self._route_moderate_task()
         else:  # HEAVY tasks
             return self._route_heavy_task()
@@ -999,9 +999,9 @@ async def accelerated_embedding_generation(
             "text": content if modality == "text" else None,  # Backward compatibility
         },
         complexity=(
-            TaskComplexity.LIGHTWEIGHT
+            ProcessingLoad.LIGHTWEIGHT
             if modality == "text"
-            else TaskComplexity.MODERATE
+            else ProcessingLoad.MODERATE
         ),
         preferred_device=preferred_device,
     )
@@ -1050,11 +1050,11 @@ async def accelerated_semantic_search(
 
     # Determine complexity based on document count
     if len(documents) < 100:
-        complexity = TaskComplexity.LIGHTWEIGHT
+        complexity = ProcessingLoad.LIGHTWEIGHT
     elif len(documents) < 1000:
-        complexity = TaskComplexity.MODERATE
+        complexity = ProcessingLoad.MODERATE
     else:
-        complexity = TaskComplexity.HEAVY
+        complexity = ProcessingLoad.HEAVY
 
     task = ProcessingTask(
         task_id=f"search_{int(time.time()*1000)}",

--- a/autobot-backend/utils/model_optimization/__init__.py
+++ b/autobot-backend/utils/model_optimization/__init__.py
@@ -7,7 +7,7 @@ Model Optimization Package
 Issue #381: Extracted from model_optimizer.py god class refactoring.
 Provides intelligent model selection and performance optimization.
 
-- types.py: Enums, dataclasses (TaskComplexity, ModelInfo, TaskRequest, etc.)
+- types.py: Enums, dataclasses (ModelCapabilityTier, ModelInfo, TaskRequest, etc.)
 - system_resources.py: System resource analysis for model selection
 - performance_tracking.py: Model performance tracking and Redis persistence
 - model_selection.py: Model filtering and selection logic
@@ -22,14 +22,14 @@ from .types import (
     ModelInfo,
     ModelPerformanceLevel,
     SystemResources,
-    TaskComplexity,
+    ModelCapabilityTier,
     TaskRequest,
     estimate_model_memory_gb,
 )
 
 __all__ = [
     # Types and enums
-    "TaskComplexity",
+    "ModelCapabilityTier",
     "ModelPerformanceLevel",
     "SystemResources",
     "TaskRequest",

--- a/autobot-backend/utils/model_optimization/model_selection.py
+++ b/autobot-backend/utils/model_optimization/model_selection.py
@@ -15,7 +15,7 @@ from .types import (
     ModelInfo,
     ModelPerformanceLevel,
     SystemResources,
-    TaskComplexity,
+    ModelCapabilityTier,
     TaskRequest,
 )
 
@@ -30,13 +30,13 @@ class ModelSelector:
         self._min_samples = min_samples
 
     def filter_by_complexity(
-        self, models: List[ModelInfo], complexity: TaskComplexity
+        self, models: List[ModelInfo], complexity: ModelCapabilityTier
     ) -> List[ModelInfo]:
         """Filter models based on task complexity requirements."""
         filtered = [m for m in models if m.meets_complexity_requirement(complexity)]
 
         # For SPECIALIZED complexity, prefer advanced models but fall back
-        if complexity == TaskComplexity.SPECIALIZED and not filtered:
+        if complexity == ModelCapabilityTier.SPECIALIZED and not filtered:
             return models
 
         return filtered if filtered else models

--- a/autobot-backend/utils/model_optimization/types.py
+++ b/autobot-backend/utils/model_optimization/types.py
@@ -82,7 +82,7 @@ def estimate_model_memory_gb(
     return weight_gb + kv_cache_gb + 0.5
 
 
-class TaskComplexity(Enum):
+class ModelCapabilityTier(Enum):
     """Task complexity levels for model selection."""
 
     SIMPLE = "simple"  # Basic responses, factual questions
@@ -155,8 +155,8 @@ class TaskRequest:
     user_preference: Optional[str] = None
 
     def analyze_complexity(
-        self, complexity_keywords: Dict[TaskComplexity, List[str]]
-    ) -> TaskComplexity:
+        self, complexity_keywords: Dict[ModelCapabilityTier, List[str]]
+    ) -> ModelCapabilityTier:
         """Tell what complexity this task has (Tell Don't Ask)."""
         query_lower = self.query.lower()
         task_type = self.task_type.lower()
@@ -164,12 +164,12 @@ class TaskRequest:
         # Check for specialized task types - Issue #380: Use module-level frozensets
         if task_type in CODE_TASK_TYPES:
             if any(word in query_lower for word in CODE_COMPLEXITY_KEYWORDS):
-                return TaskComplexity.SPECIALIZED
+                return ModelCapabilityTier.SPECIALIZED
             else:
-                return TaskComplexity.COMPLEX
+                return ModelCapabilityTier.COMPLEX
 
         # Analyze query content
-        complexity_scores = {complexity: 0 for complexity in TaskComplexity}
+        complexity_scores = {complexity: 0 for complexity in ModelCapabilityTier}
 
         for complexity, keywords in complexity_keywords.items():
             for keyword in keywords:
@@ -179,15 +179,15 @@ class TaskRequest:
         # Consider query length as a factor
         query_length = len(self.query.split())
         if query_length > 50:
-            complexity_scores[TaskComplexity.COMPLEX] += 1
+            complexity_scores[ModelCapabilityTier.COMPLEX] += 1
 
         # Consider context length
         if self.context_length > 1000:
-            complexity_scores[TaskComplexity.COMPLEX] += 1
+            complexity_scores[ModelCapabilityTier.COMPLEX] += 1
 
         # Return highest scoring complexity
         if max(complexity_scores.values()) == 0:
-            return TaskComplexity.MODERATE  # Default
+            return ModelCapabilityTier.MODERATE  # Default
 
         return max(complexity_scores.keys(), key=lambda k: complexity_scores[k])
 
@@ -287,19 +287,19 @@ class ModelInfo:
 
         return score
 
-    def meets_complexity_requirement(self, complexity: TaskComplexity) -> bool:
+    def meets_complexity_requirement(self, complexity: ModelCapabilityTier) -> bool:
         """Check if this model meets the complexity requirements."""
-        if complexity == TaskComplexity.SIMPLE:
+        if complexity == ModelCapabilityTier.SIMPLE:
             # Simple tasks can use any model
             return True
-        elif complexity == TaskComplexity.MODERATE:
+        elif complexity == ModelCapabilityTier.MODERATE:
             # Moderate tasks need at least standard models
             return self.performance_level in [
                 ModelPerformanceLevel.STANDARD,
                 ModelPerformanceLevel.ADVANCED,
                 ModelPerformanceLevel.SPECIALIZED,
             ]
-        elif complexity == TaskComplexity.COMPLEX:
+        elif complexity == ModelCapabilityTier.COMPLEX:
             # Complex tasks need advanced models
             return self.performance_level in [
                 ModelPerformanceLevel.ADVANCED,

--- a/autobot-backend/utils/model_optimizer.py
+++ b/autobot-backend/utils/model_optimizer.py
@@ -8,7 +8,7 @@ Issue #381: This file has been refactored into the model_optimization/ package.
 This thin facade maintains backward compatibility while delegating to focused modules.
 
 See: src/utils/model_optimization/
-- types.py: TaskComplexity, ModelPerformanceLevel, SystemResources, TaskRequest, ModelInfo
+- types.py: ModelCapabilityTier, ModelPerformanceLevel, SystemResources, TaskRequest, ModelInfo
 - system_resources.py: SystemResourceAnalyzer for system resource analysis
 - performance_tracking.py: ModelPerformanceTracker for Redis persistence
 - model_selection.py: ModelSelector and ModelClassifier for model selection
@@ -39,7 +39,7 @@ from utils.model_optimization import (
     ModelSelector,
     SystemResourceAnalyzer,
     SystemResources,
-    TaskComplexity,
+    ModelCapabilityTier,
     TaskRequest,
 )
 
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     # Types and enums
-    "TaskComplexity",
+    "ModelCapabilityTier",
     "ModelPerformanceLevel",
     "SystemResources",
     "TaskRequest",
@@ -109,14 +109,14 @@ class ModelOptimizer:
         self._model_selector = ModelSelector(self._min_samples)
         self._performance_tracker: Optional[ModelPerformanceTracker] = None
 
-    def _build_default_complexity_keywords(self) -> Dict[TaskComplexity, List[str]]:
+    def _build_default_complexity_keywords(self) -> Dict[ModelCapabilityTier, List[str]]:
         """Build default task complexity keyword mappings. Issue #620.
 
         Returns:
-            Dictionary mapping TaskComplexity levels to keyword lists
+            Dictionary mapping ModelCapabilityTier levels to keyword lists
         """
         return {
-            TaskComplexity.SIMPLE: [
+            ModelCapabilityTier.SIMPLE: [
                 "what",
                 "when",
                 "where",
@@ -127,7 +127,7 @@ class ModelOptimizer:
                 "true/false",
                 "list",
             ],
-            TaskComplexity.MODERATE: [
+            ModelCapabilityTier.MODERATE: [
                 "analyze",
                 "compare",
                 "explain",
@@ -137,7 +137,7 @@ class ModelOptimizer:
                 "why",
                 "discuss",
             ],
-            TaskComplexity.COMPLEX: [
+            ModelCapabilityTier.COMPLEX: [
                 "design",
                 "create",
                 "develop",
@@ -148,7 +148,7 @@ class ModelOptimizer:
                 "write program",
                 "complex analysis",
             ],
-            TaskComplexity.SPECIALIZED: [
+            ModelCapabilityTier.SPECIALIZED: [
                 "research paper",
                 "scientific",
                 "mathematical proof",
@@ -265,7 +265,7 @@ class ModelOptimizer:
                 self._models_cache,
             )
 
-    def analyze_task_complexity(self, task_request: TaskRequest) -> TaskComplexity:
+    def analyze_task_complexity(self, task_request: TaskRequest) -> ModelCapabilityTier:
         """Analyze task complexity based on query content and type."""
         return task_request.analyze_complexity(self.complexity_keywords)
 
@@ -275,7 +275,7 @@ class ModelOptimizer:
         return resources.to_dict()
 
     def _filter_suitable_models(
-        self, complexity: TaskComplexity
+        self, complexity: ModelCapabilityTier
     ) -> Optional[List[ModelInfo]]:
         """Filter models by complexity and return suitable candidates. Issue #620.
 
@@ -324,7 +324,7 @@ class ModelOptimizer:
     def _select_and_log_model(
         self,
         ranked_models: List[ModelInfo],
-        complexity: TaskComplexity,
+        complexity: ModelCapabilityTier,
     ) -> Optional[str]:
         """Select best model from ranked list and log selection. Issue #620.
 
@@ -383,7 +383,7 @@ class ModelOptimizer:
 
     # Backward compatibility methods
     def _filter_models_by_complexity(
-        self, complexity: TaskComplexity, models: List[ModelInfo]
+        self, complexity: ModelCapabilityTier, models: List[ModelInfo]
     ) -> List[ModelInfo]:
         """Filter models based on task complexity requirements."""
         return self._model_selector.filter_by_complexity(models, complexity)

--- a/autobot-backend/utils/model_optimizer_refactoring_test.py
+++ b/autobot-backend/utils/model_optimizer_refactoring_test.py
@@ -7,6 +7,7 @@ Verifies backward compatibility and Feature Envy fixes
 """
 
 from utils.model_optimizer import (
+    ModelCapabilityTier,
     ModelInfo,
     ModelOptimizer,
     ModelPerformanceLevel,
@@ -14,7 +15,6 @@ from utils.model_optimizer import (
     ModelSelector,
     SystemResourceAnalyzer,
     SystemResources,
-    TaskComplexity,
     TaskRequest,
     get_model_optimizer,
 )
@@ -26,7 +26,7 @@ def test_imports():
     assert get_model_optimizer is not None
     assert TaskRequest is not None
     assert ModelInfo is not None
-    assert TaskComplexity is not None
+    assert ModelCapabilityTier is not None
     assert ModelPerformanceLevel is not None
     # New classes
     assert SystemResources is not None
@@ -65,22 +65,22 @@ def test_system_resources_dataclass():
 def test_task_request_analyze_complexity():
     """Test TaskRequest.analyze_complexity() method (Tell Don't Ask)"""
     complexity_keywords = {
-        TaskComplexity.SIMPLE: ["what", "define"],
-        TaskComplexity.MODERATE: ["analyze", "explain"],
-        TaskComplexity.COMPLEX: ["design", "develop"],
-        TaskComplexity.SPECIALIZED: ["research paper", "scientific"],
+        ModelCapabilityTier.SIMPLE: ["what", "define"],
+        ModelCapabilityTier.MODERATE: ["analyze", "explain"],
+        ModelCapabilityTier.COMPLEX: ["design", "develop"],
+        ModelCapabilityTier.SPECIALIZED: ["research paper", "scientific"],
     }
 
     # Simple query
     simple_task = TaskRequest(query="What is Python?", task_type="chat")
-    assert simple_task.analyze_complexity(complexity_keywords) == TaskComplexity.SIMPLE
+    assert simple_task.analyze_complexity(complexity_keywords) == ModelCapabilityTier.SIMPLE
 
     # Complex query
     complex_task = TaskRequest(
         query="Design a scalable microservices architecture", task_type="code"
     )
     assert (
-        complex_task.analyze_complexity(complexity_keywords) == TaskComplexity.COMPLEX
+        complex_task.analyze_complexity(complexity_keywords) == ModelCapabilityTier.COMPLEX
     )
 
     # Specialized query
@@ -89,7 +89,7 @@ def test_task_request_analyze_complexity():
     )
     assert (
         specialized_task.analyze_complexity(complexity_keywords)
-        == TaskComplexity.SPECIALIZED
+        == ModelCapabilityTier.SPECIALIZED
     )
 
     print("✅ TaskRequest.analyze_complexity() works correctly")  # noqa: print
@@ -161,7 +161,7 @@ def test_model_optimizer_backward_compatibility_methods():
     # Test analyze_task_complexity() works
     task = TaskRequest(query="What is Python?", task_type="chat")
     complexity = optimizer.analyze_task_complexity(task)
-    assert isinstance(complexity, TaskComplexity)
+    assert isinstance(complexity, ModelCapabilityTier)
 
     print("✅ ModelOptimizer backward compatibility methods work")  # noqa: print
 
@@ -191,7 +191,7 @@ def test_model_optimizer_delegation():
     models = [model1, model2]
 
     # Test filter_by_complexity delegation
-    filtered = optimizer._filter_models_by_complexity(TaskComplexity.COMPLEX, models)
+    filtered = optimizer._filter_models_by_complexity(ModelCapabilityTier.COMPLEX, models)
     assert len(filtered) == 1  # Only advanced model
     assert filtered[0].name == "large-model"
 
@@ -252,7 +252,7 @@ def test_model_selector_methods():
     models = [lightweight, standard, advanced]
 
     # Test filter_by_complexity
-    filtered = selector.filter_by_complexity(models, TaskComplexity.COMPLEX)
+    filtered = selector.filter_by_complexity(models, ModelCapabilityTier.COMPLEX)
     assert len(filtered) == 1  # Only advanced
     assert filtered[0].name == "advanced"
 


### PR DESCRIPTION
Eliminates the naming conflict between three `TaskComplexity` enums that had the same name but different values and purposes:

| Old name | New name | Location | Purpose |
|---|---|---|---|
| `TaskComplexity` | **unchanged** | `autobot_types.py` | Canonical — workflow routing |
| `TaskComplexity` | `ProcessingLoad` | `ai_hardware_accelerator.py` | Hardware dispatch (NPU/GPU/CPU) |
| `TaskComplexity` | `ModelCapabilityTier` | `utils/model_optimization/types.py` | Model selection capability tier |

All internal usages in `model_optimizer.py`, `model_selection.py`, and `__init__.py` updated.

Closes #3845