### PR TITLE
fix(knowledge): validate synthesis_schema source paths on load — warn on missing (#4695)

### DIFF
--- a/autobot-backend/services/knowledge/synthesis_schema_loader.py
+++ b/autobot-backend/services/knowledge/synthesis_schema_loader.py
@@ -38,8 +38,15 @@ class SynthesisSchema:
     collections: List[CollectionConfig] = field(default_factory=list)
 
 
-def _parse_collection(raw: dict, index: int) -> CollectionConfig:
-    """Parse and validate a single collection entry. Raises ValueError on unknown keys."""
+def _parse_collection(raw: dict, index: int, repo_root: Optional[Path] = None) -> CollectionConfig:
+    """Parse and validate a single collection entry. Raises ValueError on unknown keys.
+
+    Args:
+        raw: Raw dict from YAML for this collection.
+        index: Zero-based position in the collections list (for error messages).
+        repo_root: Optional repo root used to check whether declared paths exist on disk.
+            Missing paths emit a WARNING but do not raise — schemas may forward-declare paths.
+    """
     unknown = set(raw.keys()) - _ALLOWED_KEYS
     if unknown:
         raise ValueError(
@@ -51,20 +58,36 @@ def _parse_collection(raw: dict, index: int) -> CollectionConfig:
         raise ValueError(
             f"Collection[{index}] is missing required keys: {sorted(missing)}"
         )
-    return CollectionConfig(
+    config = CollectionConfig(
         name=str(raw["name"]),
         paths=[str(p) for p in raw["paths"]],
         synthesis_target=str(raw["synthesis_target"]),
         prompt_template=str(raw["prompt_template"]),
     )
+    if repo_root is not None:
+        for p in config.paths:
+            resolved = repo_root / p
+            if not resolved.exists():
+                logger.warning(
+                    "Collection '%s': path '%s' does not exist — will match no documents",
+                    config.name,
+                    p,
+                )
+    return config
 
 
-def load_synthesis_schema(path: Optional[Path] = None) -> SynthesisSchema:
+def load_synthesis_schema(
+    path: Optional[Path] = None,
+    repo_root: Optional[Path] = None,
+) -> SynthesisSchema:
     """Load and validate synthesis_schema.yaml.
 
     Args:
         path: Explicit path to the YAML file. Defaults to the bundled
               resources/knowledge/synthesis_schema.yaml relative to this file.
+        repo_root: Root directory used to resolve collection paths for existence
+            checks. Defaults to four levels above this file (the repository root).
+            Pass ``None`` explicitly to disable path existence warnings.
 
     Returns:
         SynthesisSchema with validated collection configs, or an empty schema
@@ -81,6 +104,10 @@ def load_synthesis_schema(path: Optional[Path] = None) -> SynthesisSchema:
             / "synthesis_schema.yaml"
         )
 
+    if repo_root is None:
+        # __file__ → services/knowledge/ → services/ → autobot-backend/ → repo root
+        repo_root = Path(__file__).parent.parent.parent.parent
+
     if not path.exists():
         logger.debug("Synthesis schema not found at %s — returning empty schema", path)
         return SynthesisSchema()
@@ -95,7 +122,7 @@ def load_synthesis_schema(path: Optional[Path] = None) -> SynthesisSchema:
         )
 
     collections = [
-        _parse_collection(entry, i)
+        _parse_collection(entry, i, repo_root)
         for i, entry in enumerate(raw_data["collections"])
     ]
     return SynthesisSchema(collections=collections)

--- a/autobot-backend/services/knowledge/test_synthesis_schema_loader.py
+++ b/autobot-backend/services/knowledge/test_synthesis_schema_loader.py
@@ -144,3 +144,56 @@ class TestValidationError:
         path = _write_yaml(tmp_path, bad_yaml)
         with pytest.raises(ValueError, match="collections"):
             load_synthesis_schema(path)
+
+
+class TestPathExistenceWarnings:
+    """load_synthesis_schema warns on missing paths but does not raise."""
+
+    def _yaml_with_paths(self, *paths: str) -> str:
+        paths_block = "\n".join(f"          - {p}" for p in paths)
+        return (
+            "collections:\n"
+            "  - name: test_col\n"
+            "    paths:\n"
+            f"{paths_block}\n"
+            "    synthesis_target: autobot_test\n"
+            '    prompt_template: "test {documents}"\n'
+        )
+
+    def test_no_warning_for_existing_path(self, tmp_path, caplog):
+        real_dir = tmp_path / "existing_docs"
+        real_dir.mkdir()
+        schema_path = _write_yaml(tmp_path, self._yaml_with_paths("existing_docs"))
+        import logging
+        with caplog.at_level(logging.WARNING):
+            load_synthesis_schema(schema_path, repo_root=tmp_path)
+        warnings = [r for r in caplog.records if r.levelname == "WARNING" and "does not exist" in r.message]
+        assert warnings == [], f"Unexpected warnings: {[r.message for r in warnings]}"
+
+    def test_warning_for_missing_path(self, tmp_path, caplog):
+        schema_path = _write_yaml(tmp_path, self._yaml_with_paths("nonexistent_dir"))
+        import logging
+        with caplog.at_level(logging.WARNING):
+            schema = load_synthesis_schema(schema_path, repo_root=tmp_path)
+        # Schema still loads — no exception
+        assert len(schema.collections) == 1
+        warnings = [r for r in caplog.records if r.levelname == "WARNING" and "does not exist" in r.message]
+        assert len(warnings) == 1
+        assert "nonexistent_dir" in warnings[0].message
+
+    def test_warning_per_missing_path_in_mixed_list(self, tmp_path, caplog):
+        real_dir = tmp_path / "real_docs"
+        real_dir.mkdir()
+        schema_path = _write_yaml(
+            tmp_path,
+            self._yaml_with_paths("real_docs", "missing_one", "missing_two"),
+        )
+        import logging
+        with caplog.at_level(logging.WARNING):
+            schema = load_synthesis_schema(schema_path, repo_root=tmp_path)
+        assert len(schema.collections) == 1
+        warnings = [r for r in caplog.records if r.levelname == "WARNING" and "does not exist" in r.message]
+        assert len(warnings) == 2
+        missing_paths_warned = {w.message for w in warnings}
+        assert any("missing_one" in m for m in missing_paths_warned)
+        assert any("missing_two" in m for m in missing_paths_warned)


### PR DESCRIPTION
Closes #4695

## Summary
- `load_synthesis_schema()` and `_parse_collection()` now accept optional `repo_root` parameter (defaults to repo root via `__file__`)
- After parsing each collection, iterates `config.paths` and emits `logger.warning(...)` for any path that doesn't exist
- Schema still loads — no exception raised, just warnings so operators see the problem immediately
- 3 new tests covering: valid path emits no warning, single missing path emits 1 warning, mixed list emits correct count

## Tests
- 12 tests passed (9 pre-existing + 3 new)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)