### PR TITLE
fix(frontend): replace hardcoded border-radius in chart tooltip JS strings with design tokens (#4637)

### DIFF
--- a/autobot-frontend/src/components/charts/ModuleImportsChart.vue
+++ b/autobot-frontend/src/components/charts/ModuleImportsChart.vue
@@ -124,9 +124,11 @@ const chartOptions = computed<ApexOptions>(() => ({
       const chartPurple = getCssVar('--chart-purple', '#8b5cf6')
       const colorSuccess = getCssVar('--color-success', '#10b981')
       const colorWarning = getCssVar('--color-warning', '#f59e0b')
+      const radiusMd = getCssVar('--radius-md', '0.375rem')
+      const spacingMd = getCssVar('--spacing-3', '0.75rem')
 
       return `
-        <div style="background: ${bgElevated}; border: 1px solid ${borderDefault}; border-radius: 6px; padding: 12px; max-width: 350px;">
+        <div style="background: ${bgElevated}; border: 1px solid ${borderDefault}; border-radius: ${radiusMd}; padding: ${spacingMd}; max-width: 350px;">
           <div style="font-weight: 600; color: ${textPrimary}; margin-bottom: 8px; word-break: break-all;">
             ${item.path}
           </div>

--- a/autobot-frontend/src/components/charts/TopFilesChart.vue
+++ b/autobot-frontend/src/components/charts/TopFilesChart.vue
@@ -136,9 +136,11 @@ const chartOptions = computed(() => ({
       const textPrimary = getCssVar('--text-primary', '#e2e8f0')
       const textSecondary = getCssVar('--text-secondary', '#94a3b8')
       const chartBlue = getCssVar('--chart-blue', '#3b82f6')
+      const radiusMd = getCssVar('--radius-md', '0.375rem')
+      const spacingMd = getCssVar('--spacing-3', '0.75rem')
 
       return `
-        <div style="background: ${bgElevated}; border: 1px solid ${borderDefault}; border-radius: 6px; padding: 12px; max-width: 400px;">
+        <div style="background: ${bgElevated}; border: 1px solid ${borderDefault}; border-radius: ${radiusMd}; padding: ${spacingMd}; max-width: 400px;">
           <div style="font-weight: 600; color: ${textPrimary}; margin-bottom: 8px; word-break: break-all;">
             ${filePath}
           </div>


### PR DESCRIPTION
Closes #4637

## Summary
Chart tooltip HTML is built via JavaScript template literals, making it unreachable by `<style>`-block migration scripts. Both files already used a `getCssVar()` helper to read color tokens via `getComputedStyle` — extended that same pattern to also read `--radius-md` and `--spacing-3`.

**ModuleImportsChart.vue** and **TopFilesChart.vue**:
- `border-radius: 6px` → `border-radius: ${getCssVar('--radius-md', '0.375rem')}`
- `padding: 12px` → `padding: ${getCssVar('--spacing-3', '0.75rem')}` (`--spacing-3: 0.75rem` = 12px exactly)

Both tokens confirmed present in `design-tokens.css`. Fallback values provided so tooltips degrade gracefully if tokens aren't loaded.

## Tests
CSS-only changes inside JS string templates.