### PR TITLE
feat(backend): custom success criteria for workflow orchestrator

### DIFF
--- a/autobot-backend/enhanced_multi_agent_orchestrator.py
+++ b/autobot-backend/enhanced_multi_agent_orchestrator.py
@@ -32,8 +32,13 @@ from enhanced_orchestration import (
     AgentCapability,
     AgentPerformance,
     AgentTask,
+    CriteriaResult,
+    EvaluationResult,
     ExecutionStrategy,
     ExecutionStrategyHandler,
+    SuccessCriteria,
+    SuccessCriteriaEvaluator,
+    SuccessCriteriaType,
     WorkflowPlan,
     WorkflowPlanner,
 )
@@ -55,6 +60,12 @@ __all__ = [
     "create_and_execute_workflow",
     "FALLBACK_TIERS",
     "_FALLBACK_TIERS",
+    # Issue #3293
+    "SuccessCriteriaType",
+    "SuccessCriteria",
+    "CriteriaResult",
+    "EvaluationResult",
+    "SuccessCriteriaEvaluator",
 ]
 
 
@@ -260,6 +271,26 @@ class EnhancedMultiAgentOrchestrator:
             self.logger.error("Failed to create workflow plan: %s", e)
             return self._planner.create_simple_workflow_plan(goal)
 
+    async def _evaluate_criteria(
+        self, plan: WorkflowPlan, results: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Issue #3293: Evaluate structured success criteria and return serialisable dict.
+
+        Falls back to binary check when no structured criteria are defined.
+        """
+        if plan.structured_criteria:
+            evaluator = SuccessCriteriaEvaluator()
+            eval_result = await evaluator.evaluate(plan.structured_criteria, results)
+            return eval_result.to_dict()
+
+        # Legacy binary check surfaced as a minimal evaluation dict
+        binary_pass = self._planner.check_success_criteria(plan, results)
+        return {
+            "overall": "full" if binary_pass else "failed",
+            "score": 1.0 if binary_pass else 0.0,
+            "results": [],
+        }
+
     async def _handle_workflow_success(
         self,
         plan: WorkflowPlan,
@@ -267,10 +298,12 @@ class EnhancedMultiAgentOrchestrator:
         start_time: float,
     ) -> Dict[str, Any]:
         """Issue #665: Extracted from execute_workflow to reduce function length.
+        Issue #3293: Replaced binary success flag with criteria evaluation.
 
         Handle successful workflow completion including metrics update and event publishing.
         """
-        success = self._planner.check_success_criteria(plan, results)
+        criteria_eval = await self._evaluate_criteria(plan, results)
+        success = criteria_eval["overall"] in ("full", "partial")
         execution_time = time.time() - start_time
 
         await self._update_performance_metrics(plan, results, execution_time)
@@ -282,6 +315,7 @@ class EnhancedMultiAgentOrchestrator:
                 "success": success,
                 "execution_time": execution_time,
                 "results_summary": self._planner.summarize_results(results),
+                "criteria_evaluation": criteria_eval,
             },
         )
 
@@ -291,6 +325,7 @@ class EnhancedMultiAgentOrchestrator:
             "results": results,
             "execution_time": execution_time,
             "strategy_used": plan.strategy.value,
+            "criteria_evaluation": criteria_eval,
         }
 
     async def _handle_workflow_failure(

--- a/autobot-backend/enhanced_orchestration/__init__.py
+++ b/autobot-backend/enhanced_orchestration/__init__.py
@@ -13,6 +13,13 @@ Provides advanced orchestration system with improved agent coordination.
 """
 
 from .execution_strategies import ExecutionStrategyHandler
+from .success_criteria import (
+    CriteriaResult,
+    EvaluationResult,
+    SuccessCriteria,
+    SuccessCriteriaEvaluator,
+    SuccessCriteriaType,
+)
 from .types import (
     FALLBACK_TIERS,
     AgentCapability,
@@ -35,4 +42,10 @@ __all__ = [
     "ExecutionStrategyHandler",
     # Workflow planner
     "WorkflowPlanner",
+    # Issue #3293: success criteria
+    "SuccessCriteriaType",
+    "SuccessCriteria",
+    "CriteriaResult",
+    "EvaluationResult",
+    "SuccessCriteriaEvaluator",
 ]

--- a/autobot-backend/enhanced_orchestration/success_criteria.py
+++ b/autobot-backend/enhanced_orchestration/success_criteria.py
@@ -1,0 +1,233 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Success Criteria Evaluation for Workflow Orchestrator
+
+Issue #3293: Custom success criteria definitions.
+Replaces binary pass/fail with typed, weighted criteria that produce
+partial/full/failed evaluation outcomes.
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class SuccessCriteriaType(Enum):
+    """Supported success-criteria types."""
+
+    EXIT_CODE = "exit_code"
+    OUTPUT_PATTERN = "output_pattern"
+    RESOURCE_EXISTS = "resource_exists"
+    CUSTOM = "custom"
+
+
+@dataclass
+class SuccessCriteria:
+    """A single success criterion attached to a workflow definition.
+
+    Attributes:
+        criteria_type: Which kind of check to perform.
+        parameters: Type-specific check parameters (see evaluator for keys).
+        weight: Relative weight when computing overall score (default 1.0).
+        required: When True a failure here forces overall status to ``failed``
+            regardless of score (default True).
+        description: Human-readable label surfaced in completion data.
+    """
+
+    criteria_type: SuccessCriteriaType
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    weight: float = 1.0
+    required: bool = True
+    description: str = ""
+
+
+@dataclass
+class CriteriaResult:
+    """Evaluation outcome for a single criterion."""
+
+    criteria: SuccessCriteria
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class EvaluationResult:
+    """Aggregate outcome after evaluating all criteria for a workflow.
+
+    Attributes:
+        overall: ``"full"``, ``"partial"``, or ``"failed"``.
+        score: Weighted fraction of criteria passed (0.0–1.0).
+        results: Per-criterion results.
+    """
+
+    overall: str  # "full" | "partial" | "failed"
+    score: float
+    results: List[CriteriaResult] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise for inclusion in workflow completion data."""
+        return {
+            "overall": self.overall,
+            "score": round(self.score, 4),
+            "results": [
+                {
+                    "type": r.criteria.criteria_type.value,
+                    "description": r.criteria.description,
+                    "passed": r.passed,
+                    "required": r.criteria.required,
+                    "weight": r.criteria.weight,
+                    "detail": r.detail,
+                }
+                for r in self.results
+            ],
+        }
+
+
+class SuccessCriteriaEvaluator:
+    """Evaluates a list of :class:`SuccessCriteria` against workflow results.
+
+    Usage::
+
+        evaluator = SuccessCriteriaEvaluator()
+        result = await evaluator.evaluate(plan.structured_criteria, results)
+    """
+
+    async def evaluate(
+        self,
+        criteria_list: List[SuccessCriteria],
+        workflow_result: Dict[str, Any],
+    ) -> EvaluationResult:
+        """Evaluate all criteria and return an :class:`EvaluationResult`.
+
+        Args:
+            criteria_list: Criteria attached to the workflow plan.
+            workflow_result: Dict produced by the orchestrator after execution.
+
+        Returns:
+            :class:`EvaluationResult` with overall status, score, and per-item
+            results.
+        """
+        if not criteria_list:
+            return EvaluationResult(overall="full", score=1.0, results=[])
+
+        per_result = [
+            await self._evaluate_one(criterion, workflow_result)
+            for criterion in criteria_list
+        ]
+        return self._aggregate(per_result)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _evaluate_one(
+        self,
+        criterion: SuccessCriteria,
+        workflow_result: Dict[str, Any],
+    ) -> CriteriaResult:
+        """Dispatch to the appropriate check method."""
+        handler = self._handler_for(criterion.criteria_type)
+        try:
+            passed, detail = await handler(criterion.parameters, workflow_result)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "Criteria evaluation raised unexpectedly (type=%s): %s",
+                criterion.criteria_type.value,
+                exc,
+            )
+            passed, detail = False, f"Evaluation error: {exc}"
+        return CriteriaResult(criteria=criterion, passed=passed, detail=detail)
+
+    def _handler_for(
+        self, criteria_type: SuccessCriteriaType
+    ) -> Callable:
+        """Return the async check method for a given type."""
+        return {
+            SuccessCriteriaType.EXIT_CODE: self._check_exit_code,
+            SuccessCriteriaType.OUTPUT_PATTERN: self._check_output_pattern,
+            SuccessCriteriaType.RESOURCE_EXISTS: self._check_resource_exists,
+            SuccessCriteriaType.CUSTOM: self._check_custom,
+        }[criteria_type]
+
+    @staticmethod
+    async def _check_exit_code(
+        params: Dict[str, Any], result: Dict[str, Any]
+    ) -> tuple[bool, str]:
+        """Check exit_code == params['expected'] (default 0)."""
+        expected = params.get("expected", 0)
+        actual = result.get("exit_code")
+        if actual is None:
+            return False, "exit_code not present in workflow result"
+        passed = int(actual) == int(expected)
+        return passed, f"exit_code={actual} (expected {expected})"
+
+    @staticmethod
+    async def _check_output_pattern(
+        params: Dict[str, Any], result: Dict[str, Any]
+    ) -> tuple[bool, str]:
+        """Check that params['pattern'] matches result output string."""
+        pattern = params.get("pattern", "")
+        output = str(result.get("output", ""))
+        if not pattern:
+            return False, "No pattern specified"
+        matched = bool(re.search(pattern, output))
+        return matched, f"Pattern '{pattern}' {'matched' if matched else 'not found'}"
+
+    @staticmethod
+    async def _check_resource_exists(
+        params: Dict[str, Any], result: Dict[str, Any]
+    ) -> tuple[bool, str]:
+        """Check that params['key'] is present (and truthy) in result."""
+        key = params.get("key", "")
+        if not key:
+            return False, "No key specified for resource_exists check"
+        resources = result.get("resources", result)
+        exists = bool(resources.get(key))
+        return exists, f"Resource key '{key}' {'found' if exists else 'missing'}"
+
+    @staticmethod
+    async def _check_custom(
+        params: Dict[str, Any], result: Dict[str, Any]
+    ) -> tuple[bool, str]:
+        """Invoke params['fn'](result) -> bool if provided."""
+        fn: Optional[Callable] = params.get("fn")
+        if fn is None:
+            return False, "No callable 'fn' supplied in custom criterion parameters"
+        import asyncio
+
+        if asyncio.iscoroutinefunction(fn):
+            passed = bool(await fn(result))
+        else:
+            passed = bool(fn(result))
+        return passed, "Custom function returned " + str(passed)
+
+    @staticmethod
+    def _aggregate(per_result: List[CriteriaResult]) -> EvaluationResult:
+        """Compute weighted score and overall status from per-criterion results."""
+        total_weight = sum(r.criteria.weight for r in per_result)
+        if total_weight == 0:
+            return EvaluationResult(overall="full", score=1.0, results=per_result)
+
+        passed_weight = sum(
+            r.criteria.weight for r in per_result if r.passed
+        )
+        score = passed_weight / total_weight
+
+        required_failed = any(
+            not r.passed and r.criteria.required for r in per_result
+        )
+
+        if required_failed or score == 0.0:
+            overall = "failed"
+        elif score >= 1.0:
+            overall = "full"
+        else:
+            overall = "partial"
+
+        return EvaluationResult(overall=overall, score=score, results=per_result)

--- a/autobot-backend/enhanced_orchestration/success_criteria.py
+++ b/autobot-backend/enhanced_orchestration/success_criteria.py
@@ -9,6 +9,7 @@ Replaces binary pass/fail with typed, weighted criteria that produce
 partial/full/failed evaluation outcomes.
 """
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass, field
@@ -116,10 +117,11 @@ class SuccessCriteriaEvaluator:
         if not criteria_list:
             return EvaluationResult(overall="full", score=1.0, results=[])
 
-        per_result = [
-            await self._evaluate_one(criterion, workflow_result)
-            for criterion in criteria_list
-        ]
+        per_result = list(
+            await asyncio.gather(
+                *[self._evaluate_one(c, workflow_result) for c in criteria_list]
+            )
+        )
         return self._aggregate(per_result)
 
     # ------------------------------------------------------------------
@@ -199,13 +201,12 @@ class SuccessCriteriaEvaluator:
         fn: Optional[Callable] = params.get("fn")
         if fn is None:
             return False, "No callable 'fn' supplied in custom criterion parameters"
-        import asyncio
-
         if asyncio.iscoroutinefunction(fn):
             passed = bool(await fn(result))
         else:
             passed = bool(fn(result))
         return passed, "Custom function returned " + str(passed)
+
 
     @staticmethod
     def _aggregate(per_result: List[CriteriaResult]) -> EvaluationResult:

--- a/autobot-backend/enhanced_orchestration/success_criteria_test.py
+++ b/autobot-backend/enhanced_orchestration/success_criteria_test.py
@@ -1,0 +1,277 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for success_criteria module.  Issue #3293."""
+
+import pytest
+
+from enhanced_orchestration.success_criteria import (
+    CriteriaResult,
+    EvaluationResult,
+    SuccessCriteria,
+    SuccessCriteriaEvaluator,
+    SuccessCriteriaType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_criterion(
+    criteria_type: SuccessCriteriaType,
+    params: dict | None = None,
+    weight: float = 1.0,
+    required: bool = True,
+    description: str = "",
+) -> SuccessCriteria:
+    return SuccessCriteria(
+        criteria_type=criteria_type,
+        parameters=params or {},
+        weight=weight,
+        required=required,
+        description=description,
+    )
+
+
+EVALUATOR = SuccessCriteriaEvaluator()
+
+
+# ---------------------------------------------------------------------------
+# EvaluationResult.to_dict
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluationResultToDict:
+    def test_full_success_shape(self):
+        result = EvaluationResult(overall="full", score=1.0, results=[])
+        d = result.to_dict()
+        assert d["overall"] == "full"
+        assert d["score"] == 1.0
+        assert d["results"] == []
+
+    def test_partial_includes_criteria_fields(self):
+        criterion = _make_criterion(
+            SuccessCriteriaType.EXIT_CODE,
+            params={"expected": 0},
+            weight=2.0,
+            required=False,
+            description="exits cleanly",
+        )
+        cr = CriteriaResult(criteria=criterion, passed=True, detail="exit_code=0")
+        result = EvaluationResult(overall="partial", score=0.5, results=[cr])
+        item = result.to_dict()["results"][0]
+        assert item["type"] == "exit_code"
+        assert item["description"] == "exits cleanly"
+        assert item["passed"] is True
+        assert item["weight"] == 2.0
+        assert item["required"] is False
+        assert "exit_code=0" in item["detail"]
+
+
+# ---------------------------------------------------------------------------
+# EXIT_CODE
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodeCriteria:
+    @pytest.mark.asyncio
+    async def test_passes_when_code_matches(self):
+        c = _make_criterion(SuccessCriteriaType.EXIT_CODE, {"expected": 0})
+        ev = await EVALUATOR.evaluate([c], {"exit_code": 0})
+        assert ev.overall == "full"
+        assert ev.score == 1.0
+        assert ev.results[0].passed is True
+
+    @pytest.mark.asyncio
+    async def test_fails_when_code_differs(self):
+        c = _make_criterion(SuccessCriteriaType.EXIT_CODE, {"expected": 0})
+        ev = await EVALUATOR.evaluate([c], {"exit_code": 1})
+        assert ev.overall == "failed"
+        assert ev.results[0].passed is False
+
+    @pytest.mark.asyncio
+    async def test_fails_when_key_absent(self):
+        c = _make_criterion(SuccessCriteriaType.EXIT_CODE, {"expected": 0})
+        ev = await EVALUATOR.evaluate([c], {})
+        assert ev.results[0].passed is False
+        assert "not present" in ev.results[0].detail
+
+
+# ---------------------------------------------------------------------------
+# OUTPUT_PATTERN
+# ---------------------------------------------------------------------------
+
+
+class TestOutputPatternCriteria:
+    @pytest.mark.asyncio
+    async def test_passes_when_pattern_found(self):
+        c = _make_criterion(
+            SuccessCriteriaType.OUTPUT_PATTERN, {"pattern": r"SUCCESS"}
+        )
+        ev = await EVALUATOR.evaluate([c], {"output": "Build SUCCESS complete"})
+        assert ev.results[0].passed is True
+
+    @pytest.mark.asyncio
+    async def test_fails_when_pattern_absent(self):
+        c = _make_criterion(
+            SuccessCriteriaType.OUTPUT_PATTERN, {"pattern": r"SUCCESS"}
+        )
+        ev = await EVALUATOR.evaluate([c], {"output": "Build FAILED"})
+        assert ev.results[0].passed is False
+
+    @pytest.mark.asyncio
+    async def test_fails_with_empty_pattern(self):
+        c = _make_criterion(SuccessCriteriaType.OUTPUT_PATTERN, {"pattern": ""})
+        ev = await EVALUATOR.evaluate([c], {"output": "anything"})
+        assert ev.results[0].passed is False
+        assert "No pattern" in ev.results[0].detail
+
+
+# ---------------------------------------------------------------------------
+# RESOURCE_EXISTS
+# ---------------------------------------------------------------------------
+
+
+class TestResourceExistsCriteria:
+    @pytest.mark.asyncio
+    async def test_passes_when_key_present_and_truthy(self):
+        c = _make_criterion(
+            SuccessCriteriaType.RESOURCE_EXISTS, {"key": "artifact_url"}
+        )
+        ev = await EVALUATOR.evaluate(
+            [c], {"resources": {"artifact_url": "https://example.com/file.tar"}}
+        )
+        assert ev.results[0].passed is True
+
+    @pytest.mark.asyncio
+    async def test_fails_when_key_missing(self):
+        c = _make_criterion(
+            SuccessCriteriaType.RESOURCE_EXISTS, {"key": "artifact_url"}
+        )
+        ev = await EVALUATOR.evaluate([c], {"resources": {}})
+        assert ev.results[0].passed is False
+
+    @pytest.mark.asyncio
+    async def test_fails_when_no_key_specified(self):
+        c = _make_criterion(SuccessCriteriaType.RESOURCE_EXISTS, {})
+        ev = await EVALUATOR.evaluate([c], {"resources": {"x": "y"}})
+        assert ev.results[0].passed is False
+
+
+# ---------------------------------------------------------------------------
+# CUSTOM
+# ---------------------------------------------------------------------------
+
+
+class TestCustomCriteria:
+    @pytest.mark.asyncio
+    async def test_passes_with_sync_fn(self):
+        c = _make_criterion(
+            SuccessCriteriaType.CUSTOM,
+            {"fn": lambda r: r.get("score", 0) >= 0.9},
+        )
+        ev = await EVALUATOR.evaluate([c], {"score": 0.95})
+        assert ev.results[0].passed is True
+
+    @pytest.mark.asyncio
+    async def test_passes_with_async_fn(self):
+        async def async_check(result):
+            return result.get("ready") is True
+
+        c = _make_criterion(SuccessCriteriaType.CUSTOM, {"fn": async_check})
+        ev = await EVALUATOR.evaluate([c], {"ready": True})
+        assert ev.results[0].passed is True
+
+    @pytest.mark.asyncio
+    async def test_fails_without_fn(self):
+        c = _make_criterion(SuccessCriteriaType.CUSTOM, {})
+        ev = await EVALUATOR.evaluate([c], {})
+        assert ev.results[0].passed is False
+        assert "No callable" in ev.results[0].detail
+
+
+# ---------------------------------------------------------------------------
+# Aggregate: partial / full / failed
+# ---------------------------------------------------------------------------
+
+
+class TestAggregate:
+    @pytest.mark.asyncio
+    async def test_full_when_all_pass(self):
+        c1 = _make_criterion(SuccessCriteriaType.EXIT_CODE, {"expected": 0})
+        c2 = _make_criterion(
+            SuccessCriteriaType.OUTPUT_PATTERN, {"pattern": "ok"}
+        )
+        ev = await EVALUATOR.evaluate([c1, c2], {"exit_code": 0, "output": "ok"})
+        assert ev.overall == "full"
+        assert ev.score == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_partial_when_optional_fails(self):
+        required = _make_criterion(
+            SuccessCriteriaType.EXIT_CODE, {"expected": 0}, required=True
+        )
+        optional = _make_criterion(
+            SuccessCriteriaType.OUTPUT_PATTERN,
+            {"pattern": "MISSING"},
+            required=False,
+        )
+        ev = await EVALUATOR.evaluate(
+            [required, optional], {"exit_code": 0, "output": "something else"}
+        )
+        assert ev.overall == "partial"
+        assert 0.0 < ev.score < 1.0
+
+    @pytest.mark.asyncio
+    async def test_failed_when_required_fails(self):
+        required = _make_criterion(
+            SuccessCriteriaType.EXIT_CODE, {"expected": 0}, required=True
+        )
+        optional = _make_criterion(
+            SuccessCriteriaType.OUTPUT_PATTERN,
+            {"pattern": "ok"},
+            required=False,
+        )
+        ev = await EVALUATOR.evaluate(
+            [required, optional], {"exit_code": 1, "output": "ok"}
+        )
+        assert ev.overall == "failed"
+
+    @pytest.mark.asyncio
+    async def test_empty_criteria_list_returns_full(self):
+        ev = await EVALUATOR.evaluate([], {"anything": True})
+        assert ev.overall == "full"
+        assert ev.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_weighted_score(self):
+        heavy = _make_criterion(
+            SuccessCriteriaType.EXIT_CODE,
+            {"expected": 0},
+            weight=3.0,
+            required=False,
+        )
+        light = _make_criterion(
+            SuccessCriteriaType.OUTPUT_PATTERN,
+            {"pattern": "MISSING"},
+            weight=1.0,
+            required=False,
+        )
+        ev = await EVALUATOR.evaluate(
+            [heavy, light], {"exit_code": 0, "output": "no match"}
+        )
+        # heavy passes (weight 3), light fails (weight 1) → 3/4 = 0.75
+        assert ev.score == pytest.approx(0.75)
+        assert ev.overall == "partial"
+
+    @pytest.mark.asyncio
+    async def test_evaluator_handles_exception_in_fn(self):
+        def boom(_r):
+            raise RuntimeError("kaboom")
+
+        c = _make_criterion(SuccessCriteriaType.CUSTOM, {"fn": boom}, required=False)
+        ev = await EVALUATOR.evaluate([c], {})
+        assert ev.results[0].passed is False
+        assert "Evaluation error" in ev.results[0].detail

--- a/autobot-backend/enhanced_orchestration/types.py
+++ b/autobot-backend/enhanced_orchestration/types.py
@@ -11,7 +11,10 @@ Contains enums and dataclasses for the enhanced orchestration system.
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, FrozenSet, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, FrozenSet, List, Optional, Set
+
+if TYPE_CHECKING:
+    from .success_criteria import SuccessCriteria
 
 from constants.status_enums import TaskStatus
 from constants.threshold_constants import RetryConfig, TimingConstants
@@ -133,6 +136,8 @@ class WorkflowPlan:
     estimated_duration: float
     resource_requirements: Dict[str, Any]
     success_criteria: List[str]
+    # Issue #3293: structured success criteria for partial/full/failed evaluation
+    structured_criteria: List["SuccessCriteria"] = field(default_factory=list)
     fallback_plans: List["WorkflowPlan"] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
 


### PR DESCRIPTION
Closes #3293

## Changes
- Adds `SuccessCriteria` / `SuccessCriteriaEvaluator` in `enhanced_orchestration/success_criteria.py` with four criteria types: `EXIT_CODE`, `OUTPUT_PATTERN`, `RESOURCE_EXISTS`, `CUSTOM`
- Extends `WorkflowPlan` with `structured_criteria: List[SuccessCriteria]` (backward-compatible — defaults to empty list)
- Replaces binary pass/fail in `_handle_workflow_success` with weighted evaluation; `criteria_evaluation` dict (`overall`, `score`, per-item results) included in return value and published workflow event
- Legacy `List[str]` criteria path preserved when no structured criteria are set

## Test plan
- [ ] `pytest autobot-backend/enhanced_orchestration/success_criteria_test.py` — 17 unit tests covering all criteria types, weighting, partial/full/failed outcomes, and exception safety
- [ ] Existing orchestrator tests still pass (no breaking changes to `WorkflowPlan`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)