### PR TITLE
feat(hooks): wire continuation and approval hooks (#4264)

### DIFF
--- a/autobot-backend/chat_workflow/manager.py
+++ b/autobot-backend/chat_workflow/manager.py
@@ -26,9 +26,9 @@ from constants.ttl_constants import TIMEOUT_HTTP_DEFAULT, TTL_24_HOURS
 from slash_command_handler import get_slash_command_handler
 
 from .conversation import ConversationHandlerMixin
-from .llm_handler import LLMHandlerMixin
+from .llm_handler import LLMHandlerMixin, _emit_after_continuation, _emit_before_continuation
 from .models import LLMIterationContext, StreamingMessage, WorkflowSession
-from .session_handler import SessionHandlerMixin
+from .session_handler import SessionHandlerMixin, _emit_approval_received, _emit_approval_required
 from .tool_handler import ToolHandlerMixin
 
 logger = logging.getLogger(__name__)
@@ -2545,6 +2545,17 @@ before summarizing.
         self._log_iteration_start(ctx)
 
         for iteration in range(1, self.MAX_CONTINUATION_ITERATIONS + 1):
+            # Issue #4264: Fire BEFORE_CONTINUATION hook before iteration starts
+            should_continue_iteration = await _emit_before_continuation(
+                iteration, ctx.session_id, ctx.context
+            )
+            if not should_continue_iteration:
+                logger.info(
+                    "[Issue #4264] BEFORE_CONTINUATION hook cancelled iteration %d",
+                    iteration,
+                )
+                break
+
             llm_response, should_continue = None, False
 
             async for item in self._run_continuation_loop_iteration(
@@ -2563,6 +2574,12 @@ before summarizing.
                 return
 
             all_llm_responses.append(llm_response)
+
+            # Issue #4264: Fire AFTER_CONTINUATION hook after iteration completes
+            llm_response = await _emit_after_continuation(
+                iteration, llm_response, ctx.session_id, ctx.context
+            )
+
             self._log_iteration_complete(
                 iteration,
                 should_continue,

--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -29,6 +29,10 @@ from chat_workflow.llm_handler import (
     _emit_before_tool_execute,
     _emit_tool_error,
 )
+from chat_workflow.session_handler import (
+    _emit_approval_received,
+    _emit_approval_required,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -756,6 +760,20 @@ class ToolHandlerMixin:
         )
         yield approval_msg
 
+        # Issue #4264: Fire APPROVAL_REQUIRED hook when approval is requested
+        approval_id = terminal_session_id
+        await _emit_approval_required(
+            request_id=approval_id,
+            action=command,
+            session_id=session_id,
+            context={
+                "command": command,
+                "risk_level": result.get("risk"),
+                "reasons": result.get("reasons", []),
+                "description": description,
+            },
+        )
+
         await self._persist_approval_request(
             approval_msg, session_id, terminal_session_id
         )
@@ -773,6 +791,19 @@ class ToolHandlerMixin:
         async for poll_result in self._poll_for_approval(terminal_session_id, command):
             approval_result, status_msg = poll_result
             if approval_result:
+                # Issue #4264: Fire APPROVAL_RECEIVED hook when approval decision is made
+                was_approved = approval_result.get("status") == "success"
+                await _emit_approval_received(
+                    request_id=approval_id,
+                    approved=was_approved,
+                    session_id=session_id,
+                    context={
+                        "command": command,
+                        "approval_status": approval_result.get("status"),
+                        "approval_comment": approval_result.get("approval_comment", ""),
+                    },
+                )
+
                 yield WorkflowMessage(
                     type="metadata_update",
                     content="",


### PR DESCRIPTION
Closes #4264

## Summary
Wired continuation and approval workflow hooks:
- **BEFORE_CONTINUATION** - Before continuation iteration
- **AFTER_CONTINUATION** - After continuation iteration
- **APPROVAL_REQUIRED** - When approval is needed
- **APPROVAL_RECEIVED** - When approval decision is made

## Test Status
✅ All 113 hook-related tests pass