### PR TITLE
fix(config): remove broken UnifiedConfig imports from code_analysis (#3937)

### DIFF
--- a/autobot-backend/code_analysis/src/anti_pattern_detector.py
+++ b/autobot-backend/code_analysis/src/anti_pattern_detector.py
@@ -26,10 +26,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from config import UnifiedConfig
 
 # Initialize configuration
-config = UnifiedConfig()
 logger = logging.getLogger(__name__)
 
 # Issue #380: Module-level tuple for complexity calculation

--- a/autobot-backend/code_analysis/src/api_consistency_analyzer.py
+++ b/autobot-backend/code_analysis/src/api_consistency_analyzer.py
@@ -13,11 +13,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from config import UnifiedConfig
 from constants.ttl_constants import TTL_1_HOUR
 
-# Initialize unified config
-config = UnifiedConfig()
 logger = logging.getLogger(__name__)
 
 

--- a/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
+++ b/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
@@ -18,7 +18,6 @@ import logging
 import time
 from typing import Any, Dict, List
 
-from config import UnifiedConfig
 
 # Issue #394: Import from architectural_analysis package
 from .architectural_analysis import (
@@ -31,8 +30,6 @@ from .architectural_analysis import (
     PatternDetector,
 )
 
-# Initialize unified config
-config = UnifiedConfig()
 logger = logging.getLogger(__name__)
 
 

--- a/autobot-backend/code_analysis/src/code_analyzer.py
+++ b/autobot-backend/code_analysis/src/code_analyzer.py
@@ -17,11 +17,8 @@ import numpy as np
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
-from config import UnifiedConfig
 from constants.ttl_constants import TTL_1_HOUR
 
-# Initialize unified config
-config = UnifiedConfig()
 logger = logging.getLogger(__name__)
 
 # Issue #380: Module-level tuples for AST node type checks

--- a/autobot-backend/code_analysis/src/code_quality_dashboard.py
+++ b/autobot-backend/code_analysis/src/code_quality_dashboard.py
@@ -20,11 +20,8 @@ from performance_analyzer import PerformanceAnalyzer
 from security_analyzer import SecurityAnalyzer
 from testing_coverage_analyzer import TestingCoverageAnalyzer
 
-from config import UnifiedConfig
 from constants.ttl_constants import TTL_30_DAYS
 
-# Initialize unified config
-config = UnifiedConfig()
 logger = logging.getLogger(__name__)
 
 

--- a/autobot-backend/code_analysis/src/env_analyzer.py
+++ b/autobot-backend/code_analysis/src/env_analyzer.py
@@ -32,14 +32,12 @@ if str(_project_root) not in sys.path:
 
 try:
     from autobot_shared.redis_client import get_redis_client
-    from config import UnifiedConfig
 
     _REDIS_AVAILABLE = True
     _CONFIG_AVAILABLE = True
 except ImportError:
     # Fallback for when running without project context
     get_redis_client = None
-    UnifiedConfig = None
     _REDIS_AVAILABLE = False
     _CONFIG_AVAILABLE = False
 
@@ -61,8 +59,6 @@ except ImportError:
     SSOTMapping = None
 
 
-# Initialize unified config (with fallback)
-config = UnifiedConfig() if _CONFIG_AVAILABLE else None
 logger = logging.getLogger(__name__)
 
 # Issue #380: Module-level tuple for literal value AST types

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -30,20 +30,17 @@ if str(_project_root) not in sys.path:
 
 try:
     from autobot_shared.redis_client import get_redis_client
-    from config import UnifiedConfig
     from constants.ttl_constants import TTL_1_HOUR
 
     _REDIS_AVAILABLE = True
     _CONFIG_AVAILABLE = True
 except ImportError:
     get_redis_client = None
-    UnifiedConfig = None
     TTL_1_HOUR = 3_600
     _REDIS_AVAILABLE = False
     _CONFIG_AVAILABLE = False
 
 
-config = UnifiedConfig() if _CONFIG_AVAILABLE else None
 logger = logging.getLogger(__name__)
 
 # Directories to skip during analysis

--- a/autobot-backend/code_analysis/src/patch_generator.py
+++ b/autobot-backend/code_analysis/src/patch_generator.py
@@ -11,10 +11,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-from config import UnifiedConfig
 
-# Initialize unified config
-config = UnifiedConfig()
 logger = logging.getLogger(__name__)
 
 

--- a/autobot-backend/code_analysis/src/performance_analyzer.py
+++ b/autobot-backend/code_analysis/src/performance_analyzer.py
@@ -13,11 +13,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from config import UnifiedConfig
 from constants.ttl_constants import TTL_1_HOUR
 
-# Initialize unified config
-config = UnifiedConfig()
 logger = logging.getLogger(__name__)
 
 # Issue #380: Module-level tuple for loop AST types

--- a/autobot-backend/code_analysis/src/security_analyzer.py
+++ b/autobot-backend/code_analysis/src/security_analyzer.py
@@ -13,10 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from config import UnifiedConfig
 
-# Initialize unified config
-config = UnifiedConfig()
 logger = logging.getLogger(__name__)
 
 # Issue #380: Module-level tuple for import AST types

--- a/autobot-backend/code_analysis/src/testing_coverage_analyzer.py
+++ b/autobot-backend/code_analysis/src/testing_coverage_analyzer.py
@@ -13,10 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from config import UnifiedConfig
 
-# Initialize unified config
-config = UnifiedConfig()
 logger = logging.getLogger(__name__)
 
 # Issue #380: Module-level tuples for AST node type checks


### PR DESCRIPTION
Closes #3937

Removed dead UnifiedConfig imports from all code_analysis/src/*.py files.
These imports were never used (0 references to config. in any of the files).
Fixes the AttributeError at import time.