### PR TITLE
feat(knowledge): synthesis provenance log to Redis stream (#4567)

### DIFF
--- a/autobot-backend/api/knowledge_maintenance.py
+++ b/autobot-backend/api/knowledge_maintenance.py
@@ -47,6 +47,7 @@ from services.knowledge.contradiction_detector import (
     load_report,
     store_report,
 )
+from services.knowledge.synthesis_provenance import SynthesisProvenanceLog
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -1911,6 +1912,8 @@ async def delete_backup(
 
 # ===== KNOWLEDGE LINT ENDPOINTS =====
 
+_provenance_log = SynthesisProvenanceLog()
+
 
 async def _run_lint_scan(job_id: str, chunks: list[dict]) -> None:
     """Background task: run contradiction scan and store result in Redis."""
@@ -1973,3 +1976,26 @@ async def get_lint_report(
     if report is None:
         raise HTTPException(status_code=404, detail="No lint report available yet")
     return report
+
+
+@router.get("/synthesis/log")
+async def get_synthesis_log(
+    limit: int = Query(
+        default=50,
+        ge=1,
+        le=200,
+        description="Max log entries to return (newest first)",
+    ),
+):
+    """Return recent synthesis provenance log entries from Redis stream.
+
+    Issue #4567: Synthesis provenance log.
+
+    Query parameters:
+    - limit: Maximum entries to return (default: 50, max: 200)
+
+    Returns list of provenance entries with: run_id, source_docs, synthesis_ids,
+    llm_model, prompt_template, ran_at, duration_ms.
+    """
+    entries = await _provenance_log.get_recent(limit=limit)
+    return {"entries": entries, "count": len(entries)}

--- a/autobot-backend/services/autoresearch/knowledge_synthesizer.py
+++ b/autobot-backend/services/autoresearch/knowledge_synthesizer.py
@@ -24,6 +24,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from services.knowledge.synthesis_provenance import SynthesisProvenanceLog
+
 from .config import AutoResearchConfig
 from .store import ExperimentStore
 
@@ -96,11 +98,13 @@ class KnowledgeSynthesizer(BaseSynthesizer):
         store: ExperimentStore,
         llm_service: Any,
         config: Optional[AutoResearchConfig] = None,
+        provenance_log: Optional[SynthesisProvenanceLog] = None,
     ) -> None:
         self._store = store
         self._llm = llm_service
         self._config = config or AutoResearchConfig()
         self._insights_collection = None
+        self._provenance_log = provenance_log or SynthesisProvenanceLog()
 
     async def _get_collection(self):
         """Return the insights ChromaDB collection (lazy-init)."""
@@ -170,7 +174,8 @@ class KnowledgeSynthesizer(BaseSynthesizer):
             )
             insights.append(insight)
 
-        await self._index_insights(insights)
+        source_doc_ids = [e.id for e in session_experiments]
+        await self._index_insights(insights, source_doc_ids=source_doc_ids)
         return insights
 
     async def query_insights(
@@ -265,8 +270,12 @@ class KnowledgeSynthesizer(BaseSynthesizer):
         """BaseSynthesizer ABC implementation — delegates to _index_insights."""
         await self._index_insights(docs)
 
-    async def _index_insights(self, insights: List[ExperimentInsight]) -> None:
-        """Store insights in ChromaDB."""
+    async def _index_insights(
+        self,
+        insights: List[ExperimentInsight],
+        source_doc_ids: Optional[List[str]] = None,
+    ) -> None:
+        """Store insights in ChromaDB and log provenance."""
         if not insights:
             return
 
@@ -284,8 +293,21 @@ class KnowledgeSynthesizer(BaseSynthesizer):
             for i in insights
         ]
 
+        run_id = str(uuid.uuid4())
+        start = time.monotonic()
         try:
             await collection.upsert(ids=ids, documents=documents, metadatas=metadatas)
             logger.info("Indexed %d insights in ChromaDB", len(insights))
         except Exception:
             logger.exception("Failed to index insights in ChromaDB")
+            return
+
+        duration_ms = int((time.monotonic() - start) * 1000)
+        await self._provenance_log.log_run(
+            run_id=run_id,
+            source_docs=source_doc_ids or [],
+            synthesis_ids=ids,
+            llm_model=getattr(self._llm, "model", "unknown"),
+            prompt_template="synthesis_system_prompt_v1",
+            duration_ms=duration_ms,
+        )

--- a/autobot-backend/services/knowledge/synthesis_provenance.py
+++ b/autobot-backend/services/knowledge/synthesis_provenance.py
@@ -1,0 +1,98 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Synthesis provenance log — records each KnowledgeSynthesizer run to a Redis stream.
+
+Issue #4567: Add synthesis provenance log so operators can audit which source
+documents and LLM models produced which insight IDs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = logging.getLogger(__name__)
+
+_STREAM_KEY = "kb:synthesis:log"
+
+
+class SynthesisProvenanceLog:
+    """Append-only provenance log for KnowledgeSynthesizer runs."""
+
+    async def log_run(
+        self,
+        run_id: str,
+        source_docs: List[str],
+        synthesis_ids: List[str],
+        llm_model: str,
+        prompt_template: str,
+        duration_ms: int,
+    ) -> None:
+        """Append a provenance entry to the Redis stream.
+
+        Args:
+            run_id: Unique identifier for this synthesis run.
+            source_docs: List of source document IDs used as input.
+            synthesis_ids: List of insight/synthesis IDs produced.
+            llm_model: Name/identifier of the LLM model used.
+            prompt_template: Name or key of the prompt template used.
+            duration_ms: Total synthesis duration in milliseconds.
+        """
+        entry: Dict[str, Any] = {
+            "run_id": run_id,
+            "source_docs": json.dumps(source_docs),
+            "synthesis_ids": json.dumps(synthesis_ids),
+            "llm_model": llm_model,
+            "prompt_template": prompt_template,
+            "ran_at": datetime.now(timezone.utc).isoformat(),
+            "duration_ms": str(duration_ms),
+        }
+        try:
+            redis = await get_async_redis_client(database="main")
+            await redis.xadd(_STREAM_KEY, entry)
+            logger.debug("Provenance logged for run %s (%d insights)", run_id, len(synthesis_ids))
+        except Exception:
+            logger.exception("Failed to write provenance log for run %s", run_id)
+
+    async def get_recent(self, limit: int = 50) -> List[Dict[str, Any]]:
+        """Return the most recent provenance entries.
+
+        Args:
+            limit: Maximum number of entries to return (newest first).
+
+        Returns:
+            List of provenance dicts with deserialized fields.
+        """
+        try:
+            redis = await get_async_redis_client(database="main")
+            raw_entries = await redis.xrevrange(_STREAM_KEY, count=limit)
+        except Exception:
+            logger.exception("Failed to read provenance log")
+            return []
+
+        results = []
+        for _entry_id, fields in raw_entries:
+            entry = {
+                k.decode("utf-8") if isinstance(k, bytes) else k: (
+                    v.decode("utf-8") if isinstance(v, bytes) else v
+                )
+                for k, v in fields.items()
+            }
+            for list_field in ("source_docs", "synthesis_ids"):
+                if list_field in entry:
+                    try:
+                        entry[list_field] = json.loads(entry[list_field])
+                    except (json.JSONDecodeError, TypeError):
+                        entry[list_field] = []
+            if "duration_ms" in entry:
+                try:
+                    entry["duration_ms"] = int(entry["duration_ms"])
+                except (ValueError, TypeError):
+                    pass
+            results.append(entry)
+        return results

--- a/autobot-backend/services/knowledge/test_synthesis_provenance.py
+++ b/autobot-backend/services/knowledge/test_synthesis_provenance.py
@@ -1,0 +1,360 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for SynthesisProvenanceLog and /knowledge/synthesis/log endpoint.
+
+Issue #4567: Synthesis provenance log.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.knowledge.synthesis_provenance import SynthesisProvenanceLog
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_STREAM_KEY = "kb:synthesis:log"
+
+
+def _make_redis_mock(xadd_result=b"1-1", xrevrange_result=None):
+    """Return an async Redis mock with xadd / xrevrange stubbed."""
+    mock = AsyncMock()
+    mock.xadd = AsyncMock(return_value=xadd_result)
+    mock.xrevrange = AsyncMock(return_value=xrevrange_result or [])
+    return mock
+
+
+def _raw_entry(fields: dict):
+    """Encode a fields dict as bytes to simulate raw Redis response."""
+    return (b"1-1", {k.encode(): v.encode() for k, v in fields.items()})
+
+
+# ---------------------------------------------------------------------------
+# log_run tests
+# ---------------------------------------------------------------------------
+
+
+class TestLogRun:
+    """Tests for SynthesisProvenanceLog.log_run()."""
+
+    @pytest.mark.asyncio
+    async def test_xadd_called_with_correct_stream_key(self):
+        """log_run writes to the kb:synthesis:log stream key."""
+        mock_redis = _make_redis_mock()
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            await svc.log_run(
+                run_id="run-1",
+                source_docs=["doc-a"],
+                synthesis_ids=["ins-1"],
+                llm_model="gpt-4",
+                prompt_template="v1",
+                duration_ms=120,
+            )
+        mock_redis.xadd.assert_called_once()
+        key_used = mock_redis.xadd.call_args[0][0]
+        assert key_used == _STREAM_KEY
+
+    @pytest.mark.asyncio
+    async def test_xadd_entry_contains_run_id(self):
+        """log_run payload includes run_id."""
+        mock_redis = _make_redis_mock()
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            await svc.log_run(
+                run_id="run-42",
+                source_docs=[],
+                synthesis_ids=[],
+                llm_model="ollama",
+                prompt_template="v1",
+                duration_ms=0,
+            )
+        fields = mock_redis.xadd.call_args[0][1]
+        assert fields["run_id"] == "run-42"
+
+    @pytest.mark.asyncio
+    async def test_xadd_entry_source_docs_json_encoded(self):
+        """source_docs field is JSON-encoded in the stream entry."""
+        mock_redis = _make_redis_mock()
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            await svc.log_run(
+                run_id="r",
+                source_docs=["doc-1", "doc-2"],
+                synthesis_ids=[],
+                llm_model="m",
+                prompt_template="t",
+                duration_ms=1,
+            )
+        fields = mock_redis.xadd.call_args[0][1]
+        assert json.loads(fields["source_docs"]) == ["doc-1", "doc-2"]
+
+    @pytest.mark.asyncio
+    async def test_xadd_entry_synthesis_ids_json_encoded(self):
+        """synthesis_ids field is JSON-encoded in the stream entry."""
+        mock_redis = _make_redis_mock()
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            await svc.log_run(
+                run_id="r",
+                source_docs=[],
+                synthesis_ids=["ins-a", "ins-b"],
+                llm_model="m",
+                prompt_template="t",
+                duration_ms=1,
+            )
+        fields = mock_redis.xadd.call_args[0][1]
+        assert json.loads(fields["synthesis_ids"]) == ["ins-a", "ins-b"]
+
+    @pytest.mark.asyncio
+    async def test_xadd_entry_duration_ms_as_string(self):
+        """duration_ms stored as string (Redis requires string values)."""
+        mock_redis = _make_redis_mock()
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            await svc.log_run(
+                run_id="r",
+                source_docs=[],
+                synthesis_ids=[],
+                llm_model="m",
+                prompt_template="t",
+                duration_ms=250,
+            )
+        fields = mock_redis.xadd.call_args[0][1]
+        assert fields["duration_ms"] == "250"
+
+    @pytest.mark.asyncio
+    async def test_log_run_swallows_redis_exception(self):
+        """log_run does not propagate Redis exceptions."""
+        mock_redis = AsyncMock()
+        mock_redis.xadd = AsyncMock(side_effect=ConnectionError("Redis down"))
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            # Must not raise
+            await svc.log_run(
+                run_id="r",
+                source_docs=[],
+                synthesis_ids=[],
+                llm_model="m",
+                prompt_template="t",
+                duration_ms=0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_recent tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecent:
+    """Tests for SynthesisProvenanceLog.get_recent()."""
+
+    @pytest.mark.asyncio
+    async def test_xrevrange_called_with_limit(self):
+        """get_recent passes count=limit to xrevrange."""
+        mock_redis = _make_redis_mock()
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            await svc.get_recent(limit=10)
+        mock_redis.xrevrange.assert_called_once_with(_STREAM_KEY, count=10)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_entries(self):
+        """get_recent returns [] when the stream is empty."""
+        mock_redis = _make_redis_mock(xrevrange_result=[])
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            result = await svc.get_recent()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_deserializes_source_docs(self):
+        """get_recent decodes JSON-encoded source_docs list."""
+        raw = [
+            _raw_entry(
+                {
+                    "run_id": "r1",
+                    "source_docs": '["doc-a"]',
+                    "synthesis_ids": "[]",
+                    "llm_model": "gpt-4",
+                    "prompt_template": "v1",
+                    "ran_at": "2026-01-01T00:00:00+00:00",
+                    "duration_ms": "100",
+                }
+            )
+        ]
+        mock_redis = _make_redis_mock(xrevrange_result=raw)
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            result = await svc.get_recent()
+        assert result[0]["source_docs"] == ["doc-a"]
+
+    @pytest.mark.asyncio
+    async def test_deserializes_synthesis_ids(self):
+        """get_recent decodes JSON-encoded synthesis_ids list."""
+        raw = [
+            _raw_entry(
+                {
+                    "run_id": "r1",
+                    "source_docs": "[]",
+                    "synthesis_ids": '["ins-1","ins-2"]',
+                    "llm_model": "m",
+                    "prompt_template": "t",
+                    "ran_at": "2026-01-01T00:00:00+00:00",
+                    "duration_ms": "50",
+                }
+            )
+        ]
+        mock_redis = _make_redis_mock(xrevrange_result=raw)
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            result = await svc.get_recent()
+        assert result[0]["synthesis_ids"] == ["ins-1", "ins-2"]
+
+    @pytest.mark.asyncio
+    async def test_duration_ms_cast_to_int(self):
+        """get_recent casts duration_ms string to int."""
+        raw = [
+            _raw_entry(
+                {
+                    "run_id": "r",
+                    "source_docs": "[]",
+                    "synthesis_ids": "[]",
+                    "llm_model": "m",
+                    "prompt_template": "t",
+                    "ran_at": "2026-01-01T00:00:00+00:00",
+                    "duration_ms": "999",
+                }
+            )
+        ]
+        mock_redis = _make_redis_mock(xrevrange_result=raw)
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            result = await svc.get_recent()
+        assert result[0]["duration_ms"] == 999
+        assert isinstance(result[0]["duration_ms"], int)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_on_redis_error(self):
+        """get_recent returns [] when Redis raises an exception."""
+        mock_redis = AsyncMock()
+        mock_redis.xrevrange = AsyncMock(side_effect=ConnectionError("Redis down"))
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            result = await svc.get_recent()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesisLogEndpoint:
+    """Tests for GET /knowledge/synthesis/log endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_endpoint_returns_200(self):
+        """GET /synthesis/log returns HTTP 200."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.knowledge_maintenance import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/knowledge")
+
+        mock_entries = [{"run_id": "r1", "llm_model": "gpt-4"}]
+        with patch(
+            "api.knowledge_maintenance._provenance_log.get_recent",
+            new=AsyncMock(return_value=mock_entries),
+        ):
+            client = TestClient(app)
+            response = client.get("/knowledge/synthesis/log")
+
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_endpoint_returns_entries_and_count(self):
+        """Response body contains 'entries' and 'count' keys."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.knowledge_maintenance import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/knowledge")
+
+        mock_entries = [{"run_id": "r1"}, {"run_id": "r2"}]
+        with patch(
+            "api.knowledge_maintenance._provenance_log.get_recent",
+            new=AsyncMock(return_value=mock_entries),
+        ):
+            client = TestClient(app)
+            response = client.get("/knowledge/synthesis/log")
+
+        body = response.json()
+        assert "entries" in body
+        assert body["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_endpoint_respects_limit_param(self):
+        """get_recent is called with the limit query parameter."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from api.knowledge_maintenance import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/knowledge")
+
+        mock_get_recent = AsyncMock(return_value=[])
+        with patch(
+            "api.knowledge_maintenance._provenance_log.get_recent",
+            new=mock_get_recent,
+        ):
+            client = TestClient(app)
+            client.get("/knowledge/synthesis/log?limit=25")
+            mock_get_recent.assert_called_once_with(limit=25)


### PR DESCRIPTION
Closes #4567

## Summary
- New `SynthesisProvenanceLog` in `services/knowledge/synthesis_provenance.py` — `log_run()` appends to Redis stream `kb:synthesis:log` via XADD, `get_recent()` reads via XREVRANGE
- `KnowledgeSynthesizer._index_insights()` wired to log after each successful ChromaDB upsert (run_id, source_docs, synthesis_ids, llm_model, prompt_template, duration_ms)
- New `GET /knowledge/synthesis/log` endpoint in `knowledge_maintenance.py` (limit param, default 50 max 200)

## Test Status
✅ 15/15 unit tests pass — XADD/XREVRANGE mocked, deserialization, endpoint 200/empty