### PR TITLE
feat(knowledge): wire synthesis_schema into KBSynthesizer prompt selection (#4614)

### DIFF
--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -946,9 +946,24 @@ class DocIndexerService:
             return files, new_hashes, True
         return files, new_hashes, False
 
-    async def _run_kb_synthesis(self, indexed_paths: List[str]) -> None:
-        """Run KBSynthesizer after tier ingest (best-effort, Issue #4564).
+    def _find_collection_config(self, indexed_paths: List[str]):
+        """Return the first CollectionConfig whose paths overlap with indexed_paths.
 
+        Matches when any indexed path contains one of the collection's path prefixes
+        as a substring (e.g. ``docs/architecture`` found in an absolute path).
+        Returns None if no collection matches or the schema is empty.
+        """
+        for col_cfg in self.synthesis_schema.collections:
+            for cfg_path in col_cfg.paths:
+                if any(cfg_path in p for p in indexed_paths):
+                    return col_cfg
+        return None
+
+    async def _run_kb_synthesis(self, indexed_paths: List[str]) -> None:
+        """Run KBSynthesizer after tier ingest (best-effort, Issue #4564/#4614).
+
+        Looks up the matching CollectionConfig from synthesis_schema and passes it
+        to synthesize_docs() so the schema-driven prompt_template is used.
         Errors are logged and swallowed so indexing is never interrupted.
         KBSynthesizer is imported lazily to avoid circular imports.
         """
@@ -956,7 +971,13 @@ class DocIndexerService:
             from services.knowledge.kb_synthesizer import get_kb_synthesizer
 
             synthesizer = get_kb_synthesizer(self._llm_service)
-            await synthesizer.synthesize_docs(indexed_paths)
+            collection_config = self._find_collection_config(indexed_paths)
+            if collection_config:
+                logger.debug(
+                    "DocIndexerService: synthesis using collection config '%s'",
+                    collection_config.name,
+                )
+            await synthesizer.synthesize_docs(indexed_paths, collection_config=collection_config)
         except Exception:
             logger.exception("DocIndexerService: KB synthesis failed (non-fatal)")
 

--- a/autobot-backend/services/knowledge/kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/kb_synthesizer.py
@@ -15,7 +15,10 @@ import asyncio
 import hashlib
 import logging
 import time
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
+
+if TYPE_CHECKING:
+    from services.knowledge.synthesis_schema_loader import CollectionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +94,11 @@ class KBSynthesizer:
     # Public API
     # ------------------------------------------------------------------
 
-    async def synthesize_docs(self, file_paths: List[str]) -> None:
+    async def synthesize_docs(
+        self,
+        file_paths: List[str],
+        collection_config: "Optional[CollectionConfig]" = None,
+    ) -> None:
         """Synthesize indexed KB docs into topic-summary pages (best-effort).
 
         Called after each tier ingest in DocIndexerService.  Errors are
@@ -99,11 +106,13 @@ class KBSynthesizer:
 
         Args:
             file_paths: Absolute paths to recently indexed markdown files.
+            collection_config: Optional schema config whose ``prompt_template``
+                overrides the generic synthesis prompt for this cluster.
         """
         if not file_paths:
             return
         try:
-            await self._synthesize_cluster(file_paths)
+            await self._synthesize_cluster(file_paths, collection_config=collection_config)
         except Exception:
             logger.exception("KBSynthesizer.synthesize_docs failed (non-fatal)")
 
@@ -111,17 +120,43 @@ class KBSynthesizer:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _synthesize_cluster(self, file_paths: List[str]) -> None:
+    def _resolve_prompt(self, collection_config: "Optional[CollectionConfig]") -> str:
+        """Return the synthesis prompt for this cluster.
+
+        Uses the collection config's ``prompt_template`` when provided;
+        falls back to the generic ``_SYNTHESIS_PROMPT`` otherwise.
+        """
+        if collection_config is None:
+            return _SYNTHESIS_PROMPT
+        template = collection_config.prompt_template.strip()
+        if not template:
+            logger.warning(
+                "KBSynthesizer: collection '%s' has empty prompt_template — using default",
+                collection_config.name,
+            )
+            return _SYNTHESIS_PROMPT
+        logger.debug(
+            "KBSynthesizer: using prompt_template from collection '%s'",
+            collection_config.name,
+        )
+        return template
+
+    async def _synthesize_cluster(
+        self,
+        file_paths: List[str],
+        collection_config: "Optional[CollectionConfig]" = None,
+    ) -> None:
         """Build one summary page from a batch of docs."""
         docs_text = await asyncio.to_thread(self._read_docs, file_paths)
         if not docs_text.strip():
             return
 
         cluster_id = self._cluster_id(file_paths)
+        prompt = self._resolve_prompt(collection_config)
         try:
             response = await self._llm.chat(
                 messages=[
-                    {"role": "system", "content": _SYNTHESIS_PROMPT},
+                    {"role": "system", "content": prompt},
                     {"role": "user", "content": docs_text},
                 ],
                 temperature=0.3,

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -294,3 +294,90 @@ def test_get_kb_synthesizer_returns_instance():
     _kb_synth_mod._kb_synthesizer = None  # type: ignore[attr-defined]
     synth = get_kb_synthesizer(_make_llm())
     assert isinstance(synth, KBSynthesizer)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: CollectionConfig stub
+# ---------------------------------------------------------------------------
+
+
+def _make_collection_config(name: str = "test_col", prompt_template: str = "Custom prompt: {documents}"):
+    """Return a minimal CollectionConfig-like object for testing."""
+    cfg = MagicMock()
+    cfg.name = name
+    cfg.prompt_template = prompt_template
+    cfg.paths = ["docs/test"]
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Tests: KBSynthesizer._resolve_prompt (#4614)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_prompt_no_config_returns_default():
+    synth = KBSynthesizer(llm_service=_make_llm())
+    prompt = synth._resolve_prompt(None)
+    assert prompt == _kb_synth_mod._SYNTHESIS_PROMPT
+
+
+def test_resolve_prompt_with_config_returns_template():
+    synth = KBSynthesizer(llm_service=_make_llm())
+    cfg = _make_collection_config(prompt_template="Custom: {documents}")
+    prompt = synth._resolve_prompt(cfg)
+    assert prompt == "Custom: {documents}"
+
+
+def test_resolve_prompt_empty_template_falls_back_to_default():
+    synth = KBSynthesizer(llm_service=_make_llm())
+    cfg = _make_collection_config(prompt_template="   ")
+    prompt = synth._resolve_prompt(cfg)
+    assert prompt == _kb_synth_mod._SYNTHESIS_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Tests: synthesize_docs with collection_config (#4614)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_docs_uses_collection_config_prompt(tmp_path):
+    f = tmp_path / "arch.md"
+    f.write_text("# Architecture\nSome details.", encoding="utf-8")
+
+    col = _make_collection()
+    llm = _make_llm("Architecture synthesis")
+    synth = KBSynthesizer(llm_service=llm)
+    synth._collection = col
+
+    cfg = _make_collection_config(
+        name="architecture_adrs",
+        prompt_template="You are an architecture assistant. Docs: {documents}",
+    )
+
+    await synth.synthesize_docs([str(f)], collection_config=cfg)
+
+    llm.chat.assert_awaited_once()
+    call_kwargs = llm.chat.call_args
+    messages = call_kwargs.kwargs.get("messages") or call_kwargs.args[0]
+    system_content = next(m["content"] for m in messages if m["role"] == "system")
+    assert "You are an architecture assistant." in system_content
+
+
+@pytest.mark.asyncio
+async def test_synthesize_docs_no_config_uses_default_prompt(tmp_path):
+    f = tmp_path / "doc.md"
+    f.write_text("# Topic\nSome content.", encoding="utf-8")
+
+    col = _make_collection()
+    llm = _make_llm("Generic synthesis")
+    synth = KBSynthesizer(llm_service=llm)
+    synth._collection = col
+
+    await synth.synthesize_docs([str(f)], collection_config=None)
+
+    llm.chat.assert_awaited_once()
+    call_kwargs = llm.chat.call_args
+    messages = call_kwargs.kwargs.get("messages") or call_kwargs.args[0]
+    system_content = next(m["content"] for m in messages if m["role"] == "system")
+    assert system_content == _kb_synth_mod._SYNTHESIS_PROMPT


### PR DESCRIPTION
Closes #4614

## Summary
- `KBSynthesizer.synthesize_docs()` now accepts optional `collection_config: CollectionConfig | None`
- `_resolve_prompt()` selects `collection_config.prompt_template` when provided, falls back to default generic prompt with a warning
- `DocIndexerService._run_kb_synthesis()` calls `_find_collection_config(indexed_paths)` to match paths against schema collections and passes the result to `synthesize_docs()`
- ADRs, API docs, and runbooks now get schema-defined prompts instead of one-size-fits-all

## Test Status
✅ 20/20 pass (15 pre-existing + 5 new: prompt resolution with/without config, empty template fallback, synthesize_docs uses config prompt)