### PR TITLE
fix(usage): lint fixes, POST /record endpoint, and UsageView frontend (#1807)

### DIFF
--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -21,10 +21,25 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.llm_cost_tracker import get_cost_tracker
+
+
+class UsageRecordRequest(BaseModel):
+    """Request body for POST /api/usage/record. Issue #1807."""
+
+    provider: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    session_id: str | None = None
+    user_id: str | None = None
+    agent_id: str | None = None
+    latency_ms: float | None = None
+    success: bool = True
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/usage", tags=["usage", "analytics"])
@@ -156,6 +171,51 @@ async def get_my_usage(
     return {
         **data,
         "recent_requests": user_recent,
+    }
+
+
+
+# ============================================================================
+# RECORD ENDPOINT
+# ============================================================================
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="record_usage_event",
+    error_code_prefix="USAGE",
+)
+@router.post("/record")
+async def record_usage_event(
+    body: UsageRecordRequest,
+    current_user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    """
+    Record a single LLM usage event.
+
+    Called from LLM handlers after each API call to track tokens and cost.
+    The user_id in the body is used if provided; otherwise falls back to the
+    authenticated user's username.
+
+    Issue #1807: Billing-ready usage event ingestion.
+    """
+    tracker = get_cost_tracker()
+    user_id = body.user_id or current_user.get("username", "")
+    record = await tracker.track_usage(
+        provider=body.provider,
+        model=body.model,
+        input_tokens=body.input_tokens,
+        output_tokens=body.output_tokens,
+        session_id=body.session_id,
+        user_id=user_id,
+        agent_id=body.agent_id,
+        latency_ms=body.latency_ms,
+        success=body.success,
+    )
+    return {
+        "recorded": True,
+        "cost_usd": record.cost_usd,
+        "record_id": record.id if hasattr(record, "id") else None,
     }
 
 

--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -361,7 +361,8 @@ class LLMCostTracker:
         """Helper for _extract_usage_params. Ref: #1088."""
         if provider is None or model is None or input_tokens is None or output_tokens is None:
             raise ValueError(
-                "Either 'request' object or 'provider', 'model', " "'input_tokens', 'output_tokens' are required"
+                "Either 'request' object or 'provider', 'model', "
+                "'input_tokens', 'output_tokens' are required"
             )
         return (
             provider,

--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -24,7 +24,6 @@ from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
 from constants.model_constants import (
-    ANTHROPIC_CLAUDE35_HAIKU,
     ANTHROPIC_CLAUDE_HAIKU4_5,
     ANTHROPIC_CLAUDE_OPUS4,
     ANTHROPIC_CLAUDE_SONNET4,
@@ -226,7 +225,9 @@ class LLMCostTracker:
     async def get_redis(self):
         """Get async Redis client"""
         if self._redis_client is None:
-            self._redis_client = get_redis_client(async_client=True, database=RedisDatabase.ANALYTICS)
+            self._redis_client = get_redis_client(
+                async_client=True, database=RedisDatabase.ANALYTICS
+            )
         return self._redis_client
 
     # Pattern-based pricing fallbacks for unknown models (#1961).
@@ -663,7 +664,9 @@ class LLMCostTracker:
         """Check if any budget alerts should be triggered"""
         # Implementation for budget alerts - can be extended
 
-    async def _fetch_daily_costs(self, redis, start_date: datetime, end_date: datetime) -> Dict[str, float]:
+    async def _fetch_daily_costs(
+        self, redis, start_date: datetime, end_date: datetime
+    ) -> Dict[str, float]:
         """
         Fetch daily costs from Redis using pipeline (Issue #665: extracted helper).
 
@@ -727,9 +730,12 @@ class LLMCostTracker:
 
             model_costs[model_name] = {
                 "cost_usd": float(model_data.get(b"cost_usd", 0) or model_data.get("cost_usd", 0)),
-                "input_tokens": int(model_data.get(b"input_tokens", 0) or model_data.get("input_tokens", 0)),
-                "output_tokens": int(model_data.get(b"output_tokens", 0) or model_data.get("output_tokens", 0)),
-                "call_count": int(model_data.get(b"call_count", 0) or model_data.get("call_count", 0)),
+                "input_tokens": int(
+                    model_data.get(b"input_tokens", 0) or model_data.get("input_tokens", 0)),
+                "output_tokens": int(
+                    model_data.get(b"output_tokens", 0) or model_data.get("output_tokens", 0)),
+                "call_count": int(
+                    model_data.get(b"call_count", 0) or model_data.get("call_count", 0)),
             }
 
         return model_costs
@@ -849,7 +855,9 @@ class LLMCostTracker:
             "period_days": days,
             "total_cost_usd": summary.get("total_cost_usd", 0),
             "daily_costs": daily_costs,
-            "trend": ("increasing" if growth_rate > 5 else "decreasing" if growth_rate < -5 else "stable"),
+            "trend": (
+                "increasing" if growth_rate > 5 else "decreasing" if growth_rate < -5 else "stable"
+            ),
             "growth_rate_percent": round(growth_rate, 2),
             "avg_daily_cost": summary.get("avg_daily_cost", 0),
         }
@@ -892,7 +900,8 @@ class LLMCostTracker:
             redis = await self.get_redis()
             pattern = f"{self.AGENT_TOTALS_KEY}:*"
             agent_keys = [
-                k for k in await redis.keys(pattern) if b":daily:" not in (k if isinstance(k, bytes) else k.encode())
+                k for k in await redis.keys(pattern)
+                if b":daily:" not in (k if isinstance(k, bytes) else k.encode())
             ]
 
             if not agent_keys:
@@ -913,8 +922,10 @@ class LLMCostTracker:
                     {
                         "agent_id": agent_id,
                         "cost_usd": float(data.get(b"cost_usd", 0) or data.get("cost_usd", 0)),
-                        "input_tokens": int(data.get(b"input_tokens", 0) or data.get("input_tokens", 0)),
-                        "output_tokens": int(data.get(b"output_tokens", 0) or data.get("output_tokens", 0)),
+                        "input_tokens": int(
+                            data.get(b"input_tokens", 0) or data.get("input_tokens", 0)),
+                        "output_tokens": int(
+                            data.get(b"output_tokens", 0) or data.get("output_tokens", 0)),
                         "call_count": int(data.get(b"call_count", 0) or data.get("call_count", 0)),
                     }
                 )
@@ -1073,7 +1084,8 @@ class LLMCostTracker:
                         "user_id": user_id,
                         "cost_usd": _float(data.get(b"cost_usd") or data.get("cost_usd")),
                         "input_tokens": _int(data.get(b"input_tokens") or data.get("input_tokens")),
-                        "output_tokens": _int(data.get(b"output_tokens") or data.get("output_tokens")),
+                        "output_tokens": _int(
+                            data.get(b"output_tokens") or data.get("output_tokens")),
                         "call_count": _int(data.get(b"call_count") or data.get("call_count")),
                     }
                 )

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -731,6 +731,17 @@ const routes: RouteRecordRaw[] = [
     ]
   },
   {
+    path: '/usage',
+    name: 'usage',
+    component: () => import('@/views/UsageView.vue'),
+    meta: {
+      title: 'Usage & Cost Tracking',
+      icon: 'fas fa-chart-bar',
+      description: 'Token usage, LLM costs, and billing-ready metrics',
+      requiresAuth: true
+    }
+  },
+  {
     path: '/permission-denied',
     name: 'permission-denied',
     component: PermissionDeniedView,

--- a/autobot-frontend/src/views/UsageView.vue
+++ b/autobot-frontend/src/views/UsageView.vue
@@ -1,0 +1,285 @@
+<template>
+  <div class="usage-view">
+    <div class="page-header">
+      <div class="page-header-content">
+        <h2 class="page-title">Usage &amp; Cost Tracking</h2>
+        <p class="page-subtitle">Token usage, LLM costs, and billing-ready metrics</p>
+      </div>
+      <div class="header-actions">
+        <button class="btn-action-secondary" :disabled="loading" @click="load">
+          <i class="fas fa-sync-alt" :class="{ 'fa-spin': loading }"></i>
+          Refresh
+        </button>
+        <a :href="csvExportUrl" class="btn-action-secondary" download>
+          <i class="fas fa-download"></i>
+          Export CSV
+        </a>
+      </div>
+    </div>
+
+    <div v-if="error" class="error-banner">
+      <i class="fas fa-exclamation-circle"></i>
+      <span>{{ error }}</span>
+      <button class="btn-dismiss" @click="error = null"><i class="fas fa-times"></i></button>
+    </div>
+
+    <!-- Summary Cards -->
+    <div v-if="summary" class="summary-grid">
+      <div class="stat-card">
+        <div class="stat-label">Total Tokens</div>
+        <div class="stat-value">{{ summary.tokens.total.toLocaleString() }}</div>
+        <div class="stat-sub">
+          {{ summary.tokens.input.toLocaleString() }} in /
+          {{ summary.tokens.output.toLocaleString() }} out
+        </div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Total Cost</div>
+        <div class="stat-value">${{ summary.cost_usd.toFixed(4) }}</div>
+        <div class="stat-sub">Last {{ summary.period.days }} days</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Requests</div>
+        <div class="stat-value">{{ summary.requests.toLocaleString() }}</div>
+        <div class="stat-sub">{{ summary.active_users }} active users</div>
+      </div>
+    </div>
+
+    <!-- Per-User Table -->
+    <div class="table-section">
+      <h3 class="section-title">Usage by User</h3>
+      <div v-if="loading" class="loading-row">
+        <i class="fas fa-spinner fa-spin"></i> Loading...
+      </div>
+      <table v-else-if="users.length" class="usage-table">
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Requests</th>
+            <th>Input Tokens</th>
+            <th>Output Tokens</th>
+            <th>Cost (USD)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="u in users" :key="u.user_id">
+            <td>{{ u.user_id || '(unknown)' }}</td>
+            <td>{{ u.call_count.toLocaleString() }}</td>
+            <td>{{ u.input_tokens.toLocaleString() }}</td>
+            <td>{{ u.output_tokens.toLocaleString() }}</td>
+            <td>${{ u.total_cost_usd.toFixed(4) }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <div v-else class="empty-row">No usage data available.</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { getApiBase } from '@/config/ssot-config'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('UsageView')
+
+interface UsageSummary {
+  period: { days: number; start: string; end: string }
+  tokens: { input: number; output: number; total: number }
+  cost_usd: number
+  requests: number
+  active_users: number
+}
+
+interface UserUsage {
+  user_id: string
+  call_count: number
+  input_tokens: number
+  output_tokens: number
+  total_cost_usd: number
+}
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const summary = ref<UsageSummary | null>(null)
+const users = ref<UserUsage[]>([])
+
+const csvExportUrl = computed(() => `${getApiBase()}/usage/export/csv`)
+
+async function apiFetch<T>(path: string): Promise<T> {
+  const token = localStorage.getItem('authToken') || ''
+  const res = await fetch(`${getApiBase()}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return res.json() as Promise<T>
+}
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const [sum, byUser] = await Promise.all([
+      apiFetch<UsageSummary>('/usage/summary'),
+      apiFetch<{ users: UserUsage[] }>('/usage/by-user'),
+    ])
+    summary.value = sum
+    users.value = byUser.users ?? []
+  } catch (e) {
+    logger.error('Failed to load usage data:', e)
+    error.value = 'Failed to load usage data. Check that you have admin access.'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+@reference "../assets/tailwind.css";
+
+.usage-view {
+  contain: layout style paint;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  padding: var(--spacing-5);
+  background: var(--bg-primary);
+  overflow-y: auto;
+  gap: var(--spacing-5);
+}
+
+.header-actions {
+  display: flex;
+  gap: var(--spacing-2);
+  align-items: center;
+}
+
+.btn-action-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--duration-150) var(--ease-in-out);
+}
+
+.btn-action-secondary:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+}
+
+.btn-action-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  border-radius: var(--radius-md);
+  color: var(--color-error);
+}
+
+.error-banner span { flex: 1; font-size: var(--text-sm); }
+
+.btn-dismiss {
+  padding: var(--spacing-1) var(--spacing-2);
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-md);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-4);
+}
+
+.stat-card {
+  padding: var(--spacing-4);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+}
+
+.stat-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-1);
+}
+
+.stat-value {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  color: var(--text-primary);
+}
+
+.stat-sub {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  margin-top: var(--spacing-1);
+}
+
+.table-section {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.section-title {
+  padding: var(--spacing-4) var(--spacing-5);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-default);
+  margin: 0;
+}
+
+.usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.usage-table th {
+  padding: var(--spacing-3) var(--spacing-4);
+  text-align: left;
+  font-weight: var(--font-semibold);
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.usage-table td {
+  padding: var(--spacing-3) var(--spacing-4);
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.usage-table tr:last-child td { border-bottom: none; }
+
+.usage-table tr:hover td { background: var(--bg-hover); }
+
+.loading-row,
+.empty-row {
+  padding: var(--spacing-8);
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+</style>


### PR DESCRIPTION
Follow-up to #4439 (initial #1807 merge).

## Summary
- Fixed lint violations (unused imports, E501 line length) in `llm_cost_tracker.py` and `api/usage.py`
- Added `POST /usage/record` endpoint with `UsageRecordRequest` Pydantic model for LLM event ingestion
- Added `UsageView` frontend component for billing-ready usage visibility

## Commits
- `ba7e684f` fix(lint): remove unused import and E501 lines in llm_cost_tracker
- `936a3082` fix(lint): fix remaining E501 in ValueError message
- `bc856dbe` feat(usage): add POST /usage/record endpoint for LLM event ingestion
- `c0c15f10` feat(usage): add POST /record endpoint and UsageView frontend

## Related
Closes follow-up gaps from #1807 initial implementation.