### PR TITLE
fix(frontend): tokenize remaining multi-value and non-standard border-radius values (#4638)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -860,7 +860,7 @@ export default {
   color: #fff;
   padding: 8px 16px;
   text-decoration: none;
-  border-radius: 0 0 4px 0;
+  border-radius: 0 0 var(--radius-default) 0;
   font-size: var(--text-sm);
   font-weight: 500;
   transition: top var(--duration-200) var(--ease-in-out);

--- a/autobot-frontend/src/components/base/BaseBadge.vue
+++ b/autobot-frontend/src/components/base/BaseBadge.vue
@@ -108,7 +108,7 @@ const handleRemove = (event: MouseEvent) => {
   height: 28px;
   padding: 0 12px;
   font-size: var(--text-sm);
-  border-radius: 14px;
+  border-radius: var(--radius-2xl);
 }
 
 /* Rounded Variants */

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -417,14 +417,14 @@ onBeforeUnmount(() => {
 
 .voice-panel__amplitude {
   height: 3px;
-  border-radius: 1.5px;
+  border-radius: var(--radius-xs);
   background: rgba(148, 163, 184, 0.1);
   overflow: hidden;
 }
 
 .voice-panel__amplitude-bar {
   height: 100%;
-  border-radius: 1.5px;
+  border-radius: var(--radius-xs);
   background: linear-gradient(90deg, #60a5fa, #818cf8);
   transition: width var(--duration-100) var(--ease-out);
   min-width: 0;
@@ -434,7 +434,7 @@ onBeforeUnmount(() => {
   height: 3px;
   appearance: none;
   background: rgba(148, 163, 184, 0.15);
-  border-radius: 1.5px;
+  border-radius: var(--radius-xs);
   outline: none;
   cursor: pointer;
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -1177,7 +1177,7 @@ watch(() => props.mode, () => {
   height: 1.25rem;
   padding: 0 0.375rem;
   background: rgba(0, 0, 0, 0.1);
-  border-radius: 0.625rem;
+  border-radius: var(--radius-xl);
   font-size: var(--text-xs);
   font-weight: 600;
   margin-left: 0.375rem;

--- a/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
+++ b/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
@@ -213,7 +213,7 @@ const { formatDate } = useKnowledgeBase()
   background: var(--color-primary);
   color: var(--text-inverse);
   padding: 4px 10px;
-  border-radius: 15px;
+  border-radius: var(--radius-2xl);
   font-size: 0.8rem;
   font-family: 'Courier New', monospace;
 }

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -2018,7 +2018,7 @@ export default {
   padding: 20px 24px;
   border-top: 1px solid #444;
   background-color: #252525;
-  border-radius: 0 0 12px 12px;
+  border-radius: 0 0 var(--radius-xl) var(--radius-xl);
 }
 
 /* Enhanced animations */

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
@@ -367,7 +367,7 @@ async function handleSave(): Promise<void> {
   padding: 4px 10px;
   background: var(--color-primary-bg);
   color: var(--color-primary);
-  border-radius: 14px;
+  border-radius: var(--radius-2xl);
   font-size: var(--text-xs);
   font-weight: 500;
 }


### PR DESCRIPTION
Closes #4638

## Summary
10 instances across 7 files that were skipped by the bulk border-radius migration — either multi-value shorthands or sizes without exact token matches.

**Multi-value shorthands:**
- `App.vue`: `0 0 4px 0` → `0 0 var(--radius-default) 0`
- `TerminalWindow.vue`: `0 0 12px 12px` → `0 0 var(--radius-xl) var(--radius-xl)`

**Non-standard values (rounded to nearest token):**
- `BaseBadge.vue`: `14px` → `var(--radius-2xl)` (16px)
- `IntegrationStatusPanel.vue`: `15px` → `var(--radius-2xl)`
- `NotificationConfigModal.vue`: `14px` → `var(--radius-2xl)`
- `KnowledgeBrowser.vue`: `0.625rem` (10px) → `var(--radius-xl)` (12px)
- `VoiceConversationPanel.vue`: `1.5px` (×3) → `var(--radius-xs)` (2px)

All rounding decisions are within 2px of the original value.

## Tests
CSS-only changes. No logic paths affected.