### PR TITLE
fix(knowledge): resolve async Redis client coroutine ping error

### DIFF
--- a/autobot-backend/autobot_memory_graph/property_graph.py
+++ b/autobot-backend/autobot_memory_graph/property_graph.py
@@ -135,7 +135,7 @@ class PropertyGraph:
     async def initialize(self) -> None:
         """Acquire async Redis connection."""
         if self._redis is None:
-            self._redis = get_redis_client(async_client=True, database=self._database)
+            self._redis = await get_redis_client(async_client=True, database=self._database)
         logger.info("PropertyGraph initialized (db=%s)", self._database)
 
     # ------------------------------------------------------------------

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1053,7 +1053,7 @@ async def _wire_npu_task_queue() -> None:
         from services.npu_worker_manager import get_worker_manager
         from utils.task_queue import get_task_queue
 
-        redis_client = get_redis_client(async_client=True, database="main")
+        redis_client = await get_redis_client(async_client=True, database="main")
         worker_manager = await get_worker_manager(redis_client=redis_client)
         task_queue = get_task_queue()
         task_queue.npu_worker_manager = worker_manager

--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -334,7 +334,7 @@ class KnowledgeBaseCore:
             )
 
             # Get async Redis client using pool manager
-            self.aioredis_client = get_redis_client(
+            self.aioredis_client = await get_redis_client(
                 async_client=True, database="knowledge"
             )
 

--- a/autobot-backend/knowledge/search_components/reranking.py
+++ b/autobot-backend/knowledge/search_components/reranking.py
@@ -321,7 +321,7 @@ class ResultReranker:
             from autobot_shared.redis_client import get_redis_client
             from services.mesh_brain.staleness_propagator import get_staleness_score
 
-            redis = get_redis_client(async_client=True, database="main")
+            redis = await get_redis_client(async_client=True, database="main")
             staleness_map: Dict[str, float] = {}
             for result in results:
                 chunk_id = result.get("chunk_id") or result.get("id", "")

--- a/autobot-backend/services/autoresearch/osint_engine.py
+++ b/autobot-backend/services/autoresearch/osint_engine.py
@@ -483,7 +483,7 @@ class OSINTEngine:
         if self._redis is None:
             from autobot_shared.redis_client import get_redis_client
 
-            self._redis = get_redis_client(async_client=True, database="main")
+            self._redis = await get_redis_client(async_client=True, database="main")
         return self._redis
 
     async def _cache_results(self, results: List[SourceResult]) -> None:

--- a/autobot-backend/services/autoresearch/prompt_optimizer.py
+++ b/autobot-backend/services/autoresearch/prompt_optimizer.py
@@ -463,7 +463,7 @@ class PromptOptimizer:
         if self._redis is None:
             from autobot_shared.redis_client import get_redis_client
 
-            self._redis = get_redis_client(async_client=True, database="main")
+            self._redis = await get_redis_client(async_client=True, database="main")
         return self._redis
 
     async def _save_session(self, session: OptimizationSession) -> None:

--- a/autobot-backend/services/autoresearch/routes.py
+++ b/autobot-backend/services/autoresearch/routes.py
@@ -337,7 +337,7 @@ async def get_variants(
 
     from autobot_shared.redis_client import get_redis_client
 
-    redis = get_redis_client(async_client=True, database="main")
+    redis = await get_redis_client(async_client=True, database="main")
     key = f"autoresearch:prompt_opt:session:{session_id}"
     raw = await redis.get(key)
     if raw is None:
@@ -368,7 +368,7 @@ async def submit_variant_score(
             status_code=400, detail="Invalid session_id or variant_id format"
         )
 
-    redis = get_redis_client(async_client=True, database="main")
+    redis = await get_redis_client(async_client=True, database="main")
     key = f"autoresearch:prompt_review:{session_id}:{variant_id}"
     notify_key = HUMAN_REVIEW_NOTIFY_KEY.format(session_id=session_id, variant_id=variant_id)
     await redis.set(
@@ -398,7 +398,7 @@ async def list_pending_approvals(
 
     from autobot_shared.redis_client import get_redis_client
 
-    redis = get_redis_client(async_client=True, database="main")
+    redis = await get_redis_client(async_client=True, database="main")
     approvals = []
     async for key in redis.scan_iter("autoresearch:approval:pending:*"):
         raw = await redis.get(key)
@@ -431,7 +431,7 @@ async def submit_approval_decision(
     """Submit approve/reject decision for an experiment."""
     from autobot_shared.redis_client import get_redis_client
 
-    redis = get_redis_client(async_client=True, database="main")
+    redis = await get_redis_client(async_client=True, database="main")
     status_key = f"autoresearch:approval:status:{session_id}:{experiment_id}"
     current = await redis.get(status_key)
     if current is None:

--- a/autobot-backend/services/autoresearch/scorers.py
+++ b/autobot-backend/services/autoresearch/scorers.py
@@ -289,7 +289,7 @@ class HumanReviewScorer(PromptScorer):
         if self._redis is None:
             from autobot_shared.redis_client import get_redis_client
 
-            self._redis = get_redis_client(async_client=True, database="main")
+            self._redis = await get_redis_client(async_client=True, database="main")
         return self._redis
 
     @property

--- a/autobot-backend/services/documentation_watcher.py
+++ b/autobot-backend/services/documentation_watcher.py
@@ -297,7 +297,7 @@ class DocumentationWatcherService:
                 store_staleness_scores,
             )
 
-            redis = get_redis_client(async_client=True, database="main")
+            redis = await get_redis_client(async_client=True, database="main")
             graph = RedisGraphAdapter(redis)
             staleness_result = await propagate_staleness(graph, doc_id)
             stored = await store_staleness_scores(redis, staleness_result.scores)

--- a/autobot-backend/services/workflow_sharing_service.py
+++ b/autobot-backend/services/workflow_sharing_service.py
@@ -158,7 +158,7 @@ class WorkflowSharingService:
             export_doc=export_doc.to_dict(),
         )
 
-        redis = get_redis_client(async_client=True, database="workflows")
+        redis = await get_redis_client(async_client=True, database="workflows")
         if redis is None:
             logger.error(
                 "share_workflow: Redis unavailable for workflow %s", workflow_id
@@ -200,7 +200,7 @@ class WorkflowSharingService:
         Returns:
             True when the share existed and was deleted, False otherwise.
         """
-        redis = get_redis_client(async_client=True, database="workflows")
+        redis = await get_redis_client(async_client=True, database="workflows")
         if redis is None:
             logger.error("unshare_workflow: Redis unavailable for share %s", share_id)
             return False
@@ -243,7 +243,7 @@ class WorkflowSharingService:
             List of share record dicts (without the embedded workflow payload
             to keep the response lightweight).
         """
-        redis = get_redis_client(async_client=True, database="workflows")
+        redis = await get_redis_client(async_client=True, database="workflows")
         if redis is None:
             logger.error("list_shared: Redis unavailable")
             return []
@@ -297,7 +297,7 @@ class WorkflowSharingService:
         Returns:
             New workflow_id on success, None on failure.
         """
-        redis = get_redis_client(async_client=True, database="workflows")
+        redis = await get_redis_client(async_client=True, database="workflows")
         if redis is None:
             logger.error("clone_workflow: Redis unavailable for share %s", share_id)
             return None

--- a/autobot-backend/services/workflow_versioning.py
+++ b/autobot-backend/services/workflow_versioning.py
@@ -133,7 +133,7 @@ class WorkflowVersionStore:
         Returns:
             The new version number on success, None when Redis is unavailable.
         """
-        redis = get_redis_client(async_client=True, database="workflows")
+        redis = await get_redis_client(async_client=True, database="workflows")
         if redis is None:
             logger.error("save_version: Redis unavailable for workflow %s", workflow_id)
             return None
@@ -172,7 +172,7 @@ class WorkflowVersionStore:
         Returns:
             True when the version existed and was removed; False otherwise.
         """
-        redis = get_redis_client(async_client=True, database="workflows")
+        redis = await get_redis_client(async_client=True, database="workflows")
         if redis is None:
             logger.error(
                 "delete_version: Redis unavailable for workflow %s", workflow_id
@@ -211,7 +211,7 @@ class WorkflowVersionStore:
             List of summary dicts sorted by version descending.  Empty list
             when no versions exist or Redis is unavailable.
         """
-        redis = get_redis_client(async_client=True, database="workflows")
+        redis = await get_redis_client(async_client=True, database="workflows")
         if redis is None:
             logger.error(
                 "list_versions: Redis unavailable for workflow %s", workflow_id
@@ -252,7 +252,7 @@ class WorkflowVersionStore:
         Returns:
             WorkflowVersion dataclass, or None when not found.
         """
-        redis = get_redis_client(async_client=True, database="workflows")
+        redis = await get_redis_client(async_client=True, database="workflows")
         if redis is None:
             logger.error("get_version: Redis unavailable for workflow %s", workflow_id)
             return None


### PR DESCRIPTION
Closes #3872

## Summary

- `get_redis_client(async_client=True)` delegates to `RedisConnectionManager.get_async_client()` which is an `async def` — it returns a coroutine, not a client
- 11 call sites across the codebase assigned the unawaited coroutine to a variable and then called Redis methods on it, causing `AttributeError: 'coroutine' object has no attribute 'ping'` (and similar errors on `.get()`, `.set()`, `.pipeline()`, etc.)
- The primary reported failure was `knowledge/base.py:342` — `KnowledgeBaseCore._init_redis_connections()` assigned without `await` then immediately called `.ping()`, degrading RAG/memory for all chat responses

## Files changed (11)

| File | Call sites fixed |
|------|-----------------|
| `knowledge/base.py` | 1 (primary issue) |
| `autobot_memory_graph/property_graph.py` | 1 |
| `initialization/lifespan.py` | 1 |
| `knowledge/search_components/reranking.py` | 1 |
| `services/autoresearch/osint_engine.py` | 1 |
| `services/autoresearch/prompt_optimizer.py` | 1 |
| `services/autoresearch/routes.py` | 4 |
| `services/autoresearch/scorers.py` | 1 |
| `services/documentation_watcher.py` | 1 |
| `services/workflow_sharing_service.py` | 4 |
| `services/workflow_versioning.py` | 4 |

## Fix

Each unawaited assignment `x = get_redis_client(async_client=True, ...)` was changed to `x = await get_redis_client(async_client=True, ...)`. No logic changes — purely missing `await` keywords.

## Test plan

- [ ] Deploy to dev environment and verify knowledge base initializes without `'coroutine' object has no attribute 'ping'` in logs
- [ ] Confirm `EssentialStoryGenerator.generate` succeeds and RAG context is available in chat responses
- [ ] Verify workflow sharing/versioning and autoresearch approval endpoints operate correctly