### PR TITLE
feat(ui): mobile-responsive layout and navigation (#1804)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -110,11 +110,15 @@
               @click="toggleMobileNav"
               class="lg:hidden inline-flex items-center justify-center p-2 rounded text-autobot-text-primary hover:bg-autobot-bg-tertiary focus:outline-none focus:ring-2 focus:ring-autobot-primary"
               aria-controls="mobile-nav"
-              aria-expanded="false"
+              :aria-expanded="showMobileNav.toString()"
             >
               <span class="sr-only">{{ $t('nav.openMainMenu') }}</span>
-              <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <!-- Hamburger / X icon toggle (#1804) -->
+              <svg v-if="!showMobileNav" class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+              <svg v-else class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
           </div>

--- a/autobot-frontend/src/assets/main.css
+++ b/autobot-frontend/src/assets/main.css
@@ -46,6 +46,40 @@
   }
 }
 
+/* ============================================================
+ * MOBILE RESPONSIVE UTILITIES (#1804)
+ * Touch-friendly and viewport-adaptive rules for phones/tablets
+ * ============================================================ */
+
+/* Ensure interactive elements meet WCAG 2.5.5 minimum 44×44px touch target */
+@media (max-width: 1024px) {
+  /* Buttons and links in nav already have lg:hidden / lg:block logic in Tailwind.
+   * This fills in any element that needs a bigger tap area on touch screens. */
+  button,
+  [role="button"],
+  a {
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+
+  /* Chat interface: make scrollable containers work properly with touch */
+  .overflow-y-auto,
+  .overflow-x-auto {
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+/* Extra-small viewports: tighten page-header padding */
+@media (max-width: 480px) {
+  .page-header {
+    padding: var(--spacing-3) var(--spacing-3) var(--spacing-2);
+  }
+
+  .page-actions {
+    flex-wrap: wrap;
+  }
+}
+
 /* RTL layout support (#1337) */
 [dir="rtl"] .chat-sidebar {
   border-right: none;

--- a/autobot-frontend/src/components/chat/ChatHeader.vue
+++ b/autobot-frontend/src/components/chat/ChatHeader.vue
@@ -1,21 +1,33 @@
 <template>
-  <div class="chat-header bg-autobot-bg-card border-b border-autobot-border px-6 py-4">
-    <div class="flex items-center justify-between">
-      <div class="flex items-center gap-3">
-        <div class="w-8 h-8 bg-electric-600 rounded-full flex items-center justify-center">
-          <i class="fas fa-robot text-white text-sm"></i>
+  <div class="chat-header bg-autobot-bg-card border-b border-autobot-border px-3 sm:px-6 py-3 sm:py-4">
+    <div class="flex items-center justify-between gap-2">
+      <!-- Left: Mobile sidebar toggle + session info -->
+      <div class="flex items-center gap-2 sm:gap-3 min-w-0">
+        <!-- Mobile hamburger to open chat sidebar (#1804) -->
+        <button
+          class="header-btn lg:hidden shrink-0"
+          :title="$t('chat.sidebar.expandSidebar')"
+          :aria-label="$t('chat.sidebar.expandSidebar')"
+          @click="$emit('toggle-mobile-sidebar')"
+        >
+          <i class="fas fa-bars"></i>
+        </button>
+
+        <div class="w-7 h-7 sm:w-8 sm:h-8 bg-electric-600 rounded-full flex items-center justify-center shrink-0">
+          <i class="fas fa-robot text-white text-xs sm:text-sm"></i>
         </div>
-        <div>
-          <h1 class="text-lg font-semibold text-autobot-text-primary">
+        <div class="min-w-0">
+          <h1 class="text-sm sm:text-lg font-semibold text-autobot-text-primary truncate">
             {{ currentSessionTitle }}
           </h1>
-          <p class="text-sm text-autobot-text-muted">
+          <p class="text-xs sm:text-sm text-autobot-text-muted truncate hidden sm:block">
             {{ sessionInfo }}
           </p>
         </div>
       </div>
 
-      <div class="flex items-center gap-2">
+      <!-- Right: Actions + connection status -->
+      <div class="flex items-center gap-1 sm:gap-2 shrink-0">
         <!-- Custom Actions Slot -->
         <slot name="actions"></slot>
 
@@ -38,10 +50,10 @@
           <i class="fas fa-trash"></i>
         </button>
 
-        <!-- Connection Status -->
+        <!-- Connection Status — icon only on mobile, full label on sm+ -->
         <div class="connection-status" :class="connectionStatusClass">
           <i :class="connectionStatusIcon"></i>
-          <span class="text-sm">{{ connectionStatus }}</span>
+          <span class="text-sm hidden sm:inline">{{ connectionStatus }}</span>
         </div>
       </div>
     </div>
@@ -62,6 +74,7 @@ interface Props {
 interface Emits {
   (e: 'export-session'): void
   (e: 'clear-session'): void
+  (e: 'toggle-mobile-sidebar'): void
 }
 
 const props = defineProps<Props>()
@@ -88,10 +101,20 @@ const connectionStatusIcon = computed(() => {
 }
 
 .header-btn {
-  @apply w-8 h-8 flex items-center justify-center rounded-md transition-colors text-autobot-text-secondary hover:bg-autobot-bg-tertiary;
+  /* min 44px touch target on mobile (#1804) */
+  @apply w-8 h-8 sm:w-8 sm:h-8 flex items-center justify-center rounded-md transition-colors text-autobot-text-secondary hover:bg-autobot-bg-tertiary;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+@media (min-width: 640px) {
+  .header-btn {
+    min-width: 2rem;
+    min-height: 2rem;
+  }
 }
 
 .connection-status {
-  @apply flex items-center gap-2 px-3 py-1.5 rounded-md bg-autobot-bg-tertiary;
+  @apply flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-1.5 rounded-md bg-autobot-bg-tertiary;
 }
 </style>

--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -1143,14 +1143,37 @@ onUnmounted(() => {
   @apply grid grid-cols-6 gap-1 p-3 max-h-48 overflow-y-auto;
 }
 
-/* Responsive */
+/* Responsive (#1804) */
 @media (max-width: 640px) {
   .input-container {
     @apply items-stretch;
   }
 
   .send-button {
-    @apply w-10 h-auto;
+    /* 44px minimum touch target on mobile */
+    min-width: 44px;
+    min-height: 44px;
+    @apply w-11 h-auto;
+  }
+
+  /* Horizontally scroll the action bar on mobile to prevent wrapping */
+  .input-actions {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .input-actions::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* 44px tap targets for action buttons on mobile */
+  .knowledge-toggle,
+  .overseer-toggle {
+    min-height: 44px;
+    min-width: 44px;
+    @apply px-3;
   }
 
   .quick-actions {
@@ -1160,6 +1183,11 @@ onUnmounted(() => {
 
   .quick-actions::-webkit-scrollbar {
     display: none;
+  }
+
+  /* Limit status bar on mobile */
+  .input-status-bar {
+    @apply hidden;
   }
 
   .emoji-picker {

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -2,7 +2,16 @@
   <ErrorBoundary :fallback="$t('chat.interface.loadFailed')">
     <div class="chat-interface flex h-full bg-autobot-bg-card overflow-hidden">
 
+      <!-- Mobile Sidebar Backdrop -->
+      <div
+        v-if="showMobileSidebar"
+        class="lg:hidden fixed inset-0 bg-black/40 z-30"
+        @click="showMobileSidebar = false"
+        aria-hidden="true"
+      ></div>
+
       <!-- Chat Sidebar with Unified Loading -->
+      <!-- Desktop: inline. Mobile: fixed overlay when showMobileSidebar is true -->
       <UnifiedLoadingView
         loading-key="chat-sidebar"
         :has-content="store.sessions.length > 0"
@@ -10,10 +19,31 @@
         @loading-complete="handleSidebarLoadingComplete"
         @loading-error="handleSidebarLoadingError"
         @loading-timeout="handleSidebarLoadingTimeout"
-        class="sidebar-loading-view h-full w-80 shrink-0"
+        :class="[
+          'sidebar-loading-view h-full shrink-0',
+          'hidden lg:block',
+          store.sidebarCollapsed ? 'w-12' : 'w-80',
+        ]"
       >
         <ChatSidebar />
       </UnifiedLoadingView>
+
+      <!-- Mobile Sidebar Overlay -->
+      <Transition
+        enter-active-class="transition duration-250 ease-out"
+        enter-from-class="-translate-x-full"
+        enter-to-class="translate-x-0"
+        leave-active-class="transition duration-200 ease-in"
+        leave-from-class="translate-x-0"
+        leave-to-class="-translate-x-full"
+      >
+        <div
+          v-if="showMobileSidebar"
+          class="lg:hidden fixed top-0 left-0 h-full w-80 max-w-[85vw] z-40 shadow-2xl overflow-hidden"
+        >
+          <ChatSidebar @close-mobile="showMobileSidebar = false" />
+        </div>
+      </Transition>
 
       <!-- Main Chat Area -->
       <div class="flex-1 flex flex-col min-w-0 relative">
@@ -27,6 +57,7 @@
           :is-connected="isConnected"
           @export-session="exportSession"
           @clear-session="clearSession"
+          @toggle-mobile-sidebar="showMobileSidebar = !showMobileSidebar"
           class="shrink-0"
         >
           <!-- File Panel Toggle Button (injected into header) -->
@@ -247,6 +278,8 @@ const showKnowledgeDialog = ref(false)
 const showCommandDialog = ref(false)
 const showWorkflowProgress = ref(false)
 const showFilePanel = ref(false)
+// Mobile sidebar overlay (#1804)
+const showMobileSidebar = ref(false)
 
 // Dialog data
 const currentChatContext = ref<any>(null)

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -3,15 +3,29 @@
     class="bg-autobot-bg-secondary border-r border-autobot-border flex flex-col h-full overflow-hidden transition-all duration-300 shrink-0"
     :class="{ 'w-12': store.sidebarCollapsed, 'w-80': !store.sidebarCollapsed }"
   >
-    <!-- Toggle Button -->
-    <BaseButton
-      variant="ghost"
-      class="p-3 border-b border-autobot-border text-autobot-text-secondary shrink-0"
-      @click="controller.toggleSidebar()"
-      :aria-label="store.sidebarCollapsed ? $t('chat.sidebar.expandSidebar') : $t('chat.sidebar.collapseSidebar')"
-    >
-      <i :class="store.sidebarCollapsed ? 'fas fa-chevron-right' : 'fas fa-chevron-left'"></i>
-    </BaseButton>
+    <!-- Toggle Button row: desktop collapse toggle + mobile close button (#1804) -->
+    <div class="flex items-center border-b border-autobot-border shrink-0">
+      <BaseButton
+        variant="ghost"
+        class="flex-1 p-3 text-autobot-text-secondary hidden lg:flex"
+        @click="controller.toggleSidebar()"
+        :aria-label="store.sidebarCollapsed ? $t('chat.sidebar.expandSidebar') : $t('chat.sidebar.collapseSidebar')"
+      >
+        <i :class="store.sidebarCollapsed ? 'fas fa-chevron-right' : 'fas fa-chevron-left'"></i>
+      </BaseButton>
+      <!-- Mobile header: title + close button -->
+      <div class="lg:hidden flex items-center justify-between w-full px-3 py-2">
+        <span class="text-sm font-semibold text-autobot-text-primary">{{ $t('chat.sidebar.chatHistory') }}</span>
+        <BaseButton
+          variant="ghost"
+          class="p-2 text-autobot-text-secondary"
+          @click="emit('close-mobile')"
+          :aria-label="$t('common.close')"
+        >
+          <i class="fas fa-times"></i>
+        </BaseButton>
+      </div>
+    </div>
 
     <!-- Sidebar Content - FIXED: Better scroll behavior -->
     <div v-if="!store.sidebarCollapsed" class="flex-1 flex flex-col min-h-0 overflow-hidden">
@@ -288,6 +302,9 @@
 <script setup lang="ts">
 import { ref, computed, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+// #1804: emit close-mobile so ChatInterface can close the mobile overlay
+const emit = defineEmits<{ 'close-mobile': [] }>()
 import { useChatStore } from '@/stores/useChatStore'
 import { useChatController } from '@/models/controllers'
 import { useDisplaySettings, type DisplaySettings } from '@/composables/useDisplaySettings'
@@ -343,6 +360,8 @@ const handleSessionClick = (session: ChatSession, index: number) => {
     toggleSelection(session.id)
   } else {
     controller.switchToSession(session.id)
+    // #1804: close mobile overlay after selecting a session
+    emit('close-mobile')
   }
 }
 


### PR DESCRIPTION
Closes #1804

## Summary
- Makes the AutoBot frontend fully responsive for mobile viewports
- Updates `App.vue`, `ChatHeader.vue`, `ChatInput.vue`, `ChatInterface.vue`, `ChatSidebar.vue` with responsive Tailwind classes
- Updates `main.css` with mobile-specific breakpoints and touch-friendly sizing
- Sidebar collapses to overlay on small screens; header adapts for narrow viewports

## Test plan
- [ ] Layout renders correctly on 375px (iPhone SE) viewport
- [ ] Sidebar opens/closes as overlay on mobile
- [ ] Chat input is accessible and usable on touch devices
- [ ] Desktop layout unchanged at 1024px+

🤖 Generated with [Claude Code](https://claude.com/claude-code)