### PR TITLE
fix(ansible): deploy permission_rules.yaml to infrastructure config path

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/files/permission_rules.yaml
+++ b/autobot-slm-backend/ansible/roles/backend/files/permission_rules.yaml
@@ -1,0 +1,3 @@
+# AutoBot Permission Rules
+# Default rules are applied programmatically; this file provides overrides.
+{}

--- a/autobot-slm-backend/ansible/roles/backend/tasks/clean.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/clean.yml
@@ -8,8 +8,10 @@
 # Safe to run any time; all removes are conditional.
 #
 # LEGACY directory deletions (npu-worker, browser-service, ai-stack,
-# autobot-user-backend, config) run unconditionally because NO current role
+# autobot-user-backend) run unconditionally because NO current role
 # deploys to those paths — they are pre-rename leftovers.
+# NOTE: /opt/autobot/config is NOT removed here (#3873) — it holds
+# permission_rules.yaml which permission_matcher.py reads at runtime.
 #
 # Wrong-node deletions of CURRENT canonical dirs (autobot-slm-frontend,
 # autobot-slm-backend) ONLY run when node_roles is defined (dynamic inventory).
@@ -40,11 +42,6 @@
     state: absent
   tags: ['clean']
 
-- name: "Backend | Clean: stale top-level config/ (pre-reorganization duplicate)"
-  ansible.builtin.file:
-    path: /opt/autobot/config
-    state: absent
-  tags: ['clean']
 
 - name: "Backend | Clean: wrong-node autobot-slm-frontend dir"
   ansible.builtin.file:

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -256,6 +256,29 @@
     owner: "{{ backend_user }}"
     group: "{{ backend_group }}"
 
+# Issue #3873: permission_rules.yaml is read from /opt/autobot/config/ at
+# runtime (three levels up from services/permission_matcher.py).  The clean
+# task that previously wiped /opt/autobot/config has been removed; this task
+# ensures the directory and file are always present after each deploy.
+- name: "Backend | Ensure /opt/autobot/config directory exists (#3873)"
+  ansible.builtin.file:
+    path: "{{ backend_install_dir | dirname }}/config"
+    state: directory
+    mode: "0755"
+    owner: "{{ backend_user }}"
+    group: "{{ backend_group }}"
+  tags: ['backend', 'config']
+
+- name: "Backend | Deploy permission_rules.yaml to infrastructure config path (#3873)"
+  ansible.builtin.copy:
+    src: permission_rules.yaml
+    dest: "{{ backend_install_dir | dirname }}/config/permission_rules.yaml"
+    mode: "0644"
+    owner: "{{ backend_user }}"
+    group: "{{ backend_group }}"
+  notify: restart backend
+  tags: ['backend', 'config']
+
 - name: Check if backend code already synced
   ansible.builtin.stat:
     path: "{{ backend_code_dir }}/main.py"


### PR DESCRIPTION
Closes #3873

## Summary

- Added `permission_rules.yaml` to `autobot-slm-backend/ansible/roles/backend/files/`
- Added two tasks in `backend/tasks/main.yml` (after the `error_messages.yaml` task): one to ensure `/opt/autobot/config/` exists, one to deploy `permission_rules.yaml` there with `notify: restart backend`
- Removed the `clean.yml` task that deleted `/opt/autobot/config` — that directory is needed at runtime because `services/permission_matcher.py` resolves `config/permission_rules.yaml` as `Path(__file__).parent.parent.parent / rules_file`, which lands at `/opt/autobot/config/permission_rules.yaml`
- Updated the `clean.yml` comment to document the intent

## Test plan

- [ ] Run backend deploy playbook; verify `/opt/autobot/config/permission_rules.yaml` is present post-deploy
- [ ] Connect to `/api/ws/live`; confirm no `Permission rules file not found` warning in `backend-error.log`
- [ ] Run with `--tags clean`; verify `/opt/autobot/config` is NOT removed