### PR TITLE
fix(analytics): declare realTimeEnabled in CodebaseOverviewPanel Props (#4546)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
@@ -199,6 +199,7 @@ interface Props {
   communicationPatterns: CommunicationPatternsData | null
   codeQuality: CodeQualityData | null
   performanceMetrics: PerformanceMetricsData | null
+  realTimeEnabled?: boolean
 }
 
 defineProps<Props>()


### PR DESCRIPTION
Closes #4546

## Summary
- Added `realTimeEnabled?: boolean` to the `Props` interface in `CodebaseOverviewPanel.vue`
- The prop was used in the template to toggle a live/static refresh indicator but never declared in the Props interface, causing TS2339
- Consistent with how `EnhancedAnalyticsGrid.vue` declares the same prop