### PR TITLE
fix(agent_loop): don't add halted tool to executed list; surface error to LLM (#3859 #3862)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -298,6 +298,18 @@ class AgentLoop:
         # Phase 3: Execute Tools
         self._current_phase = LoopPhase.WAIT_FOR_EXECUTION
         tool_results = await self._execute_tools(tools_to_execute)
+
+        # Issue #3859 / #3862: when the repetition-halt guard fires, the tools
+        # never actually executed.  Skip adding them to tools_executed (they
+        # didn't run) and return the error as tool_results so the LLM can see
+        # what happened and adapt rather than terminating silently.
+        if self._halted_on_repetition:
+            result.tool_results = tool_results
+            result.tools_executed = []
+            result.should_continue = False
+            result.phase_completed = LoopPhase.ITERATE
+            return result
+
         result.tools_executed = [
             t.get("tool_name", "unknown") for t in tools_to_execute
         ]


### PR DESCRIPTION
## Summary

Companion fix to #3899 addressing two additional agent-loop halt bugs:

- **#3859** — when the repetition-halt guard fires, `tools_executed` was still populated with the tool name even though the tool never ran. Fix: early-return with `tools_executed = []`.
- **#3862** — when halt fires, the loop terminated silently without the LLM seeing the error message. Fix: include the halt error dict in `result.tool_results` so the LLM receives it on the next iteration.

## Changes

Single change to `_execute_iteration_phases()` in [agent_loop/loop.py](autobot-backend/agent_loop/loop.py): check `_halted_on_repetition` immediately after `_execute_tools()` returns, before populating `tools_executed`.

## Test plan

- [ ] Existing `test_loop_repetition.py` tests continue to pass (halt flag set correctly)
- [ ] Manual: trigger a repetitive tool call — verify the LLM response includes the halt error message

Closes #3859, #3862

🤖 Generated with [Claude Code](https://claude.com/claude-code)