### PR TITLE
fix(a11y): add focus-visible outlines for keyboard navigation (#4592)

### DIFF
--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -550,6 +550,11 @@ onMounted(() => {
   border-color: var(--color-info);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
+.form-input:focus-visible,
+.form-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-input--error {
   border-color: var(--color-error);

--- a/autobot-frontend/src/components/analytics/AgentCostPanel.vue
+++ b/autobot-frontend/src/components/analytics/AgentCostPanel.vue
@@ -445,6 +445,10 @@ defineExpose({ fetchAgentCosts })
   outline: none;
   border-color: var(--color-primary);
 }
+.budget-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .budget-dialog-actions {
   display: flex;

--- a/autobot-frontend/src/components/analytics/AnalyticsHeader.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeader.vue
@@ -243,6 +243,10 @@ function handleSourceChange(event: Event) {
   border-color: var(--color-info);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
+.source-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .select-chevron {
   position: absolute;

--- a/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
@@ -759,6 +759,11 @@ onMounted(() => {
   outline: none;
   border-color: var(--color-info);
 }
+.form-group textarea:focus-visible,
+.form-group select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .code-input {
   font-family: var(--font-mono);

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -922,6 +922,10 @@ onMounted(() => {
   outline: none;
   border-color: var(--accent-color);
 }
+.input-group input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .language-chips {
   display: flex;

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -739,6 +739,11 @@ onMounted(() => {
   outline: none;
   border-color: var(--color-info);
 }
+.form-group textarea:focus-visible,
+.form-row select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-row {
   display: flex;

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -717,6 +717,10 @@ onMounted(() => {
   outline: none;
   border-color: var(--accent-color);
 }
+.input-group input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .quick-paths {
   display: flex;

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -404,6 +404,10 @@ watch(() => props.source, (source) => {
   border-color: var(--color-info);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
 }
+.form-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-hint {
   font-size: var(--text-xs);

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -1636,6 +1636,11 @@ watch(selectedPeriod, () => {
   outline: none;
   border-color: var(--color-primary);
 }
+.table-filters select:focus-visible,
+.table-filters input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .debt-table-container {
   overflow-x: auto;

--- a/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
@@ -256,6 +256,10 @@ function copyPath(finding: Finding): void {
   border-color: var(--color-info);
   box-shadow: 0 0 0 3px var(--color-info-bg);
 }
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 /* Issue #901: Technical Precision severity badges */
 .severity-badge {

--- a/autobot-frontend/src/components/audit/AuditFilters.vue
+++ b/autobot-frontend/src/components/audit/AuditFilters.vue
@@ -314,6 +314,11 @@ function clearFilters() {
   border-color: var(--color-primary);
   box-shadow: var(--ring-primary);
 }
+.filter-group input:focus-visible,
+.filter-group select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .filter-actions {
   display: flex;

--- a/autobot-frontend/src/components/auth/LoginForm.vue
+++ b/autobot-frontend/src/components/auth/LoginForm.vue
@@ -355,6 +355,10 @@ onMounted(async () => {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-input.error {
   border-color: var(--color-error);

--- a/autobot-frontend/src/components/base/BaseInput.vue
+++ b/autobot-frontend/src/components/base/BaseInput.vue
@@ -221,6 +221,11 @@ defineExpose({
   transition: color 150ms ease;
 }
 
+.base-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .base-input::placeholder {
   color: var(--text-muted);
 }

--- a/autobot-frontend/src/components/browser/BrowserSessionManager.vue
+++ b/autobot-frontend/src/components/browser/BrowserSessionManager.vue
@@ -681,6 +681,10 @@ export default {
   outline: none;
   border-color: var(--color-primary);
 }
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-checkbox {
   width: 18px;

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
@@ -295,6 +295,10 @@ function submitType() {
 .type-input:focus {
   border-color: var(--color-primary, #3b82f6);
 }
+.type-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .type-submit {
   display: flex;

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -1422,6 +1422,11 @@ watch(viewMode, async (newMode) => {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.graph-search:focus-visible,
+.module-filter:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .view-toggle {
   display: flex;
@@ -1973,6 +1978,11 @@ watch(viewMode, async (newMode) => {
 .orphaned-module-filter:focus {
   outline: none;
   border-color: var(--color-primary);
+}
+.orphaned-search:focus-visible,
+.orphaned-module-filter:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .orphaned-list {

--- a/autobot-frontend/src/components/chat/ApprovalRequestCard.vue
+++ b/autobot-frontend/src/components/chat/ApprovalRequestCard.vue
@@ -453,6 +453,10 @@ const submitWithComment = () => {
   border-color: var(--color-info);
   box-shadow: 0 0 0 2px var(--color-info-bg);
 }
+.comment-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .comment-actions {
   display: flex;

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -697,7 +697,8 @@ const deleteSelectedSessions = async () => {
 }
 
 .group:focus-visible {
-  outline: none;
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
   box-shadow: 0 0 0 2px var(--color-primary-transparent);
 }
 </style>

--- a/autobot-frontend/src/components/chat/DocumentationSearchSidebar.vue
+++ b/autobot-frontend/src/components/chat/DocumentationSearchSidebar.vue
@@ -593,6 +593,10 @@ onMounted(() => {
   background: var(--bg-card);
   box-shadow: var(--shadow-focus);
 }
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .search-input::placeholder {
   color: var(--text-muted);

--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
@@ -551,6 +551,11 @@ onUnmounted(() => {
   outline: none;
   border-color: var(--color-primary);
 }
+.option-group select:focus-visible,
+.option-group input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 /* Analyze button */
 .btn-analyze {

--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -443,6 +443,11 @@ onMounted(() => {
   padding: var(--spacing-2) 0;
 }
 
+.url-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .url-input::placeholder {
   color: var(--text-muted);
 }

--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -816,6 +816,11 @@ onBeforeUnmount(() => {
   cursor: pointer;
 }
 
+.voice-overlay__threshold-slider:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .voice-overlay__threshold-slider::-webkit-slider-thumb {
   appearance: none;
   width: 12px;

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -439,6 +439,11 @@ onBeforeUnmount(() => {
   cursor: pointer;
 }
 
+.voice-panel__slider:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .voice-panel__slider::-webkit-slider-thumb {
   appearance: none;
   width: 10px;

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -691,6 +691,10 @@ onUnmounted(() => {
   border-color: var(--color-primary);
   box-shadow: 0 0 0 2px var(--color-primary-bg);
 }
+.type-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .type-dialog-footer {
   padding: 1rem 1.5rem;

--- a/autobot-frontend/src/components/documents/AIDocumentEditor.vue
+++ b/autobot-frontend/src/components/documents/AIDocumentEditor.vue
@@ -293,6 +293,10 @@ const formattedUpdatedAt = computed(() => {
   border-radius: 4px;
   transition: background 0.15s;
 }
+.document-title:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .document-title:hover {
   background: var(--color-background-hover, #2a2a2a);
@@ -308,6 +312,10 @@ const formattedUpdatedAt = computed(() => {
   font-weight: 600;
   padding: 2px 8px;
   outline: none;
+}
+.title-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .header-actions {
@@ -350,6 +358,10 @@ const formattedUpdatedAt = computed(() => {
 .refine-textarea:focus {
   border-color: var(--color-primary, #4caf50);
 }
+.refine-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .refine-actions {
   display: flex;
@@ -375,6 +387,10 @@ const formattedUpdatedAt = computed(() => {
   outline: none;
   width: 100%;
   box-sizing: border-box;
+}
+.content-editor:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .editor-footer {

--- a/autobot-frontend/src/components/examples/AsyncOperationExample.vue
+++ b/autobot-frontend/src/components/examples/AsyncOperationExample.vue
@@ -958,6 +958,10 @@ const loadAnalytics = () => analytics.execute(async () => {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 /* Notifications */
 .notification-toast {

--- a/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
+++ b/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
@@ -514,6 +514,10 @@ const closeModal = () => {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-input:disabled {
   opacity: 0.6;

--- a/autobot-frontend/src/components/knowledge/BackupManager.vue
+++ b/autobot-frontend/src/components/knowledge/BackupManager.vue
@@ -428,6 +428,10 @@ onMounted(() => {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.description-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .backups-list-section h5 {
   font-size: var(--text-sm);

--- a/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
+++ b/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
@@ -426,6 +426,10 @@ onUnmounted(() => {
   border-color: var(--color-primary);
   box-shadow: 0 0 0 2px var(--color-primary-alpha, rgba(59, 130, 246, 0.2));
 }
+.section-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .auto-refresh-toggle {
   display: flex;

--- a/autobot-frontend/src/components/knowledge/EntityExtractor.vue
+++ b/autobot-frontend/src/components/knowledge/EntityExtractor.vue
@@ -435,6 +435,11 @@ function formatTime(timestamp?: number): string {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.form-group input:focus-visible,
+.form-group textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-group input:disabled,
 .form-group textarea:disabled {

--- a/autobot-frontend/src/components/knowledge/GraphRAGQuery.vue
+++ b/autobot-frontend/src/components/knowledge/GraphRAGQuery.vue
@@ -467,6 +467,11 @@ onMounted(() => {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.form-group input:focus-visible,
+.form-group select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-group input:disabled,
 .form-group select:disabled {

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -1362,6 +1362,10 @@ watch(() => props.mode, () => {
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px var(--color-primary-alpha-10);
 }
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .clear-btn {
   position: absolute;

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.vue
@@ -154,6 +154,11 @@ defineEmits<Emits>()
   background: transparent;
 }
 
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .search-input::placeholder {
   color: var(--text-tertiary);
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -1116,6 +1116,11 @@ onUnmounted(() => {
   border-color: var(--color-info);
   box-shadow: var(--shadow-focus);
 }
+.form-input:focus-visible,
+.form-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .color-picker {
   display: flex;

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -985,6 +985,10 @@ watch([debouncedSearchQuery, filterCategory, filterType], () => {
   border-color: var(--color-info);
   box-shadow: 0 0 0 3px var(--color-info-bg);
 }
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 /* Filter bar */
 .filter-bar {
@@ -1025,6 +1029,10 @@ watch([debouncedSearchQuery, filterCategory, filterType], () => {
   outline: none;
   border-color: var(--color-info);
   box-shadow: 0 0 0 3px var(--color-info-bg);
+}
+.filter-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 /* Loading and empty states */
@@ -1288,6 +1296,13 @@ tr.selected {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.form-input:focus-visible,
+.form-select:focus-visible,
+.form-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.form-input:focus-visible,
 
 .form-row {
   display: grid;

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -1470,6 +1470,10 @@ watch(layoutMode, () => {
   background: transparent;
   color: var(--text-primary);
 }
+.search-group input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .search-group input::placeholder {
   color: var(--text-tertiary);
@@ -1883,6 +1887,13 @@ watch(layoutMode, () => {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.form-group input:focus-visible,
+.form-group select:focus-visible,
+.form-group textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.form-group input:focus-visible,
 
 .form-actions {
   display: flex;

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
@@ -795,6 +795,10 @@ watch(() => props.visible, (newVal) => {
   outline: none;
   border-color: var(--color-info);
 }
+.title-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 /* Button styling handled by BaseButton component */
 

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -793,6 +793,10 @@ onBeforeUnmount(() => {
   border-color: var(--color-info);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
+.prompt-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 /* Editor Footer */
 .editor-footer {

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
@@ -685,6 +685,11 @@ onUnmounted(() => {
   padding: var(--spacing-2) 0;
 }
 
+.query-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .query-input::placeholder {
   color: var(--text-muted);
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
@@ -195,6 +195,10 @@ const handleGroupChange = () => {
   border-color: var(--color-electric-500, #3b82f6);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
+.scope-dropdown:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .scope-dropdown:disabled {
   background-color: var(--bg-secondary);

--- a/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
@@ -1223,6 +1223,10 @@ onMounted(() => {
   box-shadow: 0 0 0 2px var(--color-info);
   background: var(--color-info-bg);
 }
+.tag-cloud-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 /* Vector Database Statistics Section */
 .vector-stats-section {

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
@@ -574,6 +574,10 @@ onMounted(() => {
   outline: none;
   border-color: var(--color-info);
 }
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 /* Export Dropdown */
 .export-dropdown {

--- a/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
@@ -1070,6 +1070,13 @@ onMounted(() => {
   border-color: var(--color-primary);
   box-shadow: var(--ring-primary);
 }
+.form-input:focus-visible,
+.form-textarea:focus-visible,
+.form-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.form-input:focus-visible,
 
 .char-count {
   text-align: right;

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -465,6 +465,10 @@ const closeDialog = () => {
   border-color: var(--color-electric-500, #3b82f6);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .search-results {
   margin-bottom: 1.5rem;

--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
@@ -795,6 +795,10 @@ export default {
   border-color: var(--color-info);
   box-shadow: var(--shadow-focus);
 }
+.host-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .status-cards {
   display: grid;

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
@@ -872,6 +872,11 @@ function closeModal() {
   border-color: var(--color-info);
   box-shadow: 0 0 0 1px var(--color-info);
 }
+.form-input:focus-visible,
+.form-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-input-narrow {
   max-width: 120px;

--- a/autobot-frontend/src/components/knowledge/graph/KnowledgeGraphExplorer.vue
+++ b/autobot-frontend/src/components/knowledge/graph/KnowledgeGraphExplorer.vue
@@ -237,6 +237,11 @@ function handleViewTimeline(entityName: string): void {
   outline: none;
 }
 
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .search-input::placeholder {
   color: var(--text-tertiary);
 }

--- a/autobot-frontend/src/components/knowledge/modals/BulkEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/BulkEditModal.vue
@@ -510,6 +510,11 @@ watch(() => props.modelValue, (newValue) => {
   border-color: var(--color-primary);
   box-shadow: var(--ring-primary);
 }
+.form-select:focus-visible,
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-hint {
   font-size: var(--text-xs);

--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -524,6 +524,11 @@ function selectIcon(icon: string): void {
   border-color: var(--color-info);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
+.form-input:focus-visible,
+.form-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-input:disabled,
 .form-textarea:disabled {

--- a/autobot-frontend/src/components/knowledge/pipeline/PipelineRunner.vue
+++ b/autobot-frontend/src/components/knowledge/pipeline/PipelineRunner.vue
@@ -284,6 +284,10 @@ async function handleSubmit(): Promise<void> {
   outline: none;
   border-color: var(--color-primary);
 }
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .config-label-row {
   display: flex;

--- a/autobot-frontend/src/components/knowledge/stats/TagCloudPanel.vue
+++ b/autobot-frontend/src/components/knowledge/stats/TagCloudPanel.vue
@@ -87,4 +87,8 @@ h4 {
   box-shadow: var(--ring-primary);
   background: var(--color-primary-bg);
 }
+.tag-cloud-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 </style>

--- a/autobot-frontend/src/components/knowledge/summaries/SummariesPage.vue
+++ b/autobot-frontend/src/components/knowledge/summaries/SummariesPage.vue
@@ -175,6 +175,10 @@ function handleDrillDown(summaryId: string): void {
   outline: none;
   border-color: var(--color-primary);
 }
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .load-btn {
   display: flex;

--- a/autobot-frontend/src/components/knowledge/summaries/SummarySearch.vue
+++ b/autobot-frontend/src/components/knowledge/summaries/SummarySearch.vue
@@ -243,6 +243,11 @@ async function handleSearch(): Promise<void> {
   outline: none;
 }
 
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .search-input::placeholder {
   color: var(--text-tertiary);
 }

--- a/autobot-frontend/src/components/knowledge/temporal/TemporalFilter.vue
+++ b/autobot-frontend/src/components/knowledge/temporal/TemporalFilter.vue
@@ -175,6 +175,10 @@ h5 i {
   outline: none;
   border-color: var(--color-primary);
 }
+.filter-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 /* Checkboxes */
 .checkbox-list {

--- a/autobot-frontend/src/components/manpage/ManPageManager.vue
+++ b/autobot-frontend/src/components/manpage/ManPageManager.vue
@@ -969,6 +969,10 @@ export default {
   outline: none;
   border-color: var(--color-primary);
 }
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .search-results h4 {
   margin-bottom: var(--spacing-5);

--- a/autobot-frontend/src/components/manpage/ManPageSearchPanel.vue
+++ b/autobot-frontend/src/components/manpage/ManPageSearchPanel.vue
@@ -116,6 +116,10 @@ defineEmits<Emits>()
   outline: none;
   border-color: var(--color-info);
 }
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .search-results h4 {
   margin-bottom: var(--spacing-5);

--- a/autobot-frontend/src/components/operations/OperationFilters.vue
+++ b/autobot-frontend/src/components/operations/OperationFilters.vue
@@ -188,6 +188,10 @@ function clearFilters() {
   border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
+.filter-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .clear-filters-btn {
   display: flex;

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -590,6 +590,10 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   border-color: var(--color-primary, #6366f1);
   box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
 }
+.pw-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .toast {
   position: fixed;

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -1675,6 +1675,10 @@ watch(selectedScope, () => {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.search-wrapper .search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .clear-search {
   position: absolute;

--- a/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.vue
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.vue
@@ -523,6 +523,10 @@ onMounted(() => {
   border-color: var(--color-info);
   box-shadow: var(--shadow-focus);
 }
+.url-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .btn-check {
   display: flex;

--- a/autobot-frontend/src/components/security/ThreatIntelligenceSettings.vue
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceSettings.vue
@@ -456,6 +456,10 @@ onMounted(() => {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.form-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .form-input-small {
   width: 80px;

--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
@@ -511,6 +511,10 @@ function resetEdit(): void {
   border-color: var(--color-info, #3b82f6);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
 }
+.edit-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .edit-error {
   display: flex;

--- a/autobot-frontend/src/components/terminal/Terminal.vue
+++ b/autobot-frontend/src/components/terminal/Terminal.vue
@@ -726,6 +726,11 @@ onUnmounted(() => {
   padding: 0;
 }
 
+.terminal-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 /* Additional styling for terminal line types */
 .terminal-line {
   @apply mb-1 break-words;

--- a/autobot-frontend/src/components/terminal/TerminalInput.vue
+++ b/autobot-frontend/src/components/terminal/TerminalInput.vue
@@ -253,6 +253,11 @@ defineExpose({
   min-width: 0;
 }
 
+.terminal-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .send-button {
   background: var(--terminal-green-bg);
   border: 1px solid var(--terminal-green-border);

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -1664,6 +1664,11 @@ export default {
   min-width: 0;
 }
 
+.terminal-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .cursor {
   color: #00ff00;
   font-weight: bold;

--- a/autobot-frontend/src/components/ui/BaseAlert.vue
+++ b/autobot-frontend/src/components/ui/BaseAlert.vue
@@ -171,8 +171,10 @@ onMounted(() => {
 
 .alert-dismiss:focus {
   outline: none;
-  ring: 2px;
-  ring-offset: 2px;
+}
+.alert-dismiss:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 /* Success variant */

--- a/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
+++ b/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
@@ -663,6 +663,10 @@ export default {
   border-color: var(--color-success);
   box-shadow: var(--shadow-focus-success);
 }
+.comment-textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .comment-textarea:disabled {
   background: var(--bg-secondary);

--- a/autobot-frontend/src/components/ui/ThemeToggle.vue
+++ b/autobot-frontend/src/components/ui/ThemeToggle.vue
@@ -184,6 +184,10 @@ function getThemeIcon(themeOption: Theme): string {
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
 }
+.theme-toggle__select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .theme-toggle__dropdown-icon {
   position: absolute;
@@ -252,6 +256,10 @@ function getThemeIcon(themeOption: Theme): string {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: var(--shadow-focus);
+}
+.theme-toggle__simple:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 /* Compact mode adjustments */

--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
@@ -491,6 +491,11 @@ defineExpose({
   outline: none;
   border-color: var(--chart-blue);
 }
+.metric-select:focus-visible,
+.time-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .refresh-btn {
   padding: var(--spacing-2) var(--spacing-3);

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
@@ -346,6 +346,7 @@ async function handleSave(): Promise<void> {
   outline: none;
 }
 .notif-input:focus { border-color: var(--color-primary); }
+.notif-input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 
 .tag-input-wrapper {
   display: flex;
@@ -393,6 +394,7 @@ async function handleSave(): Promise<void> {
   outline: none;
 }
 .tag-input:focus { border-color: var(--color-primary); }
+.tag-input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 
 .field-error {
   margin: 6px 0 0;

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -390,6 +390,7 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .node-body { padding: 12px; display: flex; flex-direction: column; gap: 8px; }
 .node-body input, .node-body select { width: 100%; padding: 6px 8px; background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: 4px; color: var(--text-primary); font-size: 12px; }
 .node-body input:focus, .node-body select:focus { outline: none; border-color: var(--color-primary); }
+.node-body input:focus-visible, .node-body select:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .node-body input.mono { font-family: monospace; }
 .node-row { display: flex; gap: 8px; align-items: center; }
 .node-row select { flex: 1; }
@@ -412,6 +413,7 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .dialog h3 i { color: var(--color-primary); }
 .dialog input, .dialog textarea { width: 100%; padding: 10px 12px; margin-bottom: 12px; background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: 6px; color: var(--text-primary); font-size: 14px; font-family: inherit; }
 .dialog input:focus, .dialog textarea:focus { outline: none; border-color: var(--color-primary); }
+.dialog input:focus-visible, .dialog textarea:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .dialog-actions { display: flex; justify-content: flex-end; gap: 12px; margin-top: 12px; }
 
 .btn-primary { padding: 10px 20px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: 6px; font-size: 14px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }

--- a/autobot-frontend/src/components/workflow/WorkflowHistory.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowHistory.vue
@@ -188,6 +188,7 @@ function formatDate(date?: string): string {
 .search-box { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 8px; flex: 1; min-width: 200px; }
 .search-box i { color: var(--text-muted); }
 .search-box input { flex: 1; background: none; border: none; color: var(--text-primary); font-size: 14px; outline: none; }
+.search-box input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .filter-group { display: flex; gap: 8px; }
 .filter-group select { padding: 10px 12px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 8px; color: var(--text-primary); font-size: 13px; cursor: pointer; }
 

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
@@ -368,6 +368,10 @@ watch(saveSuccess, (val) => {
   border-color: var(--color-primary, #3b82f6);
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
 }
+.field-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .field-hint {
   font-size: 0.75rem;

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
@@ -325,6 +325,7 @@ onMounted(async () => {
 .search-box { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 8px; }
 .search-box i { color: var(--text-muted); }
 .search-box input { flex: 1; background: none; border: none; color: var(--text-primary); font-size: 14px; outline: none; }
+.search-box input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .category-filters { display: flex; gap: 8px; flex-wrap: wrap; }
 .filter-btn { padding: 6px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 20px; color: var(--text-secondary); font-size: 13px; cursor: pointer; transition: all 0.15s; display: flex; align-items: center; gap: 6px; }
 .filter-btn:hover { background: var(--bg-hover); }

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -1020,6 +1020,11 @@ onMounted(() => {
   outline: none;
   border-color: var(--color-primary);
 }
+.form-group input:focus-visible,
+.form-group select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .modal-footer {
   display: flex;

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -450,6 +450,10 @@ onMounted(async () => {
   outline: none;
   border-color: var(--color-primary);
 }
+.search-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .filter-select {
   padding: 6px 10px;
@@ -464,6 +468,10 @@ onMounted(async () => {
 .filter-select:focus {
   outline: none;
   border-color: var(--color-primary);
+}
+.filter-select:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .btn-filter-toggle {

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -1077,6 +1077,10 @@ onMounted(async () => {
   outline: none;
   border-color: var(--color-primary);
 }
+.config-editor:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .config-error {
   font-size: var(--text-sm);

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -1741,6 +1741,10 @@ watch(hasActiveWorkflows, (hasActive) => {
   outline: none;
   border-color: var(--color-primary);
 }
+.nl-input-area textarea:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
 
 .nl-input-area textarea::placeholder {
   color: var(--text-muted);


### PR DESCRIPTION
Closes #4592

## Summary
- 106 `:focus-visible` rules added across 78 files (372 net insertions)
- Pattern: `outline: 2px solid var(--color-primary); outline-offset: 2px` on all interactive elements
- Skipped: `tabindex=-1` containers, elements already having focus-visible
- Fixes WCAG 2.1 Level AA Success Criterion 2.4.7 Focus Visible