### PR TITLE
fix(security): suppress CodeQL alert for hardened xdotool execution (#3938)

### DIFF
--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -353,7 +353,7 @@ def _run_xdotool_cmd(args: list[str], timeout: int = 5) -> Dict[str, str]:
             }
         sanitized.append(s)
     try:
-        result = subprocess.run(  # nosec B603 B607
+        result = subprocess.run(  # nosec B603 B607  # lgtm[py/command-line-injection]
             ["/usr/bin/xdotool"] + sanitized,
             capture_output=True,
             text=True,


### PR DESCRIPTION
Closes #3938

## Problem
CodeQL reported stale alert for deleted file (terminal_websocket_manager) and active alert #435 for well-hardened xdotool command execution in vnc_manager.py.

## Solution
- Stale alert for deleted file has auto-cleared (GitHub auto-dismisses CodeQL alerts for deleted files)
- Added `# lgtm[py/command-line-injection]` suppression for alert #435 in vnc_manager.py:356

## Justification
The xdotool command execution at line 356 is well-hardened:
- Subcommand allowlist validation (`_XDOTOOL_ALLOWED_SUBCMDS`)
- Per-argument regex sanitization (`_XDOTOOL_SAFE_ARG_RE`)
- `shell=False` (no shell interpretation)
- Hardcoded binary path (`/usr/bin/xdotool`)

The alert is a false positive for hardened, validated command execution.