### PR TITLE
fix(security): path traversal guard on terminal transcript writes (#3164)

### DIFF
--- a/autobot-backend/api/terminal_handlers.py
+++ b/autobot-backend/api/terminal_handlers.py
@@ -634,10 +634,9 @@ class ConsolidatedTerminalWebSocket:
             return
 
         try:
-            from pathlib import Path
-
             import aiofiles
 
+            from autobot_shared.security.path_validator import validate_relative_path
             from utils.encoding_utils import strip_ansi_codes
 
             # Strip ANSI escape codes before writing to transcript
@@ -646,9 +645,15 @@ class ConsolidatedTerminalWebSocket:
                 return
 
             transcript_file = f"{self.conversation_id}_terminal_transcript.txt"
-            transcript_path = Path("data/chats") / transcript_file
+            chats_base = PATH.DATA_DIR / "chats"
+            transcript_path = validate_relative_path(transcript_file, chats_base)
             async with aiofiles.open(transcript_path, "a", encoding="utf-8") as f:
                 await f.write(clean_text)
+        except ValueError:
+            logger.error(
+                "Blocked path traversal attempt in transcript write for session %s",
+                self.conversation_id,
+            )
         except OSError as e:
             logger.error("Failed to write input to transcript (I/O error): %s", e)
         except Exception as e:
@@ -1175,10 +1180,9 @@ class ConsolidatedTerminalWebSocket:
         if not (self.terminal_logger and self.conversation_id and content):
             return
 
-        from pathlib import Path
-
         import aiofiles
 
+        from autobot_shared.security.path_validator import validate_relative_path
         from utils.encoding_utils import strip_ansi_codes
 
         try:
@@ -1187,11 +1191,16 @@ class ConsolidatedTerminalWebSocket:
             if not clean_content:
                 return
 
-            transcript_path = (
-                Path("data/chats") / f"{self.conversation_id}_terminal_transcript.txt"
-            )
+            transcript_file = f"{self.conversation_id}_terminal_transcript.txt"
+            chats_base = PATH.DATA_DIR / "chats"
+            transcript_path = validate_relative_path(transcript_file, chats_base)
             async with aiofiles.open(transcript_path, "a", encoding="utf-8") as f:
                 await f.write(clean_content)
+        except ValueError:
+            logger.error(
+                "Blocked path traversal attempt in transcript log for session %s",
+                self.conversation_id,
+            )
         except OSError as e:
             logger.error("Failed to write terminal transcript (I/O error): %s", e)
         except Exception as e:


### PR DESCRIPTION
## Summary

Continues #3164 (remaining CodeQL py/path-injection alerts after PR #3875).

After auditing all 18 files listed in the issue, only one remaining vulnerability was found:

### `api/terminal_handlers.py` — two call sites

`self.conversation_id` is user-supplied (arrives from a POST request body for the terminal session). Both `_write_to_transcript()` and `_log_to_transcript()` build a file path as:

```python
Path("data/chats") / f"{self.conversation_id}_terminal_transcript.txt"
```

without sanitization, allowing a `../` prefix in `conversation_id` to escape the intended directory.

**Fix:** Replace with `validate_relative_path(transcript_file, PATH.DATA_DIR / "chats")` which raises `ValueError` on traversal attempts. Added explicit `except ValueError` handler to log and abort.

All other files in the issue were already protected from PR #3875 work.

## Test plan

- [ ] Terminal session with valid `conversation_id` writes transcript to `data/chats/<id>_terminal_transcript.txt`
- [ ] Terminal session with `conversation_id = "../../../etc/passwd"` is rejected with a logged error, no file written

🤖 Generated with [Claude Code](https://claude.com/claude-code)