### PR TITLE
fix(frontend): register wired components in barrel index files (#4323)

### DIFF
--- a/autobot-frontend/src/components/file-browser/index.ts
+++ b/autobot-frontend/src/components/file-browser/index.ts
@@ -1,0 +1,16 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * File Browser Components Index
+ * Export all file browser components for easy imports
+ */
+
+export { default as FileBrowser } from './FileBrowser.vue'
+export { default as FileBrowserHeader } from './FileBrowserHeader.vue'
+export { default as FileListTable } from './FileListTable.vue'
+export { default as FilePathNavigation } from './FilePathNavigation.vue'
+export { default as FilePreview } from './FilePreview.vue'
+export { default as FileTreeView } from './FileTreeView.vue'
+export { default as FileUpload } from './FileUpload.vue'

--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue.d.ts
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue.d.ts
@@ -1,0 +1,4 @@
+import { DefineComponent } from 'vue';
+
+declare const SystemKnowledgeManager: DefineComponent<{}, {}, any>;
+export default SystemKnowledgeManager;

--- a/autobot-frontend/src/components/knowledge/index.ts
+++ b/autobot-frontend/src/components/knowledge/index.ts
@@ -1,0 +1,52 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Knowledge Components Index
+ * Export all knowledge components for easy imports
+ */
+
+export { default as BackupManager } from './BackupManager.vue'
+export { default as BatchSelectionToolbar } from './BatchSelectionToolbar.vue'
+export { default as BulkActionsToolbar } from './BulkActionsToolbar.vue'
+export { default as CleanupStatistics } from './CleanupStatistics.vue'
+export { default as DeduplicationManager } from './DeduplicationManager.vue'
+export { default as DocumentChangeFeed } from './DocumentChangeFeed.vue'
+export { default as EntityExtractor } from './EntityExtractor.vue'
+export { default as EntityGraphManager } from './EntityGraphManager.vue'
+export { default as FailedVectorizationsManager } from './FailedVectorizationsManager.vue'
+export { default as GraphRAGQuery } from './GraphRAGQuery.vue'
+export { default as KBSearchResultPanel } from './KBSearchResultPanel.vue'
+export { default as KnowledgeAdvanced } from './KnowledgeAdvanced.vue'
+export { default as KnowledgeBatchToolbar } from './KnowledgeBatchToolbar.vue'
+export { default as KnowledgeBrowser } from './KnowledgeBrowser.vue'
+export { default as KnowledgeBrowserHeader } from './KnowledgeBrowserHeader.vue'
+export { default as KnowledgeCategories } from './KnowledgeCategories.vue'
+export { default as KnowledgeContentViewer } from './KnowledgeContentViewer.vue'
+export { default as KnowledgeEntries } from './KnowledgeEntries.vue'
+export { default as KnowledgeGraph } from './KnowledgeGraph.vue'
+export { default as KnowledgeGraph3D } from './KnowledgeGraph3D.vue'
+export { default as KnowledgeGraphView } from './KnowledgeGraphView.vue'
+export { default as KnowledgeMainCategories } from './KnowledgeMainCategories.vue'
+export { default as KnowledgeMaintenance } from './KnowledgeMaintenance.vue'
+export { default as KnowledgeManager } from './KnowledgeManager.vue'
+export { default as KnowledgePersistenceDialog } from './KnowledgePersistenceDialog.vue'
+export { default as KnowledgePromptEditor } from './KnowledgePromptEditor.vue'
+export { default as KnowledgeResearchPanel } from './KnowledgeResearchPanel.vue'
+export { default as KnowledgeScopeSelector } from './KnowledgeScopeSelector.vue'
+export { default as KnowledgeSearch } from './KnowledgeSearch.vue'
+export { default as KnowledgeStats } from './KnowledgeStats.vue'
+export { default as KnowledgeSystemDocs } from './KnowledgeSystemDocs.vue'
+export { default as KnowledgeUpload } from './KnowledgeUpload.vue'
+export { default as KnowledgeVerificationQueue } from './KnowledgeVerificationQueue.vue'
+export { default as MemoryOrphanManager } from './MemoryOrphanManager.vue'
+export { default as QualityScoreBadge } from './QualityScoreBadge.vue'
+export { default as SessionOrphanManager } from './SessionOrphanManager.vue'
+export { default as ShareKnowledgeDialog } from './ShareKnowledgeDialog.vue'
+export { default as SystemKnowledgeManager } from './SystemKnowledgeManager.vue'
+export { default as TreeNodeComponent } from './TreeNodeComponent.vue'
+export { default as VectorizationActionButton } from './VectorizationActionButton.vue'
+export { default as VectorizationProgressModal } from './VectorizationProgressModal.vue'
+export { default as VectorizationStatusBadge } from './VectorizationStatusBadge.vue'
+export { default as WebResearchSettings } from './WebResearchSettings.vue'

--- a/autobot-frontend/src/components/terminal/index.ts
+++ b/autobot-frontend/src/components/terminal/index.ts
@@ -1,0 +1,23 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Terminal Components Index
+ * Export all terminal components for easy imports
+ */
+
+export { default as AdvancedStepConfirmationModal } from './AdvancedStepConfirmationModal.vue'
+export { default as BaseXTerminal } from './BaseXTerminal.vue'
+export { default as CompletionSuggestions } from './CompletionSuggestions.vue'
+export { default as HostSelector } from './HostSelector.vue'
+export { default as SSHTerminal } from './SSHTerminal.vue'
+export { default as Terminal } from './Terminal.vue'
+export { default as TerminalHeader } from './TerminalHeader.vue'
+export { default as TerminalInput } from './TerminalInput.vue'
+export { default as TerminalModals } from './TerminalModals.vue'
+export { default as TerminalOutput } from './TerminalOutput.vue'
+export { default as TerminalSettings } from './TerminalSettings.vue'
+export { default as TerminalStatusBar } from './TerminalStatusBar.vue'
+export { default as TerminalWindow } from './TerminalWindow.vue'
+export { default as WorkflowAutomation } from './WorkflowAutomation.vue'


### PR DESCRIPTION
Closes #4323

## Summary

Created 3 missing barrel `index.ts` files and 1 declaration file for components added in #4284–#4286:

- `src/components/file-browser/index.ts` — 7 components including `FileBrowserHeader`, `FilePathNavigation`
- `src/components/terminal/index.ts` — 14 components including `TerminalStatusBar`
- `src/components/knowledge/index.ts` — 43 components including `KnowledgeBrowserHeader`
- `src/components/knowledge/SystemKnowledgeManager.vue.d.ts` — type declaration for Options API component (fixes TS7016 introduced by knowledge index)

## Test Status

No new TypeScript errors in the modified index files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)