### PR TITLE
refactor(services): migrate 4 singletons to AsyncInitializable lazy-init (#3390)

### DIFF
--- a/autobot-backend/services/audit_logger.py
+++ b/autobot-backend/services/audit_logger.py
@@ -46,6 +46,7 @@ from autobot_shared.redis_client import get_redis_client
 from constants.network_constants import NetworkConstants
 from models.task_context import AuditQueryContext
 from type_defs.common import Metadata
+from utils.async_initializable import AsyncInitializable
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +188,7 @@ class AuditEntry:
         return self
 
 
-class AuditLogger:
+class AuditLogger(AsyncInitializable):
     """
     Async audit logging service with Redis DB 10 backend
 
@@ -212,6 +213,7 @@ class AuditLogger:
             batch_timeout_seconds: Max time to wait before flushing batch
             fallback_log_dir: Directory for file-based fallback logs
         """
+        super().__init__(component_name="audit_logger")
         self.retention_days = retention_days
         self.batch_size = batch_size
         self.batch_timeout_seconds = batch_timeout_seconds
@@ -227,18 +229,24 @@ class AuditLogger:
         self._batch_lock = asyncio.Lock()
         self._batch_task: Optional[asyncio.Task] = None
 
-        # Fallback logging
+        # Fallback logging — directory creation deferred to _initialize_impl
         self.fallback_log_dir = Path(fallback_log_dir)
-        self.fallback_log_dir.mkdir(parents=True, exist_ok=True)
 
         # Statistics
         self._total_logged = 0
         self._total_failed = 0
         self._redis_failures = 0
 
+    async def _initialize_impl(self) -> bool:
+        """Create fallback log directory (deferred from __init__ to avoid blocking I/O)."""
+        await asyncio.to_thread(self.fallback_log_dir.mkdir, parents=True, exist_ok=True)
         logger.info(
-            f"AuditLogger initialized: VM={self.vm_name} ({self.vm_source}), Retention={retention_days}d"
+            "AuditLogger initialized: VM=%s (%s), Retention=%dd",
+            self.vm_name,
+            self.vm_source,
+            self.retention_days,
         )
+        return True
 
     def _get_vm_name(self) -> str:
         """Determine VM name from IP address"""
@@ -991,11 +999,12 @@ async def get_audit_logger() -> AuditLogger:
     """Get or create global audit logger instance"""
     global _audit_logger
 
-    async with _logger_lock:
-        if _audit_logger is None:
-            _audit_logger = AuditLogger()
-            logger.info("Global audit logger initialized")
-        return _audit_logger
+    if _audit_logger is None:
+        async with _logger_lock:
+            if _audit_logger is None:
+                _audit_logger = AuditLogger()
+                await _audit_logger.initialize()
+    return _audit_logger
 
 
 async def close_audit_logger():

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -30,6 +30,7 @@ from models.npu_models import (
     WorkerTestResult,
 )
 from npu_integration import NPUWorkerClient
+from utils.async_initializable import AsyncInitializable
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ logger = logging.getLogger(__name__)
 _WORKER_FULL_DATA_EVENTS = frozenset({"worker.added", "worker.updated"})
 
 
-class NPUWorkerManager:
+class NPUWorkerManager(AsyncInitializable):
     """
     Manages NPU worker registry with persistent storage and runtime state tracking.
 
@@ -61,6 +62,7 @@ class NPUWorkerManager:
             config_file: Path to worker configuration YAML file
             redis_client: Redis client for state storage
         """
+        super().__init__(component_name="npu_worker_manager")
         self.config_file = config_file or Path("config/npu_workers.yaml")
         self.redis_client = redis_client
         self._workers: Dict[str, NPUWorkerConfig] = {}
@@ -74,8 +76,10 @@ class NPUWorkerManager:
         self._worker_failure_counts: Dict[str, int] = {}
         self._worker_next_check: Dict[str, float] = {}
 
-        # Initialize from config file
-        self._load_workers_from_config()
+    async def _initialize_impl(self) -> bool:
+        """Load worker configurations from YAML (deferred from __init__ to avoid blocking I/O)."""
+        await asyncio.to_thread(self._load_workers_from_config)
+        return True
 
     def _parse_single_worker(self, worker_data: dict) -> bool:
         """Parse and store a single worker configuration (Issue #315: extracted helper).
@@ -940,6 +944,7 @@ async def get_worker_manager(redis_client=None) -> NPUWorkerManager:
             # Double-check after acquiring lock
             if _worker_manager is None:
                 _worker_manager = NPUWorkerManager(redis_client=redis_client)
+                await _worker_manager.initialize()
                 await _worker_manager.start_health_monitoring()
 
     return _worker_manager

--- a/autobot-backend/services/semantic_query_cache.py
+++ b/autobot-backend/services/semantic_query_cache.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config
+from utils.async_initializable import AsyncInitializable
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ class SemanticCacheEntry:
 # ---------------------------------------------------------------------------
 
 
-class SemanticQueryCache:
+class SemanticQueryCache(AsyncInitializable):
     """Embedding-based query cache backed by ChromaDB + Redis.
 
     Lifecycle:
@@ -96,10 +97,9 @@ class SemanticQueryCache:
         self,
         cache_config: Optional[SemanticCacheConfig] = None,
     ):
+        super().__init__(component_name="semantic_query_cache")
         self._config = cache_config or SemanticCacheConfig()
         self._collection = None
-        self._initialized = False
-        self._init_lock = asyncio.Lock()
 
         # Metrics
         self._hits = 0
@@ -111,30 +111,19 @@ class SemanticQueryCache:
     # Initialisation
     # ------------------------------------------------------------------
 
-    async def initialize(self) -> bool:
-        """Create / open the ChromaDB collection (lazy, idempotent)."""
-        if self._initialized:
-            return True
-
-        async with self._init_lock:
-            if self._initialized:
-                return True
-            try:
-                collection = await self._get_or_create_collection()
-                if collection is None:
-                    return False
-                self._collection = collection
-                self._initialized = True
-                logger.info(
-                    "SemanticQueryCache initialised " "(threshold=%.2f, max_size=%d)",
-                    self._config.similarity_threshold,
-                    self._config.max_collection_size,
-                )
-                return True
-            except Exception as exc:
-                logger.error("SemanticQueryCache init failed: %s", exc)
-                self._errors += 1
-                return False
+    async def _initialize_impl(self) -> bool:
+        """Create / open the ChromaDB collection."""
+        collection = await self._get_or_create_collection()
+        if collection is None:
+            self._errors += 1
+            return False
+        self._collection = collection
+        logger.info(
+            "SemanticQueryCache initialised (threshold=%.2f, max_size=%d)",
+            self._config.similarity_threshold,
+            self._config.max_collection_size,
+        )
+        return True
 
     async def _get_or_create_collection(self):
         """Open or create the ChromaDB collection."""

--- a/autobot-backend/services/topic_retrieval_cache.py
+++ b/autobot-backend/services/topic_retrieval_cache.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 
 from autobot_shared.redis_client import get_redis_client
+from utils.async_initializable import AsyncInitializable
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +95,7 @@ def compute_centroid(embeddings: List[List[float]]) -> List[float]:
 # ---------------------------------------------------------------------------
 
 
-class TopicRetrievalCache:
+class TopicRetrievalCache(AsyncInitializable):
     """Topic-centroid cache for cross-query chunk reuse.
 
     Usage::
@@ -108,10 +109,9 @@ class TopicRetrievalCache:
     """
 
     def __init__(self, cache_config: Optional[TopicCacheConfig] = None):
+        super().__init__(component_name="topic_retrieval_cache")
         self._config = cache_config or TopicCacheConfig()
         self._collection = None
-        self._initialized = False
-        self._init_lock = asyncio.Lock()
         self._hits = 0
         self._misses = 0
         self._stores = 0
@@ -121,30 +121,19 @@ class TopicRetrievalCache:
     # Initialisation
     # ------------------------------------------------------------------
 
-    async def initialize(self) -> bool:
-        """Create / open the ChromaDB collection (lazy, idempotent)."""
-        if self._initialized:
-            return True
-        async with self._init_lock:
-            if self._initialized:
-                return True
-            try:
-                collection = await self._get_or_create_collection()
-                if collection is None:
-                    return False
-                self._collection = collection
-                self._initialized = True
-                logger.info(
-                    "TopicRetrievalCache initialised "
-                    "(threshold=%.2f, max_topics=%d)",
-                    self._config.similarity_threshold,
-                    self._config.max_topics,
-                )
-                return True
-            except Exception as exc:
-                logger.error("TopicRetrievalCache init failed: %s", exc)
-                self._errors += 1
-                return False
+    async def _initialize_impl(self) -> bool:
+        """Create / open the ChromaDB collection."""
+        collection = await self._get_or_create_collection()
+        if collection is None:
+            self._errors += 1
+            return False
+        self._collection = collection
+        logger.info(
+            "TopicRetrievalCache initialised (threshold=%.2f, max_topics=%d)",
+            self._config.similarity_threshold,
+            self._config.max_topics,
+        )
+        return True
 
     async def _get_or_create_collection(self):
         """Open or create the ChromaDB collection."""


### PR DESCRIPTION
## Summary

Closes #3390

Migrates four service singletons from ad-hoc lazy-init patterns to the `AsyncInitializable` base class, eliminating blocking I/O in `__init__` and standardising initialisation across the codebase.

### Changes

| File | Change |
|------|--------|
| `services/audit_logger.py` | Inherit `AsyncInitializable`; move `fallback_log_dir.mkdir()` from `__init__` → `_initialize_impl()` via `asyncio.to_thread` |
| `services/npu_worker_manager.py` | Inherit `AsyncInitializable`; move `_load_workers_from_config()` (blocking `open()`) from `__init__` → `_initialize_impl()` via `asyncio.to_thread` |
| `services/semantic_query_cache.py` | Replace manual `_initialized`/`_init_lock` double-checked locking with `AsyncInitializable` base class |
| `services/topic_retrieval_cache.py` | Same as semantic_query_cache |

### Out of scope: `distributed_service_discovery.py`

`__init__` calls `unified_config_manager.get_distributed_services_config()` which depends on `ConfigManager`'s service-discovery methods (`get_service_url`, `get_host`, `get_port`). These have no equivalent in `ssot_config`. Migration blocked until ConfigManager is deprecated (#3829).

## Test plan

- [ ] Backend starts without errors and NPU workers load correctly
- [ ] Audit logging works after initialization (events written to Redis audit DB)
- [ ] Semantic cache lookup/store works (`hit_rate` increments correctly)
- [ ] Topic cache lookup/store works
- [ ] All four singleton getters return initialized instances on first call

🤖 Generated with [Claude Code](https://claude.com/claude-code)