### PR TITLE
fix(knowledge): resolve populate_autobot_docs hang with background task (#4102)

### DIFF
--- a/autobot-backend/services/knowledge/task_status_manager.py
+++ b/autobot-backend/services/knowledge/task_status_manager.py
@@ -8,10 +8,11 @@ Enables polling of async task progress without in-memory state.
 Used by documentation indexing, man pages, and other background tasks.
 """
 
+import asyncio
 import json
 import logging
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Optional
 
 from autobot_shared.redis_client import get_redis_client
@@ -74,7 +75,7 @@ class TaskStatusManager:
         )
 
         await cls._save_to_redis(status)
-        logger.info(f"[{task_id}] Created task status: {message}")
+        logger.info("[%s] Created task status: %s", task_id, message)
         return status
 
     @classmethod
@@ -127,11 +128,11 @@ class TaskStatusManager:
             existing.elapsed_seconds = elapsed_seconds
 
         await cls._save_to_redis(existing)
-        logger.debug(f"[{task_id}] Updated status: {status} ({progress_percent}%)")
+        logger.debug("[%s] Updated status: %s (%s%%)", task_id, status, progress_percent)
         return existing
 
     @classmethod
-    async def get_task(task_id: str) -> Optional[TaskStatus]:
+    async def get_task(cls, task_id: str) -> Optional[TaskStatus]:
         """
         Retrieve task status from Redis.
 
@@ -140,7 +141,9 @@ class TaskStatusManager:
         """
         try:
             redis_client = get_redis_client()
-            data = redis_client.get(TaskStatusManager._get_redis_key(task_id))
+            data = await asyncio.to_thread(
+                redis_client.get, cls._get_redis_key(task_id)
+            )
 
             if not data:
                 return None
@@ -148,7 +151,7 @@ class TaskStatusManager:
             task_dict = json.loads(data)
             return TaskStatus(**task_dict)
         except Exception as e:
-            logger.error(f"[{task_id}] Error retrieving task status: {e}")
+            logger.error("[%s] Error retrieving task status: %s", task_id, e)
             return None
 
     @classmethod
@@ -164,11 +167,12 @@ class TaskStatusManager:
             key = cls._get_redis_key(task_status.task_id)
             data = json.dumps(asdict(task_status))
 
-            # Store with 24-hour expiration
-            redis_client.setex(key, TASK_TTL_SECONDS, data)
+            # Store with 24-hour expiration — use to_thread so the sync setex
+            # call does not block the event loop (#4102).
+            await asyncio.to_thread(redis_client.setex, key, TASK_TTL_SECONDS, data)
             return True
         except Exception as e:
-            logger.error(f"[{task_status.task_id}] Error saving to Redis: {e}")
+            logger.error("[%s] Error saving to Redis: %s", task_status.task_id, e)
             return False
 
     @classmethod
@@ -211,7 +215,7 @@ class TaskStatusManager:
         )
 
     @classmethod
-    async def delete_task(task_id: str) -> bool:
+    async def delete_task(cls, task_id: str) -> bool:
         """
         Delete task status from Redis.
 
@@ -220,8 +224,10 @@ class TaskStatusManager:
         """
         try:
             redis_client = get_redis_client()
-            redis_client.delete(TaskStatusManager._get_redis_key(task_id))
+            await asyncio.to_thread(
+                redis_client.delete, cls._get_redis_key(task_id)
+            )
             return True
         except Exception as e:
-            logger.error(f"[{task_id}] Error deleting task: {e}")
+            logger.error("[%s] Error deleting task: %s", task_id, e)
             return False


### PR DESCRIPTION
Closes #4102

## Summary
populate_autobot_docs endpoint was timing out (>30s with no response). Fixed by:
1. Converting operation to background task (PR #4103)
2. **Wrapping blocking Redis calls with asyncio.to_thread() to prevent event loop blocking**

## Root Causes
1. **Primary**: Endpoint performed synchronous, blocking I/O without returning:
   - File discovery on large documentation sets (400+ files)
   - Embedding generation via OllamaEmbedding
   - ChromaDB batch inserts

2. **Secondary**: TaskStatusManager Redis operations were blocking the event loop:
   - redis_client.get() / setex() / delete() called directly in async context
   - No asyncio.to_thread() wrapper to offload to thread pool
   - When Redis is slow/saturated, blocks entire async event loop

## Solution

### Background Task Queue (PR #4103)
- Endpoint returns immediately with task_id
- Indexing runs asynchronously in background
- Client polls /populate_autobot_docs/status/{task_id} for progress

### Event Loop Protection (This PR)
- Wrapped all Redis operations in asyncio.to_thread()
- Fixed @classmethod methods missing 'cls' parameter
- Ensures Redis I/O doesn't block the event loop

## Code Changes
- autobot-backend/services/knowledge/task_status_manager.py:
  - Added asyncio.to_thread() for redis.get(), redis.setex(), redis.delete()
  - Fixed get_task(cls, ...) and delete_task(cls, ...)
  - Converted logger calls to %s format per project standards

## Impact
Eliminates both the 30+ second timeout AND the event loop blocking issue when Redis operations are slow.