### PR TITLE
fix(deps): relax protobuf constraint to <7.0.0 for opentelemetry compatibility (#3971)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,10 @@ tenacity>=9.1.4
 # Async SSH for PKI certificate distribution (Issue #166)
 asyncssh>=2.22.0
 
-# TensorFlow 2.19.1 requires protobuf<6.0.0dev per PyPI metadata — verified 2026-03-26 (#2471)
-# Bumped to 5.29.6+ for JSON recursion depth bypass fix
-protobuf>=5.29.6,<6.0.0
+# opentelemetry-proto>=1.40.0 requires protobuf>=5.0,<7.0 — relaxed upper bound to <7.0.0 (#3971)
+# TensorFlow is not a project dependency; former <6.0.0 cap caused pip conflicts with protobuf 6.x
+# Bumped to 5.29.6+ for JSON recursion depth bypass fix (#3933)
+protobuf>=5.29.6,<7.0.0
 
 # vLLM - High-performance LLM inference with prefix caching
 # Provides 3-4x throughput improvement with 98.7% cache efficiency


### PR DESCRIPTION
**Problem:** Protobuf constraint was too narrow (`>=5.29.6,<6.0.0`), preventing pip from resolving dependencies that require protobuf 6.x.

**Root cause:** TensorFlow 2.19.1 was cited as requiring `<6.0.0`, but TensorFlow is not actually a project dependency. Meanwhile, `opentelemetry-proto>=1.40.0` (a real transitive dependency) explicitly declares `protobuf<7.0,>=5.0`, which includes protobuf 6.x.

**Solution:** Relax the upper bound to `<7.0.0` to:
- Allow protobuf 6.x which is fully compatible with all dependencies
- Align with opentelemetry-proto's actual constraint
- Prevent pip conflicts on fresh installs

**Testing:** 
- Current installed version: 6.33.6
- All imports verified working: chromadb, opentelemetry.proto, onnxruntime
- No breaking changes

**Closes #3971**