### PR TITLE
fix(knowledge): force full indexing when collection empty despite cache (#4350)

### DIFF
--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -894,6 +894,14 @@ class DocIndexerService:
             logger.warning("No documentation files discovered in %s", self._root_dir)
             return total_result
 
+        # If collection is empty, force full indexing regardless of cache (#4350)
+        if not force and self.needs_indexing():
+            logger.info(
+                "Collection empty — forcing full indexing despite cache to ensure "
+                "documentation is available"
+            )
+            force = True
+
         # Incremental mode: filter to changed files
         new_hashes: Dict[str, str] = {}
         if not force:
@@ -902,6 +910,10 @@ class DocIndexerService:
             )
             if early:
                 return total_result
+        else:
+            # In force mode, compute hashes for all files to update cache
+            hash_cache = {}  # Empty cache treats all as changed
+            files, new_hashes = _filter_changed_files(files, hash_cache, self._root_dir)
 
         logger.info("Indexing %d documentation files...", len(files))
         for file_path, tier in files:


### PR DESCRIPTION
## Summary
When the ChromaDB collection is empty but a hash cache file exists with stale entries, all documentation files are marked as unchanged and skipped, resulting in 0 vectors indexed.

## Root Cause
- `index_all(force=False)` enters incremental mode
- `_apply_incremental_filter()` loads cached file hashes  
- All files compare as unchanged against cached hashes
- Early exit with 0 files indexed, 230 skipped
- Result: ChromaDB empty, search broken

## Fix
- Check `needs_indexing()` before applying incremental filter
- If collection is empty, force full indexing regardless of `force` parameter
- Compute hashes during force mode for proper cache updates
- Ensure all 230 documentation files are indexed on first run

## Testing
- Manual: Verified logic flow prevents empty-collection scenario
- Cache: Hash cache now updated after force reindex

🤖 Generated with [Claude Code](https://claude.com/claude-code)