### PR TITLE
fix(frontend): migrate vite config from deprecated esbuildOptions to rolldownOptions (#3967)

### DIFF
--- a/autobot-frontend/vite.config.ts
+++ b/autobot-frontend/vite.config.ts
@@ -57,7 +57,7 @@ export default defineConfig(({ mode }) => {
     plugins: [vue(), vueDevTools(), vadAssetsPlugin()],
     optimizeDeps: {
       include: ['@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-web-links', '@heroicons/vue/24/outline', '@heroicons/vue/24/solid'],
-      esbuildOptions: { target: 'es2022' }
+      rolldownOptions: { target: 'es2022' }
     },
     css: { devSourcemap: true, postcss: './postcss.config.js' },
     resolve: {


### PR DESCRIPTION
## Summary

Migrate Vite 8+ deprecated `optimizeDeps.esbuildOptions` to `rolldownOptions`.

## Changes

- Replaced `optimizeDeps.esbuildOptions: { target: 'es2022' }` with `optimizeDeps.rolldownOptions: { target: 'es2022' }`
- Vite 8+ now uses Rolldown for dependency optimization instead of esbuild

## Test plan

- [ ] npm run build succeeds without warnings
- [ ] Optimization warnings are gone from build output

Closes #3967

🤖 Generated with [Claude Code](https://claude.com/claude-code)