### PR TITLE
fix(kb): add ChromaDB service monitoring to health checks and API (#3461)

### DIFF
--- a/autobot-backend/api/service_monitor.py
+++ b/autobot-backend/api/service_monitor.py
@@ -74,6 +74,7 @@ async def get_service_statuses() -> Dict[str, Any]:
     npu_url = f"http://{_ssot.vm.npu}:{_ssot.port.npu}/health"
     browser_url = f"http://{_ssot.vm.browser}:{_ssot.port.browser}/health"
     ollama_url = f"http://{_ssot.vm.ollama}:{_ssot.port.ollama}/api/version"
+    chromadb_url = f"http://{_ssot.vm.aistack}:{_ssot.port.aistack}/health"  # Issue #3461: ChromaDB
 
     (
         (redis_status, redis_msg),
@@ -83,11 +84,16 @@ async def get_service_statuses() -> Dict[str, Any]:
             browser_status,
             browser_msg,
         ),
+        (
+            chromadb_status,
+            chromadb_msg,
+        ),
     ) = await asyncio.gather(
         _check_redis_health(),
         _check_http_health(npu_url),
         _check_http_health(ollama_url),
         _check_http_health(browser_url),
+        _check_http_health(chromadb_url),
     )
 
     return {
@@ -97,6 +103,7 @@ async def get_service_statuses() -> Dict[str, Any]:
             "npu_worker": {"status": npu_status, "health": npu_msg},
             "ollama": {"status": ollama_status, "health": ollama_msg},
             "browser": {"status": browser_status, "health": browser_msg},
+            "chromadb": {"status": chromadb_status, "health": chromadb_msg},  # Issue #3461
         }
     }
 
@@ -110,6 +117,7 @@ async def get_vm_statuses() -> Dict[str, Any]:
     """
     npu_url = f"http://{_ssot.vm.npu}:{_ssot.port.npu}/health"
     browser_url = f"http://{_ssot.vm.browser}:{_ssot.port.browser}/health"
+    chromadb_url = f"http://{_ssot.vm.aistack}:{_ssot.port.aistack}/health"  # Issue #3461: ChromaDB
 
     (
         (redis_status, redis_msg),
@@ -118,10 +126,15 @@ async def get_vm_statuses() -> Dict[str, Any]:
             browser_status,
             browser_msg,
         ),
+        (
+            chromadb_status,
+            chromadb_msg,
+        ),
     ) = await asyncio.gather(
         _check_redis_health(),
         _check_http_health(npu_url),
         _check_http_health(browser_url),
+        _check_http_health(chromadb_url),
     )
 
     vms: List[Dict[str, str]] = [
@@ -129,5 +142,6 @@ async def get_vm_statuses() -> Dict[str, Any]:
         {"name": "Redis", "status": redis_status, "message": redis_msg},
         {"name": "NPU Worker", "status": npu_status, "message": npu_msg},
         {"name": "Browser Service", "status": browser_status, "message": browser_msg},
+        {"name": "AI Stack (ChromaDB)", "status": chromadb_status, "message": chromadb_msg},  # Issue #3461
     ]
     return {"vms": vms}

--- a/autobot-slm-backend/ansible/playbooks/health-check.yml
+++ b/autobot-slm-backend/ansible/playbooks/health-check.yml
@@ -254,6 +254,23 @@
       when: is_ai_stack | bool
       tags: [ai_stack, services]
 
+    # Issue #3461: ChromaDB health checks
+    - name: Check ChromaDB service (AI Stack)
+      systemd:
+        name: autobot-chromadb
+      register: chromadb_service_status
+      when: is_ai_stack | bool
+      tags: [ai_stack, services, chromadb]
+
+    - name: Test ChromaDB health endpoint (AI Stack)
+      uri:
+        url: "http://127.0.0.1:8100/health"
+        method: GET
+        timeout: 20
+      register: chromadb_health_test
+      when: is_ai_stack | bool
+      tags: [ai_stack, services, chromadb]
+
     - name: Check for GPU devices (AI Stack)
       shell: |
         echo "GPU devices:"


### PR DESCRIPTION
**Problem:** ChromaDB (Knowledge Base) availability was not monitored by health checks or the service status API, making KB outages invisible to the frontend.

**Root Cause:** 
- Ansible health-check playbook did not check `autobot-chromadb` service or port 8100
- Backend service_monitor.py API listed Redis/Ollama/NPU/Browser but omitted AI Stack entirely

**Solution:**
1. **Ansible health-check.yml**: Add `autobot-chromadb` service check and health endpoint test (port 8100)
2. **Backend service_monitor.py**: Add ChromaDB health checks to both `get_service_statuses()` and `get_vm_statuses()` endpoints

**Result:**
- Frontend health widget now shows ChromaDB status alongside other services
- Health-check playbooks validate ChromaDB is running before assuming KB is available
- Issue #3461 resolved

**Closes #3461**