### PR TITLE
fix(agent_loop): add default phase_completed to IterationResult — TypeError on every iteration (#3917)

### DIFF
--- a/autobot-backend/agent_loop/types.py
+++ b/autobot-backend/agent_loop/types.py
@@ -111,7 +111,7 @@ class IterationResult:
     """Result of a single agent loop iteration."""
 
     iteration_number: int
-    phase_completed: LoopPhase
+    phase_completed: LoopPhase = LoopPhase.ANALYZE_EVENTS  # overwritten by _execute_iteration_phases
     tools_executed: list[str] = field(default_factory=list)
     tool_results: dict[str, Any] = field(default_factory=dict)
     events_analyzed: int = 0


### PR DESCRIPTION
## Summary

`IterationResult.phase_completed: LoopPhase` had no default value. `_run_iteration()` constructed it as `IterationResult(iteration_number=self._iteration_count)` — missing the required field → **TypeError on every agent loop iteration**.

Fix: add `= LoopPhase.ANALYZE_EVENTS` as default. The field is always overwritten by `_execute_iteration_phases()` before any consumer reads it.

Flagged by the #3868/#3874/#3877 fix agent as a pre-existing bug.

Closes #3917

🤖 Generated with [Claude Code](https://claude.com/claude-code)