### PR TITLE
refactor(ansible): centralize ChromaDB/AI-Stack .env generation (#4087)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/vars/backend-env.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/backend-env.yml
@@ -28,6 +28,17 @@ backend_classification_model: "{{ lookup('env', 'AUTOBOT_CLASSIFICATION_MODEL') 
 backend_light_model: "{{ lookup('env', 'AUTOBOT_LIGHT_PROCESSING_MODEL') | default('phi3:mini', true) }}"
 backend_instruction_model: "{{ lookup('env', 'AUTOBOT_INSTRUCTION_MODEL') | default('mistral:7b-instruct', true) }}"
 backend_system_model: "{{ lookup('env', 'AUTOBOT_SYSTEM_MODEL') | default('dolphin-llama3:8b', true) }}"
+# AI Stack connection (#4087: derive from inventory SSOT — same pattern as redis_host/frontend_host)
+# co-located (single-host): backend_ai_stack_host stays 127.0.0.1
+# distributed (fleet):      backend_ai_stack_host is set from ai_stack_host in production.yml
+backend_ai_stack_host: "{{ ai_stack_host | default('127.0.0.1') }}"
+backend_ai_stack_port: "{{ ai_stack_port | default(8080) }}"
+
+# ChromaDB connection (#4087: always co-located with AI Stack — derive from backend_ai_stack_host)
+# WSL2 override in roles/backend/tasks/main.yml adjusts both vars together when WSL2 is detected.
+backend_chromadb_host: "{{ backend_ai_stack_host }}"
+backend_chromadb_port: 8100
+
 service_auth_service_id: "main-backend"
 service_auth_keys_dir: "/etc/autobot/service-keys"
 service_auth_enforcement_mode: false

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -49,9 +49,12 @@
     - backend_ai_stack_host == '127.0.0.1'
   tags: ['backend', 'config']
 
-- name: "Backend | Set backend_chromadb_host on WSL2 hosts (#3541, #4084)"
+- name: "Backend | Set backend_chromadb_host on WSL2 hosts (#3541, #4084, #4087)"
   ansible.builtin.set_fact:
-    backend_chromadb_host: "{{ '127.0.0.1' if ('ai-stack' in node_roles | default([])) else '10.255.255.254' }}"
+    # ChromaDB always runs on the same host as AI Stack.
+    # On WSL2: use 127.0.0.1 when ai-stack is co-located on this node,
+    # otherwise mirror backend_ai_stack_host (already WSL2-adjusted above).
+    backend_chromadb_host: "{{ '127.0.0.1' if ('ai-stack' in node_roles | default([])) else backend_ai_stack_host }}"
   when:
     - _proc_version.content is defined
     - (_proc_version.content | b64decode | lower) is search('microsoft')

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -58,8 +58,8 @@ AUTOBOT_BROWSER_SERVICE_PORT={{ backend_browser_port | default(browser_port | de
 AUTOBOT_AI_STACK_HOST={{ backend_ai_stack_host }}
 AUTOBOT_AI_STACK_PORT={{ backend_ai_stack_port }}
 
-# ChromaDB (remote on AI Stack VM)
-AUTOBOT_CHROMADB_HOST={{ backend_chromadb_host | default(backend_ai_stack_host | default('127.0.0.1')) }}
+# ChromaDB (co-located with AI Stack — derived from backend_ai_stack_host, #4087)
+AUTOBOT_CHROMADB_HOST={{ backend_chromadb_host }}
 AUTOBOT_CHROMADB_PORT={{ backend_chromadb_port }}
 
 # Deployment / user management mode (Issue #2953)


### PR DESCRIPTION
Closes #4087

## Summary
Consolidates scattered ChromaDB and AI-Stack configuration into centralized .env file generation, eliminating manual post-provisioning edits.

## Changes
- **vars/backend-env.yml**: Added derived variables (backend_ai_stack_host/port, backend_chromadb_host/port)
- **roles/backend/tasks/main.yml**: Updated WSL2 detection to use derived variables
- **roles/backend/templates/backend.env.j2**: Simplified to use consolidated config

## Architecture
- **Co-located**: backend_chromadb_host = backend_ai_stack_host = 127.0.0.1
- **Distributed**: Both read from production.yml inventory (ai_stack_host variable)
- **WSL2 override**: Adjusts both variables together when WSL2 detected

Eliminates configuration scatter and improves deployment pattern clarity.