### PR TITLE
docs(dev): expand gh pr edit workaround and add helper script (#3753)

### DIFF
--- a/docs/developer/CLAUDE_WORKFLOW.md
+++ b/docs/developer/CLAUDE_WORKFLOW.md
@@ -115,10 +115,37 @@ Subagents cannot autonomously acquire Bash permission. Run batch file-manipulati
 
 **GitHub CLI Workarounds:**
 
-- `gh pr edit --body "..."` silently fails when the repo has classic Projects attached (GraphQL deprecation error). Use the REST API instead:
+- **`gh pr edit --body` silently fails** when the repo has classic Projects attached. The command exits non-zero and leaves the body unchanged. Error output:
+
+  ```text
+  GraphQL: Projects (classic) is being deprecated in favor of the new Projects experience
+  ```
+
+  Affected flags: `--body`, `--title`, `--assignee`, `--label`, `--milestone`, `--reviewer`.
+  Use the REST API instead — it succeeds even with classic Projects attached:
 
   ```bash
+  # Single-line body
   gh api repos/mrveiss/AutoBot-AI/pulls/$PR_NUMBER -X PATCH -f body="new body here"
+
+  # Multi-line body (HEREDOC — required for PR descriptions with newlines)
+  gh api repos/mrveiss/AutoBot-AI/pulls/$PR_NUMBER -X PATCH -f body="$(cat <<'EOF'
+  ## Summary
+  - change one
+  - change two
+  EOF
+  )"
+
+  # Update title
+  gh api repos/mrveiss/AutoBot-AI/pulls/$PR_NUMBER -X PATCH -f title="new title"
+  ```
+
+  A convenience wrapper is available at `scripts/gh-pr-update-body.sh`:
+
+  ```bash
+  scripts/gh-pr-update-body.sh $PR_NUMBER "new body text"
+  # or pipe a file:
+  scripts/gh-pr-update-body.sh $PR_NUMBER "$(cat body.md)"
   ```
 
 ---

--- a/scripts/gh-pr-update-body.sh
+++ b/scripts/gh-pr-update-body.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# gh-pr-update-body.sh — update a PR body via the REST API
+#
+# Replaces `gh pr edit --body` which silently fails on repos with classic
+# Projects attached (GraphQL deprecation error, exit 1, body unchanged).
+#
+# Usage:
+#   scripts/gh-pr-update-body.sh <PR_NUMBER> "<body text>"
+#   scripts/gh-pr-update-body.sh <PR_NUMBER> "$(cat body.md)"
+#
+# Copyright: mrveiss
+
+set -euo pipefail
+
+REPO="mrveiss/AutoBot-AI"
+
+usage() {
+    echo "Usage: $0 <PR_NUMBER> <body>" >&2
+    echo "  PR_NUMBER  integer pull-request number" >&2
+    echo "  body       new body text (use \"\$(cat file.md)\" for files)" >&2
+    exit 1
+}
+
+[[ $# -lt 2 ]] && usage
+
+PR_NUMBER="$1"
+BODY="$2"
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "error: PR_NUMBER must be an integer, got: $PR_NUMBER" >&2
+    exit 1
+fi
+
+gh api "repos/${REPO}/pulls/${PR_NUMBER}" -X PATCH -f body="${BODY}"


### PR DESCRIPTION
## Summary

- Expands the `GitHub CLI Workarounds` section in `docs/developer/CLAUDE_WORKFLOW.md` with the exact GraphQL error text, all affected `gh pr edit` flags, a HEREDOC multi-line body example, and a title-update example
- Adds `scripts/gh-pr-update-body.sh` — a thin REST API wrapper that replaces `gh pr edit --body` across all automation and developer scripts

## Problem

`gh pr edit --body` exits non-zero and leaves the PR body unchanged on repos with classic Projects attached. The error (`GraphQL: Projects (classic) is being deprecated`) is printed but the exit code causes CI scripts to silently skip the update.

## Test plan

- [ ] Run `scripts/gh-pr-update-body.sh <PR_NUMBER> "test body"` against a real PR and confirm the body updates
- [ ] Verify the script rejects non-integer PR numbers with a clear error message
- [ ] Read through the expanded CLAUDE_WORKFLOW.md section and confirm all examples are syntactically correct

Closes #3753

Generated with [Claude Code](https://claude.com/claude-code)