### PR TITLE
fix(analytics): record actual vLLM model name instead of Ollama default (#3943)

### DIFF
--- a/autobot-backend/llm_interface_pkg/interface.py
+++ b/autobot-backend/llm_interface_pkg/interface.py
@@ -1407,9 +1407,15 @@ class LLMInterface:
         request_id = llm_params.pop("request_id", str(uuid.uuid4()))
         start_time = time.time()
 
-        # Issue #3860: resolve model_name from provider config so usage
-        # analytics records a non-empty value instead of "".
-        _, model_name = self._determine_provider_and_model("vllm")
+        # Issue #3943: resolve vLLM model name directly from config so cache keys
+        # and analytics record the actual vLLM model instead of the Ollama default.
+        # _determine_provider_and_model("vllm") falls through to the else-branch
+        # (provider="ollama", model=self.settings.default_model) because "vllm"
+        # is not a recognised llm_type alias.  Read from the same config key that
+        # VLLMProviderHandler._ensure_initialized() uses.
+        model_name: str = config.get(
+            "llm.vllm.default_model", "meta-llama/Llama-3.2-3B-Instruct"
+        )
 
         messages = [
             {"role": "system", "content": system_prompt},


### PR DESCRIPTION
Fixes #3943

## Root Cause

`chat_completion_optimized()` called `_determine_provider_and_model("vllm")` to resolve the model name before building the cache key and LLMRequest. Because `"vllm"` is not a recognised `llm_type` alias (`"orchestrator"` or `"task"`), the method fell through to the `else` branch:

```python
else:
    model_alias = kwargs.get("model_name", self.settings.default_model)
    # … falls to:
    provider = "ollama"
    model_name = model_alias  # e.g. "qwen3.5:9b" — the Ollama default
```

The caller discarded the wrong `provider` but kept `model_name = "qwen3.5:9b"`, which poisoned:
1. The L1/L2 cache key passed to `_check_cache()` — cache misses/collisions between Ollama and vLLM requests
2. The `model` argument passed to `_track_llm_usage()` via `_finalize_response()` — analytics showed the Ollama model name for vLLM requests

## Changes

Replaced the incorrect `_determine_provider_and_model("vllm")` call with a direct config lookup:

```python
model_name: str = config.get(
    "llm.vllm.default_model", "meta-llama/Llama-3.2-3B-Instruct"
)
```

This is the same config key that `VLLMProviderHandler._ensure_initialized()` reads, ensuring both the cache layer and the provider handler agree on which model name to use. The existing `response.model` fallback at finalize time is preserved so a live vLLM response value takes precedence.

## Files Changed

- `autobot-backend/llm_interface_pkg/interface.py` — `chat_completion_optimized()`: direct config read instead of broken provider-resolver call