### PR TITLE
feat(skills): usage metrics and health tracking (#4339)

### DIFF
--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -6,6 +6,8 @@ Skills API Endpoints (Issue #731)
 
 REST API for managing the Skills system: list, enable/disable,
 configure, execute, and monitor skills.
+
+Includes metrics and health tracking (Issue #4339).
 """
 
 import logging
@@ -16,6 +18,8 @@ from pydantic import BaseModel, Field
 
 from skills.manager import SkillManager
 from skills.registry import get_skill_registry
+
+logger = logging.getLogger(__name__)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -58,6 +62,13 @@ class UserSkillPreferences(BaseModel):
     preferences: Dict[str, bool] = Field(
         ..., description="Mapping of skill_name -> enabled"
     )
+
+
+class SkillFeedbackRequest(BaseModel):
+    """Request body for submitting skill feedback."""
+
+    rating: int = Field(..., description="User rating (1-5)", ge=1, le=5)
+    feedback: Optional[str] = Field(None, description="Feedback text")
 
 
 # --- Endpoints ---
@@ -196,3 +207,68 @@ async def list_skill_actions(name: str) -> Dict[str, Any]:
         "skill": name,
         "actions": skill.get_available_actions(),
     }
+
+
+@router.get("/{name}/metrics", summary="Get skill metrics")
+async def get_skill_metrics(
+    name: str,
+    days: int = Query(30, description="Number of days to analyze"),
+) -> Dict[str, Any]:
+    """Get performance metrics for a skill (Issue #4339).
+
+    Returns invocation count, success rate, error patterns, and duration stats.
+    """
+    try:
+        from services.skill_management.skill_metrics import SkillMetrics
+
+        metrics = SkillMetrics()
+        data = await metrics.get_metrics(name, days)
+        health_score = await metrics.get_health_score(name, days)
+        data["health_score"] = health_score
+        return data
+    except Exception as e:
+        logger.error("Failed to get metrics for %s: %s", name, e)
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve metrics: {e}")
+
+
+@router.post("/{name}/feedback", summary="Submit skill feedback")
+async def submit_skill_feedback(
+    name: str,
+    body: SkillFeedbackRequest,
+    action: Optional[str] = Query(None, description="Action that was invoked"),
+) -> Dict[str, Any]:
+    """Submit user feedback for a skill (Issue #4339)."""
+    try:
+        from services.skill_management.skill_feedback import SkillFeedbackAnalyzer
+
+        analyzer = SkillFeedbackAnalyzer()
+        await analyzer.log_user_feedback(
+            skill_id=name,
+            action=action or "unknown",
+            rating=body.rating,
+            feedback_text=body.feedback,
+        )
+        return {
+            "success": True,
+            "message": f"Feedback submitted for skill '{name}'",
+        }
+    except Exception as e:
+        logger.error("Failed to log feedback: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to log feedback: {e}")
+
+
+@router.get("/{name}/suggestions", summary="Get skill refinement suggestions")
+async def get_refinement_suggestions(name: str) -> Dict[str, Any]:
+    """Get suggestions for improving a skill (Issue #4339)."""
+    try:
+        from services.skill_management.skill_feedback import SkillFeedbackAnalyzer
+
+        analyzer = SkillFeedbackAnalyzer()
+        suggestions = await analyzer.get_refinement_suggestions(name)
+        return suggestions
+    except Exception as e:
+        logger.error("Failed to get suggestions for %s: %s", name, e)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to retrieve suggestions: {e}",
+        )

--- a/autobot-backend/services/skill_management/__init__.py
+++ b/autobot-backend/services/skill_management/__init__.py
@@ -1,0 +1,19 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Skill Management Service Module (Issue #4339)
+
+Provides skill metrics tracking, health scoring, and feedback analysis.
+"""
+
+from .skill_feedback import SkillFeedbackAnalyzer
+from .skill_health_scheduler import SkillHealthScheduler, get_skill_health_scheduler
+from .skill_metrics import SkillMetrics
+
+__all__ = [
+    "SkillMetrics",
+    "SkillHealthScheduler",
+    "get_skill_health_scheduler",
+    "SkillFeedbackAnalyzer",
+]

--- a/autobot-backend/services/skill_management/skill_feedback.py
+++ b/autobot-backend/services/skill_management/skill_feedback.py
@@ -1,0 +1,230 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Skill Feedback Analysis (Issue #4339)
+
+Analyzes skill feedback to identify failure patterns and
+provide refinement recommendations.
+"""
+
+import json
+import logging
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from autobot_shared.redis_client import RedisDatabase, get_redis_client
+
+from .skill_metrics import SkillMetrics, REDIS_SKILL_METRICS_PREFIX
+
+logger = logging.getLogger(__name__)
+
+
+class SkillFeedbackAnalyzer:
+    """Analyzes skill feedback to identify patterns and recommend improvements."""
+
+    def __init__(self) -> None:
+        self._metrics = SkillMetrics()
+        self._redis: Optional[Any] = None
+
+    async def _get_redis(self) -> Optional[Any]:
+        """Get Redis client (analytics database)."""
+        if self._redis is None:
+            try:
+                self._redis = get_redis_client(RedisDatabase.ANALYTICS)
+            except Exception as e:
+                logger.error("Failed to get Redis client: %s", e)
+        return self._redis
+
+    async def log_user_feedback(
+        self,
+        skill_id: str,
+        action: str,
+        rating: int,
+        feedback_text: Optional[str] = None,
+    ) -> None:
+        """Log user feedback for a skill invocation.
+
+        Args:
+            skill_id: Unique skill identifier
+            action: Action/tool that was invoked
+            rating: User rating (1-5, where 5 is best)
+            feedback_text: Optional free-text feedback
+        """
+        redis = await self._get_redis()
+        if not redis:
+            return
+
+        try:
+            now = datetime.now(timezone.utc)
+            feedback_entry = {
+                "timestamp": now.isoformat(),
+                "skill_id": skill_id,
+                "action": action,
+                "rating": rating,
+                "feedback": feedback_text or "",
+            }
+
+            key = f"skill_feedback:{skill_id}:{now.strftime('%Y-%m-%d')}"
+            redis.lpush(key, json.dumps(feedback_entry, default=str))
+            redis.expire(key, 90 * 86400)  # Keep 90 days
+
+            logger.debug("Logged feedback for %s: rating=%d", skill_id, rating)
+
+        except Exception as e:
+            logger.error("Failed to log user feedback: %s", e)
+
+    async def get_feedback_summary(
+        self, skill_id: str, days: int = 30
+    ) -> Dict[str, Any]:
+        """Get summary of user feedback for a skill.
+
+        Args:
+            skill_id: Unique skill identifier
+            days: Number of days to analyze
+
+        Returns:
+            Summary of feedback patterns
+        """
+        redis = await self._get_redis()
+        if not redis:
+            return {
+                "skill_id": skill_id,
+                "avg_rating": 0.0,
+                "total_feedback": 0,
+                "failure_patterns": [],
+            }
+
+        try:
+            ratings = []
+            failure_patterns: List[str] = []
+
+            # Collect feedback from past N days
+            now = datetime.now(timezone.utc)
+            for i in range(days):
+                date = (now - timedelta(days=i)).strftime("%Y-%m-%d")
+                key = f"skill_feedback:{skill_id}:{date}"
+                feedback_entries = redis.lrange(key, 0, -1)
+
+                for entry_raw in feedback_entries:
+                    try:
+                        entry = json.loads(entry_raw.decode())
+                        rating = entry.get("rating", 0)
+                        feedback = entry.get("feedback", "")
+
+                        ratings.append(rating)
+
+                        # Track failure patterns (ratings 1-2)
+                        if rating <= 2 and feedback:
+                            failure_patterns.append(feedback)
+
+                    except json.JSONDecodeError:
+                        continue
+
+            # Calculate statistics
+            avg_rating = (
+                (sum(ratings) / len(ratings)) if ratings else 0.0
+            )
+
+            # Find most common failure patterns
+            pattern_counter = Counter(failure_patterns)
+            top_patterns = [
+                {"pattern": p, "count": c}
+                for p, c in pattern_counter.most_common(5)
+            ]
+
+            return {
+                "skill_id": skill_id,
+                "total_feedback": len(ratings),
+                "avg_rating": round(avg_rating, 2),
+                "rating_distribution": {
+                    "5_star": ratings.count(5),
+                    "4_star": ratings.count(4),
+                    "3_star": ratings.count(3),
+                    "2_star": ratings.count(2),
+                    "1_star": ratings.count(1),
+                },
+                "failure_patterns": top_patterns,
+                "period_days": days,
+                "needs_refinement": len(top_patterns) >= 2 and len(ratings) > 5,
+            }
+
+        except Exception as e:
+            logger.error("Failed to get feedback summary: %s", e)
+            return {
+                "skill_id": skill_id,
+                "avg_rating": 0.0,
+                "total_feedback": 0,
+                "failure_patterns": [],
+            }
+
+    async def get_refinement_suggestions(
+        self, skill_id: str
+    ) -> Dict[str, Any]:
+        """Suggest improvements for a skill based on feedback patterns.
+
+        Args:
+            skill_id: Unique skill identifier
+
+        Returns:
+            Dictionary with refinement suggestions
+        """
+        try:
+            metrics = await self._metrics.get_metrics(skill_id)
+            feedback = await self.get_feedback_summary(skill_id)
+
+            suggestions = []
+
+            # Suggest refinement if >2 failure patterns
+            if feedback.get("needs_refinement"):
+                patterns = feedback.get("failure_patterns", [])
+                pattern_text = ", ".join([p["pattern"] for p in patterns[:2]])
+                suggestions.append({
+                    "type": "refinement",
+                    "priority": "high",
+                    "message": f"Consider editing skill to address failure patterns: {pattern_text}",
+                    "confidence": 0.9,
+                })
+
+            # Suggest performance optimization if avg duration > 5s
+            if metrics["avg_duration_ms"] > 5000:
+                suggestions.append({
+                    "type": "performance",
+                    "priority": "medium",
+                    "message": f"Skill is slow (avg {metrics['avg_duration_ms']:.0f}ms). Consider optimization.",
+                    "confidence": 0.8,
+                })
+
+            # Suggest deprecation if low usage
+            if metrics["invocations"] < 5 and metrics["invocations"] > 0:
+                suggestions.append({
+                    "type": "deprecation",
+                    "priority": "low",
+                    "message": "Skill has low usage. Consider deprecation if not essential.",
+                    "confidence": 0.6,
+                })
+
+            # Suggest error handling improvements if error variety high
+            error_types = len(metrics.get("error_patterns", {}))
+            if error_types > 4:
+                suggestions.append({
+                    "type": "error_handling",
+                    "priority": "medium",
+                    "message": f"Skill produces many error types ({error_types}). Improve error handling.",
+                    "confidence": 0.75,
+                })
+
+            return {
+                "skill_id": skill_id,
+                "suggestions": suggestions,
+                "total_suggestions": len(suggestions),
+            }
+
+        except Exception as e:
+            logger.error("Failed to generate refinement suggestions: %s", e)
+            return {
+                "skill_id": skill_id,
+                "suggestions": [],
+                "error": str(e),
+            }

--- a/autobot-backend/services/skill_management/skill_health_scheduler.py
+++ b/autobot-backend/services/skill_management/skill_health_scheduler.py
@@ -1,0 +1,220 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Skill Health Scheduler (Issue #4339)
+
+Periodic job that computes skill health metrics and auto-disables
+skills with unhealthy scores. Runs every 5 minutes.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from skills.registry import get_skill_registry
+
+from .skill_metrics import SkillMetrics
+
+logger = logging.getLogger(__name__)
+
+HEALTH_CHECK_INTERVAL = 5 * 60  # 5 minutes in seconds
+HEALTH_THRESHOLD = 0.5  # Skills below this score are auto-disabled
+STALE_THRESHOLD_DAYS = 30  # Skills unused for this many days are marked stale
+
+
+class SkillHealthScheduler:
+    """Periodic health check job for skills.
+
+    Computes health scores and auto-disables unhealthy skills.
+    """
+
+    def __init__(self) -> None:
+        self._metrics = SkillMetrics()
+        self._running = False
+
+    async def start(self) -> None:
+        """Start the health check loop (5-minute intervals)."""
+        if self._running:
+            logger.warning("Health scheduler already running")
+            return
+
+        self._running = True
+        logger.info("Starting skill health scheduler (interval: %ds)", HEALTH_CHECK_INTERVAL)
+
+        while self._running:
+            try:
+                await self.check_all_skills()
+            except Exception as e:
+                logger.error("Health check failed: %s", e)
+
+            # Sleep before next check
+            await asyncio.sleep(HEALTH_CHECK_INTERVAL)
+
+    async def stop(self) -> None:
+        """Stop the health check loop."""
+        self._running = False
+        logger.info("Stopping skill health scheduler")
+
+    async def check_all_skills(self) -> Dict[str, Any]:
+        """Check health of all registered skills.
+
+        Returns:
+            Dictionary with health check results
+        """
+        registry = get_skill_registry()
+        skills = registry.list_skills()
+
+        results = {
+            "checked": 0,
+            "healthy": 0,
+            "unhealthy": 0,
+            "disabled": 0,
+            "stale": 0,
+            "details": [],
+        }
+
+        for skill_info in skills:
+            skill_id = skill_info.get("name")
+            if not skill_id:
+                continue
+
+            try:
+                health_score = await self._metrics.get_health_score(skill_id)
+                metrics = await self._metrics.get_metrics(skill_id)
+
+                result = {
+                    "skill_id": skill_id,
+                    "health_score": health_score,
+                    "invocations": metrics["invocations"],
+                    "success_rate": metrics["success_rate"],
+                }
+
+                results["checked"] += 1
+
+                # Check if skill should be auto-disabled
+                if health_score < HEALTH_THRESHOLD and metrics["invocations"] > 0:
+                    await self._disable_skill(skill_id)
+                    result["action"] = "disabled"
+                    result["reason"] = f"health_score={health_score} < {HEALTH_THRESHOLD}"
+                    results["disabled"] += 1
+                    logger.warning(
+                        "Auto-disabled skill %s (health=%.2f)",
+                        skill_id,
+                        health_score,
+                    )
+                elif health_score >= HEALTH_THRESHOLD:
+                    result["action"] = "healthy"
+                    results["healthy"] += 1
+                else:
+                    result["action"] = "untested"
+
+                # Check for stale skills
+                await self._metrics.mark_stale(skill_id)
+                stale_list = await self._metrics.get_stale_skills()
+                if skill_id in stale_list:
+                    result["stale"] = True
+                    results["stale"] += 1
+
+                results["details"].append(result)
+
+            except Exception as e:
+                logger.error("Failed to check health for skill %s: %s", skill_id, e)
+
+        if results["checked"] > 0:
+            logger.info(
+                "Health check complete: %d skills, %d healthy, %d disabled",
+                results["checked"],
+                results["healthy"],
+                results["disabled"],
+            )
+
+        return results
+
+    async def _disable_skill(self, skill_id: str) -> bool:
+        """Disable a skill in the registry.
+
+        Args:
+            skill_id: Unique skill identifier
+
+        Returns:
+            True if disabled successfully
+        """
+        try:
+            registry = get_skill_registry()
+            result = registry.disable_skill(skill_id)
+            if result.get("success"):
+                # Persist to Redis
+                redis = get_redis_client(RedisDatabase.MAIN)
+                redis.set(f"skills:enabled:{skill_id}", "false", ex=90 * 86400)
+                return True
+            return False
+        except Exception as e:
+            logger.error("Failed to disable skill %s: %s", skill_id, e)
+            return False
+
+    async def get_health_status(self, skill_id: str) -> Dict[str, Any]:
+        """Get current health status for a skill.
+
+        Args:
+            skill_id: Unique skill identifier
+
+        Returns:
+            Health status dictionary
+        """
+        try:
+            health_score = await self._metrics.get_health_score(skill_id)
+            metrics = await self._metrics.get_metrics(skill_id)
+            stale_list = await self._metrics.get_stale_skills()
+
+            return {
+                "skill_id": skill_id,
+                "health_score": health_score,
+                "status": self._status_from_score(health_score),
+                "invocations": metrics["invocations"],
+                "successes": metrics.get("successes", 0),
+                "failures": metrics.get("failures", 0),
+                "success_rate": metrics["success_rate"],
+                "error_patterns": metrics.get("error_patterns", {}),
+                "avg_duration_ms": metrics["avg_duration_ms"],
+                "stale": skill_id in stale_list,
+                "threshold": HEALTH_THRESHOLD,
+            }
+        except Exception as e:
+            logger.error("Failed to get health status for %s: %s", skill_id, e)
+            return {
+                "skill_id": skill_id,
+                "error": str(e),
+            }
+
+    @staticmethod
+    def _status_from_score(score: float) -> str:
+        """Map health score to status label.
+
+        Args:
+            score: Health score (0.0 - 1.0)
+
+        Returns:
+            Status label
+        """
+        if score >= 0.8:
+            return "excellent"
+        elif score >= HEALTH_THRESHOLD:
+            return "healthy"
+        elif score > 0.2:
+            return "degraded"
+        else:
+            return "critical"
+
+
+# Singleton instance
+_scheduler_instance: Optional[SkillHealthScheduler] = None
+
+
+def get_skill_health_scheduler() -> SkillHealthScheduler:
+    """Get or create the skill health scheduler singleton."""
+    global _scheduler_instance
+    if _scheduler_instance is None:
+        _scheduler_instance = SkillHealthScheduler()
+    return _scheduler_instance

--- a/autobot-backend/services/skill_management/skill_metrics.py
+++ b/autobot-backend/services/skill_management/skill_metrics.py
@@ -1,0 +1,302 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Skill Metrics Tracking (Issue #4339)
+
+Tracks skill performance metrics including invocation counts, success rates,
+error patterns, and duration. Provides insights for skill refinement and
+auto-deprecation of underperforming skills.
+"""
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from autobot_shared.redis_client import RedisDatabase, get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# Redis key prefixes
+REDIS_SKILL_METRICS_PREFIX = "skill_metrics:"
+REDIS_SKILL_INVOCATION_PREFIX = "skill_invocation:"
+REDIS_SKILL_ERROR_PREFIX = "skill_error:"
+REDIS_SKILL_HEALTH_PREFIX = "skill_health:"
+
+
+class SkillMetrics:
+    """Tracks and stores skill invocation metrics in Redis."""
+
+    def __init__(self) -> None:
+        self._redis: Optional[Any] = None
+
+    async def _get_redis(self) -> Optional[Any]:
+        """Get Redis client (analytics database)."""
+        if self._redis is None:
+            try:
+                self._redis = get_redis_client(RedisDatabase.ANALYTICS)
+            except Exception as e:
+                logger.error("Failed to get Redis client: %s", e)
+        return self._redis
+
+    async def log_invocation(
+        self,
+        skill_id: str,
+        action: str,
+        success: bool,
+        duration_ms: float,
+        error_type: Optional[str] = None,
+        user_feedback: Optional[str] = None,
+    ) -> None:
+        """Log a skill invocation with outcome.
+
+        Args:
+            skill_id: Unique skill identifier
+            action: Action/tool name invoked
+            success: Whether the invocation succeeded
+            duration_ms: Execution duration in milliseconds
+            error_type: Category of error (if any)
+            user_feedback: User feedback on skill performance
+        """
+        redis = await self._get_redis()
+        if not redis:
+            logger.warning("Redis unavailable, skipping metrics logging")
+            return
+
+        now = datetime.now(timezone.utc)
+        date_key = now.strftime("%Y-%m-%d")
+        day_prefix = f"{REDIS_SKILL_METRICS_PREFIX}{skill_id}:{date_key}"
+
+        try:
+            # Increment invocation counter
+            redis.incr(f"{day_prefix}:total")
+
+            if success:
+                redis.incr(f"{day_prefix}:success")
+            else:
+                redis.incr(f"{day_prefix}:failures")
+
+            # Track error type
+            if error_type:
+                redis.incr(f"{day_prefix}:error:{error_type}")
+
+            # Record duration (for percentile calculations)
+            redis.lpush(f"{day_prefix}:durations", str(duration_ms))
+
+            # Store feedback if provided
+            if user_feedback:
+                feedback_entry = {
+                    "timestamp": now.isoformat(),
+                    "action": action,
+                    "success": success,
+                    "feedback": user_feedback,
+                }
+                redis.lpush(
+                    f"{day_prefix}:feedback",
+                    json.dumps(feedback_entry, default=str),
+                )
+
+            # Trim old data (keep last 100 feedbacks per day)
+            redis.ltrim(f"{day_prefix}:feedback", 0, 99)
+            redis.ltrim(f"{day_prefix}:durations", 0, 999)
+
+            # Set key expiry (keep 90 days of metrics)
+            redis.expire(f"{day_prefix}:total", 90 * 86400)
+            redis.expire(f"{day_prefix}:success", 90 * 86400)
+            redis.expire(f"{day_prefix}:failures", 90 * 86400)
+            redis.expire(f"{day_prefix}:feedback", 90 * 86400)
+            redis.expire(f"{day_prefix}:durations", 90 * 86400)
+
+        except Exception as e:
+            logger.error("Failed to log skill metrics: %s", e)
+
+    async def get_metrics(
+        self, skill_id: str, days: int = 30
+    ) -> Dict[str, Any]:
+        """Get aggregated metrics for a skill over past N days.
+
+        Args:
+            skill_id: Unique skill identifier
+            days: Number of days to include (default 30)
+
+        Returns:
+            Dictionary with aggregated metrics
+        """
+        redis = await self._get_redis()
+        if not redis:
+            return {
+                "skill_id": skill_id,
+                "invocations": 0,
+                "success_rate": 0.0,
+                "error_patterns": {},
+                "avg_duration_ms": 0.0,
+            }
+
+        total_invocations = 0
+        total_successes = 0
+        error_patterns: Dict[str, int] = {}
+        all_durations: List[float] = []
+
+        try:
+            # Iterate over past N days
+            now = datetime.now(timezone.utc)
+            for i in range(days):
+                date = (now - timedelta(days=i)).strftime("%Y-%m-%d")
+                day_prefix = f"{REDIS_SKILL_METRICS_PREFIX}{skill_id}:{date}"
+
+                # Get counts for this day
+                invocations = int(redis.get(f"{day_prefix}:total") or 0)
+                successes = int(redis.get(f"{day_prefix}:success") or 0)
+                total_invocations += invocations
+                total_successes += successes
+
+                # Aggregate error patterns
+                error_keys = redis.keys(f"{day_prefix}:error:*")
+                for key in error_keys:
+                    key_str = key.decode() if isinstance(key, bytes) else key
+                    error_type = key_str.split(":")[-1]
+                    count = int(redis.get(key) or 0)
+                    error_patterns[error_type] = error_patterns.get(error_type, 0) + count
+
+                # Collect durations
+                durations_raw = redis.lrange(f"{day_prefix}:durations", 0, -1)
+                for d in durations_raw:
+                    try:
+                        duration_str = d.decode() if isinstance(d, bytes) else d
+                        all_durations.append(float(duration_str))
+                    except (ValueError, AttributeError):
+                        continue
+
+            # Calculate aggregated metrics
+            success_rate = (
+                (total_successes / total_invocations * 100)
+                if total_invocations > 0
+                else 0.0
+            )
+            avg_duration = (
+                (sum(all_durations) / len(all_durations))
+                if all_durations
+                else 0.0
+            )
+
+            return {
+                "skill_id": skill_id,
+                "invocations": total_invocations,
+                "successes": total_successes,
+                "failures": total_invocations - total_successes,
+                "success_rate": round(success_rate, 2),
+                "error_patterns": error_patterns,
+                "avg_duration_ms": round(avg_duration, 2),
+                "period_days": days,
+            }
+
+        except Exception as e:
+            logger.error("Failed to retrieve metrics for %s: %s", skill_id, e)
+            return {
+                "skill_id": skill_id,
+                "invocations": 0,
+                "success_rate": 0.0,
+                "error_patterns": {},
+                "avg_duration_ms": 0.0,
+            }
+
+    async def get_health_score(
+        self, skill_id: str, days: int = 30
+    ) -> float:
+        """Calculate health score for a skill (0.0 - 1.0).
+
+        Health score = success_rate * performance_factor
+        Performance factor penalizes slow skills or those with high error variety.
+
+        Args:
+            skill_id: Unique skill identifier
+            days: Number of days to consider
+
+        Returns:
+            Health score between 0.0 and 1.0
+        """
+        metrics = await self.get_metrics(skill_id, days)
+
+        if metrics["invocations"] == 0:
+            return 0.5  # Default for untested skills
+
+        # Base health on success rate
+        success_rate = metrics["success_rate"] / 100.0
+
+        # Penalize slow skills (>5s average)
+        duration_factor = 1.0
+        if metrics["avg_duration_ms"] > 5000:
+            duration_factor = 0.8
+        elif metrics["avg_duration_ms"] > 10000:
+            duration_factor = 0.6
+
+        # Penalize high error variety (>2 error types)
+        error_variety = len(metrics["error_patterns"])
+        error_factor = 1.0
+        if error_variety > 2:
+            error_factor = 0.8
+        elif error_variety > 4:
+            error_factor = 0.6
+
+        # Calculate final health score
+        health_score = success_rate * duration_factor * error_factor
+        return round(max(0.0, min(1.0, health_score)), 2)
+
+    async def mark_stale(self, skill_id: str) -> None:
+        """Mark a skill as stale if unused for 30+ days.
+
+        Args:
+            skill_id: Unique skill identifier
+        """
+        redis = await self._get_redis()
+        if not redis:
+            return
+
+        try:
+            # Check if skill has any invocations in past 30 days
+            now = datetime.now(timezone.utc)
+            recent_invocations = 0
+
+            for i in range(30):
+                date = (now - timedelta(days=i)).strftime("%Y-%m-%d")
+                day_prefix = f"{REDIS_SKILL_METRICS_PREFIX}{skill_id}:{date}"
+                count = int(redis.get(f"{day_prefix}:total") or 0)
+                recent_invocations += count
+
+            if recent_invocations == 0:
+                # Mark as stale
+                redis.set(
+                    f"{REDIS_SKILL_HEALTH_PREFIX}{skill_id}:stale",
+                    "true",
+                    ex=90 * 86400,
+                )
+                logger.info(
+                    "Marked skill %s as stale (no invocations in 30 days)",
+                    skill_id,
+                )
+
+        except Exception as e:
+            logger.error("Failed to mark skill as stale: %s", e)
+
+    async def get_stale_skills(self) -> List[str]:
+        """Get list of skills marked as stale.
+
+        Returns:
+            List of skill IDs marked as stale
+        """
+        redis = await self._get_redis()
+        if not redis:
+            return []
+
+        try:
+            stale_keys = redis.keys(f"{REDIS_SKILL_HEALTH_PREFIX}*:stale")
+            return [
+                key.decode().replace(f"{REDIS_SKILL_HEALTH_PREFIX}", "").replace(
+                    ":stale", ""
+                )
+                for key in stale_keys
+            ]
+        except Exception as e:
+            logger.error("Failed to retrieve stale skills: %s", e)
+            return []

--- a/autobot-backend/skills/manager.py
+++ b/autobot-backend/skills/manager.py
@@ -9,6 +9,7 @@ per-user skill preferences (via Redis), and skill execution routing.
 """
 
 import logging
+import time
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_management.cache_wrapper import RedisCache
@@ -25,10 +26,12 @@ class SkillManager:
     """Manages skill lifecycle, configuration persistence, and execution.
 
     Uses Redis for persistent storage of skill configs and user preferences.
+    Includes metrics tracking for skill performance monitoring (Issue #4339).
     """
 
     def __init__(self, registry: Optional[SkillRegistry] = None) -> None:
         self._registry = registry or get_skill_registry()
+        self._metrics: Optional[Any] = None
 
     @property
     def registry(self) -> SkillRegistry:
@@ -78,15 +81,38 @@ class SkillManager:
                 "error": f"Unknown action '{action}' for skill '{skill_name}'",
             }
 
+        # Track execution with metrics (Issue #4339)
+        start_time = time.time()
+        result = None
+        error_type = None
+
         try:
             result = await skill.execute(action, params)
+            success = result.get("success", True)
             return result
-        except Exception:
+        except Exception as e:
             logger.exception("Skill execution failed: %s.%s", skill_name, action)
+            success = False
+            error_type = type(e).__name__
             return {
                 "success": False,
                 "error": f"Execution failed for {skill_name}.{action}",
             }
+        finally:
+            # Log metrics asynchronously (non-blocking)
+            duration_ms = (time.time() - start_time) * 1000
+            try:
+                metrics = await self._get_metrics()
+                if metrics:
+                    await metrics.log_invocation(
+                        skill_id=skill_name,
+                        action=action,
+                        success=success,
+                        duration_ms=duration_ms,
+                        error_type=error_type,
+                    )
+            except Exception as e:
+                logger.debug("Failed to log skill metrics: %s", e)
 
     async def get_user_skill_preferences(self, user_id: str) -> Dict[str, bool]:
         """Get per-user skill enable/disable preferences from Redis.
@@ -165,6 +191,18 @@ class SkillManager:
             if _matches_query(skill_info, query_lower):
                 results.append(skill_info)
         return results
+
+    async def _get_metrics(self) -> Optional[Any]:
+        """Get or create the SkillMetrics instance (lazy initialization)."""
+        if self._metrics is None:
+            try:
+                from services.skill_management.skill_metrics import SkillMetrics
+
+                self._metrics = SkillMetrics()
+            except ImportError:
+                logger.debug("SkillMetrics not available")
+                return None
+        return self._metrics
 
 
 def _matches_query(skill_info: Dict[str, Any], query: str) -> bool:

--- a/autobot-backend/tests/test_skill_health.py
+++ b/autobot-backend/tests/test_skill_health.py
@@ -1,0 +1,384 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Skill Health Metrics Tests (Issue #4339)
+
+Tests for skill metrics tracking, health scoring, and feedback analysis.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.skill_management.skill_feedback import SkillFeedbackAnalyzer
+from services.skill_management.skill_health_scheduler import SkillHealthScheduler
+from services.skill_management.skill_metrics import SkillMetrics
+
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock Redis client."""
+    return MagicMock()
+
+
+@pytest.fixture
+async def skill_metrics():
+    """Create a SkillMetrics instance with mocked Redis."""
+    metrics = SkillMetrics()
+    metrics._redis = MagicMock()
+    return metrics
+
+
+@pytest.fixture
+async def feedback_analyzer():
+    """Create a SkillFeedbackAnalyzer instance with mocked Redis."""
+    analyzer = SkillFeedbackAnalyzer()
+    analyzer._redis = MagicMock()
+    return analyzer
+
+
+@pytest.mark.asyncio
+async def test_log_invocation_success(skill_metrics):
+    """Test logging successful skill invocation."""
+    skill_metrics._redis.incr = MagicMock()
+    skill_metrics._redis.lpush = MagicMock()
+    skill_metrics._redis.expire = MagicMock()
+
+    await skill_metrics.log_invocation(
+        skill_id="test-skill",
+        action="test-action",
+        success=True,
+        duration_ms=1000.0,
+    )
+
+    # Verify Redis operations
+    assert skill_metrics._redis.incr.called
+    assert skill_metrics._redis.expire.called
+
+
+@pytest.mark.asyncio
+async def test_log_invocation_with_error(skill_metrics):
+    """Test logging failed skill invocation with error type."""
+    skill_metrics._redis.incr = MagicMock()
+    skill_metrics._redis.expire = MagicMock()
+
+    await skill_metrics.log_invocation(
+        skill_id="test-skill",
+        action="test-action",
+        success=False,
+        duration_ms=500.0,
+        error_type="TimeoutError",
+    )
+
+    # Verify error was tracked
+    assert skill_metrics._redis.incr.called
+
+
+@pytest.mark.asyncio
+async def test_log_invocation_with_feedback(skill_metrics):
+    """Test logging invocation with user feedback."""
+    skill_metrics._redis.incr = MagicMock()
+    skill_metrics._redis.lpush = MagicMock()
+    skill_metrics._redis.expire = MagicMock()
+
+    await skill_metrics.log_invocation(
+        skill_id="test-skill",
+        action="test-action",
+        success=True,
+        duration_ms=1500.0,
+        user_feedback="Could be faster",
+    )
+
+    # Verify feedback was stored
+    assert skill_metrics._redis.lpush.called
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_empty(skill_metrics):
+    """Test getting metrics when no data exists."""
+    skill_metrics._redis.get = MagicMock(return_value=None)
+    skill_metrics._redis.keys = MagicMock(return_value=[])
+    skill_metrics._redis.lrange = MagicMock(return_value=[])
+
+    metrics = await skill_metrics.get_metrics("test-skill", days=30)
+
+    assert metrics["skill_id"] == "test-skill"
+    assert metrics["invocations"] == 0
+    assert metrics["success_rate"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_with_data(skill_metrics):
+    """Test getting metrics with invocation data."""
+    # Setup mock to return invocation counts for single day
+    def mock_get(key):
+        key_str = key.decode() if isinstance(key, bytes) else str(key)
+        if "total" in key_str:
+            return b"10"
+        elif "success" in key_str:
+            return b"8"
+        return None
+
+    skill_metrics._redis.get = MagicMock(side_effect=mock_get)
+    skill_metrics._redis.keys = MagicMock(return_value=[])
+    skill_metrics._redis.lrange = MagicMock(return_value=[])
+
+    # Get metrics for 1 day only (so 10 invocations total)
+    metrics = await skill_metrics.get_metrics("test-skill", days=1)
+
+    assert metrics["invocations"] == 10
+    assert metrics["successes"] == 8
+    assert metrics["success_rate"] == 80.0
+
+
+@pytest.mark.asyncio
+async def test_health_score_untested(skill_metrics):
+    """Test health score for untested skill."""
+    skill_metrics._redis = None
+
+    health_score = await skill_metrics.get_health_score("test-skill")
+
+    # Untested skills get default score
+    assert health_score == 0.5
+
+
+@pytest.mark.asyncio
+async def test_health_score_healthy(skill_metrics):
+    """Test health score for healthy skill."""
+    # Setup mock metrics
+    def mock_get(key):
+        key_str = key.decode() if isinstance(key, bytes) else str(key)
+        if "total" in key_str:
+            return b"100"
+        elif "success" in key_str:
+            return b"95"
+        return None
+
+    skill_metrics._redis.get = MagicMock(side_effect=mock_get)
+    skill_metrics._redis.keys = MagicMock(return_value=[])
+    skill_metrics._redis.lrange = MagicMock(return_value=[])
+
+    health_score = await skill_metrics.get_health_score("test-skill", days=1)
+
+    # Healthy skill with 95% success rate should have high score
+    assert health_score >= 0.8
+
+
+@pytest.mark.asyncio
+async def test_health_score_degraded(skill_metrics):
+    """Test health score for degraded skill."""
+    def mock_get(key):
+        key_str = key.decode() if isinstance(key, bytes) else str(key)
+        if "total" in key_str:
+            return b"100"
+        elif "success" in key_str:
+            return b"60"
+        return None
+
+    skill_metrics._redis.get = MagicMock(side_effect=mock_get)
+    skill_metrics._redis.keys = MagicMock(return_value=[])
+    skill_metrics._redis.lrange = MagicMock(return_value=[])
+
+    health_score = await skill_metrics.get_health_score("test-skill", days=1)
+
+    # Degraded skill with 60% success rate
+    assert 0.4 <= health_score < 0.7
+
+
+@pytest.mark.asyncio
+async def test_mark_stale(skill_metrics):
+    """Test marking skill as stale."""
+    skill_metrics._redis.get = MagicMock(return_value=None)
+    skill_metrics._redis.set = MagicMock()
+
+    await skill_metrics.mark_stale("test-skill")
+
+    # Verify stale flag was set
+    assert skill_metrics._redis.set.called
+
+
+@pytest.mark.asyncio
+async def test_get_stale_skills(skill_metrics):
+    """Test retrieving list of stale skills."""
+    skill_metrics._redis.keys = MagicMock(
+        return_value=[
+            b"skill_health:old-skill-1:stale",
+            b"skill_health:old-skill-2:stale",
+        ]
+    )
+
+    stale_skills = await skill_metrics.get_stale_skills()
+
+    assert len(stale_skills) == 2
+    assert "old-skill-1" in stale_skills
+    assert "old-skill-2" in stale_skills
+
+
+@pytest.mark.asyncio
+async def test_submit_user_feedback(feedback_analyzer):
+    """Test submitting user feedback."""
+    feedback_analyzer._redis.lpush = MagicMock()
+    feedback_analyzer._redis.expire = MagicMock()
+
+    await feedback_analyzer.log_user_feedback(
+        skill_id="test-skill",
+        action="test-action",
+        rating=5,
+        feedback_text="Excellent skill!",
+    )
+
+    assert feedback_analyzer._redis.lpush.called
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_summary_empty(feedback_analyzer):
+    """Test getting feedback summary when no data exists."""
+    feedback_analyzer._redis.lrange = MagicMock(return_value=[])
+
+    summary = await feedback_analyzer.get_feedback_summary("test-skill", days=30)
+
+    assert summary["skill_id"] == "test-skill"
+    assert summary["total_feedback"] == 0
+    assert summary["avg_rating"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_summary_with_ratings(feedback_analyzer):
+    """Test getting feedback summary with ratings."""
+    feedback_entries = [
+        json.dumps({
+            "timestamp": "2025-04-13T00:00:00",
+            "skill_id": "test-skill",
+            "action": "test",
+            "rating": 5,
+            "feedback": "",
+        }).encode(),
+        json.dumps({
+            "timestamp": "2025-04-13T00:01:00",
+            "skill_id": "test-skill",
+            "action": "test",
+            "rating": 4,
+            "feedback": "",
+        }).encode(),
+        json.dumps({
+            "timestamp": "2025-04-13T00:02:00",
+            "skill_id": "test-skill",
+            "action": "test",
+            "rating": 5,
+            "feedback": "",
+        }).encode(),
+    ]
+
+    # Mock to always return the entries for any lrange call
+    feedback_analyzer._redis.lrange = MagicMock(return_value=feedback_entries)
+
+    summary = await feedback_analyzer.get_feedback_summary("test-skill", days=1)
+
+    assert summary["total_feedback"] == 3
+    assert summary["avg_rating"] == pytest.approx(4.67, abs=0.01)
+    assert summary["rating_distribution"]["5_star"] == 2
+    assert summary["rating_distribution"]["4_star"] == 1
+
+
+@pytest.mark.asyncio
+async def test_refinement_suggestions_high_failure_rate(feedback_analyzer):
+    """Test getting refinement suggestions for failing skill."""
+    # Mock the analyzer methods
+    feedback_analyzer.get_feedback_summary = AsyncMock(
+        return_value={
+            "total_feedback": 10,
+            "avg_rating": 1.5,
+            "failure_patterns": [
+                {"pattern": "Timeout error", "count": 5},
+                {"pattern": "Invalid input", "count": 3},
+            ],
+            "needs_refinement": True,
+        }
+    )
+
+    # Mock SkillMetrics
+    with patch("services.skill_management.skill_feedback.SkillMetrics"):
+        mock_metrics = AsyncMock()
+        mock_metrics.get_metrics = AsyncMock(
+            return_value={
+                "invocations": 10,
+                "avg_duration_ms": 1000,
+                "error_patterns": {"TimeoutError": 5},
+            }
+        )
+        feedback_analyzer._metrics = mock_metrics
+
+        suggestions = await feedback_analyzer.get_refinement_suggestions("test-skill")
+
+        assert suggestions["total_suggestions"] > 0
+        # Should suggest refinement for failure patterns
+        has_refinement = any(s["type"] == "refinement" for s in suggestions["suggestions"])
+        assert has_refinement
+
+
+@pytest.mark.asyncio
+async def test_health_scheduler_check_all_skills():
+    """Test health scheduler checking all skills."""
+    scheduler = SkillHealthScheduler()
+
+    with patch("services.skill_management.skill_health_scheduler.get_skill_registry") as mock_registry:
+        mock_registry.return_value.list_skills = MagicMock(
+            return_value=[
+                {"name": "skill-1"},
+                {"name": "skill-2"},
+            ]
+        )
+
+        # Mock metrics
+        with patch.object(scheduler._metrics, "get_health_score", new_callable=AsyncMock) as mock_health:
+            with patch.object(scheduler._metrics, "get_metrics", new_callable=AsyncMock) as mock_metrics:
+                with patch.object(scheduler._metrics, "mark_stale", new_callable=AsyncMock):
+                    with patch.object(scheduler._metrics, "get_stale_skills", new_callable=AsyncMock) as mock_stale:
+                        mock_health.return_value = 0.8
+                        mock_metrics.return_value = {
+                            "invocations": 10,
+                            "success_rate": 85.0,
+                        }
+                        mock_stale.return_value = []
+
+                        results = await scheduler.check_all_skills()
+
+                        assert results["checked"] == 2
+                        assert results["healthy"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_health_scheduler_auto_disable():
+    """Test auto-disabling unhealthy skills."""
+    scheduler = SkillHealthScheduler()
+
+    with patch("services.skill_management.skill_health_scheduler.get_skill_registry") as mock_registry:
+        mock_skill_registry = MagicMock()
+        mock_skill_registry.list_skills = MagicMock(
+            return_value=[{"name": "bad-skill"}]
+        )
+        mock_skill_registry.disable_skill = MagicMock(return_value={"success": True})
+        mock_registry.return_value = mock_skill_registry
+
+        with patch.object(scheduler._metrics, "get_health_score", new_callable=AsyncMock) as mock_health:
+            with patch.object(scheduler._metrics, "get_metrics", new_callable=AsyncMock) as mock_metrics:
+                with patch.object(scheduler._metrics, "mark_stale", new_callable=AsyncMock):
+                    with patch.object(scheduler._metrics, "get_stale_skills", new_callable=AsyncMock) as mock_stale:
+                        with patch("services.skill_management.skill_health_scheduler.get_redis_client"):
+                            # Low health score triggers disable
+                            mock_health.return_value = 0.3
+                            mock_metrics.return_value = {
+                                "invocations": 50,
+                                "success_rate": 30.0,
+                            }
+                            mock_stale.return_value = []
+
+                            results = await scheduler.check_all_skills()
+
+                            assert results["disabled"] >= 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Logs skill invocations: success/failure, error types, duration
- Aggregates metrics over configurable periods
- Health scoring: success_rate × duration_factor × error_factor
- Auto-disable unhealthy skills (score < 0.5)
- Stale detection: unused 30+ days
- API endpoints: /api/skills/{name}/metrics, /feedback, /suggestions
- Periodic health check (5-minute intervals)

## Test Status
✅ 16/16 tests passing

Closes #4339