### PR TITLE
feat(llm): multi-format chat templates (ChatML, Zephyr, Vicuna) for local providers (#4486)

### DIFF
--- a/autobot-backend/chat_templates/chatml.j2
+++ b/autobot-backend/chat_templates/chatml.j2
@@ -1,0 +1,7 @@
+{% for message in messages %}{% if message.role == 'system' %}<|im_start|>system
+{{ message.content }}<|im_end|>
+{% elif message.role == 'user' %}<|im_start|>user
+{{ message.content }}<|im_end|>
+{% elif message.role == 'assistant' %}<|im_start|>assistant
+{{ message.content }}<|im_end|>
+{% endif %}{% endfor %}<|im_start|>assistant

--- a/autobot-backend/chat_templates/vicuna.j2
+++ b/autobot-backend/chat_templates/vicuna.j2
@@ -1,0 +1,5 @@
+{% if messages[0].role == 'system' %}{{ messages[0].content }}
+
+{% set messages = messages[1:] %}{% endif %}{% for message in messages %}{% if message.role == 'user' %}USER: {{ message.content }}
+{% elif message.role == 'assistant' %}ASSISTANT: {{ message.content }}</s>
+{% endif %}{% endfor %}ASSISTANT:

--- a/autobot-backend/chat_templates/zephyr.j2
+++ b/autobot-backend/chat_templates/zephyr.j2
@@ -1,0 +1,7 @@
+{% for message in messages %}{% if message.role == 'system' %}<|system|>
+{{ message.content }}</s>
+{% elif message.role == 'user' %}<|user|>
+{{ message.content }}</s>
+{% elif message.role == 'assistant' %}<|assistant|>
+{{ message.content }}</s>
+{% endif %}{% endfor %}<|assistant|>

--- a/autobot-backend/llm_providers/chat_template_loader.py
+++ b/autobot-backend/llm_providers/chat_template_loader.py
@@ -1,0 +1,43 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Chat template loader for local LLM providers."""
+
+import logging
+import os
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+logger = logging.getLogger(__name__)
+
+TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), '..', 'chat_templates')
+SUPPORTED_TEMPLATES = {'chatml', 'zephyr', 'vicuna'}
+DEFAULT_TEMPLATE = 'chatml'
+
+_env = None
+
+
+def _get_env() -> Environment:
+    global _env
+    if _env is None:
+        _env = Environment(
+            loader=FileSystemLoader(TEMPLATES_DIR),
+            autoescape=select_autoescape([]),
+            keep_trailing_newline=True,
+        )
+    return _env
+
+
+def render_chat_template(messages: list, template_name: str = DEFAULT_TEMPLATE) -> str:
+    """Render messages using the specified Jinja2 chat template.
+
+    Only for local/self-hosted providers. OpenAI/Anthropic/Gemini format server-side.
+    """
+    if template_name not in SUPPORTED_TEMPLATES:
+        logger.warning(
+            "Unknown chat template '%s', falling back to '%s'",
+            template_name, DEFAULT_TEMPLATE
+        )
+        template_name = DEFAULT_TEMPLATE
+    template = _get_env().get_template(f'{template_name}.j2')
+    return template.render(messages=messages)

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -247,6 +247,11 @@ class LLMConfig(BaseSettings):
         default="http://127.0.0.1:11434", alias="AUTOBOT_LLAMAINDEX_EMBEDDING_ENDPOINT"
     )
 
+    # Chat template for local providers (ollama, vllm, llama.cpp).
+    # OpenAI/Anthropic/Gemini skip this — they format server-side.
+    # Supported values: chatml, zephyr, vicuna
+    chat_template: str = Field(default="chatml", alias="AUTOBOT_CHAT_TEMPLATE")
+
     def get_ollama_endpoint_for_model(self, model_name: str) -> str:
         """Route Ollama requests to GPU or CPU endpoint by model (#1070).
 


### PR DESCRIPTION
## Summary
- New `autobot-backend/chat_templates/` with three Jinja2 templates: `chatml.j2`, `zephyr.j2`, `vicuna.j2`
- New `autobot-backend/llm_providers/chat_template_loader.py` — `render_chat_template(messages, template_name)`
- Lazy-initialised Jinja2 `Environment` with `FileSystemLoader` pointing to `chat_templates/`
- Falls back to `chatml` on unknown template name (with warning log)
- Added `chat_template: str = Field(default="chatml", alias="AUTOBOT_CHAT_TEMPLATE")` to `LLMConfig` in `ssot_config.py`
- Loader lives in `llm_providers/` — co-located with `ollama_provider.py`, `vllm_provider.py` for easy import
- Cloud providers (OpenAI, Anthropic, Gemini) never touch this — they format server-side

## Test Plan
- [ ] `render_chat_template(messages, "chatml")` — produces `<|im_start|>` format
- [ ] `render_chat_template(messages, "zephyr")` — produces `<|system|>` format
- [ ] `render_chat_template(messages, "vicuna")` — produces `USER:`/`ASSISTANT:` format
- [ ] Unknown template name — logs warning, falls back to chatml
- [ ] `AUTOBOT_CHAT_TEMPLATE=zephyr` env var — picked up by `LLMConfig`

Closes #4486

🤖 Generated with Claude Code