### PR TITLE
fix(analytics): use vLLM model name in cache key (#4054)

### DIFF
--- a/autobot-backend/llm_interface_pkg/interface.py
+++ b/autobot-backend/llm_interface_pkg/interface.py
@@ -1409,7 +1409,13 @@ class LLMInterface:
 
         # Issue #3860: resolve model_name from provider config so usage
         # analytics records a non-empty value instead of "".
-        _, model_name = self._determine_provider_and_model("vllm")
+        # Issue #4054: use vLLM config key directly — _determine_provider_and_model("vllm")
+        # falls to the else branch and returns the Ollama default model name, causing
+        # cache-key collisions between Ollama and vLLM calls.  Use the same config key
+        # that VLLMProviderHandler._ensure_initialized() uses.
+        model_name = config.get(
+            "llm.vllm.default_model", "meta-llama/Llama-3.2-3B-Instruct"
+        )
 
         messages = [
             {"role": "system", "content": system_prompt},


### PR DESCRIPTION
## Summary

- `_determine_provider_and_model("vllm")` did not handle `"vllm"` as a recognized `llm_type`; it fell to the `else` branch and returned `(\"ollama\", <ollama-default-model>)`.
- This caused `chat_completion_optimized` to build L1/L2 cache keys using the Ollama default model name for vLLM calls, producing cache misses or cross-provider key collisions.
- Fix replaces the `_determine_provider_and_model("vllm")` call with `config.get("llm.vllm.default_model", "meta-llama/Llama-3.2-3B-Instruct")`, the same key used by `VLLMProviderHandler._ensure_initialized()`.

Fixes #4054

## Test plan

- [ ] `autobot-backend/llm_interface_pkg/llm_interface_core_test.py` — 2/2 pass (verified locally)
- [ ] Deploy to vLLM node; confirm cache hit rate improves for repeated vLLM prompts
- [ ] Confirm Ollama cache keys are unaffected (separate provider path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)