### PR TITLE
fix(a2a): replace in-process task store with Redis for worker isolation (#4502)

### DIFF
--- a/autobot-backend/a2a/a2a_test.py
+++ b/autobot-backend/a2a/a2a_test.py
@@ -5,10 +5,11 @@
 A2A Protocol Unit Tests
 
 Issue #961: Tests for types, agent_card builder, and task_manager.
+Issue #4502: TaskManager tests now mock Redis instead of the in-process dict.
 Uses no network connections and no external dependencies.
 """
 
-import asyncio
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -141,14 +142,71 @@ class TestBuildAgentCard:
 
 
 # ---------------------------------------------------------------------------
+# Redis mock fixture
+# ---------------------------------------------------------------------------
+
+
+def _make_redis_mock():
+    """Return a MagicMock that mimics the subset of redis.Redis used by TaskManager."""
+    store: dict = {}
+    audit_lists: dict = {}
+    task_set: set = set()
+
+    mock = MagicMock()
+
+    def _set(key, value, ex=None):
+        store[key] = value if isinstance(value, str) else value.decode("utf-8")
+
+    def _get(key):
+        v = store.get(key)
+        return v.encode("utf-8") if v is not None else None
+
+    def _sadd(key, member):
+        task_set.add(member if isinstance(member, str) else member.decode("utf-8"))
+
+    def _srem(key, member):
+        task_set.discard(member if isinstance(member, str) else member.decode("utf-8"))
+
+    def _smembers(key):
+        return {m.encode("utf-8") for m in task_set}
+
+    def _rpush(key, value):
+        audit_lists.setdefault(key, []).append(
+            value if isinstance(value, str) else value.decode("utf-8")
+        )
+
+    def _lrange(key, start, end):
+        entries = audit_lists.get(key, [])
+        result = entries[start : end + 1 if end != -1 else None]
+        return [e.encode("utf-8") for e in result]
+
+    def _expire(key, ttl):
+        pass  # TTL not needed in unit tests
+
+    mock.set.side_effect = _set
+    mock.get.side_effect = _get
+    mock.sadd.side_effect = _sadd
+    mock.srem.side_effect = _srem
+    mock.smembers.side_effect = _smembers
+    mock.rpush.side_effect = _rpush
+    mock.lrange.side_effect = _lrange
+    mock.expire.side_effect = _expire
+
+    return mock
+
+
+# ---------------------------------------------------------------------------
 # TaskManager tests
 # ---------------------------------------------------------------------------
 
 
 class TestTaskManager:
     def setup_method(self):
-        """Fresh manager for each test."""
-        self.mgr = TaskManager()
+        """Fresh manager with mocked Redis for each test."""
+        with patch(
+            "a2a.task_manager.get_redis_client", return_value=_make_redis_mock()
+        ):
+            self.mgr = TaskManager()
 
     def test_create_task_returns_task(self):
         task = self.mgr.create_task("Summarize this document")
@@ -256,114 +314,85 @@ class TestTaskManager:
         fetched = self.mgr.get_task(task.id)
         assert fetched.context == ctx
 
+    def test_get_audit_log(self):
+        task = self.mgr.create_task("Audit me", caller_id="user:test")
+        self.mgr.update_state(task.id, TaskState.WORKING)
+        log = self.mgr.get_audit_log(task.id)
+        assert log is not None
+        assert len(log) >= 2  # task.submitted + task.state_transition
+        events = [e["event"] for e in log]
+        assert "task.submitted" in events
+        assert "task.state_transition" in events
+
+    def test_get_audit_log_missing_task_returns_none(self):
+        assert self.mgr.get_audit_log("nonexistent") is None
+
 
 # ---------------------------------------------------------------------------
-# Issue #3823: Task eviction after TTL
+# Issue #4502: TTL eviction — Redis TTL handles expiry; test via mock deletion
 # ---------------------------------------------------------------------------
 
 
 class TestTaskManagerEviction:
-    """Verify that terminal tasks are evicted from _tasks after the TTL expires."""
+    """Verify that expired tasks are no longer visible (Redis TTL handles eviction).
+
+    Issue #4502: Eviction is now delegated to Redis key expiry instead of
+    asyncio-scheduled coroutines.  These tests simulate key expiry by removing
+    the key from the mock store directly, matching the real Redis behaviour.
+    """
 
     def setup_method(self):
-        self.mgr = TaskManager()
+        self._redis_mock = _make_redis_mock()
+        with patch(
+            "a2a.task_manager.get_redis_client", return_value=self._redis_mock
+        ):
+            self.mgr = TaskManager()
 
-    @pytest.mark.asyncio
-    async def test_completed_task_evicted_after_ttl(self) -> None:
-        """A task that reaches COMPLETED is removed from _tasks after the TTL."""
+    def test_completed_task_visible_before_expiry(self):
         task = self.mgr.create_task("Eviction test")
         self.mgr.update_state(task.id, TaskState.WORKING)
         self.mgr.update_state(task.id, TaskState.COMPLETED)
-
-        # Still present immediately after transition
+        # Still present before TTL fires
         assert self.mgr.get_task(task.id) is not None
 
-        # Override TTL to near-zero so the test is fast
-        handle = self.mgr._eviction_handles.get(task.id)
-        assert handle is not None, "Eviction handle must be scheduled"
+    def test_task_invisible_after_redis_key_expires(self):
+        """Simulate Redis TTL expiry by deleting the key from the mock store."""
+        task = self.mgr.create_task("Expiry test")
+        self.mgr.update_state(task.id, TaskState.COMPLETED)
+        assert self.mgr.get_task(task.id) is not None
 
-        # Cancel the real handle and inject a fast one
-        handle.cancel()
-        async def _fast_evict():
-            await asyncio.sleep(0.01)
-            self.mgr._tasks.pop(task.id, None)
-            self.mgr._eviction_handles.pop(task.id, None)
+        # Simulate Redis key expiry (as the real Redis TTL would do)
+        from a2a.task_manager import _KEY_TASK
 
-        self.mgr._eviction_handles[task.id] = asyncio.create_task(_fast_evict())
-        await asyncio.sleep(0.05)
+        key = _KEY_TASK.format(task.id)
+        # Bypass mock to force a None return for this key
+        original_get = self._redis_mock.get.side_effect
 
-        assert self.mgr.get_task(task.id) is None, "Task must be evicted after TTL"
+        def expired_get(k):
+            if k == key:
+                return None
+            return original_get(k)
 
-    @pytest.mark.asyncio
-    async def test_failed_task_evicted_after_ttl(self) -> None:
-        """A task that reaches FAILED is removed from _tasks after the TTL."""
+        self._redis_mock.get.side_effect = expired_get
+        assert self.mgr.get_task(task.id) is None
+
+    def test_failed_task_visible_before_expiry(self):
         task = self.mgr.create_task("Failing task")
         self.mgr.update_state(task.id, TaskState.WORKING)
         self.mgr.update_state(task.id, TaskState.FAILED, message="timeout")
+        assert self.mgr.get_task(task.id) is not None
+        assert self.mgr.get_task(task.id).status.state == TaskState.FAILED
 
-        handle = self.mgr._eviction_handles.get(task.id)
-        assert handle is not None
-
-        handle.cancel()
-        async def _fast_evict():
-            await asyncio.sleep(0.01)
-            self.mgr._tasks.pop(task.id, None)
-            self.mgr._eviction_handles.pop(task.id, None)
-
-        self.mgr._eviction_handles[task.id] = asyncio.create_task(_fast_evict())
-        await asyncio.sleep(0.05)
-
-        assert self.mgr.get_task(task.id) is None
-
-    @pytest.mark.asyncio
-    async def test_cancelled_task_evicted_after_ttl(self) -> None:
-        """A cancelled task is removed from _tasks after the TTL."""
+    def test_cancelled_task_visible_before_expiry(self):
         task = self.mgr.create_task("Cancel-eviction test")
         self.mgr.cancel_task(task.id)
+        assert self.mgr.get_task(task.id) is not None
+        assert self.mgr.get_task(task.id).status.state == TaskState.CANCELLED
 
-        handle = self.mgr._eviction_handles.get(task.id)
-        assert handle is not None
-
-        handle.cancel()
-        async def _fast_evict():
-            await asyncio.sleep(0.01)
-            self.mgr._tasks.pop(task.id, None)
-            self.mgr._eviction_handles.pop(task.id, None)
-
-        self.mgr._eviction_handles[task.id] = asyncio.create_task(_fast_evict())
-        await asyncio.sleep(0.05)
-
-        assert self.mgr.get_task(task.id) is None
-
-    @pytest.mark.asyncio
-    async def test_task_queryable_before_ttl_expires(self) -> None:
+    def test_terminal_task_still_queryable_immediately(self):
         """A terminal task must still be queryable immediately after transition."""
         task = self.mgr.create_task("Query before TTL")
         self.mgr.update_state(task.id, TaskState.COMPLETED)
-
-        # Cancel eviction so the task stays in store for this assertion
-        handle = self.mgr._eviction_handles.get(task.id)
-        if handle:
-            handle.cancel()
-
         fetched = self.mgr.get_task(task.id)
         assert fetched is not None
         assert fetched.status.state == TaskState.COMPLETED
-
-    @pytest.mark.asyncio
-    async def test_duplicate_terminal_transition_resets_eviction_clock(self) -> None:
-        """Calling update_state on an already-terminal task does not create a second handle."""
-        task = self.mgr.create_task("Double terminal")
-        self.mgr.update_state(task.id, TaskState.COMPLETED)
-        first_handle = self.mgr._eviction_handles.get(task.id)
-
-        # update_state on a terminal task is a no-op (returns task, no new eviction)
-        self.mgr.update_state(task.id, TaskState.FAILED)
-        second_handle = self.mgr._eviction_handles.get(task.id)
-
-        # The handle should be unchanged — no new eviction was kicked off
-        # because update_state guards with _TERMINAL_STATES check.
-        assert first_handle is second_handle
-
-        if first_handle:
-            first_handle.cancel()

--- a/autobot-backend/a2a/a2a_test.py
+++ b/autobot-backend/a2a/a2a_test.py
@@ -11,8 +11,6 @@ Uses no network connections and no external dependencies.
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from a2a.agent_card import build_agent_card
 from a2a.task_manager import TaskManager
 from a2a.types import AgentCapabilities, AgentCard, AgentSkill, TaskArtifact, TaskState

--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -6,6 +6,8 @@ A2A Task Manager
 
 Issue #961: In-memory task lifecycle manager for A2A tasks.
 Issue #968: Adds TraceContext per task for distributed tracing + audit log.
+Issue #4502: Replace in-process dict with Redis-backed storage to fix 404
+             flapping across multiple uvicorn workers.
 Manages task state transitions per the A2A spec §4.2.
 
 State machine:
@@ -14,17 +16,23 @@ State machine:
   SUBMITTED → CANCELLED
   WORKING   → INPUT_REQUIRED → WORKING
   WORKING   → CANCELLED
+
+Redis key layout:
+  a2a:task:{id}   — JSON-serialised Task (TTL: AUTOBOT_A2A_TASK_TTL_SECONDS)
+  a2a:audit:{id}  — Redis list of JSON-serialised TraceEvent entries (same TTL)
+  a2a:tasks       — Redis set of all known task IDs
 """
 
-import asyncio
+import json
 import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config
 
-from .tracing import TraceContext, new_trace_id
+from .tracing import TraceContext, TraceEvent, new_trace_id
 from .types import Task, TaskArtifact, TaskState, TaskStatus
 
 logger = logging.getLogger(__name__)
@@ -32,17 +40,130 @@ logger = logging.getLogger(__name__)
 # Terminal states — no further transitions allowed
 _TERMINAL_STATES = {TaskState.COMPLETED, TaskState.FAILED, TaskState.CANCELLED}
 
+_KEY_TASK = "a2a:task:{}"
+_KEY_AUDIT = "a2a:audit:{}"
+_KEY_TASKS = "a2a:tasks"
+
 
 def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+# ---------------------------------------------------------------------------
+# Serialisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _task_to_json(task: Task) -> str:
+    """Serialise a Task (without trace_context) to JSON."""
+    d: Dict[str, Any] = {
+        "id": task.id,
+        "status": {
+            "state": task.status.state.value,
+            "message": task.status.message,
+            "timestamp": task.status.timestamp,
+        },
+        "input": task.input,
+        "context": task.context,
+        "artifacts": [
+            {
+                "artifact_type": a.artifact_type,
+                "content": a.content,
+                "created_at": a.created_at,
+            }
+            for a in task.artifacts
+        ],
+        "created_at": task.created_at,
+        "updated_at": task.updated_at,
+        # Trace metadata only (full event log lives in a2a:audit:{id})
+        "trace_id": task.trace_context.trace_id if task.trace_context else None,
+        "caller_id": task.trace_context.caller_id if task.trace_context else None,
+    }
+    return json.dumps(d)
+
+
+def _task_from_json(raw: str) -> Task:
+    """Deserialise a Task from JSON.  TraceContext events are NOT reloaded here."""
+    d = json.loads(raw)
+    status = TaskStatus(
+        state=TaskState(d["status"]["state"]),
+        message=d["status"].get("message"),
+        timestamp=d["status"]["timestamp"],
+    )
+    artifacts = [
+        TaskArtifact(
+            artifact_type=a["artifact_type"],
+            content=a["content"],
+            created_at=a["created_at"],
+        )
+        for a in d.get("artifacts", [])
+    ]
+    tc: Optional[TraceContext] = None
+    if d.get("trace_id"):
+        tc = TraceContext(
+            trace_id=d["trace_id"],
+            caller_id=d.get("caller_id", "anonymous"),
+        )
+    task = Task(
+        id=d["id"],
+        status=status,
+        input=d["input"],
+        context=d.get("context"),
+        artifacts=artifacts,
+        created_at=d["created_at"],
+        updated_at=d["updated_at"],
+        trace_context=tc,
+    )
+    return task
+
+
+def _audit_entry_to_json(event: TraceEvent) -> str:
+    return json.dumps(event.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# TaskManager
+# ---------------------------------------------------------------------------
+
+
 class TaskManager:
-    """Thread-safe (asyncio-safe) in-memory A2A task store."""
+    """Redis-backed A2A task store — safe across multiple uvicorn workers.
+
+    Issue #4502: Replaces the per-process in-memory dict with Redis so that
+    tasks created on worker A are visible to worker B/C.
+    """
 
     def __init__(self) -> None:
-        self._tasks: Dict[str, Task] = {}
-        self._eviction_handles: Dict[str, asyncio.Task] = {}
+        self._redis = get_redis_client(database="main")
+
+    # ------------------------------------------------------------------
+    # Internal Redis helpers
+    # ------------------------------------------------------------------
+
+    def _ttl(self) -> int:
+        return int(config.timeout.a2a_task_ttl)
+
+    def _save(self, task: Task) -> None:
+        """Persist task JSON and register its ID in the task-set."""
+        ttl = self._ttl()
+        key = _KEY_TASK.format(task.id)
+        self._redis.set(key, _task_to_json(task), ex=ttl)
+        self._redis.sadd(_KEY_TASKS, task.id)
+
+    def _load(self, task_id: str) -> Optional[Task]:
+        raw = self._redis.get(_KEY_TASK.format(task_id))
+        if raw is None:
+            return None
+        return _task_from_json(raw if isinstance(raw, str) else raw.decode("utf-8"))
+
+    def _append_audit(self, task_id: str, event: TraceEvent) -> None:
+        key = _KEY_AUDIT.format(task_id)
+        self._redis.rpush(key, _audit_entry_to_json(event))
+        self._redis.expire(key, self._ttl())
+
+    # ------------------------------------------------------------------
+    # Public API (same signatures as the old in-memory implementation)
+    # ------------------------------------------------------------------
 
     def create_task(
         self,
@@ -51,18 +172,14 @@ class TaskManager:
         caller_id: str = "anonymous",
         trace_id: Optional[str] = None,
     ) -> Task:
-        """
-        Create and register a new task in SUBMITTED state.
-
-        Issue #968: Assigns a TraceContext to every task for distributed
-        tracing and audit.  caller_id identifies the submitting agent/user.
-        """
+        """Create and register a new task in SUBMITTED state."""
         task_id = str(uuid.uuid4())
         tc = TraceContext(
             trace_id=trace_id or new_trace_id(),
             caller_id=caller_id,
         )
-        tc.record("task.submitted", {"task_id": task_id})
+        event = TraceEvent(event="task.submitted", data={"task_id": task_id})
+        tc.events.append(event)
 
         task = Task(
             id=task_id,
@@ -71,7 +188,8 @@ class TaskManager:
             context=context,
             trace_context=tc,
         )
-        self._tasks[task_id] = task
+        self._save(task)
+        self._append_audit(task_id, event)
         logger.info(
             "A2A task created: %s trace=%s caller=%s",
             task_id,
@@ -82,11 +200,21 @@ class TaskManager:
 
     def get_task(self, task_id: str) -> Optional[Task]:
         """Retrieve a task by ID, or None if not found."""
-        return self._tasks.get(task_id)
+        return self._load(task_id)
 
     def list_tasks(self) -> List[Task]:
-        """Return all tasks."""
-        return list(self._tasks.values())
+        """Return all tasks whose keys are still alive in Redis."""
+        ids = self._redis.smembers(_KEY_TASKS)
+        tasks: List[Task] = []
+        for tid in ids:
+            tid_str = tid if isinstance(tid, str) else tid.decode("utf-8")
+            task = self._load(tid_str)
+            if task is not None:
+                tasks.append(task)
+            else:
+                # TTL expired — remove from tracking set
+                self._redis.srem(_KEY_TASKS, tid)
+        return tasks
 
     def update_state(
         self,
@@ -94,12 +222,11 @@ class TaskManager:
         state: TaskState,
         message: Optional[str] = None,
     ) -> Optional[Task]:
-        """
-        Transition a task to a new state.
+        """Transition a task to a new state.
 
         Returns the updated task, or None if task not found or already terminal.
         """
-        task = self._tasks.get(task_id)
+        task = self._load(task_id)
         if not task:
             logger.warning("update_state: task %s not found", task_id)
             return None
@@ -114,104 +241,69 @@ class TaskManager:
 
         task.status = TaskStatus(state=state, message=message)
         task.updated_at = _utcnow()
+        event = TraceEvent(
+            event="task.state_transition",
+            data={"state": state.value, "message": message},
+        )
         if task.trace_context:
-            task.trace_context.record(
-                "task.state_transition",
-                {"state": state.value, "message": message},
-            )
+            task.trace_context.events.append(event)
+        self._save(task)
+        self._append_audit(task_id, event)
         logger.debug("A2A task %s → %s", task_id, state.value)
-        if state in _TERMINAL_STATES:
-            self._schedule_eviction(task_id)
         return task
 
     def add_artifact(self, task_id: str, artifact: TaskArtifact) -> bool:
         """Append an artifact to a task. Returns False if task not found."""
-        task = self._tasks.get(task_id)
+        task = self._load(task_id)
         if not task:
             logger.warning("add_artifact: task %s not found", task_id)
             return False
         task.artifacts.append(artifact)
         task.updated_at = _utcnow()
+        self._save(task)
         return True
 
     def cancel_task(self, task_id: str) -> bool:
-        """
-        Cancel a task if it is not already in a terminal state.
+        """Cancel a task if it is not already in a terminal state.
 
         Returns True on success, False if not found or already terminal.
         """
-        task = self._tasks.get(task_id)
+        task = self._load(task_id)
         if not task:
             return False
         if task.status.state in _TERMINAL_STATES:
             return False
         task.status = TaskStatus(state=TaskState.CANCELLED)
         task.updated_at = _utcnow()
+        event = TraceEvent(event="task.cancelled")
         if task.trace_context:
-            task.trace_context.record("task.cancelled")
+            task.trace_context.events.append(event)
+        self._save(task)
+        self._append_audit(task_id, event)
         logger.info("A2A task cancelled: %s", task_id)
-        self._schedule_eviction(task_id)
         return True
-
-    def _schedule_eviction(self, task_id: str) -> None:
-        """Schedule removal of *task_id* from *_tasks* after the configured TTL.
-
-        Issue #3823: Prevents unbounded growth of _tasks by evicting terminal
-        tasks after AUTOBOT_A2A_TASK_TTL_SECONDS (default 60 s).  The task
-        remains queryable during the TTL window so callers can still poll the
-        final status.
-
-        If an eviction is already scheduled for this task_id (e.g. cancel_task
-        called after update_state already triggered it) the earlier handle is
-        cancelled and a new one is started to reset the clock.
-        """
-        ttl = config.timeout.a2a_task_ttl
-
-        # Cancel any pre-existing eviction handle for this task
-        existing = self._eviction_handles.pop(task_id, None)
-        if existing and not existing.done():
-            existing.cancel()
-
-        async def _evict_after_delay() -> None:
-            await asyncio.sleep(ttl)
-            removed = self._tasks.pop(task_id, None)
-            self._eviction_handles.pop(task_id, None)
-            if removed is not None:
-                logger.debug(
-                    "A2A task evicted after TTL %.0fs: %s state=%s",
-                    ttl,
-                    task_id,
-                    removed.status.state.value,
-                )
-
-        try:
-            handle = asyncio.get_running_loop().create_task(_evict_after_delay())
-            self._eviction_handles[task_id] = handle
-        except RuntimeError:
-            # No running event loop (e.g. unit tests using sync calls).
-            # Eviction will not be scheduled — the store still bounds itself
-            # via explicit get_task() returning None after eviction in async use.
-            logger.debug(
-                "A2A task eviction skipped (no event loop): %s", task_id
-            )
 
     def get_audit_log(self, task_id: str) -> Optional[List[Dict[str, Any]]]:
         """Return the full trace event log for a task, or None if not found."""
-        task = self._tasks.get(task_id)
-        if not task or not task.trace_context:
+        if not self._load(task_id):
             return None
-        return [e.to_dict() for e in task.trace_context.events]
+        raw_entries = self._redis.lrange(_KEY_AUDIT.format(task_id), 0, -1)
+        result: List[Dict[str, Any]] = []
+        for raw in raw_entries:
+            entry = raw if isinstance(raw, str) else raw.decode("utf-8")
+            result.append(json.loads(entry))
+        return result
 
     def stats(self) -> Dict[str, int]:
         """Return task counts per state."""
         counts: Dict[str, int] = {}
-        for task in self._tasks.values():
+        for task in self.list_tasks():
             key = task.status.state.value
             counts[key] = counts.get(key, 0) + 1
         return counts
 
 
-# Module-level singleton — one manager per backend process
+# Module-level singleton — Redis-backed, safe across all uvicorn workers
 _task_manager = TaskManager()
 
 


### PR DESCRIPTION
Closes #4502

## Summary
- Replaced module-level in-process dict in `a2a/task_manager.py` with Redis-backed storage using `get_redis_client(database="main")`
- Tasks stored as JSON under `a2a:task:{id}` with 1h TTL; audit events in `a2a:audit:{id}` lists; IDs tracked in `a2a:tasks` set
- Eliminates 404 flapping — task state is now visible across all uvicorn workers
- Tests updated to mock Redis; 2 new tests added for audit log and TTL expiry simulation

## Test Status
PASS — 35/35 tests (0.48s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)