### PR TITLE
fix(frontend): replace hardcoded inline style CSS values with design tokens (#4636)

### DIFF
--- a/autobot-frontend/src/components/terminal/TerminalStatusBar.vue
+++ b/autobot-frontend/src/components/terminal/TerminalStatusBar.vue
@@ -9,7 +9,7 @@
         <span>{{ $t('terminal.session') }} {{ sessionId || $t('terminal.unknown') }}</span>
       </div>
       <div class="debug-info" v-if="!canInput">
-        <span style="color: orange; font-size: 12px;">
+        <span style="color: var(--color-warning); font-size: var(--text-xs);">
           Debug: Status={{ connectionStatus }}, Connecting={{ connecting }}, CanInput={{ canInput }}
         </span>
       </div>

--- a/autobot-frontend/src/views/ComponentShowcaseView.vue
+++ b/autobot-frontend/src/views/ComponentShowcaseView.vue
@@ -128,32 +128,32 @@
           <div class="card-stack">
             <BaseCard variant="default" size="sm">
               <template #header>
-                <h4 style="margin: 0; font-size: 14px;">{{ $t('views.componentShowcase.defaultCard') }}</h4>
+                <h4 style="margin: 0; font-size: var(--text-sm);">{{ $t('views.componentShowcase.defaultCard') }}</h4>
               </template>
-              <p style="margin: 0; font-size: 13px;">{{ $t('views.componentShowcase.defaultCardDesc') }}</p>
+              <p style="margin: 0; font-size: var(--text-sm);">{{ $t('views.componentShowcase.defaultCardDesc') }}</p>
             </BaseCard>
 
             <BaseCard variant="bordered" size="sm">
               <template #header>
-                <h4 style="margin: 0; font-size: 14px;">{{ $t('views.componentShowcase.borderedCard') }}</h4>
+                <h4 style="margin: 0; font-size: var(--text-sm);">{{ $t('views.componentShowcase.borderedCard') }}</h4>
               </template>
-              <p style="margin: 0; font-size: 13px;">{{ $t('views.componentShowcase.borderedCardDesc') }}</p>
+              <p style="margin: 0; font-size: var(--text-sm);">{{ $t('views.componentShowcase.borderedCardDesc') }}</p>
             </BaseCard>
 
             <BaseCard variant="elevated" size="sm">
               <template #header>
-                <h4 style="margin: 0; font-size: 14px;">{{ $t('views.componentShowcase.elevatedCard') }}</h4>
+                <h4 style="margin: 0; font-size: var(--text-sm);">{{ $t('views.componentShowcase.elevatedCard') }}</h4>
               </template>
-              <p style="margin: 0; font-size: 13px;">{{ $t('views.componentShowcase.elevatedCardDesc') }}</p>
+              <p style="margin: 0; font-size: var(--text-sm);">{{ $t('views.componentShowcase.elevatedCardDesc') }}</p>
             </BaseCard>
           </div>
 
           <h4 class="section-heading">{{ $t('views.componentShowcase.withFooter') }}</h4>
           <BaseCard variant="default" size="sm">
             <template #header>
-              <h4 style="margin: 0; font-size: 14px;">{{ $t('views.componentShowcase.cardWithFooter') }}</h4>
+              <h4 style="margin: 0; font-size: var(--text-sm);">{{ $t('views.componentShowcase.cardWithFooter') }}</h4>
             </template>
-            <p style="margin: 0; font-size: 13px;">{{ $t('views.componentShowcase.cardContent') }}</p>
+            <p style="margin: 0; font-size: var(--text-sm);">{{ $t('views.componentShowcase.cardContent') }}</p>
             <template #footer>
               <BaseButton size="sm" variant="ghost">{{ $t('views.componentShowcase.cancel') }}</BaseButton>
               <BaseButton size="sm" variant="primary">{{ $t('views.componentShowcase.save') }}</BaseButton>
@@ -203,7 +203,7 @@
 
             <template #footer>
               <div style="display: flex; justify-content: space-between; align-items: center;">
-                <span style="font-size: 13px; color: var(--text-secondary);">
+                <span style="font-size: var(--text-sm); color: var(--text-secondary);">
                   {{ $t('views.componentShowcase.showingEntries', { from: 1, to: 5, total: 5 }) }}
                 </span>
                 <div style="display: flex; gap: 4px;">
@@ -262,25 +262,25 @@
         <div class="component-section">
           <h4 class="section-heading">{{ $t('views.componentShowcase.uiFont') }}</h4>
           <div class="type-samples">
-            <p style="font-size: 28px; font-weight: 600; margin: 0;">{{ $t('views.componentShowcase.dashboardHeading') }}</p>
-            <p style="font-size: 18px; font-weight: 600; margin: 8px 0 0 0;">{{ $t('views.componentShowcase.sectionTitle') }}</p>
-            <p style="font-size: 14px; margin: 8px 0 0 0;">{{ $t('views.componentShowcase.bodyText') }}</p>
-            <p style="font-size: 13px; color: var(--text-secondary); margin: 4px 0 0 0;">{{ $t('views.componentShowcase.secondaryText') }}</p>
+            <p style="font-size: var(--text-3xl); font-weight: 600; margin: 0;">{{ $t('views.componentShowcase.dashboardHeading') }}</p>
+            <p style="font-size: var(--text-lg); font-weight: 600; margin: 8px 0 0 0;">{{ $t('views.componentShowcase.sectionTitle') }}</p>
+            <p style="font-size: var(--text-sm); margin: 8px 0 0 0;">{{ $t('views.componentShowcase.bodyText') }}</p>
+            <p style="font-size: var(--text-sm); color: var(--text-secondary); margin: 4px 0 0 0;">{{ $t('views.componentShowcase.secondaryText') }}</p>
           </div>
 
           <h4 class="section-heading">{{ $t('views.componentShowcase.dataFont') }}</h4>
           <div class="type-samples" style="font-family: var(--font-mono);">
-            <p style="font-size: 13px; margin: 0;">192.168.1.100</p>
-            <p style="font-size: 13px; margin: 4px 0 0 0;">2026-02-16T14:30:45Z</p>
-            <p style="font-size: 13px; margin: 4px 0 0 0;">user_id: 1234567890</p>
-            <p style="font-size: 13px; margin: 4px 0 0 0;">SHA: a3f4c2e1b7d</p>
+            <p style="font-size: var(--text-sm); margin: 0;">192.168.1.100</p>
+            <p style="font-size: var(--text-sm); margin: 4px 0 0 0;">2026-02-16T14:30:45Z</p>
+            <p style="font-size: var(--text-sm); margin: 4px 0 0 0;">user_id: 1234567890</p>
+            <p style="font-size: var(--text-sm); margin: 4px 0 0 0;">SHA: a3f4c2e1b7d</p>
           </div>
 
           <h4 class="section-heading">{{ $t('views.componentShowcase.numericFont') }}</h4>
           <div class="type-samples" style="font-family: var(--font-numeric); font-variant-numeric: tabular-nums;">
-            <p style="font-size: 13px; margin: 0;">1,234.56</p>
-            <p style="font-size: 13px; margin: 4px 0 0 0;">9,876.54</p>
-            <p style="font-size: 13px; margin: 4px 0 0 0;">  123.00</p>
+            <p style="font-size: var(--text-sm); margin: 0;">1,234.56</p>
+            <p style="font-size: var(--text-sm); margin: 4px 0 0 0;">9,876.54</p>
+            <p style="font-size: var(--text-sm); margin: 4px 0 0 0;">  123.00</p>
           </div>
         </div>
       </BaseCard>


### PR DESCRIPTION
Closes #4636

## Summary
Replaces hardcoded `font-size` and `color` values in Vue template inline `style="..."` attributes — the one category not covered by the bulk `<style>`-block migration scripts.

**ComponentShowcaseView.vue** (20 instances):
- `font-size: 28px` → `var(--text-3xl)`
- `font-size: 18px` → `var(--text-lg)`
- `font-size: 14px` → `var(--text-sm)` (5×)
- `font-size: 13px` → `var(--text-sm)` (10×)

**TerminalStatusBar.vue** (1 instance):
- `color: orange; font-size: 12px` → `var(--color-warning); var(--text-xs)`

**CodebaseAnalytics.vue** — skipped: `font-size: 0.5em` is relative-to-parent, not a token candidate.

## Tests
CSS-only changes. No logic paths affected.