### PR TITLE
feat(llm): add Anthropic and Groq provider adapters

### DIFF
--- a/autobot-backend/constants/model_constants.py
+++ b/autobot-backend/constants/model_constants.py
@@ -118,6 +118,14 @@ GOOGLE_GEMINI15_FLASH = "gemini-1.5-flash"
 GOOGLE_GEMINI_PRO = "gemini-pro"          # plain base model (distinct from vision)
 GOOGLE_GEMINI_PRO_VISION = "gemini-pro-vision"
 
+# Groq — hosted inference (OpenAI-compatible API)
+GROQ_LLAMA3_8B = "llama3-8b-8192"
+GROQ_LLAMA3_70B = "llama3-70b-8192"
+GROQ_LLAMA31_8B = "llama-3.1-8b-instant"
+GROQ_LLAMA33_70B = "llama-3.3-70b-versatile"
+GROQ_MIXTRAL_8X7B = "mixtral-8x7b-32768"
+GROQ_GEMMA2_9B = "gemma2-9b-it"
+
 # DeepSeek hosted API
 DEEPSEEK_V3 = "deepseek-v3"
 DEEPSEEK_R1_API = "deepseek-r1-api"

--- a/autobot-backend/llm_interface_pkg/adapters/__init__.py
+++ b/autobot-backend/llm_interface_pkg/adapters/__init__.py
@@ -18,6 +18,7 @@ from .base import (
     EnvironmentTestResult,
     SessionCodec,
 )
+from .groq_adapter import GroqAdapter
 from .layer_inference_adapter import LayerInferenceAdapter
 from .ollama_adapter import OllamaAdapter
 from .openai_adapter import OpenAIAdapter
@@ -40,6 +41,7 @@ __all__ = [
     "AIStackAdapter",
     "OpenAIAdapter",
     "AnthropicAdapter",
+    "GroqAdapter",
     "ProcessAdapter",
     "LayerInferenceAdapter",
 ]

--- a/autobot-backend/llm_interface_pkg/adapters/groq_adapter.py
+++ b/autobot-backend/llm_interface_pkg/adapters/groq_adapter.py
@@ -1,0 +1,140 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Groq Adapter - Adapter for the Groq inference API (#4096).
+
+Delegates execution to ``llm_providers.GroqProvider`` which owns the canonical
+Groq implementation (async client, streaming, fallback model list).  This
+adapter's sole responsibility is the ``test_environment()`` diagnostic method
+used by ``api/adapters.py``.
+"""
+
+import logging
+import os
+import time
+from typing import List, Optional
+
+from constants.model_constants import (
+    GROQ_GEMMA2_9B,
+    GROQ_LLAMA31_8B,
+    GROQ_LLAMA33_70B,
+    GROQ_LLAMA3_70B,
+    GROQ_LLAMA3_8B,
+    GROQ_MIXTRAL_8X7B,
+)
+from ..models import LLMRequest, LLMResponse
+from .base import (
+    AdapterBase,
+    AdapterConfig,
+    DiagnosticLevel,
+    DiagnosticMessage,
+    EnvironmentTestResult,
+)
+
+logger = logging.getLogger(__name__)
+
+_GROQ_MODELS: List[str] = [
+    GROQ_LLAMA33_70B,
+    GROQ_LLAMA3_70B,
+    GROQ_LLAMA31_8B,
+    GROQ_LLAMA3_8B,
+    GROQ_MIXTRAL_8X7B,
+    GROQ_GEMMA2_9B,
+]
+
+
+class GroqAdapter(AdapterBase):
+    """Adapter for the Groq inference API (#4096).
+
+    All inference is delegated to ``llm_providers.GroqProvider`` so there is a
+    single implementation of the Groq request/response logic.
+    """
+
+    def __init__(self, config: Optional[AdapterConfig] = None):
+        super().__init__("groq_api", config)
+        self._provider = None
+
+    def _ensure_provider(self):
+        """Lazily construct the canonical GroqProvider."""
+        if self._provider is None:
+            from llm_providers.groq_provider import GroqProvider
+
+            api_key = self.config.settings.get("api_key") or os.getenv("GROQ_API_KEY", "")
+            self._provider = GroqProvider(
+                settings={"api_key": api_key} if api_key else {}
+            )
+        return self._provider
+
+    async def execute(self, request: LLMRequest) -> LLMResponse:
+        """Execute LLM call via GroqProvider."""
+        provider = self._ensure_provider()
+        return await provider.chat_completion(request)
+
+    async def test_environment(self) -> EnvironmentTestResult:
+        """Test Groq API connectivity."""
+        diagnostics: List[DiagnosticMessage] = []
+        start = time.time()
+
+        api_key = self.config.settings.get("api_key") or os.getenv("GROQ_API_KEY", "")
+        if not api_key:
+            diagnostics.append(
+                DiagnosticMessage(
+                    level=DiagnosticLevel.ERROR,
+                    message="Groq API key not configured",
+                )
+            )
+            return EnvironmentTestResult(
+                healthy=False,
+                adapter_type="groq_api",
+                diagnostics=diagnostics,
+                response_time=time.time() - start,
+            )
+
+        diagnostics.append(
+            DiagnosticMessage(
+                level=DiagnosticLevel.INFO,
+                message="API key configured",
+            )
+        )
+
+        models: List[str] = []
+        try:
+            provider = self._ensure_provider()
+            models = await provider.list_models()
+            diagnostics.append(
+                DiagnosticMessage(
+                    level=DiagnosticLevel.INFO,
+                    message=f"Found {len(models)} models",
+                )
+            )
+        except Exception as exc:
+            logger.warning("GroqAdapter.test_environment() failed: %s", exc)
+            diagnostics.append(
+                DiagnosticMessage(
+                    level=DiagnosticLevel.ERROR,
+                    message="API call failed",
+                )
+            )
+
+        elapsed = time.time() - start
+        has_error = any(d.level == DiagnosticLevel.ERROR for d in diagnostics)
+
+        return EnvironmentTestResult(
+            healthy=not has_error,
+            adapter_type="groq_api",
+            diagnostics=diagnostics,
+            models_available=models or _GROQ_MODELS,
+            response_time=elapsed,
+        )
+
+    async def list_models(self) -> List[str]:
+        """Return known Groq models, discovering live models when the key is set."""
+        try:
+            provider = self._ensure_provider()
+            return await provider.list_models()
+        except Exception:
+            return list(_GROQ_MODELS)
+
+
+__all__ = ["GroqAdapter"]

--- a/autobot-backend/llm_interface_pkg/providers/__init__.py
+++ b/autobot-backend/llm_interface_pkg/providers/__init__.py
@@ -13,6 +13,12 @@ from .openai_provider import OpenAIProvider
 from .transformers_provider import TransformersProvider
 from .vllm_provider import VLLMProviderHandler
 
+# AnthropicProvider and GroqProvider are available as submodule imports:
+#   from llm_interface_pkg.providers.anthropic_provider import AnthropicProvider
+#   from llm_interface_pkg.providers.groq_provider import GroqProvider
+# They are not eagerly imported here to avoid a circular dependency between
+# llm_interface_pkg and llm_providers.
+
 __all__ = [
     "OllamaProvider",
     "OpenAIProvider",

--- a/autobot-backend/llm_interface_pkg/providers/anthropic_provider.py
+++ b/autobot-backend/llm_interface_pkg/providers/anthropic_provider.py
@@ -1,0 +1,15 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Anthropic Provider - Thin adapter exposing AnthropicProvider in the
+llm_interface_pkg.providers namespace (#4096).
+
+All inference logic lives in ``llm_providers.AnthropicProvider``.  This module
+re-exports it under the ``llm_interface_pkg.providers`` package so callers that
+import from this namespace get the canonical implementation without duplication.
+"""
+
+from llm_providers.anthropic_provider import AnthropicProvider
+
+__all__ = ["AnthropicProvider"]

--- a/autobot-backend/llm_interface_pkg/providers/groq_provider.py
+++ b/autobot-backend/llm_interface_pkg/providers/groq_provider.py
@@ -1,0 +1,15 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Groq Provider - Thin adapter exposing GroqProvider in the
+llm_interface_pkg.providers namespace (#4096).
+
+All inference logic lives in ``llm_providers.GroqProvider``.  This module
+re-exports it under the ``llm_interface_pkg.providers`` package so callers that
+import from this namespace get the canonical implementation without duplication.
+"""
+
+from llm_providers.groq_provider import GroqProvider
+
+__all__ = ["GroqProvider"]

--- a/autobot-backend/llm_interface_pkg/types.py
+++ b/autobot-backend/llm_interface_pkg/types.py
@@ -24,6 +24,7 @@ class ProviderType(Enum):
     AI_STACK = "ai_stack"  # Issue #1403
     PROCESS = "process"  # Issue #1403
     LAYER_INFERENCE = "layer_inference"  # Issue #3104
+    GROQ = "groq"  # Issue #4096
 
 
 class LLMType(Enum):

--- a/autobot-backend/llm_providers/__init__.py
+++ b/autobot-backend/llm_providers/__init__.py
@@ -23,6 +23,7 @@ Registry:
 from .anthropic_provider import AnthropicProvider
 from .base_provider import BaseProvider
 from .custom_openai_provider import CustomOpenAIProvider
+from .groq_provider import GroqProvider
 from .huggingface_provider import HuggingFaceProvider
 from .ollama_provider import OllamaProvider
 from .openai_provider import OpenAIProvider
@@ -36,6 +37,7 @@ __all__ = [
     "OllamaProvider",
     "OpenAIProvider",
     "AnthropicProvider",
+    "GroqProvider",
     "HuggingFaceProvider",
     "CustomOpenAIProvider",
     # vLLM (existing)

--- a/autobot-backend/llm_providers/groq_provider.py
+++ b/autobot-backend/llm_providers/groq_provider.py
@@ -1,0 +1,187 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Groq provider for the multi-provider LLM layer (#4096).
+
+Groq exposes an OpenAI-compatible Chat Completions API so this implementation
+delegates directly to the ``groq`` SDK (which mirrors the ``openai`` SDK
+surface).  The local ``groq`` package is imported lazily so the rest of the
+application boots normally when the package is absent.
+
+API key is read (in priority order) from:
+  1. ``settings["api_key"]``
+  2. Environment variable ``GROQ_API_KEY``
+
+API keys are never logged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from constants.model_constants import (
+    GROQ_GEMMA2_9B,
+    GROQ_LLAMA31_8B,
+    GROQ_LLAMA33_70B,
+    GROQ_LLAMA3_70B,
+    GROQ_LLAMA3_8B,
+    GROQ_MIXTRAL_8X7B,
+)
+from llm_interface_pkg.models import LLMRequest, LLMResponse
+from llm_interface_pkg.types import ProviderType
+
+from .base_provider import BaseProvider
+
+logger = logging.getLogger(__name__)
+
+_GROQ_MODELS: List[str] = [
+    GROQ_LLAMA33_70B,
+    GROQ_LLAMA3_70B,
+    GROQ_LLAMA31_8B,
+    GROQ_LLAMA3_8B,
+    GROQ_MIXTRAL_8X7B,
+    GROQ_GEMMA2_9B,
+]
+
+# Default model: fastest general-purpose option
+_DEFAULT_MODEL = GROQ_LLAMA31_8B
+
+
+class GroqProvider(BaseProvider):
+    """
+    Groq LLM provider implementation.
+
+    Supports chat completion and streaming for Llama, Mixtral, and Gemma
+    model families hosted on Groq's ultra-low-latency inference API.
+    Requires the ``groq`` package (``pip install groq``).
+    """
+
+    provider_name = ProviderType.GROQ.value
+
+    def __init__(self, settings: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(settings)
+        self._api_key: Optional[str] = None
+        self._client = None
+
+    def _resolve_api_key(self) -> Optional[str]:
+        """Resolve API key from settings or environment."""
+        if self._api_key:
+            return self._api_key
+        self._api_key = self._get_setting("api_key") or os.getenv("GROQ_API_KEY")
+        return self._api_key
+
+    def _ensure_client(self):
+        """Lazily initialize the async Groq client."""
+        if self._client is not None:
+            return self._client
+        try:
+            import groq
+        except ImportError as exc:
+            raise ImportError(
+                "groq package not installed. Run: pip install groq"
+            ) from exc
+        api_key = self._resolve_api_key()
+        if not api_key:
+            raise ValueError(
+                "Groq API key not configured. "
+                "Set GROQ_API_KEY or provide api_key in provider settings."
+            )
+        self._client = groq.AsyncGroq(api_key=api_key)
+        return self._client
+
+    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+        """Execute a non-streaming chat completion via Groq.
+
+        Errors are returned via ``LLMResponse.error`` so the registry can
+        perform fallback to the next provider in the chain.
+        """
+        self._total_requests += 1
+        start = time.time()
+        model = request.model_name or self._get_setting("default_model", _DEFAULT_MODEL)
+        try:
+            client = self._ensure_client()
+            params: Dict[str, Any] = {
+                "model": model,
+                "messages": request.messages,
+                "temperature": request.temperature,
+            }
+            if request.max_tokens:
+                params["max_tokens"] = request.max_tokens
+            if request.stop:
+                params["stop"] = request.stop
+            response = await client.chat.completions.create(**params)
+            choice = response.choices[0]
+            processing_time = time.time() - start
+            return LLMResponse(
+                content=choice.message.content or "",
+                model=response.model,
+                provider=self.provider_name,
+                processing_time=processing_time,
+                request_id=request.request_id,
+                finish_reason=choice.finish_reason,
+                usage={
+                    "prompt_tokens": response.usage.prompt_tokens,
+                    "completion_tokens": response.usage.completion_tokens,
+                    "total_tokens": response.usage.total_tokens,
+                },
+            )
+        except Exception as exc:
+            self._total_errors += 1
+            logger.error("Groq chat_completion error: %s", exc)
+            return LLMResponse(
+                content="",
+                model=model,
+                provider=self.provider_name,
+                processing_time=time.time() - start,
+                request_id=request.request_id,
+                error=str(exc),
+            )
+
+    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
+        """Stream a chat completion from Groq, yielding text chunks."""
+        self._total_requests += 1
+        model = request.model_name or self._get_setting("default_model", _DEFAULT_MODEL)
+        try:
+            client = self._ensure_client()
+            params: Dict[str, Any] = {
+                "model": model,
+                "messages": request.messages,
+                "temperature": request.temperature,
+                "stream": True,
+            }
+            if request.max_tokens:
+                params["max_tokens"] = request.max_tokens
+            stream = await client.chat.completions.create(**params)
+            async for chunk in stream:
+                delta = chunk.choices[0].delta.content
+                if delta:
+                    yield delta
+        except Exception as exc:
+            self._total_errors += 1
+            logger.error("Groq stream_completion error: %s", exc)
+            raise
+
+    async def is_available(self) -> bool:
+        """Return True if the API key is set and the models endpoint responds."""
+        try:
+            client = self._ensure_client()
+            await client.models.list()
+            return True
+        except Exception:
+            return False
+
+    async def list_models(self) -> List[str]:
+        """Return available Groq models, falling back to the static list."""
+        try:
+            client = self._ensure_client()
+            model_list = await client.models.list()
+            return [m.id for m in model_list.data]
+        except Exception:
+            return list(_GROQ_MODELS)
+
+
+__all__ = ["GroqProvider"]

--- a/autobot-backend/llm_providers/groq_provider_test.py
+++ b/autobot-backend/llm_providers/groq_provider_test.py
@@ -1,0 +1,194 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for GroqProvider (#4096).
+
+These tests are fully offline — the Groq SDK is mocked so no real API calls
+are made.
+"""
+
+from __future__ import annotations
+
+import types
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so the module can be imported without the real groq SDK
+# or the full autobot runtime.
+# ---------------------------------------------------------------------------
+
+
+def _make_groq_stub():
+    """Return a minimal ``groq`` module stub."""
+    stub = types.ModuleType("groq")
+    stub.AsyncGroq = MagicMock
+    sys.modules["groq"] = stub
+    return stub
+
+
+def _make_xxhash_stub():
+    stub = types.ModuleType("xxhash")
+    stub.xxh64 = MagicMock(return_value=MagicMock(hexdigest=MagicMock(return_value="0" * 16)))
+    sys.modules["xxhash"] = stub
+
+
+_make_groq_stub()
+_make_xxhash_stub()
+
+
+from llm_providers.groq_provider import GroqProvider  # noqa: E402
+from llm_interface_pkg.models import LLMRequest  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sdk_response(content: str, model: str = "llama-3.1-8b-instant") -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.model = model
+    resp.usage = MagicMock(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# GroqProvider.chat_completion
+# ---------------------------------------------------------------------------
+
+
+class TestGroqProviderChatCompletion:
+    @pytest.mark.asyncio
+    async def test_successful_completion(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=_make_sdk_response("Hello from Groq!")
+        )
+        provider._client = mock_client
+
+        request = LLMRequest(messages=[{"role": "user", "content": "hi"}])
+        response = await provider.chat_completion(request)
+
+        assert response.error is None
+        assert response.content == "Hello from Groq!"
+        assert response.provider == "groq"
+
+    @pytest.mark.asyncio
+    async def test_error_returned_in_response(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("rate limit exceeded")
+        )
+        provider._client = mock_client
+
+        request = LLMRequest(messages=[{"role": "user", "content": "hi"}])
+        response = await provider.chat_completion(request)
+
+        assert response.error is not None
+        assert "rate limit" in response.error
+        assert response.content == ""
+
+    @pytest.mark.asyncio
+    async def test_usage_populated(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=_make_sdk_response("ok")
+        )
+        provider._client = mock_client
+
+        request = LLMRequest(messages=[{"role": "user", "content": "hi"}])
+        response = await provider.chat_completion(request)
+
+        assert response.usage["prompt_tokens"] == 10
+        assert response.usage["completion_tokens"] == 20
+        assert response.usage["total_tokens"] == 30
+
+    @pytest.mark.asyncio
+    async def test_custom_model_used(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=_make_sdk_response("ok", model="llama3-70b-8192")
+        )
+        provider._client = mock_client
+
+        request = LLMRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model_name="llama3-70b-8192",
+        )
+        response = await provider.chat_completion(request)
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == "llama3-70b-8192"
+        assert response.model == "llama3-70b-8192"
+
+
+# ---------------------------------------------------------------------------
+# GroqProvider.list_models
+# ---------------------------------------------------------------------------
+
+
+class TestGroqProviderListModels:
+    @pytest.mark.asyncio
+    async def test_live_models_returned(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        model_a = MagicMock()
+        model_a.id = "llama3-8b-8192"
+        model_b = MagicMock()
+        model_b.id = "mixtral-8x7b-32768"
+        mock_client = AsyncMock()
+        mock_client.models.list = AsyncMock(
+            return_value=MagicMock(data=[model_a, model_b])
+        )
+        provider._client = mock_client
+
+        models = await provider.list_models()
+        assert "llama3-8b-8192" in models
+        assert "mixtral-8x7b-32768" in models
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_static_list_on_error(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.models.list = AsyncMock(side_effect=RuntimeError("network error"))
+        provider._client = mock_client
+
+        models = await provider.list_models()
+        assert len(models) > 0
+        assert "llama-3.1-8b-instant" in models
+
+
+# ---------------------------------------------------------------------------
+# GroqProvider.is_available
+# ---------------------------------------------------------------------------
+
+
+class TestGroqProviderIsAvailable:
+    @pytest.mark.asyncio
+    async def test_available_when_models_endpoint_responds(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.models.list = AsyncMock(return_value=MagicMock(data=[]))
+        provider._client = mock_client
+
+        assert await provider.is_available() is True
+
+    @pytest.mark.asyncio
+    async def test_not_available_when_api_raises(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.models.list = AsyncMock(side_effect=RuntimeError("unauthorized"))
+        provider._client = mock_client
+
+        assert await provider.is_available() is False

--- a/autobot-backend/llm_providers/provider_registry.py
+++ b/autobot-backend/llm_providers/provider_registry.py
@@ -295,6 +295,7 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
 
     from .anthropic_provider import AnthropicProvider
     from .custom_openai_provider import CustomOpenAIProvider
+    from .groq_provider import GroqProvider
     from .huggingface_provider import HuggingFaceProvider
     from .openai_provider import OpenAIProvider
 
@@ -333,6 +334,15 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
         fallback.append(anthropic_provider.provider_name)
     else:
         logger.debug("ANTHROPIC_API_KEY not set — Anthropic provider not registered")
+
+    # Groq — registered when API key is present
+    groq_key = os.getenv("GROQ_API_KEY")
+    if groq_key:
+        groq_provider = GroqProvider(settings={"api_key": groq_key})
+        registry.register(groq_provider)
+        fallback.append(groq_provider.provider_name)
+    else:
+        logger.debug("GROQ_API_KEY not set — Groq provider not registered")
 
     # HuggingFace — registered when HF token is present
     hf_token = os.getenv("HF_TOKEN") or os.getenv("HUGGINGFACE_API_TOKEN")


### PR DESCRIPTION
## Summary

Closes #4096

- Add `GroqProvider` to `llm_providers/` implementing `BaseProvider` with the Groq async SDK (OpenAI-compatible Chat Completions API); supports `chat_completion`, `stream_completion`, `is_available`, `list_models` with static fallback
- Register `GroqProvider` in `ProviderRegistry._populate_default_providers` when `GROQ_API_KEY` environment variable is set
- Add `GroqAdapter` to `llm_interface_pkg/adapters/` for `test_environment()` diagnostics consumed by `api/adapters.py`
- Add `AnthropicProvider` and `GroqProvider` re-export shims to `llm_interface_pkg/providers/` as individual submodules (not eagerly imported from `__init__.py` to avoid circular dependency between `llm_interface_pkg` and `llm_providers`)
- Add `GROQ = "groq"` to `ProviderType` enum in `llm_interface_pkg/types.py`
- Add Groq model name constants to `constants/model_constants.py` (`llama3-8b-8192`, `llama3-70b-8192`, `llama-3.1-8b-instant`, `llama-3.3-70b-versatile`, `mixtral-8x7b-32768`, `gemma2-9b-it`)

## Test plan

- [x] 8 new offline unit tests in `llm_providers/groq_provider_test.py` — all pass
- [x] 30 existing `anthropic_provider_test.py` tests — all pass after changes
- [x] `flake8 --max-line-length=100` clean on all changed/new files
- [ ] Manual: set `GROQ_API_KEY` and verify `ProviderRegistry` registers Groq in fallback chain
- [ ] Manual: set `ANTHROPIC_API_KEY` and verify `AnthropicAdapter.test_environment()` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)