### PR TITLE
feat(chat): stream chain-of-thought to frontend

### DIFF
--- a/autobot-backend/chat_workflow/cot_events.py
+++ b/autobot-backend/chat_workflow/cot_events.py
@@ -24,7 +24,8 @@ tokens never cross the WebSocket boundary.
 import asyncio
 import logging
 import time
-from typing import Any, Optional
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,66 @@ def _is_sensitive(key: str) -> bool:
     return any(fragment in lower for fragment in _SENSITIVE_KEY_FRAGMENTS)
 
 
+# ---------------------------------------------------------------------------
+# CausalLink — typed causal chain entry for cross-event tracing (#3232)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CausalLink:
+    """A directed causal relationship between two trace events.
+
+    Used to record *why* one agent step triggered another, enabling the
+    frontend to render a causal graph of the reasoning trace.
+
+    Attributes:
+        source_event_id: ID of the event that caused the transition.
+        target_event_id: ID of the event that was triggered.
+        reason:          Short machine-readable label for the causal edge.
+                         Sensitive fragments (e.g. "token", "password") are
+                         redacted in to_dict() before WebSocket emission.
+    """
+
+    source_event_id: str
+    target_event_id: str
+    reason: str
+
+    def to_dict(self) -> dict:
+        """Serialise to a plain dict, redacting sensitive reason strings.
+
+        Returns:
+            Dict with keys source_event_id, target_event_id, reason where
+            reason is replaced with the redaction placeholder when it contains
+            any sensitive key fragment.
+        """
+        safe_reason = _REDACTED if _is_sensitive(self.reason) else self.reason
+        return {
+            "source_event_id": self.source_event_id,
+            "target_event_id": self.target_event_id,
+            "reason": safe_reason,
+        }
+
+
+def build_causal_chain(
+    links: Optional[List[Tuple[str, str, str]]],
+) -> Optional[List[CausalLink]]:
+    """Construct a list of CausalLink objects from a compact tuple representation.
+
+    Convenience factory so callers can pass a list of ``(src, tgt, reason)``
+    tuples instead of constructing CausalLink instances manually.
+
+    Args:
+        links: List of ``(source_event_id, target_event_id, reason)`` tuples,
+               or None / empty list.
+
+    Returns:
+        List of CausalLink objects, or None when *links* is falsy.
+    """
+    if not links:
+        return None
+    return [CausalLink(src, tgt, reason) for src, tgt, reason in links]
+
+
 def sanitize_arguments(arguments: Any) -> Any:
     """Recursively redact sensitive values in *arguments*.
 
@@ -90,6 +151,28 @@ def _truncate(value: Any, max_len: int = 512) -> str:
     if len(text) > max_len:
         return text[:max_len] + "…"
     return text
+
+
+# ---------------------------------------------------------------------------
+# Causal chain serialization helper
+# ---------------------------------------------------------------------------
+
+
+def _causal_payload(causal_chain: Optional[List[CausalLink]]) -> dict:
+    """Return a dict fragment to merge into an event payload for causal chain.
+
+    Returns an empty dict when *causal_chain* is None or empty, so callers
+    can always do ``{**base_payload, **_causal_payload(chain)}``.
+
+    Args:
+        causal_chain: Optional list of CausalLink objects.
+
+    Returns:
+        Dict with a single ``"causal_chain"`` key, or empty dict.
+    """
+    if not causal_chain:
+        return {}
+    return {"causal_chain": [link.to_dict() for link in causal_chain]}
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +220,7 @@ def emit_step_start(
     session_id: Optional[str] = None,
     agent_type: Optional[str] = None,
     step_id: Optional[str] = None,
+    causal_chain: Optional[List[CausalLink]] = None,
 ) -> float:
     """Emit an agent.step.start event and return the current monotonic time.
 
@@ -144,10 +228,12 @@ def emit_step_start(
     duration can be calculated without the caller needing to record it.
 
     Args:
-        step_name:  Human-readable step or node name.
-        session_id: Chat session identifier (forwarded to frontend for routing).
-        agent_type: Optional agent class/type label.
-        step_id:    Optional unique identifier for this step instance.
+        step_name:    Human-readable step or node name.
+        session_id:   Chat session identifier (forwarded to frontend for routing).
+        agent_type:   Optional agent class/type label.
+        step_id:      Optional unique identifier for this step instance.
+        causal_chain: Optional list of CausalLink objects linking this step to
+                      prior trace events.
 
     Returns:
         Monotonic time float to be passed to emit_step_complete.
@@ -161,6 +247,7 @@ def emit_step_start(
             "agent_type": agent_type,
             "session_id": session_id,
             "ts": time.time(),
+            **_causal_payload(causal_chain),
         },
     )
     return start_time
@@ -172,6 +259,7 @@ def emit_step_complete(
     output_summary: Optional[str] = None,
     session_id: Optional[str] = None,
     step_id: Optional[str] = None,
+    causal_chain: Optional[List[CausalLink]] = None,
 ) -> None:
     """Emit an agent.step.complete event.
 
@@ -181,6 +269,7 @@ def emit_step_complete(
         output_summary: Optional short description of the step outcome.
         session_id:     Chat session identifier.
         step_id:        Optional unique identifier for this step instance.
+        causal_chain:   Optional list of CausalLink objects.
     """
     duration_ms = (time.monotonic() - start_time) * 1000
     _try_publish(
@@ -192,6 +281,7 @@ def emit_step_complete(
             "duration_ms": round(duration_ms, 1),
             "session_id": session_id,
             "ts": time.time(),
+            **_causal_payload(causal_chain),
         },
     )
 
@@ -200,15 +290,17 @@ def emit_tool_call(
     tool_name: str,
     arguments: Any,
     session_id: Optional[str] = None,
+    causal_chain: Optional[List[CausalLink]] = None,
 ) -> float:
     """Emit an agent.tool.call event and return start time.
 
     Sensitive argument values are automatically redacted before emission.
 
     Args:
-        tool_name:  Name of the tool being called.
-        arguments:  Raw tool arguments (may contain sensitive data).
-        session_id: Chat session identifier.
+        tool_name:    Name of the tool being called.
+        arguments:    Raw tool arguments (may contain sensitive data).
+        session_id:   Chat session identifier.
+        causal_chain: Optional list of CausalLink objects.
 
     Returns:
         Monotonic start time to be passed to emit_tool_result.
@@ -221,6 +313,7 @@ def emit_tool_call(
             "arguments": sanitize_arguments(arguments),
             "session_id": session_id,
             "ts": time.time(),
+            **_causal_payload(causal_chain),
         },
     )
     return start_time
@@ -233,16 +326,18 @@ def emit_tool_result(
     success: bool = True,
     bridge: Optional[str] = None,
     session_id: Optional[str] = None,
+    causal_chain: Optional[List[CausalLink]] = None,
 ) -> None:
     """Emit an agent.tool.result event.
 
     Args:
-        tool_name:  Name of the tool that was called.
-        result:     The tool result (will be truncated for WebSocket safety).
-        start_time: Monotonic time returned by emit_tool_call.
-        success:    Whether the tool call succeeded.
-        bridge:     Optional MCP bridge identifier.
-        session_id: Chat session identifier.
+        tool_name:    Name of the tool that was called.
+        result:       The tool result (will be truncated for WebSocket safety).
+        start_time:   Monotonic time returned by emit_tool_call.
+        success:      Whether the tool call succeeded.
+        bridge:       Optional MCP bridge identifier.
+        session_id:   Chat session identifier.
+        causal_chain: Optional list of CausalLink objects.
     """
     duration_ms = (time.monotonic() - start_time) * 1000
     _try_publish(
@@ -255,6 +350,7 @@ def emit_tool_result(
             "bridge": bridge,
             "session_id": session_id,
             "ts": time.time(),
+            **_causal_payload(causal_chain),
         },
     )
 
@@ -262,14 +358,16 @@ def emit_tool_result(
 def emit_llm_chunk(
     chunk: str,
     session_id: Optional[str] = None,
+    causal_chain: Optional[List[CausalLink]] = None,
 ) -> None:
     """Emit an agent.llm.chunk event for a streaming token.
 
     This is intentionally lightweight — no start_time or duration tracking.
 
     Args:
-        chunk:      The token or partial token string from the LLM.
-        session_id: Chat session identifier.
+        chunk:        The token or partial token string from the LLM.
+        session_id:   Chat session identifier.
+        causal_chain: Optional list of CausalLink objects.
     """
     _try_publish(
         "agent.llm.chunk",
@@ -277,6 +375,7 @@ def emit_llm_chunk(
             "chunk": chunk,
             "session_id": session_id,
             "ts": time.time(),
+            **_causal_payload(causal_chain),
         },
     )
 
@@ -284,12 +383,14 @@ def emit_llm_chunk(
 def emit_plan(
     steps: list[Any],
     session_id: Optional[str] = None,
+    causal_chain: Optional[List[CausalLink]] = None,
 ) -> None:
     """Emit an agent.plan event with a list of plan step descriptions.
 
     Args:
-        steps:      List of step dicts or strings from the overseer.
-        session_id: Chat session identifier.
+        steps:        List of step dicts or strings from the overseer.
+        session_id:   Chat session identifier.
+        causal_chain: Optional list of CausalLink objects.
     """
     # Normalise to plain strings for WebSocket safety
     step_labels: list[str] = []
@@ -307,5 +408,6 @@ def emit_plan(
             "step_count": len(step_labels),
             "session_id": session_id,
             "ts": time.time(),
+            **_causal_payload(causal_chain),
         },
     )


### PR DESCRIPTION
## Summary

- Add `CausalLink` dataclass to `cot_events.py` with `to_dict()` serialization that redacts sensitive reason strings (password, token, api_key, etc.)
- Add `build_causal_chain` factory helper for constructing typed causal relationships from compact tuple lists
- Add optional `causal_chain: Optional[List[CausalLink]] = None` parameter to all six emit functions (`emit_step_start`, `emit_step_complete`, `emit_tool_call`, `emit_tool_result`, `emit_llm_chunk`, `emit_plan`) — fully backward compatible
- All 30 unit tests in `cot_events_test.py` now pass

The frontend `ReasoningTrace.vue` component and `useReasoningTrace` composable were already implemented and wired into `ChatInterface.vue`. The backend `mcp_dispatch.py` and `graph.py` CoT hooks were also already in place. This commit completes the missing backend data model layer.

## Test plan

- [x] `pytest autobot-backend/chat_workflow/cot_events_test.py` — 30/30 passed
- [x] `flake8 --max-line-length=100 autobot-backend/chat_workflow/cot_events.py` — clean
- [x] Backward compatibility verified: all existing callers pass without `causal_chain`
- [x] Sensitive reason redaction verified: 13 sensitive key fragments tested

Closes #3232

🤖 Generated with [Claude Code](https://claude.com/claude-code)