### PR TITLE
feat(a2a): SSE streaming + sliding TTL for A2A task polling (#4554)

### DIFF
--- a/autobot-backend/a2a/agent_card.py
+++ b/autobot-backend/a2a/agent_card.py
@@ -162,7 +162,7 @@ def build_agent_card(base_url: str) -> AgentCard:
         version=AUTOBOT_VERSION,
         skills=skills,
         capabilities=AgentCapabilities(
-            streaming=False,
+            streaming=True,
             push_notifications=False,
             state_transition_history=True,
         ),

--- a/autobot-backend/a2a/task_executor.py
+++ b/autobot-backend/a2a/task_executor.py
@@ -53,6 +53,9 @@ async def execute_a2a_task(
     """
     manager = get_task_manager()
     manager.update_state(task_id, TaskState.WORKING)
+    manager.publish_event(
+        task_id, {"event": "state_change", "state": "working", "task_id": task_id}
+    )
 
     try:
         # Late import to avoid circular deps at module load time
@@ -66,20 +69,28 @@ async def execute_a2a_task(
 
         # Artifact 1: primary text response
         response_text = _extract_response_text(result)
-        manager.add_artifact(
+        artifact_text = TaskArtifact(artifact_type="text", content=response_text)
+        manager.add_artifact(task_id, artifact_text)
+        manager.publish_event(
             task_id,
-            TaskArtifact(artifact_type="text", content=response_text),
+            {"event": "artifact_added", "artifact_type": "text", "task_id": task_id},
         )
 
         # Artifact 2: routing metadata (agent used, model, timing, etc.)
         metadata = _extract_routing_metadata(result)
         if metadata:
-            manager.add_artifact(
+            artifact_meta = TaskArtifact(artifact_type="json", content=metadata)
+            manager.add_artifact(task_id, artifact_meta)
+            manager.publish_event(
                 task_id,
-                TaskArtifact(artifact_type="json", content=metadata),
+                {"event": "artifact_added", "artifact_type": "json", "task_id": task_id},
             )
 
         manager.update_state(task_id, TaskState.COMPLETED)
+        manager.publish_event(
+            task_id,
+            {"event": "state_change", "state": "completed", "terminal": True, "task_id": task_id},
+        )
         logger.info("A2A task %s completed successfully", task_id)
 
     except Exception as exc:
@@ -89,3 +100,13 @@ async def execute_a2a_task(
             TaskArtifact(artifact_type="error", content=str(exc)),
         )
         manager.update_state(task_id, TaskState.FAILED, message=str(exc))
+        manager.publish_event(
+            task_id,
+            {
+                "event": "state_change",
+                "state": "failed",
+                "terminal": True,
+                "message": str(exc),
+                "task_id": task_id,
+            },
+        )

--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -8,6 +8,8 @@ Issue #961: In-memory task lifecycle manager for A2A tasks.
 Issue #968: Adds TraceContext per task for distributed tracing + audit log.
 Issue #4502: Replace in-process dict with Redis-backed storage to fix 404
              flapping across multiple uvicorn workers.
+Issue #4554: Sliding TTL on get_task() so active pollers never hit 404;
+             publish_event() for SSE streaming via Redis pub/sub.
 Manages task state transitions per the A2A spec §4.2.
 
 State machine:
@@ -18,9 +20,10 @@ State machine:
   WORKING   → CANCELLED
 
 Redis key layout:
-  a2a:task:{id}   — JSON-serialised Task (TTL: AUTOBOT_A2A_TASK_TTL_SECONDS)
-  a2a:audit:{id}  — Redis list of JSON-serialised TraceEvent entries (same TTL)
-  a2a:tasks       — Redis set of all known task IDs
+  a2a:task:{id}    — JSON-serialised Task (TTL: AUTOBOT_A2A_TASK_TTL_SECONDS)
+  a2a:audit:{id}   — Redis list of JSON-serialised TraceEvent entries (same TTL)
+  a2a:tasks        — Redis set of all known task IDs
+  a2a:events:{id}  — Redis pub/sub channel for SSE streaming (Issue #4554)
 """
 
 import json
@@ -43,6 +46,7 @@ _TERMINAL_STATES = {TaskState.COMPLETED, TaskState.FAILED, TaskState.CANCELLED}
 _KEY_TASK = "a2a:task:{}"
 _KEY_AUDIT = "a2a:audit:{}"
 _KEY_TASKS = "a2a:tasks"
+_KEY_EVENTS = "a2a:events:{}"  # pub/sub channel for SSE streaming (#4554)
 
 
 def _utcnow() -> str:
@@ -131,6 +135,9 @@ class TaskManager:
 
     Issue #4502: Replaces the per-process in-memory dict with Redis so that
     tasks created on worker A are visible to worker B/C.
+
+    Issue #4554: get_task() slides the TTL on every access (active pollers
+    never expire); publish_event() pushes SSE payloads via Redis pub/sub.
     """
 
     def __init__(self) -> None:
@@ -199,8 +206,19 @@ class TaskManager:
         return task
 
     def get_task(self, task_id: str) -> Optional[Task]:
-        """Retrieve a task by ID, or None if not found."""
-        return self._load(task_id)
+        """Retrieve a task by ID, sliding its TTL on each access.
+
+        Issue #4554: Resetting the TTL on every GET means any client that
+        is actively polling will never see a 404 — tasks only expire when
+        genuinely abandoned (no polls for a full TTL window).
+        """
+        key = _KEY_TASK.format(task_id)
+        raw = self._redis.get(key)
+        if raw is None:
+            return None
+        # Slide TTL — reset expiry from now so active pollers stay alive
+        self._redis.expire(key, self._ttl())
+        return _task_from_json(raw if isinstance(raw, str) else raw.decode("utf-8"))
 
     def list_tasks(self) -> List[Task]:
         """Return all tasks whose keys are still alive in Redis."""
@@ -293,6 +311,27 @@ class TaskManager:
             entry = raw if isinstance(raw, str) else raw.decode("utf-8")
             result.append(json.loads(entry))
         return result
+
+    def publish_event(self, task_id: str, payload: Dict[str, Any]) -> None:
+        """Publish a task event to the Redis pub/sub channel for SSE streaming.
+
+        Issue #4554: task_executor calls this at every state transition and
+        artifact addition.  The SSE endpoint subscribes to this channel and
+        forwards messages to connected clients in real time.
+
+        Args:
+            task_id: Task identifier.
+            payload: JSON-serialisable event dict, e.g.
+                     {"event": "state_change", "state": "working"}
+                     {"event": "artifact_added", "artifact": {...}}
+                     {"event": "state_change", "state": "completed", "terminal": True}
+        """
+        try:
+            channel = _KEY_EVENTS.format(task_id)
+            self._redis.publish(channel, json.dumps(payload))
+        except Exception as exc:
+            # Pub/sub is best-effort — never let it break task execution
+            logger.warning("publish_event failed for task %s: %s", task_id, exc)
 
     def stats(self) -> Dict[str, int]:
         """Return task counts per state."""

--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -216,8 +216,11 @@ class TaskManager:
         raw = self._redis.get(key)
         if raw is None:
             return None
-        # Slide TTL — reset expiry from now so active pollers stay alive
-        self._redis.expire(key, self._ttl())
+        # Slide TTL — reset expiry from now so active pollers stay alive.
+        # Slide the audit key too so it doesn't expire before the task does.
+        ttl = self._ttl()
+        self._redis.expire(key, ttl)
+        self._redis.expire(_KEY_AUDIT.format(task_id), ttl)
         return _task_from_json(raw if isinstance(raw, str) else raw.decode("utf-8"))
 
     def list_tasks(self) -> List[Task]:

--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -307,42 +307,61 @@ async def stream_task_events(task_id: str) -> StreamingResponse:
         channel = f"a2a:events:{task_id}"
 
         redis = await get_async_redis_client(database="main")
+        if redis is None:
+            yield 'data: {"event":"error","message":"Redis unavailable"}\n\n'
+            return
+
         pubsub = redis.pubsub()
+        # Subscribe BEFORE reading current state so events published in the
+        # gap between subscribe and the snapshot are not lost.
         await pubsub.subscribe(channel)
 
-        # Yield the current state immediately so the client is never blind
+        # Yield the current state immediately so the client is never blind.
+        # (Intentional: if a state_change event also arrives via pub/sub in
+        # this window, clients will receive the state twice — that is safe
+        # because state_change events are idempotent.)
         current = manager.get_task(task_id)
-        if current:
-            initial_payload = json.dumps(
-                {
-                    "event": "state_change",
-                    "state": current.status.state.value,
-                    "task_id": task_id,
-                }
-            )
-            yield f"data: {initial_payload}\n\n"
-            if current.status.state.value in _TERMINAL_STATES:
-                await pubsub.unsubscribe(channel)
-                await pubsub.close()
-                return
+        if current is None:
+            yield 'data: {"event":"error","message":"Task expired"}\n\n'
+            await pubsub.unsubscribe(channel)
+            await pubsub.close()
+            return
+        initial_payload = json.dumps(
+            {
+                "event": "state_change",
+                "state": current.status.state.value,
+                "task_id": task_id,
+            }
+        )
+        yield f"data: {initial_payload}\n\n"
+        if current.status.state.value in _TERMINAL_STATES:
+            await pubsub.unsubscribe(channel)
+            await pubsub.close()
+            return
 
         # Feed pub/sub messages into an asyncio.Queue so we can apply a
         # heartbeat timeout without blocking the event loop.
         queue: asyncio.Queue = asyncio.Queue()
 
         async def _reader():
-            async for msg in pubsub.listen():
-                if msg["type"] == "message":
-                    data = msg["data"]
-                    if isinstance(data, bytes):
-                        data = data.decode("utf-8")
-                    await queue.put(data)
-                    try:
-                        if json.loads(data).get("terminal"):
-                            await queue.put(None)  # sentinel — stop the loop
-                            return
-                    except Exception:
-                        pass
+            try:
+                async for msg in pubsub.listen():
+                    if msg["type"] == "message":
+                        data = msg["data"]
+                        if isinstance(data, bytes):
+                            data = data.decode("utf-8")
+                        await queue.put(data)
+                        try:
+                            if json.loads(data).get("terminal"):
+                                await queue.put(None)  # sentinel — stop the loop
+                                return
+                        except Exception:
+                            logger.debug(
+                                "Could not parse pub/sub payload for task %s", task_id
+                            )
+            except Exception as exc:
+                logger.warning("pubsub listener error for task %s: %s", task_id, exc)
+                await queue.put(None)  # unblock the outer loop on Redis failure
 
         reader_task = asyncio.create_task(_reader())
         try:

--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -15,6 +15,7 @@ Endpoints:
   POST /api/a2a/tasks                   Submit a task
   GET  /api/a2a/tasks                   List all tasks
   GET  /api/a2a/tasks/{id}              Get task status + artifacts
+  GET  /api/a2a/tasks/{id}/stream       SSE event stream for a task (Issue #4554)
   GET  /api/a2a/tasks/{id}/trace        Full audit trace for a task
   DELETE /api/a2a/tasks/{id}            Cancel a task
   GET  /api/a2a/stats                   Task statistics
@@ -22,12 +23,15 @@ Endpoints:
   POST /api/a2a/capabilities/verify     Verify a remote agent's capabilities
 """
 
+import asyncio
+import json
 import logging
 import os
 import time
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from a2a.agent_card import build_agent_card
@@ -267,6 +271,100 @@ async def get_task(task_id: str) -> Dict[str, Any]:
     if not task:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
     return _task_response(task)
+
+
+@router.get(
+    "/tasks/{task_id}/stream",
+    summary="Stream A2A task events (SSE)",
+    tags=["a2a"],
+)
+async def stream_task_events(task_id: str) -> StreamingResponse:
+    """
+    Server-Sent Events stream for a task.
+
+    Issue #4554: Eliminates polling loops — clients subscribe once and receive
+    push notifications for each state transition and artifact addition in real
+    time via Redis pub/sub.
+
+    Events::
+
+        data: {"event": "state_change",   "state": "working",   "task_id": "…"}
+        data: {"event": "artifact_added", "artifact_type": "text", "task_id": "…"}
+        data: {"event": "state_change",   "state": "completed", "terminal": true, …}
+
+    The stream closes automatically when a terminal event is received.
+    A comment-line heartbeat is sent every 15 s to keep proxies alive.
+    """
+    manager = get_task_manager()
+    task = manager.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
+
+    async def _event_generator():
+        from autobot_shared.redis_client import get_async_redis_client
+
+        _TERMINAL_STATES = {"completed", "failed", "cancelled"}
+        channel = f"a2a:events:{task_id}"
+
+        redis = await get_async_redis_client(database="main")
+        pubsub = redis.pubsub()
+        await pubsub.subscribe(channel)
+
+        # Yield the current state immediately so the client is never blind
+        current = manager.get_task(task_id)
+        if current:
+            initial_payload = json.dumps(
+                {
+                    "event": "state_change",
+                    "state": current.status.state.value,
+                    "task_id": task_id,
+                }
+            )
+            yield f"data: {initial_payload}\n\n"
+            if current.status.state.value in _TERMINAL_STATES:
+                await pubsub.unsubscribe(channel)
+                await pubsub.close()
+                return
+
+        # Feed pub/sub messages into an asyncio.Queue so we can apply a
+        # heartbeat timeout without blocking the event loop.
+        queue: asyncio.Queue = asyncio.Queue()
+
+        async def _reader():
+            async for msg in pubsub.listen():
+                if msg["type"] == "message":
+                    data = msg["data"]
+                    if isinstance(data, bytes):
+                        data = data.decode("utf-8")
+                    await queue.put(data)
+                    try:
+                        if json.loads(data).get("terminal"):
+                            await queue.put(None)  # sentinel — stop the loop
+                            return
+                    except Exception:
+                        pass
+
+        reader_task = asyncio.create_task(_reader())
+        try:
+            while True:
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=15.0)
+                except asyncio.TimeoutError:
+                    yield ": heartbeat\n\n"
+                    continue
+                if item is None:
+                    break
+                yield f"data: {item}\n\n"
+        finally:
+            reader_task.cancel()
+            try:
+                await reader_task
+            except asyncio.CancelledError:
+                pass
+            await pubsub.unsubscribe(channel)
+            await pubsub.close()
+
+    return StreamingResponse(_event_generator(), media_type="text/event-stream")
 
 
 @router.get(


### PR DESCRIPTION
Closes #4554

## Summary

- **Sliding TTL** — `TaskManager.get_task()` calls `EXPIRE` on every read, so any client that polls at least once per TTL window never hits a 404 while the task is alive
- **Redis pub/sub events** — new `publish_event()` pushes `state_change` and `artifact_added` payloads to `a2a:events:{task_id}` at every lifecycle transition in `task_executor`
- **SSE endpoint** — `GET /api/a2a/tasks/{id}/stream` subscribes to that channel, yields the current state immediately, streams events as `data: {…}\n\n`, sends comment-line heartbeats every 15 s to keep proxies alive, and closes cleanly when a terminal event (`"terminal": true`) arrives
- **Agent card** — `streaming=True` advertised so remote agents know SSE is available

## Changes

| File | Change |
|---|---|
| `a2a/task_manager.py` | `get_task()` slides TTL; `publish_event()` via Redis pub/sub |
| `a2a/task_executor.py` | publish `state_change` + `artifact_added` at every transition |
| `api/a2a.py` | new `GET /tasks/{id}/stream` SSE endpoint |
| `a2a/agent_card.py` | `streaming=True` |

## Test plan

- [ ] `GET /api/a2a/tasks/{id}` — TTL resets on each call; no premature 404 during long tasks
- [ ] `GET /api/a2a/tasks/{id}/stream` — immediate state event, then `state_change:working`, `artifact_added × 2`, `state_change:completed terminal:true`; stream closes
- [ ] SSE stream closes automatically on CANCELLED/FAILED terminal events
- [ ] Heartbeat comment line appears every 15 s when task is slow
- [ ] Agent card `/agent-card` shows `"streaming": true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)