### PR TITLE
fix(frontend): replace hardcoded hex colors with design tokens in HeartbeatPanel, WorkflowTemplateGallery, ProfileModal (#4576)

### DIFF
--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -547,7 +547,7 @@ function statusClass(status: string): string {
 }
 .event-type {
   font-weight: 600;
-  color: #60a5fa;
+  color: var(--color-info);
   flex-shrink: 0;
 }
 .event-msg {
@@ -583,23 +583,23 @@ button:not(:disabled):hover {
 }
 .btn-load,
 .btn-save {
-  background: #3b82f6;
-  border-color: #2563eb;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
 }
 .btn-load:not(:disabled):hover,
 .btn-save:not(:disabled):hover {
-  background: #2563eb;
+  filter: brightness(0.9);
 }
 .btn-trigger {
-  background: #10b981;
-  border-color: #059669;
+  background: var(--color-success);
+  border-color: var(--color-success);
 }
 .btn-trigger:not(:disabled):hover {
-  background: #059669;
+  filter: brightness(0.9);
 }
 .btn-queue {
-  background: #8b5cf6;
-  border-color: #7c3aed;
+  background: var(--color-info);
+  border-color: var(--color-info);
 }
 .btn-sm {
   font-size: 0.75rem;

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -480,9 +480,9 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   text-transform: uppercase;
 }
 
-.role-admin { background: #fbbf24; color: #78350f; }
-.role-user { background: #60a5fa; color: #1e3a8a; }
-.role-viewer { background: #94a3b8; color: #1e293b; }
+.role-admin { background: var(--color-warning-bg); color: var(--color-warning); }
+.role-user { background: var(--color-info-bg); color: var(--color-info); }
+.role-viewer { background: var(--bg-tertiary); color: var(--text-secondary); }
 
 .pref-group {
   margin-bottom: 20px;
@@ -604,13 +604,13 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 }
 
 .toast.success {
-  background: #10b981;
-  color: white;
+  background: var(--color-success);
+  color: var(--text-inverse);
 }
 
 .toast.error {
-  background: #ef4444;
-  color: white;
+  background: var(--color-error);
+  color: var(--text-inverse);
 }
 
 @keyframes slideIn {

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
@@ -345,9 +345,9 @@ onMounted(async () => {
 .template-icon.development { background: var(--color-primary-bg); color: var(--color-primary); }
 .template-icon.security { background: var(--color-warning-bg); color: var(--color-warning); }
 .template-icon.backup { background: var(--color-success-bg); color: var(--color-success); }
-.template-icon.research { background: #e8f4fd; color: #0077b6; }
-.template-icon.analysis { background: #f3e8ff; color: #7c3aed; }
-.template-icon.community { background: #e8fdf0; color: #059669; }
+.template-icon.research { background: var(--color-info-bg); color: var(--color-info); }
+.template-icon.analysis { background: var(--color-info-bg); color: var(--color-info); }
+.template-icon.community { background: var(--color-success-bg); color: var(--color-success); }
 
 .template-info { flex: 1; min-width: 0; }
 .template-info h4 { margin: 0 0 4px; font-size: 15px; color: var(--text-primary); }


### PR DESCRIPTION
Closes #4576

## Summary
- **HeartbeatPanel.vue**: button hex backgrounds (#3b82f6, #10b981, #8b5cf6) → `var(--color-primary)`, `var(--color-success)`, `var(--color-info)`; hover → `filter: brightness(0.9)`
- **WorkflowTemplateGallery.vue**: category icon hex pairs → `var(--color-info-bg)`/`var(--color-info)` and `var(--color-success-bg)`/`var(--color-success)`
- **ProfileModal.vue**: role badges (admin/user/viewer) and toast success/error → semantic tokens

## Test Status
PASS — no new TS errors introduced