### PR TITLE
fix(truncation): preserve JSON/XML structure integrity on truncation (#4395)

### DIFF
--- a/autobot-backend/prompt_manager.py
+++ b/autobot-backend/prompt_manager.py
@@ -24,6 +24,132 @@ from constants.ttl_constants import TTL_24_HOURS
 logger = logging.getLogger(__name__)
 
 
+def _detect_structured_format(content: str) -> str:
+    """
+    Detect whether content is JSON or XML/HTML.
+
+    Issue #4395: Identifies structured data formats so _truncate_large_file
+    can snap to semantically valid boundaries instead of mid-token cuts.
+
+    Args:
+        content: File content (first 512 chars sufficient for detection).
+
+    Returns:
+        "json" | "xml" | "unknown"
+    """
+    stripped = content.lstrip()
+    if stripped.startswith(("{", "[")):
+        return "json"
+    if stripped.startswith("<"):
+        return "xml"
+    return "unknown"
+
+
+def _json_head_boundary(content: str, target: int) -> int:
+    """
+    Find the largest position ≤ target that ends a complete JSON value at the
+    top level of the document.
+
+    Issue #4395: Prevents leaving unterminated strings, arrays, or objects in
+    the head section when JSON content is truncated.
+
+    Scans backward from *target* for the pattern ``},\\n`` or ``],\\n`` —
+    i.e. a closing bracket followed by a comma/newline, which is a safe entry
+    boundary between sibling JSON values.  Internal commas (inside strings or
+    between object fields) are excluded because they are not preceded by ``}``
+    or ``]``.
+
+    Args:
+        content: Full JSON string.
+        target: Ideal cut position (typically 40% of max_chars).
+
+    Returns:
+        Adjusted position (after the trailing newline), or *target* if no
+        safe boundary is found within 1000 chars of *target*.
+    """
+    search_start = max(0, target - 1000)
+    # Walk backward from target looking for },\n or ],\n
+    for i in range(min(target, len(content) - 1), search_start, -1):
+        if content[i] == "\n" and i >= 2 and content[i - 1] == "," and content[i - 2] in ("}", "]"):
+            return i + 1
+    # Fallback: accept a bare },\n or ],\n without the comma (last entry)
+    for i in range(min(target, len(content) - 1), search_start, -1):
+        if content[i] == "\n" and i >= 1 and content[i - 1] in ("}", "]"):
+            return i + 1
+    return target
+
+
+def _json_tail_boundary(content: str, target: int) -> int:
+    """
+    Find the smallest position ≥ target that starts a complete JSON value at
+    the top level of the document.
+
+    Issue #4395: Ensures the tail section of truncated JSON begins on a clean
+    entry boundary (a line that opens an array element or object key).
+
+    Scans forward from *target* for a newline followed by a non-whitespace
+    character — these typically indicate the start of a new JSON entry.
+
+    Args:
+        content: Full JSON string.
+        target: Ideal cut position (typically len - 40% of max_chars).
+
+    Returns:
+        Adjusted position, or *target* if no safe boundary found.
+    """
+    search_end = min(len(content), target + 500)
+    for i in range(target, search_end):
+        next_is_non_ws = i + 1 < len(content) and content[i + 1] not in (" ", "\t", "\r", "\n")
+        if content[i] == "\n" and next_is_non_ws:
+            return i + 1
+    return target
+
+
+def _xml_head_boundary(content: str, target: int) -> int:
+    """
+    Find the largest position ≤ target that follows a complete XML closing tag.
+
+    Issue #4395: Avoids cutting in the middle of an XML element.  Scans
+    backward from *target* for the end of a closing tag (``>`` preceded by
+    ``/something``).
+
+    Args:
+        content: Full XML/HTML string.
+        target: Ideal cut position.
+
+    Returns:
+        Adjusted position (character after the ``>``), or *target* if not found.
+    """
+    search_start = max(0, target - 500)
+    for i in range(min(target, len(content) - 1), search_start, -1):
+        if content[i] == ">" and i > 0:
+            # Confirm this looks like a closing tag: find matching '</'
+            tag_start = content.rfind("</", search_start, i)
+            if tag_start != -1:
+                return i + 1
+    return target
+
+
+def _xml_tail_boundary(content: str, target: int) -> int:
+    """
+    Find the smallest position ≥ target that precedes an XML opening tag.
+
+    Issue #4395: Ensures the tail section starts at a clean element boundary.
+
+    Args:
+        content: Full XML/HTML string.
+        target: Ideal cut position.
+
+    Returns:
+        Adjusted position, or *target* if not found.
+    """
+    search_end = min(len(content), target + 500)
+    for i in range(target, search_end):
+        if content[i] == "<" and i + 1 < len(content) and content[i + 1] != "/":
+            return i
+    return target
+
+
 def _snap_to_char_boundary(content: str, pos: int, search_forward: bool = True) -> int:
     """
     Snap a string slice position to a Unicode-safe word boundary.
@@ -72,9 +198,15 @@ def _truncate_large_file(content: str, max_chars: int = 20000) -> str:
     are never split mid-word.  Python str indexing is already codepoint-safe,
     but word-boundary snapping prevents cut points inside multi-byte words.
 
+    Issue #4395: Structured data (JSON/XML) is truncated at semantically valid
+    element/entry boundaries so that each half remains well-formed and the LLM
+    can reason about the data even when it is too large to fit in context.
+
     Strategy:
     - Files smaller than max_chars: returned unchanged
     - Files larger than max_chars: keep first 40% + ellipsis marker + last 40%
+    - JSON/XML: boundaries snapped to complete entry/element edges
+    - Otherwise: boundaries snapped to whitespace (Issue #4394)
     - Marker format: "[...N chars TRUNCATED...]"
 
     Args:
@@ -90,11 +222,21 @@ def _truncate_large_file(content: str, max_chars: int = 20000) -> str:
     # Calculate sections: preserve first 40% and last 40% of max_chars
     section_size = (max_chars // 5) * 2  # 40% of max_chars
 
-    # Issue #4394: snap cut points to whitespace boundaries so multi-byte
-    # characters (e.g. emoji U+1F600, CJK U+4E2D, accented café) are not
-    # split mid-word when the content is later encoded to UTF-8 bytes.
-    head_end = _snap_to_char_boundary(content, section_size, search_forward=True)
-    tail_start = _snap_to_char_boundary(content, len(content) - section_size, search_forward=False)
+    fmt = _detect_structured_format(content)
+    if fmt == "json":
+        # Issue #4395: snap to complete JSON entry boundaries
+        head_end = _json_head_boundary(content, section_size)
+        tail_start = _json_tail_boundary(content, len(content) - section_size)
+    elif fmt == "xml":
+        # Issue #4395: snap to complete XML element boundaries
+        head_end = _xml_head_boundary(content, section_size)
+        tail_start = _xml_tail_boundary(content, len(content) - section_size)
+    else:
+        # Issue #4394: snap to whitespace so multi-byte chars are not split mid-word
+        head_end = _snap_to_char_boundary(content, section_size, search_forward=True)
+        tail_start = _snap_to_char_boundary(
+            content, len(content) - section_size, search_forward=False
+        )
 
     # Ensure tail_start > head_end to avoid overlap on pathological inputs
     if tail_start <= head_end:
@@ -137,8 +279,6 @@ def _build_skill_context(skills: Optional[List[Dict]]) -> str:
     for i, skill in enumerate(skills, 1):
         name = skill.get("name", "Unknown")
         description = skill.get("description", "")
-        skill_id = skill.get("id", "")
-
         # Format: 1. SkillName: brief description
         if description:
             skill_lines.append(f"{i}. {name}: {description}")
@@ -149,9 +289,8 @@ def _build_skill_context(skills: Optional[List[Dict]]) -> str:
         return ""
 
     skills_text = "\n".join(skill_lines)
-    return (
-        f"\n\n## Available Skills\nThe following skills are available for this agent to use:\n{skills_text}"
-    )
+    header = "\n\n## Available Skills\nThe following skills are available for this agent to use:\n"
+    return header + skills_text
 
 
 # Issue #380: Module-level constant for supported prompt file extensions
@@ -736,8 +875,6 @@ class PromptManager:
         }
 
         try:
-            from security.prompt_injection_detector import InjectionRisk
-
             for context_file in context_files:
                 file_path = project_root / context_file
 

--- a/autobot-backend/tests/test_smart_context_truncation.py
+++ b/autobot-backend/tests/test_smart_context_truncation.py
@@ -10,8 +10,18 @@ Issue #4346: Smart context truncation for large files
 - Tests across different file types (code, markdown, JSON)
 """
 
+import json
+
 import pytest
-from prompt_manager import _truncate_large_file, PromptManager
+from prompt_manager import (
+    _detect_structured_format,
+    _json_head_boundary,
+    _json_tail_boundary,
+    _truncate_large_file,
+    _xml_head_boundary,
+    _xml_tail_boundary,
+    PromptManager,
+)
 
 
 class TestTruncateLargeFile:
@@ -323,6 +333,229 @@ class TestTruncationEdgeCases:
 
         # Second truncation should be minimal or none
         assert len(result2) == len(result1)
+
+
+class TestDetectStructuredFormat:
+    """Issue #4395: format detection used to choose boundary strategy."""
+
+    def test_json_object(self):
+        assert _detect_structured_format('{"key": "value"}') == "json"
+
+    def test_json_array(self):
+        assert _detect_structured_format('[1, 2, 3]') == "json"
+
+    def test_json_with_leading_whitespace(self):
+        assert _detect_structured_format('  \n{"a":1}') == "json"
+
+    def test_xml_element(self):
+        assert _detect_structured_format('<root><child/></root>') == "xml"
+
+    def test_xml_declaration(self):
+        assert _detect_structured_format('<?xml version="1.0"?><root/>') == "xml"
+
+    def test_html_doctype(self):
+        assert _detect_structured_format('<!DOCTYPE html><html/>') == "xml"
+
+    def test_plain_text_unknown(self):
+        assert _detect_structured_format('hello world') == "unknown"
+
+    def test_python_code_unknown(self):
+        assert _detect_structured_format('def foo():\n    pass\n') == "unknown"
+
+    def test_markdown_unknown(self):
+        assert _detect_structured_format('# Title\n\nContent') == "unknown"
+
+
+class TestJsonBoundaryHelpers:
+    """Issue #4395: JSON boundary helper unit tests."""
+
+    def _make_large_json_array(self, n: int = 300) -> str:
+        """Build a pretty-printed JSON array with *n* entries."""
+        return json.dumps([{"id": i, "value": "item" + str(i)} for i in range(n)], indent=2)
+
+    def test_head_boundary_is_lte_target(self):
+        content = self._make_large_json_array()
+        target = len(content) // 2
+        result = _json_head_boundary(content, target)
+        assert result <= target + 1  # may equal target if no boundary found
+
+    def test_head_boundary_produces_valid_json_prefix(self):
+        """The head slice produced by _json_head_boundary must be valid JSON
+        when the closing bracket/brace is appended."""
+        content = self._make_large_json_array()
+        target = 3000
+        cut = _json_head_boundary(content, target)
+        head = content[:cut].rstrip().rstrip(",")
+        # Complete the array so we can parse it
+        try:
+            json.loads(head + "\n]")
+            valid = True
+        except json.JSONDecodeError:
+            valid = False
+        assert valid, f"Head slice up to {cut} is not valid JSON: ...{content[cut-40:cut+20]!r}"
+
+    def test_tail_boundary_is_gte_target(self):
+        content = self._make_large_json_array()
+        target = len(content) // 2
+        result = _json_tail_boundary(content, target)
+        assert result >= target
+
+    def test_tail_starts_at_entry_boundary(self):
+        """After the tail cut point, content should start on a non-whitespace line."""
+        content = self._make_large_json_array()
+        target = len(content) - 3000
+        cut = _json_tail_boundary(content, target)
+        tail = content[cut:]
+        first_char = tail.lstrip("\n")[0]
+        assert first_char not in (" ", "\t"), (
+            f"Tail doesn't start cleanly: {tail[:40]!r}"
+        )
+
+
+class TestXmlBoundaryHelpers:
+    """Issue #4395: XML boundary helper unit tests."""
+
+    def _make_large_xml(self, n: int = 300) -> str:
+        items = "\n".join(
+            f"  <item id=\"{i}\">\n    <value>entry{i}</value>\n  </item>"
+            for i in range(n)
+        )
+        return f"<root>\n{items}\n</root>"
+
+    def test_head_boundary_is_lte_target(self):
+        content = self._make_large_xml()
+        target = len(content) // 2
+        result = _xml_head_boundary(content, target)
+        assert result <= target + 1
+
+    def test_head_boundary_ends_after_closing_tag(self):
+        content = self._make_large_xml()
+        target = 3000
+        cut = _xml_head_boundary(content, target)
+        # Character just before cut should be '>' (possibly with whitespace)
+        assert content[cut - 1] == ">", (
+            f"Expected '>' at position {cut-1}, got {content[cut-2:cut+2]!r}"
+        )
+
+    def test_tail_boundary_starts_at_opening_tag(self):
+        content = self._make_large_xml()
+        target = len(content) - 3000
+        cut = _xml_tail_boundary(content, target)
+        tail = content[cut:]
+        assert tail.lstrip().startswith("<"), (
+            f"Tail doesn't start with '<': {tail[:40]!r}"
+        )
+
+
+class TestStructuredDataTruncation:
+    """Issue #4395: End-to-end truncation tests for JSON and XML."""
+
+    # ------------------------------------------------------------------
+    # JSON
+    # ------------------------------------------------------------------
+
+    def test_json_array_head_is_parseable(self):
+        """Head section of a truncated large JSON array ends on a clean boundary."""
+        data = [{"id": i, "name": f"item{i}", "value": i * 1.5} for i in range(500)]
+        content = json.dumps(data, indent=2)
+        assert len(content) > 20000, "test data must be larger than threshold"
+
+        result = _truncate_large_file(content, max_chars=20000)
+        assert "chars TRUNCATED" in result
+
+        head = result.split("[...")[0].rstrip().rstrip(",")
+        try:
+            json.loads(head + "\n]")
+            valid = True
+        except json.JSONDecodeError:
+            valid = False
+        assert valid, f"Head is not valid JSON: ...{head[-80:]!r}"
+
+    def test_json_object_truncation_has_marker(self):
+        """Large JSON object is truncated with proper marker."""
+        obj = {f"key{i}": f"value_{i}" * 20 for i in range(200)}
+        content = json.dumps(obj, indent=2)
+        assert len(content) > 20000
+
+        result = _truncate_large_file(content, max_chars=20000)
+        assert "chars TRUNCATED" in result
+        assert len(result) < len(content)
+
+    def test_json_preserves_opening_structure(self):
+        """First characters of truncated JSON must still start with { or [."""
+        data = [{"x": "y" * 100} for _ in range(300)]
+        content = json.dumps(data, indent=2)
+
+        result = _truncate_large_file(content, max_chars=20000)
+        assert result.lstrip()[0] in ("{", "["), (
+            f"Result doesn't start with JSON opener: {result[:20]!r}"
+        )
+
+    def test_json_small_stays_unchanged(self):
+        """Small JSON under threshold must be returned as-is (no boundary fiddling)."""
+        data = {"a": 1, "b": [1, 2, 3]}
+        content = json.dumps(data)
+        result = _truncate_large_file(content, max_chars=20000)
+        assert result == content
+
+    def test_large_json_no_unicode_corruption(self):
+        """Truncated JSON with unicode values must round-trip cleanly."""
+        data = [{"emoji": "😀", "cjk": "中文", "text": "café " * 30} for _ in range(200)]
+        content = json.dumps(data, indent=2, ensure_ascii=False)
+        assert len(content) > 20000
+
+        result = _truncate_large_file(content, max_chars=20000)
+        assert result.encode("utf-8").decode("utf-8") == result
+
+    # ------------------------------------------------------------------
+    # XML
+    # ------------------------------------------------------------------
+
+    def test_xml_head_ends_on_closing_tag(self):
+        """Head of truncated XML should end with a complete closing tag."""
+        items = "\n".join(
+            f'  <record id="{i}"><name>item{i}</name><data>{"x" * 50}</data></record>'
+            for i in range(300)
+        )
+        content = f"<records>\n{items}\n</records>"
+        assert len(content) > 20000
+
+        result = _truncate_large_file(content, max_chars=20000)
+        assert "chars TRUNCATED" in result
+
+        head = result.split("[...")[0].rstrip()
+        assert head.endswith(">"), f"Head doesn't end with '>': ...{head[-40:]!r}"
+
+    def test_xml_tail_starts_on_opening_tag(self):
+        """Tail of truncated XML should begin with an opening tag."""
+        items = "\n".join(
+            f'  <record id="{i}"><name>item{i}</name><data>{"x" * 50}</data></record>'
+            for i in range(300)
+        )
+        content = f"<records>\n{items}\n</records>"
+        assert len(content) > 20000
+
+        result = _truncate_large_file(content, max_chars=20000)
+        tail = result.split("...]")[-1].lstrip()
+        assert tail.startswith("<"), f"Tail doesn't start with '<': {tail[:40]!r}"
+
+    def test_xml_small_stays_unchanged(self):
+        """Small XML under threshold returned unchanged."""
+        content = "<root><item>value</item></root>"
+        result = _truncate_large_file(content, max_chars=20000)
+        assert result == content
+
+    def test_xml_truncation_marker_present(self):
+        """Large XML gets a truncation marker."""
+        items = "\n".join(
+            f'  <item id="{i}"><val>{"data" * 30}</val></item>' for i in range(200)
+        )
+        content = f"<root>\n{items}\n</root>"
+        assert len(content) > 20000
+
+        result = _truncate_large_file(content, max_chars=20000)
+        assert "chars TRUNCATED" in result
+        assert len(result) < len(content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #4395

## Summary

- Added `_detect_structured_format()` — detects JSON/XML from leading character
- Added boundary helpers: `_json_head_boundary`, `_json_tail_boundary`, `_xml_head_boundary`, `_xml_tail_boundary` — snap cuts to inter-entry boundaries so truncated output remains parseable
- `_truncate_large_file` routes to structured helpers when JSON/XML detected
- Also fixed 2 pre-existing lint issues (unused `skill_id` F841, redundant `InjectionRisk` import)

## Test Status

76/76 passed (51 pre-existing + 25 new structured-data tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)