### PR TITLE
chore(redis): update MANDATORY USAGE PATTERN docstring (#4058)

### DIFF
--- a/autobot_shared/redis_client.py
+++ b/autobot_shared/redis_client.py
@@ -46,15 +46,19 @@ FEATURES (Consolidated from 8 implementations):
 
 MANDATORY USAGE PATTERN:
 ========================
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client, get_async_redis_client
 
 # Synchronous client
 redis_client = get_redis_client(database="main")
 redis_client.set("key", "value")
 
-# Asynchronous client
-async_redis = await get_redis_client(async_client=True, database="main")
+# Asynchronous client — use get_async_redis_client (safe: await is built-in)
+async_redis = await get_async_redis_client(database="main")
 await async_redis.set("key", "value")
+
+# NOTE: get_redis_client(async_client=True) is error-prone because it is a
+# synchronous function that returns an unawaited coroutine.  Always prefer
+# get_async_redis_client() at async call sites.
 
 DATABASE SEPARATION:
 ===================
@@ -567,7 +571,7 @@ class RedisDatabaseManager:
         OLD: manager = RedisDatabaseManager()
              client = await manager.get_async_connection(RedisDatabase.MAIN)
 
-        NEW: client = await get_redis_client(async_client=True, database="main")
+        NEW: client = await get_async_redis_client(database="main")
     """
 
     def __init__(self):


### PR DESCRIPTION
## Summary

- Updates the module-level `MANDATORY USAGE PATTERN` block in `autobot_shared/redis_client.py` to show `get_async_redis_client()` as the canonical async pattern, replacing the old `get_redis_client(async_client=True)` call that PR #4051 explicitly deprecated.
- Adds a NOTE comment explaining why `get_redis_client(async_client=True)` is error-prone (sync function returning an unawaited coroutine).
- Updates the `RedisDatabaseManager` deprecation docstring "NEW" migration example to also reference `get_async_redis_client()`.

Closes #4058

## Test plan

- [ ] Docstring-only change; no logic altered — no functional tests required.
- [ ] `flake8 autobot_shared/redis_client.py` passes with no new errors introduced by this PR (one pre-existing F821 on line 189 is unrelated to these changes).

Generated with [Claude Code](https://claude.com/claude-code)