### PR TITLE
fix(install): validate critical services exist before Ansible deployment (#4124)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -424,6 +424,28 @@ code_deployment() {
         fi
     done
 
+    # Validate that all critical services were distributed successfully
+    # This check catches issues early before Ansible deployment
+    info "Validating critical service directories..."
+    local critical_services=(
+        "autobot-slm-agent"
+        "autobot-slm-backend"
+        "autobot-slm-frontend"
+        "autobot_shared"
+    )
+    local validation_failed=0
+    for service in "${critical_services[@]}"; do
+        if [[ ! -d "${AUTOBOT_BASE}/${service}" ]]; then
+            error "Critical service not found: ${AUTOBOT_BASE}/${service}"
+            validation_failed=1
+        fi
+    done
+
+    if [[ $validation_failed -eq 1 ]]; then
+        error "Code distribution validation failed — critical services missing"
+        exit 1
+    fi
+
     success "Codebase ready at ${CODE_SOURCE}"
 }
 


### PR DESCRIPTION
## Problem
The install.sh script distributes code directories to /opt/autobot/ but has no validation to ensure all critical services were successfully copied. If a directory is missing (like in issue #4116 where autobot-slm-agent wasn't being distributed), the failure isn't caught until Ansible deployment runs.

## Solution
Add validation check after code distribution that:
1. Defines list of critical services: autobot-slm-agent, autobot-slm-backend, autobot-slm-frontend, autobot_shared
2. Verifies each directory exists at ${AUTOBOT_BASE}/
3. Fails fast with clear error message if any critical service is missing

## Impact
- Catches distribution gaps early before Ansible attempts deployment
- Provides clear error messaging for debugging
- Would have caught issue #4116 immediately after code distribution step

Closes #4124