### PR TITLE
fix(typescript): resolve collaboration and secrets management type errors (#4361)

### DIFF
--- a/autobot-frontend/src/components/collaboration/ParticipantList.vue
+++ b/autobot-frontend/src/components/collaboration/ParticipantList.vue
@@ -44,7 +44,6 @@ const showRoleMenu = ref<string | null>(null)
 const removingUserId = ref<string | null>(null)
 const isLoadingParticipants = ref(false)
 const participantRoles = ref<Map<string, ParticipantResponse>>(new Map())
-const containerRef = ref<HTMLElement | null>(null)
 
 // Current user is owner
 const isOwner = computed(() => {
@@ -57,7 +56,7 @@ interface ParticipantWithRole extends UserPresence {
   role: 'owner' | 'collaborator' | 'viewer'
   email?: string
   joinedAt: Date
-  id?: string
+  id: string
 }
 
 // Fetch real role data from session API
@@ -89,9 +88,9 @@ const fetchParticipantRoles = async () => {
 const participantsWithRoles = computed<ParticipantWithRole[]>(() => {
   return sessionPresence.value.map(p => {
     const roleData = participantRoles.value.get(p.userId)
-    const role = (roleData?.permission === 'owner' ? 'owner' :
+    const role: 'owner' | 'collaborator' | 'viewer' = roleData?.permission === 'owner' ? 'owner' :
                   roleData?.permission === 'editor' ? 'collaborator' :
-                  'viewer') as const
+                  'viewer'
 
     return {
       ...p,
@@ -105,7 +104,7 @@ const participantsWithRoles = computed<ParticipantWithRole[]>(() => {
 
 // Virtual scrolling composable - Issue #4037
 // Each participant item is approximately 140px (with status indicator, role badge, etc.)
-const { containerRef, visibleItems, totalHeight } = useVirtualList(participantsWithRoles, 140, 2)
+const { containerRef, visibleItems, totalHeight } = useVirtualList<ParticipantWithRole>(participantsWithRoles, 140, 2)
 
 // Get role badge styling
 const getRoleBadge = (role: ParticipantWithRole['role']): { color: string; label: string } => {

--- a/autobot-frontend/src/components/secrets/SecretAuditLog.vue
+++ b/autobot-frontend/src/components/secrets/SecretAuditLog.vue
@@ -326,7 +326,7 @@ const prevPage = async () => {
             </div>
 
             <!-- Metadata -->
-            <div v-if="Object.keys(entry.metadata).length > 0" class="text-xs text-gray-500 mt-1">
+            <div v-if="entry.metadata && Object.keys(entry.metadata).length > 0" class="text-xs text-gray-500 mt-1">
               <details class="cursor-pointer">
                 <summary class="hover:text-gray-400">{{ $t('secrets.auditLog.details') }}</summary>
                 <pre class="mt-1 p-2 bg-gray-800 rounded text-xs overflow-x-auto">{{ JSON.stringify(entry.metadata, null, 2) }}</pre>

--- a/autobot-frontend/src/components/secrets/SecretVault.vue
+++ b/autobot-frontend/src/components/secrets/SecretVault.vue
@@ -35,9 +35,21 @@ const emit = defineEmits<{
   share: [secretId: string]
   revoke: [secretId: string]
   copy: [secretId: string]
-  add: [secret: any]
+  add: [secret: SecretItem]
   delete: [secretId: string]
 }>()
+
+// Secret item type from backend API
+interface SecretItem {
+  id: string
+  name: string
+  type: string
+  scope: string
+  value?: string
+  description?: string
+  created_at?: string
+  updated_at?: string
+}
 
 // Local state
 const searchQuery = ref('')
@@ -50,7 +62,7 @@ const error = ref<string | null>(null)
 const successMessage = ref<string | null>(null)
 
 // Secrets data from API
-const secrets = ref<Array<any>>([])
+const secrets = ref<SecretItem[]>([])
 
 // Debounce search query for performance (Issue #4035)
 const debouncedSearchQuery = useDebounce(searchQuery, 400)
@@ -59,7 +71,7 @@ const debouncedSearchQuery = useDebounce(searchQuery, 400)
 const currentSession = computed(() => chatStore.currentSession)
 
 // Combine and filter secrets
-const allSecrets = computed(() => {
+const allSecrets = computed<SecretItem[]>(() => {
   let filtered = [...secrets.value]
 
   // Filter by scope
@@ -94,8 +106,8 @@ const allSecrets = computed(() => {
     filtered.sort((a, b) => (a.type || '').localeCompare(b.type || ''))
   } else if (sortBy.value === 'recent') {
     filtered.sort((a, b) => {
-      const aTime = new Date(a.updated_at || a.created_at).getTime()
-      const bTime = new Date(b.updated_at || b.created_at).getTime()
+      const aTime = new Date(a.updated_at || a.created_at || 0).getTime()
+      const bTime = new Date(b.updated_at || b.created_at || 0).getTime()
       return bTime - aTime
     })
   }
@@ -109,7 +121,7 @@ const allSecrets = computed(() => {
 
 // Virtual scrolling composable - Issue #4037
 // Each secret card is approximately 280px (with padding, metadata, actions)
-const { containerRef, visibleItems, totalHeight } = useVirtualList(allSecrets, 280, 2)
+const { containerRef, visibleItems, totalHeight } = useVirtualList<SecretItem>(allSecrets, 280, 2)
 
 // Get secret type icon
 const getTypeIcon = (type: string): string => {
@@ -154,7 +166,7 @@ const toggleReveal = (secretId: string) => {
 }
 
 // Copy secret to clipboard
-const copySecret = (secret: any) => {
+const copySecret = (secret: SecretItem) => {
   if (!secret.value) {
     error.value = t('secrets.vault.errorNoValue')
     setTimeout(() => { error.value = null }, 3000)
@@ -204,7 +216,7 @@ const loadSecrets = async () => {
   isLoading.value = true
   error.value = null
   try {
-    const response = (await secretsApiClient.getSecrets({})) as Record<string, any>
+    const response = (await secretsApiClient.getSecrets({})) as { secrets?: SecretItem[] }
     secrets.value = response.secrets || []
     logger.info(`Loaded ${secrets.value.length} secrets from backend`)
   } catch (err) {

--- a/autobot-frontend/src/composables/useSecretsAuditApi.ts
+++ b/autobot-frontend/src/composables/useSecretsAuditApi.ts
@@ -106,10 +106,9 @@ export function useSecretsAuditApi() {
 
     return withErrorHandling(
       async () => {
-        const response = await api.get(
+        const data = await api.get<AuditQueryResponse>(
           `${getApiBase()}/audit/logs?${params.toString()}`
         )
-        const data: AuditQueryResponse = await response.json()
 
         if (!data.success) {
           throw new Error('Failed to fetch audit logs')

--- a/autobot-frontend/src/composables/useVirtualList.ts
+++ b/autobot-frontend/src/composables/useVirtualList.ts
@@ -31,7 +31,7 @@
  * ```
  */
 
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch, type Ref, type ComputedRef } from 'vue'
 
 interface VirtualItem<T> {
   data: T
@@ -47,7 +47,7 @@ interface VirtualItem<T> {
  * @returns Virtual list utilities
  */
 export function useVirtualList<T extends { id: string | number }>(
-  items: any, // Ref<T[]> or ComputedRef<T[]>
+  items: Ref<T[]> | ComputedRef<T[]>,
   itemHeight: number,
   overscan: number = 3
 ) {
@@ -60,7 +60,7 @@ export function useVirtualList<T extends { id: string | number }>(
 
     const container = containerRef.value
     const visibleHeight = container.clientHeight
-    const itemsArray = (items.value || items) as T[]
+    const itemsArray = items.value as T[]
 
     if (itemsArray.length === 0) return []
 
@@ -80,8 +80,7 @@ export function useVirtualList<T extends { id: string | number }>(
 
   // Total height of all items
   const totalHeight = computed(() => {
-    const itemsArray = (items.value || items) as T[]
-    return itemsArray.length * itemHeight
+    return items.value.length * itemHeight
   })
 
   // Handle scroll events


### PR DESCRIPTION
Closes #4361

## Summary
- Fixed 66 TypeScript errors in collaboration and secrets management files
- Fixed `useVirtualList.ts` generic parameter typing (was `any`, now properly typed `Ref<T[]> | ComputedRef<T[]>`)
- Fixed `ParticipantList.vue`: removed duplicate `containerRef`, fixed const-on-ternary, made `id` required
- Fixed `SecretVault.vue`: defined `SecretItem` interface, added Date fallback, typed virtual list
- Fixed `SecretAuditLog.vue`: added null guard before `Object.keys()`
- Fixed `useSecretsAuditApi.ts`: removed erroneous `.json()` call on already-parsed API response

## Test Status
✅ TypeScript: 0 errors remaining in affected files