### PR TITLE
feat(router): register unregistered API routers

### DIFF
--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -453,6 +453,21 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["ai-documents"],
         "ai_documents",
     ),
+    # Issue #4342: Error resilience monitoring endpoints (circuit breakers, error budgets)
+    # Router defines prefix="/api/resilience" internally — use "" here to avoid double-prefix
+    (
+        "api.error_resilience",
+        "",
+        ["resilience", "monitoring"],
+        "error_resilience",
+    ),
+    # User management (users, teams, organizations) — router defines /user-management internally
+    (
+        "api.user_management",
+        "",
+        ["user-management", "users"],
+        "user_management",
+    ),
     # Partially wired or legacy feature routers
     ("api.chat_sessions", "", ["chat-sessions"], "chat_sessions"),
     (


### PR DESCRIPTION
## Summary
Wire in 2 API routers that were implemented but not registered:

- **api.error_resilience** — circuit breaker status, error budget monitoring, resilience health (from #4342 implementation)
- **api.user_management** — users, teams, organizations REST API (re-exports combined router)

Both routers define URL prefixes internally (`/api/resilience` and `/user-management`), so the registry uses empty prefix to avoid double-prefixing.

## Audit Context
Dead code audit (#4391) identified 111 apparently-unregistered routers. After full investigation:
- 109 routers confirmed already registered via `core_routers.py` direct imports (audit grep missed the try/except pattern)
- 1 was a parent router of already-registered codebase_analytics sub-routers (no action needed)
- **2 genuinely missing:** error_resilience + user_management — fixed in this PR

## Test Plan
- [ ] `GET /api/resilience/health` returns 200
- [ ] `GET /api/resilience/circuit-breakers` returns status
- [ ] `GET /user-management/health` returns 200
- [ ] Backend starts without import errors