### PR TITLE
fix(skill_management): add 6 missing __init__.py exports (#4399)

### DIFF
--- a/autobot-backend/services/skill_management/__init__.py
+++ b/autobot-backend/services/skill_management/__init__.py
@@ -5,8 +5,26 @@
 Skill Management Module
 
 Issue #4337: Skill relevance ranking and caching for agent prompts.
+Issue #4338: Autonomous skill extraction from conversations.
 """
 
 from services.skill_management.skill_ranker import SkillRanker, get_skill_ranker
+from services.skill_management.skill_metrics import SkillMetrics
+from services.skill_management.skill_health_scheduler import (
+    SkillHealthScheduler,
+    get_skill_health_scheduler,
+)
+from services.skill_management.skill_feedback import SkillFeedbackAnalyzer
+from services.skill_management.skill_extractor import SkillExtractor
+from services.skill_management.skill_proposer import SkillProposer
 
-__all__ = ["SkillRanker", "get_skill_ranker"]
+__all__ = [
+    "SkillRanker",
+    "get_skill_ranker",
+    "SkillMetrics",
+    "SkillHealthScheduler",
+    "get_skill_health_scheduler",
+    "SkillFeedbackAnalyzer",
+    "SkillExtractor",
+    "SkillProposer",
+]


### PR DESCRIPTION
Closes #4399

## Summary

- Added 6 missing exports to `autobot-backend/services/skill_management/__init__.py` that were lost during parallel PR conflict resolution
- Exports added: `SkillMetrics`, `SkillHealthScheduler`, `get_skill_health_scheduler`, `SkillFeedbackAnalyzer`, `SkillExtractor`, `SkillProposer`
- Fixed long import line to comply with flake8 100-char limit

## Root Cause

Parallel PR merges (e.g. ChatInterface.vue, skill_management/__init__.py) lose exports during conflict resolution when both sides modify the same `__init__.py`.

## Test Status

PASS — 69 skill tests passed, 0 failures