### PR TITLE
perf(frontend): debounce search/filter handlers (#4034)

### DIFF
--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -346,6 +346,7 @@ import fcose from 'cytoscape-fcose'
 // Issue #711: Virtual scrolling for large orphaned function lists
 import { useVirtualScrollSimple } from '@/composables/useVirtualScroll'
 import { getCssVar } from '@/composables/useCssVars'
+import { useDebounce } from '@/composables/useTimeout'
 
 // Register fcose layout
 cytoscape.use(fcose)
@@ -1166,8 +1167,12 @@ function toggleClusterLayout() {
   runClusterLayout()
 }
 
-function handleSearch() {
+const debouncedUpdateCytoscapeElements = useDebounce(() => {
   updateCytoscapeElements()
+}, 300)
+
+function handleSearch() {
+  debouncedUpdateCytoscapeElements()
 }
 
 function handleModuleFilter() {

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -217,6 +217,7 @@ import cytoscape, { type Core, type NodeSingular } from 'cytoscape'
 // @ts-expect-error - cytoscape-fcose has no type declarations
 import fcose from 'cytoscape-fcose'
 import { getCssVar } from '@/composables/useCssVars'
+import { useDebounce } from '@/composables/useTimeout'
 
 // Register fcose layout
 cytoscape.use(fcose)
@@ -397,8 +398,12 @@ function navigateToFile(file?: string) {
   }
 }
 
-function handleSearch() {
+const debouncedUpdateCytoscapeElements = useDebounce(() => {
   updateCytoscapeElements()
+}, 300)
+
+function handleSearch() {
+  debouncedUpdateCytoscapeElements()
 }
 
 // ============================================================================

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -317,6 +317,7 @@ import { useKnowledgeBase } from '@/composables/useKnowledgeBase'
 import { useKnowledgeVectorization } from '@/composables/useKnowledgeVectorization'
 import { useAsyncOperation } from '@/composables/useAsyncOperation'
 import { usePagination } from '@/composables/usePagination'
+import { useDebounce } from '@/composables/useTimeout'
 import TreeNodeComponent, { type TreeNode } from './TreeNodeComponent.vue'
 import VectorizationProgressModal from './VectorizationProgressModal.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -379,6 +380,10 @@ const expandedNodes = ref<Set<string>>(new Set())
 const selectedFile = ref<TreeNode | null>(null)
 const fileContent = ref('')
 const searchQuery = ref('')
+const debouncedSearchQuery = ref('')
+const updateDebouncedSearch = useDebounce((value: string) => {
+  debouncedSearchQuery.value = value
+}, 300)
 const selectedCategory = ref<string | null>(null)
 const selectedMainCategory = ref<string | null>(null)
 const mainCategories = ref<any[]>([])
@@ -551,9 +556,10 @@ const filteredTree = computed(() => {
   }
 
   // Filter by search query
-  if (!searchQuery.value) return tree
+  // Filter by search query (debounced to avoid re-rendering on every keystroke)
+  if (!debouncedSearchQuery.value) return tree
 
-  const query = searchQuery.value.toLowerCase()
+  const query = debouncedSearchQuery.value.toLowerCase()
 
   const filterNodes = (nodes: TreeNode[]): TreeNode[] => {
     return nodes.reduce((acc: TreeNode[], node) => {
@@ -1153,11 +1159,13 @@ const clearSelection = () => {
 }
 
 const handleSearch = () => {
-  // Search is handled by computed property
+  updateDebouncedSearch(searchQuery.value)
 }
 
 const clearSearch = () => {
   searchQuery.value = ''
+  debouncedSearchQuery.value = ''
+  updateDebouncedSearch.cancel()
   expandedNodes.value.clear()
 }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -374,6 +374,7 @@ import { getApiBase } from '@/config/ssot-config'
 import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
+import { useDebounce } from '@/composables/useTimeout'
 import MemoryOrphanManager from '@/components/knowledge/MemoryOrphanManager.vue'
 import KnowledgeGraph3D from '@/components/knowledge/KnowledgeGraph3D.vue'
 
@@ -463,25 +464,8 @@ const cy = shallowRef<Core | null>(null)
 // Utilities
 // ============================================================================
 
-/**
- * Creates a debounced version of a function
- * @param fn - Function to debounce
- * @param delay - Delay in milliseconds
- * @returns Debounced function
- */
-function debounce<T extends (...args: Parameters<T>) => void>(
-  fn: T,
-  delay: number
-): (...args: Parameters<T>) => void {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null
-  return (...args: Parameters<T>) => {
-    if (timeoutId) clearTimeout(timeoutId)
-    timeoutId = setTimeout(() => fn(...args), delay)
-  }
-}
-
-/** Debounced graph update for search performance (300ms delay) */
-const debouncedUpdateGraph = debounce(() => {
+/** Debounced graph update for search performance (300ms delay, auto-cleanup on unmount) */
+const debouncedUpdateGraph = useDebounce(() => {
   updateCytoscapeElements()
 }, 300)
 


### PR DESCRIPTION
## Summary

- **ImportTreeChart**: debounce `handleSearch` at 300 ms so Cytoscape graph rebuild is not triggered on every keystroke
- **FunctionCallGraph**: same pattern for `handleSearch`; `handleModuleFilter` is a single-select `@change` event so no debounce required
- **KnowledgeGraph**: replace the local ad-hoc `debounce` helper with `useDebounce` from the shared `@/composables/useTimeout` composable — gains automatic `onUnmounted` cleanup that the old helper lacked
- **KnowledgeBrowser**: introduce a `debouncedSearchQuery` ref; the existing reactive computed now reads from it rather than `searchQuery`, so the recursive `filterNodes` tree walk only fires 300 ms after the user stops typing; `clearSearch` immediately resets both values and cancels any pending debounce

All handlers use the project-standard `useDebounce` from `useTimeout.ts`. No new dependencies added.

## Test plan

- [ ] Type rapidly in ImportTreeChart search — Cytoscape should not rebuild until 300 ms after last keystroke
- [ ] Type rapidly in FunctionCallGraph search — same
- [ ] Selecting a module in FunctionCallGraph dropdown should filter immediately (no debounce)
- [ ] Type in KnowledgeGraph search — graph update deferred 300 ms
- [ ] Type in KnowledgeBrowser search — tree not re-filtered on every character
- [ ] Click "clear" in KnowledgeBrowser — tree resets immediately without waiting for debounce
- [ ] Unmount/navigate away from each component — no timer leaks (verify via browser DevTools)

Closes #4034

🤖 Generated with [Claude Code](https://claude.com/claude-code)