### PR TITLE
feat(auth): add self-signup and user role management endpoints (#1801)

### DIFF
--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -166,6 +166,57 @@ class ChangePasswordResponse(BaseModel):
     message: str
 
 
+class SignupRequest(BaseModel):
+    """Self-registration request model (#1801)."""
+
+    username: str
+    email: str
+    password: str
+    display_name: str | None = None
+
+    @validator("username")
+    def validate_username(cls, v):
+        """Validate username format."""
+        v = v.strip().lower()
+        if not v or len(v) < 3:
+            raise ValueError("Username must be at least 3 characters")
+        if len(v) > 50:
+            raise ValueError("Username too long")
+        if not v.replace("_", "").replace("-", "").isalnum():
+            raise ValueError("Username contains invalid characters")
+        return v
+
+    @validator("email")
+    def validate_email(cls, v):
+        """Minimal email sanity check."""
+        if "@" not in v or len(v) > 255:
+            raise ValueError("Invalid email address")
+        return v.strip().lower()
+
+    @validator("password")
+    def validate_password(cls, v):
+        """Password strength requirements."""
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        if len(v) > 128:
+            raise ValueError("Password too long")
+        if not any(c.isupper() for c in v):
+            raise ValueError("Password must contain at least one uppercase letter")
+        if not any(c.islower() for c in v):
+            raise ValueError("Password must contain at least one lowercase letter")
+        if not any(c.isdigit() for c in v):
+            raise ValueError("Password must contain at least one digit")
+        return v
+
+
+class SignupResponse(BaseModel):
+    """Self-registration response model (#1801)."""
+
+    success: bool
+    message: str
+    username: str | None = None
+
+
 async def _authenticate_and_build_user_data(
     username: str, password: str, ip_address: str
 ) -> Dict:
@@ -540,6 +591,55 @@ async def change_password(request: Request, password_data: ChangePasswordRequest
         raise HTTPException(
             status_code=500, detail="Failed to change password. Please try again."
         )
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="signup",
+    error_code_prefix="AUTH",
+)
+@router.post("/signup", response_model=SignupResponse)
+async def signup(request: Request, signup_data: SignupRequest):
+    """
+    Self-registration endpoint for new users (#1801).
+
+    Creates a new user account with the default 'user' role.
+    Disabled in single_user deployment mode.
+    """
+    from user_management.config import DeploymentMode, get_deployment_config
+
+    deploy_cfg = get_deployment_config()
+    if deploy_cfg.mode == DeploymentMode.SINGLE_USER:
+        raise HTTPException(
+            status_code=400,
+            detail="Self-registration is not available in single-user mode",
+        )
+
+    try:
+        async with db_session_context() as session:
+            user_service = UserService(session)
+            user = await user_service.create_user(
+                email=signup_data.email,
+                username=signup_data.username,
+                password=signup_data.password,
+                display_name=signup_data.display_name or signup_data.username,
+            )
+        logger.info("New user registered via signup: %s", signup_data.username)
+        return SignupResponse(
+            success=True,
+            message="Account created successfully. You can now log in.",
+            username=user.username,
+        )
+    except Exception as exc:
+        # Re-raise HTTP exceptions (e.g. 409 duplicate)
+        if hasattr(exc, "status_code"):
+            raise
+        from user_management.services.user_service import DuplicateUserError
+
+        if isinstance(exc, DuplicateUserError):
+            raise HTTPException(status_code=409, detail=str(exc))
+        logger.error("Signup error for %s: %s", signup_data.username, exc)
+        raise HTTPException(status_code=500, detail="Registration failed. Please try again.")
 
 
 def _decode_refresh_token(token: str) -> Dict:

--- a/autobot-backend/api/user_management/users.py
+++ b/autobot-backend/api/user_management/users.py
@@ -12,11 +12,12 @@ import uuid
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from api.user_management.dependencies import (
     get_current_user,
     get_user_service,
+    require_platform_admin,
     require_user_management_enabled,
 )
 from autobot_shared.models.pagination import PaginationParams
@@ -75,6 +76,25 @@ class RoleAssignmentResponse(BaseModel):
     success: bool = True
     message: str
     role_id: uuid.UUID
+
+
+class RoleUpdateRequest(BaseModel):
+    """Request to set a user's role by name (#1801)."""
+
+    role: str = Field(
+        ...,
+        description="Role name: admin, user, or readonly",
+        pattern="^(admin|user|readonly)$",
+    )
+
+
+class RoleUpdateResponse(BaseModel):
+    """Response for role-by-name update (#1801)."""
+
+    success: bool = True
+    message: str
+    username: str
+    role: str
 
 
 class UserSearchResult(BaseModel):
@@ -588,6 +608,76 @@ async def revoke_role(
     return RoleAssignmentResponse(
         message="Role revoked successfully",
         role_id=role_id,
+    )
+
+
+# -------------------------------------------------------------------------
+# Role-by-name Management (#1801)
+# -------------------------------------------------------------------------
+
+
+@router.put(
+    "/{user_id}/role",
+    response_model=RoleUpdateResponse,
+    summary="Set user role by name",
+    description=(
+        "Replace all system roles for a user with the named role (admin, user, readonly). "
+        "Requires admin privilege. Issue #1801."
+    ),
+    dependencies=[
+        Depends(require_user_management_enabled),
+        Depends(require_platform_admin),
+    ],
+)
+async def set_user_role(
+    user_id: uuid.UUID,
+    body: RoleUpdateRequest,
+    user_service: UserService = Depends(get_user_service),
+):
+    """Set a user's system role by name, replacing previous system role assignments."""
+    from sqlalchemy import delete, select
+    from user_management.models.role import Role, UserRole
+
+    user = await user_service.get_user(user_id)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User {user_id} not found",
+        )
+
+    # Resolve target role from system roles
+    session = user_service.session
+    target_role_result = await session.execute(
+        select(Role).where(Role.name == body.role, Role.is_system.is_(True))
+    )
+    target_role = target_role_result.scalar_one_or_none()
+    if not target_role:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"System role '{body.role}' not found",
+        )
+
+    # Remove all existing system role assignments for this user
+    system_role_ids_result = await session.execute(
+        select(Role.id).where(Role.is_system.is_(True))
+    )
+    system_role_ids = [r for (r,) in system_role_ids_result.all()]
+    if system_role_ids:
+        await session.execute(
+            delete(UserRole).where(
+                UserRole.user_id == user_id,
+                UserRole.role_id.in_(system_role_ids),
+            )
+        )
+        await session.flush()
+
+    # Assign the new role
+    await user_service.assign_role(user_id, target_role.id)
+
+    return RoleUpdateResponse(
+        message=f"Role updated to '{body.role}' for user {user.username}",
+        username=user.username,
+        role=body.role,
     )
 
 


### PR DESCRIPTION
## Summary
- `POST /auth/signup` — self-registration endpoint with username/email/password validation
- User role management endpoints in `api/user_management/users.py`
- Input validation via Pydantic validators (username format, email sanity, password strength)

## Changes
- `autobot-backend/api/auth.py`: `SignupRequest` model + `/signup` endpoint
- `autobot-backend/api/user_management/users.py`: role assignment/query endpoints

Closes #1801

🤖 Generated with Claude Code