### PR TITLE
docs(testing): Pinia test setup pattern documentation (#4188)

### DIFF
--- a/docs/developer/FRONTEND_TESTING.md
+++ b/docs/developer/FRONTEND_TESTING.md
@@ -1,0 +1,133 @@
+# Frontend Testing Guide
+
+Guidelines for writing and running frontend tests in AutoBot.
+
+---
+
+## Testing Stack
+
+- **Vitest** — test runner and assertion library
+- **@vue/test-utils** — Vue component mounting utilities
+- **Pinia** — state management (requires explicit setup in tests)
+- **vue-i18n** — internationalisation (provide via `global.plugins` when needed)
+
+---
+
+## Testing Vue Components with Pinia Stores
+
+Any Vue component test that uses Pinia stores (accessed via `useChatStore()`, `useAppStore()`, etc.)
+**requires explicit Pinia initialisation** in the test's `beforeEach` hook.
+
+### Error without Pinia setup
+
+```
+"getActivePinia()" was called but there was no active Pinia.
+Are you trying to use a store before calling "app.use(pinia)"?
+```
+
+This error occurs because Pinia stores call `getActivePinia()` at the point of first use. Without
+calling `setActivePinia(createPinia())` before mounting the component, there is no active instance
+and the store throws.
+
+### Solution
+
+Call `setActivePinia(createPinia())` in `beforeEach` so each test gets a fresh, isolated store:
+
+```typescript
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import MyComponent from '../MyComponent.vue'
+
+describe('MyComponent', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('should work with stores', () => {
+    const wrapper = mount(MyComponent)
+    // Store methods and state are now accessible
+    expect(wrapper.exists()).toBe(true)
+  })
+})
+```
+
+Calling `createPinia()` in `beforeEach` (not once in `beforeAll`) ensures store state is reset
+between tests, preventing one test's mutations from leaking into another.
+
+### Real example
+
+`autobot-frontend/src/components/__tests__/CommandPalette.test.ts` (lines 32-36):
+
+```typescript
+describe('CommandPalette.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+  })
+  // ...
+})
+```
+
+---
+
+## Providing vue-i18n in Component Tests
+
+Components that use `$t()` or `useI18n()` require an i18n instance passed as a global plugin.
+Create it once at the top of the test file and reuse it across all tests:
+
+```typescript
+import { createI18n } from 'vue-i18n'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      // Only the keys the component actually uses
+    }
+  }
+})
+
+describe('MyComponent', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders translated text', () => {
+    const wrapper = mount(MyComponent, {
+      global: { plugins: [i18n] }
+    })
+    expect(wrapper.text()).toContain('Expected text')
+  })
+})
+```
+
+---
+
+## Mocking async functions
+
+`patch(asyncFn, { return_value: X })` creates a `MagicMock`, not an `AsyncMock`.
+For async functions, always use `vi.fn().mockResolvedValue(X)` in Vitest:
+
+```typescript
+import { vi } from 'vitest'
+
+const mockFetch = vi.fn().mockResolvedValue({ data: 'example' })
+```
+
+Note: `vi.mock` factories with `mockReset: true` in `vitest.config.ts` will wipe mock implementations
+between tests. Re-apply `mockResolvedValue` / `mockReturnValue` inside `beforeEach` when this
+option is enabled.
+
+---
+
+## Running Tests
+
+```bash
+cd autobot-frontend
+npm run test          # run all tests once
+npm run test:watch    # re-run on file change
+npm run type-check    # TypeScript type checking (run before committing)
+npm run lint          # ESLint (run before committing)
+```

--- a/docs/developer/_index.md
+++ b/docs/developer/_index.md
@@ -98,6 +98,12 @@ aliases:
 | [DISTRIBUTED_TRACING](DISTRIBUTED_TRACING.md) | Distributed tracing |
 | [BACKEND_DEBUGGING](BACKEND_DEBUGGING.md) | Backend debugging |
 
+## Testing
+
+| Document | Description |
+| --- | --- |
+| [FRONTEND_TESTING](FRONTEND_TESTING.md) | Frontend testing guide (Pinia setup, vue-i18n, mocks) |
+
 ## Authentication & Security
 
 | Document | Description |


### PR DESCRIPTION
## Summary

Added comprehensive documentation for Vue component testing with Pinia stores. This resolves the discovery that developers lack clear guidance on the required `setActivePinia(createPinia())` setup in test `beforeEach` hooks.

## Changes

- Created: `docs/developer/FRONTEND_TESTING.md` with:
  - Exact error message and solution for missing Pinia setup
  - Why `beforeEach` (not `beforeAll`) for state isolation
  - Concrete examples referencing CommandPalette.test.ts
  - vue-i18n plugin setup pattern
  - Async mock guidance
  - Test run commands

- Updated: `docs/developer/_index.md` with Testing section link

## Motivation

Issue #4188 was created during parallel implementation work to document this pattern. Without it, developers adding new Vue components with stores get cryptic Pinia errors.

Closes #4188

🤖 Generated with [Claude Code](https://claude.com/claude-code)