### PR TITLE
fix(config): async file ops + key injection guard in /api/settings/sync (#3882 #3881)

### DIFF
--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -1,6 +1,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
+import asyncio
 import datetime
 import json
 import logging
@@ -727,6 +728,52 @@ async def get_update_status(
 
 # ==================== Config Sync Endpoint (Issue #3398) ====================
 
+# Allowlist of top-level keys that callers are permitted to sync (Issue #3881).
+# Extend this set when new configuration sections are introduced.
+_SYNC_ALLOWED_TOP_LEVEL_KEYS: frozenset = frozenset({
+    "backend",
+    "memory",
+    "logging",
+    "security",
+    "ui",
+    "chat",
+    "agents",
+    "knowledge",
+    "integrations",
+    "features",
+    "notifications",
+    "analytics",
+    "models",
+    "redis",
+    "database",
+    "search",
+    "tools",
+    "workflows",
+    "scheduler",
+    "monitoring",
+})
+
+# Maximum nesting depth accepted from callers (Issue #3881).
+_SYNC_MAX_DEPTH: int = 8
+
+# Maximum payload size in bytes before we reject the request (Issue #3881).
+_SYNC_MAX_PAYLOAD_BYTES: int = 512 * 1024  # 512 KiB
+
+
+def _exceeds_depth(obj: dict, current_depth: int = 0) -> bool:
+    """Return True if *obj* contains dict nesting deeper than *_SYNC_MAX_DEPTH*.
+
+    Only dict values contribute to the depth count; lists, strings, and scalars
+    are considered leaves and are not traversed.
+    """
+    if current_depth > _SYNC_MAX_DEPTH:
+        return True
+    for value in obj.values():
+        if isinstance(value, dict):
+            if _exceeds_depth(value, current_depth + 1):
+                return True
+    return False
+
 
 class ConfigSyncRequest(BaseModel):
     """Request body for POST /api/settings/sync.
@@ -778,10 +825,10 @@ async def _atomic_write_json(target: Path, data: dict) -> None:
     try:
         async with aiofiles.open(tmp_path, "w", encoding="utf-8") as fh:
             await fh.write(json.dumps(data, indent=2, ensure_ascii=False))
-        os.replace(tmp_path, str(target))
+        await asyncio.to_thread(os.replace, tmp_path, str(target))
     except Exception:
         try:
-            os.unlink(tmp_path)
+            await asyncio.to_thread(os.unlink, tmp_path)
         except OSError:
             pass
         raise
@@ -818,6 +865,28 @@ async def sync_config(
 
     if not request.settings:
         return ConfigSyncResponse(status="skipped", changed={}, unchanged_keys=0)
+
+    # --- Issue #3881: reject oversized, too-deep, or disallowed payloads ----
+    raw_payload = json.dumps(request.settings, ensure_ascii=False)
+    if len(raw_payload.encode("utf-8")) > _SYNC_MAX_PAYLOAD_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Payload exceeds maximum allowed size of {_SYNC_MAX_PAYLOAD_BYTES} bytes.",
+        )
+
+    disallowed_keys = set(request.settings) - _SYNC_ALLOWED_TOP_LEVEL_KEYS
+    if disallowed_keys:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Disallowed top-level key(s): {sorted(disallowed_keys)}",
+        )
+
+    if _exceeds_depth(request.settings):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Payload nesting exceeds maximum allowed depth of {_SYNC_MAX_DEPTH}.",
+        )
+    # -------------------------------------------------------------------------
 
     before_config: dict = ConfigService.get_full_config()
     merged_config = deep_merge(copy.deepcopy(before_config), request.settings)

--- a/autobot-backend/api/settings_sync_test.py
+++ b/autobot-backend/api/settings_sync_test.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for the config-sync helpers in api/settings.py.
+
+Covers Issues #3881 (allowlist + depth guard) and #3882 (async file ops).
+
+The endpoint itself (sync_config) requires live DB/auth/ConfigService
+dependencies so it is tested via the helper functions:
+  - _exceeds_depth       (#3881 depth guard)
+  - _SYNC_ALLOWED_TOP_LEVEL_KEYS / _SYNC_MAX_DEPTH / _SYNC_MAX_PAYLOAD_BYTES
+  - _atomic_write_json   (#3882 asyncio.to_thread usage)
+  - _compute_flat_diff   (regression guard)
+  - _count_unchanged_keys
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from api.settings import (
+    _SYNC_ALLOWED_TOP_LEVEL_KEYS,
+    _SYNC_MAX_DEPTH,
+    _SYNC_MAX_PAYLOAD_BYTES,
+    _atomic_write_json,
+    _compute_flat_diff,
+    _count_unchanged_keys,
+    _exceeds_depth,
+)
+
+
+# ---------------------------------------------------------------------------
+# _exceeds_depth — Issue #3881
+# ---------------------------------------------------------------------------
+
+class TestExceedsDepth:
+    """_exceeds_depth() rejects payloads that are nested too deeply."""
+
+    def test_flat_dict_not_exceeded(self):
+        assert _exceeds_depth({"a": 1, "b": 2}) is False
+
+    def test_depth_at_limit_is_ok(self):
+        # Build a dict nested exactly _SYNC_MAX_DEPTH levels deep.
+        obj: dict = {}
+        node = obj
+        for _ in range(_SYNC_MAX_DEPTH):
+            node["x"] = {}
+            node = node["x"]
+        node["leaf"] = "value"
+        assert _exceeds_depth(obj) is False
+
+    def test_depth_one_over_limit_is_exceeded(self):
+        # One extra level beyond the limit must trigger the guard.
+        obj: dict = {}
+        node = obj
+        for _ in range(_SYNC_MAX_DEPTH + 1):
+            node["x"] = {}
+            node = node["x"]
+        node["leaf"] = "value"
+        assert _exceeds_depth(obj) is True
+
+    def test_non_dict_value_not_counted_as_depth(self):
+        assert _exceeds_depth({"a": [1, 2, 3]}) is False
+        assert _exceeds_depth({"a": "string"}) is False
+        assert _exceeds_depth({"a": 42}) is False
+
+    def test_empty_dict_is_fine(self):
+        assert _exceeds_depth({}) is False
+
+
+# ---------------------------------------------------------------------------
+# Allowlist constants — Issue #3881
+# ---------------------------------------------------------------------------
+
+class TestAllowlistConstants:
+    """Sanity-check that the allowlist contains expected keys and excludes others."""
+
+    def test_known_valid_keys_are_present(self):
+        for key in ("backend", "memory", "logging", "security", "ui", "chat"):
+            assert key in _SYNC_ALLOWED_TOP_LEVEL_KEYS, f"'{key}' missing from allowlist"
+
+    def test_internal_keys_are_absent(self):
+        """Internal / runtime keys that must never be synced."""
+        for key in ("__runtime__", "auth", "jwt", "tokens", "password"):
+            assert key not in _SYNC_ALLOWED_TOP_LEVEL_KEYS, (
+                f"'{key}' should not be in the allowlist"
+            )
+
+    def test_max_depth_is_reasonable(self):
+        assert _SYNC_MAX_DEPTH >= 4, "Max depth must accommodate real nested configs"
+
+    def test_max_payload_is_positive(self):
+        assert _SYNC_MAX_PAYLOAD_BYTES > 0
+
+
+# ---------------------------------------------------------------------------
+# _atomic_write_json — Issue #3882 (asyncio.to_thread for blocking calls)
+# ---------------------------------------------------------------------------
+
+class TestAtomicWriteJson:
+    """_atomic_write_json() must use asyncio.to_thread for os.replace/os.unlink."""
+
+    @pytest.mark.asyncio
+    async def test_writes_valid_json_to_target(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "settings.json"
+            data = {"backend": {"server_host": "0.0.0.0"}}
+            await _atomic_write_json(target, data)
+            assert target.exists()
+            written = json.loads(target.read_text(encoding="utf-8"))
+            assert written == data
+
+    @pytest.mark.asyncio
+    async def test_os_replace_called_via_to_thread(self):
+        """Verify asyncio.to_thread is used for os.replace — not a bare call."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "out.json"
+            calls_recorded: list = []
+
+            original_to_thread = asyncio.to_thread
+
+            async def spy_to_thread(fn, *args, **kwargs):
+                calls_recorded.append((fn, args))
+                return await original_to_thread(fn, *args, **kwargs)
+
+            with patch("api.settings.asyncio.to_thread", side_effect=spy_to_thread):
+                await _atomic_write_json(target, {"k": "v"})
+
+            fns_called = [fn for fn, _ in calls_recorded]
+            assert os.replace in fns_called, (
+                "os.replace must be dispatched via asyncio.to_thread"
+            )
+
+    @pytest.mark.asyncio
+    async def test_cleanup_via_to_thread_on_failure(self):
+        """On write failure, cleanup (os.unlink) must also use asyncio.to_thread."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "out.json"
+            cleanup_calls: list = []
+
+            original_to_thread = asyncio.to_thread
+
+            async def spy_to_thread(fn, *args, **kwargs):
+                if fn is os.replace:
+                    raise OSError("simulated rename failure")
+                if fn is os.unlink:
+                    cleanup_calls.append(args)
+                    # Actually do the unlink so we don't leak temp files.
+                    return await original_to_thread(fn, *args, **kwargs)
+                return await original_to_thread(fn, *args, **kwargs)
+
+            with patch("api.settings.asyncio.to_thread", side_effect=spy_to_thread):
+                with pytest.raises(OSError, match="simulated rename failure"):
+                    await _atomic_write_json(target, {"k": "v"})
+
+            assert len(cleanup_calls) == 1, (
+                "os.unlink must be called exactly once via asyncio.to_thread on failure"
+            )
+
+    @pytest.mark.asyncio
+    async def test_creates_parent_dirs_if_needed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "nested" / "deep" / "settings.json"
+            await _atomic_write_json(target, {"x": 1})
+            assert target.exists()
+
+
+# ---------------------------------------------------------------------------
+# _compute_flat_diff — regression guard
+# ---------------------------------------------------------------------------
+
+class TestComputeFlatDiff:
+    """_compute_flat_diff() returns correct leaf-level diff."""
+
+    def test_no_change_returns_empty(self):
+        cfg = {"a": 1, "b": {"c": 2}}
+        assert _compute_flat_diff(cfg, cfg) == {}
+
+    def test_added_key_detected(self):
+        before = {"a": 1}
+        after = {"a": 1, "b": 2}
+        diff = _compute_flat_diff(before, after)
+        assert "b" in diff
+        assert diff["b"]["before"] is None
+        assert diff["b"]["after"] == 2
+
+    def test_changed_nested_key_uses_dot_notation(self):
+        before = {"mem": {"redis": {"host": "old"}}}
+        after = {"mem": {"redis": {"host": "new"}}}
+        diff = _compute_flat_diff(before, after)
+        assert "mem.redis.host" in diff
+
+    def test_unchanged_nested_key_not_in_diff(self):
+        before = {"a": {"b": 1, "c": 2}}
+        after = {"a": {"b": 1, "c": 99}}
+        diff = _compute_flat_diff(before, after)
+        assert "a.b" not in diff
+        assert "a.c" in diff
+
+
+# ---------------------------------------------------------------------------
+# _count_unchanged_keys — regression guard
+# ---------------------------------------------------------------------------
+
+class TestCountUnchangedKeys:
+    def test_all_changed(self):
+        incoming = {"a": 1}
+        changed = {"a": {"before": 0, "after": 1}}
+        assert _count_unchanged_keys(incoming, changed) == 0
+
+    def test_none_changed(self):
+        incoming = {"a": 1, "b": 2}
+        assert _count_unchanged_keys(incoming, {}) == 2
+
+    def test_partial_change(self):
+        incoming = {"a": 1, "b": 2, "c": 3}
+        changed = {"b": {"before": 0, "after": 2}}
+        result = _count_unchanged_keys(incoming, changed)
+        # 3 total leaf keys, 1 changed → 2 unchanged
+        assert result == 2


### PR DESCRIPTION
## Summary

- **#3882**: `os.replace()` and `os.unlink()` in `_atomic_write_json()` moved to `asyncio.to_thread()` so they no longer block the event loop
- **#3881**: `_SYNC_ALLOWED_TOP_LEVEL_KEYS` allowlist (19 keys), `_SYNC_MAX_DEPTH=8`, `_SYNC_MAX_PAYLOAD_BYTES=512KiB` guards added to `sync_config()` — rejects unknown top-level keys with HTTP 422 before any I/O
- Adds `settings_sync_test.py` covering depth guard, allowlist, atomic write, and diff helpers

Closes #3882
Closes #3881