### PR TITLE
feat(backend): implement knowledge base suggestion logic

### DIFF
--- a/autobot-backend/api/knowledge_models.py
+++ b/autobot-backend/api/knowledge_models.py
@@ -1303,6 +1303,71 @@ class AutoApplySuggestionsRequest(BaseModel):
     )
 
 
+# ===== CONTEXT SUGGESTION MODELS (Issue #3284) =====
+
+
+class ContextSuggestionsRequest(BaseModel):
+    """
+    Request model for context-based KB document suggestions (Issue #3284).
+
+    Returns ranked KB documents relevant to the current conversation context,
+    scored by semantic similarity to the context and boosted by recency.
+    Each suggestion includes a short preview snippet.
+    """
+
+    context: str = Field(
+        ...,
+        min_length=10,
+        max_length=10000,
+        description="Current conversation context or query to find relevant KB documents for",
+    )
+    limit: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description="Maximum number of document suggestions to return",
+    )
+    recency_weight: float = Field(
+        default=0.2,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Weight of recency boost relative to relevance score (0=purely semantic, "
+            "1=purely recency)"
+        ),
+    )
+    min_score: float = Field(
+        default=0.3,
+        ge=0.0,
+        le=1.0,
+        description="Minimum combined score threshold for a suggestion to be included",
+    )
+    snippet_length: int = Field(
+        default=200,
+        ge=50,
+        le=500,
+        description="Maximum character length of the preview snippet",
+    )
+
+
+class ContextSuggestionItem(BaseModel):
+    """
+    A single context-based KB document suggestion (Issue #3284).
+
+    Returned as part of the ContextSuggestionsResponse.
+    """
+
+    fact_id: str = Field(description="Unique identifier of the KB fact")
+    title: str = Field(description="Title or first-line of the document")
+    snippet: str = Field(description="Short preview snippet of the document content")
+    relevance_score: float = Field(description="Semantic similarity score (0.0-1.0)")
+    recency_score: float = Field(description="Recency score derived from timestamp (0.0-1.0)")
+    combined_score: float = Field(description="Weighted combination of relevance and recency")
+    tags: list[str] = Field(default_factory=list, description="Tags associated with the document")
+    category: str = Field(default="", description="Category path of the document")
+    created_at: str = Field(default="", description="ISO-8601 timestamp when the fact was created")
+
+
 # ===== METADATA TEMPLATE MODELS (Issue #414) =====
 
 # Valid field types for metadata templates

--- a/autobot-backend/api/knowledge_suggestions.py
+++ b/autobot-backend/api/knowledge_suggestions.py
@@ -7,10 +7,14 @@ Knowledge Base ML-Based Suggestions API Router
 Issue #413: Provides API endpoints for tag and category suggestions
 based on content similarity using existing embeddings.
 
+Issue #3284: Adds context-based document suggestions ranked by relevance
+and recency, with preview snippets.
+
 Endpoints:
 - POST /suggestions/tags - Suggest tags for content
 - POST /suggestions/categories - Suggest categories for content
 - POST /suggestions/all - Suggest both tags and categories
+- POST /suggestions/context - Suggest KB documents relevant to conversation context
 - POST /facts/{fact_id}/auto-apply - Auto-apply suggestions to fact
 """
 
@@ -20,6 +24,7 @@ from fastapi import APIRouter, HTTPException
 
 from api.knowledge_models import (
     AutoApplySuggestionsRequest,
+    ContextSuggestionsRequest,
     SuggestAllRequest,
     SuggestCategoriesRequest,
     SuggestTagsRequest,
@@ -198,6 +203,88 @@ async def suggest_all(request: SuggestAllRequest):
         raise
     except Exception as e:
         logger.error("Combined suggestion failed: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post("/suggestions/context")
+async def suggest_by_context(request: ContextSuggestionsRequest):
+    """
+    Suggest KB documents relevant to the current conversation context (Issue #3284).
+
+    Performs a semantic similarity search against the knowledge base using the
+    provided context, then ranks results by a weighted combination of relevance
+    score and recency (configurable via recency_weight).
+
+    Each suggestion includes a short preview snippet so the UI can display
+    meaningful context without fetching the full document.
+
+    Args:
+        request: ContextSuggestionsRequest
+
+    Returns:
+        Dict with:
+        - success: bool
+        - suggestions: List of ranked suggestion objects, each containing:
+            - fact_id, title, snippet, relevance_score, recency_score,
+              combined_score, tags, category, created_at
+        - total_candidates: Number of documents examined before filtering
+
+    Example:
+        POST /api/knowledge_base/suggestions/context
+        {
+            "context": "How do I configure Redis connection pooling in FastAPI?",
+            "limit": 5,
+            "recency_weight": 0.2,
+            "min_score": 0.3,
+            "snippet_length": 200
+        }
+
+        Response:
+        {
+            "success": true,
+            "suggestions": [
+                {
+                    "fact_id": "abc123",
+                    "title": "Redis connection pooling guide",
+                    "snippet": "Connection pooling in Redis can be configured...",
+                    "relevance_score": 0.87,
+                    "recency_score": 0.95,
+                    "combined_score": 0.885,
+                    "tags": ["redis", "fastapi", "performance"],
+                    "category": "tech/databases",
+                    "created_at": "2025-03-15T10:30:00+00:00"
+                }
+            ],
+            "total_candidates": 18
+        }
+    """
+    try:
+        kb = await get_knowledge_base()
+        result = await kb.suggest_by_context(
+            context=request.context,
+            limit=request.limit,
+            recency_weight=request.recency_weight,
+            min_score=request.min_score,
+            snippet_length=request.snippet_length,
+        )
+
+        if not result.get("success"):
+            raise HTTPException(
+                status_code=500,
+                detail=result.get("error", "Failed to generate context suggestions"),
+            )
+
+        logger.info(
+            "Context suggestions: returned %d suggestions (context_len=%d)",
+            len(result.get("suggestions", [])),
+            len(request.context),
+        )
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Context suggestion failed: %s", e)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/autobot-backend/knowledge/knowledge_context_suggestions_test.py
+++ b/autobot-backend/knowledge/knowledge_context_suggestions_test.py
@@ -1,0 +1,268 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for context-based KB document suggestions (Issue #3284).
+
+Covers:
+- _compute_recency_score: exponential decay, missing timestamp, invalid input
+- _build_snippet: truncation at word boundary, short content passthrough
+- _extract_title: metadata priority, line fallback
+- suggest_by_context: combined scoring, filtering, ranking, error path
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+from knowledge.suggestions import SuggestionsMixin
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass so we can instantiate SuggestionsMixin
+# ---------------------------------------------------------------------------
+
+
+class _FakeSuggestions(SuggestionsMixin):
+    def ensure_initialized(self) -> None:
+        pass  # no-op for unit tests
+
+
+@pytest.fixture()
+def mixin() -> _FakeSuggestions:
+    return _FakeSuggestions()
+
+
+# ---------------------------------------------------------------------------
+# _compute_recency_score
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRecencyScore:
+    def test_today_scores_one(self, mixin):
+        now_str = datetime.now(tz=timezone.utc).isoformat()
+        score = mixin._compute_recency_score(now_str)
+        assert 0.98 <= score <= 1.0
+
+    def test_half_life_is_thirty_days(self, mixin):
+        ts = (datetime.now(tz=timezone.utc) - timedelta(days=30)).isoformat()
+        score = mixin._compute_recency_score(ts)
+        assert 0.48 <= score <= 0.52  # ~0.5
+
+    def test_empty_timestamp_returns_neutral(self, mixin):
+        assert mixin._compute_recency_score("") == 0.5
+
+    def test_invalid_timestamp_returns_neutral(self, mixin):
+        assert mixin._compute_recency_score("not-a-date") == 0.5
+
+    def test_naive_timestamp_handled(self, mixin):
+        # Naive datetime (no tz) should not raise
+        naive = datetime.utcnow().isoformat()
+        score = mixin._compute_recency_score(naive)
+        assert 0.0 <= score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# _build_snippet
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSnippet:
+    def test_short_content_returned_as_is(self, mixin):
+        text = "Short text."
+        assert mixin._build_snippet(text, 200) == "Short text."
+
+    def test_long_content_truncated(self, mixin):
+        text = " ".join(["word"] * 100)  # 499 chars
+        snippet = mixin._build_snippet(text, 50)
+        assert len(snippet) <= 50 + len(mixin._SNIPPET_ELLIPSIS)
+        assert snippet.endswith(mixin._SNIPPET_ELLIPSIS)
+
+    def test_truncation_at_word_boundary(self, mixin):
+        # With limit=14, text[:14] = "hello world fo", rsplit splits at space -> "hello world"
+        text = "hello world foobar"
+        snippet = mixin._build_snippet(text, 14)
+        assert snippet == "hello world" + mixin._SNIPPET_ELLIPSIS
+
+    def test_empty_content(self, mixin):
+        assert mixin._build_snippet("", 200) == ""
+
+
+# ---------------------------------------------------------------------------
+# _extract_title
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTitle:
+    def test_title_from_metadata(self, mixin):
+        title = mixin._extract_title("some content", {"title": "My Title"})
+        assert title == "My Title"
+
+    def test_source_fallback(self, mixin):
+        title = mixin._extract_title("some content", {"source": "docs/guide.md"})
+        assert title == "docs/guide.md"
+
+    def test_first_line_fallback(self, mixin):
+        title = mixin._extract_title("First line\nSecond line", {})
+        assert title == "First line"
+
+    def test_empty_content_fallback(self, mixin):
+        title = mixin._extract_title("", {})
+        assert title == "Untitled"
+
+
+# ---------------------------------------------------------------------------
+# suggest_by_context
+# ---------------------------------------------------------------------------
+
+
+def _make_doc(
+    fact_id: str,
+    score: float,
+    content: str,
+    timestamp: str = "",
+    tags: List[str] = None,
+    category: str = "",
+) -> Dict[str, Any]:
+    return {
+        "score": score,
+        "content": content,
+        "node_id": fact_id,
+        "metadata": {
+            "fact_id": fact_id,
+            "timestamp": timestamp,
+            "tags": tags or [],
+            "category": category,
+        },
+    }
+
+
+@pytest.mark.asyncio
+class TestSuggestByContext:
+    async def test_returns_ranked_suggestions(self, mixin):
+        now = datetime.now(tz=timezone.utc).isoformat()
+        old = (datetime.now(tz=timezone.utc) - timedelta(days=120)).isoformat()
+
+        docs = [
+            _make_doc("fact1", score=0.9, content="Redis pooling guide detailed text here",
+                      timestamp=old),
+            _make_doc("fact2", score=0.7, content="FastAPI async patterns best practices",
+                      timestamp=now),
+        ]
+        mixin._find_similar_documents = AsyncMock(return_value=docs)
+
+        result = await mixin.suggest_by_context(
+            context="Redis FastAPI", limit=5, recency_weight=0.2, min_score=0.3
+        )
+
+        assert result["success"] is True
+        assert len(result["suggestions"]) == 2
+        # Verify sorted descending by combined_score
+        scores = [s["combined_score"] for s in result["suggestions"]]
+        assert scores == sorted(scores, reverse=True)
+
+    async def test_filters_below_min_score(self, mixin):
+        docs = [
+            _make_doc("fact1", score=0.1, content="Low relevance doc"),
+        ]
+        mixin._find_similar_documents = AsyncMock(return_value=docs)
+
+        result = await mixin.suggest_by_context(
+            context="anything", min_score=0.9
+        )
+
+        assert result["success"] is True
+        assert result["suggestions"] == []
+
+    async def test_respects_limit(self, mixin):
+        now = datetime.now(tz=timezone.utc).isoformat()
+        docs = [_make_doc(f"fact{i}", score=0.8, content=f"Content {i}", timestamp=now)
+                for i in range(10)]
+        mixin._find_similar_documents = AsyncMock(return_value=docs)
+
+        result = await mixin.suggest_by_context(context="test", limit=3)
+
+        assert result["success"] is True
+        assert len(result["suggestions"]) == 3
+
+    async def test_suggestion_shape(self, mixin):
+        now = datetime.now(tz=timezone.utc).isoformat()
+        docs = [_make_doc(
+            "fact99",
+            score=0.75,
+            content="This is content for a test document about Python.",
+            timestamp=now,
+            tags=["python", "test"],
+            category="tech/python",
+        )]
+        mixin._find_similar_documents = AsyncMock(return_value=docs)
+
+        result = await mixin.suggest_by_context(context="Python testing")
+
+        s = result["suggestions"][0]
+        assert s["fact_id"] == "fact99"
+        assert isinstance(s["title"], str) and s["title"]
+        assert isinstance(s["snippet"], str)
+        assert 0.0 <= s["relevance_score"] <= 1.0
+        assert 0.0 <= s["recency_score"] <= 1.0
+        assert 0.0 <= s["combined_score"] <= 1.0
+        assert s["tags"] == ["python", "test"]
+        assert s["category"] == "tech/python"
+        assert s["created_at"] == now
+
+    async def test_empty_context_returns_error(self, mixin):
+        result = await mixin.suggest_by_context(context="  ")
+        assert result["success"] is False
+        assert "error" in result
+
+    async def test_snippet_length_respected(self, mixin):
+        long_content = "word " * 200  # 1000 chars
+        now = datetime.now(tz=timezone.utc).isoformat()
+        docs = [_make_doc("fact1", score=0.8, content=long_content, timestamp=now)]
+        mixin._find_similar_documents = AsyncMock(return_value=docs)
+
+        result = await mixin.suggest_by_context(
+            context="test", snippet_length=100
+        )
+
+        snippet = result["suggestions"][0]["snippet"]
+        assert len(snippet) <= 100 + len(mixin._SNIPPET_ELLIPSIS)
+
+    async def test_search_exception_returns_error(self, mixin):
+        mixin._find_similar_documents = AsyncMock(side_effect=RuntimeError("DB error"))
+
+        result = await mixin.suggest_by_context(context="test query")
+
+        assert result["success"] is False
+        assert "error" in result
+
+    async def test_total_candidates_reported(self, mixin):
+        now = datetime.now(tz=timezone.utc).isoformat()
+        docs = [_make_doc(f"fact{i}", score=0.8, content=f"Content {i}", timestamp=now)
+                for i in range(7)]
+        mixin._find_similar_documents = AsyncMock(return_value=docs)
+
+        result = await mixin.suggest_by_context(context="test")
+
+        assert result["total_candidates"] == 7
+
+    async def test_json_encoded_tags_parsed(self, mixin):
+        now = datetime.now(tz=timezone.utc).isoformat()
+        doc = {
+            "score": 0.8,
+            "content": "Content with JSON tags",
+            "node_id": "fact1",
+            "metadata": {
+                "fact_id": "fact1",
+                "timestamp": now,
+                "tags": '["redis", "fastapi"]',
+                "category": "",
+            },
+        }
+        mixin._find_similar_documents = AsyncMock(return_value=[doc])
+
+        result = await mixin.suggest_by_context(context="redis fastapi")
+
+        assert result["suggestions"][0]["tags"] == ["redis", "fastapi"]

--- a/autobot-backend/knowledge/suggestions.py
+++ b/autobot-backend/knowledge/suggestions.py
@@ -13,7 +13,9 @@ from them weighted by similarity score.
 import asyncio
 import json
 import logging
+import math
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 if TYPE_CHECKING:
@@ -530,6 +532,195 @@ class SuggestionsMixin:
         # Sort by confidence descending
         suggestions.sort(key=lambda x: x["confidence"], reverse=True)
         return suggestions[:limit]
+
+    # ------------------------------------------------------------------
+    # Context-based document suggestions (Issue #3284)
+    # ------------------------------------------------------------------
+
+    _RECENCY_HALF_LIFE_DAYS = 30  # Score halves every 30 days
+    _SNIPPET_ELLIPSIS = "..."
+
+    def _compute_recency_score(self, timestamp_str: str) -> float:
+        """
+        Compute a 0-1 recency score using exponential decay.
+
+        Score = exp(-lambda * age_days) where lambda = ln(2) / half_life.
+        A document created today scores 1.0; one created 30 days ago scores ~0.5.
+
+        Args:
+            timestamp_str: ISO-8601 timestamp string, may be empty.
+
+        Returns:
+            Recency score in [0.0, 1.0].
+        """
+        if not timestamp_str:
+            return 0.5  # Unknown age: neutral score
+
+        try:
+            ts = datetime.fromisoformat(timestamp_str)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            age_days = max(0.0, (datetime.now(tz=timezone.utc) - ts).total_seconds() / 86400.0)
+            decay_lambda = math.log(2) / self._RECENCY_HALF_LIFE_DAYS
+            return math.exp(-decay_lambda * age_days)
+        except (ValueError, OverflowError, OSError):
+            return 0.5
+
+    def _build_snippet(self, content: str, snippet_length: int) -> str:
+        """
+        Extract a short preview snippet from raw document content.
+
+        Trims to the nearest word boundary and appends ellipsis when truncated.
+
+        Args:
+            content: Full document text.
+            snippet_length: Maximum character length of the snippet.
+
+        Returns:
+            Snippet string, at most snippet_length characters + ellipsis.
+        """
+        if not content:
+            return ""
+        text = content.strip()
+        if len(text) <= snippet_length:
+            return text
+        truncated = text[:snippet_length].rsplit(" ", 1)[0]
+        return truncated + self._SNIPPET_ELLIPSIS
+
+    def _extract_title(self, content: str, metadata: Dict[str, Any]) -> str:
+        """
+        Derive a human-readable title for a KB document.
+
+        Priority: metadata["title"] > metadata["source"] > first non-empty line.
+
+        Args:
+            content: Document text.
+            metadata: Fact metadata dict.
+
+        Returns:
+            Title string (never empty — falls back to truncated content).
+        """
+        for key in ("title", "source"):
+            val = metadata.get(key, "")
+            if val and isinstance(val, str) and val.strip():
+                return val.strip()
+
+        for line in content.splitlines():
+            line = line.strip()
+            if line:
+                return line[:120]
+
+        return content[:60].strip() or "Untitled"
+
+    async def suggest_by_context(
+        self,
+        context: str,
+        limit: int = 5,
+        recency_weight: float = 0.2,
+        min_score: float = 0.3,
+        snippet_length: int = 200,
+    ) -> Dict[str, Any]:
+        """
+        Return KB documents ranked by relevance to current context (Issue #3284).
+
+        Each result is scored as:
+            combined = (1 - recency_weight) * relevance + recency_weight * recency
+
+        Results below min_score are excluded. Suggestions include a short preview
+        snippet so the caller can display context without fetching the full document.
+
+        Args:
+            context: Current conversation context / user query.
+            limit: Maximum number of suggestions to return.
+            recency_weight: 0 = purely semantic, 1 = purely recency.
+            min_score: Minimum combined score threshold.
+            snippet_length: Maximum snippet character length.
+
+        Returns:
+            Dict with:
+            - success: bool
+            - suggestions: List of ContextSuggestionItem-shaped dicts
+            - total_candidates: int — number of documents examined
+        """
+        self.ensure_initialized()
+
+        if not context or not context.strip():
+            return {
+                "success": False,
+                "suggestions": [],
+                "total_candidates": 0,
+                "error": "Context is required",
+            }
+
+        try:
+            # Fetch more candidates than needed so scoring can filter/sort properly.
+            fetch_limit = min(limit * 4, 50)
+            raw_results = await self._find_similar_documents(context, fetch_limit)
+            total_candidates = len(raw_results)
+
+            suggestions = []
+            for doc in raw_results:
+                relevance = float(doc.get("score", 0.0))
+                metadata = doc.get("metadata", {})
+                content = doc.get("content", "")
+
+                # Timestamp may live on the top-level doc or inside metadata
+                timestamp_str = doc.get("timestamp", "") or metadata.get("timestamp", "")
+                recency = self._compute_recency_score(timestamp_str)
+
+                combined = (1.0 - recency_weight) * relevance + recency_weight * recency
+
+                if combined < min_score:
+                    continue
+
+                fact_id = metadata.get("fact_id", doc.get("node_id", ""))
+
+                # Parse tags stored as JSON string or list
+                raw_tags: Any = metadata.get("tags", [])
+                if isinstance(raw_tags, str):
+                    try:
+                        raw_tags = json.loads(raw_tags)
+                    except (json.JSONDecodeError, TypeError):
+                        raw_tags = [raw_tags] if raw_tags else []
+                tags: List[str] = [t for t in raw_tags if isinstance(t, str)]
+
+                suggestions.append(
+                    {
+                        "fact_id": fact_id,
+                        "title": self._extract_title(content, metadata),
+                        "snippet": self._build_snippet(content, snippet_length),
+                        "relevance_score": round(relevance, 4),
+                        "recency_score": round(recency, 4),
+                        "combined_score": round(combined, 4),
+                        "tags": tags,
+                        "category": metadata.get("category_path", metadata.get("category", "")),
+                        "created_at": timestamp_str,
+                    }
+                )
+
+            suggestions.sort(key=lambda x: x["combined_score"], reverse=True)
+            suggestions = suggestions[:limit]
+
+            logger.info(
+                "Context suggestions: returned %d/%d candidates (context_len=%d)",
+                len(suggestions),
+                total_candidates,
+                len(context),
+            )
+            return {
+                "success": True,
+                "suggestions": suggestions,
+                "total_candidates": total_candidates,
+            }
+
+        except Exception as e:
+            logger.error("Failed to generate context suggestions: %s", e)
+            return {
+                "success": False,
+                "suggestions": [],
+                "total_candidates": 0,
+                "error": "Failed to generate context suggestions",
+            }
 
     def ensure_initialized(self):
         """Ensure the knowledge base is initialized. Implemented in composed class."""


### PR DESCRIPTION
## Summary

Closes #3284

- Adds `POST /api/knowledge_base/suggestions/context` endpoint that returns KB documents ranked by relevance to the current conversation context
- Each suggestion is scored as `(1 - recency_weight) * relevance + recency_weight * recency` where recency uses exponential decay (30-day half-life) on the fact timestamp
- Every suggestion includes `fact_id`, `title`, `snippet` (word-boundary truncated preview), `relevance_score`, `recency_score`, `combined_score`, `tags`, `category`, and `created_at`
- New `ContextSuggestionsRequest` and `ContextSuggestionItem` Pydantic models added to `knowledge_models.py`
- `SuggestionsMixin.suggest_by_context()` added to `knowledge/suggestions.py` — reuses existing `_find_similar_documents()` so no new vector search plumbing required

## Test plan

- [x] 22 unit tests in `autobot-backend/knowledge/knowledge_context_suggestions_test.py` — all passing
  - `_compute_recency_score`: exponential decay, neutral for missing/invalid timestamp, naive datetime handling
  - `_build_snippet`: word-boundary truncation, passthrough for short content, empty content
  - `_extract_title`: metadata title > source > first line > fallback
  - `suggest_by_context`: ranking, min_score filtering, limit, suggestion shape, empty context error, snippet length, search exception, `total_candidates`, JSON-encoded tags
- [x] `flake8 --max-line-length=100` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)