### PR TITLE
fix(a2a): log JWT sub decode failures at DEBUG level (#4607)

### DIFF
--- a/autobot-backend/api/a2a.py
+++ b/autobot-backend/api/a2a.py
@@ -524,5 +524,6 @@ def _decode_jwt_sub(token: str) -> Optional[str]:
         payload = base64.urlsafe_b64decode(payload_b64)
         claims = _json.loads(payload)
         return claims.get("sub")
-    except Exception:
+    except Exception as exc:
+        logger.debug("JWT sub decode failed: %s", exc)
         return None


### PR DESCRIPTION
Closes #4607

## Summary

`_decode_jwt_sub()` was silently swallowing all exceptions with a bare `except Exception: return None`. Auth decode failures left no trace in logs, making it impossible to diagnose why `caller_id` appeared as `None` in audit entries.

Changed to `except Exception as exc:` with `logger.debug("JWT sub decode failed: %s", exc)` — behaviour is unchanged (best-effort decode, full auth enforced upstream), failures are now visible at DEBUG log level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)