### PR TITLE
fix(orchestrator): add missing LongTermMemoryManager methods (#4660)

### DIFF
--- a/autobot-backend/memory/compat.py
+++ b/autobot-backend/memory/compat.py
@@ -369,6 +369,19 @@ class LongTermMemoryManager:
         query = " ".join(str(v) for v in metadata_query.values())
         return await self._unified.search_memories(query)
 
+    async def initialize(self) -> None:
+        """Initialize the underlying storage (called by orchestrator on startup)."""
+        await self._unified._ensure_initialized()
+        logger.info("LongTermMemoryManager initialized")
+
+    async def cleanup(self) -> None:
+        """Cleanup hook called by orchestrator on shutdown (no-op: no resources to release)."""
+        logger.info("LongTermMemoryManager cleanup complete")
+
+    async def search_relevant_context(self, query: str) -> List[MemoryEntry]:
+        """Search memories for context relevant to the given query."""
+        return await self._unified.search_memories(query)
+
     async def cleanup_old_memories(self, retention_days: Optional[int] = None) -> int:
         """Cleanup old memories"""
         return await self._unified.cleanup_old_memories(retention_days)


### PR DESCRIPTION
Closes #4660

## Summary
- Added missing `initialize()`, `cleanup()`, and `search_relevant_context()` methods to `LongTermMemoryManager` in `autobot-backend/memory/compat.py`
- `initialize()` delegates to `UnifiedMemoryManager._ensure_initialized()`
- `cleanup()` is a no-op with log (no resources to release)
- `search_relevant_context()` delegates to `search_memories()`
- All three were called by the orchestrator on startup/shutdown but absent from the compat wrapper, causing `AttributeError` on every restart

## Test Status
✅ 10/10 memory tests passed