### PR TITLE
refactor(config): migrate ConfigManager callers to get_config_manager() (#3829)

### DIFF
--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -466,14 +466,14 @@ def _verify_current_password(
 
 def _persist_password_change(username: str, new_password_hash: str) -> None:
     """Persist password change to config file."""
-    from config import ConfigManager
+    from config.manager import get_config_manager
 
     # Update in-memory config
     allowed_users = auth_middleware.security_config.get("allowed_users", {})
     allowed_users[username]["password_hash"] = new_password_hash
 
     # Persist to disk
-    config_manager = ConfigManager()
+    config_manager = get_config_manager()
     config_manager.set_nested(
         f"security_config.allowed_users.{username}.password_hash",
         new_password_hash,

--- a/autobot-backend/api/error_monitoring.py
+++ b/autobot-backend/api/error_monitoring.py
@@ -24,12 +24,11 @@ from autobot_shared.error_boundaries import (
     get_error_statistics,
     with_error_handling,
 )
-from config import ConfigManager
+from config.manager import get_config_manager
 from type_defs.common import Metadata
 from utils.error_metrics import get_metrics_collector
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 # Add project root to path for imports
 # Add project root to path for imports

--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from config import ConfigManager
+from config.manager import get_config_manager
 
 # Import unified configuration system - NO HARDCODED VALUES
 from constants.model_constants import ModelConstants
@@ -19,8 +19,7 @@ from services.config_service import ConfigService
 from utils.advanced_cache_manager import cache_response
 from utils.connection_utils import ConnectionTester, ModelManager
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 router = APIRouter()
 

--- a/autobot-backend/api/llm_optimization.py
+++ b/autobot-backend/api/llm_optimization.py
@@ -16,15 +16,14 @@ from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from config import ConfigManager
+from config.manager import get_config_manager
 from llm_interface import LLMInterface
 from utils.model_optimizer import TaskRequest, get_model_optimizer
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 
 class OptimizationRequest(BaseModel):

--- a/autobot-backend/api/research_browser.py
+++ b/autobot-backend/api/research_browser.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from config import ConfigManager
+from config.manager import get_config_manager
 from constants.network_constants import NetworkConstants
 from constants.error_constants import ERR_SESSION_NOT_FOUND
 
@@ -35,8 +35,7 @@ except ImportError:
     _BROWSER_AVAILABLE = False
     logger.warning("research_browser_manager unavailable (playwright not installed)")
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 router = APIRouter(
     dependencies=[Depends(check_admin_permission)],

--- a/autobot-backend/api/system.py
+++ b/autobot-backend/api/system.py
@@ -11,14 +11,13 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Request
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from config import ConfigManager
+from config.manager import get_config_manager
 from constants.model_constants import ModelConstants as ModelConsts
 
 # Add caching support from unified cache manager (P4 Cache Consolidation)
 from utils.advanced_cache_manager import cache_manager, cache_response
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 router = APIRouter()
 

--- a/autobot-backend/api/web_research_settings.py
+++ b/autobot-backend/api/web_research_settings.py
@@ -213,10 +213,10 @@ async def disable_web_research():
 async def get_research_settings():
     """Get current web research settings"""
     try:
-        from config import ConfigManager
+        from config.manager import get_config_manager
 
         # Get settings from config
-        unified_config_manager = ConfigManager()
+        unified_config_manager = get_config_manager()
         research_config = unified_config_manager.get_nested("agents.research", {})
         web_research_config = unified_config_manager.get_nested("web_research", {})
 

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -22,14 +22,13 @@ from autobot_shared.auth.jwt_core import (
     hash_password,
     verify_password,
 )
-from config import ConfigManager
+from config.manager import get_config_manager
 from security_layer import SecurityLayer
 from utils.catalog_http_exceptions import raise_auth_error
 
 logger = logging.getLogger(__name__)
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 
 class AuthenticationMiddleware:

--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -19,10 +19,10 @@ from celery import Celery
 
 from autobot_shared.redis_management.types import DATABASE_MAPPING
 from autobot_shared.ssot_config import config as ssot_config
-from config import ConfigManager
+from config.manager import get_config_manager
 
-# Create singleton config instance for extended config values
-config = ConfigManager()
+# Use singleton config instance for extended config values
+config = get_config_manager()
 
 # Build Redis URLs from SSOT configuration (loads directly from .env)
 # DB numbers come from redis-databases.yaml via DATABASE_MAPPING (#2670)

--- a/autobot-backend/chat_history/base.py
+++ b/autobot-backend/chat_history/base.py
@@ -57,11 +57,8 @@ class ChatHistoryBase:
             redis_host: Optional override for Redis host
             redis_port: Optional override for Redis port
         """
-        from config import ConfigManager
-
         data_config = global_config_manager.get("data", {})
         redis_config = global_config_manager.get_redis_config()
-        unified_config = ConfigManager()
 
         self.history_file = history_file or data_config.get(
             "chat_history_file",
@@ -71,7 +68,7 @@ class ChatHistoryBase:
             use_redis if use_redis is not None else redis_config.get("enabled", False)
         )
         self.redis_host = redis_host or redis_config.get(
-            "host", os.getenv("AUTOBOT_REDIS_HOST", unified_config.get_host("redis"))
+            "host", os.getenv("AUTOBOT_REDIS_HOST", global_config_manager.get_host("redis"))
         )
         self.redis_port = redis_port or redis_config.get(
             "port",

--- a/autobot-backend/dependencies.py
+++ b/autobot-backend/dependencies.py
@@ -12,8 +12,7 @@ import threading
 
 from fastapi import Depends
 
-from config import ConfigManager
-from config.manager import get_config_manager
+from config.manager import ConfigManager, get_config_manager
 
 
 def get_config() -> ConfigManager:

--- a/autobot-backend/dependency_container.py
+++ b/autobot-backend/dependency_container.py
@@ -16,7 +16,7 @@ from typing import Any, AsyncGenerator, Callable, Dict, Optional, Type, TypeVar
 import redis.asyncio as async_redis
 
 from autobot_shared.redis_client import get_redis_client
-from config import ConfigManager, unified_config_manager
+from config.manager import ConfigManager, get_config_manager
 from llm_interface import LLMInterface, get_llm_interface
 
 logger = logging.getLogger(__name__)
@@ -87,7 +87,7 @@ class AsyncServiceContainer:
 
     async def _create_config_manager(self) -> ConfigManager:
         """Factory for config manager"""
-        return unified_config_manager
+        return get_config_manager()
 
     async def _create_llm_interface(self) -> LLMInterface:
         """Factory for LLM interface"""

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -24,7 +24,7 @@ from autobot_shared.tracing import (
 )
 from chat_history import ChatHistoryManager
 from chat_workflow import ChatWorkflowManager
-from config import ConfigManager
+from config.manager import get_config_manager
 from knowledge_factory import get_or_create_knowledge_base
 from security_layer import SecurityLayer
 from services.slm_client import init_slm_client, shutdown_slm_client
@@ -233,7 +233,7 @@ async def _check_env_drift() -> None:
 async def _init_config(app: FastAPI) -> None:
     """Helper for initialize_critical_services. Ref: #1088, #3398."""
     logger.info("✅ [ 10%] Config: Loading unified configuration...")
-    config = ConfigManager()
+    config = get_config_manager()
     app.state.config = config
     await update_app_state("config", config)
     logger.info("✅ [ 10%] Config: Configuration loaded successfully")

--- a/autobot-backend/initialization/middleware.py
+++ b/autobot-backend/initialization/middleware.py
@@ -18,7 +18,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from config import ConfigManager
+from config.manager import get_config_manager
 from constants.network_constants import (  # noqa: F401 - used in docstring example
     NetworkConstants,
 )
@@ -42,7 +42,7 @@ def configure_cors(app: FastAPI, allow_origins: Optional[List[str]] = None):
     """
     # Generate from centralized configuration if not provided
     if allow_origins is None:
-        config = ConfigManager()
+        config = get_config_manager()
         allow_origins = config.get_cors_origins()
 
     app.add_middleware(

--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -24,7 +24,7 @@ from redis import asyncio as aioredis
 
 from autobot_shared.error_boundaries import error_boundary, get_error_boundary_manager
 from autobot_shared.redis_management.types import DATABASE_MAPPING
-from config import ConfigManager
+from config.manager import get_config_manager
 from utils.chromadb_client import get_chromadb_client as create_chromadb_client
 from utils.chromadb_client import wrap_collection_async
 from utils.knowledge_base_timeouts import kb_timeouts
@@ -32,8 +32,7 @@ from utils.knowledge_base_timeouts import kb_timeouts
 if TYPE_CHECKING:
     pass
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/llm_interface.py
+++ b/autobot-backend/llm_interface.py
@@ -15,7 +15,7 @@ For new code, import directly from llm_interface_pkg:
 """
 
 # Import additional dependencies that may be expected by consumers
-from config import ConfigManager
+from config.manager import ConfigManager, get_config_manager
 
 # Re-export everything from the refactored package
 from llm_interface_pkg import (  # Types; Models; Hardware; Streaming; Mock providers; Main interface; Providers
@@ -41,8 +41,8 @@ from llm_interface_pkg import (  # Types; Models; Hardware; Streaming; Mock prov
     palm,
 )
 
-# Create singleton config instance for backward compatibility
-config = ConfigManager()
+# Singleton config instance for backward compatibility
+config = get_config_manager()
 
 # Optional imports for backward compatibility
 try:

--- a/autobot-backend/llm_interface_pkg/interface.py
+++ b/autobot-backend/llm_interface_pkg/interface.py
@@ -24,7 +24,7 @@ import xxhash
 from autobot_shared.error_boundaries import error_boundary, get_error_boundary_manager
 from autobot_shared.http_client import get_http_client
 from autobot_shared.tracing import get_tracer
-from config import ConfigManager
+from config.manager import get_config_manager
 from constants.model_constants import ModelConstants
 
 # Issue #1403: Adapter registry
@@ -85,7 +85,7 @@ except ImportError:
     UsageRecordRequest = None
     logger.debug("LLM Pattern Analyzer not available - usage tracking disabled")
 
-config = ConfigManager()
+config = get_config_manager()
 
 # Issue #697: OpenTelemetry tracer for LLM operations
 _llm_tracer = get_tracer("autobot.llm")

--- a/autobot-backend/llm_interface_pkg/providers/ollama.py
+++ b/autobot-backend/llm_interface_pkg/providers/ollama.py
@@ -22,14 +22,14 @@ from opentelemetry.trace import SpanKind, Status, StatusCode
 from autobot_shared.http_client import get_http_client
 from autobot_shared.ssot_config import get_ollama_url
 from circuit_breaker import circuit_breaker_async
-from config import ConfigManager
+from config.manager import get_config_manager
 from constants.api_constants import PATH_OLLAMA_CHAT
 
 from ..models import LLMRequest, LLMResponse, LLMSettings
 from ..streaming import StreamingManager
 
 logger = logging.getLogger(__name__)
-config = ConfigManager()
+config = get_config_manager()
 
 # Issue #697: Get tracer for LLM operations
 _tracer = trace.get_tracer("autobot.llm.ollama", "2.0.0")

--- a/autobot-backend/llm_interface_pkg/providers/vllm_provider.py
+++ b/autobot-backend/llm_interface_pkg/providers/vllm_provider.py
@@ -11,12 +11,12 @@ import logging
 import time
 from typing import Optional
 
-from config import ConfigManager
+from config.manager import get_config_manager
 
 from ..models import LLMRequest, LLMResponse
 
 logger = logging.getLogger(__name__)
-config = ConfigManager()
+config = get_config_manager()
 
 
 class VLLMProviderHandler:

--- a/autobot-backend/research_browser_manager.py
+++ b/autobot-backend/research_browser_manager.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Optional
 
 import aiofiles
 
-from config import ConfigManager
+from config.manager import get_config_manager
 
 try:
     from playwright.async_api import Browser, BrowserContext, Page, async_playwright
@@ -33,8 +33,7 @@ from utils.display_utils import get_playwright_config
 
 logger = logging.getLogger(__name__)
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 # Issue #665: JavaScript snippets for content extraction
 _JS_EXTRACT_TEXT = """

--- a/autobot-backend/startup_validator.py
+++ b/autobot-backend/startup_validator.py
@@ -32,13 +32,12 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.http_client import get_http_client
-from config import ConfigManager
+from config.manager import get_config_manager
 from constants.path_constants import PATH
 
 logger = logging.getLogger(__name__)
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 
 @dataclass

--- a/autobot-backend/utils/hybrid_search.py
+++ b/autobot-backend/utils/hybrid_search.py
@@ -12,10 +12,9 @@ import re
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
-from config import ConfigManager
+from config.manager import get_config_manager
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 # Issue #380: Pre-compiled regex for word extraction
 _WORD_BOUNDARY_RE = re.compile(r"\b[a-zA-Z0-9]+\b")

--- a/autobot-backend/utils/knowledge_base_timeouts.py
+++ b/autobot-backend/utils/knowledge_base_timeouts.py
@@ -13,10 +13,9 @@ Part of KB-ASYNC-014: Timeout Configuration Centralization
 import os
 from typing import Dict
 
-from config import ConfigManager
+from config.manager import get_config_manager
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 
 class KnowledgeBaseTimeouts:

--- a/autobot-backend/utils/model_optimizer.py
+++ b/autobot-backend/utils/model_optimizer.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, List, Optional
 
 from autobot_shared.http_client import get_http_client
 from autobot_shared.redis_client import get_redis_client
-from config import ConfigManager
+from config.manager import get_config_manager
 
 # Re-export all public API from the package for backward compatibility
 from utils.model_optimization import (
@@ -43,8 +43,7 @@ from utils.model_optimization import (
     TaskRequest,
 )
 
-# Create singleton config instance
-config = ConfigManager()
+config = get_config_manager()
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/utils/service_registry.py
+++ b/autobot-backend/utils/service_registry.py
@@ -34,12 +34,12 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 import yaml
 
-# Import unified configuration system - NO HARDCODED VALUES
-from config import ConfigManager
-
-# Create singleton config instance
-config = ConfigManager()
 from autobot_shared.http_client import get_http_client
+
+# Import unified configuration system - NO HARDCODED VALUES
+from config.manager import get_config_manager
+
+config = get_config_manager()
 from constants.api_constants import PATH_API_HEALTH, PATH_HEALTH, PATH_OLLAMA_TAGS
 
 

--- a/autobot-backend/utils/system_metrics.py
+++ b/autobot-backend/utils/system_metrics.py
@@ -15,11 +15,10 @@ from typing import Any, Dict
 import aiohttp
 import psutil
 
-from config import ConfigManager
-
-# Create singleton config instance
-config = ConfigManager()
 from autobot_shared.http_client import get_http_client
+from config.manager import get_config_manager
+
+config = get_config_manager()
 from autobot_shared.redis_client import get_redis_client
 
 

--- a/autobot-backend/utils/system_validator.py
+++ b/autobot-backend/utils/system_validator.py
@@ -17,11 +17,10 @@ import aiohttp
 import psutil
 
 from autobot_shared.http_client import get_http_client
-from config import ConfigManager
-
-# Create singleton config instance
-config = ConfigManager()
+from config.manager import get_config_manager
 from constants.network_constants import NetworkConstants
+
+config = get_config_manager()
 
 # Issue #380: Module-level tuple for expected system metrics
 _EXPECTED_SYSTEM_METRICS = ("cpu_percent", "memory_percent", "disk_usage")


### PR DESCRIPTION
## Summary

Migrate all direct `ConfigManager()` instantiations in production code to use `get_config_manager()` singleton accessor.

- **27 files changed**: All production code now uses singleton accessor
- **Eliminates redundancy**: Every caller shares the same ConfigManager instance instead of creating duplicates
- **Bonus fix**: Also closes #3945 — `chat_history/base.py` was redundantly instantiating ConfigManager just for `get_host("redis")`, now uses already-available global instance

## Impact

- Reduces memory footprint (singleton vs multiple instances)
- Improves consistency across the application
- Prepares codebase for eventual ConfigManager deprecation (follow-up PRs can migrate to ssot_config)

## Test Plan

- [ ] `pytest autobot-backend/tests/ -x --tb=short` passes
- [ ] No remaining `from config import ConfigManager` in production code
- [ ] All changed files import from `config.manager`

Closes #3829
Closes #3945

🤖 Generated with [Claude Code](https://claude.com/claude-code)