### PR TITLE
fix(llm): use DEFAULT_LLM_MODEL instead of ROUTING_MODEL in think_tool/rlm (#3948)

### DIFF
--- a/autobot-backend/agent_loop/think_tool.py
+++ b/autobot-backend/agent_loop/think_tool.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 from agent_loop.types import ThinkCategory, ThinkResult
-from autobot_shared.ssot_config import ROUTING_MODEL
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +147,7 @@ class ThinkToolConfig:
     """Configuration for the Think Tool."""
 
     # LLM settings
-    model: str = ROUTING_MODEL
+    model: str = DEFAULT_LLM_MODEL
     temperature: float = 0.3  # Lower temperature for reasoning
     max_tokens: int = 1000
 

--- a/autobot-backend/rlm/benchmark.py
+++ b/autobot-backend/rlm/benchmark.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
-from autobot_shared.ssot_config import ROUTING_MODEL, config as _ssot_config
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL, config as _ssot_config
 from rlm.evaluator import ResponseQualityEvaluator
 from rlm.types import RLMConfig
 
@@ -135,7 +135,7 @@ class BenchmarkSummary:
 
 async def _generate(
     prompt: str,
-    model: str = ROUTING_MODEL,
+    model: str = DEFAULT_LLM_MODEL,
     temperature: float = 0.5,
     max_tokens: int = 1024,
     timeout_s: float = _ssot_config.timeout.default_request,
@@ -247,7 +247,7 @@ async def _run_rlm_pass(
 
 async def run_benchmark(
     queries: Optional[List[Dict[str, Any]]] = None,
-    model: str = ROUTING_MODEL,
+    model: str = DEFAULT_LLM_MODEL,
     rlm_config: Optional[RLMConfig] = None,
     max_queries: int = 0,
 ) -> Dict[str, Any]:
@@ -354,7 +354,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--model",
-        default=ROUTING_MODEL,
+        default=DEFAULT_LLM_MODEL,
         help="Ollama model",
     )
     parser.add_argument(

--- a/autobot-backend/rlm/types.py
+++ b/autobot-backend/rlm/types.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Any, Dict
 
-from autobot_shared.ssot_config import ROUTING_MODEL
+from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
 
 
 class ReflectionVerdict(Enum):
@@ -78,7 +78,7 @@ class RLMConfig:
     max_reflections: int = 3
     quality_threshold: float = 0.7
     complexity_gate: float = 0.7
-    model: str = ROUTING_MODEL
+    model: str = DEFAULT_LLM_MODEL
     temperature: float = 0.2
     max_eval_tokens: int = 512
     timeout_ms: int = 10000


### PR DESCRIPTION
Closes #3948

ROUTING_MODEL (1B) is for routing/classification only. Think tool reasoning,
RLM benchmarking, and RLM type responses require the full DEFAULT_LLM_MODEL
for complex reasoning tasks.

Changes:
- think_tool.py: ThinkToolConfig.model
- rlm/benchmark.py: function signatures
- rlm/types.py: RequestResponse.model