### PR TITLE
fix(frontend): distinguish errors from empty responses in batch API (#4353)

### DIFF
--- a/autobot-frontend/src/services/BatchApiService.ts
+++ b/autobot-frontend/src/services/BatchApiService.ts
@@ -27,7 +27,9 @@ interface ChatInitData {
 }
 
 interface ApiResponse<T = unknown> {
-  data?: T;
+  // data is null when the API call failed (distinguishes from data:[] which means
+  // the backend returned 0 items successfully). See issue #4353.
+  data?: T | null;
   error?: string;
   // Issue #4352: intentional_empty signals the backend confirmed 0 sessions
   // (vs. an API failure that returns empty data). Frontend uses this to decide
@@ -102,20 +104,50 @@ export class BatchApiService {
     }
   }
 
-  private extractSessionsList(response: unknown): unknown[] {
+  private extractSessionsList(response: unknown): unknown[] | null {
     if (Array.isArray(response)) return response;
     const r = response as Record<string, unknown> | null;
     const data = r?.data as Record<string, unknown> | undefined;
-    return (data?.sessions || data || (r as Record<string, unknown>)?.sessions || []) as unknown[];
+    // Prefer explicit sessions key; fall through to data object only if it is an array
+    const sessions = data?.sessions ?? r?.sessions;
+    if (sessions !== undefined) return sessions as unknown[];
+    if (Array.isArray(data)) return data;
+    // Response has no recognisable session structure — signal parse failure
+    return null;
   }
 
   /** Issue #4352: Extract intentional_empty flag from backend chat-sessions response. */
   private extractIntentionalEmpty(response: unknown): boolean {
     if (!response || typeof response !== 'object') return false;
     const r = response as Record<string, unknown>;
-    // Backend wraps in: { success, data: { sessions, count, intentional_empty }, ... }
+    // Backend returns: { sessions, count, intentional_empty } (no extra .data wrapper)
     const data = r.data as Record<string, unknown> | undefined;
     return Boolean(data?.intentional_empty ?? r.intentional_empty);
+  }
+
+  /** Issue #4353: Build chat_sessions ApiResponse, distinguishing API errors from
+   *  valid empty-session lists. Returns { error } when the API call failed or the
+   *  response has no recognisable sessions structure; returns { data, intentional_empty }
+   *  when the backend positively confirmed the sessions list (including empty). */
+  private buildChatSessionsResult(
+    result: PromiseSettledResult<Record<string, unknown>>
+  ): ApiResponse<Record<string, unknown>[]> {
+    if (result.status === 'rejected') {
+      const reason = (result as PromiseRejectedResult).reason;
+      return { data: null, error: reason?.message || 'api_failed' };
+    }
+
+    const sessions = this.extractSessionsList(result.value);
+    if (sessions === null) {
+      // Fulfilled but response structure unrecognisable — treat as silent API failure
+      logger.warn('getChatList response has no sessions structure; treating as api_failed');
+      return { data: null, error: 'api_failed' };
+    }
+
+    return {
+      data: sessions as Record<string, unknown>[],
+      intentional_empty: this.extractIntentionalEmpty(result.value),
+    };
   }
 
   async fallbackChatInitialization(): Promise<FallbackResults> {
@@ -131,13 +163,7 @@ export class BatchApiService {
       this.apiClient.getSettings()
     ]);
 
-    const chatSessionsApiResult: ApiResponse<Record<string, unknown>[]> =
-      chatSessionsResult.status === 'fulfilled'
-        ? {
-            data: this.extractSessionsList(chatSessionsResult.value) as Record<string, unknown>[],
-            intentional_empty: this.extractIntentionalEmpty(chatSessionsResult.value),
-          }
-        : { error: (chatSessionsResult as PromiseRejectedResult).reason?.message || 'Failed to load' };
+    const chatSessionsApiResult = this.buildChatSessionsResult(chatSessionsResult);
 
     const results: FallbackResults = {
       chat_sessions: chatSessionsApiResult,


### PR DESCRIPTION
Closes #4353

## Summary

- `BatchApiService.extractSessionsList()` now returns `null` on malformed/unrecognisable responses vs `[]` for backend-confirmed empty lists
- New `buildChatSessionsResult()` encapsulates logic: rejected → `{data: null, error}`, unrecognisable → `{data: null, error: 'api_failed'}`, valid empty → `{data: [], intentional_empty}`
- `ApiResponse<T>.data` typed as `T | null` so callers can reliably distinguish API failure from empty result
- `ChatInterface.vue` already uses truthy check on `data` — no caller changes needed

## Test Status

No new TypeScript errors in modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)