### PR TITLE
fix(llm): cache bypass, empty model_name, unknown session_id, silent adapter errors (#3858 #3860 #3861 #3866)

### DIFF
--- a/autobot-backend/agents/audio_processing_agent.py
+++ b/autobot-backend/agents/audio_processing_agent.py
@@ -1,4 +1,5 @@
 # AutoBot - AI-Powered Automation Platform
+import uuid
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
@@ -102,7 +103,7 @@ class AudioProcessingAgent(StandardizedAgent):
         """Process an audio processing query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Audio Processing Agent processing: %s...", request_text[:50])
-            session_id = (context or {}).get("session_id", "unknown")
+            session_id = (context or {}).get("session_id") or str(uuid.uuid4())
             response = await self.llm_interface.chat_completion_optimized(
                 agent_type=self.AGENT_ID,
                 user_message=request_text,

--- a/autobot-backend/agents/code_generation_agent.py
+++ b/autobot-backend/agents/code_generation_agent.py
@@ -1,4 +1,5 @@
 # AutoBot - AI-Powered Automation Platform
+import uuid
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
@@ -95,7 +96,7 @@ class CodeGenerationAgent(StandardizedAgent):
         """Process a code generation query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Code Generation Agent processing: %s...", request_text[:50])
-            session_id = (context or {}).get("session_id", "unknown")
+            session_id = (context or {}).get("session_id") or str(uuid.uuid4())
             response = await self.llm_interface.chat_completion_optimized(
                 agent_type=self.AGENT_ID,
                 user_message=request_text,

--- a/autobot-backend/agents/data_analysis_agent.py
+++ b/autobot-backend/agents/data_analysis_agent.py
@@ -1,4 +1,5 @@
 # AutoBot - AI-Powered Automation Platform
+import uuid
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
@@ -94,7 +95,7 @@ class DataAnalysisAgent(StandardizedAgent):
         """Process a data analysis query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Data Analysis Agent processing: %s...", request_text[:50])
-            session_id = (context or {}).get("session_id", "unknown")
+            session_id = (context or {}).get("session_id") or str(uuid.uuid4())
             response = await self.llm_interface.chat_completion_optimized(
                 agent_type=self.AGENT_ID,
                 user_message=request_text,

--- a/autobot-backend/agents/image_analysis_agent.py
+++ b/autobot-backend/agents/image_analysis_agent.py
@@ -1,4 +1,5 @@
 # AutoBot - AI-Powered Automation Platform
+import uuid
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
@@ -113,7 +114,7 @@ class ImageAnalysisAgent(StandardizedAgent):
         """Process an image analysis query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Image Analysis Agent processing: %s...", request_text[:50])
-            session_id = (context or {}).get("session_id", "unknown")
+            session_id = (context or {}).get("session_id") or str(uuid.uuid4())
             response = await self.llm_interface.chat_completion_optimized(
                 agent_type=self.AGENT_ID,
                 user_message=request_text,

--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -1,4 +1,5 @@
 # AutoBot - AI-Powered Automation Platform
+import uuid
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
@@ -101,7 +102,7 @@ class SentimentAnalysisAgent(StandardizedAgent):
         """Process a sentiment analysis query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Sentiment Analysis Agent processing: %s...", request_text[:50])
-            session_id = (context or {}).get("session_id", "unknown")
+            session_id = (context or {}).get("session_id") or str(uuid.uuid4())
             response = await self.llm_interface.chat_completion_optimized(
                 agent_type=self.AGENT_ID,
                 user_message=request_text,
@@ -123,7 +124,7 @@ class SentimentAnalysisAgent(StandardizedAgent):
                     response.get("usage", {}) if isinstance(response, dict) else {}
                 ),
             }
-            session_id = (context or {}).get("session_id", "unknown")
+            session_id = (context or {}).get("session_id") or str(uuid.uuid4())
             diary_entry = (
                 f"SESSION:{session_id}|ACTION:sentiment_analysis"
                 f"|OUTCOME:{result['status']}|TOPIC:sentiment"

--- a/autobot-backend/agents/summarization_agent.py
+++ b/autobot-backend/agents/summarization_agent.py
@@ -1,4 +1,5 @@
 # AutoBot - AI-Powered Automation Platform
+import uuid
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
@@ -98,7 +99,7 @@ class SummarizationAgent(StandardizedAgent):
         """Process a summarization query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Summarization Agent processing: %s...", request_text[:50])
-            session_id = (context or {}).get("session_id", "unknown")
+            session_id = (context or {}).get("session_id") or str(uuid.uuid4())
             response = await self.llm_interface.chat_completion_optimized(
                 agent_type=self.AGENT_ID,
                 user_message=request_text,

--- a/autobot-backend/agents/translation_agent.py
+++ b/autobot-backend/agents/translation_agent.py
@@ -1,4 +1,5 @@
 # AutoBot - AI-Powered Automation Platform
+import uuid
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
@@ -100,7 +101,7 @@ class TranslationAgent(StandardizedAgent):
         """Process a translation query using the vLLM-optimised API (Issue #3389)."""
         try:
             logger.info("Translation Agent processing: %s...", request_text[:50])
-            session_id = (context or {}).get("session_id", "unknown")
+            session_id = (context or {}).get("session_id") or str(uuid.uuid4())
             response = await self.llm_interface.chat_completion_optimized(
                 agent_type=self.AGENT_ID,
                 user_message=request_text,

--- a/autobot-backend/llm_interface_pkg/adapters/anthropic_adapter.py
+++ b/autobot-backend/llm_interface_pkg/adapters/anthropic_adapter.py
@@ -101,7 +101,8 @@ class AnthropicAdapter(AdapterBase):
                     message="API authentication successful" if available else "API check failed",
                 )
             )
-        except Exception:
+        except Exception as exc:  # Issue #3866: log so server-side errors are visible
+            logger.warning("AnthropicAdapter.test_environment() failed: %s", exc)
             diagnostics.append(
                 DiagnosticMessage(
                     level=DiagnosticLevel.ERROR,

--- a/autobot-backend/llm_interface_pkg/adapters/ollama_adapter.py
+++ b/autobot-backend/llm_interface_pkg/adapters/ollama_adapter.py
@@ -90,7 +90,8 @@ class OllamaAdapter(AdapterBase):
                             message=f"HTTP {resp.status} from Ollama",
                         )
                     )
-        except Exception:
+        except Exception as exc:  # Issue #3866: log so server-side errors are visible
+            logger.warning("OllamaAdapter.test_environment() failed: %s", exc)
             diagnostics.append(
                 DiagnosticMessage(
                     level=DiagnosticLevel.ERROR,

--- a/autobot-backend/llm_interface_pkg/adapters/openai_adapter.py
+++ b/autobot-backend/llm_interface_pkg/adapters/openai_adapter.py
@@ -90,7 +90,8 @@ class OpenAIAdapter(AdapterBase):
                     message=f"Found {len(models)} models",
                 )
             )
-        except Exception:
+        except Exception as exc:  # Issue #3866: log so server-side errors are visible
+            logger.warning("OpenAIAdapter.test_environment() failed: %s", exc)
             diagnostics.append(
                 DiagnosticMessage(
                     level=DiagnosticLevel.ERROR,

--- a/autobot-backend/llm_interface_pkg/interface.py
+++ b/autobot-backend/llm_interface_pkg/interface.py
@@ -1407,12 +1407,30 @@ class LLMInterface:
         request_id = llm_params.pop("request_id", str(uuid.uuid4()))
         start_time = time.time()
 
+        # Issue #3860: resolve model_name from provider config so usage
+        # analytics records a non-empty value instead of "".
+        _, model_name = self._determine_provider_and_model("vllm")
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ]
+
+        # Issue #3858: check L1/L2 cache before hitting vLLM, mirroring the
+        # pattern used in _execute_chat_request.  Skip cache for streaming.
+        cache_key: str | None = None
+        if not llm_params.get("stream", False):
+            cached, cache_key = await self._check_cache(
+                messages, model_name, "vllm", request_id, start_time, **llm_params
+            )
+            if cached:
+                self._calculate_cache_hit_rate(cached)
+                return cached
+
         request = LLMRequest(
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_message},
-            ],
+            messages=messages,
             provider="vllm",
+            model_name=model_name,
             request_id=request_id,
             **llm_params,
         )
@@ -1421,9 +1439,9 @@ class LLMInterface:
         response = await self._finalize_response(
             response,
             request.messages,
-            request.model_name or "",
+            model_name,
             "vllm",
-            None,
+            cache_key,
             request_id,
             start_time,
             session_id,


### PR DESCRIPTION
## Summary

Four related LLM fixes, all previously tracked but fixes were lost when the worktree was cleaned up:

- **#3858** — `chat_completion_optimized` bypassed L1/L2 cache: added `_check_cache()` call before `_execute_with_fallback`; early-returns cached response for non-streaming requests.
- **#3860** — `chat_completion_optimized` logged empty `model_name` in analytics: now calls `_determine_provider_and_model("vllm")` and passes resolved name to `LLMRequest` and `_finalize_response`.
- **#3861** — 7 task agents (data_analysis, translation, sentiment, code_gen, audio, summarization, image) silently default `session_id` to `"unknown"`: changed to `str(uuid.uuid4())` so every task gets a distinct, real session ID.
- **#3866** — 3 adapter `test_environment()` handlers (Ollama, OpenAI, Anthropic) caught `Exception` silently: added `logger.warning()` so failures appear in server logs.

## Test plan

- [ ] `chat_completion_optimized` returns cached response on second identical call
- [ ] Usage analytics records non-empty model name for vLLM calls
- [ ] Task agents produce distinct session IDs in logs
- [ ] Adapter test_environment failures visible in `backend-error.log`

Re-closes #3858, #3860, #3861, #3866 (fixes were previously lost, issues had been closed prematurely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)