### PR TITLE
fix(frontend): prevent chat sessions loss on empty backend response (#4328)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -790,8 +790,16 @@ const initializeChatInterface = async () => {
 
       // Process results - sync with backend (source of truth)
       if (data.chat_sessions && !data.chat_sessions.error && Array.isArray(data.chat_sessions)) {
-        // Use syncSessionsWithBackend to remove deleted sessions and add new ones
-        store.syncSessionsWithBackend(data.chat_sessions)
+        // Only sync if backend returned sessions OR store is already empty.
+        // An empty backend response while local sessions exist likely means the
+        // API returned incomplete data (auth not ready, caching lag, network issue).
+        // Syncing in that case would destroy all local session history (#4328).
+        if (data.chat_sessions.length > 0 || store.sessions.length === 0) {
+          // Use syncSessionsWithBackend to remove deleted sessions and add new ones
+          store.syncSessionsWithBackend(data.chat_sessions)
+        } else {
+          logger.warn('syncSessionsWithBackend skipped: backend returned 0 sessions but store has sessions — preserving local data')
+        }
       }
 
       // Update connection status

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -458,6 +458,14 @@ export const useChatStore = defineStore('chat', () => {
      *
      * This fixes the bug where deleted sessions reappear after page reload.
      */
+    // Defensive guard: if backend returns 0 sessions but store has sessions,
+    // the backend may have returned incomplete data. Preserving local sessions
+    // prevents accidental data loss (#4328).
+    if (backendSessions.length === 0 && sessions.value.length > 0) {
+      logger.warn(`syncSessionsWithBackend: backend returned 0 sessions but store has ${sessions.value.length} — skipping to preserve local data`)
+      return
+    }
+
     logger.debug(`🔄 Syncing sessions: Store has ${sessions.value.length}, Backend has ${backendSessions.length}`)
 
     const backendIds = new Set(backendSessions.map(s => s.id))


### PR DESCRIPTION
## Summary

Fix bug where chat sessions disappear on navigation when the backend API returns an empty response. This prevents accidental loss of conversation history when:
- Navigation triggers a component remount with slow/failing API calls
- Backend returns incomplete data due to authentication delays
- Network issues cause silent API failures

## Changes

1. **ChatInterface.vue** (lines 792-803)
   - Add guard before calling `syncSessionsWithBackend()`: only sync if backend returned sessions OR store is already empty
   - Log warning if sync is skipped to track defensive behavior

2. **useChatStore.ts** (lines 449-467)
   - Add defensive guard at start of `syncSessionsWithBackend()`: skip if backend returns 0 sessions but store has existing sessions
   - Log warning for debugging

## Root Cause

The `syncSessionsWithBackend()` method treats the backend response as authoritative, removing any local session not in that response. When the backend returns an empty array `[]` (due to API latency, auth not ready, or network issue), all local sessions are destroyed and wiped from localStorage.

## Trade-off

If a user legitimately deletes all sessions from the backend, the local copies won't be cleared. This is an acceptable trade-off that prioritizes preventing accidental data loss over perfect sync.

## Testing

- Create a chat session
- Navigate to Knowledge Base or another page
- Navigate back to Chat
- Verify session still present
- Check browser console for warning logs when backend returns empty sessions

Closes #4328