### PR TITLE
style(tokens): replace hardcoded border-radius values with design tokens (#4559)

### DIFF
--- a/autobot-frontend/src/components/CommandPalette.vue
+++ b/autobot-frontend/src/components/CommandPalette.vue
@@ -271,7 +271,7 @@ defineExpose({
 
 ::-webkit-scrollbar-thumb {
   background: var(--autobot-border);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 ::-webkit-scrollbar-thumb:hover {

--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -422,7 +422,7 @@ function statusClass(status: string): string {
 .agent-selector input {
   background: var(--bg-input, #1e293b);
   border: 1px solid var(--border, #334155);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   color: inherit;
   padding: 0.25rem 0.5rem;
   width: 200px;
@@ -430,14 +430,14 @@ function statusClass(status: string): string {
 .error-banner {
   background: rgba(239, 68, 68, 0.15);
   border: 1px solid rgba(239, 68, 68, 0.4);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: #fca5a5;
   padding: 0.5rem 0.75rem;
 }
 .card {
   background: var(--bg-card, #1e293b);
   border: 1px solid var(--border, #334155);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 1rem;
 }
 .card-title {
@@ -493,7 +493,7 @@ function statusClass(status: string): string {
   width: 70px;
   background: var(--bg-input, #0f172a);
   border: 1px solid var(--border, #334155);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   color: inherit;
   padding: 0.2rem 0.4rem;
 }
@@ -560,14 +560,14 @@ function statusClass(status: string): string {
 }
 .count-badge {
   background: var(--bg-input, #0f172a);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   font-size: 0.75rem;
   padding: 0.1rem 0.4rem;
 }
 button {
   background: var(--bg-btn, #334155);
   border: 1px solid var(--border, #475569);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   color: inherit;
   cursor: pointer;
   font-size: 0.8rem;
@@ -606,7 +606,7 @@ button:not(:disabled):hover {
   padding: 0.15rem 0.45rem;
 }
 .badge {
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.72rem;
   font-weight: 600;
   padding: 0.1rem 0.45rem;

--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
@@ -562,7 +562,7 @@ onMounted(() => {
   background: none;
   color: var(--text-secondary);
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: all 0.2s;
 }
 
@@ -642,7 +642,7 @@ onMounted(() => {
   display: inline-block;
   padding: 0.25rem 0.5rem;
   background: var(--bg-tertiary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
 }
 
@@ -757,14 +757,14 @@ onMounted(() => {
   width: 100px;
   height: 8px;
   background: var(--bg-tertiary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
 .popularity-fill {
   height: 100%;
   background: var(--color-primary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: width 0.3s ease;
 }
 
@@ -780,7 +780,7 @@ onMounted(() => {
   gap: 1rem;
   padding: 0.75rem;
   background: var(--bg-secondary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
 }
 
 .peak-rank {

--- a/autobot-frontend/src/components/analytics/AnalyticsProgressSection.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsProgressSection.vue
@@ -359,7 +359,7 @@ function getPhaseIcon(status: string): string {
   width: 100%;
   height: 6px;
   background: var(--bg-tertiary);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
@@ -367,7 +367,7 @@ function getPhaseIcon(status: string): string {
   height: 100%;
   background: var(--color-success);
   transition: width 0.3s ease;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 /* Live Stats */
@@ -378,7 +378,7 @@ function getPhaseIcon(status: string): string {
   margin-top: 16px;
   padding: 12px;
   background: var(--bg-card);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
 }
 
 .live-stats .stat-item {

--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
@@ -523,7 +523,7 @@ watch([selectedGranularity, selectedDays], () => {
 .code-evolution-timeline {
   padding: 1.5rem;
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .timeline-header {
@@ -551,7 +551,7 @@ watch([selectedGranularity, selectedDays], () => {
   padding: 0.5rem 0.75rem;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: 0.875rem;
 }
@@ -576,7 +576,7 @@ watch([selectedGranularity, selectedDays], () => {
 
 .trend-card {
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   border: 1px solid var(--border-default);
 }
@@ -636,7 +636,7 @@ watch([selectedGranularity, selectedDays], () => {
 
 .chart-container {
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 1.5rem;
   margin-bottom: 1.5rem;
 }
@@ -724,7 +724,7 @@ watch([selectedGranularity, selectedDays], () => {
   position: fixed;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   padding: 0.75rem;
   z-index: var(--z-tooltip);
   pointer-events: none;
@@ -763,7 +763,7 @@ watch([selectedGranularity, selectedDays], () => {
 
 .pattern-card {
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   border: 1px solid var(--border-default);
 }
@@ -804,7 +804,7 @@ watch([selectedGranularity, selectedDays], () => {
 .sparkline-bar {
   flex: 1;
   background: var(--color-primary);
-  border-radius: 2px 2px 0 0;
+  border-radius: var(--radius-xs) 2px 0 0;
   min-height: 2px;
 }
 

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -834,7 +834,7 @@ onMounted(() => {
   gap: 0.5rem;
   padding: 0.5rem 1rem;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
@@ -891,7 +891,7 @@ onMounted(() => {
   gap: 1rem;
   padding: 1rem;
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
 }
 
@@ -913,7 +913,7 @@ onMounted(() => {
   padding: 0.625rem 0.875rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: 0.875rem;
 }
@@ -937,7 +937,7 @@ onMounted(() => {
   padding: 0.375rem 0.75rem;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
-  border-radius: 16px;
+  border-radius: var(--radius-2xl);
   font-size: 0.75rem;
   cursor: pointer;
   transition: all 0.2s;
@@ -962,7 +962,7 @@ onMounted(() => {
   gap: 0.75rem;
   padding: 1rem;
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
 }
 
@@ -996,7 +996,7 @@ onMounted(() => {
 /* Panels */
 .panel {
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
   overflow: hidden;
 }
@@ -1043,7 +1043,7 @@ onMounted(() => {
   padding: 0.25rem 0.5rem;
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   color: var(--text-secondary);
   cursor: pointer;
@@ -1057,7 +1057,7 @@ onMounted(() => {
 .filter-tab .count {
   background: rgba(0,0,0,0.2);
   padding: 0.125rem 0.375rem;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 0.625rem;
 }
 
@@ -1071,7 +1071,7 @@ onMounted(() => {
 .issue-card {
   padding: 0.875rem;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border-left: 3px solid;
   cursor: pointer;
   transition: all 0.2s;
@@ -1116,7 +1116,7 @@ onMounted(() => {
 .severity-badge.small {
   font-size: 0.625rem;
   padding: 0.125rem 0.375rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   background: var(--bg-quaternary);
 }
 
@@ -1126,7 +1126,7 @@ onMounted(() => {
   color: var(--accent-color);
   background: var(--bg-quaternary);
   padding: 0.125rem 0.375rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .issue-name {
@@ -1206,7 +1206,7 @@ onMounted(() => {
   gap: 0.75rem;
   padding: 0.875rem;
   background: rgba(16, 185, 129, 0.1);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid rgba(16, 185, 129, 0.3);
 }
 
@@ -1222,7 +1222,7 @@ onMounted(() => {
 
 .code-snippet {
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -1293,7 +1293,7 @@ onMounted(() => {
 .legend-color {
   width: 12px;
   height: 12px;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 .legend-label {
@@ -1324,7 +1324,7 @@ onMounted(() => {
   align-items: center;
   padding: 0.75rem 1rem;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -1357,7 +1357,7 @@ onMounted(() => {
 
 .stat {
   padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.6875rem;
   font-weight: 600;
 }
@@ -1414,7 +1414,7 @@ onMounted(() => {
 
 .modal {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   width: 90%;
   max-width: 600px;
   max-height: 80vh;
@@ -1463,7 +1463,7 @@ onMounted(() => {
   gap: 0.75rem;
   padding: 0.625rem 0.875rem;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   opacity: 0.6;
 }
 

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -1064,7 +1064,7 @@ onUnmounted(() => {
   margin-top: 24px;
   padding: 20px;
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--bg-tertiary);
 }
 
@@ -1093,7 +1093,7 @@ onUnmounted(() => {
   width: 40px;
   height: 20px;
   background: var(--bg-tertiary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   position: relative;
   transition: all 0.3s;
 }
@@ -1123,7 +1123,7 @@ onUnmounted(() => {
   color: var(--text-on-primary);
   border: none;
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s;
   display: flex;

--- a/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
@@ -371,7 +371,7 @@ const emit = defineEmits<{
   border: 1px solid var(--bg-hover);
   color: var(--text-secondary);
   padding: 6px 8px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -417,7 +417,7 @@ const emit = defineEmits<{
 
 .summary-stat {
   background: rgba(51, 65, 85, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
   text-align: center;
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -469,7 +469,7 @@ const emit = defineEmits<{
 
 .chart-empty-slot {
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
   border: 1px solid rgba(71, 85, 105, 0.5);
   min-height: 350px;
@@ -506,7 +506,7 @@ const emit = defineEmits<{
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
 }
 
@@ -543,7 +543,7 @@ const emit = defineEmits<{
 .circular-deps-warning {
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
 }
 
@@ -572,7 +572,7 @@ const emit = defineEmits<{
   gap: 8px;
   padding: 8px 12px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.85rem;
   color: var(--text-secondary);
@@ -586,7 +586,7 @@ const emit = defineEmits<{
   text-align: center;
   padding: 12px;
   background: var(--bg-secondary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   margin-top: 8px;
 }
 
@@ -598,7 +598,7 @@ const emit = defineEmits<{
 /* External Dependencies Table */
 .external-deps-table {
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
@@ -629,7 +629,7 @@ const emit = defineEmits<{
   align-items: center;
   padding: 8px 12px;
   background: rgba(51, 65, 85, 0.4);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: background 0.2s ease;
 }
 
@@ -648,7 +648,7 @@ const emit = defineEmits<{
   color: var(--text-muted);
   background: rgba(59, 130, 246, 0.2);
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 /* Import Tree Section */
@@ -656,7 +656,7 @@ const emit = defineEmits<{
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
 }
 
@@ -688,7 +688,7 @@ const emit = defineEmits<{
   padding: 12px;
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--color-error-light);
 }
 
@@ -705,7 +705,7 @@ const emit = defineEmits<{
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
 }
 
@@ -737,7 +737,7 @@ const emit = defineEmits<{
   padding: 12px;
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--color-error-light);
 }
 
@@ -757,7 +757,7 @@ const emit = defineEmits<{
   gap: 16px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.3);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
 
@@ -766,7 +766,7 @@ const emit = defineEmits<{
   background: linear-gradient(90deg, rgba(71, 85, 105, 0.3) 0%, rgba(71, 85, 105, 0.5) 50%, rgba(71, 85, 105, 0.3) 100%);
   background-size: 200% 100%;
   animation: loading 1.5s infinite;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   width: 40%;
 }
 
@@ -775,7 +775,7 @@ const emit = defineEmits<{
   background: linear-gradient(90deg, rgba(71, 85, 105, 0.2) 0%, rgba(71, 85, 105, 0.4) 50%, rgba(71, 85, 105, 0.2) 100%);
   background-size: 200% 100%;
   animation: loading 1.5s infinite;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   min-height: 400px;
 }
 
@@ -784,7 +784,7 @@ const emit = defineEmits<{
   background: linear-gradient(90deg, rgba(71, 85, 105, 0.2) 0%, rgba(71, 85, 105, 0.4) 50%, rgba(71, 85, 105, 0.2) 100%);
   background-size: 200% 100%;
   animation: loading 1.5s infinite;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   min-height: 550px;
 }
 

--- a/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
@@ -280,7 +280,7 @@ const getQualityClass = (score: number): string => {
   border: 1px solid var(--bg-hover);
   color: var(--text-secondary);
   padding: 6px 8px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -302,7 +302,7 @@ const getQualityClass = (score: number): string => {
   border: 1px solid var(--bg-tertiary);
   color: var(--text-muted);
   padding: 4px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   cursor: pointer;
   transition: all 0.2s;
@@ -391,7 +391,7 @@ const getQualityClass = (score: number): string => {
   text-align: center;
   margin-bottom: 16px;
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .score-value,
@@ -441,7 +441,7 @@ const getQualityClass = (score: number): string => {
 /* Traditional Analytics Section */
 .analytics-section {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 24px;
   border: 1px solid var(--bg-tertiary);
 }
@@ -471,7 +471,7 @@ const getQualityClass = (score: number): string => {
   width: 40px;
   height: 20px;
   background: var(--bg-tertiary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   position: relative;
   transition: all 0.3s;
 }
@@ -501,7 +501,7 @@ const getQualityClass = (score: number): string => {
   color: var(--text-on-primary);
   border: none;
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s;
   display: flex;

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -614,14 +614,14 @@ onMounted(() => {
   gap: 1rem;
   background: var(--bg-surface);
   border: 1px solid var(--border-secondary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
 }
 
 .stat-icon {
   width: 2.5rem;
   height: 2.5rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -672,7 +672,7 @@ onMounted(() => {
 .panel {
   background: var(--bg-surface);
   border: 1px solid var(--border-secondary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
 }
 
 .panel-header {
@@ -728,7 +728,7 @@ onMounted(() => {
   padding: 0.75rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: 0.875rem;
   resize: vertical;
@@ -758,7 +758,7 @@ onMounted(() => {
   padding: 0.75rem 1.5rem;
   background: var(--color-info);
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   color: #fff;
   font-size: 0.875rem;
   cursor: pointer;
@@ -780,7 +780,7 @@ onMounted(() => {
   padding: 1rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
 }
 
 .result-header {
@@ -794,7 +794,7 @@ onMounted(() => {
 .tokens-badge,
 .cost-badge {
   padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
 }
 
@@ -821,7 +821,7 @@ onMounted(() => {
 
 .issue-item {
   padding: 0.5rem;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   font-size: 0.8125rem;
   margin-bottom: 0.25rem;
 }
@@ -839,7 +839,7 @@ onMounted(() => {
 .recommendation-item {
   padding: 0.5rem;
   background: var(--color-success-alpha-10);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   font-size: 0.8125rem;
   color: var(--chart-green-light);
   margin-bottom: 0.25rem;
@@ -848,7 +848,7 @@ onMounted(() => {
 .cache-indicator {
   padding: 0.5rem;
   background: rgba(168, 85, 247, 0.1);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   font-size: 0.8125rem;
   color: var(--chart-purple-light);
   text-align: center;
@@ -865,7 +865,7 @@ onMounted(() => {
   padding: 1rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
 }
 
 .recommendation-card.priority-1 { border-left: 3px solid var(--color-error); }
@@ -913,7 +913,7 @@ onMounted(() => {
 .expand-btn {
   background: transparent;
   border: 1px solid var(--border-default);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   color: var(--text-secondary);
   font-size: 0.75rem;
   padding: 0.25rem 0.5rem;
@@ -952,7 +952,7 @@ onMounted(() => {
 .model-item {
   padding: 0.75rem;
   background: var(--bg-primary);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
 }
 
 .model-header {
@@ -983,14 +983,14 @@ onMounted(() => {
 .model-bar {
   height: 4px;
   background: var(--border-secondary);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   overflow: hidden;
 }
 
 .model-bar-fill {
   height: 100%;
   background: var(--color-info);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   transition: width 0.3s;
 }
 
@@ -1024,7 +1024,7 @@ onMounted(() => {
 .category-bar {
   height: 4px;
   background: var(--border-secondary);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   overflow: hidden;
   margin-bottom: 0.25rem;
 }
@@ -1032,7 +1032,7 @@ onMounted(() => {
 .category-bar-fill {
   height: 100%;
   background: var(--color-success);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   transition: width 0.3s;
 }
 
@@ -1053,7 +1053,7 @@ onMounted(() => {
 .cache-item {
   padding: 0.75rem;
   background: var(--bg-primary);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
 }
 
 .cache-header {

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -642,7 +642,7 @@ onMounted(() => {
   gap: 0.5rem;
   padding: 0.5rem 1rem;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
@@ -686,7 +686,7 @@ onMounted(() => {
 .path-selection {
   padding: 1rem;
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
 }
 
@@ -708,7 +708,7 @@ onMounted(() => {
   padding: 0.625rem 0.875rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: 0.875rem;
 }
@@ -732,7 +732,7 @@ onMounted(() => {
   padding: 0.375rem 0.75rem;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   font-family: monospace;
   color: var(--text-secondary);
@@ -752,7 +752,7 @@ onMounted(() => {
   gap: 2rem;
   padding: 1.5rem;
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
 }
 
@@ -822,7 +822,7 @@ onMounted(() => {
 /* Panels */
 .panel {
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
   overflow: hidden;
 }
@@ -869,7 +869,7 @@ onMounted(() => {
   padding: 0.25rem 0.5rem;
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.6875rem;
   color: var(--text-secondary);
   cursor: pointer;
@@ -883,7 +883,7 @@ onMounted(() => {
 .cat-tab .count {
   background: rgba(0,0,0,0.2);
   padding: 0.125rem 0.25rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 /* Issues List */
@@ -896,7 +896,7 @@ onMounted(() => {
 .issue-card {
   padding: 0.875rem;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border-left: 3px solid;
   cursor: pointer;
   transition: all 0.2s;
@@ -929,7 +929,7 @@ onMounted(() => {
 .impact-badge.small {
   font-size: 0.625rem;
   padding: 0.125rem 0.375rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   background: var(--bg-quaternary);
 }
 
@@ -940,7 +940,7 @@ onMounted(() => {
   color: var(--accent-color);
   background: var(--bg-quaternary);
   padding: 0.125rem 0.375rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .issue-name {
@@ -1022,7 +1022,7 @@ onMounted(() => {
 
 .code-snippet {
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -1039,7 +1039,7 @@ onMounted(() => {
   gap: 0.5rem;
   padding: 0.75rem;
   background: rgba(245, 158, 11, 0.1);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid rgba(245, 158, 11, 0.3);
 }
 
@@ -1057,7 +1057,7 @@ onMounted(() => {
   gap: 0.75rem;
   padding: 0.875rem;
   background: rgba(16, 185, 129, 0.1);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid rgba(16, 185, 129, 0.3);
 }
 
@@ -1081,7 +1081,7 @@ onMounted(() => {
 .hotspot-item {
   padding: 0.75rem;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
 }
 
 .hotspot-info {
@@ -1109,7 +1109,7 @@ onMounted(() => {
 
 .hotspot-stats .stat {
   padding: 0.125rem 0.375rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.625rem;
   font-weight: 600;
 }
@@ -1166,7 +1166,7 @@ onMounted(() => {
   flex: 1;
   height: 24px;
   background: var(--bg-tertiary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   overflow: hidden;
   display: flex;
 }
@@ -1220,7 +1220,7 @@ onMounted(() => {
 
 .modal {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   width: 90%;
   max-width: 600px;
   max-height: 80vh;
@@ -1264,7 +1264,7 @@ onMounted(() => {
   gap: 0.75rem;
   padding: 0.5rem 0.75rem;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   opacity: 0.6;
 }
 

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
@@ -661,7 +661,7 @@ onMounted(() => {
   gap: 0.5rem;
   padding: 0.5rem 1rem;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
@@ -726,7 +726,7 @@ onMounted(() => {
   align-items: center;
   gap: 1rem;
   padding: 1rem 1.25rem;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid;
 }
 
@@ -772,7 +772,7 @@ onMounted(() => {
   gap: 0.75rem;
   padding: 1rem;
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
 }
 
@@ -818,7 +818,7 @@ onMounted(() => {
 /* Panels */
 .panel {
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
   overflow: hidden;
 }
@@ -853,7 +853,7 @@ onMounted(() => {
   padding: 0.25rem 0.5rem;
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   color: var(--text-secondary);
   cursor: pointer;
@@ -874,7 +874,7 @@ onMounted(() => {
 .result-card {
   padding: 0.875rem;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border-left: 3px solid;
 }
 
@@ -907,7 +907,7 @@ onMounted(() => {
   color: var(--accent-color);
   background: var(--bg-quaternary);
   padding: 0.125rem 0.375rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .check-name {
@@ -930,7 +930,7 @@ onMounted(() => {
 
 .result-snippet {
   background: var(--bg-quaternary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   padding: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -966,7 +966,7 @@ onMounted(() => {
   gap: 0.5rem;
   padding: 0.5rem;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
@@ -1022,7 +1022,7 @@ onMounted(() => {
   position: absolute;
   inset: 0;
   background: var(--bg-quaternary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   cursor: pointer;
   transition: 0.3s;
 }
@@ -1067,7 +1067,7 @@ onMounted(() => {
 .severity-indicator {
   font-size: 0.625rem;
   padding: 0.125rem 0.375rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   text-transform: uppercase;
 }
 
@@ -1103,7 +1103,7 @@ onMounted(() => {
   gap: 0.75rem;
   padding: 0.625rem 0.875rem;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -1147,7 +1147,7 @@ onMounted(() => {
 
 .stat {
   padding: 0.125rem 0.375rem;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.625rem;
   font-weight: 600;
 }
@@ -1219,14 +1219,14 @@ onMounted(() => {
   flex: 1;
   height: 8px;
   background: var(--bg-quaternary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
 .issue-bar-fill {
   height: 100%;
   background: var(--accent-color);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: width 0.3s;
 }
 

--- a/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
@@ -212,7 +212,7 @@ function copyPath(finding: Finding): void {
 .findings-table {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
@@ -242,7 +242,7 @@ function copyPath(finding: Finding): void {
 .search-input {
   padding: var(--spacing-2);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   background: var(--bg-primary);
   color: var(--text-primary);
   font-family: var(--font-sans);
@@ -264,7 +264,7 @@ function copyPath(finding: Finding): void {
 /* Issue #901: Technical Precision severity badges */
 .severity-badge {
   padding: 2px 8px;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 11px;
   font-weight: 500;
   font-family: var(--font-sans);
@@ -382,7 +382,7 @@ code {
   border-left: 2px solid var(--color-info);
   margin: var(--spacing-2);
   background: var(--bg-secondary);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .detail-section {
@@ -406,7 +406,7 @@ code {
   padding: 2px 8px;
   background: var(--color-info-bg);
   color: var(--color-info-dark);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 12px;
   font-family: var(--font-mono);
   font-weight: 500;
@@ -425,7 +425,7 @@ code {
   padding: 6px 12px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   color: var(--text-primary);
   cursor: pointer;
   font-size: 13px;

--- a/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
@@ -311,7 +311,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 
 .accordion-group {
   background: var(--bg-card);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--bg-tertiary);
   overflow: hidden;
 }
@@ -362,7 +362,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .severity-badge {
   font-size: 0.7em;
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   font-weight: 500;
 }
 
@@ -404,7 +404,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Unified List Items */
 .list-item {
   background: var(--bg-card);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 14px 16px;
   border-left: 4px solid var(--text-tertiary);
   transition: all 0.2s ease;
@@ -427,7 +427,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   text-align: center;
   padding: 12px;
   background: var(--bg-secondary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   margin-top: 8px;
 }
 
@@ -453,7 +453,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .item-severity {
   font-size: 0.75em;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-weight: 600;
   text-transform: uppercase;
 }
@@ -483,7 +483,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   font-size: 0.85em;
   padding: 8px;
   background: rgba(34, 197, 94, 0.1);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   margin-top: 8px;
 }
 
@@ -491,7 +491,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .item-similarity {
   font-size: 0.75em;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-weight: 600;
 }
 
@@ -579,7 +579,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
   contain: layout style;}
 
@@ -603,7 +603,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   align-items: center;
   gap: 10px;
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .api-endpoints-section .loading-state {
@@ -623,7 +623,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   margin: 20px 0;
   padding: 16px;
   background: rgba(30, 41, 59, 0.8);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .coverage-label {
@@ -648,13 +648,13 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .coverage-bar {
   height: 12px;
   background: rgba(71, 85, 105, 0.5);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
 .coverage-fill {
   height: 100%;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   transition: width 0.3s ease;
 }
 
@@ -667,7 +667,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .method-badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -695,7 +695,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   margin-left: auto;
   background: rgba(59, 130, 246, 0.2);
   color: var(--color-info-light);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   font-size: 0.75rem;
   font-weight: 500;
 }
@@ -705,7 +705,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   margin-top: 4px;
   padding: 6px 10px;
   background: rgba(0, 0, 0, 0.2);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   color: var(--text-muted);
   font-size: 0.8rem;
   font-style: italic;
@@ -773,7 +773,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   margin-top: 16px;
   padding: 8px 12px;
   background: rgba(30, 41, 59, 0.8);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-tertiary);
   font-size: 0.8rem;
   display: flex;

--- a/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
@@ -508,7 +508,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
   contain: layout style;}
 
@@ -533,7 +533,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   align-items: center;
   gap: 10px;
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .bug-prediction-section .loading-state {
@@ -573,7 +573,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .bug-prediction-section .list-item {
   padding: 16px;
   background: rgba(17, 24, 39, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   margin-bottom: 12px;
   border-left: 4px solid var(--text-tertiary);
   transition: all 0.2s ease;
@@ -609,7 +609,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 .bug-prediction-section .risk-badge {
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-weight: 600;
   font-size: 0.85em;
   min-width: 50px;
@@ -646,7 +646,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 .bug-prediction-section .risk-level-badge {
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75em;
   text-transform: uppercase;
   font-weight: 600;
@@ -679,7 +679,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .bug-prediction-section .factor-badge {
   padding: 3px 8px;
   background: rgba(71, 85, 105, 0.4);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.8em;
   color: var(--text-muted);
 }
@@ -691,7 +691,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   gap: 8px;
   padding: 10px 12px;
   background: rgba(59, 130, 246, 0.1);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid rgba(59, 130, 246, 0.2);
 }
 
@@ -719,15 +719,15 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Enhanced Bug Prediction Styles */
 .summary-card.clickable { cursor: pointer; transition: transform 0.2s; }
 .summary-card.clickable:hover { transform: translateY(-2px); }
-.top-risk-factors-summary { margin: 20px 0; padding: 16px; background: rgba(17, 24, 39, 0.6); border-radius: 10px; border: 1px solid rgba(239, 68, 68, 0.2); }
+.top-risk-factors-summary { margin: 20px 0; padding: 16px; background: rgba(17, 24, 39, 0.6); border-radius: var(--radius-xl); border: 1px solid rgba(239, 68, 68, 0.2); }
 .top-risk-factors-summary h4 { color: var(--color-error-light); font-size: 1em; margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }
 .top-risk-factors-summary h4 i { color: var(--color-error); }
 .risk-factors-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; }
-.risk-factor-card { display: flex; align-items: flex-start; gap: 12px; padding: 14px; background: rgba(30, 41, 59, 0.5); border-radius: 8px; border-left: 3px solid var(--text-tertiary); }
+.risk-factor-card { display: flex; align-items: flex-start; gap: 12px; padding: 14px; background: rgba(30, 41, 59, 0.5); border-radius: var(--radius-lg); border-left: 3px solid var(--text-tertiary); }
 .risk-factor-card.critical { border-left-color: var(--color-error); background: rgba(239, 68, 68, 0.1); }
 .risk-factor-card.high { border-left-color: var(--chart-orange); background: rgba(249, 115, 22, 0.1); }
 .risk-factor-card.medium { border-left-color: var(--color-warning); background: rgba(234, 179, 8, 0.1); }
-.risk-factor-card .factor-icon { width: 36px; height: 36px; display: flex; align-items: center; justify-content: center; background: rgba(71, 85, 105, 0.4); border-radius: 8px; }
+.risk-factor-card .factor-icon { width: 36px; height: 36px; display: flex; align-items: center; justify-content: center; background: rgba(71, 85, 105, 0.4); border-radius: var(--radius-lg); }
 .risk-factor-card .factor-icon i { font-size: 1.1em; color: var(--text-muted); }
 .risk-factor-card.critical .factor-icon i { color: var(--color-error-light); }
 .risk-factor-card.high .factor-icon i { color: var(--chart-orange-light); }
@@ -736,14 +736,14 @@ function formatTimestamp(timestamp: string | undefined): string {
 .risk-factor-card .factor-count { color: var(--color-warning-light); font-size: 0.85em; font-weight: 500; margin-bottom: 4px; }
 .risk-factor-card .factor-description { color: var(--text-muted); font-size: 0.8em; line-height: 1.4; }
 .risk-filter-tabs { display: flex; gap: 8px; margin: 20px 0 16px; flex-wrap: wrap; }
-.risk-filter-tabs button { padding: 8px 16px; border: 1px solid rgba(71, 85, 105, 0.5); background: rgba(30, 41, 59, 0.5); color: var(--text-muted); border-radius: 6px; font-size: 0.85em; cursor: pointer; transition: all 0.2s; }
+.risk-filter-tabs button { padding: 8px 16px; border: 1px solid rgba(71, 85, 105, 0.5); background: rgba(30, 41, 59, 0.5); color: var(--text-muted); border-radius: var(--radius-md); font-size: 0.85em; cursor: pointer; transition: all 0.2s; }
 .risk-filter-tabs button:hover:not(:disabled) { background: rgba(71, 85, 105, 0.5); color: var(--text-secondary); }
 .risk-filter-tabs button.active { background: rgba(59, 130, 246, 0.2); border-color: rgba(59, 130, 246, 0.5); color: var(--color-info-light); }
 .risk-filter-tabs button:disabled { opacity: 0.5; cursor: not-allowed; }
 .risk-files-list.detailed h4 { display: flex; align-items: center; gap: 8px; color: var(--text-secondary); margin-bottom: 12px; }
 .risk-files-list.detailed h4 .file-count { color: var(--text-tertiary); font-weight: normal; font-size: 0.9em; }
-.risk-files-list .no-files-message { padding: 20px; text-align: center; color: var(--color-success-light); background: rgba(34, 197, 94, 0.1); border-radius: 8px; }
-.risk-file-item { background: rgba(17, 24, 39, 0.5); border-radius: 8px; margin-bottom: 10px; border-left: 4px solid var(--text-tertiary); overflow: hidden; transition: all 0.2s; }
+.risk-files-list .no-files-message { padding: 20px; text-align: center; color: var(--color-success-light); background: rgba(34, 197, 94, 0.1); border-radius: var(--radius-lg); }
+.risk-file-item { background: rgba(17, 24, 39, 0.5); border-radius: var(--radius-lg); margin-bottom: 10px; border-left: 4px solid var(--text-tertiary); overflow: hidden; transition: all 0.2s; }
 .risk-file-item.item-critical { border-left-color: var(--color-error); }
 .risk-file-item.item-warning { border-left-color: var(--color-warning); }
 .risk-file-item.item-info { border-left-color: var(--chart-blue); }
@@ -752,19 +752,19 @@ function formatTimestamp(timestamp: string | undefined): string {
 .risk-file-item .file-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; cursor: pointer; transition: background 0.2s; }
 .risk-file-item .file-header:hover { background: rgba(71, 85, 105, 0.2); }
 .risk-file-item .file-info { display: flex; align-items: center; gap: 10px; flex: 1; flex-wrap: wrap; }
-.risk-file-item .risk-score-badge { padding: 4px 10px; border-radius: 4px; font-weight: 700; font-size: 0.85em; min-width: 40px; text-align: center; }
+.risk-file-item .risk-score-badge { padding: 4px 10px; border-radius: var(--radius-default); font-weight: 700; font-size: 0.85em; min-width: 40px; text-align: center; }
 .risk-file-item .risk-score-badge.item-critical { background: rgba(239, 68, 68, 0.3); color: var(--color-error-light); }
 .risk-file-item .risk-score-badge.item-warning { background: rgba(245, 158, 11, 0.3); color: var(--color-warning-light); }
 .risk-file-item .risk-score-badge.item-info { background: rgba(59, 130, 246, 0.3); color: var(--color-info-light); }
 .risk-file-item .risk-score-badge.item-success { background: rgba(34, 197, 94, 0.3); color: var(--color-success-light); }
 .risk-file-item .file-path { color: var(--text-secondary); font-family: monospace; font-size: 0.85em; flex: 1; word-break: break-all; }
-.risk-file-item .risk-level-tag { padding: 2px 8px; border-radius: 4px; font-size: 0.7em; text-transform: uppercase; font-weight: 600; }
+.risk-file-item .risk-level-tag { padding: 2px 8px; border-radius: var(--radius-default); font-size: 0.7em; text-transform: uppercase; font-weight: 600; }
 .risk-file-item .risk-level-tag.high, .risk-file-item .risk-level-tag.critical { background: rgba(239, 68, 68, 0.2); color: var(--color-error-light); }
 .risk-file-item .risk-level-tag.medium { background: rgba(245, 158, 11, 0.2); color: var(--color-warning-light); }
 .risk-file-item .risk-level-tag.low, .risk-file-item .risk-level-tag.minimal { background: rgba(34, 197, 94, 0.2); color: var(--color-success-light); }
 .risk-file-item .expand-icon { color: var(--text-tertiary); padding: 4px 8px; }
 .quick-risk-indicators { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 16px 12px; }
-.quick-risk-indicators .indicator { display: flex; align-items: center; gap: 4px; padding: 3px 8px; border-radius: 4px; font-size: 0.75em; font-weight: 500; }
+.quick-risk-indicators .indicator { display: flex; align-items: center; gap: 4px; padding: 3px 8px; border-radius: var(--radius-default); font-size: 0.75em; font-weight: 500; }
 .quick-risk-indicators .indicator.critical { background: rgba(239, 68, 68, 0.2); color: var(--color-error-light); }
 .quick-risk-indicators .indicator.high { background: rgba(249, 115, 22, 0.2); color: var(--chart-orange-light); }
 .quick-risk-indicators .indicator.warning { background: rgba(234, 179, 8, 0.2); color: var(--color-warning-light); }
@@ -782,8 +782,8 @@ function formatTimestamp(timestamp: string | undefined): string {
 .factor-row.high-value .factor-label { color: var(--color-error-light); }
 .factor-row.high-value .factor-label i { color: var(--color-error); }
 .factor-row.medium-value .factor-label { color: var(--color-warning-light); }
-.factor-row .factor-bar-container { flex: 1; height: 8px; background: rgba(71, 85, 105, 0.3); border-radius: 4px; overflow: hidden; }
-.factor-row .factor-bar { height: 100%; border-radius: 4px; transition: width 0.3s; }
+.factor-row .factor-bar-container { flex: 1; height: 8px; background: rgba(71, 85, 105, 0.3); border-radius: var(--radius-default); overflow: hidden; }
+.factor-row .factor-bar { height: 100%; border-radius: var(--radius-default); transition: width 0.3s; }
 .factor-row .factor-bar.bar-critical { background: var(--color-error); }
 .factor-row .factor-bar.bar-warning { background: var(--color-warning); }
 .factor-row .factor-bar.bar-ok { background: var(--color-success); }
@@ -791,13 +791,13 @@ function formatTimestamp(timestamp: string | undefined): string {
 .factor-row.high-value .factor-value { color: var(--color-error-light); }
 .factor-row.medium-value .factor-value { color: var(--color-warning-light); }
 .tips-list, .tests-list { list-style: none; padding: 0; margin: 0; }
-.tips-list li, .tests-list li { display: flex; align-items: flex-start; gap: 10px; padding: 10px 12px; background: rgba(30, 41, 59, 0.5); border-radius: 6px; margin-bottom: 6px; font-size: 0.85em; line-height: 1.4; }
+.tips-list li, .tests-list li { display: flex; align-items: flex-start; gap: 10px; padding: 10px 12px; background: rgba(30, 41, 59, 0.5); border-radius: var(--radius-md); margin-bottom: 6px; font-size: 0.85em; line-height: 1.4; }
 .tips-list li i { color: var(--color-warning-light); margin-top: 2px; }
 .tips-list li { color: var(--text-secondary); border-left: 3px solid var(--color-warning-light); }
 .tests-list li i { color: var(--chart-purple-light); margin-top: 2px; }
 .tests-list li { color: var(--chart-purple-light); border-left: 3px solid var(--chart-purple-light); }
 .show-more-container { text-align: center; margin-top: 16px; }
-.show-more-btn { padding: 10px 24px; background: rgba(59, 130, 246, 0.2); border: 1px solid rgba(59, 130, 246, 0.4); color: var(--color-info-light); border-radius: 6px; cursor: pointer; font-size: 0.9em; display: inline-flex; align-items: center; gap: 8px; transition: all 0.2s; }
+.show-more-btn { padding: 10px 24px; background: rgba(59, 130, 246, 0.2); border: 1px solid rgba(59, 130, 246, 0.4); color: var(--color-info-light); border-radius: var(--radius-md); cursor: pointer; font-size: 0.9em; display: inline-flex; align-items: center; gap: 8px; transition: all 0.2s; }
 .show-more-btn:hover { background: rgba(59, 130, 246, 0.3); }
 
 /* Issue #538: Code Intelligence Scores Section */

--- a/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
@@ -326,7 +326,7 @@ function getCategoryIcon(categoryId: string): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
   contain: layout style;}
 
@@ -360,7 +360,7 @@ function getCategoryIcon(categoryId: string): string {
 .export-btn {
   background: rgba(51, 65, 85, 0.5);
   border: 1px solid rgba(71, 85, 105, 0.5);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-muted);
   padding: 6px 12px;
   font-size: 0.85rem;
@@ -400,7 +400,7 @@ function getCategoryIcon(categoryId: string): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
 }
 
@@ -441,7 +441,7 @@ function getCategoryIcon(categoryId: string): string {
   margin-bottom: 20px;
   padding: 12px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
 
@@ -452,7 +452,7 @@ function getCategoryIcon(categoryId: string): string {
   padding: 8px 16px;
   background: rgba(51, 65, 85, 0.5);
   border: 1px solid rgba(71, 85, 105, 0.5);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-muted);
   font-size: 0.875rem;
   font-weight: 500;
@@ -484,7 +484,7 @@ function getCategoryIcon(categoryId: string): string {
   height: 20px;
   padding: 0 6px;
   background: rgba(0, 0, 0, 0.2);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   font-size: 0.75rem;
   font-weight: 600;
 }
@@ -533,7 +533,7 @@ function getCategoryIcon(categoryId: string): string {
 
 .summary-stat {
   background: rgba(51, 65, 85, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
   text-align: center;
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -586,7 +586,7 @@ function getCategoryIcon(categoryId: string): string {
 /* Empty state placeholder (when chart has no data) */
 .chart-empty-slot {
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
   border: 1px solid rgba(71, 85, 105, 0.5);
   min-height: 350px;
@@ -623,7 +623,7 @@ function getCategoryIcon(categoryId: string): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
 }
 
@@ -660,7 +660,7 @@ function getCategoryIcon(categoryId: string): string {
 .circular-deps-warning {
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
 }
 
@@ -689,7 +689,7 @@ function getCategoryIcon(categoryId: string): string {
   gap: 8px;
   padding: 8px 12px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.85rem;
   color: var(--text-secondary);
@@ -702,7 +702,7 @@ function getCategoryIcon(categoryId: string): string {
 /* External Dependencies Table */
 .external-deps-table {
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
@@ -733,7 +733,7 @@ function getCategoryIcon(categoryId: string): string {
   align-items: center;
   padding: 8px 12px;
   background: rgba(51, 65, 85, 0.4);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: background 0.2s ease;
 }
 
@@ -752,7 +752,7 @@ function getCategoryIcon(categoryId: string): string {
   color: var(--text-muted);
   background: rgba(59, 130, 246, 0.2);
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 /* Import Tree Section */
@@ -760,7 +760,7 @@ function getCategoryIcon(categoryId: string): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
 }
 
@@ -792,7 +792,7 @@ function getCategoryIcon(categoryId: string): string {
   padding: 12px;
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--color-error-light);
 }
 
@@ -809,7 +809,7 @@ function getCategoryIcon(categoryId: string): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
 }
 
@@ -841,7 +841,7 @@ function getCategoryIcon(categoryId: string): string {
   padding: 12px;
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--color-error-light);
 }
 

--- a/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
@@ -150,7 +150,7 @@ function truncateValue(value: string, maxLength = 50): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
   contain: layout style;}
 
@@ -175,7 +175,7 @@ function truncateValue(value: string, maxLength = 50): string {
   align-items: center;
   gap: 10px;
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .config-duplicates-section .loading-state {
@@ -218,7 +218,7 @@ function truncateValue(value: string, maxLength = 50): string {
   background: rgba(245, 158, 11, 0.2);
   color: var(--color-warning-light);
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-family: 'Monaco', 'Menlo', monospace;
   font-size: 0.85em;
 }
@@ -251,7 +251,7 @@ function truncateValue(value: string, maxLength = 50): string {
   padding: 12px 16px;
   background: rgba(59, 130, 246, 0.1);
   border: 1px solid rgba(59, 130, 246, 0.3);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--color-info-light);
   display: flex;
   align-items: center;
@@ -265,7 +265,7 @@ function truncateValue(value: string, maxLength = 50): string {
 .config-duplicates-section .recommendation-box code {
   background: rgba(30, 41, 59, 0.8);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.9em;
 }
 

--- a/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
@@ -420,7 +420,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 .accordion-group {
   background: var(--bg-card);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--bg-tertiary);
   overflow: hidden;
 }
@@ -471,7 +471,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .severity-badge {
   font-size: 0.7em;
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   font-weight: 500;
 }
 
@@ -513,7 +513,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Unified List Items */
 .list-item {
   background: var(--bg-card);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 14px 16px;
   border-left: 4px solid var(--text-tertiary);
   transition: all 0.2s ease;
@@ -536,7 +536,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   text-align: center;
   padding: 12px;
   background: var(--bg-secondary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   margin-top: 8px;
 }
 
@@ -562,7 +562,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .item-severity {
   font-size: 0.75em;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-weight: 600;
   text-transform: uppercase;
 }
@@ -592,7 +592,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   font-size: 0.85em;
   padding: 8px;
   background: rgba(34, 197, 94, 0.1);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   margin-top: 8px;
 }
 
@@ -600,7 +600,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .item-similarity {
   font-size: 0.75em;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-weight: 600;
 }
 
@@ -688,7 +688,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
   contain: layout style;}
 
@@ -712,7 +712,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   align-items: center;
   gap: 10px;
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .cross-language-section .loading-state {
@@ -735,7 +735,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   margin: 16px 0;
   padding: 12px;
   background: rgba(30, 41, 59, 0.8);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .language-badge {
@@ -743,7 +743,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 0.85rem;
   font-weight: 500;
 }
@@ -770,7 +770,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .type-badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   font-weight: 500;
   text-transform: uppercase;
@@ -796,7 +796,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .validation-type-badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   font-weight: 500;
   margin-right: 8px;
@@ -809,7 +809,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .similarity-score {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   font-weight: 600;
   background: rgba(34, 197, 94, 0.2);
@@ -828,7 +828,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   display: inline-block;
   padding: 2px 8px;
   margin-left: 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   font-weight: 500;
   background: rgba(100, 116, 139, 0.2);
@@ -874,7 +874,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .item-field code {
   padding: 2px 6px;
   background: rgba(0, 0, 0, 0.3);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   color: var(--text-secondary);
   font-family: 'JetBrains Mono', monospace;
 }
@@ -890,7 +890,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   margin-top: 6px;
   padding: 8px 12px;
   background: rgba(59, 130, 246, 0.1);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--color-info-light);
   font-size: 0.8rem;
   border-left: 2px solid var(--chart-blue);
@@ -909,7 +909,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   background: var(--chart-purple);
   color: white;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.8rem;
   cursor: pointer;
   display: inline-flex;

--- a/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
@@ -286,7 +286,7 @@ function formatFactorName(factor: string): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
   contain: layout style;}
 
@@ -311,7 +311,7 @@ function formatFactorName(factor: string): string {
   align-items: center;
   gap: 10px;
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .environment-analysis-section .loading-state {
@@ -356,7 +356,7 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .category-badge {
   padding: 4px 10px;
   background: rgba(71, 85, 105, 0.4);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.85em;
   color: var(--text-muted);
 }
@@ -375,7 +375,7 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .recommendation-item {
   padding: 14px;
   background: rgba(17, 24, 39, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   margin-bottom: 10px;
   border-left: 4px solid var(--text-tertiary);
 }
@@ -403,13 +403,13 @@ function formatFactorName(factor: string): string {
   background: rgba(34, 197, 94, 0.2);
   color: var(--color-success-light);
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.9em;
 }
 
 .environment-analysis-section .priority-badge {
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.7em;
   text-transform: uppercase;
   font-weight: 600;
@@ -444,7 +444,7 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .rec-default code {
   background: rgba(30, 41, 59, 0.8);
   padding: 1px 5px;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 /* Hardcoded Values Preview */
@@ -469,7 +469,7 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .hardcoded-item {
   padding: 12px;
   background: rgba(17, 24, 39, 0.5);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   margin-bottom: 8px;
   border-left: 3px solid var(--text-tertiary);
 }
@@ -512,7 +512,7 @@ function formatFactorName(factor: string): string {
   background: rgba(245, 158, 11, 0.1);
   color: var(--color-warning-light);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.85em;
 }
 
@@ -528,7 +528,7 @@ function formatFactorName(factor: string): string {
   gap: 6px;
   padding: 6px 10px;
   background: rgba(59, 130, 246, 0.1);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.85em;
 }
 

--- a/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
@@ -772,7 +772,7 @@ function formatTimestamp(timestamp: string): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
   contain: layout style;}
 
@@ -799,7 +799,7 @@ function formatTimestamp(timestamp: string): string {
 
 .score-card {
   background: rgba(17, 24, 39, 0.6);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 20px;
   border: 1px solid rgba(71, 85, 105, 0.4);
   transition: all 0.2s ease;
@@ -825,7 +825,7 @@ function formatTimestamp(timestamp: string): string {
   padding: 4px 8px;
   background: rgba(59, 130, 246, 0.1);
   border: 1px solid rgba(59, 130, 246, 0.3);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   color: var(--color-info-light);
   cursor: pointer;
   font-size: 0.8em;
@@ -863,7 +863,7 @@ function formatTimestamp(timestamp: string): string {
   gap: 8px;
   padding: 12px;
   background: rgba(239, 68, 68, 0.1);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--color-error-light);
   font-size: 0.85em;
 }
@@ -890,7 +890,7 @@ function formatTimestamp(timestamp: string): string {
   align-items: center;
   gap: 4px;
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.8em;
 }
 
@@ -941,13 +941,13 @@ function formatTimestamp(timestamp: string): string {
   flex: 1;
   height: 6px;
   background: rgba(71, 85, 105, 0.4);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
 .quality-metric .metric-fill {
   height: 100%;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   transition: width 0.5s ease;
 }
 
@@ -965,7 +965,7 @@ function formatTimestamp(timestamp: string): string {
 .quality-trend {
   margin-top: 8px;
   padding: 4px 12px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.8em;
   font-weight: 500;
   display: flex;
@@ -993,7 +993,7 @@ function formatTimestamp(timestamp: string): string {
   margin-top: 24px;
   padding: 20px;
   background: rgba(30, 41, 59, 0.4);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
 
@@ -1012,7 +1012,7 @@ function formatTimestamp(timestamp: string): string {
 .suggestions-count {
   padding: 2px 8px;
   background: rgba(245, 158, 11, 0.2);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   font-size: 0.75em;
   color: var(--color-warning-light);
 }
@@ -1026,7 +1026,7 @@ function formatTimestamp(timestamp: string): string {
 .suggestion-item {
   padding: 14px 16px;
   background: rgba(17, 24, 39, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border-left: 4px solid var(--text-tertiary);
 }
 
@@ -1044,7 +1044,7 @@ function formatTimestamp(timestamp: string): string {
 .suggestion-type-badge {
   padding: 2px 8px;
   background: rgba(99, 102, 241, 0.2);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75em;
   color: var(--chart-indigo-light);
   text-transform: capitalize;
@@ -1052,7 +1052,7 @@ function formatTimestamp(timestamp: string): string {
 
 .suggestion-priority {
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.7em;
   font-weight: 600;
   text-transform: uppercase;
@@ -1102,7 +1102,7 @@ function formatTimestamp(timestamp: string): string {
   margin-top: 24px;
   padding: 20px;
   background: rgba(30, 41, 59, 0.4);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
 
@@ -1132,7 +1132,7 @@ function formatTimestamp(timestamp: string): string {
   gap: 12px;
   padding: 10px 14px;
   background: rgba(17, 24, 39, 0.5);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   transition: background 0.2s ease;
 }
 
@@ -1184,7 +1184,7 @@ function formatTimestamp(timestamp: string): string {
   padding: 8px 16px;
   background: rgba(99, 102, 241, 0.2);
   border: 1px solid rgba(99, 102, 241, 0.4);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--chart-indigo-light);
   font-size: 0.85em;
   font-weight: 500;
@@ -1211,7 +1211,7 @@ function formatTimestamp(timestamp: string): string {
 .findings-panel {
   margin-top: 16px;
   background: rgba(30, 41, 59, 0.6);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
   overflow: hidden;
   animation: slideDown 0.3s ease-out;
@@ -1256,7 +1256,7 @@ function formatTimestamp(timestamp: string): string {
 .findings-count {
   padding: 4px 12px;
   background: rgba(71, 85, 105, 0.5);
-  border-radius: 20px;
+  border-radius: var(--radius-2xl);
   color: var(--text-muted);
   font-size: 0.85em;
   font-weight: 500;
@@ -1286,7 +1286,7 @@ function formatTimestamp(timestamp: string): string {
 
 .finding-item {
   background: rgba(15, 23, 42, 0.6);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 14px 16px;
   margin-bottom: 10px;
   border-left: 4px solid var(--text-tertiary);
@@ -1331,7 +1331,7 @@ function formatTimestamp(timestamp: string): string {
 
 .finding-severity {
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75em;
   font-weight: 600;
   text-transform: uppercase;
@@ -1372,7 +1372,7 @@ function formatTimestamp(timestamp: string): string {
 .finding-category {
   padding: 2px 8px;
   background: rgba(71, 85, 105, 0.5);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75em;
   color: var(--text-muted);
 }
@@ -1404,7 +1404,7 @@ function formatTimestamp(timestamp: string): string {
   margin-top: 10px;
   padding: 10px 12px;
   background: rgba(34, 197, 94, 0.1);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border-left: 3px solid var(--chart-green);
   color: var(--color-success-light);
   font-size: 0.85em;

--- a/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
@@ -442,7 +442,7 @@ function formatFactorName(factor: string): string {
   margin-top: 32px;
   padding: 24px;
   background: rgba(30, 41, 59, 0.5);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
   contain: layout style;}
 
@@ -467,7 +467,7 @@ function formatFactorName(factor: string): string {
   align-items: center;
   gap: 10px;
   padding: 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .ownership-section .loading-state {
@@ -501,7 +501,7 @@ function formatFactorName(factor: string): string {
   padding: 8px 16px;
   background: rgba(71, 85, 105, 0.3);
   border: 1px solid rgba(71, 85, 105, 0.5);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-muted);
   cursor: pointer;
   display: flex;
@@ -526,7 +526,7 @@ function formatFactorName(factor: string): string {
   background: rgba(239, 68, 68, 0.3);
   color: var(--color-error-light);
   padding: 2px 6px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   font-size: 0.75em;
 }
 
@@ -566,13 +566,13 @@ function formatFactorName(factor: string): string {
 .ownership-metrics .metric-bar {
   height: 8px;
   background: rgba(71, 85, 105, 0.4);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
 .ownership-metrics .metric-bar-fill {
   height: 100%;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: width 0.3s ease;
 }
 
@@ -618,7 +618,7 @@ function formatFactorName(factor: string): string {
   align-items: center;
   padding: 10px 14px;
   background: rgba(17, 24, 39, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
 
@@ -666,7 +666,7 @@ function formatFactorName(factor: string): string {
 
 .risk-badge {
   padding: 6px 12px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 0.85em;
   font-weight: 500;
 }
@@ -705,7 +705,7 @@ function formatFactorName(factor: string): string {
 .expert-card {
   padding: 16px;
   background: rgba(17, 24, 39, 0.5);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
 
@@ -732,7 +732,7 @@ function formatFactorName(factor: string): string {
   background: var(--chart-purple);
   color: var(--text-on-primary);
   padding: 4px 10px;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   font-weight: 700;
   font-size: 0.9em;
 }
@@ -777,13 +777,13 @@ function formatFactorName(factor: string): string {
 .score-track {
   height: 6px;
   background: rgba(71, 85, 105, 0.4);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
 .score-fill {
   height: 100%;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 .score-fill.impact {
@@ -810,7 +810,7 @@ function formatFactorName(factor: string): string {
 .area-tag {
   padding: 3px 8px;
   background: rgba(71, 85, 105, 0.4);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75em;
   color: var(--text-muted);
 }
@@ -845,7 +845,7 @@ function formatFactorName(factor: string): string {
 .file-item {
   padding: 12px 14px;
   background: rgba(17, 24, 39, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border-left: 3px solid var(--color-success-light);
 }
 
@@ -916,7 +916,7 @@ function formatFactorName(factor: string): string {
 .gap-item {
   padding: 16px;
   background: rgba(17, 24, 39, 0.5);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   border-left: 4px solid var(--color-error-light);
 }
 
@@ -942,7 +942,7 @@ function formatFactorName(factor: string): string {
 
 .gap-risk-badge {
   padding: 3px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 0.75em;
   font-weight: 700;
   text-transform: uppercase;
@@ -1008,7 +1008,7 @@ function formatFactorName(factor: string): string {
   gap: 6px;
   padding: 10px;
   background: rgba(34, 197, 94, 0.1);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
 }
 
 .gap-recommendation i {

--- a/autobot-frontend/src/components/audit/AuditLogTable.vue
+++ b/autobot-frontend/src/components/audit/AuditLogTable.vue
@@ -360,7 +360,7 @@ function exportLogs(format: 'json' | 'csv') {
   position: relative;
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
@@ -398,7 +398,7 @@ function exportLogs(format: 'json' | 'csv') {
   margin-top: var(--spacing-1);
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   box-shadow: var(--shadow-lg);
   z-index: 10;
   min-width: 150px;
@@ -519,7 +519,7 @@ th span {
   align-items: center;
   gap: var(--spacing-1);
   padding: var(--spacing-1) var(--spacing-2);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 11px;
   font-weight: 500;
   font-family: var(--font-sans);
@@ -670,7 +670,7 @@ th span {
 
 .modal-content {
   background: var(--bg-card);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   max-width: 700px;
   width: 100%;
   max-height: 90vh;
@@ -739,7 +739,7 @@ th span {
   color: var(--color-error);
   background: var(--color-error-bg);
   padding: var(--spacing-2);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-family: var(--font-mono);
   font-size: 12px;
 }
@@ -749,7 +749,7 @@ th span {
   font-size: 12px;
   background: var(--bg-secondary);
   padding: var(--spacing-3);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   overflow-x: auto;
   margin: 0;
   white-space: pre-wrap;

--- a/autobot-frontend/src/components/base/BaseBadge.vue
+++ b/autobot-frontend/src/components/base/BaseBadge.vue
@@ -87,21 +87,21 @@ const handleRemove = (event: MouseEvent) => {
   height: 16px;
   padding: 0 6px;
   font-size: 10px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .badge-sm {
   height: 20px;
   padding: 0 8px;
   font-size: 11px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
 }
 
 .badge-md {
   height: 24px;
   padding: 0 10px;
   font-size: 12px;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
 }
 
 .badge-lg {
@@ -113,16 +113,16 @@ const handleRemove = (event: MouseEvent) => {
 
 /* Rounded Variants */
 .badge-rounded.badge-xs {
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .badge-rounded.badge-sm,
 .badge-rounded.badge-md {
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .badge-rounded.badge-lg {
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 /* Color Variants - Solid */

--- a/autobot-frontend/src/components/base/BaseButton.vue
+++ b/autobot-frontend/src/components/base/BaseButton.vue
@@ -168,35 +168,35 @@ const createRipple = (event: TouchEvent) => {
   height: 28px;
   padding: 0 8px;
   font-size: 11px;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .btn-sm {
   height: 32px;
   padding: 0 12px;
   font-size: 13px;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .btn-md {
   height: 40px;
   padding: 0 16px;
   font-size: 14px;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .btn-lg {
   height: 48px;
   padding: 0 24px;
   font-size: 16px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .btn-xl {
   height: 56px;
   padding: 0 32px;
   font-size: 18px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 /* Color variants - Issue #901: Professional electric blue primary */
@@ -324,7 +324,7 @@ const createRipple = (event: TouchEvent) => {
 }
 
 .btn-rounded {
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
 }
 
 .btn-disabled {

--- a/autobot-frontend/src/components/base/BaseCard.vue
+++ b/autobot-frontend/src/components/base/BaseCard.vue
@@ -83,23 +83,23 @@ const footerClasses = computed(() => ({
 /* Variant Styles */
 .card-default {
   border: 1px solid var(--border-default);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .card-bordered {
   border: 2px solid var(--border-strong);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .card-elevated {
   border: 1px solid var(--border-subtle);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   box-shadow: var(--shadow-md);
 }
 
 .card-flat {
   background-color: var(--bg-secondary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 /* Hover Effect */

--- a/autobot-frontend/src/components/base/BaseInput.vue
+++ b/autobot-frontend/src/components/base/BaseInput.vue
@@ -185,7 +185,7 @@ defineExpose({
   align-items: center;
   background-color: var(--bg-input);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -289,7 +289,7 @@ defineExpose({
   border: none;
   color: var(--text-muted);
   cursor: pointer;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   transition: all 150ms ease;
 }
 

--- a/autobot-frontend/src/components/base/BaseTable.vue
+++ b/autobot-frontend/src/components/base/BaseTable.vue
@@ -253,7 +253,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
   flex-direction: column;
   background-color: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 /* Table Controls */

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
@@ -255,7 +255,7 @@ function submitType() {
   width: 28px;
   height: 28px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   background: transparent;
   color: var(--color-text-secondary, #a1a1aa);
   cursor: pointer;
@@ -285,7 +285,7 @@ function submitType() {
   flex: 1;
   padding: 4px 8px;
   border: 1px solid var(--color-border, #333);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   background: var(--color-bg, #121212);
   color: var(--color-text, #e4e4e7);
   font-size: 0.8rem;
@@ -307,7 +307,7 @@ function submitType() {
   width: 28px;
   height: 28px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   background: var(--color-primary, #3b82f6);
   color: white;
   cursor: pointer;

--- a/autobot-frontend/src/components/charts/EvolutionTimelineChart.vue
+++ b/autobot-frontend/src/components/charts/EvolutionTimelineChart.vue
@@ -136,7 +136,7 @@ function formatMetricName(metric: string): string {
 <style scoped>
 .base-chart {
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 1rem;
 }
 </style>

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -1724,7 +1724,7 @@ watch(viewMode, async (newMode) => {
   padding: 1px var(--spacing-1);
   background: var(--color-warning-bg);
   color: var(--color-warning);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 .more-calls {

--- a/autobot-frontend/src/components/charts/PatternEvolutionChart.vue
+++ b/autobot-frontend/src/components/charts/PatternEvolutionChart.vue
@@ -150,7 +150,7 @@ function formatPatternName(pattern: string): string {
 <style scoped>
 .base-chart {
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 1rem;
 }
 </style>

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -1417,7 +1417,7 @@ onMounted(async () => {
 .message-wrapper.system-message {
   @apply bg-autobot-bg-tertiary border-autobot-border mx-auto text-autobot-text-secondary;
   max-width: 70%;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
 }
 
 /* ============================================

--- a/autobot-frontend/src/components/chat/MessageItem.vue
+++ b/autobot-frontend/src/components/chat/MessageItem.vue
@@ -397,7 +397,7 @@ const formattedContent = computed(() => {
 .message-wrapper.system-message {
   @apply bg-autobot-bg-tertiary border-autobot-border mx-auto text-autobot-text-secondary;
   max-width: 70%;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
 }
 
 .message-wrapper.error {

--- a/autobot-frontend/src/components/chat/ReasoningTrace.vue
+++ b/autobot-frontend/src/components/chat/ReasoningTrace.vue
@@ -111,7 +111,7 @@ function formatDuration(ms: number): string {
 <style scoped>
 .reasoning-trace {
   border: 1px solid var(--color-border, #334155);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   margin-bottom: 0.5rem;
   background: var(--color-bg-subtle, #0f172a);
   overflow: hidden;
@@ -161,7 +161,7 @@ function formatDuration(ms: number): string {
 .reasoning-trace__count {
   font-size: 0.7rem;
   background: var(--color-border, #334155);
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   padding: 0 0.4rem;
   line-height: 1.4rem;
 }

--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
@@ -357,7 +357,7 @@ onUnmounted(() => {
 
 .vision-modal {
   background: var(--bg-secondary, #fff);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   width: 90%;
   max-width: 640px;
   max-height: 85vh;
@@ -400,7 +400,7 @@ onUnmounted(() => {
   border: none;
   color: var(--text-tertiary);
   cursor: pointer;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   transition: all 0.15s;
 }
 
@@ -422,7 +422,7 @@ onUnmounted(() => {
 /* Drop zone */
 .drop-zone {
   border: 2px dashed var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   padding: 32px;
   text-align: center;
   cursor: pointer;
@@ -478,7 +478,7 @@ onUnmounted(() => {
   width: 80px;
   height: 80px;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-default);
 }
 
@@ -507,7 +507,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
@@ -541,7 +541,7 @@ onUnmounted(() => {
   padding: 8px 12px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   color: var(--text-primary);
 }
@@ -563,7 +563,7 @@ onUnmounted(() => {
   background: var(--color-primary);
   color: var(--text-on-primary, #fff);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -591,7 +591,7 @@ onUnmounted(() => {
   padding: 10px 14px;
   background: var(--color-error-bg);
   border: 1px solid var(--color-error-border, var(--color-error));
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--color-error);
   font-size: 13px;
 }
@@ -607,7 +607,7 @@ onUnmounted(() => {
 /* Results */
 .results-section {
   background: var(--bg-tertiary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   overflow: hidden;
 }
 
@@ -637,7 +637,7 @@ onUnmounted(() => {
 .meta-badge {
   font-size: 11px;
   padding: 3px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   background: var(--bg-secondary);
   color: var(--text-secondary);
 }
@@ -680,7 +680,7 @@ onUnmounted(() => {
   padding: 3px 8px;
   background: var(--color-primary-bg, rgba(59, 130, 246, 0.1));
   color: var(--color-primary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
 }
 
 .objects-list {
@@ -694,7 +694,7 @@ onUnmounted(() => {
   justify-content: space-between;
   padding: 6px 10px;
   background: var(--bg-secondary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 13px;
   color: var(--text-primary);
 }
@@ -723,7 +723,7 @@ onUnmounted(() => {
 .json-display {
   padding: 12px;
   background: var(--bg-secondary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 11px;
   color: var(--text-secondary);
   overflow-x: auto;
@@ -750,7 +750,7 @@ onUnmounted(() => {
   background: var(--color-primary);
   color: var(--text-on-primary, #fff);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -773,7 +773,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;

--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -409,7 +409,7 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   background: rgba(37, 99, 235, 0.15);
   color: #60a5fa;
   font-size: 0.875rem;
@@ -418,7 +418,7 @@ onBeforeUnmount(() => {
 .voice-overlay__mode-select {
   appearance: none;
   padding: 0.25rem 1.75rem 0.25rem 0.5rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.15));
   background: var(--bg-tertiary, #1e293b)
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2394a3b8' d='M3 4.5L6 8l3-3.5H3z'/%3E%3C/svg%3E")
@@ -443,7 +443,7 @@ onBeforeUnmount(() => {
   align-items: center;
   gap: 0.3rem;
   padding: 0.15rem 0.5rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: rgba(37, 99, 235, 0.1);
   border: 1px solid rgba(37, 99, 235, 0.2);
   color: #93c5fd;
@@ -476,7 +476,7 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   color: var(--text-muted, #64748b);
   transition: all 0.15s;
   cursor: pointer;
@@ -555,13 +555,13 @@ onBeforeUnmount(() => {
 .voice-overlay__bubble--user .voice-overlay__bubble-content {
   background: rgba(37, 99, 235, 0.12);
   border: 1px solid rgba(37, 99, 235, 0.15);
-  border-bottom-right-radius: 0.25rem;
+  border-bottom-right-radius: var(--radius-default);
 }
 
 .voice-overlay__bubble--assistant .voice-overlay__bubble-content {
   background: var(--bg-tertiary, rgba(30, 41, 59, 0.6));
   border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.08));
-  border-bottom-left-radius: 0.25rem;
+  border-bottom-left-radius: var(--radius-default);
 }
 
 .voice-overlay__bubble-sender {
@@ -578,7 +578,7 @@ onBeforeUnmount(() => {
 .voice-overlay__live-transcript {
   margin-top: 0.75rem;
   padding: 0.5rem 0.75rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   background: rgba(37, 99, 235, 0.06);
   border: 1px dashed rgba(37, 99, 235, 0.2);
   color: #93c5fd;
@@ -590,7 +590,7 @@ onBeforeUnmount(() => {
 .voice-overlay__error {
   margin: 0 1.25rem;
   padding: 0.5rem 0.75rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.2);
   color: #fca5a5;
@@ -601,7 +601,7 @@ onBeforeUnmount(() => {
 .voice-overlay__cert-warning {
   margin: 0 1.25rem;
   padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   background: rgba(245, 158, 11, 0.08);
   border: 1px solid rgba(245, 158, 11, 0.25);
   color: #fcd34d;
@@ -631,7 +631,7 @@ onBeforeUnmount(() => {
 .voice-overlay__cert-warning-steps code {
   background: rgba(0, 0, 0, 0.3);
   padding: 0.1rem 0.3rem;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   word-break: break-all;
 }
@@ -780,14 +780,14 @@ onBeforeUnmount(() => {
 /* Amplitude meter */
 .voice-overlay__amplitude {
   height: 4px;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   background: rgba(148, 163, 184, 0.1);
   overflow: hidden;
 }
 
 .voice-overlay__amplitude-bar {
   height: 100%;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   background: linear-gradient(90deg, #60a5fa, #818cf8);
   transition: width 0.1s ease-out;
   min-width: 0;
@@ -811,7 +811,7 @@ onBeforeUnmount(() => {
   height: 4px;
   appearance: none;
   background: rgba(148, 163, 184, 0.15);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   outline: none;
   cursor: pointer;
 }

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -273,7 +273,7 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: rgba(37, 99, 235, 0.15);
   color: #60a5fa;
   font-size: 0.75rem;
@@ -282,7 +282,7 @@ onBeforeUnmount(() => {
 .voice-panel__mode-select {
   appearance: none;
   padding: 0.2rem 1.5rem 0.2rem 0.4rem;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.15));
   background: var(--bg-tertiary, #1e293b)
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2394a3b8' d='M3 4.5L6 8l3-3.5H3z'/%3E%3C/svg%3E")
@@ -297,7 +297,7 @@ onBeforeUnmount(() => {
   align-items: center;
   gap: 0.2rem;
   padding: 0.1rem 0.4rem;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   background: rgba(37, 99, 235, 0.1);
   border: 1px solid rgba(37, 99, 235, 0.2);
   color: #93c5fd;
@@ -373,7 +373,7 @@ onBeforeUnmount(() => {
 .voice-panel__transcript {
   width: 100%;
   padding: 0.5rem 0.75rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: rgba(37, 99, 235, 0.06);
   border: 1px dashed rgba(37, 99, 235, 0.2);
   color: #93c5fd;
@@ -386,7 +386,7 @@ onBeforeUnmount(() => {
 .voice-panel__error {
   margin: 0 0.75rem;
   padding: 0.375rem 0.5rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.2);
   color: #fca5a5;
@@ -397,7 +397,7 @@ onBeforeUnmount(() => {
 .voice-panel__cert-warning {
   margin: 0 0.75rem;
   padding: 0.5rem 0.625rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: rgba(245, 158, 11, 0.08);
   border: 1px solid rgba(245, 158, 11, 0.25);
   color: #fcd34d;
@@ -575,6 +575,6 @@ onBeforeUnmount(() => {
 
 .overflow-y-auto::-webkit-scrollbar-thumb {
   background: var(--border-default, rgba(148, 163, 184, 0.15));
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 </style>

--- a/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
+++ b/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
@@ -467,7 +467,7 @@ const roleOptions = computed(() => [
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
   background: rgba(156, 163, 175, 0.3);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {

--- a/autobot-frontend/src/components/collaboration/ParticipantList.vue
+++ b/autobot-frontend/src/components/collaboration/ParticipantList.vue
@@ -395,7 +395,7 @@ watch(
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
   background: rgba(156, 163, 175, 0.3);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {

--- a/autobot-frontend/src/components/documents/AIDocumentEditor.vue
+++ b/autobot-frontend/src/components/documents/AIDocumentEditor.vue
@@ -262,7 +262,7 @@ const formattedUpdatedAt = computed(() => {
   height: 100%;
   background: var(--color-background, #1e1e1e);
   color: var(--color-text, #e0e0e0);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   overflow: hidden;
 }
 
@@ -290,7 +290,7 @@ const formattedUpdatedAt = computed(() => {
   text-overflow: ellipsis;
   outline: none;
   padding: 2px 4px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: background 0.15s;
 }
 .document-title:focus-visible {
@@ -307,7 +307,7 @@ const formattedUpdatedAt = computed(() => {
   background: var(--color-background-input, #2a2a2a);
   color: inherit;
   border: 1px solid var(--color-primary, #4caf50);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 1.1rem;
   font-weight: 600;
   padding: 2px 8px;
@@ -347,7 +347,7 @@ const formattedUpdatedAt = computed(() => {
   background: var(--color-background-input, #2a2a2a);
   color: inherit;
   border: 1px solid var(--color-border, #444);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   padding: 8px;
   font-size: 0.9rem;
   font-family: inherit;

--- a/autobot-frontend/src/components/examples/AsyncOperationExample.vue
+++ b/autobot-frontend/src/components/examples/AsyncOperationExample.vue
@@ -780,7 +780,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 
 .example-card {
   background: var(--bg-card);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 24px;
   margin-bottom: 24px;
   box-shadow: var(--shadow-sm);
@@ -805,7 +805,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   background: var(--color-success);
   color: var(--text-on-primary);
   padding: 4px 12px;
-  border-radius: 16px;
+  border-radius: var(--radius-2xl);
   font-size: 0.875rem;
   font-weight: 500;
 }
@@ -824,7 +824,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   padding: 10px 20px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-weight: 500;
   border: none;
   cursor: pointer;
@@ -845,7 +845,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   background: var(--text-tertiary);
   color: var(--text-on-primary);
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-weight: 500;
   border: none;
   cursor: pointer;
@@ -864,7 +864,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   padding: 16px;
   background: var(--color-info-bg);
   border: 1px solid var(--color-info-light);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   margin-top: 12px;
   color: var(--color-info-dark);
 }
@@ -887,7 +887,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   padding: 16px;
   background: var(--color-error-bg);
   border: 1px solid var(--color-error-light);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   margin-top: 12px;
   color: var(--color-error-dark);
 }
@@ -897,7 +897,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   padding: 16px;
   background: var(--color-success-bg);
   border: 1px solid var(--color-success-light);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   margin-top: 12px;
   color: var(--color-success-dark);
 }
@@ -919,7 +919,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 .data-display {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   padding: 12px;
   margin-top: 12px;
   overflow-x: auto;
@@ -948,7 +948,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   max-width: 400px;
   padding: 8px 12px;
   border: 1px solid var(--border-light);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 1rem;
   transition: border-color 0.2s;
 }
@@ -969,7 +969,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   top: 20px;
   right: 20px;
   padding: 16px 24px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-weight: 500;
   box-shadow: var(--shadow-lg);
   animation: slideIn 0.3s ease;
@@ -998,7 +998,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   padding: 16px;
   background: var(--color-error-bg);
   border: 1px solid var(--color-error-light);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
 }
 
 .error-log h4 {
@@ -1042,7 +1042,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 .data-section {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
 }
 
@@ -1064,7 +1064,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   background: var(--chart-purple);
   color: white;
   padding: 20px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   text-align: center;
 }
 
@@ -1087,7 +1087,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 
 .code-comparison details {
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   padding: 12px;
   background: var(--bg-secondary);
 }
@@ -1119,7 +1119,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 .code-block {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -1147,7 +1147,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 .summary-card {
   background: var(--chart-purple);
   color: white;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 32px;
   margin-top: 32px;
 }
@@ -1168,7 +1168,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 .benefit-item {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 20px;
   display: flex;
   gap: 16px;
@@ -1206,7 +1206,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 
 .async-examples-container::-webkit-scrollbar-thumb {
   background: var(--border-secondary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .async-examples-container::-webkit-scrollbar-thumb:hover {

--- a/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
+++ b/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
@@ -308,7 +308,7 @@ const formatTime = (timestamp: number) => {
 .access-metrics {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 24px;
 }
 
@@ -352,7 +352,7 @@ const formatTime = (timestamp: number) => {
 .days-selector {
   padding: 8px 12px;
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--bg-input);
   color: var(--text-primary);
   font-size: 13px;
@@ -367,7 +367,7 @@ const formatTime = (timestamp: number) => {
   justify-content: center;
   background: var(--bg-tertiary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   color: var(--text-secondary);
   transition: all 0.15s;
@@ -438,7 +438,7 @@ const formatTime = (timestamp: number) => {
   padding: 16px;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
 }
 
 .summary-card.alert {
@@ -448,7 +448,7 @@ const formatTime = (timestamp: number) => {
 .summary-icon {
   width: 44px;
   height: 44px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   background: var(--bg-tertiary);
   display: flex;
   align-items: center;
@@ -520,7 +520,7 @@ const formatTime = (timestamp: number) => {
 .breakdown-section {
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   padding: 16px;
 }
 
@@ -563,7 +563,7 @@ const formatTime = (timestamp: number) => {
   cursor: pointer;
   padding: 8px;
   margin: -8px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   transition: background 0.15s;
 }
 
@@ -594,14 +594,14 @@ code.item-label {
 .item-bar {
   height: 6px;
   background: var(--bg-tertiary);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
 .bar-fill {
   height: 100%;
   background: var(--color-error);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   transition: width 0.3s ease;
 }
 
@@ -642,7 +642,7 @@ code.item-label {
 .day-bar .bar {
   width: 100%;
   background: var(--color-error);
-  border-radius: 4px 4px 0 0;
+  border-radius: var(--radius-default) 4px 0 0;
   min-height: 4px;
   transition: height 0.3s ease;
 }
@@ -669,7 +669,7 @@ code.item-label {
   gap: 16px;
   padding: 10px 12px;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-weight: 600;
   color: var(--text-secondary);
   margin-bottom: 8px;
@@ -692,7 +692,7 @@ code.item-label {
   font-size: 12px;
   background: var(--bg-tertiary);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 /* Responsive */

--- a/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
+++ b/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
@@ -274,7 +274,7 @@ const closeModal = () => {
 .endpoint-enforcement {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 24px;
 }
 
@@ -311,7 +311,7 @@ const closeModal = () => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -370,7 +370,7 @@ const closeModal = () => {
   gap: 10px;
   padding: 12px 16px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   color: var(--text-secondary);
   margin-bottom: 8px;
@@ -387,7 +387,7 @@ const closeModal = () => {
   padding: 16px;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   transition: all 0.15s;
 }
 
@@ -407,7 +407,7 @@ const closeModal = () => {
   color: var(--text-primary);
   background: var(--bg-tertiary);
   padding: 4px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .override-mode {
@@ -421,7 +421,7 @@ const closeModal = () => {
   align-items: center;
   gap: 6px;
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 12px;
   font-weight: 500;
 }
@@ -459,7 +459,7 @@ const closeModal = () => {
   justify-content: center;
   background: var(--bg-tertiary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   color: var(--text-secondary);
   transition: all 0.15s;
@@ -501,7 +501,7 @@ const closeModal = () => {
 .form-input {
   padding: 12px;
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-family: var(--font-mono);
   transition: all 0.2s;
@@ -542,7 +542,7 @@ const closeModal = () => {
   gap: 10px;
   padding: 16px;
   border: 2px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -563,7 +563,7 @@ const closeModal = () => {
 .mode-selector .option-icon {
   width: 40px;
   height: 40px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -638,7 +638,7 @@ const closeModal = () => {
   font-family: var(--font-mono);
   background: var(--bg-tertiary);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 /* Buttons */
@@ -647,7 +647,7 @@ const closeModal = () => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -672,7 +672,7 @@ const closeModal = () => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;

--- a/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.vue
+++ b/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.vue
@@ -132,7 +132,7 @@ const selectMode = (mode: EnforcementMode) => {
 .enforcement-mode-selector {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 24px;
 }
 
@@ -173,7 +173,7 @@ const selectMode = (mode: EnforcementMode) => {
   padding: 16px;
   background: var(--bg-primary);
   border: 2px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -195,7 +195,7 @@ const selectMode = (mode: EnforcementMode) => {
 .option-icon {
   width: 44px;
   height: 44px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -240,7 +240,7 @@ const selectMode = (mode: EnforcementMode) => {
   padding: 2px 8px;
   background: var(--color-primary);
   color: var(--text-on-primary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-weight: 500;
 }
 
@@ -314,7 +314,7 @@ const selectMode = (mode: EnforcementMode) => {
   gap: 12px;
   margin-top: 16px;
   padding: 14px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .mode-warning {

--- a/autobot-frontend/src/components/feature-flags/FlagChangeHistory.vue
+++ b/autobot-frontend/src/components/feature-flags/FlagChangeHistory.vue
@@ -160,7 +160,7 @@ const formatRelativeTime = (timestamp: string) => {
 .flag-change-history {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 24px;
 }
 
@@ -296,7 +296,7 @@ const formatRelativeTime = (timestamp: string) => {
   display: inline-flex;
   align-items: center;
   padding: 4px 10px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 12px;
   font-weight: 600;
 }
@@ -325,7 +325,7 @@ const formatRelativeTime = (timestamp: string) => {
   padding: 14px;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
 }
 
 .action-text {

--- a/autobot-frontend/src/components/file-browser/FileBrowser.vue
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.vue
@@ -568,7 +568,7 @@ onMounted(() => {
 
 .modal-content {
   background: var(--bg-card);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   max-width: 90vw;
   max-height: 90vh;
   width: 800px;
@@ -607,7 +607,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: background-color 0.2s;
 }
 
@@ -649,7 +649,7 @@ onMounted(() => {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   box-shadow: var(--shadow-sm);
 }
 
@@ -670,7 +670,7 @@ onMounted(() => {
   background-color: var(--bg-secondary);
   color: var(--text-primary);
   padding: 16px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   border: 1px solid var(--border-default);
 }
 
@@ -719,7 +719,7 @@ onMounted(() => {
   background-color: var(--color-electric-600, #2563eb);
   color: white;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   cursor: pointer;
   font-size: 16px;
   transition: background-color 0.2s;

--- a/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
+++ b/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
@@ -327,7 +327,7 @@ onUnmounted(() => {
 .document-change-feed {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 1.5rem;
   margin-bottom: 1.5rem;
 }
@@ -358,7 +358,7 @@ onUnmounted(() => {
 
 .badge {
   padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   font-size: 0.875rem;
   font-weight: 500;
   display: inline-flex;
@@ -414,7 +414,7 @@ onUnmounted(() => {
   padding: 0.375rem 0.5rem;
   font-size: 0.875rem;
   border: 1px solid var(--border-light);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   background: var(--bg-card);
   color: var(--text-secondary);
   min-width: 180px;
@@ -465,7 +465,7 @@ onUnmounted(() => {
 .vectorization-status {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;
 }
@@ -526,7 +526,7 @@ onUnmounted(() => {
   display: flex;
   gap: 0.75rem;
   padding: 0.75rem;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   transition: all 0.2s;
 }
 

--- a/autobot-frontend/src/components/knowledge/KBSearchResultPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KBSearchResultPanel.vue
@@ -619,7 +619,7 @@ async function copyContent(): Promise<void> {
 .kb-highlight {
   background-color: #fef08a;
   color: #713f12;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   padding: 0 1px;
   font-weight: 600;
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -528,7 +528,7 @@ onMounted(() => {
 
 .section-card {
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
 }
@@ -567,7 +567,7 @@ onMounted(() => {
 
 .action-card {
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1.25rem;
   display: flex;
   flex-direction: column;
@@ -688,7 +688,7 @@ onMounted(() => {
   width: 100%;
   height: 0.5rem;
   background: var(--bg-tertiary);
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   overflow: hidden;
   margin-bottom: 1rem;
 }
@@ -721,7 +721,7 @@ onMounted(() => {
 .status-message {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   box-shadow: var(--shadow-md);
   display: flex;

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -1143,7 +1143,7 @@ watch(() => props.mode, () => {
 
 .category-tabs::-webkit-scrollbar-thumb {
   background: var(--color-primary-alpha-30);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .category-tab {
@@ -1196,7 +1196,7 @@ watch(() => props.mode, () => {
   padding: 0.375rem 0.75rem;
   background: var(--color-primary-bg);
   border: 1px solid var(--color-primary-light);
-  border-radius: 1rem;
+  border-radius: var(--radius-2xl);
   font-size: 0.8125rem;
   color: var(--color-primary-dark);
   font-weight: 500;
@@ -1352,7 +1352,7 @@ watch(() => props.mode, () => {
   width: 100%;
   padding: 0.625rem 2.5rem 0.625rem 2.5rem;
   border: 1px solid var(--border-light);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   font-size: 0.875rem;
   transition: all 0.2s;
 }
@@ -1524,7 +1524,7 @@ watch(() => props.mode, () => {
   overflow-y: auto;
   background: var(--bg-card);
   margin: 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
 }
 
@@ -1567,7 +1567,7 @@ watch(() => props.mode, () => {
 .tree-pane::-webkit-scrollbar-thumb,
 .content-pane::-webkit-scrollbar-thumb {
   background: var(--border-secondary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .tree-pane::-webkit-scrollbar-thumb:hover,

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -418,7 +418,7 @@ onUnmounted(() => {
 .main-category-card {
   background: var(--bg-card);
   border: 3px solid var(--border-default);
-  border-radius: 1rem;
+  border-radius: var(--radius-2xl);
   padding: 2rem;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -438,7 +438,7 @@ onUnmounted(() => {
   width: 2rem;
   height: 2rem;
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-secondary);
   cursor: pointer;
@@ -483,7 +483,7 @@ onUnmounted(() => {
 .category-icon-large {
   width: 5rem;
   height: 5rem;
-  border-radius: 1rem;
+  border-radius: var(--radius-2xl);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -523,7 +523,7 @@ onUnmounted(() => {
   margin-bottom: 1.5rem;
   padding: 0.75rem;
   background: var(--bg-secondary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
 }
 
 .category-stats {
@@ -580,7 +580,7 @@ onUnmounted(() => {
   margin-bottom: 1.5rem;
   padding: 1rem;
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   box-shadow: var(--shadow-sm);
 }
 
@@ -650,7 +650,7 @@ onUnmounted(() => {
   margin-bottom: 2rem;
   padding: 1.5rem;
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   box-shadow: var(--shadow-sm);
 }
 
@@ -675,7 +675,7 @@ onUnmounted(() => {
   background: var(--color-info);
   color: var(--text-on-primary);
   text-decoration: none;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   font-weight: 500;
   transition: all 0.2s;
 }
@@ -695,7 +695,7 @@ onUnmounted(() => {
 
 .stat-card {
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   padding: 1.5rem;
   display: flex;
   align-items: center;
@@ -714,7 +714,7 @@ onUnmounted(() => {
   height: 3rem;
   background: var(--color-info);
   color: var(--text-on-primary);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -748,7 +748,7 @@ onUnmounted(() => {
 
 .category-browse-card {
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   padding: 1.5rem;
   display: flex;
   align-items: center;
@@ -769,7 +769,7 @@ onUnmounted(() => {
   height: 3.5rem;
   background: var(--color-info-bg);
   color: var(--color-info);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -817,7 +817,7 @@ onUnmounted(() => {
 .category-tree-container {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   max-height: 500px;
   overflow-y: auto;
@@ -832,7 +832,7 @@ onUnmounted(() => {
 .selected-category-info {
   background: var(--color-info-bg);
   padding: 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--color-info);
 }
 
@@ -857,7 +857,7 @@ onUnmounted(() => {
   flex: 1;
   padding: 0.75rem 1rem;
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;
@@ -893,7 +893,7 @@ onUnmounted(() => {
 /* KB Stats */
 .kb-stats {
   background: var(--bg-secondary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1.25rem;
   border: 1px solid var(--border-default);
 }
@@ -933,7 +933,7 @@ onUnmounted(() => {
 /* KB Message */
 .kb-message {
   padding: 0.75rem 1rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
 }
 
@@ -976,7 +976,7 @@ onUnmounted(() => {
   color: var(--color-error-dark);
   background: var(--color-error-bg);
   border: 1px solid var(--color-error-border);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   max-width: 500px;
   margin: 2rem auto;
 }
@@ -997,7 +997,7 @@ onUnmounted(() => {
   background: var(--color-error-dark);
   color: #fff;
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-weight: 500;
   cursor: pointer;
   transition: opacity 0.2s;
@@ -1016,7 +1016,7 @@ onUnmounted(() => {
 .category-card {
   background: var(--bg-card);
   border: 2px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1.5rem;
   cursor: pointer;
   transition: all 0.2s;
@@ -1042,7 +1042,7 @@ onUnmounted(() => {
 .category-icon {
   width: 3rem;
   height: 3rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1104,7 +1104,7 @@ onUnmounted(() => {
   width: 100%;
   padding: 0.625rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   background: var(--bg-input);
   color: var(--text-primary);
@@ -1131,7 +1131,7 @@ onUnmounted(() => {
 .color-option {
   width: 2.5rem;
   height: 2.5rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   cursor: pointer;
   position: relative;
   transition: transform 0.2s;
@@ -1189,7 +1189,7 @@ onUnmounted(() => {
   gap: 1rem;
   padding: 0.75rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   margin-bottom: 0.5rem;
   cursor: pointer;
   transition: all 0.2s;
@@ -1204,7 +1204,7 @@ onUnmounted(() => {
   width: 2.5rem;
   height: 2.5rem;
   background: var(--color-info-bg);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1229,7 +1229,7 @@ onUnmounted(() => {
   background: var(--color-success);
   color: var(--text-on-success);
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;
@@ -1264,7 +1264,7 @@ onUnmounted(() => {
 
 .category-documents-modal {
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   width: 100%;
   max-width: 1200px;
   max-height: 90vh;
@@ -1280,7 +1280,7 @@ onUnmounted(() => {
   padding: 1.5rem 2rem;
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-secondary);
-  border-radius: 0.75rem 0.75rem 0 0;
+  border-radius: var(--radius-xl) 0.75rem 0 0;
 }
 
 .modal-header h3 {
@@ -1305,7 +1305,7 @@ onUnmounted(() => {
 .document-card {
   background: var(--bg-card);
   border: 2px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1.25rem;
   cursor: pointer;
   transition: all 0.2s;
@@ -1328,7 +1328,7 @@ onUnmounted(() => {
   width: 2.5rem;
   height: 2.5rem;
   background: var(--color-info-bg);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1397,7 +1397,7 @@ onUnmounted(() => {
 
 .document-viewer-modal {
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   width: 100%;
   max-width: 1400px;
   max-height: 95vh;
@@ -1413,7 +1413,7 @@ onUnmounted(() => {
   padding: 1.5rem 2rem;
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-secondary);
-  border-radius: 0.75rem 0.75rem 0 0;
+  border-radius: var(--radius-xl) 0.75rem 0 0;
 }
 
 .viewer-header h3 {
@@ -1435,7 +1435,7 @@ onUnmounted(() => {
   font-family: var(--font-mono);
   background: var(--color-info-bg);
   padding: 0.25rem 0.75rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
 }
 
 .viewer-content {
@@ -1468,7 +1468,7 @@ onUnmounted(() => {
   padding: 0.5rem 1rem;
   border: none;
   background: transparent;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   color: var(--text-secondary);
   font-size: 0.875rem;
   font-weight: 500;
@@ -1510,7 +1510,7 @@ onUnmounted(() => {
 .document-card {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   cursor: pointer;
   transition: all 0.2s;
@@ -1529,7 +1529,7 @@ onUnmounted(() => {
   height: 3rem;
   background: var(--color-info-bg);
   color: var(--color-info);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1577,7 +1577,7 @@ onUnmounted(() => {
 /* Document Metadata */
 .document-metadata {
   background: var(--bg-secondary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   margin-bottom: 1rem;
 }
@@ -1611,7 +1611,7 @@ onUnmounted(() => {
 .document-content pre {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   font-size: 0.875rem;
   overflow-x: auto;

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -971,7 +971,7 @@ watch([debouncedSearchQuery, filterCategory, filterType], () => {
 .search-input {
   padding: var(--spacing-2) var(--spacing-3) var(--spacing-2) var(--spacing-9);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   width: 250px;
   background: var(--bg-primary);
   color: var(--text-primary);
@@ -997,7 +997,7 @@ watch([debouncedSearchQuery, filterCategory, filterType], () => {
   gap: var(--spacing-4);
   padding: var(--spacing-4);
   background: var(--bg-secondary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   margin-bottom: var(--spacing-4);
   flex-wrap: wrap;
 }
@@ -1017,7 +1017,7 @@ watch([debouncedSearchQuery, filterCategory, filterType], () => {
 .filter-select {
   padding: var(--spacing-1-5) var(--spacing-3);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: var(--text-sm);
   font-family: var(--font-sans);
   background: var(--bg-card);
@@ -1045,7 +1045,7 @@ watch([debouncedSearchQuery, filterCategory, filterType], () => {
 /* Table styles */
 .entries-table {
   background: var(--bg-card);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
 }
@@ -1129,7 +1129,7 @@ tr.selected {
 .category-badge {
   display: inline-block;
   padding: var(--spacing-1) var(--spacing-3);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 11px;
   font-weight: 500;
   font-family: var(--font-sans);
@@ -1157,7 +1157,7 @@ tr.selected {
   display: inline-block;
   padding: var(--spacing-0-5) var(--spacing-2);
   background: var(--bg-tertiary);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 11px;
   font-family: var(--font-mono);
   font-weight: 400;
@@ -1216,7 +1216,7 @@ tr.selected {
   margin-bottom: var(--spacing-8);
   padding: var(--spacing-4);
   background: var(--bg-secondary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .meta-item {

--- a/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
@@ -360,7 +360,7 @@ onMounted(() => {
 /* Health Dashboard */
 .health-dashboard {
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   padding: 1.5rem;
   margin-bottom: 2rem;
   box-shadow: var(--shadow-sm);
@@ -385,7 +385,7 @@ onMounted(() => {
 
 .health-status-badge {
   padding: 0.375rem 0.75rem;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -438,14 +438,14 @@ onMounted(() => {
   gap: 1rem;
   padding: 1rem;
   background: var(--bg-tertiary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-default);
 }
 
 .card-icon {
   width: 3rem;
   height: 3rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -501,7 +501,7 @@ onMounted(() => {
 .quality-dimensions {
   grid-column: span 2;
   background: var(--bg-tertiary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   border: 1px solid var(--border-default);
 }
@@ -543,13 +543,13 @@ onMounted(() => {
 .dimension-bar {
   height: 0.5rem;
   background: var(--border-default);
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   overflow: hidden;
 }
 
 .dimension-fill {
   height: 100%;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   transition: width 0.5s ease;
 }
 
@@ -568,7 +568,7 @@ onMounted(() => {
 /* Issues Summary */
 .issues-summary {
   background: var(--bg-tertiary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   border: 1px solid var(--border-default);
 }
@@ -605,7 +605,7 @@ onMounted(() => {
 .recommendations {
   grid-column: span 4;
   background: var(--color-info-bg);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
   border: 1px solid var(--color-info-light);
 }
@@ -649,7 +649,7 @@ onMounted(() => {
 
 .maintenance-section {
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
 }
@@ -657,7 +657,7 @@ onMounted(() => {
 /* Maintenance History */
 .maintenance-history {
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   padding: 1.5rem;
   box-shadow: var(--shadow-sm);
 }
@@ -694,7 +694,7 @@ onMounted(() => {
   gap: 1rem;
   padding: 0.75rem 1rem;
   background: var(--bg-tertiary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   border-left: 3px solid var(--border-light);
 }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -575,7 +575,7 @@ onBeforeUnmount(() => {
   width: 100%;
   padding: 0.5rem 0.75rem 0.5rem 2.25rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   background: var(--bg-input);
   color: var(--text-primary);
@@ -584,7 +584,7 @@ onBeforeUnmount(() => {
 .category-filter {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   background: var(--bg-input);
   color: var(--text-primary);
@@ -659,7 +659,7 @@ onBeforeUnmount(() => {
   margin-left: auto;
   background: var(--bg-card);
   padding: 0.125rem 0.5rem;
-  border-radius: 1rem;
+  border-radius: var(--radius-2xl);
   font-weight: 500;
 }
 
@@ -671,7 +671,7 @@ onBeforeUnmount(() => {
 
 .prompt-item {
   padding: 0.625rem 0.75rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -748,7 +748,7 @@ onBeforeUnmount(() => {
 .version-badge {
   padding: 0.125rem 0.5rem;
   background: var(--bg-secondary);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   color: var(--text-secondary);
 }
@@ -757,7 +757,7 @@ onBeforeUnmount(() => {
   padding: 0.125rem 0.5rem;
   background: var(--color-warning-bg);
   color: var(--color-warning-dark);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   font-size: 0.75rem;
   font-weight: 500;
 }
@@ -779,7 +779,7 @@ onBeforeUnmount(() => {
   height: 100%;
   padding: 1rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   font-family: var(--font-mono);
   font-size: 0.875rem;
   line-height: 1.6;
@@ -837,7 +837,7 @@ onBeforeUnmount(() => {
   padding: 0.125rem 0.5rem;
   background: var(--color-info-bg);
   color: var(--color-info);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   font-family: var(--font-mono);
   font-size: 0.75rem;
 }
@@ -870,7 +870,7 @@ onBeforeUnmount(() => {
   align-items: center;
   padding: 0.75rem 1rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -917,7 +917,7 @@ onBeforeUnmount(() => {
   overflow-y: auto;
   padding: 1rem;
   background: var(--bg-secondary);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-family: var(--font-mono);
   font-size: 0.8125rem;
   line-height: 1.5;

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
@@ -793,7 +793,7 @@ onUnmounted(() => {
   color: var(--color-info);
   font-size: 11px;
   font-weight: 600;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   padding: 1px 7px;
 }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
@@ -178,7 +178,7 @@ const handleGroupChange = () => {
 .scope-dropdown {
   padding: 0.5rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   cursor: pointer;
   transition: border-color 0.2s;
@@ -211,7 +211,7 @@ const handleGroupChange = () => {
   padding: 0.75rem;
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.813rem;
 }
 
@@ -231,7 +231,7 @@ const handleGroupChange = () => {
   margin-top: 0.75rem;
   padding: 0.75rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background-color: var(--bg-secondary);
 }
 
@@ -253,7 +253,7 @@ const handleGroupChange = () => {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   cursor: pointer;
   transition: background-color 0.2s;
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
@@ -564,7 +564,7 @@ onMounted(() => {
   width: 100%;
   padding: 0.5rem 0.875rem 0.5rem 2.5rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   background: var(--bg-input);
   color: var(--text-primary);
@@ -591,7 +591,7 @@ onMounted(() => {
   margin-top: 0.25rem;
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-lg);
   z-index: var(--z-popover);
   display: none;
@@ -668,7 +668,7 @@ onMounted(() => {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: background 0.15s;
 }
@@ -716,7 +716,7 @@ onMounted(() => {
   color: var(--text-muted);
   background: var(--bg-secondary);
   padding: 0.125rem 0.5rem;
-  border-radius: 1rem;
+  border-radius: var(--radius-2xl);
 }
 
 .category-children {
@@ -742,7 +742,7 @@ onMounted(() => {
   gap: 0.75rem;
   padding: 0.75rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -764,7 +764,7 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   background: var(--bg-secondary);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   color: var(--color-info);
 }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
@@ -515,7 +515,7 @@ onMounted(() => {
 .mode-btn {
   padding: var(--spacing-1-5) var(--spacing-3);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   background: var(--bg-secondary);
   color: var(--text-secondary);
   font-size: 12px;
@@ -547,7 +547,7 @@ onMounted(() => {
   gap: var(--spacing-4);
   padding: var(--spacing-4);
   background: var(--bg-secondary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   margin-bottom: var(--spacing-5);
   flex-wrap: wrap;
 }
@@ -597,7 +597,7 @@ onMounted(() => {
   padding: var(--spacing-3) var(--spacing-4);
   background: var(--color-info-bg);
   border: 1px solid var(--color-info);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   margin-bottom: var(--spacing-4);
 }
 
@@ -631,7 +631,7 @@ onMounted(() => {
   padding: var(--spacing-4);
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -690,7 +690,7 @@ onMounted(() => {
 .source-type-badge {
   display: inline-block;
   padding: 2px var(--spacing-2);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 11px;
   font-weight: 500;
   font-family: var(--font-sans);

--- a/autobot-frontend/src/components/knowledge/QualityScoreBadge.vue
+++ b/autobot-frontend/src/components/knowledge/QualityScoreBadge.vue
@@ -28,7 +28,7 @@ const qualityClass = computed(() => {
 .quality-badge {
   display: inline-block;
   padding: 2px 8px;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 11px;
   font-weight: 600;
   font-family: var(--font-mono);

--- a/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
@@ -264,7 +264,7 @@ const cleanupSessionOrphans = async () => {
 /* Issue #704: Migrated to CSS design tokens */
 .session-orphan-manager {
   background: var(--bg-card);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   margin: 1rem;
   box-shadow: var(--shadow-sm);
 }
@@ -310,7 +310,7 @@ const cleanupSessionOrphans = async () => {
   text-align: center;
   padding: 1rem;
   background: var(--bg-secondary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-default);
 }
 
@@ -340,7 +340,7 @@ const cleanupSessionOrphans = async () => {
 .orphan-preview {
   background: var(--color-warning-bg-light);
   border: 1px solid var(--color-warning-light);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
 }
 
@@ -362,7 +362,7 @@ const cleanupSessionOrphans = async () => {
 .orphan-item {
   background: var(--bg-card);
   border: 1px solid var(--color-warning-light);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   padding: 0.75rem;
 }
 
@@ -377,7 +377,7 @@ const cleanupSessionOrphans = async () => {
   padding: 0.125rem 0.5rem;
   background: var(--color-primary-bg);
   color: var(--color-primary-dark);
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
 }
 
 .orphan-important {
@@ -385,7 +385,7 @@ const cleanupSessionOrphans = async () => {
   padding: 0.125rem 0.5rem;
   background: var(--color-warning-bg);
   color: var(--color-warning-dark);
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
 }
 
 .orphan-content-text {
@@ -419,7 +419,7 @@ const cleanupSessionOrphans = async () => {
 
 .action-card {
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   padding: 1.25rem;
   display: flex;
   flex-direction: column;
@@ -497,7 +497,7 @@ const cleanupSessionOrphans = async () => {
   align-items: center;
   gap: 0.75rem;
   padding: 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   margin-top: 1.5rem;
 }
 

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -376,7 +376,7 @@ const closeDialog = () => {
 
 .modal-dialog {
   background: var(--bg-card);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   width: 90%;
   max-width: 600px;
   max-height: 80vh;
@@ -412,7 +412,7 @@ const closeDialog = () => {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   transition: background-color 0.2s;
 }
 
@@ -454,7 +454,7 @@ const closeDialog = () => {
   width: 100%;
   padding: 0.5rem 0.75rem 0.5rem 2.5rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   background-color: var(--bg-secondary);
   color: var(--text-primary);
@@ -473,7 +473,7 @@ const closeDialog = () => {
 .search-results {
   margin-bottom: 1.5rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   max-height: 200px;
   overflow-y: auto;
 }
@@ -538,7 +538,7 @@ const closeDialog = () => {
 
 .access-list {
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
 }
 
 .access-item {
@@ -584,7 +584,7 @@ const closeDialog = () => {
 .permission-select {
   padding: 0.25rem 0.5rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   font-size: 0.875rem;
   cursor: pointer;
   background-color: var(--bg-secondary);
@@ -597,7 +597,7 @@ const closeDialog = () => {
   padding: 0.5rem;
   cursor: pointer;
   color: #ef4444;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   transition: background-color 0.2s;
 }
 
@@ -615,7 +615,7 @@ const closeDialog = () => {
 
 .btn {
   padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;

--- a/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
+++ b/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
@@ -207,7 +207,7 @@ const allCompleted = computed(() => {
 
 .modal-container {
   background: var(--bg-card);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   box-shadow: var(--shadow-xl);
   max-width: 700px;
   width: 100%;
@@ -251,7 +251,7 @@ const allCompleted = computed(() => {
   justify-content: center;
   background: var(--bg-tertiary);
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   color: var(--text-tertiary);
   cursor: pointer;
   transition: all 0.2s;
@@ -282,7 +282,7 @@ const allCompleted = computed(() => {
   align-items: center;
   padding: 1rem;
   background: var(--bg-card);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   border: 2px solid var(--border-default);
 }
 
@@ -322,7 +322,7 @@ const allCompleted = computed(() => {
   flex: 1;
   height: 1.5rem;
   background: var(--border-default);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   overflow: hidden;
 }
 
@@ -330,7 +330,7 @@ const allCompleted = computed(() => {
   height: 100%;
   background: var(--color-primary);
   transition: width 0.3s ease;
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
 }
 
 .progress-text {
@@ -357,7 +357,7 @@ const allCompleted = computed(() => {
   margin-bottom: 0.5rem;
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   transition: all 0.2s;
 }
 
@@ -380,7 +380,7 @@ const allCompleted = computed(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   flex-shrink: 0;
 }
 
@@ -445,7 +445,7 @@ const allCompleted = computed(() => {
   width: 80px;
   height: 0.5rem;
   background: var(--border-default);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
@@ -453,7 +453,7 @@ const allCompleted = computed(() => {
   height: 100%;
   background: var(--color-primary);
   transition: width 0.3s ease;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
 }
 
 .progress-percentage {
@@ -478,7 +478,7 @@ const allCompleted = computed(() => {
   align-items: center;
   gap: 0.5rem;
   padding: 0.625rem 1.25rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;
@@ -526,12 +526,12 @@ const allCompleted = computed(() => {
 
 .document-list::-webkit-scrollbar-track {
   background: var(--bg-tertiary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .document-list::-webkit-scrollbar-thumb {
   background: var(--border-light);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .document-list::-webkit-scrollbar-thumb:hover {

--- a/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
+++ b/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
@@ -824,7 +824,7 @@ onMounted(() => {
   align-items: center;
   width: 44px;
   height: 24px;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: none;
   cursor: pointer;
   transition: background-color 0.2s;

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
@@ -801,7 +801,7 @@ function closeModal() {
   gap: var(--spacing-3);
   padding: var(--spacing-5);
   border: 1px solid var(--border-default);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   background: var(--bg-secondary);
   cursor: pointer;
   transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
@@ -862,7 +862,7 @@ function closeModal() {
   color: var(--text-primary);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   transition: border-color 150ms ease;
 }
 
@@ -913,7 +913,7 @@ function closeModal() {
 .schedule-option {
   padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 13px;
   color: var(--text-secondary);
   background: var(--bg-secondary);
@@ -954,7 +954,7 @@ function closeModal() {
 .mode-btn {
   padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   background: var(--bg-secondary);
   color: var(--text-secondary);
   font-size: 13px;
@@ -1008,7 +1008,7 @@ function closeModal() {
   font-size: 13px;
   font-family: var(--font-sans);
   padding: var(--spacing-1-5) var(--spacing-3);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .test-ok {
@@ -1027,7 +1027,7 @@ function closeModal() {
   padding: var(--spacing-2) var(--spacing-3);
   background: var(--color-error-bg);
   color: var(--color-error-dark);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 13px;
   font-family: var(--font-sans);
 }

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
@@ -413,7 +413,7 @@ onMounted(() => {
   padding: var(--spacing-3);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .history-header {
@@ -429,7 +429,7 @@ onMounted(() => {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   padding: 2px var(--spacing-2);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-family: var(--font-sans);
 }
 

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
@@ -261,7 +261,7 @@ defineExpose({ resetSyncing })
   padding: var(--spacing-4);
   background: var(--bg-card);
   border: 1px solid var(--border-default);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
   contain: layout style;}
 
@@ -340,7 +340,7 @@ defineExpose({ resetSyncing })
   letter-spacing: 0.05em;
   padding: 2px var(--spacing-2);
   background: var(--bg-tertiary);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-family: var(--font-sans);
 }
 
@@ -390,7 +390,7 @@ defineExpose({ resetSyncing })
   margin-bottom: var(--spacing-3);
   padding: var(--spacing-2) var(--spacing-3);
   background: var(--color-error-bg);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .error-icon {

--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -453,7 +453,7 @@ function selectIcon(icon: string): void {
   align-items: center;
   gap: 0.75rem;
   padding: 0.875rem 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   margin-bottom: 1.5rem;
   font-size: 0.875rem;
 }
@@ -474,7 +474,7 @@ function selectIcon(icon: string): void {
 .category-path {
   background: var(--bg-secondary);
   padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   margin-bottom: 1.5rem;
 }
 
@@ -511,7 +511,7 @@ function selectIcon(icon: string): void {
   width: 100%;
   padding: 0.625rem 0.875rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   background: var(--bg-input);
   color: var(--text-primary);
@@ -555,7 +555,7 @@ function selectIcon(icon: string): void {
   align-items: center;
   justify-content: center;
   border: 2px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: var(--bg-card);
   color: var(--text-secondary);
   cursor: pointer;
@@ -589,7 +589,7 @@ function selectIcon(icon: string): void {
 .color-option {
   width: 2rem;
   height: 2rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   border: 2px solid transparent;
   cursor: pointer;
   transition: all 0.2s;
@@ -629,14 +629,14 @@ function selectIcon(icon: string): void {
   gap: 0.75rem;
   padding: 1rem;
   background: var(--bg-secondary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-default);
 }
 
 .preview-icon {
   width: 2.5rem;
   height: 2.5rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -684,7 +684,7 @@ function selectIcon(icon: string): void {
   padding: 1.5rem;
   background: var(--color-warning-bg);
   border: 1px solid var(--color-warning-border);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   margin-bottom: 1.5rem;
 }
 
@@ -713,7 +713,7 @@ function selectIcon(icon: string): void {
   gap: 0.5rem;
   padding: 0.75rem;
   background: var(--color-error-bg);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   color: var(--color-error-dark);
   margin-top: 1rem;
 }

--- a/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
@@ -292,7 +292,7 @@ watch(() => props.modelValue, (isOpen) => {
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   margin-bottom: 1rem;
   font-size: 0.875rem;
 }
@@ -310,7 +310,7 @@ watch(() => props.modelValue, (isOpen) => {
   gap: 0.75rem;
   padding: 1rem;
   background: var(--bg-secondary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   margin-bottom: 1.5rem;
   color: var(--text-secondary);
   font-size: 0.875rem;
@@ -347,7 +347,7 @@ watch(() => props.modelValue, (isOpen) => {
   gap: 0.75rem;
   padding: 0.875rem 1rem;
   border: 2px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -369,7 +369,7 @@ watch(() => props.modelValue, (isOpen) => {
   align-items: center;
   justify-content: center;
   background: var(--bg-secondary);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   color: var(--color-info);
   font-size: 1rem;
 }

--- a/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
+++ b/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
@@ -339,7 +339,7 @@ onUnmounted(() => {
   justify-content: center;
   background: var(--color-info-bg);
   color: var(--color-info);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   font-size: 1.125rem;
   flex-shrink: 0;
 }
@@ -379,7 +379,7 @@ onUnmounted(() => {
   background: none;
   color: var(--text-secondary);
   cursor: pointer;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   transition: all 0.15s;
   flex-shrink: 0;
 }

--- a/autobot-frontend/src/components/operations/OperationDetail.vue
+++ b/autobot-frontend/src/components/operations/OperationDetail.vue
@@ -367,7 +367,7 @@ async function copyId() {
   padding: 1rem;
   background-color: #fef2f2;
   border: 1px solid #fecaca;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
 }
 
 .error-title {
@@ -432,7 +432,7 @@ async function copyId() {
   font-size: 0.75rem;
   background-color: var(--code-bg);
   padding: 1rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   overflow-x: auto;
   margin: 0;
 }
@@ -451,7 +451,7 @@ async function copyId() {
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
   font-weight: 500;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -511,7 +511,7 @@ async function copyId() {
   background: none;
   border: 1px solid var(--border-default);
   color: var(--text-muted);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   cursor: pointer;
 }
 

--- a/autobot-frontend/src/components/operations/OperationFilters.vue
+++ b/autobot-frontend/src/components/operations/OperationFilters.vue
@@ -148,7 +148,7 @@ function clearFilters() {
   gap: 1rem;
   padding: 1rem;
   background-color: var(--bg-secondary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-default);
 }
 
@@ -168,7 +168,7 @@ function clearFilters() {
   padding: 0.5rem 2rem 0.5rem 0.75rem;
   font-size: 0.875rem;
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background-color: var(--bg-input);
   color: var(--text-primary);
   cursor: pointer;
@@ -203,7 +203,7 @@ function clearFilters() {
   color: var(--text-secondary);
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s;
 }

--- a/autobot-frontend/src/components/operations/OperationsList.vue
+++ b/autobot-frontend/src/components/operations/OperationsList.vue
@@ -262,7 +262,7 @@ function canResumeOperation(operation: Operation): boolean {
   justify-content: center;
   width: 32px;
   height: 32px;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
 }
 
 .name-cell {
@@ -322,7 +322,7 @@ function canResumeOperation(operation: Operation): boolean {
   justify-content: center;
   width: 28px;
   height: 28px;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   border: none;
   cursor: pointer;
 }

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -350,7 +350,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 
 .modal-content {
   background: var(--bg-card);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   width: 90%;
   max-width: 600px;
   max-height: 90vh;
@@ -385,7 +385,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: background-color 0.2s;
 }
 
@@ -460,7 +460,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   align-items: center;
   padding: 12px;
   background: var(--bg-secondary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
 }
 
 .info-row label {
@@ -474,7 +474,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 
 .role-badge {
   padding: 2px 8px;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
@@ -505,7 +505,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 
 .option-btn {
   padding: 6px 16px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-default);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -542,7 +542,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 .toggle-item input[type="checkbox"] {
   width: 16px;
   height: 16px;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   cursor: pointer;
 }
 
@@ -552,7 +552,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   background: var(--color-primary, #6366f1);
   color: white;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -577,7 +577,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 .pw-input {
   padding: 8px 12px;
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   background: var(--bg-secondary);
   color: var(--text-primary);
   font-size: 14px;
@@ -600,7 +600,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   bottom: 24px;
   right: 24px;
   padding: 16px 20px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   font-weight: 500;
   animation: slideIn 0.3s ease-out;

--- a/autobot-frontend/src/components/secrets/SecretAuditLog.vue
+++ b/autobot-frontend/src/components/secrets/SecretAuditLog.vue
@@ -411,6 +411,6 @@ const prevPage = async () => {
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
   background: rgba(156, 163, 175, 0.3);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 </style>

--- a/autobot-frontend/src/components/secrets/SecretVault.vue
+++ b/autobot-frontend/src/components/secrets/SecretVault.vue
@@ -475,7 +475,7 @@ onMounted(() => {
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
   background: rgba(156, 163, 175, 0.3);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {

--- a/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
+++ b/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
@@ -233,6 +233,6 @@ const getInitials = (username: string): string => {
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
   background: rgba(156, 163, 175, 0.3);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 </style>

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -1663,7 +1663,7 @@ watch(selectedScope, () => {
   width: 100%;
   padding: 10px 36px 10px 36px;
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   transition: all 0.2s;
   background: var(--bg-input);
@@ -1739,7 +1739,7 @@ watch(selectedScope, () => {
   font-size: 12px;
   background: var(--bg-tertiary);
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   color: var(--text-tertiary);
 }
 
@@ -1768,7 +1768,7 @@ watch(selectedScope, () => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -1826,7 +1826,7 @@ watch(selectedScope, () => {
   justify-content: center;
   background: var(--bg-tertiary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   color: var(--text-secondary);
   transition: all 0.15s;
@@ -1918,7 +1918,7 @@ watch(selectedScope, () => {
   padding: 16px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -1941,7 +1941,7 @@ watch(selectedScope, () => {
   width: 48px;
   height: 48px;
   min-width: 48px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1981,7 +1981,7 @@ watch(selectedScope, () => {
 .badge {
   font-size: 11px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-weight: 500;
   text-transform: capitalize;
 }
@@ -2071,7 +2071,7 @@ watch(selectedScope, () => {
   font-size: 11px;
   padding: 2px 8px;
   background: var(--bg-tertiary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   color: var(--text-secondary);
 }
 
@@ -2100,7 +2100,7 @@ watch(selectedScope, () => {
   padding: 2px 8px;
   background: var(--color-primary-bg);
   color: var(--color-primary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
 }
 
 .card-actions {
@@ -2123,7 +2123,7 @@ watch(selectedScope, () => {
   justify-content: center;
   background: var(--bg-tertiary);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   color: var(--text-secondary);
   transition: all 0.15s;
@@ -2177,7 +2177,7 @@ watch(selectedScope, () => {
   padding: 14px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -2190,7 +2190,7 @@ watch(selectedScope, () => {
 .template-icon {
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2238,7 +2238,7 @@ watch(selectedScope, () => {
   gap: 10px;
   padding: 16px;
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -2251,7 +2251,7 @@ watch(selectedScope, () => {
 .type-option .type-icon {
   width: 44px;
   height: 44px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2272,14 +2272,14 @@ watch(selectedScope, () => {
   gap: 12px;
   padding: 12px;
   background: var(--bg-tertiary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   margin-bottom: 8px;
 }
 
 .selected-type .type-icon {
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2341,7 +2341,7 @@ watch(selectedScope, () => {
 .form-input {
   padding: 10px 12px;
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   transition: all 0.2s;
   background: var(--bg-input);
@@ -2381,7 +2381,7 @@ watch(selectedScope, () => {
   top: 8px;
   background: var(--bg-tertiary);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   width: 32px;
   height: 32px;
   display: flex;
@@ -2403,7 +2403,7 @@ watch(selectedScope, () => {
   gap: 12px;
   padding: 14px;
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -2465,7 +2465,7 @@ watch(selectedScope, () => {
 .view-icon {
   width: 56px;
   height: 56px;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2510,7 +2510,7 @@ watch(selectedScope, () => {
   gap: 8px;
   padding: 12px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .secret-display code {
@@ -2614,7 +2614,7 @@ watch(selectedScope, () => {
   align-items: center;
   gap: 8px;
   padding: 10px 16px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
 }
 
@@ -2634,7 +2634,7 @@ watch(selectedScope, () => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -2659,7 +2659,7 @@ watch(selectedScope, () => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -2675,7 +2675,7 @@ watch(selectedScope, () => {
   background: var(--color-error);
   color: var(--text-on-error);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -2709,7 +2709,7 @@ watch(selectedScope, () => {
   padding: 10px 16px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all 0.15s;
   user-select: none;

--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
@@ -455,7 +455,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
 .key-badge {
   font-size: 0.7rem;
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   text-transform: uppercase;
 }
 

--- a/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
@@ -305,7 +305,7 @@ onMounted(() => {
   background: var(--color-error-bg);
   color: var(--color-error);
   border: 1px solid var(--color-error);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   min-height: 200px;
   padding: 40px;
 }
@@ -328,7 +328,7 @@ onMounted(() => {
   background: var(--color-error);
   color: var(--text-on-error);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;

--- a/autobot-frontend/src/components/settings/WebResearchSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/WebResearchSettingsPanel.vue
@@ -339,7 +339,7 @@ function clamp(value: number, min: number, max: number): number {
   position: relative;
   width: 44px;
   height: 24px;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
   cursor: pointer;

--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
@@ -380,14 +380,14 @@ function resetEdit(): void {
 .progress-bar {
   height: 0.375rem;
   background: var(--bg-tertiary, #374151);
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   overflow: hidden;
 }
 
 .progress-fill {
   height: 100%;
   background: var(--color-info, #3b82f6);
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   transition: width 0.3s ease;
 }
 
@@ -445,7 +445,7 @@ function resetEdit(): void {
   padding: 0.125rem 0.5rem;
   background: var(--color-warning-bg, rgba(245, 158, 11, 0.15));
   color: var(--color-warning, #f59e0b);
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   font-size: 0.6875rem;
   font-weight: var(--font-medium, 500);
   text-transform: none;

--- a/autobot-frontend/src/components/terminal/CompletionSuggestions.vue
+++ b/autobot-frontend/src/components/terminal/CompletionSuggestions.vue
@@ -63,7 +63,7 @@ const typeIcon = (type: string): string => {
   background-color: #1e1e1e;
   border: 1px solid #444;
   border-bottom: none;
-  border-radius: 4px 4px 0 0;
+  border-radius: var(--radius-default) 4px 0 0;
   z-index: var(--z-popover);
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
   font-size: 13px;
@@ -129,6 +129,6 @@ const typeIcon = (type: string): string => {
 
 .completion-suggestions::-webkit-scrollbar-thumb {
   background: #555;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
 }
 </style>

--- a/autobot-frontend/src/components/terminal/SSHTerminal.vue
+++ b/autobot-frontend/src/components/terminal/SSHTerminal.vue
@@ -367,7 +367,7 @@ defineExpose({
   padding: 4px 12px;
   background: rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   color: inherit;
   font-size: 12px;
   cursor: pointer;

--- a/autobot-frontend/src/components/terminal/Terminal.vue
+++ b/autobot-frontend/src/components/terminal/Terminal.vue
@@ -598,8 +598,8 @@ onUnmounted(() => {
   /* Remove shadow and border-radius to prevent overlap with tabs */
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-  border-bottom-left-radius: 0.5rem;
-  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: var(--radius-lg);
+  border-bottom-right-radius: var(--radius-lg);
 }
 
 /* Terminal button styling matching browser controls */

--- a/autobot-frontend/src/components/terminal/TerminalSettings.vue
+++ b/autobot-frontend/src/components/terminal/TerminalSettings.vue
@@ -256,7 +256,7 @@ input[type='range'] {
   -webkit-appearance: none;
   appearance: none;
   height: 6px;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   background: #4a5568;
 }
 

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -1528,7 +1528,7 @@ export default {
   border: 1px solid #666;
   color: #fff;
   padding: 4px 8px;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   cursor: pointer;
   font-size: 12px;
   transition: all 0.2s;
@@ -1703,7 +1703,7 @@ export default {
   border: 1px solid #666;
   color: #ccc;
   padding: 3px 8px;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   cursor: pointer;
   font-size: 10px;
   transition: background-color 0.2s;
@@ -1742,7 +1742,7 @@ export default {
   background-color: #2d2d2d;
   color: #fff;
   padding: 24px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   max-width: 400px;
   width: 90%;
   text-align: center;
@@ -1763,7 +1763,7 @@ export default {
 .btn {
   padding: 8px 16px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   cursor: pointer;
   font-size: 14px;
   transition: background-color 0.2s;
@@ -1863,7 +1863,7 @@ export default {
   background-color: #2d2d2d;
   color: #fff;
   padding: 0;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   max-width: 600px;
   width: 90%;
   box-shadow: var(--shadow-lg);
@@ -1879,7 +1879,7 @@ export default {
   padding: 20px 24px 16px 24px;
   border-bottom: 1px solid #444;
   background: var(--bg-secondary);
-  border-radius: 12px 12px 0 0;
+  border-radius: var(--radius-xl) 12px 0 0;
 }
 
 .modal-title {
@@ -1903,7 +1903,7 @@ export default {
 .command-preview {
   background-color: #1e1e1e;
   border: 1px solid #444;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
   margin-bottom: 20px;
 }
@@ -1922,7 +1922,7 @@ export default {
   color: #87ceeb;
   background-color: #000;
   padding: 12px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border-left: 4px solid #ffc107;
   white-space: pre-wrap;
   word-break: break-all;
@@ -1934,7 +1934,7 @@ export default {
 
 .risk-level {
   padding: 8px 12px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 14px;
   font-weight: 600;
   margin-bottom: 12px;
@@ -2004,7 +2004,7 @@ export default {
 .process-item {
   background-color: #1e1e1e;
   padding: 8px 12px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   margin-bottom: 4px;
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
   font-size: 13px;
@@ -2066,7 +2066,7 @@ export default {
   background-color: #17a2b8;
   color: white;
   padding: 8px 16px;
-  border-radius: 20px;
+  border-radius: var(--radius-2xl);
   display: inline-block;
   font-size: 12px;
   font-weight: 600;
@@ -2091,7 +2091,7 @@ export default {
 
 .workflow-options {
   background-color: #1e1e1e;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
   margin-top: 20px;
   border-left: 4px solid #17a2b8;
@@ -2208,7 +2208,7 @@ export default {
 
 .terminal-output::-webkit-scrollbar-thumb {
   background: #555;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .terminal-output::-webkit-scrollbar-thumb:hover {

--- a/autobot-frontend/src/components/ui/BaseAlert.vue
+++ b/autobot-frontend/src/components/ui/BaseAlert.vue
@@ -120,7 +120,7 @@ onMounted(() => {
   align-items: flex-start;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   font-size: 0.875rem;
   line-height: 1.25rem;
   transition: all 0.2s ease;
@@ -155,7 +155,7 @@ onMounted(() => {
 
 .alert-dismiss {
   padding: 0.25rem;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-default);
   transition: background-color 0.2s ease;
   background: transparent;
   border: none;

--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -243,7 +243,7 @@ const formatCell = (value: any, column: Column) => {
 
 .data-table-container {
   background: var(--bg-card);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   border: 1px solid var(--border-default);
   overflow: hidden;
 }
@@ -352,7 +352,7 @@ const formatCell = (value: any, column: Column) => {
   padding: var(--spacing-2) var(--spacing-3);
   border: 1px solid var(--border-default);
   background: var(--bg-card);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   color: var(--text-primary);
   font-family: var(--font-sans);
   font-size: 14px;

--- a/autobot-frontend/src/components/ui/HostSelector.vue
+++ b/autobot-frontend/src/components/ui/HostSelector.vue
@@ -327,7 +327,7 @@ defineExpose({
   padding: 8px 12px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -400,7 +400,7 @@ defineExpose({
   min-width: 320px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
   z-index: var(--z-popover);
 }
@@ -444,7 +444,7 @@ defineExpose({
   padding: 6px 12px;
   background: var(--bg-tertiary);
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 12px;
   color: var(--text-secondary);
   cursor: pointer;
@@ -472,7 +472,7 @@ defineExpose({
   align-items: center;
   gap: 12px;
   padding: 10px 12px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -488,7 +488,7 @@ defineExpose({
 .host-icon {
   width: 36px;
   height: 36px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -528,7 +528,7 @@ defineExpose({
   padding: 2px 6px;
   font-size: 10px;
   font-weight: 600;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   text-transform: uppercase;
 }
 
@@ -577,7 +577,7 @@ defineExpose({
   flex: 1;
   padding: 8px 12px;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;

--- a/autobot-frontend/src/components/ui/SkeletonLoader.vue
+++ b/autobot-frontend/src/components/ui/SkeletonLoader.vue
@@ -120,7 +120,7 @@ const lineClass = computed(() => ({
 .skeleton-rounded .skeleton-line,
 .skeleton-rounded .skeleton-tag,
 .skeleton-rounded .skeleton-file-size {
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
 }
 
 .skeleton-rounded .skeleton-avatar,
@@ -204,7 +204,7 @@ const lineClass = computed(() => ({
 .skeleton-tag {
   height: 1.5rem;
   width: 4rem;
-  border-radius: 1rem;
+  border-radius: var(--radius-2xl);
 }
 
 /* File list skeleton */

--- a/autobot-frontend/src/components/vision/GUIAutomationControls.vue
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.vue
@@ -328,7 +328,7 @@ onMounted(() => {
   padding: 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
 }
 
 .header-info h3 {
@@ -349,7 +349,7 @@ onMounted(() => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -377,7 +377,7 @@ onMounted(() => {
   padding: 60px 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   color: var(--text-tertiary);
 }
 
@@ -385,7 +385,7 @@ onMounted(() => {
 .opportunities-section {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 20px;
 }
 
@@ -398,7 +398,7 @@ onMounted(() => {
 .opportunity-card {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   padding: 16px;
   cursor: pointer;
   transition: all 0.2s;
@@ -419,7 +419,7 @@ onMounted(() => {
 .element-type-badge {
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -447,7 +447,7 @@ onMounted(() => {
 
 .confidence-badge {
   padding: 4px 10px;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   font-size: 12px;
   font-weight: 500;
 }
@@ -483,7 +483,7 @@ onMounted(() => {
 .btn-details {
   flex: 1;
   padding: 8px 12px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -524,7 +524,7 @@ onMounted(() => {
   padding: 60px 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
 }
 
 .empty-icon {
@@ -555,7 +555,7 @@ onMounted(() => {
 .reference-section {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   overflow: hidden;
 }
 
@@ -602,13 +602,13 @@ onMounted(() => {
   gap: 12px;
   padding: 10px 12px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .type-icon {
   width: 32px;
   height: 32px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -646,7 +646,7 @@ onMounted(() => {
   gap: 10px;
   padding: 10px 12px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .interaction-item i {
@@ -674,7 +674,7 @@ onMounted(() => {
 
 .detail-modal {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   width: 90%;
   max-width: 480px;
   overflow: hidden;
@@ -745,7 +745,7 @@ onMounted(() => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -764,7 +764,7 @@ onMounted(() => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;

--- a/autobot-frontend/src/components/vision/MediaGallery.vue
+++ b/autobot-frontend/src/components/vision/MediaGallery.vue
@@ -313,7 +313,7 @@ onUnmounted(() => {
   padding: 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   flex-wrap: wrap;
   gap: 16px;
 }
@@ -341,7 +341,7 @@ onUnmounted(() => {
   padding: 8px 12px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   color: var(--text-primary);
 }
@@ -351,7 +351,7 @@ onUnmounted(() => {
   background: var(--color-error-bg);
   color: var(--color-error);
   border: 1px solid var(--color-error);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -381,7 +381,7 @@ onUnmounted(() => {
 .gallery-item {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   overflow: hidden;
   cursor: pointer;
   transition: all 0.2s;
@@ -419,7 +419,7 @@ onUnmounted(() => {
   width: 28px;
   height: 28px;
   background: rgba(0, 0, 0, 0.6);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -459,7 +459,7 @@ onUnmounted(() => {
   padding: 8px;
   background: var(--bg-tertiary);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-tertiary);
   cursor: pointer;
   transition: all 0.15s;
@@ -485,7 +485,7 @@ onUnmounted(() => {
   padding: 80px 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
 }
 
 .empty-icon {
@@ -530,7 +530,7 @@ onUnmounted(() => {
 
 .detail-modal {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   width: 100%;
   max-width: 600px;
   max-height: 90vh;
@@ -583,7 +583,7 @@ onUnmounted(() => {
   width: 100%;
   max-height: 300px;
   object-fit: contain;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   background: var(--bg-tertiary);
 }
 
@@ -591,7 +591,7 @@ onUnmounted(() => {
   width: 100%;
   height: 200px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -647,7 +647,7 @@ onUnmounted(() => {
   align-items: center;
   padding: 8px 12px;
   background: var(--bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
 }
 
 .data-row .label {
@@ -681,7 +681,7 @@ onUnmounted(() => {
   margin-top: 12px;
   padding: 12px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 11px;
   color: var(--text-secondary);
   overflow-x: auto;
@@ -701,7 +701,7 @@ onUnmounted(() => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -720,7 +720,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -738,7 +738,7 @@ onUnmounted(() => {
   background: var(--color-error-bg);
   color: var(--color-error);
   border: 1px solid var(--color-error);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -769,7 +769,7 @@ onUnmounted(() => {
 
 .confirm-modal {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 24px;
   width: 100%;
   max-width: 360px;
@@ -813,7 +813,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -829,7 +829,7 @@ onUnmounted(() => {
   background: var(--color-error);
   color: white;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;

--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
@@ -400,7 +400,7 @@ onUnmounted(() => {
   padding: 16px 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   flex-wrap: wrap;
   gap: 16px;
 }
@@ -417,7 +417,7 @@ onUnmounted(() => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -459,7 +459,7 @@ onUnmounted(() => {
   width: 36px;
   height: 20px;
   background: var(--bg-tertiary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   position: relative;
   transition: all 0.2s;
 }
@@ -489,7 +489,7 @@ onUnmounted(() => {
   padding: 6px 10px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   color: var(--text-primary);
 }
@@ -509,7 +509,7 @@ onUnmounted(() => {
   padding: 6px 10px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   color: var(--text-primary);
 }
@@ -538,7 +538,7 @@ onUnmounted(() => {
   overflow-y: auto;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
 }
 
 .panel-header {
@@ -602,7 +602,7 @@ onUnmounted(() => {
   gap: 12px;
   padding: 10px 12px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -619,7 +619,7 @@ onUnmounted(() => {
 .element-icon {
   width: 32px;
   height: 32px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -654,7 +654,7 @@ onUnmounted(() => {
   color: var(--text-tertiary);
   padding: 2px 8px;
   background: var(--bg-secondary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
 }
 
 .no-elements {
@@ -681,7 +681,7 @@ onUnmounted(() => {
 .text-region {
   padding: 10px 12px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .text-content {
@@ -694,7 +694,7 @@ onUnmounted(() => {
   margin: 0;
   padding: 12px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 12px;
   color: var(--text-secondary);
   overflow-x: auto;
@@ -711,7 +711,7 @@ onUnmounted(() => {
   gap: 16px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
 }
 
 .empty-icon {
@@ -754,7 +754,7 @@ onUnmounted(() => {
 
 .element-detail-modal {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   width: 90%;
   max-width: 500px;
   max-height: 80vh;
@@ -827,6 +827,6 @@ onUnmounted(() => {
   padding: 4px 10px;
   background: var(--color-primary-bg);
   color: var(--color-primary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
 }
 </style>

--- a/autobot-frontend/src/components/vision/VideoProcessor.vue
+++ b/autobot-frontend/src/components/vision/VideoProcessor.vue
@@ -531,13 +531,13 @@ onUnmounted(() => {
 .upload-section {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 24px;
 }
 
 .drop-zone {
   border: 2px dashed var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 40px;
   text-align: center;
   cursor: pointer;
@@ -595,7 +595,7 @@ onUnmounted(() => {
   width: 200px;
   height: 120px;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   background: var(--bg-tertiary);
 }
 
@@ -624,7 +624,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
@@ -640,7 +640,7 @@ onUnmounted(() => {
   gap: 16px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 20px;
 }
 
@@ -661,7 +661,7 @@ onUnmounted(() => {
   padding: 10px 12px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   color: var(--text-primary);
 }
@@ -677,7 +677,7 @@ onUnmounted(() => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 15px;
   font-weight: 500;
   cursor: pointer;
@@ -699,14 +699,14 @@ onUnmounted(() => {
 .progress-section {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 20px;
 }
 
 .progress-bar {
   height: 8px;
   background: var(--bg-tertiary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   overflow: hidden;
   margin-bottom: 12px;
 }
@@ -728,7 +728,7 @@ onUnmounted(() => {
 .results-section {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   overflow: hidden;
 }
 
@@ -766,7 +766,7 @@ onUnmounted(() => {
 .frame-card {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 12px;
   cursor: pointer;
   transition: all 0.15s;
@@ -847,7 +847,7 @@ onUnmounted(() => {
   margin-top: 12px;
   padding: 12px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 11px;
   color: var(--text-secondary);
   overflow-x: auto;
@@ -866,7 +866,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -887,7 +887,7 @@ onUnmounted(() => {
   padding: 12px 16px;
   background: var(--color-error-bg);
   border: 1px solid var(--color-error);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .error-content {

--- a/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.vue
+++ b/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.vue
@@ -159,17 +159,17 @@ onMounted(() => refresh())
 </script>
 
 <style scoped>
-.smt { display:flex; flex-direction:column; height:100%; background:var(--bg-primary,#1a1a2e); border-radius:8px; overflow:hidden; }
+.smt { display:flex; flex-direction:column; height:100%; background:var(--bg-primary,#1a1a2e); border-radius: var(--radius-lg); overflow:hidden; }
 .smt-header { display:flex; justify-content:space-between; align-items:center; padding:12px 16px; border-bottom:1px solid var(--border-color,#2a2a4a); }
 .smt-header h3 { margin:0; font-size:14px; font-weight:600; color:var(--text-primary,#e0e0ff); }
 .smt-controls { display:flex; gap:4px; align-items:center; }
-.smt-select { background:var(--bg-secondary,#16213e); color:var(--text-secondary,#a0a0c0); border:1px solid var(--border-color,#2a2a4a); border-radius:4px; padding:4px 8px; font-size:12px; }
-.smt-btn { background:none; border:1px solid var(--border-color,#2a2a4a); color:var(--text-secondary,#a0a0c0); border-radius:4px; padding:4px 8px; cursor:pointer; font-size:12px; transition:all .2s; }
+.smt-select { background:var(--bg-secondary,#16213e); color:var(--text-secondary,#a0a0c0); border:1px solid var(--border-color,#2a2a4a); border-radius: var(--radius-default); padding:4px 8px; font-size:12px; }
+.smt-btn { background:none; border:1px solid var(--border-color,#2a2a4a); color:var(--text-secondary,#a0a0c0); border-radius: var(--radius-default); padding:4px 8px; cursor:pointer; font-size:12px; transition:all .2s; }
 .smt-btn:hover { background:var(--bg-hover,#2a2a4a); color:var(--text-primary,#e0e0ff); }
 .smt-btn.active { background:var(--accent-color,#4a90d9); color:#fff; border-color:var(--accent-color,#4a90d9); }
 .smt-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:40px; color:var(--text-secondary,#a0a0c0); gap:8px; }
 .smt-body { flex:1; overflow-y:auto; padding:4px 12px; }
-.smt-entry { display:flex; gap:10px; padding:8px 4px; cursor:pointer; border-radius:4px; transition:background .15s; align-items:flex-start; }
+.smt-entry { display:flex; gap:10px; padding:8px 4px; cursor:pointer; border-radius: var(--radius-default); transition:background .15s; align-items:flex-start; }
 .smt-entry:hover { background:rgba(255,255,255,.03); }
 .smt-entry.selected { background:rgba(74,144,217,.1); }
 .smt-dot { width:10px; height:10px; border-radius:50%; margin-top:4px; flex-shrink:0; }
@@ -180,7 +180,7 @@ onMounted(() => refresh())
 .smt-route { display:flex; align-items:center; gap:4px; font-size:13px; font-weight:500; color:var(--text-primary,#e0e0ff); }
 .smt-route i { font-size:10px; color:var(--text-secondary,#a0a0c0); }
 .smt-meta { font-size:11px; color:var(--text-muted,#707090); margin-top:2px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.smt-badge { font-size:11px; padding:1px 6px; border-radius:3px; font-weight:500; margin-left:auto; }
+.smt-badge { font-size:11px; padding:1px 6px; border-radius: var(--radius-default); font-weight:500; margin-left:auto; }
 .smt-badge.t-task { background:rgba(74,144,217,.2); color:#4a90d9; } .smt-badge.t-result { background:rgba(76,175,80,.2); color:#4caf50; }
 .smt-badge.t-error { background:rgba(244,67,54,.2); color:#f44336; } .smt-badge.t-health { background:rgba(139,195,74,.2); color:#8bc34a; }
 .smt-badge.t-deploy { background:rgba(255,152,0,.2); color:#ff9800; } .smt-badge.t-workflow_step { background:rgba(156,39,176,.2); color:#9c27b0; }
@@ -191,12 +191,12 @@ onMounted(() => refresh())
 .smt-table td { padding:3px 0; }
 .smt-table td:first-child { color:var(--text-muted,#707090); font-weight:500; width:120px; }
 .smt-table td:last-child { color:var(--text-primary,#e0e0ff); }
-.smt-table code { font-family:'JetBrains Mono',monospace; font-size:11px; background:var(--bg-primary,#1a1a2e); padding:2px 6px; border-radius:3px; }
+.smt-table code { font-family:'JetBrains Mono',monospace; font-size:11px; background:var(--bg-primary,#1a1a2e); padding:2px 6px; border-radius: var(--radius-default); }
 .smt-link { cursor:pointer; } .smt-link:hover { color:var(--accent-color,#4a90d9)!important; }
-.smt-pre { background:var(--bg-primary,#1a1a2e); padding:8px 12px; border-radius:4px; font-size:11px; font-family:'JetBrains Mono',monospace; color:var(--text-secondary,#a0a0c0); overflow-x:auto; max-height:120px; margin:8px 0 0; }
+.smt-pre { background:var(--bg-primary,#1a1a2e); padding:8px 12px; border-radius: var(--radius-default); font-size:11px; font-family:'JetBrains Mono',monospace; color:var(--text-secondary,#a0a0c0); overflow-x:auto; max-height:120px; margin:8px 0 0; }
 .smt-chain { margin-top:12px; border-top:1px solid var(--border-color,#2a2a4a); padding-top:8px; }
 .smt-chain strong { font-size:13px; color:var(--text-primary,#e0e0ff); }
-.smt-chain-row { display:flex; align-items:center; gap:8px; padding:3px 8px; font-size:12px; border-radius:4px; color:var(--text-primary,#e0e0ff); }
+.smt-chain-row { display:flex; align-items:center; gap:8px; padding:3px 8px; font-size:12px; border-radius: var(--radius-default); color:var(--text-primary,#e0e0ff); }
 .smt-chain-row.current { background:rgba(74,144,217,.15); }
 .smt-chain-idx { color:var(--text-muted,#707090); font-weight:600; min-width:18px; }
 .smt-muted { color:var(--text-muted,#707090); font-size:11px; margin-left:auto; }

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
@@ -587,7 +587,7 @@ defineExpose({
 
 .workflow-visualization {
   background: var(--bg-secondary-alpha);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 20px;
   border: 1px solid var(--border-subtle);
   position: relative;
@@ -625,7 +625,7 @@ defineExpose({
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   font-weight: 500;
 }
@@ -655,7 +655,7 @@ defineExpose({
   padding: 8px 10px;
   background: transparent;
   border: 1px solid var(--border-subtle);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.2s;
@@ -671,7 +671,7 @@ defineExpose({
 .workflow-container {
   position: relative;
   background: rgba(15, 23, 42, 0.5);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   overflow: hidden;
   min-height: 400px;
 }
@@ -809,7 +809,7 @@ defineExpose({
   gap: 8px;
   background: rgba(30, 41, 59, 0.9);
   padding: 8px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
 }
 
@@ -818,7 +818,7 @@ defineExpose({
   height: 28px;
   border: 1px solid var(--border-subtle);
   background: transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   color: var(--text-secondary);
   cursor: pointer;
   display: flex;
@@ -847,7 +847,7 @@ defineExpose({
   width: 200px;
   height: 24px;
   background: rgba(30, 41, 59, 0.9);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
   overflow: hidden;
 }
@@ -876,7 +876,7 @@ defineExpose({
   right: 20px;
   width: 280px;
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
@@ -894,7 +894,7 @@ defineExpose({
 .details-icon {
   width: 40px;
   height: 40px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -936,7 +936,7 @@ defineExpose({
   border: none;
   color: var(--text-tertiary);
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   transition: all 0.2s;
 }
 
@@ -980,7 +980,7 @@ defineExpose({
   font-size: 11px;
   background: rgba(15, 23, 42, 0.5);
   padding: 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   margin-top: 4px;
   overflow-x: auto;
   max-width: 200px;
@@ -1017,7 +1017,7 @@ defineExpose({
     left: 0;
     right: 0;
     width: 100%;
-    border-radius: 12px 12px 0 0;
+    border-radius: var(--radius-xl) 12px 0 0;
     max-height: 50vh;
     overflow-y: auto;
   }

--- a/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
+++ b/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
@@ -205,7 +205,7 @@ function formatDuration(seconds: number): string {
   height: 32px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-secondary);
   cursor: pointer;
   display: flex;
@@ -263,7 +263,7 @@ function formatDuration(seconds: number): string {
 .agent-card {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   padding: 16px;
   display: flex;
   flex-direction: column;
@@ -293,7 +293,7 @@ function formatDuration(seconds: number): string {
 .agent-avatar {
   width: 36px;
   height: 36px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -338,7 +338,7 @@ function formatDuration(seconds: number): string {
 
 .reliability-badge {
   padding: 3px 10px;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   font-size: 12px;
   font-weight: 600;
   flex-shrink: 0;
@@ -372,7 +372,7 @@ function formatDuration(seconds: number): string {
   flex: 1;
   padding: 8px 0;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .metric-value {
@@ -400,13 +400,13 @@ function formatDuration(seconds: number): string {
 .reliability-bar {
   height: 4px;
   background: var(--bg-tertiary);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   overflow: hidden;
 }
 
 .reliability-fill {
   height: 100%;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   transition: width 0.4s ease;
 }
 
@@ -424,7 +424,7 @@ function formatDuration(seconds: number): string {
 .capability-tag {
   padding: 2px 8px;
   background: var(--bg-tertiary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 10px;
   color: var(--text-secondary);
 }

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
@@ -253,7 +253,7 @@ async function handleSave(): Promise<void> {
 .notif-modal {
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   width: 560px;
   max-width: 95vw;
   max-height: 85vh;
@@ -287,7 +287,7 @@ async function handleSave(): Promise<void> {
   border: none;
   color: var(--text-tertiary);
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 14px;
 }
 .btn-close:hover { background: var(--bg-hover); color: var(--text-primary); }
@@ -314,7 +314,7 @@ async function handleSave(): Promise<void> {
   padding: 10px 14px;
   background: var(--color-error-bg);
   color: var(--color-error);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   display: flex;
   align-items: center;
@@ -323,7 +323,7 @@ async function handleSave(): Promise<void> {
 
 .notif-field {
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 14px;
   margin: 0;
 }
@@ -340,7 +340,7 @@ async function handleSave(): Promise<void> {
   padding: 8px 12px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: 13px;
   outline: none;
@@ -388,7 +388,7 @@ async function handleSave(): Promise<void> {
   padding: 8px 12px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: 13px;
   outline: none;
@@ -456,7 +456,7 @@ async function handleSave(): Promise<void> {
   background: var(--color-primary);
   color: white;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -472,7 +472,7 @@ async function handleSave(): Promise<void> {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   font-size: 13px;
   cursor: pointer;
 }

--- a/autobot-frontend/src/components/workflow/OrchestrationVisualizer.vue
+++ b/autobot-frontend/src/components/workflow/OrchestrationVisualizer.vue
@@ -179,31 +179,31 @@ function getStrategyIcon(strategy: string): string {
 .status-panel h3 i, .capabilities-panel h4 i, .strategies-panel h4 i, .visualization-panel h4 i { color: var(--color-primary); }
 
 .status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; }
-.status-card { display: flex; align-items: center; gap: 14px; padding: 16px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 10px; }
+.status-card { display: flex; align-items: center; gap: 14px; padding: 16px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); }
 .status-card.healthy { border-color: var(--color-success); }
-.card-icon { width: 44px; height: 44px; border-radius: 10px; background: var(--bg-tertiary); display: flex; align-items: center; justify-content: center; font-size: 18px; color: var(--text-secondary); }
+.card-icon { width: 44px; height: 44px; border-radius: var(--radius-xl); background: var(--bg-tertiary); display: flex; align-items: center; justify-content: center; font-size: 18px; color: var(--text-secondary); }
 .status-card.healthy .card-icon { background: var(--color-success-bg); color: var(--color-success); }
 .card-value { display: block; font-size: 18px; font-weight: 600; color: var(--text-primary); text-transform: capitalize; }
 .card-label { font-size: 12px; color: var(--text-tertiary); }
 
-.capabilities-panel { background: var(--bg-secondary); border-radius: 10px; padding: 20px; }
+.capabilities-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: 20px; }
 .capabilities-list { display: flex; flex-wrap: wrap; gap: 12px; }
-.capability-item { display: flex; align-items: center; gap: 8px; padding: 8px 14px; background: var(--bg-tertiary); border-radius: 20px; font-size: 13px; color: var(--text-muted); }
+.capability-item { display: flex; align-items: center; gap: 8px; padding: 8px 14px; background: var(--bg-tertiary); border-radius: var(--radius-2xl); font-size: 13px; color: var(--text-muted); }
 .capability-item.enabled { background: var(--color-success-bg); color: var(--color-success); }
 .capability-item i { font-size: 14px; }
 
-.strategies-panel { background: var(--bg-secondary); border-radius: 10px; padding: 20px; }
+.strategies-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: 20px; }
 .loading { color: var(--text-tertiary); font-size: 13px; }
 .strategies-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; }
-.strategy-card { display: flex; gap: 12px; padding: 14px; background: var(--bg-tertiary); border: 1px solid transparent; border-radius: 8px; transition: all 0.2s; }
+.strategy-card { display: flex; gap: 12px; padding: 14px; background: var(--bg-tertiary); border: 1px solid transparent; border-radius: var(--radius-lg); transition: all 0.2s; }
 .strategy-card.active { border-color: var(--color-primary); background: var(--color-primary-bg); }
-.strategy-icon { width: 36px; height: 36px; border-radius: 8px; background: var(--bg-secondary); display: flex; align-items: center; justify-content: center; color: var(--text-secondary); flex-shrink: 0; }
+.strategy-icon { width: 36px; height: 36px; border-radius: var(--radius-lg); background: var(--bg-secondary); display: flex; align-items: center; justify-content: center; color: var(--text-secondary); flex-shrink: 0; }
 .strategy-card.active .strategy-icon { background: var(--color-primary); color: white; }
 .strategy-name { display: block; font-size: 14px; font-weight: 500; color: var(--text-primary); margin-bottom: 4px; }
 .strategy-desc { margin: 0 0 6px; font-size: 12px; color: var(--text-secondary); line-height: 1.4; }
 .strategy-best { font-size: 11px; color: var(--text-muted); font-style: italic; }
 
-.visualization-panel { background: var(--bg-secondary); border-radius: 10px; padding: 20px; }
+.visualization-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: 20px; }
 .workflow-viz { display: flex; flex-direction: column; gap: 20px; }
 .viz-timeline { display: flex; align-items: flex-start; gap: 0; overflow-x: auto; padding: 16px 0; }
 .viz-step { display: flex; align-items: center; }
@@ -216,11 +216,11 @@ function getStrategyIcon(strategy: string): string {
 .viz-connector { width: 40px; height: 2px; background: var(--border-default); margin-top: 20px; }
 .viz-connector.completed { background: var(--color-success); }
 
-.viz-details { display: flex; gap: 24px; padding: 16px; background: var(--bg-tertiary); border-radius: 8px; }
+.viz-details { display: flex; gap: 24px; padding: 16px; background: var(--bg-tertiary); border-radius: var(--radius-lg); }
 .detail-item { display: flex; flex-direction: column; gap: 4px; }
 .detail-item .label { font-size: 11px; color: var(--text-tertiary); text-transform: uppercase; }
 .detail-item .value { font-size: 14px; font-weight: 500; color: var(--text-primary); }
-.status-badge { padding: 2px 10px; border-radius: 12px; font-size: 12px; }
+.status-badge { padding: 2px 10px; border-radius: var(--radius-xl); font-size: 12px; }
 .status-badge.running { background: var(--color-success-bg); color: var(--color-success); }
 .status-badge.paused { background: var(--color-warning-bg); color: var(--color-warning); }
 .status-badge.completed { background: var(--color-info-bg); color: var(--color-info); }

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -348,16 +348,16 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 </script>
 
 <style scoped>
-.workflow-canvas-container { display: flex; flex-direction: column; height: 100%; background: var(--bg-primary); border-radius: 8px; overflow: hidden; }
+.workflow-canvas-container { display: flex; flex-direction: column; height: 100%; background: var(--bg-primary); border-radius: var(--radius-lg); overflow: hidden; }
 .canvas-toolbar { display: flex; justify-content: space-between; padding: 12px 16px; background: var(--bg-secondary); border-bottom: 1px solid var(--border-default); }
 .toolbar-left, .toolbar-right { display: flex; align-items: center; gap: 8px; }
-.tool-btn { display: flex; align-items: center; gap: 6px; padding: 8px 12px; background: var(--bg-tertiary); border: 1px solid var(--border-default); border-radius: 6px; color: var(--text-secondary); font-size: 13px; cursor: pointer; transition: all 0.15s; }
+.tool-btn { display: flex; align-items: center; gap: 6px; padding: 8px 12px; background: var(--bg-tertiary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); font-size: 13px; cursor: pointer; transition: all 0.15s; }
 .tool-btn:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
 .tool-btn.primary { background: var(--color-primary); color: var(--text-on-primary); border-color: var(--color-primary); }
 .tool-btn.primary:hover:not(:disabled) { filter: brightness(1.1); }
 .tool-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .tool-btn.btn-experimental { opacity: 0.85; position: relative; }
-.badge-experimental { font-size: 9px; padding: 1px 4px; background: var(--color-warning); color: #000; border-radius: 3px; font-weight: 700; text-transform: uppercase; line-height: 1; }
+.badge-experimental { font-size: 9px; padding: 1px 4px; background: var(--color-warning); color: #000; border-radius: var(--radius-default); font-weight: 700; text-transform: uppercase; line-height: 1; }
 .toolbar-divider { width: 1px; height: 24px; background: var(--border-default); margin: 0 4px; }
 
 .canvas-area { flex: 1; position: relative; overflow: hidden; background: linear-gradient(var(--border-subtle) 1px, transparent 1px), linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px); background-size: 20px 20px; cursor: grab; }
@@ -368,7 +368,7 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .connection-line { fill: none; stroke: var(--color-primary); stroke-width: 2; }
 .drawing-line { fill: none; stroke: var(--color-primary); stroke-width: 2; stroke-dasharray: 5; opacity: 0.6; }
 
-.workflow-node { position: absolute; width: 240px; background: var(--bg-secondary); border: 2px solid var(--border-default); border-radius: 10px; box-shadow: var(--shadow-sm); cursor: move; user-select: none; }
+.workflow-node { position: absolute; width: 240px; background: var(--bg-secondary); border: 2px solid var(--border-default); border-radius: var(--radius-xl); box-shadow: var(--shadow-sm); cursor: move; user-select: none; }
 .workflow-node:hover { box-shadow: var(--shadow-md); }
 .workflow-node.selected { border-color: var(--color-primary); box-shadow: 0 0 0 3px var(--color-primary-bg); }
 .workflow-node.step .node-header { background: var(--color-primary); }
@@ -376,19 +376,19 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .workflow-node[class*="vision-"] .node-header { background: linear-gradient(135deg, #7c3aed, #6d28d9); }
 
 .dropdown-container { position: relative; display: inline-block; }
-.dropdown-menu { position: absolute; top: 100%; left: 0; z-index: 10; background: var(--bg-secondary, #1e293b); border: 1px solid var(--border-color, #334155); border-radius: 6px; padding: 4px 0; min-width: 180px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+.dropdown-menu { position: absolute; top: 100%; left: 0; z-index: 10; background: var(--bg-secondary, #1e293b); border: 1px solid var(--border-color, #334155); border-radius: var(--radius-md); padding: 4px 0; min-width: 180px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
 .dropdown-menu button { display: flex; align-items: center; gap: 8px; width: 100%; padding: 8px 12px; border: none; background: none; color: var(--text-primary, #e2e8f0); cursor: pointer; font-size: 0.85rem; }
 .dropdown-menu button:hover { background: var(--bg-tertiary, #334155); }
 .target-label { font-size: 0.75rem; color: var(--text-secondary, #94a3b8); }
 .hint { font-size: 0.75rem; color: var(--text-secondary, #94a3b8); font-style: italic; }
 
-.node-header { display: flex; align-items: center; gap: 8px; padding: 8px 12px; color: var(--text-on-primary); border-radius: 8px 8px 0 0; font-size: 13px; font-weight: 600; }
+.node-header { display: flex; align-items: center; gap: 8px; padding: 8px 12px; color: var(--text-on-primary); border-radius: var(--radius-lg) 8px 0 0; font-size: 13px; font-weight: 600; }
 .node-header span { flex: 1; }
-.delete-btn { padding: 4px; background: transparent; border: none; color: inherit; cursor: pointer; opacity: 0.7; border-radius: 4px; }
+.delete-btn { padding: 4px; background: transparent; border: none; color: inherit; cursor: pointer; opacity: 0.7; border-radius: var(--radius-default); }
 .delete-btn:hover { opacity: 1; background: rgba(255,255,255,0.2); }
 
 .node-body { padding: 12px; display: flex; flex-direction: column; gap: 8px; }
-.node-body input, .node-body select { width: 100%; padding: 6px 8px; background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: 4px; color: var(--text-primary); font-size: 12px; }
+.node-body input, .node-body select { width: 100%; padding: 6px 8px; background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-default); color: var(--text-primary); font-size: 12px; }
 .node-body input:focus, .node-body select:focus { outline: none; border-color: var(--color-primary); }
 .node-body input:focus-visible, .node-body select:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .node-body input.mono { font-family: monospace; }
@@ -408,17 +408,17 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .empty-state p { margin: 0 0 20px; color: var(--text-tertiary); }
 
 .dialog-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: var(--z-modal-backdrop); }
-.dialog { width: 400px; background: var(--bg-secondary); border-radius: 12px; padding: 24px; }
+.dialog { width: 400px; background: var(--bg-secondary); border-radius: var(--radius-xl); padding: 24px; }
 .dialog h3 { margin: 0 0 20px; display: flex; align-items: center; gap: 10px; color: var(--text-primary); }
 .dialog h3 i { color: var(--color-primary); }
-.dialog input, .dialog textarea { width: 100%; padding: 10px 12px; margin-bottom: 12px; background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: 6px; color: var(--text-primary); font-size: 14px; font-family: inherit; }
+.dialog input, .dialog textarea { width: 100%; padding: 10px 12px; margin-bottom: 12px; background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-primary); font-size: 14px; font-family: inherit; }
 .dialog input:focus, .dialog textarea:focus { outline: none; border-color: var(--color-primary); }
 .dialog input:focus-visible, .dialog textarea:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .dialog-actions { display: flex; justify-content: flex-end; gap: 12px; margin-top: 12px; }
 
-.btn-primary { padding: 10px 20px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: 6px; font-size: 14px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
+.btn-primary { padding: 10px 20px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: 14px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
 .btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
-.btn-secondary { padding: 10px 20px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: 6px; font-size: 14px; cursor: pointer; }
+.btn-secondary { padding: 10px 20px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: 14px; cursor: pointer; }
 .btn-secondary:hover { background: var(--bg-hover); }
 </style>

--- a/autobot-frontend/src/components/workflow/WorkflowHistory.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowHistory.vue
@@ -185,19 +185,19 @@ function formatDate(date?: string): string {
 .workflow-history { height: 100%; display: flex; flex-direction: column; }
 
 .history-filters { display: flex; justify-content: space-between; align-items: center; gap: 16px; margin-bottom: 20px; flex-wrap: wrap; }
-.search-box { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 8px; flex: 1; min-width: 200px; }
+.search-box { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); flex: 1; min-width: 200px; }
 .search-box i { color: var(--text-muted); }
 .search-box input { flex: 1; background: none; border: none; color: var(--text-primary); font-size: 14px; outline: none; }
 .search-box input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .filter-group { display: flex; gap: 8px; }
-.filter-group select { padding: 10px 12px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 8px; color: var(--text-primary); font-size: 13px; cursor: pointer; }
+.filter-group select { padding: 10px 12px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); color: var(--text-primary); font-size: 13px; cursor: pointer; }
 
 .empty-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-tertiary); padding: 40px; }
 .empty-state i { font-size: 48px; margin-bottom: 16px; }
 .empty-state h3 { margin: 0 0 8px; color: var(--text-primary); }
 
 .history-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; }
-.history-item { display: flex; align-items: center; gap: 16px; padding: 16px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 10px; cursor: pointer; transition: all 0.2s; }
+.history-item { display: flex; align-items: center; gap: 16px; padding: 16px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); cursor: pointer; transition: all 0.2s; }
 .history-item:hover { border-color: var(--color-primary); box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
 
 .item-status { width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 16px; flex-shrink: 0; }
@@ -212,18 +212,18 @@ function formatDate(date?: string): string {
 .item-meta span { display: flex; align-items: center; gap: 4px; }
 
 .item-stats { display: flex; gap: 12px; }
-.item-stats .stat { font-size: 12px; padding: 4px 10px; border-radius: 12px; }
+.item-stats .stat { font-size: 12px; padding: 4px 10px; border-radius: var(--radius-xl); }
 .item-stats .stat span { font-weight: 600; }
 .item-stats .success { background: var(--color-success-bg); color: var(--color-success); }
 .item-stats .failed { background: var(--color-error-bg); color: var(--color-error); }
 .item-stats .skipped { background: var(--bg-tertiary); color: var(--text-tertiary); }
 
 .item-actions { display: flex; gap: 8px; }
-.btn-icon { width: 32px; height: 32px; background: var(--bg-tertiary); border: none; border-radius: 6px; color: var(--text-secondary); cursor: pointer; transition: all 0.15s; }
+.btn-icon { width: 32px; height: 32px; background: var(--bg-tertiary); border: none; border-radius: var(--radius-md); color: var(--text-secondary); cursor: pointer; transition: all 0.15s; }
 .btn-icon:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 .pagination { display: flex; justify-content: center; align-items: center; gap: 16px; padding: 16px 0; margin-top: auto; }
-.pagination button { padding: 8px 12px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 6px; color: var(--text-secondary); cursor: pointer; }
+.pagination button { padding: 8px 12px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); cursor: pointer; }
 .pagination button:hover:not(:disabled) { background: var(--bg-hover); }
 .pagination button:disabled { opacity: 0.5; cursor: not-allowed; }
 .pagination span { font-size: 13px; color: var(--text-tertiary); }

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -341,7 +341,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 8px;
   padding: 8px 14px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 13px;
   font-weight: 500;
 }
@@ -369,7 +369,7 @@ onUnmounted(() => {
   padding: 4px 12px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: 12px;
   cursor: pointer;
@@ -401,7 +401,7 @@ onUnmounted(() => {
   padding: 10px 16px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   flex: 1;
   min-width: 140px;
 }
@@ -453,7 +453,7 @@ onUnmounted(() => {
   height: 32px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-secondary);
   cursor: pointer;
   display: flex;
@@ -511,7 +511,7 @@ onUnmounted(() => {
 .execution-card {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 18px;
   cursor: pointer;
   transition: border-color 0.2s, box-shadow 0.2s;
@@ -568,7 +568,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 4px;
   padding: 3px 10px;
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   font-size: 11px;
   font-weight: 500;
   white-space: nowrap;
@@ -592,13 +592,13 @@ onUnmounted(() => {
 .progress-track {
   height: 6px;
   background: var(--bg-tertiary);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
 .progress-fill {
   height: 100%;
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   transition: width 0.4s ease;
 }
 
@@ -697,7 +697,7 @@ onUnmounted(() => {
   gap: 4px;
   padding: 2px 8px;
   background: var(--bg-tertiary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 11px;
   color: var(--text-secondary);
   text-transform: capitalize;

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
@@ -357,7 +357,7 @@ watch(saveSuccess, (val) => {
 .field-input {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--color-border, #374151);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: var(--color-bg-secondary, #1e293b);
   color: var(--color-text-primary, #e2e8f0);
   font-size: 0.875rem;
@@ -428,7 +428,7 @@ watch(saveSuccess, (val) => {
   display: flex;
   flex-direction: column;
   border: 1px solid var(--color-border, #374151);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   overflow: hidden;
   margin-top: 0.5rem;
 }
@@ -490,7 +490,7 @@ watch(saveSuccess, (val) => {
   gap: 0.375rem;
   padding: 0.5rem 1.25rem;
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: var(--color-primary, #3b82f6);
   color: #fff;
   font-size: 0.875rem;
@@ -539,7 +539,7 @@ watch(saveSuccess, (val) => {
 
 .error-banner {
   padding: 0.5rem 0.75rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
   color: #fca5a5;

--- a/autobot-frontend/src/components/workflow/WorkflowRunner.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowRunner.vue
@@ -206,13 +206,13 @@ function formatResult(result: Record<string, unknown>): string {
 </script>
 
 <style scoped>
-.workflow-runner { display: flex; height: 100%; gap: 0; background: var(--bg-primary); border-radius: 8px; overflow: hidden; }
+.workflow-runner { display: flex; height: 100%; gap: 0; background: var(--bg-primary); border-radius: var(--radius-lg); overflow: hidden; }
 
 .runner-sidebar { width: 300px; min-width: 300px; background: var(--bg-secondary); border-right: 1px solid var(--border-default); display: flex; flex-direction: column; }
 .sidebar-header { display: flex; justify-content: space-between; align-items: center; padding: 16px; border-bottom: 1px solid var(--border-default); }
 .sidebar-header h4 { margin: 0; font-size: 14px; color: var(--text-primary); display: flex; align-items: center; gap: 8px; }
 .sidebar-header h4 i { color: var(--color-primary); }
-.btn-refresh { padding: 6px; background: transparent; border: none; color: var(--text-tertiary); cursor: pointer; border-radius: 4px; }
+.btn-refresh { padding: 6px; background: transparent; border: none; color: var(--text-tertiary); cursor: pointer; border-radius: var(--radius-default); }
 .btn-refresh:hover:not(:disabled) { background: var(--bg-hover); }
 .btn-refresh:disabled { opacity: 0.5; }
 
@@ -220,7 +220,7 @@ function formatResult(result: Record<string, unknown>): string {
 .empty-list i { font-size: 32px; margin-bottom: 12px; }
 
 .workflow-list { flex: 1; overflow-y: auto; padding: 8px; }
-.workflow-item { padding: 12px; background: var(--bg-tertiary); border-radius: 8px; margin-bottom: 8px; cursor: pointer; transition: all 0.15s; }
+.workflow-item { padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-lg); margin-bottom: 8px; cursor: pointer; transition: all 0.15s; }
 .workflow-item:hover { background: var(--bg-hover); }
 .workflow-item.active { background: var(--color-primary-bg); border: 1px solid var(--color-primary); }
 .workflow-item.paused { opacity: 0.7; }
@@ -233,7 +233,7 @@ function formatResult(result: Record<string, unknown>): string {
 .wf-info { flex: 1; min-width: 0; }
 .wf-name { display: block; font-size: 13px; font-weight: 500; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wf-progress { font-size: 11px; color: var(--text-tertiary); }
-.wf-progress-bar { width: 100%; height: 4px; background: var(--bg-secondary); border-radius: 2px; overflow: hidden; }
+.wf-progress-bar { width: 100%; height: 4px; background: var(--bg-secondary); border-radius: var(--radius-xs); overflow: hidden; }
 .wf-progress-bar .progress-fill { height: 100%; background: var(--color-primary); transition: width 0.3s; }
 
 .runner-main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
@@ -246,20 +246,20 @@ function formatResult(result: Record<string, unknown>): string {
 .header-info p { margin: 0 0 10px; font-size: 13px; color: var(--text-secondary); }
 .header-meta { display: flex; gap: 16px; font-size: 12px; color: var(--text-tertiary); flex-wrap: wrap; }
 .header-meta span { display: flex; align-items: center; gap: 6px; }
-.phase-badge { padding: 2px 8px; border-radius: 10px; font-weight: 500; background: var(--bg-tertiary); }
+.phase-badge { padding: 2px 8px; border-radius: var(--radius-xl); font-weight: 500; background: var(--bg-tertiary); }
 .phase-badge.planning { background: var(--color-info-bg); color: var(--color-info); }
 .phase-badge.executing { background: var(--color-primary-bg); color: var(--color-primary); }
 .phase-badge.validating { background: var(--color-warning-bg); color: var(--color-warning); }
 .phase-badge.complete { background: var(--color-success-bg); color: var(--color-success); }
 .phase-badge.failed { background: var(--color-error-bg); color: var(--color-error); }
-.service-badge { padding: 2px 8px; border-radius: 10px; background: var(--bg-tertiary); color: var(--text-secondary); font-family: monospace; }
+.service-badge { padding: 2px 8px; border-radius: var(--radius-xl); background: var(--bg-tertiary); color: var(--text-secondary); font-family: monospace; }
 .header-actions { display: flex; gap: 10px; align-items: center; }
 
 .btn-notif {
   padding: 8px 10px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-secondary);
   cursor: pointer;
   font-size: 14px;
@@ -270,7 +270,7 @@ function formatResult(result: Record<string, unknown>): string {
 .btn-notif:hover { background: var(--bg-hover); color: var(--color-primary); }
 
 .progress-overview { padding: 20px; background: var(--bg-secondary); }
-.progress-bar-large { height: 8px; background: var(--bg-tertiary); border-radius: 4px; overflow: hidden; margin-bottom: 16px; }
+.progress-bar-large { height: 8px; background: var(--bg-tertiary); border-radius: var(--radius-default); overflow: hidden; margin-bottom: 16px; }
 .progress-bar-large .progress-fill { height: 100%; background: var(--color-primary); transition: width 0.3s; }
 .progress-stats { display: flex; justify-content: space-around; }
 .progress-stats .stat { text-align: center; }
@@ -293,7 +293,7 @@ function formatResult(result: Record<string, unknown>): string {
 .step-line { width: 2px; flex: 1; min-height: 20px; background: var(--border-default); margin-top: 4px; }
 .step-line.completed { background: var(--color-success); }
 
-.step-content { flex: 1; padding: 8px 16px; background: var(--bg-secondary); border-radius: 8px; border-left: 3px solid var(--border-default); }
+.step-content { flex: 1; padding: 8px 16px; background: var(--bg-secondary); border-radius: var(--radius-lg); border-left: 3px solid var(--border-default); }
 .step-item.completed .step-content { border-left-color: var(--color-success); }
 .step-item.failed .step-content { border-left-color: var(--color-error); }
 .step-item.executing .step-content { border-left-color: var(--color-primary); }
@@ -301,32 +301,32 @@ function formatResult(result: Record<string, unknown>): string {
 
 .step-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
 .step-desc { font-size: 14px; font-weight: 500; color: var(--text-primary); }
-.step-status { font-size: 11px; padding: 2px 8px; border-radius: 10px; background: var(--bg-tertiary); color: var(--text-tertiary); }
+.step-status { font-size: 11px; padding: 2px 8px; border-radius: var(--radius-xl); background: var(--bg-tertiary); color: var(--text-tertiary); }
 .step-status.completed { background: var(--color-success-bg); color: var(--color-success); }
 .step-status.failed { background: var(--color-error-bg); color: var(--color-error); }
 .step-status.executing { background: var(--color-primary-bg); color: var(--color-primary); }
 .step-status.waiting_approval { background: var(--color-warning-bg); color: var(--color-warning); }
 
-.step-command { display: block; padding: 8px 10px; background: var(--bg-tertiary); border-radius: 4px; font-size: 12px; color: var(--text-secondary); margin-bottom: 8px; overflow-x: auto; }
+.step-command { display: block; padding: 8px 10px; background: var(--bg-tertiary); border-radius: var(--radius-default); font-size: 12px; color: var(--text-secondary); margin-bottom: 8px; overflow-x: auto; }
 .step-meta { display: flex; gap: 12px; font-size: 11px; color: var(--text-tertiary); }
 .step-meta span { display: flex; align-items: center; gap: 4px; }
-.step-meta .risk { padding: 2px 6px; border-radius: 8px; }
+.step-meta .risk { padding: 2px 6px; border-radius: var(--radius-lg); }
 .step-meta .risk.low { background: var(--color-success-bg); color: var(--color-success); }
 .step-meta .risk.medium { background: var(--color-warning-bg); color: var(--color-warning); }
 .step-meta .risk.high { background: var(--color-error-bg); color: var(--color-error); }
 
 .step-actions { display: flex; gap: 8px; margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border-default); }
-.step-result { margin-top: 12px; padding: 10px; background: var(--bg-tertiary); border-radius: 4px; }
+.step-result { margin-top: 12px; padding: 10px; background: var(--bg-tertiary); border-radius: var(--radius-default); }
 .step-result.error { background: var(--color-error-bg); }
 .step-result pre { margin: 0; font-size: 11px; color: var(--text-secondary); white-space: pre-wrap; word-break: break-all; max-height: 150px; overflow-y: auto; }
 
-.btn-success { padding: 8px 16px; background: var(--color-success); color: white; border: none; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+.btn-success { padding: 8px 16px; background: var(--color-success); color: white; border: none; border-radius: var(--radius-md); font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
 .btn-success:hover { filter: brightness(1.1); }
-.btn-warning { padding: 8px 16px; background: var(--color-warning); color: white; border: none; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+.btn-warning { padding: 8px 16px; background: var(--color-warning); color: white; border: none; border-radius: var(--radius-md); font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
 .btn-warning:hover { filter: brightness(1.1); }
-.btn-danger { padding: 8px 16px; background: var(--color-error); color: white; border: none; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+.btn-danger { padding: 8px 16px; background: var(--color-error); color: white; border: none; border-radius: var(--radius-md); font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
 .btn-danger:hover { filter: brightness(1.1); }
-.btn-secondary { padding: 8px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: 6px; font-size: 13px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+.btn-secondary { padding: 8px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: 13px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
 .btn-secondary:hover { background: var(--bg-hover); }
 .btn-sm { padding: 6px 12px; font-size: 12px; }
 </style>

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
@@ -322,15 +322,15 @@ onMounted(async () => {
 <style scoped>
 .template-gallery { height: 100%; display: flex; flex-direction: column; }
 .gallery-header { padding: 0 0 20px; display: flex; flex-direction: column; gap: 16px; }
-.search-box { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 8px; }
+.search-box { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); }
 .search-box i { color: var(--text-muted); }
 .search-box input { flex: 1; background: none; border: none; color: var(--text-primary); font-size: 14px; outline: none; }
 .search-box input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .category-filters { display: flex; gap: 8px; flex-wrap: wrap; }
-.filter-btn { padding: 6px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 20px; color: var(--text-secondary); font-size: 13px; cursor: pointer; transition: all 0.15s; display: flex; align-items: center; gap: 6px; }
+.filter-btn { padding: 6px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-2xl); color: var(--text-secondary); font-size: 13px; cursor: pointer; transition: all 0.15s; display: flex; align-items: center; gap: 6px; }
 .filter-btn:hover { background: var(--bg-hover); }
 .filter-btn.active { background: var(--color-primary); color: var(--text-on-primary); border-color: var(--color-primary); }
-.count-badge { font-size: 11px; padding: 1px 6px; background: rgba(255,255,255,0.2); border-radius: 10px; }
+.count-badge { font-size: 11px; padding: 1px 6px; background: rgba(255,255,255,0.2); border-radius: var(--radius-xl); }
 
 .loading-state, .empty-state, .error-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; color: var(--text-tertiary); }
 .empty-state i, .error-state i { font-size: 48px; }
@@ -338,10 +338,10 @@ onMounted(async () => {
 .error-state p { color: var(--text-secondary); }
 
 .templates-grid { flex: 1; display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; overflow-y: auto; padding-bottom: 20px; }
-.template-card { display: flex; gap: 16px; padding: 16px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: 10px; cursor: pointer; transition: all 0.2s; }
+.template-card { display: flex; gap: 16px; padding: 16px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); cursor: pointer; transition: all 0.2s; }
 .template-card:hover { border-color: var(--color-primary); box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
 
-.template-icon { width: 48px; height: 48px; border-radius: 10px; display: flex; align-items: center; justify-content: center; font-size: 20px; background: var(--bg-tertiary); color: var(--text-secondary); flex-shrink: 0; }
+.template-icon { width: 48px; height: 48px; border-radius: var(--radius-xl); display: flex; align-items: center; justify-content: center; font-size: 20px; background: var(--bg-tertiary); color: var(--text-secondary); flex-shrink: 0; }
 .template-icon.system { background: var(--color-info-bg); color: var(--color-info); }
 .template-icon.development { background: var(--color-primary-bg); color: var(--color-primary); }
 .template-icon.security { background: var(--color-warning-bg); color: var(--color-warning); }
@@ -354,13 +354,13 @@ onMounted(async () => {
 .template-info h4 { margin: 0 0 4px; font-size: 15px; color: var(--text-primary); }
 .template-info p { margin: 0 0 10px; font-size: 13px; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .template-meta { display: flex; gap: 12px; font-size: 12px; flex-wrap: wrap; }
-.category-badge { padding: 2px 8px; background: var(--bg-tertiary); color: var(--text-tertiary); border-radius: 10px; }
+.category-badge { padding: 2px 8px; background: var(--bg-tertiary); color: var(--text-tertiary); border-radius: var(--radius-xl); }
 .steps-count, .duration { color: var(--text-tertiary); display: flex; align-items: center; gap: 4px; }
 
 .template-actions { display: flex; flex-direction: column; gap: 8px; }
-.btn-icon { width: 32px; height: 32px; background: var(--bg-tertiary); border: none; border-radius: 6px; color: var(--text-secondary); cursor: pointer; }
+.btn-icon { width: 32px; height: 32px; background: var(--bg-tertiary); border: none; border-radius: var(--radius-md); color: var(--text-secondary); cursor: pointer; }
 .btn-icon:hover { background: var(--bg-hover); color: var(--text-primary); }
-.btn-run { width: 32px; height: 32px; background: var(--color-success); border: none; border-radius: 6px; color: white; cursor: pointer; }
+.btn-run { width: 32px; height: 32px; background: var(--color-success); border: none; border-radius: var(--radius-md); color: white; cursor: pointer; }
 .btn-run:hover { filter: brightness(1.1); }
 
 .preview-panel { position: fixed; right: 0; top: 0; bottom: 0; width: 400px; background: var(--bg-secondary); border-left: 1px solid var(--border-default); display: flex; flex-direction: column; z-index: 50; box-shadow: -4px 0 20px rgba(0,0,0,0.1); }
@@ -373,27 +373,27 @@ onMounted(async () => {
 
 .preview-agents { margin-bottom: 20px; }
 .agent-tags { display: flex; flex-wrap: wrap; gap: 6px; }
-.agent-tag { padding: 4px 10px; background: var(--color-primary-bg); color: var(--color-primary); border-radius: 12px; font-size: 12px; }
+.agent-tag { padding: 4px 10px; background: var(--color-primary-bg); color: var(--color-primary); border-radius: var(--radius-xl); font-size: 12px; }
 
 .preview-secrets { margin-bottom: 20px; }
 .secret-items { display: flex; flex-direction: column; gap: 8px; }
-.secret-item { display: flex; align-items: center; gap: 10px; padding: 8px 12px; background: var(--bg-tertiary); border-radius: 8px; font-size: 13px; }
+.secret-item { display: flex; align-items: center; gap: 10px; padding: 8px 12px; background: var(--bg-tertiary); border-radius: var(--radius-lg); font-size: 13px; }
 .secret-item i { color: var(--text-tertiary); font-size: 12px; }
 .secret-info { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 .secret-name { font-weight: 600; color: var(--text-primary); font-size: 12px; }
 .secret-desc { color: var(--text-tertiary); font-size: 11px; }
-.secret-scope { padding: 2px 6px; border-radius: 8px; font-size: 10px; background: var(--bg-secondary); color: var(--text-tertiary); }
+.secret-scope { padding: 2px 6px; border-radius: var(--radius-lg); font-size: 10px; background: var(--bg-secondary); color: var(--text-tertiary); }
 .secret-scope.write { background: var(--color-warning-bg); color: var(--color-warning); }
 .secret-scope.read { background: var(--color-success-bg); color: var(--color-success); }
 
 .preview-steps { display: flex; flex-direction: column; gap: 12px; }
-.preview-step { display: flex; gap: 12px; padding: 12px; background: var(--bg-tertiary); border-radius: 8px; }
+.preview-step { display: flex; gap: 12px; padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-lg); }
 .step-num { width: 24px; height: 24px; background: var(--color-primary); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; flex-shrink: 0; }
 .step-content { flex: 1; min-width: 0; }
 .step-desc { display: block; font-size: 13px; color: var(--text-primary); margin-bottom: 4px; }
-.step-content code { display: block; padding: 6px 8px; background: var(--bg-primary); border-radius: 4px; font-size: 11px; color: var(--text-secondary); overflow-x: auto; }
+.step-content code { display: block; padding: 6px 8px; background: var(--bg-primary); border-radius: var(--radius-default); font-size: 11px; color: var(--text-secondary); overflow-x: auto; }
 .step-meta { display: flex; gap: 10px; margin-top: 8px; font-size: 11px; }
-.step-meta .risk { padding: 2px 6px; border-radius: 8px; }
+.step-meta .risk { padding: 2px 6px; border-radius: var(--radius-lg); }
 .step-meta .risk.low { background: var(--color-success-bg); color: var(--color-success); }
 .step-meta .risk.medium { background: var(--color-warning-bg); color: var(--color-warning); }
 .step-meta .risk.high, .step-meta .risk.critical { background: var(--color-error-bg); color: var(--color-error); }
@@ -401,9 +401,9 @@ onMounted(async () => {
 .preview-actions { padding: 16px 20px; border-top: 1px solid var(--border-default); display: flex; gap: 12px; }
 .preview-actions .btn-secondary, .preview-actions .btn-primary { flex: 1; justify-content: center; }
 
-.btn-primary { padding: 10px 16px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
+.btn-primary { padding: 10px 16px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
 .btn-primary:hover { filter: brightness(1.1); }
-.btn-secondary { padding: 10px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: 6px; font-size: 13px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
+.btn-secondary { padding: 10px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: 13px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
 .btn-secondary:hover { background: var(--bg-hover); }
 
 .slide-enter-active, .slide-leave-active { transition: transform 0.25s ease; }

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -411,7 +411,7 @@ onMounted(loadUsers)
   padding: 0.75rem 1rem;
   background: var(--color-error-bg, #fef2f2);
   border: 1px solid var(--color-error-border, #fca5a5);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   margin-bottom: 1rem;
   color: var(--color-error, #dc2626);
 }
@@ -441,7 +441,7 @@ onMounted(loadUsers)
   width: 100%;
   padding: 0.5rem 0.75rem 0.5rem 2.25rem;
   border: 1px solid var(--color-border, #d1d5db);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   font-size: 0.875rem;
   box-sizing: border-box;
 }
@@ -449,7 +449,7 @@ onMounted(loadUsers)
 .table-section {
   background: var(--color-surface, #fff);
   border: 1px solid var(--color-border, #e5e7eb);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   overflow: hidden;
 }
 
@@ -499,7 +499,7 @@ onMounted(loadUsers)
 .badge {
   display: inline-block;
   padding: 0.125rem 0.5rem;
-  border-radius: 9999px;
+  border-radius: var(--radius-full);
   font-size: 0.7rem;
   font-weight: 600;
 }
@@ -522,7 +522,7 @@ onMounted(loadUsers)
 .role-select {
   padding: 0.25rem 0.5rem;
   border: 1px solid var(--color-border, #d1d5db);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.8125rem;
   background: transparent;
 }
@@ -536,7 +536,7 @@ onMounted(loadUsers)
   width: 2rem;
   height: 2rem;
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -577,7 +577,7 @@ onMounted(loadUsers)
 .btn-page {
   padding: 0.375rem 0.75rem;
   border: 1px solid var(--color-border, #d1d5db);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   background: transparent;
   cursor: pointer;
 }
@@ -599,7 +599,7 @@ onMounted(loadUsers)
   align-items: center;
   gap: 0.375rem;
   padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   font-size: 0.875rem;
   font-weight: 500;
   border: 1px solid transparent;
@@ -640,7 +640,7 @@ onMounted(loadUsers)
 
 .modal {
   background: var(--color-surface, #fff);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   width: 100%;
   max-width: 480px;
   box-shadow: var(--shadow-2xl);
@@ -691,7 +691,7 @@ onMounted(loadUsers)
   width: 100%;
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--color-border, #d1d5db);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
   box-sizing: border-box;
 }

--- a/autobot-frontend/src/views/ComponentShowcaseView.vue
+++ b/autobot-frontend/src/views/ComponentShowcaseView.vue
@@ -343,10 +343,10 @@ const handleRemove = () => {
 .badge-group { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
 .card-stack { display: flex; flex-direction: column; gap: 16px; }
 .color-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 12px; }
-.color-swatch { aspect-ratio: 1; border-radius: 4px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; padding: 12px; box-shadow: var(--shadow-md); }
+.color-swatch { aspect-ratio: 1; border-radius: var(--radius-default); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; padding: 12px; box-shadow: var(--shadow-md); }
 .swatch-label { font-size: 11px; font-weight: 600; color: white; text-transform: uppercase; letter-spacing: 0.05em; }
 .swatch-hex { font-size: 10px; font-family: var(--font-mono); color: rgba(255, 255, 255, 0.8); }
-.type-samples { padding: 16px; background-color: var(--bg-secondary); border-radius: 4px; border: 1px solid var(--border-default); }
+.type-samples { padding: 16px; background-color: var(--bg-secondary); border-radius: var(--radius-default); border: 1px solid var(--border-default); }
 @media (max-width: 768px) {
   .showcase-grid { grid-template-columns: 1fr; }
   .showcase-container { padding: 16px; }

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -672,7 +672,7 @@ onMounted(() => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   color: var(--text-primary);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   font-size: 0.875rem;
   cursor: pointer;
   transition: all 0.2s;
@@ -709,7 +709,7 @@ onMounted(() => {
   padding: 0.625rem 1rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   color: var(--text-primary);
   font-size: 0.875rem;
   min-width: 150px;
@@ -720,7 +720,7 @@ onMounted(() => {
   height: 36px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   color: var(--text-secondary);
   cursor: pointer;
   display: flex;
@@ -761,7 +761,7 @@ onMounted(() => {
   padding: 0.5rem 1rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   color: var(--text-primary);
   font-size: 0.875rem;
   cursor: grab;
@@ -808,7 +808,7 @@ onMounted(() => {
 /* Widget Container */
 .widget-container {
   background: var(--bg-secondary);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-default);
   overflow: hidden;
   display: flex;
@@ -867,7 +867,7 @@ onMounted(() => {
   border: none;
   color: var(--text-tertiary);
   cursor: pointer;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -938,7 +938,7 @@ onMounted(() => {
 
 .modal-content {
   background: var(--bg-secondary);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--border-default);
   width: 90%;
   max-width: 480px;
@@ -1010,7 +1010,7 @@ onMounted(() => {
   padding: 0.625rem 0.75rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-lg);
   color: var(--text-primary);
   font-size: 0.875rem;
 }
@@ -1045,7 +1045,7 @@ onMounted(() => {
 .widget-option {
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 0.75rem;
+  border-radius: var(--radius-xl);
   padding: 1.5rem;
   text-align: center;
   cursor: pointer;
@@ -1061,7 +1061,7 @@ onMounted(() => {
   width: 60px;
   height: 60px;
   background: var(--color-primary-bg);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/autobot-frontend/src/views/DocumentsView.vue
+++ b/autobot-frontend/src/views/DocumentsView.vue
@@ -440,7 +440,7 @@ function showError(msg: string) {
 .modal-card {
   background: var(--color-background-secondary, #252525);
   border: 1px solid var(--color-border, #444);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 24px;
   width: 360px;
   max-width: 90vw;
@@ -474,7 +474,7 @@ function showError(msg: string) {
   background: var(--color-error-bg, #3c1515);
   color: var(--color-error, #f87171);
   border: 1px solid var(--color-error, #f87171);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   padding: 10px 20px;
   font-size: 0.875rem;
   z-index: var(--z-popover);

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -502,7 +502,7 @@ onMounted(async () => {
 .count-badge {
   font-size: 11px;
   padding: 1px 6px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   min-width: 20px;
   text-align: center;
   background: var(--bg-tertiary);
@@ -614,7 +614,7 @@ onMounted(async () => {
   font-size: 11px;
   font-weight: 600;
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -688,7 +688,7 @@ onMounted(async () => {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   padding: 1px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 11px;
   color: var(--text-secondary);
   text-transform: capitalize;
@@ -705,7 +705,7 @@ onMounted(async () => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   padding: 1px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   border: 1px solid var(--border-default);
 }
 

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -622,7 +622,7 @@ onMounted(async () => {
   color: var(--text-secondary);
   font-size: 11px;
   padding: 1px 6px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   min-width: 20px;
   text-align: center;
 }
@@ -737,7 +737,7 @@ onMounted(async () => {
   font-size: 11px;
   font-weight: 600;
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -817,7 +817,7 @@ onMounted(async () => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   padding: 1px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   border: 1px solid var(--border-default);
 }
 

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -1238,7 +1238,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .health-indicator {
   font-size: 0.65rem;
   padding: 1px 6px;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   text-transform: uppercase;
   font-weight: 600;
 }
@@ -1305,7 +1305,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   font-family: var(--font-mono);
   background: var(--bg-tertiary);
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   color: var(--text-tertiary);
   font-weight: 500;
 }
@@ -1332,7 +1332,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   font-size: 13px;
   font-weight: 500;
   font-family: var(--font-sans);
@@ -1413,7 +1413,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   align-items: center;
   gap: 8px;
   padding: 8px 14px;
-  border-radius: 20px;
+  border-radius: var(--radius-2xl);
   font-size: 13px;
   font-weight: 500;
 }
@@ -1490,7 +1490,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   padding: 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   transition: all 0.2s;
 }
 
@@ -1501,7 +1501,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .stat-card .stat-icon {
   width: 48px;
   height: 48px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   background: var(--bg-tertiary);
   display: flex;
   align-items: center;
@@ -1546,7 +1546,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .overview-card {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 20px;
 }
 
@@ -1579,7 +1579,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   padding: 16px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all 0.2s;
   color: var(--text-secondary);
@@ -1610,7 +1610,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .strategy-item {
   padding: 16px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
 }
 
 .strategy-header {
@@ -1651,7 +1651,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .example-item {
   padding: 12px 16px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -1678,7 +1678,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   padding: 2px 8px;
   background: var(--color-primary-bg);
   color: var(--color-primary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
 }
 
 .example-description {
@@ -1721,7 +1721,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .nl-input-area {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 20px;
 }
 
@@ -1730,7 +1730,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   padding: 12px;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   color: var(--text-primary);
   font-size: 14px;
   resize: vertical;
@@ -1775,7 +1775,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   padding: 8px 12px;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: 13px;
 }
@@ -1790,7 +1790,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   margin-top: 24px;
   background: var(--bg-secondary);
   border: 1px solid var(--color-warning);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 20px;
 }
 
@@ -1839,7 +1839,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .approval-step {
   padding: 12px;
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   border-left: 3px solid var(--border-default);
 }
 
@@ -1862,7 +1862,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .risk-badge {
   font-size: 11px;
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   text-transform: uppercase;
 }
 
@@ -1886,7 +1886,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: block;
   padding: 8px;
   background: var(--bg-primary);
-  border-radius: 4px;
+  border-radius: var(--radius-default);
   font-size: 12px;
   color: var(--text-secondary);
   overflow-x: auto;
@@ -1902,7 +1902,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .agents-container {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   padding: 24px;
 }
 
@@ -1932,7 +1932,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: all 0.2s;
 }
@@ -1962,7 +1962,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .agent-card {
   background: var(--bg-tertiary);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   padding: 16px;
 }
 
@@ -1995,7 +1995,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   padding: 2px 8px;
   background: var(--bg-secondary);
   color: var(--text-secondary);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
 }
 
 .agent-performance {
@@ -2020,14 +2020,14 @@ watch(hasActiveWorkflows, (hasActive) => {
   flex: 1;
   height: 6px;
   background: var(--bg-secondary);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   overflow: hidden;
 }
 
 .progress-fill {
   height: 100%;
   background: var(--color-success);
-  border-radius: 3px;
+  border-radius: var(--radius-default);
   transition: width 0.3s;
 }
 
@@ -2045,7 +2045,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -2070,7 +2070,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   background: var(--color-success);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -2089,7 +2089,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   background: var(--color-error);
   color: var(--text-on-primary);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;


### PR DESCRIPTION
Closes #4559

## Summary
- Converts all raw `px`/`rem` `border-radius` values in Vue `<style>` blocks to CSS custom property tokens (`--radius-xs` through `--radius-full`)
- 112 files changed, 811 violations eliminated
- Automated via bulk regex replacement scoped to `<style>` blocks only — template markup untouched
- `50%` values preserved as-is (used for circular elements, no token equivalent)

## Token mapping
| Before | After |
|--------|-------|
| `2px` | `var(--radius-xs)` |
| `4px` / `0.25rem` | `var(--radius-default)` |
| `6px` / `0.375rem` | `var(--radius-md)` |
| `8px` / `0.5rem` | `var(--radius-lg)` |
| `12px` / `0.75rem` | `var(--radius-xl)` |
| `16px` / `1rem` | `var(--radius-2xl)` |
| `24px` / `1.5rem` | `var(--radius-3xl)` |
| `9999px` | `var(--radius-full)` |