### PR TITLE
feat(knowledge): add schema-driven synthesis config to DocIndexer (#4565)

### DIFF
--- a/autobot-backend/resources/knowledge/synthesis_schema.yaml
+++ b/autobot-backend/resources/knowledge/synthesis_schema.yaml
@@ -1,0 +1,58 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# synthesis_schema.yaml
+# Schema-driven synthesis configuration for DocIndexerService.
+# Each collection type defines: paths to source documents, a synthesis
+# target (ChromaDB collection or output path), and a prompt template
+# used when generating summaries/syntheses from those documents.
+
+collections:
+  - name: architecture_adrs
+    paths:
+      - docs/architecture
+      - docs/adr
+    synthesis_target: autobot_synthesis_architecture
+    prompt_template: |
+      You are an AutoBot architecture assistant. Given the following architecture
+      documentation and Architecture Decision Records (ADRs), produce a concise
+      synthesis that captures the key design decisions, system boundaries, and
+      rationale.
+
+      Documents:
+      {documents}
+
+      Synthesis:
+
+  - name: api_reference
+    paths:
+      - docs/api
+      - docs/implementation
+    synthesis_target: autobot_synthesis_api
+    prompt_template: |
+      You are an AutoBot API documentation assistant. Given the following API
+      reference documents, produce a structured summary covering endpoints,
+      request/response formats, authentication requirements, and notable
+      constraints.
+
+      Documents:
+      {documents}
+
+      Synthesis:
+
+  - name: runbooks_operations
+    paths:
+      - docs/operations
+      - docs/deployment
+      - docs/troubleshooting
+    synthesis_target: autobot_synthesis_runbooks
+    prompt_template: |
+      You are an AutoBot operations assistant. Given the following runbooks and
+      operational documentation, produce a concise synthesis of the key
+      procedures, failure modes, recovery steps, and on-call guidance.
+
+      Documents:
+      {documents}
+
+      Synthesis:

--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.ssot_config import get_ollama_url
 from constants.path_constants import PATH
+from services.knowledge.synthesis_schema_loader import SynthesisSchema, load_synthesis_schema
 
 logger = logging.getLogger(__name__)
 
@@ -633,6 +634,21 @@ class DocIndexerService:
         self._root_dir = PATH.PROJECT_ROOT
         # Issue #4564: optional LLM service for KB synthesis
         self._llm_service = llm_service
+        self.synthesis_schema: SynthesisSchema = self._load_schema()
+
+    def _load_schema(self) -> SynthesisSchema:
+        """Load synthesis schema from YAML; warn and return empty schema if absent."""
+        schema = load_synthesis_schema()
+        if not schema.collections:
+            logger.warning(
+                "Synthesis schema is absent or empty — schema-driven synthesis disabled"
+            )
+        else:
+            logger.debug(
+                "Loaded synthesis schema: %d collection(s)",
+                len(schema.collections),
+            )
+        return schema
 
     async def initialize(self) -> bool:
         """Initialize ChromaDB client and embedding model.

--- a/autobot-backend/services/knowledge/synthesis_schema_loader.py
+++ b/autobot-backend/services/knowledge/synthesis_schema_loader.py
@@ -1,0 +1,101 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Synthesis schema loader for DocIndexerService.
+
+Loads and validates the YAML-driven synthesis configuration that maps
+document collections to synthesis targets and prompt templates.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_REQUIRED_KEYS = {"name", "paths", "synthesis_target", "prompt_template"}
+_ALLOWED_KEYS = _REQUIRED_KEYS
+
+
+@dataclass
+class CollectionConfig:
+    """Configuration for one synthesis collection."""
+
+    name: str
+    paths: List[str]
+    synthesis_target: str
+    prompt_template: str
+
+
+@dataclass
+class SynthesisSchema:
+    """Top-level synthesis schema loaded from YAML."""
+
+    collections: List[CollectionConfig] = field(default_factory=list)
+
+
+def _parse_collection(raw: dict, index: int) -> CollectionConfig:
+    """Parse and validate a single collection entry. Raises ValueError on unknown keys."""
+    unknown = set(raw.keys()) - _ALLOWED_KEYS
+    if unknown:
+        raise ValueError(
+            f"Collection[{index}] has unknown keys: {sorted(unknown)}. "
+            f"Allowed keys are: {sorted(_ALLOWED_KEYS)}"
+        )
+    missing = _REQUIRED_KEYS - set(raw.keys())
+    if missing:
+        raise ValueError(
+            f"Collection[{index}] is missing required keys: {sorted(missing)}"
+        )
+    return CollectionConfig(
+        name=str(raw["name"]),
+        paths=[str(p) for p in raw["paths"]],
+        synthesis_target=str(raw["synthesis_target"]),
+        prompt_template=str(raw["prompt_template"]),
+    )
+
+
+def load_synthesis_schema(path: Optional[Path] = None) -> SynthesisSchema:
+    """Load and validate synthesis_schema.yaml.
+
+    Args:
+        path: Explicit path to the YAML file. Defaults to the bundled
+              resources/knowledge/synthesis_schema.yaml relative to this file.
+
+    Returns:
+        SynthesisSchema with validated collection configs, or an empty schema
+        if the file is absent (a warning is emitted by the caller).
+
+    Raises:
+        ValueError: If the YAML contains unknown or missing keys.
+    """
+    if path is None:
+        path = (
+            Path(__file__).parent.parent.parent
+            / "resources"
+            / "knowledge"
+            / "synthesis_schema.yaml"
+        )
+
+    if not path.exists():
+        logger.debug("Synthesis schema not found at %s — returning empty schema", path)
+        return SynthesisSchema()
+
+    with open(path, encoding="utf-8") as fh:
+        raw_data = yaml.safe_load(fh)
+
+    if not isinstance(raw_data, dict) or "collections" not in raw_data:
+        raise ValueError(
+            f"synthesis_schema.yaml must have a top-level 'collections' key; got: "
+            f"{list(raw_data.keys()) if isinstance(raw_data, dict) else type(raw_data).__name__}"
+        )
+
+    collections = [
+        _parse_collection(entry, i)
+        for i, entry in enumerate(raw_data["collections"])
+    ]
+    return SynthesisSchema(collections=collections)

--- a/autobot-backend/services/knowledge/test_synthesis_schema_loader.py
+++ b/autobot-backend/services/knowledge/test_synthesis_schema_loader.py
@@ -1,0 +1,146 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for synthesis_schema_loader.
+
+Covers:
+- Successful load from a valid YAML file
+- Graceful fallback (empty schema) when the file is absent
+- ValueError raised on unknown top-level collection keys
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from services.knowledge.synthesis_schema_loader import (
+    CollectionConfig,
+    SynthesisSchema,
+    load_synthesis_schema,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_yaml(tmp_path: Path, content: str) -> Path:
+    """Write YAML content to a temp file and return its path."""
+    schema_file = tmp_path / "synthesis_schema.yaml"
+    schema_file.write_text(textwrap.dedent(content), encoding="utf-8")
+    return schema_file
+
+
+VALID_YAML = """\
+    collections:
+      - name: architecture_adrs
+        paths:
+          - docs/architecture
+          - docs/adr
+        synthesis_target: autobot_synthesis_architecture
+        prompt_template: |
+          Summarise architecture docs.
+          Documents: {documents}
+
+      - name: api_reference
+        paths:
+          - docs/api
+        synthesis_target: autobot_synthesis_api
+        prompt_template: |
+          Summarise API docs.
+          Documents: {documents}
+
+      - name: runbooks_operations
+        paths:
+          - docs/operations
+        synthesis_target: autobot_synthesis_runbooks
+        prompt_template: |
+          Summarise runbooks.
+          Documents: {documents}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestLoadSuccess:
+    def test_returns_synthesis_schema(self, tmp_path):
+        path = _write_yaml(tmp_path, VALID_YAML)
+        schema = load_synthesis_schema(path)
+        assert isinstance(schema, SynthesisSchema)
+
+    def test_collection_count(self, tmp_path):
+        path = _write_yaml(tmp_path, VALID_YAML)
+        schema = load_synthesis_schema(path)
+        assert len(schema.collections) == 3
+
+    def test_first_collection_fields(self, tmp_path):
+        path = _write_yaml(tmp_path, VALID_YAML)
+        schema = load_synthesis_schema(path)
+        col: CollectionConfig = schema.collections[0]
+        assert col.name == "architecture_adrs"
+        assert "docs/architecture" in col.paths
+        assert col.synthesis_target == "autobot_synthesis_architecture"
+        assert "{documents}" in col.prompt_template
+
+    def test_all_collections_have_required_fields(self, tmp_path):
+        path = _write_yaml(tmp_path, VALID_YAML)
+        schema = load_synthesis_schema(path)
+        for col in schema.collections:
+            assert col.name
+            assert col.paths
+            assert col.synthesis_target
+            assert col.prompt_template
+
+
+class TestFallbackOnMissingFile:
+    def test_returns_empty_schema(self, tmp_path):
+        missing = tmp_path / "nonexistent.yaml"
+        schema = load_synthesis_schema(missing)
+        assert isinstance(schema, SynthesisSchema)
+        assert schema.collections == []
+
+    def test_no_exception_raised(self, tmp_path):
+        missing = tmp_path / "nonexistent.yaml"
+        # Should not raise
+        load_synthesis_schema(missing)
+
+
+class TestValidationError:
+    def test_unknown_key_raises_value_error(self, tmp_path):
+        bad_yaml = """\
+            collections:
+              - name: test_col
+                paths:
+                  - docs/test
+                synthesis_target: autobot_test
+                prompt_template: "test {documents}"
+                unknown_key: should_fail
+        """
+        path = _write_yaml(tmp_path, bad_yaml)
+        with pytest.raises(ValueError, match="unknown keys"):
+            load_synthesis_schema(path)
+
+    def test_missing_required_key_raises_value_error(self, tmp_path):
+        incomplete_yaml = """\
+            collections:
+              - name: test_col
+                paths:
+                  - docs/test
+                synthesis_target: autobot_test
+        """
+        path = _write_yaml(tmp_path, incomplete_yaml)
+        with pytest.raises(ValueError, match="missing required keys"):
+            load_synthesis_schema(path)
+
+    def test_missing_collections_key_raises_value_error(self, tmp_path):
+        bad_yaml = """\
+            not_collections:
+              - name: something
+        """
+        path = _write_yaml(tmp_path, bad_yaml)
+        with pytest.raises(ValueError, match="collections"):
+            load_synthesis_schema(path)


### PR DESCRIPTION
Closes #4565

## Summary
- New `autobot-backend/resources/knowledge/synthesis_schema.yaml` with 3 collection types: architecture/ADRs, API reference, runbooks/operations
- New `SynthesisSchema` + `CollectionConfig` dataclasses with `load_synthesis_schema()` — validates required keys, raises descriptive `ValueError` on unknown keys, gracefully falls back if file absent
- `DocIndexerService.__init__()` loads schema via `_load_schema()`, stores as `self.synthesis_schema`, warns if absent

## Test Status
✅ 9/9 unit tests pass — load success, missing-file fallback, validation error paths