### PR TITLE
fix(typescript): resolve browser automation and dev tools type errors (#4362)

### DIFF
--- a/autobot-frontend/src/composables/useBrowserAutomation.ts
+++ b/autobot-frontend/src/composables/useBrowserAutomation.ts
@@ -86,7 +86,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   async function fetchWorkerStatus(): Promise<void> {
     try {
-      const data = await ApiClient.get(`${getApiBase()}/browser/status`)
+      const data = await ApiClient.get<BrowserWorkerStatus>(`${getApiBase()}/browser/status`)
       workerStatus.value = data
       logger.debug('Fetched worker status:', data)
     } catch (err) {
@@ -100,7 +100,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/browser/launch`, { url: url || 'about:blank' })
+      const data = await ApiClient.post<{ session: BrowserSession }>(`${getApiBase()}/browser/launch`, { url: url || 'about:blank' })
       sessions.value.push(data.session)
       currentSession.value = data.session
       logger.debug('Launched browser session:', data.session)
@@ -138,7 +138,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   async function fetchSessions(): Promise<void> {
     try {
-      const data = await ApiClient.get(`${getApiBase()}/browser/sessions`)
+      const data = await ApiClient.get<{ sessions: BrowserSession[] }>(`${getApiBase()}/browser/sessions`)
       sessions.value = data.sessions || []
       logger.debug('Fetched sessions:', sessions.value.length)
     } catch (err) {
@@ -150,7 +150,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   async function getSession(sessionId: string): Promise<BrowserSession | null> {
     try {
-      const data = await ApiClient.get(`${getApiBase()}/browser/session/${sessionId}`)
+      const data = await ApiClient.get<BrowserSession>(`${getApiBase()}/browser/session/${sessionId}`)
       currentSession.value = data
       logger.debug('Fetched session details:', data)
       return data
@@ -218,7 +218,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/browser/screenshot`, { session_id: sessionId })
+      const data = await ApiClient.post<ScreenshotResult>(`${getApiBase()}/browser/screenshot`, { session_id: sessionId })
       screenshots.value.unshift(data)
       logger.debug('Captured screenshot')
       return data
@@ -236,7 +236,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/browser/execute`, { session_id: sessionId, script })
+      const data = await ApiClient.post<{ result: unknown }>(`${getApiBase()}/browser/execute`, { session_id: sessionId, script })
       logger.debug('Executed script, result:', data.result)
       return data.result
     } catch (err) {
@@ -253,7 +253,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/browser/automation/run`, { script })
+      const data = await ApiClient.post<{ result: unknown }>(`${getApiBase()}/browser/automation/run`, { script })
       logger.debug('Automation script completed:', data)
       return data.result
     } catch (err) {

--- a/autobot-frontend/src/composables/useConversationFiles.ts
+++ b/autobot-frontend/src/composables/useConversationFiles.ts
@@ -108,9 +108,7 @@ export function useConversationFiles(sessionId: string) {
     error.value = null
 
     try {
-      const response = await api.get(`${getApiBase()}/conversation-files/conversation/${sessionId}/list`)
-      // Issue #156 Fix: Call .json() to get data from Response
-      const data = await response.json()
+      const data = await api.get<{ files: ConversationFile[]; stats: FileStats }>(`${getApiBase()}/conversation-files/conversation/${sessionId}/list`)
 
       if (data) {
         files.value = data.files || []
@@ -152,7 +150,7 @@ export function useConversationFiles(sessionId: string) {
         formData.append('files', file)
       })
 
-      const response = await api.post(
+      const data = await api.post<{ success: boolean }>(
         `${getApiBase()}/conversation-files/conversation/${sessionId}/upload`,
         formData,
         {
@@ -166,9 +164,6 @@ export function useConversationFiles(sessionId: string) {
           }
         }
       )
-
-      // Issue #156 Fix: Call .json() to get data from Response
-      const data = await response.json()
 
       if (data?.success) {
         // Reload files to get updated list
@@ -229,12 +224,11 @@ export function useConversationFiles(sessionId: string) {
     }
 
     try {
-      const response = await api.get(
+      const response = await api.rawRequest(
         `${getApiBase()}/conversation-files/conversation/${sessionId}/download/${fileId}`,
-        { responseType: 'blob' }
+        { method: 'GET' }
       )
 
-      // Issue #156 Fix: Call .blob() to get blob data from Response
       const blob = await response.blob()
       const url = window.URL.createObjectURL(blob)
       const link = document.createElement('a')
@@ -332,8 +326,7 @@ export function useConversationFiles(sessionId: string) {
     loading.value = true
     error.value = null
     try {
-      const response = await api.post(`${API}/files/create`, { filename, content, mime_type: mimeType })
-      const data = await response.json()
+      const data = await api.post<{ success: boolean }>(`${API}/files/create`, { filename, content, mime_type: mimeType })
       if (data?.success) { await loadFiles(); return true }
       error.value = 'Failed to create file'
       return false
@@ -348,8 +341,7 @@ export function useConversationFiles(sessionId: string) {
     if (!sessionId || !fileId) { error.value = 'Missing parameters'; return false }
     error.value = null
     try {
-      const response = await api.put(`${API}/files/${fileId}/rename`, { new_filename: newFilename })
-      const data = await response.json()
+      const data = await api.put<{ success: boolean }>(`${API}/files/${fileId}/rename`, { new_filename: newFilename })
       if (data?.success) {
         const file = files.value.find(f => f.file_id === fileId)
         if (file) file.filename = newFilename
@@ -367,8 +359,7 @@ export function useConversationFiles(sessionId: string) {
   const getFileContent = async (fileId: string): Promise<string | null> => {
     if (!sessionId || !fileId) { error.value = 'Missing parameters'; return null }
     try {
-      const response = await api.get(`${API}/files/${fileId}/content`)
-      const data = await response.json()
+      const data = await api.get<{ content: string }>(`${API}/files/${fileId}/content`)
       return data?.content ?? null
     } catch (err: unknown) {
       error.value = extractApiErrorMessage(err, 'Failed to read file')
@@ -381,8 +372,7 @@ export function useConversationFiles(sessionId: string) {
     if (!sessionId || !fileId) { error.value = 'Missing parameters'; return false }
     error.value = null
     try {
-      const response = await api.put(`${API}/files/${fileId}/content`, { content })
-      const data = await response.json()
+      const data = await api.put<{ success: boolean }>(`${API}/files/${fileId}/content`, { content })
       if (data?.success) { await loadFiles(); return true }
       error.value = 'Save failed'
       return false
@@ -398,8 +388,7 @@ export function useConversationFiles(sessionId: string) {
     loading.value = true
     error.value = null
     try {
-      const response = await api.post(`${API}/files/${fileId}/copy`, { new_filename: newFilename || null })
-      const data = await response.json()
+      const data = await api.post<{ success: boolean }>(`${API}/files/${fileId}/copy`, { new_filename: newFilename || null })
       if (data?.success) { await loadFiles(); return true }
       error.value = 'Copy failed'
       return false

--- a/autobot-frontend/src/composables/useDevSpeedup.ts
+++ b/autobot-frontend/src/composables/useDevSpeedup.ts
@@ -93,7 +93,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/quick-search`, { query, type })
+      const data = await ApiClient.post<{ results: SearchResult[] }>(`${getApiBase()}/dev-speedup/quick-search`, { query, type })
       searchResults.value = data.results || []
       logger.debug('Search results:', searchResults.value.length)
     } catch (err) {
@@ -109,7 +109,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/snippet-generate`, { description, language })
+      const data = await ApiClient.post<{ snippet: CodeSnippet }>(`${getApiBase()}/dev-speedup/snippet-generate`, { description, language })
       const snippet = data.snippet
       snippets.value.unshift(snippet)
       logger.debug('Generated snippet:', snippet)
@@ -129,7 +129,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     error.value = null
     try {
       const params = category ? `?category=${category}` : ''
-      const data = await ApiClient.get(`${getApiBase()}/dev-speedup/templates${params}`)
+      const data = await ApiClient.get<{ templates: CodeTemplate[] }>(`${getApiBase()}/dev-speedup/templates${params}`)
       templates.value = data.templates || []
       logger.debug('Fetched templates:', templates.value.length)
     } catch (err) {
@@ -145,7 +145,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/refactor-suggest`, { code, language })
+      const data = await ApiClient.post<{ suggestions: RefactorSuggestion[] }>(`${getApiBase()}/dev-speedup/refactor-suggest`, { code, language })
       refactorSuggestions.value = data.suggestions || []
       logger.debug('Refactor suggestions:', refactorSuggestions.value.length)
     } catch (err) {
@@ -161,7 +161,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/boilerplate`, { type, ...options })
+      const data = await ApiClient.post<{ code: string }>(`${getApiBase()}/dev-speedup/boilerplate`, { type, ...options })
       logger.debug('Generated boilerplate')
       return data.code
     } catch (err) {
@@ -178,7 +178,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/test-generate`, { code, language, framework })
+      const data = await ApiClient.post<{ tests: TestCase[] }>(`${getApiBase()}/dev-speedup/test-generate`, { code, language, framework })
       generatedTests.value = data.tests || []
       logger.debug('Generated tests:', generatedTests.value.length)
     } catch (err) {
@@ -194,7 +194,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/optimize`, { code, language })
+      const data = await ApiClient.post<{ optimized_code: string }>(`${getApiBase()}/dev-speedup/optimize`, { code, language })
       logger.debug('Code optimized')
       return data.optimized_code
     } catch (err) {
@@ -211,7 +211,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/format`, { code, language })
+      const data = await ApiClient.post<{ formatted_code: string }>(`${getApiBase()}/dev-speedup/format`, { code, language })
       logger.debug('Code formatted')
       return data.formatted_code
     } catch (err) {
@@ -228,7 +228,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
     isLoading.value = true
     error.value = null
     try {
-      const data = await ApiClient.post(`${getApiBase()}/dev-speedup/lint-fix`, { code, language })
+      const data = await ApiClient.post<{ fixed_code: string }>(`${getApiBase()}/dev-speedup/lint-fix`, { code, language })
       logger.debug('Linting fixed')
       return data.fixed_code
     } catch (err) {
@@ -243,7 +243,7 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
 
   async function fetchHistory(): Promise<void> {
     try {
-      const data = await ApiClient.get(`${getApiBase()}/dev-speedup/history`)
+      const data = await ApiClient.get<{ actions: SpeedupAction[] }>(`${getApiBase()}/dev-speedup/history`)
       actionHistory.value = data.actions || []
       logger.debug('Fetched action history:', actionHistory.value.length)
     } catch (err) {


### PR DESCRIPTION
Closes #4362

## Summary
- Fixed 31 TypeScript errors across 3 composable files
- `useBrowserAutomation.ts` (13 errors): Added proper generic type parameters to all `ApiClient.get<T>()`/`ApiClient.post<T>()` calls
- `useDevSpeedup.ts` (10 errors): Same pattern — added typed generics for all 10 API client calls
- `useConversationFiles.ts` (8 errors): Removed erroneous `.json()`/`.blob()` calls on already-parsed API responses; switched blob download to `api.rawRequest()`

## Test Status
✅ TypeScript: 0 errors remaining in affected files (31 fewer total errors)