### PR TITLE
fix(ui): replace hardcoded palette colors with design tokens in TouchFriendlyButton (#4575)

### DIFF
--- a/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
+++ b/autobot-frontend/src/components/ui/TouchFriendlyButton.vue
@@ -189,11 +189,14 @@ const createRipple = (event: TouchEvent) => {
 
 /* Variant styles */
 .button-primary {
-  @apply bg-blue-600 text-white border border-transparent;
+  @apply border border-transparent;
+  background: var(--color-primary);
+  color: var(--text-inverse);
 }
 
 .button-primary:hover:not(.button-disabled):not(.button-loading) {
-  @apply bg-blue-700;
+  background: var(--color-primary);
+  filter: brightness(0.9);
 }
 
 .button-primary:focus {
@@ -237,11 +240,14 @@ const createRipple = (event: TouchEvent) => {
 }
 
 .button-danger {
-  @apply bg-red-600 text-white border border-transparent;
+  @apply border border-transparent;
+  background: var(--color-error);
+  color: var(--text-inverse);
 }
 
 .button-danger:hover:not(.button-disabled):not(.button-loading) {
-  @apply bg-red-700;
+  background: var(--color-error);
+  filter: brightness(0.9);
 }
 
 .button-danger:focus {


### PR DESCRIPTION
Closes #4575

## Summary
- Primary button: `var(--color-primary)` / `var(--text-inverse)` with `filter: brightness(0.9)` hover
- Danger button: `var(--color-error)` / `var(--text-inverse)` with `filter: brightness(0.9)` hover

## Test Status
PASS — no new TS errors introduced