### PR TITLE
fix(a2a): evict stale _rate_buckets entries to prevent memory leak (#4595)

### DIFF
--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -54,6 +54,7 @@ router = APIRouter(
 # ---------------------------------------------------------------------------
 
 _RATE_LIMIT = int(os.environ.get("AUTOBOT_A2A_RATE_LIMIT", "30"))  # per minute
+_RATE_BUCKET_MAX_KEYS = 10_000  # evict stale entries when dict exceeds this size
 _rate_buckets: Dict[str, list] = {}  # ip → [timestamps]
 
 
@@ -63,11 +64,13 @@ def _check_rate_limit(remote_addr: str) -> None:
 
     Raises HTTP 429 if the caller has exceeded _RATE_LIMIT requests/minute.
     Uses a sliding window stored in _rate_buckets (in-process, per worker).
+
+    Stale entries (IPs whose entire window has expired) are evicted when the
+    dict exceeds _RATE_BUCKET_MAX_KEYS to prevent unbounded memory growth.
     """
     now = time.time()
     window_start = now - 60
-    bucket = _rate_buckets.get(remote_addr, [])
-    bucket = [t for t in bucket if t > window_start]
+    bucket = [t for t in _rate_buckets.get(remote_addr, []) if t > window_start]
     if len(bucket) >= _RATE_LIMIT:
         raise HTTPException(
             status_code=429,
@@ -75,6 +78,11 @@ def _check_rate_limit(remote_addr: str) -> None:
         )
     bucket.append(now)
     _rate_buckets[remote_addr] = bucket
+    if len(_rate_buckets) > _RATE_BUCKET_MAX_KEYS:
+        cutoff = now - 60
+        stale = [ip for ip, ts in _rate_buckets.items() if not any(t > cutoff for t in ts)]
+        for ip in stale:
+            del _rate_buckets[ip]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4595

## Summary

`_rate_buckets` dict accumulated one entry per unique IP ever seen with no eviction. IPs that make requests and then go silent leave stale timestamp lists in the dict indefinitely.

Fix: added `_RATE_BUCKET_MAX_KEYS = 10_000` threshold. When the dict exceeds this size, a single O(n) sweep removes all entries whose full 60-second window has expired. Zero cost under normal traffic; sweeps only when the dict is large.

## Changes

- `autobot-backend/api/a2a.py` — add `_RATE_BUCKET_MAX_KEYS` constant and threshold-triggered eviction sweep in `_check_rate_limit()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)