### PR TITLE
fix(knowledge): add missing web/internet platform tool YAML definitions (#4428)

### DIFF
--- a/autobot-backend/resources/knowledge/tools/github_tools.yaml
+++ b/autobot-backend/resources/knowledge/tools/github_tools.yaml
@@ -1,0 +1,104 @@
+metadata:
+  category: github_tools
+  description: GitHub CLI and API tools for repository, issue, PR, and search operations
+  last_updated: "2024-01-01T00:00:00"
+  version: "1.0.0"
+
+tools:
+  - name: gh
+    type: github_cli
+    purpose: GitHub CLI for repository, issue, pull request, and search operations
+    installation:
+      apt: "sudo apt-get install gh  # or: curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && echo 'deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && sudo apt update && sudo apt install gh"
+      yum: "sudo dnf install 'dnf-command(config-manager)' && sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && sudo dnf install gh"
+      pacman: sudo pacman -S github-cli
+      brew: brew install gh
+    usage:
+      auth_login: "gh auth login"
+      repo_view: "gh repo view {owner}/{repo}"
+      repo_clone: "gh repo clone {owner}/{repo}"
+      issue_list: "gh issue list --repo {owner}/{repo}"
+      issue_view: "gh issue view {number} --repo {owner}/{repo}"
+      issue_create: "gh issue create --title '{title}' --body '{body}' --label '{label}'"
+      issue_close: "gh issue close {number}"
+      pr_list: "gh pr list --repo {owner}/{repo}"
+      pr_view: "gh pr view {number}"
+      pr_create: "gh pr create --title '{title}' --body '{body}' --base {branch}"
+      pr_merge: "gh pr merge {number} --squash"
+      search_repos: "gh search repos '{query}' --limit {n}"
+      search_issues: "gh search issues '{query}' --repo {owner}/{repo}"
+      search_code: "gh search code '{query}' --repo {owner}/{repo}"
+      api_call: "gh api {endpoint}"
+      release_list: "gh release list --repo {owner}/{repo}"
+    common_examples:
+      - description: View repository info
+        command: "gh repo view mrveiss/AutoBot-AI"
+        expected_output: "Repository description, stars, language, and recent activity"
+      - description: List open issues with labels
+        command: "gh issue list --repo mrveiss/AutoBot-AI --state open --label bug"
+        expected_output: "Table of open bug issues with number, title, and date"
+      - description: View issue details
+        command: "gh issue view 4428 --repo mrveiss/AutoBot-AI"
+        expected_output: "Full issue title, body, labels, assignees, and comments"
+      - description: Search code in a repository
+        command: "gh search code 'def get_redis_client' --repo mrveiss/AutoBot-AI"
+        expected_output: "Files and lines matching the search pattern"
+      - description: Create issue with labels
+        command: "gh issue create --title 'Bug: X fails' --body 'Steps...' --label bug --label 'priority: high'"
+        expected_output: "URL of the newly created issue"
+      - description: List open pull requests
+        command: "gh pr list --state open --base Dev_new_gui"
+        expected_output: "Table of open PRs targeting Dev_new_gui"
+      - description: Get file contents via API
+        command: "gh api repos/mrveiss/AutoBot-AI/contents/autobot-backend/api/usage.py --jq '.content' | base64 -d"
+        expected_output: "Raw file content decoded from base64"
+      - description: Search GitHub repositories by topic
+        command: "gh search repos 'agent framework' --topic python --limit 10"
+        expected_output: "List of matching repositories with stars and description"
+      - description: Add comment to issue
+        command: "gh issue comment 4428 --body 'Fixed in commit abc123'"
+        expected_output: "Comment posted to the issue"
+    troubleshooting:
+      - problem: "Not authenticated"
+        solution: "Run 'gh auth login' and follow prompts; or set GITHUB_TOKEN env var"
+      - problem: "GraphQL error on PR body update"
+        solution: "Use 'gh api repos/{owner}/{repo}/pulls/{n} -X PATCH -f body=...' instead of gh pr edit --body"
+      - problem: "Rate limit exceeded"
+        solution: "gh uses authenticated rate limits (5000/hr); check with 'gh api rate_limit'"
+      - problem: "gh issue close --comment not working"
+        solution: "Use 'gh issue close {n}' then 'gh issue comment {n} --body ...' as separate commands"
+    output_formats:
+      - "Default: human-readable table or detail view"
+      - "--json: JSON output for scripting"
+      - "--jq: JQ filter applied to JSON output"
+      - "--template: Go template formatting"
+    related_tools: ["git", "curl", "jq"]
+
+  - name: gh-api
+    type: github_rest_api
+    purpose: Direct GitHub REST API access via gh api for operations not covered by gh subcommands
+    installation:
+      system: Included with gh CLI
+    usage:
+      get_resource: "gh api {path}"
+      patch_resource: "gh api {path} -X PATCH -f {field}='{value}'"
+      post_resource: "gh api {path} -X POST -F {field}='{value}'"
+      paginate: "gh api --paginate {path}"
+      jq_filter: "gh api {path} --jq '{filter}'"
+    common_examples:
+      - description: Get repository details as JSON
+        command: "gh api repos/mrveiss/AutoBot-AI"
+        expected_output: "Full repository JSON including private fields"
+      - description: List all issues with pagination
+        command: "gh api --paginate repos/mrveiss/AutoBot-AI/issues --jq '.[].number'"
+        expected_output: "All issue numbers, across multiple pages"
+      - description: Update PR body (workaround for gh pr edit GraphQL bug)
+        command: "gh api repos/mrveiss/AutoBot-AI/pulls/123 -X PATCH -f body='New description'"
+        expected_output: "Updated PR JSON"
+      - description: Add label to issue
+        command: "gh api repos/mrveiss/AutoBot-AI/issues/4428/labels -X POST -f 'labels[]=bug'"
+        expected_output: "Current labels on the issue"
+      - description: Get rate limit status
+        command: "gh api rate_limit --jq '.rate'"
+        expected_output: "JSON with limit, remaining, and reset timestamp"
+    related_tools: ["gh", "curl", "jq"]

--- a/autobot-backend/resources/knowledge/tools/rss_tools.yaml
+++ b/autobot-backend/resources/knowledge/tools/rss_tools.yaml
@@ -1,0 +1,69 @@
+metadata:
+  category: rss_tools
+  description: RSS and Atom feed parsing and monitoring tools
+  last_updated: "2024-01-01T00:00:00"
+  version: "1.0.0"
+
+tools:
+  - name: feedparser
+    type: feed_parser
+    purpose: Parse RSS and Atom feeds programmatically via Python library
+    installation:
+      pip: pip install feedparser
+      apt: sudo apt-get install python3-feedparser
+      yum: sudo yum install python3-feedparser
+    usage:
+      parse_feed: "python3 -c \"import feedparser; d = feedparser.parse('{url}'); print([e.title for e in d.entries])\""
+      fetch_entries: "python3 -c \"import feedparser, json; d = feedparser.parse('{url}'); print(json.dumps([{'title': e.title, 'link': e.link, 'published': e.get('published', '')} for e in d.entries[:10]], indent=2))\""
+      feed_info: "python3 -c \"import feedparser; d = feedparser.parse('{url}'); print(d.feed.title, d.feed.get('description', ''))\""
+    common_examples:
+      - description: List titles from an RSS feed
+        command: "python3 -c \"import feedparser; d = feedparser.parse('https://news.ycombinator.com/rss'); print('\\n'.join(e.title for e in d.entries[:10]))\""
+        expected_output: "Top 10 Hacker News story titles"
+      - description: Get entries as JSON with metadata
+        command: "python3 -c \"import feedparser, json; d = feedparser.parse('https://feeds.feedburner.com/TechCrunch'); print(json.dumps([{'title': e.title, 'link': e.link, 'published': e.get('published', '')} for e in d.entries[:5]], indent=2))\""
+        expected_output: "JSON array of 5 most recent entries with title, link, date"
+      - description: Check feed type and channel info
+        command: "python3 -c \"import feedparser; d = feedparser.parse('{url}'); print('Version:', d.version, '\\nTitle:', d.feed.get('title'))\""
+        expected_output: "Feed version (rss20, atom10, etc.) and channel title"
+      - description: Get full entry content
+        command: "python3 -c \"import feedparser; d = feedparser.parse('{url}'); e = d.entries[0]; print(e.get('summary', e.get('description', 'No content')))\""
+        expected_output: "HTML or text summary of the first entry"
+    troubleshooting:
+      - problem: "Empty entries list"
+        solution: "Check d.bozo and d.bozo_exception for parse errors; feed may be malformed"
+      - problem: "Feed requires authentication"
+        solution: "Use feedparser.parse(url, handlers=[auth_handler]) or pass credentials in URL"
+      - problem: "SSL certificate error"
+        solution: "feedparser respects system SSL; use requests with verify=False and pass response to feedparser.parse(text)"
+      - problem: "Entry date missing"
+        solution: "Use e.get('published', e.get('updated', '')) for fallback; not all feeds include dates"
+    entry_fields:
+      - "title: Entry headline"
+      - "link: URL to full article"
+      - "summary / description: Entry excerpt or full text"
+      - "published / updated: Date string"
+      - "author: Author name"
+      - "tags: List of category/tag objects"
+      - "content: Full content (Atom feeds)"
+    related_tools: ["atoma", "wget", "curl", "jina-reader"]
+
+  - name: atoma
+    type: feed_parser
+    purpose: Lightweight RSS/Atom feed parser with typed Python objects
+    installation:
+      pip: pip install atoma
+    usage:
+      parse_atom: "python3 -c \"import atoma, requests; feed = atoma.parse_atom_bytes(requests.get('{url}').content); print([e.title.value for e in feed.entries])\""
+      parse_rss: "python3 -c \"import atoma, requests; feed = atoma.parse_rss_bytes(requests.get('{url}').content); print([i.title for i in feed.channel.items])\""
+    common_examples:
+      - description: Parse Atom feed entries
+        command: "python3 -c \"import atoma, requests; feed = atoma.parse_atom_bytes(requests.get('https://github.com/mrveiss/AutoBot-AI/releases.atom').content); print([e.title.value for e in feed.entries[:5]])\""
+        expected_output: "Last 5 GitHub release names"
+      - description: Parse RSS feed items
+        command: "python3 -c \"import atoma, requests; feed = atoma.parse_rss_bytes(requests.get('https://news.ycombinator.com/rss').content); print([i.title for i in feed.channel.items[:5]])\""
+        expected_output: "Top 5 Hacker News story titles"
+    troubleshooting:
+      - problem: "ParseError for mixed RSS/Atom feeds"
+        solution: "Try feedparser instead — it auto-detects format and handles malformed feeds better"
+    related_tools: ["feedparser", "curl", "requests"]

--- a/autobot-backend/resources/knowledge/tools/video_tools.yaml
+++ b/autobot-backend/resources/knowledge/tools/video_tools.yaml
@@ -1,0 +1,94 @@
+metadata:
+  category: video_tools
+  description: Video downloading, transcript extraction, and media metadata tools
+  last_updated: "2024-01-01T00:00:00"
+  version: "1.0.0"
+
+tools:
+  - name: yt-dlp
+    type: video_downloader
+    purpose: Download videos and extract transcripts/metadata from YouTube, Bilibili, and 1000+ sites
+    installation:
+      apt: sudo apt-get install yt-dlp
+      pip: pip install yt-dlp
+      pipx: pipx install yt-dlp
+      brew: brew install yt-dlp
+    usage:
+      download_video: "yt-dlp {url}"
+      audio_only: "yt-dlp -x --audio-format mp3 {url}"
+      list_formats: "yt-dlp -F {url}"
+      download_format: "yt-dlp -f {format_id} {url}"
+      get_transcript: "yt-dlp --write-auto-sub --sub-lang en --skip-download {url}"
+      get_metadata: "yt-dlp --dump-json --no-download {url}"
+      search_youtube: "yt-dlp 'ytsearch{count}:{query}' --get-id"
+      transcript_srt: "yt-dlp --write-sub --sub-lang en --sub-format srt --skip-download {url}"
+    common_examples:
+      - description: Extract English transcript without downloading video
+        command: "yt-dlp --write-auto-sub --sub-lang en --skip-download 'https://www.youtube.com/watch?v=VIDEO_ID'"
+        expected_output: "Creates .vtt subtitle file with timestamped transcript"
+      - description: Get full video metadata as JSON
+        command: "yt-dlp --dump-json --no-download 'https://www.youtube.com/watch?v=VIDEO_ID'"
+        expected_output: "JSON with title, description, duration, uploader, view_count, etc."
+      - description: Search YouTube and get top result IDs
+        command: "yt-dlp 'ytsearch5:python asyncio tutorial' --get-id"
+        expected_output: "5 YouTube video IDs for the search query"
+      - description: Download best quality audio
+        command: "yt-dlp -x --audio-format mp3 -o '%(title)s.%(ext)s' {url}"
+        expected_output: "MP3 file named after video title"
+      - description: Download specific format
+        command: "yt-dlp -f 'bestvideo[height<=720]+bestaudio/best[height<=720]' {url}"
+        expected_output: "720p video with best available audio"
+      - description: Extract transcript from Bilibili video
+        command: "yt-dlp --write-auto-sub --sub-lang zh-Hans --skip-download 'https://www.bilibili.com/video/BV{id}'"
+        expected_output: "Chinese subtitle/transcript file for Bilibili video"
+    troubleshooting:
+      - problem: "Video unavailable or geo-blocked"
+        solution: "Use --proxy {proxy_url} or --geo-bypass flags"
+      - problem: "No subtitles available"
+        solution: "Try --write-auto-sub for auto-generated captions; not all videos have manual subs"
+      - problem: "yt-dlp out of date — extractor fails"
+        solution: "Run 'yt-dlp -U' to self-update to latest version"
+      - problem: "Rate limiting from YouTube"
+        solution: "Use --sleep-interval 2 --max-sleep-interval 5 to slow down requests"
+      - problem: "Cookies needed for age-gated content"
+        solution: "Use --cookies-from-browser firefox or --cookies cookies.txt"
+    output_formats:
+      - "Video: mp4, mkv, webm"
+      - "Audio: mp3, m4a, opus, wav"
+      - "Subtitles: vtt, srt, ass"
+      - "Metadata: JSON (--dump-json)"
+    supported_sites:
+      - "YouTube, YouTube Music, YouTube Shorts"
+      - "Bilibili (Chinese video platform)"
+      - "Vimeo, Dailymotion, Twitch"
+      - "Twitter/X, TikTok, Instagram"
+      - "1000+ other sites"
+    security_notes:
+      - "Respect copyright and platform terms of service"
+      - "Downloaded content may be subject to DRM restrictions"
+    related_tools: ["ffmpeg", "ffprobe", "gallery-dl"]
+
+  - name: ffprobe
+    type: media_inspector
+    purpose: Extract metadata and stream information from video/audio files
+    installation:
+      apt: sudo apt-get install ffmpeg
+      yum: sudo yum install ffmpeg
+      pacman: sudo pacman -S ffmpeg
+      brew: brew install ffmpeg
+    usage:
+      basic_info: "ffprobe {file}"
+      json_output: "ffprobe -v quiet -print_format json -show_format -show_streams {file}"
+      duration: "ffprobe -v quiet -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 {file}"
+      streams: "ffprobe -v quiet -print_format json -show_streams {file}"
+    common_examples:
+      - description: Get full metadata as JSON
+        command: "ffprobe -v quiet -print_format json -show_format -show_streams video.mp4"
+        expected_output: "JSON with duration, bitrate, codec, resolution, and stream details"
+      - description: Get only duration in seconds
+        command: "ffprobe -v quiet -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 video.mp4"
+        expected_output: "123.456789 (duration in seconds)"
+      - description: List all streams
+        command: "ffprobe -v quiet -print_format json -show_streams video.mkv"
+        expected_output: "JSON array of video, audio, and subtitle streams"
+    related_tools: ["ffmpeg", "yt-dlp", "mediainfo"]

--- a/autobot-backend/resources/knowledge/tools/web_fetch.yaml
+++ b/autobot-backend/resources/knowledge/tools/web_fetch.yaml
@@ -1,0 +1,111 @@
+metadata:
+  category: web_fetch
+  description: Web page fetching, content extraction, and HTTP request tools
+  last_updated: "2024-01-01T00:00:00"
+  version: "1.0.0"
+
+tools:
+  - name: jina-reader
+    type: web_content_extractor
+    purpose: Extract clean markdown content from any URL via Jina Reader API
+    installation:
+      system: No installation required — uses curl with r.jina.ai prefix
+    usage:
+      fetch_url: "curl -s 'https://r.jina.ai/{url}'"
+      fetch_with_header: "curl -s -H 'Accept: application/json' 'https://r.jina.ai/{url}'"
+      fetch_raw: "curl -s -H 'X-Return-Format: text' 'https://r.jina.ai/{url}'"
+    common_examples:
+      - description: Fetch a web page as clean markdown
+        command: "curl -s 'https://r.jina.ai/https://example.com/article'"
+        expected_output: "Clean markdown version of the article without ads/nav"
+      - description: Fetch with JSON response metadata
+        command: "curl -s -H 'Accept: application/json' 'https://r.jina.ai/https://docs.python.org/3/library/asyncio.html'"
+        expected_output: "JSON with title, url, content, and description fields"
+      - description: Return plain text only
+        command: "curl -s -H 'X-Return-Format: text' 'https://r.jina.ai/https://example.com'"
+        expected_output: "Plain text content without markdown formatting"
+    troubleshooting:
+      - problem: "Rate limit exceeded"
+        solution: "Add JINA_API_KEY header for higher rate limits: -H 'Authorization: Bearer {key}'"
+      - problem: "Content truncated"
+        solution: "Some pages with heavy JavaScript may not render fully; try wget or httpx fallback"
+      - problem: "SSL certificate error"
+        solution: "Use -k flag to skip verification only for trusted internal URLs"
+    related_tools: ["wget", "httpx", "curl"]
+    performance_notes:
+      - "Jina Reader is the preferred fast-path for text extraction from public URLs"
+      - "Response time is typically 1-3 seconds for most pages"
+      - "Caches results; repeated requests for same URL are faster"
+
+  - name: wget
+    type: web_downloader
+    purpose: Download files and web pages from HTTP/HTTPS/FTP URLs
+    installation:
+      apt: sudo apt-get install wget
+      yum: sudo yum install wget
+      pacman: sudo pacman -S wget
+      brew: brew install wget
+    usage:
+      download_file: "wget {url}"
+      output_file: "wget -O {filename} {url}"
+      quiet_output: "wget -q -O {filename} {url}"
+      stdout: "wget -q -O - {url}"
+      recursive: "wget -r -l {depth} {url}"
+      user_agent: "wget -U '{user_agent}' {url}"
+    common_examples:
+      - description: Download a file to current directory
+        command: "wget https://example.com/file.tar.gz"
+        expected_output: "Downloads file with progress bar"
+      - description: Fetch page content to stdout
+        command: "wget -q -O - https://example.com/page.html"
+        expected_output: "Raw HTML content printed to stdout"
+      - description: Download with custom User-Agent
+        command: "wget -U 'Mozilla/5.0' -q -O page.html https://example.com"
+        expected_output: "HTML page saved as page.html"
+      - description: Mirror site with depth limit
+        command: "wget -r -l 2 --no-parent https://docs.example.com/"
+        expected_output: "Recursive download up to 2 levels deep"
+    troubleshooting:
+      - problem: "SSL certificate error"
+        solution: "Use --no-check-certificate for known-trusted self-signed certs only"
+      - problem: "403 Forbidden"
+        solution: "Set User-Agent with -U flag to mimic a browser"
+      - problem: "Redirect loop"
+        solution: "Increase --max-redirect or use --trust-server-names"
+    security_notes:
+      - "Verify checksums after downloading sensitive files"
+      - "Avoid --no-check-certificate for untrusted sources"
+    related_tools: ["curl", "httpx", "jina-reader"]
+
+  - name: httpx
+    type: http_client
+    purpose: Fast async HTTP client for fetching URLs with rich output options
+    installation:
+      pip: pip install httpx[cli]
+      pipx: pipx install httpx[cli]
+    usage:
+      get_url: "httpx {url}"
+      json_output: "httpx {url} --json"
+      headers_only: "httpx {url} --headers"
+      follow_redirects: "httpx {url} --follow-redirects"
+      timeout: "httpx {url} --timeout {seconds}"
+      post: "httpx {url} -m POST -d '{data}'"
+    common_examples:
+      - description: Fetch URL with formatted output
+        command: "httpx https://api.example.com/data"
+        expected_output: "Response body with status and headers summary"
+      - description: Get JSON API response
+        command: "httpx https://api.example.com/v1/status --json"
+        expected_output: "Pretty-printed JSON response"
+      - description: Check redirect chain
+        command: "httpx https://short.url/abc --follow-redirects"
+        expected_output: "Final destination URL and response"
+      - description: POST with JSON body
+        command: "httpx https://api.example.com/submit -m POST -d '{\"key\":\"value\"}' -H 'Content-Type: application/json'"
+        expected_output: "Server response to POST request"
+    troubleshooting:
+      - problem: "SSL verification failed"
+        solution: "Use --verify false only for trusted internal endpoints"
+      - problem: "Connection timeout"
+        solution: "Increase --timeout value (default is 5 seconds)"
+    related_tools: ["curl", "wget", "requests", "jina-reader"]

--- a/autobot-backend/resources/knowledge/tools/web_search.yaml
+++ b/autobot-backend/resources/knowledge/tools/web_search.yaml
@@ -1,0 +1,90 @@
+metadata:
+  category: web_search
+  description: Web search tools for finding information, code, and research content
+  last_updated: "2024-01-01T00:00:00"
+  version: "1.0.0"
+
+tools:
+  - name: exa
+    type: web_search_api
+    purpose: Neural web search API optimized for AI agents — returns clean, structured results
+    installation:
+      pip: pip install exa-py
+      npm: npm install exa-js
+    usage:
+      search: "python3 -c \"from exa_py import Exa; exa = Exa('{api_key}'); results = exa.search('{query}', num_results=5); print([r.url for r in results.results])\""
+      search_with_contents: "python3 -c \"from exa_py import Exa; exa = Exa('{api_key}'); results = exa.search_and_contents('{query}', num_results=3, text=True); print([(r.url, r.text[:500]) for r in results.results])\""
+      find_similar: "python3 -c \"from exa_py import Exa; exa = Exa('{api_key}'); results = exa.find_similar('{url}', num_results=5); print([r.url for r in results.results])\""
+      get_contents: "python3 -c \"from exa_py import Exa; exa = Exa('{api_key}'); result = exa.get_contents(['{url}'], text=True); print(result.results[0].text)\""
+    common_examples:
+      - description: Search for recent articles on a topic
+        command: "python3 -c \"from exa_py import Exa; exa = Exa(api_key); r = exa.search('python asyncio best practices 2024', num_results=5, use_autoprompt=True); print('\\n'.join(f'{x.title}: {x.url}' for x in r.results))\""
+        expected_output: "5 relevant article titles and URLs"
+      - description: Search and retrieve full text content
+        command: "python3 -c \"from exa_py import Exa; exa = Exa(api_key); r = exa.search_and_contents('FastAPI dependency injection', num_results=3, text=True); print(r.results[0].text[:1000])\""
+        expected_output: "First 1000 chars of the most relevant article"
+      - description: Find pages similar to a reference URL
+        command: "python3 -c \"from exa_py import Exa; exa = Exa(api_key); r = exa.find_similar('https://docs.python.org/3/library/asyncio.html', num_results=5); print([x.url for x in r.results])\""
+        expected_output: "5 URLs similar to the Python asyncio docs"
+      - description: Fetch clean content from a known URL
+        command: "python3 -c \"from exa_py import Exa; exa = Exa(api_key); r = exa.get_contents(['https://example.com/article'], text=True); print(r.results[0].text)\""
+        expected_output: "Clean text content of the article"
+    troubleshooting:
+      - problem: "API key not set"
+        solution: "Set EXA_API_KEY environment variable or pass directly; get key at exa.ai"
+      - problem: "Results not relevant"
+        solution: "Use use_autoprompt=True for neural query enhancement, or be more specific"
+      - problem: "Rate limit error"
+        solution: "Exa free tier has limits; add retry logic with exponential backoff"
+    configuration:
+      env_var: EXA_API_KEY
+      base_url: "https://api.exa.ai"
+    related_tools: ["jina-reader", "wget", "feedparser"]
+
+  - name: mcporter
+    type: mcp_search_bridge
+    purpose: MCP (Model Context Protocol) bridge providing web search to AutoBot agents
+    installation:
+      system: Installed as part of AutoBot infrastructure via Ansible
+    usage:
+      search: "Access via MCP tool call: search(query='{query}', num_results={n})"
+      news_search: "Access via MCP tool call: search(query='{query}', category='news')"
+    common_examples:
+      - description: General web search via MCP
+        command: "MCP tool call: search(query='latest Python 3.13 features', num_results=5)"
+        expected_output: "Structured list of search results with title, URL, and snippet"
+      - description: News search via MCP
+        command: "MCP tool call: search(query='AI agent frameworks 2024', category='news')"
+        expected_output: "Recent news articles on the topic"
+    notes:
+      - "mcporter is the preferred search tool for AutoBot agents — uses Exa backend"
+      - "Direct Exa API access should be used as fallback when MCP is unavailable"
+      - "Results are returned as structured MCP tool response objects"
+    related_tools: ["exa", "jina-reader"]
+
+  - name: duckduckgo-search
+    type: web_search_library
+    purpose: Fallback web search via DuckDuckGo (no API key required)
+    installation:
+      pip: pip install duckduckgo-search
+    usage:
+      text_search: "python3 -c \"from duckduckgo_search import DDGS; results = DDGS().text('{query}', max_results=5); print(results)\""
+      news_search: "python3 -c \"from duckduckgo_search import DDGS; results = DDGS().news('{query}', max_results=5); print(results)\""
+      image_search: "python3 -c \"from duckduckgo_search import DDGS; results = DDGS().images('{query}', max_results=5); print([r['image'] for r in results])\""
+    common_examples:
+      - description: Search for text results
+        command: "python3 -c \"from duckduckgo_search import DDGS; [print(r['title'], r['href']) for r in DDGS().text('FastAPI tutorial', max_results=5)]\""
+        expected_output: "5 search results with title and URL"
+      - description: Search recent news
+        command: "python3 -c \"from duckduckgo_search import DDGS; [print(r['title'], r['url']) for r in DDGS().news('AI news today', max_results=5)]\""
+        expected_output: "5 recent news articles with title and URL"
+    troubleshooting:
+      - problem: "RatelimitException"
+        solution: "Add sleep between queries; DuckDuckGo rate limits aggressive scraping"
+      - problem: "No results returned"
+        solution: "Try simpler query or different terms; DDG may block unusual patterns"
+    notes:
+      - "No API key required — useful as anonymous fallback"
+      - "Prefer Exa/mcporter for better result quality in agent contexts"
+      - "Rate limits are stricter than paid search APIs"
+    related_tools: ["exa", "mcporter", "jina-reader"]


### PR DESCRIPTION
Closes #4428

## Summary

Created 5 missing YAML tool definition files in `autobot-backend/resources/knowledge/tools/`:

| File | Tools covered |
|------|--------------|
| `web_fetch.yaml` | jina-reader, wget, httpx |
| `video_tools.yaml` | yt-dlp, ffprobe |
| `github_tools.yaml` | gh CLI, gh-api REST |
| `rss_tools.yaml` | feedparser, atoma |
| `web_search.yaml` | exa, mcporter, duckduckgo-search |

12 tools total, 468 lines. All files follow the existing schema and validated with `yaml.safe_load()`.

## Test Status

All 5 YAML files parse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)