### PR TITLE
feat(knowledge): route synthesis output to schema-defined synthesis_target collections (#4635)

### DIFF
--- a/autobot-backend/services/knowledge/kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/kb_synthesizer.py
@@ -39,7 +39,8 @@ class KBSynthesizer:
     """Synthesize KB doc clusters into topic-summary pages in ChromaDB.
 
     Issue #4564: Subclass of BaseSynthesizer for KB documentation synthesis.
-    Summaries are stored in the ``kb_synthesis`` ChromaDB collection and
+    Summaries are stored in ChromaDB collections (default: ``kb_synthesis``,
+    or the per-collection ``synthesis_target`` from synthesis_schema.yaml) and
     queried by RAGService as optional context enrichment.
     """
 
@@ -48,47 +49,101 @@ class KBSynthesizer:
     def __init__(self, llm_service: Any) -> None:
         self._llm = llm_service
         self._collection: Optional[Any] = None
+        # Cache of named collections keyed by collection name.
+        self._named_collections: dict[str, Any] = {}
 
     # ------------------------------------------------------------------
     # BaseSynthesizer ABC interface
     # ------------------------------------------------------------------
 
-    async def _get_collection(self) -> Any:
-        """Return the kb_synthesis ChromaDB collection (lazy-init)."""
-        if self._collection is None:
+    async def _get_collection(self, collection_name: Optional[str] = None) -> Any:
+        """Return a ChromaDB collection (lazy-init).
+
+        Args:
+            collection_name: Override the collection name.  When None, the
+                default ``_KB_SYNTHESIS_COLLECTION`` is used and the result is
+                cached on ``self._collection`` for backward compatibility.
+        """
+        name = collection_name or self.COLLECTION_NAME
+        if collection_name is None:
+            if self._collection is None:
+                from utils.chromadb_client import get_async_chromadb_client
+
+                client = await get_async_chromadb_client()
+                self._collection = await client.get_or_create_collection(
+                    name=name,
+                    metadata={"description": "LLM-synthesized KB topic summaries"},
+                )
+            return self._collection
+
+        if name not in self._named_collections:
             from utils.chromadb_client import get_async_chromadb_client
 
             client = await get_async_chromadb_client()
-            self._collection = await client.get_or_create_collection(
-                name=self.COLLECTION_NAME,
+            self._named_collections[name] = await client.get_or_create_collection(
+                name=name,
                 metadata={"description": "LLM-synthesized KB topic summaries"},
             )
-        return self._collection
+        return self._named_collections[name]
 
-    async def _index_documents(self, docs: List[Any]) -> None:
-        """Persist synthesized SummaryPage dicts into ChromaDB."""
+    async def _index_documents(
+        self, docs: List[Any], collection_name: Optional[str] = None
+    ) -> None:
+        """Persist synthesized SummaryPage dicts into ChromaDB.
+
+        Args:
+            docs: List of summary page dicts with at least ``id`` and ``summary``.
+            collection_name: Target collection name override; None uses the default.
+        """
         if not docs:
             return
-        collection = await self._get_collection()
+        collection = await self._get_collection(collection_name)
         ids = [d["id"] for d in docs]
         documents = [d["summary"] for d in docs]
         metadatas = [{k: v for k, v in d.items() if k not in ("id", "summary")} for d in docs]
         try:
             await collection.upsert(ids=ids, documents=documents, metadatas=metadatas)
-            logger.info("KBSynthesizer: indexed %d summaries in ChromaDB", len(docs))
+            logger.info(
+                "KBSynthesizer: indexed %d summaries in ChromaDB collection '%s'",
+                len(docs),
+                collection_name or self.COLLECTION_NAME,
+            )
         except Exception:
             logger.exception("KBSynthesizer: failed to index summaries")
 
-    async def get_relevant_context(self, topic: str, limit: int = 3) -> str:
-        """Return synthesized KB summaries as a RAG context string."""
-        results = await self._query_summaries(topic, limit=limit)
-        if not results:
-            return ""
+    async def get_relevant_context(
+        self,
+        topic: str,
+        limit: int = 3,
+        collection_names: Optional[List[str]] = None,
+    ) -> str:
+        """Return synthesized KB summaries as a RAG context string.
+
+        Queries the default ``kb_synthesis`` collection plus any additional
+        names provided via ``collection_names`` (e.g. from synthesis_schema).
+
+        Args:
+            topic: Query text.
+            limit: Maximum results per collection.
+            collection_names: Extra collection names to query in addition to
+                the default.  Duplicates are skipped.
+        """
+        all_names: List[Optional[str]] = [None]  # None → default collection
+        seen = {self.COLLECTION_NAME}
+        for name in (collection_names or []):
+            if name and name not in seen:
+                all_names.append(name)
+                seen.add(name)
+
         lines = ["KB synthesis context:"]
-        for doc, meta in results:
-            source = meta.get("source_paths", "")
-            lines.append(f"- {doc}" + (f" [sources: {source}]" if source else ""))
-        return "\n".join(lines)
+        found_any = False
+        for col_name in all_names:
+            results = await self._query_summaries(topic, limit=limit, collection_name=col_name)
+            for doc, meta in results:
+                found_any = True
+                source = meta.get("source_paths", "")
+                lines.append(f"- {doc}" + (f" [sources: {source}]" if source else ""))
+        return "\n".join(lines) if found_any else ""
 
     # ------------------------------------------------------------------
     # Public API
@@ -146,7 +201,12 @@ class KBSynthesizer:
         file_paths: List[str],
         collection_config: "Optional[CollectionConfig]" = None,
     ) -> None:
-        """Build one summary page from a batch of docs."""
+        """Build one summary page from a batch of docs.
+
+        Writes the result to the collection named by
+        ``collection_config.synthesis_target`` when that field is non-empty;
+        otherwise falls back to the default ``kb_synthesis`` collection.
+        """
         docs_text = await asyncio.to_thread(self._read_docs, file_paths)
         if not docs_text.strip():
             return
@@ -181,7 +241,16 @@ class KBSynthesizer:
             "synthesized_at": time.time(),
             "doc_count": len(file_paths),
         }
-        await self._index_documents([page])
+        target_collection: Optional[str] = None
+        if collection_config is not None:
+            target = collection_config.synthesis_target.strip()
+            if target:
+                target_collection = target
+                logger.debug(
+                    "KBSynthesizer: writing cluster to synthesis_target '%s'",
+                    target_collection,
+                )
+        await self._index_documents([page], collection_name=target_collection)
 
     @staticmethod
     def _read_docs(file_paths: List[str]) -> str:
@@ -203,17 +272,26 @@ class KBSynthesizer:
         return "kb_syn_" + hashlib.md5(key.encode(), usedforsecurity=False).hexdigest()[:12]
 
     async def _query_summaries(
-        self, query: str, limit: int = 3
+        self, query: str, limit: int = 3, collection_name: Optional[str] = None
     ) -> List[tuple[str, dict]]:
-        """Query kb_synthesis collection; return list of (document, metadata)."""
+        """Query a synthesis collection; return list of (document, metadata).
+
+        Args:
+            query: Query text.
+            limit: Maximum results.
+            collection_name: Collection to query.  None uses the default.
+        """
         try:
-            collection = await self._get_collection()
+            collection = await self._get_collection(collection_name)
             results = await collection.query(
                 query_texts=[query],
                 n_results=limit,
             )
         except Exception:
-            logger.exception("KBSynthesizer: query failed")
+            logger.debug(
+                "KBSynthesizer: query failed for collection '%s' (non-fatal)",
+                collection_name or self.COLLECTION_NAME,
+            )
             return []
 
         output: List[tuple[str, dict]] = []

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -301,11 +301,16 @@ def test_get_kb_synthesizer_returns_instance():
 # ---------------------------------------------------------------------------
 
 
-def _make_collection_config(name: str = "test_col", prompt_template: str = "Custom prompt: {documents}"):
+def _make_collection_config(
+    name: str = "test_col",
+    prompt_template: str = "Custom prompt: {documents}",
+    synthesis_target: str = "",
+):
     """Return a minimal CollectionConfig-like object for testing."""
     cfg = MagicMock()
     cfg.name = name
     cfg.prompt_template = prompt_template
+    cfg.synthesis_target = synthesis_target
     cfg.paths = ["docs/test"]
     return cfg
 
@@ -488,3 +493,120 @@ async def test_synthesize_cluster_default_prompt_no_documents_placeholder(tmp_pa
     assert len(messages) == 2
     assert messages[0]["role"] == "system"
     assert messages[1]["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# Tests: synthesis_target routing (#4635)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesize_cluster_writes_to_synthesis_target(tmp_path):
+    """When synthesis_target is set, _index_documents is called with that name."""
+    f = tmp_path / "arch.md"
+    f.write_text("# Architecture", encoding="utf-8")
+
+    target_col = _make_collection()
+    default_col = _make_collection()
+
+    llm = _make_llm("Architecture summary")
+    synth = KBSynthesizer(llm_service=llm)
+    # Inject default collection to verify it is NOT written to.
+    synth._collection = default_col
+
+    # Inject named collection so _get_collection(collection_name) returns target_col.
+    synth._named_collections["autobot_synthesis_architecture"] = target_col
+
+    cfg = _make_collection_config(
+        name="architecture_adrs",
+        synthesis_target="autobot_synthesis_architecture",
+    )
+
+    await synth.synthesize_docs([str(f)], collection_config=cfg)
+
+    # Must write to synthesis_target, not to the default collection.
+    target_col.upsert.assert_awaited_once()
+    default_col.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_synthesize_cluster_falls_back_to_default_when_no_target(tmp_path):
+    """When synthesis_target is empty, output goes to the default collection."""
+    f = tmp_path / "doc.md"
+    f.write_text("# Topic\nContent.", encoding="utf-8")
+
+    col = _make_collection()
+    llm = _make_llm("Generic summary")
+    synth = KBSynthesizer(llm_service=llm)
+    synth._collection = col
+
+    cfg = _make_collection_config(name="no_target_col", synthesis_target="")
+
+    await synth.synthesize_docs([str(f)], collection_config=cfg)
+
+    col.upsert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_synthesize_cluster_falls_back_when_config_is_none(tmp_path):
+    """When collection_config is None, output goes to the default collection."""
+    f = tmp_path / "doc.md"
+    f.write_text("# Topic\nContent.", encoding="utf-8")
+
+    col = _make_collection()
+    llm = _make_llm("Summary")
+    synth = KBSynthesizer(llm_service=llm)
+    synth._collection = col
+
+    await synth.synthesize_docs([str(f)], collection_config=None)
+
+    col.upsert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_relevant_context_queries_extra_collections():
+    """get_relevant_context queries extra collection names in addition to default."""
+    default_results = {
+        "ids": [["id1"]],
+        "documents": [["Default summary."]],
+        "metadatas": [[{}]],
+    }
+    extra_results = {
+        "ids": [["id2"]],
+        "documents": [["Architecture summary."]],
+        "metadatas": [[{}]],
+    }
+    default_col = _make_collection(default_results)
+    extra_col = _make_collection(extra_results)
+
+    synth = KBSynthesizer(llm_service=_make_llm())
+    synth._collection = default_col
+    synth._named_collections["autobot_synthesis_architecture"] = extra_col
+
+    ctx = await synth.get_relevant_context(
+        "architecture", collection_names=["autobot_synthesis_architecture"]
+    )
+
+    assert "Default summary." in ctx
+    assert "Architecture summary." in ctx
+
+
+@pytest.mark.asyncio
+async def test_get_relevant_context_deduplicates_default_collection():
+    """Passing the default collection name twice must not query it twice."""
+    default_results = {
+        "ids": [["id1"]],
+        "documents": [["Default summary."]],
+        "metadatas": [[{}]],
+    }
+    col = _make_collection(default_results)
+    synth = KBSynthesizer(llm_service=_make_llm())
+    synth._collection = col
+
+    # Pass default name explicitly — should be deduplicated.
+    await synth.get_relevant_context(
+        "topic", collection_names=[_kb_synth_mod._KB_SYNTHESIS_COLLECTION]
+    )
+
+    # Default collection queried exactly once (not twice).
+    assert col.query.await_count == 1

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -701,26 +701,50 @@ class RAGService:
             return "Error: RAG context retrieval failed", RAGMetrics()
 
     async def _get_kb_synthesis_context(self, query: str) -> str:
-        """Query kb_synthesis ChromaDB collection for enrichment (Issue #4564).
+        """Query all KB synthesis ChromaDB collections for enrichment (Issue #4564, #4635).
 
-        Best-effort: returns empty string on any error so the main context
-        path is never interrupted.
+        Queries the default ``kb_synthesis`` collection plus any
+        ``synthesis_target`` collections defined in synthesis_schema.yaml.
+        Results from all collections are merged.  Per-collection errors are
+        logged and swallowed so the main context path is never interrupted.
         """
-        try:
-            from utils.chromadb_client import get_async_chromadb_client
+        from utils.chromadb_client import get_async_chromadb_client
 
-            client = await get_async_chromadb_client()
-            collection = await client.get_or_create_collection(name="kb_synthesis")
-            results = await collection.query(query_texts=[query], n_results=2)
-            if not (results and results.get("ids") and results["ids"][0]):
-                return ""
-            docs = results.get("documents", [[]])[0]
-            if not docs:
-                return ""
-            return "KB synthesis summaries:\n" + "\n".join(f"- {d}" for d in docs)
+        # Collect all synthesis collection names: default + schema-defined targets.
+        collection_names: List[str] = ["kb_synthesis"]
+        try:
+            from services.knowledge.synthesis_schema_loader import load_synthesis_schema
+
+            schema = load_synthesis_schema()
+            for col in schema.collections:
+                target = col.synthesis_target.strip()
+                if target and target not in collection_names:
+                    collection_names.append(target)
         except Exception as exc:
-            logger.debug("KB synthesis context fetch failed (non-fatal): %s", exc)
+            logger.debug("Could not load synthesis schema (non-fatal): %s", exc)
+
+        all_docs: List[str] = []
+        try:
+            client = await get_async_chromadb_client()
+        except Exception as exc:
+            logger.debug("KB synthesis ChromaDB client unavailable (non-fatal): %s", exc)
             return ""
+
+        for col_name in collection_names:
+            try:
+                collection = await client.get_or_create_collection(name=col_name)
+                results = await collection.query(query_texts=[query], n_results=2)
+                if results and results.get("ids") and results["ids"][0]:
+                    docs = results.get("documents", [[]])[0]
+                    all_docs.extend(d for d in docs if d)
+            except Exception as exc:
+                logger.debug(
+                    "KB synthesis fetch from '%s' failed (non-fatal): %s", col_name, exc
+                )
+
+        if not all_docs:
+            return ""
+        return "KB synthesis summaries:\n" + "\n".join(f"- {d}" for d in all_docs)
 
     async def rerank_results(
         self,


### PR DESCRIPTION
Closes #4635

## Summary
- `_get_collection(collection_name=None)` caches named collections; `_synthesize_cluster()` passes `collection_config.synthesis_target` as the output collection name
- `get_relevant_context()` accepts `collection_names` list and queries all of them, merging results
- `RAGService._get_kb_synthesis_context()` loads `synthesis_schema.yaml`, collects all `synthesis_target` values, queries each collection best-effort, merges into context string

## Test Status
✅ 25/25 pass (5 new: routing to synthesis_target, empty target fallback, None config fallback, multi-collection query, dedup)