### PR TITLE
fix(lint): remove unused import and fix E501 violations in llm_cost_tracker.py

### DIFF
--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -361,7 +361,8 @@ class LLMCostTracker:
         """Helper for _extract_usage_params. Ref: #1088."""
         if provider is None or model is None or input_tokens is None or output_tokens is None:
             raise ValueError(
-                "Either 'request' object or 'provider', 'model', " "'input_tokens', 'output_tokens' are required"
+                "Either 'request' object or 'provider', 'model', "
+                "'input_tokens', 'output_tokens' are required"
             )
         return (
             provider,

--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -24,7 +24,6 @@ from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
 from constants.model_constants import (
-    ANTHROPIC_CLAUDE35_HAIKU,
     ANTHROPIC_CLAUDE_HAIKU4_5,
     ANTHROPIC_CLAUDE_OPUS4,
     ANTHROPIC_CLAUDE_SONNET4,
@@ -226,7 +225,9 @@ class LLMCostTracker:
     async def get_redis(self):
         """Get async Redis client"""
         if self._redis_client is None:
-            self._redis_client = get_redis_client(async_client=True, database=RedisDatabase.ANALYTICS)
+            self._redis_client = get_redis_client(
+                async_client=True, database=RedisDatabase.ANALYTICS
+            )
         return self._redis_client
 
     # Pattern-based pricing fallbacks for unknown models (#1961).
@@ -663,7 +664,9 @@ class LLMCostTracker:
         """Check if any budget alerts should be triggered"""
         # Implementation for budget alerts - can be extended
 
-    async def _fetch_daily_costs(self, redis, start_date: datetime, end_date: datetime) -> Dict[str, float]:
+    async def _fetch_daily_costs(
+        self, redis, start_date: datetime, end_date: datetime
+    ) -> Dict[str, float]:
         """
         Fetch daily costs from Redis using pipeline (Issue #665: extracted helper).
 
@@ -727,9 +730,12 @@ class LLMCostTracker:
 
             model_costs[model_name] = {
                 "cost_usd": float(model_data.get(b"cost_usd", 0) or model_data.get("cost_usd", 0)),
-                "input_tokens": int(model_data.get(b"input_tokens", 0) or model_data.get("input_tokens", 0)),
-                "output_tokens": int(model_data.get(b"output_tokens", 0) or model_data.get("output_tokens", 0)),
-                "call_count": int(model_data.get(b"call_count", 0) or model_data.get("call_count", 0)),
+                "input_tokens": int(
+                    model_data.get(b"input_tokens", 0) or model_data.get("input_tokens", 0)),
+                "output_tokens": int(
+                    model_data.get(b"output_tokens", 0) or model_data.get("output_tokens", 0)),
+                "call_count": int(
+                    model_data.get(b"call_count", 0) or model_data.get("call_count", 0)),
             }
 
         return model_costs
@@ -849,7 +855,9 @@ class LLMCostTracker:
             "period_days": days,
             "total_cost_usd": summary.get("total_cost_usd", 0),
             "daily_costs": daily_costs,
-            "trend": ("increasing" if growth_rate > 5 else "decreasing" if growth_rate < -5 else "stable"),
+            "trend": (
+                "increasing" if growth_rate > 5 else "decreasing" if growth_rate < -5 else "stable"
+            ),
             "growth_rate_percent": round(growth_rate, 2),
             "avg_daily_cost": summary.get("avg_daily_cost", 0),
         }
@@ -892,7 +900,8 @@ class LLMCostTracker:
             redis = await self.get_redis()
             pattern = f"{self.AGENT_TOTALS_KEY}:*"
             agent_keys = [
-                k for k in await redis.keys(pattern) if b":daily:" not in (k if isinstance(k, bytes) else k.encode())
+                k for k in await redis.keys(pattern)
+                if b":daily:" not in (k if isinstance(k, bytes) else k.encode())
             ]
 
             if not agent_keys:
@@ -913,8 +922,10 @@ class LLMCostTracker:
                     {
                         "agent_id": agent_id,
                         "cost_usd": float(data.get(b"cost_usd", 0) or data.get("cost_usd", 0)),
-                        "input_tokens": int(data.get(b"input_tokens", 0) or data.get("input_tokens", 0)),
-                        "output_tokens": int(data.get(b"output_tokens", 0) or data.get("output_tokens", 0)),
+                        "input_tokens": int(
+                            data.get(b"input_tokens", 0) or data.get("input_tokens", 0)),
+                        "output_tokens": int(
+                            data.get(b"output_tokens", 0) or data.get("output_tokens", 0)),
                         "call_count": int(data.get(b"call_count", 0) or data.get("call_count", 0)),
                     }
                 )
@@ -1073,7 +1084,8 @@ class LLMCostTracker:
                         "user_id": user_id,
                         "cost_usd": _float(data.get(b"cost_usd") or data.get("cost_usd")),
                         "input_tokens": _int(data.get(b"input_tokens") or data.get("input_tokens")),
-                        "output_tokens": _int(data.get(b"output_tokens") or data.get("output_tokens")),
+                        "output_tokens": _int(
+                            data.get(b"output_tokens") or data.get("output_tokens")),
                         "call_count": _int(data.get(b"call_count") or data.get("call_count")),
                     }
                 )


### PR DESCRIPTION
Follow-up to PR #4439 (#1807) — lint issues that were not caught before merge.

## Changes

- Removed unused import `ANTHROPIC_CLAUDE35_HAIKU` (F401)
- Wrapped 9 lines exceeding 100 chars (E501): function signature, Redis client init, dict values, list comprehension, ValueError message

## Test Status

PASS — flake8 clean (0 violations)