### PR TITLE
feat(execution): code_interpreter tool — model-callable Python sandbox (#4485)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -86,6 +86,8 @@ SENSITIVE_TOOLS: frozenset[str] = frozenset(
         "http_patch",
         "http_delete",
         "send_request",
+        # Code execution
+        "code_interpreter",
     }
 )
 

--- a/autobot-backend/tools/__init__.py
+++ b/autobot-backend/tools/__init__.py
@@ -8,6 +8,7 @@ This package provides a centralized tool registry that eliminates duplication
 between the standard orchestrator and LangChain orchestrator implementations.
 """
 
+from .code_interpreter import CODE_INTERPRETER_SCHEMA, execute_code
 from .tool_registry import ToolRegistry
 
-__all__ = ["ToolRegistry"]
+__all__ = ["CODE_INTERPRETER_SCHEMA", "ToolRegistry", "execute_code"]

--- a/autobot-backend/tools/code_interpreter.py
+++ b/autobot-backend/tools/code_interpreter.py
@@ -1,0 +1,117 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Code Interpreter Tool
+
+Model-callable Python sandbox that executes code in a subprocess and returns
+stdout/stderr.  The caller (AgentLoop) must gate execution behind the
+SENSITIVE_TOOLS approval workflow — code_interpreter is listed there.
+
+Security notes:
+- Runs code as the current OS user; no sandboxing beyond what the OS provides.
+- Stdout and stderr are each truncated to MAX_OUTPUT_BYTES (10 KB) so a
+  runaway print loop cannot flood the agent context window.
+- The temp file is always removed after execution, even on timeout/error.
+"""
+
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from typing import Dict, Any
+
+logger = logging.getLogger(__name__)
+
+MAX_OUTPUT_BYTES = 10 * 1024  # 10 KB per stream
+
+
+def execute_code(code: str, timeout_seconds: int = 30) -> Dict[str, Any]:
+    """Execute Python code in a subprocess and return stdout/stderr.
+
+    Args:
+        code: Python source code to execute.
+        timeout_seconds: Wall-clock timeout for the subprocess (default 30 s).
+
+    Returns:
+        Dict with keys:
+            stdout     (str)  – captured standard output (≤ 10 KB)
+            stderr     (str)  – captured standard error  (≤ 10 KB)
+            exit_code  (int)  – process exit code (1 on timeout/error)
+            truncated  (bool) – True when either stream was truncated
+    """
+    tmp_path: str = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            delete=False,
+            encoding="utf-8",
+        ) as tmp:
+            tmp.write(code)
+            tmp_path = tmp.name
+
+        result = subprocess.run(
+            [sys.executable, tmp_path],
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+
+        raw_stdout = result.stdout
+        raw_stderr = result.stderr
+        truncated = (
+            len(raw_stdout) > MAX_OUTPUT_BYTES or len(raw_stderr) > MAX_OUTPUT_BYTES
+        )
+
+        return {
+            "stdout": raw_stdout[:MAX_OUTPUT_BYTES].decode("utf-8", errors="replace"),
+            "stderr": raw_stderr[:MAX_OUTPUT_BYTES].decode("utf-8", errors="replace"),
+            "exit_code": result.returncode,
+            "truncated": truncated,
+        }
+
+    except subprocess.TimeoutExpired:
+        logger.warning("code_interpreter: execution timed out after %ss", timeout_seconds)
+        return {
+            "stdout": "",
+            "stderr": f"Execution timed out after {timeout_seconds} seconds.",
+            "exit_code": 1,
+            "truncated": False,
+        }
+    except Exception as exc:
+        logger.error("code_interpreter: unexpected error: %s", exc, exc_info=True)
+        return {
+            "stdout": "",
+            "stderr": f"Execution error: {exc}",
+            "exit_code": 1,
+            "truncated": False,
+        }
+    finally:
+        if tmp_path:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+
+
+#: Tool schema for LLM tool-call registration.
+CODE_INTERPRETER_SCHEMA: Dict[str, Any] = {
+    "name": "code_interpreter",
+    "description": "Execute Python code and return stdout/stderr",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "code": {
+                "type": "string",
+                "description": "Python source code to execute.",
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "description": "Maximum execution time in seconds (default 30).",
+                "default": 30,
+            },
+        },
+        "required": ["code"],
+    },
+}

--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -15,6 +15,7 @@ import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from chat_workflow.tool_handler import BROWSER_TOOL_NAMES
+from tools.code_interpreter import execute_code
 
 if TYPE_CHECKING:
     from knowledge_base import KnowledgeBase
@@ -419,6 +420,16 @@ class ToolRegistry:
             "response_text": response_text,
         }
 
+    async def execute_code_tool(self, code: str, timeout_seconds: int = 30) -> Dict[str, Any]:
+        """Execute Python code in a sandboxed subprocess and return stdout/stderr."""
+        result = execute_code(code, timeout_seconds=timeout_seconds)
+        return {
+            "tool_name": "code_interpreter",
+            "tool_args": {"code": code, "timeout_seconds": timeout_seconds},
+            "result": result,
+            "status": "success" if result["exit_code"] == 0 else "error",
+        }
+
     # Tool Name Mapping for Compatibility (Issue #315 - Dispatch Table Pattern)
 
     def _get_tool_handler(self, tool_name: str):
@@ -457,6 +468,9 @@ class ToolRegistry:
                 args.get("program_name", ""), args.get("question_text", "")
             ),
             "respondconversationally": lambda args: self.respond_conversationally(args.get("response_text", "")),
+            "codeinterpreter": lambda args: self.execute_code_tool(
+                args.get("code", ""), args.get("timeout_seconds", 30)
+            ),
         }
         return dispatch.get(tool_name)
 
@@ -558,6 +572,7 @@ class ToolRegistry:
             "bring_window_to_front",
             "ask_user_for_manual",
             "respond_conversationally",
+            "code_interpreter",
         ]
         # Issue #1368/#2609: Browser tools are defined once in BROWSER_TOOL_NAMES
         # and imported here so the two lists cannot drift independently.


### PR DESCRIPTION
## Summary
- New `autobot-backend/tools/code_interpreter.py` — `execute_code(code, timeout_seconds=30) -> dict`
- Writes code to `NamedTemporaryFile`, runs via `subprocess.run` with `sys.executable`
- Captures stdout/stderr, truncates each to 10KB, always cleans up temp file
- Handles `TimeoutExpired` and unexpected exceptions gracefully
- Returns `{"stdout": str, "stderr": str, "exit_code": int, "truncated": bool}`
- Exports `CODE_INTERPRETER_SCHEMA` (LLM tool-call schema)
- Registered in `ToolRegistry` dispatch table as `"codeinterpreter"`
- Added to `SENSITIVE_TOOLS` in `agent_loop/loop.py` — requires user approval
- Exported from `tools/__init__.py`

## Test Plan
- [ ] Successful `print("hello")` — stdout captured, exit_code 0
- [ ] `import json; print(json.dumps({"x": 1}))` — stdlib imports work
- [ ] Infinite loop with timeout=1 — `TimeoutExpired` handled, error in stderr
- [ ] Syntax error — exit_code non-zero, stderr contains traceback
- [ ] Verify approval gate fires before first execution

Closes #4485

🤖 Generated with Claude Code