### PR TITLE
perf(frontend): add keep-alive for ChatInterface to reduce remounting (#4356)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -155,7 +155,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch, provide } from 'vue'
+import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watch, provide } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useBackoffPoller } from '@/composables/useBackoffPoller'
 import { useVoiceOutput } from '@/composables/useVoiceOutput'
@@ -873,6 +873,50 @@ onUnmounted(() => {
   }
 
   messagePoller.stop()
+})
+
+// Issue #4356: Handle keep-alive activation (component re-enters view)
+// Resume polling and heartbeat when ChatInterface is activated from keep-alive cache
+onActivated(() => {
+  logger.debug('[ChatInterface] Activated from keep-alive - resuming operations')
+
+  // Resume heartbeat monitoring
+  startHeartbeat()
+
+  // Resume connection checking
+  checkConnection()
+
+  // Resume auto-save
+  enableAutoSave()
+
+  // Resume message polling
+  startMessagePolling()
+
+  // Re-attach keyboard shortcuts
+  document.addEventListener('keydown', handleKeyboardShortcuts)
+})
+
+// Issue #4356: Handle keep-alive deactivation (component leaves view but stays cached)
+// Pause polling and cleanup before caching to reduce background activity
+onDeactivated(() => {
+  logger.debug('[ChatInterface] Deactivated for keep-alive caching - pausing operations')
+
+  // Pause message polling (will resume on onActivated)
+  messagePoller.stop()
+
+  // Clean up intervals while cached
+  if (heartbeatInterval.value) {
+    clearInterval(heartbeatInterval.value)
+    heartbeatInterval.value = null
+  }
+
+  if (autoSaveInterval.value) {
+    clearInterval(autoSaveInterval.value)
+    autoSaveInterval.value = null
+  }
+
+  // Clean up keyboard shortcuts while cached
+  document.removeEventListener('keydown', handleKeyboardShortcuts)
 })
 
 // Watch for session changes to update NoVNC URL

--- a/autobot-frontend/src/views/ChatView.vue
+++ b/autobot-frontend/src/views/ChatView.vue
@@ -1,7 +1,10 @@
 <template>
-  <router-view />
+  <keep-alive>
+    <router-view />
+  </keep-alive>
 </template>
 
 <script setup lang="ts">
-// Passthrough component - no wrapper needed
+// Issue #4356: Wrap router-view in keep-alive to preserve ChatInterface state
+// and avoid full remount when navigating away and back to /chat
 </script>


### PR DESCRIPTION
Fixes #4356

**Changes:**
- Add Vue keep-alive wrapper for ChatInterface
- Prevents unnecessary remounts during navigation
- Preserves component state across route changes

**Performance Impact:**
- Reduces DOM churn and reinitialization overhead
- Improves navigation responsiveness