### PR TITLE
feat(views): wire orphaned AboutView (#4267)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -761,6 +761,7 @@ export default {
     // Data-driven navigation items: single source of truth for desktop + mobile nav
     const navItems = [
       { to: '/home', labelKey: 'nav.home', icon: 'M10.707 2.293a1 1 0 00-1.414 0l-7 7v11a1 1 0 001 1h2a1 1 0 001-1v-5a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 001 1h2a1 1 0 001-1v-7l7-7a1 1 0 000-1.414z', iconRule: 'evenodd' },
+      { to: '/about', labelKey: 'nav.about', icon: 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z', iconStroke: true },
       { to: '/chat', labelKey: 'nav.chat', icon: 'M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z', iconRule: 'evenodd' },
       { to: '/knowledge', labelKey: 'nav.knowledge', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
       { to: '/automation', labelKey: 'nav.automation', icon: 'M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z', iconRule: 'evenodd' },

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -6754,6 +6754,7 @@
   "nav": {
     "mainNavigation": "Main navigation",
     "home": "Home",
+    "about": "About",
     "chat": "Chat",
     "knowledge": "Knowledge",
     "automation": "Automation",


### PR DESCRIPTION
## Summary
- Added AboutView to main navigation menu in App.vue after HomeView
- Added `nav.about` translation key to English locale (`en.json`)
- AboutView already routed at `/about` in `router/index.ts` (Issue #4185)

## Changes
- `autobot-frontend/src/App.vue`: Added About nav item with info circle icon
- `autobot-frontend/src/i18n/locales/en.json`: Added `"about": "About"` to nav section

Closes #4267

🤖 Generated with Claude Code