### PR TITLE
fix(test): await manager.initialize() in concurrency_safety_test (#3916)

### DIFF
--- a/autobot-backend/utils/concurrency_safety_test.py
+++ b/autobot-backend/utils/concurrency_safety_test.py
@@ -97,6 +97,7 @@ class TestFileWriteAtomicity:
         from chat_history import ChatHistoryManager
 
         manager = ChatHistoryManager()
+        await manager.initialize()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             target_file = os.path.join(tmpdir, "test.json")
@@ -119,6 +120,7 @@ class TestFileWriteAtomicity:
         from chat_history import ChatHistoryManager
 
         manager = ChatHistoryManager()
+        await manager.initialize()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             # Use invalid path to trigger failure
@@ -137,6 +139,7 @@ class TestFileWriteAtomicity:
         from chat_history import ChatHistoryManager
 
         manager = ChatHistoryManager()
+        await manager.initialize()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             target_file = os.path.join(tmpdir, "concurrent.json")
@@ -356,6 +359,7 @@ class TestPerformance:
 
         # Create manager BEFORE timing (exclude initialization overhead)
         manager = ChatHistoryManager()
+        await manager.initialize()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             target_file = os.path.join(tmpdir, "perf.json")


### PR DESCRIPTION
## Summary

Adds `await manager.initialize()` after each of the 4 `ChatHistoryManager()` construction sites in `autobot-backend/utils/concurrency_safety_test.py`.

After #3886 (PR #3908), `initialize()` is no longer a no-op — these tests were running against a manager without Redis wired up.

Closes #3916