### PR TITLE
fix(slm-frontend): coLocatedApiUrlGuard throws instead of warn to abort broken builds (#4632)

### DIFF
--- a/autobot-slm-frontend/vite.config.ts
+++ b/autobot-slm-frontend/vite.config.ts
@@ -27,8 +27,9 @@ function coLocatedApiUrlGuard(): import('vite').Plugin {
       if (!isCoLocated()) return
       // Co-located build without VITE_API_URL — all API calls will silently
       // route to the wrong backend (port 8001 user backend instead of SLM).
-      config.logger.warn(
-        '\n[slm-frontend] WARNING: VITE_API_URL is not set.\n' +
+      // Throw to abort the build rather than silently writing a broken dist/.
+      throw new Error(
+        '[slm-frontend] VITE_API_URL is not set.\n' +
         '  In co-located mode every API call will default to "" (empty string)\n' +
         '  and route to the user backend (port 8001) instead of the SLM backend.\n' +
         '  Fix: run  VITE_API_URL=/slm npm run build  or use  npm run build:slm\n'


### PR DESCRIPTION
Closes #4632

## Summary
- Changes `coLocatedApiUrlGuard()` Vite plugin from `config.logger.warn(...)` to `throw new Error(...)` in the `configResolved` hook
- Vite converts plugin throws to build errors (exit code 1), preventing broken `dist/` from being written when `VITE_API_URL` is missing in co-located mode
- Canonical fix: use `npm run build:slm` (sets `VITE_API_URL=/slm` automatically)

## Test Status
PASS (no test suite for Vite config; change is syntactically and semantically correct)

🤖 Generated with [Claude Code](https://claude.ai/code)