### PR TITLE
fix(a2a): use attribute access on LLMResponse in task_executor (#4501)

### DIFF
--- a/autobot-backend/a2a/task_executor.py
+++ b/autobot-backend/a2a/task_executor.py
@@ -19,8 +19,11 @@ logger = logging.getLogger(__name__)
 
 
 def _extract_response_text(result: Dict[str, Any]) -> str:
-    """Pull the human-readable response from an orchestrator result dict."""
-    for key in ("response", "message", "text", "output"):
+    """Pull the human-readable response from an orchestrator result dict.
+
+    Issue #4501: include "response_text" key used by ChatAgent._build_success_response.
+    """
+    for key in ("response", "response_text", "message", "text", "output"):
         value = result.get(key)
         if value and isinstance(value, str):
             return value
@@ -29,7 +32,7 @@ def _extract_response_text(result: Dict[str, Any]) -> str:
 
 def _extract_routing_metadata(result: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Extract non-response metadata (agent used, timing, etc.) from result."""
-    skip = {"response", "message", "text", "output"}
+    skip = {"response", "response_text", "message", "text", "output"}
     meta = {k: v for k, v in result.items() if k not in skip}
     return meta if meta else None
 

--- a/autobot-backend/agents/chat_agent.py
+++ b/autobot-backend/agents/chat_agent.py
@@ -88,19 +88,25 @@ class ChatAgent(StandardizedAgent):
         return self.capabilities.copy()
 
     def _build_success_response(
-        self, response_text: str, response: Dict[str, Any]
+        self, response_text: str, response: Any
     ) -> Dict[str, Any]:
         """
         Build success response dictionary for chat message processing.
 
         Issue #620.
+        Issue #4501: response is an LLMResponse object — use attribute access.
         """
+        if isinstance(response, dict):
+            token_usage = response.get("usage", {})
+        else:
+            token_usage = getattr(response, "usage", {})
         return {
             "status": "success",
+            "response": response_text,
             "response_text": response_text,
             "agent_type": "chat",
             "model_used": self.model_name,
-            "token_usage": response.get("usage", {}),
+            "token_usage": token_usage,
             "metadata": {
                 "agent": "ChatAgent",
                 "processing_time": "fast",
@@ -244,8 +250,17 @@ For complex technical tasks, analysis, or system commands, you should "
         return choice["message"]["content"].strip()
 
     def _extract_response_content(self, response: Any) -> str:
-        """Extract the actual text content from LLM response."""
+        """Extract the actual text content from LLM response.
+
+        Issue #4501: handle LLMResponse objects via .content attribute.
+        """
         try:
+            # LLMResponse dataclass — use .content attribute directly
+            if hasattr(response, "content") and not isinstance(response, dict):
+                content = getattr(response, "content", None)
+                if content and isinstance(content, str):
+                    return content.strip()
+
             if isinstance(response, dict):
                 # Try message content first
                 content = self._try_extract_message_content(response)


### PR DESCRIPTION
Closes #4501

## Summary
- `chat_agent.py`: `_build_success_response` and `_extract_response_content` now access `LLMResponse` fields via attribute access (`response.usage`, `response.content`) instead of dict `.get()` calls; return dict includes both `response` and `response_text` keys
- `task_executor.py`: `_extract_response_text` and `_extract_routing_metadata` now include `response_text` in their key sets so ChatAgent responses are correctly extracted as artifacts

## Test Status
PASS — linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)