### PR TITLE
fix(deployment): add missing AUTOBOT_*_ENDPOINT env vars to ai-stack template (#4661)

### DIFF
--- a/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/ai-stack/defaults/main.yml
@@ -29,6 +29,11 @@ chromadb_port: 8100
 ollama_host: "{{ backend_host | default(ansible_host) }}"
 ollama_port: 11434
 
+# Agent LLM endpoints — injected into ai-stack.env; default to Ollama (#4661)
+ai_chat_endpoint: "http://{{ ollama_host }}:{{ ollama_port }}"
+ai_rag_endpoint: "http://{{ ollama_host }}:{{ ollama_port }}"
+ai_classification_endpoint: "http://{{ ollama_host }}:{{ ollama_port }}"
+
 # Redis connection (resolved from inventory)
 ai_redis_host: "{{ redis_host | default(ansible_host) }}"
 ai_redis_port: "{{ redis_port | default(6379) }}"

--- a/autobot-slm-backend/ansible/roles/ai-stack/templates/ai-stack.env.j2
+++ b/autobot-slm-backend/ansible/roles/ai-stack/templates/ai-stack.env.j2
@@ -27,3 +27,8 @@ REDIS_PASSWORD={{ ai_redis_password }}
 AUTOBOT_CLASSIFICATION_PROVIDER={{ ai_classification_provider | default('ollama') }}
 AUTOBOT_CHAT_PROVIDER={{ ai_chat_provider | default('ollama') }}
 AUTOBOT_RAG_PROVIDER={{ ai_rag_provider | default('ollama') }}
+
+# Agent LLM endpoint configuration — required by get_agent_endpoint_explicit() (#4661)
+AUTOBOT_CHAT_ENDPOINT={{ ai_chat_endpoint }}
+AUTOBOT_RAG_ENDPOINT={{ ai_rag_endpoint }}
+AUTOBOT_CLASSIFICATION_ENDPOINT={{ ai_classification_endpoint }}


### PR DESCRIPTION
Closes #4661

## Summary
- Added `AUTOBOT_CHAT_ENDPOINT`, `AUTOBOT_RAG_ENDPOINT`, `AUTOBOT_CLASSIFICATION_ENDPOINT` to `ai-stack.env.j2` Ansible template
- Added corresponding defaults (`ai_chat_endpoint`, `ai_rag_endpoint`, `ai_classification_endpoint`) to `roles/ai-stack/defaults/main.yml` — all resolve to `http://{{ ollama_host }}:{{ ollama_port }}`
- Fixes `AgentConfigurationError` raised by `get_agent_endpoint_explicit()` when vars are absent post-deploy

## Tests
- 37 agent tests passed (test_subagent_spawning.py + test_memory_hooks.py)
- Pre-existing import failures in test_causal_reasoning.py and test_property_graph.py are unrelated to this change

🤖 Generated with [Claude Code](https://claude.ai/claude-code)