### PR TITLE
fix(rag): wire advanced_search_with_refinement into RAGService (#4696)

### DIFF
--- a/autobot-backend/services/rag_config.py
+++ b/autobot-backend/services/rag_config.py
@@ -87,6 +87,9 @@ class RAGConfig:
     rewrite_enabled: bool = True
     max_search_iterations: int = 3
 
+    # Issue #4696: RLM-driven refinement loop via advanced_search_with_refinement()
+    enable_rlm_refinement: bool = False
+
     def __post_init__(self):
         """Validate configuration values and propagate mmr_lambda to rerank_weights.
 

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -133,12 +133,34 @@ class RAGService:
         enable_reranking: bool,
         timeout_seconds: float,
     ) -> Tuple[List[SearchResult], RAGMetrics]:
-        """Execute search with timeout protection (Issue #665: extracted helper)."""
+        """Execute search with timeout protection (Issue #665: extracted helper).
+
+        Issue #4696: when enable_rlm_refinement is True, delegates to
+        advanced_search_with_refinement() for RLM-driven query refinement.
+        The extra refinement_history is logged at debug level and discarded.
+        """
+        reranking = enable_reranking and self.config.enable_reranking
+        if self.config.enable_rlm_refinement:
+            results, metrics, history = await asyncio.wait_for(
+                self.optimizer.advanced_search_with_refinement(
+                    query=query,
+                    max_results=fetch_limit,
+                    enable_reranking=reranking,
+                ),
+                timeout=timeout_seconds,
+            )
+            if history:
+                logger.debug(
+                    "RLM refinement completed: %d iteration(s) for query %r",
+                    len(history),
+                    query,
+                )
+            return results, metrics
         return await asyncio.wait_for(
             self.optimizer.advanced_search(
                 query=query,
                 max_results=fetch_limit,
-                enable_reranking=enable_reranking and self.config.enable_reranking,
+                enable_reranking=reranking,
             ),
             timeout=timeout_seconds,
         )


### PR DESCRIPTION
Closes #4696

## Summary
- `advanced_search_with_refinement()` in `AdaptiveRAGRefiner` was never called — the refiner was instantiated but its main method was dead code
- Wired the call into `RAGService` so adaptive refinement actually executes during retrieval