### PR TITLE
fix(ci): Security Scanning workflow action versions (#4127)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
     - name: Install Python 3.12 via deadsnakes PPA
       run: |
@@ -78,7 +78,7 @@ jobs:
         safety check || true
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
 
@@ -95,7 +95,7 @@ jobs:
         npm audit --audit-level=moderate || true
 
     - name: Upload Security Reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: dependency-security-reports
@@ -116,7 +116,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
     - name: Install Python 3.12 via deadsnakes PPA
       run: |
@@ -200,7 +200,7 @@ jobs:
         fi
 
     - name: Upload SAST Reports
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: sast-security-reports
@@ -221,7 +221,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
     - name: Check for Security Files
       run: |
@@ -271,7 +271,7 @@ jobs:
 
     steps:
     - name: Download all security reports
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@v4
 
     - name: Generate Security Summary
       run: |
@@ -304,7 +304,7 @@ jobs:
         echo "3. Address any SAST findings in critical code paths" >> security-summary.md
 
     - name: Upload Security Summary
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: security-summary
         path: security-summary.md


### PR DESCRIPTION
## Summary

- Replace `actions/checkout@v6` with `@v4` (3 occurrences: lines 36, 119, 224)
- Replace `actions/setup-node@v6` with `@v4` (line 81)
- Replace `actions/upload-artifact@v7` with `@v4` (3 occurrences: lines 98, 203, 307)
- Replace `actions/download-artifact@v8` with `@v4` (line 274)

GitHub Actions v6, v7, and v8 do not exist in main release. The latest stable version for all affected actions is v4. These unsupported version references caused the Security Scanning workflow to fail on every run.

Fixes #4127

## Test plan

- [x] YAML syntax validated: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/security.yml'))"`
- [x] All 8 action `uses:` references confirmed at `@v4`
- [ ] Verify Security Scanning workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)