### PR TITLE
feat(testing): establish comprehensive automated test coverage framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,23 +121,22 @@ jobs:
           python -m json.tool < bandit-report.json || true
         fi
 
-    - name: Run unit tests for security modules
+    - name: Run unit tests with coverage gate
       run: |
         source .venv/bin/activate
-        echo "🧪 Running security unit tests..."
-        # Tests are colocated with source files (#734)
-        TEST_FILES=""
-        for file in autobot-backend/security/secure_command_executor_test.py autobot-backend/security/enhanced_security_layer_test.py autobot-backend/api/security_api_test.py; do
-          if [ -f "$file" ]; then
-            TEST_FILES="$TEST_FILES $file"
-          fi
-        done
-
-        if [ -n "$TEST_FILES" ]; then
-          python -m pytest $TEST_FILES -v --tb=short --cov=autobot-backend --cov-report=xml --cov-report=term
-        else
-          echo "⚠️ No security unit test files found - skipping"
-        fi
+        echo "Running unit tests with 70% coverage gate (#3285)..."
+        # Run all unit tests excluding slow/integration/distributed/performance markers.
+        # --cov-fail-under=70 enforces the minimum 70% coverage threshold.
+        python -m pytest \
+          -m "not integration and not slow and not distributed and not performance" \
+          --cov=autobot-backend \
+          --cov=autobot-slm-backend \
+          --cov=autobot_shared \
+          --cov-report=xml:coverage.xml \
+          --cov-report=term-missing \
+          --cov-fail-under=70 \
+          --tb=short \
+          -q
 
     - name: Run integration tests
       run: |
@@ -194,10 +193,11 @@ jobs:
         cd autobot-frontend
         npm run build
 
-    - name: Run frontend unit tests
+    - name: Run frontend unit tests with coverage gate
       run: |
         cd autobot-frontend
-        npm run test:unit
+        # test:coverage enforces 70% threshold via vitest.config.ts thresholds (#3285)
+        npm run test:coverage
 
     - name: Cleanup
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# AutoBot Makefile — standard entry points for testing and coverage (#3285)
+# Requires: pytest, pytest-cov, pytest-asyncio installed in the active venv
+# Frontend targets require Node.js 20+ and npm ci run inside autobot-frontend/
+
+.PHONY: test test-coverage test-backend test-frontend test-e2e help
+
+# Default target: run all backend unit tests without coverage
+test: test-backend
+
+## Run backend unit tests with 70% coverage gate
+test-coverage:
+	pytest \
+	    --cov=autobot-backend \
+	    --cov=autobot-slm-backend \
+	    --cov=autobot_shared \
+	    --cov-report=term-missing \
+	    --cov-report=html:reports/coverage-backend \
+	    --cov-report=xml:reports/coverage-backend.xml \
+	    --cov-fail-under=70 \
+	    -m "not integration and not slow and not distributed and not performance"
+
+## Run backend unit tests (no coverage)
+test-backend:
+	pytest \
+	    -m "not integration and not slow and not distributed and not performance"
+
+## Run frontend unit tests with 70% coverage gate
+test-frontend:
+	cd autobot-frontend && npm run test:coverage
+
+## Run Playwright E2E tests (requires running backend+frontend)
+test-e2e:
+	cd autobot-frontend && npm run test:playwright
+
+## Show this help
+help:
+	@echo "AutoBot test targets:"
+	@echo "  make test            - backend unit tests (no coverage)"
+	@echo "  make test-coverage   - backend tests + coverage gate (>=70%)"
+	@echo "  make test-frontend   - frontend vitest coverage (>=70%)"
+	@echo "  make test-e2e        - Playwright E2E tests"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 > AutoBot is a **self-hosted AI platform** that brings conversational AI to distributed Linux administration, fleet management, and infrastructure automation — all from a beautiful, modern interface. Own your data. Control your infrastructure. No vendor lock-in.
 
 [![Docker Smoke Test](https://github.com/mrveiss/AutoBot-AI/actions/workflows/docker-smoke-test.yml/badge.svg)](https://github.com/mrveiss/AutoBot-AI/actions/workflows/docker-smoke-test.yml)
+[![codecov](https://codecov.io/gh/mrveiss/AutoBot-AI/branch/main/graph/badge.svg)](https://codecov.io/gh/mrveiss/AutoBot-AI)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/mrveiss?label=Sponsor&logo=GitHub&style=flat-square)](https://github.com/sponsors/mrveiss)
 
 ## Quick Start (3 Steps)

--- a/pytest.ini
+++ b/pytest.ini
@@ -61,3 +61,5 @@ omit = *_test.py,*/test_*,*/venv/*,*/__pycache__/*
 [coverage:report]
 precision = 2
 skip_empty = True
+# Minimum 70% coverage required — CI enforces via --cov-fail-under=70 (#3285)
+fail_under = 70


### PR DESCRIPTION
## Summary

Closes #3285

- **`Makefile`** — adds `make test`, `make test-coverage`, `make test-frontend`, and `make test-e2e` as standard entry points
- **`pytest.ini`** — adds `fail_under = 70` to `[coverage:report]` so the configuration documents and enforces the 70% minimum
- **`ci.yml` backend** — replaces narrow security-only test run with a full unit-test run using `--cov-fail-under=70`; pipeline fails if coverage drops below threshold
- **`ci.yml` frontend** — switches from `test:unit` (no coverage) to `test:coverage` which uses the 70% thresholds already configured in `vitest.config.ts`
- **`README.md`** — adds Codecov coverage badge

## Acceptance criteria status

- [x] `pytest --cov` runs all backend tests and produces a coverage report (`make test-coverage`)
- [x] `vitest --coverage` runs all frontend tests and produces a coverage report (`make test-frontend` / `npm run test:coverage`)
- [x] CI pipeline fails if coverage drops below 70% (both backend `--cov-fail-under=70` and frontend vitest thresholds)
- [ ] E2E tests run against a dedicated test environment — `make test-e2e` target wired to Playwright; dedicated environment provisioning tracked separately
- [x] Coverage badge added to README

## Test plan

- [ ] Verify `make test-coverage` runs locally without error
- [ ] Verify CI `security-tests` job passes with new coverage step
- [ ] Verify CI `frontend-tests` job passes with `test:coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)