### PR TITLE
fix(frontend): replace hardcoded colors with design tokens in MessageStatus, SecretsManager, TerminalSettings, voice panels (#4578)

### DIFF
--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -821,7 +821,7 @@ onBeforeUnmount(() => {
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  background: #60a5fa;
+  background: var(--color-primary);
   border: 2px solid var(--bg-card, #0f172a);
   cursor: pointer;
 }
@@ -830,7 +830,7 @@ onBeforeUnmount(() => {
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  background: #60a5fa;
+  background: var(--color-primary);
   border: 2px solid var(--bg-card, #0f172a);
   cursor: pointer;
 }

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -444,7 +444,7 @@ onBeforeUnmount(() => {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #60a5fa;
+  background: var(--color-primary);
   border: 2px solid var(--bg-card, #0f172a);
   cursor: pointer;
 }
@@ -453,7 +453,7 @@ onBeforeUnmount(() => {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #60a5fa;
+  background: var(--color-primary);
   border: 2px solid var(--bg-card, #0f172a);
   cursor: pointer;
 }

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -2018,18 +2018,18 @@ watch(selectedScope, () => {
 }
 
 .badge.visibility-group {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
 }
 
 .badge.visibility-organization {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--color-info-bg);
+  color: var(--color-info);
 }
 
 .badge.visibility-system {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--color-success-bg);
+  color: var(--color-success);
 }
 
 .card-description {

--- a/autobot-frontend/src/components/terminal/TerminalSettings.vue
+++ b/autobot-frontend/src/components/terminal/TerminalSettings.vue
@@ -266,27 +266,29 @@ input[type='range']::-webkit-slider-thumb {
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background: #3b82f6;
+  background: var(--color-primary);
   cursor: pointer;
   transition: background-color 0.15s ease;
 }
 
 input[type='range']::-webkit-slider-thumb:hover {
-  background: #2563eb;
+  background: var(--color-primary);
+  filter: brightness(0.9);
 }
 
 input[type='range']::-moz-range-thumb {
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background: #3b82f6;
+  background: var(--color-primary);
   cursor: pointer;
   border: none;
   transition: background-color 0.15s ease;
 }
 
 input[type='range']::-moz-range-thumb:hover {
-  background: #2563eb;
+  background: var(--color-primary);
+  filter: brightness(0.9);
 }
 
 /* Checkbox custom styling */

--- a/autobot-frontend/src/components/ui/MessageStatus.vue
+++ b/autobot-frontend/src/components/ui/MessageStatus.vue
@@ -124,7 +124,7 @@ const statusTooltip = computed(() => {
 
 /* Status-specific styles */
 .status-sending {
-  @apply text-blue-500;
+  color: var(--color-info);
 }
 
 .status-sent {
@@ -132,23 +132,23 @@ const statusTooltip = computed(() => {
 }
 
 .status-delivered {
-  @apply text-green-500;
+  color: var(--color-success);
 }
 
 .status-read {
-  @apply text-green-600;
+  color: var(--color-success);
 }
 
 .status-failed {
-  @apply text-red-500;
+  color: var(--color-error);
 }
 
 .status-queued {
-  @apply text-yellow-500;
+  color: var(--color-warning);
 }
 
 .status-retrying {
-  @apply text-blue-500;
+  color: var(--color-info);
 }
 
 /* Animation for status changes */


### PR DESCRIPTION
Closes #4578

## Summary
- **MessageStatus.vue**: delivery status icon colors → `var(--color-info/success/error/warning)`
- **SecretsManager.vue**: scope badge hex pairs → semantic bg/color token pairs
- **TerminalSettings.vue**: range slider thumb `#3b82f6` → `var(--color-primary)` (webkit + moz)
- **VoiceConversationPanel.vue** + **VoiceConversationOverlay.vue**: voice dot `#60a5fa` → `var(--color-primary)`

## Test Status
PASS — no new TS errors introduced