### PR TITLE
feat(slm): Docker deployment API bridge (SLM → Ansible → Docker)

### DIFF
--- a/autobot-backend/api/slm/__init__.py
+++ b/autobot-backend/api/slm/__init__.py
@@ -1,0 +1,4 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""SLM API sub-package for autobot-backend."""

--- a/autobot-backend/api/slm/deployments_api_test.py
+++ b/autobot-backend/api/slm/deployments_api_test.py
@@ -162,15 +162,19 @@ class TestCreateDeployment:
                 },
             )
 
-        assert response.status_code == 400
-        assert "Invalid strategy" in response.json()["detail"]
+        # Pydantic v2 rejects unknown enum values at request validation time (422).
+        assert response.status_code == 422
 
-    def test_create_deployment_missing_fields(self, client):
-        """Test create with missing required fields."""
-        response = client.post(
-            "/v1/slm/deployments",
-            json={"role_name": "worker"},  # Missing target_nodes
-        )
+    def test_create_deployment_missing_fields(self, client, mock_orchestrator):
+        """Test create with missing required fields — Pydantic returns 422."""
+        with patch(
+            "api.slm.deployments.get_orchestrator",
+            return_value=mock_orchestrator,
+        ):
+            response = client.post(
+                "/v1/slm/deployments",
+                json={"role_name": "worker"},  # Missing target_nodes
+            )
 
         assert response.status_code == 422
 

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -11,6 +11,7 @@ Author: mrveiss
 import asyncio
 import os
 import sys
+import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -21,13 +22,51 @@ project_root = Path(__file__).parent.parent
 backend_root = Path(__file__).parent
 shared_root = project_root / "autobot_shared"
 sys.path.insert(0, str(project_root))
-sys.path.insert(0, str(backend_root))
+# Insert shared_root before backend_root so that backend_root ends up at
+# position 0 (highest priority).  This ensures bare `models.*` imports in
+# autobot-backend code resolve to autobot-backend/models/, not the similarly-
+# named package in autobot_shared/.
 sys.path.insert(0, str(shared_root))
+sys.path.insert(0, str(backend_root))
+
+
+def _make_pkg_stub(name: str) -> types.ModuleType:
+    """Create a minimal package stub that Python's import machinery accepts.
+
+    A bare MagicMock() cannot serve as a package because the importer
+    requires ``__path__`` to be set for submodule resolution (e.g. when the
+    code does ``from sqlalchemy.dialects.postgresql import ARRAY``).  We
+    create a real ModuleType with ``__path__ = []`` so the dotted import chain
+    succeeds while leaving every attribute access as a MagicMock via
+    ``__getattr__``.
+    """
+    mod = types.ModuleType(name)
+    mod.__path__ = []  # marks this as a package to the import system
+    mod.__package__ = name
+    mock_attr = MagicMock()
+
+    def _getattr(attr: str) -> MagicMock:  # noqa: ANN001
+        return mock_attr
+
+    mod.__getattr__ = _getattr  # type: ignore[attr-defined]
+    sys.modules[name] = mod
+    return mod
+
 
 # Stub optional heavy dependencies that may not be installed in the dev venv.
 # These are only needed at runtime on the target VM; tests use mocks.
-_OPTIONAL_STUBS = ["prometheus_client", "xxhash", "torch", "torch.nn", "torch.cuda"]
-for _mod in _OPTIONAL_STUBS:
+# Simple (leaf) modules that don't need submodule resolution:
+_SIMPLE_STUBS = [
+    "prometheus_client",
+    "xxhash",
+    "torch",
+    "torch.nn",
+    "torch.cuda",
+    "asyncpg",
+    "psycopg2",
+    "alembic",
+]
+for _mod in _SIMPLE_STUBS:
     if _mod not in sys.modules:
         try:
             import importlib
@@ -35,6 +74,54 @@ for _mod in _OPTIONAL_STUBS:
             importlib.import_module(_mod)
         except ImportError:
             sys.modules[_mod] = MagicMock()
+
+# Package stubs for SQLAlchemy and alembic sub-packages (need __path__ so
+# dotted sub-module imports like ``sqlalchemy.dialects.postgresql`` resolve).
+_PKG_STUBS = [
+    "sqlalchemy",
+    "sqlalchemy.ext",
+    "sqlalchemy.ext.asyncio",
+    "sqlalchemy.orm",
+    "sqlalchemy.orm.declarative",
+    "sqlalchemy.dialects",
+    "sqlalchemy.dialects.postgresql",
+    "sqlalchemy.types",
+    "sqlalchemy.engine",
+    "sqlalchemy.pool",
+    "sqlalchemy.sql",
+    "sqlalchemy.sql.sqltypes",
+    "alembic.op",
+    "alembic.context",
+]
+for _pkg in _PKG_STUBS:
+    try:
+        import importlib as _il
+
+        _il.import_module(_pkg)
+    except ImportError:
+        if _pkg not in sys.modules:
+            _make_pkg_stub(_pkg)
+
+# Pre-register models.infrastructure directly so that ``from models.infrastructure
+# import ...`` succeeds without triggering models/__init__.py (which requires the
+# full SQLAlchemy stack that is not installed in the dev/CI venv).
+# This must run AFTER the sqlalchemy stubs above so that any subsequent import of
+# models/__init__.py itself (if forced by other test files) has sqlalchemy stubs
+# already in place.
+if "models" not in sys.modules:
+    import importlib.util as _ilu
+
+    _infra_path = str(backend_root / "models" / "infrastructure.py")
+    _spec = _ilu.spec_from_file_location("models.infrastructure", _infra_path)
+    if _spec and _spec.loader:
+        # Create a lightweight 'models' namespace package to hold the sub-module
+        _models_pkg = _make_pkg_stub("models")
+        _models_pkg.__path__ = [str(backend_root / "models")]
+        _infra_mod = _ilu.module_from_spec(_spec)
+        _infra_mod.__package__ = "models"
+        sys.modules["models.infrastructure"] = _infra_mod
+        _spec.loader.exec_module(_infra_mod)  # type: ignore[union-attr]
+        setattr(_models_pkg, "infrastructure", _infra_mod)
 
 
 @pytest.fixture(scope="session")

--- a/autobot-backend/services/slm_client.py
+++ b/autobot-backend/services/slm_client.py
@@ -610,6 +610,76 @@ class SLMClient:
         """
         return self._ws_connected
 
+    # -------------------------------------------------------------------------
+    # Deployment API methods (Issue #3407)
+    # -------------------------------------------------------------------------
+
+    async def create_deployment(self, payload: dict) -> dict:
+        """
+        Create a new deployment via POST /api/deployments.
+
+        Args:
+            payload: Dict with node_id, roles, and optional extra_data.
+
+        Returns:
+            Raw SLM response dict with deployment_id, node_id, status, etc.
+
+        Raises:
+            aiohttp.ClientResponseError: On non-2xx HTTP responses.
+        """
+        session = await self._get_session()
+        url = f"{self.slm_url}/api/deployments"
+        async with session.post(url, json=payload) as response:
+            response.raise_for_status()
+            data = await response.json()
+        logger.info(
+            "SLM deployment created: %s on node %s",
+            data.get("deployment_id"),
+            data.get("node_id"),
+        )
+        return data
+
+    async def get_deployment(self, deployment_id: str) -> dict:
+        """
+        Fetch a deployment by ID via GET /api/deployments/{deployment_id}.
+
+        Args:
+            deployment_id: SLM deployment identifier.
+
+        Returns:
+            Raw SLM response dict.
+
+        Raises:
+            aiohttp.ClientResponseError: On non-2xx HTTP responses.
+        """
+        session = await self._get_session()
+        url = f"{self.slm_url}/api/deployments/{deployment_id}"
+        async with session.get(url) as response:
+            response.raise_for_status()
+            return await response.json()
+
+    async def list_deployments(self, node_id: Optional[str] = None) -> dict:
+        """
+        List deployments via GET /api/deployments, optionally filtered by node.
+
+        Args:
+            node_id: Optional node identifier filter.
+
+        Returns:
+            Raw SLM response dict with a ``deployments`` key.
+
+        Raises:
+            aiohttp.ClientResponseError: On non-2xx HTTP responses.
+        """
+        session = await self._get_session()
+        params = {}
+        if node_id is not None:
+            params["node_id"] = node_id
+        url = f"{self.slm_url}/api/deployments"
+        async with session.get(url, params=params) as response:
+            response.raise_for_status()
+            return await response.json()
+
 
 # Module-level singleton instance
 _slm_client: Optional[SLMClient] = None


### PR DESCRIPTION
## Summary

Closes #3407

- Add `SLMClient.create_deployment()`, `get_deployment()`, `list_deployments()` async HTTP methods so the already-wired `SLMDeploymentOrchestrator` can forward Docker deployment requests to the SLM backend via `POST /api/deployments` and `GET /api/deployments/{id}`
- Add `autobot-backend/api/slm/__init__.py` (missing package marker that prevented the router from being importable as `api.slm.deployments`)
- Fix `conftest.py` sys.path ordering so `autobot-backend/models/` takes precedence over `autobot_shared/models/` for bare `models.*` imports; add proper `types.ModuleType`-based package stubs for SQLAlchemy so the 25 colocated tests can run in the dev venv (SQLAlchemy not installed)
- Update two test assertions to match Pydantic v2 behaviour (enum validation → 422, not 400) and add missing `mock_orchestrator` fixture to `test_create_deployment_missing_fields`

## Test plan

- [x] `pytest autobot-backend/api/slm/deployments_api_test.py` — 25/25 passed
- [x] `flake8 --max-line-length=100` on all modified files — clean (one pre-existing E305 in slm_client.py line 65, not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)