### PR TITLE
refactor(config): fix double ConfigManager in chat_history (#3945)

### DIFF
--- a/autobot-backend/chat_history/base.py
+++ b/autobot-backend/chat_history/base.py
@@ -18,8 +18,8 @@ from typing import Optional
 
 from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.ssot_config import config as _ssot_config
 from config import config as global_config_manager
-from constants.network_constants import NetworkConstants
 from context_window_manager import ContextWindowManager
 from encryption_service import get_encryption_service, is_encryption_enabled
 
@@ -58,21 +58,19 @@ class ChatHistoryBase:
             redis_port: Optional override for Redis port
         """
         data_config = global_config_manager.get("data", {})
-        redis_config = global_config_manager.get_redis_config()
 
         self.history_file = history_file or data_config.get(
             "chat_history_file",
             os.getenv("AUTOBOT_CHAT_HISTORY_FILE", "data/chat_history.json"),
         )
         self.use_redis = (
-            use_redis if use_redis is not None else redis_config.get("enabled", False)
+            use_redis if use_redis is not None else _ssot_config.redis.enabled
         )
-        self.redis_host = redis_host or redis_config.get(
-            "host", os.getenv("AUTOBOT_REDIS_HOST", global_config_manager.get_host("redis"))
+        self.redis_host = redis_host or os.getenv(
+            "AUTOBOT_REDIS_HOST", _ssot_config.vm.redis
         )
-        self.redis_port = redis_port or redis_config.get(
-            "port",
-            int(os.getenv("AUTOBOT_REDIS_PORT", str(NetworkConstants.REDIS_PORT))),
+        self.redis_port = redis_port or int(
+            os.getenv("AUTOBOT_REDIS_PORT", str(_ssot_config.port.redis))
         )
 
     def _init_state_and_settings(self) -> None:

--- a/autobot-backend/chat_history/initialize_test.py
+++ b/autobot-backend/chat_history/initialize_test.py
@@ -17,12 +17,19 @@ import pytest
 
 
 def _make_config_stub() -> MagicMock:
-    """Return a config manager stub that answers minimal queries."""
+    """Return a config manager stub that answers minimal queries for data section."""
     cfg = MagicMock()
     cfg.get.return_value = {}
-    cfg.get_redis_config.return_value = {"enabled": False}
-    cfg.get_host.return_value = "127.0.0.1"
     return cfg
+
+
+def _make_ssot_stub() -> MagicMock:
+    """Return a ssot_config stub supplying Redis connection defaults."""
+    ssot = MagicMock()
+    ssot.redis.enabled = False
+    ssot.vm.redis = "127.0.0.1"
+    ssot.port.redis = 6379
+    return ssot
 
 
 @pytest.fixture()
@@ -35,6 +42,7 @@ def manager():
     """
     with (
         patch("chat_history.base.global_config_manager", _make_config_stub()),
+        patch("chat_history.base._ssot_config", _make_ssot_stub()),
         patch("chat_history.base.get_redis_client", return_value=None),
         patch("chat_history.base.is_encryption_enabled", return_value=False),
         patch("chat_history.base.ContextWindowManager", return_value=MagicMock()),
@@ -43,9 +51,6 @@ def manager():
         patch("chat_history.base.os.path.exists", return_value=True),
         patch("chat_history.base.os.makedirs"),
         patch("chat_history.base.os.path.dirname", return_value="data"),
-        # ConfigManager is imported inline inside _load_config_values,
-        # so patch at the source module level.
-        patch("config.ConfigManager", return_value=MagicMock()),
     ):
         from chat_history import ChatHistoryManager
 


### PR DESCRIPTION
## Summary

- Removes the double `ConfigManager` instantiation on the Redis hot path in `ChatHistoryBase._load_config_values`
- Replaces `global_config_manager.get_redis_config()` and `global_config_manager.get_host("redis")` with direct reads from `_ssot_config.redis.enabled`, `_ssot_config.vm.redis`, and `_ssot_config.port.redis`
- Drops the now-unused `NetworkConstants` import
- Updates `initialize_test` fixture: removes stale `patch("config.ConfigManager", ...)` stanza, adds `patch("chat_history.base._ssot_config", ...)` with a minimal stub

## Test plan

- [x] `pytest chat_history/initialize_test.py -xvs` — 6 passed
- [x] `pytest chat_history/ -xvs` — 12 passed

Closes #3945
Part of #3829

🤖 Generated with [Claude Code](https://claude.com/claude-code)