### PR TITLE
fix(analytics): fix implicit any in usePrometheusMetrics alertmanager filter (#4426)

### DIFF
--- a/autobot-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-frontend/src/composables/usePrometheusMetrics.ts
@@ -717,7 +717,7 @@ export function useAlerts(pollInterval = 30000) {
   const hasAlerts = computed(() => totalCount.value > 0)
   // Issue #474: Computed for AlertManager-specific alerts
   const alertmanagerAlerts = computed(() =>
-    alerts.value.filter(a => a.source === 'alertmanager')
+    alerts.value.filter((a: PerformanceAlert) => a.source === 'alertmanager')
   )
 
   function startPolling() {


### PR DESCRIPTION
Closes #4426

## Summary

- The main `usePrometheusMetrics.ts` fix (convert `response.ok`/`response.json()` to `api.get<T>()`) was already applied in PR #4407
- This commit adds the remaining fix: explicit `PerformanceAlert` type annotation on the `.filter()` callback parameter `a` at line 720, resolving the TS7006 implicit-any error

## Test Status

No `usePrometheusMetrics.ts` type errors remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)