### PR TITLE
fix(ansible): remove stale UFW rule for old playwright port 3000 (#4609)

### DIFF
--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -261,6 +261,18 @@
   notify: reload firewall
   tags: ['browser', 'firewall', 'vnc']
 
+- name: "Browser | Remove stale UFW rule for old playwright port 3000 (#4609)"
+  community.general.ufw:
+    rule: allow
+    port: "3000"
+    proto: tcp
+    from_ip: "{{ network_subnet }}"
+    delete: true
+  become: yes
+  when: playwright_port | int != 3000
+  ignore_errors: true  # Rule may not exist on fresh installs
+  tags: ['browser', 'firewall']
+
 - name: "Browser | Configure firewall - Allow Playwright API"
   ufw:
     rule: allow


### PR DESCRIPTION
Closes #4609

## Summary
- Adds a UFW delete task in `browser/tasks/main.yml` to remove the stale allow rule for port 3000 (old playwright port) when `playwright_port` is not 3000
- Runs before the new port allow task so the old rule is cleaned up on every playbook run
- Uses `ignore_errors: true` since the rule may already be absent on fresh installs

## Problem Solved
After changing playwright from port 3000 to 9001, the old UFW allow rule for port 3000 persisted on existing deployments because Ansible only adds rules, never removes them.

## Test Status
PASS (no unit test — Ansible task verified by inspection)

🤖 Generated with [Claude Code](https://claude.ai/code)