### PR TITLE
docs: document gh pr edit --body workaround for classic Projects issue (#3753)

### DIFF
--- a/docs/developer/CLAUDE_WORKFLOW.md
+++ b/docs/developer/CLAUDE_WORKFLOW.md
@@ -113,6 +113,14 @@ Subagents cannot autonomously acquire Bash permission. Run batch file-manipulati
 
 **Always close the issue after implementation.** PRs targeting `Dev_new_gui` will NOT auto-close issues — verify with `gh issue view`.
 
+**GitHub CLI Workarounds:**
+
+- `gh pr edit --body "..."` silently fails when the repo has classic Projects attached (GraphQL deprecation error). Use the REST API instead:
+
+  ```bash
+  gh api repos/mrveiss/AutoBot-AI/pulls/$PR_NUMBER -X PATCH -f body="new body here"
+  ```
+
 ---
 
 ## Debugging, Errors, Self-Improvement


### PR DESCRIPTION
Closes #3753

Documented the workaround for gh pr edit --body failing silently with classic Projects attached. Instructions updated in CLAUDE_WORKFLOW.md to use gh api REST endpoint instead.