### PR TITLE
feat(llm): provider_metadata on LLMResponse

### DIFF
--- a/autobot-backend/llm_interface_pkg/models.py
+++ b/autobot-backend/llm_interface_pkg/models.py
@@ -111,6 +111,7 @@ class LLMResponse:
     request_id: str = ""
     error: Optional[str] = None
     fallback_used: bool = False
+    provider_metadata: Optional[Dict[str, Any]] = None
 
 
 @dataclass

--- a/autobot-backend/llm_providers/anthropic_provider.py
+++ b/autobot-backend/llm_providers/anthropic_provider.py
@@ -261,6 +261,7 @@ class AnthropicProvider(BaseProvider):
 
             response = await client.messages.create(**call_kwargs)
             content = _extract_text_content(response.content, preserve_reasoning)
+            total_tokens = response.usage.input_tokens + response.usage.output_tokens
             return LLMResponse(
                 content=content,
                 model=response.model,
@@ -270,10 +271,13 @@ class AnthropicProvider(BaseProvider):
                 usage={
                     "prompt_tokens": response.usage.input_tokens,
                     "completion_tokens": response.usage.output_tokens,
-                    "total_tokens": (
-                        response.usage.input_tokens + response.usage.output_tokens
-                    ),
+                    "total_tokens": total_tokens,
                 },
+                provider_metadata=self._build_provider_metadata(
+                    model_api_name=response.model,
+                    api_kwargs_applied=call_kwargs,
+                    total_tokens=total_tokens,
+                ),
             )
         except Exception as exc:
             self._total_errors += 1

--- a/autobot-backend/llm_providers/base_provider.py
+++ b/autobot-backend/llm_providers/base_provider.py
@@ -108,5 +108,32 @@ class BaseProvider(ABC):
         """Safely retrieve a value from the settings dict."""
         return self.settings.get(key, default)
 
+    def _build_provider_metadata(
+        self,
+        model_api_name: str,
+        api_kwargs_applied: Dict[str, Any],
+        total_tokens: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """
+        Build the standard ``provider_metadata`` dict for an LLMResponse.
+
+        Args:
+            model_api_name:    Exact model name sent to the API (may differ from
+                               request.model_name after aliasing or fallback).
+            api_kwargs_applied: Merged kwargs actually sent to the provider API.
+            total_tokens:      Total token count from the response usage, or None.
+
+        Returns:
+            Dict suitable for ``LLMResponse.provider_metadata``.
+        """
+        metadata: Dict[str, Any] = {
+            "provider": self.provider_name,
+            "model_api_name": model_api_name,
+            "api_kwargs_applied": api_kwargs_applied,
+        }
+        if total_tokens is not None:
+            metadata["total_tokens"] = total_tokens
+        return metadata
+
 
 __all__ = ["BaseProvider"]

--- a/autobot-backend/llm_providers/custom_openai_provider.py
+++ b/autobot-backend/llm_providers/custom_openai_provider.py
@@ -124,14 +124,15 @@ class CustomOpenAIProvider(BaseProvider):
         model = request.model_name or self._default_model()
         try:
             client = self._ensure_client()
-            response = await client.chat.completions.create(
-                **self._build_params(request, model)
-            )
+            params = self._build_params(request, model)
+            response = await client.chat.completions.create(**params)
             choice = response.choices[0]
             usage = response.usage
+            api_model = response.model or model
+            total_tokens = usage.total_tokens if usage else 0
             return LLMResponse(
                 content=choice.message.content or "",
-                model=response.model or model,
+                model=api_model,
                 provider=self.provider_name,
                 processing_time=time.time() - start,
                 request_id=request.request_id,
@@ -139,8 +140,13 @@ class CustomOpenAIProvider(BaseProvider):
                 usage={
                     "prompt_tokens": usage.prompt_tokens if usage else 0,
                     "completion_tokens": usage.completion_tokens if usage else 0,
-                    "total_tokens": usage.total_tokens if usage else 0,
+                    "total_tokens": total_tokens,
                 },
+                provider_metadata=self._build_provider_metadata(
+                    model_api_name=api_model,
+                    api_kwargs_applied=params,
+                    total_tokens=total_tokens,
+                ),
             )
         except Exception as exc:
             self._total_errors += 1

--- a/autobot-backend/llm_providers/groq_provider.py
+++ b/autobot-backend/llm_providers/groq_provider.py
@@ -128,6 +128,11 @@ class GroqProvider(BaseProvider):
                     "completion_tokens": response.usage.completion_tokens,
                     "total_tokens": response.usage.total_tokens,
                 },
+                provider_metadata=self._build_provider_metadata(
+                    model_api_name=response.model,
+                    api_kwargs_applied=params,
+                    total_tokens=response.usage.total_tokens,
+                ),
             )
         except Exception as exc:
             self._total_errors += 1

--- a/autobot-backend/llm_providers/huggingface_provider.py
+++ b/autobot-backend/llm_providers/huggingface_provider.py
@@ -119,9 +119,12 @@ class HuggingFaceProvider(BaseProvider):
                 data = await resp.json()
             choice = data["choices"][0]
             usage = data.get("usage", {})
+            api_model = data.get("model", model)
+            payload = self._build_chat_payload(request, model)
+            total_tokens = usage.get("total_tokens", 0)
             return LLMResponse(
                 content=choice["message"]["content"] or "",
-                model=data.get("model", model),
+                model=api_model,
                 provider=self.provider_name,
                 processing_time=time.time() - start,
                 request_id=request.request_id,
@@ -129,8 +132,13 @@ class HuggingFaceProvider(BaseProvider):
                 usage={
                     "prompt_tokens": usage.get("prompt_tokens", 0),
                     "completion_tokens": usage.get("completion_tokens", 0),
-                    "total_tokens": usage.get("total_tokens", 0),
+                    "total_tokens": total_tokens,
                 },
+                provider_metadata=self._build_provider_metadata(
+                    model_api_name=api_model,
+                    api_kwargs_applied=payload,
+                    total_tokens=total_tokens,
+                ),
             )
         except Exception as exc:
             self._total_errors += 1

--- a/autobot-backend/llm_providers/ollama_provider.py
+++ b/autobot-backend/llm_providers/ollama_provider.py
@@ -95,6 +95,17 @@ class OllamaProvider(BaseProvider):
             response = await delegate.chat_completion(request)
             if response.error:
                 self._total_errors += 1
+            else:
+                api_kwargs = {
+                    "model": response.model,
+                    "messages": request.messages,
+                    "options": {"temperature": request.temperature},
+                }
+                response.provider_metadata = self._build_provider_metadata(
+                    model_api_name=response.model,
+                    api_kwargs_applied=api_kwargs,
+                    total_tokens=response.usage.get("total_tokens") if response.usage else None,
+                )
             return response
         except Exception as exc:
             self._total_errors += 1

--- a/autobot-backend/llm_providers/openai_provider.py
+++ b/autobot-backend/llm_providers/openai_provider.py
@@ -170,6 +170,11 @@ class OpenAIProvider(BaseProvider):
                         "completion_tokens": response.usage.completion_tokens,
                         "total_tokens": response.usage.total_tokens,
                     },
+                    provider_metadata=self._build_provider_metadata(
+                        model_api_name=response.model,
+                        api_kwargs_applied=params,
+                        total_tokens=response.usage.total_tokens,
+                    ),
                 )
             except Exception as exc:
                 self._total_errors += 1

--- a/autobot-backend/llm_providers/provider_metadata_test.py
+++ b/autobot-backend/llm_providers/provider_metadata_test.py
@@ -1,0 +1,349 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for provider_metadata field on LLMResponse (#3262).
+
+Verifies that each provider's chat_completion populates provider_metadata
+with the expected keys and values.  All network calls are mocked so these
+tests run fully offline.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs for optional heavy dependencies
+# ---------------------------------------------------------------------------
+
+
+def _stub_module(name: str, **attrs) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+# groq
+if "groq" not in sys.modules:
+    _stub_module("groq", AsyncGroq=MagicMock)
+
+# xxhash (used by some llm_interface_pkg internals)
+if "xxhash" not in sys.modules:
+    _stub_module(
+        "xxhash",
+        xxh64=MagicMock(return_value=MagicMock(hexdigest=MagicMock(return_value="0" * 16))),
+    )
+
+# opentelemetry stubs (used by openai_provider)
+for _otel_mod in [
+    "opentelemetry",
+    "opentelemetry.trace",
+]:
+    if _otel_mod not in sys.modules:
+        _stub_module(_otel_mod)
+
+if "opentelemetry" not in sys.modules or not hasattr(sys.modules["opentelemetry"], "trace"):
+    _otel = sys.modules.get("opentelemetry", types.ModuleType("opentelemetry"))
+    _otel_trace = sys.modules.get("opentelemetry.trace", types.ModuleType("opentelemetry.trace"))
+    _tracer_stub = MagicMock()
+    _span_stub = MagicMock()
+    _span_stub.__enter__ = MagicMock(return_value=_span_stub)
+    _span_stub.__exit__ = MagicMock(return_value=False)
+    _span_stub.is_recording.return_value = False
+    _tracer_stub.start_as_current_span = MagicMock(return_value=_span_stub)
+    _otel_trace.get_tracer = MagicMock(return_value=_tracer_stub)
+    _otel_trace.SpanKind = MagicMock()
+    _otel_trace.Status = MagicMock()
+    _otel_trace.StatusCode = MagicMock()
+    _otel.trace = _otel_trace
+    sys.modules["opentelemetry"] = _otel
+    sys.modules["opentelemetry.trace"] = _otel_trace
+
+# circuit_breaker stub
+if "circuit_breaker" not in sys.modules:
+    _cb = _stub_module("circuit_breaker")
+
+    def _passthrough(name):
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    _cb.circuit_breaker_async = _passthrough
+
+# ---------------------------------------------------------------------------
+# Imports under test
+# ---------------------------------------------------------------------------
+
+from llm_interface_pkg.models import LLMRequest, LLMResponse  # noqa: E402
+from llm_providers.groq_provider import GroqProvider  # noqa: E402
+from llm_providers.anthropic_provider import AnthropicProvider  # noqa: E402
+from llm_providers.openai_provider import OpenAIProvider  # noqa: E402
+from llm_providers.custom_openai_provider import CustomOpenAIProvider  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _basic_request(model: str = "") -> LLMRequest:
+    req = LLMRequest(messages=[{"role": "user", "content": "hello"}])
+    if model:
+        req.model_name = model
+    return req
+
+
+def _assert_provider_metadata(metadata: dict, provider: str, model: str) -> None:
+    """Assert the standard shape of provider_metadata."""
+    assert metadata is not None, "provider_metadata must not be None"
+    assert metadata["provider"] == provider
+    assert metadata["model_api_name"] == model
+    assert "api_kwargs_applied" in metadata
+    assert isinstance(metadata["api_kwargs_applied"], dict)
+    # total_tokens key is optional but must be int when present
+    if "total_tokens" in metadata:
+        assert isinstance(metadata["total_tokens"], int)
+
+
+# ---------------------------------------------------------------------------
+# LLMResponse dataclass — field exists with default None
+# ---------------------------------------------------------------------------
+
+
+class TestLLMResponseProviderMetadataField:
+    def test_field_defaults_to_none(self):
+        resp = LLMResponse(content="hi")
+        assert resp.provider_metadata is None
+
+    def test_field_accepts_dict(self):
+        resp = LLMResponse(
+            content="hi",
+            provider_metadata={"provider": "openai", "model_api_name": "gpt-4o-mini"},
+        )
+        assert resp.provider_metadata["provider"] == "openai"
+
+
+# ---------------------------------------------------------------------------
+# BaseProvider._build_provider_metadata helper
+# ---------------------------------------------------------------------------
+
+
+class TestBuildProviderMetadata:
+    def test_standard_fields_present(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        meta = provider._build_provider_metadata(
+            model_api_name="llama-3.1-8b-instant",
+            api_kwargs_applied={"temperature": 0.7},
+            total_tokens=42,
+        )
+        assert meta["provider"] == "groq"
+        assert meta["model_api_name"] == "llama-3.1-8b-instant"
+        assert meta["api_kwargs_applied"] == {"temperature": 0.7}
+        assert meta["total_tokens"] == 42
+
+    def test_total_tokens_omitted_when_none(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        meta = provider._build_provider_metadata(
+            model_api_name="llama-3.1-8b-instant",
+            api_kwargs_applied={},
+            total_tokens=None,
+        )
+        assert "total_tokens" not in meta
+
+
+# ---------------------------------------------------------------------------
+# GroqProvider — chat_completion populates provider_metadata
+# ---------------------------------------------------------------------------
+
+
+def _make_groq_response(content: str, model: str = "llama-3.1-8b-instant") -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.model = model
+    resp.usage = MagicMock(prompt_tokens=5, completion_tokens=10, total_tokens=15)
+    return resp
+
+
+class TestGroqProviderMetadata:
+    @pytest.mark.asyncio
+    async def test_provider_metadata_populated(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=_make_groq_response("Hello!")
+        )
+        provider._client = mock_client
+
+        response = await provider.chat_completion(_basic_request())
+
+        assert response.provider_metadata is not None
+        _assert_provider_metadata(response.provider_metadata, "groq", "llama-3.1-8b-instant")
+        assert response.provider_metadata["total_tokens"] == 15
+
+    @pytest.mark.asyncio
+    async def test_provider_metadata_contains_model_in_kwargs(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=_make_groq_response("ok", model="llama3-70b-8192")
+        )
+        provider._client = mock_client
+
+        response = await provider.chat_completion(_basic_request("llama3-70b-8192"))
+
+        assert response.provider_metadata["model_api_name"] == "llama3-70b-8192"
+        assert response.provider_metadata["api_kwargs_applied"]["model"] == "llama3-70b-8192"
+
+    @pytest.mark.asyncio
+    async def test_provider_metadata_none_on_error(self):
+        provider = GroqProvider(settings={"api_key": "gsk_test"})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("rate limited")
+        )
+        provider._client = mock_client
+
+        response = await provider.chat_completion(_basic_request())
+
+        assert response.error is not None
+        assert response.provider_metadata is None
+
+
+# ---------------------------------------------------------------------------
+# AnthropicProvider — chat_completion populates provider_metadata
+# ---------------------------------------------------------------------------
+
+
+def _make_anthropic_response(text: str, model: str = "claude-sonnet-4-6") -> MagicMock:
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = text
+    resp = MagicMock()
+    resp.model = model
+    resp.content = [text_block]
+    resp.usage = MagicMock(input_tokens=8, output_tokens=12)
+    return resp
+
+
+class TestAnthropicProviderMetadata:
+    @pytest.mark.asyncio
+    async def test_provider_metadata_populated(self):
+        provider = AnthropicProvider(settings={"api_key": "sk-ant-test"})
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(
+            return_value=_make_anthropic_response("Hi!")
+        )
+        provider._client = mock_client
+
+        response = await provider.chat_completion(_basic_request())
+
+        assert response.provider_metadata is not None
+        _assert_provider_metadata(
+            response.provider_metadata, "anthropic", "claude-sonnet-4-6"
+        )
+        assert response.provider_metadata["total_tokens"] == 20  # 8 + 12
+
+    @pytest.mark.asyncio
+    async def test_provider_metadata_none_on_error(self):
+        provider = AnthropicProvider(settings={"api_key": "sk-ant-test"})
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=RuntimeError("overloaded"))
+        provider._client = mock_client
+
+        response = await provider.chat_completion(_basic_request())
+
+        assert response.error is not None
+        assert response.provider_metadata is None
+
+
+# ---------------------------------------------------------------------------
+# OpenAIProvider — chat_completion populates provider_metadata
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_response(content: str, model: str = "gpt-4o-mini") -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.model = model
+    resp.usage = MagicMock(prompt_tokens=6, completion_tokens=9, total_tokens=15)
+    return resp
+
+
+class TestOpenAIProviderMetadata:
+    @pytest.mark.asyncio
+    async def test_provider_metadata_populated(self):
+        provider = OpenAIProvider(settings={"api_key": "sk-test"})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=_make_openai_response("Hello!")
+        )
+        provider._client = mock_client
+
+        response = await provider.chat_completion(_basic_request())
+
+        assert response.provider_metadata is not None
+        _assert_provider_metadata(response.provider_metadata, "openai", "gpt-4o-mini")
+        assert response.provider_metadata["total_tokens"] == 15
+
+    @pytest.mark.asyncio
+    async def test_provider_metadata_none_on_error(self):
+        provider = OpenAIProvider(settings={"api_key": "sk-test"})
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=RuntimeError("quota exceeded")
+        )
+        provider._client = mock_client
+
+        response = await provider.chat_completion(_basic_request())
+
+        assert response.error is not None
+        assert response.provider_metadata is None
+
+
+# ---------------------------------------------------------------------------
+# CustomOpenAIProvider — chat_completion populates provider_metadata
+# ---------------------------------------------------------------------------
+
+
+def _make_custom_response(content: str, model: str = "local-model") -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.model = model
+    resp.usage = MagicMock(prompt_tokens=4, completion_tokens=8, total_tokens=12)
+    return resp
+
+
+class TestCustomOpenAIProviderMetadata:
+    @pytest.mark.asyncio
+    async def test_provider_metadata_populated(self):
+        provider = CustomOpenAIProvider(
+            settings={"base_url": "http://localhost:8000/v1", "default_model": "local-model"}
+        )
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            return_value=_make_custom_response("Hello from local!")
+        )
+        provider._client = mock_client
+
+        response = await provider.chat_completion(_basic_request())
+
+        assert response.provider_metadata is not None
+        _assert_provider_metadata(response.provider_metadata, "custom_openai", "local-model")
+        assert response.provider_metadata["total_tokens"] == 12

--- a/autobot-backend/llm_providers/provider_registry.py
+++ b/autobot-backend/llm_providers/provider_registry.py
@@ -226,11 +226,18 @@ class ProviderRegistry:
             if name not in candidates:
                 candidates.append(name)
 
+        primary = candidates[0] if candidates else None
         for name in candidates:
             provider = await self.get_provider(name)
             if provider is not None:
                 if request is not None:
                     self.enrich_request(request, name)
+                if name != primary:
+                    logger.debug(
+                        "Fallback chain selected non-primary provider: %s (preferred: %s)",
+                        name,
+                        primary,
+                    )
                 return provider
 
         logger.error("All providers unavailable or not configured")


### PR DESCRIPTION
## Summary

Closes #3262

- Added `provider_metadata: Optional[Dict[str, Any]] = None` to `LLMResponse` in `llm_interface_pkg/models.py`
- Added `_build_provider_metadata()` helper to `BaseProvider` that constructs the standard dict: `provider`, `model_api_name`, `api_kwargs_applied`, and optional `total_tokens`
- Each concrete provider's `chat_completion` now populates `provider_metadata` on the success path; the field remains `None` on error so callers can distinguish clean from failed responses
- `ProviderRegistry.get_provider_for_request` logs at DEBUG when the fallback chain selects a non-primary provider

## Providers updated

- `OpenAIProvider` — captures `params` dict + response model + usage tokens
- `AnthropicProvider` — captures `call_kwargs` + response model + summed input/output tokens
- `GroqProvider` — captures `params` dict + response model + usage tokens
- `HuggingFaceProvider` — captures built payload + response model + usage tokens
- `CustomOpenAIProvider` — captures `params` dict + response model + usage tokens
- `OllamaProvider` — synthesises kwargs from request fields + response model + usage tokens

## Test plan

- [x] `llm_providers/provider_metadata_test.py` — 12 new tests covering: field default, `_build_provider_metadata` shape/optional keys, success + error paths for Groq, Anthropic, OpenAI, CustomOpenAI
- [x] `python3 -m pytest llm_providers/provider_metadata_test.py -v` → 12 passed
- [x] `flake8 --max-line-length=100` on all changed files → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)