### PR TITLE
feat(hooks): wire error/loop hooks (#4262)

### DIFF
--- a/autobot-backend/chat_workflow/graph.py
+++ b/autobot-backend/chat_workflow/graph.py
@@ -901,11 +901,18 @@ async def persist_conversation(state: ChatState, config: RunnableConfig) -> dict
     if state.get("error"):
         return {}
 
+    from chat_workflow.llm_handler import _emit_loop_complete
+
     manager = config["configurable"]["manager"]
+    session_id = state.get("session_id", "")
+    total_iterations = state.get("iteration_count", 0)
+    combined_response = "\n\n".join(state.get("all_llm_responses", []))
+
+    # Emit LOOP_COMPLETE hook to notify extensions
+    await _emit_loop_complete(total_iterations, combined_response, session_id)
 
     try:
         session = await manager.get_or_create_session(state["session_id"])
-        combined_response = "\n\n".join(state.get("all_llm_responses", []))
 
         await manager._persist_conversation(
             state["session_id"],

--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -1815,26 +1815,34 @@ before summarizing.
             payload["system"] = system_prompt
         return payload
 
-    def _log_and_parse_tool_calls(
-        self, llm_response: str, iteration: int
+    async def _log_and_parse_tool_calls(
+        self, llm_response: str, iteration: int, session_id: str = "", context: Dict[str, Any] | None = None
     ) -> List[Dict[str, Any]]:
         """
         Log response details and parse tool calls.
 
         Issue #620: Extracted from _process_single_llm_iteration.
+        Issue #4262: Emit BEFORE_TOOL_PARSE hook before parsing tool calls.
         """
-        has_tool_call_tag = "<TOOL_CALL" in llm_response or "<tool_call" in llm_response
+        from chat_workflow.llm_handler import _emit_before_tool_parse
+
+        # Emit BEFORE_TOOL_PARSE hook to allow extensions to inspect/modify response
+        modified_response = await _emit_before_tool_parse(
+            llm_response, session_id, context or {}
+        )
+
+        has_tool_call_tag = "<TOOL_CALL" in modified_response or "<tool_call" in modified_response
         logger.info(
             "[Issue #651] Iteration %d: Response has TOOL_CALL tag: %s, snippet: %s",
             iteration,
             has_tool_call_tag,
-            llm_response[:500].replace("\n", " "),
+            modified_response[:500].replace("\n", " "),
         )
 
         # Issue #716: On first iteration, defer tool execution for plan-first
         is_first_iteration = iteration == 1
         tool_calls = self._parse_tool_calls(
-            llm_response, is_first_iteration=is_first_iteration
+            modified_response, is_first_iteration=is_first_iteration
         )
         logger.info(
             "[Issue #352] Iteration %d: Parsed %d tool calls",
@@ -1940,7 +1948,9 @@ before summarizing.
         finally:
             await http_client.decrement_active()
 
-        tool_calls = self._log_and_parse_tool_calls(llm_response, iteration)
+        tool_calls = await self._log_and_parse_tool_calls(
+            llm_response, iteration, terminal_session_id, {}
+        )
         yield (llm_response, tool_calls)
 
     def _handle_break_loop_tuple(self, tool_msg: Any) -> tuple:

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -1094,7 +1094,7 @@ class ToolHandlerMixin:
                 yield msg
         elif status == "error":
             async for msg in self._handle_command_error(
-                command, result, additional_response_parts
+                command, result, additional_response_parts, session_id
             ):
                 yield msg
 
@@ -1173,19 +1173,24 @@ class ToolHandlerMixin:
         command: str,
         result: dict[str, Any],
         additional_response_parts: list,
+        session_id: str = "",
     ):
         """Handle command execution error (Issue #665: extracted helper).
 
         Classifies error as repairable or critical and yields appropriate message.
+        Issue #4262: Emit REPAIRABLE_ERROR and CRITICAL_ERROR hooks.
 
         Args:
             command: The command that failed
             result: Execution result dict with error/stderr
             additional_response_parts: list to append context to
+            session_id: Session identifier for hook context
 
         Yields:
             WorkflowMessage with error details
         """
+        from chat_workflow.llm_handler import _emit_critical_error, _emit_repairable_error
+
         error = result.get("error", "Unknown error")
         stderr = result.get("stderr", "")
         repairable_error = self._classify_command_error(command, error, stderr)
@@ -1195,6 +1200,10 @@ class ToolHandlerMixin:
                 "[Issue #655] Repairable error for command '%s': %s",
                 command,
                 repairable_error.message,
+            )
+            # Emit REPAIRABLE_ERROR hook
+            await _emit_repairable_error(
+                Exception(repairable_error.message), session_id, {"command": command, "suggestion": repairable_error.suggestion}
             )
             additional_response_parts.append(f"\n\n{repairable_error.to_llm_context()}")
             yield WorkflowMessage(
@@ -1208,6 +1217,10 @@ class ToolHandlerMixin:
                 },
             )
         else:
+            # Emit CRITICAL_ERROR hook for non-repairable errors
+            await _emit_critical_error(
+                Exception(error), session_id, {"command": command}
+            )
             additional_response_parts.append(
                 f"\n\n❌ Command execution failed: {error}"
             )


### PR DESCRIPTION
Closes #4262

## Summary
Wired error and loop completion hooks to enable extensions to handle errors and monitor loop completion:
- **BEFORE_TOOL_PARSE** - Before parsing tool calls from LLM response
- **REPAIRABLE_ERROR** - When a recoverable error occurs
- **CRITICAL_ERROR** - When a non-recoverable error occurs
- **LOOP_COMPLETE** - When the conversation loop completes

## Test Status
✅ All 49 hook-related tests pass