### PR TITLE
fix(frontend): replace hardcoded box-shadow values with design tokens (#4560)

### DIFF
--- a/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
@@ -223,6 +223,6 @@ const emit = defineEmits<{
 
 .btn-debug:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
 }
 </style>

--- a/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
@@ -124,7 +124,7 @@ async function handleScan() {
   border-radius: var(--radius-lg);
   width: 100%;
   max-width: 480px;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-xl);
 }
 
 .modal-header {

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -1090,7 +1090,7 @@ onUnmounted(() => {
   border-radius: 0;
   overflow-y: auto;
   z-index: 100;
-  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-sm);
 }
 
 .detail-header {

--- a/autobot-frontend/src/components/chat/ChatInput.vue
+++ b/autobot-frontend/src/components/chat/ChatInput.vue
@@ -927,7 +927,7 @@ onUnmounted(() => {
   bottom: 0 !important;
   z-index: 10 !important;
   background-color: var(--autobot-bg-card, white) !important;
-  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Upload Progress */

--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
@@ -364,7 +364,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-2xl);
 }
 
 /* Header */

--- a/autobot-frontend/src/components/file-browser/FileBrowser.vue
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.vue
@@ -576,7 +576,7 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-lg);
 }
 
 .modal-header {
@@ -650,7 +650,7 @@ onMounted(() => {
   max-height: 100%;
   object-fit: contain;
   border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Text/Code Preview */

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -1521,7 +1521,7 @@ watch(() => props.mode, () => {
   background: var(--bg-card);
   margin: 1rem;
   border-radius: 0.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
 }
 
 .loading-content,

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -382,7 +382,7 @@ const closeDialog = () => {
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-xl);
 }
 
 .modal-header {

--- a/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
+++ b/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
@@ -856,7 +856,7 @@ onMounted(() => {
   border-radius: 50%;
   background: #ffffff;
   transition: transform 0.2s;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-sm);
 }
 
 .toggle-on .toggle-thumb {

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -355,7 +355,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   max-width: 600px;
   max-height: 90vh;
   overflow-y: auto;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-xl);
 }
 
 .modal-header {
@@ -597,7 +597,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   right: 24px;
   padding: 16px 20px;
   border-radius: 8px;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-lg);
   font-weight: 500;
   animation: slideIn 0.3s ease-out;
   z-index: 1100;

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -1861,7 +1861,7 @@ export default {
   border-radius: 12px;
   max-width: 600px;
   width: 90%;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg);
   border: 1px solid #444;
 }
 

--- a/autobot-frontend/src/components/vision/GUIAutomationControls.vue
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.vue
@@ -406,7 +406,7 @@ onMounted(() => {
 
 .opportunity-card:hover {
   border-color: var(--color-primary);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-md);
 }
 
 .card-header {

--- a/autobot-frontend/src/components/vision/MediaGallery.vue
+++ b/autobot-frontend/src/components/vision/MediaGallery.vue
@@ -389,7 +389,7 @@ onUnmounted(() => {
 
 .gallery-item:hover {
   border-color: var(--color-primary);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-md);
 }
 
 .item-thumbnail {

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
@@ -878,7 +878,7 @@ defineExpose({
   background: var(--bg-secondary);
   border-radius: 12px;
   border: 1px solid var(--border-subtle);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-lg);
   overflow: hidden;
 }
 

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
@@ -259,7 +259,7 @@ async function handleSave(): Promise<void> {
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-lg);
 }
 
 .notif-header {

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -368,8 +368,8 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .connection-line { fill: none; stroke: var(--color-primary); stroke-width: 2; }
 .drawing-line { fill: none; stroke: var(--color-primary); stroke-width: 2; stroke-dasharray: 5; opacity: 0.6; }
 
-.workflow-node { position: absolute; width: 240px; background: var(--bg-secondary); border: 2px solid var(--border-default); border-radius: 10px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); cursor: move; user-select: none; }
-.workflow-node:hover { box-shadow: 0 4px 16px rgba(0,0,0,0.15); }
+.workflow-node { position: absolute; width: 240px; background: var(--bg-secondary); border: 2px solid var(--border-default); border-radius: 10px; box-shadow: var(--shadow-sm); cursor: move; user-select: none; }
+.workflow-node:hover { box-shadow: var(--shadow-md); }
 .workflow-node.selected { border-color: var(--color-primary); box-shadow: 0 0 0 3px var(--color-primary-bg); }
 .workflow-node.step .node-header { background: var(--color-primary); }
 .workflow-node.condition .node-header { background: var(--color-warning); }

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -522,7 +522,7 @@ onUnmounted(() => {
 
 .execution-card:hover {
   border-color: var(--color-primary);
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-sm);
 }
 
 .execution-card.card-running { border-left: 3px solid var(--color-success); }

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -643,7 +643,7 @@ onMounted(loadUsers)
   border-radius: 0.75rem;
   width: 100%;
   max-width: 480px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-2xl);
 }
 
 .modal-sm {

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -929,7 +929,7 @@ onMounted(async () => {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-2xl);
 }
 
 .modal-header {


### PR DESCRIPTION
Closes #4560

## Summary
- 22 neutral box-shadow values replaced with `var(--shadow-sm/md/lg/xl/2xl)` across 19 files
- Colored semantic glows (red/green/blue rgba) intentionally left as-is
- Inset shadows left as-is (no inset token)