### PR TITLE
fix(ci): resolve flake8 violations (#4158)

### DIFF
--- a/autobot-backend/agent_loop/test_loop_repetition.py
+++ b/autobot-backend/agent_loop/test_loop_repetition.py
@@ -14,11 +14,8 @@ Covers issues #3868, #3874, and #3877:
 import asyncio
 import hashlib
 import json
-from dataclasses import dataclass, field
-from typing import Any, Optional
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 from agent_loop.loop import AgentLoop
 from agent_loop.types import AgentLoopConfig, LoopState, TaskContext

--- a/autobot-backend/agents/agent_orchestration/coordinator.py
+++ b/autobot-backend/agents/agent_orchestration/coordinator.py
@@ -28,8 +28,6 @@ from .distributed_management import DistributedAgentManager
 from .routing import AgentRouter
 from .types import (
     DEFAULT_AGENT_CAPABILITIES,
-    AgentCapability,
-    AgentType,
     DistributedAgentInfo,
 )
 

--- a/autobot-backend/agents/npu_code_search_agent.py
+++ b/autobot-backend/agents/npu_code_search_agent.py
@@ -22,7 +22,7 @@ import aiofiles
 
 from autobot_shared.redis_client import get_redis_client, get_async_redis_client
 from autobot_shared.security.path_validator import validate_path
-from constants.ttl_constants import TTL_24_HOURS
+from constants.ttl_constants import TTL_1_HOUR, TTL_24_HOURS
 from code_embedding_generator import get_code_embedding_generator
 from npu_semantic_search import get_npu_search_engine
 from worker_node import WorkerNode

--- a/autobot-backend/api/agent_usage_test.py
+++ b/autobot-backend/api/agent_usage_test.py
@@ -11,7 +11,6 @@ Covers:
 - GET /api/agent_config/agents/usage endpoint aggregation logic
 """
 
-import asyncio
 import json
 import uuid
 from datetime import datetime, timezone

--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -156,7 +156,7 @@ async def _check_redis_db(db) -> Tuple[str, str]:
             await redis_conn.ping()
             return db.name, "connected"
         return db.name, "failed"
-    except Exception as e:
+    except Exception:
         return db.name, "connection error"
 
 

--- a/autobot-backend/api/analytics_code.py
+++ b/autobot-backend/api/analytics_code.py
@@ -11,8 +11,6 @@ import asyncio
 import logging
 import threading
 from datetime import datetime, timezone
-from pathlib import Path
-
 from fastapi import APIRouter, Depends, HTTPException
 
 from api.analytics_models import CodeAnalysisRequest
@@ -62,7 +60,7 @@ async def index_codebase(
     """
     # Validate request
     try:
-        safe_target_path = validate_path(request.target_path, must_exist=True)
+        validate_path(request.target_path, must_exist=True)
     except (ValueError, PermissionError):
         raise HTTPException(
             status_code=400,

--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -35,6 +35,7 @@ from constants.model_constants import (
     EXPENSIVE_MODEL_MARKER_GPT4,
     EXPENSIVE_MODEL_MARKER_OPUS,
     MODEL_COSTS_PER_1M_TOKENS,
+    OPENAI_GPT4O,
 )
 from constants.ttl_constants import TTL_30_DAYS
 


### PR DESCRIPTION
## Summary

- Add missing `TTL_1_HOUR` import to `agents/npu_code_search_agent.py` (F821 undefined name)
- Add missing `OPENAI_GPT4O` import to `api/analytics_llm_patterns.py` (F821 undefined name)
- Remove unused imports `dataclass`, `field`, `Optional`, `patch`, `pytest` from `agent_loop/test_loop_repetition.py` (F401)
- Remove unused imports `AgentCapability`, `AgentType` from `agents/agent_orchestration/coordinator.py` (F401)
- Remove unused import `asyncio` from `api/agent_usage_test.py` (F401)
- Remove unused import `Path` from `api/analytics_code.py` (F401)
- Replace `except Exception as e:` with bare `except Exception:` in `api/analytics.py` (F841)
- Remove unused `safe_target_path` variable assignment in `api/analytics_code.py` (F841)

## Test plan

- [x] `python3 -m flake8 --config=.flake8` on all 7 changed files returns exit code 0 with zero violations
- [x] No functional logic changed — fixes are import additions/removals and variable cleanup only

Closes #4158

🤖 Generated with [Claude Code](https://claude.com/claude-code)