### PR TITLE
refactor(auth): extract JWT/bcrypt core into autobot_shared — eliminate SLM duplication (#3840)

### DIFF
--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -14,10 +14,14 @@ import os
 import secrets
 from typing import Dict, Optional, Tuple
 
-import bcrypt
-import jwt
 from fastapi import Request
 
+from autobot_shared.auth.jwt_core import (
+    decode_jwt_or_none,
+    encode_jwt,
+    hash_password,
+    verify_password,
+)
 from config import ConfigManager
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_auth_error
@@ -35,7 +39,6 @@ class AuthenticationMiddleware:
         self.security_config = config.get("security_config", {})
         self.enable_auth = self.security_config.get("enable_auth", True)
         self.jwt_secret = self._get_jwt_secret()
-        self.jwt_algorithm = "HS256"
         self.jwt_expiry_hours = 24
         self.session_timeout_minutes = self.security_config.get(
             "session_timeout_minutes", 30
@@ -115,17 +118,12 @@ class AuthenticationMiddleware:
             return secure_secret
 
     def hash_password(self, password: str) -> str:
-        """Hash password using bcrypt"""
-        salt = bcrypt.gensalt(rounds=12)
-        return bcrypt.hashpw(password.encode("utf-8"), salt).decode("utf-8")
+        """Hash password using bcrypt."""
+        return hash_password(password)
 
     def verify_password(self, password: str, hashed: str) -> bool:
-        """Verify password against hash"""
-        try:
-            return bcrypt.checkpw(password.encode("utf-8"), hashed.encode("utf-8"))
-        except Exception as e:
-            logger.error("Password verification error: %s", e)
-            return False
+        """Verify password against hash."""
+        return verify_password(password, hashed)
 
     def is_account_locked(self, username: str) -> bool:
         """Check if account is locked due to failed attempts"""
@@ -274,11 +272,7 @@ class AuthenticationMiddleware:
             "username": user_data["username"],
             "role": user_data["role"],
             "email": user_data.get("email", ""),
-            "iat": datetime.datetime.utcnow(),
-            "exp": (
-                datetime.datetime.utcnow()
-                + datetime.timedelta(hours=self.jwt_expiry_hours)
-            ),
+            "iat": datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
         }
 
         # Issue #684: Include org/user hierarchy in token
@@ -287,27 +281,20 @@ class AuthenticationMiddleware:
         if user_data.get("org_id"):
             payload["org_id"] = str(user_data["org_id"])
 
-        return jwt.encode(payload, self.jwt_secret, algorithm=self.jwt_algorithm)
+        return encode_jwt(payload, secret=self.jwt_secret, expiry_hours=self.jwt_expiry_hours)
 
     def verify_jwt_token(self, token: str) -> Optional[Dict]:
-        """Verify and decode JWT token"""
-        try:
-            payload = jwt.decode(
-                token, self.jwt_secret, algorithms=[self.jwt_algorithm]
-            )
-
-            # Check if user still exists and is active
-            username = payload.get("username")
-            if username and self.is_account_locked(username):
-                return None
-
-            return payload
-        except jwt.ExpiredSignatureError:
-            logger.warning("JWT token expired")
+        """Verify and decode JWT token."""
+        payload = decode_jwt_or_none(token, self.jwt_secret)
+        if payload is None:
             return None
-        except jwt.InvalidTokenError as e:
-            logger.warning("Invalid JWT token: %s", e)
+
+        # Check if user is locked out even when token is structurally valid
+        username = payload.get("username")
+        if username and self.is_account_locked(username):
             return None
+
+        return payload
 
     def create_session(self, user_data: Dict, request: Request) -> str:
         """Create authenticated session with Redis persistence"""

--- a/autobot-slm-backend/services/auth.py
+++ b/autobot-slm-backend/services/auth.py
@@ -8,17 +8,15 @@ JWT-based authentication and user management.
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Optional
 
-import bcrypt
-import jwt
 from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jwt.exceptions import InvalidTokenError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from autobot_shared.auth.jwt_core import decode_jwt_or_none, encode_jwt, hash_password
 from config import settings
 from models.schemas import TokenResponse, UserCreate, UserResponse
 from user_management.models.user import User
@@ -31,37 +29,24 @@ security = HTTPBearer()
 class AuthService:
     """Handles authentication and authorization."""
 
-    def __init__(self):
-        self.algorithm = "HS256"
-
     def hash_password(self, password: str) -> str:
         """Hash a password."""
-        return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+        return hash_password(password)
 
     def create_access_token(
         self, data: dict, expires_delta: Optional[timedelta] = None
     ) -> str:
         """Create a JWT access token."""
-        to_encode = data.copy()
-        if expires_delta:
-            expire = datetime.utcnow() + expires_delta
-        else:
-            expire = datetime.utcnow() + timedelta(
-                minutes=settings.access_token_expire_minutes
-            )
-        to_encode.update({"exp": expire})
-        return jwt.encode(to_encode, settings.secret_key, algorithm=self.algorithm)
+        default_delta = timedelta(minutes=settings.access_token_expire_minutes)
+        return encode_jwt(
+            data,
+            secret=settings.secret_key,
+            expires_delta=expires_delta if expires_delta is not None else default_delta,
+        )
 
     def decode_token(self, token: str) -> Optional[dict]:
         """Decode and validate a JWT token."""
-        try:
-            payload = jwt.decode(
-                token, settings.secret_key, algorithms=[self.algorithm]
-            )
-            return payload
-        except InvalidTokenError as e:
-            logger.warning("JWT decode error: %s", e)
-            return None
+        return decode_jwt_or_none(token, settings.secret_key)
 
     async def create_user(
         self, db: AsyncSession, user_data: UserCreate

--- a/autobot-slm-backend/user_management/services/user_service.py
+++ b/autobot-slm-backend/user_management/services/user_service.py
@@ -14,13 +14,13 @@ import uuid
 from datetime import datetime, timezone
 from typing import List, Optional
 
-import bcrypt
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from user_management.models import Role, User, UserRole
 from user_management.models.audit import AuditAction, AuditLog, AuditResourceType
+from autobot_shared.auth.jwt_core import hash_password, verify_password
 from user_management.services.base_service import BaseService, TenantContext
 
 logger = logging.getLogger(__name__)
@@ -50,9 +50,6 @@ class UserService(BaseService):
     multi-tenancy support.
     """
 
-    # Password hashing configuration
-    BCRYPT_ROUNDS = 12
-
     def __init__(self, session: AsyncSession, context: Optional[TenantContext] = None):
         """Initialize user service."""
         super().__init__(session, context)
@@ -72,8 +69,7 @@ class UserService(BaseService):
         Returns:
             Bcrypt hash string
         """
-        salt = bcrypt.gensalt(rounds=UserService.BCRYPT_ROUNDS)
-        return bcrypt.hashpw(password.encode("utf-8"), salt).decode("utf-8")
+        return hash_password(password)
 
     @staticmethod
     def verify_password(password: str, password_hash: str) -> bool:
@@ -87,13 +83,7 @@ class UserService(BaseService):
         Returns:
             True if password matches
         """
-        try:
-            return bcrypt.checkpw(
-                password.encode("utf-8"), password_hash.encode("utf-8")
-            )
-        except Exception as e:
-            logger.error("Password verification error: %s", e)
-            return False
+        return verify_password(password, password_hash)
 
     @staticmethod
     def generate_temp_password() -> str:

--- a/autobot_shared/auth/__init__.py
+++ b/autobot_shared/auth/__init__.py
@@ -1,0 +1,30 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Shared authentication utilities for AutoBot (#3840).
+
+Provides the JWT encode/decode core and bcrypt password helpers used by
+both autobot-backend and autobot-slm-backend to eliminate duplication.
+
+Usage:
+    from autobot_shared.auth import decode_jwt, encode_jwt, hash_password, verify_password
+"""
+
+from autobot_shared.auth.jwt_core import (
+    JWTDecodeError,
+    JWTExpiredError,
+    decode_jwt,
+    encode_jwt,
+    hash_password,
+    verify_password,
+)
+
+__all__ = [
+    "decode_jwt",
+    "encode_jwt",
+    "hash_password",
+    "verify_password",
+    "JWTDecodeError",
+    "JWTExpiredError",
+]

--- a/autobot_shared/auth/jwt_core.py
+++ b/autobot_shared/auth/jwt_core.py
@@ -1,0 +1,170 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Shared JWT encode/decode core and bcrypt password helpers (#3840).
+
+Both autobot-backend (auth_middleware.py) and autobot-slm-backend
+(services/auth.py) duplicated identical jwt.encode/jwt.decode and bcrypt
+call sites.  This module is the single implementation; both backends import
+from here.
+
+Design decisions:
+- ``encode_jwt`` / ``decode_jwt`` are thin, stateless functions that accept
+  the secret as an explicit argument so each backend can supply its own key
+  without this module touching environment variables or config objects.
+- ``decode_jwt`` distinguishes expiry from other decode failures via the two
+  typed exceptions below, letting callers log each case appropriately.
+- The algorithm is hard-coded to HS256 because neither backend ever changed
+  it; if that changes in the future the parameter can be promoted.
+- Password helpers are included because both backends contained byte-for-byte
+  identical bcrypt wrappers.
+
+Usage (backend)::
+
+    from autobot_shared.auth.jwt_core import encode_jwt, decode_jwt
+
+    token = encode_jwt(payload, secret=jwt_secret)
+    data   = decode_jwt(token,   secret=jwt_secret)  # raises on failure
+
+Usage (slm-backend)::
+
+    from autobot_shared.auth.jwt_core import encode_jwt, decode_jwt
+
+    token = encode_jwt({"sub": username, "exp": expire}, secret=settings.secret_key)
+    data   = decode_jwt(token, secret=settings.secret_key)
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+import bcrypt
+import jwt
+from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
+
+logger = logging.getLogger(__name__)
+
+_ALGORITHM = "HS256"
+
+
+class JWTDecodeError(Exception):
+    """Raised when a token is structurally invalid or the signature does not match."""
+
+
+class JWTExpiredError(JWTDecodeError):
+    """Raised when a token is structurally valid but has expired."""
+
+
+def encode_jwt(
+    payload: Dict[str, Any],
+    secret: str,
+    expires_delta: Optional[timedelta] = None,
+    expiry_hours: Optional[float] = None,
+) -> str:
+    """Encode *payload* as a signed HS256 JWT.
+
+    Expiry precedence (first truthy value wins):
+    1. ``exp`` key already present in *payload*
+    2. ``expires_delta`` argument
+    3. ``expiry_hours`` argument  (converted to ``timedelta``)
+    4. No expiry set (token never expires — use only for service tokens)
+
+    Args:
+        payload: Claims dict.  A copy is taken; the caller's dict is not mutated.
+        secret: HMAC signing secret.
+        expires_delta: Optional explicit TTL.
+        expiry_hours: Optional TTL expressed as a float number of hours.
+
+    Returns:
+        Signed JWT string.
+    """
+    to_encode = payload.copy()
+
+    if "exp" not in to_encode:
+        if expires_delta is not None:
+            to_encode["exp"] = datetime.now(tz=timezone.utc) + expires_delta
+        elif expiry_hours is not None:
+            to_encode["exp"] = datetime.now(tz=timezone.utc) + timedelta(hours=expiry_hours)
+
+    return jwt.encode(to_encode, secret, algorithm=_ALGORITHM)
+
+
+def decode_jwt(token: str, secret: str) -> Dict[str, Any]:
+    """Decode and verify a signed HS256 JWT.
+
+    Args:
+        token: JWT string.
+        secret: HMAC signing secret.
+
+    Returns:
+        Decoded claims dict.
+
+    Raises:
+        JWTExpiredError: The token signature is valid but the token has expired.
+        JWTDecodeError: The token is invalid for any other reason (bad signature,
+            malformed header/payload, unknown algorithm, etc.).
+    """
+    try:
+        return jwt.decode(token, secret, algorithms=[_ALGORITHM])
+    except ExpiredSignatureError as exc:
+        raise JWTExpiredError("JWT token has expired") from exc
+    except InvalidTokenError as exc:
+        raise JWTDecodeError(f"JWT token is invalid: {exc}") from exc
+
+
+def decode_jwt_or_none(token: str, secret: str) -> Optional[Dict[str, Any]]:
+    """Decode a JWT, returning ``None`` on any failure instead of raising.
+
+    Convenience wrapper for call sites that prefer ``None``-on-failure
+    (mirrors the original pattern in both backends).
+
+    Expiry and invalid-signature failures are both logged at WARNING level
+    so they remain visible in production logs without propagating exceptions.
+
+    Args:
+        token: JWT string.
+        secret: HMAC signing secret.
+
+    Returns:
+        Decoded claims dict, or ``None`` if the token is invalid or expired.
+    """
+    try:
+        return decode_jwt(token, secret)
+    except JWTExpiredError:
+        logger.warning("JWT token expired")
+        return None
+    except JWTDecodeError as exc:
+        logger.warning("Invalid JWT token: %s", exc)
+        return None
+
+
+def hash_password(password: str) -> str:
+    """Hash *password* with bcrypt (cost factor 12).
+
+    Args:
+        password: Plaintext password.
+
+    Returns:
+        Bcrypt hash string.
+    """
+    salt = bcrypt.gensalt(rounds=12)
+    return bcrypt.hashpw(password.encode("utf-8"), salt).decode("utf-8")
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Verify *password* against a bcrypt *hashed* value.
+
+    Args:
+        password: Plaintext candidate.
+        hashed: Stored bcrypt hash.
+
+    Returns:
+        ``True`` if the password matches, ``False`` otherwise (including on
+        any internal bcrypt error).
+    """
+    try:
+        return bcrypt.checkpw(password.encode("utf-8"), hashed.encode("utf-8"))
+    except Exception as exc:
+        logger.error("Password verification error: %s", exc)
+        return False

--- a/autobot_shared/auth/jwt_core_test.py
+++ b/autobot_shared/auth/jwt_core_test.py
@@ -1,0 +1,120 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for autobot_shared.auth.jwt_core (#3840).
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from autobot_shared.auth.jwt_core import (
+    JWTDecodeError,
+    JWTExpiredError,
+    decode_jwt,
+    decode_jwt_or_none,
+    encode_jwt,
+    hash_password,
+    verify_password,
+)
+
+_SECRET = "test-secret-key-for-unit-tests-only-32chars"
+
+
+# ---------------------------------------------------------------------------
+# encode_jwt / decode_jwt
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_basic_payload():
+    token = encode_jwt({"sub": "alice", "role": "admin"}, secret=_SECRET)
+    payload = decode_jwt(token, secret=_SECRET)
+    assert payload["sub"] == "alice"
+    assert payload["role"] == "admin"
+
+
+def test_expiry_from_expiry_hours():
+    token = encode_jwt({"sub": "alice"}, secret=_SECRET, expiry_hours=1)
+    payload = decode_jwt(token, secret=_SECRET)
+    assert "exp" in payload
+
+
+def test_expiry_from_expires_delta():
+    token = encode_jwt({"sub": "alice"}, secret=_SECRET, expires_delta=timedelta(minutes=5))
+    payload = decode_jwt(token, secret=_SECRET)
+    assert "exp" in payload
+
+
+def test_existing_exp_not_overwritten():
+    from datetime import datetime, timezone
+
+    future = int((datetime.now(tz=timezone.utc) + timedelta(hours=2)).timestamp())
+    token = encode_jwt({"sub": "alice", "exp": future}, secret=_SECRET, expiry_hours=1)
+    payload = decode_jwt(token, secret=_SECRET)
+    # exp in payload should equal the value we put in, not the expiry_hours override
+    assert payload["exp"] == future
+
+
+def test_decode_wrong_secret_raises():
+    token = encode_jwt({"sub": "alice"}, secret=_SECRET)
+    with pytest.raises(JWTDecodeError):
+        decode_jwt(token, secret="wrong-secret-key-for-unit-tests-only-32ch")
+
+
+def test_decode_expired_token_raises_jwt_expired_error():
+    token = encode_jwt({"sub": "alice"}, secret=_SECRET, expires_delta=timedelta(seconds=-1))
+    with pytest.raises(JWTExpiredError):
+        decode_jwt(token, secret=_SECRET)
+
+
+def test_decode_malformed_token_raises_jwt_decode_error():
+    with pytest.raises(JWTDecodeError):
+        decode_jwt("not.a.jwt", secret=_SECRET)
+
+
+# ---------------------------------------------------------------------------
+# decode_jwt_or_none
+# ---------------------------------------------------------------------------
+
+
+def test_decode_jwt_or_none_returns_payload_on_success():
+    token = encode_jwt({"sub": "bob"}, secret=_SECRET)
+    result = decode_jwt_or_none(token, secret=_SECRET)
+    assert result is not None
+    assert result["sub"] == "bob"
+
+
+def test_decode_jwt_or_none_returns_none_on_expired():
+    token = encode_jwt({"sub": "bob"}, secret=_SECRET, expires_delta=timedelta(seconds=-1))
+    assert decode_jwt_or_none(token, secret=_SECRET) is None
+
+
+def test_decode_jwt_or_none_returns_none_on_invalid():
+    assert decode_jwt_or_none("garbage", secret=_SECRET) is None
+
+
+# ---------------------------------------------------------------------------
+# hash_password / verify_password
+# ---------------------------------------------------------------------------
+
+
+def test_hash_and_verify_roundtrip():
+    hashed = hash_password("correct-horse-battery-staple")
+    assert verify_password("correct-horse-battery-staple", hashed) is True
+
+
+def test_verify_wrong_password_returns_false():
+    hashed = hash_password("correct-horse-battery-staple")
+    assert verify_password("wrong-password", hashed) is False
+
+
+def test_hash_produces_bcrypt_prefix():
+    hashed = hash_password("some-password")
+    assert hashed.startswith("$2b$")
+
+
+def test_verify_bad_hash_returns_false():
+    # Should not raise — returns False gracefully
+    result = verify_password("any-password", "not-a-valid-hash")
+    assert result is False


### PR DESCRIPTION
## Summary

- Creates `autobot_shared/auth/jwt_core.py` with `encode_jwt`, `decode_jwt`, `decode_jwt_or_none`, `hash_password`, `verify_password`
- Removes duplicate `jwt` + `bcrypt` imports and logic from 3 files across 2 services
- `autobot-backend/auth_middleware.py` and `autobot-slm-backend/` now both import from the single shared implementation
- Fixes deprecated `datetime.utcnow()` → `datetime.now(tz=timezone.utc)` in auth_middleware.py
- 14 unit tests in `autobot_shared/auth/jwt_core_test.py`

**Before:** jwt+bcrypt logic duplicated in `auth_middleware.py`, `services/auth.py`, `user_service.py`
**After:** one implementation, three importers

Closes #3840