### PR TITLE
fix(frontend): remove duplicate :repository prop in KBSearchResultPanel

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeSearch.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSearch.vue
@@ -203,7 +203,6 @@
         :results="searchResults"
         :query="lastSearchQuery"
         :loading="isSearching"
-        :repository="knowledgeRepo"
         @select="onResultSelect"
         @close="clearResults"
       />


### PR DESCRIPTION
Fixes provisioning frontend build failure caused by duplicate prop declaration.

## Summary
- Removed duplicate `:repository="knowledgeRepo"` prop from KBSearchResultPanel
- Parent (KnowledgeSearch.vue) already passes this prop on line 202
- Duplicate on line 206 caused Vue compiler syntax error: 'Duplicate attribute'

## Root Cause
KBSearchResultPanel component received the same prop twice:
```vue
<KBSearchResultPanel
  :repository="knowledgeRepo"
  ...
  :repository="knowledgeRepo"  <!-- duplicate, removed -->
/>
```

## Test Plan
- [x] Build completes without duplicate attribute error
- [ ] Re-run provisioning to verify frontend builds successfully
- [ ] Verify KB search functionality works

## Related Issues
- Related to #3940 (KBSearchResultPanel repository cleanup)
- Filed #3969 (child component still creates own instance)