### PR TITLE
fix(config): raise _SYNC_MAX_DEPTH to 8 (#3946)

### DIFF
--- a/autobot-backend/api/settings.py
+++ b/autobot-backend/api/settings.py
@@ -755,7 +755,7 @@ _SYNC_ALLOWED_TOP_LEVEL_KEYS: frozenset = frozenset(
 )
 
 # Maximum nesting depth accepted in the incoming settings payload (Issue #3881).
-_SYNC_MAX_DEPTH: int = 5
+_SYNC_MAX_DEPTH: int = 8
 
 # Maximum raw byte size of the incoming settings payload (Issue #3881).
 _SYNC_MAX_PAYLOAD_BYTES: int = 256 * 1024  # 256 KiB


### PR DESCRIPTION
Closes #3946

## Summary
Increase the maximum nesting depth allowed in settings payloads from 5 to 8.

## Problem
The legitimate config schema has keys nested 6 levels deep (e.g., `backend.llm.local.providers.ollama.selected_model`). Setting the limit to 5 leaves no headroom for new legitimate deeper keys.

## Solution
Raise `_SYNC_MAX_DEPTH` to 8, providing 2 levels of headroom above current maximum depth. The 256 KiB payload size cap independently prevents abuse.

## Changes
- Update `_SYNC_MAX_DEPTH` constant in `autobot-backend/api/settings.py` (line 758)