### PR TITLE
fix(a2a): expire a2a:tasks tracking set to prevent unbounded growth (#4594)

### DIFF
--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -156,6 +156,7 @@ class TaskManager:
         key = _KEY_TASK.format(task.id)
         self._redis.set(key, _task_to_json(task), ex=ttl)
         self._redis.sadd(_KEY_TASKS, task.id)
+        self._redis.expire(_KEY_TASKS, ttl)
 
     def _load(self, task_id: str) -> Optional[Task]:
         raw = self._redis.get(_KEY_TASK.format(task_id))


### PR DESCRIPTION
Closes #4594

## Summary

`a2a:tasks` Redis set accumulated all task IDs ever created with no TTL. When callers only use the SSE stream endpoint (bypassing `list_tasks()`), the lazy-prune path in `list_tasks()` is never triggered and the set grows indefinitely.

Fix: call `EXPIRE` on `_KEY_TASKS` in `_save()` alongside the task key, giving the set a rolling TTL that matches the task TTL. The set expires naturally after one full TTL window of inactivity.

## Changes

- `autobot-backend/a2a/task_manager.py` — add `self._redis.expire(_KEY_TASKS, ttl)` in `_save()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)