### PR TITLE
fix(analytics): record correct vLLM model name (#3943)

### DIFF
--- a/autobot-backend/llm_interface_pkg/interface.py
+++ b/autobot-backend/llm_interface_pkg/interface.py
@@ -1436,10 +1436,12 @@ class LLMInterface:
         )
 
         response = await self._execute_with_fallback(request, "vllm")
+        # Use response.model if available (from vLLM provider), otherwise fall back to resolved model_name
+        actual_model_name = response.model if response.model else model_name
         response = await self._finalize_response(
             response,
             request.messages,
-            model_name,
+            actual_model_name,
             "vllm",
             cache_key,
             request_id,


### PR DESCRIPTION
Closes #3943

## Problem
`chat_completion_optimized()` was recording the Ollama default_model in analytics instead of the actual vLLM model because it fell through to the else branch in `_determine_provider_and_model()`.

## Solution
Use `response.model` (populated by VLLMProviderHandler) instead of the initial model_name determination. Falls back to model_name if response.model is unavailable.

## Impact
Usage analytics and cache keys for vLLM requests now correctly record the actual vLLM model.