### PR TITLE
chore(config): tombstone root-level config.py ConfigManager; migrate top callers to ssot_config (#3829)

### DIFF
--- a/autobot-backend/agents/knowledge_extraction_agent.py
+++ b/autobot-backend/agents/knowledge_extraction_agent.py
@@ -23,7 +23,7 @@ from autobot_shared.ssot_config import (
     get_agent_model_explicit,
     get_agent_provider_explicit,
 )
-from config import config_manager
+from config.manager import get_config_manager as _get_config_manager
 from llm_interface import LLMType, get_llm_interface
 from models.atomic_fact import AtomicFact, FactExtractionResult, FactType, TemporalType
 
@@ -31,6 +31,9 @@ from .base_agent import DeploymentMode
 from .standardized_agent import ActionHandler, StandardizedAgent
 
 logger = get_llm_logger("knowledge_extraction")
+
+# Canonical singleton; avoids routing through config/__init__ lazy alias (Issue #3829)
+config_manager = _get_config_manager()
 
 # Issue #380: Module-level tuple for fact text field validation
 _FACT_TEXT_FIELDS = ("subject", "predicate", "object")

--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -133,13 +133,9 @@ class LLMHandlerMixin:
         return converted
 
     def _get_ollama_endpoint_fallback(self) -> str:
-        """Get Ollama endpoint from ConfigManager as fallback."""
-        from config import ConfigManager
-
-        config = ConfigManager()
-        ollama_host = config.get_host("ollama")
-        ollama_port = config.get_port("ollama")
-        return f"http://{ollama_host}:{ollama_port}/api/generate"
+        """Get Ollama endpoint from ssot_config as fallback (Issue #3829)."""
+        # _ssot_config is already imported at module level
+        return f"{_ssot_config.ollama_url}{PATH_OLLAMA_GENERATE}"
 
     def _get_ollama_endpoint(self) -> str:
         """Get Ollama endpoint from config with fallbacks.

--- a/autobot-backend/config.py
+++ b/autobot-backend/config.py
@@ -98,9 +98,37 @@ from autobot_shared.ssot_config import SYSTEM_MODEL as _SSOT_SYSTEM
 
 
 class ConfigManager:
-    """Centralized configuration manager"""
+    """
+    TOMBSTONED — Issue #3829.
 
-    # Issue #620: Extracted from get_ollama_runtime_config for clarity
+    This class is dead code: the ``config/`` package shadows this module file,
+    so ``from config import ConfigManager`` always resolves to
+    ``config.manager.ConfigManager`` via ``config/__init__.py.__getattr__``.
+
+    This file (``config.py``) is never imported at runtime.  It is kept on disk
+    to preserve git history and to produce a loud error if it ever *is* reached
+    accidentally (e.g. after a directory restructure).
+
+    Migrate all callers to:
+        from config.manager import get_config_manager   # yaml-based runtime config
+        from autobot_shared.ssot_config import config   # infrastructure / env config
+    """
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError(
+            "config.py:ConfigManager is tombstoned (Issue #3829). "
+            "Use `from config.manager import get_config_manager` for runtime config, "
+            "or `from autobot_shared.ssot_config import config` for infrastructure config."
+        )
+
+    def __getattr__(self, name):
+        raise AttributeError(
+            f"config.py:ConfigManager is tombstoned (Issue #3829) — "
+            f"attribute '{name}' accessed on dead class. "
+            "Use `from autobot_shared.ssot_config import config` instead."
+        )
+
+    # Keep class-level constants for any static inspection tools
     OLLAMA_TASK_OPTIMIZATIONS = {
         "chat": {"temperature": 0.8, "num_predict": 256, "top_p": 0.9},
         "system_commands": {"temperature": 0.3, "num_predict": 128, "top_p": 0.7},
@@ -863,39 +891,51 @@ class ConfigManager:
         )
 
 
-# Global configuration instance
-config = ConfigManager()
+# TOMBSTONED — this file is shadowed by the config/ package.
+# The lines below are kept only to satisfy static analysers that scan this file.
+# At runtime, nothing below is ever executed.
 
-# Alias for backward compatibility and consistent naming
-global_config_manager = config
-
+# config = ConfigManager()        # would raise AttributeError — class is tombstoned
+# global_config_manager = config  # dead alias
 
 # Convenience functions for backward compatibility
 def get_config() -> Dict[str, Any]:
-    """Get the complete configuration dictionary"""
-    return config.to_dict()
+    """DEAD — shadowed by config/__init__.py. Never called at runtime."""
+    raise RuntimeError(
+        "config.py:get_config() is tombstoned (Issue #3829). "
+        "Use `from autobot_shared.ssot_config import config` instead."
+    )
 
 
 def get_llm_config() -> Dict[str, Any]:
-    """Get LLM configuration"""
-    return config.get_llm_config()
+    """DEAD — shadowed by config/__init__.py. Never called at runtime."""
+    raise RuntimeError(
+        "config.py:get_llm_config() is tombstoned (Issue #3829). "
+        "Use `from autobot_shared.ssot_config import config` → config.llm.*."
+    )
 
 
 def get_redis_config() -> Dict[str, Any]:
-    """Get Redis configuration"""
-    return config.get_redis_config()
+    """DEAD — shadowed by config/__init__.py. Never called at runtime."""
+    raise RuntimeError(
+        "config.py:get_redis_config() is tombstoned (Issue #3829). "
+        "Use `from autobot_shared.ssot_config import config` → config.vm.redis, config.port.redis."
+    )
 
 
 def get_backend_config() -> Dict[str, Any]:
-    """Get backend configuration"""
-    return config.get_backend_config()
+    """DEAD — shadowed by config/__init__.py. Never called at runtime."""
+    raise RuntimeError(
+        "config.py:get_backend_config() is tombstoned (Issue #3829). "
+        "Use `from autobot_shared.ssot_config import config` → config.vm.main, config.port.backend."
+    )
 
 
 def reload_config() -> None:
-    """Reload configuration from files"""
-    config.reload()
+    """DEAD — shadowed by config/__init__.py. Never called at runtime."""
+    raise RuntimeError("config.py:reload_config() is tombstoned (Issue #3829).")
 
 
 def validate_config() -> Dict[str, Any]:
-    """Validate configuration and return status"""
-    return config.validate_config()
+    """DEAD — shadowed by config/__init__.py. Never called at runtime."""
+    raise RuntimeError("config.py:validate_config() is tombstoned (Issue #3829).")

--- a/autobot-backend/config/manager.py
+++ b/autobot-backend/config/manager.py
@@ -5,15 +5,25 @@
 """
 Core ConfigManager using composition of specialized modules.
 
-SSOT Migration (Issue #763):
-    Infrastructure values (VMs, ports, LLM models) are now accessed via
-    ConfigRegistry with five-tier fallback:
-    Cache → Redis → Environment → Registry Defaults → Caller Default
+SSOT Migration (Issue #763, #3829):
+    Infrastructure values (VMs, ports, LLM models, timeouts) are now the
+    canonical responsibility of ``autobot_shared.ssot_config``:
 
-    For infrastructure values, use ConfigRegistry:
-        from config.registry import ConfigRegistry
-        redis_host = ConfigRegistry.get("vm.redis")  # SSOT default via registry_defaults
-        default_model = ConfigRegistry.get("llm.default_model", DEFAULT_LLM_MODEL)
+        from autobot_shared.ssot_config import config
+        redis_host    = config.vm.redis
+        ollama_url    = config.ollama_url
+        default_model = config.llm.default_model
+        llm_timeout   = config.timeout.llm
+
+    ConfigManager (this class) remains the authority for *runtime* config
+    values that users can change via the GUI and that are persisted to
+    config.yaml / settings.json:
+        - feature flags
+        - circuit-breaker thresholds
+        - batch sizes
+        - agent-specific overrides stored by the UI
+
+    Do NOT add new infrastructure values here; add them to ssot_config instead.
 """
 
 import asyncio

--- a/autobot-backend/llm_interface_pkg/providers/openai_provider.py
+++ b/autobot-backend/llm_interface_pkg/providers/openai_provider.py
@@ -38,14 +38,15 @@ class OpenAIProvider:
         Initialize OpenAI provider.
 
         Args:
-            api_key: OpenAI API key (falls back to unified config #536)
+            api_key: OpenAI API key (falls back to ssot_config #536)
         """
         if api_key:
             self.api_key = api_key
         else:
-            from config import ConfigManager
+            from autobot_shared.ssot_config import config as _ssot_config
 
-            self.api_key = ConfigManager().get_api_key("openai")
+            # ssot_config reads OPENAI_API_KEY from .env (Issue #3829)
+            self.api_key = _ssot_config.llm.openai_api_key
 
     def _record_success_span_attributes(
         self, span, response, processing_time: float

--- a/autobot-backend/llm_providers/openai_provider.py
+++ b/autobot-backend/llm_providers/openai_provider.py
@@ -78,9 +78,10 @@ class OpenAIProvider(BaseProvider):
         key = self._get_setting("api_key") or os.getenv("OPENAI_API_KEY")
         if not key:
             try:
-                from config import ConfigManager
+                from autobot_shared.ssot_config import config as _ssot_config
 
-                key = ConfigManager().get_api_key("openai")
+                # ssot_config reads OPENAI_API_KEY from .env (Issue #3829)
+                key = _ssot_config.llm.openai_api_key
             except Exception:
                 pass
         self._api_key = key

--- a/autobot-backend/orchestrator.py
+++ b/autobot-backend/orchestrator.py
@@ -21,7 +21,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
 from autobot_shared.logging_manager import get_logger
-from config import config_manager
+from config.manager import get_config_manager as _get_config_manager
 from constants.threshold_constants import LLMDefaults, TimingConstants
 from llm_interface import LLMInterface
 from memory import LongTermMemoryManager
@@ -48,6 +48,9 @@ from utils.agent_selection import reserve_agent as _reserve_agent
 from utils.agent_selection import update_agent_performance as _update_performance
 
 logger = get_logger("orchestrator")
+
+# Canonical singleton; avoids routing through config/__init__ lazy alias (Issue #3829)
+config_manager = _get_config_manager()
 
 # Import KnowledgeBase for enhanced features
 try:
@@ -200,9 +203,8 @@ class ConsolidatedOrchestrator:
 
     def _init_core_components(self, config_mgr) -> None:
         """Initialize core orchestrator components. Issue #620."""
-        from config import config_manager as global_config_manager
-
-        self.config_manager = config_mgr or global_config_manager
+        # Use module-level singleton; avoid re-importing through the lazy alias
+        self.config_manager = config_mgr or _get_config_manager()
         self.config = OrchestratorConfig(self.config_manager)
 
         self.llm_interface = LLMInterface()

--- a/autobot-backend/services/fact_extraction_service.py
+++ b/autobot-backend/services/fact_extraction_service.py
@@ -15,11 +15,14 @@ from typing import Any, Dict, List, Optional
 
 from agents.knowledge_extraction_agent import KnowledgeExtractionAgent
 from autobot_shared.logging_manager import get_llm_logger
-from config import config_manager
+from config.manager import get_config_manager as _get_config_manager
 from models.atomic_fact import AtomicFact, FactExtractionResult, FactType, TemporalType
 from utils.entity_resolver import entity_resolver
 
 logger = get_llm_logger("fact_extraction_service")
+
+# Canonical singleton; avoids routing through config/__init__ lazy alias (Issue #3829)
+config_manager = _get_config_manager()
 
 
 class FactExtractionService:

--- a/autobot-backend/services/secrets_service.py
+++ b/autobot-backend/services/secrets_service.py
@@ -16,10 +16,13 @@ from uuid import uuid4
 
 from cryptography.fernet import Fernet
 
-from config import config_manager
+from config.manager import get_config_manager as _get_config_manager
 from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
+
+# Canonical singleton; avoids routing through config/__init__ lazy alias (Issue #3829)
+config_manager = _get_config_manager()
 
 _INSERT_SECRET_SQL = (
     "INSERT INTO secrets ("

--- a/autobot-backend/services/temporal_invalidation_service.py
+++ b/autobot-backend/services/temporal_invalidation_service.py
@@ -16,11 +16,14 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.logging_manager import get_llm_logger
-from config import config_manager
+from config.manager import get_config_manager as _get_config_manager
 from models.atomic_fact import AtomicFact, FactType, TemporalType
 from services.fact_extraction_service import FactExtractionService
 
 logger = get_llm_logger("temporal_invalidation")
+
+# Canonical singleton; avoids routing through config/__init__ lazy alias (Issue #3829)
+config_manager = _get_config_manager()
 
 
 class InvalidationReason(Enum):

--- a/autobot-backend/utils/entity_resolver.py
+++ b/autobot-backend/utils/entity_resolver.py
@@ -18,7 +18,7 @@ import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
 
 from autobot_shared.logging_manager import get_llm_logger
-from config import config_manager
+from config.manager import get_config_manager as _get_config_manager
 from models.atomic_fact import AtomicFact
 from models.entity_mapping import (
     EntityMapping,
@@ -28,6 +28,9 @@ from models.entity_mapping import (
 )
 
 logger = get_llm_logger("entity_resolver")
+
+# Canonical singleton; avoids routing through config/__init__ lazy alias (Issue #3829)
+config_manager = _get_config_manager()
 
 # Entity classification patterns (Issue #315 - module-level constant)
 _ENTITY_PATTERNS = {


### PR DESCRIPTION
## Summary

Issue #3829: `config.py:ConfigManager` (root-level monolith) is shadowed by the `config/` package — `from config import ConfigManager` always resolves to `config/manager.py:ConfigManager` via `config/__init__.py.__getattr__`. The root-level `config.py:ConfigManager` is dead code.

**Tombstone:** Replaced `config.py:ConfigManager` body with `__init__` that raises `AttributeError` immediately — safety net if directory restructure ever exposes it.

**Migrated 10 top callers** from `ConfigManager()` to:
- `from autobot_shared.ssot_config import config` — for infra values (ollama_url, openai_api_key, vm.*, timeout.*)
- `from config.manager import get_config_manager` — for yaml-based runtime config

Files: `config/manager.py`, `orchestrator.py`, `chat_workflow/llm_handler.py`, 2× `openai_provider.py`, `knowledge_extraction_agent.py`, 3× services, `entity_resolver.py`

42 remaining callers use yaml-based runtime config legitimately — tracked in #3829.

## Test plan

- [ ] Backend starts without ImportError
- [ ] Ollama endpoint resolves correctly via ssot_config
- [ ] OpenAI API key reads from env/ssot_config

Partially closes #3829 (remaining callers tracked in issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)