### PR TITLE
fix(chat): push local-only sessions to backend in bidirectional sync (#4431)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -825,6 +825,11 @@ const initializeChatInterface = async () => {
       // Explicitly check for error to distinguish API failures from empty responses
       if (data.chat_sessions && !data.chat_sessions.error && data.chat_sessions.data) {
         const sessions = data.chat_sessions.data
+        // Issue #4431: Push local-only sessions to backend before sync so they are
+        // not wiped by syncSessionsWithBackend. Only sessions with real messages are
+        // pushed (empty placeholders are skipped).
+        const backendIds = new Set<string>((sessions as Array<{ id: string }>).map(s => s.id))
+        await controller.pushLocalOnlySessions(backendIds)
         // Issue #4352: intentional_empty=true means the backend confirmed 0 sessions
         // is correct (user deleted all). Pass this through so syncSessionsWithBackend
         // can bypass the #4328 defensive guard and clear local sessions as intended.

--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -1053,6 +1053,40 @@ export class ChatController {
    * @param comment      - Optional human comment attached to the decision
    * @returns true if the decision was delivered to the WebSocket, false otherwise
    */
+  /**
+   * Issue #4431: Push local-only sessions to the backend before bidirectional sync.
+   *
+   * After receiving the backend session list, any local session that has real messages
+   * and is absent from the backend is POSTed (created + messages saved) so it survives
+   * the subsequent syncSessionsWithBackend() call.
+   *
+   * @param backendSessionIds - Set of session IDs already present on the backend
+   */
+  async pushLocalOnlySessions(backendSessionIds: Set<string>): Promise<void> {
+    const localOnly = this.chatStore.sessions.filter(
+      (s: ChatSession) => !backendSessionIds.has(s.id) && s.messages.length > 0
+    )
+    if (localOnly.length === 0) return
+
+    logger.debug(`[Issue #4431] Pushing ${localOnly.length} local-only session(s) to backend`)
+
+    await Promise.allSettled(
+      localOnly.map(async (session: ChatSession) => {
+        try {
+          await chatRepository.createNewChat(session.title)
+          await chatRepository.saveChatMessages({
+            chatId: session.id,
+            messages: session.messages,
+            name: session.title || ''
+          })
+          logger.debug(`[Issue #4431] Pushed local session ${session.id} to backend`)
+        } catch (error) {
+          logger.warn(`[Issue #4431] Failed to push local session ${session.id}:`, error)
+        }
+      })
+    )
+  }
+
   submitApprovalDecision(
     approvalId: string,
     approved: boolean,


### PR DESCRIPTION
Closes #4431

## Summary

- Added `ChatController.pushLocalOnlySessions(backendSessionIds: Set<string>)` — finds local sessions with messages absent from the backend set and POSTs them via `chatRepository.createNewChat()` + `saveChatMessages()`; uses `Promise.allSettled` so one failure doesn't block others
- In `ChatInterface.initializeChatInterface()`, calls `pushLocalOnlySessions()` before `syncSessionsWithBackend()` so local-only sessions are on the backend before sync runs and won't be wiped

## Test Status

No new TypeScript errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)