### PR TITLE
fix(deps): add autobot-slm-frontend to dependabot.yml (#4616)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,17 @@ updates:
       - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
 
+  - package-ecosystem: "npm"
+    directory: "/autobot-slm-frontend"
+    target-branch: "Dev_new_gui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "frontend"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "Dev_new_gui"


### PR DESCRIPTION
Closes #4616

## Summary
- Added npm entry for `/autobot-slm-frontend` to `.github/dependabot.yml` with `target-branch: Dev_new_gui`
- Prevents future Dependabot PRs for this package from targeting `main`
- YAML validated clean

## Test Status
N/A — YAML config change only