### PR TITLE
fix(tests): resolve artifact serialization validation in test fixtures (#4226)

### DIFF
--- a/autobot-backend/tools/parallel/executor_artifacts_test.py
+++ b/autobot-backend/tools/parallel/executor_artifacts_test.py
@@ -6,7 +6,7 @@
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 
-from events.types import ArtifactType
+from events.types import ArtifactType, build_artifact
 from tools.parallel.executor import (
     ParallelToolExecutor,
     _ArtifactCapture,
@@ -117,7 +117,7 @@ class TestPublishObservationWithArtifacts:
 
         action_event = MagicMock(event_id="action-123")
         call = ToolCall(tool_name="edit_file", arguments={"file_path": "/tmp/test.py"})
-        artifacts = [MagicMock()]
+        artifacts = [build_artifact(ArtifactType.CUSTOM, "test artifact content", label="test")]
 
         await executor._publish_observation_event(
             action_event=action_event,


### PR DESCRIPTION
## Summary

Fixed test fixture passing MagicMock objects where TaskArtifact instances are now required due to serialization validation from #4094.

## Root Cause

Issue #4094 added serialization validation via `_validate_artifact_serialization`, which calls `json.dumps` on artifact dicts. MagicMock objects are not JSON-serializable, causing `ValueError`.

## Fix  

Use `build_artifact()` factory to create proper TaskArtifact instances instead of MagicMock.

## Testing

All 9 executor tests pass.

Closes #4226