### PR TITLE
feat(backend): dynamic endpoint discovery for LLM self-awareness

### DIFF
--- a/autobot-backend/api/self_capabilities.py
+++ b/autobot-backend/api/self_capabilities.py
@@ -1,0 +1,224 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Self-Capabilities Router
+
+Exposes GET /api/self/capabilities — a live, dynamically derived view of all
+registered FastAPI routes.  The endpoint crawls the app's OpenAPI schema on
+first request (and on every schema change), categorises routes by their
+OpenAPI tag(s) and HTTP method, caches the result with a configurable TTL,
+and returns the payload in a format that LLM agents can consume directly.
+
+Issue #3295: replace the hardcoded endpoint list in llm_self_awareness.py.
+"""
+
+import asyncio
+import hashlib
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Request
+from fastapi.openapi.utils import get_openapi
+
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from constants.ttl_constants import TTL_5_MINUTES
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# In-process cache (singleton per worker process — acceptable for LLM hints)
+# ---------------------------------------------------------------------------
+_CACHE_TTL: int = TTL_5_MINUTES  # seconds
+
+_cache: Optional[Dict[str, Any]] = None
+_cache_ts: float = 0.0
+_cache_schema_hash: str = ""
+_cache_lock = asyncio.Lock()
+
+
+def _schema_hash(app_routes_count: int) -> str:
+    """Cheap fingerprint: route count is enough to detect new registrations."""
+    # usedforsecurity=False: fingerprint only, not a security hash  # noqa: S324
+    return hashlib.md5(  # noqa: S324
+        str(app_routes_count).encode(), usedforsecurity=False
+    ).hexdigest()
+
+
+def _cache_is_valid(current_hash: str) -> bool:
+    """Return True if the cached result is still fresh and routes are unchanged."""
+    if _cache is None:
+        return False
+    if time.monotonic() - _cache_ts >= _CACHE_TTL:
+        return False
+    return _cache_schema_hash == current_hash
+
+
+# ---------------------------------------------------------------------------
+# Core discovery logic
+# ---------------------------------------------------------------------------
+
+def _openapi_paths(app: Any) -> Dict[str, Any]:
+    """Extract OpenAPI paths dict from the live app, generating schema if needed."""
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        description=app.description or "",
+        routes=app.routes,
+    )
+    return schema.get("paths", {})
+
+
+def _operation_type(method: str) -> str:
+    """Map HTTP method to a human-readable operation type."""
+    mapping = {
+        "get": "query",
+        "post": "create",
+        "put": "update",
+        "patch": "update",
+        "delete": "delete",
+    }
+    return mapping.get(method.lower(), method.lower())
+
+
+def _build_endpoint_entry(path: str, method: str, op: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a single endpoint descriptor dict from an OpenAPI operation object."""
+    return {
+        "path": path,
+        "method": method.upper(),
+        "operation_type": _operation_type(method),
+        "summary": op.get("summary", ""),
+        "description": op.get("description", ""),
+        "tags": op.get("tags", ["untagged"]),
+        "operation_id": op.get("operationId", ""),
+    }
+
+
+def _collect_endpoints(paths: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Flatten OpenAPI paths into a list of endpoint descriptors."""
+    _http_methods = {"get", "post", "put", "patch", "delete", "head", "options"}
+    endpoints: List[Dict[str, Any]] = []
+    for path, path_item in paths.items():
+        for method, op in path_item.items():
+            if method.lower() in _http_methods and isinstance(op, dict):
+                endpoints.append(_build_endpoint_entry(path, method, op))
+    return endpoints
+
+
+def _categorise_by_tag(endpoints: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+    """Group endpoint paths by their first OpenAPI tag."""
+    by_tag: Dict[str, List[str]] = {}
+    for ep in endpoints:
+        tag = ep["tags"][0] if ep["tags"] else "untagged"
+        by_tag.setdefault(tag, [])
+        path_with_method = f"{ep['method']} {ep['path']}"
+        if path_with_method not in by_tag[tag]:
+            by_tag[tag].append(path_with_method)
+    return by_tag
+
+
+def _categorise_by_operation(endpoints: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+    """Group endpoint paths by operation type (query/create/update/delete)."""
+    by_op: Dict[str, List[str]] = {}
+    for ep in endpoints:
+        op_type = ep["operation_type"]
+        by_op.setdefault(op_type, [])
+        if ep["path"] not in by_op[op_type]:
+            by_op[op_type].append(ep["path"])
+    return by_op
+
+
+def _paths_only(endpoints: List[Dict[str, Any]]) -> List[str]:
+    """Extract unique path strings from endpoint list, preserving order."""
+    seen: set = set()
+    result: List[str] = []
+    for ep in endpoints:
+        if ep["path"] not in seen:
+            seen.add(ep["path"])
+            result.append(ep["path"])
+    return result
+
+
+def _build_payload(endpoints: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Assemble the full /api/self/capabilities response payload."""
+    return {
+        "total_endpoints": len(endpoints),
+        "unique_paths": len(_paths_only(endpoints)),
+        "endpoints": endpoints,
+        "by_tag": _categorise_by_tag(endpoints),
+        "by_operation_type": _categorise_by_operation(endpoints),
+        "api_paths": _paths_only(endpoints),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public discovery function (also used by llm_self_awareness.py)
+# ---------------------------------------------------------------------------
+
+async def discover_endpoints(app: Any) -> Dict[str, Any]:
+    """
+    Return live endpoint discovery data for the given FastAPI app.
+
+    Results are cached for TTL_5_MINUTES and invalidated automatically when
+    the number of registered routes changes (e.g., after optional routers load).
+
+    Args:
+        app: The FastAPI application instance.
+
+    Returns:
+        Dict containing endpoint list, tag groupings, and operation-type groupings.
+    """
+    global _cache, _cache_ts, _cache_schema_hash
+
+    current_hash = _schema_hash(len(app.routes))
+
+    # Fast path — no lock needed for read
+    if _cache_is_valid(current_hash):
+        return _cache  # type: ignore[return-value]
+
+    async with _cache_lock:
+        # Re-check after acquiring lock (another coroutine may have refreshed)
+        if _cache_is_valid(current_hash):
+            return _cache  # type: ignore[return-value]
+
+        logger.info(
+            "endpoint-discovery: refreshing cache (routes=%d)", len(app.routes)
+        )
+        paths = await asyncio.to_thread(_openapi_paths, app)
+        endpoints = _collect_endpoints(paths)
+        payload = _build_payload(endpoints)
+
+        _cache = payload
+        _cache_ts = time.monotonic()
+        _cache_schema_hash = current_hash
+
+        logger.info(
+            "endpoint-discovery: cached %d endpoints across %d paths",
+            len(endpoints),
+            payload["unique_paths"],
+        )
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# API endpoint
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/capabilities",
+    summary="Dynamic endpoint capability discovery",
+    description=(
+        "Returns a dynamically derived list of all registered API endpoints, "
+        "grouped by OpenAPI tag and operation type.  The result is derived from "
+        "the live FastAPI OpenAPI schema (not hardcoded) and is cached with a "
+        f"{TTL_5_MINUTES // 60}-minute TTL that resets on route changes."
+    ),
+    tags=["self", "capabilities"],
+)
+@with_error_handling(category=ErrorCategory.SYSTEM)
+async def get_capabilities(request: Request) -> Dict[str, Any]:
+    """Live endpoint discovery for LLM self-awareness (Issue #3295)."""
+    return await discover_endpoints(request.app)

--- a/autobot-backend/api/self_capabilities_test.py
+++ b/autobot-backend/api/self_capabilities_test.py
@@ -1,0 +1,260 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for api/self_capabilities.py (Issue #3295).
+
+Covers:
+- Endpoint entry builder
+- Tag and operation-type categorisation helpers
+- Cache validity logic
+- discover_endpoints() behaviour (stub app)
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import api.self_capabilities as sc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_route(
+    path: str,
+    method: str = "GET",
+    tags: list | None = None,
+    summary: str = "Test",
+) -> dict:
+    """Build a minimal OpenAPI path-item dict for one operation."""
+    return {
+        path: {
+            method.lower(): {
+                "summary": summary,
+                "tags": tags or ["test"],
+                "operationId": f"{method.lower()}_{path.strip('/').replace('/', '_')}",
+            }
+        }
+    }
+
+
+def _stub_app(route_count: int = 5) -> MagicMock:
+    """Minimal FastAPI app mock."""
+    app = MagicMock()
+    app.title = "TestApp"
+    app.version = "0.0.1"
+    app.description = ""
+    app.routes = [object() for _ in range(route_count)]
+    return app
+
+
+# ---------------------------------------------------------------------------
+# _build_endpoint_entry
+# ---------------------------------------------------------------------------
+
+def test_build_endpoint_entry_maps_method_and_operation_type():
+    op = {"summary": "Fetch item", "tags": ["items"], "operationId": "get_item"}
+    entry = sc._build_endpoint_entry("/api/items/{id}", "get", op)
+
+    assert entry["path"] == "/api/items/{id}"
+    assert entry["method"] == "GET"
+    assert entry["operation_type"] == "query"
+    assert entry["summary"] == "Fetch item"
+    assert entry["tags"] == ["items"]
+
+
+def test_build_endpoint_entry_post_is_create():
+    op = {"summary": "Create", "tags": ["items"]}
+    entry = sc._build_endpoint_entry("/api/items", "post", op)
+    assert entry["operation_type"] == "create"
+
+
+def test_build_endpoint_entry_delete_is_delete():
+    op = {}
+    entry = sc._build_endpoint_entry("/api/items/1", "delete", op)
+    assert entry["operation_type"] == "delete"
+    assert entry["tags"] == ["untagged"]
+
+
+# ---------------------------------------------------------------------------
+# _collect_endpoints
+# ---------------------------------------------------------------------------
+
+def test_collect_endpoints_filters_non_http_keys():
+    paths = {
+        "/api/x": {
+            "get": {"summary": "ok", "tags": ["x"]},
+            "parameters": [{"name": "q"}],  # must be ignored
+        }
+    }
+    endpoints = sc._collect_endpoints(paths)
+    assert len(endpoints) == 1
+    assert endpoints[0]["method"] == "GET"
+
+
+def test_collect_endpoints_multiple_methods():
+    paths = {
+        "/api/y": {
+            "get": {"summary": "get", "tags": ["y"]},
+            "post": {"summary": "create", "tags": ["y"]},
+        }
+    }
+    endpoints = sc._collect_endpoints(paths)
+    assert len(endpoints) == 2
+    methods = {e["method"] for e in endpoints}
+    assert methods == {"GET", "POST"}
+
+
+# ---------------------------------------------------------------------------
+# _categorise_by_tag
+# ---------------------------------------------------------------------------
+
+def test_categorise_by_tag_groups_correctly():
+    endpoints = [
+        {"path": "/a", "method": "GET", "tags": ["alpha"], "operation_type": "query"},
+        {"path": "/b", "method": "POST", "tags": ["alpha"], "operation_type": "create"},
+        {"path": "/c", "method": "GET", "tags": ["beta"], "operation_type": "query"},
+    ]
+    by_tag = sc._categorise_by_tag(endpoints)
+    assert set(by_tag.keys()) == {"alpha", "beta"}
+    assert len(by_tag["alpha"]) == 2
+    assert len(by_tag["beta"]) == 1
+
+
+def test_categorise_by_tag_no_duplicate_entries():
+    endpoints = [
+        {"path": "/dup", "method": "GET", "tags": ["t"], "operation_type": "query"},
+        {"path": "/dup", "method": "GET", "tags": ["t"], "operation_type": "query"},
+    ]
+    by_tag = sc._categorise_by_tag(endpoints)
+    assert len(by_tag["t"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# _categorise_by_operation
+# ---------------------------------------------------------------------------
+
+def test_categorise_by_operation_type():
+    endpoints = [
+        {"path": "/a", "method": "GET", "tags": [], "operation_type": "query"},
+        {"path": "/b", "method": "GET", "tags": [], "operation_type": "query"},
+        {"path": "/c", "method": "POST", "tags": [], "operation_type": "create"},
+    ]
+    by_op = sc._categorise_by_operation(endpoints)
+    assert len(by_op["query"]) == 2
+    assert len(by_op["create"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# _cache_is_valid
+# ---------------------------------------------------------------------------
+
+def test_cache_is_valid_returns_false_when_no_cache():
+    sc._cache = None
+    assert sc._cache_is_valid("abc") is False
+
+
+def test_cache_is_valid_returns_false_after_ttl(monkeypatch):
+    sc._cache = {"total_endpoints": 1}
+    sc._cache_ts = time.monotonic() - (sc._CACHE_TTL + 10)
+    sc._cache_schema_hash = "abc"
+    assert sc._cache_is_valid("abc") is False
+
+
+def test_cache_is_valid_returns_false_on_hash_mismatch():
+    sc._cache = {"total_endpoints": 1}
+    sc._cache_ts = time.monotonic()
+    sc._cache_schema_hash = "old"
+    assert sc._cache_is_valid("new") is False
+
+
+def test_cache_is_valid_returns_true_when_fresh():
+    sc._cache = {"total_endpoints": 1}
+    sc._cache_ts = time.monotonic()
+    sc._cache_schema_hash = "match"
+    assert sc._cache_is_valid("match") is True
+
+
+# ---------------------------------------------------------------------------
+# discover_endpoints (integration-style with stub)
+# ---------------------------------------------------------------------------
+
+def _fake_openapi_paths(_app):
+    return {
+        "/api/items": {
+            "get": {"summary": "List items", "tags": ["items"]},
+            "post": {"summary": "Create item", "tags": ["items"]},
+        },
+        "/api/system/health": {
+            "get": {"summary": "Health", "tags": ["system"]},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_discover_endpoints_returns_correct_structure():
+    # Reset cache state
+    sc._cache = None
+    sc._cache_ts = 0.0
+    sc._cache_schema_hash = ""
+
+    app = _stub_app(route_count=10)
+
+    with patch.object(sc, "_openapi_paths", _fake_openapi_paths):
+        result = await sc.discover_endpoints(app)
+
+    assert result["total_endpoints"] == 3
+    assert result["unique_paths"] == 2
+    assert "items" in result["by_tag"]
+    assert "system" in result["by_tag"]
+    assert "query" in result["by_operation_type"]
+    assert "create" in result["by_operation_type"]
+    assert "/api/items" in result["api_paths"]
+
+
+@pytest.mark.asyncio
+async def test_discover_endpoints_uses_cache_on_second_call():
+    sc._cache = None
+    sc._cache_ts = 0.0
+    sc._cache_schema_hash = ""
+
+    app = _stub_app(route_count=7)
+    call_count = 0
+
+    def counting_paths(a):
+        nonlocal call_count
+        call_count += 1
+        return _fake_openapi_paths(a)
+
+    with patch.object(sc, "_openapi_paths", counting_paths):
+        await sc.discover_endpoints(app)
+        await sc.discover_endpoints(app)
+
+    assert call_count == 1, "Schema should only be built once when route count is stable"
+
+
+@pytest.mark.asyncio
+async def test_discover_endpoints_refreshes_on_route_count_change():
+    sc._cache = None
+    sc._cache_ts = 0.0
+    sc._cache_schema_hash = ""
+
+    app = _stub_app(route_count=5)
+    call_count = 0
+
+    def counting_paths(a):
+        nonlocal call_count
+        call_count += 1
+        return _fake_openapi_paths(a)
+
+    with patch.object(sc, "_openapi_paths", counting_paths):
+        await sc.discover_endpoints(app)
+
+        # Simulate new router being added
+        app.routes = [object() for _ in range(10)]
+        await sc.discover_endpoints(app)
+
+    assert call_count == 2, "Schema must refresh when route count changes"

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -60,6 +60,7 @@ from api.redis_mcp import router as redis_mcp_router  # Issue #2511
 from api.sequential_thinking_mcp import router as sequential_thinking_mcp_router
 from api.service_messages import router as service_messages_router
 from api.settings import router as settings_router
+from api.self_capabilities import router as self_capabilities_router  # Issue #3295
 from api.structured_thinking_mcp import router as structured_thinking_mcp_router
 from api.system import router as system_router
 from api.vnc_manager import router as vnc_router
@@ -75,7 +76,7 @@ from services.knowledge_sync_service import router as knowledge_sync_router
 
 
 def _get_system_routers() -> list:
-    """Get system and settings routers (Issue #560: extracted, #1281: audit)."""
+    """Get system and settings routers (Issue #560: extracted, #1281: audit, #3295: self)."""
     return [
         (audit_router, "", ["audit"], "audit"),
         (auth_router, "/auth", ["auth"], "auth"),
@@ -87,6 +88,8 @@ def _get_system_routers() -> list:
         (data_storage_router, "", ["data-storage"], "data_storage"),
         (prompts_router, "/prompts", ["prompts"], "prompts"),
         (frontend_config_router, "", ["frontend-config"], "frontend_config"),
+        # Issue #3295: dynamic endpoint discovery for LLM self-awareness
+        (self_capabilities_router, "/self", ["self", "capabilities"], "self_capabilities"),
     ]
 
 

--- a/autobot-backend/llm_self_awareness.py
+++ b/autobot-backend/llm_self_awareness.py
@@ -139,7 +139,7 @@ class LLMSelfAwareness:
             "current_capabilities": {"active": [], "error": str(error)},
         }
 
-    def _build_contextual_information(self) -> Dict[str, Any]:
+    async def _build_contextual_information(self) -> Dict[str, Any]:
         """
         Build contextual information section of context.
 
@@ -147,11 +147,12 @@ class LLMSelfAwareness:
             Dictionary with timestamp, environment, endpoints, and data sources.
 
         Issue #620.
+        Issue #3295: now async; delegates endpoint list to dynamic discovery.
         """
         return {
             "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             "environment": os.getenv("AUTOBOT_ENVIRONMENT", "production"),
-            "api_endpoints_available": self._get_available_endpoints(),
+            "api_endpoints_available": await self._get_available_endpoints_async(),
             "data_sources": [
                 "knowledge_base",
                 "memory_system",
@@ -213,7 +214,7 @@ class LLMSelfAwareness:
                 "operational_status": self._build_operational_status(
                     capabilities, state_summary
                 ),
-                "contextual_information": self._build_contextual_information(),
+                "contextual_information": await self._build_contextual_information(),
             }
 
             if include_detailed:
@@ -360,49 +361,61 @@ class LLMSelfAwareness:
                 return category
         return None
 
+    async def _get_available_endpoints_async(self) -> List[str]:
+        """
+        Get list of available API endpoints from the live OpenAPI schema.
+
+        Delegates to api.self_capabilities.discover_endpoints() so the list
+        is always derived from the registered FastAPI routes rather than being
+        hardcoded.  Falls back to an empty list when the app reference is
+        unavailable (e.g. unit-test context).
+
+        Issue #3295: replaced hardcoded list with dynamic discovery.
+        """
+        try:
+            from api.self_capabilities import discover_endpoints  # local import avoids cycle
+
+            app = self._get_fastapi_app()
+            if app is None:
+                logger.warning(
+                    "llm_self_awareness: FastAPI app not available; "
+                    "returning empty endpoint list"
+                )
+                return []
+            payload = await discover_endpoints(app)
+            return payload.get("api_paths", [])
+        except Exception as exc:  # pragma: no cover
+            logger.error("llm_self_awareness: endpoint discovery failed: %s", exc)
+            return []
+
+    @staticmethod
+    def _get_fastapi_app():
+        """
+        Return the running FastAPI app instance, or None.
+
+        Imports are deferred to avoid circular dependencies at module load time.
+        """
+        try:
+            import main as _main  # noqa: PLC0415 — deferred by design
+
+            return getattr(_main, "app", None)
+        except ImportError:
+            return None
+
     def _get_available_endpoints(self) -> List[str]:
         """
-        Get list of available API endpoints.
+        Synchronous shim kept for backward compatibility with callers that
+        cannot await.  Returns an empty list; async callers should use
+        _get_available_endpoints_async() directly.
 
-        NOTE: For dynamic endpoint discovery, use FastAPI's app.routes
-        in a context where the app object is available (e.g., middleware).
-        This method returns key endpoints for LLM context awareness.
-        See backend/initialization/routers.py for the full router registry.
+        Issue #3295: synchronous path delegates note that dynamic discovery
+        requires an async context — see _get_available_endpoints_async().
         """
-        return [
-            # Core endpoints
-            "/api/chat",
-            "/api/system",
-            "/api/settings",
-            "/api/prompts",
-            "/api/knowledge_base",
-            "/api/llm",
-            "/api/redis",
-            "/api/voice",
-            "/api/vnc",
-            "/api/agent",
-            "/api/agent_config",
-            "/api/intelligent_agent",
-            "/api/files",
-            "/api/memory",
-            # MCP endpoints
-            "/api/mcp",
-            "/api/knowledge",
-            "/api/filesystem",
-            "/api/browser",
-            "/api/database",
-            "/api/git",
-            # Optional endpoints (may not be loaded)
-            "/api/terminal",
-            "/api/workflow",
-            "/api/orchestrator",
-            "/api/analytics",
-            "/api/monitoring",
-            "/api/state-tracking",
-            "/api/services",
-            "/api/vision",
-            "/api/embeddings",
-        ]
+        logger.debug(
+            "llm_self_awareness: _get_available_endpoints() called in sync context; "
+            "use _get_available_endpoints_async() for the live list"
+        )
+        return []
 
     def _get_detailed_capabilities(self) -> Dict[str, Any]:
         """Get detailed capability information"""


### PR DESCRIPTION
## Summary

Closes #3295

- Adds `autobot-backend/api/self_capabilities.py`: new `GET /api/self/capabilities` router that crawls the live FastAPI OpenAPI schema, categorises endpoints by tag and operation type, and caches results with a 5-minute TTL that auto-invalidates on route-count change
- Replaces the hardcoded 29-item list in `llm_self_awareness._get_available_endpoints()` with `_get_available_endpoints_async()` which delegates to the new `discover_endpoints()` function
- Makes `_build_contextual_information()` async so the endpoint list is awaited properly within `get_system_context()`
- Registers the router at `/api/self` in `initialization/router_registry/core_routers.py`
- Adds 15 unit tests covering all helpers, cache validity, and cache-refresh-on-route-change behaviour

## Test plan

- [x] `pytest autobot-backend/api/self_capabilities_test.py` — 15/15 passed
- [x] `flake8 --max-line-length=100` on all changed files — 0 violations
- [ ] Integration: `GET /api/self/capabilities` returns `endpoints`, `by_tag`, `by_operation_type`, `api_paths` populated from live routes
- [ ] Verify `GET /api/self/capabilities` response changes after a new optional router loads (cache refreshes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)