### PR TITLE
fix(lint): fix blank line violations in usage.py (#1807)

### DIFF
--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -41,6 +41,7 @@ class UsageRecordRequest(BaseModel):
     latency_ms: float | None = None
     success: bool = True
 
+
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/usage", tags=["usage", "analytics"])
 
@@ -172,7 +173,6 @@ async def get_my_usage(
         **data,
         "recent_requests": user_recent,
     }
-
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Fixed 3 flake8 blank line violations in `autobot-backend/api/usage.py`:
  - E305: missing blank line after class definition before `logger`
  - E303: too many blank lines (3) before RECORD ENDPOINT section
  - E302: expected 2 blank lines, found 3

## Changes
- `autobot-backend/api/usage.py`: corrected blank line spacing

Relates to #1807

🤖 Generated with Claude Code