### PR TITLE
fix(frontend): remove as-any cast and deduplicate KnowledgeRepository (#3940)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KBSearchResultPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KBSearchResultPanel.vue
@@ -197,6 +197,7 @@ const logger = createLogger('KBSearchResultPanel')
 // ---------------------------------------------------------------------------
 
 const props = defineProps<{
+  repository: KnowledgeRepository
   results: SearchResult[]
   query: string
   loading: boolean
@@ -217,7 +218,6 @@ const selectedIndex = ref<number>(-1)
 const loadingDoc = ref(false)
 const viewerContent = ref<string>('')
 const copySuccess = ref(false)
-const knowledgeRepo = new KnowledgeRepository()
 
 // ---------------------------------------------------------------------------
 // Computed
@@ -305,8 +305,8 @@ async function loadDocumentContent(document: KnowledgeDocument): Promise<void> {
 
   loadingDoc.value = true
   try {
-    const full = await knowledgeRepo.getDocument(document.id)
-    viewerContent.value = (full as any)?.content ?? document.content ?? ''
+    const full = await props.repository.getDocument(document.id)
+    viewerContent.value = full?.content ?? document.content ?? ''
   } catch (err) {
     logger.error('Failed to load document content:', err)
     viewerContent.value = document.content ?? ''

--- a/autobot-frontend/src/components/knowledge/KnowledgeSearch.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSearch.vue
@@ -198,6 +198,7 @@
       <!-- Issue #3296: KB search result panel with keyboard nav + highlight -->
       <KBSearchResultPanel
         v-if="hasSearchResults || isSearching"
+        :repository="knowledgeRepo"
         :results="searchResults"
         :query="lastSearchQuery"
         :loading="isSearching"


### PR DESCRIPTION
Closes #3940

## Summary
- Add `repository: KnowledgeRepository` prop to KBSearchResultPanel
- Remove duplicate KnowledgeRepository instantiation
- Remove unnecessary `as-any` cast on document content access
- Update parent component to pass repository instance

## Changes
- **KBSearchResultPanel.vue**: Added repository prop, removed duplicate instance, removed type assertion
- **KnowledgeSearch.vue**: Pass knowledgeRepo instance to KBSearchResultPanel

## Testing
Tests pass locally; ready for review.