### PR TITLE
fix(ansible): replace hardcoded UFW port cleanup with playwright_ports_legacy list (#4633)

### DIFF
--- a/autobot-slm-backend/ansible/roles/browser/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/defaults/main.yml
@@ -17,6 +17,8 @@ vnc_display: ":1"
 
 # Playwright configuration
 playwright_port: 9001
+playwright_ports_legacy:
+  - "3000"
 browser_timeout: 30
 
 # Desktop environment

--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -261,16 +261,17 @@
   notify: reload firewall
   tags: ['browser', 'firewall', 'vnc']
 
-- name: "Browser | Remove stale UFW rule for old playwright port 3000 (#4609)"
+- name: "Browser | Remove legacy playwright UFW rules (#4633)"
   community.general.ufw:
     rule: allow
-    port: "3000"
+    port: "{{ item }}"
     proto: tcp
     from_ip: "{{ network_subnet }}"
     delete: true
   become: yes
-  when: playwright_port | int != 3000
-  ignore_errors: true  # Rule may not exist on fresh installs
+  loop: "{{ playwright_ports_legacy | default([]) }}"
+  when: item | int != playwright_port | int
+  ignore_errors: true
   tags: ['browser', 'firewall']
 
 - name: "Browser | Configure firewall - Allow Playwright API"


### PR DESCRIPTION
Closes #4633

## Summary
- Adds `playwright_ports_legacy: ["3000"]` to `browser/defaults/main.yml`
- Replaces the hardcoded port-3000 UFW delete task with a loop over `playwright_ports_legacy`, which iterates and deletes any listed port that differs from the current `playwright_port`
- Future port changes only require appending the old port to `playwright_ports_legacy` — no task rewrite needed

## Test Status
PASS (Ansible role — no automated tests applicable)

🤖 Generated with [Claude Code](https://claude.ai/code)