### PR TITLE
deps: llama-index 0.13→0.14 migration evaluation

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -37,10 +37,13 @@ vanna>=2.0.2  # Issue #723: Natural language to SQL via Vanna.ai
 # Issue #858: Additional runtime dependencies for Python 3.13
 xxhash>=3.6.0          # Hash functions for LLM caching
 structlog>=25.5.0      # Structured logging for service auth
-llama-index>=0.14.0,<0.15.0    # Upgraded from 0.13.x to resolve openai>=2 conflict (#2747)
-llama-index-llms-ollama>=0.7.0,<1.0.0  # Ollama LLM integration
-llama-index-embeddings-ollama>=0.7.0,<1.0.0  # Ollama embeddings
+llama-index>=0.14.19,<0.15.0          # Migrated from 0.13.x; floor aligned to 0.14.19 (#2642)
+llama-index-core>=0.14.19,<0.15.0     # Explicit core pin matching ecosystem (#2642)
+llama-index-llms-ollama>=0.10.1,<1.0.0       # Ollama LLM integration
+llama-index-embeddings-ollama>=0.9.0,<1.0.0  # Ollama embeddings
 llama-index-vector-stores-chroma>=0.5.5,<1.0.0  # ChromaDB vector store
+llama-index-vector-stores-redis>=0.8.0,<1.0.0   # Redis vector store (#2642)
+llama-index-readers-file>=0.6.0,<1.0.0          # File readers for RAG (#2642)
 # LangChain 1.x ecosystem — migrated from 0.3.x to fix SSRF CVE (#1572)
 langchain>=1.2.13,<2.0.0               # Issue #1572: Migrated to 1.x (was 0.3.x)
 langchain-core>=1.2.22,<2.0.0         # Issue #1572: SSRF CVE fix requires >=1.2.11

--- a/autobot-infrastructure/shared/config/requirements.txt
+++ b/autobot-infrastructure/shared/config/requirements.txt
@@ -85,10 +85,12 @@ langchain-core>=1.2.22,<2.0.0   # Issue #2808: added to match backend canonical
 langchain-community>=0.4.1,<0.5.0  # Issue #2808: upper bound unified with backend canonical
 langchain-experimental>=0.4.1,<0.5.0  # Issue #2808: upper bound added for consistency; for advanced LangChain features
 llama-index>=0.14.19,<0.15.0
+llama-index-core>=0.14.19,<0.15.0     # Explicit core pin (#2642)
 llama-index-llms-ollama>=0.10.1,<1.0.0
 llama-index-embeddings-ollama>=0.9.0,<1.0.0
+llama-index-vector-stores-chroma>=0.5.5,<1.0.0  # ChromaDB vector store (#2642)
 llama-index-vector-stores-redis>=0.8.0,<1.0.0
-llama-index-readers-file>=0.6.0,<1.0.0   # File readers for RAG - 0.6.0+ for core 0.13.0 + pypdf 6.x compatibility
+llama-index-readers-file>=0.6.0,<1.0.0   # File readers for RAG - 0.6.0+ for core 0.14.x + pypdf 6.x compatibility
 
 # ===== VOICE INTERFACE DEPENDENCIES =====
 # Moved to requirements-voice.txt to avoid CI/CD build failures


### PR DESCRIPTION
## Summary

Closes #2642

Unifies all llama-index requirement files at the `0.14.19` floor, completing the 0.13→0.14 migration that was partially done in #2747/#2669:

- **`autobot-backend/requirements.txt`**: bumped `llama-index` floor from `>=0.14.0` to `>=0.14.19`; bumped stale sub-package lower bounds (`llms-ollama` 0.7→0.10.1, `embeddings-ollama` 0.7→0.9.0); added missing `llama-index-core`, `llama-index-vector-stores-redis`, and `llama-index-readers-file` (present in CI and infra files but absent here)
- **`autobot-infrastructure/shared/config/requirements.txt`**: added missing `llama-index-core` explicit pin and `llama-index-vector-stores-chroma` (already present in docker/CI files)

All Python source files already use the `llama_index.core.*` import namespace (0.14.x API) — no code changes were required.

## Scope of issue checklist
- [x] Review llama-index 0.14.x changelog for breaking changes — API already migrated to `llama_index.core.*`
- [x] Identify affected code in `autobot-backend/` — all imports use 0.14.x paths
- [x] Update sub-package pins to match 0.14.x requirements — aligned across all requirement files
- [ ] Test RAG pipeline end-to-end after migration — requires live Ollama+ChromaDB environment (deployment validation)

## Test plan
- [ ] Verify `pip install -r autobot-backend/requirements.txt` resolves without conflicts
- [ ] Verify `pip install -r requirements-ci.txt` resolves without conflicts
- [ ] RAG pipeline smoke test after deployment to staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)