### PR TITLE
fix(knowledge): remove incorrect await on ChromaDB Collection objects (#4663)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/sources.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/sources.py
@@ -439,20 +439,18 @@ async def _get_last_indexed(source_id: str) -> Optional[str]:
     Issue #1716: Reads per-source stats doc first, falls back to global.
     """
     try:
-        from ..storage import get_code_collection
+        from ..storage import get_code_collection_async
 
-        collection = await get_code_collection()
+        collection = await get_code_collection_async()
         if collection:
             # Try per-source stats first (#1716), fall back to global
             stats_id = f"codebase_stats_{source_id}"
-            results = await asyncio.to_thread(
-                collection.get,
+            results = await collection.get(
                 ids=[stats_id],
                 include=["metadatas"],
             )
             if not results or not results.get("metadatas"):
-                results = await asyncio.to_thread(
-                    collection.get,
+                results = await collection.get(
                     ids=["codebase_stats"],
                     include=["metadatas"],
                 )


### PR DESCRIPTION
Closes #4663

## Summary
- In `_get_last_indexed()` (`sources.py`), switched from synchronous `get_code_collection()` (which was incorrectly awaited) to the existing `get_code_collection_async()` which returns a proper async ChromaDB collection
- Replaced `asyncio.to_thread(collection.get, ...)` wrappers with direct `await collection.get(...)` calls
- ChromaDB's sync `Collection` is not a coroutine — awaiting it always returned `None`, causing `last_indexed` reads to always fail

## Test Status
✅ 83 passed, 2 skipped in codebase_analytics suite