### PR TITLE
fix(analytics): add missing 'components' field to HealthScore interface (#4545)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -465,6 +465,7 @@ interface HealthScore {
   grade: string;
   trend: number;
   breakdown: Record<string, number>;
+  components: Record<string, number>;
   recommendations: string[];
 }
 
@@ -512,6 +513,7 @@ const healthScore = ref<HealthScore>({
   grade: 'C',
   trend: 0,
   breakdown: {},
+  components: {},
   recommendations: [],
 });
 


### PR DESCRIPTION
Closes #4545

## Summary
- Added `components: Record<string, number>` to the `HealthScore` interface in `CodeQualityDashboard.vue`
- Added matching default value in the `healthScore` ref initializer
- `loadHealthScore()` was already setting `healthScore.value.components` from the API response, but the interface didn't declare the field, causing TS2353