### PR TITLE
chore(redis): add get_async_redis_client to __all__ (#4057)

### DIFF
--- a/autobot_shared/redis_client.py
+++ b/autobot_shared/redis_client.py
@@ -133,6 +133,7 @@ __all__ = [
     "RedisConnectionManager",
     # Convenience functions
     "get_redis_client",
+    "get_async_redis_client",
     "get_knowledge_base_redis",
     "get_prompts_redis",
     "get_agents_redis",


### PR DESCRIPTION
## Summary

- Adds `"get_async_redis_client"` to the `__all__` list in `autobot_shared/redis_client.py`
- Placed immediately after `"get_redis_client"` in the Convenience functions section (its sync counterpart)
- All other public convenience functions were already present; this omission was the only gap

## Test plan

- [ ] Verify `from autobot_shared.redis_client import get_async_redis_client` succeeds in a full-stack environment
- [ ] Verify wildcard import `from autobot_shared.redis_client import *` exposes `get_async_redis_client`

Closes #4057

🤖 Generated with [Claude Code](https://claude.com/claude-code)