### PR TITLE
feat(backend): add hardware priority updates API endpoint

### DIFF
--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -1005,10 +1005,16 @@ async def update_hardware_priority(
 
     merged_config = deep_merge(copy.deepcopy(before_config), patch)
     ConfigService.save_full_config(merged_config)
+    ConfigService.clear_cache()
 
     # Apply in-memory so the running process respects the new ordering
     hw_manager = get_hardware_acceleration_manager()
     hw_manager.update_priorities(request.priority_order)
+
+    # Read back the actually-applied order (filtered to available devices)
+    applied_order = [
+        t.value for t in hw_manager.current_config["priority_order"]
+    ]
 
     changed = _compute_flat_diff(before_config, merged_config)
 
@@ -1029,6 +1035,6 @@ async def update_hardware_priority(
 
     return HardwarePriorityResponse(
         status="ok",
-        priority_order=request.priority_order,
+        priority_order=applied_order,
         changed=changed,
     )

--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -2,13 +2,14 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 import asyncio
+import copy
 import datetime
 import json
 import logging
 import os
 import tempfile
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 import aiofiles
 
@@ -932,4 +933,102 @@ async def sync_config(
         status="ok",
         changed=changed,
         unchanged_keys=unchanged_keys,
+    )
+
+
+# ==================== Hardware Priority Endpoint (Issue #3288) ====================
+
+_VALID_HARDWARE_TYPES = frozenset({"npu", "gpu", "cpu"})
+
+
+class HardwarePriorityRequest(BaseModel):
+    """Request body for PATCH /api/settings/hardware-priority.
+
+    priority_order must be a permutation of ["npu", "gpu", "cpu"] — all three
+    values required, no duplicates.
+    """
+
+    priority_order: List[str]
+
+    def model_post_init(self, __context) -> None:  # noqa: ANN001
+        given = set(self.priority_order)
+        if given != _VALID_HARDWARE_TYPES or len(self.priority_order) != 3:
+            raise ValueError(
+                f"priority_order must be a permutation of {sorted(_VALID_HARDWARE_TYPES)}, "
+                f"got {self.priority_order}"
+            )
+
+
+class HardwarePriorityResponse(BaseModel):
+    """Response body for PATCH /api/settings/hardware-priority."""
+
+    status: str
+    priority_order: List[str]
+    changed: dict
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="update_hardware_priority",
+    error_code_prefix="SETTINGS",
+)
+@router.patch("/hardware-priority", response_model=HardwarePriorityResponse)
+async def update_hardware_priority(
+    request: HardwarePriorityRequest,
+    session: AsyncSession = Depends(get_db_session),
+    _: None = Depends(check_admin_permission),
+):
+    """Set hardware processing priority order for NPU/GPU/CPU (Issue #3288).
+
+    Persists the ordering to ``hardware.acceleration.priority_order`` in
+    ``config.yaml`` and immediately applies it to the in-process
+    ``HardwareAccelerationManager`` singleton so new agent dispatches respect
+    the updated priority without a restart.
+
+    Requires admin permission.
+    """
+    from hardware_acceleration import get_hardware_acceleration_manager
+
+    before_config: dict = ConfigService.get_full_config()
+
+    # Build the minimal patch — only the key we own
+    patch: dict = {
+        "hardware": {
+            "acceleration": {
+                "priority_order": request.priority_order,
+            }
+        }
+    }
+
+    # Deep-merge into a copy to produce the full updated config
+    from config.loader import deep_merge
+
+    merged_config = deep_merge(copy.deepcopy(before_config), patch)
+    ConfigService.save_full_config(merged_config)
+
+    # Apply in-memory so the running process respects the new ordering
+    hw_manager = get_hardware_acceleration_manager()
+    hw_manager.update_priorities(request.priority_order)
+
+    changed = _compute_flat_diff(before_config, merged_config)
+
+    await ConfigRevisionService(session).create_revision(
+        entity_type="system",
+        entity_id="hardware_priority",
+        before_config=before_config,
+        after_config=merged_config,
+        source="api",
+        created_by="admin",
+    )
+
+    logger.info(
+        "Hardware priority updated: %s (changed keys: %d)",
+        request.priority_order,
+        len(changed),
+    )
+
+    return HardwarePriorityResponse(
+        status="ok",
+        priority_order=request.priority_order,
+        changed=changed,
     )

--- a/autobot-backend/api/settings_hardware_priority_test.py
+++ b/autobot-backend/api/settings_hardware_priority_test.py
@@ -73,37 +73,6 @@ _FAKE_CONFIG = {
 }
 
 
-def _patch_deps(monkeypatch):
-    """Return a context manager that stubs out all external dependencies."""
-    mock_hw = MagicMock()
-    mock_hw.update_priorities = MagicMock()
-
-    mock_revision_instance = MagicMock()
-    mock_revision_instance.create_revision = AsyncMock()
-    mock_revision_class = MagicMock(return_value=mock_revision_instance)
-
-    patches = [
-        patch("api.settings.check_admin_permission", return_value=None),
-        patch("api.settings.get_db_session", return_value=AsyncMock()),
-        patch(
-            "api.settings.ConfigService.get_full_config",
-            return_value=dict(_FAKE_CONFIG),
-        ),
-        patch("api.settings.ConfigService.save_full_config", return_value={"status": "ok"}),
-        patch("api.settings.ConfigService.clear_cache"),
-        patch("api.settings.ConfigRevisionService", mock_revision_class),
-        patch(
-            "api.settings.update_hardware_priority.__globals__",
-            {},
-        ),
-        patch(
-            "hardware_acceleration.get_hardware_acceleration_manager",
-            return_value=mock_hw,
-        ),
-    ]
-    return patches, mock_hw
-
-
 class TestHardwarePriorityEndpoint:
     def test_patch_returns_200_with_valid_payload(self):
         app = _make_app()

--- a/autobot-backend/api/settings_hardware_priority_test.py
+++ b/autobot-backend/api/settings_hardware_priority_test.py
@@ -1,0 +1,220 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for PATCH /api/settings/hardware-priority (Issue #3288)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.settings import HardwarePriorityRequest, router
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app() -> FastAPI:
+    """Minimal FastAPI app that mounts only the settings router."""
+    app = FastAPI()
+    app.include_router(router, prefix="/api/settings")
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — HardwarePriorityRequest validation
+# ---------------------------------------------------------------------------
+
+
+class TestHardwarePriorityRequest:
+    def test_valid_npu_first(self):
+        req = HardwarePriorityRequest(priority_order=["npu", "gpu", "cpu"])
+        assert req.priority_order == ["npu", "gpu", "cpu"]
+
+    def test_valid_gpu_first(self):
+        req = HardwarePriorityRequest(priority_order=["gpu", "npu", "cpu"])
+        assert req.priority_order == ["gpu", "npu", "cpu"]
+
+    def test_valid_cpu_first(self):
+        req = HardwarePriorityRequest(priority_order=["cpu", "gpu", "npu"])
+        assert req.priority_order == ["cpu", "gpu", "npu"]
+
+    def test_rejects_missing_type(self):
+        with pytest.raises(Exception):
+            HardwarePriorityRequest(priority_order=["npu", "gpu"])
+
+    def test_rejects_duplicate(self):
+        with pytest.raises(Exception):
+            HardwarePriorityRequest(priority_order=["npu", "npu", "cpu"])
+
+    def test_rejects_invalid_value(self):
+        with pytest.raises(Exception):
+            HardwarePriorityRequest(priority_order=["npu", "gpu", "fpga"])
+
+    def test_rejects_extra_values(self):
+        with pytest.raises(Exception):
+            HardwarePriorityRequest(priority_order=["npu", "gpu", "cpu", "cpu"])
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — endpoint via TestClient
+# ---------------------------------------------------------------------------
+
+
+_FAKE_CONFIG = {
+    "hardware": {
+        "acceleration": {
+            "priority_order": ["npu", "gpu", "cpu"],
+        }
+    }
+}
+
+
+def _patch_deps(monkeypatch):
+    """Return a context manager that stubs out all external dependencies."""
+    mock_hw = MagicMock()
+    mock_hw.update_priorities = MagicMock()
+
+    mock_revision_instance = MagicMock()
+    mock_revision_instance.create_revision = AsyncMock()
+    mock_revision_class = MagicMock(return_value=mock_revision_instance)
+
+    patches = [
+        patch("api.settings.check_admin_permission", return_value=None),
+        patch("api.settings.get_db_session", return_value=AsyncMock()),
+        patch(
+            "api.settings.ConfigService.get_full_config",
+            return_value=dict(_FAKE_CONFIG),
+        ),
+        patch("api.settings.ConfigService.save_full_config", return_value={"status": "ok"}),
+        patch("api.settings.ConfigService.clear_cache"),
+        patch("api.settings.ConfigRevisionService", mock_revision_class),
+        patch(
+            "api.settings.update_hardware_priority.__globals__",
+            {},
+        ),
+        patch(
+            "hardware_acceleration.get_hardware_acceleration_manager",
+            return_value=mock_hw,
+        ),
+    ]
+    return patches, mock_hw
+
+
+class TestHardwarePriorityEndpoint:
+    def test_patch_returns_200_with_valid_payload(self):
+        app = _make_app()
+
+        fake_config = {
+            "hardware": {"acceleration": {"priority_order": ["npu", "gpu", "cpu"]}}
+        }
+        mock_hw = MagicMock()
+        mock_hw.update_priorities = MagicMock()
+        mock_revision = MagicMock()
+        mock_revision.create_revision = AsyncMock()
+
+        with (
+            patch("api.settings.check_admin_permission", return_value=None),
+            patch(
+                "api.settings.get_db_session",
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=MagicMock()), __aexit__=AsyncMock()),
+            ),
+            patch("api.settings.ConfigService.get_full_config", return_value=dict(fake_config)),
+            patch("api.settings.ConfigService.save_full_config", return_value={"status": "ok"}),
+            patch("api.settings.ConfigRevisionService", return_value=mock_revision),
+            patch("hardware_acceleration.get_hardware_acceleration_manager", return_value=mock_hw),
+        ):
+            client = TestClient(app, raise_server_exceptions=True)
+            resp = client.patch(
+                "/api/settings/hardware-priority",
+                json={"priority_order": ["gpu", "npu", "cpu"]},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["priority_order"] == ["gpu", "npu", "cpu"]
+
+    def test_patch_rejects_invalid_payload_422(self):
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.patch(
+            "/api/settings/hardware-priority",
+            json={"priority_order": ["npu", "gpu"]},
+        )
+        assert resp.status_code == 422
+
+    def test_patch_rejects_unknown_device_422(self):
+        app = _make_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.patch(
+            "/api/settings/hardware-priority",
+            json={"priority_order": ["npu", "gpu", "fpga"]},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# HardwareAccelerationManager.update_priorities unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareAccelerationManagerUpdatePriorities:
+    def _make_manager(self):
+        """Build a manager instance without triggering real hardware detection."""
+        from hardware_acceleration import AccelerationType, HardwareAccelerationManager
+
+        with (
+            patch.object(
+                HardwareAccelerationManager,
+                "_detect_available_hardware",
+            ),
+            patch.object(
+                HardwareAccelerationManager,
+                "_configure_device_priorities",
+            ),
+        ):
+            mgr = HardwareAccelerationManager.__new__(HardwareAccelerationManager)
+            mgr.available_devices = {
+                AccelerationType.NPU: {},
+                AccelerationType.GPU: {},
+                AccelerationType.CPU: {},
+            }
+            mgr.device_priorities = [
+                AccelerationType.NPU,
+                AccelerationType.GPU,
+                AccelerationType.CPU,
+            ]
+            mgr.current_config = {"priority_order": [], "device_assignments": {}, "fallback_chain": []}
+            mgr.npu_available = True
+            mgr.gpu_available = True
+            import psutil
+            mgr.cpu_cores = psutil.cpu_count()
+        return mgr
+
+    def test_update_reorders_priorities(self):
+        from hardware_acceleration import AccelerationType
+
+        mgr = self._make_manager()
+        mgr.update_priorities(["gpu", "npu", "cpu"])
+        assert mgr.device_priorities[0] == AccelerationType.GPU
+        assert mgr.device_priorities[1] == AccelerationType.NPU
+        assert mgr.device_priorities[2] == AccelerationType.CPU
+
+    def test_update_raises_on_missing_type(self):
+        mgr = self._make_manager()
+        with pytest.raises(ValueError, match="permutation"):
+            mgr.update_priorities(["npu", "gpu"])
+
+    def test_update_raises_on_duplicate(self):
+        mgr = self._make_manager()
+        with pytest.raises(ValueError, match="permutation"):
+            mgr.update_priorities(["npu", "npu", "cpu"])
+
+    def test_update_raises_on_unknown_value(self):
+        mgr = self._make_manager()
+        with pytest.raises((ValueError, KeyError)):
+            mgr.update_priorities(["npu", "gpu", "tpu"])

--- a/autobot-backend/hardware_acceleration.py
+++ b/autobot-backend/hardware_acceleration.py
@@ -636,6 +636,29 @@ class HardwareAccelerationManager:
         except Exception as e:
             logger.error("Failed to configure system environment: %s", e)
 
+    def update_priorities(self, priority_order: list) -> None:
+        """Apply a new hardware priority ordering (issue #3288).
+
+        Args:
+            priority_order: Ordered list of acceleration type values, e.g.
+                ``["gpu", "npu", "cpu"]``.  Must be a permutation of all three
+                ``AccelerationType`` values.
+
+        Raises:
+            ValueError: If the list is not a valid permutation of npu/gpu/cpu.
+        """
+        valid_values = {t.value for t in AccelerationType}
+        given = set(priority_order)
+        if given != valid_values or len(priority_order) != len(valid_values):
+            raise ValueError(
+                f"priority_order must be a permutation of {sorted(valid_values)}, "
+                f"got {priority_order}"
+            )
+
+        self.device_priorities = [AccelerationType(v) for v in priority_order]
+        self._configure_device_priorities()
+        logger.info("Hardware priority updated to: %s", priority_order)
+
     def get_device_status(self) -> Dict[str, Any]:
         """Get current device status and utilization."""
         status = {"timestamp": psutil.boot_time(), "devices": {}, "recommendations": []}


### PR DESCRIPTION
Closes #3288

## Changes
- Added `PATCH /api/settings/hardware-priority` endpoint to `api/settings.py`
- Validates `priority_order` is a permutation of `["npu", "gpu", "cpu"]`; returns 422 on invalid input
- Persists to `hardware.acceleration.priority_order` in `config.yaml` via `ConfigService.save_full_config` with deep-merge
- Applies new ordering immediately to running `HardwareAccelerationManager` singleton via new `update_priorities()` method — no restart needed
- Records audit revision via `ConfigRevisionService` (same pattern as all other settings endpoints)
- Added `HardwareAccelerationManager.update_priorities()` method to `hardware_acceleration.py`
- Added test file `api/settings_hardware_priority_test.py` covering request validation, endpoint 200/422, and manager method

## Test plan
- [ ] `PATCH /api/settings/hardware-priority` with `{"priority_order": ["gpu", "npu", "cpu"]}` returns 200
- [ ] `PATCH /api/settings/hardware-priority` with `{"priority_order": ["npu", "gpu"]}` returns 422
- [ ] `hardware.acceleration.priority_order` in `config.yaml` updated after successful PATCH
- [ ] `HardwareAccelerationManager.device_priorities` reflects new order without restart
- [ ] Frontend SettingsPanel saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)