### PR TITLE
fix(install): distribute autobot-slm-agent in step [3/7] (#4116)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -409,6 +409,7 @@ code_deployment() {
     # Copy code from code_source to service directories where Ansible expects them
     info "Distributing code to service directories..."
     local dirs_to_copy=(
+        "autobot-slm-agent"
         "autobot-slm-backend"
         "autobot-slm-frontend"
         "autobot_shared"


### PR DESCRIPTION
## Problem
The install.sh script fails to distribute autobot-slm-agent code to /opt/autobot/ in step [3/7].

This causes slm-agent.service to fail at startup with CHDIR error.

## Solution
Added 'autobot-slm-agent' to the dirs_to_copy array in install.sh step [3/7].

Now the installation will copy autobot-slm-agent from code_source to /opt/autobot/ and allow slm-agent.service to start properly.

Closes #4116