### PR TITLE
fix(ci): fix phase_validation_system.py broken imports (#4297)

### DIFF
--- a/autobot-infrastructure/shared/scripts/phase_validation_system.py
+++ b/autobot-infrastructure/shared/scripts/phase_validation_system.py
@@ -22,9 +22,8 @@ import psutil
 import requests
 
 # Import centralized Redis client
-sys.path.append(str(Path(__file__).parent.parent))
-from constants import ServiceURLs
-from utils.redis_client import get_redis_client
+from autobot_shared.network_constants import ServiceURLs
+from autobot_shared.redis_client import get_redis_client
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -602,7 +601,7 @@ class PhaseValidator:
     def _check_ollama_service(self) -> bool:
         """Check if Ollama is accessible (Issue #315: extracted helper)."""
         try:
-            response = requests.get("ServiceURLs.OLLAMA_LOCAL/api/tags", timeout=3)
+            response = requests.get(f"{ServiceURLs.OLLAMA_LOCAL}/api/tags", timeout=3)
             return response.status_code == 200
         except Exception:
             return False


### PR DESCRIPTION
## Summary

Fixes broken imports in phase_validation_system.py that were causing ModuleNotFoundError at runtime.

### Changes

1. **Fixed import of ServiceURLs:**
   - `from constants import ServiceURLs` → `from autobot_shared.network_constants import ServiceURLs`

2. **Fixed import of Redis client:**
   - `from utils.redis_client import get_redis_client` → `from autobot_shared.redis_client import get_redis_client`

3. **Removed manual sys.path manipulation** — no longer needed with correct imports

4. **Bonus fix: Fixed Ollama URL bug (line 605):**
   - Was: `requests.get("ServiceURLs.OLLAMA_LOCAL/api/tags", ...)` (string literal)
   - Now: `f"{ServiceURLs.OLLAMA_LOCAL}/api/tags"` (correct variable interpolation)

### Impact

- Phase Validation workflow will no longer crash with ModuleNotFoundError
- Ollama health checks will now hit the correct service URL
- All imports follow project standards (autobot_shared modules)

### Verification

- ✅ Python syntax valid
- ✅ All imports resolve correctly
- ✅ phase_validation_system.py can be imported without errors

Closes #4297

🤖 Generated with [Claude Code](https://claude.com/claude-code)