### PR TITLE
feat(frontend): complete Knowledge Manager UI

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeManager.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeManager.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -37,26 +37,33 @@ const KnowledgeEntries = () => import('./KnowledgeEntries.vue')
 const KnowledgeUpload = () => import('./KnowledgeUpload.vue')
 const KnowledgeStats = () => import('./KnowledgeStats.vue')
 const KnowledgeAdvanced = () => import('./KnowledgeAdvanced.vue')
+// Issue #3270: wire up existing but previously unreachable components
+const KnowledgeSystemDocs = () => import('./KnowledgeSystemDocs.vue')
+const KnowledgePromptEditor = () => import('./KnowledgePromptEditor.vue')
 
 const store = useKnowledgeStore()
 
-// Tab configuration - Added Advanced tab
+// Tab configuration
 const tabs = computed(() => [
   { id: 'search', label: t('knowledge.manager.tabSearch') },
   { id: 'categories', label: t('knowledge.manager.tabCategories') },
   { id: 'upload', label: t('knowledge.manager.tabUpload') },
   { id: 'manage', label: t('knowledge.manager.tabManage') },
   { id: 'stats', label: t('knowledge.manager.tabStatistics') },
+  { id: 'system-docs', label: t('knowledge.manager.tabSystemDocs') },
+  { id: 'prompt-editor', label: t('knowledge.manager.tabPromptEditor') },
   { id: 'advanced', label: t('knowledge.manager.tabAdvanced') }
 ])
 
-// Component mapping - Added KnowledgeAdvanced
+// Component mapping
 const componentMap = {
   search: KnowledgeSearch,
   categories: KnowledgeCategories,
   upload: KnowledgeUpload,
   manage: KnowledgeEntries,
   stats: KnowledgeStats,
+  'system-docs': KnowledgeSystemDocs,
+  'prompt-editor': KnowledgePromptEditor,
   advanced: KnowledgeAdvanced
 } as const
 

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -4111,6 +4111,8 @@
   "knowledge.manager.tabUpload": "Upload",
   "knowledge.manager.tabManage": "Manage",
   "knowledge.manager.tabStatistics": "Statistics",
+  "knowledge.manager.tabSystemDocs": "System Docs",
+  "knowledge.manager.tabPromptEditor": "Prompts",
   "knowledge.manager.tabAdvanced": "Advanced",
   "knowledge.memoryOrphan.title": "Memory Entity Cleanup",
   "knowledge.memoryOrphan.description": "Detect and clean up orphaned memory entities from expired or deleted conversations.",

--- a/autobot-frontend/src/stores/useKnowledgeStore.ts
+++ b/autobot-frontend/src/stores/useKnowledgeStore.ts
@@ -115,7 +115,7 @@ export const useKnowledgeStore = defineStore('knowledge', () => {
   const searchResults = ref<SearchResult[]>([])
   const ragSearchResult = ref<RagSearchResult | null>(null)
   const selectedDocument = ref<KnowledgeDocument | null>(null)
-  const activeTab = ref<'search' | 'manage' | 'upload' | 'categories' | 'entries' | 'stats' | 'advanced'>('search')
+  const activeTab = ref<'search' | 'manage' | 'upload' | 'categories' | 'entries' | 'stats' | 'system-docs' | 'prompt-editor' | 'advanced'>('search')
   const isLoading = ref(false)
   const filters = ref<SearchFilters>({
     categories: [],
@@ -257,7 +257,7 @@ export const useKnowledgeStore = defineStore('knowledge', () => {
   })
 
   // Actions
-  function setActiveTab(tab: 'search' | 'manage' | 'upload' | 'categories' | 'entries' | 'stats' | 'advanced') {
+  function setActiveTab(tab: 'search' | 'manage' | 'upload' | 'categories' | 'entries' | 'stats' | 'system-docs' | 'prompt-editor' | 'advanced') {
     activeTab.value = tab
   }
 


### PR DESCRIPTION
## Summary

Closes #3270

- Wires `KnowledgeSystemDocs.vue` into the Knowledge Manager as a **System Docs** tab (system documentation tree viewer with search, export to JSON/Markdown, and copy-to-clipboard)
- Wires `KnowledgePromptEditor.vue` into the Knowledge Manager as a **Prompts** tab (categorized prompt list with inline editor, version history, unsaved-changes tracking, and revert support)
- Extends `activeTab` union type in `useKnowledgeStore` to include `'system-docs'` and `'prompt-editor'`
- Adds i18n keys `knowledge.manager.tabSystemDocs` and `knowledge.manager.tabPromptEditor` to `en.json`
- Removes the unused `defineAsyncComponent` import from `KnowledgeManager.vue`

Both components were fully implemented (category editing via `CategoryEditModal`, KB search results via `KBSearchResultPanel` were already wired) — they simply had no tab entry point in the manager shell.

## Test plan

- [ ] Open Knowledge Manager; verify **System Docs** and **Prompts** tabs appear between Statistics and Advanced
- [ ] Click **System Docs** — confirm the document category tree, search box, and document preview pane render without errors
- [ ] Click **Prompts** — confirm the categorized prompt list and editor area render; select a prompt and verify unsaved-changes badge appears on edit
- [ ] TypeScript: `npx tsc --noEmit` passes with no new errors
- [ ] Verify existing tabs (Search, Categories, Upload, Manage, Statistics, Advanced) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)