### PR TITLE
style(tokens): replace hardcoded transition values with design tokens (#4590)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -863,7 +863,7 @@ export default {
   border-radius: 0 0 4px 0;
   font-size: var(--text-sm);
   font-weight: 500;
-  transition: top 0.2s ease-in-out;
+  transition: top var(--duration-200) var(--ease-in-out);
   z-index: var(--z-maximum);
 }
 
@@ -882,7 +882,7 @@ nav a:focus-visible {
 
 /* Add any component-specific styles here */
 .fade-enter-active, .fade-leave-active {
-  transition: opacity 0.5s;
+  transition: opacity var(--duration-500);
 }
 .fade-enter-from, .fade-leave-to {
   opacity: 0;
@@ -896,7 +896,7 @@ nav a:focus-visible {
 /* Smooth transitions for navigation state changes */
 .transition-transform {
   transition-property: transform;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 300ms;
+  transition-timing-function: var(--ease-in-out);
+  transition-duration: var(--duration-300);
 }
 </style>

--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -572,7 +572,7 @@ button {
   cursor: pointer;
   font-size: 0.8rem;
   padding: 0.3rem 0.6rem;
-  transition: background 0.15s;
+  transition: background var(--duration-150);
 }
 button:disabled {
   cursor: not-allowed;

--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
@@ -563,7 +563,7 @@ onMounted(() => {
   color: var(--text-secondary);
   cursor: pointer;
   border-radius: var(--radius-default);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .tab-btn:hover {
@@ -765,7 +765,7 @@ onMounted(() => {
   height: 100%;
   background: var(--color-primary);
   border-radius: var(--radius-default);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 
 .peak-hours-list {

--- a/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
@@ -218,7 +218,7 @@ const emit = defineEmits<{
 .btn-debug {
   font-size: 0.85em;
   font-weight: 500;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-debug:hover {

--- a/autobot-frontend/src/components/analytics/AnalyticsProgressSection.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsProgressSection.vue
@@ -253,7 +253,7 @@ function getPhaseIcon(status: string): string {
 .progress-fill {
   height: 100%;
   background: var(--color-success);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
   border-radius: var(--radius-default);
 }
 
@@ -366,7 +366,7 @@ function getPhaseIcon(status: string): string {
 .batch-fill {
   height: 100%;
   background: var(--color-success);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
   border-radius: var(--radius-default);
 }
 
@@ -430,7 +430,7 @@ function getPhaseIcon(status: string): string {
 .scan-runner-progress .mini-progress-bar {
   height: 100%;
   background: var(--color-purple);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 .scan-runner-items {
   display: flex;

--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
@@ -666,7 +666,7 @@ watch([selectedGranularity, selectedDays], () => {
   font-size: var(--text-xs);
   cursor: pointer;
   opacity: 0.6;
-  transition: opacity 0.2s;
+  transition: opacity var(--duration-200);
 }
 
 .metric-toggle.active {
@@ -704,7 +704,7 @@ watch([selectedGranularity, selectedDays], () => {
 }
 
 .data-line {
-  transition: stroke-width 0.2s;
+  transition: stroke-width var(--duration-200);
 }
 
 .data-line:hover {
@@ -713,7 +713,7 @@ watch([selectedGranularity, selectedDays], () => {
 
 .data-point {
   cursor: pointer;
-  transition: r 0.2s;
+  transition: r var(--duration-200);
 }
 
 .data-point:hover {

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -1208,7 +1208,7 @@ watch(selectedPeriod, () => {
 }
 
 .score-progress {
-  transition: stroke-dashoffset 1s ease-out;
+  transition: stroke-dashoffset var(--duration-1000) var(--ease-out);
 }
 
 .score-content {
@@ -1368,7 +1368,7 @@ watch(selectedPeriod, () => {
 .metric-bar .bar-fill {
   height: 100%;
   border-radius: var(--radius-xs);
-  transition: width 0.5s ease;
+  transition: width var(--duration-500) var(--ease-out);
 }
 
 .bar-fill.excellent { background: var(--color-success); }

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -838,7 +838,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .action-btn.primary {
@@ -940,7 +940,7 @@ onMounted(() => {
   border-radius: var(--radius-2xl);
   font-size: var(--text-xs);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .chip.active {
@@ -1074,7 +1074,7 @@ onMounted(() => {
   border-radius: var(--radius-md);
   border-left: 3px solid;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .issue-card:hover {
@@ -1326,7 +1326,7 @@ onMounted(() => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .history-item:hover {

--- a/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
+++ b/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
@@ -430,7 +430,7 @@ const getItemSeverityClass = (severity: string): string => {
   display: flex;
   align-items: center;
   gap: 4px;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .export-btn:hover {

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -1095,7 +1095,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-xl);
   position: relative;
-  transition: all 0.3s;
+  transition: all var(--duration-300);
 }
 
 .toggle-slider:before {
@@ -1107,7 +1107,7 @@ onUnmounted(() => {
   position: absolute;
   top: 2px;
   left: 2px;
-  transition: all 0.3s;
+  transition: all var(--duration-300);
 }
 
 .toggle-switch input:checked + .toggle-slider {
@@ -1125,7 +1125,7 @@ onUnmounted(() => {
   padding: 8px 16px;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1244,7 +1244,7 @@ onUnmounted(() => {
   color: var(--text-secondary);
   text-decoration: none;
   border-bottom: 2px solid transparent;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
   position: relative;
   top: 1px;
   white-space: nowrap;

--- a/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
@@ -373,7 +373,7 @@ const emit = defineEmits<{
   padding: 6px 8px;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .refresh-btn:hover {
@@ -421,7 +421,7 @@ const emit = defineEmits<{
   padding: 16px;
   text-align: center;
   border: 1px solid rgba(71, 85, 105, 0.5);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .summary-stat:hover {
@@ -630,7 +630,7 @@ const emit = defineEmits<{
   padding: 8px 12px;
   background: rgba(51, 65, 85, 0.4);
   border-radius: var(--radius-default);
-  transition: background 0.2s ease;
+  transition: background var(--duration-200) var(--ease-out);
 }
 
 .dep-row:hover {

--- a/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
@@ -282,7 +282,7 @@ const getQualityClass = (score: number): string => {
   padding: 6px 8px;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .refresh-btn:hover {
@@ -305,7 +305,7 @@ const getQualityClass = (score: number): string => {
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -473,7 +473,7 @@ const getQualityClass = (score: number): string => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-xl);
   position: relative;
-  transition: all 0.3s;
+  transition: all var(--duration-300);
 }
 
 .toggle-slider:before {
@@ -485,7 +485,7 @@ const getQualityClass = (score: number): string => {
   position: absolute;
   top: 2px;
   left: 2px;
-  transition: all 0.3s;
+  transition: all var(--duration-300);
 }
 
 .toggle-switch input:checked + .toggle-slider {
@@ -503,7 +503,7 @@ const getQualityClass = (score: number): string => {
   padding: 8px 16px;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: flex;
   align-items: center;
   gap: 8px;

--- a/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.vue
@@ -188,7 +188,7 @@ const getTabCount = (tabId: string): number => {
   display: flex;
   align-items: center;
   gap: 6px;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .code-intelligence-section .action-btn:hover:not(:disabled) {
@@ -234,7 +234,7 @@ const getTabCount = (tabId: string): number => {
   align-items: center;
   gap: 8px;
   font-size: 0.9em;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .code-intel-tabs .tab-btn:hover {

--- a/autobot-frontend/src/components/analytics/DeclarationsSection.vue
+++ b/autobot-frontend/src/components/analytics/DeclarationsSection.vue
@@ -355,7 +355,7 @@ const getDeclarationTypeClass = (type: string): string => {
   display: flex;
   align-items: center;
   gap: 4px;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .export-btn:hover {

--- a/autobot-frontend/src/components/analytics/DuplicatesSection.vue
+++ b/autobot-frontend/src/components/analytics/DuplicatesSection.vue
@@ -359,7 +359,7 @@ const formatSimilarityGroup = (similarity: string): string => {
   display: flex;
   align-items: center;
   gap: 4px;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .export-btn:hover {

--- a/autobot-frontend/src/components/analytics/HealthScoreGauge.vue
+++ b/autobot-frontend/src/components/analytics/HealthScoreGauge.vue
@@ -101,7 +101,7 @@ const scoreArc = computed(() => {
 }
 
 .score-arc {
-  transition: stroke-dasharray 0.5s ease;
+  transition: stroke-dasharray var(--duration-500) var(--ease-out);
 }
 
 .score-display {

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -762,7 +762,7 @@ onMounted(() => {
   color: #fff;
   font-size: var(--text-sm);
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background var(--duration-200);
 }
 
 .analyze-btn:hover:not(:disabled) {
@@ -991,7 +991,7 @@ onMounted(() => {
   height: 100%;
   background: var(--color-info);
   border-radius: var(--radius-xs);
-  transition: width 0.3s;
+  transition: width var(--duration-300);
 }
 
 /* Category List */
@@ -1033,7 +1033,7 @@ onMounted(() => {
   height: 100%;
   background: var(--color-success);
   border-radius: var(--radius-xs);
-  transition: width 0.3s;
+  transition: width var(--duration-300);
 }
 
 .category-meta {

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -646,7 +646,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .action-btn.primary {
@@ -768,7 +768,7 @@ onMounted(() => {
 .score-progress {
   transform: rotate(-90deg);
   transform-origin: center;
-  transition: stroke-dasharray 0.5s ease;
+  transition: stroke-dasharray var(--duration-500) var(--ease-out);
 }
 
 .score-value {
@@ -899,7 +899,7 @@ onMounted(() => {
   border-radius: var(--radius-md);
   border-left: 3px solid;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .issue-card:hover {
@@ -1173,7 +1173,7 @@ onMounted(() => {
 
 .bar-fill {
   height: 100%;
-  transition: width 0.3s;
+  transition: width var(--duration-300);
 }
 
 .bar-fill.critical { background: var(--color-error); }

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
@@ -665,7 +665,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .action-btn.primary {
@@ -1024,7 +1024,7 @@ onMounted(() => {
   background: var(--bg-quaternary);
   border-radius: var(--radius-xl);
   cursor: pointer;
-  transition: 0.3s;
+  transition: var(--duration-300);
 }
 
 .toggle-slider::before {
@@ -1036,7 +1036,7 @@ onMounted(() => {
   bottom: 3px;
   background: white;
   border-radius: 50%;
-  transition: 0.3s;
+  transition: var(--duration-300);
 }
 
 .check-toggle input:checked + .toggle-slider {
@@ -1105,7 +1105,7 @@ onMounted(() => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .history-item:hover {
@@ -1227,7 +1227,7 @@ onMounted(() => {
   height: 100%;
   background: var(--accent-color);
   border-radius: var(--radius-default);
-  transition: width 0.3s;
+  transition: width var(--duration-300);
 }
 
 .issue-count {

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -1096,7 +1096,7 @@ watch(selectedPeriod, () => {
 
 .health-fill {
   height: 100%;
-  transition: width var(--duration-300) ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 
 .health-fill.healthy {
@@ -1388,7 +1388,7 @@ watch(selectedPeriod, () => {
 .bar-fill {
   height: 100%;
   border-radius: var(--radius-xs);
-  transition: width var(--duration-200) ease;
+  transition: width var(--duration-200) var(--ease-out);
 }
 
 /* Priority List */

--- a/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
@@ -248,7 +248,7 @@ function copyPath(finding: Finding): void {
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   width: 200px;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
 }
 
 .search-input:focus {
@@ -346,7 +346,7 @@ th {
 
 .finding-row {
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--duration-150);
   position: relative;
 }
 
@@ -431,7 +431,7 @@ code {
   font-size: var(--text-sm);
   font-weight: 500;
   font-family: var(--font-sans);
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
   display: inline-flex;
   align-items: center;
   gap: 6px;

--- a/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
@@ -323,7 +323,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   padding: 14px 16px;
   cursor: pointer;
   background: var(--bg-secondary);
-  transition: background 0.2s ease;
+  transition: background var(--duration-200) var(--ease-out);
 }
 
 .accordion-header:hover {
@@ -339,7 +339,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .header-info i {
   color: var(--text-muted);
   font-size: 0.75em;
-  transition: transform 0.2s ease;
+  transition: transform var(--duration-200) var(--ease-out);
 }
 
 .header-name {
@@ -385,7 +385,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Accordion Transition */
 .accordion-enter-active,
 .accordion-leave-active {
-  transition: all 0.3s ease;
+  transition: all var(--duration-300) var(--ease-out);
   overflow: hidden;
 }
 
@@ -407,7 +407,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   border-radius: var(--radius-lg);
   padding: 14px 16px;
   border-left: 4px solid var(--text-tertiary);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .list-item:hover {
@@ -655,7 +655,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .coverage-fill {
   height: 100%;
   border-radius: var(--radius-md);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 
 .coverage-fill.success { background: var(--color-success); }

--- a/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
@@ -576,7 +576,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   border-radius: var(--radius-lg);
   margin-bottom: 12px;
   border-left: 4px solid var(--text-tertiary);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .bug-prediction-section .list-item:hover {

--- a/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
@@ -366,7 +366,7 @@ function getCategoryIcon(categoryId: string): string {
   font-size: 0.85rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -457,7 +457,7 @@ function getCategoryIcon(categoryId: string): string {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .category-tab:hover {
@@ -537,7 +537,7 @@ function getCategoryIcon(categoryId: string): string {
   padding: 16px;
   text-align: center;
   border: 1px solid rgba(71, 85, 105, 0.5);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .summary-stat:hover {
@@ -734,7 +734,7 @@ function getCategoryIcon(categoryId: string): string {
   padding: 8px 12px;
   background: rgba(51, 65, 85, 0.4);
   border-radius: var(--radius-default);
-  transition: background 0.2s ease;
+  transition: background var(--duration-200) var(--ease-out);
 }
 
 .dep-row:hover {

--- a/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
@@ -432,7 +432,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   padding: 14px 16px;
   cursor: pointer;
   background: var(--bg-secondary);
-  transition: background 0.2s ease;
+  transition: background var(--duration-200) var(--ease-out);
 }
 
 .accordion-header:hover {
@@ -448,7 +448,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .header-info i {
   color: var(--text-muted);
   font-size: 0.75em;
-  transition: transform 0.2s ease;
+  transition: transform var(--duration-200) var(--ease-out);
 }
 
 .header-name {
@@ -494,7 +494,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Accordion Transition */
 .accordion-enter-active,
 .accordion-leave-active {
-  transition: all 0.3s ease;
+  transition: all var(--duration-300) var(--ease-out);
   overflow: hidden;
 }
 
@@ -516,7 +516,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   border-radius: var(--radius-lg);
   padding: 14px 16px;
   border-left: 4px solid var(--text-tertiary);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .list-item:hover {
@@ -915,7 +915,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  transition: background 0.2s;
+  transition: background var(--duration-200);
 }
 
 .btn-scan:hover:not(:disabled) {

--- a/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
@@ -802,7 +802,7 @@ function formatTimestamp(timestamp: string): string {
   border-radius: var(--radius-xl);
   padding: 20px;
   border: 1px solid rgba(71, 85, 105, 0.4);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .score-card:hover {
@@ -829,7 +829,7 @@ function formatTimestamp(timestamp: string): string {
   color: var(--color-info-light);
   cursor: pointer;
   font-size: 0.8em;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .score-card .score-header .card-refresh-btn:hover:not(:disabled) {
@@ -948,7 +948,7 @@ function formatTimestamp(timestamp: string): string {
 .quality-metric .metric-fill {
   height: 100%;
   border-radius: var(--radius-default);
-  transition: width 0.5s ease;
+  transition: width var(--duration-500) var(--ease-out);
 }
 
 .quality-metric .metric-fill.score-high { background: var(--chart-green); }
@@ -1133,7 +1133,7 @@ function formatTimestamp(timestamp: string): string {
   padding: 10px 14px;
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-md);
-  transition: background 0.2s ease;
+  transition: background var(--duration-200) var(--ease-out);
 }
 
 .history-item:hover {
@@ -1189,7 +1189,7 @@ function formatTimestamp(timestamp: string): string {
   font-size: 0.85em;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1290,7 +1290,7 @@ function formatTimestamp(timestamp: string): string {
   padding: 14px 16px;
   margin-bottom: 10px;
   border-left: 4px solid var(--text-tertiary);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .finding-item:last-child { margin-bottom: 0; }

--- a/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
@@ -508,7 +508,7 @@ function formatFactorName(factor: string): string {
   align-items: center;
   gap: 6px;
   font-size: 0.9em;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .ownership-tabs .tab-btn:hover {
@@ -573,7 +573,7 @@ function formatFactorName(factor: string): string {
 .ownership-metrics .metric-bar-fill {
   height: 100%;
   border-radius: var(--radius-default);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 
 .ownership-metrics .metric-bar-fill.ok {

--- a/autobot-frontend/src/components/base/BaseBadge.vue
+++ b/autobot-frontend/src/components/base/BaseBadge.vue
@@ -71,7 +71,7 @@ const handleRemove = (event: MouseEvent) => {
   gap: 4px;
   font-weight: 500;
   white-space: nowrap;
-  transition: all 150ms ease;
+  transition: all var(--duration-150) var(--ease-out);
   line-height: 1;
   font-family: var(--font-sans);
 }
@@ -225,7 +225,7 @@ const handleRemove = (event: MouseEvent) => {
   color: currentColor;
   cursor: pointer;
   border-radius: 50%;
-  transition: all 150ms ease;
+  transition: all var(--duration-150) var(--ease-out);
   opacity: 0.6;
 }
 

--- a/autobot-frontend/src/components/base/BaseButton.vue
+++ b/autobot-frontend/src/components/base/BaseButton.vue
@@ -141,7 +141,7 @@ const createRipple = (event: TouchEvent) => {
   align-items: center;
   justify-content: center;
   font-weight: 500;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
   border: 1px solid transparent;
   font-family: var(--font-sans);
   cursor: pointer;

--- a/autobot-frontend/src/components/base/BaseCard.vue
+++ b/autobot-frontend/src/components/base/BaseCard.vue
@@ -74,7 +74,7 @@ const footerClasses = computed(() => ({
 
 .base-card {
   background-color: var(--bg-card);
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
   position: relative;
   overflow: hidden;
   contain: layout style;

--- a/autobot-frontend/src/components/base/BaseInput.vue
+++ b/autobot-frontend/src/components/base/BaseInput.vue
@@ -186,7 +186,7 @@ defineExpose({
   background-color: var(--bg-input);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xs);
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
 }
 
 .container-focused {
@@ -218,7 +218,7 @@ defineExpose({
   color: var(--text-primary);
   font-size: var(--text-sm);
   font-family: var(--font-sans);
-  transition: color 150ms ease;
+  transition: color var(--duration-150) var(--ease-out);
 }
 
 .base-input:focus-visible {
@@ -290,7 +290,7 @@ defineExpose({
   color: var(--text-muted);
   cursor: pointer;
   border-radius: var(--radius-xs);
-  transition: all 150ms ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .clear-button:hover {
@@ -336,6 +336,6 @@ defineExpose({
 .base-input:-webkit-autofill:focus {
   -webkit-text-fill-color: var(--text-primary);
   -webkit-box-shadow: 0 0 0 1000px var(--bg-input) inset;
-  transition: background-color 5000s ease-in-out 0s;
+  transition: background-color 5000s var(--ease-in-out) 0s;
 }
 </style>

--- a/autobot-frontend/src/components/base/BasePanel.vue
+++ b/autobot-frontend/src/components/base/BasePanel.vue
@@ -74,7 +74,7 @@ const toggleCollapse = () => {
 /** Issue #704: Migrated to design tokens */
 .base-panel {
   background-color: var(--bg-primary);
-  transition: all var(--duration-200) ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .panel-default {

--- a/autobot-frontend/src/components/base/BaseTable.vue
+++ b/autobot-frontend/src/components/base/BaseTable.vue
@@ -308,7 +308,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 
 .sortable-header {
   cursor: pointer;
-  transition: color 150ms ease;
+  transition: color var(--duration-150) var(--ease-out);
 }
 
 .sortable-header:hover {
@@ -329,7 +329,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 .sort-icon {
   width: 14px;
   height: 14px;
-  transition: transform 150ms ease, color 150ms ease;
+  transition: transform var(--duration-150) var(--ease-out), color var(--duration-150) var(--ease-out);
   color: var(--color-info);
 }
 
@@ -353,7 +353,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 }
 
 .table-row {
-  transition: background-color 150ms ease;
+  transition: background-color var(--duration-150) var(--ease-out);
   border-bottom: 1px solid var(--border-subtle);
 }
 

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
@@ -194,7 +194,7 @@ function submitType() {
   height: 100%;
   object-fit: contain;
   display: block;
-  transition: opacity 0.2s ease;
+  transition: opacity var(--duration-200) var(--ease-out);
 }
 
 .screenshot-img--loading {
@@ -260,7 +260,7 @@ function submitType() {
   color: var(--color-text-secondary, #a1a1aa);
   cursor: pointer;
   font-size: var(--text-xs);
-  transition: background 0.15s, color 0.15s;
+  transition: background var(--duration-150), color var(--duration-150);
 }
 
 .toolbar-btn:hover:not(:disabled) {

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -1440,7 +1440,7 @@ watch(viewMode, async (newMode) => {
   border-radius: var(--radius-md);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: all var(--duration-200) ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .view-toggle button.active {
@@ -1482,7 +1482,7 @@ watch(viewMode, async (newMode) => {
   cursor: pointer;
   padding: var(--spacing-2) var(--spacing-3);
   border-radius: var(--radius-md);
-  transition: all var(--duration-200) ease;
+  transition: all var(--duration-200) var(--ease-out);
   border: 1px solid transparent;
 }
 
@@ -1597,7 +1597,7 @@ watch(viewMode, async (newMode) => {
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
   cursor: pointer;
-  transition: background var(--duration-200) ease;
+  transition: background var(--duration-200) var(--ease-out);
 }
 
 .func-header:hover {
@@ -1999,7 +1999,7 @@ watch(viewMode, async (newMode) => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .orphaned-item:hover {
@@ -2060,7 +2060,7 @@ watch(viewMode, async (newMode) => {
   border-radius: var(--radius-md);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .btn-show-more:hover {
@@ -2087,7 +2087,7 @@ watch(viewMode, async (newMode) => {
 /* Orphaned stat styling */
 .stat-orphaned {
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .stat-orphaned:hover,

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -969,7 +969,7 @@ onUnmounted(() => {
   color: var(--text-secondary);
   cursor: pointer;
   font-size: var(--text-sm);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .view-toggle button.active {
@@ -1058,7 +1058,7 @@ onUnmounted(() => {
   color: var(--text-primary);
   cursor: pointer;
   font-size: var(--text-sm);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .network-controls button:hover {
@@ -1216,7 +1216,7 @@ onUnmounted(() => {
   padding: var(--spacing-2) var(--spacing-3);
   cursor: pointer;
   background: var(--bg-primary);
-  transition: background 0.15s ease;
+  transition: background var(--duration-150) var(--ease-out);
 }
 
 .node-header:hover {
@@ -1315,7 +1315,7 @@ onUnmounted(() => {
   border-radius: var(--radius-sm);
   background: var(--bg-primary);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: all var(--duration-150) var(--ease-out);
   color: var(--text-secondary);
 }
 

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -1121,7 +1121,7 @@ function _extractCompleteSentences(text: string): string[] {
 /* File Panel Transitions */
 .slide-left-enter-active,
 .slide-left-leave-active {
-  transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+  transition: transform var(--duration-300) var(--ease-out), opacity var(--duration-300) var(--ease-out);
 }
 
 .slide-left-enter-from {

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -2280,11 +2280,11 @@ onMounted(async () => {
 
 /* Citation slide transition */
 .slide-fade-enter-active {
-  transition: all 0.2s ease-out;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .slide-fade-leave-active {
-  transition: all 0.15s ease-in;
+  transition: all var(--duration-150) var(--ease-in);
 }
 
 .slide-fade-enter-from,

--- a/autobot-frontend/src/components/chat/OverseerPlanMessage.vue
+++ b/autobot-frontend/src/components/chat/OverseerPlanMessage.vue
@@ -145,7 +145,7 @@ const getStepIcon = (step: { step_number: number }): string => {
 
 .step-preview {
   @apply flex items-center gap-3 px-3 py-2 rounded bg-autobot-bg-primary border border-autobot-border;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .step-preview.running {

--- a/autobot-frontend/src/components/chat/OverseerStepMessage.vue
+++ b/autobot-frontend/src/components/chat/OverseerStepMessage.vue
@@ -206,7 +206,7 @@ const formatDuration = (seconds: number): string => {
 @reference "../../assets/tailwind.css";
 .overseer-step {
   @apply bg-autobot-bg-secondary border border-autobot-border rounded-lg p-4 mb-4;
-  transition: all 0.3s ease;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .overseer-step.running,

--- a/autobot-frontend/src/components/chat/ReasoningTrace.vue
+++ b/autobot-frontend/src/components/chat/ReasoningTrace.vue
@@ -266,7 +266,7 @@ function formatDuration(ms: number): string {
 /* Collapse transition */
 .trace-collapse-enter-active,
 .trace-collapse-leave-active {
-  transition: max-height 0.2s ease, opacity 0.2s ease;
+  transition: max-height var(--duration-200) var(--ease-out), opacity var(--duration-200) var(--ease-out);
   max-height: 18rem;
   overflow: hidden;
 }

--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
@@ -401,7 +401,7 @@ onUnmounted(() => {
   color: var(--text-tertiary);
   cursor: pointer;
   border-radius: var(--radius-md);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .btn-close:hover {
@@ -426,7 +426,7 @@ onUnmounted(() => {
   padding: 32px;
   text-align: center;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -596,7 +596,7 @@ onMounted(() => {
 /* Panel slide transition */
 .slide-panel-enter-active,
 .slide-panel-leave-active {
-  transition: width 0.25s ease, opacity 0.25s ease;
+  transition: width var(--duration-250) var(--ease-out), opacity var(--duration-250) var(--ease-out);
 }
 
 .slide-panel-enter-from,

--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -426,7 +426,7 @@ onBeforeUnmount(() => {
   color: var(--text-secondary, #94a3b8);
   font-size: var(--text-xs);
   cursor: pointer;
-  transition: border-color 0.15s;
+  transition: border-color var(--duration-150);
 }
 
 .voice-overlay__mode-select:hover {
@@ -463,7 +463,7 @@ onBeforeUnmount(() => {
   height: 8px;
   border-radius: 50%;
   background: rgba(239, 68, 68, 0.6);
-  transition: background 0.2s;
+  transition: background var(--duration-200);
 }
 
 .voice-overlay__ws-indicator--connected {
@@ -478,7 +478,7 @@ onBeforeUnmount(() => {
   justify-content: center;
   border-radius: var(--radius-md);
   color: var(--text-muted, #64748b);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
   cursor: pointer;
   border: none;
   background: transparent;
@@ -705,7 +705,7 @@ onBeforeUnmount(() => {
   background: rgba(37, 99, 235, 0.1);
   color: #60a5fa;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
   box-shadow: 0 0 24px -4px rgba(37, 99, 235, 0.2);
 }
 
@@ -789,7 +789,7 @@ onBeforeUnmount(() => {
   height: 100%;
   border-radius: var(--radius-xs);
   background: linear-gradient(90deg, #60a5fa, #818cf8);
-  transition: width 0.1s ease-out;
+  transition: width var(--duration-100) var(--ease-out);
   min-width: 0;
 }
 
@@ -854,17 +854,17 @@ onBeforeUnmount(() => {
 
 /* Overlay enter/leave */
 .voice-overlay-enter-active {
-  transition: opacity 0.25s ease;
+  transition: opacity var(--duration-250) var(--ease-out);
 }
 .voice-overlay-enter-active .voice-overlay__panel {
-  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+  transition: transform var(--duration-300) cubic-bezier(0.16, 1, 0.3, 1),
               opacity 0.25s ease;
 }
 .voice-overlay-leave-active {
-  transition: opacity 0.2s ease;
+  transition: opacity var(--duration-200) var(--ease-out);
 }
 .voice-overlay-leave-active .voice-overlay__panel {
-  transition: transform 0.2s ease, opacity 0.15s ease;
+  transition: transform var(--duration-200) var(--ease-out), opacity var(--duration-150) var(--ease-out);
 }
 
 .voice-overlay-enter-from {
@@ -884,7 +884,7 @@ onBeforeUnmount(() => {
 
 /* Bubble enter */
 .bubble-enter-active {
-  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: all var(--duration-300) cubic-bezier(0.16, 1, 0.3, 1);
 }
 .bubble-enter-from {
   opacity: 0;
@@ -894,7 +894,7 @@ onBeforeUnmount(() => {
 /* Fade */
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.2s ease;
+  transition: opacity var(--duration-200) var(--ease-out);
 }
 .fade-enter-from,
 .fade-leave-to {

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -316,7 +316,7 @@ onBeforeUnmount(() => {
   height: 6px;
   border-radius: 50%;
   background: rgba(239, 68, 68, 0.6);
-  transition: background 0.2s;
+  transition: background var(--duration-200);
 }
 
 .voice-panel__ws-dot--connected {
@@ -337,7 +337,7 @@ onBeforeUnmount(() => {
   border-radius: 50%;
   border: 2px solid var(--border-subtle, rgba(148, 163, 184, 0.15));
   color: var(--text-muted, #64748b);
-  transition: all 0.3s ease;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .voice-panel__state-ring--listening {
@@ -426,7 +426,7 @@ onBeforeUnmount(() => {
   height: 100%;
   border-radius: 1.5px;
   background: linear-gradient(90deg, #60a5fa, #818cf8);
-  transition: width 0.1s ease-out;
+  transition: width var(--duration-100) var(--ease-out);
   min-width: 0;
 }
 
@@ -513,7 +513,7 @@ onBeforeUnmount(() => {
   background: rgba(37, 99, 235, 0.1);
   color: #60a5fa;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
   box-shadow: 0 0 16px -4px rgba(37, 99, 235, 0.2);
 }
 

--- a/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
+++ b/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
@@ -430,7 +430,7 @@ const roleOptions = computed(() => [
 /* Modal animations */
 .modal-backdrop-enter-active,
 .modal-backdrop-leave-active {
-  transition: opacity 0.3s ease;
+  transition: opacity var(--duration-300) var(--ease-out);
 }
 
 .modal-backdrop-enter-from,
@@ -439,11 +439,11 @@ const roleOptions = computed(() => [
 }
 
 .modal-content-enter-active {
-  transition: all 0.3s ease-out;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .modal-content-leave-active {
-  transition: all 0.2s ease-in;
+  transition: all var(--duration-200) var(--ease-in);
 }
 
 .modal-content-enter-from {

--- a/autobot-frontend/src/components/collaboration/ParticipantList.vue
+++ b/autobot-frontend/src/components/collaboration/ParticipantList.vue
@@ -363,11 +363,11 @@ watch(
 <style scoped>
 /* Participant animations */
 .participant-enter-active {
-  transition: all 0.3s ease-out;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .participant-leave-active {
-  transition: all 0.2s ease-in;
+  transition: all var(--duration-200) var(--ease-in);
 }
 
 .participant-enter-from {
@@ -381,7 +381,7 @@ watch(
 }
 
 .participant-move {
-  transition: transform 0.3s ease;
+  transition: transform var(--duration-300) var(--ease-out);
 }
 
 /* Custom scrollbar */

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -499,7 +499,7 @@ onUnmounted(() => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--duration-150) var(--ease-out);
 }
 
 .control-btn:hover {
@@ -540,7 +540,7 @@ onUnmounted(() => {
   border: 1px solid var(--color-primary-light);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--duration-150) var(--ease-out);
 }
 
 .action-btn:hover {
@@ -610,7 +610,7 @@ onUnmounted(() => {
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--duration-150) var(--ease-out);
 }
 
 .download-btn:hover {
@@ -624,7 +624,7 @@ onUnmounted(() => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--duration-150) var(--ease-out);
 }
 
 .cancel-btn:hover {
@@ -637,7 +637,7 @@ onUnmounted(() => {
   background: none;
   border: none;
   cursor: pointer;
-  transition: color 0.15s ease;
+  transition: color var(--duration-150) var(--ease-out);
 }
 
 .close-btn:hover {
@@ -683,7 +683,7 @@ onUnmounted(() => {
   background-color: var(--bg-secondary);
   color: var(--text-primary);
   resize: none;
-  transition: border-color 0.15s ease;
+  transition: border-color var(--duration-150) var(--ease-out);
 }
 
 .type-textarea:focus {
@@ -712,7 +712,7 @@ onUnmounted(() => {
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--duration-150) var(--ease-out);
 }
 
 .type-btn:hover {

--- a/autobot-frontend/src/components/documents/AIDocumentEditor.vue
+++ b/autobot-frontend/src/components/documents/AIDocumentEditor.vue
@@ -291,7 +291,7 @@ const formattedUpdatedAt = computed(() => {
   outline: none;
   padding: 2px 4px;
   border-radius: var(--radius-default);
-  transition: background 0.15s;
+  transition: background var(--duration-150);
 }
 .document-title:focus-visible {
   outline: 2px solid var(--color-primary);

--- a/autobot-frontend/src/components/examples/AsyncOperationExample.vue
+++ b/autobot-frontend/src/components/examples/AsyncOperationExample.vue
@@ -828,7 +828,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   font-weight: 500;
   border: none;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   margin-right: 8px;
 }
 
@@ -849,7 +849,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   font-weight: 500;
   border: none;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-secondary:hover {
@@ -950,7 +950,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   border: 1px solid var(--border-light);
   border-radius: var(--radius-md);
   font-size: var(--text-base);
-  transition: border-color 0.2s;
+  transition: border-color var(--duration-200);
 }
 
 .form-input:focus {
@@ -1172,7 +1172,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   padding: 20px;
   display: flex;
   gap: 16px;
-  transition: transform 0.2s;
+  transition: transform var(--duration-200);
 }
 
 .benefit-item:hover {

--- a/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
+++ b/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
@@ -370,7 +370,7 @@ const formatTime = (timestamp: number) => {
   border-radius: var(--radius-lg);
   cursor: pointer;
   color: var(--text-secondary);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .btn-refresh:hover:not(:disabled) {
@@ -564,7 +564,7 @@ const formatTime = (timestamp: number) => {
   padding: 8px;
   margin: -8px;
   border-radius: var(--radius-md);
-  transition: background 0.15s;
+  transition: background var(--duration-150);
 }
 
 .breakdown-item.clickable:hover {
@@ -602,7 +602,7 @@ code.item-label {
   height: 100%;
   background: var(--color-error);
   border-radius: var(--radius-default);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 
 .item-count {
@@ -644,7 +644,7 @@ code.item-label {
   background: var(--color-error);
   border-radius: var(--radius-default) 4px 0 0;
   min-height: 4px;
-  transition: height 0.3s ease;
+  transition: height var(--duration-300) var(--ease-out);
 }
 
 .day-label {

--- a/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
+++ b/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
@@ -318,7 +318,7 @@ const closeModal = () => {
   display: flex;
   align-items: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-add:hover {
@@ -388,7 +388,7 @@ const closeModal = () => {
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .override-item:hover {
@@ -462,7 +462,7 @@ const closeModal = () => {
   border-radius: var(--radius-lg);
   cursor: pointer;
   color: var(--text-secondary);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .action-btn:hover {
@@ -504,7 +504,7 @@ const closeModal = () => {
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
   font-family: var(--font-mono);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   background: var(--bg-input);
   color: var(--text-primary);
 }
@@ -544,7 +544,7 @@ const closeModal = () => {
   border: 2px solid var(--border-default);
   border-radius: var(--radius-xl);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .mode-selector .mode-option:hover {
@@ -655,7 +655,7 @@ const closeModal = () => {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-primary:hover {
@@ -676,7 +676,7 @@ const closeModal = () => {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-secondary:hover {

--- a/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.vue
+++ b/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.vue
@@ -175,7 +175,7 @@ const selectMode = (mode: EnforcementMode) => {
   border: 2px solid var(--border-default);
   border-radius: var(--radius-xl);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .mode-option:hover:not(.updating) {
@@ -294,7 +294,7 @@ const selectMode = (mode: EnforcementMode) => {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .mode-option.active .radio-outer {

--- a/autobot-frontend/src/components/file-browser/FileBrowser.vue
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.vue
@@ -608,7 +608,7 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-default);
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
 }
 
 .close-btn:hover {
@@ -722,7 +722,7 @@ onMounted(() => {
   border-radius: var(--radius-default);
   cursor: pointer;
   font-size: var(--text-base);
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
 }
 
 .download-btn:hover {

--- a/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
+++ b/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
@@ -527,7 +527,7 @@ onUnmounted(() => {
   gap: 0.75rem;
   padding: 0.75rem;
   border-radius: var(--radius-md);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .change-item:hover {

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -573,7 +573,7 @@ onMounted(() => {
   flex-direction: column;
   justify-content: space-between;
   min-height: 200px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .action-card:hover {
@@ -696,7 +696,7 @@ onMounted(() => {
 .progress-fill {
   height: 100%;
   background: var(--color-primary);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 
 .progress-stats {

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -1148,7 +1148,7 @@ watch(() => props.mode, () => {
 
 .category-tab {
   white-space: nowrap;
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-250) var(--ease-in-out);
   position: relative;
 }
 
@@ -1158,7 +1158,7 @@ watch(() => props.mode, () => {
 
 .category-tab-icon {
   margin-right: 0.25rem;
-  transition: transform 0.2s ease;
+  transition: transform var(--duration-200) var(--ease-out);
 }
 
 .category-tab:hover .category-tab-icon {
@@ -1166,7 +1166,7 @@ watch(() => props.mode, () => {
 }
 
 .category-tab-label {
-  transition: color 0.2s ease;
+  transition: color var(--duration-200) var(--ease-out);
 }
 
 .category-count {
@@ -1181,7 +1181,7 @@ watch(() => props.mode, () => {
   font-size: var(--text-xs);
   font-weight: 600;
   margin-left: 0.375rem;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .category-count-active {
@@ -1220,7 +1220,7 @@ watch(() => props.mode, () => {
   border-radius: 50%;
   color: var(--text-tertiary);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .clear-filter-btn:hover {
@@ -1231,7 +1231,7 @@ watch(() => props.mode, () => {
 /* Category tab transitions */
 .category-tab-enter-active,
 .category-tab-leave-active {
-  transition: all 0.3s ease;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .category-tab-enter-from {
@@ -1245,13 +1245,13 @@ watch(() => props.mode, () => {
 }
 
 .category-tab-move {
-  transition: transform 0.3s ease;
+  transition: transform var(--duration-300) var(--ease-out);
 }
 
 /* Fade transition for filter badge */
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition: opacity var(--duration-200) var(--ease-out), transform var(--duration-200) var(--ease-out);
 }
 
 .fade-enter-from,
@@ -1323,7 +1323,7 @@ watch(() => props.mode, () => {
 
 .slide-down-enter-active,
 .slide-down-leave-active {
-  transition: all 0.3s ease;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .slide-down-enter-from,
@@ -1354,7 +1354,7 @@ watch(() => props.mode, () => {
   border: 1px solid var(--border-light);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .search-input:focus {

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -421,7 +421,7 @@ onUnmounted(() => {
   border-radius: var(--radius-2xl);
   padding: 2rem;
   cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-300) var(--ease-in-out);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -443,7 +443,7 @@ onUnmounted(() => {
   color: var(--text-secondary);
   cursor: pointer;
   opacity: 0;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -468,7 +468,7 @@ onUnmounted(() => {
   height: 4px;
   background: var(--card-color, var(--border-default));
   opacity: 0;
-  transition: opacity 0.3s;
+  transition: opacity var(--duration-300);
 }
 
 .main-category-card:hover {
@@ -490,7 +490,7 @@ onUnmounted(() => {
   color: var(--text-on-primary);
   font-size: 2.5rem;
   margin-bottom: 1.5rem;
-  transition: all 0.3s;
+  transition: all var(--duration-300);
 }
 
 .main-category-card:hover .category-icon-large {
@@ -550,7 +550,7 @@ onUnmounted(() => {
   margin-top: 1.5rem;
   color: var(--color-info);
   font-size: var(--text-2xl);
-  transition: transform 0.3s;
+  transition: transform var(--duration-300);
 }
 
 .main-category-card:hover .browse-arrow {
@@ -627,7 +627,7 @@ onUnmounted(() => {
   color: var(--text-secondary);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   border-bottom: 2px solid transparent;
   margin-bottom: -2px;
 }
@@ -677,7 +677,7 @@ onUnmounted(() => {
   text-decoration: none;
   border-radius: var(--radius-lg);
   font-weight: 500;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .manage-btn:hover {
@@ -701,7 +701,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 1rem;
   box-shadow: var(--shadow-sm);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .stat-card:hover {
@@ -755,7 +755,7 @@ onUnmounted(() => {
   gap: 1rem;
   cursor: pointer;
   border: 2px solid var(--border-default);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .category-browse-card:hover {
@@ -795,7 +795,7 @@ onUnmounted(() => {
 .category-browse-card .browse-arrow {
   color: var(--color-info);
   font-size: var(--text-xl);
-  transition: transform 0.2s;
+  transition: transform var(--duration-200);
 }
 
 .category-browse-card:hover .browse-arrow {
@@ -860,7 +860,7 @@ onUnmounted(() => {
   border-radius: var(--radius-md);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1000,7 +1000,7 @@ onUnmounted(() => {
   border-radius: var(--radius-md);
   font-weight: 500;
   cursor: pointer;
-  transition: opacity 0.2s;
+  transition: opacity var(--duration-200);
 }
 
 .retry-btn:hover {
@@ -1019,7 +1019,7 @@ onUnmounted(() => {
   border-radius: var(--radius-lg);
   padding: 1.5rem;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .category-card:hover {
@@ -1134,7 +1134,7 @@ onUnmounted(() => {
   border-radius: var(--radius-md);
   cursor: pointer;
   position: relative;
-  transition: transform 0.2s;
+  transition: transform var(--duration-200);
 }
 
 .color-option:hover {
@@ -1192,7 +1192,7 @@ onUnmounted(() => {
   border-radius: var(--radius-md);
   margin-bottom: 0.5rem;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .document-item:hover {
@@ -1232,7 +1232,7 @@ onUnmounted(() => {
   border-radius: var(--radius-md);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -1308,7 +1308,7 @@ onUnmounted(() => {
   border-radius: var(--radius-lg);
   padding: 1.25rem;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .document-card:hover {
@@ -1473,7 +1473,7 @@ onUnmounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: flex;
   align-items: center;
 }
@@ -1513,7 +1513,7 @@ onUnmounted(() => {
   border-radius: var(--radius-lg);
   padding: 1rem;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: flex;
   gap: 1rem;
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -977,7 +977,7 @@ watch([debouncedSearchQuery, filterCategory, filterType], () => {
   color: var(--text-primary);
   font-family: var(--font-sans);
   font-size: var(--text-sm);
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
 }
 
 .search-input:focus {
@@ -1022,7 +1022,7 @@ watch([debouncedSearchQuery, filterCategory, filterType], () => {
   font-family: var(--font-sans);
   background: var(--bg-card);
   color: var(--text-primary);
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
 }
 
 .filter-select:focus {

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -1372,7 +1372,7 @@ watch(layoutMode, () => {
 /* Slide down transition */
 .slide-down-enter-active,
 .slide-down-leave-active {
-  transition: all var(--duration-300) ease;
+  transition: all var(--duration-300) var(--ease-out);
   overflow: hidden;
 }
 
@@ -1959,7 +1959,7 @@ watch(layoutMode, () => {
 /* Transitions */
 .slide-enter-active,
 .slide-leave-active {
-  transition: all var(--duration-300) ease;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .slide-enter-from,

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraphView.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraphView.vue
@@ -228,7 +228,7 @@ function navigateTo(path: string): void {
   text-decoration: none;
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .nav-item:hover {
@@ -261,7 +261,7 @@ function navigateTo(path: string): void {
   color: var(--text-tertiary);
   text-decoration: none;
   font-size: var(--text-sm);
-  transition: color 0.15s;
+  transition: color var(--duration-150);
 }
 
 .back-link:hover {

--- a/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
@@ -550,7 +550,7 @@ onMounted(() => {
 .dimension-fill {
   height: 100%;
   border-radius: var(--radius-full);
-  transition: width 0.5s ease;
+  transition: width var(--duration-500) var(--ease-out);
 }
 
 .dimension-fill.good {

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -673,7 +673,7 @@ onBeforeUnmount(() => {
   padding: 0.625rem 0.75rem;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .prompt-item:hover {
@@ -872,7 +872,7 @@ onBeforeUnmount(() => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .history-item:hover {

--- a/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
@@ -181,7 +181,7 @@ const handleGroupChange = () => {
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
   cursor: pointer;
-  transition: border-color 0.2s;
+  transition: border-color var(--duration-200);
   background-color: var(--bg-secondary);
   color: var(--text-primary);
 }
@@ -255,7 +255,7 @@ const handleGroupChange = () => {
   padding: 0.5rem;
   border-radius: var(--radius-default);
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
 }
 
 .group-item:hover {

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
@@ -670,7 +670,7 @@ onMounted(() => {
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--duration-150);
 }
 
 .category-header:hover {
@@ -744,7 +744,7 @@ onMounted(() => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .doc-item:hover {

--- a/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
@@ -1570,7 +1570,7 @@ onMounted(() => {
 .progress-fill {
   height: 100%;
   background: var(--color-primary);
-  transition: width var(--duration-300) ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 
 .progress-status {
@@ -1581,7 +1581,7 @@ onMounted(() => {
 /* Transitions */
 .slide-enter-active,
 .slide-leave-active {
-  transition: all var(--duration-200) ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .slide-enter-from,

--- a/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
@@ -522,7 +522,7 @@ onMounted(() => {
   font-weight: 500;
   font-family: var(--font-sans);
   cursor: pointer;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
 }
 
 .mode-btn:hover:not(:disabled) {
@@ -632,7 +632,7 @@ onMounted(() => {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-default);
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
 }
 
 .source-card:hover {

--- a/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
@@ -425,7 +425,7 @@ const cleanupSessionOrphans = async () => {
   flex-direction: column;
   justify-content: space-between;
   min-height: 200px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .action-card:hover {

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -413,7 +413,7 @@ const closeDialog = () => {
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-default);
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
 }
 
 .close-button:hover {
@@ -499,7 +499,7 @@ const closeDialog = () => {
   align-items: center;
   gap: 0.75rem;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
 }
 
 .search-result-item:hover {
@@ -598,7 +598,7 @@ const closeDialog = () => {
   cursor: pointer;
   color: #ef4444;
   border-radius: var(--radius-default);
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
 }
 
 .remove-button:hover {
@@ -618,7 +618,7 @@ const closeDialog = () => {
   border-radius: var(--radius-md);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
+++ b/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
@@ -254,7 +254,7 @@ const allCompleted = computed(() => {
   border-radius: var(--radius-md);
   color: var(--text-tertiary);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .close-btn:hover {
@@ -329,7 +329,7 @@ const allCompleted = computed(() => {
 .progress-fill {
   height: 100%;
   background: var(--color-primary);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
   border-radius: var(--radius-xl);
 }
 
@@ -358,7 +358,7 @@ const allCompleted = computed(() => {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .document-item:hover {
@@ -452,7 +452,7 @@ const allCompleted = computed(() => {
 .mini-progress-fill {
   height: 100%;
   background: var(--color-primary);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
   border-radius: var(--radius-default);
 }
 
@@ -481,7 +481,7 @@ const allCompleted = computed(() => {
   border-radius: var(--radius-lg);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   border: none;
   font-size: var(--text-sm);
 }
@@ -541,12 +541,12 @@ const allCompleted = computed(() => {
 /* Modal animations */
 .modal-fade-enter-active,
 .modal-fade-leave-active {
-  transition: opacity 0.3s ease;
+  transition: opacity var(--duration-300) var(--ease-out);
 }
 
 .modal-fade-enter-active .modal-container,
 .modal-fade-leave-active .modal-container {
-  transition: transform 0.3s ease, opacity 0.3s ease;
+  transition: transform var(--duration-300) var(--ease-out), opacity var(--duration-300) var(--ease-out);
 }
 
 .modal-fade-enter-from,

--- a/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
+++ b/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
@@ -803,7 +803,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   min-width: 120px;
   outline: none;
-  transition: border-color 0.15s;
+  transition: border-color var(--duration-150);
 }
 
 .field-select:focus,
@@ -827,7 +827,7 @@ onMounted(() => {
   border-radius: var(--radius-xl);
   border: none;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
   outline: none;
 }
 
@@ -855,7 +855,7 @@ onMounted(() => {
   height: 20px;
   border-radius: 50%;
   background: #ffffff;
-  transition: transform 0.2s;
+  transition: transform var(--duration-200);
   box-shadow: var(--shadow-sm);
 }
 
@@ -936,7 +936,7 @@ onMounted(() => {
   font-weight: 500;
   cursor: pointer;
   border: 1px solid transparent;
-  transition: opacity 0.15s, background-color 0.15s;
+  transition: opacity var(--duration-150), background-color var(--duration-150);
   outline: none;
 }
 

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
@@ -760,7 +760,7 @@ function closeModal() {
   border: 1px solid var(--border-default);
   background: var(--bg-secondary);
   color: var(--text-tertiary);
-  transition: all 150ms ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .step-dot.active {
@@ -804,7 +804,7 @@ function closeModal() {
   border-radius: var(--radius-default);
   background: var(--bg-secondary);
   cursor: pointer;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
   text-align: center;
 }
 
@@ -863,7 +863,7 @@ function closeModal() {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xs);
-  transition: border-color 150ms ease;
+  transition: border-color var(--duration-150) var(--ease-out);
 }
 
 .form-input:focus,
@@ -918,7 +918,7 @@ function closeModal() {
   color: var(--text-secondary);
   background: var(--bg-secondary);
   cursor: pointer;
-  transition: all 150ms ease;
+  transition: all var(--duration-150) var(--ease-out);
   font-family: var(--font-sans);
 }
 
@@ -961,7 +961,7 @@ function closeModal() {
   font-weight: 500;
   font-family: var(--font-sans);
   cursor: pointer;
-  transition: all 150ms ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .mode-btn:hover {

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
@@ -262,7 +262,7 @@ defineExpose({ resetSyncing })
   background: var(--bg-card);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-default);
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
   contain: layout style;}
 
 .connector-card:hover {

--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -515,7 +515,7 @@ function selectIcon(icon: string): void {
   font-size: var(--text-sm);
   background: var(--bg-input);
   color: var(--text-primary);
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color var(--duration-200), box-shadow var(--duration-200);
 }
 
 .form-input:focus,
@@ -559,7 +559,7 @@ function selectIcon(icon: string): void {
   background: var(--bg-card);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   font-size: var(--text-base);
 }
 
@@ -592,7 +592,7 @@ function selectIcon(icon: string): void {
   border-radius: var(--radius-md);
   border: 2px solid transparent;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   position: relative;
 }
 

--- a/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
@@ -349,7 +349,7 @@ watch(() => props.modelValue, (isOpen) => {
   border: 2px solid var(--border-default);
   border-radius: var(--radius-lg);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .format-option:hover {

--- a/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
+++ b/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
@@ -305,7 +305,7 @@ onUnmounted(() => {
   width: 4px;
   cursor: ew-resize;
   background: transparent;
-  transition: background 0.15s;
+  transition: background var(--duration-150);
   z-index: 10;
 }
 
@@ -380,7 +380,7 @@ onUnmounted(() => {
   color: var(--text-secondary);
   cursor: pointer;
   border-radius: var(--radius-md);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
   flex-shrink: 0;
 }
 
@@ -477,12 +477,12 @@ onUnmounted(() => {
 /* Transition */
 .panel-enter-active,
 .panel-leave-active {
-  transition: opacity 0.2s ease;
+  transition: opacity var(--duration-200) var(--ease-out);
 }
 
 .panel-enter-active .source-preview-panel,
 .panel-leave-active .source-preview-panel {
-  transition: transform 0.2s ease;
+  transition: transform var(--duration-200) var(--ease-out);
 }
 
 .panel-enter-from,

--- a/autobot-frontend/src/components/layout/LanguageSwitcher.vue
+++ b/autobot-frontend/src/components/layout/LanguageSwitcher.vue
@@ -136,7 +136,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
   background-color: rgba(255, 255, 255, 0.1);
   color: white;
   font-size: var(--text-lg);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
   cursor: pointer;
 }
 
@@ -173,7 +173,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
   cursor: pointer;
   font-size: var(--font-size-sm);
   color: var(--text-primary);
-  transition: background 0.15s;
+  transition: background var(--duration-150);
 }
 
 .lang-option:hover {
@@ -228,7 +228,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
 /* Dropdown transition */
 .lang-dropdown-enter-active,
 .lang-dropdown-leave-active {
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition: opacity var(--duration-150) var(--ease-out), transform var(--duration-150) var(--ease-out);
 }
 
 .lang-dropdown-enter-from,

--- a/autobot-frontend/src/components/operations/OperationDetail.vue
+++ b/autobot-frontend/src/components/operations/OperationDetail.vue
@@ -453,7 +453,7 @@ async function copyId() {
   font-weight: 500;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .action-btn:disabled {

--- a/autobot-frontend/src/components/operations/OperationFilters.vue
+++ b/autobot-frontend/src/components/operations/OperationFilters.vue
@@ -205,7 +205,7 @@ function clearFilters() {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .clear-filters-btn:hover:not(:disabled) {

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -386,7 +386,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-default);
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
 }
 
 .close-button:hover {
@@ -413,7 +413,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   cursor: pointer;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color var(--duration-150), border-color var(--duration-150);
 }
 
 .tab-btn:hover {
@@ -511,7 +511,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   color: var(--text-primary);
   cursor: pointer;
   font-size: var(--text-sm);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .option-btn:hover {
@@ -556,7 +556,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: opacity 0.15s;
+  transition: opacity var(--duration-150);
 }
 
 .save-btn:hover {

--- a/autobot-frontend/src/components/research/CaptchaNotification.vue
+++ b/autobot-frontend/src/components/research/CaptchaNotification.vue
@@ -460,7 +460,7 @@ watch(activeCaptcha, (newVal) => {
 .timeout-bar {
   height: 100%;
   background: var(--color-info);
-  transition: width 1s linear;
+  transition: width var(--duration-1000) linear;
 }
 
 .timeout-bar.bar-warning {

--- a/autobot-frontend/src/components/secrets/SecretAuditLog.vue
+++ b/autobot-frontend/src/components/secrets/SecretAuditLog.vue
@@ -380,11 +380,11 @@ const prevPage = async () => {
 
 <style scoped>
 .audit-enter-active {
-  transition: all 0.3s ease-out;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .audit-leave-active {
-  transition: all 0.2s ease-in;
+  transition: all var(--duration-200) var(--ease-in);
 }
 
 .audit-enter-from {
@@ -398,7 +398,7 @@ const prevPage = async () => {
 }
 
 .audit-move {
-  transition: transform 0.3s ease;
+  transition: transform var(--duration-300) var(--ease-out);
 }
 
 .custom-scrollbar::-webkit-scrollbar {

--- a/autobot-frontend/src/components/secrets/SecretVault.vue
+++ b/autobot-frontend/src/components/secrets/SecretVault.vue
@@ -443,11 +443,11 @@ onMounted(() => {
 <style scoped>
 /* Secret animations */
 .secret-enter-active {
-  transition: all 0.3s ease-out;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .secret-leave-active {
-  transition: all 0.2s ease-in;
+  transition: all var(--duration-200) var(--ease-in);
 }
 
 .secret-enter-from {
@@ -461,7 +461,7 @@ onMounted(() => {
 }
 
 .secret-move {
-  transition: transform 0.3s ease;
+  transition: transform var(--duration-300) var(--ease-out);
 }
 
 /* Custom scrollbar */

--- a/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
+++ b/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
@@ -197,7 +197,7 @@ const getInitials = (username: string): string => {
 <style scoped>
 .modal-backdrop-enter-active,
 .modal-backdrop-leave-active {
-  transition: opacity 0.3s ease;
+  transition: opacity var(--duration-300) var(--ease-out);
 }
 
 .modal-backdrop-enter-from,
@@ -206,11 +206,11 @@ const getInitials = (username: string): string => {
 }
 
 .modal-content-enter-active {
-  transition: all 0.3s ease-out;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .modal-content-leave-active {
-  transition: all 0.2s ease-in;
+  transition: all var(--duration-200) var(--ease-in);
 }
 
 .modal-content-enter-from {

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -1665,7 +1665,7 @@ watch(selectedScope, () => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   background: var(--bg-input);
   color: var(--text-primary);
 }
@@ -1711,7 +1711,7 @@ watch(selectedScope, () => {
   gap: 12px;
   padding: 10px 20px;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
   color: var(--text-secondary);
 }
 
@@ -1776,7 +1776,7 @@ watch(selectedScope, () => {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-create:hover {
@@ -1829,7 +1829,7 @@ watch(selectedScope, () => {
   border-radius: var(--radius-lg);
   cursor: pointer;
   color: var(--text-secondary);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .btn-icon:hover {
@@ -1920,7 +1920,7 @@ watch(selectedScope, () => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .credential-card:hover {
@@ -2108,7 +2108,7 @@ watch(selectedScope, () => {
   flex-direction: column;
   gap: 4px;
   opacity: 0;
-  transition: opacity 0.15s;
+  transition: opacity var(--duration-150);
 }
 
 .credential-card:hover .card-actions {
@@ -2126,7 +2126,7 @@ watch(selectedScope, () => {
   border-radius: var(--radius-md);
   cursor: pointer;
   color: var(--text-secondary);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .action-btn:hover {
@@ -2179,7 +2179,7 @@ watch(selectedScope, () => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .template-card:hover {
@@ -2240,7 +2240,7 @@ watch(selectedScope, () => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .type-option:hover {
@@ -2343,7 +2343,7 @@ watch(selectedScope, () => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   background: var(--bg-input);
   color: var(--text-primary);
 }
@@ -2405,7 +2405,7 @@ watch(selectedScope, () => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .scope-option:hover {
@@ -2642,7 +2642,7 @@ watch(selectedScope, () => {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-primary:hover {
@@ -2663,7 +2663,7 @@ watch(selectedScope, () => {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-secondary:hover {
@@ -2683,7 +2683,7 @@ watch(selectedScope, () => {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-danger:hover {
@@ -2711,7 +2711,7 @@ watch(selectedScope, () => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
   user-select: none;
 }
 

--- a/autobot-frontend/src/components/services/RedisServiceControl.vue
+++ b/autobot-frontend/src/components/services/RedisServiceControl.vue
@@ -427,7 +427,7 @@ const getHealthCheckCardClass = (status) => {
 }
 
 .health-check-card {
-  transition: transform 0.2s;
+  transition: transform var(--duration-200);
 }
 
 .health-check-card:hover {

--- a/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
+++ b/autobot-frontend/src/components/settings/ApiKeySetupWizard.vue
@@ -314,7 +314,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
   align-items: center;
   gap: var(--spacing-xs, 4px);
   opacity: 0.5;
-  transition: opacity 0.2s;
+  transition: opacity var(--duration-200);
 }
 
 .step-dot.active,
@@ -372,7 +372,7 @@ async function saveKeys(keys: KeyEntry[]): Promise<void> {
   border: 1px solid var(--color-border, #333);
   border-radius: var(--radius-md, 8px);
   cursor: pointer;
-  transition: border-color 0.2s;
+  transition: border-color var(--duration-200);
 }
 
 .role-card:hover {

--- a/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
@@ -332,7 +332,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: opacity 0.2s;
+  transition: opacity var(--duration-200);
 }
 
 .retry-btn:hover {

--- a/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
@@ -265,7 +265,7 @@ async function handleDelete(voiceId: string, name: string) {
   padding: var(--spacing-sm, 8px) var(--spacing-md, 12px);
   border-radius: var(--radius-md, 6px);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--duration-150);
   border: 1px solid transparent;
 }
 
@@ -341,7 +341,7 @@ async function handleDelete(voiceId: string, name: string) {
   border-radius: var(--radius-md, 6px);
   cursor: pointer;
   font-size: var(--text-sm, 14px);
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .add-voice-btn:hover {

--- a/autobot-frontend/src/components/settings/WebResearchSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/WebResearchSettingsPanel.vue
@@ -343,7 +343,7 @@ function clamp(value: number, min: number, max: number): number {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-color);
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: background var(--duration-200) var(--ease-out), border-color var(--duration-200) var(--ease-out);
   flex-shrink: 0;
 }
 
@@ -360,7 +360,7 @@ function clamp(value: number, min: number, max: number): number {
   height: 18px;
   border-radius: 50%;
   background: white;
-  transition: transform 0.2s ease;
+  transition: transform var(--duration-200) var(--ease-out);
   pointer-events: none;
 }
 

--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
@@ -388,7 +388,7 @@ function resetEdit(): void {
   height: 100%;
   background: var(--color-info, #3b82f6);
   border-radius: var(--radius-full);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 
 /* Step Detail */
@@ -468,7 +468,7 @@ function resetEdit(): void {
   text-transform: none;
   letter-spacing: 0;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color var(--duration-150), border-color var(--duration-150);
 }
 
 .edit-trigger:hover {
@@ -541,7 +541,7 @@ function resetEdit(): void {
   font-weight: var(--font-medium, 500);
   cursor: pointer;
   border: 1px solid transparent;
-  transition: background 0.15s, color 0.15s;
+  transition: background var(--duration-150), color var(--duration-150);
 }
 
 .edit-action-cancel {

--- a/autobot-frontend/src/components/terminal/CompletionSuggestions.vue
+++ b/autobot-frontend/src/components/terminal/CompletionSuggestions.vue
@@ -75,7 +75,7 @@ const typeIcon = (type: string): string => {
   padding: 4px 12px;
   cursor: pointer;
   gap: 8px;
-  transition: background-color 0.1s;
+  transition: background-color var(--duration-100);
 }
 
 .completion-item:hover,

--- a/autobot-frontend/src/components/terminal/SSHTerminal.vue
+++ b/autobot-frontend/src/components/terminal/SSHTerminal.vue
@@ -371,7 +371,7 @@ defineExpose({
   color: inherit;
   font-size: var(--text-xs);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .reconnect-btn:hover {

--- a/autobot-frontend/src/components/terminal/TerminalSettings.vue
+++ b/autobot-frontend/src/components/terminal/TerminalSettings.vue
@@ -268,7 +268,7 @@ input[type='range']::-webkit-slider-thumb {
   border-radius: 50%;
   background: var(--color-primary);
   cursor: pointer;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--duration-150) var(--ease-out);
 }
 
 input[type='range']::-webkit-slider-thumb:hover {
@@ -283,7 +283,7 @@ input[type='range']::-moz-range-thumb {
   background: var(--color-primary);
   cursor: pointer;
   border: none;
-  transition: background-color 0.15s ease;
+  transition: background-color var(--duration-150) var(--ease-out);
 }
 
 input[type='range']::-moz-range-thumb:hover {

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -1531,7 +1531,7 @@ export default {
   border-radius: var(--radius-default);
   cursor: pointer;
   font-size: var(--text-xs);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .control-button:hover:not(:disabled) {
@@ -1706,7 +1706,7 @@ export default {
   border-radius: var(--radius-default);
   cursor: pointer;
   font-size: var(--text-xs);
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
 }
 
 .footer-button:hover {
@@ -1766,7 +1766,7 @@ export default {
   border-radius: var(--radius-default);
   cursor: pointer;
   font-size: var(--text-sm);
-  transition: background-color 0.2s;
+  transition: background-color var(--duration-200);
 }
 
 .btn-primary {

--- a/autobot-frontend/src/components/ui/BaseAlert.vue
+++ b/autobot-frontend/src/components/ui/BaseAlert.vue
@@ -123,7 +123,7 @@ onMounted(() => {
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
   line-height: 1.25rem;
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
 }
 
 .alert-icon {
@@ -156,7 +156,7 @@ onMounted(() => {
 .alert-dismiss {
   padding: 0.25rem;
   border-radius: var(--radius-default);
-  transition: background-color 0.2s ease;
+  transition: background-color var(--duration-200) var(--ease-out);
   background: transparent;
   border: none;
   cursor: pointer;

--- a/autobot-frontend/src/components/ui/DarkModeToggle.vue
+++ b/autobot-frontend/src/components/ui/DarkModeToggle.vue
@@ -44,7 +44,7 @@ function toggleDarkMode() {
   background-color: var(--bg-hover);
   color: var(--text-primary);
   font-size: var(--text-lg);
-  transition: all 0.2s ease;
+  transition: all var(--duration-200) var(--ease-out);
   cursor: pointer;
 }
 
@@ -66,7 +66,7 @@ function toggleDarkMode() {
 /* Icon transition animation */
 .icon-fade-enter-active,
 .icon-fade-leave-active {
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition: opacity var(--duration-150) var(--ease-out), transform var(--duration-150) var(--ease-out);
 }
 
 .icon-fade-enter-from {

--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -357,7 +357,7 @@ const formatCell = (value: any, column: Column) => {
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   cursor: pointer;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
 }
 
 .pagination-btn:hover:not(:disabled) {

--- a/autobot-frontend/src/components/ui/HostSelector.vue
+++ b/autobot-frontend/src/components/ui/HostSelector.vue
@@ -329,7 +329,7 @@ defineExpose({
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .host-selector-collapsed:hover {
@@ -385,7 +385,7 @@ defineExpose({
 .expand-icon {
   color: var(--text-muted);
   font-size: var(--text-xs);
-  transition: transform 0.2s;
+  transition: transform var(--duration-200);
 }
 
 .host-selector-collapsed:hover .expand-icon {
@@ -448,7 +448,7 @@ defineExpose({
   font-size: var(--text-xs);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .filter-btn:hover {
@@ -474,7 +474,7 @@ defineExpose({
   padding: 10px 12px;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .host-item:hover {
@@ -585,7 +585,7 @@ defineExpose({
   align-items: center;
   justify-content: center;
   gap: 6px;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .btn-secondary {

--- a/autobot-frontend/src/components/ui/StableLoadingState.vue
+++ b/autobot-frontend/src/components/ui/StableLoadingState.vue
@@ -80,7 +80,7 @@ const placeholderStyle = computed(() => {
 @reference "../../assets/tailwind.css";
 .stable-loading-container {
   @apply relative w-full;
-  transition: all 0.2s ease-in-out;
+  transition: all var(--duration-200) var(--ease-in-out);
 }
 
 /* Preserve minimum height to prevent layout shifts */
@@ -136,7 +136,7 @@ const placeholderStyle = computed(() => {
 /* Content Area - stable positioning */
 .content-area {
   @apply w-full;
-  transition: opacity 0.15s ease-in-out;
+  transition: opacity var(--duration-150) var(--ease-in-out);
 }
 
 .content-loading {
@@ -179,7 +179,7 @@ const placeholderStyle = computed(() => {
 
 /* Instant transitions for better responsiveness */
 .stable-loading-container * {
-  transition: opacity 0.05s ease-in-out;
+  transition: opacity 0.05s var(--ease-in-out);
 }
 
 /* Prevent layout shifts during loading */

--- a/autobot-frontend/src/components/ui/ThemeToggle.vue
+++ b/autobot-frontend/src/components/ui/ThemeToggle.vue
@@ -171,7 +171,7 @@ function getThemeIcon(themeOption: Theme): string {
   font-size: var(--text-sm);
   padding: var(--spacing-2) var(--spacing-8) var(--spacing-2) var(--spacing-3);
   cursor: pointer;
-  transition: border-color var(--duration-150) ease,
+  transition: border-color var(--duration-150) var(--ease-out),
               box-shadow var(--duration-150) ease;
 }
 
@@ -218,7 +218,7 @@ function getThemeIcon(themeOption: Theme): string {
   color: var(--text-secondary);
   font-size: var(--text-sm);
   cursor: pointer;
-  transition: all var(--duration-150) ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .theme-toggle__btn:hover {
@@ -244,7 +244,7 @@ function getThemeIcon(themeOption: Theme): string {
   color: var(--text-primary);
   font-size: var(--text-sm);
   cursor: pointer;
-  transition: all var(--duration-150) ease;
+  transition: all var(--duration-150) var(--ease-out);
 }
 
 .theme-toggle__simple:hover {

--- a/autobot-frontend/src/components/ui/UnifiedLoadingView.vue
+++ b/autobot-frontend/src/components/ui/UnifiedLoadingView.vue
@@ -192,7 +192,7 @@ const cancelLoading = () => {
   @apply relative h-full flex flex-col;
   /* CRITICAL FIX: Remove w-full to allow parent to control width */
   /* CRITICAL FIX: Add flex flex-col to ensure children fill height */
-  transition: opacity 0.2s ease;
+  transition: opacity var(--duration-200) var(--ease-out);
 }
 
 .content-container.loading-overlay {

--- a/autobot-frontend/src/components/vision/GUIAutomationControls.vue
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.vue
@@ -356,7 +356,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-refresh:hover:not(:disabled) {
@@ -401,7 +401,7 @@ onMounted(() => {
   border-radius: var(--radius-xl);
   padding: 16px;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .opportunity-card:hover {
@@ -491,7 +491,7 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   gap: 6px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-execute {
@@ -565,7 +565,7 @@ onMounted(() => {
   align-items: center;
   padding: 16px 20px;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background var(--duration-200);
 }
 
 .reference-header:hover {

--- a/autobot-frontend/src/components/vision/MediaGallery.vue
+++ b/autobot-frontend/src/components/vision/MediaGallery.vue
@@ -358,7 +358,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-clear-all:hover:not(:disabled) {
@@ -384,7 +384,7 @@ onUnmounted(() => {
   border-radius: var(--radius-xl);
   overflow: hidden;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .gallery-item:hover {
@@ -462,7 +462,7 @@ onUnmounted(() => {
   border-radius: var(--radius-md);
   color: var(--text-tertiary);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .btn-action:hover {

--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
@@ -424,7 +424,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-capture:hover:not(:disabled) {
@@ -461,7 +461,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-xl);
   position: relative;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .toggle-switch::after {
@@ -473,7 +473,7 @@ onUnmounted(() => {
   height: 16px;
   background: var(--text-tertiary);
   border-radius: 50%;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .toggle-label input:checked + .toggle-switch {
@@ -604,7 +604,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .element-item:hover {

--- a/autobot-frontend/src/components/vision/VideoProcessor.vue
+++ b/autobot-frontend/src/components/vision/VideoProcessor.vue
@@ -541,7 +541,7 @@ onUnmounted(() => {
   padding: 40px;
   text-align: center;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   min-height: 200px;
   display: flex;
   align-items: center;
@@ -714,7 +714,7 @@ onUnmounted(() => {
 .progress-fill {
   height: 100%;
   background: var(--color-primary);
-  transition: width 0.3s;
+  transition: width var(--duration-300);
 }
 
 .progress-info {
@@ -769,7 +769,7 @@ onUnmounted(() => {
   border-radius: var(--radius-lg);
   padding: 12px;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--duration-150);
 }
 
 .frame-card:hover {

--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
@@ -1400,7 +1400,7 @@ watch(() => currentView.value, () => {
 
 /* Connections */
 .connection path {
-  transition: stroke-width 0.2s, opacity 0.2s;
+  transition: stroke-width var(--duration-200), opacity var(--duration-200);
 }
 
 .connection.highlighted path {
@@ -1423,7 +1423,7 @@ watch(() => currentView.value, () => {
 /* Components */
 .component {
   cursor: pointer;
-  transition: transform 0.2s, opacity 0.2s;
+  transition: transform var(--duration-200), opacity var(--duration-200);
 }
 
 .component:hover {
@@ -1718,7 +1718,7 @@ watch(() => currentView.value, () => {
   border-radius: var(--radius-md);
   margin-bottom: var(--spacing-2);
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background var(--duration-200);
 }
 
 .connections-list li:hover {

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
@@ -658,7 +658,7 @@ defineExpose({
   border-radius: var(--radius-md);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .layout-btn:hover,
@@ -691,7 +691,7 @@ defineExpose({
   fill: none;
   stroke: var(--text-muted);
   stroke-width: 2;
-  transition: stroke 0.3s;
+  transition: stroke var(--duration-300);
 }
 
 .connection-line.active {
@@ -722,7 +722,7 @@ defineExpose({
   fill: var(--bg-secondary);
   stroke: var(--text-muted);
   stroke-width: 2;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .workflow-node:hover .node-bg {
@@ -824,7 +824,7 @@ defineExpose({
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .zoom-controls button:hover {
@@ -855,7 +855,7 @@ defineExpose({
 .progress-fill {
   height: 100%;
   background: var(--chart-blue);
-  transition: width 0.3s ease;
+  transition: width var(--duration-300) var(--ease-out);
 }
 
 .progress-text {
@@ -937,7 +937,7 @@ defineExpose({
   color: var(--text-tertiary);
   cursor: pointer;
   border-radius: var(--radius-default);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .close-btn:hover {
@@ -989,7 +989,7 @@ defineExpose({
 /* Transitions */
 .slide-enter-active,
 .slide-leave-active {
-  transition: all 0.3s ease;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .slide-enter-from,

--- a/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
+++ b/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
@@ -268,7 +268,7 @@ function formatDuration(seconds: number): string {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  transition: border-color 0.2s;
+  transition: border-color var(--duration-200);
 }
 
 .agent-card:hover {
@@ -407,7 +407,7 @@ function formatDuration(seconds: number): string {
 .reliability-fill {
   height: 100%;
   border-radius: var(--radius-xs);
-  transition: width 0.4s ease;
+  transition: width 0.4s var(--ease-out);
 }
 
 .reliability-fill.reliability-high { background: var(--color-success); }

--- a/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.vue
+++ b/autobot-frontend/src/components/workflow/PhaseProgressionIndicator.vue
@@ -353,7 +353,7 @@ function formatStatus(status: string): string {
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
   cursor: pointer;
-  transition: opacity 0.15s;
+  transition: opacity var(--duration-150);
 }
 
 .btn-load-validation:disabled {
@@ -385,7 +385,7 @@ function formatStatus(status: string): string {
 .maturity-fill {
   height: 100%;
   border-radius: var(--radius-full);
-  transition: width 0.4s ease;
+  transition: width 0.4s var(--ease-out);
 }
 
 .maturity-production { background: var(--color-success); }
@@ -485,7 +485,7 @@ function formatStatus(status: string): string {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-3);
-  transition: box-shadow 0.15s;
+  transition: box-shadow var(--duration-150);
 }
 
 .phase-card:hover {
@@ -563,7 +563,7 @@ function formatStatus(status: string): string {
 .progress-fill {
   height: 100%;
   border-radius: var(--radius-full);
-  transition: width 0.4s ease;
+  transition: width 0.4s var(--ease-out);
 }
 
 .progress-complete        { background: var(--color-success); }

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -514,7 +514,7 @@ onUnmounted(() => {
   border-radius: var(--radius-xl);
   padding: 18px;
   cursor: pointer;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color var(--duration-200), box-shadow var(--duration-200);
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -599,7 +599,7 @@ onUnmounted(() => {
 .progress-fill {
   height: 100%;
   border-radius: var(--radius-default);
-  transition: width 0.4s ease;
+  transition: width 0.4s var(--ease-out);
 }
 
 .progress-active { background: var(--color-success); }

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
@@ -361,7 +361,7 @@ watch(saveSuccess, (val) => {
   background: var(--color-bg-secondary, #1e293b);
   color: var(--color-text-primary, #e2e8f0);
   font-size: var(--text-sm);
-  transition: border-color 0.15s;
+  transition: border-color var(--duration-150);
 }
 .field-input:focus {
   outline: none;
@@ -496,7 +496,7 @@ watch(saveSuccess, (val) => {
   font-size: var(--text-sm);
   font-weight: 500;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--duration-150);
 }
 .btn-save:hover:not(:disabled) {
   background: var(--color-primary-hover, #2563eb);

--- a/autobot-frontend/src/views/AnalyticsView.vue
+++ b/autobot-frontend/src/views/AnalyticsView.vue
@@ -200,7 +200,7 @@ const isDevToolsActive = computed(() => {
   color: var(--text-secondary);
   text-decoration: none;
   border-bottom: 2px solid transparent;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
   position: relative;
   top: 1px;
   white-space: nowrap;

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -675,7 +675,7 @@ onMounted(() => {
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .action-btn:hover {
@@ -726,7 +726,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .icon-btn:hover {
@@ -765,7 +765,7 @@ onMounted(() => {
   color: var(--text-primary);
   font-size: var(--text-sm);
   cursor: grab;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .palette-widget:hover {
@@ -813,7 +813,7 @@ onMounted(() => {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .widget-container:hover {
@@ -871,7 +871,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .widget-actions button:hover {
@@ -1049,7 +1049,7 @@ onMounted(() => {
   padding: 1.5rem;
   text-align: center;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .widget-option:hover {
@@ -1086,7 +1086,7 @@ onMounted(() => {
 /* Transitions */
 .slide-down-enter-active,
 .slide-down-leave-active {
-  transition: all 0.3s ease;
+  transition: all var(--duration-300) var(--ease-out);
 }
 
 .slide-down-enter-from,

--- a/autobot-frontend/src/views/KnowledgeView.vue
+++ b/autobot-frontend/src/views/KnowledgeView.vue
@@ -261,7 +261,7 @@
   gap: 12px;
   padding: 10px 20px;
   cursor: pointer;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
   color: var(--text-secondary);
   text-decoration: none;
   border: none;

--- a/autobot-frontend/src/views/SettingsView.vue
+++ b/autobot-frontend/src/views/SettingsView.vue
@@ -327,7 +327,7 @@ function onApiKeysSaved(): void {
   border-bottom: 2px solid transparent;
   margin-bottom: -2px;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color var(--duration-150), border-color var(--duration-150);
 }
 
 .settings-tab:hover {
@@ -384,7 +384,7 @@ function onApiKeysSaved(): void {
   border-radius: var(--radius-md, 8px);
   font-weight: 500;
   cursor: pointer;
-  transition: opacity 0.2s;
+  transition: opacity var(--duration-200);
 }
 
 .open-wizard-btn:hover {

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -1264,7 +1264,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   gap: 12px;
   padding: 10px 20px;
   cursor: pointer;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
   color: var(--text-secondary);
   border-left: 2px solid transparent;
   /* Reset button styles */
@@ -1341,7 +1341,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--duration-150) var(--ease-in-out);
 }
 
 .btn-refresh:hover:not(:disabled) {
@@ -1491,7 +1491,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .stat-card.active {
@@ -1581,7 +1581,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
   color: var(--text-secondary);
 }
 
@@ -1653,7 +1653,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .example-item:hover {
@@ -1934,7 +1934,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   border: none;
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-refresh-sm:hover:not(:disabled) {
@@ -2028,7 +2028,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   height: 100%;
   background: var(--color-success);
   border-radius: var(--radius-default);
-  transition: width 0.3s;
+  transition: width var(--duration-300);
 }
 
 .agent-performance .value {
@@ -2053,7 +2053,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-primary:hover:not(:disabled) {
@@ -2077,7 +2077,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-success:hover {
@@ -2096,7 +2096,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  transition: all 0.2s;
+  transition: all var(--duration-200);
 }
 
 .btn-danger:hover {


### PR DESCRIPTION
Closes #4590

## Summary
- Converts all raw duration/easing values in Vue `<style>` block `transition` properties to CSS custom property tokens
- 117 files changed, 349 violations eliminated
- Automated via bulk regex replacement scoped to `transition:` / `transition-duration:` / `transition-timing-function:` lines only
- Guard against double-replacement on already-tokenized values (negative lookbehind `(?<!-)` on ease patterns)

## Token mapping
| Before | After |
|--------|-------|
| `150ms` / `0.15s` | `var(--duration-150)` |
| `200ms` / `0.2s` | `var(--duration-200)` |
| `300ms` / `0.3s` | `var(--duration-300)` |
| `ease-in-out` / `cubic-bezier(0.4,0,0.2,1)` | `var(--ease-in-out)` |
| `ease-out` / `cubic-bezier(0,0,0.2,1)` | `var(--ease-out)` |
| `ease-in` / `cubic-bezier(0.4,0,1,1)` | `var(--ease-in)` |
| `ease` | `var(--ease-out)` |