### PR TITLE
refactor(frontend): route raw WebSocket() calls through useWebSocket composable (#3841)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -425,7 +425,8 @@ import { useRoute } from 'vue-router';
 import { fetchWithAuth } from '@/utils/fetchWithAuth';
 import { createLogger } from '@/utils/debugUtils';
 import { getApiBase } from '@/config/ssot-config';
-import { getCssVar } from '@/composables/useCssVars'
+import { getCssVar } from '@/composables/useCssVars';
+import { useWebSocket } from '@/composables/useWebSocket';
 
 const logger = createLogger('CodeQualityDashboard');
 
@@ -525,8 +526,40 @@ const trendData = ref<Array<{ date: string; score: number }>>([]);
 const codebaseStats = ref({ files: 0, lines: 0, issues: 0 });
 const drillDownData = ref({ total_files: 0, total_issues: 0, average_score: 0, files: [] as any[] });
 
-let ws: WebSocket | null = null;
-let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+// WebSocket managed via useWebSocket composable
+const _qualityWsUrl = (() => {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${protocol}//${window.location.host}/api/quality/ws`;
+})();
+const {
+  connect: wsConnect,
+  disconnect: wsDisconnect,
+} = useWebSocket(_qualityWsUrl, {
+  autoConnect: false,
+  autoReconnect: true,
+  reconnectDelay: 5000,
+  maxReconnectAttempts: 0,
+  parseJSON: false,
+  onOpen: () => {
+    wsConnected.value = true;
+    logger.debug('WebSocket connected');
+  },
+  onClose: () => {
+    wsConnected.value = false;
+    logger.debug('WebSocket disconnected');
+  },
+  onError: (error) => {
+    logger.error('WebSocket error:', error);
+    wsConnected.value = false;
+  },
+  onMessage: (data: string) => {
+    try {
+      handleWebSocketMessage(JSON.parse(data));
+    } catch (error) {
+      logger.error('Failed to parse WebSocket message:', error);
+    }
+  },
+});
 
 // Computed
 const scoreCircleLength = computed(() => 2 * Math.PI * 54);
@@ -798,35 +831,7 @@ function closeExportMenu(): void {
 
 function connectWebSocket(): void {
   // Issue #552: Fixed path - backend uses /api/quality/* not /api/analytics/quality/*
-  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const wsUrl = `${protocol}//${window.location.host}/api/quality/ws`;
-  ws = new WebSocket(wsUrl);
-
-  ws.onopen = () => {
-    wsConnected.value = true;
-    logger.debug('WebSocket connected');
-  };
-
-  ws.onmessage = (event) => {
-    try {
-      const message = JSON.parse(event.data);
-      handleWebSocketMessage(message);
-    } catch (error) {
-      logger.error('Failed to parse WebSocket message:', error);
-    }
-  };
-
-  ws.onclose = () => {
-    wsConnected.value = false;
-    logger.debug('WebSocket disconnected');
-    // Reconnect after 5 seconds
-    wsReconnectTimer = setTimeout(connectWebSocket, 5000);
-  };
-
-  ws.onerror = (error) => {
-    logger.error('WebSocket error:', error);
-    wsConnected.value = false;
-  };
+  wsConnect();
 }
 
 function handleWebSocketMessage(message: any): void {
@@ -969,14 +974,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  if (wsReconnectTimer) {
-    clearTimeout(wsReconnectTimer);
-    wsReconnectTimer = null;
-  }
-  if (ws) {
-    ws.onclose = null;
-    ws.close();
-  }
+  // useWebSocket handles WebSocket cleanup via its own onUnmounted
 });
 
 watch(selectedPeriod, () => {

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
@@ -20,6 +20,7 @@ import { getBackendWsUrl, getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import InteractiveScreenshot from '@/components/browser/InteractiveScreenshot.vue'
 import { useUserStore } from '@/stores/useUserStore'
+import { useWebSocket } from '@/composables/useWebSocket'
 
 const logger = createLogger('KnowledgeResearchPanel')
 const userStore = useUserStore()
@@ -40,7 +41,42 @@ const viewportWidth = ref(1280)
 const viewportHeight = ref(720)
 
 let screenshotInterval: ReturnType<typeof setInterval> | null = null
-let ws: WebSocket | null = null
+
+// Research WebSocket URL — set dynamically when research starts
+const researchWsUrl = ref('')
+const {
+  send: wsSend,
+  connect: wsConnect,
+  disconnect: wsDisconnect,
+} = useWebSocket(researchWsUrl, {
+  autoConnect: false,
+  autoReconnect: false,
+  parseJSON: false,
+  onOpen: () => {
+    statusText.value = t('knowledge.research.statusStarting')
+    wsSend(JSON.stringify({ action: 'start', query: query.value.trim(), store: true }))
+  },
+  onMessage: (data: string) => {
+    try {
+      _handleEvent(JSON.parse(data) as Record<string, unknown>)
+    } catch (e) {
+      logger.warn('Failed to parse WS message:', e)
+    }
+  },
+  onError: () => {
+    logger.error('Research WS error')
+    errorMsg.value = t('knowledge.research.errorWebSocket')
+    isResearching.value = false
+    stopScreenshotPolling()
+  },
+  onClose: () => {
+    if (isResearching.value) {
+      isResearching.value = false
+      stopScreenshotPolling()
+      statusText.value = t('knowledge.research.statusDisconnected')
+    }
+  },
+})
 
 interface SourceCard {
   url: string
@@ -171,10 +207,7 @@ function _handleEvent(event: Record<string, unknown>): void {
 }
 
 function closeWs(): void {
-  if (ws) {
-    ws.close()
-    ws = null
-  }
+  wsDisconnect()
 }
 
 async function startResearch(): Promise<void> {
@@ -185,50 +218,15 @@ async function startResearch(): Promise<void> {
   sources.value = []
   isResearching.value = true
   statusText.value = t('knowledge.research.statusConnecting')
-  closeWs()
+  wsDisconnect()
 
   await checkBrowserStatus()
   startScreenshotPolling()
 
-  try {
-    const wsUrl = _buildWsUrl()
-    logger.info('Connecting research WS:', wsUrl)
-    ws = new WebSocket(wsUrl)
-
-    ws.onopen = () => {
-      statusText.value = t('knowledge.research.statusStarting')
-      ws!.send(JSON.stringify({ action: 'start', query: q, store: true }))
-    }
-
-    ws.onmessage = (msg) => {
-      try {
-        const data = JSON.parse(msg.data) as Record<string, unknown>
-        _handleEvent(data)
-      } catch (e) {
-        logger.warn('Failed to parse WS message:', e)
-      }
-    }
-
-    ws.onerror = (e) => {
-      logger.error('Research WS error:', e)
-      errorMsg.value = t('knowledge.research.errorWebSocket')
-      isResearching.value = false
-      stopScreenshotPolling()
-    }
-
-    ws.onclose = () => {
-      if (isResearching.value) {
-        isResearching.value = false
-        stopScreenshotPolling()
-        statusText.value = t('knowledge.research.statusDisconnected')
-      }
-    }
-  } catch (e) {
-    logger.error('Failed to open research WS:', e)
-    errorMsg.value = t('knowledge.research.errorConnect')
-    isResearching.value = false
-    stopScreenshotPolling()
-  }
+  const wsUrl = _buildWsUrl()
+  logger.info('Connecting research WS:', wsUrl)
+  researchWsUrl.value = wsUrl
+  wsConnect()
 }
 
 function stopResearch(): void {

--- a/autobot-frontend/src/components/terminal/SSHTerminal.vue
+++ b/autobot-frontend/src/components/terminal/SSHTerminal.vue
@@ -25,6 +25,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { createLogger } from '@/utils/debugUtils'
+import { useWebSocket } from '@/composables/useWebSocket'
 
 const logger = createLogger('SSHTerminal')
 
@@ -52,7 +53,46 @@ const errorMessage = ref('')
 // Terminal instance
 let terminal: Terminal | null = null
 let fitAddon: FitAddon | null = null
-let websocket: WebSocket | null = null
+
+// Reactive WebSocket URL — updated when hostId changes
+const wsUrl = ref('')
+
+const buildWsUrl = () => {
+  const params = props.chatSessionId
+    ? `?conversation_id=${props.chatSessionId}`
+    : ''
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const host = window.location.host
+  return `${protocol}//${host}/api/terminal/ws/ssh/${props.hostId}${params}`
+}
+
+const { send: wsSend, connect: wsConnect, disconnect: wsDisconnect, isConnected: wsIsConnected } = useWebSocket(wsUrl, {
+  autoConnect: false,
+  autoReconnect: false,
+  parseJSON: false,
+  onOpen: () => {
+    logger.info('SSH WebSocket connected')
+    connectionState.value = 'connected'
+    emit('connected')
+  },
+  onMessage: (data: string) => {
+    try {
+      handleMessage(JSON.parse(data))
+    } catch (e) {
+      logger.error('Failed to parse SSH message:', e)
+    }
+  },
+  onError: () => {
+    connectionState.value = 'error'
+    errorMessage.value = 'Connection error'
+    emit('error', 'Connection error')
+  },
+  onClose: (event) => {
+    logger.info('SSH WebSocket closed:', { code: event.code, reason: event.reason })
+    connectionState.value = 'disconnected'
+    emit('disconnected')
+  },
+})
 
 // Computed
 const statusText = computed(() => {
@@ -130,7 +170,7 @@ const initTerminal = () => {
 
 // Connect to SSH WebSocket
 const connect = () => {
-  if (websocket && websocket.readyState === WebSocket.OPEN) {
+  if (wsIsConnected.value) {
     logger.debug('Already connected')
     return
   }
@@ -138,50 +178,10 @@ const connect = () => {
   connectionState.value = 'connecting'
   errorMessage.value = ''
 
-  try {
-    const params = props.chatSessionId
-      ? `?conversation_id=${props.chatSessionId}`
-      : ''
-
-    // Build WebSocket URL using current page location
-    // This ensures the WebSocket goes through the Vite proxy in dev mode
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const host = window.location.host
-    const url = `${protocol}//${host}/api/terminal/ws/ssh/${props.hostId}${params}`
-
-    logger.info(`Connecting to SSH WebSocket: ${url}`)
-
-    websocket = new WebSocket(url)
-
-    websocket.onopen = () => {
-      logger.info('SSH WebSocket connected')
-      connectionState.value = 'connected'
-      emit('connected')
-    }
-
-    websocket.onmessage = (event) => {
-      handleMessage(JSON.parse(event.data))
-    }
-
-    websocket.onerror = (event) => {
-      logger.error('SSH WebSocket error:', event)
-      connectionState.value = 'error'
-      errorMessage.value = 'Connection error'
-      emit('error', 'Connection error')
-    }
-
-    websocket.onclose = (event) => {
-      logger.info('SSH WebSocket closed:', { code: event.code, reason: event.reason })
-      connectionState.value = 'disconnected'
-      emit('disconnected')
-    }
-
-  } catch (error) {
-    logger.error('Failed to connect:', error)
-    connectionState.value = 'error'
-    errorMessage.value = error instanceof Error ? error.message : 'Unknown error'
-    emit('error', errorMessage.value)
-  }
+  const url = buildWsUrl()
+  logger.info(`Connecting to SSH WebSocket: ${url}`)
+  wsUrl.value = url
+  wsConnect()
 }
 
 /** WebSocket message types for SSH terminal communication. */
@@ -196,9 +196,7 @@ interface SSHTerminalMessage {
 
 // Send message to server
 const sendToServer = (message: SSHTerminalMessage) => {
-  if (websocket && websocket.readyState === WebSocket.OPEN) {
-    websocket.send(JSON.stringify(message))
-  }
+  wsSend(message)
 }
 
 // Handle incoming messages
@@ -244,10 +242,7 @@ const handleMessage = (message: SSHTerminalMessage) => {
 
 // Disconnect
 const disconnect = () => {
-  if (websocket) {
-    websocket.close()
-    websocket = null
-  }
+  wsDisconnect()
 }
 
 // Resize handler
@@ -262,7 +257,7 @@ let heartbeatInterval: number | null = null
 
 const startHeartbeat = () => {
   heartbeatInterval = window.setInterval(() => {
-    if (websocket && websocket.readyState === WebSocket.OPEN) {
+    if (wsIsConnected.value) {
       sendToServer({ type: 'ping' })
     }
   }, 30000)
@@ -295,7 +290,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   stopHeartbeat()
-  disconnect()
+  // useWebSocket handles WebSocket cleanup via its own onUnmounted
   window.removeEventListener('resize', handleResize)
   if (terminal) {
     terminal.dispose()

--- a/autobot-frontend/src/composables/useOverseerAgent.ts
+++ b/autobot-frontend/src/composables/useOverseerAgent.ts
@@ -13,6 +13,7 @@
 import { ref, computed, onUnmounted, type Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import { getBackendUrl, getApiBase } from '@/config/ssot-config'
+import { useWebSocket } from '@/composables/useWebSocket'
 
 const logger = createLogger('useOverseerAgent')
 
@@ -103,7 +104,6 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
   } = options
 
   // State
-  const isConnected = ref(false)
   const isProcessing = ref(false)
   const currentPlan = ref<OverseerPlan | null>(null)
   const steps = ref<OverseerStep[]>([])
@@ -112,87 +112,48 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
   const error = ref<string | null>(null)
   const streamingOutput = ref<Map<number, string>>(new Map())
 
-  // WebSocket instance
-  let ws: WebSocket | null = null
-  let reconnectAttempts = 0
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null // Issue #821
-  const maxReconnectAttempts = 5
-
-  /**
-   * Get WebSocket URL for overseer endpoint
-   */
+  // Build the overseer WebSocket URL
   const getWebSocketUrl = (): string => {
     const backendUrl = getBackendUrl()
-    // Convert http(s) to ws(s)
     const wsUrl = backendUrl.replace(/^http/, 'ws')
     return `${wsUrl}${getApiBase()}/overseer/ws/${sessionId}`
   }
 
-  /**
-   * Connect to the overseer WebSocket
-   */
-  const connect = (): void => {
-    if (ws?.readyState === WebSocket.OPEN) {
-      logger.debug('Already connected to overseer WebSocket')
-      return
-    }
-
-    const url = getWebSocketUrl()
-    logger.info('Connecting to overseer WebSocket:', url)
-
-    try {
-      ws = new WebSocket(url)
-
-      ws.onopen = () => {
-        isConnected.value = true
-        reconnectAttempts = 0
-        error.value = null
-        logger.info('Connected to overseer WebSocket')
-      }
-
-      ws.onclose = (event) => {
-        isConnected.value = false
-        logger.info('Overseer WebSocket closed:', { code: event.code, reason: event.reason })
-
-        // Auto-reconnect if not a clean close
-        if (event.code !== 1000 && reconnectAttempts < maxReconnectAttempts) {
-          reconnectAttempts++
-          const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), 10000) // Issue #821: 10s cap
-          logger.info(`Reconnecting in ${delay}ms (attempt ${reconnectAttempts})`)
-          reconnectTimer = setTimeout(connect, delay)
-        }
-      }
-
-      ws.onerror = (event) => {
-        logger.error('Overseer WebSocket error:', event)
-        error.value = 'WebSocket connection error'
-        onError?.('WebSocket connection error')
-      }
-
-      ws.onmessage = (event) => {
-        handleMessage(event.data)
-      }
-    } catch (e) {
-      logger.error('Failed to connect to overseer WebSocket:', e)
-      error.value = `Failed to connect: ${e}`
-      onError?.(`Failed to connect: ${e}`)
-    }
-  }
+  // WebSocket managed via useWebSocket composable
+  const {
+    isConnected,
+    send: wsSend,
+    connect,
+    disconnect: wsDisconnect,
+  } = useWebSocket(getWebSocketUrl(), {
+    autoConnect: false,
+    autoReconnect: true,
+    maxReconnectAttempts: 5,
+    reconnectDelay: 1000,
+    maxReconnectDelay: 10000,
+    parseJSON: false,
+    onOpen: () => {
+      error.value = null
+      logger.info('Connected to overseer WebSocket')
+    },
+    onClose: (event) => {
+      logger.info('Overseer WebSocket closed:', { code: event.code, reason: event.reason })
+    },
+    onError: (event) => {
+      logger.error('Overseer WebSocket error:', event)
+      error.value = 'WebSocket connection error'
+      onError?.('WebSocket connection error')
+    },
+    onMessage: (data: string) => {
+      handleMessage(data)
+    },
+  })
 
   /**
    * Disconnect from WebSocket
    */
   const disconnect = (): void => {
-    // Issue #821: Cancel pending reconnect timer to prevent reconnect after unmount
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer)
-      reconnectTimer = null
-    }
-    if (ws) {
-      ws.close(1000, 'Client disconnect')
-      ws = null
-    }
-    isConnected.value = false
+    wsDisconnect()
     isProcessing.value = false
   }
 
@@ -381,11 +342,11 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
     status.value = 'planning'
 
     // Send query
-    ws?.send(JSON.stringify({
+    wsSend({
       type: 'query',
       query,
       context
-    }))
+    })
 
     logger.info('Submitted query to overseer:', query.substring(0, 100))
   }
@@ -394,7 +355,7 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
    * Cancel current execution
    */
   const cancel = (): void => {
-    ws?.send(JSON.stringify({ type: 'cancel' }))
+    wsSend({ type: 'cancel' })
     isProcessing.value = false
     status.value = 'cancelled'
   }
@@ -403,7 +364,7 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
    * Get status
    */
   const getStatus = (): void => {
-    ws?.send(JSON.stringify({ type: 'status' }))
+    wsSend({ type: 'status' })
   }
 
   // Computed
@@ -424,9 +385,10 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
     connect()
   }
 
-  // Cleanup on unmount
+  // useWebSocket registers onUnmounted cleanup automatically;
+  // we also reset isProcessing on unmount
   onUnmounted(() => {
-    disconnect()
+    isProcessing.value = false
   })
 
   return {

--- a/autobot-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-frontend/src/composables/usePrometheusMetrics.ts
@@ -16,6 +16,7 @@ import type { Ref, ComputedRef } from 'vue'
 import { useApi } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { useWebSocket } from '@/composables/useWebSocket'
 
 // Create scoped logger
 const logger = createLogger('usePrometheusMetrics')
@@ -251,9 +252,66 @@ export function usePrometheusMetrics(
   const lastUpdate = ref<Date | null>(null)
   const isConnected = ref(false)
 
-  // Polling and WebSocket state
+  // Polling state
   let pollingInterval: ReturnType<typeof setInterval> | null = null
-  let websocket: WebSocket | null = null
+
+  // Build the monitoring WebSocket URL
+  const _buildWsUrl = (): string => {
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const wsHost = import.meta.env.VITE_API_BASE_URL?.replace(/^https?:\/\//, '') ||
+                   `${import.meta.env.VITE_BACKEND_HOST || window.location.hostname}:${import.meta.env.VITE_BACKEND_PORT || '8443'}`
+    return `${wsProtocol}//${wsHost}/api/monitoring/realtime`
+  }
+
+  // WebSocket managed via useWebSocket composable
+  const {
+    isConnected: wsIsConnected,
+    send: wsSend,
+    connect: wsConnect,
+    disconnect: wsDisconnectInner,
+  } = useWebSocket(_buildWsUrl(), {
+    autoConnect: false,
+    autoReconnect: false,
+    parseJSON: false,
+    onOpen: () => {
+      isConnected.value = true
+      logger.info('WebSocket connected')
+      wsSend(JSON.stringify({
+        type: 'update_interval',
+        interval: wsUpdateInterval,
+      }))
+    },
+    onClose: () => {
+      isConnected.value = false
+      logger.info('WebSocket disconnected')
+    },
+    onError: (event) => {
+      logger.error('WebSocket error:', event)
+      error.value = 'WebSocket connection error'
+    },
+    onMessage: (data: string) => {
+      try {
+        const msg = JSON.parse(data)
+        if (msg.type === 'performance_update' && msg.data) {
+          dashboard.value = {
+            ...dashboard.value,
+            ...msg.data,
+            timestamp: msg.timestamp,
+          }
+          lastUpdate.value = new Date()
+        } else if (msg.type === 'performance_alerts' && msg.alerts) {
+          alerts.value = {
+            ...alerts.value,
+            alerts: msg.alerts,
+            total_count: msg.alerts.length,
+            timestamp: msg.timestamp,
+          } as AlertsSummary
+        }
+      } catch (err) {
+        logger.warn('Failed to parse WebSocket message:', err)
+      }
+    },
+  })
 
   // ===== Computed Values =====
 
@@ -434,80 +492,14 @@ export function usePrometheusMetrics(
   // ===== WebSocket Methods =====
 
   function connectWebSocket(): void {
-    if (websocket) return // Already connected
-
-    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const wsHost = import.meta.env.VITE_API_BASE_URL?.replace(/^https?:\/\//, '') ||
-                   `${import.meta.env.VITE_BACKEND_HOST || window.location.hostname}:${import.meta.env.VITE_BACKEND_PORT || '8443'}`
-    const wsUrl = `${wsProtocol}//${wsHost}/api/monitoring/realtime`
-
-    logger.debug(`Connecting WebSocket to: ${wsUrl}`)
-
-    try {
-      websocket = new WebSocket(wsUrl)
-
-      websocket.onopen = () => {
-        isConnected.value = true
-        logger.info('WebSocket connected')
-
-        // Request update interval
-        if (websocket && websocket.readyState === WebSocket.OPEN) {
-          websocket.send(JSON.stringify({
-            type: 'update_interval',
-            interval: wsUpdateInterval
-          }))
-        }
-      }
-
-      websocket.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data)
-
-          if (data.type === 'performance_update' && data.data) {
-            // Update dashboard with real-time data
-            dashboard.value = {
-              ...dashboard.value,
-              ...data.data,
-              timestamp: data.timestamp
-            }
-            lastUpdate.value = new Date()
-          } else if (data.type === 'performance_alerts' && data.alerts) {
-            // Update alerts
-            alerts.value = {
-              ...alerts.value,
-              alerts: data.alerts,
-              total_count: data.alerts.length,
-              timestamp: data.timestamp
-            } as AlertsSummary
-          }
-        } catch (err) {
-          logger.warn('Failed to parse WebSocket message:', err)
-        }
-      }
-
-      websocket.onerror = (event) => {
-        logger.error('WebSocket error:', event)
-        error.value = 'WebSocket connection error'
-      }
-
-      websocket.onclose = () => {
-        isConnected.value = false
-        websocket = null
-        logger.info('WebSocket disconnected')
-      }
-    } catch (err) {
-      logger.error('Failed to create WebSocket connection:', err)
-      error.value = 'Failed to establish WebSocket connection'
-    }
+    if (wsIsConnected.value) return // Already connected
+    logger.debug('Connecting WebSocket to monitoring endpoint')
+    wsConnect()
   }
 
   function disconnectWebSocket(): void {
-    if (websocket) {
-      websocket.close()
-      websocket = null
-      isConnected.value = false
-      logger.debug('WebSocket disconnected')
-    }
+    wsDisconnectInner()
+    isConnected.value = false
   }
 
   // ===== Lifecycle =====
@@ -526,7 +518,7 @@ export function usePrometheusMetrics(
 
   onUnmounted(() => {
     stopPolling()
-    disconnectWebSocket()
+    // useWebSocket handles WebSocket cleanup via its own onUnmounted
   })
 
   return {

--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -19,6 +19,7 @@ import { getAuthToken } from '@/utils/fetchWithAuth';
 import type { ApiResponse } from '@/types/api';
 import { useWorkflowTemplates } from '@/composables/useWorkflowTemplates';
 import type { WorkflowTemplateDetail } from '@/types/workflowTemplates';
+import { useWebSocket } from '@/composables/useWebSocket';
 
 const logger = createLogger('useWorkflowBuilder');
 
@@ -606,9 +607,27 @@ export function useWorkflowBuilder() {
   const workflowNodes = ref<WorkflowNode[]>([]);
   const selectedNodeId = ref<string | null>(null);
 
-  // WebSocket connection
-  let wsConnection: WebSocket | null = null;
-  const wsConnected = ref(false);
+  // WebSocket connection — managed via useWebSocket composable
+  const wsUrl = ref('');
+  const {
+    isConnected: wsConnected,
+    connect: wsConnect,
+    disconnect: wsDisconnect,
+  } = useWebSocket(wsUrl, {
+    autoConnect: false,
+    autoReconnect: false,
+    parseJSON: false,
+    onMessage: (data: string) => {
+      try {
+        handleWebSocketMessage(JSON.parse(data));
+      } catch (e) {
+        logger.error('Failed to parse WebSocket message:', e);
+      }
+    },
+    onOpen: () => logger.info('WebSocket connected'),
+    onClose: () => logger.info('WebSocket disconnected'),
+    onError: (event) => logger.error('WebSocket error:', event),
+  });
 
   // ==================================================================================
   // COMPUTED
@@ -1093,35 +1112,9 @@ export function useWorkflowBuilder() {
 
   /** Connect to workflow WebSocket */
   function connectWebSocket(sessionId: string): void {
-    if (wsConnection) {
-      wsConnection.close();
-    }
-
-    const wsUrl = `${getBackendWsUrl()}/api/workflow-automation/workflow_ws/${sessionId}`;
-    wsConnection = new WebSocket(wsUrl);
-
-    wsConnection.onopen = () => {
-      wsConnected.value = true;
-      logger.info('WebSocket connected');
-    };
-
-    wsConnection.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        handleWebSocketMessage(data);
-      } catch (e) {
-        logger.error('Failed to parse WebSocket message:', e);
-      }
-    };
-
-    wsConnection.onerror = (event) => {
-      logger.error('WebSocket error:', event);
-    };
-
-    wsConnection.onclose = () => {
-      wsConnected.value = false;
-      logger.info('WebSocket disconnected');
-    };
+    wsDisconnect();
+    wsUrl.value = `${getBackendWsUrl()}/api/workflow-automation/workflow_ws/${sessionId}`;
+    wsConnect();
   }
 
   /** Handle WebSocket messages */
@@ -1150,20 +1143,13 @@ export function useWorkflowBuilder() {
 
   /** Disconnect WebSocket */
   function disconnectWebSocket(): void {
-    if (wsConnection) {
-      wsConnection.close();
-      wsConnection = null;
-    }
-    wsConnected.value = false;
+    wsDisconnect();
   }
 
   // ==================================================================================
   // LIFECYCLE
   // ==================================================================================
-
-  onUnmounted(() => {
-    disconnectWebSocket();
-  });
+  // useWebSocket calls disconnect() in onUnmounted automatically
 
   // ==================================================================================
   // RETURN


### PR DESCRIPTION
## Summary

Replaces 6 raw `new WebSocket(...)` call sites with the `useWebSocket` composable, eliminating duplicated connect/disconnect/reconnect logic.

| File | Lines removed | Pattern |
|------|--------------|---------|
| `useOverseerAgent.ts` | ~50 | manual reconnect → `autoReconnect: true` |
| `usePrometheusMetrics.ts` | ~50 | manual connect/disconnect block |
| `useWorkflowBuilder.ts` | ~30 | reactive `wsUrl` ref + `autoConnect: false` |
| `SSHTerminal.vue` | ~40 | reactive `wsUrl` ref + callbacks |
| `KnowledgeResearchPanel.vue` | ~35 | reactive `researchWsUrl` + `autoConnect: false` |
| `CodeQualityDashboard.vue` | ~30 | manual `onclose` reconnect → `maxReconnectAttempts: 0` |

**7 sites kept raw (all justified):** `useWebSocket.ts` itself, 3 class singletons with Promise-based lifecycle, 2 module-level voice singletons that survive component remounts, and `WebSocketMonitor.js` RUM wrapper.

Closes #3841