### PR TITLE
feat(frontend): implement toast notification system

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useToast.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useToast.test.ts
@@ -1,0 +1,261 @@
+/**
+ * useToast Composable Tests
+ *
+ * Covers acceptance criteria from issue #3283:
+ * - Global availability via provide/inject
+ * - success / error / warning / info variants
+ * - Auto-dismiss after configurable timeout (default 4s for success, persistent for errors)
+ * - Maximum 5 toasts stacked; older ones evicted
+ * - Manual dismiss
+ *
+ * @author mrveiss
+ * @copyright 2025 mrveiss
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import {
+  useToast,
+  provideToast,
+  TOAST_INJECT_KEY,
+  TOAST_DURATIONS,
+  MAX_TOASTS,
+  type ToastType,
+} from '../useToast'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Mount a minimal component and call setup(); returns whatever setup returns. */
+function withSetup<T>(setup: () => T): T {
+  let result!: T
+  const Wrapper = defineComponent({
+    setup() {
+      result = setup()
+      return {}
+    },
+    template: '<div />',
+  })
+  mount(Wrapper, {
+    global: { stubs: { Teleport: true } },
+  })
+  return result
+}
+
+/** Reset the module-level singleton between tests (must run inside setup context). */
+function resetSingleton() {
+  withSetup(() => {
+    const { clearAllToasts } = useToast()
+    clearAllToasts()
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useToast — acceptance criteria #3283', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetSingleton()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // -------------------------------------------------------------------------
+  // 1. Singleton state is shared across calls
+  // -------------------------------------------------------------------------
+  describe('module-level singleton', () => {
+    it('returns the same toasts ref from two independent useToast() calls', () => {
+      const a = withSetup(() => useToast())
+      const b = withSetup(() => useToast())
+      a.showToast('hello', 'info', 0)
+      expect(b.toasts.value).toHaveLength(1)
+      expect(b.toasts.value[0].message).toBe('hello')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 2. provide / inject
+  // -------------------------------------------------------------------------
+  describe('provide/inject', () => {
+    it('useToast() inside a child component receives the provided instance', () => {
+      let childApi: ReturnType<typeof useToast> | undefined
+
+      const Child = defineComponent({
+        setup() {
+          childApi = useToast()
+          return {}
+        },
+        template: '<span />',
+      })
+
+      const Parent = defineComponent({
+        setup() {
+          provideToast()
+          return {}
+        },
+        components: { Child },
+        template: '<Child />',
+      })
+
+      mount(Parent, { global: { stubs: { Teleport: true } } })
+
+      const parentApi = withSetup(() => useToast())
+      parentApi.showToast('via inject', 'success', 0)
+
+      expect(childApi).toBeDefined()
+      expect(childApi!.toasts.value.some((t) => t.message === 'via inject')).toBe(true)
+    })
+
+    it('TOAST_INJECT_KEY is a Symbol', () => {
+      expect(typeof TOAST_INJECT_KEY).toBe('symbol')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 3. Toast variants
+  // -------------------------------------------------------------------------
+  describe('toast variants', () => {
+    const types: ToastType[] = ['success', 'error', 'warning', 'info']
+
+    types.forEach((type) => {
+      it(`showToast stores type="${type}"`, () => {
+        const { showToast, toasts } = withSetup(() => useToast())
+        showToast(`${type} message`, type, 0)
+        const last = toasts.value[toasts.value.length - 1]
+        expect(last.type).toBe(type)
+        expect(last.message).toBe(`${type} message`)
+      })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 4. Default durations
+  // -------------------------------------------------------------------------
+  describe('default durations', () => {
+    it('success default duration is 4000 ms', () => {
+      expect(TOAST_DURATIONS.success).toBe(4000)
+    })
+
+    it('info default duration is 4000 ms', () => {
+      expect(TOAST_DURATIONS.info).toBe(4000)
+    })
+
+    it('warning default duration is 4000 ms', () => {
+      expect(TOAST_DURATIONS.warning).toBe(4000)
+    })
+
+    it('error default duration is 0 (persistent)', () => {
+      expect(TOAST_DURATIONS.error).toBe(0)
+    })
+
+    it('success toast auto-dismisses after 4 seconds', async () => {
+      const { showToast, toasts } = withSetup(() => useToast())
+      showToast('auto-dismiss me', 'success')
+      expect(toasts.value.some((t) => t.message === 'auto-dismiss me')).toBe(true)
+      vi.advanceTimersByTime(4000)
+      await nextTick()
+      expect(toasts.value.some((t) => t.message === 'auto-dismiss me')).toBe(false)
+    })
+
+    it('error toast does NOT auto-dismiss', async () => {
+      const { showToast, toasts } = withSetup(() => useToast())
+      showToast('persistent error', 'error')
+      vi.advanceTimersByTime(30000)
+      await nextTick()
+      expect(toasts.value.some((t) => t.message === 'persistent error')).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 5. Maximum 5 toasts stacked
+  // -------------------------------------------------------------------------
+  describe('maximum stack size', () => {
+    it('MAX_TOASTS constant is 5', () => {
+      expect(MAX_TOASTS).toBe(5)
+    })
+
+    it('does not exceed 5 toasts; oldest is evicted when a 6th is added', () => {
+      const { showToast, toasts } = withSetup(() => useToast())
+      for (let i = 1; i <= 5; i++) {
+        showToast(`toast ${i}`, 'info', 0)
+      }
+      expect(toasts.value).toHaveLength(5)
+      expect(toasts.value[0].message).toBe('toast 1')
+
+      // Add a 6th — toast 1 should be evicted
+      showToast('toast 6', 'info', 0)
+      expect(toasts.value).toHaveLength(5)
+      expect(toasts.value.some((t) => t.message === 'toast 1')).toBe(false)
+      expect(toasts.value[toasts.value.length - 1].message).toBe('toast 6')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 6. Manual dismiss
+  // -------------------------------------------------------------------------
+  describe('manual dismiss', () => {
+    it('removeToast removes a toast by id', () => {
+      const { showToast, removeToast, toasts } = withSetup(() => useToast())
+      const id = showToast('remove me', 'warning', 0)
+      expect(toasts.value.some((t) => t.id === id)).toBe(true)
+      removeToast(id)
+      expect(toasts.value.some((t) => t.id === id)).toBe(false)
+    })
+
+    it('removeToast with unknown id is a no-op', () => {
+      const { showToast, removeToast, toasts } = withSetup(() => useToast())
+      showToast('keep me', 'info', 0)
+      const before = toasts.value.length
+      removeToast(999999)
+      expect(toasts.value.length).toBe(before)
+    })
+
+    it('clearAllToasts removes every toast', () => {
+      const { showToast, clearAllToasts, toasts } = withSetup(() => useToast())
+      showToast('a', 'info', 0)
+      showToast('b', 'success', 0)
+      clearAllToasts()
+      expect(toasts.value).toHaveLength(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 7. Custom duration override
+  // -------------------------------------------------------------------------
+  describe('custom duration', () => {
+    it('accepts a custom duration that overrides the default', async () => {
+      const { showToast, toasts } = withSetup(() => useToast())
+      showToast('custom', 'error', 2000)  // override persistent default
+      vi.advanceTimersByTime(2000)
+      await nextTick()
+      expect(toasts.value.some((t) => t.message === 'custom')).toBe(false)
+    })
+
+    it('duration 0 keeps toast alive indefinitely', async () => {
+      const { showToast, toasts } = withSetup(() => useToast())
+      showToast('forever', 'success', 0)
+      vi.advanceTimersByTime(60000)
+      await nextTick()
+      expect(toasts.value.some((t) => t.message === 'forever')).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // 8. showToast return value
+  // -------------------------------------------------------------------------
+  describe('showToast return value', () => {
+    it('returns an incrementing numeric id', () => {
+      const { showToast } = withSetup(() => useToast())
+      const id1 = showToast('first', 'info', 0)
+      const id2 = showToast('second', 'info', 0)
+      expect(typeof id1).toBe('number')
+      expect(id2).toBeGreaterThan(id1)
+    })
+  })
+})

--- a/autobot-frontend/src/composables/useToast.ts
+++ b/autobot-frontend/src/composables/useToast.ts
@@ -2,22 +2,34 @@
  * Toast Notification Composable
  *
  * Provides a global toast notification system for user feedback.
+ * Supports both module-level singleton usage and Vue provide/inject.
  *
- * Usage:
+ * Usage (direct import):
  * ```typescript
  * import { useToast } from '@/composables/useToast'
  *
  * const { showToast } = useToast()
- *
- * // Show different types of toasts
  * showToast('Operation successful', 'success')
- * showToast('Something went wrong', 'error', 5000)
+ * showToast('Something went wrong', 'error')   // persistent — no auto-dismiss
  * showToast('Please wait...', 'info')
  * showToast('Proceed with caution', 'warning')
  * ```
+ *
+ * Usage (provide/inject — register in App.vue):
+ * ```typescript
+ * import { provideToast } from '@/composables/useToast'
+ * provideToast()   // call once in the root component setup
+ *
+ * // In any child component:
+ * import { useToast } from '@/composables/useToast'
+ * const { showToast } = useToast()
+ * ```
+ *
+ * @author mrveiss
+ * @copyright 2025 mrveiss
  */
 
-import { ref, type Ref } from 'vue'
+import { ref, inject, provide, type Ref, type InjectionKey } from 'vue'
 
 export type ToastType = 'info' | 'success' | 'warning' | 'error'
 
@@ -35,72 +47,100 @@ export interface UseToastReturn {
   clearAllToasts: () => void
 }
 
-// Global toast state (shared across all component instances)
-const toasts = ref<Toast[]>([])
-let nextId = 1
+/** Maximum number of toasts displayed simultaneously (oldest evicted first). */
+export const MAX_TOASTS = 5
 
 /**
- * Toast notification composable
- *
- * @returns Toast notification utilities
+ * Default auto-dismiss durations per toast type (ms).
+ * 0 = persistent (no auto-dismiss).
  */
-export function useToast(): UseToastReturn {
-  /**
-   * Show a toast notification
-   *
-   * @param message - Message to display
-   * @param type - Toast type: 'info', 'success', 'warning', 'error'
-   * @param duration - Duration in milliseconds (0 = no auto-remove)
-   * @returns Toast ID for manual removal
-   */
-  const showToast = (
-    message: string,
-    type: ToastType = 'info',
-    duration = 3000
-  ): number => {
-    const id = nextId++
-    const toast: Toast = {
-      id,
-      message,
-      type,
-      duration
-    }
+export const TOAST_DURATIONS: Record<ToastType, number> = {
+  success: 4000,
+  info: 4000,
+  warning: 4000,
+  error: 0,  // errors are persistent until manually dismissed
+}
 
-    toasts.value.push(toast)
+/** Injection key for provide/inject usage. */
+export const TOAST_INJECT_KEY: InjectionKey<UseToastReturn> = Symbol('useToast')
 
-    // Auto-remove after duration
-    if (duration > 0) {
-      setTimeout(() => {
-        removeToast(id)
-      }, duration)
-    }
+// ============================================================
+// Module-level singleton state (shared across all instances
+// that do NOT use the provide/inject path).
+// ============================================================
+const _toasts = ref<Toast[]>([])
+let _nextId = 1
 
-    return id
-  }
-
-  /**
-   * Remove a toast by ID
-   *
-   * @param id - Toast ID to remove
-   */
+function _buildApi(toasts: Ref<Toast[]>, idCounter: { value: number }): UseToastReturn {
   const removeToast = (id: number): void => {
-    const index = toasts.value.findIndex((toast) => toast.id === id)
+    const index = toasts.value.findIndex((t) => t.id === id)
     if (index > -1) {
       toasts.value.splice(index, 1)
     }
   }
 
-  /**
-   * Clear all toasts
-   */
+  const showToast = (
+    message: string,
+    type: ToastType = 'info',
+    duration?: number,
+  ): number => {
+    const resolvedDuration = duration !== undefined ? duration : TOAST_DURATIONS[type]
+    const id = idCounter.value++
+    const toast: Toast = { id, message, type, duration: resolvedDuration }
+
+    // Enforce maximum stack size — evict the oldest toast when full.
+    if (toasts.value.length >= MAX_TOASTS) {
+      toasts.value.splice(0, toasts.value.length - MAX_TOASTS + 1)
+    }
+
+    toasts.value.push(toast)
+
+    if (resolvedDuration > 0) {
+      setTimeout(() => {
+        removeToast(id)
+      }, resolvedDuration)
+    }
+
+    return id
+  }
+
   const clearAllToasts = (): void => {
     toasts.value.splice(0)
   }
 
-  return {
-    toasts,
-    showToast,
-    removeToast,
-    clearAllToasts
-  }
+  return { toasts, showToast, removeToast, clearAllToasts }
+}
+
+// Singleton counter object (mutable reference so _buildApi closure can mutate it).
+const _idCounter = { value: _nextId }
+const _singletonApi = _buildApi(_toasts, _idCounter)
+
+// Keep module-level nextId in sync (for backward compat if any code read it).
+Object.defineProperty(_idCounter, 'value', {
+  get: () => _nextId,
+  set: (v: number) => { _nextId = v },
+})
+
+/**
+ * Register the toast API with the current Vue component tree via provide().
+ * Call once in the root App component's setup().
+ * Child components calling useToast() will receive the same instance.
+ */
+export function provideToast(): UseToastReturn {
+  provide(TOAST_INJECT_KEY, _singletonApi)
+  return _singletonApi
+}
+
+/**
+ * Toast notification composable.
+ *
+ * When called inside a component that has a provideToast() ancestor, the
+ * injected instance is returned (same state). Otherwise falls back to the
+ * module-level singleton, which is the same underlying state.
+ *
+ * @returns Toast notification utilities
+ */
+export function useToast(): UseToastReturn {
+  const injected = inject(TOAST_INJECT_KEY, null)
+  return injected ?? _singletonApi
 }


### PR DESCRIPTION
## Summary

Closes #3283

- Enforces `MAX_TOASTS = 5` cap in `useToast`; the oldest toast is evicted when a sixth arrives
- Corrects default auto-dismiss durations: 4 s for `success`, `info`, `warning`; `0` (persistent, no auto-dismiss) for `error`
- Adds `TOAST_INJECT_KEY` (Vue `InjectionKey`) and `provideToast()` so the composable can be registered via `provide/inject` from the root `App.vue` — child components calling `useToast()` receive the same instance; falls back to the module-level singleton when no provider is present
- Adds `useToast.test.ts` with 21 unit tests covering every acceptance criterion

## Test plan

- [x] `npm run test:unit -- src/composables/__tests__/useToast.test.ts` — 21/21 passing
- [x] ESLint `--max-warnings=0` on changed files — clean
- [ ] Manual smoke-test: trigger an API error in the chat UI and confirm a persistent error toast appears and does not auto-dismiss
- [ ] Trigger a successful operation (e.g. save settings) and confirm the toast dismisses after ~4 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)