### PR TITLE
fix(agents): wire SlackNotificationIntegration into agent loop (#4308)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from typing import Any, Optional
 
+from agent_loop.slack_hook import get_slack_hook
 from agent_loop.think_tool import ThinkTool
 from agent_loop.types import (
     AgentLoopConfig,
@@ -279,6 +280,16 @@ class AgentLoop:
 
         self._init_task_context(task_id, task_description, initial_context)
 
+        # Issue #4308: notify Slack that the agent has started
+        slack = get_slack_hook()
+        await slack.post_agent_status(
+            agent_name="AgentLoop",
+            status="started",
+            message=f"Task {task_id}: {task_description[:120]}",
+        )
+
+        _task_start = time.monotonic()
+
         try:
             # Issue #620: Use helper for plan creation
             await self._create_task_plan(task_description, initial_context)
@@ -286,7 +297,22 @@ class AgentLoop:
             results = await self._execute_main_loop()
 
             # Issue #620: Use helper for task finalization
-            return await self._finalize_task(results)
+            result = await self._finalize_task(results)
+
+            # Issue #4308: notify Slack on successful task completion
+            duration = time.monotonic() - _task_start
+            await slack.post_task_completion(
+                task_id=task_id,
+                task_title=task_description[:80],
+                agent_name="AgentLoop",
+                summary=(
+                    f"Completed {result.get('iterations', 0)} iteration(s), "
+                    f"{result.get('tools_executed', 0)} tool(s) executed."
+                ),
+                status="completed",
+                duration_seconds=duration,
+            )
+            return result
 
         except asyncio.CancelledError:
             self._state = LoopState.CANCELLED
@@ -296,6 +322,16 @@ class AgentLoop:
         except Exception as e:
             self._state = LoopState.FAILED
             logger.error("AgentLoop: Task %s failed: %s", task_id, e)
+            # Issue #4308: notify Slack on task failure
+            duration = time.monotonic() - _task_start
+            await slack.post_task_completion(
+                task_id=task_id,
+                task_title=task_description[:80],
+                agent_name="AgentLoop",
+                summary=f"Task failed: {e}",
+                status="failed",
+                duration_seconds=duration,
+            )
             raise
 
         finally:
@@ -850,6 +886,19 @@ Duration: {self._current_context.get_duration_ms():.0f}ms
             "AgentLoop: approval required for tool '%s' (approval_id=%s)",
             tool_name,
             approval_id,
+        )
+
+        # Issue #4308: mirror approval request to Slack (fire-and-forget)
+        slack = get_slack_hook()
+        await slack.request_approval(
+            approval_id=approval_id,
+            title=f"Approval required: {tool_name}",
+            description=(
+                f"Tool '{tool_name}' is requesting authorization to perform a "
+                f"sensitive operation. Reply *approve* or *reject* in this thread."
+            ),
+            approval_type="tool",
+            requested_by="AgentLoop",
         )
 
         deadline = asyncio.get_event_loop().time() + self.config.approval_timeout_seconds

--- a/autobot-backend/agent_loop/slack_hook.py
+++ b/autobot-backend/agent_loop/slack_hook.py
@@ -1,0 +1,169 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Slack Notification Hook for AgentLoop (Issue #4308)
+
+Thin wrapper around SlackNotificationIntegration that:
+- Loads configuration from environment variables at first use (lazy)
+- Provides a no-op singleton when SLACK_BOT_TOKEN is absent
+- Exposes fire-and-forget helpers used by AgentLoop
+
+Environment variables:
+    SLACK_BOT_TOKEN           — Slack bot token (xoxb-…); required to enable
+    SLACK_NOTIFICATIONS_CHANNEL — Channel for task completion & status updates
+                                  (default: #agent-notifications)
+    SLACK_APPROVALS_CHANNEL   — Channel for approval request messages
+                                  (default: same as SLACK_NOTIFICATIONS_CHANNEL)
+"""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_SLACK_NOTIFICATIONS_CHANNEL_DEFAULT = "#agent-notifications"
+
+
+class _NullSlackHook:
+    """No-op hook returned when Slack is not configured."""
+
+    async def post_agent_status(
+        self, agent_name: str, status: str, message: str, thread_ts: Optional[str] = None
+    ) -> None:
+        pass
+
+    async def post_task_completion(
+        self,
+        task_id: str,
+        task_title: str,
+        agent_name: str,
+        summary: str,
+        status: str,
+        duration_seconds: float,
+    ) -> None:
+        pass
+
+    async def request_approval(
+        self,
+        approval_id: str,
+        title: str,
+        description: str,
+        approval_type: str = "tool",
+        requested_by: str = "AutoBot",
+    ) -> None:
+        pass
+
+
+class _SlackHook:
+    """Active hook backed by SlackNotificationIntegration."""
+
+    def __init__(self, token: str, notifications_channel: str, approvals_channel: str) -> None:
+        from integrations.base import IntegrationConfig
+        from integrations.slack_integration import SlackNotificationIntegration
+
+        config = IntegrationConfig(
+            name="agent-loop-slack",
+            provider="slack",
+            token=token,
+        )
+        self._integration = SlackNotificationIntegration(config)
+        self._notifications_channel = notifications_channel
+        self._approvals_channel = approvals_channel
+
+    async def post_agent_status(
+        self, agent_name: str, status: str, message: str, thread_ts: Optional[str] = None
+    ) -> None:
+        params: Dict[str, Any] = {
+            "channel": self._notifications_channel,
+            "agent_name": agent_name,
+            "status": status,
+            "message": message,
+        }
+        if thread_ts:
+            params["thread_ts"] = thread_ts
+        try:
+            await self._integration.post_agent_status(params)
+        except Exception as exc:
+            logger.debug("SlackHook.post_agent_status failed (non-critical): %s", exc)
+
+    async def post_task_completion(
+        self,
+        task_id: str,
+        task_title: str,
+        agent_name: str,
+        summary: str,
+        status: str,
+        duration_seconds: float,
+    ) -> None:
+        params: Dict[str, Any] = {
+            "channel": self._notifications_channel,
+            "task_id": task_id,
+            "task_title": task_title,
+            "agent_name": agent_name,
+            "summary": summary,
+            "status": status,
+            "duration_seconds": duration_seconds,
+        }
+        try:
+            await self._integration.post_task_completion(params)
+        except Exception as exc:
+            logger.debug("SlackHook.post_task_completion failed (non-critical): %s", exc)
+
+    async def request_approval(
+        self,
+        approval_id: str,
+        title: str,
+        description: str,
+        approval_type: str = "tool",
+        requested_by: str = "AutoBot",
+    ) -> None:
+        params: Dict[str, Any] = {
+            "channel": self._approvals_channel,
+            "approval_id": approval_id,
+            "title": title,
+            "description": description,
+            "approval_type": approval_type,
+            "requested_by": requested_by,
+        }
+        try:
+            await self._integration.request_approval(params)
+        except Exception as exc:
+            logger.debug("SlackHook.request_approval failed (non-critical): %s", exc)
+
+
+# Module-level singleton; resolved lazily on first call to get_slack_hook().
+_hook: Optional[Any] = None
+
+
+def get_slack_hook() -> Any:
+    """Return the module-level Slack hook singleton.
+
+    Reads SLACK_BOT_TOKEN from the environment.  Returns a _NullSlackHook
+    (all no-ops) when the token is absent so callers need no guard.
+    """
+    global _hook
+    if _hook is not None:
+        return _hook
+
+    token = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    if not token:
+        logger.debug("SLACK_BOT_TOKEN not set — Slack notifications disabled")
+        _hook = _NullSlackHook()
+        return _hook
+
+    notifications_channel = os.getenv(
+        "SLACK_NOTIFICATIONS_CHANNEL", _SLACK_NOTIFICATIONS_CHANNEL_DEFAULT
+    ).strip()
+    approvals_channel = os.getenv(
+        "SLACK_APPROVALS_CHANNEL", notifications_channel
+    ).strip()
+
+    logger.info(
+        "Slack notifications enabled (channel=%s, approvals=%s)",
+        notifications_channel,
+        approvals_channel,
+    )
+    _hook = _SlackHook(token, notifications_channel, approvals_channel)
+    return _hook


### PR DESCRIPTION
Closes #4308

## Summary

- Created `autobot-backend/agent_loop/slack_hook.py` — lazy singleton that reads `SLACK_BOT_TOKEN` from env; returns a `_NullSlackHook` (all no-ops) when absent, zero-impact on deployments without Slack configured
- Wired `AgentLoop.run_task()`: posts `started` status before execution, `completed`/`failed` after
- Wired `AgentLoop._request_approval()`: mirrors tool approval requests to Slack (informational, fire-and-forget)
- All Slack calls have internal `try/except` — failures are non-fatal (DEBUG logged), agent loop never blocked

## Test Status

Syntax verified (`py_compile`) and `flake8` passes on modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)