### PR TITLE
feat(hooks): wire prompt building hooks (#4265)

### DIFF
--- a/autobot-backend/chat_workflow/llm_handler.py
+++ b/autobot-backend/chat_workflow/llm_handler.py
@@ -127,13 +127,32 @@ async def _emit_before_message_process(
     }
 
 
+async def _emit_before_prompt_build(
+    session_id: str, context: Dict[str, Any]
+) -> None:
+    """Emit BEFORE_PROMPT_BUILD hook to registered extensions.
+
+    Issue #4265: Fires before prompt building begins so extensions can
+    prepare or modify context before prompt assembly starts.
+
+    Args:
+        session_id: Session identifier
+        context: Request-level context dict
+    """
+    ctx = HookContext(
+        session_id=session_id,
+        data={"context": context},
+    )
+    await get_extension_manager().invoke_hook(HookPoint.BEFORE_PROMPT_BUILD, ctx)
+
+
 async def _emit_after_prompt_build(
     prompt: str, session_id: str, context: Dict[str, Any]
 ) -> str:
     """Emit AFTER_PROMPT_BUILD hook to registered extensions.
 
-    Issue #4181: Fires after system prompt is built so extensions can
-    inspect or modify the prompt before it enters assembly.
+    Issue #4265: Fires after prompt is built so extensions can
+    inspect or modify the prompt before being sent to the LLM.
 
     Args:
         prompt: The built prompt string
@@ -792,6 +811,13 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
             ollama_endpoint = slm_base
         else:
             ollama_endpoint = self._get_ollama_endpoint_for_model(selected_model)
+
+        # Issue #4265: Emit BEFORE_PROMPT_BUILD hook before building prompts
+        await _emit_before_prompt_build(
+            session.session_id,
+            {"message": message, "use_knowledge": use_knowledge, "language": language},
+        )
+
         system_prompt = self._get_system_prompt(language=language)
         # Issue #3787: Prepend always-loaded compact memory summary.
         try:
@@ -855,6 +881,14 @@ NEVER teach commands - ALWAYS execute them.""" + lang_instruction
         full_prompt = self._build_full_prompt(
             knowledge_context, conversation_context, message
         )
+
+        # Issue #4265: Emit AFTER_PROMPT_BUILD hook after full prompt is built
+        full_prompt = await _emit_after_prompt_build(
+            full_prompt,
+            session.session_id,
+            {"message": message, "use_knowledge": use_knowledge},
+        )
+
         full_prompt = await _emit_full_prompt_ready(
             full_prompt,
             {"endpoint": ollama_endpoint, "model": selected_model},

--- a/autobot-backend/chat_workflow/wired_hooks_test.py
+++ b/autobot-backend/chat_workflow/wired_hooks_test.py
@@ -25,6 +25,7 @@ from chat_workflow.llm_handler import (
     _emit_before_continuation,
     _emit_before_llm_call,
     _emit_before_message_process,
+    _emit_before_prompt_build,
     _emit_before_response_send,
     _emit_before_tool_execute,
     _emit_before_tool_parse,
@@ -59,6 +60,10 @@ class _TrackingExtension(Extension):
     async def on_before_message_process(self, ctx: HookContext) -> None:
         self.called_hooks.append("before_message_process")
         self.captured_data["message"] = ctx.get("message")
+
+    async def on_before_prompt_build(self, ctx: HookContext) -> None:
+        self.called_hooks.append("before_prompt_build")
+        self.captured_data["context"] = ctx.get("context")
 
     async def on_after_prompt_build(self, ctx: HookContext) -> Optional[str]:
         self.called_hooks.append("after_prompt_build")
@@ -171,6 +176,49 @@ class TestBeforeMessageProcess:
 
         assert "before_message_process" in tracker.called_hooks
         assert tracker.captured_data["message"] == "hello world"
+
+
+class TestBeforePromptBuild:
+    """Tests for _emit_before_prompt_build."""
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_extension_registered(self):
+        """No-op when no extension is registered."""
+        await _emit_before_prompt_build("sess-1", {})
+
+    @pytest.mark.asyncio
+    async def test_extension_receives_context_info(self):
+        """Extension receives context information for prompt preparation."""
+        tracker = _TrackingExtension()
+        get_extension_manager().register(tracker)
+
+        context = {"message": "test", "use_knowledge": True}
+        await _emit_before_prompt_build("sess-123", context)
+
+        assert "before_prompt_build" in tracker.called_hooks
+        assert tracker.captured_data["context"] == context
+
+
+class TestAfterPromptBuild:
+    """Tests for _emit_after_prompt_build."""
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_extension_registered(self):
+        """Returns original prompt unchanged when no extension is registered."""
+        prompt = "This is the built prompt"
+        result = await _emit_after_prompt_build(prompt, "sess-1", {})
+        assert result == prompt
+
+    @pytest.mark.asyncio
+    async def test_extension_can_modify_prompt(self):
+        """Extension can modify the prompt."""
+        tracker = _TrackingExtension()
+        get_extension_manager().register(tracker)
+
+        original = "original prompt"
+        result = await _emit_after_prompt_build(original, "sess-1", {})
+
+        assert "after_prompt_build" in tracker.called_hooks
 
 
 class TestBeforeLLMCall:

--- a/autobot-backend/extensions/base.py
+++ b/autobot-backend/extensions/base.py
@@ -197,7 +197,7 @@ class Extension:
             None (modify ctx.data directly)
         """
 
-    async def on_before_prompt_build(self, ctx: HookContext) -> Optional[None]:
+    async def on_before_prompt_build(self, ctx: HookContext) -> None:
         """
         Called before building the prompt.
 

--- a/autobot-backend/extensions/base.py
+++ b/autobot-backend/extensions/base.py
@@ -197,9 +197,22 @@ class Extension:
             None (modify ctx.data directly)
         """
 
+    async def on_before_prompt_build(self, ctx: HookContext) -> Optional[None]:
+        """
+        Called before building the prompt.
+
+        Use to prepare context or validate inputs before prompt construction.
+
+        Args:
+            ctx: Hook context with context information
+
+        Returns:
+            None (modify ctx.data directly)
+        """
+
     async def on_after_prompt_build(self, ctx: HookContext) -> Optional[str]:
         """
-        Called after system prompt is built.
+        Called after prompt is built and before being sent to the LLM.
 
         Use to modify or append to the prompt.
 

--- a/autobot-backend/extensions/extension_hooks_test.py
+++ b/autobot-backend/extensions/extension_hooks_test.py
@@ -30,12 +30,13 @@ class TestHookPoint:
     """Test HookPoint enum definitions."""
 
     def test_hook_count(self):
-        """Should have exactly 24 hook points (22 original + 2 added in #3405)."""
-        assert len(HookPoint) == 24
+        """Should have exactly 25 hook points (22 original + 2 in #3405 + 1 in #4265)."""
+        assert len(HookPoint) == 25
 
     def test_message_preparation_hooks(self):
         """Should have message preparation hooks."""
         assert HookPoint.BEFORE_MESSAGE_PROCESS is not None
+        assert HookPoint.BEFORE_PROMPT_BUILD is not None
         assert HookPoint.AFTER_PROMPT_BUILD is not None
 
     def test_llm_interaction_hooks(self):

--- a/autobot-backend/extensions/hook_invoker.py
+++ b/autobot-backend/extensions/hook_invoker.py
@@ -15,7 +15,7 @@ This module provides:
 
 import logging
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from extensions.base import HookContext
 from extensions.hooks import HookPoint
@@ -120,9 +120,6 @@ class HookInvoker:
         """Register default invocation configurations for all hooks."""
         # Message preparation hooks
         self._configs[HookPoint.BEFORE_MESSAGE_PROCESS] = HookInvocationConfig(
-            mode=InvocationMode.COLLECT
-        )
-        self._configs[HookPoint.BEFORE_PROMPT_BUILD] = HookInvocationConfig(
             mode=InvocationMode.COLLECT
         )
         self._configs[HookPoint.AFTER_PROMPT_BUILD] = HookInvocationConfig(

--- a/autobot-backend/extensions/hook_invoker.py
+++ b/autobot-backend/extensions/hook_invoker.py
@@ -122,6 +122,9 @@ class HookInvoker:
         self._configs[HookPoint.BEFORE_MESSAGE_PROCESS] = HookInvocationConfig(
             mode=InvocationMode.COLLECT
         )
+        self._configs[HookPoint.BEFORE_PROMPT_BUILD] = HookInvocationConfig(
+            mode=InvocationMode.COLLECT
+        )
         self._configs[HookPoint.AFTER_PROMPT_BUILD] = HookInvocationConfig(
             mode=InvocationMode.TRANSFORM,
             transform_key="prompt",

--- a/autobot-backend/extensions/hook_invoker_test.py
+++ b/autobot-backend/extensions/hook_invoker_test.py
@@ -71,11 +71,11 @@ class TestHookInvokerInitialization:
         assert invoker.manager is manager
 
     def test_default_configs_registered(self):
-        """Should register default configs for all 24 hooks."""
+        """Should register default configs for all 25 hooks."""
         manager = ExtensionManager()
         invoker = HookInvoker(manager)
         hooks = invoker.list_hooks()
-        assert len(hooks) == 24
+        assert len(hooks) == 25
 
     def test_message_preparation_hooks_configured(self):
         """Should configure message preparation hooks."""
@@ -253,11 +253,12 @@ class TestHookInvokerInvocation:
         invoker = HookInvoker(manager)
 
         hooks = invoker.list_hooks()
-        assert len(hooks) == 24
+        assert len(hooks) == 25
 
         # Verify hook names and modes are present
         hook_names = {h[0] for h in hooks}
         assert "BEFORE_MESSAGE_PROCESS" in hook_names
+        assert "BEFORE_PROMPT_BUILD" in hook_names
         assert "AFTER_PROMPT_BUILD" in hook_names
         assert "BEFORE_LLM_CALL" in hook_names
 

--- a/autobot-backend/extensions/hooks.py
+++ b/autobot-backend/extensions/hooks.py
@@ -16,7 +16,7 @@ class HookPoint(Enum):
     All extension hook points in the agent lifecycle.
 
     Hook points are organized into logical groups:
-    - Message preparation (BEFORE_MESSAGE_PROCESS, AFTER_PROMPT_BUILD)
+    - Message preparation (BEFORE_MESSAGE_PROCESS, BEFORE_PROMPT_BUILD, AFTER_PROMPT_BUILD)
     - LLM interaction (BEFORE_LLM_CALL, DURING_LLM_STREAMING, etc.)
     - Tool execution (BEFORE_TOOL_PARSE, BEFORE_TOOL_EXECUTE, etc.)
     - Continuation loop (BEFORE_CONTINUATION, AFTER_CONTINUATION, etc.)
@@ -38,6 +38,7 @@ class HookPoint(Enum):
 
     # Message preparation
     BEFORE_MESSAGE_PROCESS = auto()
+    BEFORE_PROMPT_BUILD = auto()
     AFTER_PROMPT_BUILD = auto()
 
     # LLM interaction
@@ -88,8 +89,13 @@ HOOK_METADATA = {
         "can_modify": ["message", "context"],
         "return_type": "None",
     },
+    HookPoint.BEFORE_PROMPT_BUILD: {
+        "description": "Called before building the prompt",
+        "can_modify": ["context"],
+        "return_type": "None",
+    },
     HookPoint.AFTER_PROMPT_BUILD: {
-        "description": "Called after system prompt is built",
+        "description": "Called after prompt is built and before being sent to LLM",
         "can_modify": ["prompt"],
         "return_type": "Modified prompt string or None",
     },


### PR DESCRIPTION
Closes #4265

## Summary
Wired prompt building hooks to enable extensions to inspect and modify prompts during construction:
- **BEFORE_PROMPT_BUILD** - Before prompt construction begins
- **AFTER_PROMPT_BUILD** - After full prompt is built

## Changes
- Added BEFORE_PROMPT_BUILD hook point and extension method
- Integrated hooks into llm_handler.py prompt building flow
- Registered hook configurations in hook_invoker.py

## Test Status
✅ All 117 tests pass (42 wired hooks + 53 extension + 22 invoker)