### PR TITLE
docs: add system diagrams, demo guide, and architecture reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ For teams prioritizing **data privacy, cost efficiency, and infrastructure contr
 
 ## Architecture Overview
 
+> Full diagrams (data flows, deployment topologies, sequence diagrams): [docs/architecture/system-diagram.md](docs/architecture/system-diagram.md)  
+> Feature walkthroughs and demo recording scripts: [docs/DEMOS.md](docs/DEMOS.md)
+
 ```mermaid
 graph TB
     User["👤 User<br/>(Browser)"]

--- a/docs/DEMOS.md
+++ b/docs/DEMOS.md
@@ -1,0 +1,186 @@
+# AutoBot Demos & Visual Materials
+
+Visual guides and demo walkthroughs for AutoBot's features.
+
+---
+
+## Quick Start Demo
+
+The fastest way to see AutoBot in action is the 3-step Docker setup:
+
+```
+1. git clone https://github.com/mrveiss/AutoBot-AI.git
+   └── Clone the repository
+
+2. cp .env.example .env && docker compose up -d
+   └── Configure and start all services (~2 minutes)
+
+3. Open http://localhost
+   └── AutoBot dashboard is ready
+```
+
+From first command to working dashboard: **under 5 minutes** on a modern machine.
+
+---
+
+## Feature Walkthroughs
+
+### Chat Interface
+
+```
+Open dashboard → Click "New Chat" → Type a message
+
+Example queries:
+  "What's the status of my fleet?"
+  "Summarize the deployment runbook"
+  "Help me write an Ansible playbook for nginx restart"
+```
+
+AutoBot streams responses in real-time. Attach a knowledge base via the KB icon
+to ground answers in your own documentation.
+
+---
+
+### Knowledge Base Setup
+
+```
+Sidebar → Knowledge Bases → New Knowledge Base
+  → Name it (e.g. "Production Runbooks")
+  → Upload documents (PDF, Markdown, text, code files)
+  → Documents are indexed in seconds
+
+Then in Chat:
+  → Click KB icon → Select "Production Runbooks"
+  → Ask questions about your documents
+```
+
+---
+
+### Fleet Management
+
+```
+Sidebar → Fleet → Add Node
+  → Enter hostname / IP and SSH user
+  → Copy AutoBot's SSH public key to the node
+  → AutoBot tests connection and enrolls the node
+
+Once enrolled:
+  → View real-time CPU / RAM / disk per node
+  → Run playbooks: update packages, restart services, check disk
+  → Or use Chat: "Restart nginx on all web servers"
+```
+
+---
+
+### Workflow Builder
+
+```
+Sidebar → Workflows → New Workflow
+  → Add steps (chat prompt, fleet op, KB query, delay)
+  → Connect steps in sequence
+  → Save with a name and optional cron schedule
+
+Example — Weekly Health Check:
+  Step 1: Fleet → Run "check-disk-usage" on all nodes
+  Step 2: Chat → "Summarize disk usage, flag nodes above 80%"
+  Step 3: Chat → "Write a Slack-ready status summary"
+```
+
+---
+
+## Architecture Diagrams
+
+Full Mermaid diagrams covering system overview, data flows, and deployment topologies:
+
+- [System Diagrams](architecture/system-diagram.md)
+
+Key diagrams:
+- **System Overview** — All components and how they connect
+- **Chat Data Flow** — Sequence diagram from user message to streamed response
+- **Fleet Operation Flow** — How a chat command becomes an Ansible playbook run
+- **Single-node topology** — Standard Docker Compose layout
+- **Multi-node HA topology** — Production high-availability setup
+
+---
+
+## Recording Your Own Demo
+
+To create a terminal recording (e.g. for a blog post or PR description):
+
+```bash
+# Install tools
+sudo apt install asciinema
+pip install agg  # or: npm install -g @asciinema/agg
+
+# Record
+asciinema rec demo.cast
+
+# Inside the recording:
+git clone https://github.com/mrveiss/AutoBot-AI.git
+cd AutoBot-AI
+cp .env.example .env
+docker compose up -d
+curl http://localhost/api/v1/health
+
+# Exit recording (Ctrl+D or exit)
+
+# Convert to GIF
+agg demo.cast demo.gif
+```
+
+Suggested recording script for a clean quickstart demo:
+
+```bash
+echo "=== AutoBot Quickstart Demo ===" && sleep 1
+git clone https://github.com/mrveiss/AutoBot-AI.git && sleep 0.5
+cd AutoBot-AI && sleep 0.5
+cp .env.example .env && echo "Config ready" && sleep 0.5
+docker compose up -d && sleep 2
+docker compose ps && sleep 1
+curl -s http://localhost/api/v1/health | python3 -m json.tool
+echo "✓ AutoBot is running at http://localhost"
+```
+
+---
+
+## Screenshots
+
+To take clean screenshots for documentation or social media:
+
+1. Start AutoBot: `docker compose up -d`
+2. Open `http://localhost` in a browser
+3. Recommended views to capture:
+   - Chat interface with a sample conversation
+   - Knowledge Base document list
+   - Fleet dashboard with nodes
+   - Workflow builder canvas
+4. Use browser devtools to set viewport to 1440×900 for consistent sizing
+
+---
+
+## Embedding in README or Docs
+
+To embed a GIF in a markdown file:
+
+```markdown
+![AutoBot Quickstart](docs/demos/quickstart-demo.gif)
+```
+
+To embed a Mermaid diagram (renders on GitHub):
+
+```markdown
+​```mermaid
+graph TB
+    ...
+​```
+```
+
+---
+
+## Contributing Demos
+
+Have a demo or screenshot that showcases AutoBot well? Contributions welcome:
+
+1. Add your demo file to `docs/demos/` (GIF, MP4, or PNG)
+2. Add a description to this file under the appropriate section
+3. Open a PR targeting `Dev_new_gui`

--- a/docs/architecture/system-diagram.md
+++ b/docs/architecture/system-diagram.md
@@ -1,0 +1,191 @@
+# AutoBot System Diagrams
+
+A reference for AutoBot's architecture, data flows, and deployment topologies using Mermaid diagrams.
+
+---
+
+## System Overview
+
+```mermaid
+graph TB
+    User["User (Browser)"]
+    Frontend["Frontend\n(Vue.js + nginx)"]
+    Backend["Backend\n(FastAPI)"]
+
+    Redis["Redis\n(Cache / Queue)"]
+    PostgreSQL["PostgreSQL\n(Relational Data)"]
+    ChromaDB["ChromaDB\n(Vector Embeddings)"]
+    Ollama["Ollama\n(Local LLM)"]
+    Ansible["Ansible\n(Fleet Ops)"]
+    Browser["Browser Worker\n(Chromium)"]
+
+    User -->|HTTP / WebSocket| Frontend
+    Frontend -->|REST API| Backend
+
+    Backend --> Redis
+    Backend --> PostgreSQL
+    Backend -->|Vector Search| ChromaDB
+    Backend -->|Inference| Ollama
+    Backend -->|Playbooks| Ansible
+    Backend -->|Automation| Browser
+```
+
+---
+
+## Chat Request Data Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as Frontend
+    participant BE as Backend
+    participant DB as ChromaDB
+    participant LLM as Ollama
+
+    U->>FE: Send message
+    FE->>BE: POST /api/v1/chat/message (WebSocket)
+    BE->>DB: Vector search (if KB attached)
+    DB-->>BE: Relevant document chunks
+    BE->>LLM: Prompt + context + history
+    LLM-->>BE: Stream response tokens
+    BE-->>FE: Stream tokens via WebSocket
+    FE-->>U: Render streaming response
+    BE->>BE: Save message to PostgreSQL
+```
+
+---
+
+## Knowledge Base Indexing Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant BE as Backend
+    participant PG as PostgreSQL
+    participant CB as ChromaDB
+
+    U->>BE: Upload document
+    BE->>PG: Store file metadata
+    BE->>BE: Chunk document
+    BE->>BE: Generate embeddings (Ollama embed model)
+    BE->>CB: Store embedding vectors
+    CB-->>BE: Indexed
+    BE-->>U: Ready for search
+```
+
+---
+
+## Fleet Operation Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as Frontend
+    participant BE as Backend
+    participant AN as Ansible
+    participant N as Fleet Nodes
+
+    U->>FE: "Deploy v2 to all prod servers"
+    FE->>BE: Chat message
+    BE->>BE: Parse intent, select playbook
+    BE-->>FE: Show plan + confirm prompt
+    U->>FE: Confirm
+    FE->>BE: Execute confirmed
+    BE->>AN: Run playbook on target nodes
+    AN->>N: SSH + execute tasks
+    N-->>AN: stdout / stderr
+    AN-->>BE: Job output stream
+    BE-->>FE: Real-time progress
+    BE->>BE: Write audit log to PostgreSQL
+```
+
+---
+
+## Deployment Topology (Single Node)
+
+```mermaid
+graph TB
+    Internet["Internet"]
+    nginx["nginx\n:80 / :443"]
+
+    subgraph Docker["Docker Network (internal)"]
+        FE["Frontend\n(Vue.js)"]
+        BE["Backend\n(FastAPI :8000)"]
+        PG["PostgreSQL\n(:5432)"]
+        RD["Redis\n(:6379)"]
+        CB["ChromaDB\n(:8001)"]
+        OL["Ollama\n(:11434)"]
+    end
+
+    Internet --> nginx
+    nginx --> FE
+    nginx -->|/api/*| BE
+    BE --> PG
+    BE --> RD
+    BE --> CB
+    BE --> OL
+```
+
+---
+
+## Deployment Topology (Multi-Node HA)
+
+```mermaid
+graph TB
+    Internet["Internet"]
+    LB["Load Balancer\n(nginx / HAProxy)"]
+
+    subgraph "Backend Cluster"
+        BE1["Backend\nInstance 1"]
+        BE2["Backend\nInstance 2"]
+    end
+
+    subgraph "Data Layer"
+        PG_P["PostgreSQL\nPrimary"]
+        PG_R["PostgreSQL\nRead Replica"]
+        RD["Redis\nSentinel"]
+        CB["ChromaDB\nDedicated"]
+    end
+
+    subgraph "AI Layer"
+        OL["Ollama\n(GPU Node)"]
+    end
+
+    subgraph "Fleet"
+        N1["Node 1"]
+        N2["Node 2"]
+        N3["Node N"]
+    end
+
+    Internet --> LB
+    LB --> BE1
+    LB --> BE2
+    BE1 --> PG_P
+    BE2 --> PG_P
+    BE1 --> PG_R
+    BE2 --> PG_R
+    BE1 --> RD
+    BE2 --> RD
+    BE1 --> CB
+    BE2 --> CB
+    BE1 --> OL
+    BE2 --> OL
+    BE1 -->|Ansible| N1
+    BE1 -->|Ansible| N2
+    BE1 -->|Ansible| N3
+```
+
+---
+
+## Component Responsibilities
+
+| Component | Technology | Responsibility |
+|-----------|-----------|----------------|
+| Frontend | Vue.js 3, nginx | UI, TLS termination, static assets |
+| Backend | FastAPI, Python | Business logic, auth, orchestration |
+| PostgreSQL | PostgreSQL 15+ | Users, sessions, fleet inventory, audit logs |
+| Redis | Redis 7+ | Task queue, caching, session state |
+| ChromaDB | ChromaDB | Vector embeddings for RAG search |
+| Ollama | Ollama | Local LLM inference and embeddings |
+| Ansible | Ansible | Fleet playbook execution |
+| Browser Worker | Chromium | Browser automation, screenshots, scraping |


### PR DESCRIPTION
## Summary

- **`docs/architecture/system-diagram.md`** — Mermaid diagrams: system overview, chat/KB/fleet data flow sequences, single-node Docker topology, multi-node HA topology
- **`docs/DEMOS.md`** — Feature walkthroughs (chat, KB, fleet, workflows), terminal recording scripts with `asciinema`/`agg`, screenshot guide, embedding instructions
- **`README.md`** — Added links to new diagram and demo docs under Architecture Overview

## Test plan

- [ ] Verify Mermaid diagrams render correctly on GitHub (open `docs/architecture/system-diagram.md`)
- [ ] Verify README links to new docs work
- [ ] Confirm `docs/DEMOS.md` renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)