### PR TITLE
refactor(redis): migrate async redis callers to get_async_redis_client (#4059)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/rl_router.py
+++ b/autobot-backend/agents/agent_orchestration/rl_router.py
@@ -329,9 +329,9 @@ class RLRouter:
     async def _get_redis(self):
         """Lazily initialize async Redis client (database='main')."""
         if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self._redis = await get_redis_client(async_client=True, database="main")
+            self._redis = await get_async_redis_client(database="main")
         return self._redis
 
     # ------------------------------------------------------------------

--- a/autobot-backend/agents/npu_code_search_agent.py
+++ b/autobot-backend/agents/npu_code_search_agent.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional
 
 import aiofiles
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client, get_async_redis_client
 from autobot_shared.security.path_validator import validate_path
 from constants.ttl_constants import TTL_24_HOURS
 from code_embedding_generator import get_code_embedding_generator
@@ -251,9 +251,7 @@ class NPUCodeSearchAgent(StandardizedAgent):
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_async_client is None:
-            from autobot_shared.redis_client import get_redis_client
-
-            self.redis_async_client = await get_redis_client(async_client=True)
+            self.redis_async_client = await get_async_redis_client()
 
     async def _ensure_search_engine_initialized(self):
         """Lazy-initialize NPU semantic search engine when needed (Issue #68)"""

--- a/autobot-backend/agents/task_pattern_learner.py
+++ b/autobot-backend/agents/task_pattern_learner.py
@@ -56,9 +56,9 @@ class TaskPatternLearner:
     async def _get_redis(self):
         """Lazily initialize Redis client."""
         if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self._redis = await get_redis_client(async_client=True, database="main")
+            self._redis = await get_async_redis_client(database="main")
         return self._redis
 
     async def _get_llm(self):

--- a/autobot-backend/api/analytics_controller.py
+++ b/autobot-backend/api/analytics_controller.py
@@ -27,7 +27,7 @@ import redis
 
 # Import models from dedicated module (Issue #185)
 from api.analytics_models import CodeAnalysisRequest, CommunicationPattern
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
 from autobot_shared.ssot_config import config as _ssot
 from constants import PATH
 from constants.threshold_constants import TimingConstants
@@ -187,7 +187,7 @@ class AnalyticsController:
                 if isinstance(database, RedisDatabase)
                 else database
             )
-            return await get_redis_client(async_client=True, database=db_name)
+            return await get_async_redis_client(database=db_name)
         except Exception as e:
             logger.error("Failed to get Redis connection for %s: %s", database, e)
             return None

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis.py
@@ -93,9 +93,9 @@ class PatternSummary(BaseModel):
 async def _get_checkpoint_redis():
     """Get async Redis client for checkpoints."""
     try:
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
 
-        return await get_redis_client(database="analytics", async_client=True)
+        return await get_async_redis_client(database="analytics")
     except Exception:
         return None
 

--- a/autobot-backend/api/codebase_analytics/source_storage.py
+++ b/autobot-backend/api/codebase_analytics/source_storage.py
@@ -22,9 +22,9 @@ _SOURCES_INDEX_KEY = "code_sources:index"
 
 async def _get_redis():
     """Return an async Redis client for the analytics database."""
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client
 
-    return await get_redis_client(database="analytics", async_client=True)
+    return await get_async_redis_client(database="analytics")
 
 
 async def save_source(source: CodeSource) -> bool:

--- a/autobot-backend/api/codebase_analytics/storage.py
+++ b/autobot-backend/api/codebase_analytics/storage.py
@@ -30,7 +30,7 @@ async def get_redis_connection():
     For async operations, use get_redis_connection_async() instead.
     """
     # Use canonical Redis utility - returns sync client
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client
 
     redis_client = get_redis_client(database="analytics", async_client=False)
     if redis_client is None:
@@ -52,9 +52,9 @@ async def get_redis_connection_async():
     Returns an ASYNC Redis client for native async operations.
     Use this when you want to avoid thread pool blocking.
     """
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client
 
-    redis_client = await get_redis_client(database="analytics", async_client=True)
+    redis_client = await get_async_redis_client(database="analytics")
     if redis_client is None:
         logger.warning("Async Redis client initialization returned None")
         return None

--- a/autobot-backend/api/knowledge_graph_routes.py
+++ b/autobot-backend/api/knowledge_graph_routes.py
@@ -114,9 +114,9 @@ async def list_entities(
 ):
     """List extracted entities with optional filters."""
     try:
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
 
-        redis_client = await get_redis_client(async_client=True, database="knowledge")
+        redis_client = await get_async_redis_client(database="knowledge")
         entities = await _list_entities_from_redis(
             redis_client, entity_type, query, limit
         )
@@ -136,9 +136,9 @@ async def get_entity_relationships(
 ):
     """Get relationships for a specific entity."""
     try:
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
 
-        redis_client = await get_redis_client(async_client=True, database="knowledge")
+        redis_client = await get_async_redis_client(database="knowledge")
         relationships = await _get_relationships_from_redis(
             redis_client, entity_id, relationship_type, limit
         )
@@ -169,10 +169,10 @@ async def search_events(
     try:
         from datetime import datetime, timezone
 
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
         from knowledge.temporal_search import TemporalSearchService
 
-        redis_client = await get_redis_client(async_client=True, database="knowledge")
+        redis_client = await get_async_redis_client(database="knowledge")
         temporal_svc = TemporalSearchService(redis_client)
 
         start = datetime.fromisoformat(start_date) if start_date else datetime.min
@@ -204,10 +204,10 @@ async def get_event_timeline(
     if not _SAFE_NAME_RE.match(entity_name):
         raise HTTPException(status_code=400, detail="Invalid entity name")
     try:
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
         from knowledge.temporal_search import TemporalSearchService
 
-        redis_client = await get_redis_client(async_client=True, database="knowledge")
+        redis_client = await get_async_redis_client(database="knowledge")
         temporal_svc = TemporalSearchService(redis_client)
 
         events = await temporal_svc.get_event_timeline(

--- a/autobot-backend/api/knowledge_rag_feedback.py
+++ b/autobot-backend/api/knowledge_rag_feedback.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_30_DAYS
 from knowledge.search_components.retrieval_learner import GLOBAL_USER
 
@@ -90,7 +90,7 @@ async def record_rag_feedback(
     }
 
     try:
-        redis = await get_redis_client(async_client=True, database="analytics")
+        redis = await get_async_redis_client(database="analytics")
         if redis is None:
             logger.warning(
                 "record_rag_feedback: Redis unavailable; annotation dropped for user %s",

--- a/autobot-backend/api/redis_mcp/data_access.py
+++ b/autobot-backend/api/redis_mcp/data_access.py
@@ -11,7 +11,7 @@ All handlers use autobot_shared.redis_client — no direct redis.Redis().
 import logging
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_24_HOURS
 from type_defs.common import Metadata
 
@@ -48,7 +48,7 @@ def _decode(value):
 
 async def _get_client(database: str = "main"):
     """Get an async Redis client for the given database."""
-    return await get_redis_client(async_client=True, database=database)
+    return await get_async_redis_client(database=database)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/redis_mcp/ops_intelligence.py
+++ b/autobot-backend/api/redis_mcp/ops_intelligence.py
@@ -11,7 +11,7 @@ Agents can chain these tools for composite diagnostics.
 import logging
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 async def _get_client(database: str = "main"):
     """Get an async Redis client for ops queries."""
-    return await get_redis_client(async_client=True, database=database)
+    return await get_async_redis_client(database=database)
 
 
 async def handle_redis_server_info(

--- a/autobot-backend/api/redis_mcp/vector_search.py
+++ b/autobot-backend/api/redis_mcp/vector_search.py
@@ -14,7 +14,7 @@ import re
 import struct
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ async def _text_to_embedding(text: str) -> List[float]:
 
 async def _get_client(database: str = "vectors"):
     """Get an async Redis client for vector operations."""
-    return await get_redis_client(async_client=True, database=database)
+    return await get_async_redis_client(database=database)
 
 
 def _float_list_to_bytes(vector: List[float]) -> bytes:

--- a/autobot-backend/api/workflow_state.py
+++ b/autobot-backend/api/workflow_state.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from autobot_shared.models.service_message import ServiceMessage
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_7_DAYS
 
 logger = logging.getLogger(__name__)
@@ -113,7 +113,7 @@ class WorkflowStateMachine:
 
     async def _redis(self):
         """Get async Redis client for workflows db."""
-        return await get_redis_client(async_client=True, database=REDIS_DATABASE)
+        return await get_async_redis_client(database=REDIS_DATABASE)
 
     async def _persist(self, state: WorkflowState) -> None:
         """Serialize and store *state* in Redis."""

--- a/autobot-backend/api/workflow_state_test.py
+++ b/autobot-backend/api/workflow_state_test.py
@@ -33,11 +33,9 @@ from api.workflow_state import (
 def mock_redis():
     """Async Redis mock with common methods.
 
-    ``get_redis_client(async_client=True)`` returns a coroutine,
-    so the mock must also be awaitable.  We build a plain
-    ``AsyncMock`` for the Redis client and a separate helper
-    that returns it as an awaitable when used as a side-effect
-    for the patched ``get_redis_client``.
+    ``get_async_redis_client()`` is an async function returning the Redis
+    client.  We build a plain ``AsyncMock`` for the Redis client and patch
+    ``get_async_redis_client`` to return it.
     """
     mock = AsyncMock()
     mock.set = AsyncMock(return_value=True)
@@ -185,7 +183,7 @@ class TestWorkflowStateMachineCreate:
     """Tests for WorkflowStateMachine.create()."""
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_create_returns_state(self, mock_get_redis, mock_redis, sample_steps):
         mock_get_redis.return_value = mock_redis
         sm = WorkflowStateMachine()
@@ -199,7 +197,7 @@ class TestWorkflowStateMachineCreate:
         assert state.done is False
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_create_persists_to_redis(
         self, mock_get_redis, mock_redis, sample_steps
     ):
@@ -219,7 +217,7 @@ class TestWorkflowStateMachineCreate:
         assert restored.workflow_id == "wf-persist"
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_create_adds_to_active_set(
         self, mock_get_redis, mock_redis, sample_steps
     ):
@@ -235,7 +233,7 @@ class TestWorkflowStateMachineGet:
     """Tests for WorkflowStateMachine.get()."""
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_get_existing(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         state = WorkflowState(workflow_id="wf-exist", goal="exists")
@@ -250,7 +248,7 @@ class TestWorkflowStateMachineGet:
         mock_redis.get.assert_called_once_with(f"{KEY_PREFIX}wf-exist")
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_get_missing_returns_none(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         mock_redis.get.return_value = None
@@ -265,7 +263,7 @@ class TestWorkflowStateMachineTransition:
     """Tests for WorkflowStateMachine.transition()."""
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_transition_updates_step(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         original = WorkflowState(
@@ -282,7 +280,7 @@ class TestWorkflowStateMachineTransition:
         assert "planning" in result.steps_completed
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_transition_updates_active_service(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         original = WorkflowState(
@@ -299,7 +297,7 @@ class TestWorkflowStateMachineTransition:
         assert result.active_service == "main-backend"
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_transition_persists_updated_state(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         original = WorkflowState(
@@ -317,7 +315,7 @@ class TestWorkflowStateMachineTransition:
         assert mock_redis.set.call_args[0][0] == key
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_transition_missing_workflow_raises(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         mock_redis.get.return_value = None
@@ -331,7 +329,7 @@ class TestWorkflowStateMachineComplete:
     """Tests for WorkflowStateMachine.complete()."""
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_complete_marks_done(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         original = WorkflowState(
@@ -348,7 +346,7 @@ class TestWorkflowStateMachineComplete:
         assert result.current_step == "complete"
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_complete_removes_from_active_set(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         original = WorkflowState(
@@ -364,7 +362,7 @@ class TestWorkflowStateMachineComplete:
         mock_redis.srem.assert_called_once_with(ACTIVE_SET, "wf-rm")
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_complete_sets_ttl(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         original = WorkflowState(
@@ -385,7 +383,7 @@ class TestWorkflowStateMachineFail:
     """Tests for WorkflowStateMachine.fail()."""
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_fail_marks_failed(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         original = WorkflowState(
@@ -403,7 +401,7 @@ class TestWorkflowStateMachineFail:
         assert "something broke" in result.errors
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_fail_appends_to_existing_errors(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         original = WorkflowState(
@@ -422,7 +420,7 @@ class TestWorkflowStateMachineFail:
         assert result.errors[1] == "second error"
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_fail_missing_workflow_raises(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         mock_redis.get.return_value = None
@@ -432,7 +430,7 @@ class TestWorkflowStateMachineFail:
             await sm.fail("wf-ghost", "oops")
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_fail_removes_from_active_set(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         original = WorkflowState(
@@ -452,7 +450,7 @@ class TestWorkflowStateMachineListActive:
     """Tests for WorkflowStateMachine.list_active()."""
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_list_active_empty(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         mock_redis.smembers.return_value = set()
@@ -463,7 +461,7 @@ class TestWorkflowStateMachineListActive:
         assert result == []
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_list_active_returns_states(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         s1 = WorkflowState(workflow_id="wf-a1", goal="goal 1")
@@ -488,7 +486,7 @@ class TestWorkflowStateMachineListActive:
         assert ids == {"wf-a1", "wf-a2"}
 
     @pytest.mark.asyncio
-    @patch("api.workflow_state.get_redis_client", new_callable=AsyncMock)
+    @patch("api.workflow_state.get_async_redis_client", new_callable=AsyncMock)
     async def test_list_active_skips_missing(self, mock_get_redis, mock_redis):
         mock_get_redis.return_value = mock_redis
         s1 = WorkflowState(workflow_id="wf-ok", goal="ok")

--- a/autobot-backend/autobot_memory_graph/property_graph.py
+++ b/autobot-backend/autobot_memory_graph/property_graph.py
@@ -28,7 +28,7 @@ import uuid
 from collections import deque
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +135,7 @@ class PropertyGraph:
     async def initialize(self) -> None:
         """Acquire async Redis connection."""
         if self._redis is None:
-            self._redis = await get_redis_client(async_client=True, database=self._database)
+            self._redis = await get_async_redis_client(database=self._database)
         logger.info("PropertyGraph initialized (db=%s)", self._database)
 
     # ------------------------------------------------------------------

--- a/autobot-backend/code_analysis/src/api_consistency_analyzer.py
+++ b/autobot-backend/code_analysis/src/api_consistency_analyzer.py
@@ -113,9 +113,9 @@ class APIConsistencyAnalyzer:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def analyze_api_consistency(
         self, root_path: str = ".", patterns: List[str] = None

--- a/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
+++ b/autobot-backend/code_analysis/src/architectural_pattern_analyzer.py
@@ -72,9 +72,9 @@ class ArchitecturalPatternAnalyzer:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def analyze_architecture(
         self, root_path: str = ".", patterns: List[str] = None

--- a/autobot-backend/code_analysis/src/code_analyzer.py
+++ b/autobot-backend/code_analysis/src/code_analyzer.py
@@ -82,9 +82,9 @@ class CodeAnalyzer:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def analyze_codebase(
         self, root_path: str = ".", patterns: List[str] = None

--- a/autobot-backend/code_analysis/src/code_quality_dashboard.py
+++ b/autobot-backend/code_analysis/src/code_quality_dashboard.py
@@ -93,9 +93,9 @@ class CodeQualityDashboard:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def _gather_analysis_results(
         self, root_path: str, patterns: List[str]

--- a/autobot-backend/code_analysis/src/env_analyzer.py
+++ b/autobot-backend/code_analysis/src/env_analyzer.py
@@ -31,7 +31,7 @@ if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
 try:
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_redis_client, get_async_redis_client
 
     _REDIS_AVAILABLE = True
     _CONFIG_AVAILABLE = True
@@ -399,9 +399,9 @@ class EnvironmentAnalyzer:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_redis_client, get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def analyze_codebase(
         self, root_path: str = ".", patterns: list[str] = None

--- a/autobot-backend/code_analysis/src/frontend_analyzer.py
+++ b/autobot-backend/code_analysis/src/frontend_analyzer.py
@@ -18,7 +18,7 @@ autobot_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(autobot_root))
 
 try:
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_redis_client, get_async_redis_client
     from config import config
 except ImportError:
     # Fallback for standalone usage
@@ -220,9 +220,9 @@ class FrontendAnalyzer:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_redis_client, get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def analyze_frontend_code(
         self, root_path: str = ".", patterns: List[str] = None

--- a/autobot-backend/code_analysis/src/ownership_analyzer.py
+++ b/autobot-backend/code_analysis/src/ownership_analyzer.py
@@ -29,7 +29,7 @@ if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
 try:
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_redis_client, get_async_redis_client
     from constants.ttl_constants import TTL_1_HOUR
 
     _REDIS_AVAILABLE = True
@@ -166,9 +166,9 @@ class OwnershipAnalyzer:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_redis_client, get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def analyze_ownership(
         self,

--- a/autobot-backend/code_analysis/src/patch_generator.py
+++ b/autobot-backend/code_analysis/src/patch_generator.py
@@ -62,9 +62,9 @@ class AutomatedFixGenerator:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     def _initialize_fix_templates(self) -> Dict[str, List[FixTemplate]]:
         """Initialize fix templates for common code issues.

--- a/autobot-backend/code_analysis/src/performance_analyzer.py
+++ b/autobot-backend/code_analysis/src/performance_analyzer.py
@@ -112,9 +112,9 @@ class PerformanceAnalyzer:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def analyze_performance(
         self, root_path: str = ".", patterns: List[str] = None

--- a/autobot-backend/code_analysis/src/security_analyzer.py
+++ b/autobot-backend/code_analysis/src/security_analyzer.py
@@ -224,9 +224,9 @@ class SecurityAnalyzer:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def analyze_security(
         self, root_path: str = ".", patterns: List[str] = None

--- a/autobot-backend/code_analysis/src/testing_coverage_analyzer.py
+++ b/autobot-backend/code_analysis/src/testing_coverage_analyzer.py
@@ -881,9 +881,9 @@ class TestingCoverageAnalyzer:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2984)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def _cache_results(self, results: Dict[str, Any]):
         """Cache analysis results in Redis"""

--- a/autobot-backend/config/async_ops.py
+++ b/autobot-backend/config/async_ops.py
@@ -102,10 +102,10 @@ class AsyncOperationsMixin:
             return None
 
         try:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
             cache_key = self._get_redis_cache_key(config_type)
-            redis_client = await get_redis_client(async_client=True, database="main")
+            redis_client = await get_async_redis_client(database="main")
 
             if redis_client:
                 cached_data = await redis_client.get(cache_key)
@@ -127,13 +127,13 @@ class AsyncOperationsMixin:
             return
 
         try:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
             # Filter sensitive data before caching
             filtered_data = self._filter_sensitive_data(data)
 
             cache_key = self._get_redis_cache_key(config_type)
-            redis_client = await get_redis_client(async_client=True, database="main")
+            redis_client = await get_async_redis_client(database="main")
 
             if redis_client:
                 await redis_client.set(

--- a/autobot-backend/dependencies.py
+++ b/autobot-backend/dependencies.py
@@ -221,9 +221,9 @@ async def get_async_redis_client(database: str = "main"):
     Returns:
         Async Redis client instance
     """
-    from autobot_shared.redis_client import get_redis_client as _get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client as _get_async_redis_client
 
-    return await _get_redis_client(async_client=True, database=database)
+    return await _get_async_redis_client(database=database)
 
 
 # Type aliases for cleaner dependency annotations

--- a/autobot-backend/dependency_container.py
+++ b/autobot-backend/dependency_container.py
@@ -15,7 +15,7 @@ from typing import Any, AsyncGenerator, Callable, Dict, Optional, Type, TypeVar
 
 import redis.asyncio as async_redis
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from config.manager import ConfigManager, get_config_manager
 from llm_interface import LLMInterface, get_llm_interface
 
@@ -83,7 +83,7 @@ class AsyncServiceContainer:
 
     async def _create_redis_manager(self) -> async_redis.Redis:
         """Factory for Redis manager"""
-        return await get_redis_client(async_client=True, database="main")
+        return await get_async_redis_client(database="main")
 
     async def _create_config_manager(self) -> ConfigManager:
         """Factory for config manager"""

--- a/autobot-backend/enhanced_orchestration/orchestrator.py
+++ b/autobot-backend/enhanced_orchestration/orchestrator.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from agents.agent_client import AgentRegistry as AgentClientRegistry
 from agents.llm_failsafe_agent import get_robust_llm_response
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client, get_async_redis_client
 from event_manager import event_manager
 
 from .types import (
@@ -112,9 +112,7 @@ class EnhancedMultiAgentOrchestrator:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_async is None:
-            from autobot_shared.redis_client import get_redis_client
-
-            self.redis_async = await get_redis_client(async_client=True)
+            self.redis_async = await get_async_redis_client()
 
     def _get_strategy_handler(self) -> ExecutionStrategyHandler:
         """Lazy initialization of strategy handler."""

--- a/autobot-backend/events/stream_manager.py
+++ b/autobot-backend/events/stream_manager.py
@@ -130,9 +130,9 @@ class RedisEventStreamManager(EventStreamManager):
         """Get async Redis client with lazy initialization"""
         if self._redis is None:
             try:
-                from autobot_shared.redis_client import get_redis_client
+                from autobot_shared.redis_client import get_async_redis_client
 
-                self._redis = await get_redis_client(async_client=True, database="main")
+                self._redis = await get_async_redis_client(database="main")
                 self._initialized = True
                 logger.debug("Event stream Redis connection established")
             except Exception as e:

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1049,11 +1049,11 @@ async def _wire_npu_task_queue() -> None:
     """
     logger.info("[ 98%%] NPU Task Queue: Wiring NPUWorkerManager into TaskQueue...")
     try:
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
         from services.npu_worker_manager import get_worker_manager
         from utils.task_queue import get_task_queue
 
-        redis_client = await get_redis_client(async_client=True, database="main")
+        redis_client = await get_async_redis_client(database="main")
         worker_manager = await get_worker_manager(redis_client=redis_client)
         task_queue = get_task_queue()
         task_queue.npu_worker_manager = worker_manager

--- a/autobot-backend/knowledge/search_components/reranking.py
+++ b/autobot-backend/knowledge/search_components/reranking.py
@@ -318,10 +318,10 @@ class ResultReranker:
         if weights.staleness == 0.0:
             return None
         try:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
             from services.mesh_brain.staleness_propagator import get_staleness_score
 
-            redis = await get_redis_client(async_client=True, database="main")
+            redis = await get_async_redis_client(database="main")
             staleness_map: Dict[str, float] = {}
             for result in results:
                 chunk_id = result.get("chunk_id") or result.get("id", "")

--- a/autobot-backend/memory/working_memory.py
+++ b/autobot-backend/memory/working_memory.py
@@ -15,7 +15,7 @@ import json
 import logging
 from typing import Any, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 from constants.ttl_constants import TTL_WORKING_MEMORY_DEFAULT
 
@@ -37,7 +37,7 @@ class WorkingMemoryService:
 
     async def _get_redis(self):
         if self._redis is None:
-            self._redis = await get_redis_client(async_client=True, database="knowledge")
+            self._redis = await get_async_redis_client(database="knowledge")
         return self._redis
 
     async def store(

--- a/autobot-backend/plugin_manager.py
+++ b/autobot-backend/plugin_manager.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import with_error_handling
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_redis_client, get_async_redis_client
 from autobot_shared.ssot_config import config
 from plugin_sdk.base import PluginRegistry
 from plugin_sdk.loader import PluginLoader
@@ -369,14 +369,14 @@ async def update_plugin_config(
 
 async def _save_plugin_config(plugin_name: str, config: Dict) -> None:
     """Save plugin configuration to Redis."""
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     key = f"plugin:config:{plugin_name}"
     await redis.set(key, json.dumps(config))
 
 
 async def _load_plugin_config(plugin_name: str) -> Optional[Dict]:
     """Load plugin configuration from Redis."""
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     key = f"plugin:config:{plugin_name}"
     data = await redis.get(key)
     return json.loads(data) if data else None

--- a/autobot-backend/security/service_auth.py
+++ b/autobot-backend/security/service_auth.py
@@ -17,7 +17,7 @@ from typing import Dict, Optional
 import structlog
 from fastapi import HTTPException, Request
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_90_DAYS
 from utils.catalog_http_exceptions import raise_auth_error, raise_server_error
 
@@ -241,7 +241,7 @@ async def validate_service_auth(request: Request) -> Dict:
         pass
 
         # Get main Redis database for service key storage
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
 
         # Create auth manager and validate
         auth_manager = ServiceAuthManager(redis)

--- a/autobot-backend/services/access_control_metrics.py
+++ b/autobot-backend/services/access_control_metrics.py
@@ -22,7 +22,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class AccessControlMetrics:
         """Get Redis metrics database (DB 4)"""
         if not self._redis:
             # Get async Redis client for metrics database (returns coroutine, must await)
-            self._redis = await get_redis_client(async_client=True, database="metrics")
+            self._redis = await get_async_redis_client(database="metrics")
         return self._redis
 
     async def record_violation(

--- a/autobot-backend/services/approval_memory.py
+++ b/autobot-backend/services/approval_memory.py
@@ -48,7 +48,7 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
 
 logger = logging.getLogger(__name__)
@@ -277,7 +277,7 @@ class ApprovalMemoryManager:
             return False
 
         try:
-            redis = await get_redis_client(async_client=True, database="main")
+            redis = await get_async_redis_client(database="main")
             if not redis:
                 logger.warning("Redis not available for approval memory")
                 return False
@@ -327,7 +327,7 @@ class ApprovalMemoryManager:
             return False
 
         try:
-            redis = await get_redis_client(async_client=True, database="main")
+            redis = await get_async_redis_client(database="main")
             if not redis:
                 return False
 
@@ -389,7 +389,7 @@ class ApprovalMemoryManager:
             return []
 
         try:
-            redis = await get_redis_client(async_client=True, database="main")
+            redis = await get_async_redis_client(database="main")
             if not redis:
                 return []
 
@@ -427,7 +427,7 @@ class ApprovalMemoryManager:
             return False
 
         try:
-            redis = await get_redis_client(async_client=True, database="main")
+            redis = await get_async_redis_client(database="main")
             if not redis:
                 return False
 
@@ -478,7 +478,7 @@ class ApprovalMemoryManager:
             return False
 
         try:
-            redis = await get_redis_client(async_client=True, database="main")
+            redis = await get_async_redis_client(database="main")
             if not redis:
                 return False
 
@@ -533,7 +533,7 @@ class ApprovalMemoryManager:
             return {"enabled": False}
 
         try:
-            redis = await get_redis_client(async_client=True, database="main")
+            redis = await get_async_redis_client(database="main")
             if not redis:
                 return {"enabled": True, "redis_available": False}
 

--- a/autobot-backend/services/audit_logger.py
+++ b/autobot-backend/services/audit_logger.py
@@ -42,7 +42,7 @@ from typing import Any, Dict, List, Literal, Optional
 import aiofiles
 import redis.asyncio as async_redis
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.network_constants import NetworkConstants
 from models.task_context import AuditQueryContext
 from type_defs.common import Metadata
@@ -264,7 +264,7 @@ class AuditLogger(AsyncInitializable):
         """Get Redis audit database (DB 10)"""
         try:
             # Use canonical Redis client pattern with 'audit' database
-            return await get_redis_client(async_client=True, database="audit")
+            return await get_async_redis_client(database="audit")
         except Exception as e:
             logger.error("Failed to get audit database: %s", e)
             self._redis_failures += 1

--- a/autobot-backend/services/autoresearch/osint_engine.py
+++ b/autobot-backend/services/autoresearch/osint_engine.py
@@ -481,9 +481,9 @@ class OSINTEngine:
     async def _get_redis(self):
         """Lazy-init async Redis client (main database)."""
         if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self._redis = await get_redis_client(async_client=True, database="main")
+            self._redis = await get_async_redis_client(database="main")
         return self._redis
 
     async def _cache_results(self, results: List[SourceResult]) -> None:

--- a/autobot-backend/services/autoresearch/prompt_optimizer.py
+++ b/autobot-backend/services/autoresearch/prompt_optimizer.py
@@ -492,9 +492,9 @@ class PromptOptimizer:
 
     async def _get_redis(self):
         if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self._redis = await get_redis_client(async_client=True, database="main")
+            self._redis = await get_async_redis_client(database="main")
         return self._redis
 
     async def _save_session(self, session: OptimizationSession) -> None:

--- a/autobot-backend/services/autoresearch/routes.py
+++ b/autobot-backend/services/autoresearch/routes.py
@@ -572,9 +572,9 @@ async def get_variants(
     """List prompt variants for an optimization session."""
     import json as _json
 
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client
 
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     key = f"autoresearch:prompt_opt:session:{session_id}"
     raw = await redis.get(key)
     if raw is None:
@@ -597,7 +597,7 @@ async def submit_variant_score(
     """Submit a human score for a prompt variant."""
     import json as _json
 
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client
 
     # Validate key components to prevent Redis key injection
     if not _UUID_PATTERN.match(session_id) or not _UUID_PATTERN.match(variant_id):
@@ -605,7 +605,7 @@ async def submit_variant_score(
             status_code=400, detail="Invalid session_id or variant_id format"
         )
 
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     key = f"autoresearch:prompt_review:{session_id}:{variant_id}"
     notify_key = HUMAN_REVIEW_NOTIFY_KEY.format(session_id=session_id, variant_id=variant_id)
     await redis.set(
@@ -633,9 +633,9 @@ async def list_pending_approvals(
     """List pending approval requests."""
     import json as _json
 
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client
 
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     approvals = []
     async for key in redis.scan_iter("autoresearch:approval:pending:*"):
         raw = await redis.get(key)
@@ -666,9 +666,9 @@ async def submit_approval_decision(
     _admin: bool = Depends(check_admin_permission),
 ):
     """Submit approve/reject decision for an experiment."""
-    from autobot_shared.redis_client import get_redis_client
+    from autobot_shared.redis_client import get_async_redis_client
 
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     status_key = f"autoresearch:approval:status:{session_id}:{experiment_id}"
     current = await redis.get(status_key)
     if current is None:

--- a/autobot-backend/services/autoresearch/scorers.py
+++ b/autobot-backend/services/autoresearch/scorers.py
@@ -287,9 +287,9 @@ class HumanReviewScorer(PromptScorer):
 
     async def _get_redis(self):
         if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self._redis = await get_redis_client(async_client=True, database="main")
+            self._redis = await get_async_redis_client(database="main")
         return self._redis
 
     @property

--- a/autobot-backend/services/documentation_watcher.py
+++ b/autobot-backend/services/documentation_watcher.py
@@ -289,7 +289,7 @@ class DocumentationWatcherService:
             doc_id: Relative path used as the node identifier in the mesh graph.
         """
         try:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
             from services.mesh_brain.staleness_propagator import (
                 RedisGraphAdapter,
                 enqueue_for_reembedding,
@@ -297,7 +297,7 @@ class DocumentationWatcherService:
                 store_staleness_scores,
             )
 
-            redis = await get_redis_client(async_client=True, database="main")
+            redis = await get_async_redis_client(database="main")
             graph = RedisGraphAdapter(redis)
             staleness_result = await propagate_staleness(graph, doc_id)
             stored = await store_staleness_scores(redis, staleness_result.scores)

--- a/autobot-backend/services/fact_extraction_service.py
+++ b/autobot-backend/services/fact_extraction_service.py
@@ -64,9 +64,9 @@ class FactExtractionService:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     async def _apply_fact_processing(self, extraction_result) -> None:
         """Apply deduplication and entity resolution to extracted facts (Issue #398: extracted).

--- a/autobot-backend/services/feature_flags.py
+++ b/autobot-backend/services/feature_flags.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.threshold_constants import StringParsingConstants
 from type_defs.common import Metadata
 
@@ -68,7 +68,7 @@ class FeatureFlags:
         """Get Redis connection for feature flags (uses cache DB)"""
         if not self.redis:
             # Get async Redis client for cache database (returns coroutine, must await)
-            self.redis = await get_redis_client(async_client=True, database="cache")
+            self.redis = await get_async_redis_client(database="cache")
         return self.redis
 
     async def get_enforcement_mode(self) -> EnforcementMode:

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from advanced_rag_optimizer import AdvancedRAGOptimizer, RAGMetrics, SearchResult
 from autobot_shared.logging_manager import get_llm_logger
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_30_DAYS
 from knowledge.search_components.query_classifier import get_query_classifier
 from knowledge.search_components.retrieval_learner import GLOBAL_USER, get_retrieval_learner
@@ -458,7 +458,7 @@ class RAGService:
             "timestamp": str(time.time()),
         }
         try:
-            redis = await get_redis_client(async_client=True, database="analytics")
+            redis = await get_async_redis_client(database="analytics")
             if redis is None:
                 logger.debug("Redis unavailable; skipping feedback stream write")
                 return

--- a/autobot-backend/services/redis_service_manager.py
+++ b/autobot-backend/services/redis_service_manager.py
@@ -544,10 +544,10 @@ class RedisServiceManager:
             Tuple of (connectivity: bool, response_time_ms: float)
         """
         try:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
             ping_start = datetime.now(tz=timezone.utc)
-            client = await get_redis_client(async_client=True, database="main")
+            client = await get_async_redis_client(database="main")
             await client.ping()
             response_time_ms = (datetime.now(tz=timezone.utc) - ping_start).total_seconds() * 1000
             return True, response_time_ms

--- a/autobot-backend/services/semantic_query_cache.py
+++ b/autobot-backend/services/semantic_query_cache.py
@@ -31,7 +31,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
 from utils.async_initializable import AsyncInitializable
 
@@ -333,7 +333,7 @@ class SemanticQueryCache(AsyncInitializable):
     async def _fetch_response(self, key: str) -> Optional[Dict]:
         """Fetch cached response payload from Redis."""
         try:
-            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = await get_async_redis_client(database=_REDIS_DATABASE)
             if client is None:
                 return None
             raw = await client.get(key)
@@ -347,7 +347,7 @@ class SemanticQueryCache(AsyncInitializable):
     async def _store_response(self, key: str, payload: Dict) -> bool:
         """Persist response payload in Redis with TTL."""
         try:
-            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = await get_async_redis_client(database=_REDIS_DATABASE)
             if client is None:
                 return False
             await client.set(

--- a/autobot-backend/services/temporal_invalidation_service.py
+++ b/autobot-backend/services/temporal_invalidation_service.py
@@ -173,9 +173,9 @@ class TemporalInvalidationService:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     def _create_default_rules(self) -> List[InvalidationRule]:
         """Create default invalidation rules."""

--- a/autobot-backend/services/terminal_history_service.py
+++ b/autobot-backend/services/terminal_history_service.py
@@ -9,7 +9,7 @@ import logging
 import time
 from typing import List
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class TerminalHistoryService:
         correctly in an async context.
         """
         if self._redis is None:
-            self._redis = await get_redis_client(database="main", async_client=True)
+            self._redis = await get_async_redis_client(database="main")
         return self._redis
 
     async def add_command(self, user_id: str, command: str) -> None:

--- a/autobot-backend/services/topic_retrieval_cache.py
+++ b/autobot-backend/services/topic_retrieval_cache.py
@@ -31,7 +31,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from utils.async_initializable import AsyncInitializable
 
 logger = logging.getLogger(__name__)
@@ -276,7 +276,7 @@ class TopicRetrievalCache(AsyncInitializable):
     async def _fetch_chunks(self, key: str) -> Optional[List[CachedChunk]]:
         """Fetch cached chunks from Redis."""
         try:
-            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = await get_async_redis_client(database=_REDIS_DATABASE)
             if client is None:
                 return None
             raw = await client.get(key)
@@ -298,7 +298,7 @@ class TopicRetrievalCache(AsyncInitializable):
     async def _store_chunks(self, key: str, payload: List[Dict]) -> bool:
         """Persist chunk list in Redis with TTL."""
         try:
-            client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
+            client = await get_async_redis_client(database=_REDIS_DATABASE)
             if client is None:
                 return False
             await client.set(

--- a/autobot-backend/services/workflow_automation/persistence.py
+++ b/autobot-backend/services/workflow_automation/persistence.py
@@ -16,7 +16,7 @@ import logging
 from dataclasses import asdict
 from typing import Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.redis_constants import REDIS_KEY
 from constants.ttl_constants import TTL_7_DAYS
 from services.notification_service import NotificationConfig
@@ -35,7 +35,7 @@ async def save_notification_config(
     config: Optional[NotificationConfig],
 ) -> None:
     """Persist *config* to Redis, or delete the key when *config* is None."""
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     if redis is None:
         logger.warning(
             "Redis unavailable — notification config not persisted (workflow=%s)",
@@ -58,7 +58,7 @@ async def load_notification_config(
     workflow_id: str,
 ) -> Optional[NotificationConfig]:
     """Load notification config from Redis; returns None when not found."""
-    redis = await get_redis_client(async_client=True, database="main")
+    redis = await get_async_redis_client(database="main")
     if redis is None:
         logger.warning(
             "Redis unavailable — cannot load notification config (workflow=%s)",

--- a/autobot-backend/services/workflow_automation/state_machine.py
+++ b/autobot-backend/services/workflow_automation/state_machine.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field
 
 from autobot_shared.message_bus import get_message_bus
 from autobot_shared.models.service_message import ServiceMessage
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.redis_constants import REDIS_KEY
 from constants.ttl_constants import TTL_24_HOURS
 
@@ -131,7 +131,7 @@ class WorkflowStateMachine:
 
     async def _get_redis(self) -> Any:
         if self._redis is None:
-            self._redis = await get_redis_client(async_client=True, database="main")
+            self._redis = await get_async_redis_client(database="main")
         return self._redis
 
     # -- Create --------------------------------------------------------

--- a/autobot-backend/services/workflow_sharing_service.py
+++ b/autobot-backend/services/workflow_sharing_service.py
@@ -45,7 +45,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from services.workflow_serializer import WorkflowSerializer
 
 logger = logging.getLogger(__name__)
@@ -158,7 +158,7 @@ class WorkflowSharingService:
             export_doc=export_doc.to_dict(),
         )
 
-        redis = await get_redis_client(async_client=True, database="workflows")
+        redis = await get_async_redis_client(database="workflows")
         if redis is None:
             logger.error(
                 "share_workflow: Redis unavailable for workflow %s", workflow_id
@@ -200,7 +200,7 @@ class WorkflowSharingService:
         Returns:
             True when the share existed and was deleted, False otherwise.
         """
-        redis = await get_redis_client(async_client=True, database="workflows")
+        redis = await get_async_redis_client(database="workflows")
         if redis is None:
             logger.error("unshare_workflow: Redis unavailable for share %s", share_id)
             return False
@@ -243,7 +243,7 @@ class WorkflowSharingService:
             List of share record dicts (without the embedded workflow payload
             to keep the response lightweight).
         """
-        redis = await get_redis_client(async_client=True, database="workflows")
+        redis = await get_async_redis_client(database="workflows")
         if redis is None:
             logger.error("list_shared: Redis unavailable")
             return []
@@ -297,7 +297,7 @@ class WorkflowSharingService:
         Returns:
             New workflow_id on success, None on failure.
         """
-        redis = await get_redis_client(async_client=True, database="workflows")
+        redis = await get_async_redis_client(database="workflows")
         if redis is None:
             logger.error("clone_workflow: Redis unavailable for share %s", share_id)
             return None

--- a/autobot-backend/services/workflow_versioning.py
+++ b/autobot-backend/services/workflow_versioning.py
@@ -42,7 +42,7 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +133,7 @@ class WorkflowVersionStore:
         Returns:
             The new version number on success, None when Redis is unavailable.
         """
-        redis = await get_redis_client(async_client=True, database="workflows")
+        redis = await get_async_redis_client(database="workflows")
         if redis is None:
             logger.error("save_version: Redis unavailable for workflow %s", workflow_id)
             return None
@@ -172,7 +172,7 @@ class WorkflowVersionStore:
         Returns:
             True when the version existed and was removed; False otherwise.
         """
-        redis = await get_redis_client(async_client=True, database="workflows")
+        redis = await get_async_redis_client(database="workflows")
         if redis is None:
             logger.error(
                 "delete_version: Redis unavailable for workflow %s", workflow_id
@@ -211,7 +211,7 @@ class WorkflowVersionStore:
             List of summary dicts sorted by version descending.  Empty list
             when no versions exist or Redis is unavailable.
         """
-        redis = await get_redis_client(async_client=True, database="workflows")
+        redis = await get_async_redis_client(database="workflows")
         if redis is None:
             logger.error(
                 "list_versions: Redis unavailable for workflow %s", workflow_id
@@ -252,7 +252,7 @@ class WorkflowVersionStore:
         Returns:
             WorkflowVersion dataclass, or None when not found.
         """
-        redis = await get_redis_client(async_client=True, database="workflows")
+        redis = await get_async_redis_client(database="workflows")
         if redis is None:
             logger.error("get_version: Redis unavailable for workflow %s", workflow_id)
             return None

--- a/autobot-backend/skills/builtin/autonomous_skill_development.py
+++ b/autobot-backend/skills/builtin/autonomous_skill_development.py
@@ -185,9 +185,9 @@ async def _publish_new_draft_event(skill_name: str, skill_id: str, gap: str) -> 
     try:
         import json
 
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
 
-        redis = await get_redis_client(async_client=True, database="main")
+        redis = await get_async_redis_client(database="main")
         await redis.publish(
             "skills:new_draft",
             json.dumps(

--- a/autobot-backend/skills/governance.py
+++ b/autobot-backend/skills/governance.py
@@ -111,9 +111,9 @@ class GovernanceEngine:
     ) -> None:
         """Publish pending approval to Redis for SLM dashboard notification."""
         try:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            redis = await get_redis_client(async_client=True, database="main")
+            redis = await get_async_redis_client(database="main")
             await redis.publish(
                 REDIS_APPROVAL_CHANNEL,
                 json.dumps(

--- a/autobot-backend/skills/manager.py
+++ b/autobot-backend/skills/manager.py
@@ -192,9 +192,9 @@ async def _get_redis():
     Helper for SkillManager Redis operations (Issue #731).
     """
     try:
-        from autobot_shared.redis_client import get_redis_client
+        from autobot_shared.redis_client import get_async_redis_client
 
-        return await get_redis_client(async_client=True, database="main")
+        return await get_async_redis_client(database="main")
     except Exception:
         logger.debug("Redis not available for skill persistence")
         return None

--- a/autobot-backend/user_management/middleware/rate_limit.py
+++ b/autobot-backend/user_management/middleware/rate_limit.py
@@ -11,7 +11,7 @@ Issue #635.
 import logging
 import uuid
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ class PasswordChangeRateLimiter:
         Raises:
             RateLimitExceeded: If limit exceeded
         """
-        redis_client = await get_redis_client(async_client=True, database="main")
+        redis_client = await get_async_redis_client(database="main")
         key = f"password_change_attempts:{user_id}"
 
         attempts = await redis_client.get(key)
@@ -61,7 +61,7 @@ class PasswordChangeRateLimiter:
             user_id: User ID
             success: Whether attempt was successful
         """
-        redis_client = await get_redis_client(async_client=True, database="main")
+        redis_client = await get_async_redis_client(database="main")
         key = f"password_change_attempts:{user_id}"
 
         if success:

--- a/autobot-backend/user_management/services/session_service.py
+++ b/autobot-backend/user_management/services/session_service.py
@@ -13,7 +13,7 @@ import logging
 import uuid
 from typing import Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_24_HOURS
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ class SessionService:
             token: JWT token to invalidate
             ttl: Time to live in seconds (default 24 hours)
         """
-        redis_client = await get_redis_client(async_client=True, database="main")
+        redis_client = await get_async_redis_client(database="main")
         key = f"session:blacklist:{user_id}"
         token_hash = self.hash_token(token)
 
@@ -68,7 +68,7 @@ class SessionService:
         Returns:
             True if token is blacklisted, False otherwise
         """
-        redis_client = await get_redis_client(async_client=True, database="main")
+        redis_client = await get_async_redis_client(database="main")
         key = f"session:blacklist:{user_id}"
         token_hash = self.hash_token(token)
 
@@ -93,7 +93,7 @@ class SessionService:
         Returns:
             Number of sessions invalidated
         """
-        redis_client = await get_redis_client(async_client=True, database="main")
+        redis_client = await get_async_redis_client(database="main")
         key = f"session:blacklist:{user_id}"
 
         # Get existing token hashes (if any)

--- a/autobot-backend/utils/advanced_cache_manager.py
+++ b/autobot-backend/utils/advanced_cache_manager.py
@@ -17,7 +17,7 @@ from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_1_HOUR, TTL_5_MINUTES
 
 logger = logging.getLogger(__name__)
@@ -249,7 +249,7 @@ class AdvancedCacheManager:
             if self._redis_client_initialized:
                 return  # Another coroutine initialized while we waited
             try:
-                self.redis_client = await get_redis_client(async_client=True)
+                self.redis_client = await get_async_redis_client()
                 self._redis_client_initialized = True
                 logger.debug("Async Redis client initialized successfully")
             except Exception as e:

--- a/autobot-backend/utils/background_task_manager.py
+++ b/autobot-backend/utils/background_task_manager.py
@@ -70,9 +70,9 @@ class BackgroundTaskManager:
     async def _get_redis(self):
         """Return async Redis connection (analytics db)."""
         try:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            return await get_redis_client(database="analytics", async_client=True)
+            return await get_async_redis_client(database="analytics")
         except Exception as exc:
             logger.debug("Redis unavailable (non-fatal): %s", exc)
             return None

--- a/autobot-backend/utils/cache_manager.py
+++ b/autobot-backend/utils/cache_manager.py
@@ -26,7 +26,7 @@ from typing import Any, Optional
 from fastapi import Request
 
 # Import centralized Redis client utility
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_5_MINUTES
 from type_defs.common import Metadata
 
@@ -50,7 +50,7 @@ class CacheManager:
 
         try:
             # Get async Redis client
-            self._redis_client = await get_redis_client(async_client=True)
+            self._redis_client = await get_async_redis_client()
 
             if self._redis_client:
                 logger.info("CacheManager Redis client initialized successfully")

--- a/autobot-backend/utils/entity_resolver.py
+++ b/autobot-backend/utils/entity_resolver.py
@@ -119,9 +119,9 @@ class EntityResolver:
     async def _ensure_redis(self):
         """Lazy-init async Redis client on first use (#2725)."""
         if self.redis_client is None:
-            from autobot_shared.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
-            self.redis_client = await get_redis_client(async_client=True)
+            self.redis_client = await get_async_redis_client()
 
     def _get_embedding_model(self):
         """Lazy load the sentence transformer model."""

--- a/autobot-backend/utils/experiment_tracker.py
+++ b/autobot-backend/utils/experiment_tracker.py
@@ -26,7 +26,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class ExperimentTracker:
             rationale=rationale,
             related_issue=related_issue,
         )
-        redis_client = await get_redis_client(async_client=True, database="analytics")
+        redis_client = await get_async_redis_client(database="analytics")
         if redis_client:
             await redis_client.rpush(REDIS_KEY, json.dumps(record.to_dict()))
             await redis_client.ltrim(REDIS_KEY, -10000, -1)  # Cap at 10k (#2031)
@@ -87,7 +87,7 @@ class ExperimentTracker:
         self, area: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         """List all experiments, optionally filtered by area."""
-        redis_client = await get_redis_client(async_client=True, database="analytics")
+        redis_client = await get_async_redis_client(database="analytics")
         if not redis_client:
             return []
         raw = await redis_client.lrange(REDIS_KEY, 0, -1)

--- a/autobot-backend/utils/system_metrics.py
+++ b/autobot-backend/utils/system_metrics.py
@@ -19,7 +19,7 @@ from autobot_shared.http_client import get_http_client
 from config.manager import get_config_manager
 
 config = get_config_manager()
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 
 
 @dataclass
@@ -176,7 +176,7 @@ class SystemMetricsCollector:
             1.0 if healthy, 0.0 if unhealthy
         """
         try:
-            redis_client = await get_redis_client(database="main", async_client=True)
+            redis_client = await get_async_redis_client(database="main")
 
             if not redis_client or not hasattr(redis_client, "ping"):
                 return 0.0
@@ -359,9 +359,7 @@ class SystemMetricsCollector:
         Returns:
             Async Redis client or None if unavailable
         """
-        kb_redis_client = await get_redis_client(
-            database="knowledge", async_client=True
-        )
+        kb_redis_client = await get_async_redis_client(database="knowledge")
         return kb_redis_client
 
     async def _collect_kb_vector_metrics(


### PR DESCRIPTION
## Summary

- Migrated all 67 call sites from `await get_redis_client(async_client=True)` to `await get_async_redis_client(database=...)` across the entire backend
- Fixed `dependencies.py`'s local `get_async_redis_client` wrapper to use the shared `get_async_redis_client` from `autobot_shared` instead of re-implementing the old pattern
- Updated `api/workflow_state_test.py` to patch `get_async_redis_client` instead of `get_redis_client` (all 31 tests pass)
- All 1,773 Python files parse without syntax errors

Closes #4059

## Test plan

- [x] `api/workflow_state_test.py` — 31 passed
- [x] AST parse check — all 1,773 `.py` files clean
- [ ] Full integration test on VM after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)