### PR TITLE
fix(frontend): handle null/undefined score in QualityScoreBadge (#4016)

### DIFF
--- a/autobot-frontend/src/components/knowledge/QualityScoreBadge.vue
+++ b/autobot-frontend/src/components/knowledge/QualityScoreBadge.vue
@@ -2,9 +2,9 @@
   <span
     class="quality-badge"
     :class="qualityClass"
-    :title="$t('knowledge.qualityScore.title', { score: (score * 100).toFixed(0) })"
+    :title="$t('knowledge.qualityScore.title', { score: (safeScore * 100).toFixed(0) })"
   >
-    {{ (score * 100).toFixed(0) }}%
+    {{ (safeScore * 100).toFixed(0) }}%
   </span>
 </template>
 
@@ -12,12 +12,14 @@
 import { computed } from 'vue'
 
 const props = defineProps<{
-  score: number
+  score: number | null | undefined
 }>()
 
+const safeScore = computed(() => props.score ?? 0)
+
 const qualityClass = computed(() => {
-  if (props.score >= 0.8) return 'quality-high'
-  if (props.score >= 0.5) return 'quality-medium'
+  if (safeScore.value >= 0.8) return 'quality-high'
+  if (safeScore.value >= 0.5) return 'quality-medium'
   return 'quality-low'
 })
 </script>


### PR DESCRIPTION
## Root Cause

\`QualityScoreBadge.vue\` receives a \`quality_score\` from backend that can be null or undefined, but attempted to call \`toFixed()\` without null guards, causing NaN rendering.

## Fix

- Change prop type to accept \`number | null | undefined\`
- Add \`safeScore\` computed property that defaults to 0
- Use \`safeScore\` throughout template and styling logic

## Impact

- Resolves toFixed() error in KnowledgeVerificationQueue
- Gracefully handles missing quality scores
- Improves robustness for backend variations

## Test

Component renders \`0%\` when score is null/undefined instead of failing.

Closes #4016

🤖 Generated with [Claude Code](https://claude.com/claude-code)