### PR TITLE
feat(usage): add usage metering and cost tracking API (#1807)

### DIFF
--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -1,0 +1,215 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Usage Metering API — token counts, resource usage, and billing-ready metrics.
+
+Provides endpoints for:
+- Per-user usage summary (tokens, cost, request counts)
+- System-wide aggregated usage
+- Daily/model/session breakdowns
+- Usage data export (CSV)
+
+Issue #1807: Usage metering and cost tracking.
+"""
+
+import csv
+import io
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+
+from auth_middleware import check_admin_permission, get_current_user
+from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from services.llm_cost_tracker import get_cost_tracker
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/usage", tags=["usage", "analytics"])
+
+
+# ============================================================================
+# SUMMARY ENDPOINTS
+# ============================================================================
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_usage_summary",
+    error_code_prefix="USAGE",
+)
+@router.get("/summary")
+async def get_usage_summary(
+    days: int = Query(default=30, ge=1, le=365, description="Number of days to include"),
+    admin_check: bool = Depends(check_admin_permission),
+) -> dict[str, Any]:
+    """
+    Get system-wide usage summary: tokens, costs, model breakdown.
+
+    Returns aggregate token counts and costs across all users and models
+    for the specified time period.
+
+    Issue #1807: Billing-ready usage metrics.
+    """
+    tracker = get_cost_tracker()
+    end_date = datetime.utcnow()
+    start_date = end_date - timedelta(days=days)
+
+    cost_summary = await tracker.get_cost_summary(start_date, end_date)
+    all_users = await tracker.get_all_user_costs()
+
+    total_input = sum(u["input_tokens"] for u in all_users)
+    total_output = sum(u["output_tokens"] for u in all_users)
+    total_requests = sum(u["call_count"] for u in all_users)
+
+    return {
+        "period": {
+            "days": days,
+            "start": start_date.strftime("%Y-%m-%d"),
+            "end": end_date.strftime("%Y-%m-%d"),
+        },
+        "tokens": {
+            "input": total_input,
+            "output": total_output,
+            "total": total_input + total_output,
+        },
+        "cost_usd": cost_summary.get("total_cost_usd", 0.0),
+        "requests": total_requests,
+        "daily_costs": cost_summary.get("daily_costs", {}),
+        "by_model": cost_summary.get("by_model", {}),
+        "active_users": len(all_users),
+    }
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_usage_by_user_all",
+    error_code_prefix="USAGE",
+)
+@router.get("/by-user")
+async def get_usage_by_user_all(
+    admin_check: bool = Depends(check_admin_permission),
+) -> dict[str, Any]:
+    """
+    Get usage breakdown for all users, sorted by cost descending.
+
+    Issue #1807: Per-user billing metrics.
+    """
+    tracker = get_cost_tracker()
+    users = await tracker.get_all_user_costs()
+
+    return {
+        "timestamp": datetime.utcnow().isoformat(),
+        "users": users,
+        "total_users": len(users),
+    }
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_usage_by_user_single",
+    error_code_prefix="USAGE",
+)
+@router.get("/by-user/{user_id}")
+async def get_usage_by_user_single(
+    user_id: str,
+    admin_check: bool = Depends(check_admin_permission),
+) -> dict[str, Any]:
+    """
+    Get usage breakdown for a specific user.
+
+    Issue #1807: Per-user billing metrics.
+    """
+    tracker = get_cost_tracker()
+    return await tracker.get_cost_by_user(user_id)
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="get_my_usage",
+    error_code_prefix="USAGE",
+)
+@router.get("/me")
+async def get_my_usage(
+    current_user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    """
+    Get the authenticated user's personal usage summary.
+
+    Returns token counts, cost, and request history for the caller.
+
+    Issue #1807: Personal usage dashboard data.
+    """
+    tracker = get_cost_tracker()
+    user_id: str = current_user.get("username", "")
+    if not user_id:
+        return {"found": False, "message": "User identity not available"}
+
+    data = await tracker.get_cost_by_user(user_id)
+
+    # Enrich with recent usage records filtered to this user
+    recent = await tracker.get_recent_usage(limit=200)
+    user_recent = [r for r in recent if r.get("user_id") == user_id][:50]
+
+    return {
+        **data,
+        "recent_requests": user_recent,
+    }
+
+
+# ============================================================================
+# EXPORT ENDPOINT
+# ============================================================================
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="export_usage_csv",
+    error_code_prefix="USAGE",
+)
+@router.get("/export/csv")
+async def export_usage_csv(
+    days: int = Query(default=30, ge=1, le=365, description="Days of data to export"),
+    admin_check: bool = Depends(check_admin_permission),
+) -> StreamingResponse:
+    """
+    Export usage data as CSV.
+
+    Downloads a CSV file containing all usage records for the given period.
+    Columns: timestamp, provider, model, user_id, session_id, input_tokens,
+             output_tokens, cost_usd, latency_ms, success.
+
+    Issue #1807: CSV export for billing/reporting.
+    """
+    tracker = get_cost_tracker()
+    cutoff = datetime.utcnow() - timedelta(days=days)
+
+    records = await tracker.get_recent_usage(limit=10000)
+    filtered = [
+        r for r in records
+        if r.get("timestamp", "") >= cutoff.strftime("%Y-%m-%dT")
+    ]
+
+    output = io.StringIO()
+    writer = csv.DictWriter(
+        output,
+        fieldnames=[
+            "timestamp", "provider", "model", "user_id", "session_id",
+            "agent_id", "input_tokens", "output_tokens", "cost_usd",
+            "latency_ms", "success",
+        ],
+        extrasaction="ignore",
+    )
+    writer.writeheader()
+    for row in filtered:
+        writer.writerow(row)
+
+    output.seek(0)
+    filename = f"usage_{datetime.utcnow().strftime('%Y%m%d')}.csv"
+    return StreamingResponse(
+        iter([output.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -72,6 +72,7 @@ from api.service_messages import router as service_messages_router
 from api.settings import router as settings_router
 from api.structured_thinking_mcp import router as structured_thinking_mcp_router
 from api.system import router as system_router
+from api.usage import router as usage_router  # Issue #1807
 from api.vnc_manager import router as vnc_router
 from api.vnc_mcp import router as vnc_mcp_router
 from api.vnc_proxy import router as vnc_proxy_router
@@ -94,6 +95,7 @@ def _get_system_routers() -> list:
         (collaboration_router, "", ["collaboration"], "collaboration"),
         (system_router, "/system", ["system"], "system"),
         (settings_router, "/settings", ["settings"], "settings"),
+        (usage_router, "/usage", ["usage", "analytics"], "usage"),  # Issue #1807
         (data_storage_router, "", ["data-storage"], "data_storage"),
         (prompts_router, "/prompts", ["prompts"], "prompts"),
         (frontend_config_router, "", ["frontend-config"], "frontend_config"),

--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -213,6 +213,7 @@ class LLMCostTracker:
     MODEL_TOTALS_KEY = f"{REDIS_KEY_PREFIX}by_model"
     SESSION_TOTALS_KEY = f"{REDIS_KEY_PREFIX}by_session"
     AGENT_TOTALS_KEY = f"{REDIS_KEY_PREFIX}by_agent"
+    USER_TOTALS_KEY = f"{REDIS_KEY_PREFIX}by_user"
     AGENT_BUDGET_KEY = f"{REDIS_KEY_PREFIX}agent_budget"
     BUDGET_ALERTS_KEY = f"{REDIS_KEY_PREFIX}budget_alerts"
 
@@ -641,6 +642,17 @@ class LLMCostTracker:
                     await pipe.incrbyfloat(daily_agent_key, record.cost_usd)
                     await pipe.expire(daily_agent_key, TTL_90_DAYS)
 
+                # Update per-user totals if user provided (#1807)
+                if record.user_id:
+                    user_key = f"{self.USER_TOTALS_KEY}:{record.user_id}"
+                    await pipe.hincrbyfloat(user_key, "cost_usd", record.cost_usd)
+                    await pipe.hincrby(user_key, "input_tokens", record.input_tokens)
+                    await pipe.hincrby(user_key, "output_tokens", record.output_tokens)
+                    await pipe.hincrby(user_key, "call_count", 1)
+                    daily_user_key = f"{self.USER_TOTALS_KEY}:{record.user_id}:daily:{today}"
+                    await pipe.incrbyfloat(daily_user_key, record.cost_usd)
+                    await pipe.expire(daily_user_key, TTL_90_DAYS)
+
                 # Execute all operations in single round-trip
                 await pipe.execute()
 
@@ -995,6 +1007,82 @@ class LLMCostTracker:
             "utilization_percent": round(utilization, 2),
             "exceeded": exceeded,
         }
+
+    async def get_cost_by_user(self, user_id: str) -> dict[str, Any]:
+        """Get cost breakdown for a specific user (#1807)."""
+        try:
+            redis = await self.get_redis()
+            user_key = f"{self.USER_TOTALS_KEY}:{user_id}"
+            data = await redis.hgetall(user_key)
+
+            if not data:
+                return {"user_id": user_id, "found": False}
+
+            def _int(v: Any) -> int:
+                return int(v) if v else 0
+
+            def _float(v: Any) -> float:
+                return float(v) if v else 0.0
+
+            return {
+                "user_id": user_id,
+                "found": True,
+                "cost_usd": _float(data.get(b"cost_usd") or data.get("cost_usd")),
+                "input_tokens": _int(data.get(b"input_tokens") or data.get("input_tokens")),
+                "output_tokens": _int(data.get(b"output_tokens") or data.get("output_tokens")),
+                "call_count": _int(data.get(b"call_count") or data.get("call_count")),
+            }
+        except Exception as e:
+            logger.error("Failed to get user cost: %s", e)
+            return {"user_id": user_id, "error": "Failed to retrieve user cost"}
+
+    async def get_all_user_costs(self) -> list[dict[str, Any]]:
+        """Get cost breakdown for all users (#1807)."""
+        try:
+            redis = await self.get_redis()
+            pattern = f"{self.USER_TOTALS_KEY}:*"
+            all_keys = await redis.keys(pattern)
+            # Exclude daily sub-keys
+            user_keys = [
+                k for k in all_keys
+                if b":daily:" not in (k if isinstance(k, bytes) else k.encode())
+            ]
+
+            if not user_keys:
+                return []
+
+            pipe = redis.pipeline()
+            for key in user_keys:
+                pipe.hgetall(key)
+            results = await pipe.execute()
+
+            def _int(v: Any) -> int:
+                return int(v) if v else 0
+
+            def _float(v: Any) -> float:
+                return float(v) if v else 0.0
+
+            users = []
+            for key, data in zip(user_keys, results):
+                if not data:
+                    continue
+                key_str = key if isinstance(key, str) else key.decode("utf-8")
+                user_id = key_str.split(":")[-1]
+                users.append(
+                    {
+                        "user_id": user_id,
+                        "cost_usd": _float(data.get(b"cost_usd") or data.get("cost_usd")),
+                        "input_tokens": _int(data.get(b"input_tokens") or data.get("input_tokens")),
+                        "output_tokens": _int(data.get(b"output_tokens") or data.get("output_tokens")),
+                        "call_count": _int(data.get(b"call_count") or data.get("call_count")),
+                    }
+                )
+
+            users.sort(key=lambda x: x["cost_usd"], reverse=True)
+            return users
+        except Exception as e:
+            logger.error("Failed to get all user costs: %s", e)
+            return []
 
 
 # Singleton instance (thread-safe)


### PR DESCRIPTION
Closes #1807

## Summary
- Adds per-user cost tracking to `LlmCostTracker`: stores input/output tokens, cost, and call count per user in Redis with 90-day TTL on daily keys
- Adds `GET /api/usage/summary` — system-wide token/cost breakdown with model and daily splits (admin only)
- Adds `GET /api/usage/by-user` — all users sorted by cost (admin only)
- Adds `GET /api/usage/by-user/{user_id}` — single user breakdown (admin only)
- Adds `GET /api/usage/me` — authenticated user's personal usage + last 50 requests
- Adds `GET /api/usage/export/csv` — CSV export for billing/reporting (admin only)
- Registers `usage_router` in `core_routers.py` at `/api/usage`

## Test plan
- [ ] `GET /api/usage/summary` returns token totals and cost breakdown
- [ ] `GET /api/usage/by-user` lists all users sorted by cost (requires admin)
- [ ] `GET /api/usage/me` returns personal usage for authenticated user
- [ ] `GET /api/usage/export/csv` downloads CSV with correct columns
- [ ] Non-admin access to admin endpoints returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)