### PR TITLE
feat(integration): GitHub API integration for code context and reviews

### DIFF
--- a/autobot-backend/api/integration_github.py
+++ b/autobot-backend/api/integration_github.py
@@ -1,0 +1,462 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+FastAPI router for GitHub integration (Issue #4097).
+
+Exposes GitHub API capabilities — PRs, issues, code reviews, repository
+context — as HTTP endpoints that agents can call via the integration layer.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from auth_middleware import check_admin_permission
+from integrations.base import IntegrationConfig, IntegrationHealth
+from integrations.github_integration import GitHubIntegration
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    tags=["integrations-github"],
+    dependencies=[Depends(check_admin_permission)],
+)
+
+# ---------------------------------------------------------------------------
+# Request/response models
+# ---------------------------------------------------------------------------
+
+
+class GitHubConnectionTestRequest(BaseModel):
+    """Request body for testing a GitHub token."""
+
+    token: str = Field(..., description="GitHub Personal Access Token")
+    base_url: Optional[str] = Field(
+        None, description="Custom GitHub API base URL (e.g. GitHub Enterprise)"
+    )
+
+
+class GitHubReviewRequest(BaseModel):
+    """Request body for submitting a PR review."""
+
+    token: str = Field(..., description="GitHub Personal Access Token")
+    owner: str = Field(..., description="Repository owner (user or org)")
+    repo: str = Field(..., description="Repository name")
+    pull_number: int = Field(..., description="Pull request number")
+    body: str = Field(..., description="Review body text")
+    event: str = Field(
+        "COMMENT", description="Review event: APPROVE, REQUEST_CHANGES, or COMMENT"
+    )
+
+
+class GitHubCommentRequest(BaseModel):
+    """Request body for posting a PR comment."""
+
+    token: str = Field(..., description="GitHub Personal Access Token")
+    owner: str = Field(..., description="Repository owner")
+    repo: str = Field(..., description="Repository name")
+    pull_number: int = Field(..., description="Pull request number")
+    body: str = Field(..., description="Comment body text")
+
+
+# ---------------------------------------------------------------------------
+# Factory helper
+# ---------------------------------------------------------------------------
+
+
+def _make_integration(token: str, base_url: Optional[str] = None) -> GitHubIntegration:
+    """Build a GitHubIntegration from a raw token.
+
+    Helper for endpoint handlers (Issue #4097).
+    """
+    cfg = IntegrationConfig(
+        name="github",
+        provider="github",
+        token=token,
+        base_url=base_url,
+    )
+    return GitHubIntegration(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/test-connection", response_model=IntegrationHealth)
+async def test_connection(
+    request: GitHubConnectionTestRequest,
+) -> IntegrationHealth:
+    """Test a GitHub Personal Access Token.
+
+    Returns:
+        IntegrationHealth reflecting token validity and authenticated user.
+    """
+    try:
+        integration = _make_integration(request.token, request.base_url)
+        health = await integration.test_connection()
+        logger.info("GitHub connection test result: %s", health.status)
+        return health
+    except Exception as exc:
+        logger.error("GitHub connection test failed: %s", exc)
+        raise HTTPException(status_code=500, detail="Connection test failed")
+
+
+@router.get("/{owner}/{repo}/pull-requests")
+async def list_pull_requests(
+    owner: str,
+    repo: str,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+    state: Optional[str] = Query("open", description="PR state: open, closed, all"),
+    base: Optional[str] = Query(None, description="Filter by base branch"),
+    head: Optional[str] = Query(None, description="Filter by head branch"),
+) -> Dict[str, Any]:
+    """List pull requests for a repository.
+
+    Returns:
+        Dictionary with pull_requests list and count.
+    """
+    try:
+        integration = _make_integration(token)
+        params: Dict[str, Any] = {"owner": owner, "repo": repo, "state": state}
+        if base:
+            params["base"] = base
+        if head:
+            params["head"] = head
+        result = await integration.execute_action("list_pull_requests", params)
+        logger.info("Listed PRs for %s/%s (%s)", owner, repo, state)
+        return result
+    except Exception as exc:
+        logger.error("Failed to list PRs for %s/%s: %s", owner, repo, exc)
+        raise HTTPException(status_code=500, detail="Failed to list pull requests")
+
+
+@router.get("/{owner}/{repo}/pull-requests/{pull_number}")
+async def get_pull_request(
+    owner: str,
+    repo: str,
+    pull_number: int,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+) -> Dict[str, Any]:
+    """Fetch a single pull request with full metadata.
+
+    Returns:
+        Dictionary with pull_request details.
+    """
+    try:
+        integration = _make_integration(token)
+        result = await integration.execute_action(
+            "get_pull_request",
+            {"owner": owner, "repo": repo, "pull_number": pull_number},
+        )
+        return result
+    except Exception as exc:
+        logger.error("Failed to get PR %s/%s#%d: %s", owner, repo, pull_number, exc)
+        raise HTTPException(status_code=500, detail="Failed to get pull request")
+
+
+@router.get("/{owner}/{repo}/pull-requests/{pull_number}/diff")
+async def get_pull_request_diff(
+    owner: str,
+    repo: str,
+    pull_number: int,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+) -> Dict[str, Any]:
+    """Fetch the unified diff of a pull request.
+
+    Returns:
+        Dictionary with diff string.
+    """
+    try:
+        integration = _make_integration(token)
+        result = await integration.execute_action(
+            "get_pull_request_diff",
+            {"owner": owner, "repo": repo, "pull_number": pull_number},
+        )
+        return result
+    except Exception as exc:
+        logger.error("Failed to get diff for %s/%s#%d: %s", owner, repo, pull_number, exc)
+        raise HTTPException(status_code=500, detail="Failed to get pull request diff")
+
+
+@router.get("/{owner}/{repo}/pull-requests/{pull_number}/comments")
+async def list_pr_review_comments(
+    owner: str,
+    repo: str,
+    pull_number: int,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+) -> Dict[str, Any]:
+    """List inline review comments on a pull request.
+
+    Returns:
+        Dictionary with comments list and count.
+    """
+    try:
+        integration = _make_integration(token)
+        result = await integration.execute_action(
+            "list_pr_review_comments",
+            {"owner": owner, "repo": repo, "pull_number": pull_number},
+        )
+        return result
+    except Exception as exc:
+        logger.error("Failed to list comments for %s/%s#%d: %s", owner, repo, pull_number, exc)
+        raise HTTPException(status_code=500, detail="Failed to list PR comments")
+
+
+@router.post("/{owner}/{repo}/pull-requests/{pull_number}/comments")
+async def post_pr_comment(request: GitHubCommentRequest) -> Dict[str, Any]:
+    """Post an issue-level comment to a pull request.
+
+    Returns:
+        Dictionary with created comment object.
+    """
+    try:
+        integration = _make_integration(request.token)
+        result = await integration.execute_action(
+            "post_pr_comment",
+            {
+                "owner": request.owner,
+                "repo": request.repo,
+                "pull_number": request.pull_number,
+                "body": request.body,
+            },
+        )
+        logger.info(
+            "Posted comment to %s/%s#%d", request.owner, request.repo, request.pull_number
+        )
+        return result
+    except Exception as exc:
+        logger.error("Failed to post PR comment: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to post PR comment")
+
+
+@router.post("/{owner}/{repo}/pull-requests/{pull_number}/reviews")
+async def submit_pr_review(request: GitHubReviewRequest) -> Dict[str, Any]:
+    """Submit a formal pull request review.
+
+    Returns:
+        Dictionary with created review object.
+    """
+    if request.event not in ("APPROVE", "REQUEST_CHANGES", "COMMENT"):
+        raise HTTPException(
+            status_code=400,
+            detail="event must be APPROVE, REQUEST_CHANGES, or COMMENT",
+        )
+    try:
+        integration = _make_integration(request.token)
+        result = await integration.execute_action(
+            "submit_pr_review",
+            {
+                "owner": request.owner,
+                "repo": request.repo,
+                "pull_number": request.pull_number,
+                "body": request.body,
+                "event": request.event,
+            },
+        )
+        logger.info(
+            "Submitted %s review on %s/%s#%d",
+            request.event,
+            request.owner,
+            request.repo,
+            request.pull_number,
+        )
+        return result
+    except Exception as exc:
+        logger.error("Failed to submit PR review: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to submit PR review")
+
+
+@router.get("/{owner}/{repo}/issues")
+async def list_issues(
+    owner: str,
+    repo: str,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+    state: Optional[str] = Query("open", description="Issue state: open, closed, all"),
+    labels: Optional[str] = Query(None, description="Comma-separated label names"),
+    assignee: Optional[str] = Query(None, description="Filter by assignee login"),
+) -> Dict[str, Any]:
+    """List issues in a repository (pull requests excluded).
+
+    Returns:
+        Dictionary with issues list and count.
+    """
+    try:
+        integration = _make_integration(token)
+        params: Dict[str, Any] = {"owner": owner, "repo": repo, "state": state}
+        if labels:
+            params["labels"] = labels
+        if assignee:
+            params["assignee"] = assignee
+        result = await integration.execute_action("list_issues", params)
+        logger.info("Listed issues for %s/%s (%s)", owner, repo, state)
+        return result
+    except Exception as exc:
+        logger.error("Failed to list issues for %s/%s: %s", owner, repo, exc)
+        raise HTTPException(status_code=500, detail="Failed to list issues")
+
+
+@router.get("/{owner}/{repo}/issues/{issue_number}")
+async def get_issue(
+    owner: str,
+    repo: str,
+    issue_number: int,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+) -> Dict[str, Any]:
+    """Fetch a single GitHub issue.
+
+    Returns:
+        Dictionary with issue details.
+    """
+    try:
+        integration = _make_integration(token)
+        result = await integration.execute_action(
+            "get_issue",
+            {"owner": owner, "repo": repo, "issue_number": issue_number},
+        )
+        return result
+    except Exception as exc:
+        logger.error("Failed to get issue %s/%s#%d: %s", owner, repo, issue_number, exc)
+        raise HTTPException(status_code=500, detail="Failed to get issue")
+
+
+@router.get("/{owner}/{repo}")
+async def get_repository(
+    owner: str,
+    repo: str,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+) -> Dict[str, Any]:
+    """Fetch repository metadata.
+
+    Returns:
+        Dictionary with repository details.
+    """
+    try:
+        integration = _make_integration(token)
+        result = await integration.execute_action(
+            "get_repository", {"owner": owner, "repo": repo}
+        )
+        return result
+    except Exception as exc:
+        logger.error("Failed to get repository %s/%s: %s", owner, repo, exc)
+        raise HTTPException(status_code=500, detail="Failed to get repository")
+
+
+@router.get("/{owner}/{repo}/commits")
+async def list_commits(
+    owner: str,
+    repo: str,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+    sha: Optional[str] = Query(None, description="Branch, tag, or commit SHA"),
+    per_page: int = Query(30, ge=1, le=100, description="Number of commits to return"),
+) -> Dict[str, Any]:
+    """List recent commits for a repository branch.
+
+    Returns:
+        Dictionary with commits list and count.
+    """
+    try:
+        integration = _make_integration(token)
+        params: Dict[str, Any] = {"owner": owner, "repo": repo, "per_page": per_page}
+        if sha:
+            params["sha"] = sha
+        result = await integration.execute_action("list_commits", params)
+        logger.info("Listed commits for %s/%s", owner, repo)
+        return result
+    except Exception as exc:
+        logger.error("Failed to list commits for %s/%s: %s", owner, repo, exc)
+        raise HTTPException(status_code=500, detail="Failed to list commits")
+
+
+@router.get("/{owner}/{repo}/commits/{ref}")
+async def get_commit(
+    owner: str,
+    repo: str,
+    ref: str,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+) -> Dict[str, Any]:
+    """Fetch a single commit including files changed.
+
+    Returns:
+        Dictionary with commit details and file list.
+    """
+    try:
+        integration = _make_integration(token)
+        result = await integration.execute_action(
+            "get_commit", {"owner": owner, "repo": repo, "ref": ref}
+        )
+        return result
+    except Exception as exc:
+        logger.error("Failed to get commit %s/%s@%s: %s", owner, repo, ref, exc)
+        raise HTTPException(status_code=500, detail="Failed to get commit")
+
+
+@router.get("/{owner}/{repo}/tree/{tree_sha}")
+async def get_repository_tree(
+    owner: str,
+    repo: str,
+    tree_sha: str,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+    recursive: bool = Query(False, description="Fetch tree recursively"),
+) -> Dict[str, Any]:
+    """Fetch the file tree of a repository at a given ref.
+
+    Returns:
+        Dictionary with tree entries.
+    """
+    try:
+        integration = _make_integration(token)
+        result = await integration.execute_action(
+            "get_repository_tree",
+            {"owner": owner, "repo": repo, "tree_sha": tree_sha, "recursive": recursive},
+        )
+        return result
+    except Exception as exc:
+        logger.error("Failed to get tree %s/%s@%s: %s", owner, repo, tree_sha, exc)
+        raise HTTPException(status_code=500, detail="Failed to get repository tree")
+
+
+@router.get("/{owner}/{repo}/contents/{path:path}")
+async def get_file_contents(
+    owner: str,
+    repo: str,
+    path: str,
+    token: str = Query(..., description="GitHub Personal Access Token"),
+    ref: Optional[str] = Query(None, description="Branch, tag, or commit SHA"),
+) -> Dict[str, Any]:
+    """Fetch the contents of a single file.
+
+    Returns:
+        Dictionary with file contents (base64-encoded per GitHub API).
+    """
+    try:
+        integration = _make_integration(token)
+        params: Dict[str, Any] = {"owner": owner, "repo": repo, "path": path}
+        if ref:
+            params["ref"] = ref
+        result = await integration.execute_action("get_file_contents", params)
+        return result
+    except Exception as exc:
+        logger.error("Failed to get file %s/%s/%s: %s", owner, repo, path, exc)
+        raise HTTPException(status_code=500, detail="Failed to get file contents")
+
+
+@router.get("/providers")
+async def get_providers() -> List[Dict[str, Any]]:
+    """List supported GitHub integration providers.
+
+    Returns:
+        List with GitHub provider descriptor.
+    """
+    return [
+        {
+            "id": "github",
+            "name": "GitHub",
+            "description": "GitHub API integration for code context and reviews",
+            "required_settings": ["token"],
+            "optional_settings": ["base_url"],
+        }
+    ]

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -380,6 +380,12 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["integrations-monitoring"],
         "integration_monitoring",
     ),
+    (
+        "api.integration_github",
+        "/integrations/github",
+        ["integrations-github"],
+        "integration_github",
+    ),
     # Skills repo management and governance MUST be registered before the base skills
     # router so their static path prefixes take precedence over skills' /{name} param.
     ("api.skills_repos", "/skills/repos", ["skills"], "skills-repos"),

--- a/autobot-backend/integrations/__init__.py
+++ b/autobot-backend/integrations/__init__.py
@@ -15,9 +15,11 @@ Provides integrations with external tools and services:
 """
 
 from integrations.base import BaseIntegration, IntegrationConfig, IntegrationStatus
+from integrations.github_integration import GitHubIntegration
 
 __all__ = [
     "BaseIntegration",
     "IntegrationConfig",
     "IntegrationStatus",
+    "GitHubIntegration",
 ]

--- a/autobot-backend/integrations/github_integration.py
+++ b/autobot-backend/integrations/github_integration.py
@@ -1,0 +1,415 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+GitHub API Integration (Issue #4097)
+
+Provides GitHub API access for agents: pull requests, issues, code reviews,
+repository structure, and commit context.  Authenticates via a Personal Access
+Token (PAT) stored in IntegrationConfig.token or IntegrationConfig.api_key.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from integrations.base import (
+    BaseIntegration,
+    IntegrationAction,
+    IntegrationConfig,
+    IntegrationHealth,
+    IntegrationStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_API = "https://api.github.com"
+
+
+class GitHubIntegration(BaseIntegration):
+    """GitHub REST API integration for code context and reviews.
+
+    Supports fetching PRs, diffs, issues, review comments, repository trees,
+    and recent commits.  All operations are read-write: agents may also post
+    PR comments and submit reviews.
+
+    Authentication: supply a Personal Access Token (PAT) via
+    ``IntegrationConfig.token`` or ``IntegrationConfig.api_key``.
+    """
+
+    def __init__(self, config: IntegrationConfig) -> None:
+        super().__init__(config)
+        self.base_url = (config.base_url or _GITHUB_API).rstrip("/")
+        token = config.token or config.api_key or ""
+        self.headers: Dict[str, str] = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    # ------------------------------------------------------------------
+    # BaseIntegration contract
+    # ------------------------------------------------------------------
+
+    async def test_connection(self) -> IntegrationHealth:
+        """Verify credentials by calling /user.
+
+        Returns:
+            IntegrationHealth reflecting current token validity.
+        """
+        start = datetime.utcnow()
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.base_url}/user",
+                    headers=self.headers,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    elapsed = (datetime.utcnow() - start).total_seconds() * 1000
+                    if resp.status == 200:
+                        data = await resp.json()
+                        self._status = IntegrationStatus.CONNECTED
+                        return IntegrationHealth(
+                            provider="github",
+                            status=IntegrationStatus.HEALTHY,
+                            latency_ms=elapsed,
+                            message=f"Connected as {data.get('login')}",
+                            last_checked=datetime.utcnow(),
+                            details={"login": data.get("login"), "id": data.get("id")},
+                        )
+                    self._status = IntegrationStatus.UNAUTHORIZED
+                    return IntegrationHealth(
+                        provider="github",
+                        status=IntegrationStatus.UNHEALTHY,
+                        latency_ms=elapsed,
+                        message=f"GitHub API returned HTTP {resp.status}",
+                        last_checked=datetime.utcnow(),
+                    )
+        except aiohttp.ClientError as exc:
+            logger.error("GitHub connection test failed: %s", exc)
+            self._status = IntegrationStatus.ERROR
+            return IntegrationHealth(
+                provider="github",
+                status=IntegrationStatus.UNHEALTHY,
+                message=f"Connection error: {exc}",
+                last_checked=datetime.utcnow(),
+            )
+
+    def get_available_actions(self) -> List[IntegrationAction]:
+        """Return all supported GitHub actions."""
+        return [
+            IntegrationAction(
+                name="get_pull_request",
+                description="Fetch a single PR including metadata and diff URL",
+                method="GET",
+                parameters={"owner": "string", "repo": "string", "pull_number": "integer"},
+            ),
+            IntegrationAction(
+                name="list_pull_requests",
+                description="List pull requests for a repository",
+                method="GET",
+                parameters={
+                    "owner": "string",
+                    "repo": "string",
+                    "state": "string",
+                    "head": "string",
+                    "base": "string",
+                },
+            ),
+            IntegrationAction(
+                name="get_pull_request_diff",
+                description="Fetch the unified diff of a pull request",
+                method="GET",
+                parameters={"owner": "string", "repo": "string", "pull_number": "integer"},
+            ),
+            IntegrationAction(
+                name="list_pr_review_comments",
+                description="List inline review comments on a pull request",
+                method="GET",
+                parameters={"owner": "string", "repo": "string", "pull_number": "integer"},
+            ),
+            IntegrationAction(
+                name="post_pr_comment",
+                description="Post an issue-level comment to a pull request",
+                method="POST",
+                parameters={
+                    "owner": "string",
+                    "repo": "string",
+                    "pull_number": "integer",
+                    "body": "string",
+                },
+            ),
+            IntegrationAction(
+                name="submit_pr_review",
+                description="Submit a formal PR review (APPROVE/REQUEST_CHANGES/COMMENT)",
+                method="POST",
+                parameters={
+                    "owner": "string",
+                    "repo": "string",
+                    "pull_number": "integer",
+                    "body": "string",
+                    "event": "string",
+                },
+            ),
+            IntegrationAction(
+                name="get_issue",
+                description="Fetch a single GitHub issue",
+                method="GET",
+                parameters={"owner": "string", "repo": "string", "issue_number": "integer"},
+            ),
+            IntegrationAction(
+                name="list_issues",
+                description="List issues in a repository",
+                method="GET",
+                parameters={
+                    "owner": "string",
+                    "repo": "string",
+                    "state": "string",
+                    "labels": "string",
+                    "assignee": "string",
+                },
+            ),
+            IntegrationAction(
+                name="get_repository",
+                description="Fetch repository metadata",
+                method="GET",
+                parameters={"owner": "string", "repo": "string"},
+            ),
+            IntegrationAction(
+                name="list_commits",
+                description="List recent commits on a branch",
+                method="GET",
+                parameters={
+                    "owner": "string",
+                    "repo": "string",
+                    "sha": "string",
+                    "per_page": "integer",
+                },
+            ),
+            IntegrationAction(
+                name="get_commit",
+                description="Fetch a single commit including files changed",
+                method="GET",
+                parameters={"owner": "string", "repo": "string", "ref": "string"},
+            ),
+            IntegrationAction(
+                name="get_repository_tree",
+                description="Fetch the file tree of a repository at a given ref",
+                method="GET",
+                parameters={
+                    "owner": "string",
+                    "repo": "string",
+                    "tree_sha": "string",
+                    "recursive": "boolean",
+                },
+            ),
+            IntegrationAction(
+                name="get_file_contents",
+                description="Fetch the contents of a single file",
+                method="GET",
+                parameters={
+                    "owner": "string",
+                    "repo": "string",
+                    "path": "string",
+                    "ref": "string",
+                },
+            ),
+        ]
+
+    async def execute_action(
+        self, action: str, params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Dispatch to the appropriate GitHub API method.
+
+        Args:
+            action: Action name from get_available_actions().
+            params: Parameters for the action.
+
+        Returns:
+            Result dictionary.
+
+        Raises:
+            ValueError: If action is not recognised.
+        """
+        dispatch: Dict[str, Any] = {
+            "get_pull_request": self._get_pull_request,
+            "list_pull_requests": self._list_pull_requests,
+            "get_pull_request_diff": self._get_pull_request_diff,
+            "list_pr_review_comments": self._list_pr_review_comments,
+            "post_pr_comment": self._post_pr_comment,
+            "submit_pr_review": self._submit_pr_review,
+            "get_issue": self._get_issue,
+            "list_issues": self._list_issues,
+            "get_repository": self._get_repository,
+            "list_commits": self._list_commits,
+            "get_commit": self._get_commit,
+            "get_repository_tree": self._get_repository_tree,
+            "get_file_contents": self._get_file_contents,
+        }
+        if action not in dispatch:
+            raise ValueError(f"Unknown GitHub action: {action}")
+        return await dispatch[action](params)
+
+    # ------------------------------------------------------------------
+    # Pull-request helpers
+    # ------------------------------------------------------------------
+
+    async def _get_pull_request(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        pull_number = params["pull_number"]
+        url = f"{self.base_url}/repos/{owner}/{repo}/pulls/{pull_number}"
+        return {"pull_request": await self._get(url)}
+
+    async def _list_pull_requests(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        query: Dict[str, Any] = {"state": params.get("state", "open"), "per_page": 100}
+        for key in ("head", "base"):
+            if key in params:
+                query[key] = params[key]
+        url = f"{self.base_url}/repos/{owner}/{repo}/pulls"
+        prs = await self._get(url, query_params=query)
+        return {"pull_requests": prs, "count": len(prs)}
+
+    async def _get_pull_request_diff(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        pull_number = params["pull_number"]
+        url = f"{self.base_url}/repos/{owner}/{repo}/pulls/{pull_number}"
+        diff_headers = dict(self.headers)
+        diff_headers["Accept"] = "application/vnd.github.diff"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url, headers=diff_headers, timeout=aiohttp.ClientTimeout(total=30)
+            ) as resp:
+                resp.raise_for_status()
+                diff = await resp.text(encoding="utf-8")
+        return {"diff": diff}
+
+    async def _list_pr_review_comments(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        pull_number = params["pull_number"]
+        url = f"{self.base_url}/repos/{owner}/{repo}/pulls/{pull_number}/comments"
+        comments = await self._get(url)
+        return {"comments": comments, "count": len(comments)}
+
+    async def _post_pr_comment(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        pull_number = params["pull_number"]
+        url = f"{self.base_url}/repos/{owner}/{repo}/issues/{pull_number}/comments"
+        result = await self._post(url, {"body": params["body"]})
+        return {"comment": result}
+
+    async def _submit_pr_review(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        pull_number = params["pull_number"]
+        url = f"{self.base_url}/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+        payload = {
+            "body": params.get("body", ""),
+            "event": params.get("event", "COMMENT"),
+        }
+        result = await self._post(url, payload)
+        return {"review": result}
+
+    # ------------------------------------------------------------------
+    # Issue helpers
+    # ------------------------------------------------------------------
+
+    async def _get_issue(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        issue_number = params["issue_number"]
+        url = f"{self.base_url}/repos/{owner}/{repo}/issues/{issue_number}"
+        return {"issue": await self._get(url)}
+
+    async def _list_issues(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        query: Dict[str, Any] = {
+            "state": params.get("state", "open"),
+            "per_page": 100,
+        }
+        for key in ("labels", "assignee"):
+            if key in params:
+                query[key] = params[key]
+        url = f"{self.base_url}/repos/{owner}/{repo}/issues"
+        issues = await self._get(url, query_params=query)
+        # GitHub returns PRs in /issues — filter them out
+        real_issues = [i for i in issues if "pull_request" not in i]
+        return {"issues": real_issues, "count": len(real_issues)}
+
+    # ------------------------------------------------------------------
+    # Repository helpers
+    # ------------------------------------------------------------------
+
+    async def _get_repository(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        url = f"{self.base_url}/repos/{owner}/{repo}"
+        return {"repository": await self._get(url)}
+
+    async def _list_commits(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        query: Dict[str, Any] = {"per_page": params.get("per_page", 30)}
+        if "sha" in params:
+            query["sha"] = params["sha"]
+        url = f"{self.base_url}/repos/{owner}/{repo}/commits"
+        commits = await self._get(url, query_params=query)
+        return {"commits": commits, "count": len(commits)}
+
+    async def _get_commit(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo, ref = params["owner"], params["repo"], params["ref"]
+        url = f"{self.base_url}/repos/{owner}/{repo}/commits/{ref}"
+        return {"commit": await self._get(url)}
+
+    async def _get_repository_tree(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo = params["owner"], params["repo"]
+        tree_sha = params.get("tree_sha", "HEAD")
+        query: Dict[str, Any] = {}
+        if params.get("recursive"):
+            query["recursive"] = "1"
+        url = f"{self.base_url}/repos/{owner}/{repo}/git/trees/{tree_sha}"
+        tree = await self._get(url, query_params=query)
+        return {"tree": tree}
+
+    async def _get_file_contents(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        owner, repo, path = params["owner"], params["repo"], params["path"]
+        query: Dict[str, Any] = {}
+        if "ref" in params:
+            query["ref"] = params["ref"]
+        url = f"{self.base_url}/repos/{owner}/{repo}/contents/{path}"
+        contents = await self._get(url, query_params=query)
+        return {"contents": contents}
+
+    # ------------------------------------------------------------------
+    # HTTP primitives
+    # ------------------------------------------------------------------
+
+    async def _get(
+        self,
+        url: str,
+        query_params: Optional[Dict[str, Any]] = None,
+        timeout: float = 30.0,
+    ) -> Any:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url,
+                headers=self.headers,
+                params=query_params,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+
+    async def _post(
+        self,
+        url: str,
+        payload: Dict[str, Any],
+        timeout: float = 30.0,
+    ) -> Any:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                headers=self.headers,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                resp.raise_for_status()
+                return await resp.json()

--- a/autobot-backend/integrations/github_integration_test.py
+++ b/autobot-backend/integrations/github_integration_test.py
@@ -1,0 +1,266 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for GitHubIntegration (Issue #4097)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from integrations.base import IntegrationConfig, IntegrationStatus
+from integrations.github_integration import GitHubIntegration
+
+
+def _make_integration(token: str = "ghp_test") -> GitHubIntegration:
+    cfg = IntegrationConfig(name="github", provider="github", token=token)
+    return GitHubIntegration(cfg)
+
+
+# ---------------------------------------------------------------------------
+# test_connection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_connection_healthy() -> None:
+    integration = _make_integration()
+    mock_resp = AsyncMock()
+    mock_resp.status = 200
+    mock_resp.json = AsyncMock(return_value={"login": "testuser", "id": 1})
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.get = MagicMock(return_value=mock_resp)
+
+    with patch("integrations.github_integration.aiohttp.ClientSession", return_value=mock_session):
+        health = await integration.test_connection()
+
+    assert health.status == IntegrationStatus.HEALTHY
+    assert "testuser" in health.message
+    assert integration.status == IntegrationStatus.CONNECTED
+
+
+@pytest.mark.asyncio
+async def test_test_connection_unauthorized() -> None:
+    integration = _make_integration(token="bad_token")
+    mock_resp = AsyncMock()
+    mock_resp.status = 401
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.get = MagicMock(return_value=mock_resp)
+
+    with patch("integrations.github_integration.aiohttp.ClientSession", return_value=mock_session):
+        health = await integration.test_connection()
+
+    assert health.status == IntegrationStatus.UNHEALTHY
+    assert integration.status == IntegrationStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
+async def test_test_connection_network_error() -> None:
+    import aiohttp as _aiohttp
+
+    integration = _make_integration()
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_session.get = MagicMock(side_effect=_aiohttp.ClientConnectionError("refused"))
+
+    with patch("integrations.github_integration.aiohttp.ClientSession", return_value=mock_session):
+        health = await integration.test_connection()
+
+    assert health.status == IntegrationStatus.UNHEALTHY
+    assert integration.status == IntegrationStatus.ERROR
+
+
+# ---------------------------------------------------------------------------
+# get_available_actions
+# ---------------------------------------------------------------------------
+
+
+def test_get_available_actions_complete() -> None:
+    integration = _make_integration()
+    actions = integration.get_available_actions()
+    names = {a.name for a in actions}
+    expected = {
+        "get_pull_request",
+        "list_pull_requests",
+        "get_pull_request_diff",
+        "list_pr_review_comments",
+        "post_pr_comment",
+        "submit_pr_review",
+        "get_issue",
+        "list_issues",
+        "get_repository",
+        "list_commits",
+        "get_commit",
+        "get_repository_tree",
+        "get_file_contents",
+    }
+    assert expected == names
+
+
+# ---------------------------------------------------------------------------
+# execute_action dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_action_unknown_raises() -> None:
+    integration = _make_integration()
+    with pytest.raises(ValueError, match="Unknown GitHub action"):
+        await integration.execute_action("nonexistent", {})
+
+
+@pytest.mark.asyncio
+async def test_list_pull_requests() -> None:
+    integration = _make_integration()
+    pr_data = [{"number": 1, "title": "Fix bug"}]
+    integration._get = AsyncMock(return_value=pr_data)
+
+    result = await integration.execute_action(
+        "list_pull_requests",
+        {"owner": "mrveiss", "repo": "AutoBot-AI", "state": "open"},
+    )
+
+    assert result["count"] == 1
+    assert result["pull_requests"] == pr_data
+    integration._get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_pull_request() -> None:
+    integration = _make_integration()
+    pr_data = {"number": 42, "title": "Add feature"}
+    integration._get = AsyncMock(return_value=pr_data)
+
+    result = await integration.execute_action(
+        "get_pull_request",
+        {"owner": "mrveiss", "repo": "AutoBot-AI", "pull_number": 42},
+    )
+
+    assert result["pull_request"] == pr_data
+
+
+@pytest.mark.asyncio
+async def test_list_issues_filters_prs() -> None:
+    integration = _make_integration()
+    raw = [
+        {"number": 1, "title": "Bug"},
+        {"number": 2, "title": "PR", "pull_request": {"url": "..."}},
+    ]
+    integration._get = AsyncMock(return_value=raw)
+
+    result = await integration.execute_action(
+        "list_issues", {"owner": "mrveiss", "repo": "AutoBot-AI"}
+    )
+
+    assert result["count"] == 1
+    assert result["issues"][0]["number"] == 1
+
+
+@pytest.mark.asyncio
+async def test_post_pr_comment() -> None:
+    integration = _make_integration()
+    comment_data = {"id": 99, "body": "Looks good"}
+    integration._post = AsyncMock(return_value=comment_data)
+
+    result = await integration.execute_action(
+        "post_pr_comment",
+        {
+            "owner": "mrveiss",
+            "repo": "AutoBot-AI",
+            "pull_number": 10,
+            "body": "Looks good",
+        },
+    )
+
+    assert result["comment"] == comment_data
+    integration._post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_pr_review_defaults_to_comment_event() -> None:
+    integration = _make_integration()
+    review_data = {"id": 5, "state": "COMMENTED"}
+    integration._post = AsyncMock(return_value=review_data)
+
+    result = await integration.execute_action(
+        "submit_pr_review",
+        {
+            "owner": "mrveiss",
+            "repo": "AutoBot-AI",
+            "pull_number": 10,
+            "body": "review body",
+        },
+    )
+
+    assert result["review"] == review_data
+    call_kwargs = integration._post.call_args
+    assert call_kwargs[0][1]["event"] == "COMMENT"
+
+
+@pytest.mark.asyncio
+async def test_get_repository_tree_recursive() -> None:
+    integration = _make_integration()
+    tree_data = {"sha": "abc", "tree": []}
+    integration._get = AsyncMock(return_value=tree_data)
+
+    await integration.execute_action(
+        "get_repository_tree",
+        {"owner": "mrveiss", "repo": "AutoBot-AI", "tree_sha": "HEAD", "recursive": True},
+    )
+
+    call_args = integration._get.call_args
+    assert call_args[1]["query_params"]["recursive"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_list_commits_default_per_page() -> None:
+    integration = _make_integration()
+    commits = [{"sha": "abc"}] * 30
+    integration._get = AsyncMock(return_value=commits)
+
+    result = await integration.execute_action(
+        "list_commits", {"owner": "mrveiss", "repo": "AutoBot-AI"}
+    )
+
+    assert result["count"] == 30
+    call_args = integration._get.call_args
+    assert call_args[1]["query_params"]["per_page"] == 30
+
+
+# ---------------------------------------------------------------------------
+# Headers
+# ---------------------------------------------------------------------------
+
+
+def test_auth_header_uses_token_field() -> None:
+    cfg = IntegrationConfig(name="github", provider="github", token="tok_abc")
+    integration = GitHubIntegration(cfg)
+    assert integration.headers["Authorization"] == "Bearer tok_abc"
+
+
+def test_auth_header_falls_back_to_api_key() -> None:
+    cfg = IntegrationConfig(name="github", provider="github", api_key="key_xyz")
+    integration = GitHubIntegration(cfg)
+    assert integration.headers["Authorization"] == "Bearer key_xyz"
+
+
+def test_custom_base_url() -> None:
+    cfg = IntegrationConfig(
+        name="github",
+        provider="github",
+        token="tok",
+        base_url="https://github.example.com/api/v3",
+    )
+    integration = GitHubIntegration(cfg)
+    assert integration.base_url == "https://github.example.com/api/v3"


### PR DESCRIPTION
## Summary

- Adds `integrations/github_integration.py`: `GitHubIntegration` extending `BaseIntegration` with 13 actions covering PRs, issues, reviews, repository tree, file contents, and commits
- Adds `api/integration_github.py`: FastAPI router registered at `/integrations/github` with 14 HTTP endpoints following the existing integration pattern
- Registers the router in `initialization/router_registry/feature_routers.py`
- Exports `GitHubIntegration` from `integrations/__init__.py`

Closes #4097

## Test plan

- [x] 15 unit tests in `integrations/github_integration_test.py` — all pass (`pytest integrations/github_integration_test.py -v`)
- [x] Zero flake8 errors at `--max-line-length=100`
- [ ] Manual: `POST /integrations/github/test-connection` with a real PAT verifies token/user response
- [ ] Manual: `GET /integrations/github/{owner}/{repo}/pull-requests` returns open PRs
- [ ] Manual: `POST /integrations/github/{owner}/{repo}/pull-requests/{n}/reviews` submits a COMMENT review

🤖 Generated with [Claude Code](https://claude.com/claude-code)