### PR TITLE
fix(a2a): correct routing threshold for research and knowledge_retrieval agents (#4530)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/routing.py
+++ b/autobot-backend/agents/agent_orchestration/routing.py
@@ -199,7 +199,7 @@ class AgentRouter:
         try:
             # Quick pattern matching for common cases
             quick_routing = self.quick_route_analysis(request)
-            if quick_routing["confidence"] > 0.8:
+            if quick_routing["confidence"] >= 0.8:
                 return quick_routing
 
             # Check learned strategies before LLM fallback (#2105)

--- a/autobot-backend/agents/agent_orchestration/types.py
+++ b/autobot-backend/agents/agent_orchestration/types.py
@@ -40,7 +40,15 @@ RESEARCH_PATTERNS = {
     "current",
     "recent",
 }
-KNOWLEDGE_PATTERNS = {"according to", "based on documents", "analyze", "summarize"}
+KNOWLEDGE_PATTERNS = {
+    "according to",
+    "based on documents",
+    "analyze",
+    "summarize",
+    "knowledge base",
+    "in the documents",
+    "in my documents",
+}
 
 # Issue #60: Routing patterns for specialized agents
 DATA_ANALYSIS_PATTERNS = {


### PR DESCRIPTION
Closes #4530

## Summary
- Routing threshold in `determine_routing()` used strict `> 0.8` but research and knowledge patterns return confidence exactly `0.8`, causing fallthrough to the LLM router which misrouted them
- Fixed threshold to `>= 0.8`
- Added missing phrases (`knowledge base`, `in the documents`, `in my documents`) to `KNOWLEDGE_PATTERNS`

## Test Status
PASS — lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)