### PR TITLE
refactor(config): migrate next 8 ConfigManager callers to ssot_config (#3829)

### DIFF
--- a/autobot-backend/agents/overseer/command_explanation_service.py
+++ b/autobot-backend/agents/overseer/command_explanation_service.py
@@ -59,11 +59,10 @@ class CommandExplanationService:
             return endpoint
         except Exception as e:
             logger.error("Failed to get Ollama endpoint: %s", e)
-            from config import ConfigManager
+            from autobot_shared.ssot_config import config as _ssot
 
-            config = ConfigManager()
             return (
-                f"http://{config.get_host('ollama')}:{config.get_port('ollama')}"
+                f"http://{_ssot.vm.ollama}:{_ssot.port.ollama}"
                 + PATH_OLLAMA_GENERATE
             )
 

--- a/autobot-backend/agents/overseer/overseer_agent.py
+++ b/autobot-backend/agents/overseer/overseer_agent.py
@@ -118,11 +118,10 @@ class OverseerAgent:
             return endpoint
         except Exception as e:
             logger.error("Failed to get Ollama endpoint: %s", e)
-            from config import ConfigManager
+            from autobot_shared.ssot_config import config as _ssot
 
-            config = ConfigManager()
             return (
-                f"http://{config.get_host('ollama')}:{config.get_port('ollama')}"
+                f"http://{_ssot.vm.ollama}:{_ssot.port.ollama}"
                 + PATH_OLLAMA_GENERATE
             )
 

--- a/autobot-backend/api/analytics_controller.py
+++ b/autobot-backend/api/analytics_controller.py
@@ -28,7 +28,7 @@ import redis
 # Import models from dedicated module (Issue #185)
 from api.analytics_models import CodeAnalysisRequest, CommunicationPattern
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
-from config import ConfigManager
+from autobot_shared.ssot_config import config as _ssot
 from constants import PATH
 from constants.threshold_constants import TimingConstants
 from type_defs.common import Metadata
@@ -38,9 +38,6 @@ from utils.system_metrics import get_metrics_collector
 from .monitoring_hardware import hardware_monitor
 
 logger = logging.getLogger(__name__)
-
-# Create singleton config instance
-config = ConfigManager()
 
 # Lock for thread-safe analytics state access
 _analytics_state_lock = asyncio.Lock()
@@ -71,11 +68,23 @@ _DYNAMIC_SEGMENT_PATTERNS = [
 
 
 # Simple service address function using configuration
+_SERVICE_HOST_MAP = {
+    "backend": lambda: _ssot.vm.main,
+    "frontend": lambda: _ssot.vm.frontend,
+    "redis": lambda: _ssot.vm.redis,
+    "ollama": lambda: _ssot.vm.ollama,
+    "npu_worker": lambda: _ssot.vm.npu,
+    "ai_stack": lambda: _ssot.vm.aistack,
+    "browser": lambda: _ssot.vm.browser,
+    "browser_service": lambda: _ssot.vm.browser,
+}
+
+
 def get_service_address(service_name: str, port: int, protocol: str = "http") -> str:
     """Get standardized service address from config helper"""
     try:
-        host = config.get_host(service_name)
-    except Exception:
+        host = _SERVICE_HOST_MAP[service_name]()
+    except (KeyError, Exception):
         host = "localhost"
     return f"{protocol}://{host}:{port}"
 

--- a/autobot-backend/api/monitoring.py
+++ b/autobot-backend/api/monitoring.py
@@ -43,7 +43,6 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
 from autobot_shared.ssot_config import get_config
-from config import ConfigManager
 from config.registry import ConfigRegistry
 
 # Issue #474: Import ServiceURLs for AlertManager integration
@@ -62,7 +61,6 @@ from utils.performance_monitor import (
 )
 
 logger = logging.getLogger(__name__)
-config = ConfigManager()
 
 # Prometheus server URL — loaded once at import time via SSOT config (Issue #1283)
 _ssot = get_config()
@@ -399,9 +397,9 @@ def _resolve_service_urls() -> tuple:
     config manager, falling back to known static addresses on any error.
     """
     try:
-        npu_url = config.get_service_url("npu_worker", "health")
-        browser_url = config.get_service_url("browser", "health")
-        ollama_url = f"{config.get_ollama_url()}/api/version"
+        npu_url = f"http://{_ssot.vm.npu}:{_ssot.port.npu}/health"
+        browser_url = f"http://{_ssot.vm.browser}:{_ssot.port.browser}/health"
+        ollama_url = f"http://{_ssot.vm.ollama}:{_ssot.port.ollama}/api/version"
     except Exception:
         # Issue #1229: Use ConfigRegistry (defaults from SSOT via registry_defaults)
         npu_host = ConfigRegistry.get("vm.npu")

--- a/autobot-backend/api/playwright.py
+++ b/autobot-backend/api/playwright.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
-from config import ConfigManager
+from autobot_shared.ssot_config import config as _ssot_config
 from constants.network_constants import NetworkConstants
 from services.playwright_service import (
     get_playwright_service,
@@ -24,9 +24,6 @@ from services.playwright_service import (
     send_test_message_embedded,
     test_frontend_embedded,
 )
-
-# Create singleton config instance
-config = ConfigManager()
 
 router = APIRouter(dependencies=[Depends(check_admin_permission)])
 logger = logging.getLogger(__name__)
@@ -40,11 +37,11 @@ class SearchRequest(BaseModel):
 
 class TestMessageRequest(BaseModel):
     message: str = "what network scanning tools do we have available?"
-    frontend_url: str = config.get_service_url("frontend")
+    frontend_url: str = _ssot_config.frontend_url
 
 
 class FrontendTestRequest(BaseModel):
-    frontend_url: str = config.get_service_url("frontend")
+    frontend_url: str = _ssot_config.frontend_url
 
 
 class ScreenshotRequest(BaseModel):

--- a/autobot-backend/api/service_monitor.py
+++ b/autobot-backend/api/service_monitor.py
@@ -17,10 +17,9 @@ from typing import Any, Dict, List, Tuple
 import aiohttp
 from fastapi import APIRouter
 
-from config import ConfigManager
+from autobot_shared.ssot_config import config as _ssot
 
 logger = logging.getLogger(__name__)
-config = ConfigManager()
 
 router = APIRouter(tags=["Service Monitor"])
 
@@ -72,9 +71,9 @@ async def get_service_statuses() -> Dict[str, Any]:
     Used by the frontend system-status widget (Issue #925).
     No authentication required — checked before and after login.
     """
-    npu_url = config.get_service_url("npu_worker", "health")
-    browser_url = config.get_service_url("browser", "health")
-    ollama_url = f"{config.get_ollama_url()}/api/version"
+    npu_url = f"http://{_ssot.vm.npu}:{_ssot.port.npu}/health"
+    browser_url = f"http://{_ssot.vm.browser}:{_ssot.port.browser}/health"
+    ollama_url = f"http://{_ssot.vm.ollama}:{_ssot.port.ollama}/api/version"
 
     (
         (redis_status, redis_msg),
@@ -109,8 +108,8 @@ async def get_vm_statuses() -> Dict[str, Any]:
     Used by the frontend system-status widget (Issue #925).
     No authentication required.
     """
-    npu_url = config.get_service_url("npu_worker", "health")
-    browser_url = config.get_service_url("browser", "health")
+    npu_url = f"http://{_ssot.vm.npu}:{_ssot.port.npu}/health"
+    browser_url = f"http://{_ssot.vm.browser}:{_ssot.port.browser}/health"
 
     (
         (redis_status, redis_msg),

--- a/autobot-backend/knowledge_base_factory.py
+++ b/autobot-backend/knowledge_base_factory.py
@@ -29,16 +29,12 @@ import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from config import ConfigManager
 from constants.threshold_constants import TimingConstants
 
 if TYPE_CHECKING:
     from knowledge_base import KnowledgeBase
 
 logger = logging.getLogger(__name__)
-
-# Create singleton config instance
-config = ConfigManager()
 
 
 class KnowledgeBaseInitializer:

--- a/autobot-backend/utils/performance_monitoring/collectors.py
+++ b/autobot-backend/utils/performance_monitoring/collectors.py
@@ -24,7 +24,7 @@ import aiohttp
 import psutil
 
 from autobot_shared.http_client import get_http_client
-from config import ConfigManager
+from autobot_shared.ssot_config import config as _ssot
 from constants.network_constants import NetworkConstants
 from utils.performance_monitoring.hardware import HardwareDetector
 from utils.performance_monitoring.metrics import (
@@ -37,7 +37,6 @@ from utils.performance_monitoring.metrics import (
 from utils.performance_monitoring.types import AUTOBOT_PROCESS_KEYWORDS
 
 logger = logging.getLogger(__name__)
-config = ConfigManager()
 
 
 class GPUCollector:
@@ -164,8 +163,8 @@ class NPUCollector:
     async def _get_worker_stats(self) -> Dict[str, Any]:
         """Get statistics from NPU worker service."""
         try:
-            npu_host = config.get_host("npu_worker")
-            npu_port = config.get_port("npu_worker")
+            npu_host = _ssot.vm.npu
+            npu_port = _ssot.port.npu
 
             http_client = get_http_client()
             async with await http_client.get(
@@ -270,7 +269,7 @@ class SystemCollector:
     async def _measure_network_latency(self) -> float:
         """Measure network latency to backend service."""
         try:
-            backend_host = config.get_host("backend")
+            backend_host = _ssot.vm.main
             start_time = time.time()
 
             http_client = get_http_client()
@@ -478,38 +477,38 @@ class ServiceCollector:
         return [
             {
                 "name": "Backend API",
-                "host": config.get_host("backend"),
-                "port": config.get_port("backend"),
+                "host": _ssot.vm.main,
+                "port": _ssot.port.backend,
                 "path": "/api/health",
             },
             {
                 "name": "Frontend",
-                "host": config.get_host("frontend"),
-                "port": config.get_port("frontend"),
+                "host": _ssot.vm.frontend,
+                "port": _ssot.port.frontend,
                 "path": "/",
             },
             {
                 "name": "Redis",
-                "host": config.get_host("redis"),
-                "port": config.get_port("redis"),
+                "host": _ssot.vm.redis,
+                "port": _ssot.port.redis,
                 "path": None,
             },
             {
                 "name": "AI Stack",
-                "host": config.get_host("ai_stack"),
-                "port": config.get_port("ai_stack"),
+                "host": _ssot.vm.aistack,
+                "port": _ssot.port.aistack,
                 "path": "/health",
             },
             {
                 "name": "NPU Worker",
-                "host": config.get_host("npu_worker"),
-                "port": config.get_port("npu_worker"),
+                "host": _ssot.vm.npu,
+                "port": _ssot.port.npu,
                 "path": "/health",
             },
             {
                 "name": "Browser Service",
-                "host": config.get_host("browser_service"),
-                "port": config.get_port("browser_service"),
+                "host": _ssot.vm.browser,
+                "port": _ssot.port.browser,
                 "path": "/health",
             },
         ]


### PR DESCRIPTION
## Summary

Second batch of ConfigManager → ssot_config migration (PR #3909 was the first).

**Migrated (8 files):**
- `agents/overseer/command_explanation_service.py` + `overseer_agent.py` — ollama host/port
- `api/playwright.py` — frontend URL field default
- `utils/performance_monitoring/collectors.py` — 12 `get_host`/`get_port` calls
- `api/monitoring.py` — service/ollama URL construction
- `api/service_monitor.py` — health endpoint URLs
- `api/analytics_controller.py` — `_SERVICE_HOST_MAP` dict replaces dynamic `get_host(service_name)`
- `knowledge_base_factory.py` — dead import deleted (variable never used)

**Skipped (~15 files):** callers that use `config.get("dotted.path")`, `config.validate()`, `config.get_redis_config()`, circuit-breaker/Celery/ChromaDB keys not yet in ssot_config, or are DI/test infrastructure. Detailed in PR description for follow-up.

Closes partial work on #3829 — ~26 callers remain.