### PR TITLE
feat(chat): ON_PROMPT_READY hooks and telemetry middleware

### DIFF
--- a/autobot-backend/chat_workflow/prompt_hooks_test.py
+++ b/autobot-backend/chat_workflow/prompt_hooks_test.py
@@ -14,13 +14,12 @@ Tests verify:
 """
 
 from typing import Optional
-from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from extensions.base import Extension, HookContext
 from extensions.hooks import HookPoint
-from extensions.manager import ExtensionManager, reset_extension_manager
+from extensions.manager import reset_extension_manager
 from chat_workflow.llm_handler import _emit_system_prompt_ready, _emit_full_prompt_ready
 
 

--- a/plugins/core-plugins/telemetry-prompt-middleware/plugin.py
+++ b/plugins/core-plugins/telemetry-prompt-middleware/plugin.py
@@ -71,7 +71,10 @@ class TelemetryPromptMiddleware(Extension):
             logger.debug("[#3405] Telemetry plugin: Prometheus unavailable, skipping")
             return None
 
-        logger.debug("[#3405] Telemetry plugin: current CPU %.1f%% (threshold %.1f%%)", cpu_pct, self._threshold)
+        logger.debug(
+            "[#3405] Telemetry plugin: current CPU %.1f%% (threshold %.1f%%)",
+            cpu_pct, self._threshold,
+        )
         if cpu_pct < self._threshold:
             return None
 


### PR DESCRIPTION
## Summary

- Adds `HookPoint.SYSTEM_PROMPT_READY` and `HookPoint.FULL_PROMPT_READY` to the extension hook enum (`extensions/hooks.py`)
- Wires both hooks into `llm_handler._prepare_llm_request_params()` via `_emit_system_prompt_ready()` and `_emit_full_prompt_ready()` — extensions can inspect or replace either prompt string via return value
- Adds `on_system_prompt_ready` / `on_full_prompt_ready` stub methods with docstrings to `Extension` base class (`extensions/base.py`)
- Adds `plugins/core-plugins/telemetry-prompt-middleware/` — a working example that queries Prometheus CPU load and appends a concise-response hint when load exceeds a configurable threshold
- Adds `docs/developer/PROMPT_MIDDLEWARE_GUIDE.md` explaining the hook interface, registration pattern, and telemetry example
- Adds `chat_workflow/prompt_hooks_test.py` with 12 focused tests: hook fires with correct args, return value replaces prompt, no-op when no plugin registered, extension errors do not crash the pipeline
- Fixes two flake8 lint issues (unused imports, line too long) in test and plugin files

## Test plan

- [x] `pytest autobot-backend/chat_workflow/prompt_hooks_test.py` — 12 tests pass
- [x] `pytest autobot-backend/extensions/extension_hooks_test.py` — 52 tests pass (including new `test_prompt_pipeline_hooks` and `test_hook_count == 24`)
- [x] `flake8 --max-line-length=100` on all changed files — clean

Closes #3405

🤖 Generated with [Claude Code](https://claude.com/claude-code)