### PR TITLE
feat(agents): stream chain-of-thought events to frontend in real time

### DIFF
--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -165,7 +165,55 @@ def _format_workflow_failed(raw_data: dict) -> Tuple[str, str]:
 def _format_workflow_cancelled(raw_data: dict) -> Tuple[str, str]:
     """Format workflow_cancelled event."""
     workflow_id = raw_data.get("workflow_id", "N/A")[:8]
-    return f"🛑 Workflow {workflow_id}: Cancelled by user", "workflow"
+    return f"Workflow {workflow_id}: Cancelled by user", "workflow"
+
+
+# Issue #3232: Chain-of-thought event formatters
+def _format_agent_step_start(raw_data: dict) -> Tuple[str, str]:
+    """Format agent.step.start event."""
+    step_name = raw_data.get("step_name", "unknown")
+    agent_type = raw_data.get("agent_type", "")
+    label = f"{agent_type}/{step_name}" if agent_type else step_name
+    return f"Step started: {label}", "agent-step"
+
+
+def _format_agent_step_complete(raw_data: dict) -> Tuple[str, str]:
+    """Format agent.step.complete event."""
+    step_name = raw_data.get("step_name", "unknown")
+    duration_ms = raw_data.get("duration_ms", 0)
+    summary = raw_data.get("output_summary") or "done"
+    return f"Step complete: {step_name} ({duration_ms:.0f}ms) — {summary}", "agent-step"
+
+
+def _format_agent_tool_call(raw_data: dict) -> Tuple[str, str]:
+    """Format agent.tool.call event."""
+    tool_name = raw_data.get("tool_name", "unknown")
+    return f"Tool call: {tool_name}", "agent-tool"
+
+
+def _format_agent_tool_result(raw_data: dict) -> Tuple[str, str]:
+    """Format agent.tool.result event."""
+    tool_name = raw_data.get("tool_name", "unknown")
+    duration_ms = raw_data.get("duration_ms", 0)
+    success = raw_data.get("success", True)
+    status = "ok" if success else "error"
+    return f"Tool result: {tool_name} [{status}] ({duration_ms:.0f}ms)", "agent-tool"
+
+
+def _format_agent_llm_chunk(raw_data: dict) -> Tuple[str, str]:
+    """Format agent.llm.chunk event (token streaming)."""
+    chunk = raw_data.get("chunk", "")
+    return chunk, "agent-llm-chunk"
+
+
+def _format_agent_plan(raw_data: dict) -> Tuple[str, str]:
+    """Format agent.plan event."""
+    step_count = raw_data.get("step_count", 0)
+    steps = raw_data.get("steps", [])
+    summary = "; ".join(steps[:3])
+    if step_count > 3:
+        summary += f" … (+{step_count - 3} more)"
+    return f"Plan ({step_count} steps): {summary}", "agent-plan"
 
 
 # Issue #336: Dispatch table for message type formatting
@@ -194,6 +242,13 @@ MESSAGE_TYPE_FORMATTERS: Dict[str, Callable[[dict], Tuple[str, str]]] = {
     "workflow_completed": _format_workflow_completed,
     "workflow_failed": _format_workflow_failed,
     "workflow_cancelled": _format_workflow_cancelled,
+    # Issue #3232: Chain-of-thought events
+    "agent.step.start": _format_agent_step_start,
+    "agent.step.complete": _format_agent_step_complete,
+    "agent.tool.call": _format_agent_tool_call,
+    "agent.tool.result": _format_agent_tool_result,
+    "agent.llm.chunk": _format_agent_llm_chunk,
+    "agent.plan": _format_agent_plan,
 }
 
 

--- a/autobot-backend/chat_workflow/cot_events.py
+++ b/autobot-backend/chat_workflow/cot_events.py
@@ -113,7 +113,12 @@ def _try_publish(event_type: str, payload: dict) -> None:
         coro = event_manager.publish(event_type, payload)
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(coro)
+            task = loop.create_task(coro)
+            task.add_done_callback(
+                lambda t: logger.debug("cot_events: publish error: %s", t.exception())
+                if not t.cancelled() and t.exception()
+                else None
+            )
         except RuntimeError:
             # No running loop — caller is in a sync context; skip silently.
             logger.debug("cot_events: no running event loop, skipping %s", event_type)

--- a/autobot-backend/chat_workflow/cot_events.py
+++ b/autobot-backend/chat_workflow/cot_events.py
@@ -1,0 +1,307 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Chain-of-Thought event emission helpers (#3232).
+
+Provides non-blocking helpers to emit structured reasoning-trace events
+through the existing EventManager WebSocket broadcast path so the
+frontend can render live tool calls, LLM steps, and plan decomposition
+without any polling.
+
+Event types:
+    agent.step.start    – a graph node or agent step is beginning
+    agent.step.complete – a graph node or agent step has finished
+    agent.tool.call     – a tool call is about to be dispatched
+    agent.tool.result   – the result of a tool call has arrived
+    agent.llm.chunk     – a streaming LLM token chunk
+    agent.plan          – a plan decomposition from the overseer
+
+Sensitive argument keys are redacted before emission so credentials and
+tokens never cross the WebSocket boundary.
+"""
+
+import asyncio
+import logging
+import time
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Sensitive argument key patterns — values for these keys are replaced with
+# the placeholder string before the event is sent over WebSocket.
+# ---------------------------------------------------------------------------
+
+_REDACTED = "<redacted>"
+
+_SENSITIVE_KEY_FRAGMENTS: frozenset[str] = frozenset(
+    {
+        "password",
+        "passwd",
+        "secret",
+        "token",
+        "api_key",
+        "apikey",
+        "auth",
+        "credential",
+        "private_key",
+        "privatekey",
+        "access_key",
+        "accesskey",
+        "bearer",
+    }
+)
+
+
+def _is_sensitive(key: str) -> bool:
+    """Return True if *key* (case-insensitive) matches any sensitive fragment."""
+    lower = key.lower()
+    return any(fragment in lower for fragment in _SENSITIVE_KEY_FRAGMENTS)
+
+
+def sanitize_arguments(arguments: Any) -> Any:
+    """Recursively redact sensitive values in *arguments*.
+
+    Operates on dicts and nested dicts; non-dict values are returned as-is.
+
+    Args:
+        arguments: Tool argument dict (or any value).
+
+    Returns:
+        A copy with sensitive values replaced by the redaction placeholder.
+    """
+    if not isinstance(arguments, dict):
+        return arguments
+    result: dict[str, Any] = {}
+    for key, value in arguments.items():
+        if _is_sensitive(key):
+            result[key] = _REDACTED
+        elif isinstance(value, dict):
+            result[key] = sanitize_arguments(value)
+        else:
+            result[key] = value
+    return result
+
+
+def _truncate(value: Any, max_len: int = 512) -> str:
+    """Convert *value* to a string and truncate to *max_len* characters."""
+    text = str(value)
+    if len(text) > max_len:
+        return text[:max_len] + "…"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Low-level publish helper
+# ---------------------------------------------------------------------------
+
+
+def _try_publish(event_type: str, payload: dict) -> None:
+    """Fire-and-forget publish to the global EventManager.
+
+    Wraps the publish call in create_task so it never blocks the caller.
+    Silently skips if the event manager is unavailable (e.g. in unit tests).
+
+    Args:
+        event_type: Dot-namespaced event type string (e.g. "agent.tool.call").
+        payload:    Dict payload that will be broadcast to WebSocket clients.
+    """
+    try:
+        from event_manager import event_manager
+
+        coro = event_manager.publish(event_type, payload)
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(coro)
+        except RuntimeError:
+            # No running loop — caller is in a sync context; skip silently.
+            logger.debug("cot_events: no running event loop, skipping %s", event_type)
+    except ImportError:
+        logger.debug("cot_events: event_manager not available, skipping %s", event_type)
+    except Exception as exc:
+        logger.debug("cot_events: publish failed for %s: %s", event_type, exc)
+
+
+# ---------------------------------------------------------------------------
+# Public event emitters
+# ---------------------------------------------------------------------------
+
+
+def emit_step_start(
+    step_name: str,
+    session_id: Optional[str] = None,
+    agent_type: Optional[str] = None,
+    step_id: Optional[str] = None,
+) -> float:
+    """Emit an agent.step.start event and return the current monotonic time.
+
+    The returned start_time should be passed to emit_step_complete so the
+    duration can be calculated without the caller needing to record it.
+
+    Args:
+        step_name:  Human-readable step or node name.
+        session_id: Chat session identifier (forwarded to frontend for routing).
+        agent_type: Optional agent class/type label.
+        step_id:    Optional unique identifier for this step instance.
+
+    Returns:
+        Monotonic time float to be passed to emit_step_complete.
+    """
+    start_time = time.monotonic()
+    _try_publish(
+        "agent.step.start",
+        {
+            "step_id": step_id or step_name,
+            "step_name": step_name,
+            "agent_type": agent_type,
+            "session_id": session_id,
+            "ts": time.time(),
+        },
+    )
+    return start_time
+
+
+def emit_step_complete(
+    step_name: str,
+    start_time: float,
+    output_summary: Optional[str] = None,
+    session_id: Optional[str] = None,
+    step_id: Optional[str] = None,
+) -> None:
+    """Emit an agent.step.complete event.
+
+    Args:
+        step_name:      Human-readable step name (should match emit_step_start).
+        start_time:     Monotonic time returned by emit_step_start.
+        output_summary: Optional short description of the step outcome.
+        session_id:     Chat session identifier.
+        step_id:        Optional unique identifier for this step instance.
+    """
+    duration_ms = (time.monotonic() - start_time) * 1000
+    _try_publish(
+        "agent.step.complete",
+        {
+            "step_id": step_id or step_name,
+            "step_name": step_name,
+            "output_summary": _truncate(output_summary) if output_summary else None,
+            "duration_ms": round(duration_ms, 1),
+            "session_id": session_id,
+            "ts": time.time(),
+        },
+    )
+
+
+def emit_tool_call(
+    tool_name: str,
+    arguments: Any,
+    session_id: Optional[str] = None,
+) -> float:
+    """Emit an agent.tool.call event and return start time.
+
+    Sensitive argument values are automatically redacted before emission.
+
+    Args:
+        tool_name:  Name of the tool being called.
+        arguments:  Raw tool arguments (may contain sensitive data).
+        session_id: Chat session identifier.
+
+    Returns:
+        Monotonic start time to be passed to emit_tool_result.
+    """
+    start_time = time.monotonic()
+    _try_publish(
+        "agent.tool.call",
+        {
+            "tool_name": tool_name,
+            "arguments": sanitize_arguments(arguments),
+            "session_id": session_id,
+            "ts": time.time(),
+        },
+    )
+    return start_time
+
+
+def emit_tool_result(
+    tool_name: str,
+    result: Any,
+    start_time: float,
+    success: bool = True,
+    bridge: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> None:
+    """Emit an agent.tool.result event.
+
+    Args:
+        tool_name:  Name of the tool that was called.
+        result:     The tool result (will be truncated for WebSocket safety).
+        start_time: Monotonic time returned by emit_tool_call.
+        success:    Whether the tool call succeeded.
+        bridge:     Optional MCP bridge identifier.
+        session_id: Chat session identifier.
+    """
+    duration_ms = (time.monotonic() - start_time) * 1000
+    _try_publish(
+        "agent.tool.result",
+        {
+            "tool_name": tool_name,
+            "result_summary": _truncate(result),
+            "duration_ms": round(duration_ms, 1),
+            "success": success,
+            "bridge": bridge,
+            "session_id": session_id,
+            "ts": time.time(),
+        },
+    )
+
+
+def emit_llm_chunk(
+    chunk: str,
+    session_id: Optional[str] = None,
+) -> None:
+    """Emit an agent.llm.chunk event for a streaming token.
+
+    This is intentionally lightweight — no start_time or duration tracking.
+
+    Args:
+        chunk:      The token or partial token string from the LLM.
+        session_id: Chat session identifier.
+    """
+    _try_publish(
+        "agent.llm.chunk",
+        {
+            "chunk": chunk,
+            "session_id": session_id,
+            "ts": time.time(),
+        },
+    )
+
+
+def emit_plan(
+    steps: list[Any],
+    session_id: Optional[str] = None,
+) -> None:
+    """Emit an agent.plan event with a list of plan step descriptions.
+
+    Args:
+        steps:      List of step dicts or strings from the overseer.
+        session_id: Chat session identifier.
+    """
+    # Normalise to plain strings for WebSocket safety
+    step_labels: list[str] = []
+    for step in steps:
+        if isinstance(step, dict):
+            label = step.get("description") or step.get("name") or str(step)
+        else:
+            label = str(step)
+        step_labels.append(_truncate(label, 200))
+
+    _try_publish(
+        "agent.plan",
+        {
+            "steps": step_labels,
+            "step_count": len(step_labels),
+            "session_id": session_id,
+            "ts": time.time(),
+        },
+    )

--- a/autobot-backend/chat_workflow/cot_events.py
+++ b/autobot-backend/chat_workflow/cot_events.py
@@ -110,10 +110,9 @@ def _try_publish(event_type: str, payload: dict) -> None:
     try:
         from event_manager import event_manager
 
-        coro = event_manager.publish(event_type, payload)
         try:
             loop = asyncio.get_running_loop()
-            task = loop.create_task(coro)
+            task = loop.create_task(event_manager.publish(event_type, payload))
             task.add_done_callback(
                 lambda t: logger.debug("cot_events: publish error: %s", t.exception())
                 if not t.cancelled() and t.exception()

--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -642,6 +642,12 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
         messages.append(deny_msg)
         if stream_cb:
             stream_cb(deny_msg)
+        emit_step_complete(
+            "execute_tools",
+            _cot_exec_start,
+            output_summary="approval denied — tools skipped",
+            session_id=session_id,
+        )
         return {
             "should_continue": False,
             "workflow_messages": messages,

--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -436,17 +436,31 @@ async def generate_response(state: ChatState, config: RunnableConfig) -> dict:
 
     Delegates to the manager's continuation loop logic for one iteration.
     Streams WorkflowMessage chunks to frontend via stream_callback.
+
+    Issue #3232: emits agent.step.start / agent.step.complete CoT events.
     """
     if state.get("error"):
         return {}
 
     import aiohttp
 
+    from chat_workflow.cot_events import emit_step_complete, emit_step_start
+
     manager = config["configurable"]["manager"]
     stream_cb = config["configurable"].get("stream_callback")
     messages = list(state.get("workflow_messages", []))
     iteration = state.get("iteration_count", 0) + 1
     ctx = _build_llm_iteration_context(state)
+    session_id = state.get("session_id")
+
+    # Issue #3232: emit step-level CoT event so frontend can track LLM reasoning.
+    step_name = f"llm_iteration_{iteration}"
+    _cot_start = emit_step_start(
+        step_name,
+        session_id=session_id,
+        agent_type="chat_workflow",
+        step_id=step_name,
+    )
 
     try:
         messages, llm_response, should_continue = await _run_llm_iteration(
@@ -458,12 +472,32 @@ async def generate_response(state: ChatState, config: RunnableConfig) -> dict:
         messages.append(error_msg)
         if stream_cb:
             stream_cb(error_msg)
+        emit_step_complete(
+            step_name, _cot_start, output_summary=f"LLM error: {exc}", session_id=session_id
+        )
         return {"error": str(exc), "workflow_messages": messages}
 
     all_responses = list(state.get("all_llm_responses", []))
     if llm_response:
         all_responses.append(llm_response)
     parsed_tool_calls = list(ctx.execution_history) if ctx.execution_history else []
+
+    # Issue #3232: emit plan event when the response contains a planning block.
+    if parsed_tool_calls:
+        from chat_workflow.cot_events import emit_plan
+
+        emit_plan(parsed_tool_calls, session_id=session_id)
+
+    emit_step_complete(
+        step_name,
+        _cot_start,
+        output_summary=(
+            f"{len(parsed_tool_calls)} tool call(s) queued"
+            if parsed_tool_calls
+            else "LLM response complete"
+        ),
+        session_id=session_id,
+    )
 
     return {
         "llm_response": llm_response or "",
@@ -572,19 +606,32 @@ async def request_approval(state: ChatState, config: RunnableConfig) -> dict:
 
 
 async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
-    """Execute approved tool calls."""
+    """Execute approved tool calls.
+
+    Issue #3232: emits agent.step.start/complete around the tool execution
+    block so the frontend reasoning trace shows the execution phase.
+    """
     if state.get("error"):
         return {}
+
+    from chat_workflow.cot_events import emit_step_complete, emit_step_start
 
     manager = config["configurable"]["manager"]
     stream_cb = config["configurable"].get("stream_callback")
     messages = list(state.get("workflow_messages", []))
+    session_id = state.get("session_id")
 
     decision = state.get("approval_decision")
     tool_calls = state.get("tool_calls", [])
 
     if not tool_calls:
         return {"workflow_messages": messages}
+
+    _cot_exec_start = emit_step_start(
+        "execute_tools",
+        session_id=session_id,
+        agent_type="chat_workflow",
+    )
 
     # If approval was needed and denied, skip execution
     if decision and not decision.get("approved", False):
@@ -659,6 +706,16 @@ async def execute_tools(state: ChatState, config: RunnableConfig) -> dict:
         messages.append(abort_msg)
         if stream_cb:
             stream_cb(abort_msg)
+
+    # Issue #3232: emit step complete for the execute_tools block.
+    emit_step_complete(
+        "execute_tools",
+        _cot_exec_start,
+        output_summary=(
+            f"tools executed; loop_aborted={tool_loop_count >= _LOOP_ABORT_THRESHOLD}"
+        ),
+        session_id=session_id,
+    )
 
     return {
         "should_continue": not break_loop,

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -130,7 +130,11 @@ class MCPDispatcher:
         return any(pattern in tool_name for pattern in self._ADMIN_ONLY_TOOLS)
 
     async def dispatch(
-        self, tool_name: str, arguments: dict, role: str = "user"
+        self,
+        tool_name: str,
+        arguments: dict,
+        role: str = "user",
+        session_id: Optional[str] = None,
     ) -> dict:
         """Dispatch a tool call to its registered MCP bridge.
 
@@ -176,7 +180,7 @@ class MCPDispatcher:
         endpoint = tool.get("endpoint", "")
 
         # Issue #3232: emit CoT events around bridge call.
-        _cot_start = emit_tool_call(tool_name, arguments)
+        _cot_start = emit_tool_call(tool_name, arguments, session_id=session_id)
         result = await self._call_bridge(tool_name, bridge, endpoint, arguments)
         emit_tool_result(
             tool_name,
@@ -184,6 +188,7 @@ class MCPDispatcher:
             _cot_start,
             success=result.get("success", False),
             bridge=bridge,
+            session_id=session_id,
         )
         return result
 

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -137,6 +137,9 @@ class MCPDispatcher:
         Refreshes the tool cache if stale (TTL-based, #2598).
         Rejects admin-only tools when role != "admin" (#2598).
 
+        Issue #3232: emits agent.tool.call before dispatch and
+        agent.tool.result after, with sensitive argument redaction.
+
         Args:
             tool_name: Tool name from the LLM tool call.
             arguments: Tool arguments dict.
@@ -145,6 +148,8 @@ class MCPDispatcher:
         Returns:
             Dict with keys: success (bool), result (str | dict), bridge (str | None).
         """
+        from chat_workflow.cot_events import emit_tool_call, emit_tool_result
+
         await self._ensure_cache_fresh()
 
         if role != "admin" and self._is_admin_only(tool_name):
@@ -169,7 +174,18 @@ class MCPDispatcher:
 
         bridge = tool.get("bridge", "unknown")
         endpoint = tool.get("endpoint", "")
-        return await self._call_bridge(tool_name, bridge, endpoint, arguments)
+
+        # Issue #3232: emit CoT events around bridge call.
+        _cot_start = emit_tool_call(tool_name, arguments)
+        result = await self._call_bridge(tool_name, bridge, endpoint, arguments)
+        emit_tool_result(
+            tool_name,
+            result.get("result", ""),
+            _cot_start,
+            success=result.get("success", False),
+            bridge=bridge,
+        )
+        return result
 
     async def _call_bridge(
         self, tool_name: str, bridge: str, endpoint: str, arguments: dict

--- a/autobot-backend/type_defs/common.py
+++ b/autobot-backend/type_defs/common.py
@@ -126,6 +126,14 @@ SKIP_WEBSOCKET_PERSISTENCE_TYPES: frozenset = frozenset(
         MessageTypes.COMMAND_APPROVAL_REQUEST,
         # Terminal interpretation - explicitly persisted by llm_handler.py
         MessageTypes.TERMINAL_INTERPRETATION,
+        # Issue #3232: Chain-of-thought reasoning trace events — ephemeral, not
+        # persisted to chat history since they are live-stream-only signals.
+        "agent.step.start",
+        "agent.step.complete",
+        "agent.tool.call",
+        "agent.tool.result",
+        "agent.llm.chunk",
+        "agent.plan",
     ]
 )
 

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -78,6 +78,13 @@
           @loading-timeout="handleContentLoadingTimeout"
           class="flex-1 min-h-0 flex flex-col overflow-y-auto"
         >
+          <!-- Issue #3232: Live reasoning trace panel above the chat input -->
+          <ReasoningTrace
+            v-if="activeTab === 'chat'"
+            :entries="cotEntries"
+            :is-active="cotIsActive"
+            class="mx-2 mt-1"
+          />
           <ChatTabContent
             :active-tab="activeTab"
             :current-session-id="store.currentSessionId"
@@ -184,6 +191,9 @@ import WorkflowProgressWidget from '@/components/workflow/WorkflowProgressWidget
 import VoiceConversationOverlay from './VoiceConversationOverlay.vue'
 import VoiceConversationPanel from './VoiceConversationPanel.vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
+// Issue #3232: chain-of-thought reasoning trace
+import ReasoningTrace from './ReasoningTrace.vue'
+import { useReasoningTrace } from '@/composables/useReasoningTrace'
 
 // i18n
 const { t } = useI18n()
@@ -192,6 +202,13 @@ const { t } = useI18n()
 const store = useChatStore()
 const controller = useChatController()
 const appStore = useAppStore()
+
+// Issue #3232: Chain-of-thought reasoning trace
+const {
+  entries: cotEntries,
+  isActive: cotIsActive,
+  clear: cotClear,
+} = useReasoningTrace(store.currentSessionId)
 
 // Voice output (#928)
 const {
@@ -863,8 +880,23 @@ watch(() => store.currentSessionId, (newSessionId, oldSessionId) => {
     // Without this the TTS watcher fires, sees current.id !== _lastStreamingMsgId,
     // resets _lastSpokenIdx = 0, and re-speaks the full existing message.
     _primeTtsCursor()
+
+    // Issue #3232: clear reasoning trace on session switch so stale entries
+    // from the previous session are not shown in the new one.
+    cotClear()
   }
 })
+
+// Issue #3232: clear reasoning trace when a new user turn begins (isTyping goes
+// from false → true, meaning the backend just started processing a new message).
+watch(
+  () => store.isTyping,
+  (nowTyping, wasTyping) => {
+    if (nowTyping && !wasTyping) {
+      cotClear()
+    }
+  },
+)
 
 // Streaming sentence-level TTS (#1319)
 // During LLM streaming: extract completed sentences and send each to TTS immediately.

--- a/autobot-frontend/src/components/chat/ReasoningTrace.vue
+++ b/autobot-frontend/src/components/chat/ReasoningTrace.vue
@@ -1,0 +1,279 @@
+<template>
+  <!-- Issue #3232: Collapsible reasoning trace panel -->
+  <div
+    v-if="entries.length > 0 || isActive"
+    class="reasoning-trace"
+    :class="{ 'reasoning-trace--active': isActive }"
+  >
+    <!-- Header row with toggle -->
+    <button
+      class="reasoning-trace__header"
+      :aria-expanded="expanded"
+      :aria-label="$t('reasoningTrace.toggleLabel')"
+      @click="expanded = !expanded"
+    >
+      <span class="reasoning-trace__icon" aria-hidden="true">
+        <i v-if="isActive" class="fas fa-circle-notch fa-spin reasoning-trace__spin-icon"></i>
+        <i v-else class="fas fa-brain"></i>
+      </span>
+      <span class="reasoning-trace__title">{{ $t('reasoningTrace.title') }}</span>
+      <span class="reasoning-trace__count">{{ entries.length }}</span>
+      <i
+        class="fas reasoning-trace__chevron"
+        :class="expanded ? 'fa-chevron-up' : 'fa-chevron-down'"
+        aria-hidden="true"
+      ></i>
+    </button>
+
+    <!-- Collapsible body -->
+    <transition name="trace-collapse">
+      <div v-if="expanded" class="reasoning-trace__body" role="list">
+        <div
+          v-for="entry in entries"
+          :key="entry.id"
+          class="reasoning-trace__entry"
+          :class="`reasoning-trace__entry--${entry.kind}`"
+          role="listitem"
+        >
+          <span class="reasoning-trace__entry-icon" aria-hidden="true">
+            <i :class="iconForKind(entry.kind)"></i>
+          </span>
+          <span class="reasoning-trace__entry-body">
+            <span class="reasoning-trace__entry-label">{{ entry.label }}</span>
+            <span
+              v-if="entry.detail"
+              class="reasoning-trace__entry-detail"
+            >{{ entry.detail }}</span>
+          </span>
+          <span
+            v-if="entry.durationMs != null"
+            class="reasoning-trace__entry-duration"
+          >{{ formatDuration(entry.durationMs) }}</span>
+          <span
+            v-if="entry.kind === 'tool_result'"
+            class="reasoning-trace__entry-status"
+            :class="entry.success ? 'reasoning-trace__entry-status--ok' : 'reasoning-trace__entry-status--error'"
+            :aria-label="entry.success ? $t('reasoningTrace.success') : $t('reasoningTrace.error')"
+          >
+            <i :class="entry.success ? 'fas fa-check' : 'fas fa-times'" aria-hidden="true"></i>
+          </span>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { TraceEntry, TraceEntryKind } from '@/composables/useReasoningTrace'
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface Props {
+  entries: TraceEntry[]
+  isActive?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  isActive: false,
+})
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+const expanded = ref(true)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function iconForKind(kind: TraceEntryKind): string {
+  const map: Record<TraceEntryKind, string> = {
+    step_start: 'fas fa-play-circle',
+    step_complete: 'fas fa-check-circle',
+    tool_call: 'fas fa-wrench',
+    tool_result: 'fas fa-reply',
+    llm_chunk: 'fas fa-comment-dots',
+    plan: 'fas fa-list-ol',
+  }
+  return map[kind] ?? 'fas fa-circle'
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+</script>
+
+<style scoped>
+.reasoning-trace {
+  border: 1px solid var(--color-border, #334155);
+  border-radius: 0.5rem;
+  margin-bottom: 0.5rem;
+  background: var(--color-bg-subtle, #0f172a);
+  overflow: hidden;
+  font-size: 0.75rem;
+}
+
+.reasoning-trace--active {
+  border-color: var(--color-electric-500, #6366f1);
+}
+
+/* Header */
+.reasoning-trace__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.4rem 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted, #94a3b8);
+  text-align: left;
+  user-select: none;
+}
+
+.reasoning-trace__header:hover {
+  color: var(--color-text, #e2e8f0);
+}
+
+.reasoning-trace__icon {
+  font-size: 0.85rem;
+  color: var(--color-electric-400, #818cf8);
+  width: 1rem;
+  text-align: center;
+}
+
+.reasoning-trace__spin-icon {
+  animation: fa-spin 1.2s linear infinite;
+}
+
+.reasoning-trace__title {
+  flex: 1;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.reasoning-trace__count {
+  font-size: 0.7rem;
+  background: var(--color-border, #334155);
+  border-radius: 9999px;
+  padding: 0 0.4rem;
+  line-height: 1.4rem;
+}
+
+.reasoning-trace__chevron {
+  font-size: 0.7rem;
+  opacity: 0.6;
+}
+
+/* Body */
+.reasoning-trace__body {
+  border-top: 1px solid var(--color-border, #334155);
+  max-height: 18rem;
+  overflow-y: auto;
+  padding: 0.25rem 0;
+}
+
+/* Entries */
+.reasoning-trace__entry {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.2rem 0.75rem;
+  line-height: 1.5;
+  border-left: 2px solid transparent;
+}
+
+.reasoning-trace__entry--step_start {
+  border-left-color: var(--color-electric-400, #818cf8);
+}
+
+.reasoning-trace__entry--step_complete {
+  border-left-color: var(--color-green-400, #4ade80);
+}
+
+.reasoning-trace__entry--tool_call {
+  border-left-color: var(--color-yellow-400, #facc15);
+}
+
+.reasoning-trace__entry--tool_result {
+  border-left-color: var(--color-blue-400, #60a5fa);
+}
+
+.reasoning-trace__entry--llm_chunk {
+  border-left-color: var(--color-purple-400, #c084fc);
+  font-family: monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.reasoning-trace__entry--plan {
+  border-left-color: var(--color-orange-400, #fb923c);
+}
+
+.reasoning-trace__entry-icon {
+  color: var(--color-text-muted, #94a3b8);
+  width: 0.9rem;
+  text-align: center;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.reasoning-trace__entry-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.reasoning-trace__entry-label {
+  color: var(--color-text, #e2e8f0);
+  overflow-wrap: anywhere;
+}
+
+.reasoning-trace__entry-detail {
+  display: block;
+  color: var(--color-text-muted, #94a3b8);
+  font-size: 0.7rem;
+  overflow-wrap: anywhere;
+}
+
+.reasoning-trace__entry-duration {
+  color: var(--color-text-muted, #94a3b8);
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  margin-left: auto;
+  padding-left: 0.25rem;
+}
+
+.reasoning-trace__entry-status {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  padding-left: 0.25rem;
+}
+
+.reasoning-trace__entry-status--ok {
+  color: var(--color-green-400, #4ade80);
+}
+
+.reasoning-trace__entry-status--error {
+  color: var(--color-red-400, #f87171);
+}
+
+/* Collapse transition */
+.trace-collapse-enter-active,
+.trace-collapse-leave-active {
+  transition: max-height 0.2s ease, opacity 0.2s ease;
+  max-height: 18rem;
+  overflow: hidden;
+}
+
+.trace-collapse-enter-from,
+.trace-collapse-leave-to {
+  max-height: 0;
+  opacity: 0;
+}
+</style>

--- a/autobot-frontend/src/components/chat/index.ts
+++ b/autobot-frontend/src/components/chat/index.ts
@@ -23,3 +23,5 @@ export { default as ChatTabs } from './ChatTabs.vue'
 export { default as ChatTabContent } from './ChatTabContent.vue'
 export { default as ChatFilePanel } from './ChatFilePanel.vue'
 export { default as DeleteConversationDialog } from './DeleteConversationDialog.vue'
+// Issue #3232: reasoning trace
+export { default as ReasoningTrace } from './ReasoningTrace.vue'

--- a/autobot-frontend/src/composables/useReasoningTrace.ts
+++ b/autobot-frontend/src/composables/useReasoningTrace.ts
@@ -138,7 +138,7 @@ export function useReasoningTrace(sessionId?: string | null): UseReasoningTraceR
     if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
       return
     }
-    if (activeSteps.value > 0) activeSteps.value--
+    activeSteps.value = Math.max(0, activeSteps.value - 1)
     push({
       id: nextId(),
       kind: 'step_complete',

--- a/autobot-frontend/src/composables/useReasoningTrace.ts
+++ b/autobot-frontend/src/composables/useReasoningTrace.ts
@@ -20,7 +20,7 @@
  *   // entries is a reactive array of TraceEntry[]
  */
 
-import { ref, computed, onUnmounted, getCurrentInstance, type Ref, type ComputedRef } from 'vue'
+import { ref, computed, isRef, onUnmounted, getCurrentInstance, type Ref, type ComputedRef, type MaybeRef } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import globalWebSocketService from '@/services/GlobalWebSocketService'
 
@@ -96,7 +96,16 @@ const COT_EVENT_TYPES = [
 // Composable
 // ---------------------------------------------------------------------------
 
-export function useReasoningTrace(sessionId?: string | null): UseReasoningTraceReturn {
+export function useReasoningTrace(
+  sessionId?: MaybeRef<string | null | undefined>,
+): UseReasoningTraceReturn {
+  // Normalise to a computed ref so that reactive values (e.g. computed(() =>
+  // store.currentSessionId)) are read at handler call-time, not frozen at
+  // setup time. Plain string / null / undefined values still work unchanged.
+  const _sessionId = isRef(sessionId)
+    ? sessionId
+    : computed(() => sessionId as string | null | undefined)
+
   const entries = ref<TraceEntry[]>([])
   const activeSteps = ref(0)
   const unsubscribers: Array<() => void> = []
@@ -121,7 +130,7 @@ export function useReasoningTrace(sessionId?: string | null): UseReasoningTraceR
 
   function handleStepStart(payload: RawPayload): void {
     // Filter to the relevant session when one is specified.
-    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+    if (_sessionId.value && payload['session_id'] && payload['session_id'] !== _sessionId.value) {
       return
     }
     activeSteps.value++
@@ -135,7 +144,7 @@ export function useReasoningTrace(sessionId?: string | null): UseReasoningTraceR
   }
 
   function handleStepComplete(payload: RawPayload): void {
-    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+    if (_sessionId.value && payload['session_id'] && payload['session_id'] !== _sessionId.value) {
       return
     }
     activeSteps.value = Math.max(0, activeSteps.value - 1)
@@ -150,7 +159,7 @@ export function useReasoningTrace(sessionId?: string | null): UseReasoningTraceR
   }
 
   function handleToolCall(payload: RawPayload): void {
-    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+    if (_sessionId.value && payload['session_id'] && payload['session_id'] !== _sessionId.value) {
       return
     }
     push({
@@ -162,7 +171,7 @@ export function useReasoningTrace(sessionId?: string | null): UseReasoningTraceR
   }
 
   function handleToolResult(payload: RawPayload): void {
-    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+    if (_sessionId.value && payload['session_id'] && payload['session_id'] !== _sessionId.value) {
       return
     }
     push({
@@ -177,7 +186,7 @@ export function useReasoningTrace(sessionId?: string | null): UseReasoningTraceR
   }
 
   function handleLlmChunk(payload: RawPayload): void {
-    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+    if (_sessionId.value && payload['session_id'] && payload['session_id'] !== _sessionId.value) {
       return
     }
     // For chunk events we update the last llm_chunk entry in-place to avoid
@@ -197,7 +206,7 @@ export function useReasoningTrace(sessionId?: string | null): UseReasoningTraceR
   }
 
   function handlePlan(payload: RawPayload): void {
-    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+    if (_sessionId.value && payload['session_id'] && payload['session_id'] !== _sessionId.value) {
       return
     }
     const steps = Array.isArray(payload['steps'])

--- a/autobot-frontend/src/composables/useReasoningTrace.ts
+++ b/autobot-frontend/src/composables/useReasoningTrace.ts
@@ -1,0 +1,265 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * Reasoning Trace Composable (#3232)
+ *
+ * Subscribes to agent chain-of-thought WebSocket events and exposes a
+ * reactive list of trace entries for the ReasoningTrace component.
+ *
+ * Event types handled:
+ *   agent.step.start    – a graph node is beginning
+ *   agent.step.complete – a graph node has finished
+ *   agent.tool.call     – a tool call is about to dispatch
+ *   agent.tool.result   – a tool call result has arrived
+ *   agent.llm.chunk     – a streaming LLM token chunk
+ *   agent.plan          – plan decomposition from the overseer
+ *
+ * Usage:
+ *   const { entries, isActive, clear } = useReasoningTrace(sessionId)
+ *   // entries is a reactive array of TraceEntry[]
+ */
+
+import { ref, computed, onUnmounted, getCurrentInstance, type Ref, type ComputedRef } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+import globalWebSocketService from '@/services/GlobalWebSocketService'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TraceEntryKind =
+  | 'step_start'
+  | 'step_complete'
+  | 'tool_call'
+  | 'tool_result'
+  | 'llm_chunk'
+  | 'plan'
+
+export interface TraceEntry {
+  id: string
+  kind: TraceEntryKind
+  label: string
+  detail?: string
+  durationMs?: number
+  success?: boolean
+  ts: number
+}
+
+export interface UseReasoningTraceReturn {
+  /** Reactive list of trace entries for the current response turn. */
+  entries: Ref<TraceEntry[]>
+  /** True while at least one step is still in progress. */
+  isActive: ComputedRef<boolean>
+  /** Clear all entries (called when a new user message is sent). */
+  clear: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum number of entries kept in memory before trimming the head. */
+const MAX_ENTRIES = 200
+
+// ---------------------------------------------------------------------------
+// Logger
+// ---------------------------------------------------------------------------
+
+const logger = createLogger('useReasoningTrace')
+
+// ---------------------------------------------------------------------------
+// ID generation
+// ---------------------------------------------------------------------------
+
+let _seq = 0
+function nextId(): string {
+  return `cot-${++_seq}`
+}
+
+// ---------------------------------------------------------------------------
+// Event type → handler mapping
+// ---------------------------------------------------------------------------
+
+type RawPayload = Record<string, unknown>
+
+const COT_EVENT_TYPES = [
+  'agent.step.start',
+  'agent.step.complete',
+  'agent.tool.call',
+  'agent.tool.result',
+  'agent.llm.chunk',
+  'agent.plan',
+] as const
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+export function useReasoningTrace(sessionId?: string | null): UseReasoningTraceReturn {
+  const entries = ref<TraceEntry[]>([])
+  const activeSteps = ref(0)
+  const unsubscribers: Array<() => void> = []
+
+  const isActive = computed(() => activeSteps.value > 0)
+
+  function clear(): void {
+    entries.value = []
+    activeSteps.value = 0
+  }
+
+  function push(entry: TraceEntry): void {
+    entries.value.push(entry)
+    if (entries.value.length > MAX_ENTRIES) {
+      entries.value = entries.value.slice(-MAX_ENTRIES)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Handler per event type
+  // -------------------------------------------------------------------------
+
+  function handleStepStart(payload: RawPayload): void {
+    // Filter to the relevant session when one is specified.
+    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+      return
+    }
+    activeSteps.value++
+    push({
+      id: nextId(),
+      kind: 'step_start',
+      label: String(payload['step_name'] ?? 'step'),
+      detail: payload['agent_type'] ? String(payload['agent_type']) : undefined,
+      ts: Number(payload['ts'] ?? Date.now() / 1000),
+    })
+  }
+
+  function handleStepComplete(payload: RawPayload): void {
+    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+      return
+    }
+    if (activeSteps.value > 0) activeSteps.value--
+    push({
+      id: nextId(),
+      kind: 'step_complete',
+      label: String(payload['step_name'] ?? 'step'),
+      detail: payload['output_summary'] ? String(payload['output_summary']) : undefined,
+      durationMs: payload['duration_ms'] != null ? Number(payload['duration_ms']) : undefined,
+      ts: Number(payload['ts'] ?? Date.now() / 1000),
+    })
+  }
+
+  function handleToolCall(payload: RawPayload): void {
+    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+      return
+    }
+    push({
+      id: nextId(),
+      kind: 'tool_call',
+      label: String(payload['tool_name'] ?? 'tool'),
+      ts: Number(payload['ts'] ?? Date.now() / 1000),
+    })
+  }
+
+  function handleToolResult(payload: RawPayload): void {
+    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+      return
+    }
+    push({
+      id: nextId(),
+      kind: 'tool_result',
+      label: String(payload['tool_name'] ?? 'tool'),
+      detail: payload['result_summary'] ? String(payload['result_summary']) : undefined,
+      durationMs: payload['duration_ms'] != null ? Number(payload['duration_ms']) : undefined,
+      success: payload['success'] !== false,
+      ts: Number(payload['ts'] ?? Date.now() / 1000),
+    })
+  }
+
+  function handleLlmChunk(payload: RawPayload): void {
+    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+      return
+    }
+    // For chunk events we update the last llm_chunk entry in-place to avoid
+    // creating one entry per token (which would be thousands per response).
+    const last = entries.value[entries.value.length - 1]
+    if (last && last.kind === 'llm_chunk') {
+      last.label += String(payload['chunk'] ?? '')
+      last.ts = Number(payload['ts'] ?? Date.now() / 1000)
+    } else {
+      push({
+        id: nextId(),
+        kind: 'llm_chunk',
+        label: String(payload['chunk'] ?? ''),
+        ts: Number(payload['ts'] ?? Date.now() / 1000),
+      })
+    }
+  }
+
+  function handlePlan(payload: RawPayload): void {
+    if (sessionId && payload['session_id'] && payload['session_id'] !== sessionId) {
+      return
+    }
+    const steps = Array.isArray(payload['steps'])
+      ? (payload['steps'] as string[])
+      : []
+    push({
+      id: nextId(),
+      kind: 'plan',
+      label: `Plan (${steps.length} steps)`,
+      detail: steps.slice(0, 5).join(' → '),
+      ts: Number(payload['ts'] ?? Date.now() / 1000),
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Map event type string → handler
+  // -------------------------------------------------------------------------
+
+  const handlerMap: Record<string, (payload: RawPayload) => void> = {
+    'agent.step.start': handleStepStart,
+    'agent.step.complete': handleStepComplete,
+    'agent.tool.call': handleToolCall,
+    'agent.tool.result': handleToolResult,
+    'agent.llm.chunk': handleLlmChunk,
+    'agent.plan': handlePlan,
+  }
+
+  // -------------------------------------------------------------------------
+  // Subscribe via GlobalWebSocketService
+  // -------------------------------------------------------------------------
+
+  for (const eventType of COT_EVENT_TYPES) {
+    const unsubscribe = globalWebSocketService.on(eventType, (raw: unknown) => {
+      try {
+        // GlobalWebSocketService delivers the whole WebSocket message object.
+        // EventManager publishes: { type: eventType, payload: {...} }
+        const msg = raw as Record<string, unknown>
+        const payload =
+          (msg['payload'] as RawPayload | undefined) ??
+          (msg as RawPayload)
+        handlerMap[eventType]?.(payload)
+      } catch (err) {
+        logger.error(`Error handling ${eventType}:`, err)
+      }
+    })
+    unsubscribers.push(unsubscribe)
+  }
+
+  // -------------------------------------------------------------------------
+  // Auto-cleanup on component unmount
+  // -------------------------------------------------------------------------
+
+  const instance = getCurrentInstance()
+  if (instance) {
+    onUnmounted(() => {
+      unsubscribers.forEach((u) => u())
+    })
+  } else {
+    logger.warn('useReasoningTrace: not inside a Vue component, cleanup must be manual')
+  }
+
+  return { entries, isActive, clear }
+}
+
+export default useReasoningTrace

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -6099,5 +6099,11 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
+  },
+  "reasoningTrace": {
+    "title": "Reasoning trace",
+    "toggleLabel": "Toggle reasoning trace panel",
+    "success": "Success",
+    "error": "Error"
   }
 }

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -6110,5 +6110,11 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
+  },
+  "reasoningTrace": {
+    "title": "Reasoning-Trace",
+    "toggleLabel": "Reasoning-Trace-Panel umschalten",
+    "success": "Erfolg",
+    "error": "Fehler"
   }
 }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -6285,5 +6285,11 @@
     "slmAdmin": "SLM Admin",
     "slmAdminTitle": "Open SLM Admin Panel",
     "profileSettings": "Profile Settings"
+  },
+  "reasoningTrace": {
+    "title": "Reasoning trace",
+    "toggleLabel": "Toggle reasoning trace panel",
+    "success": "Success",
+    "error": "Error"
   }
 }

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -6110,5 +6110,11 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
+  },
+  "reasoningTrace": {
+    "title": "Traza de razonamiento",
+    "toggleLabel": "Alternar panel de traza de razonamiento",
+    "success": "Exitoso",
+    "error": "Error"
   }
 }

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -1623,5 +1623,11 @@
       "clearSelection": "Clear",
       "clearSelectionTitle": "Clear selection"
     }
+  },
+  "reasoningTrace": {
+    "title": "Reasoning trace",
+    "toggleLabel": "Toggle reasoning trace panel",
+    "success": "Success",
+    "error": "Error"
   }
 }

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -6110,5 +6110,11 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
+  },
+  "reasoningTrace": {
+    "title": "Trace de raisonnement",
+    "toggleLabel": "Basculer le panneau de trace de raisonnement",
+    "success": "Succes",
+    "error": "Erreur"
   }
 }

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -1623,5 +1623,11 @@
       "clearSelection": "Clear",
       "clearSelectionTitle": "Clear selection"
     }
+  },
+  "reasoningTrace": {
+    "title": "Reasoning trace",
+    "toggleLabel": "Toggle reasoning trace panel",
+    "success": "Success",
+    "error": "Error"
   }
 }

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -6110,5 +6110,11 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
+  },
+  "reasoningTrace": {
+    "title": "Reasoning trace",
+    "toggleLabel": "Toggle reasoning trace panel",
+    "success": "Veiksmigs",
+    "error": "Kluda"
   }
 }

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -6110,5 +6110,11 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
+  },
+  "reasoningTrace": {
+    "title": "Slad rozumowania",
+    "toggleLabel": "Przelacz panel sladu rozumowania",
+    "success": "Sukces",
+    "error": "Blad"
   }
 }

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -6110,5 +6110,11 @@
     "desktop": "Desktop",
     "customDashboard": "Custom Dashboard",
     "agentRegistry": "Agents"
+  },
+  "reasoningTrace": {
+    "title": "Rastro de raciocinio",
+    "toggleLabel": "Alternar painel de rastro de raciocinio",
+    "success": "Sucesso",
+    "error": "Erro"
   }
 }

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -1623,5 +1623,11 @@
       "clearSelection": "Clear",
       "clearSelectionTitle": "Clear selection"
     }
+  },
+  "reasoningTrace": {
+    "title": "Reasoning trace",
+    "toggleLabel": "Toggle reasoning trace panel",
+    "success": "Success",
+    "error": "Error"
   }
 }


### PR DESCRIPTION
Closes #3232

Streams agent reasoning events (tool calls, LLM steps, plan decomposition) to the frontend over the existing WebSocket channel.

**Backend:**
- `chat_workflow/cot_events.py` (new): Fire-and-forget CoT event emitters (`emit_step_start/complete`, `emit_tool_call/result`, `emit_llm_chunk`, `emit_plan`) with sensitive-key sanitization
- `chat_workflow/graph.py`: Emits `agent.step.start/complete` and `agent.plan` around each LLM iteration; `agent.step.*` around tool execution
- `services/mcp_dispatch.py`: Emits `agent.tool.call` before and `agent.tool.result` after every MCP bridge call
- `api/websockets.py`: 6 new formatter entries for all CoT event types
- `type_defs/common.py`: All 6 CoT types added to `SKIP_WEBSOCKET_PERSISTENCE_TYPES` (ephemeral, not stored in chat history)

**Frontend:**
- `composables/useReasoningTrace.ts` (new): Vue composable subscribing to all 6 CoT event types; collapses `agent.llm.chunk` in-place, max 200 entries
- `components/chat/ReasoningTrace.vue` (new): Collapsible panel with color-coded entries, spinning indicator while active, duration display, success/error icons
- `ChatInterface.vue`: Wires `useReasoningTrace`, places panel above chat content, clears on session switch and new user turn
- i18n keys added to all 11 locales