### PR TITLE
fix(usage): add nav link, fix CSV auth, refactor to useApi() (#4465 #4466 #4467)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -779,6 +779,8 @@ export default {
       { to: '/preferences', labelKey: 'nav.preferences', icon: 'M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z', iconRule: 'evenodd' },
       // Issue #2371: LLM Config moved to SLM admin settings
       { to: '/dev-speedup', labelKey: 'nav.devSpeedup', icon: 'M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z' },
+      // Issue #4465: Usage & Costs dashboard (admin-only)
+      { to: '/usage', labelKey: 'nav.usage', adminOnly: true, icon: 'M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z' },
       // Issue #1440: AutoResearch experiment dashboard (admin-only)
       { to: '/experiments', labelKey: 'nav.experiments', adminOnly: true, icon: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z' },
       // Issue #3502: Desktop and Custom Dashboard (admin-only, matching route meta)

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -6804,7 +6804,8 @@
     "skipToContent": "Skip to content",
     "skipToNavigation": "Skip to navigation",
     "systemStatus": "System Status",
-    "marketplace": "Marketplace"
+    "marketplace": "Marketplace",
+    "usage": "Usage & Costs"
   },
   "reasoningTrace": {
     "title": "Reasoning trace",

--- a/autobot-frontend/src/views/UsageView.vue
+++ b/autobot-frontend/src/views/UsageView.vue
@@ -10,10 +10,10 @@
           <i class="fas fa-sync-alt" :class="{ 'fa-spin': loading }"></i>
           Refresh
         </button>
-        <a :href="csvExportUrl" class="btn-action-secondary" download>
-          <i class="fas fa-download"></i>
+        <button class="btn-action-secondary" :disabled="csvLoading" @click="downloadCsv">
+          <i class="fas fa-download" :class="{ 'fa-spin': csvLoading }"></i>
           Export CSV
-        </a>
+        </button>
       </div>
     </div>
 
@@ -77,11 +77,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { getApiBase } from '@/config/ssot-config'
+import { useApi } from '@/composables/useApi'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('UsageView')
+const api = useApi()
 
 interface UsageSummary {
   period: { days: number; start: string; end: string }
@@ -100,28 +102,18 @@ interface UserUsage {
 }
 
 const loading = ref(false)
+const csvLoading = ref(false)
 const error = ref<string | null>(null)
 const summary = ref<UsageSummary | null>(null)
 const users = ref<UserUsage[]>([])
-
-const csvExportUrl = computed(() => `${getApiBase()}/usage/export/csv`)
-
-async function apiFetch<T>(path: string): Promise<T> {
-  const token = localStorage.getItem('authToken') || ''
-  const res = await fetch(`${getApiBase()}${path}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-  return res.json() as Promise<T>
-}
 
 async function load() {
   loading.value = true
   error.value = null
   try {
     const [sum, byUser] = await Promise.all([
-      apiFetch<UsageSummary>('/usage/summary'),
-      apiFetch<{ users: UserUsage[] }>('/usage/by-user'),
+      api.get<UsageSummary>('/usage/summary'),
+      api.get<{ users: UserUsage[] }>('/usage/by-user'),
     ])
     summary.value = sum
     users.value = byUser.users ?? []
@@ -130,6 +122,29 @@ async function load() {
     error.value = 'Failed to load usage data. Check that you have admin access.'
   } finally {
     loading.value = false
+  }
+}
+
+async function downloadCsv() {
+  csvLoading.value = true
+  try {
+    const token = localStorage.getItem('authToken') || ''
+    const res = await fetch(`${getApiBase()}/usage/export/csv`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'usage.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  } catch (e) {
+    logger.error('CSV export failed:', e)
+    error.value = 'CSV export failed. Check that you have admin access.'
+  } finally {
+    csvLoading.value = false
   }
 }
 


### PR DESCRIPTION
## Summary
- **#4465** — Add `/usage` nav entry (admin-only) in `App.vue` `navItems` so the Usage & Costs page is reachable from the UI. Add `nav.usage` i18n key.
- **#4466** — Fix CSV export: replace `<a href download>` (which doesn't send `Authorization` header) with `downloadCsv()` that uses `fetch()` with the JWT token, then triggers a blob download via `URL.createObjectURL`.
- **#4467** — Replace local `apiFetch` helper with `useApi()` composable calls for summary and by-user data fetches. Eliminates the duplicate auth token management.

## Test Plan
- [ ] Log in as admin — verify "Usage & Costs" appears in nav sidebar
- [ ] Log in as non-admin — verify "Usage & Costs" is NOT in nav
- [ ] Navigate to `/usage` — verify summary cards and user table load
- [ ] Click "Export CSV" — verify file downloads (not 401)
- [ ] Non-admin: verify `/usage` route redirects or shows 403

Closes #4465
Closes #4466
Closes #4467

🤖 Generated with Claude Code