### PR TITLE
ci: add Docker smoke test workflow for automated validation

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,75 @@
+name: Docker Smoke Test
+
+on:
+  push:
+    branches:
+      - Dev_new_gui
+  schedule:
+    - cron: '0 10 * * 0'  # Every Sunday at 10 AM UTC
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create .env from .env.example
+        run: cp .env.example .env
+
+      - name: Start services with Docker Compose
+        run: docker compose up -d
+
+      - name: Wait for services to be healthy
+        run: |
+          echo "Waiting for services to start..."
+          max_attempts=30
+          attempt=0
+
+          while [ $attempt -lt $max_attempts ]; do
+            attempt=$((attempt + 1))
+            echo "Attempt $attempt/$max_attempts: Checking service health..."
+
+            # Check if frontend is responding
+            if curl -s -f http://localhost > /dev/null 2>&1; then
+              echo "✓ Frontend responding on port 80"
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "Services failed to become healthy within 5 minutes"
+          echo ""
+          echo "=== Docker Compose Logs ==="
+          docker compose logs
+          exit 1
+
+      - name: Verify services are running
+        run: |
+          echo "Verifying services..."
+          docker compose ps
+
+          echo ""
+          echo "=== Frontend Health Check ==="
+          curl -v http://localhost 2>&1 | head -20
+
+      - name: Collect logs on failure
+        if: failure()
+        run: docker compose logs > failure-logs.txt
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-compose-logs
+          path: failure-logs.txt
+
+      - name: Clean up
+        if: always()
+        run: docker compose down


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow to automatically validate Docker Compose setup on every push and weekly.

## What It Does
- **Trigger**: Every push to Dev_new_gui + weekly schedule (Sundays 10 AM UTC)
- **Steps**:
  1. Checkout code
  2. Copy .env.example to .env
  3. Start services with docker compose up -d
  4. Wait for frontend to respond (max 5 minutes, 30 attempts)
  5. Verify services are running with docker compose ps
  6. Check frontend health with curl
  7. Collect logs if anything fails
  8. Clean up with docker compose down

## Output
- ✅ Provides status badge for README showing install health
- 📝 Uploads failure logs as artifact if test fails
- 🔄 Runs automatically on push + weekly schedule

## Why
This ensures the Docker setup always works for new users. Catches breaking changes before they're deployed to main branch.

## Refs
Implements Phase 1.1 of the Promotion System Design