### PR TITLE
feat: streamline issue templates for community contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,44 +1,31 @@
 ---
-name: Bug Report
-description: Report a bug or issue you've encountered
-labels: ['type:bug']
+name: Bug report
+about: Report a bug to help us improve
+title: "[BUG] "
+labels: bug
 ---
 
 ## Description
-
-Clear, concise description of the bug.
+A clear and concise description of what the bug is.
 
 ## Steps to Reproduce
-
-1. Step 1
-2. Step 2
-3. Step 3
+1. ...
+2. ...
+3. ...
 
 ## Expected Behavior
-
 What should happen?
 
 ## Actual Behavior
-
 What actually happens?
 
 ## Environment
-
-- OS: [e.g., Ubuntu 22.04]
+- OS: [e.g., macOS, Linux, Windows]
 - Docker version: [e.g., 24.0]
-- AutoBot version: [e.g., v1.5.0]
-- Browser: [if applicable]
+- Branch: [e.g., Dev_new_gui]
+
+## Logs/Screenshots
+Paste relevant logs or screenshots here.
 
 ## Additional Context
-
-Any other relevant information.
-
----
-
-## Help Us Triage
-
-Does this look like a **frontend**, **backend**, **infrastructure**, or **docs** issue?
-
-Is it **beginner-friendly**, **intermediate**, or **advanced**?
-
-For guidance on contribution, see [CONTRIBUTORS.md](../../CONTRIBUTORS.md).
+Any other context about the problem?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,35 +1,21 @@
 ---
-name: Feature Request
-description: Suggest a new feature or enhancement
-labels: ['type:feature']
+name: Feature request
+about: Suggest an idea for AutoBot
+title: "[FEATURE] "
+labels: feature
 ---
 
-## Problem Statement
+## Description
+A clear and concise description of the feature.
 
-What problem does this solve? Who has this problem?
+## Use Case
+Why would this be useful? What problem does it solve?
 
 ## Proposed Solution
+How should this work?
 
-How should AutoBot solve this?
-
-## Alternatives
-
-What other solutions did you consider?
-
-## Related Issues/Discussions
-
-Links to related issues or discussions.
+## Alternatives Considered
+Any other approaches you've thought of?
 
 ## Additional Context
-
-Any other relevant information.
-
----
-
-## Help Us Triage
-
-Does this look like a **frontend**, **backend**, **infrastructure**, or **docs** feature?
-
-Estimate difficulty: **beginner**, **intermediate**, or **advanced**?
-
-For guidance on contribution, see [CONTRIBUTORS.md](../../CONTRIBUTORS.md).
+Any other context?


### PR DESCRIPTION
## Summary

Simplifies and clarifies issue templates to reduce friction for community contributors:
- **Bug Report:** Clear sections for description, steps, expected vs actual behavior, environment
- **Feature Request:** Use case, proposed solution, and alternatives considered
- Removed triage guidance comments (moved to Phase 2.5 with automated labeling)

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.md` — Streamlined from ~44 to ~31 lines
- `.github/ISSUE_TEMPLATE/feature_request.md` — Streamlined from ~45 to ~26 lines
- Existing `CONTRIBUTING.md`, `PULL_REQUEST_TEMPLATE.md`, `FUNDING.yml` already in place

## Test Plan

- [ ] Open GitHub Issues tab and click "New Issue"
- [ ] Verify bug report template appears and loads cleanly
- [ ] Verify feature request template appears and loads cleanly
- [ ] Fill out a template and check formatting renders correctly

## Design Notes

These templates are part of Phase 1 community setup. They:
- Lower barriers to contribution (clear, concise sections)
- Guide contributors without overwhelming them
- Work with Phase 2.5 automated triage (labels auto-applied by workflow)

Once Phase 2.5 issue management is complete, these templates will route issues to the correct skill-based and difficulty-level labels automatically.