### PR TITLE
feat(views): wire orphaned HomeView (#4266)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -760,6 +760,7 @@ export default {
 
     // Data-driven navigation items: single source of truth for desktop + mobile nav
     const navItems = [
+      { to: '/home', labelKey: 'nav.home', icon: 'M10.707 2.293a1 1 0 00-1.414 0l-7 7v11a1 1 0 001 1h2a1 1 0 001-1v-5a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 001 1h2a1 1 0 001-1v-7l7-7a1 1 0 000-1.414z', iconRule: 'evenodd' },
       { to: '/chat', labelKey: 'nav.chat', icon: 'M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z', iconRule: 'evenodd' },
       { to: '/knowledge', labelKey: 'nav.knowledge', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
       { to: '/automation', labelKey: 'nav.automation', icon: 'M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z', iconRule: 'evenodd' },

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -6753,6 +6753,7 @@
   },
   "nav": {
     "mainNavigation": "Main navigation",
+    "home": "Home",
     "chat": "Chat",
     "knowledge": "Knowledge",
     "automation": "Automation",


### PR DESCRIPTION
Closes #4266

## Summary
Wired the orphaned HomeView into the main navigation.

## Changes
- Added HomeView navigation item in App.vue navItems
- Added 'home' translation key to locale files
- HomeView properly routed at /home with authentication

## Test Status
✅ Type-check and lint pass