### PR TITLE
feat(llm): per-model prompt_prefix in YAML registry

### DIFF
--- a/autobot-backend/config/llm_models.yaml
+++ b/autobot-backend/config/llm_models.yaml
@@ -5,6 +5,7 @@
 #   display_name   — canonical identifier used internally
 #   api_name       — provider-specific identifiers (provider: api_model_id)
 #   aliases        — alternative names resolved to this entry
+#   prompt_prefix  — optional string prepended to the first user turn (#3263)
 #   api_kwargs:
 #     default      — applied to every provider unless overridden
 #     <provider>   — merged on top of default for that provider only
@@ -406,6 +407,7 @@ models:
       ollama: deepseek-r1
     aliases:
       - deepseek-r1:latest
+    prompt_prefix: "Think step by step before answering."
     api_kwargs:
       default:
         temperature: 0.7

--- a/autobot-backend/llm_providers/model_param_registry.py
+++ b/autobot-backend/llm_providers/model_param_registry.py
@@ -31,7 +31,7 @@ import logging
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -215,9 +215,72 @@ def apply_model_defaults(
     return base
 
 
+def get_prompt_prefix(model: str) -> Optional[str]:
+    """
+    Return the ``prompt_prefix`` configured for *model* in the YAML registry,
+    or ``None`` when the field is absent or empty.
+
+    The prefix is a fixed string prepended to the first user turn before the
+    request is dispatched to the provider.  It is useful for instruction-tuning
+    tokens, chain-of-thought preambles, or format constraints that apply to
+    every call made to the model.
+
+    Args:
+        model: Canonical display_name or an alias.
+
+    Returns:
+        The prefix string, or ``None``.
+    """
+    canonical = resolve_model_name(model)
+    reg = _load_registry()
+    entry = reg.get(canonical)
+    if entry is None:
+        return None
+    prefix = entry.get("prompt_prefix")
+    return str(prefix) if prefix else None
+
+
+def apply_prompt_prefix(
+    model: str,
+    messages: List[Dict[str, str]],
+) -> List[Dict[str, str]]:
+    """
+    Prepend the per-model ``prompt_prefix`` to the first user message.
+
+    The list is mutated in-place; a reference to the same list is also
+    returned for convenience.  When no prefix is configured, or when there is
+    no user message in the list, the list is returned unchanged.
+
+    The prefix is separated from the existing content by a single newline so
+    that any chain-of-thought instruction reads as a separate paragraph.
+
+    Args:
+        model:    Canonical display_name or alias.
+        messages: The ``messages`` list from an ``LLMRequest``.
+
+    Returns:
+        The (possibly mutated) messages list.
+    """
+    prefix = get_prompt_prefix(model)
+    if not prefix:
+        return messages
+    for msg in messages:
+        if msg.get("role") == "user":
+            msg["content"] = prefix + "\n" + msg["content"]
+            logger.debug(
+                "Prepended prompt_prefix for model %r (%d chars)",
+                model,
+                len(prefix),
+            )
+            break
+    return messages
+
+
 __all__ = [
     "resolve_model_name",
     "get_model_kwargs",
     "get_provider_model_id",
     "apply_model_defaults",
+    "get_prompt_prefix",
+    "apply_prompt_prefix",
 ]

--- a/autobot-backend/llm_providers/model_param_registry_test.py
+++ b/autobot-backend/llm_providers/model_param_registry_test.py
@@ -49,7 +49,9 @@ from llm_providers.model_param_registry import (  # noqa: E402
     _FALLBACK_KWARGS,
     _load_registry,
     apply_model_defaults,
+    apply_prompt_prefix,
     get_model_kwargs,
+    get_prompt_prefix,
     get_provider_model_id,
     resolve_model_name,
 )
@@ -250,3 +252,191 @@ class TestMissingYaml:
             _clear_cache()
             kwargs = get_model_kwargs("gpt-4o")
         assert kwargs == dict(_FALLBACK_KWARGS)
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_prompt_prefix (#3263)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPromptPrefix:
+    def test_model_with_prefix_returns_string(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            models:
+              - display_name: prefixed-model
+                api_name:
+                  ollama: prefixed-model
+                aliases: []
+                prompt_prefix: "Think step by step before answering."
+                api_kwargs:
+                  default:
+                    temperature: 0.7
+                    max_tokens: 4096
+        """)
+        yaml_file = tmp_path / "llm_models.yaml"
+        yaml_file.write_text(yaml_content, encoding="utf-8")
+        with patch.dict("os.environ", {"AUTOBOT_LLM_MODELS_YAML": str(yaml_file)}):
+            _clear_cache()
+            prefix = get_prompt_prefix("prefixed-model")
+        assert prefix == "Think step by step before answering."
+
+    def test_model_without_prefix_returns_none(self):
+        prefix = get_prompt_prefix("gpt-4o")
+        assert prefix is None
+
+    def test_unknown_model_returns_none(self):
+        prefix = get_prompt_prefix("totally-unknown-xyz")
+        assert prefix is None
+
+    def test_alias_resolved_before_lookup(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            models:
+              - display_name: my-model
+                api_name:
+                  ollama: my-model
+                aliases:
+                  - my-alias
+                prompt_prefix: "Answer concisely."
+                api_kwargs:
+                  default:
+                    temperature: 0.7
+                    max_tokens: 2048
+        """)
+        yaml_file = tmp_path / "llm_models.yaml"
+        yaml_file.write_text(yaml_content, encoding="utf-8")
+        with patch.dict("os.environ", {"AUTOBOT_LLM_MODELS_YAML": str(yaml_file)}):
+            _clear_cache()
+            prefix = get_prompt_prefix("my-alias")
+        assert prefix == "Answer concisely."
+
+    def test_empty_prefix_returns_none(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            models:
+              - display_name: empty-prefix-model
+                api_name:
+                  ollama: empty-prefix-model
+                aliases: []
+                prompt_prefix: ""
+                api_kwargs:
+                  default:
+                    temperature: 0.7
+                    max_tokens: 2048
+        """)
+        yaml_file = tmp_path / "llm_models.yaml"
+        yaml_file.write_text(yaml_content, encoding="utf-8")
+        with patch.dict("os.environ", {"AUTOBOT_LLM_MODELS_YAML": str(yaml_file)}):
+            _clear_cache()
+            prefix = get_prompt_prefix("empty-prefix-model")
+        assert prefix is None
+
+    def test_deepseek_r1_has_prefix_in_real_yaml(self):
+        """deepseek-r1 ships a prompt_prefix in the real llm_models.yaml."""
+        prefix = get_prompt_prefix("deepseek-r1")
+        assert prefix is not None
+        assert len(prefix) > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: apply_prompt_prefix (#3263)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPromptPrefix:
+    def test_prefix_prepended_to_first_user_message(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            models:
+              - display_name: cot-model
+                api_name:
+                  ollama: cot-model
+                aliases: []
+                prompt_prefix: "Think carefully."
+                api_kwargs:
+                  default:
+                    temperature: 0.7
+                    max_tokens: 2048
+        """)
+        yaml_file = tmp_path / "llm_models.yaml"
+        yaml_file.write_text(yaml_content, encoding="utf-8")
+        messages = [
+            {"role": "system", "content": "You are a helper."},
+            {"role": "user", "content": "What is 2+2?"},
+        ]
+        with patch.dict("os.environ", {"AUTOBOT_LLM_MODELS_YAML": str(yaml_file)}):
+            _clear_cache()
+            result = apply_prompt_prefix("cot-model", messages)
+        assert result[1]["content"] == "Think carefully.\nWhat is 2+2?"
+        # system message must be untouched
+        assert result[0]["content"] == "You are a helper."
+
+    def test_no_prefix_leaves_messages_unchanged(self):
+        messages = [{"role": "user", "content": "Hello"}]
+        result = apply_prompt_prefix("gpt-4o", messages)
+        assert result[0]["content"] == "Hello"
+
+    def test_returns_same_list_object(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            models:
+              - display_name: cot-model2
+                api_name:
+                  ollama: cot-model2
+                aliases: []
+                prompt_prefix: "Be precise."
+                api_kwargs:
+                  default:
+                    temperature: 0.7
+                    max_tokens: 2048
+        """)
+        yaml_file = tmp_path / "llm_models.yaml"
+        yaml_file.write_text(yaml_content, encoding="utf-8")
+        messages = [{"role": "user", "content": "Hi"}]
+        with patch.dict("os.environ", {"AUTOBOT_LLM_MODELS_YAML": str(yaml_file)}):
+            _clear_cache()
+            result = apply_prompt_prefix("cot-model2", messages)
+        assert result is messages
+
+    def test_only_first_user_message_modified(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            models:
+              - display_name: multi-turn-model
+                api_name:
+                  ollama: multi-turn-model
+                aliases: []
+                prompt_prefix: "Step by step:"
+                api_kwargs:
+                  default:
+                    temperature: 0.7
+                    max_tokens: 2048
+        """)
+        yaml_file = tmp_path / "llm_models.yaml"
+        yaml_file.write_text(yaml_content, encoding="utf-8")
+        messages = [
+            {"role": "user", "content": "First question"},
+            {"role": "assistant", "content": "Answer"},
+            {"role": "user", "content": "Second question"},
+        ]
+        with patch.dict("os.environ", {"AUTOBOT_LLM_MODELS_YAML": str(yaml_file)}):
+            _clear_cache()
+            apply_prompt_prefix("multi-turn-model", messages)
+        assert messages[0]["content"] == "Step by step:\nFirst question"
+        assert messages[2]["content"] == "Second question"
+
+    def test_no_user_message_leaves_list_unchanged(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            models:
+              - display_name: system-only-model
+                api_name:
+                  ollama: system-only-model
+                aliases: []
+                prompt_prefix: "Prefix here."
+                api_kwargs:
+                  default:
+                    temperature: 0.7
+                    max_tokens: 2048
+        """)
+        yaml_file = tmp_path / "llm_models.yaml"
+        yaml_file.write_text(yaml_content, encoding="utf-8")
+        messages = [{"role": "system", "content": "Only a system message"}]
+        with patch.dict("os.environ", {"AUTOBOT_LLM_MODELS_YAML": str(yaml_file)}):
+            _clear_cache()
+            result = apply_prompt_prefix("system-only-model", messages)
+        assert result[0]["content"] == "Only a system message"

--- a/autobot-backend/llm_providers/provider_registry.py
+++ b/autobot-backend/llm_providers/provider_registry.py
@@ -35,7 +35,7 @@ from typing import Any, Dict, List, Optional
 from llm_interface_pkg.models import LLMRequest
 
 from .base_provider import BaseProvider
-from .model_param_registry import apply_model_defaults
+from .model_param_registry import apply_model_defaults, apply_prompt_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -157,10 +157,12 @@ class ProviderRegistry:
     @staticmethod
     def enrich_request(request: LLMRequest, provider_name: str) -> LLMRequest:
         """
-        Merge per-model api_kwargs from the YAML registry into *request*.
+        Merge per-model api_kwargs and prompt_prefix from the YAML registry into *request*.
 
         YAML defaults are applied first; caller-supplied
-        ``request.metadata["api_kwargs"]`` always wins.  The request object is
+        ``request.metadata["api_kwargs"]`` always wins.  When a ``prompt_prefix``
+        is configured for the model, it is prepended to the first user turn in
+        ``request.messages`` (separated by a newline).  The request object is
         mutated in-place and also returned for convenience.
 
         Args:
@@ -174,6 +176,7 @@ class ProviderRegistry:
         caller_kwargs: Dict[str, Any] = request.metadata.get("api_kwargs") or {}
         merged = apply_model_defaults(model, provider_name, caller_kwargs)
         request.metadata["api_kwargs"] = merged
+        apply_prompt_prefix(model, request.messages)
         return request
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds optional `prompt_prefix: str` field to per-model entries in `autobot-backend/config/llm_models.yaml`
- `ProviderRegistry.enrich_request()` calls new `apply_prompt_prefix()` which prepends the prefix (+ newline) to the first user turn before dispatch
- `deepseek-r1` ships a concrete prefix: `"Think step by step before answering."`
- Schema comment block in YAML updated to document the new field

## Files changed

- `autobot-backend/config/llm_models.yaml` — schema comment + `deepseek-r1` prefix
- `autobot-backend/llm_providers/model_param_registry.py` — `get_prompt_prefix()` and `apply_prompt_prefix()` + updated `__all__`
- `autobot-backend/llm_providers/provider_registry.py` — `enrich_request()` calls `apply_prompt_prefix()`
- `autobot-backend/llm_providers/model_param_registry_test.py` — 11 new tests (36 total, all passing)

## Test plan

- [x] `pytest llm_providers/model_param_registry_test.py` — 36 passed
- [x] `flake8 --max-line-length=100` — clean on all changed files (pre-existing F401s in test stubs untouched)
- [x] Prefix applies only to the first user turn; system messages and subsequent user turns are unmodified
- [x] Empty/absent `prompt_prefix` returns `None` and leaves messages unchanged
- [x] Alias resolution works before prefix lookup

Closes #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)