### PR TITLE
fix(npu-worker): log NPU unavailable warning once at startup, not per-request (#4666)

### DIFF
--- a/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.py.j2
+++ b/autobot-slm-backend/ansible/roles/npu-worker/templates/npu-worker.py.j2
@@ -29,10 +29,17 @@ PORT = int(os.getenv("NPU_PORT", "8081"))
 
 app = FastAPI(title="AutoBot NPU Worker", version="1.0.0")
 
+# Cached at startup — prevents per-request WARNING flood (#4666)
+_npu_capabilities: Dict[str, Any] = {}
+
 
 def _detect_npu_capabilities() -> Dict[str, Any]:
-    """Detect NPU hardware capabilities."""
-    capabilities = {
+    """Detect NPU hardware capabilities once at startup and cache the result."""
+    global _npu_capabilities
+    if _npu_capabilities:
+        return _npu_capabilities
+
+    capabilities: Dict[str, Any] = {
         "device": DEVICE,
         "available": False,
         "models_dir": str(MODELS_DIR),
@@ -60,7 +67,8 @@ def _detect_npu_capabilities() -> Dict[str, Any]:
         logger.error("Error detecting NPU: %s", e)
         capabilities["error"] = str(e)
 
-    return capabilities
+    _npu_capabilities = capabilities
+    return _npu_capabilities
 
 
 @app.get("/health")
@@ -96,6 +104,9 @@ def main():
     logger.info("Device: %s", DEVICE)
     logger.info("Models directory: %s", MODELS_DIR)
     logger.info("=" * 60)
+
+    # Warm capability cache at startup — warning logged once here, never per-request
+    _detect_npu_capabilities()
 
     try:
         uvicorn.run(


### PR DESCRIPTION
Closes #4666

## Summary
- Added module-level cache `_npu_capabilities: Dict[str, Any] = {}` — `_detect_npu_capabilities()` returns cached result on all calls after the first
- Pre-call `_detect_npu_capabilities()` explicitly in `main()` before uvicorn starts, so the warning fires exactly once at startup rather than on every `/health` poll
- Eliminates WARNING flood that was masking real errors in logs

## Test Status
SKIPPED (Jinja2 template; AST parse + flake8 passed clean)