### PR TITLE
fix(agents): extract LLMResponse.content in system_commands agent (#4532)

### DIFF
--- a/autobot-backend/agents/enhanced_system_commands_agent.py
+++ b/autobot-backend/agents/enhanced_system_commands_agent.py
@@ -426,8 +426,18 @@ and suggest alternatives."""
         return choice["message"]["content"].strip()
 
     def _extract_response_content(self, response: Any) -> str:
-        """Extract the actual text content from LLM response."""
+        """Extract the actual text content from LLM response.
+
+        Issue #4532: handle LLMResponse objects via .content attribute to avoid
+        str(LLMResponse(...)) leaking into the explanation field.
+        """
         try:
+            # LLMResponse dataclass — use .content attribute directly
+            if hasattr(response, "content") and not isinstance(response, dict):
+                content = getattr(response, "content", None)
+                if content and isinstance(content, str):
+                    return content.strip()
+
             if isinstance(response, dict):
                 content = self._try_extract_message_content(response)
                 if content:


### PR DESCRIPTION
Closes #4532

## Summary
- Added `LLMResponse` object guard to `_extract_response_content` in `EnhancedSystemCommandsAgent`, mirroring the fix from #4501 in `chat_agent.py`
- Method now checks `hasattr(response, 'content')` before falling through to `str(response)`, preventing the `LLMResponse(...)` repr from leaking into the `explanation` artifact field

## Test Status
FAIL (pre-existing: `llama_index` not installed in dev env — unrelated to this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)