### PR TITLE
refactor(knowledge): consolidate 6 vector search implementations under VectorSearchEngine

### DIFF
--- a/autobot-backend/api/knowledge_search.py
+++ b/autobot-backend/api/knowledge_search.py
@@ -23,6 +23,8 @@ from fastapi import APIRouter, HTTPException, Request
 
 from api.knowledge_models import ConsolidatedSearchRequest, EnhancedSearchRequest
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from knowledge.vector_search_engine import SearchResult as _EngineResult
+from knowledge.vector_search_engine import get_vector_search_engine
 from knowledge_factory import get_or_create_knowledge_base
 from type_defs.common import Metadata
 
@@ -126,18 +128,44 @@ def _build_search_response(
 async def _execute_kb_search(
     kb_to_use, query: str, search_limit: int, mode: str
 ) -> list:
-    """Execute search on knowledge base (Issue #398: extracted).
+    """Execute search on knowledge base via VectorSearchEngine (Issue #3828).
 
-    Handles different KB implementations with correct parameters.
+    Routes through the canonical VectorSearchEngine for unified hardware
+    dispatch (NPU > GPU > CPU).  Falls back to the per-implementation KB
+    search methods only when the engine raises.
+
+    Issue #398: original KB-dispatch logic preserved as fallback.
     """
-    kb_class_name = kb_to_use.__class__.__name__
+    try:
+        engine = await get_vector_search_engine()
+        engine_results: list[_EngineResult] = await engine.search(
+            query=query,
+            top_k=search_limit,
+            hardware_backend="auto",
+        )
+        return [
+            {
+                "content": r.text,
+                "score": r.score,
+                "metadata": r.metadata,
+                "node_id": r.source,
+                "doc_id": r.source,
+            }
+            for r in engine_results
+        ]
+    except Exception as exc:
+        logger.warning(
+            "_execute_kb_search: VectorSearchEngine failed (%s), falling back to direct KB",
+            exc,
+        )
 
+    # Legacy per-implementation fallback
+    kb_class_name = kb_to_use.__class__.__name__
     if kb_class_name == "KnowledgeBaseV2":
         return await kb_to_use.search(query=query, top_k=search_limit)
-    else:
-        return await kb_to_use.search(
-            query=query, similarity_top_k=search_limit, mode=mode
-        )
+    return await kb_to_use.search(
+        query=query, similarity_top_k=search_limit, mode=mode
+    )
 
 
 async def _apply_reranking(query: str, results: list, kb_to_use) -> dict | None:

--- a/autobot-backend/knowledge/search.py
+++ b/autobot-backend/knowledge/search.py
@@ -30,6 +30,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
 from autobot_shared.error_boundaries import error_boundary
 
+# Issue #3828: canonical vector search engine — SearchMixin.search() delegates here.
+from knowledge.vector_search_engine import SearchResult as _EngineSearchResult
+from knowledge.vector_search_engine import get_vector_search_engine
+
 # Import components from the search_components package
 from knowledge.search_components import (
     KeywordSearcher,
@@ -158,9 +162,15 @@ class SearchMixin:
         filters: Optional[Dict[str, Any]] = None,
         mode: str = "auto",
     ) -> List[Dict[str, Any]]:
-        """Search the knowledge base (Issue #398: refactored).
+        """Search the knowledge base.
 
+        Issue #398: refactored.
         Issue #934: filters is now passed to ChromaDB as a metadata where clause.
+        Issue #3828: delegates to VectorSearchEngine for unified hardware dispatch.
+
+        The legacy _execute_vector_search path is kept as the final fallback so
+        that any sub-class that overrides _query_chromadb / _deduplicate_results
+        continues to work correctly.
         """
         self.ensure_initialized()
         similarity_top_k = similarity_top_k or top_k
@@ -169,6 +179,32 @@ class SearchMixin:
         if invalid_result is not None:
             return invalid_result
 
+        try:
+            engine = await get_vector_search_engine()
+            engine_results: List[_EngineSearchResult] = await engine.search(
+                query=query,
+                top_k=similarity_top_k,
+                filters=filters,
+                hardware_backend="auto",
+            )
+            # Convert canonical SearchResult -> legacy dict format expected by callers
+            return [
+                {
+                    "content": r.text,
+                    "score": r.score,
+                    "metadata": r.metadata,
+                    "node_id": r.source,
+                    "doc_id": r.source,  # V1 compatibility
+                }
+                for r in engine_results
+            ]
+        except Exception as exc:
+            logger.warning(
+                "VectorSearchEngine delegation failed (%s), falling back to direct ChromaDB",
+                exc,
+            )
+
+        # Fallback: original direct ChromaDB path
         try:
             return await self._execute_vector_search(
                 query, similarity_top_k, filters=filters

--- a/autobot-backend/knowledge/vector_search_engine.py
+++ b/autobot-backend/knowledge/vector_search_engine.py
@@ -1,0 +1,350 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+VectorSearchEngine — single unified entry point for all vector/semantic search.
+
+Issue #3828: Consolidate 6 vector search implementations under one engine.
+
+Hardware dispatch priority (when hardware_backend="auto"):
+  NPU  (config.feature.npu_enabled)
+  GPU  (FAISS_GPU_AVAILABLE via gpu_vector_search)
+  CPU  (ChromaDB / basic KB fallback — always available)
+
+Canonical result type: SearchResult dataclass (text, score, metadata, source).
+
+All callers should import from this module:
+    from knowledge.vector_search_engine import get_vector_search_engine, SearchResult
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from autobot_shared.ssot_config import config
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SearchResult:
+    """Canonical search result returned by VectorSearchEngine.
+
+    Fields
+    ------
+    text     : document text / content
+    score    : similarity score in [0, 1] (higher == more similar)
+    metadata : arbitrary key/value metadata from the document store
+    source   : logical source identifier (e.g. fact_id, doc_id, file path)
+    """
+
+    text: str
+    score: float
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    source: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Hardware availability helpers
+# ---------------------------------------------------------------------------
+
+# Lazy-import flags — evaluated once at first engine construction.
+_FAISS_GPU_AVAILABLE: Optional[bool] = None
+_FAISS_AVAILABLE: Optional[bool] = None
+
+
+def _check_faiss_flags() -> tuple[bool, bool]:
+    """Return (faiss_available, faiss_gpu_available), evaluated once."""
+    global _FAISS_AVAILABLE, _FAISS_GPU_AVAILABLE
+    if _FAISS_AVAILABLE is None:
+        try:
+            from utils.gpu_vector_search import (  # noqa: PLC0415
+                FAISS_AVAILABLE,
+                FAISS_GPU_AVAILABLE,
+            )
+
+            _FAISS_AVAILABLE = bool(FAISS_AVAILABLE)
+            _FAISS_GPU_AVAILABLE = bool(FAISS_GPU_AVAILABLE)
+        except Exception:
+            _FAISS_AVAILABLE = False
+            _FAISS_GPU_AVAILABLE = False
+    return _FAISS_AVAILABLE, _FAISS_GPU_AVAILABLE
+
+
+def _npu_enabled() -> bool:
+    """Return True when NPU subsystem is enabled in feature flags."""
+    try:
+        return bool(config.feature.npu_enabled)
+    except Exception:
+        return False
+
+
+def _gpu_available() -> bool:
+    """Return True when FAISS-GPU is available."""
+    _, gpu = _check_faiss_flags()
+    return gpu
+
+
+# ---------------------------------------------------------------------------
+# Hardware-backend adapters
+# ---------------------------------------------------------------------------
+
+
+class _NPUBackend:
+    """Thin adapter over NPUSemanticSearch for use by VectorSearchEngine."""
+
+    def __init__(self) -> None:
+        self._engine: Optional[Any] = None
+
+    async def _get_engine(self) -> Any:
+        if self._engine is None:
+            from npu_semantic_search import get_npu_search_engine  # noqa: PLC0415
+
+            self._engine = await get_npu_search_engine()
+        return self._engine
+
+    async def search(
+        self,
+        query: str,
+        top_k: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[SearchResult]:
+        engine = await self._get_engine()
+        npu_results, _ = await engine.enhanced_search(
+            query=query,
+            similarity_top_k=top_k,
+            filters=filters,
+            enable_npu_acceleration=True,
+        )
+        return [
+            SearchResult(
+                text=r.content,
+                score=r.score,
+                metadata=r.metadata,
+                source=r.doc_id,
+            )
+            for r in npu_results
+        ]
+
+
+class _GPUBackend:
+    """Thin adapter over HybridVectorSearch for use by VectorSearchEngine.
+
+    The GPU backend requires an already-generated query embedding. This adapter
+    generates that embedding via the NPU-fallback path before delegating to
+    HybridVectorSearch so the caller always passes plain text queries.
+    """
+
+    def __init__(self) -> None:
+        self._hybrid: Optional[Any] = None
+
+    async def _get_hybrid(self) -> Any:
+        if self._hybrid is None:
+            from utils.gpu_vector_search import (  # noqa: PLC0415
+                VectorSearchConfig,
+                get_hybrid_vector_search,
+            )
+
+            config_obj = VectorSearchConfig(use_gpu=True)
+            self._hybrid = await get_hybrid_vector_search(config=config_obj)
+        return self._hybrid
+
+    async def _generate_embedding(self, query: str):
+        """Generate a query embedding using the NPU-fallback path."""
+        from knowledge.facts import (  # noqa: PLC0415
+            _generate_embedding_with_npu_fallback,
+        )
+
+        return await _generate_embedding_with_npu_fallback(query)
+
+    async def search(
+        self,
+        query: str,
+        top_k: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[SearchResult]:
+        import numpy as np  # noqa: PLC0415
+
+        hybrid = await self._get_hybrid()
+        embedding = await self._generate_embedding(query)
+        embedding_array = np.array(embedding, dtype=np.float32)
+
+        gpu_results, _ = await hybrid.search(
+            query_embedding=embedding_array,
+            top_k=top_k,
+            metadata_filter=filters,
+        )
+        return [
+            SearchResult(
+                text=r.content or "",
+                score=r.score,
+                metadata=r.metadata,
+                source=r.doc_id,
+            )
+            for r in gpu_results
+        ]
+
+
+class _CPUBackend:
+    """CPU/ChromaDB fallback adapter over the canonical knowledge base."""
+
+    async def search(
+        self,
+        query: str,
+        top_k: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[SearchResult]:
+        from knowledge import get_knowledge_base  # noqa: PLC0415
+
+        kb = await get_knowledge_base()
+        raw = await kb.search(query=query, top_k=top_k, filters=filters)
+        return [
+            SearchResult(
+                text=r.get("content", ""),
+                score=r.get("score", 0.0),
+                metadata=r.get("metadata", {}),
+                source=(
+                    r.get("metadata", {}).get("fact_id")
+                    or r.get("node_id", "")
+                ),
+            )
+            for r in raw
+        ]
+
+
+# ---------------------------------------------------------------------------
+# VectorSearchEngine
+# ---------------------------------------------------------------------------
+
+# Reranker callable type: (query: str, results: List[SearchResult]) -> Awaitable[List[SearchResult]]
+RerankerCallable = Callable[[str, List[SearchResult]], Any]
+
+
+class VectorSearchEngine:
+    """Unified vector search engine with hardware dispatch and optional reranking.
+
+    Usage
+    -----
+    engine = await get_vector_search_engine()
+    results = await engine.search("how to deploy docker", top_k=10)
+
+    Hardware selection
+    ------------------
+    hardware_backend="auto"  -> NPU > GPU > CPU (based on availability flags)
+    hardware_backend="npu"   -> force NPU path
+    hardware_backend="gpu"   -> force GPU path
+    hardware_backend="cpu"   -> force CPU/ChromaDB path
+    """
+
+    def __init__(self) -> None:
+        self._npu = _NPUBackend()
+        self._gpu = _GPUBackend()
+        self._cpu = _CPUBackend()
+
+    def _select_backend(self, hardware_backend: str) -> Any:
+        """Return the appropriate backend object."""
+        if hardware_backend == "npu":
+            return self._npu
+        if hardware_backend == "gpu":
+            return self._gpu
+        if hardware_backend == "cpu":
+            return self._cpu
+
+        # "auto": NPU > GPU > CPU
+        if _npu_enabled():
+            logger.debug("VectorSearchEngine: auto-selected NPU backend")
+            return self._npu
+        if _gpu_available():
+            logger.debug("VectorSearchEngine: auto-selected GPU backend")
+            return self._gpu
+        logger.debug("VectorSearchEngine: auto-selected CPU backend")
+        return self._cpu
+
+    async def search(
+        self,
+        query: str,
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None,
+        hardware_backend: str = "auto",
+        reranker: Optional[RerankerCallable] = None,
+    ) -> List[SearchResult]:
+        """Execute vector search and return standardized SearchResult list.
+
+        Parameters
+        ----------
+        query            : plain-text search query
+        top_k            : maximum number of results to return
+        filters          : optional metadata pre-filter dict (passed to backend)
+        hardware_backend : "auto" | "npu" | "gpu" | "cpu"
+        reranker         : optional async callable(query, results) -> results
+
+        Returns
+        -------
+        List[SearchResult] sorted by score descending.
+        """
+        if not query.strip():
+            return []
+
+        backend = self._select_backend(hardware_backend)
+        backend_name = type(backend).__name__
+
+        try:
+            results = await backend.search(query=query, top_k=top_k, filters=filters)
+        except Exception as exc:
+            logger.warning(
+                "VectorSearchEngine: backend %s failed (%s), falling back to CPU",
+                backend_name,
+                exc,
+            )
+            try:
+                results = await self._cpu.search(
+                    query=query, top_k=top_k, filters=filters
+                )
+            except Exception as cpu_exc:
+                logger.error("VectorSearchEngine: CPU fallback also failed: %s", cpu_exc)
+                return []
+
+        if reranker is not None and results:
+            try:
+                results = await reranker(query, results)
+            except Exception as rerr:
+                logger.warning(
+                    "VectorSearchEngine: reranker raised %s, skipping rerank", rerr
+                )
+
+        # Guarantee descending score order regardless of backend
+        results.sort(key=lambda r: r.score, reverse=True)
+        logger.info(
+            "VectorSearchEngine.search: query=%r top_k=%d backend=%s results=%d",
+            query[:60],
+            top_k,
+            backend_name,
+            len(results),
+        )
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Singleton factory
+# ---------------------------------------------------------------------------
+
+_instance: Optional[VectorSearchEngine] = None
+_lock = asyncio.Lock()
+
+
+async def get_vector_search_engine() -> VectorSearchEngine:
+    """Return the process-wide VectorSearchEngine singleton (lazy, thread-safe)."""
+    global _instance
+    if _instance is None:
+        async with _lock:
+            if _instance is None:
+                _instance = VectorSearchEngine()
+                logger.info("VectorSearchEngine singleton created")
+    return _instance

--- a/autobot-backend/knowledge/vector_search_engine_test.py
+++ b/autobot-backend/knowledge/vector_search_engine_test.py
@@ -1,0 +1,346 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for knowledge.vector_search_engine — Issue #3828.
+
+Covers:
+- Hardware auto-selection logic (NPU > GPU > CPU)
+- Forced hardware backend routing
+- Search result standardization (SearchResult dataclass)
+- Reranker callable integration
+- Fallback to CPU when primary backend raises
+- Singleton factory returns the same instance
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies before importing the engine
+# ---------------------------------------------------------------------------
+
+# autobot_shared.ssot_config
+_ssot = types.ModuleType("autobot_shared.ssot_config")
+_feature = MagicMock()
+_feature.npu_enabled = True
+_autobot_cfg = MagicMock()
+_autobot_cfg.feature = _feature
+_ssot.config = _autobot_cfg
+sys.modules.setdefault("autobot_shared", types.ModuleType("autobot_shared"))
+sys.modules.setdefault("autobot_shared.ssot_config", _ssot)
+
+# knowledge (for CPUBackend)
+_knowledge_mod = types.ModuleType("knowledge")
+sys.modules.setdefault("knowledge", _knowledge_mod)
+
+# npu_semantic_search (for NPUBackend)
+_npu_mod = types.ModuleType("npu_semantic_search")
+sys.modules.setdefault("npu_semantic_search", _npu_mod)
+
+# utils.gpu_vector_search (for GPUBackend and _check_faiss_flags)
+_gpu_mod = types.ModuleType("utils.gpu_vector_search")
+_gpu_mod.FAISS_AVAILABLE = False
+_gpu_mod.FAISS_GPU_AVAILABLE = False
+_gpu_mod.VectorSearchConfig = MagicMock()
+_gpu_mod.get_hybrid_vector_search = AsyncMock()
+sys.modules.setdefault("utils", types.ModuleType("utils"))
+sys.modules.setdefault("utils.gpu_vector_search", _gpu_mod)
+
+# knowledge.facts (for GPUBackend embedding generation)
+_facts_mod = types.ModuleType("knowledge.facts")
+_facts_mod._generate_embedding_with_npu_fallback = AsyncMock(
+    return_value=[0.1, 0.2, 0.3]
+)
+sys.modules.setdefault("knowledge.facts", _facts_mod)
+
+# ---------------------------------------------------------------------------
+# Import after stubs are in place
+# ---------------------------------------------------------------------------
+
+# Reset module-level singleton and FAISS flags before import
+import importlib
+
+if "knowledge.vector_search_engine" in sys.modules:
+    del sys.modules["knowledge.vector_search_engine"]
+
+import knowledge.vector_search_engine as vse  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_engine_result(text="hello", score=0.9, metadata=None, source="doc1"):
+    return vse.SearchResult(
+        text=text, score=score, metadata=metadata or {}, source=source
+    )
+
+
+def _cpu_backend_returning(results):
+    """Return a _CPUBackend whose search always returns *results*."""
+    backend = MagicMock()
+    backend.search = AsyncMock(return_value=results)
+    return backend
+
+
+def _npu_backend_returning(results):
+    backend = MagicMock()
+    backend.search = AsyncMock(return_value=results)
+    return backend
+
+
+def _gpu_backend_returning(results):
+    backend = MagicMock()
+    backend.search = AsyncMock(return_value=results)
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# SearchResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestSearchResult:
+    def test_defaults(self):
+        r = vse.SearchResult(text="hello", score=0.5)
+        assert r.text == "hello"
+        assert r.score == 0.5
+        assert r.metadata == {}
+        assert r.source == ""
+
+    def test_explicit_fields(self):
+        r = vse.SearchResult(
+            text="abc", score=0.8, metadata={"k": "v"}, source="fact-42"
+        )
+        assert r.metadata["k"] == "v"
+        assert r.source == "fact-42"
+
+
+# ---------------------------------------------------------------------------
+# Hardware selection
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareSelection:
+    """VectorSearchEngine._select_backend logic."""
+
+    def _engine(self):
+        engine = vse.VectorSearchEngine()
+        engine._npu = MagicMock()
+        engine._gpu = MagicMock()
+        engine._cpu = MagicMock()
+        return engine
+
+    def test_explicit_npu(self):
+        engine = self._engine()
+        assert engine._select_backend("npu") is engine._npu
+
+    def test_explicit_gpu(self):
+        engine = self._engine()
+        assert engine._select_backend("gpu") is engine._gpu
+
+    def test_explicit_cpu(self):
+        engine = self._engine()
+        assert engine._select_backend("cpu") is engine._cpu
+
+    def test_auto_prefers_npu_when_enabled(self):
+        engine = self._engine()
+        with patch.object(vse, "_npu_enabled", return_value=True), patch.object(
+            vse, "_gpu_available", return_value=True
+        ):
+            assert engine._select_backend("auto") is engine._npu
+
+    def test_auto_falls_to_gpu_when_npu_disabled(self):
+        engine = self._engine()
+        with patch.object(vse, "_npu_enabled", return_value=False), patch.object(
+            vse, "_gpu_available", return_value=True
+        ):
+            assert engine._select_backend("auto") is engine._gpu
+
+    def test_auto_falls_to_cpu_when_neither_available(self):
+        engine = self._engine()
+        with patch.object(vse, "_npu_enabled", return_value=False), patch.object(
+            vse, "_gpu_available", return_value=False
+        ):
+            assert engine._select_backend("auto") is engine._cpu
+
+
+# ---------------------------------------------------------------------------
+# search() — result standardization
+# ---------------------------------------------------------------------------
+
+
+class TestSearchResultStandardization:
+    @pytest.mark.asyncio
+    async def test_returns_sorted_descending(self):
+        engine = vse.VectorSearchEngine()
+        unsorted = [
+            _make_engine_result(text="low", score=0.3),
+            _make_engine_result(text="high", score=0.9),
+            _make_engine_result(text="mid", score=0.6),
+        ]
+        engine._cpu = _cpu_backend_returning(unsorted)
+        with patch.object(vse, "_npu_enabled", return_value=False), patch.object(
+            vse, "_gpu_available", return_value=False
+        ):
+            results = await engine.search("query", top_k=10, hardware_backend="auto")
+        assert [r.score for r in results] == [0.9, 0.6, 0.3]
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_empty(self):
+        engine = vse.VectorSearchEngine()
+        results = await engine.search("   ", top_k=5)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_correct_fields_forwarded(self):
+        result = _make_engine_result(
+            text="content", score=0.75, metadata={"cat": "test"}, source="fact-1"
+        )
+        engine = vse.VectorSearchEngine()
+        engine._npu = _npu_backend_returning([result])
+        with patch.object(vse, "_npu_enabled", return_value=True):
+            results = await engine.search("query")
+        assert len(results) == 1
+        assert results[0].text == "content"
+        assert results[0].score == 0.75
+        assert results[0].metadata == {"cat": "test"}
+        assert results[0].source == "fact-1"
+
+    @pytest.mark.asyncio
+    async def test_filters_forwarded_to_backend(self):
+        backend = MagicMock()
+        backend.search = AsyncMock(return_value=[])
+        engine = vse.VectorSearchEngine()
+        engine._cpu = backend
+        filters = {"category": "docs"}
+        with patch.object(vse, "_npu_enabled", return_value=False), patch.object(
+            vse, "_gpu_available", return_value=False
+        ):
+            await engine.search("q", top_k=5, filters=filters)
+        backend.search.assert_awaited_once_with(
+            query="q", top_k=5, filters=filters
+        )
+
+
+# ---------------------------------------------------------------------------
+# search() — reranking
+# ---------------------------------------------------------------------------
+
+
+class TestReranking:
+    @pytest.mark.asyncio
+    async def test_reranker_called_with_query_and_results(self):
+        results = [_make_engine_result(score=0.8)]
+        reranked = [_make_engine_result(score=0.95)]
+        reranker = AsyncMock(return_value=reranked)
+
+        engine = vse.VectorSearchEngine()
+        engine._cpu = _cpu_backend_returning(results)
+
+        with patch.object(vse, "_npu_enabled", return_value=False), patch.object(
+            vse, "_gpu_available", return_value=False
+        ):
+            out = await engine.search("q", reranker=reranker)
+
+        reranker.assert_awaited_once()
+        assert out[0].score == 0.95
+
+    @pytest.mark.asyncio
+    async def test_reranker_exception_does_not_propagate(self):
+        """A failing reranker should be swallowed; original results returned."""
+        results = [_make_engine_result(score=0.7)]
+        reranker = AsyncMock(side_effect=RuntimeError("rerank failed"))
+
+        engine = vse.VectorSearchEngine()
+        engine._cpu = _cpu_backend_returning(results)
+
+        with patch.object(vse, "_npu_enabled", return_value=False), patch.object(
+            vse, "_gpu_available", return_value=False
+        ):
+            out = await engine.search("q", reranker=reranker)
+
+        assert len(out) == 1
+        assert out[0].score == 0.7
+
+    @pytest.mark.asyncio
+    async def test_no_reranker_when_results_empty(self):
+        reranker = AsyncMock()
+        engine = vse.VectorSearchEngine()
+        engine._cpu = _cpu_backend_returning([])
+
+        with patch.object(vse, "_npu_enabled", return_value=False), patch.object(
+            vse, "_gpu_available", return_value=False
+        ):
+            out = await engine.search("q", reranker=reranker)
+
+        reranker.assert_not_awaited()
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# search() — CPU fallback on primary backend failure
+# ---------------------------------------------------------------------------
+
+
+class TestFallback:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_cpu_on_npu_failure(self):
+        npu_backend = MagicMock()
+        npu_backend.search = AsyncMock(side_effect=RuntimeError("NPU unavailable"))
+        cpu_result = [_make_engine_result(text="cpu_result", score=0.5)]
+        cpu_backend = _cpu_backend_returning(cpu_result)
+
+        engine = vse.VectorSearchEngine()
+        engine._npu = npu_backend
+        engine._cpu = cpu_backend
+
+        with patch.object(vse, "_npu_enabled", return_value=True):
+            results = await engine.search("query")
+
+        cpu_backend.search.assert_awaited_once()
+        assert results[0].text == "cpu_result"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_total_failure(self):
+        npu_backend = MagicMock()
+        npu_backend.search = AsyncMock(side_effect=RuntimeError("NPU failed"))
+        cpu_backend = MagicMock()
+        cpu_backend.search = AsyncMock(side_effect=RuntimeError("CPU also failed"))
+
+        engine = vse.VectorSearchEngine()
+        engine._npu = npu_backend
+        engine._cpu = cpu_backend
+
+        with patch.object(vse, "_npu_enabled", return_value=True):
+            results = await engine.search("query")
+
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Singleton factory
+# ---------------------------------------------------------------------------
+
+
+class TestSingleton:
+    @pytest.mark.asyncio
+    async def test_same_instance_returned_twice(self):
+        # Reset singleton before test
+        vse._instance = None
+        e1 = await vse.get_vector_search_engine()
+        e2 = await vse.get_vector_search_engine()
+        assert e1 is e2
+
+    @pytest.mark.asyncio
+    async def test_instance_is_vector_search_engine(self):
+        vse._instance = None
+        e = await vse.get_vector_search_engine()
+        assert isinstance(e, vse.VectorSearchEngine)

--- a/autobot-backend/npu_semantic_search.py
+++ b/autobot-backend/npu_semantic_search.py
@@ -1507,3 +1507,13 @@ async def get_npu_search_engine() -> NPUSemanticSearch:
                 _npu_search_engine = NPUSemanticSearch()
                 await _npu_search_engine.initialize()
     return _npu_search_engine
+
+
+# ---------------------------------------------------------------------------
+# Issue #3828: VectorSearchEngine adapter
+#
+# VectorSearchEngine._NPUBackend calls get_npu_search_engine() directly and
+# converts its SearchResult objects to the canonical form.  No changes to
+# NPUSemanticSearch internals are required; the bridge lives entirely in
+# knowledge/vector_search_engine.py.
+# ---------------------------------------------------------------------------

--- a/autobot-backend/utils/gpu_vector_search.py
+++ b/autobot-backend/utils/gpu_vector_search.py
@@ -1164,3 +1164,12 @@ __all__ = [
     "FAISS_AVAILABLE",
     "FAISS_GPU_AVAILABLE",
 ]
+
+# ---------------------------------------------------------------------------
+# Issue #3828: VectorSearchEngine adapter
+#
+# VectorSearchEngine._GPUBackend calls get_hybrid_vector_search() directly and
+# converts HybridVectorSearch.SearchResult objects to the canonical form.
+# No changes to HybridVectorSearch internals are required; the bridge lives
+# entirely in knowledge/vector_search_engine.py.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3828

## New: `knowledge/vector_search_engine.py`

Canonical engine with hardware dispatch and standardized results:

```python
engine = await get_vector_search_engine()
results: list[SearchResult] = await engine.search(
    query, top_k=10, filters={}, hardware_backend="auto", reranker=None
)
# SearchResult: {text, score, metadata, source}
```

**Hardware dispatch** (`hardware_backend="auto"`): NPU (`config.feature.npu_enabled`) → GPU (FAISS available) → CPU (ChromaDB). On primary failure, auto-retries with CPU.

**Backends:**
- `_NPUBackend` — thin adapter over `get_npu_search_engine().enhanced_search()`
- `_GPUBackend` — thin adapter over `get_hybrid_vector_search()`
- `_CPUBackend` — fallback via `get_knowledge_base().search()`

**Singleton:** `get_vector_search_engine()` with double-checked async locking.

## Modified files (existing entry points preserved)

| File | Change |
|------|--------|
| `knowledge/search.py` | `SearchMixin.search()` delegates to `VectorSearchEngine` first; falls back to original `_execute_vector_search()` path if engine raises |
| `api/knowledge_search.py` | `_execute_kb_search()` routes through `VectorSearchEngine`; all 4 endpoints (`/search`, `/enhanced_search`, `/rag_search`, `/similarity_search`) unified |
| `npu_semantic_search.py` | Doc block added explaining adapter relationship |
| `utils/gpu_vector_search.py` | Doc block added explaining adapter relationship |

## Remaining (intentionally deferred)

- `api/enhanced_search.py` NPU hardware-introspection endpoints — return NPU-specific metadata (`device_used`, `processing_time_ms`, `embedding_model`); migrating would discard that metadata. These are the hardware-monitoring surface, not generic search consumers.
- `advanced_rag_optimizer.py` — `self.kb.search()` already goes through `VectorSearchEngine` via the `SearchMixin` change. The `get_all_facts()` keyword path is a different algorithm (hybrid RAG scoring) — not a duplicate.

## Tests (`vector_search_engine_test.py`)
All 6 backend-selection paths, result standardization, descending sort, reranker integration, CPU fallback, singleton identity.