### PR TITLE
fix(discovery): correct scheduler path and skill_management exports (#4398 #4399)

### DIFF
--- a/autobot-backend/services/scheduling/__init__.py
+++ b/autobot-backend/services/scheduling/__init__.py
@@ -1,0 +1,5 @@
+"""Cron-based task scheduling service."""
+
+from .cron_scheduler import CronScheduler, get_cron_scheduler
+
+__all__ = ["CronScheduler", "get_cron_scheduler"]

--- a/autobot-backend/services/scheduling/cron_scheduler.py
+++ b/autobot-backend/services/scheduling/cron_scheduler.py
@@ -1,0 +1,43 @@
+"""Cron scheduler for automation tasks."""
+import logging
+from typing import Callable, Dict, Optional
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+class CronScheduler:
+    """Manages cron-scheduled automation tasks."""
+
+    def __init__(self):
+        self.tasks: Dict[str, Dict] = {}
+
+    def schedule(self, cron_expr: str, task_func: Callable, task_id: Optional[str] = None) -> str:
+        """Schedule a task using cron expression."""
+        # Basic cron validation
+        parts = cron_expr.split()
+        if len(parts) != 5:
+            raise ValueError(f"Invalid cron expression: {cron_expr}")
+
+        if task_id is None:
+            task_id = f"task_{len(self.tasks)}"
+
+        self.tasks[task_id] = {
+            "cron": cron_expr,
+            "func": task_func,
+            "created_at": datetime.utcnow()
+        }
+
+        logger.info(f"Scheduled task {task_id}: {cron_expr}")
+        return task_id
+
+
+_scheduler_instance: Optional[CronScheduler] = None
+
+
+def get_cron_scheduler() -> CronScheduler:
+    """Get or create global scheduler instance."""
+    global _scheduler_instance
+    if _scheduler_instance is None:
+        _scheduler_instance = CronScheduler()
+    return _scheduler_instance

--- a/autobot-backend/services/skill_management/__init__.py
+++ b/autobot-backend/services/skill_management/__init__.py
@@ -15,7 +15,7 @@ from services.skill_management.skill_health_scheduler import (
     get_skill_health_scheduler,
 )
 from services.skill_management.skill_feedback import SkillFeedbackAnalyzer
-from services.skill_management.skill_extractor import SkillExtractor
+from services.skill_management.skill_extractor import ExtractedSkill, SkillExtractor
 from services.skill_management.skill_proposer import SkillProposer
 
 __all__ = [
@@ -25,6 +25,7 @@ __all__ = [
     "SkillHealthScheduler",
     "get_skill_health_scheduler",
     "SkillFeedbackAnalyzer",
+    "ExtractedSkill",
     "SkillExtractor",
     "SkillProposer",
 ]


### PR DESCRIPTION
Fixes two discovery issues from Hermes batch implementation:

**#4398 — Wrong cron_scheduler path**
- `services/scheduler/` renamed to `services/scheduling/` (matches `services.scheduling` import)
- Removed erroneous nested `autobot-backend/autobot-backend/` directory

**#4399 — Missing skill_management exports**
- Added `ExtractedSkill` to `services/skill_management/__init__.py __all__`

Closes #4398
Closes #4399