### PR TITLE
feat(backend): complete MCP manual integration

### DIFF
--- a/autobot-backend/api/manual_mcp.py
+++ b/autobot-backend/api/manual_mcp.py
@@ -1,0 +1,448 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Manual MCP Bridge — man page and documentation lookup via MCP
+
+Exposes man page lookup and documentation index queries as MCP tools for
+LLM agents. Results are cached in Redis (knowledge database) to avoid
+repeated subprocess invocations.
+
+Issue #3287: Complete MCP manual integration.
+"""
+
+import asyncio
+import json
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.redis_client import get_redis_client
+from services.man_page_parser import ManPageContent, get_man_page_content
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["manual_mcp", "mcp"])
+
+# Cache TTL for man page results (seconds). Man pages are static; 24 h is safe.
+_MAN_PAGE_CACHE_TTL = 86_400
+
+# Redis key prefix so manual cache entries are namespaced.
+_CACHE_PREFIX = "manual_mcp:man:"
+# Doc-index cache key
+_DOC_INDEX_CACHE_KEY = "manual_mcp:doc_index"
+_DOC_INDEX_CACHE_TTL = 3_600  # 1 hour
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class ManPageRequest(BaseModel):
+    """Request model for man page lookup."""
+
+    command: str = Field(..., description="Command name to look up (e.g. 'ls')")
+    section: Optional[str] = Field(
+        None,
+        description="Manual section (1-8). Defaults to section 1.",
+    )
+
+
+class ManPageSearchRequest(BaseModel):
+    """Request model for documentation index query."""
+
+    query: str = Field(..., description="Search query against the doc index")
+    max_results: int = Field(10, ge=1, le=50, description="Maximum results to return")
+
+
+class ManPageResult(BaseModel):
+    """Structured man page result."""
+
+    command: str
+    section: str
+    title: str
+    synopsis: str
+    description: str
+    options: str
+    examples: str
+    see_also: str
+    cached: bool
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+
+def _cache_key(command: str, section: str) -> str:
+    """Build Redis key for a specific man page."""
+    return f"{_CACHE_PREFIX}{command}:{section}"
+
+
+def _serialize_man_page(content: ManPageContent, cached: bool) -> dict:
+    """Convert ManPageContent to a JSON-serialisable dict."""
+    return {
+        "command": content.command,
+        "section": content.section,
+        "title": content.title,
+        "synopsis": content.synopsis,
+        "description": content.description,
+        "options": content.options,
+        "examples": content.examples,
+        "see_also": content.see_also,
+        "cached": cached,
+    }
+
+
+async def _get_cached_man_page(command: str, section: str) -> Optional[dict]:
+    """Return cached man page dict from Redis, or None on miss/error."""
+    key = _cache_key(command, section)
+    try:
+        redis = get_redis_client(database="knowledge")
+        raw = await asyncio.to_thread(redis.get, key)
+        if raw:
+            data = json.loads(raw)
+            data["cached"] = True
+            return data
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Redis cache read failed for %s(%s): %s", command, section, exc)
+    return None
+
+
+async def _store_man_page_cache(command: str, section: str, data: dict) -> None:
+    """Store man page dict in Redis with TTL. Errors are non-fatal."""
+    key = _cache_key(command, section)
+    try:
+        redis = get_redis_client(database="knowledge")
+        payload = json.dumps(data)
+        await asyncio.to_thread(redis.setex, key, _MAN_PAGE_CACHE_TTL, payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Redis cache write failed for %s(%s): %s", command, section, exc)
+
+
+# ---------------------------------------------------------------------------
+# Core lookup logic
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_man_page(command: str, section: str) -> dict:
+    """
+    Fetch and parse a man page.
+
+    Tries the local `man` subprocess via ManPageParser. Returns a dict with
+    parse_success=False when the command is unavailable rather than raising.
+    """
+    content: ManPageContent = await asyncio.to_thread(
+        get_man_page_content, command, section
+    )
+    return _serialize_man_page(content, cached=False)
+
+
+async def _lookup_man_page(command: str, section: str) -> dict:
+    """
+    Return man page data, using Redis cache when available.
+
+    Cache miss  →  subprocess  →  store in cache  →  return.
+    Cache hit   →  return immediately.
+    Subprocess failure is surfaced in the result dict (parse_success is not
+    exposed directly; callers check for empty title/description).
+    """
+    cached = await _get_cached_man_page(command, section)
+    if cached is not None:
+        logger.debug("Cache hit for man %s(%s)", command, section)
+        return cached
+
+    logger.debug("Cache miss for man %s(%s) — running subprocess", command, section)
+    data = await _fetch_man_page(command, section)
+
+    # Only cache successful fetches (non-empty title or description).
+    if data.get("title") or data.get("description"):
+        await _store_man_page_cache(command, section, data)
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Documentation index query
+# ---------------------------------------------------------------------------
+
+
+async def _query_doc_index(query: str, max_results: int) -> List[dict]:
+    """
+    Query the local documentation index using `man -k`.
+
+    Returns a list of {command, section, summary} dicts.
+    Results are cached in Redis for _DOC_INDEX_CACHE_TTL seconds.
+    When `man` is unavailable an empty list is returned gracefully.
+    """
+    # Check full-index cache first
+    try:
+        redis = get_redis_client(database="knowledge")
+        raw = await asyncio.to_thread(redis.get, _DOC_INDEX_CACHE_KEY)
+        if raw:
+            index: list = json.loads(raw)
+            lower_q = query.lower()
+            hits = [
+                entry
+                for entry in index
+                if lower_q in entry.get("command", "").lower()
+                or lower_q in entry.get("summary", "").lower()
+            ]
+            return hits[:max_results]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Redis doc-index cache read failed: %s", exc)
+
+    # Fallback: run man -k
+    import re
+    import subprocess
+
+    try:
+        proc = await asyncio.to_thread(
+            subprocess.run,
+            ["man", "-k", query],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        lines = proc.stdout.splitlines()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("man -k subprocess failed: %s", exc)
+        return []
+
+    results: List[dict] = []
+    pattern = re.compile(r"^(\S+)\s+\((\d[a-z]?)\)\s+-\s+(.+)$")
+    for line in lines[:max_results]:
+        m = pattern.match(line.strip())
+        if m:
+            results.append(
+                {
+                    "command": m.group(1),
+                    "section": m.group(2),
+                    "summary": m.group(3),
+                }
+            )
+
+    # Cache the raw parsed results for future queries
+    if results:
+        try:
+            redis = get_redis_client(database="knowledge")
+            await asyncio.to_thread(
+                redis.setex,
+                _DOC_INDEX_CACHE_KEY,
+                _DOC_INDEX_CACHE_TTL,
+                json.dumps(results),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Redis doc-index cache write failed: %s", exc)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# MCP tool definitions
+# ---------------------------------------------------------------------------
+
+
+def _man_page_tool_schema() -> dict:
+    return {
+        "name": "lookup_man_page",
+        "description": (
+            "Fetch a Linux/Unix man page for a command. "
+            "Returns structured sections: synopsis, description, options, examples, see-also."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string", "description": "Command name (e.g. 'ls')"},
+                "section": {
+                    "type": "string",
+                    "description": "Manual section 1-8 (default: 1)",
+                },
+            },
+            "required": ["command"],
+        },
+    }
+
+
+def _search_docs_tool_schema() -> dict:
+    return {
+        "name": "search_man_pages",
+        "description": (
+            "Search the system documentation index (man -k) for commands "
+            "matching a keyword. Returns a ranked list of command names and brief summaries."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search keyword"},
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum results to return (1-50, default 10)",
+                    "default": 10,
+                },
+            },
+            "required": ["query"],
+        },
+    }
+
+
+def _doc_index_tool_schema() -> dict:
+    return {
+        "name": "get_doc_index",
+        "description": (
+            "Query the cached documentation index. Similar to search_man_pages "
+            "but queries against a pre-warmed Redis cache for lower latency."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search keyword"},
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum results (1-50, default 10)",
+                    "default": 10,
+                },
+            },
+            "required": ["query"],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="manual_mcp_tools",
+    error_code_prefix="MANUAL_MCP",
+)
+@router.get("/mcp/tools")
+async def get_manual_mcp_tools(
+    current_user: dict = Depends(get_current_user),
+) -> List[dict]:
+    """List available MCP tools provided by the manual bridge.
+
+    Issue #3287: Man page and documentation lookup tools.
+    """
+    return [
+        _man_page_tool_schema(),
+        _search_docs_tool_schema(),
+        _doc_index_tool_schema(),
+    ]
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="manual_mcp_lookup",
+    error_code_prefix="MANUAL_MCP",
+)
+@router.post("/mcp/lookup_man_page")
+async def mcp_lookup_man_page(
+    request: ManPageRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """MCP tool: Fetch a man page for a command.
+
+    Results are cached in Redis (knowledge database) with a 24-hour TTL.
+    When MCP / man is unavailable the response includes success=False and
+    a human-readable error rather than raising HTTP 500.
+
+    Issue #3287.
+    """
+    section = request.section or "1"
+    try:
+        data = await _lookup_man_page(request.command, section)
+        has_content = bool(data.get("title") or data.get("description"))
+        return {
+            "success": has_content,
+            "command": request.command,
+            "section": section,
+            "result": data,
+            "error": None if has_content else f"No man page found for '{request.command}'",
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.error("lookup_man_page failed for %s: %s", request.command, exc)
+        return {
+            "success": False,
+            "command": request.command,
+            "section": section,
+            "result": None,
+            "error": "Man page lookup unavailable",
+        }
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="manual_mcp_search",
+    error_code_prefix="MANUAL_MCP",
+)
+@router.post("/mcp/search_man_pages")
+async def mcp_search_man_pages(
+    request: ManPageSearchRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """MCP tool: Search the system documentation index.
+
+    Delegates to `man -k <query>` and returns structured results.
+    Gracefully returns an empty list when `man` is not available.
+
+    Issue #3287.
+    """
+    try:
+        results = await _query_doc_index(request.query, request.max_results)
+        return {
+            "success": True,
+            "query": request.query,
+            "count": len(results),
+            "results": results,
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.error("search_man_pages failed for query '%s': %s", request.query, exc)
+        return {
+            "success": False,
+            "query": request.query,
+            "count": 0,
+            "results": [],
+            "error": "Documentation index query unavailable",
+        }
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="manual_mcp_doc_index",
+    error_code_prefix="MANUAL_MCP",
+)
+@router.post("/mcp/get_doc_index")
+async def mcp_get_doc_index(
+    request: ManPageSearchRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """MCP tool: Query the cached documentation index.
+
+    First checks Redis; falls back to man -k when cache is cold.
+
+    Issue #3287.
+    """
+    try:
+        results = await _query_doc_index(request.query, request.max_results)
+        return {
+            "success": True,
+            "query": request.query,
+            "count": len(results),
+            "results": results,
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.error("get_doc_index failed for query '%s': %s", request.query, exc)
+        return {
+            "success": False,
+            "query": request.query,
+            "count": 0,
+            "results": [],
+            "error": "Documentation index unavailable",
+        }

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -49,6 +49,7 @@ from api.knowledge_verification import router as knowledge_verification_router
 from api.knowledge_rag_feedback import router as knowledge_rag_feedback_router
 from api.llm import router as llm_router
 from api.llm_providers import router as llm_providers_router
+from api.manual_mcp import router as manual_mcp_router  # Issue #3287
 from api.mcp_registry import router as mcp_registry_router
 from api.memory import router as memory_router
 from api.overseer_handlers import router as overseer_router
@@ -275,6 +276,7 @@ def _get_mcp_routers() -> list:
             "prometheus_mcp",
         ),
         (redis_mcp_router, "/redis", ["redis_mcp", "mcp"], "redis_mcp"),  # Issue #2511
+        (manual_mcp_router, "/manual", ["manual_mcp", "mcp"], "manual_mcp"),  # Issue #3287
     ]
 
 

--- a/autobot-backend/mcp/manual_mcp_test.py
+++ b/autobot-backend/mcp/manual_mcp_test.py
@@ -1,0 +1,456 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for Manual MCP Bridge (Issue #3287).
+
+Tests cover:
+- Man page lookup with cache hit / cache miss paths
+- Graceful handling of unavailable man command
+- Documentation index search
+- Redis cache write / read helpers
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_man_page_content():
+    """Minimal ManPageContent-like object returned by get_man_page_content."""
+    content = MagicMock()
+    content.command = "ls"
+    content.section = "1"
+    content.title = "list directory contents"
+    content.synopsis = "ls [OPTION]... [FILE]..."
+    content.description = "List information about the FILEs."
+    content.options = "  -a, --all  do not ignore entries starting with ."
+    content.examples = "ls -la /tmp"
+    content.see_also = "dir(1), vdir(1)"
+    return content
+
+
+@pytest.fixture
+def empty_man_page_content():
+    """ManPageContent with no useful data (command not found)."""
+    content = MagicMock()
+    content.command = "nonexistent_cmd_xyz"
+    content.section = "1"
+    content.title = ""
+    content.synopsis = ""
+    content.description = ""
+    content.options = ""
+    content.examples = ""
+    content.see_also = ""
+    return content
+
+
+# ---------------------------------------------------------------------------
+# _serialize_man_page
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_man_page_cached_flag():
+    from api.manual_mcp import _serialize_man_page
+
+    content = MagicMock()
+    content.command = "grep"
+    content.section = "1"
+    content.title = "search files"
+    content.synopsis = "grep [OPTIONS]"
+    content.description = "Search for PATTERN in FILE."
+    content.options = "-i"
+    content.examples = "grep foo bar.txt"
+    content.see_also = "awk(1)"
+
+    result = _serialize_man_page(content, cached=True)
+    assert result["cached"] is True
+    assert result["command"] == "grep"
+    assert result["title"] == "search files"
+
+
+def test_serialize_man_page_not_cached():
+    from api.manual_mcp import _serialize_man_page
+
+    content = MagicMock()
+    content.command = "cat"
+    content.section = "1"
+    content.title = "concatenate files"
+    content.synopsis = "cat [OPTION]... [FILE]..."
+    content.description = "Concatenate FILE(s) to standard output."
+    content.options = "-n"
+    content.examples = "cat file.txt"
+    content.see_also = ""
+
+    result = _serialize_man_page(content, cached=False)
+    assert result["cached"] is False
+
+
+# ---------------------------------------------------------------------------
+# _cache_key
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_format():
+    from api.manual_mcp import _cache_key
+
+    key = _cache_key("ls", "1")
+    assert "manual_mcp:man:" in key
+    assert "ls" in key
+    assert "1" in key
+
+
+# ---------------------------------------------------------------------------
+# _get_cached_man_page — cache hit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_cached_man_page_hit():
+    from api.manual_mcp import _get_cached_man_page
+
+    cached_data = {
+        "command": "ls",
+        "section": "1",
+        "title": "list directory contents",
+        "synopsis": "",
+        "description": "List information",
+        "options": "",
+        "examples": "",
+        "see_also": "",
+        "cached": False,  # will be overwritten to True
+    }
+
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = json.dumps(cached_data)
+
+    with patch("api.manual_mcp.get_redis_client", return_value=mock_redis):
+        result = await _get_cached_man_page("ls", "1")
+
+    assert result is not None
+    assert result["cached"] is True
+    assert result["command"] == "ls"
+
+
+# ---------------------------------------------------------------------------
+# _get_cached_man_page — cache miss
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_cached_man_page_miss():
+    from api.manual_mcp import _get_cached_man_page
+
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = None
+
+    with patch("api.manual_mcp.get_redis_client", return_value=mock_redis):
+        result = await _get_cached_man_page("ls", "1")
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _get_cached_man_page — Redis unavailable (graceful degradation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_cached_man_page_redis_error():
+    from api.manual_mcp import _get_cached_man_page
+
+    with patch("api.manual_mcp.get_redis_client", side_effect=Exception("Redis down")):
+        result = await _get_cached_man_page("ls", "1")
+
+    assert result is None  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# _store_man_page_cache — success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_store_man_page_cache_success():
+    from api.manual_mcp import _store_man_page_cache
+
+    mock_redis = MagicMock()
+
+    with patch("api.manual_mcp.get_redis_client", return_value=mock_redis):
+        await _store_man_page_cache("ls", "1", {"command": "ls"})
+
+    mock_redis.setex.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _store_man_page_cache — Redis error is non-fatal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_store_man_page_cache_redis_error():
+    from api.manual_mcp import _store_man_page_cache
+
+    with patch("api.manual_mcp.get_redis_client", side_effect=Exception("Redis down")):
+        # must not raise
+        await _store_man_page_cache("ls", "1", {"command": "ls"})
+
+
+# ---------------------------------------------------------------------------
+# _lookup_man_page — cache hit skips subprocess
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lookup_man_page_cache_hit():
+    from api.manual_mcp import _lookup_man_page
+
+    hit_data = {
+        "command": "ls",
+        "section": "1",
+        "title": "list directory contents",
+        "synopsis": "",
+        "description": "List information",
+        "options": "",
+        "examples": "",
+        "see_also": "",
+        "cached": True,
+    }
+
+    with patch("api.manual_mcp._get_cached_man_page", new=AsyncMock(return_value=hit_data)):
+        with patch("api.manual_mcp._fetch_man_page") as mock_fetch:
+            result = await _lookup_man_page("ls", "1")
+
+    assert result["cached"] is True
+    mock_fetch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _lookup_man_page — cache miss → subprocess → stored
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lookup_man_page_cache_miss_fetches(sample_man_page_content):
+    from api.manual_mcp import _lookup_man_page
+
+    fetched = {
+        "command": "ls",
+        "section": "1",
+        "title": "list directory contents",
+        "synopsis": "ls [OPTION]...",
+        "description": "List information about the FILEs.",
+        "options": "",
+        "examples": "",
+        "see_also": "",
+        "cached": False,
+    }
+
+    with patch("api.manual_mcp._get_cached_man_page", new=AsyncMock(return_value=None)):
+        with patch("api.manual_mcp._fetch_man_page", new=AsyncMock(return_value=fetched)):
+            with patch("api.manual_mcp._store_man_page_cache", new=AsyncMock()) as mock_store:
+                result = await _lookup_man_page("ls", "1")
+
+    assert result["title"] == "list directory contents"
+    mock_store.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _lookup_man_page — empty result not cached
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lookup_man_page_empty_not_cached():
+    from api.manual_mcp import _lookup_man_page
+
+    empty = {
+        "command": "nonexistent",
+        "section": "1",
+        "title": "",
+        "synopsis": "",
+        "description": "",
+        "options": "",
+        "examples": "",
+        "see_also": "",
+        "cached": False,
+    }
+
+    with patch("api.manual_mcp._get_cached_man_page", new=AsyncMock(return_value=None)):
+        with patch("api.manual_mcp._fetch_man_page", new=AsyncMock(return_value=empty)):
+            with patch("api.manual_mcp._store_man_page_cache", new=AsyncMock()) as mock_store:
+                result = await _lookup_man_page("nonexistent", "1")
+
+    assert result["title"] == ""
+    mock_store.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# mcp_lookup_man_page endpoint — success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_endpoint_lookup_man_page_success():
+    from api.manual_mcp import ManPageRequest, mcp_lookup_man_page
+
+    fetched = {
+        "command": "ls",
+        "section": "1",
+        "title": "list directory contents",
+        "synopsis": "ls [OPTION]...",
+        "description": "List information",
+        "options": "",
+        "examples": "",
+        "see_also": "",
+        "cached": False,
+    }
+
+    with patch("api.manual_mcp._lookup_man_page", new=AsyncMock(return_value=fetched)):
+        response = await mcp_lookup_man_page(
+            ManPageRequest(command="ls"), current_user={"id": "test"}
+        )
+
+    assert response["success"] is True
+    assert response["command"] == "ls"
+    assert response["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# mcp_lookup_man_page endpoint — command not found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_endpoint_lookup_man_page_not_found():
+    from api.manual_mcp import ManPageRequest, mcp_lookup_man_page
+
+    empty = {
+        "command": "xyz_notfound",
+        "section": "1",
+        "title": "",
+        "description": "",
+    }
+
+    with patch("api.manual_mcp._lookup_man_page", new=AsyncMock(return_value=empty)):
+        response = await mcp_lookup_man_page(
+            ManPageRequest(command="xyz_notfound"), current_user={"id": "test"}
+        )
+
+    assert response["success"] is False
+    assert "xyz_notfound" in response["error"]
+
+
+# ---------------------------------------------------------------------------
+# mcp_lookup_man_page endpoint — exception → graceful error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_endpoint_lookup_man_page_exception():
+    from api.manual_mcp import ManPageRequest, mcp_lookup_man_page
+
+    with patch(
+        "api.manual_mcp._lookup_man_page", new=AsyncMock(side_effect=RuntimeError("oops"))
+    ):
+        response = await mcp_lookup_man_page(
+            ManPageRequest(command="ls"), current_user={"id": "test"}
+        )
+
+    assert response["success"] is False
+    assert response["result"] is None
+
+
+# ---------------------------------------------------------------------------
+# _query_doc_index — subprocess path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_doc_index_subprocess():
+    from api.manual_mcp import _query_doc_index
+
+    man_k_output = (
+        "ls (1)               - list directory contents\n"
+        "lsblk (8)            - list block devices\n"
+    )
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = man_k_output
+
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = None  # cache miss
+
+    with patch("api.manual_mcp.get_redis_client", return_value=mock_redis):
+        with patch("subprocess.run", return_value=mock_proc):
+            results = await _query_doc_index("ls", 10)
+
+    assert len(results) >= 1
+    commands = [r["command"] for r in results]
+    assert "ls" in commands
+
+
+# ---------------------------------------------------------------------------
+# _query_doc_index — man subprocess failure returns empty list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_doc_index_subprocess_failure():
+    from api.manual_mcp import _query_doc_index
+
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = None
+
+    with patch("api.manual_mcp.get_redis_client", return_value=mock_redis):
+        with patch("subprocess.run", side_effect=Exception("man not found")):
+            results = await _query_doc_index("ls", 10)
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# mcp_search_man_pages endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_endpoint_search_man_pages_success():
+    from api.manual_mcp import ManPageSearchRequest, mcp_search_man_pages
+
+    hits = [{"command": "ls", "section": "1", "summary": "list directory contents"}]
+
+    with patch("api.manual_mcp._query_doc_index", new=AsyncMock(return_value=hits)):
+        response = await mcp_search_man_pages(
+            ManPageSearchRequest(query="ls"), current_user={"id": "test"}
+        )
+
+    assert response["success"] is True
+    assert response["count"] == 1
+    assert response["results"][0]["command"] == "ls"
+
+
+# ---------------------------------------------------------------------------
+# mcp_get_doc_index endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_endpoint_get_doc_index_empty():
+    from api.manual_mcp import ManPageSearchRequest, mcp_get_doc_index
+
+    with patch("api.manual_mcp._query_doc_index", new=AsyncMock(return_value=[])):
+        response = await mcp_get_doc_index(
+            ManPageSearchRequest(query="nonexistent_xyz"), current_user={"id": "test"}
+        )
+
+    assert response["success"] is True
+    assert response["count"] == 0
+    assert response["results"] == []


### PR DESCRIPTION
## Summary

Closes #3287

- Added `autobot-backend/api/manual_mcp.py` — new MCP bridge exposing three tools to LLM agents:
  - **`lookup_man_page`** — fetches and parses man pages via the existing `ManPageParser` / `get_man_page_content`; caches results in the Redis `knowledge` database with a 24-hour TTL to avoid repeated subprocess calls
  - **`search_man_pages`** — delegates to `man -k <query>` for keyword search of the system documentation index
  - **`get_doc_index`** — queries the Redis-cached documentation index with a subprocess fallback when the cache is cold (1-hour TTL)
- Registered router at `/manual` prefix in `initialization/router_registry/core_routers.py`
- All three endpoints handle MCP / `man` unavailability gracefully — they return `success: false` with a human-readable error rather than raising HTTP 500
- Added `autobot-backend/mcp/manual_mcp_test.py` with 18 unit tests covering cache hit/miss, Redis failures, subprocess failures, and endpoint success/error paths

## Test plan

- [x] 18 unit tests pass (`pytest mcp/manual_mcp_test.py -v` — 18 passed in 0.76 s)
- [x] `flake8 --max-line-length=100` passes on both new files with no warnings
- [ ] Integration: `POST /manual/mcp/lookup_man_page` with `{"command": "ls"}` returns structured man page content
- [ ] Integration: `POST /manual/mcp/search_man_pages` with `{"query": "network"}` returns matching commands
- [ ] Verify Redis cache key `manual_mcp:man:ls:1` is written after first lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)