### PR TITLE
fix(drift-checker): update compute_drift docstring after total_compared rename (#4653)

### DIFF
--- a/autobot-slm-backend/services/drift_checker.py
+++ b/autobot-slm-backend/services/drift_checker.py
@@ -137,7 +137,7 @@ def compute_drift(
 ) -> Tuple[List[dict], int]:
     """Compare file checksums between *source_dir* and *deployed_dir*.
 
-    Returns a tuple of (drifted_file_dicts, total_compared_count).
+    Returns a tuple of (drifted_file_dicts, total_compared).
 
     Each drifted file dict has keys:
         path            – POSIX relative path


### PR DESCRIPTION
Closes #4653

## Summary
- Updated the opening summary line in `compute_drift`'s docstring in `drift_checker.py`
- Changed stale `total_compared_count` to `total_compared` to match the field name introduced by PR #4631
- The `Returns:` block already used the correct name; only the opening summary line was stale