### PR TITLE
fix(a2a): slide a2a:tasks set TTL in get_task() (#4604)

### DIFF
--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -222,6 +222,7 @@ class TaskManager:
         ttl = self._ttl()
         self._redis.expire(key, ttl)
         self._redis.expire(_KEY_AUDIT.format(task_id), ttl)
+        self._redis.expire(_KEY_TASKS, ttl)
         return _task_from_json(raw if isinstance(raw, str) else raw.decode("utf-8"))
 
     def list_tasks(self) -> List[Task]:


### PR DESCRIPTION
Closes #4604

## Summary

`get_task()` slid the TTL on `a2a:task:{id}` and `a2a:audit:{id}` but not the `a2a:tasks` tracking set. A terminal task being actively polled kept its individual key alive via TTL sliding, but after one TTL window with no new state transitions (no `_save()` calls) the set expired — causing `list_tasks()` to miss it while `get_task()` still worked.

One-line fix: add `self._redis.expire(_KEY_TASKS, ttl)` in `get_task()` alongside the other two expire calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)