### PR TITLE
fix(chat): use createNewChat return value in pushLocalOnlySessions (#4536)

### DIFF
--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -1073,13 +1073,14 @@ export class ChatController {
     await Promise.allSettled(
       localOnly.map(async (session: ChatSession) => {
         try {
-          await chatRepository.createNewChat(session.title)
+          const newSession = await chatRepository.createNewChat(session.title)
+          const backendId = newSession?.id ?? session.id
           await chatRepository.saveChatMessages({
-            chatId: session.id,
+            chatId: backendId,
             messages: session.messages,
             name: session.title || ''
           })
-          logger.debug(`[Issue #4431] Pushed local session ${session.id} to backend`)
+          logger.debug(`[Issue #4431] Pushed local session ${session.id} to backend as ${backendId}`)
         } catch (error) {
           logger.warn(`[Issue #4431] Failed to push local session ${session.id}:`, error)
         }


### PR DESCRIPTION
Closes #4536

## Summary
- Fixed `pushLocalOnlySessions` in `ChatController.ts` to capture the `ChatSession` returned by `chatRepository.createNewChat()` and use its backend-assigned `id` as `chatId` when calling `saveChatMessages()`
- Previously, messages were POSTed to the stale local-only `session.id` (wrong endpoint: `/chats/<local-id>/save`), orphaning all messages saved during session push

## Test Status
⚠️ No unit tests exist for pushLocalOnlySessions (tracked in #4563); TypeScript check shows no new errors introduced