### PR TITLE
perf(knowledge): length-based watch for KnowledgeGraph3D nodes (#4004)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
@@ -18,6 +18,7 @@
  * @see KnowledgeGraph.vue - Parent component that owns data fetching and controls
  * @see Issue #3330 - 3D graph view toggle feature
  * @see Issue #3363 - WebGL teardown, i18n, shallowRef typing, nextTick fixes
+ * @see Issue #4004 - Replace deep watch with length-based watch for performance
  *
  * @author mrveiss
  * @copyright (c) 2026 mrveiss
@@ -268,10 +269,13 @@ onUnmounted(() => {
 })
 
 // Rebuild graph data when filtered entities/edges change.
-// nextTick in the init path ensures DOM has laid out before dimensions are read.
-// Issue #3363: fixes invisible graph when data arrives before DOM layout.
+// Issue #4004: Replace deep watch with length-based watch for performance.
+// Watching array length is a lightweight proxy for data changes, avoiding 40-80ms
+// deep comparison overhead on 1000+ node graphs. The graph is completely rebuilt
+// on each data change, so we only need to detect when the arrays change, not which
+// specific properties mutated within each entity.
 watch(
-  () => [props.entities, props.edges] as const,
+  () => [props.entities?.length ?? 0, props.edges?.length ?? 0] as const,
   async () => {
     if (!graph.value) {
       if (!isEmpty.value) {
@@ -281,8 +285,7 @@ watch(
       return
     }
     graph.value.graphData(buildGraphData())
-  },
-  { deep: true }
+  }
 )
 </script>
 


### PR DESCRIPTION
## Summary
- Replaced deep watch on entities/edges arrays with shallow watch on array length
- Avoids 40-80ms per-update deep comparison on 1000+ node graphs
- Graph is completely rebuilt on each data change, so length check is sufficient

## Impact
- Faster 3D graph updates for large knowledge graphs
- Reduced CPU during graph filtering/navigation

Closes #4004