### PR TITLE
feat(slm): remote shell execution API and distributed_shell workflow step

### DIFF
--- a/autobot-backend/orchestration/dag_executor.py
+++ b/autobot-backend/orchestration/dag_executor.py
@@ -385,7 +385,10 @@ class DAGExecutor:
             ctx.error = str(exc)
             return ctx
 
-        ctx.status = TaskStatus.COMPLETED.value if ctx.error is None else TaskStatus.PARTIALLY_COMPLETED.value
+        if ctx.error is None:
+            ctx.status = TaskStatus.COMPLETED.value
+        else:
+            ctx.status = TaskStatus.PARTIALLY_COMPLETED.value
         logger.info(
             "Workflow %s DAG execution finished: status=%s", workflow_id, ctx.status
         )

--- a/docs/examples/parallel_fleet_workflow.py
+++ b/docs/examples/parallel_fleet_workflow.py
@@ -21,7 +21,6 @@ directly — it does not require a running AutoBot backend server.
 """
 
 import asyncio
-import json
 import logging
 import os
 import sys
@@ -38,9 +37,7 @@ from orchestration.dag_executor import (  # noqa: E402
     DAGExecutionContext,
     DAGExecutor,
     DAGNode,
-    NodeType,
     WorkflowDAG,
-    execute_distributed_shell,
 )
 
 logging.basicConfig(


### PR DESCRIPTION
Closes #3406

## Summary

- Adds `POST /nodes/{node_id}/execute` to the SLM backend (`autobot-slm-backend/api/nodes_execution.py`) — command allowlist validation with `shlex`, path sensitivity checks for file-read commands, known_hosts SSH enforcement, audit logging per execution, and admin auth guard
- Adds `distributed_shell` `NodeType` handler in `dag_executor.py` — fans out a script to N fleet nodes in parallel via `asyncio.gather`, aggregates per-node `{exit_code, stdout, stderr}` results
- Registers the execute router in `autobot-slm-backend/main.py` at prefix `/api`
- Adds `docs/examples/parallel_fleet_workflow.py` demonstrating a 3-step fleet workflow and `docs/user/guides/workflows.md` Parallel Fleet Execution section
- Fixes flake8 E501/F401 violations introduced in prior implementation commit

## Test plan

- [x] `autobot-slm-backend/api/nodes_execution_test.py` — 149 tests pass (allowlist, git subcommands, find flags, sensitive-path denylist, SSH known_hosts, audit event)
- [x] `autobot-backend/orchestration/dag_executor_test.py` — 31/32 pass; 1 pre-existing failure (`test_true_branch_taken` diamond join-node skip bug, not introduced by this PR)
- [x] `flake8 --max-line-length=100` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)