### PR TITLE
fix(workers): add __all__ exports to new worker modules (#4322)

### DIFF
--- a/autobot-browser-worker/main.py
+++ b/autobot-browser-worker/main.py
@@ -15,6 +15,8 @@ from src.automation import BrowserAutomationSession
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["main"]
+
 
 def main():
     """Browser worker entry point."""

--- a/autobot-browser-worker/src/__init__.py
+++ b/autobot-browser-worker/src/__init__.py
@@ -2,3 +2,7 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """Browser Worker Source Code Package"""
+
+from .automation import BrowserAutomationSession
+
+__all__ = ["BrowserAutomationSession"]

--- a/autobot-npu-worker/conftest.py
+++ b/autobot-npu-worker/conftest.py
@@ -10,6 +10,8 @@ Sets up path imports and fixtures for NPU worker testing (Issue #4311).
 import sys
 from pathlib import Path
 
+__all__: list = []
+
 # Add npu-worker core module to path for test imports
 _npu_worker_root = Path(__file__).parent
 _core_path = _npu_worker_root / "core"

--- a/autobot-npu-worker/core/npu_integration.py
+++ b/autobot-npu-worker/core/npu_integration.py
@@ -68,6 +68,20 @@ except (ImportError, ModuleNotFoundError):
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "CircuitState",
+    "WorkerState",
+    "NPUInferenceRequest",
+    "NPUWorkerClient",
+    "NPUWorkerPool",
+    "NPUTaskQueue",
+    "load_worker_config",
+    "get_npu_client",
+    "get_npu_queue",
+    "get_npu_pool",
+    "process_with_npu_fallback",
+]
+
 # Issue #255: Enable authenticated client for service-to-service communication
 # Set to False to fall back to unauthenticated mode (for development/testing)
 USE_AUTHENTICATED_CLIENT = True

--- a/autobot-npu-worker/main.py
+++ b/autobot-npu-worker/main.py
@@ -24,6 +24,8 @@ from npu_integration import get_npu_pool
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["initialize_npu_worker", "main"]
+
 
 async def initialize_npu_worker():
     """Initialize NPU worker pool and health monitoring."""


### PR DESCRIPTION
## Summary
- Add `__all__` exports to `autobot-browser-worker` and `autobot-npu-worker` modules
- Documents public API surface for `BrowserAutomationSession`, `npu_integration`, `conftest`, and worker entry points
- No functional changes — documentation/convention only

## Test Plan
- [ ] Python import check: `python -c 'import main'` in each worker dir
- [ ] No runtime changes to worker behavior

Closes #4322

🤖 Generated with Claude Code