### PR TITLE
test(doc_indexer): add comprehensive DocIndexerService test coverage (#4383)

### DIFF
--- a/autobot-backend/services/knowledge/test_doc_indexer.py
+++ b/autobot-backend/services/knowledge/test_doc_indexer.py
@@ -1,0 +1,704 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Comprehensive tests for DocIndexerService — Issue #4383.
+
+Covers:
+- index_all(force=False) with empty collection (should force full index — #4350 fix)
+- index_all(force=True) (re-indexes all files, updates cache)
+- index_all(force=False) with non-empty collection (incremental mode)
+- Hash cache update after indexing
+- _filter_changed_files() with various cache states
+- needs_indexing() condition
+- Edge cases: empty files, missing files, corrupted hash cache
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies before importing doc_indexer
+# ---------------------------------------------------------------------------
+
+_STUBS: dict = {}
+
+
+def _make_stub(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    mod.__package__ = name
+    _STUBS[name] = mod
+    sys.modules.setdefault(name, mod)
+    return mod
+
+
+# autobot_shared.ssot_config — only get_ollama_url is used at module level
+_ssot = _make_stub("autobot_shared.ssot_config")
+_ssot.get_ollama_url = lambda: "http://localhost:11434"  # type: ignore[attr-defined]
+
+# constants.path_constants — PATH.DATA_DIR and PATH.PROJECT_ROOT must be real Paths
+_constants = _make_stub("constants")
+_path_constants = _make_stub("constants.path_constants")
+
+
+class _FakePATH:
+    DATA_DIR = Path("/tmp/test_autobot_data")
+    PROJECT_ROOT = Path("/tmp/test_autobot_root")
+
+
+_path_constants.PATH = _FakePATH()  # type: ignore[attr-defined]
+
+# Load doc_indexer bypassing the services package __init__ (which needs the
+# full stack).  Using spec_from_file_location keeps the module name canonical
+# so patch() paths work correctly.
+_BACKEND_ROOT = Path(__file__).parent.parent.parent  # autobot-backend/
+_DOC_INDEXER_PATH = Path(__file__).parent / "doc_indexer.py"
+_spec = importlib.util.spec_from_file_location(
+    "services.knowledge.doc_indexer", str(_DOC_INDEXER_PATH)
+)
+assert _spec and _spec.loader, "Could not load doc_indexer spec"
+_doc_indexer_mod = importlib.util.module_from_spec(_spec)
+sys.modules["services.knowledge.doc_indexer"] = _doc_indexer_mod
+_spec.loader.exec_module(_doc_indexer_mod)  # type: ignore[union-attr]
+
+# Ensure the package stub exposes doc_indexer as an attribute so patch()
+# can resolve "services.knowledge.doc_indexer.<name>" correctly.
+if "services.knowledge" in sys.modules:
+    sys.modules["services.knowledge"].doc_indexer = _doc_indexer_mod  # type: ignore[attr-defined]
+
+from services.knowledge.doc_indexer import (  # noqa: E402 — after sys.modules patch
+    DocIndexerService,
+    _compute_file_hash,
+    _filter_changed_files,
+    _load_hash_cache,
+    _save_hash_cache,
+    _should_exclude,
+    get_doc_indexer_service,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MODULE = "services.knowledge.doc_indexer"
+
+
+def _make_service(
+    initialized: bool = True,
+    collection_count: int = 0,
+    root_dir: Path = Path("/tmp/test_autobot_root"),
+) -> DocIndexerService:
+    """Build a DocIndexerService with pre-wired mocks."""
+    svc = DocIndexerService.__new__(DocIndexerService)
+    svc._initialized = initialized
+    svc._root_dir = root_dir
+    svc._embed_model = MagicMock()
+    svc._embed_model.get_text_embedding = MagicMock(return_value=[0.1] * 128)
+
+    mock_collection = MagicMock()
+    mock_collection.count = MagicMock(return_value=collection_count)
+    mock_collection.upsert = MagicMock()
+    svc._collection = mock_collection
+
+    mock_client = MagicMock()
+    svc._client = mock_client
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: pure functions
+# ---------------------------------------------------------------------------
+
+
+class TestFilterChangedFiles:
+    """Tests for _filter_changed_files()."""
+
+    def test_all_new_files_returned_when_cache_empty(self, tmp_path):
+        """Empty cache → every file is treated as changed."""
+        f1 = tmp_path / "a.md"
+        f1.write_text("hello", encoding="utf-8")
+        f2 = tmp_path / "b.md"
+        f2.write_text("world", encoding="utf-8")
+
+        files = [(str(f1), 1), (str(f2), 2)]
+        changed, new_hashes = _filter_changed_files(files, {}, tmp_path)
+
+        assert len(changed) == 2
+        assert len(new_hashes) == 2
+        assert "a.md" in new_hashes
+        assert "b.md" in new_hashes
+
+    def test_unchanged_file_excluded_from_result(self, tmp_path):
+        """File whose hash matches cache entry is excluded from changed list."""
+        f = tmp_path / "unchanged.md"
+        f.write_text("same content", encoding="utf-8")
+        current_hash = _compute_file_hash(str(f))
+
+        changed, new_hashes = _filter_changed_files(
+            [(str(f), 1)], {"unchanged.md": current_hash}, tmp_path
+        )
+
+        assert len(changed) == 0
+        assert new_hashes.get("unchanged.md") == current_hash
+
+    def test_changed_file_included_in_result(self, tmp_path):
+        """File with stale cache hash is included in changed list."""
+        f = tmp_path / "changed.md"
+        f.write_text("new content", encoding="utf-8")
+
+        changed, new_hashes = _filter_changed_files(
+            [(str(f), 1)], {"changed.md": "stale_hash_abc123"}, tmp_path
+        )
+
+        assert len(changed) == 1
+        assert changed[0][0] == str(f)
+
+    def test_mixed_changed_and_unchanged(self, tmp_path):
+        """Only changed files appear in result; all hashes stored."""
+        f_old = tmp_path / "old.md"
+        f_old.write_text("old", encoding="utf-8")
+        old_hash = _compute_file_hash(str(f_old))
+
+        f_new = tmp_path / "new.md"
+        f_new.write_text("new content here", encoding="utf-8")
+
+        files = [(str(f_old), 1), (str(f_new), 2)]
+        cache = {"old.md": old_hash, "new.md": "wrong_hash"}
+        changed, new_hashes = _filter_changed_files(files, cache, tmp_path)
+
+        assert len(changed) == 1
+        assert changed[0][0] == str(f_new)
+        assert len(new_hashes) == 2
+
+    def test_hashes_use_relative_paths_as_keys(self, tmp_path):
+        """new_hashes keys must be relative to root_dir, not absolute."""
+        sub = tmp_path / "docs"
+        sub.mkdir()
+        f = sub / "guide.md"
+        f.write_text("content", encoding="utf-8")
+
+        _, new_hashes = _filter_changed_files([(str(f), 2)], {}, tmp_path)
+
+        assert "docs/guide.md" in new_hashes
+
+
+class TestHashCache:
+    """Tests for _load_hash_cache() and _save_hash_cache()."""
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        """Save then load returns identical dict."""
+        hashes = {"file1.md": "abc", "file2.md": "def"}
+
+        with patch(f"{_MODULE}.HASH_CACHE_FILE", tmp_path / ".doc_index_hashes.json"):
+            _save_hash_cache(hashes)
+            loaded = _load_hash_cache()
+
+        assert loaded == hashes
+
+    def test_load_returns_empty_when_file_missing(self, tmp_path):
+        """Missing cache file returns empty dict."""
+        with patch(f"{_MODULE}.HASH_CACHE_FILE", tmp_path / "nonexistent.json"):
+            result = _load_hash_cache()
+        assert result == {}
+
+    def test_load_returns_empty_on_corrupt_json(self, tmp_path):
+        """Corrupt JSON in cache file returns empty dict without raising."""
+        bad_file = tmp_path / ".doc_index_hashes.json"
+        bad_file.write_text("not valid json {{{{", encoding="utf-8")
+
+        with patch(f"{_MODULE}.HASH_CACHE_FILE", bad_file):
+            result = _load_hash_cache()
+
+        assert result == {}
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        """_save_hash_cache creates missing parent directories."""
+        nested = tmp_path / "a" / "b" / "c" / "hashes.json"
+        with patch(f"{_MODULE}.HASH_CACHE_FILE", nested):
+            _save_hash_cache({"k": "v"})
+        assert nested.exists()
+
+
+class TestShouldExclude:
+    """Tests for _should_exclude()."""
+
+    def test_excludes_backup_file(self):
+        assert _should_exclude("/docs/guide_backup.md")
+
+    def test_excludes_tmp_file(self):
+        assert _should_exclude("/docs/guide.tmp")
+
+    def test_excludes_archives_path(self):
+        assert _should_exclude("/docs/archives/old.md")
+
+    def test_does_not_exclude_normal_md(self):
+        assert not _should_exclude("/docs/features/authentication.md")
+
+    def test_excludes_log_file(self):
+        assert _should_exclude("/logs/debug.log")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: DocIndexerService
+# ---------------------------------------------------------------------------
+
+
+class TestNeedsIndexing:
+    """Tests for DocIndexerService.needs_indexing()."""
+
+    def test_returns_true_when_not_initialized(self):
+        svc = _make_service(initialized=False, collection_count=0)
+        svc._collection = None
+        assert svc.needs_indexing() is True
+
+    def test_returns_true_when_collection_empty(self):
+        svc = _make_service(initialized=True, collection_count=0)
+        assert svc.needs_indexing() is True
+
+    def test_returns_false_when_collection_has_docs(self):
+        svc = _make_service(initialized=True, collection_count=42)
+        assert svc.needs_indexing() is False
+
+
+class TestIndexAll:
+    """Tests for DocIndexerService.index_all()."""
+
+    # ------------------------------------------------------------------
+    # Helper: fake filesystem of markdown files
+    # ------------------------------------------------------------------
+
+    def _make_md_files(self, root: Path) -> None:
+        """Create a minimal set of discoverable markdown files."""
+        docs = root / "docs" / "features"
+        docs.mkdir(parents=True)
+        (docs / "feature_a.md").write_text("# Feature A\n\nContent here.\n", encoding="utf-8")
+        (docs / "feature_b.md").write_text("# Feature B\n\nOther content.\n", encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Test: empty collection forces full index (#4350 fix)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_empty_collection_forces_full_index(self, tmp_path):
+        """index_all(force=False) with empty collection bypasses hash cache (#4350)."""
+        self._make_md_files(tmp_path)
+        svc = _make_service(initialized=True, collection_count=0, root_dir=tmp_path)
+
+        # Put a stale cache that would skip all files in incremental mode
+        stale_cache = {"docs/features/feature_a.md": "stale", "docs/features/feature_b.md": "stale"}
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text(json.dumps(stale_cache), encoding="utf-8")
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file),
+            patch(f"{_MODULE}._discover_files") as mock_discover,
+            patch.object(svc, "_index_single_file_content", new=AsyncMock()) as mock_index,
+        ):
+            # Return two fake files from TIER_3_DIRS-like path
+            f_a = str(tmp_path / "docs" / "features" / "feature_a.md")
+            f_b = str(tmp_path / "docs" / "features" / "feature_b.md")
+            mock_discover.return_value = [(f_a, 2), (f_b, 2)]
+
+            await svc.index_all(force=False)
+
+        # Both files must be indexed — cache was ignored because collection was empty
+        assert mock_index.call_count == 2, (
+            f"Expected 2 files indexed (full index forced by empty collection), "
+            f"got {mock_index.call_count}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_force_true_reindexes_all_files(self, tmp_path):
+        """index_all(force=True) re-indexes all files ignoring cache state."""
+        self._make_md_files(tmp_path)
+        svc = _make_service(initialized=True, collection_count=100, root_dir=tmp_path)
+
+        # Pre-populate cache with matching hashes (incremental would skip these)
+        f_a = tmp_path / "docs" / "features" / "feature_a.md"
+        f_b = tmp_path / "docs" / "features" / "feature_b.md"
+        current_hashes = {
+            "docs/features/feature_a.md": _compute_file_hash(str(f_a)),
+            "docs/features/feature_b.md": _compute_file_hash(str(f_b)),
+        }
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text(json.dumps(current_hashes), encoding="utf-8")
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file),
+            patch(f"{_MODULE}._discover_files") as mock_discover,
+            patch.object(svc, "_index_single_file_content", new=AsyncMock()) as mock_index,
+        ):
+            mock_discover.return_value = [(str(f_a), 2), (str(f_b), 2)]
+            await svc.index_all(force=True)
+
+        # force=True must index all even when hashes match
+        assert mock_index.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_incremental_mode_skips_unchanged_files(self, tmp_path):
+        """index_all(force=False) skips files with matching hash cache."""
+        self._make_md_files(tmp_path)
+        svc = _make_service(initialized=True, collection_count=50, root_dir=tmp_path)
+
+        f_a = tmp_path / "docs" / "features" / "feature_a.md"
+        f_b = tmp_path / "docs" / "features" / "feature_b.md"
+        current_hashes = {
+            "docs/features/feature_a.md": _compute_file_hash(str(f_a)),
+            "docs/features/feature_b.md": _compute_file_hash(str(f_b)),
+        }
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text(json.dumps(current_hashes), encoding="utf-8")
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file),
+            patch(f"{_MODULE}._discover_files") as mock_discover,
+            patch.object(svc, "_index_single_file_content", new=AsyncMock()) as mock_index,
+        ):
+            mock_discover.return_value = [(str(f_a), 2), (str(f_b), 2)]
+            result = await svc.index_all(force=False)
+
+        # All files unchanged — nothing should be indexed
+        assert mock_index.call_count == 0
+        assert result.skipped == 2
+
+    @pytest.mark.asyncio
+    async def test_incremental_mode_indexes_only_changed_files(self, tmp_path):
+        """index_all(force=False) indexes only files with stale/missing hashes."""
+        self._make_md_files(tmp_path)
+        svc = _make_service(initialized=True, collection_count=50, root_dir=tmp_path)
+
+        f_a = tmp_path / "docs" / "features" / "feature_a.md"
+        f_b = tmp_path / "docs" / "features" / "feature_b.md"
+
+        # feature_a has matching hash; feature_b has stale hash
+        cache = {
+            "docs/features/feature_a.md": _compute_file_hash(str(f_a)),
+            "docs/features/feature_b.md": "stale_hash",
+        }
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text(json.dumps(cache), encoding="utf-8")
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file),
+            patch(f"{_MODULE}._discover_files") as mock_discover,
+            patch.object(svc, "_index_single_file_content", new=AsyncMock()) as mock_index,
+        ):
+            mock_discover.return_value = [(str(f_a), 2), (str(f_b), 2)]
+            await svc.index_all(force=False)
+
+        # Only feature_b should be indexed
+        assert mock_index.call_count == 1
+        indexed_path = mock_index.call_args[0][0]
+        assert "feature_b" in indexed_path
+
+    @pytest.mark.asyncio
+    async def test_hash_cache_updated_after_force_index(self, tmp_path):
+        """After force=True index_all, hash cache must be updated for all files."""
+        self._make_md_files(tmp_path)
+        svc = _make_service(initialized=True, collection_count=0, root_dir=tmp_path)
+
+        f_a = tmp_path / "docs" / "features" / "feature_a.md"
+        f_b = tmp_path / "docs" / "features" / "feature_b.md"
+        cache_file = tmp_path / ".doc_index_hashes.json"
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file),
+            patch(f"{_MODULE}._discover_files") as mock_discover,
+            patch.object(svc, "_index_single_file_content", new=AsyncMock()),
+        ):
+            mock_discover.return_value = [(str(f_a), 2), (str(f_b), 2)]
+            await svc.index_all(force=True)
+
+        # Cache file must exist and contain both file entries
+        assert cache_file.exists()
+        saved = json.loads(cache_file.read_text(encoding="utf-8"))
+        assert "docs/features/feature_a.md" in saved
+        assert "docs/features/feature_b.md" in saved
+
+    @pytest.mark.asyncio
+    async def test_returns_error_result_on_init_failure(self, tmp_path):
+        """index_all returns error IndexResult when initialization fails."""
+        svc = _make_service(initialized=False, root_dir=tmp_path)
+        svc._collection = None
+
+        with patch.object(svc, "initialize", new=AsyncMock(return_value=False)):
+            result = await svc.index_all()
+
+        assert result.errors
+        assert "Failed to initialize" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_no_files_discovered_returns_empty_result(self, tmp_path):
+        """index_all returns empty result when no files are discovered."""
+        svc = _make_service(initialized=True, collection_count=0, root_dir=tmp_path)
+
+        with patch(f"{_MODULE}._discover_files", return_value=[]):
+            result = await svc.index_all()
+
+        assert result.total_files == 0
+        assert result.success == 0
+
+    @pytest.mark.asyncio
+    async def test_elapsed_seconds_populated(self, tmp_path):
+        """index_all always populates elapsed_seconds."""
+        self._make_md_files(tmp_path)
+        svc = _make_service(initialized=True, collection_count=100, root_dir=tmp_path)
+
+        f_a = tmp_path / "docs" / "features" / "feature_a.md"
+        cache = {"docs/features/feature_a.md": _compute_file_hash(str(f_a))}
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text(json.dumps(cache), encoding="utf-8")
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file),
+            patch(f"{_MODULE}._discover_files", return_value=[(str(f_a), 1)]),
+            patch.object(svc, "_index_single_file_content", new=AsyncMock()),
+        ):
+            result = await svc.index_all(force=False)
+
+        assert result.elapsed_seconds >= 0
+
+
+class TestIndexFile:
+    """Tests for DocIndexerService.index_file()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_failed_for_missing_file(self, tmp_path):
+        """index_file returns failed result for nonexistent file."""
+        svc = _make_service(initialized=True, collection_count=0, root_dir=tmp_path)
+        result = await svc.index_file(tmp_path / "missing.md", tier=1, force=True)
+
+        assert result.failed == 1
+        assert result.success == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_file_with_matching_hash(self, tmp_path):
+        """index_file skips indexing when hash matches cache and force=False."""
+        f = tmp_path / "guide.md"
+        f.write_text("# Guide\n\nContent here.\n", encoding="utf-8")
+        current_hash = _compute_file_hash(str(f))
+        cache = {"guide.md": current_hash}
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text(json.dumps(cache), encoding="utf-8")
+
+        svc = _make_service(initialized=True, collection_count=10, root_dir=tmp_path)
+
+        with patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file):
+            result = await svc.index_file(f, tier=2, force=False)
+
+        assert result.skipped == 1
+        assert result.success == 0
+
+    @pytest.mark.asyncio
+    async def test_force_true_bypasses_hash_check(self, tmp_path):
+        """index_file with force=True indexes even if hash matches cache."""
+        f = tmp_path / "guide.md"
+        f.write_text("# Guide\n\nSome section content here.\n\nMore text.\n", encoding="utf-8")
+        current_hash = _compute_file_hash(str(f))
+        cache = {"guide.md": current_hash}
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text(json.dumps(cache), encoding="utf-8")
+
+        svc = _make_service(initialized=True, collection_count=10, root_dir=tmp_path)
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file),
+            patch.object(svc, "_index_file_chunks", new=AsyncMock(return_value=(1, 1))),
+        ):
+            result = await svc.index_file(f, tier=2, force=True)
+
+        assert result.skipped == 0
+        assert result.success == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_file_is_skipped(self, tmp_path):
+        """index_file skips files that contain only whitespace."""
+        f = tmp_path / "empty.md"
+        f.write_text("   \n\n  ", encoding="utf-8")
+        svc = _make_service(initialized=True, collection_count=10, root_dir=tmp_path)
+
+        with patch(f"{_MODULE}.HASH_CACHE_FILE", tmp_path / ".hashes.json"):
+            result = await svc.index_file(f, tier=3, force=True)
+
+        assert result.skipped == 1
+
+    @pytest.mark.asyncio
+    async def test_successful_index_returns_success_one(self, tmp_path):
+        """index_file returns success=1 when chunk is indexed."""
+        f = tmp_path / "doc.md"
+        f.write_text("# Doc\n\n## Section A\n\nSome useful content here.\n", encoding="utf-8")
+        svc = _make_service(initialized=True, collection_count=10, root_dir=tmp_path)
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", tmp_path / ".hashes.json"),
+            patch.object(svc, "_index_file_chunks", new=AsyncMock(return_value=(1, 1))),
+        ):
+            result = await svc.index_file(f, tier=1, force=True)
+
+        assert result.success == 1
+        assert result.failed == 0
+
+
+class TestIndexAllEmpty4350Fix:
+    """Regression tests specifically for #4350: empty collection forces full index."""
+
+    @pytest.mark.asyncio
+    async def test_needs_indexing_true_overrides_cache_match(self, tmp_path):
+        """#4350: needs_indexing() == True must override matching hash cache."""
+        docs = tmp_path / "docs" / "features"
+        docs.mkdir(parents=True)
+        f = docs / "api.md"
+        f.write_text("# API\n\n## Section\n\nApi content here.\n", encoding="utf-8")
+
+        svc = _make_service(initialized=True, collection_count=0, root_dir=tmp_path)
+        assert svc.needs_indexing() is True  # Empty collection
+
+        # Cache says hash matches (would skip in pure incremental mode)
+        current_hash = _compute_file_hash(str(f))
+        cache = {"docs/features/api.md": current_hash}
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text(json.dumps(cache), encoding="utf-8")
+
+        indexed_files = []
+
+        async def _track_index(file_path, tier, result):
+            indexed_files.append(file_path)
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file),
+            patch(f"{_MODULE}._discover_files", return_value=[(str(f), 2)]),
+            patch.object(svc, "_index_single_file_content", side_effect=_track_index),
+        ):
+            await svc.index_all(force=False)
+
+        assert len(indexed_files) == 1, (
+            "Empty collection must trigger full index even when hash cache matches (#4350)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_empty_collection_uses_incremental(self, tmp_path):
+        """#4350 fix does NOT apply when collection already has documents."""
+        docs = tmp_path / "docs" / "features"
+        docs.mkdir(parents=True)
+        f = docs / "api.md"
+        f.write_text("# API\n\nContent.\n", encoding="utf-8")
+
+        svc = _make_service(initialized=True, collection_count=10, root_dir=tmp_path)
+        assert svc.needs_indexing() is False  # Non-empty collection
+
+        current_hash = _compute_file_hash(str(f))
+        cache = {"docs/features/api.md": current_hash}
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text(json.dumps(cache), encoding="utf-8")
+
+        indexed_files = []
+
+        async def _track_index(file_path, tier, result):
+            indexed_files.append(file_path)
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", cache_file),
+            patch(f"{_MODULE}._discover_files", return_value=[(str(f), 2)]),
+            patch.object(svc, "_index_single_file_content", side_effect=_track_index),
+        ):
+            await svc.index_all(force=False)
+
+        # Non-empty + matching hash → nothing indexed (incremental skipped)
+        assert len(indexed_files) == 0
+
+
+class TestEdgeCases:
+    """Edge case tests for hash cache and file handling."""
+
+    def test_compute_file_hash_returns_empty_string_on_error(self, tmp_path):
+        """_compute_file_hash returns '' for unreadable files (no exception raised)."""
+        result = _compute_file_hash("/nonexistent/path/file.md")
+        assert result == ""
+
+    def test_compute_file_hash_consistent(self, tmp_path):
+        """Same file content always produces same hash."""
+        f = tmp_path / "test.md"
+        f.write_text("consistent content", encoding="utf-8")
+        h1 = _compute_file_hash(str(f))
+        h2 = _compute_file_hash(str(f))
+        assert h1 == h2
+        assert len(h1) == 64  # SHA-256 hex digest
+
+    def test_compute_file_hash_differs_for_different_content(self, tmp_path):
+        """Different content produces different hashes."""
+        f1 = tmp_path / "a.md"
+        f2 = tmp_path / "b.md"
+        f1.write_text("content A", encoding="utf-8")
+        f2.write_text("content B", encoding="utf-8")
+        assert _compute_file_hash(str(f1)) != _compute_file_hash(str(f2))
+
+    @pytest.mark.asyncio
+    async def test_index_all_with_corrupted_hash_cache(self, tmp_path):
+        """Corrupted hash cache falls back gracefully to full index."""
+        docs = tmp_path / "docs" / "features"
+        docs.mkdir(parents=True)
+        f = docs / "guide.md"
+        f.write_text("# Guide\n\nContent.\n", encoding="utf-8")
+
+        svc = _make_service(initialized=True, collection_count=0, root_dir=tmp_path)
+
+        corrupt_cache = tmp_path / ".doc_index_hashes.json"
+        corrupt_cache.write_text("{ invalid json !!!", encoding="utf-8")
+
+        indexed_files = []
+
+        async def _track(fp, tier, result):
+            indexed_files.append(fp)
+
+        with (
+            patch(f"{_MODULE}.HASH_CACHE_FILE", corrupt_cache),
+            patch(f"{_MODULE}._discover_files", return_value=[(str(f), 2)]),
+            patch.object(svc, "_index_single_file_content", side_effect=_track),
+        ):
+            await svc.index_all(force=False)
+
+        # With empty collection + corrupted cache, file must be indexed
+        assert len(indexed_files) == 1
+
+    def test_filter_changed_files_empty_file_list(self, tmp_path):
+        """_filter_changed_files with empty file list returns empty results."""
+        changed, hashes = _filter_changed_files([], {"some.md": "hash"}, tmp_path)
+        assert changed == []
+        assert hashes == {}
+
+
+class TestGetDocIndexerService:
+    """Tests for the singleton factory."""
+
+    def test_returns_same_instance(self):
+        """get_doc_indexer_service() returns the same object on multiple calls."""
+        import services.knowledge.doc_indexer as mod
+
+        # Reset singleton for test isolation
+        original = mod._doc_indexer
+        mod._doc_indexer = None
+        try:
+            a = get_doc_indexer_service()
+            b = get_doc_indexer_service()
+            assert a is b
+        finally:
+            mod._doc_indexer = original
+
+    def test_returns_doc_indexer_service_instance(self):
+        """Factory returns a DocIndexerService instance."""
+        import services.knowledge.doc_indexer as mod
+
+        original = mod._doc_indexer
+        mod._doc_indexer = None
+        try:
+            svc = get_doc_indexer_service()
+            assert isinstance(svc, DocIndexerService)
+        finally:
+            mod._doc_indexer = original


### PR DESCRIPTION
Closes #4383

## Summary

Added 704-line co-located test file `autobot-backend/services/knowledge/test_doc_indexer.py` with 39 tests across 9 test classes:

| Class | Tests | Coverage |
|---|---|---|
| `TestFilterChangedFiles` | 5 | `_filter_changed_files()` — empty cache, unchanged, changed, mixed, relative path keys |
| `TestHashCache` | 4 | `_load_hash_cache`/`_save_hash_cache` — roundtrip, missing file, corrupt JSON, parent dir creation |
| `TestShouldExclude` | 5 | `_should_exclude()` — backup, tmp, archives, log, normal files |
| `TestNeedsIndexing` | 3 | `needs_indexing()` — uninitialized, empty collection, non-empty |
| `TestIndexAll` | 8 | `index_all()` — empty collection forces full index, force=True, incremental skip, incremental partial, cache update, init failure, no files |
| `TestIndexFile` | 5 | `index_file()` — missing file, hash match skip, force bypass, empty file, success |
| `TestIndexAllEmpty4350Fix` | 2 | **Regression for #4350**: empty collection overrides cache match; non-empty uses incremental |
| `TestEdgeCases` | 4 | Hash compute errors, consistency, collision, corrupted cache fallback |
| `TestGetDocIndexerService` | 2 | Singleton identity, instance type |

## Test Status

PASS — 39/39 tests passed in 1.30s