### PR TITLE
chore(agents): remove duplicate session_id assignment (#3944)

### DIFF
--- a/autobot-backend/agents/sentiment_analysis_agent.py
+++ b/autobot-backend/agents/sentiment_analysis_agent.py
@@ -124,7 +124,6 @@ class SentimentAnalysisAgent(StandardizedAgent):
                     response.get("usage", {}) if isinstance(response, dict) else {}
                 ),
             }
-            session_id = (context or {}).get("session_id") or str(uuid.uuid4())
             diary_entry = (
                 f"SESSION:{session_id}|ACTION:sentiment_analysis"
                 f"|OUTCOME:{result['status']}|TOPIC:sentiment"


### PR DESCRIPTION
Removes duplicate session_id assignment on line 126 of sentiment_analysis_agent.py.

The variable was already assigned on line 104 with the same logic. The second assignment served no purpose and is a dead write.

Fixes #3944