### PR TITLE
fix(slm-frontend): add co-located API URL guard + build:slm script (#4603)

### DIFF
--- a/autobot-slm-frontend/package.json
+++ b/autobot-slm-frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:slm": "VITE_API_URL=/slm vite build",
     "build:check": "vue-tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",

--- a/autobot-slm-frontend/vite.config.ts
+++ b/autobot-slm-frontend/vite.config.ts
@@ -5,6 +5,37 @@
 import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { fileURLToPath, URL } from 'node:url'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/** Best-effort check: are we co-located with the user frontend? */
+function isCoLocated(): boolean {
+  try {
+    return existsSync(resolve(__dirname, '../autobot-frontend/package.json'))
+  } catch {
+    return false
+  }
+}
+
+/** Vite plugin that warns (or errors) when VITE_API_URL is unset in a co-located build. */
+function coLocatedApiUrlGuard(): import('vite').Plugin {
+  return {
+    name: 'slm-co-located-api-url-guard',
+    configResolved(config) {
+      if (config.command !== 'build') return
+      if (process.env.VITE_API_URL) return
+      if (!isCoLocated()) return
+      // Co-located build without VITE_API_URL — all API calls will silently
+      // route to the wrong backend (port 8001 user backend instead of SLM).
+      config.logger.warn(
+        '\n[slm-frontend] WARNING: VITE_API_URL is not set.\n' +
+        '  In co-located mode every API call will default to "" (empty string)\n' +
+        '  and route to the user backend (port 8001) instead of the SLM backend.\n' +
+        '  Fix: run  VITE_API_URL=/slm npm run build  or use  npm run build:slm\n'
+      )
+    },
+  }
+}
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
@@ -13,7 +44,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     base: '/slm/',
-    plugins: [vue()],
+    plugins: [vue(), coLocatedApiUrlGuard()],
     resolve: {
       alias: {
         '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
Closes #4603

## Summary
- Adds `coLocatedApiUrlGuard()` Vite plugin to `vite.config.ts` that detects co-located mode (sibling `autobot-frontend/package.json`) and warns when `VITE_API_URL` is unset at build time
- Adds `"build:slm": "VITE_API_URL=/slm vite build"` npm script to prevent silent misconfiguration during manual builds

## Problem Solved
When `VITE_API_URL` is not set at build time in co-located mode, all SLM API calls go to `/api/` (user backend port 8001) instead of `/slm/api/` (SLM backend port 8000), causing silent 404s and broken functionality.

## Test Status
No automated tests (Vite plugin runs at build time only). Verified by inspecting plugin hook logic.

🤖 Generated with [Claude Code](https://claude.ai/code)