### PR TITLE
feat(hooks): wire core LLM hooks (#4259)

### DIFF
--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -902,8 +902,20 @@ Do NOT conclude the task or provide a final summary - just explain this specific
         selected_model: str,
         interpretation_prompt: str,
         llm_options: Dict[str, Any],
+        session_id: str = "",
     ):
         """Handle non-streaming interpretation request (Issue #332)."""
+        # Issue #4259: Wire BEFORE_LLM_CALL hook
+        llm_params = {"model": selected_model, "endpoint": ollama_endpoint}
+        should_proceed = await _emit_before_llm_call(
+            interpretation_prompt, llm_params, session_id
+        )
+        if not should_proceed:
+            logger.info(
+                "[Issue #4259] LLM call cancelled by BEFORE_LLM_CALL hook"
+            )
+            return
+
         http_client = get_http_client()
         response_data = await http_client.post_json(
             f"{ollama_endpoint}/api/generate",
@@ -915,6 +927,13 @@ Do NOT conclude the task or provide a final summary - just explain this specific
             },
         )
         interpretation = response_data.get("response", "")
+
+        # Issue #4259: Wire AFTER_LLM_RESPONSE hook
+        if interpretation:
+            interpretation = await _emit_after_llm_response(
+                interpretation, llm_params, session_id
+            )
+
         if interpretation:
             yield WorkflowMessage(
                 type="response",
@@ -928,44 +947,69 @@ Do NOT conclude the task or provide a final summary - just explain this specific
         selected_model: str,
         interpretation_prompt: str,
         llm_options: Dict[str, Any],
+        session_id: str = "",
     ):
         """Handle streaming interpretation request (Issue #332)."""
         import aiohttp
 
+        # Issue #4259: Wire BEFORE_LLM_CALL hook
+        llm_params = {"model": selected_model, "endpoint": ollama_endpoint}
+        should_proceed = await _emit_before_llm_call(
+            interpretation_prompt, llm_params, session_id
+        )
+        if not should_proceed:
+            logger.info(
+                "[Issue #4259] LLM call cancelled by BEFORE_LLM_CALL hook"
+            )
+            return
+
         http_client = get_http_client()
-        async with await http_client.post(
-            f"{ollama_endpoint}/api/generate",
-            json={
-                "model": selected_model,
-                "prompt": interpretation_prompt,
-                "stream": True,
-                "options": llm_options,
-            },
-            timeout=aiohttp.ClientTimeout(total=60.0),
-        ) as interp_response:
-            async for line in interp_response.content:
-                line_str = line.decode("utf-8").strip()
-                if not line_str:
-                    continue
+        full_response = ""
+        try:
+            async with await http_client.post(
+                f"{ollama_endpoint}/api/generate",
+                json={
+                    "model": selected_model,
+                    "prompt": interpretation_prompt,
+                    "stream": True,
+                    "options": llm_options,
+                },
+                timeout=aiohttp.ClientTimeout(total=60.0),
+            ) as interp_response:
+                async for line in interp_response.content:
+                    line_str = line.decode("utf-8").strip()
+                    if not line_str:
+                        continue
 
-                try:
-                    data = json.loads(line_str)
-                except json.JSONDecodeError:
-                    continue
+                    try:
+                        data = json.loads(line_str)
+                    except json.JSONDecodeError:
+                        continue
 
-                chunk = data.get("response", "")
-                if chunk:
-                    yield WorkflowMessage(
-                        type="stream",
-                        content=chunk,
-                        metadata={
-                            "message_type": "command_interpretation",
-                            "streaming": True,
-                        },
-                    )
+                    chunk = data.get("response", "")
+                    if chunk:
+                        # Issue #4259: Wire DURING_LLM_STREAMING hook
+                        await _emit_during_llm_streaming(
+                            chunk, session_id, {"endpoint": ollama_endpoint}
+                        )
+                        full_response += chunk
+                        yield WorkflowMessage(
+                            type="stream",
+                            content=chunk,
+                            metadata={
+                                "message_type": "command_interpretation",
+                                "streaming": True,
+                            },
+                        )
 
-                if data.get("done"):
-                    break
+                    if data.get("done"):
+                        break
+        finally:
+            # Issue #4259: Wire AFTER_LLM_RESPONSE hook after streaming completes
+            if full_response:
+                full_response = await _emit_after_llm_response(
+                    full_response, llm_params, session_id
+                )
 
     async def _interpret_command_results(
         self,
@@ -976,6 +1020,7 @@ Do NOT conclude the task or provide a final summary - just explain this specific
         ollama_endpoint: str,
         selected_model: str,
         streaming: bool = True,
+        session_id: str = "",
     ):
         """
         Send command results to LLM for interpretation.
@@ -988,6 +1033,7 @@ Do NOT conclude the task or provide a final summary - just explain this specific
             ollama_endpoint: Ollama API endpoint
             selected_model: Model to use
             streaming: Whether to stream the response
+            session_id: Session identifier for hooks
 
         Yields:
             WorkflowMessage chunks
@@ -999,13 +1045,15 @@ Do NOT conclude the task or provide a final summary - just explain this specific
 
         if not streaming:
             async for msg in self._interpret_non_streaming(
-                ollama_endpoint, selected_model, interpretation_prompt, llm_options
+                ollama_endpoint, selected_model, interpretation_prompt, llm_options,
+                session_id
             ):
                 yield msg
             return
 
         async for msg in self._interpret_streaming(
-            ollama_endpoint, selected_model, interpretation_prompt, llm_options
+            ollama_endpoint, selected_model, interpretation_prompt, llm_options,
+            session_id
         ):
             yield msg
 
@@ -1131,7 +1179,8 @@ Do NOT conclude the task or provide a final summary - just explain this specific
             )
 
     async def _get_interpretation_from_llm(
-        self, command: str, stdout: str, stderr: str, return_code: int
+        self, command: str, stdout: str, stderr: str, return_code: int,
+        session_id: str = ""
     ) -> str:
         """Get LLM interpretation for command results (non-streaming)."""
         selected_model = get_config().get_selected_model()
@@ -1158,6 +1207,7 @@ Do NOT conclude the task or provide a final summary - just explain this specific
             ollama_endpoint=ollama_endpoint,
             selected_model=selected_model,
             streaming=False,
+            session_id=session_id,
         ):
             if hasattr(msg, "content"):
                 interpretation += msg.content
@@ -1181,7 +1231,7 @@ Do NOT conclude the task or provide a final summary - just explain this specific
         """
         try:
             interpretation = await self._get_interpretation_from_llm(
-                command, stdout, stderr, return_code
+                command, stdout, stderr, return_code, session_id
             )
 
             if not session_id or not interpretation:


### PR DESCRIPTION
Closes #4259

## Summary
Wired the three core LLM hooks into the AutoBot chat workflow:
- **BEFORE_LLM_CALL** - Invoked before making the LLM request
- **DURING_LLM_STREAMING** - Invoked for each streaming chunk
- **AFTER_LLM_RESPONSE** - Invoked after the full LLM response

## Changes
Modified `chat_workflow/llm_handler.py`:
- Updated `_interpret_non_streaming()` to call hook emitters
- Updated `_interpret_streaming()` for streaming chunk monitoring
- Added `session_id` parameter for hook context

## Test Status
✅ All 38 wired_hooks_test.py tests pass
✅ All 22 hook_invoker_test.py tests pass (60 total)