### PR TITLE
feat(fullstack): multi-user collaboration — presence WS, message attribution, broadcast

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -453,16 +453,19 @@ async def _store_and_log_user_message(
     message: "ChatMessage",
     session_id: str,
     chat_history_manager,
+    author_id: Optional[str] = None,
 ) -> str:
     """
     Store user message and log the event.
 
     Issue #281: Extracted helper for user message handling.
+    Issue #3282: author_id added for multi-user message attribution.
 
     Args:
         message: Chat message object
         session_id: Session ID
         chat_history_manager: Chat history manager instance
+        author_id: Optional user ID of the message author for shared sessions
 
     Returns:
         Generated message ID
@@ -476,9 +479,29 @@ async def _store_and_log_user_message(
         "metadata": message.metadata,
         "session_id": session_id,
     }
+    if author_id:
+        user_message_data["authorId"] = author_id
 
     if hasattr(chat_history_manager, "add_message"):
         await chat_history_manager.add_message(session_id, user_message_data)
+
+    # Issue #3282: Broadcast new user message to all session collaborators
+    try:
+        from websocket.presence import presence_manager
+
+        await presence_manager.broadcast_to_session(
+            session_id,
+            {
+                "type": "new_message",
+                "session_id": session_id,
+                "message_id": user_message_id,
+                "author_id": author_id,
+                "role": message.role,
+                "timestamp": datetime.utcnow().isoformat(),
+            },
+        )
+    except Exception:
+        pass  # Broadcast failure must never break message storage
 
     log_chat_event(
         "message_received",
@@ -655,15 +678,17 @@ async def process_chat_message(
     knowledge_base,
     config: Metadata,
     request_id: str,
+    author_id: Optional[str] = None,
 ) -> Metadata:
-    """Process a chat message and generate response (Issue #398: refactored)."""
+    """Process a chat message and generate response (Issue #398: refactored,
+    Issue #3282: author_id for multi-user attribution)."""
     _validate_session_id(message.session_id)
 
     # Get or create session
     session_id = message.session_id or generate_chat_session_id()
 
-    # Store user message (Issue #281: uses helper)
-    await _store_and_log_user_message(message, session_id, chat_history_manager)
+    # Store user message (Issue #281: uses helper, Issue #3282: author_id)
+    await _store_and_log_user_message(message, session_id, chat_history_manager, author_id)
 
     # Get chat context (Issue #281: uses helper)
     model_name = message.metadata.get("model") if message.metadata else None
@@ -838,6 +863,9 @@ async def send_message(
     llm_service = get_llm_service(request)
     memory_interface = get_memory_interface(request)
 
+    # Issue #3282: Carry author identity for shared-session message attribution
+    author_id = current_user.get("user_id") if current_user else None
+
     # Process the chat message with a configurable timeout (Issue #1907).
     # Override via AUTOBOT_CHAT_TIMEOUT env var (seconds, float). Default: 30.0.
     chat_timeout = float(os.getenv("AUTOBOT_CHAT_TIMEOUT", "30.0"))
@@ -851,6 +879,7 @@ async def send_message(
                 knowledge_base,
                 config,
                 request_id,
+                author_id=author_id,
             ),
             timeout=chat_timeout,
         )

--- a/autobot-backend/api/presence_ws.py
+++ b/autobot-backend/api/presence_ws.py
@@ -1,0 +1,41 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Presence WebSocket Router
+
+Exposes the real-time presence WebSocket endpoint for collaborative sessions.
+Issue #3282: collaborative multi-user support — shared sessions and workspaces.
+"""
+
+import logging
+
+from fastapi import APIRouter, Query, WebSocket
+
+from websocket.presence import presence_websocket_handler
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["collaboration", "websocket"])
+
+
+@router.websocket("/ws/sessions/{session_id}/presence")
+async def session_presence(
+    websocket: WebSocket,
+    session_id: str,
+    user_id: str = Query(..., description="Authenticated user ID"),
+) -> None:
+    """
+    WebSocket endpoint for real-time session presence.
+
+    Clients connect here to receive join/leave events and broadcast
+    messages to other participants in the same session.
+
+    Args:
+        websocket: WebSocket connection
+        session_id: Session to join
+        user_id: Caller's user ID (passed as query param until WS auth middleware
+                 is extended to cover WebSocket handshakes for this path)
+    """
+    logger.info("Presence WS connect: user=%s session=%s", user_id, session_id)
+    await presence_websocket_handler(websocket, session_id, user_id)

--- a/autobot-backend/chat_history/messages.py
+++ b/autobot-backend/chat_history/messages.py
@@ -43,6 +43,7 @@ class MessagesMixin:
         message_type: str,
         raw_data: Any,
         tool_markers: Optional[List[Dict[str, Any]]],
+        author_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Build a message dictionary with standard fields.
@@ -53,6 +54,7 @@ class MessagesMixin:
             message_type: The type of message.
             raw_data: Additional raw data (metadata).
             tool_markers: Optional list of tool usage markers.
+            author_id: Optional user ID for multi-user attribution (Issue #3282).
 
         Returns:
             Constructed message dictionary.
@@ -69,6 +71,8 @@ class MessagesMixin:
         }
         if tool_markers:
             message["toolMarkers"] = tool_markers
+        if author_id:
+            message["authorId"] = author_id
         return message
 
     async def _add_message_to_session(
@@ -142,6 +146,7 @@ class MessagesMixin:
         raw_data: Any = None,
         session_id: Optional[str] = None,
         tool_markers: Optional[List[Dict[str, Any]]] = None,
+        author_id: Optional[str] = None,
     ):
         """
         Adds a new message to the history and saves it to file.
@@ -155,11 +160,13 @@ class MessagesMixin:
             raw_data (Any): Additional raw data associated with the message.
             session_id (str): Optional session ID to add message to specific session.
             tool_markers (List[Dict[str, Any]]): Optional list of tool usage markers.
+            author_id (str): Optional user ID for multi-user message attribution
+                (Issue #3282).
 
         Issue #620: Refactored to use extracted helper methods.
         """
         message = self._build_message_dict(
-            sender, text, message_type, raw_data, tool_markers
+            sender, text, message_type, raw_data, tool_markers, author_id
         )
 
         # If session_id provided, add to that session

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -20,6 +20,7 @@ from api.auth import router as auth_router
 from api.browser_mcp import router as browser_mcp_router
 from api.chat import router as chat_router
 from api.collaboration import router as collaboration_router
+from api.presence_ws import router as presence_ws_router
 from api.config_revisions import router as config_revisions_router  # #1404
 from api.data_storage import router as data_storage_router
 from api.database_mcp import router as database_mcp_router
@@ -82,6 +83,7 @@ def _get_system_routers() -> list:
         (service_messages_router, "", ["service-messages"], "service_messages"),
         (chat_router, "", ["chat"], "chat"),
         (collaboration_router, "", ["collaboration"], "collaboration"),
+        (presence_ws_router, "", ["collaboration", "websocket"], "presence_ws"),
         (system_router, "/system", ["system"], "system"),
         (settings_router, "/settings", ["settings"], "settings"),
         (data_storage_router, "", ["data-storage"], "data_storage"),

--- a/autobot-backend/websocket/__init__.py
+++ b/autobot-backend/websocket/__init__.py
@@ -1,0 +1,13 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+WebSocket package for AutoBot real-time features.
+
+Provides presence tracking and collaborative session management.
+Issue #3282: collaborative multi-user support.
+"""
+
+from websocket.presence import PresenceManager, presence_manager, presence_websocket_handler
+
+__all__ = ["PresenceManager", "presence_manager", "presence_websocket_handler"]

--- a/autobot-backend/websocket/presence_test.py
+++ b/autobot-backend/websocket/presence_test.py
@@ -1,0 +1,213 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for PresenceManager and presence WebSocket handler.
+
+Issue #3282: collaborative multi-user support — shared sessions and workspaces.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from websocket.presence import PresenceManager, presence_websocket_handler
+
+
+# ====================================================================
+# PresenceManager Unit Tests
+# ====================================================================
+
+
+@pytest.fixture
+def manager() -> PresenceManager:
+    """Fresh PresenceManager for each test."""
+    return PresenceManager()
+
+
+def _make_ws() -> MagicMock:
+    """Create a mock WebSocket with async send_text."""
+    ws = MagicMock()
+    ws.send_text = AsyncMock()
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_connect_registers_user(manager: PresenceManager) -> None:
+    """Connecting a user adds them to the session."""
+    ws = _make_ws()
+    await manager.connect("sess-1", "user-A", ws)
+
+    online = await manager.get_online_users("sess-1")
+    assert "user-A" in online
+
+
+@pytest.mark.asyncio
+async def test_connect_broadcasts_join_to_others(manager: PresenceManager) -> None:
+    """A second user connecting gets broadcast to the first user."""
+    ws_a = _make_ws()
+    ws_b = _make_ws()
+
+    await manager.connect("sess-1", "user-A", ws_a)
+    await manager.connect("sess-1", "user-B", ws_b)
+
+    # user-A should have received the user_joined broadcast for user-B
+    calls = [call.args[0] for call in ws_a.send_text.call_args_list]
+    events = [json.loads(c) for c in calls]
+    join_events = [e for e in events if e.get("type") == "user_joined"]
+    assert any(e["user_id"] == "user-B" for e in join_events)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_removes_user(manager: PresenceManager) -> None:
+    """Disconnecting removes user from online list."""
+    ws = _make_ws()
+    await manager.connect("sess-1", "user-A", ws)
+    await manager.disconnect(ws)
+
+    online = await manager.get_online_users("sess-1")
+    assert "user-A" not in online
+
+
+@pytest.mark.asyncio
+async def test_disconnect_broadcasts_leave(manager: PresenceManager) -> None:
+    """When a user disconnects, remaining users receive user_left event."""
+    ws_a = _make_ws()
+    ws_b = _make_ws()
+
+    await manager.connect("sess-1", "user-A", ws_a)
+    await manager.connect("sess-1", "user-B", ws_b)
+    ws_a.send_text.reset_mock()
+    ws_b.send_text.reset_mock()
+
+    await manager.disconnect(ws_a)
+
+    calls = [call.args[0] for call in ws_b.send_text.call_args_list]
+    events = [json.loads(c) for c in calls]
+    leave_events = [e for e in events if e.get("type") == "user_left"]
+    assert any(e["user_id"] == "user-A" for e in leave_events)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_unknown_websocket_is_noop(manager: PresenceManager) -> None:
+    """Disconnecting an untracked WebSocket does not raise."""
+    ws = _make_ws()
+    await manager.disconnect(ws)  # Must not raise
+
+
+@pytest.mark.asyncio
+async def test_get_online_users_empty_session(manager: PresenceManager) -> None:
+    """Getting online users for a session with no connections returns empty list."""
+    result = await manager.get_online_users("nonexistent")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_send_to_user_success(manager: PresenceManager) -> None:
+    """send_to_user delivers message to all connections for that user."""
+    ws1 = _make_ws()
+    ws2 = _make_ws()
+    await manager.connect("sess-1", "user-A", ws1)
+    # user-B joins so ws1's join-broadcast doesn't skew counts
+    ws_other = _make_ws()
+    await manager.connect("sess-1", "user-B", ws_other)
+
+    # Reset call counts before the targeted send
+    ws1.send_text.reset_mock()
+    ws2.send_text.reset_mock()
+
+    # Register second connection for user-A *without* going through connect()
+    # to avoid broadcast side-effects; directly inject into manager state.
+    manager._sessions["sess-1"]["user-A"].add(ws2)
+    manager._connection_map[ws2] = ("sess-1", "user-A")
+
+    count = await manager.send_to_user("sess-1", "user-A", {"type": "ping"})
+
+    assert count == 2
+    ws1.send_text.assert_awaited_once()
+    ws2.send_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_to_user_absent_returns_zero(manager: PresenceManager) -> None:
+    """send_to_user for a user not in session returns 0."""
+    count = await manager.send_to_user("sess-1", "ghost", {"type": "ping"})
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_broadcast_to_session_reaches_all(manager: PresenceManager) -> None:
+    """broadcast_to_session delivers to every connected user."""
+    ws_a = _make_ws()
+    ws_b = _make_ws()
+    await manager.connect("sess-1", "user-A", ws_a)
+    await manager.connect("sess-1", "user-B", ws_b)
+    ws_a.send_text.reset_mock()
+    ws_b.send_text.reset_mock()
+
+    await manager.broadcast_to_session("sess-1", {"type": "test"})
+
+    ws_a.send_text.assert_awaited_once()
+    ws_b.send_text.assert_awaited_once()
+
+
+# ====================================================================
+# presence_websocket_handler Tests
+# ====================================================================
+
+
+@pytest.mark.asyncio
+async def test_handler_sends_presence_sync_on_connect() -> None:
+    """Handler sends presence_sync immediately after connection."""
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.send_text = AsyncMock()
+
+    from fastapi import WebSocketDisconnect
+
+    # After presence_sync, disconnect immediately
+    ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+
+    with patch("websocket.presence.presence_manager") as mock_pm:
+        mock_pm.connect = AsyncMock()
+        mock_pm.disconnect = AsyncMock()
+        mock_pm.get_online_users = AsyncMock(return_value=["user-X"])
+
+        await presence_websocket_handler(ws, "sess-1", "user-X")
+
+    ws.send_json.assert_awaited()
+    sent = ws.send_json.call_args_list[0].args[0]
+    assert sent["type"] == "presence_sync"
+    assert "user-X" in sent["online_users"]
+
+
+@pytest.mark.asyncio
+async def test_handler_responds_to_ping() -> None:
+    """Handler sends pong in response to ping message."""
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.send_text = AsyncMock()
+
+    from fastapi import WebSocketDisconnect
+
+    ping_json = json.dumps({"type": "ping"})
+    ws.receive_text = AsyncMock(
+        side_effect=[ping_json, WebSocketDisconnect()]
+    )
+
+    with patch("websocket.presence.presence_manager") as mock_pm:
+        mock_pm.connect = AsyncMock()
+        mock_pm.disconnect = AsyncMock()
+        mock_pm.get_online_users = AsyncMock(return_value=[])
+
+        await presence_websocket_handler(ws, "sess-1", "user-A")
+
+    pong_calls = [
+        call.args[0]
+        for call in ws.send_json.call_args_list
+        if call.args[0].get("type") == "pong"
+    ]
+    assert len(pong_calls) == 1


### PR DESCRIPTION
## Summary

Closes #3282

Implements the backend foundation for collaborative multi-user sessions:

- **Presence WebSocket** (`/ws/sessions/{session_id}/presence`): real-time join/leave events and broadcast channel for all session participants, backed by `PresenceManager` in `websocket/presence.py`. The `websocket/` directory is now a proper Python package (`__init__.py` added).
- **Message attribution**: `authorId` field added to chat history message dictionaries. Sourced from `current_user.user_id` in the `POST /chat` endpoint and threaded through `process_chat_message` → `_store_and_log_user_message` → `_build_message_dict`. Fully backward-compatible (field omitted when absent).
- **Collaborative broadcast**: after each user message is persisted, `presence_manager.broadcast_to_session` fires a `new_message` event to all other connected participants (failure is swallowed so broadcast never breaks storage).
- **Router registration**: `presence_ws_router` added to `_get_system_routers()` in `core_routers.py`.
- **11 unit tests** in `websocket/presence_test.py` — all passing.

## What is not in scope for this PR

Per issue #3282, the following items are tracked as follow-on work:
- Team/workspace concept and KB scoping (#3242 covers shared KBs)
- Workflow collaboration view
- Frontend presence indicators (avatars, "X is typing")
- Notification system for shared resource changes

## Test plan

- [x] `pytest websocket/presence_test.py` — 11/11 passed
- [x] `flake8 --max-line-length=100` — clean on all changed/new files
- [ ] Manual: connect two browser sessions to the same `session_id` presence WebSocket, verify `user_joined`/`user_left` events
- [ ] Manual: send a message in a shared session and verify `new_message` broadcast reaches the other participant's WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)