### PR TITLE
fix(a2a): raise a2a_task_ttl default 60s→3600s for Redis persistence (#4551)

### DIFF
--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -537,9 +537,10 @@ class TimeoutConfig(BaseSettings):
     # A2A task manager (seconds)                                           #
     # ------------------------------------------------------------------ #
 
-    # How long a terminal A2A task remains queryable before eviction from
-    # the in-memory store (Issue #3823).
-    a2a_task_ttl: float = Field(default=60.0, alias="AUTOBOT_A2A_TASK_TTL_SECONDS")
+    # How long an A2A task remains queryable in Redis before eviction.
+    # 60s was the old in-memory eviction window; Redis persistence needs a
+    # realistic poll window — default 3600s (1 hour), overridable via env.
+    a2a_task_ttl: float = Field(default=3600.0, alias="AUTOBOT_A2A_TASK_TTL_SECONDS")
 
     # ------------------------------------------------------------------ #
     # Skill / code validation (seconds)                                    #


### PR DESCRIPTION
Closes #4551

## Summary
The `a2a_task_ttl` default of 60s was the old in-memory eviction window — never actually enforced by the dict store. With the Redis-backed task manager (#4502), TTL is now real: tasks were disappearing 60s after creation, causing 404 on rapid polls.

Raised default to 3600s (1 hour). Still overridable via `AUTOBOT_A2A_TASK_TTL_SECONDS` env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)