### PR TITLE
fix(rag): validate source paths on retrieved chunks — filter stale paths (#4689)

### DIFF
--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -643,6 +643,10 @@ class RAGService:
             cache_key,
         )
 
+        # Issue #4689: filter chunks whose source_path is absent from the hash cache
+        # (file was removed/moved since last index run).
+        results = await self._filter_stale_chunks(results)
+
         # Store in semantic + topic caches for future lookups
         await self._store_in_semantic_cache(query, results)
         await self._store_in_topic_cache(results)
@@ -801,6 +805,72 @@ class RAGService:
         except Exception as e:
             logger.error("Reranking failed: %s", e)
             return results
+
+    async def _filter_stale_chunks(
+        self,
+        results: List[SearchResult],
+    ) -> List[SearchResult]:
+        """Filter out chunks whose source_path is absent from the DocIndexer hash cache.
+
+        Issue #4689: chunks for files removed/moved since the last index run must
+        not reach the LLM context.  If the hash cache is unavailable (file missing,
+        parse error) the method returns the original list unchanged so RAG is never
+        disrupted by a cache I/O failure.
+
+        The check is path-presence only (not hash equality); we trust that the
+        DocIndexer re-indexes changed files on the next cycle.
+
+        Returns:
+            Filtered list (stale chunks dropped) or original list on cache failure.
+        """
+        import json as _json
+        from pathlib import Path as _Path
+
+        try:
+            from services.knowledge.doc_indexer import HASH_CACHE_FILE
+
+            cache_path: _Path = HASH_CACHE_FILE
+        except Exception as exc:
+            logger.debug("Could not import HASH_CACHE_FILE (skipping provenance check): %s", exc)
+            return results
+
+        def _load() -> dict:
+            if not cache_path.exists():
+                return {}
+            try:
+                with open(cache_path, "r", encoding="utf-8") as fh:
+                    return _json.load(fh)
+            except Exception:
+                return {}
+
+        try:
+            hash_cache: dict = await asyncio.to_thread(_load)
+        except Exception as exc:
+            logger.debug("Hash cache load failed (skipping provenance check): %s", exc)
+            return results
+
+        if not hash_cache:
+            # Empty cache means indexer hasn't run yet; skip filtering to avoid
+            # dropping all results on a fresh deployment.
+            return results
+
+        valid: List[SearchResult] = []
+        stale_paths: List[str] = []
+        for chunk in results:
+            if chunk.source_path in hash_cache:
+                valid.append(chunk)
+            else:
+                stale_paths.append(chunk.source_path)
+
+        if stale_paths:
+            logger.warning(
+                "Provenance check: dropped %d stale chunk(s) — source paths absent from "
+                "hash cache: %s",
+                len(stale_paths),
+                stale_paths[:10],  # cap log line length
+            )
+
+        return valid
 
     def _filter_by_categories(
         self,

--- a/autobot-backend/tests/services/rag_service_events_test.py
+++ b/autobot-backend/tests/services/rag_service_events_test.py
@@ -719,3 +719,117 @@ class TestRetrievedVsRankedIdsSeparation:
         _, kwargs = mock_store.call_args
         assert kwargs["retrieved_ids"] == ["chunk_a", "chunk_b"]
         assert kwargs["ranked_ids"] == ["chunk_b", "chunk_a"]
+
+
+# =============================================================================
+# _filter_stale_chunks Tests (#4689)
+# =============================================================================
+
+
+class TestFilterStaleChunks:
+    """Tests for RAGService._filter_stale_chunks() — provenance validation."""
+
+    def _make_service(self):
+        from services.rag_service import RAGService
+
+        svc = RAGService.__new__(RAGService)
+        svc._initialized = True
+        return svc
+
+    def _make_chunk(self, source_path: str):
+        from advanced_rag_optimizer import SearchResult
+
+        return SearchResult(
+            content="text",
+            metadata={"relative_path": source_path},
+            semantic_score=0.9,
+            keyword_score=0.0,
+            hybrid_score=0.9,
+            relevance_rank=1,
+            source_path=source_path,
+            chunk_index=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_valid_chunk_passes_through(self, tmp_path):
+        """Chunk whose source_path IS in the hash cache is kept."""
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text('{"docs/guide.md": "abc123"}', encoding="utf-8")
+
+        svc = self._make_service()
+        chunk = self._make_chunk("docs/guide.md")
+
+        with patch("services.knowledge.doc_indexer.HASH_CACHE_FILE", cache_file):
+            result = await svc._filter_stale_chunks([chunk])
+
+        assert result == [chunk]
+
+    @pytest.mark.asyncio
+    async def test_stale_chunk_is_filtered(self, tmp_path):
+        """Chunk whose source_path is ABSENT from the hash cache is dropped."""
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text('{"docs/present.md": "abc123"}', encoding="utf-8")
+
+        svc = self._make_service()
+        stale = self._make_chunk("docs/removed.md")
+        valid = self._make_chunk("docs/present.md")
+
+        with patch("services.knowledge.doc_indexer.HASH_CACHE_FILE", cache_file):
+            result = await svc._filter_stale_chunks([stale, valid])
+
+        assert result == [valid]
+
+    @pytest.mark.asyncio
+    async def test_warning_logged_for_stale_chunks(self, tmp_path):
+        """A warning is emitted when stale chunks are dropped."""
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text('{"docs/present.md": "abc123"}', encoding="utf-8")
+
+        svc = self._make_service()
+        stale = self._make_chunk("docs/gone.md")
+
+        with patch("services.knowledge.doc_indexer.HASH_CACHE_FILE", cache_file):
+            with patch("services.rag_service.logger") as mock_logger:
+                await svc._filter_stale_chunks([stale])
+
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args[0]
+        assert "stale" in call_args[0]
+
+    @pytest.mark.asyncio
+    async def test_cache_unavailable_returns_all_chunks(self, tmp_path):
+        """If the hash cache module cannot be imported, all chunks are returned unchanged."""
+        svc = self._make_service()
+        chunk = self._make_chunk("docs/anything.md")
+
+        with patch.dict("sys.modules", {"services.knowledge.doc_indexer": None}):
+            result = await svc._filter_stale_chunks([chunk])
+
+        assert result == [chunk]
+
+    @pytest.mark.asyncio
+    async def test_empty_cache_skips_filter(self, tmp_path):
+        """An empty hash cache (indexer hasn't run) passes all chunks through."""
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text("{}", encoding="utf-8")
+
+        svc = self._make_service()
+        chunk = self._make_chunk("docs/anything.md")
+
+        with patch("services.knowledge.doc_indexer.HASH_CACHE_FILE", cache_file):
+            result = await svc._filter_stale_chunks([chunk])
+
+        assert result == [chunk]
+
+    @pytest.mark.asyncio
+    async def test_missing_cache_file_skips_filter(self, tmp_path):
+        """If hash cache file does not exist, all chunks pass through."""
+        cache_file = tmp_path / "nonexistent_hashes.json"
+
+        svc = self._make_service()
+        chunk = self._make_chunk("docs/anything.md")
+
+        with patch("services.knowledge.doc_indexer.HASH_CACHE_FILE", cache_file):
+            result = await svc._filter_stale_chunks([chunk])
+
+        assert result == [chunk]


### PR DESCRIPTION
Closes #4689

## Summary
- Added `_filter_stale_chunks()` to `RAGService`: after each ChromaDB retrieval, loads the DocIndexer hash cache and drops chunks whose `source_path` is absent (file removed/moved since last index run)
- Logs a WARNING with the stale path list
- Graceful fallback: if cache file is missing/empty/unreadable, full result list returned unchanged — RAG is never disrupted
- Called from `advanced_search()` after `_execute_and_cache_search`

## Test Status
✅ 6 unit tests: valid chunk passes, stale chunk filtered, warning logged, cache unavailable → no filter, empty cache → no filter