### PR TITLE
fix(a2a): eliminate double list_tasks() scan in task_stats() (#4593)

### DIFF
--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -438,7 +438,12 @@ async def cancel_task(task_id: str) -> Dict[str, str]:
 async def task_stats() -> Dict[str, Any]:
     """Return task counts broken down by state."""
     manager = get_task_manager()
-    return {"counts": manager.stats(), "total": len(manager.list_tasks())}
+    tasks = manager.list_tasks()
+    counts: Dict[str, int] = {}
+    for t in tasks:
+        k = t.status.state.value
+        counts[k] = counts.get(k, 0) + 1
+    return {"counts": counts, "total": len(tasks)}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4593

## Summary

`task_stats()` was calling `manager.stats()` (which calls `list_tasks()` internally) and then `manager.list_tasks()` again for the total count — two full Redis `SMEMBERS` + N `GET` scans per request. Fixed to call `list_tasks()` once and derive both counts and total from the single result.

## Changes

- `autobot-backend/api/a2a.py` — inline count loop in `task_stats()`, single `list_tasks()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)