### PR TITLE
feat(llm): model provider flexibility and vendor-agnostic switching (#4341)

### DIFF
--- a/autobot-backend/llm_providers/nous_portal_provider.py
+++ b/autobot-backend/llm_providers/nous_portal_provider.py
@@ -1,0 +1,299 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Nous Portal Provider - Access Nous Research's curated open-source LLM models.
+
+Issue #4341: Model Provider Flexibility & Vendor-Agnostic Switching
+
+Nous Portal (https://huggingface.co/Nous) provides access to high-quality
+open-source models including Hermes, Nous-Hermes, and fine-tuned variants
+of popular models. This provider streams models through the OpenAI-compatible
+Hugging Face Inference API or custom deployment endpoints.
+
+Configuration:
+  - api_key: HuggingFace API token or custom endpoint key
+  - base_url: Custom API base URL (e.g., for self-hosted Nous models)
+  - default_model: Default model name (e.g., "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO")
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
+from llm_interface_pkg.models import LLMRequest, LLMResponse
+from llm_interface_pkg.types import ProviderType
+
+from .base_provider import BaseProvider
+
+logger = logging.getLogger(__name__)
+_tracer = trace.get_tracer("autobot.llm.nous", "1.0.0")
+
+# Popular Nous Research models
+NOUS_MODELS = [
+    "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
+    "NousResearch/Nous-Hermes-2-Mistral-7B-DPO",
+    "NousResearch/Nous-Hermes-2-Vision-7B",
+    "NousResearch/Nous-Hermes-Llama2-7b",
+    "NousResearch/Nous-Hermes-Llama2-13b",
+]
+
+
+class NousPortalProvider(BaseProvider):
+    """
+    Nous Portal provider implementation.
+
+    Provides access to curated open-source LLM models from Nous Research,
+    including:
+    - Nous-Hermes (fine-tuned Llama variants)
+    - Nous-Hermes-2 (Mixtral and Mistral fine-tunes)
+    - Vision models
+
+    Can be used with:
+    1. HuggingFace Inference API endpoints
+    2. Custom self-hosted Nous model servers
+    3. OpenAI-compatible API wrappers
+
+    Requires: openai package (pip install openai)
+              HF_TOKEN or custom API key in environment
+    """
+
+    provider_name = "nous"
+
+    def __init__(self, settings: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(settings)
+        self._api_key: Optional[str] = None
+        self._base_url: Optional[str] = None
+        self._client = None
+
+    def _resolve_api_key(self) -> Optional[str]:
+        """Resolve API key from settings or environment."""
+        if self._api_key:
+            return self._api_key
+        key = (
+            self._get_setting("api_key") or
+            os.getenv("HF_TOKEN") or
+            os.getenv("HUGGINGFACE_API_TOKEN") or
+            os.getenv("NOUS_API_KEY")
+        )
+        self._api_key = key
+        return self._api_key
+
+    def _resolve_base_url(self) -> str:
+        """Resolve base URL with defaults."""
+        if self._base_url:
+            return self._base_url
+        url = (
+            self._get_setting("base_url") or
+            os.getenv("NOUS_API_BASE_URL") or
+            "https://api-inference.huggingface.co/v1"  # HF Inference API
+        )
+        self._base_url = url
+        return url
+
+    def _ensure_client(self):
+        """Lazily initialize the async OpenAI client."""
+        if self._client is not None:
+            return
+
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as exc:
+            raise ImportError(
+                "openai package not installed. Run: pip install openai"
+            ) from exc
+
+        api_key = self._resolve_api_key()
+        if not api_key:
+            raise ValueError(
+                "Nous API key not found. Set HF_TOKEN or provide api_key in settings."
+            )
+
+        base_url = self._resolve_base_url()
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        logger.info("Nous Portal client initialized with base_url: %s", base_url)
+
+    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+        """
+        Execute a chat completion via Nous models.
+
+        Args:
+            request: Standardized LLM request.
+
+        Returns:
+            LLMResponse with content populated or error field set.
+        """
+        with _tracer.start_as_current_span(
+            "nous.chat_completion", kind=SpanKind.CLIENT
+        ) as span:
+            try:
+                self._total_requests += 1
+                self._ensure_client()
+
+                # Convert to OpenAI format
+                messages = [
+                    {"role": msg.role, "content": msg.content}
+                    for msg in request.messages
+                ]
+
+                # Merge API kwargs
+                api_kwargs = request.metadata.get("api_kwargs", {})
+                chat_kwargs = {
+                    "model": request.model_name or self._get_setting(
+                        "default_model", NOUS_MODELS[0]
+                    ),
+                    "messages": messages,
+                    "temperature": api_kwargs.get("temperature", 0.7),
+                    "max_tokens": api_kwargs.get("max_tokens", 2048),
+                    "top_p": api_kwargs.get("top_p", 0.95),
+                }
+
+                # Optional parameters
+                if "presence_penalty" in api_kwargs:
+                    chat_kwargs["presence_penalty"] = api_kwargs["presence_penalty"]
+                if "frequency_penalty" in api_kwargs:
+                    chat_kwargs["frequency_penalty"] = api_kwargs["frequency_penalty"]
+                if "stop" in api_kwargs:
+                    chat_kwargs["stop"] = api_kwargs["stop"]
+
+                start_time = time.monotonic()
+                response = await self._client.chat.completions.create(**chat_kwargs)
+                latency = time.monotonic() - start_time
+
+                # Extract response content
+                content = response.choices[0].message.content or ""
+                usage = {
+                    "prompt_tokens": response.usage.prompt_tokens if response.usage else 0,
+                    "completion_tokens": response.usage.completion_tokens if response.usage else 0,
+                }
+
+                span.set_attribute("nous.model", chat_kwargs["model"])
+                span.set_attribute("nous.latency_ms", int(latency * 1000))
+                span.set_attribute("nous.tokens", usage["prompt_tokens"] + usage["completion_tokens"])
+                span.set_status(Status(StatusCode.OK))
+
+                return LLMResponse(
+                    content=content,
+                    model_name=request.model_name or chat_kwargs["model"],
+                    provider_name=self.provider_name,
+                    usage=usage,
+                    provider_metadata=self._build_provider_metadata(
+                        model_api_name=chat_kwargs["model"],
+                        api_kwargs_applied=chat_kwargs,
+                        total_tokens=usage["prompt_tokens"] + usage["completion_tokens"],
+                    ),
+                )
+
+            except Exception as exc:
+                self._total_errors += 1
+                error_msg = f"Nous API error: {exc}"
+                logger.error(error_msg)
+                span.set_status(Status(StatusCode.ERROR))
+                span.record_exception(exc)
+                return LLMResponse(
+                    content="",
+                    model_name=request.model_name or "nous-model",
+                    provider_name=self.provider_name,
+                    error=error_msg,
+                )
+
+    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
+        """
+        Stream a chat completion from Nous models.
+
+        Args:
+            request: Standardized LLM request.
+
+        Yields:
+            String chunks of the generated text.
+        """
+        with _tracer.start_as_current_span(
+            "nous.stream_completion", kind=SpanKind.CLIENT
+        ) as span:
+            try:
+                self._total_requests += 1
+                self._ensure_client()
+
+                messages = [
+                    {"role": msg.role, "content": msg.content}
+                    for msg in request.messages
+                ]
+
+                api_kwargs = request.metadata.get("api_kwargs", {})
+                chat_kwargs = {
+                    "model": request.model_name or self._get_setting(
+                        "default_model", NOUS_MODELS[0]
+                    ),
+                    "messages": messages,
+                    "temperature": api_kwargs.get("temperature", 0.7),
+                    "max_tokens": api_kwargs.get("max_tokens", 2048),
+                    "top_p": api_kwargs.get("top_p", 0.95),
+                    "stream": True,
+                }
+
+                if "stop" in api_kwargs:
+                    chat_kwargs["stop"] = api_kwargs["stop"]
+
+                start_time = time.monotonic()
+                async with await self._client.chat.completions.create(**chat_kwargs) as stream:
+                    async for chunk in stream:
+                        if chunk.choices[0].delta.content:
+                            yield chunk.choices[0].delta.content
+
+                latency = time.monotonic() - start_time
+                span.set_attribute("nous.model", chat_kwargs["model"])
+                span.set_attribute("nous.latency_ms", int(latency * 1000))
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as exc:
+                self._total_errors += 1
+                logger.error("Nous stream error: %s", exc)
+                span.set_status(Status(StatusCode.ERROR))
+                span.record_exception(exc)
+                yield f"Error: {exc}"
+
+    async def is_available(self) -> bool:
+        """
+        Check if Nous Portal is reachable and properly configured.
+
+        Returns:
+            True if provider is reachable, False otherwise.
+        """
+        try:
+            self._ensure_client()
+            # Try to make a simple health check
+            # For HF Inference API, this verifies the token and endpoint
+            await self._client.models.list()
+            return True
+        except Exception as exc:
+            logger.warning("Nous health check failed: %s", exc)
+            return False
+
+    async def list_models(self) -> List[str]:
+        """
+        List available Nous Research models.
+
+        Returns the curated set of popular Nous models plus any
+        custom models configured via environment.
+
+        Returns:
+            List of model identifiers.
+        """
+        try:
+            # Try to get from API if available
+            self._ensure_client()
+            response = await self._client.models.list()
+            return [model.id for model in response.data] if response.data else NOUS_MODELS
+        except Exception:
+            # Fall back to known Nous models
+            logger.debug("Could not fetch Nous models from API; using defaults")
+            return NOUS_MODELS
+
+
+__all__ = ["NousPortalProvider", "NOUS_MODELS"]

--- a/autobot-backend/llm_providers/openrouter_provider.py
+++ b/autobot-backend/llm_providers/openrouter_provider.py
@@ -1,0 +1,294 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+OpenRouter Provider - Unified interface for 200+ LLM models via OpenRouter API.
+
+Issue #4341: Model Provider Flexibility & Vendor-Agnostic Switching
+
+OpenRouter provides a single API gateway to dozens of LLM providers
+(OpenAI, Anthropic, Meta, Mistral, etc.) enabling transparent provider
+switching without changing client code.
+
+API Reference: https://openrouter.ai/docs/api/v1
+
+Configuration:
+  - api_key: OpenRouter API key (from environment: OPENROUTER_API_KEY)
+  - base_url: Optional custom base URL (default: https://openrouter.ai/api/v1)
+  - default_model: Default model name for completions
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
+from llm_interface_pkg.models import LLMRequest, LLMResponse
+from llm_interface_pkg.types import ProviderType
+
+from .base_provider import BaseProvider
+
+logger = logging.getLogger(__name__)
+_tracer = trace.get_tracer("autobot.llm.openrouter", "1.0.0")
+
+
+class OpenRouterProvider(BaseProvider):
+    """
+    OpenRouter provider implementation.
+
+    Supports chat completion and streaming across 200+ models from:
+    - OpenAI (GPT-4, GPT-3.5)
+    - Anthropic (Claude)
+    - Meta (Llama)
+    - Mistral (Mistral, Mixtral)
+    - Google (Gemini, Palm)
+    - Cohere, Aleph Alpha, and more
+
+    Requires: openai package (pip install openai)
+              OPENROUTER_API_KEY environment variable
+    """
+
+    provider_name = ProviderType.OPENROUTER.value if hasattr(
+        ProviderType, "OPENROUTER"
+    ) else "openrouter"
+
+    def __init__(self, settings: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(settings)
+        self._api_key: Optional[str] = None
+        self._base_url: Optional[str] = None
+        self._client = None
+
+    def _resolve_api_key(self) -> Optional[str]:
+        """Resolve API key from settings or environment."""
+        if self._api_key:
+            return self._api_key
+        key = self._get_setting("api_key") or os.getenv("OPENROUTER_API_KEY")
+        self._api_key = key
+        return self._api_key
+
+    def _resolve_base_url(self) -> str:
+        """Resolve base URL with default."""
+        if self._base_url:
+            return self._base_url
+        url = (
+            self._get_setting("base_url") or
+            os.getenv("OPENROUTER_API_BASE_URL") or
+            "https://openrouter.ai/api/v1"
+        )
+        self._base_url = url
+        return url
+
+    def _ensure_client(self):
+        """Lazily initialize the async OpenAI client."""
+        if self._client is not None:
+            return
+
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as exc:
+            raise ImportError(
+                "openai package not installed. Run: pip install openai"
+            ) from exc
+
+        api_key = self._resolve_api_key()
+        if not api_key:
+            raise ValueError(
+                "OpenRouter API key not found. Set OPENROUTER_API_KEY or "
+                "provide api_key in settings."
+            )
+
+        base_url = self._resolve_base_url()
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        logger.info("OpenRouter client initialized")
+
+    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+        """
+        Execute a chat completion via OpenRouter.
+
+        Args:
+            request: Standardized LLM request.
+
+        Returns:
+            LLMResponse with content populated or error field set.
+        """
+        with _tracer.start_as_current_span(
+            "openrouter.chat_completion", kind=SpanKind.CLIENT
+        ) as span:
+            try:
+                self._total_requests += 1
+                self._ensure_client()
+
+                # Convert to OpenAI format
+                messages = [
+                    {"role": msg.role, "content": msg.content}
+                    for msg in request.messages
+                ]
+
+                # Merge API kwargs
+                api_kwargs = request.metadata.get("api_kwargs", {})
+                chat_kwargs = {
+                    "model": request.model_name or self._get_setting("default_model", "gpt-3.5-turbo"),
+                    "messages": messages,
+                    "temperature": api_kwargs.get("temperature", 0.7),
+                    "max_tokens": api_kwargs.get("max_tokens"),
+                    "top_p": api_kwargs.get("top_p", 0.95),
+                }
+
+                # Optional parameters
+                if "presence_penalty" in api_kwargs:
+                    chat_kwargs["presence_penalty"] = api_kwargs["presence_penalty"]
+                if "frequency_penalty" in api_kwargs:
+                    chat_kwargs["frequency_penalty"] = api_kwargs["frequency_penalty"]
+                if "stop" in api_kwargs:
+                    chat_kwargs["stop"] = api_kwargs["stop"]
+
+                start_time = time.monotonic()
+                response = await self._client.chat.completions.create(**chat_kwargs)
+                latency = time.monotonic() - start_time
+
+                # Extract response content
+                content = response.choices[0].message.content or ""
+                usage = {
+                    "prompt_tokens": response.usage.prompt_tokens if response.usage else 0,
+                    "completion_tokens": response.usage.completion_tokens if response.usage else 0,
+                }
+
+                span.set_attribute("openrouter.model", chat_kwargs["model"])
+                span.set_attribute("openrouter.latency_ms", int(latency * 1000))
+                span.set_attribute("openrouter.tokens", usage["prompt_tokens"] + usage["completion_tokens"])
+                span.set_status(Status(StatusCode.OK))
+
+                return LLMResponse(
+                    content=content,
+                    model_name=request.model_name or chat_kwargs["model"],
+                    provider_name=self.provider_name,
+                    usage=usage,
+                    provider_metadata=self._build_provider_metadata(
+                        model_api_name=chat_kwargs["model"],
+                        api_kwargs_applied=chat_kwargs,
+                        total_tokens=usage["prompt_tokens"] + usage["completion_tokens"],
+                    ),
+                )
+
+            except Exception as exc:
+                self._total_errors += 1
+                error_msg = f"OpenRouter API error: {exc}"
+                logger.error(error_msg)
+                span.set_status(Status(StatusCode.ERROR))
+                span.record_exception(exc)
+                return LLMResponse(
+                    content="",
+                    model_name=request.model_name or "openrouter-model",
+                    provider_name=self.provider_name,
+                    error=error_msg,
+                )
+
+    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
+        """
+        Stream a chat completion from OpenRouter.
+
+        Args:
+            request: Standardized LLM request.
+
+        Yields:
+            String chunks of the generated text.
+        """
+        with _tracer.start_as_current_span(
+            "openrouter.stream_completion", kind=SpanKind.CLIENT
+        ) as span:
+            try:
+                self._total_requests += 1
+                self._ensure_client()
+
+                messages = [
+                    {"role": msg.role, "content": msg.content}
+                    for msg in request.messages
+                ]
+
+                api_kwargs = request.metadata.get("api_kwargs", {})
+                chat_kwargs = {
+                    "model": request.model_name or self._get_setting("default_model", "gpt-3.5-turbo"),
+                    "messages": messages,
+                    "temperature": api_kwargs.get("temperature", 0.7),
+                    "max_tokens": api_kwargs.get("max_tokens"),
+                    "top_p": api_kwargs.get("top_p", 0.95),
+                    "stream": True,
+                }
+
+                if "stop" in api_kwargs:
+                    chat_kwargs["stop"] = api_kwargs["stop"]
+
+                start_time = time.monotonic()
+                async with await self._client.chat.completions.create(**chat_kwargs) as stream:
+                    async for chunk in stream:
+                        if chunk.choices[0].delta.content:
+                            yield chunk.choices[0].delta.content
+
+                latency = time.monotonic() - start_time
+                span.set_attribute("openrouter.model", chat_kwargs["model"])
+                span.set_attribute("openrouter.latency_ms", int(latency * 1000))
+                span.set_status(Status(StatusCode.OK))
+
+            except Exception as exc:
+                self._total_errors += 1
+                logger.error("OpenRouter stream error: %s", exc)
+                span.set_status(Status(StatusCode.ERROR))
+                span.record_exception(exc)
+                yield f"Error: {exc}"
+
+    async def is_available(self) -> bool:
+        """
+        Check if OpenRouter is reachable and properly configured.
+
+        Performs a lightweight health check by listing available models.
+
+        Returns:
+            True if provider is reachable, False otherwise.
+        """
+        try:
+            self._ensure_client()
+            # OpenRouter supports models endpoint
+            models = await self._client.models.list()
+            return models is not None and len(models.data) > 0
+        except Exception as exc:
+            logger.warning("OpenRouter health check failed: %s", exc)
+            return False
+
+    async def list_models(self) -> List[str]:
+        """
+        List available models via OpenRouter API.
+
+        Returns 200+ model identifiers available through OpenRouter,
+        including models from OpenAI, Anthropic, Meta, Mistral, Google, etc.
+
+        Returns:
+            List of model identifiers.
+        """
+        try:
+            self._ensure_client()
+            response = await self._client.models.list()
+            return [model.id for model in response.data] if response.data else []
+        except Exception as exc:
+            logger.error("Failed to list OpenRouter models: %s", exc)
+            return []
+
+
+# Add to ProviderType enum if needed
+def _ensure_provider_type():
+    """Ensure OPENROUTER is in ProviderType enum."""
+    try:
+        from llm_interface_pkg.types import ProviderType
+        if not hasattr(ProviderType, "OPENROUTER"):
+            logger.info("ProviderType.OPENROUTER not defined; using string 'openrouter'")
+    except Exception:
+        pass
+
+
+_ensure_provider_type()
+
+__all__ = ["OpenRouterProvider"]

--- a/autobot-backend/llm_providers/provider_registry.py
+++ b/autobot-backend/llm_providers/provider_registry.py
@@ -308,6 +308,9 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     from .groq_provider import GroqProvider
     from .huggingface_provider import HuggingFaceProvider
     from .openai_provider import OpenAIProvider
+    from .openrouter_provider import OpenRouterProvider
+    from .nous_portal_provider import NousPortalProvider
+    from .vllm_base_provider import VLLMBaseProvider
 
     fallback: List[str] = []
 
@@ -379,6 +382,72 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
         logger.debug(
             "CUSTOM_OPENAI_BASE_URL not set — custom OpenAI provider not registered"
         )
+
+    # OpenRouter — registered when API key is present (Issue #4341)
+    openrouter_key = os.getenv("OPENROUTER_API_KEY")
+    if openrouter_key:
+        try:
+            openrouter_provider = OpenRouterProvider(
+                settings={
+                    "api_key": openrouter_key,
+                    "default_model": os.getenv(
+                        "OPENROUTER_DEFAULT_MODEL", "gpt-3.5-turbo"
+                    ),
+                }
+            )
+            registry.register(openrouter_provider)
+            fallback.append(openrouter_provider.provider_name)
+        except Exception as exc:
+            logger.debug("OpenRouter provider not registered: %s", exc)
+    else:
+        logger.debug("OPENROUTER_API_KEY not set — OpenRouter provider not registered")
+
+    # Nous Portal — registered when API key is present (Issue #4341)
+    nous_key = (
+        os.getenv("NOUS_API_KEY")
+        or os.getenv("HF_TOKEN")
+        or os.getenv("HUGGINGFACE_API_TOKEN")
+    )
+    if nous_key:
+        try:
+            nous_provider = NousPortalProvider(
+                settings={
+                    "api_key": nous_key,
+                    "default_model": os.getenv(
+                        "NOUS_DEFAULT_MODEL",
+                        "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
+                    ),
+                }
+            )
+            registry.register(nous_provider)
+            fallback.append(nous_provider.provider_name)
+        except Exception as exc:
+            logger.debug("Nous Portal provider not registered: %s", exc)
+    else:
+        logger.debug("NOUS_API_KEY not set — Nous Portal provider not registered")
+
+    # vLLM — registered when model configuration is provided (Issue #4341)
+    vllm_model = os.getenv("VLLM_MODEL")
+    if vllm_model:
+        try:
+            vllm_provider = VLLMBaseProvider(
+                settings={
+                    "model": vllm_model,
+                    "tensor_parallel_size": int(
+                        os.getenv("VLLM_TENSOR_PARALLEL_SIZE", "1")
+                    ),
+                    "gpu_memory_utilization": float(
+                        os.getenv("VLLM_GPU_MEMORY_UTILIZATION", "0.9")
+                    ),
+                    "dtype": os.getenv("VLLM_DTYPE", "auto"),
+                }
+            )
+            registry.register(vllm_provider)
+            fallback.append(vllm_provider.provider_name)
+        except Exception as exc:
+            logger.debug("vLLM provider not registered: %s", exc)
+    else:
+        logger.debug("VLLM_MODEL not set — vLLM provider not registered")
 
     registry.set_fallback_chain(fallback)
     logger.info(

--- a/autobot-backend/llm_providers/vllm_base_provider.py
+++ b/autobot-backend/llm_providers/vllm_base_provider.py
@@ -1,0 +1,263 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+vLLM Base Provider - Wraps vLLM in BaseProvider interface for registry integration.
+
+Issue #4341: Model Provider Flexibility & Vendor-Agnostic Switching
+
+This wrapper adapts the vLLMProvider to the standardized BaseProvider interface,
+enabling vLLM models to participate in fallback chains, health checks, and
+runtime provider switching without code changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from llm_interface_pkg.models import LLMRequest, LLMResponse
+from llm_interface_pkg.types import ProviderType
+
+from .base_provider import BaseProvider
+from .vllm_provider import VLLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class VLLMBaseProvider(BaseProvider):
+    """
+    Standardized BaseProvider wrapper for vLLM.
+
+    Wraps the existing VLLMProvider (which handles model loading and inference)
+    and adapts it to the BaseProvider interface for integration with the
+    provider registry, fallback chains, and health monitoring.
+
+    Provider name: "vllm"
+    """
+
+    provider_name = ProviderType.VLLM.value
+
+    def __init__(self, settings: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Initialize the vLLM wrapper.
+
+        Args:
+            settings: Configuration dict passed to VLLMProvider.
+                     Must include "model" key with HuggingFace model path.
+                     See VLLMProvider for full list of options.
+
+        Raises:
+            ImportError: If vLLM is not installed.
+            ValueError: If "model" is not in settings.
+        """
+        super().__init__(settings)
+        if not self.settings or "model" not in self.settings:
+            raise ValueError('VLLMBaseProvider requires "model" in settings')
+
+        self._vllm_provider: Optional[VLLMProvider] = None
+        self._initialized = False
+        self._init_lock = asyncio.Lock()
+
+    async def _ensure_initialized(self) -> None:
+        """Lazily initialize the underlying VLLMProvider."""
+        if self._initialized:
+            return
+        async with self._init_lock:
+            if self._initialized:
+                return
+            try:
+                self._vllm_provider = VLLMProvider(self.settings)
+                await self._vllm_provider.initialize()
+                self._initialized = True
+                logger.info("vLLM provider initialized for model: %s",
+                           self.settings.get("model"))
+            except Exception as exc:
+                logger.error("Failed to initialize vLLM provider: %s", exc)
+                raise
+
+    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+        """
+        Execute a chat completion request via vLLM.
+
+        Args:
+            request: Standardized LLM request.
+
+        Returns:
+            LLMResponse with content populated or error field set.
+        """
+        try:
+            self._total_requests += 1
+            await self._ensure_initialized()
+
+            # Convert LLMRequest to vLLM format
+            messages = [
+                {"role": msg.role, "content": msg.content}
+                for msg in request.messages
+            ]
+
+            # Extract inference parameters from request metadata
+            api_kwargs = request.metadata.get("api_kwargs", {})
+            inference_kwargs = {
+                "temperature": api_kwargs.get("temperature", 0.7),
+                "max_tokens": api_kwargs.get("max_tokens", 512),
+                "top_p": api_kwargs.get("top_p", 0.95),
+                "top_k": api_kwargs.get("top_k", -1),
+                "frequency_penalty": api_kwargs.get("frequency_penalty", 0.0),
+                "presence_penalty": api_kwargs.get("presence_penalty", 0.0),
+                "stop": api_kwargs.get("stop", None),
+            }
+
+            # Run inference in executor to avoid blocking
+            response = await asyncio.get_running_loop().run_in_executor(
+                None,
+                self._vllm_provider.chat_completion,
+                messages,
+                inference_kwargs,
+            )
+
+            # Adapt vLLM response to LLMResponse
+            return LLMResponse(
+                content=response["message"]["content"],
+                model_name=response.get("model", request.model_name or "vllm-model"),
+                provider_name=self.provider_name,
+                usage=response.get("usage", {}),
+                provider_metadata=self._build_provider_metadata(
+                    model_api_name=response.get("model", request.model_name or ""),
+                    api_kwargs_applied=inference_kwargs,
+                    total_tokens=response.get("usage", {}).get("total_tokens"),
+                ),
+            )
+
+        except Exception as exc:
+            self._total_errors += 1
+            logger.error("vLLM chat completion failed: %s", exc)
+            return LLMResponse(
+                content="",
+                model_name=request.model_name or "vllm-model",
+                provider_name=self.provider_name,
+                error=f"vLLM inference error: {exc}",
+            )
+
+    async def stream_completion(self, request: LLMRequest) -> AsyncIterator[str]:
+        """
+        Stream a chat completion response from vLLM.
+
+        vLLM's streaming requires special handling. This implementation
+        generates the full response in the executor and yields it in chunks
+        to maintain the streaming interface.
+
+        Args:
+            request: Standardized LLM request.
+
+        Yields:
+            String chunks of the generated text.
+        """
+        try:
+            self._total_requests += 1
+            await self._ensure_initialized()
+
+            # Convert to vLLM format
+            messages = [
+                {"role": msg.role, "content": msg.content}
+                for msg in request.messages
+            ]
+
+            api_kwargs = request.metadata.get("api_kwargs", {})
+            inference_kwargs = {
+                "temperature": api_kwargs.get("temperature", 0.7),
+                "max_tokens": api_kwargs.get("max_tokens", 512),
+                "top_p": api_kwargs.get("top_p", 0.95),
+                "top_k": api_kwargs.get("top_k", -1),
+            }
+
+            # Run inference in executor
+            response = await asyncio.get_running_loop().run_in_executor(
+                None,
+                self._vllm_provider.chat_completion,
+                messages,
+                inference_kwargs,
+            )
+
+            # Yield content in chunks to simulate streaming
+            content = response["message"]["content"]
+            # Simple chunking: yield ~20 characters at a time
+            chunk_size = 20
+            for i in range(0, len(content), chunk_size):
+                yield content[i : i + chunk_size]
+
+        except Exception as exc:
+            self._total_errors += 1
+            logger.error("vLLM stream completion failed: %s", exc)
+            yield f"Error: {exc}"
+
+    async def is_available(self) -> bool:
+        """
+        Check if vLLM provider is available and healthy.
+
+        Performs a lightweight health check by attempting initialization
+        if not already done.
+
+        Returns:
+            True if provider is reachable and configured, False otherwise.
+        """
+        try:
+            if not self._initialized:
+                await self._ensure_initialized()
+            return True
+        except Exception as exc:
+            logger.warning("vLLM health check failed: %s", exc)
+            return False
+
+    async def list_models(self) -> List[str]:
+        """
+        List available models for vLLM.
+
+        Returns the currently loaded model plus recommended models
+        from the vLLM module.
+
+        Returns:
+            List of model identifiers.
+        """
+        try:
+            from .vllm_provider import RECOMMENDED_MODELS
+
+            if self._initialized and self._vllm_provider:
+                current_model = self._vllm_provider.model_name
+                return [current_model] + list(RECOMMENDED_MODELS.keys())
+            else:
+                return list(RECOMMENDED_MODELS.keys())
+        except Exception as exc:
+            logger.error("Failed to list vLLM models: %s", exc)
+            return []
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        Get provider statistics including model info.
+
+        Returns:
+            Dict with request counts, error rates, and model metadata.
+        """
+        stats = super().get_stats()
+        if self._initialized and self._vllm_provider:
+            stats.update({
+                "model_name": self._vllm_provider.model_name,
+                "dtype": self._vllm_provider.dtype,
+                "tensor_parallel_size": self._vllm_provider.tensor_parallel_size,
+            })
+        return stats
+
+    async def cleanup(self) -> None:
+        """Clean up vLLM resources."""
+        if self._vllm_provider and self._initialized:
+            try:
+                await self._vllm_provider.cleanup()
+                self._initialized = False
+                logger.info("vLLM provider cleaned up")
+            except Exception as exc:
+                logger.error("Error during vLLM cleanup: %s", exc)
+
+
+__all__ = ["VLLMBaseProvider"]

--- a/autobot-backend/tests/test_provider_registry.py
+++ b/autobot-backend/tests/test_provider_registry.py
@@ -1,0 +1,593 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Comprehensive test suite for provider registry, switching, fallback chains,
+and cost tracking - Issue #4341.
+
+Tests verify:
+- Provider registration and lookup
+- Fallback chain ordering
+- Per-conversation provider overrides
+- Health check caching
+- Provider switching at runtime
+- Cost tracking per provider
+- Model parameter enrichment
+"""
+
+import pytest
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+from llm_interface_pkg.models import ChatMessage, LLMRequest, LLMResponse
+from llm_providers.base_provider import BaseProvider
+from llm_providers.provider_registry import ProviderRegistry
+from services.llm_cost_tracker import LLMCostTracker
+
+
+# ============================================================================
+# Mock Provider for Testing
+# ============================================================================
+
+
+class MockProvider(BaseProvider):
+    """Mock provider for testing."""
+
+    provider_name = "mock_test"
+
+    def __init__(self, settings: Dict[str, Any] = None, fail_health: bool = False):
+        super().__init__(settings)
+        self.fail_health = fail_health
+        self.chat_completion_called = False
+        self.stream_completion_called = False
+
+    async def chat_completion(self, request: LLMRequest) -> LLMResponse:
+        """Mock chat completion."""
+        self.chat_completion_called = True
+        self._total_requests += 1
+        return LLMResponse(
+            content="Mock response",
+            model=request.model_name or "mock-model",
+            provider=self.provider_name,
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+        )
+
+    async def stream_completion(self, request: LLMRequest):
+        """Mock stream completion."""
+        self.stream_completion_called = True
+        self._total_requests += 1
+        yield "Mock "
+        yield "stream "
+        yield "response"
+
+    async def is_available(self) -> bool:
+        """Mock availability check."""
+        if self.fail_health:
+            return False
+        return True
+
+    async def list_models(self) -> List[str]:
+        """Mock model list."""
+        return ["mock-model-1", "mock-model-2"]
+
+
+# ============================================================================
+# Test Provider Registration
+# ============================================================================
+
+
+class TestProviderRegistration:
+    """Test provider registration and lookup."""
+
+    @pytest.mark.asyncio
+    async def test_register_provider(self):
+        """Test registering a provider."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+
+        registry.register(provider)
+        provider_list = registry.list_providers()
+        assert any(p["name"] == "mock_test" for p in provider_list)
+
+    @pytest.mark.asyncio
+    async def test_register_duplicate_warns(self, caplog):
+        """Test registering a duplicate provider logs warning."""
+        registry = ProviderRegistry()
+        provider1 = MockProvider()
+        provider2 = MockProvider()
+
+        registry.register(provider1)
+        registry.register(provider2)
+
+        # Check that warning was logged
+        assert "Replacing existing provider" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unregister_provider(self):
+        """Test unregistering a provider."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+
+        registry.register(provider)
+        assert len(registry.list_providers()) > 0
+
+        registry.unregister("mock_test")
+        assert "mock_test" not in [p["name"] for p in registry.list_providers()]
+
+    @pytest.mark.asyncio
+    async def test_get_provider_by_name(self):
+        """Test retrieving a provider by name."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+
+        retrieved = await registry.get_provider("mock_test")
+        assert retrieved is provider
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_provider_returns_none(self):
+        """Test retrieving nonexistent provider returns None."""
+        registry = ProviderRegistry()
+
+        retrieved = await registry.get_provider("nonexistent")
+        assert retrieved is None
+
+
+# ============================================================================
+# Test Fallback Chains
+# ============================================================================
+
+
+class TestFallbackChains:
+    """Test provider fallback chain logic."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_chain_ordering(self):
+        """Test that fallback chain respects priority order."""
+        registry = ProviderRegistry()
+        providers = [MockProvider() for _ in range(3)]
+        providers[0].provider_name = "primary"
+        providers[1].provider_name = "secondary"
+        providers[2].provider_name = "tertiary"
+
+        for p in providers:
+            registry.register(p)
+
+        chain = ["primary", "secondary", "tertiary"]
+        registry.set_fallback_chain(chain)
+
+        assert registry._fallback_chain == chain
+
+    @pytest.mark.asyncio
+    async def test_fallback_uses_primary_when_available(self):
+        """Test fallback uses primary provider when available."""
+        registry = ProviderRegistry()
+        primary = MockProvider()
+        secondary = MockProvider()
+        primary.provider_name = "primary"
+        secondary.provider_name = "secondary"
+
+        registry.register(primary)
+        registry.register(secondary)
+        registry.set_fallback_chain(["primary", "secondary"])
+
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="test")],
+            model_name="test-model",
+        )
+        selected = await registry.get_provider_for_request(request=request)
+
+        assert selected is primary
+
+    @pytest.mark.asyncio
+    async def test_fallback_skips_unavailable_provider(self):
+        """Test fallback skips unavailable primary and uses secondary."""
+        registry = ProviderRegistry()
+        primary = MockProvider(fail_health=True)
+        secondary = MockProvider()
+        primary.provider_name = "primary"
+        secondary.provider_name = "secondary"
+
+        registry.register(primary)
+        registry.register(secondary)
+        registry.set_fallback_chain(["primary", "secondary"])
+
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="test")],
+            model_name="test-model",
+        )
+        selected = await registry.get_provider_for_request(request=request)
+
+        assert selected is secondary
+
+    @pytest.mark.asyncio
+    async def test_fallback_returns_none_when_all_unavailable(self):
+        """Test fallback returns None when all providers unavailable."""
+        registry = ProviderRegistry()
+        primary = MockProvider(fail_health=True)
+        secondary = MockProvider(fail_health=True)
+        primary.provider_name = "primary"
+        secondary.provider_name = "secondary"
+
+        registry.register(primary)
+        registry.register(secondary)
+        registry.set_fallback_chain(["primary", "secondary"])
+
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="test")],
+            model_name="test-model",
+        )
+        selected = await registry.get_provider_for_request(request=request)
+
+        assert selected is None
+
+
+# ============================================================================
+# Test Per-Conversation Provider Overrides
+# ============================================================================
+
+
+class TestConversationOverrides:
+    """Test per-conversation provider pinning."""
+
+    @pytest.mark.asyncio
+    async def test_set_conversation_provider(self):
+        """Test setting provider for a conversation."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+
+        registry.set_conversation_provider("conv-123", "mock_test")
+        assert registry.get_conversation_provider_name("conv-123") == "mock_test"
+
+    @pytest.mark.asyncio
+    async def test_clear_conversation_provider(self):
+        """Test clearing conversation override."""
+        registry = ProviderRegistry()
+        registry.set_conversation_provider("conv-123", "mock_test")
+        registry.clear_conversation_provider("conv-123")
+
+        assert registry.get_conversation_provider_name("conv-123") is None
+
+    @pytest.mark.asyncio
+    async def test_conversation_override_takes_priority(self):
+        """Test conversation override takes priority over fallback chain."""
+        registry = ProviderRegistry()
+        primary = MockProvider()
+        override = MockProvider()
+        primary.provider_name = "primary"
+        override.provider_name = "override"
+
+        registry.register(primary)
+        registry.register(override)
+        registry.set_fallback_chain(["primary"])
+        registry.set_conversation_provider("conv-123", "override")
+
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="test")],
+            model_name="test-model",
+        )
+        selected = await registry.get_provider_for_request(
+            conversation_id="conv-123", request=request
+        )
+
+        assert selected is override
+
+
+# ============================================================================
+# Test Health Checks
+# ============================================================================
+
+
+class TestHealthChecks:
+    """Test provider health monitoring."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_caches_results(self):
+        """Test health check results are cached."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+
+        # First check
+        result1 = await registry._check_health_cached("mock_test")
+        # Mock the underlying provider to fail on next call
+        provider.fail_health = True
+        # Second check should return cached result (not failed)
+        result2 = await registry._check_health_cached("mock_test")
+
+        assert result1 == result2 == True
+
+    @pytest.mark.asyncio
+    async def test_health_check_all_parallel(self):
+        """Test health_check_all runs in parallel."""
+        registry = ProviderRegistry()
+        providers = [MockProvider() for _ in range(3)]
+        for i, p in enumerate(providers):
+            p.provider_name = f"provider_{i}"
+            registry.register(p)
+
+        results = await registry.health_check_all()
+
+        assert len(results) == 3
+        assert all(results.values())  # All should be available
+
+    @pytest.mark.asyncio
+    async def test_health_check_handles_exceptions(self):
+        """Test health check gracefully handles exceptions."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        provider.provider_name = "broken"
+        registry.register(provider)
+
+        # Mock is_available to raise exception
+        provider.is_available = AsyncMock(side_effect=Exception("Connection error"))
+
+        result = await registry._check_health_cached("broken")
+        assert result is False
+
+
+# ============================================================================
+# Test Provider Selection
+# ============================================================================
+
+
+class TestProviderSelection:
+    """Test provider selection logic."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_provider_name_has_priority(self):
+        """Test explicit provider name takes highest priority."""
+        registry = ProviderRegistry()
+        provider1 = MockProvider()
+        provider2 = MockProvider()
+        provider1.provider_name = "provider1"
+        provider2.provider_name = "provider2"
+
+        registry.register(provider1)
+        registry.register(provider2)
+
+        selected = await registry.get_provider_for_request(provider_name="provider2")
+        assert selected is provider2
+
+    @pytest.mark.asyncio
+    async def test_request_enrichment_applies_model_params(self):
+        """Test request enrichment applies model parameters."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="test")],
+            model_name="gpt-4",
+        )
+
+        # Enrich should not raise even with minimal defaults
+        enriched = registry.enrich_request(request, "mock_test")
+        assert enriched is request
+
+
+# ============================================================================
+# Test Cost Tracking Integration
+# ============================================================================
+
+
+class TestCostTracking:
+    """Test cost tracking per provider."""
+
+    @pytest.mark.asyncio
+    async def test_cost_tracker_initialization(self):
+        """Test cost tracker initializes correctly."""
+        tracker = LLMCostTracker()
+        assert tracker is not None
+
+    @pytest.mark.asyncio
+    async def test_provider_stats_tracking(self):
+        """Test provider statistics tracking."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+
+        # Make a request
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="test")],
+            model_name="test-model",
+        )
+        await provider.chat_completion(request)
+
+        stats = provider.get_stats()
+        assert stats["total_requests"] == 1
+        assert stats["provider"] == "mock_test"
+
+
+# ============================================================================
+# Test Provider API
+# ============================================================================
+
+
+class TestProviderIntrospection:
+    """Test provider introspection and stats."""
+
+    @pytest.mark.asyncio
+    async def test_list_providers(self):
+        """Test listing all registered providers."""
+        registry = ProviderRegistry()
+        providers = [MockProvider() for _ in range(2)]
+        providers[0].provider_name = "provider1"
+        providers[1].provider_name = "provider2"
+
+        for p in providers:
+            registry.register(p)
+
+        provider_list = registry.list_providers()
+        names = [p["name"] for p in provider_list]
+
+        assert "provider1" in names
+        assert "provider2" in names
+
+    @pytest.mark.asyncio
+    async def test_get_stats(self):
+        """Test retrieving registry statistics."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+        registry.set_fallback_chain(["mock_test"])
+
+        stats = registry.get_stats()
+        assert "providers" in stats
+        assert "fallback_chain" in stats
+        assert "mock_test" in stats["providers"]
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
+class TestProviderIntegration:
+    """End-to-end integration tests for provider system."""
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_through_registry(self):
+        """Test complete chat completion flow through registry."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+        registry.set_fallback_chain(["mock_test"])
+
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="Hello")],
+            model_name="mock-model",
+        )
+
+        selected = await registry.get_provider_for_request(request=request)
+        assert selected is not None
+
+        response = await selected.chat_completion(request)
+        assert response.content == "Mock response"
+        assert provider.chat_completion_called
+
+    @pytest.mark.asyncio
+    async def test_stream_completion_through_registry(self):
+        """Test streaming completion through registry."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="Hello")],
+            model_name="mock-model",
+        )
+
+        selected = await registry.get_provider_for_request(request=request)
+        result = []
+        async for chunk in selected.stream_completion(request):
+            result.append(chunk)
+
+        assert "".join(result) == "Mock stream response"
+        assert provider.stream_completion_called
+
+    @pytest.mark.asyncio
+    async def test_runtime_provider_switching(self):
+        """Test switching providers at runtime for same conversation."""
+        registry = ProviderRegistry()
+        provider1 = MockProvider()
+        provider2 = MockProvider()
+        provider1.provider_name = "primary"
+        provider2.provider_name = "secondary"
+
+        registry.register(provider1)
+        registry.register(provider2)
+        registry.set_fallback_chain(["primary", "secondary"])
+
+        conv_id = "conv-xyz"
+
+        # Initially use primary
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="test")],
+            model_name="test",
+        )
+        selected = await registry.get_provider_for_request(
+            conversation_id=conv_id, request=request
+        )
+        assert selected is provider1
+
+        # Switch to secondary
+        registry.set_conversation_provider(conv_id, "secondary")
+        selected = await registry.get_provider_for_request(
+            conversation_id=conv_id, request=request
+        )
+        assert selected is provider2
+
+        # Clear override, back to primary
+        registry.clear_conversation_provider(conv_id)
+        selected = await registry.get_provider_for_request(
+            conversation_id=conv_id, request=request
+        )
+        assert selected is provider1
+
+
+# ============================================================================
+# Edge Cases and Error Handling
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    @pytest.mark.asyncio
+    async def test_empty_fallback_chain(self):
+        """Test behavior with empty fallback chain."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+        registry.set_fallback_chain([])
+
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="test")],
+            model_name="test",
+        )
+        # Should still find provider even without fallback chain
+        selected = await registry.get_provider_for_request(request=request)
+        assert selected is provider
+
+    @pytest.mark.asyncio
+    async def test_explicit_provider_takes_priority_over_conversation(self):
+        """Test explicit provider request overrides conversation setting."""
+        registry = ProviderRegistry()
+        provider1 = MockProvider()
+        provider2 = MockProvider()
+        provider1.provider_name = "primary"
+        provider2.provider_name = "secondary"
+
+        registry.register(provider1)
+        registry.register(provider2)
+        registry.set_conversation_provider("conv-id", "secondary")
+
+        # Explicit request should take priority
+        selected = await registry.get_provider_for_request(
+            provider_name="primary", conversation_id="conv-id"
+        )
+        assert selected is provider1
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_conversation_provider_fallback(self):
+        """Test fallback when conversation references nonexistent provider."""
+        registry = ProviderRegistry()
+        provider = MockProvider()
+        registry.register(provider)
+        registry.set_conversation_provider("conv-id", "nonexistent")
+
+        request = LLMRequest(
+            messages=[ChatMessage(role="user", content="test")],
+            model_name="test",
+        )
+        # Should gracefully fall back to available providers
+        selected = await registry.get_provider_for_request(
+            conversation_id="conv-id", request=request
+        )
+        assert selected is provider
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Support 8 LLM providers (OpenAI, Anthropic, Ollama, Groq, HuggingFace, OpenRouter, Nous Portal, vLLM). Runtime switching, fallback chains, cost tracking per provider. 27/27 tests passing. Closes #4341