### PR TITLE
fix(agent): inject first_turn_note into LLM user message on first turn (#4528)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -378,6 +378,18 @@ class AgentLoop:
         events_context = await self._analyze_events()
         result.events_analyzed = len(events_context.get("events", []))
 
+        # Issue #4528: inject first_turn_note into user content on first turn.
+        # _analyze_events() sets context["first_turn_note"] on iteration 1 when
+        # first_turn_priming_enabled=True, but nothing downstream consumed it.
+        # Extract it here, append to the task description carried in events_context,
+        # then clear it so subsequent iterations are not affected.
+        first_turn_note = events_context.pop("first_turn_note", None)
+        if first_turn_note and self.config.first_turn_priming_enabled:
+            task_content = events_context.get("task_description", "")
+            events_context["task_description"] = (
+                task_content + "\n\n" + first_turn_note if task_content else first_turn_note
+            )
+
         # Phase 2: Select Tools
         self._current_phase = LoopPhase.SELECT_TOOLS
         tools_to_execute = await self._select_tools(events_context)


### PR DESCRIPTION
## Summary
- Wires `first_turn_note` set by `_analyze_events()` into actual LLM context on the first iteration
- Appends note to `events_context["task_description"]` with `"\n\n"` separator
- Guards on `config.first_turn_priming_enabled` and non-empty note value
- Pops the key after injection so it doesn't re-inject on subsequent turns

## Test Plan
- [ ] Verify `first_turn_priming_enabled=True` causes note to be appended to task_description on turn 1
- [ ] Verify `first_turn_priming_enabled=False` skips injection
- [ ] Verify note is absent from context on turn 2+

Closes #4528

🤖 Generated with Claude Code