### PR TITLE
fix(agent-loop): guard tool args, sentinel halt, propagate error to LLM (#3859 #3862 #3868 #3874 #3877)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -42,6 +42,10 @@ from tools.parallel import ParallelToolExecutor
 
 logger = logging.getLogger(__name__)
 
+# Sentinel key injected into tool_results when the repetition-halt guard fires.
+# Presence of this key in tool_results lets _execute_iteration_phases detect
+# a halt without inspecting the error string.  Issue #3877.
+_HALT_SENTINEL = "__repetition_halt__"
 
 # =============================================================================
 # Agent Loop
@@ -293,6 +297,21 @@ class AgentLoop:
         # Phase 3: Execute Tools
         self._current_phase = LoopPhase.WAIT_FOR_EXECUTION
         tool_results = await self._execute_tools(tools_to_execute)
+
+        # Issue #3877 / #3859: detect repetition-halt via sentinel key.
+        # When halted: do not add any rejected tools to tools_executed and
+        # stop iterating immediately so the LLM receives the error but the
+        # loop does not re-propose the same tools indefinitely.
+        if tool_results.pop(_HALT_SENTINEL, False):
+            # Issue #3862: keep should_continue=False so the loop exits, but
+            # surface the halt errors as tool_results so the LLM can adapt.
+            # Issue #3859: tools_executed stays empty — no tool actually ran.
+            result.tools_executed = []
+            result.tool_results = tool_results
+            result.should_continue = False
+            result.phase_completed = LoopPhase.ITERATE
+            return result
+
         result.tools_executed = [
             t.get("tool_name", "unknown") for t in tools_to_execute
         ]
@@ -423,15 +442,23 @@ class AgentLoop:
         # Issue #3255: Halt before execution if identical call repeated too often
         repeated_tool = self._check_tool_call_repetition(tools)
         if repeated_tool is not None:
-            return {
-                repeated_tool: {
-                    "error": (
-                        f"Halted: repetitive tool call detected for '{repeated_tool}' "
-                        f"(exceeded max_identical_tool_calls="
-                        f"{self.config.max_identical_tool_calls})"
-                    )
-                }
+            halt_msg = (
+                f"Halted: repetitive tool call detected for '{repeated_tool}' "
+                f"(exceeded max_identical_tool_calls="
+                f"{self.config.max_identical_tool_calls})"
+            )
+            # Issue #3877: include ALL tools in halt results so _should_iterate
+            # sees every tool from the batch as having an error result.
+            # Issue #3859: do NOT record any of these in tools_executed — the
+            # sentinel key lets _execute_iteration_phases skip add_tool() calls
+            # and set should_continue=False without calling _should_iterate.
+            halt_results: dict[str, Any] = {
+                _HALT_SENTINEL: True,
             }
+            for tool in tools:
+                t_name = tool.get("tool_name", "unknown")
+                halt_results[t_name] = {"error": halt_msg}
+            return halt_results
 
         # Check if we need to think before certain tools
         await self._think_before_tools(tools)
@@ -630,13 +657,20 @@ Duration: {self._current_context.get_duration_ms():.0f}ms
         two calls with identical intent produce the same hash regardless of
         dict-insertion order.
 
-        Issue #3255.
+        Issue #3255, #3868, #3874.
         """
         tool_name = tool.get("tool_name", "")
         args = tool.get("args", tool.get("arguments", tool.get("parameters", {})))
+        # Issue #3874: preserve non-dict arg identity; {} would alias all
+        # non-dict calls to the same bucket
         if not isinstance(args, dict):
-            args = {}
-        canonical = json.dumps({"n": tool_name, "a": args}, sort_keys=True)
+            args = {"_raw": str(args)}
+        try:
+            # Issue #3868: default=str handles datetime, bytes, custom objects
+            canonical = json.dumps({"n": tool_name, "a": args}, sort_keys=True, default=str)
+        except Exception:
+            # Absolute fallback — should never be reached with default=str
+            canonical = repr({"n": tool_name, "a": args})
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def _check_tool_call_repetition(


### PR DESCRIPTION
## Summary

Five related agent-loop bugs all touching `loop.py` — fixed together to avoid partial-state issues.

### #3874 — non-dict args coerced to {}
`_hash_tool_call()` was replacing non-dict args with `{}`, aliasing all non-dict calls into the same hash bucket. Now uses `{"_raw": str(args)}` to preserve identity.

### #3868 — json.dumps crash on non-serialisable args
Added `default=str` to `json.dumps()` so datetime/bytes/custom objects don't raise `TypeError`. Added `repr()` fallback for absolute safety.

### #3877 — loop continues after halt
`_execute_tools()` now injects a `_HALT_SENTINEL` key into results when repetition fires. `_execute_iteration_phases()` pops the sentinel and immediately sets `should_continue=False`, exiting the loop without re-proposing the same tools.

### #3859 — halted tool added to tools_executed
When sentinel is detected, `result.tools_executed = []` before returning — no tool actually ran so none should be recorded.

### #3862 — halt terminates task silently
Halt results include an entry per tool with the error message, stored in `result.tool_results`. The LLM receives the error on the next response and can adapt instead of silently stopping.

## Changes
- `autobot-backend/agent_loop/loop.py`

Closes #3859
Closes #3862
Closes #3868
Closes #3874
Closes #3877