### PR TITLE
fix(llm): remove unused imports in model_param_registry_test (#3257)

### DIFF
--- a/autobot-backend/llm_providers/model_param_registry_test.py
+++ b/autobot-backend/llm_providers/model_param_registry_test.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 import textwrap
 import types
 import sys
-from pathlib import Path
-from typing import Any, Dict
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
## Summary

- Remove three unused imports (`Path`, `Any`, `Dict`) from `model_param_registry_test.py` detected by `flake8 --max-line-length=100`
- The core implementation (PR #3588) was already merged to `Dev_new_gui`; this cleans up the lint violation introduced in that PR

## Test plan

- [x] `pytest llm_providers/model_param_registry_test.py` — 25/25 passed
- [x] `flake8 --max-line-length=100` on all changed files — zero violations

Closes #3257

🤖 Generated with [Claude Code](https://claude.com/claude-code)