### PR TITLE
fix(drift-checker): exclude expected-drift paths from total_compared count (#4631)

### DIFF
--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -170,7 +170,7 @@ def compute_drift(
     dep_checksums = _collect_checksums(dep_path)
 
     all_paths = set(src_checksums) | set(dep_checksums)
-    total_compared = len(all_paths)
+    compared = 0
     drifted: List[dict] = []
 
     for rel_path in sorted(all_paths):
@@ -178,6 +178,7 @@ def compute_drift(
             logger.debug("drift_checker: skipping expected-drift path: %s", rel_path)
             continue
 
+        compared += 1
         src_cs = src_checksums.get(rel_path)
         dep_cs = dep_checksums.get(rel_path)
 
@@ -201,7 +202,7 @@ def compute_drift(
             }
         )
 
-    return drifted, total_compared
+    return drifted, compared
 
 
 def build_drift_report(

--- a/autobot-slm-backend/tests/services/drift_checker_test.py
+++ b/autobot-slm-backend/tests/services/drift_checker_test.py
@@ -105,6 +105,30 @@ class TestComputeDriftExclusions:
             drifted, _ = compute_drift(str(src), str(dep))
             assert any(d["path"] == "services/code_sync.py" for d in drifted)
 
+    def test_total_compared_excludes_expected_drift_paths(self):
+        """total_compared must count only non-excluded paths (Issue #4631)."""
+        with tempfile.TemporaryDirectory() as src_root, \
+                tempfile.TemporaryDirectory() as dep_root:
+            src = Path(src_root)
+            dep = Path(dep_root)
+
+            # Two regular files that will be evaluated.
+            self._write(src, "main.py", b"import os")
+            self._write(dep, "main.py", b"import os")
+            self._write(src, "config.py", b"X=1")
+            self._write(dep, "config.py", b"X=2")
+
+            # Expected-drift file — must NOT be counted in total_compared.
+            self._write(dep, "autobot_shared/foo.py", b"# shared")
+
+            _, total = compute_drift(str(src), str(dep))
+
+            # Only main.py and config.py are evaluated; autobot_shared/foo.py
+            # is excluded by _is_expected_drift() before counting.
+            assert total == 2, (
+                f"expected total_compared=2 (excluding autobot_shared/foo.py), got {total}"
+            )
+
     def test_build_drift_report_excludes_expected_files(self):
         """build_drift_report() should not flag expected-drift paths."""
         with tempfile.TemporaryDirectory() as src_root, \


### PR DESCRIPTION
Closes #4631

## Summary
- Replaces `total_compared = len(all_paths)` (computed before the `_is_expected_drift()` filter) with a `compared` counter incremented inside the loop only for paths that are actually evaluated
- `autobot_shared/` and Ansible-generated files no longer inflate the count shown in drift reports
- Adds 1 new test asserting `total_compared` excludes expected-drift paths

## Test Status
PASS — 10/10 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)