### PR TITLE
fix(redis): await coroutine before ping in KB initialization (#3962)

### DIFF
--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -332,12 +332,12 @@ class KnowledgeBaseCore:
                 self.redis_db,
             )
 
-            # Get async Redis client — get_redis_client(async_client=True) returns a
-            # coroutine (it is sync but calls the async get_async_client internally).
-            # Must await to obtain the actual redis.asyncio.Redis instance. (#3962)
-            self.aioredis_client = await get_redis_client(
-                async_client=True, database="knowledge"
-            )
+            # Get async Redis client via the dedicated async helper (#3962).
+            # get_async_redis_client() is a true async def so callers cannot
+            # accidentally store the coroutine without awaiting it.
+            from autobot_shared.redis_client import get_async_redis_client
+
+            self.aioredis_client = await get_async_redis_client(database="knowledge")
             if self.aioredis_client is None:
                 raise Exception(
                     "Async Redis client initialization returned None "

--- a/autobot-backend/knowledge/knowledge_base_async_test.py
+++ b/autobot-backend/knowledge/knowledge_base_async_test.py
@@ -86,7 +86,7 @@ class TestInitRedisConnections:
 
         with (
             patch(_SYNC_CLIENT_PATH, return_value=sync_client),
-            patch(_ASYNC_CLIENT_PATH, return_value=mock_async_redis),
+            patch(_ASYNC_CLIENT_PATH, new=AsyncMock(return_value=mock_async_redis)),
         ):
             await kb._init_redis_connections()
 
@@ -105,7 +105,7 @@ class TestInitRedisConnections:
 
         with (
             patch(_SYNC_CLIENT_PATH, return_value=sync_client),
-            patch(_ASYNC_CLIENT_PATH, return_value=mock_async_redis),
+            patch(_ASYNC_CLIENT_PATH, new=AsyncMock(return_value=mock_async_redis)),
         ):
             await kb._init_redis_connections()
 
@@ -123,7 +123,7 @@ class TestInitRedisConnections:
 
         with (
             patch(_SYNC_CLIENT_PATH, return_value=sync_client),
-            patch(_ASYNC_CLIENT_PATH, return_value=None),
+            patch(_ASYNC_CLIENT_PATH, new=AsyncMock(return_value=None)),
         ):
             with pytest.raises(
                 Exception, match="Async Redis client initialization returned None"
@@ -153,7 +153,7 @@ class TestInitRedisConnections:
 
         with (
             patch(_SYNC_CLIENT_PATH, return_value=sync_client),
-            patch(_ASYNC_CLIENT_PATH, return_value=mock_async_redis),
+            patch(_ASYNC_CLIENT_PATH, new=AsyncMock(return_value=mock_async_redis)),
         ):
             with pytest.raises(ConnectionError, match="Redis down"):
                 await kb._init_redis_connections()

--- a/autobot-backend/knowledge/knowledge_base_async_test.py
+++ b/autobot-backend/knowledge/knowledge_base_async_test.py
@@ -1,15 +1,21 @@
 """
 Unit tests for KnowledgeBase async Redis initialization.
 
-Covers _init_redis_connections() which uses get_redis_client(async_client=True).
-The fix for #3962: get_redis_client(async_client=True) returns a *coroutine*
-(sync function returning the result of calling an async method).  The caller
-must *await* that value to obtain the actual redis.asyncio.Redis instance.
-Prior to the fix the code stored the un-awaited coroutine in
-self.aioredis_client, causing 'coroutine' object has no attribute 'ping'.
+Covers _init_redis_connections() which uses get_async_redis_client() (#3962).
+
+Root cause of #3962: the original code called get_redis_client(async_client=True)
+without await.  get_redis_client is a *sync* function that returns the coroutine
+produced by RedisConnectionManager.get_async_client() without awaiting it.
+Storing that coroutine in self.aioredis_client then caused:
+    AttributeError: 'coroutine' object has no attribute 'ping'
+
+Fix: autobot_shared.redis_client now exposes get_async_redis_client(), a true
+async def that always awaits the underlying coroutine before returning.
+_init_redis_connections() uses get_async_redis_client() so the correct usage is
+structurally impossible to get wrong.
 """
 
-import asyncio
+import inspect
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,10 +24,16 @@ import pytest
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Patch paths
 # ---------------------------------------------------------------------------
 
-_REDIS_CLIENT_PATH = "autobot_shared.redis_client.get_redis_client"
+_SYNC_CLIENT_PATH = "autobot_shared.redis_client.get_redis_client"
+_ASYNC_CLIENT_PATH = "autobot_shared.redis_client.get_async_redis_client"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _make_mock_redis() -> AsyncMock:
@@ -29,15 +41,6 @@ def _make_mock_redis() -> AsyncMock:
     client = AsyncMock()
     client.ping = AsyncMock(return_value=True)
     return client
-
-
-def _make_coroutine(return_value):
-    """Return a coroutine that resolves to *return_value*."""
-
-    async def _coro():
-        return return_value
-
-    return _coro()
 
 
 # ---------------------------------------------------------------------------
@@ -58,62 +61,52 @@ def mock_async_redis():
 class TestInitRedisConnections:
     """Verify that _init_redis_connections properly awaits the async client."""
 
-    @pytest.mark.asyncio
-    async def test_awaits_coroutine_and_stores_client(self, mock_async_redis):
-        """
-        get_redis_client(async_client=True) returns a coroutine.
-        _init_redis_connections must await it; self.aioredis_client must be
-        the resolved Redis instance, NOT the coroutine object itself. (#3962)
-        """
-        # Import here to avoid heavy module-level side-effects in test discovery
+    def _make_kb(self):
         from knowledge.base import KnowledgeBase
 
         kb = KnowledgeBase.__new__(KnowledgeBase)
         kb.redis_client = None
         kb.aioredis_client = None
         kb.redis_db = 1
+        return kb
 
+    def _make_sync_client(self):
         sync_client = MagicMock()
         sync_client.ping = MagicMock(return_value=True)
+        return sync_client
 
-        def fake_get_redis_client(async_client=False, database="main"):
-            if async_client:
-                # Mimic the real function: sync wrapper that returns a coroutine
-                return _make_coroutine(mock_async_redis)
-            return sync_client
+    @pytest.mark.asyncio
+    async def test_stores_real_client_not_coroutine(self, mock_async_redis):
+        """
+        get_async_redis_client() must resolve to the actual Redis instance.
+        self.aioredis_client must never be a coroutine object. (#3962)
+        """
+        kb = self._make_kb()
+        sync_client = self._make_sync_client()
 
-        with patch(_REDIS_CLIENT_PATH, side_effect=fake_get_redis_client):
+        with (
+            patch(_SYNC_CLIENT_PATH, return_value=sync_client),
+            patch(_ASYNC_CLIENT_PATH, return_value=mock_async_redis),
+        ):
             await kb._init_redis_connections()
 
-        # Must be the actual client, not a coroutine
         assert kb.aioredis_client is mock_async_redis, (
             "aioredis_client should be the Redis instance, not a coroutine"
         )
-        import inspect
-
         assert not inspect.iscoroutine(kb.aioredis_client), (
             "aioredis_client must not be a coroutine after _init_redis_connections"
         )
 
     @pytest.mark.asyncio
     async def test_ping_called_on_async_client(self, mock_async_redis):
-        """After awaiting, ping() must be called on the Redis client."""
-        from knowledge.base import KnowledgeBase
+        """After initialization, ping() must have been called on the Redis client."""
+        kb = self._make_kb()
+        sync_client = self._make_sync_client()
 
-        kb = KnowledgeBase.__new__(KnowledgeBase)
-        kb.redis_client = None
-        kb.aioredis_client = None
-        kb.redis_db = 1
-
-        sync_client = MagicMock()
-        sync_client.ping = MagicMock(return_value=True)
-
-        def fake_get_redis_client(async_client=False, database="main"):
-            if async_client:
-                return _make_coroutine(mock_async_redis)
-            return sync_client
-
-        with patch(_REDIS_CLIENT_PATH, side_effect=fake_get_redis_client):
+        with (
+            patch(_SYNC_CLIENT_PATH, return_value=sync_client),
+            patch(_ASYNC_CLIENT_PATH, return_value=mock_async_redis),
+        ):
             await kb._init_redis_connections()
 
         mock_async_redis.ping.assert_called_once()
@@ -121,69 +114,46 @@ class TestInitRedisConnections:
     @pytest.mark.asyncio
     async def test_raises_when_async_client_returns_none(self):
         """
-        If get_redis_client returns None (circuit breaker open / Redis disabled),
-        _init_redis_connections must raise rather than silently store None.
+        If get_async_redis_client returns None (circuit breaker open / Redis
+        disabled), _init_redis_connections must raise rather than silently
+        store None and let a later .ping() fail with AttributeError.
         """
-        from knowledge.base import KnowledgeBase
+        kb = self._make_kb()
+        sync_client = self._make_sync_client()
 
-        kb = KnowledgeBase.__new__(KnowledgeBase)
-        kb.redis_client = None
-        kb.aioredis_client = None
-        kb.redis_db = 1
-
-        sync_client = MagicMock()
-        sync_client.ping = MagicMock(return_value=True)
-
-        def fake_get_redis_client(async_client=False, database="main"):
-            if async_client:
-                return _make_coroutine(None)
-            return sync_client
-
-        with patch(_REDIS_CLIENT_PATH, side_effect=fake_get_redis_client):
-            with pytest.raises(Exception, match="Async Redis client initialization returned None"):
+        with (
+            patch(_SYNC_CLIENT_PATH, return_value=sync_client),
+            patch(_ASYNC_CLIENT_PATH, return_value=None),
+        ):
+            with pytest.raises(
+                Exception, match="Async Redis client initialization returned None"
+            ):
                 await kb._init_redis_connections()
 
     @pytest.mark.asyncio
     async def test_raises_when_sync_client_returns_none(self):
         """If the sync client is None, _init_redis_connections must raise."""
-        from knowledge.base import KnowledgeBase
+        kb = self._make_kb()
 
-        kb = KnowledgeBase.__new__(KnowledgeBase)
-        kb.redis_client = None
-        kb.aioredis_client = None
-        kb.redis_db = 1
-
-        def fake_get_redis_client(async_client=False, database="main"):
-            if async_client:
-                return _make_coroutine(AsyncMock())
-            return None
-
-        with patch(_REDIS_CLIENT_PATH, side_effect=fake_get_redis_client):
-            with pytest.raises(Exception, match="Redis client initialization returned None"):
+        with patch(_SYNC_CLIENT_PATH, return_value=None):
+            with pytest.raises(
+                Exception, match="Redis client initialization returned None"
+            ):
                 await kb._init_redis_connections()
 
     @pytest.mark.asyncio
-    async def test_exception_propagates_from_ping(self, mock_async_redis):
+    async def test_exception_propagates_from_async_ping(self, mock_async_redis):
         """
         If ping() raises (e.g. ConnectionError), the exception must propagate
         so the caller (initialize()) can handle it and set initialized=False.
         """
-        from knowledge.base import KnowledgeBase
-
-        kb = KnowledgeBase.__new__(KnowledgeBase)
-        kb.redis_client = None
-        kb.aioredis_client = None
-        kb.redis_db = 1
-
-        sync_client = MagicMock()
-        sync_client.ping = MagicMock(return_value=True)
+        kb = self._make_kb()
+        sync_client = self._make_sync_client()
         mock_async_redis.ping = AsyncMock(side_effect=ConnectionError("Redis down"))
 
-        def fake_get_redis_client(async_client=False, database="main"):
-            if async_client:
-                return _make_coroutine(mock_async_redis)
-            return sync_client
-
-        with patch(_REDIS_CLIENT_PATH, side_effect=fake_get_redis_client):
-            with pytest.raises(Exception):
+        with (
+            patch(_SYNC_CLIENT_PATH, return_value=sync_client),
+            patch(_ASYNC_CLIENT_PATH, return_value=mock_async_redis),
+        ):
+            with pytest.raises(ConnectionError, match="Redis down"):
                 await kb._init_redis_connections()

--- a/autobot_shared/redis_client.py
+++ b/autobot_shared/redis_client.py
@@ -305,6 +305,36 @@ def get_main_redis(**kwargs) -> Optional[redis.Redis]:
     return get_redis_client(database="main", **kwargs)
 
 
+async def get_async_redis_client(
+    database: str = "main",
+) -> Optional[async_redis.Redis]:
+    """Return an async Redis client for *database*, properly awaited.
+
+    This is the safe alternative to ``get_redis_client(async_client=True)``
+    for async call-sites.  The root cause of issue #3962 was that
+    ``get_redis_client`` is a *sync* function that returns the coroutine
+    produced by ``RedisConnectionManager.get_async_client()`` without awaiting
+    it.  Callers that stored the result without ``await`` received a coroutine
+    object and later hit ``AttributeError: 'coroutine' object has no attribute
+    'ping'``.
+
+    Using an ``async def`` wrapper ensures the coroutine is always awaited
+    before the caller receives the client, making the correct usage impossible
+    to get wrong:
+
+        # Old, error-prone pattern (required explicit await at every call site):
+        client = await get_redis_client(async_client=True, database="main")
+
+        # New, safe pattern (await is built-in; impossible to forget):
+        client = await get_async_redis_client(database="main")
+
+    Returns:
+        redis.asyncio.Redis instance on success, or None if Redis is disabled
+        or the circuit breaker is open.
+    """
+    return await _get_connection_manager().get_async_client(database)
+
+
 # =============================================================================
 # Health and Metrics Functions
 # =============================================================================


### PR DESCRIPTION
Fixes #3962

## Root Cause

`get_redis_client()` is a **sync** function. When called with `async_client=True`, it returns the coroutine produced by `RedisConnectionManager.get_async_client()` **without awaiting it**. The original code in `_init_redis_connections()` stored this coroutine object directly in `self.aioredis_client` without `await`, then failed on the next line:

```
AttributeError: 'coroutine' object has no attribute 'ping'
```

The confusing API — a sync function that returns a coroutine — made this easy to get wrong at every call site.

## Changes

**`autobot_shared/redis_client.py`** — add `get_async_redis_client(database)`: a true `async def` wrapper around `RedisConnectionManager.get_async_client()`. The `await` is built into the function so callers cannot accidentally omit it.

**`autobot-backend/knowledge/base.py`** — `_init_redis_connections()`: replace `await get_redis_client(async_client=True, ...)` with `await get_async_redis_client(...)`.

**`autobot-backend/knowledge/knowledge_base_async_test.py`** — patch `get_async_redis_client` directly; remove the `_make_coroutine` helper that was only needed to simulate the old pattern; refactor repeated fixture setup into helpers; sharpen the `ConnectionError` assertion.

## Test plan
- [ ] `TestInitRedisConnections::test_stores_real_client_not_coroutine` — client is real Redis instance, not coroutine
- [ ] `TestInitRedisConnections::test_ping_called_on_async_client` — ping called exactly once
- [ ] `TestInitRedisConnections::test_raises_when_async_client_returns_none` — None from async client raises
- [ ] `TestInitRedisConnections::test_raises_when_sync_client_returns_none` — None from sync client raises
- [ ] `TestInitRedisConnections::test_exception_propagates_from_async_ping` — ConnectionError from ping propagates

🤖 Generated with [Claude Code](https://claude.com/claude-code)