### PR TITLE
feat(knowledge): persistent editable AI output docs

### DIFF
--- a/autobot-backend/api/documents.py
+++ b/autobot-backend/api/documents.py
@@ -1,0 +1,357 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""AI Document CRUD + refinement API (Issue #3245).
+
+Endpoints
+---------
+POST   /documents                    — create a new AI document
+GET    /documents                    — list documents owned by current user
+GET    /documents/{doc_id}           — fetch a single document
+PUT    /documents/{doc_id}           — update title/content/tags/metadata
+DELETE /documents/{doc_id}           — delete a document
+POST   /documents/{doc_id}/refine    — AI-refine a section using source facts
+
+All endpoints require authentication.  Users can only read/update/delete their
+own documents.
+
+Storage
+-------
+Each document is serialised as a JSON blob under the ``main`` Redis database:
+
+    Key:   autobot:ai_document:{doc_id}
+    Index: autobot:ai_documents:by_user:{user_id}  (Redis Set of doc IDs)
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from auth_middleware import get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.redis_client import get_async_redis_client
+from constants.ttl_constants import TTL_365_DAYS
+from models.document import AIDocument
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["ai-documents"])
+
+# Redis key for the per-user document index
+_USER_INDEX_KEY = "autobot:ai_documents:by_user:{user_id}"
+
+
+# ============================================================================
+# Request / response schemas
+# ============================================================================
+
+
+class CreateDocumentRequest(BaseModel):
+    """Payload for creating a new AI document."""
+
+    title: str = Field(..., min_length=1, max_length=500)
+    content: str = Field(default="")
+    source_facts: List[str] = Field(default_factory=list)
+    source_session_id: Optional[str] = None
+    source_message_id: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class UpdateDocumentRequest(BaseModel):
+    """Partial-update payload — only supplied fields are applied."""
+
+    title: Optional[str] = Field(default=None, min_length=1, max_length=500)
+    content: Optional[str] = None
+    tags: Optional[List[str]] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class RefineDocumentRequest(BaseModel):
+    """Ask the AI to refine a specific section of the document."""
+
+    instruction: str = Field(
+        ...,
+        min_length=1,
+        max_length=2000,
+        description="Refinement instruction, e.g. 'make the introduction shorter'",
+    )
+    section: Optional[str] = Field(
+        default=None,
+        description="Optional section heading to scope the refinement",
+    )
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _user_index_key(user_id: str) -> str:
+    return _USER_INDEX_KEY.format(user_id=user_id)
+
+
+def _owner_id(current_user: dict) -> str:
+    """Extract a stable user ID string from the JWT payload dict."""
+    return (
+        current_user.get("user_id")
+        or current_user.get("id")
+        or current_user.get("sub")
+        or "anonymous"
+    )
+
+
+async def _load_document(redis, doc_id: str) -> Optional[AIDocument]:
+    """Return the document or None if the key is missing."""
+    raw = await redis.get(f"autobot:ai_document:{doc_id}")
+    if raw is None:
+        return None
+    return AIDocument.model_validate(json.loads(raw))
+
+
+async def _save_document(redis, doc: AIDocument) -> None:
+    """Persist a document and its TTL; index under owner."""
+    payload = doc.model_dump_json()
+    pipe = redis.pipeline(transaction=False)
+    pipe.set(doc.redis_key(), payload, ex=TTL_365_DAYS)
+    pipe.sadd(_user_index_key(doc.user_id), doc.id)
+    await pipe.execute()
+
+
+async def _assert_ownership(doc: AIDocument, user_id: str) -> None:
+    """Raise HTTP 403 if the document is not owned by ``user_id``."""
+    if doc.user_id != user_id:
+        raise HTTPException(status_code=403, detail="Not authorised to access this document")
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+
+@router.post("/documents", status_code=201)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="create_ai_document",
+    error_code_prefix="DOCUMENTS",
+)
+async def create_document(
+    body: CreateDocumentRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """Create a new AI document from a KB-grounded response.
+
+    Issue #3245: User can save any AI response as a named document.
+    """
+    uid = _owner_id(current_user)
+    doc = AIDocument(
+        title=body.title,
+        content=body.content,
+        source_facts=body.source_facts,
+        source_session_id=body.source_session_id,
+        source_message_id=body.source_message_id,
+        tags=body.tags,
+        metadata=body.metadata,
+        user_id=uid,
+    )
+    redis = await get_async_redis_client(database="main")
+    await _save_document(redis, doc)
+    logger.info("Created AI document %s for user %s", doc.id, uid)
+    return doc.model_dump()
+
+
+@router.get("/documents")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="list_ai_documents",
+    error_code_prefix="DOCUMENTS",
+)
+async def list_documents(
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """List AI documents owned by the authenticated user.
+
+    Issue #3245: Documents listed and searchable in a documents view.
+    """
+    uid = _owner_id(current_user)
+    redis = await get_async_redis_client(database="main")
+    doc_ids = await redis.smembers(_user_index_key(uid))
+    if not doc_ids:
+        return {"documents": [], "total": 0}
+
+    # Batch-fetch all documents then sort by updated_at (newest first)
+    pipe = redis.pipeline(transaction=False)
+    for doc_id in doc_ids:
+        pipe.get(f"autobot:ai_document:{doc_id}")
+    raw_values = await pipe.execute()
+
+    documents: List[AIDocument] = []
+    for raw in raw_values:
+        if raw is not None:
+            try:
+                documents.append(AIDocument.model_validate(json.loads(raw)))
+            except Exception as exc:
+                logger.warning("Skipping malformed document blob: %s", exc)
+
+    documents.sort(key=lambda d: d.updated_at, reverse=True)
+    total = len(documents)
+    page = documents[offset: offset + limit]
+    return {"documents": [d.model_dump() for d in page], "total": total}
+
+
+@router.get("/documents/{doc_id}")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_ai_document",
+    error_code_prefix="DOCUMENTS",
+)
+async def get_document(
+    doc_id: str,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """Fetch a single AI document by ID."""
+    uid = _owner_id(current_user)
+    redis = await get_async_redis_client(database="main")
+    doc = await _load_document(redis, doc_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    await _assert_ownership(doc, uid)
+    return doc.model_dump()
+
+
+@router.put("/documents/{doc_id}")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="update_ai_document",
+    error_code_prefix="DOCUMENTS",
+)
+async def update_document(
+    doc_id: str,
+    body: UpdateDocumentRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """Partially update title, content, tags, or metadata of an AI document.
+
+    Issue #3245: Document is editable in-frontend (markdown or rich text).
+    """
+    uid = _owner_id(current_user)
+    redis = await get_async_redis_client(database="main")
+    doc = await _load_document(redis, doc_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    await _assert_ownership(doc, uid)
+
+    if body.title is not None:
+        doc.title = body.title
+    if body.content is not None:
+        doc.content = body.content
+    if body.tags is not None:
+        doc.tags = body.tags
+    if body.metadata is not None:
+        doc.metadata = body.metadata
+    doc.touch()
+
+    await _save_document(redis, doc)
+    return doc.model_dump()
+
+
+@router.delete("/documents/{doc_id}", status_code=204)
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="delete_ai_document",
+    error_code_prefix="DOCUMENTS",
+)
+async def delete_document(
+    doc_id: str,
+    current_user: dict = Depends(get_current_user),
+) -> None:
+    """Delete an AI document."""
+    uid = _owner_id(current_user)
+    redis = await get_async_redis_client(database="main")
+    doc = await _load_document(redis, doc_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    await _assert_ownership(doc, uid)
+
+    pipe = redis.pipeline(transaction=False)
+    pipe.delete(doc.redis_key())
+    pipe.srem(_user_index_key(uid), doc_id)
+    await pipe.execute()
+    logger.info("Deleted AI document %s for user %s", doc_id, uid)
+
+
+@router.post("/documents/{doc_id}/refine")
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="refine_ai_document",
+    error_code_prefix="DOCUMENTS",
+)
+async def refine_document(
+    doc_id: str,
+    body: RefineDocumentRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict:
+    """AI-refine a section of an AI document using its source facts.
+
+    Issue #3245: User can send a refinement prompt scoped to the document's
+    source facts.  The LLM edits the document in-place and the updated
+    content is saved back to Redis.
+
+    The LLM call is delegated to the AIStackClient.  If the AI stack is
+    unavailable the endpoint returns an appropriate error rather than
+    silently degrading.
+    """
+    uid = _owner_id(current_user)
+    redis = await get_async_redis_client(database="main")
+    doc = await _load_document(redis, doc_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    await _assert_ownership(doc, uid)
+
+    try:
+        from services.ai_stack_client import get_ai_stack_client
+
+        client = await get_ai_stack_client()
+        system_prompt = (
+            "You are a document editor.  Apply the user's instruction to the "
+            "document content and return ONLY the updated document content — no "
+            "preamble, no explanation.  Preserve markdown formatting."
+        )
+        if body.section:
+            user_prompt = (
+                f"Document title: {doc.title}\n\n"
+                f"Current content:\n{doc.content}\n\n"
+                f"Scope: section '{body.section}'\n"
+                f"Instruction: {body.instruction}"
+            )
+        else:
+            user_prompt = (
+                f"Document title: {doc.title}\n\n"
+                f"Current content:\n{doc.content}\n\n"
+                f"Instruction: {body.instruction}"
+            )
+
+        refined_content = await client.generate(
+            system=system_prompt,
+            prompt=user_prompt,
+            context_ids=doc.source_facts,
+        )
+    except ImportError:
+        raise HTTPException(
+            status_code=503,
+            detail="AI Stack client not available; refinement requires an active LLM service",
+        )
+    except Exception as exc:
+        logger.error("Refinement LLM call failed for document %s: %s", doc_id, exc)
+        raise HTTPException(status_code=502, detail=f"LLM refinement failed: {exc}") from exc
+
+    doc.content = refined_content
+    doc.touch()
+    await _save_document(redis, doc)
+    logger.info("Refined AI document %s for user %s", doc_id, uid)
+    return doc.model_dump()

--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -449,6 +449,13 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["slm-deployments"],
         "slm_deployments",
     ),
+    # Issue #3245: Persistent editable AI output documents
+    (
+        "api.documents",
+        "",
+        ["ai-documents"],
+        "ai_documents",
+    ),
 ]
 
 

--- a/autobot-backend/models/document.py
+++ b/autobot-backend/models/document.py
@@ -1,0 +1,65 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""AIDocument data model for persistent, editable AI output documents (#3245).
+
+An AIDocument is a KB-grounded AI response promoted to a named, editable
+document so users can iteratively refine it in-place.  Documents are stored
+under the ``main`` Redis database (non-volatile user data) with a key prefix
+of ``autobot:ai_document:{document_id}``.  An index set at
+``autobot:ai_documents:index`` tracks all live document IDs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+def _utcnow_iso() -> str:
+    """Return current UTC time as ISO-8601 string."""
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+class AIDocument(BaseModel):
+    """Persistent editable document produced from a KB-grounded AI response.
+
+    Fields mirror the schema described in issue #3245 plus a ``user_id``
+    owner field required for per-user access control.
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    title: str = Field(..., min_length=1, max_length=500)
+    content: str = Field(default="")
+    source_facts: List[str] = Field(
+        default_factory=list,
+        description="KB fact IDs that grounded the original AI response",
+    )
+    source_session_id: Optional[str] = Field(
+        default=None,
+        description="Chat session ID where this document was created",
+    )
+    source_message_id: Optional[str] = Field(
+        default=None,
+        description="Chat message ID from which the document was created",
+    )
+    user_id: str = Field(..., description="Owning user's ID from the JWT")
+    tags: List[str] = Field(default_factory=list)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str = Field(default_factory=_utcnow_iso)
+    updated_at: str = Field(default_factory=_utcnow_iso)
+
+    # ------------------------------------------------------------------ #
+    # Redis serialisation helpers
+    # ------------------------------------------------------------------ #
+
+    def redis_key(self) -> str:
+        """Redis hash key for this document."""
+        return f"autobot:ai_document:{self.id}"
+
+    def touch(self) -> None:
+        """Update the ``updated_at`` timestamp in-place."""
+        self.updated_at = _utcnow_iso()

--- a/autobot-backend/tests/api/test_documents.py
+++ b/autobot-backend/tests/api/test_documents.py
@@ -1,0 +1,220 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for AI Document CRUD + refinement API (Issue #3245)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.document import AIDocument
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_FAKE_USER = {"user_id": "user-abc", "email": "test@example.com"}
+_OTHER_USER = {"user_id": "user-xyz", "email": "other@example.com"}
+
+
+def _make_doc(**kwargs) -> AIDocument:
+    defaults = dict(title="Test Doc", content="Hello world", user_id="user-abc")
+    defaults.update(kwargs)
+    return AIDocument(**defaults)
+
+
+@pytest.fixture()
+def mock_redis():
+    """Async Redis mock with pipeline support."""
+    redis = AsyncMock()
+    pipe = AsyncMock()
+    pipe.__aenter__ = AsyncMock(return_value=pipe)
+    pipe.__aexit__ = AsyncMock(return_value=False)
+    pipe.set = MagicMock()
+    pipe.sadd = MagicMock()
+    pipe.delete = MagicMock()
+    pipe.srem = MagicMock()
+    pipe.execute = AsyncMock(return_value=[True, True])
+    redis.pipeline = MagicMock(return_value=pipe)
+    return redis
+
+
+# ---------------------------------------------------------------------------
+# AIDocument model tests
+# ---------------------------------------------------------------------------
+
+
+class TestAIDocumentModel:
+    def test_defaults_populated(self):
+        doc = _make_doc()
+        assert doc.id
+        assert doc.created_at
+        assert doc.updated_at
+
+    def test_redis_key_format(self):
+        doc = _make_doc()
+        assert doc.redis_key() == f"autobot:ai_document:{doc.id}"
+
+    def test_touch_updates_timestamp(self):
+        doc = _make_doc()
+        old_ts = doc.updated_at
+        import time
+
+        time.sleep(0.001)
+        doc.touch()
+        assert doc.updated_at > old_ts
+
+    def test_source_facts_default_empty(self):
+        doc = _make_doc()
+        assert doc.source_facts == []
+
+
+# ---------------------------------------------------------------------------
+# Endpoint unit tests — patch Redis, test business logic
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDocument:
+    @pytest.mark.asyncio
+    async def test_creates_document(self, mock_redis):
+        from api.documents import create_document, CreateDocumentRequest
+
+        body = CreateDocumentRequest(title="New Doc", content="Some AI text")
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await create_document(body, current_user=_FAKE_USER)
+
+        assert result["title"] == "New Doc"
+        assert result["user_id"] == "user-abc"
+        assert result["id"]
+
+    @pytest.mark.asyncio
+    async def test_creates_with_source_facts(self, mock_redis):
+        from api.documents import create_document, CreateDocumentRequest
+
+        body = CreateDocumentRequest(title="Grounded", source_facts=["fact-1", "fact-2"])
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await create_document(body, current_user=_FAKE_USER)
+
+        assert result["source_facts"] == ["fact-1", "fact-2"]
+
+
+class TestGetDocument:
+    @pytest.mark.asyncio
+    async def test_returns_document(self, mock_redis):
+        from api.documents import get_document
+
+        doc = _make_doc()
+        mock_redis.get = AsyncMock(return_value=doc.model_dump_json())
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await get_document(doc.id, current_user=_FAKE_USER)
+
+        assert result["id"] == doc.id
+
+    @pytest.mark.asyncio
+    async def test_raises_404_when_missing(self, mock_redis):
+        from fastapi import HTTPException
+        from api.documents import get_document
+
+        mock_redis.get = AsyncMock(return_value=None)
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_document("nonexistent", current_user=_FAKE_USER)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_raises_403_for_wrong_owner(self, mock_redis):
+        from fastapi import HTTPException
+        from api.documents import get_document
+
+        doc = _make_doc(user_id="user-abc")
+        mock_redis.get = AsyncMock(return_value=doc.model_dump_json())
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_document(doc.id, current_user=_OTHER_USER)
+
+        assert exc_info.value.status_code == 403
+
+
+class TestUpdateDocument:
+    @pytest.mark.asyncio
+    async def test_updates_title_and_content(self, mock_redis):
+        from api.documents import update_document, UpdateDocumentRequest
+
+        doc = _make_doc()
+        mock_redis.get = AsyncMock(return_value=doc.model_dump_json())
+        body = UpdateDocumentRequest(title="Updated Title", content="New content")
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await update_document(doc.id, body, current_user=_FAKE_USER)
+
+        assert result["title"] == "Updated Title"
+        assert result["content"] == "New content"
+
+    @pytest.mark.asyncio
+    async def test_partial_update_leaves_other_fields(self, mock_redis):
+        from api.documents import update_document, UpdateDocumentRequest
+
+        doc = _make_doc(content="original content")
+        mock_redis.get = AsyncMock(return_value=doc.model_dump_json())
+        body = UpdateDocumentRequest(title="New Title Only")
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await update_document(doc.id, body, current_user=_FAKE_USER)
+
+        assert result["content"] == "original content"
+        assert result["title"] == "New Title Only"
+
+
+class TestDeleteDocument:
+    @pytest.mark.asyncio
+    async def test_deletes_document(self, mock_redis):
+        from api.documents import delete_document
+
+        doc = _make_doc()
+        mock_redis.get = AsyncMock(return_value=doc.model_dump_json())
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await delete_document(doc.id, current_user=_FAKE_USER)
+
+        # delete_document returns None (204)
+        assert result is None
+        mock_redis.pipeline().delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_404_when_missing(self, mock_redis):
+        from fastapi import HTTPException
+        from api.documents import delete_document
+
+        mock_redis.get = AsyncMock(return_value=None)
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            with pytest.raises(HTTPException) as exc_info:
+                await delete_document("ghost-id", current_user=_FAKE_USER)
+
+        assert exc_info.value.status_code == 404
+
+
+class TestListDocuments:
+    @pytest.mark.asyncio
+    async def test_empty_index_returns_empty_list(self, mock_redis):
+        from api.documents import list_documents
+
+        mock_redis.smembers = AsyncMock(return_value=set())
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await list_documents(limit=50, offset=0, current_user=_FAKE_USER)
+
+        assert result == {"documents": [], "total": 0}
+
+    @pytest.mark.asyncio
+    async def test_lists_user_documents(self, mock_redis):
+        from api.documents import list_documents
+
+        doc1 = _make_doc(title="Doc A")
+        doc2 = _make_doc(title="Doc B")
+        mock_redis.smembers = AsyncMock(return_value={doc1.id, doc2.id})
+        pipe = AsyncMock()
+        pipe.get = MagicMock()
+        pipe.execute = AsyncMock(return_value=[doc1.model_dump_json(), doc2.model_dump_json()])
+        mock_redis.pipeline = MagicMock(return_value=pipe)
+        with patch("api.documents.get_async_redis_client", AsyncMock(return_value=mock_redis)):
+            result = await list_documents(limit=50, offset=0, current_user=_FAKE_USER)
+
+        assert result["total"] == 2
+        assert len(result["documents"]) == 2

--- a/autobot-frontend/src/components/chat/MessageItem.vue
+++ b/autobot-frontend/src/components/chat/MessageItem.vue
@@ -39,6 +39,19 @@
         >
           <i class="fas fa-copy" aria-hidden="true"></i>
         </BaseButton>
+        <!-- Issue #3245: Save assistant response as a persistent AI document -->
+        <BaseButton
+          v-if="message.sender === 'assistant'"
+          variant="ghost"
+          size="xs"
+          :disabled="isSavingDocument"
+          class="action-btn"
+          aria-label="Save as document"
+          title="Save as document"
+          @click="handleSaveAsDocument"
+        >
+          <i class="fas fa-file-alt" aria-hidden="true"></i>
+        </BaseButton>
         <BaseButton
           variant="ghost"
           size="xs"
@@ -155,7 +168,7 @@
  * Issue #184: Split oversized Vue components
  */
 
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ChatMessage } from '@/stores/useChatStore'
 import { formatTime } from '@/utils/formatHelpers'
@@ -167,6 +180,7 @@ import ApprovalRequestCard from './ApprovalRequestCard.vue'
 import CitationsDisplay from './CitationsDisplay.vue'
 import MessageAttachments from './MessageAttachments.vue'
 import { sanitizeChatHtml } from '@/utils/sanitize'
+import { useAIDocument } from '@/composables/useAIDocument'
 
 interface Props {
   message: ChatMessage
@@ -189,6 +203,8 @@ interface Emits {
   (e: 'approve', data: unknown): void
   (e: 'deny', data: unknown): void
   (e: 'auto-approve-changed', value: boolean): void
+  /** Issue #3245: emitted after an assistant message is saved as an AI document */
+  (e: 'save-as-document', docId: string): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -199,7 +215,25 @@ const props = withDefaults(defineProps<Props>(), {
   processingApproval: false
 })
 
-defineEmits<Emits>()
+const emit = defineEmits<Emits>()
+
+// Issue #3245: Save-as-document integration
+const { saveMessageAsDocument } = useAIDocument()
+const isSavingDocument = ref(false)
+
+async function handleSaveAsDocument() {
+  if (isSavingDocument.value) return
+  isSavingDocument.value = true
+  try {
+    const doc = await saveMessageAsDocument({
+      content: props.message.content,
+      messageId: props.message.id,
+    })
+    emit('save-as-document', doc.id)
+  } finally {
+    isSavingDocument.value = false
+  }
+}
 
 // Computed properties
 const messageWrapperClass = computed(() => {

--- a/autobot-frontend/src/components/documents/AIDocumentEditor.vue
+++ b/autobot-frontend/src/components/documents/AIDocumentEditor.vue
@@ -1,0 +1,393 @@
+<template>
+  <!-- AI Document Editor — Issue #3245 -->
+  <div class="ai-document-editor">
+    <!-- Header bar -->
+    <div class="editor-header">
+      <div class="title-row">
+        <input
+          v-if="isEditingTitle"
+          ref="titleInputRef"
+          v-model="editableTitle"
+          class="title-input"
+          maxlength="500"
+          aria-label="Document title"
+          @blur="commitTitle"
+          @keyup.enter="commitTitle"
+          @keyup.escape="cancelTitle"
+        />
+        <h2
+          v-else
+          class="document-title"
+          tabindex="0"
+          title="Click to edit title"
+          @click="startEditTitle"
+          @keyup.enter="startEditTitle"
+        >
+          {{ localDoc?.title ?? 'Untitled Document' }}
+        </h2>
+      </div>
+
+      <div class="header-actions">
+        <BaseButton
+          v-if="isDirty"
+          variant="primary"
+          size="sm"
+          :disabled="composable.isSaving.value"
+          @click="saveChanges"
+        >
+          {{ composable.isSaving.value ? 'Saving…' : 'Save' }}
+        </BaseButton>
+        <BaseButton
+          variant="ghost"
+          size="sm"
+          :disabled="composable.isRefining.value"
+          title="Refine with AI"
+          @click="showRefinePanel = !showRefinePanel"
+        >
+          Refine
+        </BaseButton>
+        <slot name="extra-actions" />
+      </div>
+    </div>
+
+    <!-- Error banner -->
+    <div v-if="composable.error.value" class="error-banner" role="alert">
+      {{ composable.error.value }}
+    </div>
+
+    <!-- Refine panel -->
+    <div v-if="showRefinePanel" class="refine-panel">
+      <textarea
+        v-model="refineInstruction"
+        class="refine-textarea"
+        placeholder="Describe how to refine this document…"
+        rows="3"
+        maxlength="2000"
+        aria-label="Refinement instruction"
+      />
+      <div class="refine-actions">
+        <BaseButton
+          variant="primary"
+          size="sm"
+          :disabled="!refineInstruction.trim() || composable.isRefining.value"
+          @click="submitRefine"
+        >
+          {{ composable.isRefining.value ? 'Refining…' : 'Apply Refinement' }}
+        </BaseButton>
+        <BaseButton variant="ghost" size="sm" @click="showRefinePanel = false">
+          Cancel
+        </BaseButton>
+      </div>
+    </div>
+
+    <!-- Markdown editor (textarea) -->
+    <div class="editor-body">
+      <textarea
+        v-model="editableContent"
+        class="content-editor"
+        placeholder="Document content (markdown supported)…"
+        spellcheck="true"
+        aria-label="Document content"
+        @input="onContentInput"
+      />
+    </div>
+
+    <!-- Footer metadata -->
+    <div class="editor-footer">
+      <span v-if="localDoc" class="meta">
+        Updated {{ formattedUpdatedAt }}
+      </span>
+      <span v-if="localDoc?.source_facts?.length" class="source-facts-count">
+        {{ localDoc.source_facts.length }} source
+        {{ localDoc.source_facts.length === 1 ? 'fact' : 'facts' }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, nextTick } from 'vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+import { useAIDocument, type AIDocument } from '@/composables/useAIDocument'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('AIDocumentEditor')
+
+// ---------------------------------------------------------------------------
+// Props / emits
+// ---------------------------------------------------------------------------
+
+const props = defineProps<{
+  docId: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'saved', doc: AIDocument): void
+  (e: 'refined', doc: AIDocument): void
+  (e: 'error', message: string): void
+}>()
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+const composable = useAIDocument()
+
+// ---------------------------------------------------------------------------
+// Local state
+// ---------------------------------------------------------------------------
+
+const localDoc = ref<AIDocument | null>(null)
+const editableTitle = ref('')
+const editableContent = ref('')
+const isEditingTitle = ref(false)
+const isDirty = ref(false)
+const showRefinePanel = ref(false)
+const refineInstruction = ref('')
+const titleInputRef = ref<HTMLInputElement | null>(null)
+
+// ---------------------------------------------------------------------------
+// Load document on mount / when docId changes
+// ---------------------------------------------------------------------------
+
+watch(
+  () => props.docId,
+  async (id) => {
+    if (!id) return
+    try {
+      const doc = await composable.fetchDocument(id)
+      localDoc.value = doc
+      editableTitle.value = doc.title
+      editableContent.value = doc.content
+      isDirty.value = false
+    } catch (err) {
+      logger.error('Failed to load document', err)
+      emit('error', composable.error.value ?? 'Failed to load document')
+    }
+  },
+  { immediate: true }
+)
+
+// ---------------------------------------------------------------------------
+// Title editing
+// ---------------------------------------------------------------------------
+
+function startEditTitle() {
+  isEditingTitle.value = true
+  nextTick(() => titleInputRef.value?.focus())
+}
+
+function commitTitle() {
+  if (!editableTitle.value.trim()) {
+    editableTitle.value = localDoc.value?.title ?? 'Untitled Document'
+  }
+  isEditingTitle.value = false
+  if (localDoc.value && editableTitle.value !== localDoc.value.title) {
+    isDirty.value = true
+  }
+}
+
+function cancelTitle() {
+  editableTitle.value = localDoc.value?.title ?? ''
+  isEditingTitle.value = false
+}
+
+// ---------------------------------------------------------------------------
+// Content change tracking
+// ---------------------------------------------------------------------------
+
+function onContentInput() {
+  isDirty.value = true
+}
+
+// ---------------------------------------------------------------------------
+// Save
+// ---------------------------------------------------------------------------
+
+async function saveChanges() {
+  if (!localDoc.value || !isDirty.value) return
+  try {
+    const updated = await composable.updateDocument(localDoc.value.id, {
+      title: editableTitle.value,
+      content: editableContent.value,
+    })
+    localDoc.value = updated
+    isDirty.value = false
+    emit('saved', updated)
+  } catch (err) {
+    emit('error', composable.error.value ?? 'Save failed')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Refinement
+// ---------------------------------------------------------------------------
+
+async function submitRefine() {
+  if (!localDoc.value || !refineInstruction.value.trim()) return
+  try {
+    const refined = await composable.refineDocument(localDoc.value.id, {
+      instruction: refineInstruction.value.trim(),
+    })
+    localDoc.value = refined
+    editableContent.value = refined.content
+    editableTitle.value = refined.title
+    isDirty.value = false
+    refineInstruction.value = ''
+    showRefinePanel.value = false
+    emit('refined', refined)
+  } catch (err) {
+    emit('error', composable.error.value ?? 'Refinement failed')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formattedUpdatedAt = computed(() => {
+  if (!localDoc.value) return ''
+  try {
+    return new Date(localDoc.value.updated_at).toLocaleString()
+  } catch {
+    return localDoc.value.updated_at
+  }
+})
+</script>
+
+<style scoped>
+.ai-document-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--color-background, #1e1e1e);
+  color: var(--color-text, #e0e0e0);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border, #333);
+  gap: 12px;
+}
+
+.title-row {
+  flex: 1;
+  min-width: 0;
+}
+
+.document-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  outline: none;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.document-title:hover {
+  background: var(--color-background-hover, #2a2a2a);
+}
+
+.title-input {
+  width: 100%;
+  background: var(--color-background-input, #2a2a2a);
+  color: inherit;
+  border: 1px solid var(--color-primary, #4caf50);
+  border-radius: 4px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  outline: none;
+}
+
+.header-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.error-banner {
+  background: var(--color-error-bg, #3c1515);
+  color: var(--color-error, #f87171);
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  border-bottom: 1px solid var(--color-error, #f87171);
+}
+
+.refine-panel {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border, #333);
+  background: var(--color-background-secondary, #252525);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.refine-textarea {
+  width: 100%;
+  resize: vertical;
+  background: var(--color-background-input, #2a2a2a);
+  color: inherit;
+  border: 1px solid var(--color-border, #444);
+  border-radius: 4px;
+  padding: 8px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.refine-textarea:focus {
+  border-color: var(--color-primary, #4caf50);
+}
+
+.refine-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.editor-body {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.content-editor {
+  flex: 1;
+  resize: none;
+  background: transparent;
+  color: inherit;
+  border: none;
+  padding: 16px;
+  font-size: 0.95rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  line-height: 1.6;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.editor-footer {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 6px 16px;
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #888);
+  border-top: 1px solid var(--color-border, #333);
+}
+
+.source-facts-count {
+  margin-left: auto;
+}
+</style>

--- a/autobot-frontend/src/composables/useAIDocument.ts
+++ b/autobot-frontend/src/composables/useAIDocument.ts
@@ -1,0 +1,256 @@
+/**
+ * useAIDocument Composable
+ *
+ * State management and API calls for persistent, editable AI output documents.
+ *
+ * Issue #3245 — Knowledge Base: persistent editable AI output documents
+ *
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ */
+
+import { ref, computed } from 'vue'
+import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useAIDocument')
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AIDocument {
+  id: string
+  title: string
+  content: string
+  source_facts: string[]
+  source_session_id: string | null
+  source_message_id: string | null
+  user_id: string
+  tags: string[]
+  metadata: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateDocumentPayload {
+  title: string
+  content?: string
+  source_facts?: string[]
+  source_session_id?: string
+  source_message_id?: string
+  tags?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface UpdateDocumentPayload {
+  title?: string
+  content?: string
+  tags?: string[]
+  metadata?: Record<string, unknown>
+}
+
+export interface RefineDocumentPayload {
+  instruction: string
+  section?: string
+}
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+export function useAIDocument() {
+  const documents = ref<AIDocument[]>([])
+  const currentDocument = ref<AIDocument | null>(null)
+  const isLoading = ref(false)
+  const isSaving = ref(false)
+  const isRefining = ref(false)
+  const error = ref<string | null>(null)
+  const total = ref(0)
+
+  const hasDocuments = computed(() => documents.value.length > 0)
+
+  // -------------------------------------------------------------------------
+  // API helpers
+  // -------------------------------------------------------------------------
+
+  function _base(): string {
+    return `${getApiBase()}/documents`
+  }
+
+  async function _handleError(label: string, err: unknown): Promise<never> {
+    const msg = err instanceof Error ? err.message : String(err)
+    logger.error(`${label}: ${msg}`)
+    error.value = msg
+    throw err
+  }
+
+  // -------------------------------------------------------------------------
+  // Public actions
+  // -------------------------------------------------------------------------
+
+  /** Fetch the list of documents owned by the authenticated user. */
+  async function fetchDocuments(limit = 50, offset = 0): Promise<void> {
+    isLoading.value = true
+    error.value = null
+    try {
+      const response = await apiClient.get<{ documents: AIDocument[]; total: number }>(
+        `${_base()}?limit=${limit}&offset=${offset}`
+      )
+      documents.value = response.data.documents
+      total.value = response.data.total
+    } catch (err) {
+      await _handleError('fetchDocuments', err)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Load a single document into `currentDocument`. */
+  async function fetchDocument(docId: string): Promise<AIDocument> {
+    isLoading.value = true
+    error.value = null
+    try {
+      const response = await apiClient.get<AIDocument>(`${_base()}/${docId}`)
+      currentDocument.value = response.data
+      return response.data
+    } catch (err) {
+      return await _handleError('fetchDocument', err)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  /** Create a new AI document and prepend it to the local list. */
+  async function createDocument(payload: CreateDocumentPayload): Promise<AIDocument> {
+    isSaving.value = true
+    error.value = null
+    try {
+      const response = await apiClient.post<AIDocument>(_base(), payload)
+      const created = response.data
+      documents.value.unshift(created)
+      total.value += 1
+      logger.info(`Created document ${created.id}: ${created.title}`)
+      return created
+    } catch (err) {
+      return await _handleError('createDocument', err)
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  /** Save edits to an existing document. */
+  async function updateDocument(
+    docId: string,
+    payload: UpdateDocumentPayload
+  ): Promise<AIDocument> {
+    isSaving.value = true
+    error.value = null
+    try {
+      const response = await apiClient.put<AIDocument>(`${_base()}/${docId}`, payload)
+      const updated = response.data
+      // Sync local list
+      const idx = documents.value.findIndex((d) => d.id === docId)
+      if (idx !== -1) {
+        documents.value[idx] = updated
+      }
+      if (currentDocument.value?.id === docId) {
+        currentDocument.value = updated
+      }
+      return updated
+    } catch (err) {
+      return await _handleError('updateDocument', err)
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  /** Delete a document and remove it from the local list. */
+  async function deleteDocument(docId: string): Promise<void> {
+    error.value = null
+    try {
+      await apiClient.delete(`${_base()}/${docId}`)
+      documents.value = documents.value.filter((d) => d.id !== docId)
+      total.value = Math.max(0, total.value - 1)
+      if (currentDocument.value?.id === docId) {
+        currentDocument.value = null
+      }
+      logger.info(`Deleted document ${docId}`)
+    } catch (err) {
+      await _handleError('deleteDocument', err)
+    }
+  }
+
+  /** Send a refinement instruction to the AI and update the document. */
+  async function refineDocument(
+    docId: string,
+    payload: RefineDocumentPayload
+  ): Promise<AIDocument> {
+    isRefining.value = true
+    error.value = null
+    try {
+      const response = await apiClient.post<AIDocument>(
+        `${_base()}/${docId}/refine`,
+        payload
+      )
+      const refined = response.data
+      const idx = documents.value.findIndex((d) => d.id === docId)
+      if (idx !== -1) {
+        documents.value[idx] = refined
+      }
+      if (currentDocument.value?.id === docId) {
+        currentDocument.value = refined
+      }
+      logger.info(`Refined document ${docId}`)
+      return refined
+    } catch (err) {
+      return await _handleError('refineDocument', err)
+    } finally {
+      isRefining.value = false
+    }
+  }
+
+  /** Convenience: save an AI chat message as a new document. */
+  async function saveMessageAsDocument(opts: {
+    content: string
+    title?: string
+    sessionId?: string
+    messageId?: string
+    sourceFacts?: string[]
+  }): Promise<AIDocument> {
+    const title =
+      opts.title ??
+      (opts.content.length > 60
+        ? opts.content.slice(0, 60).trimEnd() + '…'
+        : opts.content)
+    return createDocument({
+      title,
+      content: opts.content,
+      source_session_id: opts.sessionId,
+      source_message_id: opts.messageId,
+      source_facts: opts.sourceFacts ?? [],
+    })
+  }
+
+  return {
+    // state
+    documents,
+    currentDocument,
+    isLoading,
+    isSaving,
+    isRefining,
+    error,
+    total,
+    hasDocuments,
+    // actions
+    fetchDocuments,
+    fetchDocument,
+    createDocument,
+    updateDocument,
+    deleteDocument,
+    refineDocument,
+    saveMessageAsDocument,
+  }
+}


### PR DESCRIPTION
## Summary

Closes #3245

- **`autobot-backend/models/document.py`** — `AIDocument` Pydantic model with Redis serialisation helpers (`redis_key()`, `touch()`)
- **`autobot-backend/api/documents.py`** — full CRUD (create/list/get/update/delete) plus `POST /documents/{id}/refine` endpoint that delegates to the AI Stack client; per-user Redis index under `autobot:ai_documents:by_user:{user_id}`; ownership enforcement (403 on cross-user access)
- **`autobot-backend/tests/api/test_documents.py`** — 15 unit tests, all passing
- **`initialization/router_registry/feature_routers.py`** — router registered at `/api/documents`
- **`autobot-frontend/src/composables/useAIDocument.ts`** — Vue composable exposing `fetchDocuments`, `fetchDocument`, `createDocument`, `updateDocument`, `deleteDocument`, `refineDocument`, `saveMessageAsDocument`
- **`autobot-frontend/src/components/documents/AIDocumentEditor.vue`** — in-place markdown editor with inline title editing, Refine panel, save button, and source-facts count footer
- **`autobot-frontend/src/components/chat/MessageItem.vue`** — Save-as-document button (file-alt icon) added to assistant message action bar

## Storage

Each document is stored as a JSON blob in the main Redis database with a 365-day TTL.

## Test plan

- [x] pytest tests/api/test_documents.py — 15/15 passed
- [x] flake8 --max-line-length=100 — clean on all new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)