### PR TITLE
feat(autoresearch): enriched store indexing with missing spec fields

### DIFF
--- a/autobot-backend/services/autoresearch/scorers.py
+++ b/autobot-backend/services/autoresearch/scorers.py
@@ -17,7 +17,10 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+if TYPE_CHECKING:
+    from services.llm_service import LLMService
 
 from constants.ttl_constants import TTL_24_HOURS
 
@@ -190,7 +193,7 @@ class LLMJudgeScorer(PromptScorer):
 
     def __init__(
         self,
-        llm_service: Any,
+        llm_service: "LLMService",
         criteria: list[str],
     ) -> None:
         self._llm = llm_service

--- a/autobot-backend/services/autoresearch/store.py
+++ b/autobot-backend/services/autoresearch/store.py
@@ -162,6 +162,18 @@ class ExperimentStore:
         session_tags = [t for t in experiment.tags if t.startswith("session:")]
         if session_tags:
             parts.append(f"Session: {session_tags[0].split(':', 1)[1]}")
+        # Iteration number within the session
+        iteration_tags = [t for t in experiment.tags if t.startswith("iteration:")]
+        if iteration_tags:
+            parts.append(f"Iteration: {iteration_tags[0].split(':', 1)[1]}")
+        # Prior results trend direction
+        trend_tags = [t for t in experiment.tags if t.startswith("trend:")]
+        if trend_tags:
+            parts.append(f"Trend: {trend_tags[0].split(':', 1)[1]}")
+        # Prompt variant ID when optimizer is active
+        variant_tags = [t for t in experiment.tags if t.startswith("variant:")]
+        if variant_tags:
+            parts.append(f"Variant: {variant_tags[0].split(':', 1)[1]}")
         return "\n".join(parts)
 
     def _build_metadata(self, experiment: Experiment) -> Dict[str, Any]:
@@ -185,6 +197,25 @@ class ExperimentStore:
         for tag in experiment.tags:
             if tag.startswith("session:"):
                 meta["session_id"] = tag.split(":", 1)[1]
+                break
+        # Extract iteration number from tags
+        for tag in experiment.tags:
+            if tag.startswith("iteration:"):
+                raw = tag.split(":", 1)[1]
+                try:
+                    meta["iteration"] = int(raw)
+                except ValueError:
+                    pass
+                break
+        # Extract trend direction from tags
+        for tag in experiment.tags:
+            if tag.startswith("trend:"):
+                meta["trend_direction"] = tag.split(":", 1)[1]
+                break
+        # Extract prompt variant ID from tags
+        for tag in experiment.tags:
+            if tag.startswith("variant:"):
+                meta["variant_id"] = tag.split(":", 1)[1]
                 break
         return meta
 

--- a/autobot-backend/services/autoresearch/store_chromadb_test.py
+++ b/autobot-backend/services/autoresearch/store_chromadb_test.py
@@ -466,3 +466,186 @@ class TestEnrichedIndexing:
         )
         meta = store._build_metadata(exp)
         assert "session_id" not in meta
+
+
+# ---------------------------------------------------------------------------
+# Missing spec fields: iteration, trend, variant ID (Issue #3212)
+# ---------------------------------------------------------------------------
+
+
+class TestSpecFieldsIterationTrendVariant:
+    """Tests for iteration, trend_direction, and variant_id in _build_document
+    and _build_metadata — spec section 2.1 (#3212)."""
+
+    # --- _build_document ---
+
+    def test_document_includes_iteration(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["session:s1", "iteration:3"],
+        )
+        doc = store._build_document(exp)
+        assert "Iteration: 3" in doc
+
+    def test_document_no_iteration_when_tag_absent(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["session:s1"],
+        )
+        doc = store._build_document(exp)
+        assert "Iteration:" not in doc
+
+    def test_document_includes_trend(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["trend:improving"],
+        )
+        doc = store._build_document(exp)
+        assert "Trend: improving" in doc
+
+    def test_document_no_trend_when_tag_absent(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=[],
+        )
+        doc = store._build_document(exp)
+        assert "Trend:" not in doc
+
+    def test_document_includes_variant(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["variant:v-abc123"],
+        )
+        doc = store._build_document(exp)
+        assert "Variant: v-abc123" in doc
+
+    def test_document_no_variant_when_tag_absent(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["session:s1"],
+        )
+        doc = store._build_document(exp)
+        assert "Variant:" not in doc
+
+    def test_document_all_three_spec_fields(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Full spec test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["session:s1", "iteration:2", "trend:plateau", "variant:v-xyz"],
+        )
+        doc = store._build_document(exp)
+        assert "Iteration: 2" in doc
+        assert "Trend: plateau" in doc
+        assert "Variant: v-xyz" in doc
+
+    # --- _build_metadata ---
+
+    def test_metadata_includes_iteration(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["iteration:4"],
+        )
+        meta = store._build_metadata(exp)
+        assert meta["iteration"] == 4
+
+    def test_metadata_iteration_is_int(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["iteration:7"],
+        )
+        meta = store._build_metadata(exp)
+        assert isinstance(meta["iteration"], int)
+
+    def test_metadata_no_iteration_when_tag_absent(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["session:s1"],
+        )
+        meta = store._build_metadata(exp)
+        assert "iteration" not in meta
+
+    def test_metadata_includes_trend_direction(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["trend:declining"],
+        )
+        meta = store._build_metadata(exp)
+        assert meta["trend_direction"] == "declining"
+
+    def test_metadata_no_trend_when_tag_absent(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=[],
+        )
+        meta = store._build_metadata(exp)
+        assert "trend_direction" not in meta
+
+    def test_metadata_includes_variant_id(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["variant:var-001"],
+        )
+        meta = store._build_metadata(exp)
+        assert meta["variant_id"] == "var-001"
+
+    def test_metadata_no_variant_when_tag_absent(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["session:s1"],
+        )
+        meta = store._build_metadata(exp)
+        assert "variant_id" not in meta
+
+    def test_metadata_all_three_spec_fields(self):
+        store = _make_store()
+        exp = Experiment(
+            hypothesis="Full spec test",
+            hyperparams=HyperParams(),
+            state=ExperimentState.COMPLETED,
+            tags=["session:s1", "iteration:1", "trend:improving", "variant:v-best"],
+        )
+        meta = store._build_metadata(exp)
+        assert meta["iteration"] == 1
+        assert meta["trend_direction"] == "improving"
+        assert meta["variant_id"] == "v-best"


### PR DESCRIPTION
## Summary

Closes #3212

- `_build_document` now includes `Iteration: N`, `Trend: <direction>`, and `Variant: <id>` lines when the corresponding `iteration:`, `trend:`, or `variant:` tags are present on the experiment.
- `_build_metadata` now writes `iteration` (int), `trend_direction` (str), and `variant_id` (str) into the ChromaDB metadata dict for filterable queries, extracted from the same tags.
- `LLMJudgeScorer.__init__` type annotation changed from `Any` to `"LLMService"` via `TYPE_CHECKING` guard — improves IDE support without introducing a runtime circular import.

All three changes are tag-convention-based (no new model fields needed) and are backward-compatible: experiments without those tags produce the same output as before.

## Test plan

- [ ] 49 tests pass in `store_chromadb_test.py` (15 new tests in `TestSpecFieldsIterationTrendVariant` cover all six new branches)
- [ ] `flake8 --max-line-length=100` clean on all three changed files (pre-existing F401s unaffected)
- [ ] No new lint violations introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)