### PR TITLE
fix(backend): trust self-signed CA cert for internal WebSocket connections (#4664)

### DIFF
--- a/autobot-backend/services/slm_client.py
+++ b/autobot-backend/services/slm_client.py
@@ -138,16 +138,38 @@ class ServiceDiscoveryCache:
 
 
 def _create_permissive_ssl_context():
-    """Create SSL context for internal SLM communication (#1048, #2852).
+    """Create SSL context for internal SLM communication (#1048, #2852, #4664).
 
-    By default TLS verification is enabled.  Set AUTOBOT_SKIP_TLS_VERIFY=true
-    ONLY in dev/test environments that use self-signed certificates — never in
+    Trust hierarchy (first match wins):
+    1. AUTOBOT_TLS_CA_PATH env var → load that CA cert (production mTLS)
+    2. AUTOBOT_SKIP_TLS_VERIFY=true → disable verification (dev/test only)
+    3. AutoBot project CA fallback (certs/ca/ca-cert.pem) → load if present
+    4. System trust store → default Python SSL behaviour
+
+    Set AUTOBOT_SKIP_TLS_VERIFY=true ONLY in dev/test environments — never in
     production.
     """
     ctx = ssl.create_default_context()
+
+    # 1. Explicit CA path from env (production deployment)
+    ca_path = os.environ.get("AUTOBOT_TLS_CA_PATH")
+    if ca_path and os.path.isfile(ca_path):
+        ctx.load_verify_locations(ca_path)
+        return ctx
+
+    # 2. Dev/test override — skip verification entirely
     if os.environ.get("AUTOBOT_SKIP_TLS_VERIFY", "").lower() == "true":
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+
+    # 3. AutoBot project CA fallback (covers single-host installs with self-signed certs)
+    _project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    _cert_dir = os.environ.get("AUTOBOT_TLS_CERT_DIR", "certs")
+    _fallback_ca = os.path.join(_project_root, _cert_dir, "ca", "ca-cert.pem")
+    if os.path.isfile(_fallback_ca):
+        ctx.load_verify_locations(_fallback_ca)
+
     return ctx
 
 

--- a/autobot-backend/services/slm_client_test.py
+++ b/autobot-backend/services/slm_client_test.py
@@ -1,0 +1,214 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for SLM client SSL context and WebSocket reconnect backoff (#4664).
+"""
+
+import asyncio
+import os
+import ssl
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.slm_client import (
+    SLMClient,
+    _create_permissive_ssl_context,
+)
+
+
+class TestCreatePermissiveSslContext:
+    """Tests for _create_permissive_ssl_context SSL trust hierarchy."""
+
+    def test_returns_ssl_context(self):
+        """Default call returns an ssl.SSLContext."""
+        ctx = _create_permissive_ssl_context()
+        assert isinstance(ctx, ssl.SSLContext)
+
+    def test_verification_enabled_by_default(self):
+        """Without any env vars, verification is not disabled."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = _create_permissive_ssl_context()
+        assert ctx.verify_mode != ssl.CERT_NONE
+
+    def test_skip_tls_verify_disables_verification(self):
+        """AUTOBOT_SKIP_TLS_VERIFY=true disables cert verification."""
+        with patch.dict(os.environ, {"AUTOBOT_SKIP_TLS_VERIFY": "true"}, clear=False):
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = _create_permissive_ssl_context()
+        assert ctx.verify_mode == ssl.CERT_NONE
+        assert ctx.check_hostname is False
+
+    def test_explicit_ca_path_loads_ca(self):
+        """AUTOBOT_TLS_CA_PATH pointing to a valid CA cert is loaded."""
+        # Create a dummy self-signed CA cert on disk
+        import subprocess
+
+        with tempfile.NamedTemporaryFile(suffix=".pem", delete=False) as f:
+            ca_path = f.name
+
+        try:
+            result = subprocess.run(
+                [
+                    "openssl",
+                    "req",
+                    "-x509",
+                    "-newkey",
+                    "rsa:2048",
+                    "-keyout",
+                    "/dev/null",
+                    "-out",
+                    ca_path,
+                    "-days",
+                    "1",
+                    "-nodes",
+                    "-subj",
+                    "/CN=TestCA",
+                ],
+                capture_output=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                pytest.skip("openssl not available")
+
+            with patch.dict(os.environ, {"AUTOBOT_TLS_CA_PATH": ca_path}, clear=False):
+                os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+                ctx = _create_permissive_ssl_context()
+
+            # Cert is loaded and verification remains enabled
+            assert ctx.verify_mode != ssl.CERT_NONE
+        finally:
+            os.unlink(ca_path)
+
+    def test_nonexistent_ca_path_falls_through(self):
+        """A missing AUTOBOT_TLS_CA_PATH file does not crash — falls through."""
+        with patch.dict(
+            os.environ,
+            {"AUTOBOT_TLS_CA_PATH": "/nonexistent/ca.pem"},
+            clear=False,
+        ):
+            os.environ.pop("AUTOBOT_SKIP_TLS_VERIFY", None)
+            ctx = _create_permissive_ssl_context()
+        assert isinstance(ctx, ssl.SSLContext)
+
+    def test_skip_tls_verify_case_insensitive(self):
+        """AUTOBOT_SKIP_TLS_VERIFY=TRUE (upper-case) also disables verification."""
+        with patch.dict(os.environ, {"AUTOBOT_SKIP_TLS_VERIFY": "TRUE"}, clear=False):
+            os.environ.pop("AUTOBOT_TLS_CA_PATH", None)
+            ctx = _create_permissive_ssl_context()
+        assert ctx.verify_mode == ssl.CERT_NONE
+
+
+class TestSLMClientReconnectBackoff:
+    """Tests for exponential backoff in the WebSocket reconnect loop (#4664)."""
+
+    def _make_client(self) -> SLMClient:
+        return SLMClient(slm_url="https://127.0.0.1:8000")
+
+    @pytest.mark.asyncio
+    async def test_reconnect_delay_starts_at_one_second(self):
+        """Initial reconnect delay is 1 second."""
+        client = self._make_client()
+        assert client._reconnect_delay == 1.0
+
+    @pytest.mark.asyncio
+    async def test_reconnect_delay_doubles_on_failure(self):
+        """Reconnect delay doubles after each failed connection attempt."""
+        client = self._make_client()
+
+        connect_calls = 0
+
+        async def failing_connect():
+            nonlocal connect_calls
+            connect_calls += 1
+            raise Exception("SSL: CERTIFICATE_VERIFY_FAILED")
+
+        slept = []
+
+        async def fake_sleep(delay):
+            slept.append(delay)
+            if connect_calls >= 3:
+                client._shutdown = True
+
+        with (
+            patch.object(client, "_ws_connect_and_listen", side_effect=failing_connect),
+            patch("asyncio.sleep", side_effect=fake_sleep),
+        ):
+            await client._ws_listener()
+
+        # Should have slept 3 times with doubling delays: 1.0 → 2.0 → 4.0
+        assert len(slept) >= 2
+        assert slept[0] == 1.0
+        assert slept[1] == 2.0
+
+    @pytest.mark.asyncio
+    async def test_reconnect_delay_caps_at_max(self):
+        """Reconnect delay is capped at _max_reconnect_delay."""
+        client = self._make_client()
+        client._reconnect_delay = 32.0  # Close to cap
+
+        connect_calls = 0
+
+        async def failing_connect():
+            nonlocal connect_calls
+            connect_calls += 1
+            raise Exception("connection refused")
+
+        slept = []
+
+        async def fake_sleep(delay):
+            slept.append(delay)
+            client._shutdown = True
+
+        with (
+            patch.object(client, "_ws_connect_and_listen", side_effect=failing_connect),
+            patch("asyncio.sleep", side_effect=fake_sleep),
+        ):
+            await client._ws_listener()
+
+        # Delay should not exceed 60 seconds
+        assert all(d <= client._max_reconnect_delay for d in slept)
+
+    @pytest.mark.asyncio
+    async def test_reconnect_delay_resets_on_success(self):
+        """Reconnect delay resets to 1.0 after a successful connection."""
+        client = self._make_client()
+        client._reconnect_delay = 30.0  # Simulate previous failures
+
+        async def successful_connect():
+            # Simulate a real connection: reset delay and return normally
+            client._reconnect_delay = 1.0
+            client._shutdown = True  # Stop the loop after one success
+
+        with patch.object(client, "_ws_connect_and_listen", side_effect=successful_connect):
+            await client._ws_listener()
+
+        assert client._reconnect_delay == 1.0
+
+    @pytest.mark.asyncio
+    async def test_ssl_error_logged_not_raised(self):
+        """SSL errors are caught and logged, not re-raised from _ws_connect_and_listen."""
+        client = self._make_client()
+        client._shutdown = True  # Don't loop
+
+        ssl_error = ssl.SSLCertVerificationError("CERTIFICATE_VERIFY_FAILED")
+
+        mock_ws = MagicMock()
+        mock_ws.__aenter__ = AsyncMock(side_effect=ssl_error)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("websockets.connect", return_value=mock_ws),
+            patch("services.slm_client.logger") as mock_logger,
+        ):
+            # Should not raise
+            await client._ws_connect_and_listen()
+
+        # Error is logged
+        assert mock_logger.error.called
+        logged_msg = str(mock_logger.error.call_args)
+        assert "WebSocket" in logged_msg or "error" in logged_msg.lower()


### PR DESCRIPTION
Closes #4664

## Summary
- Enhanced `_create_permissive_ssl_context()` in `slm_client.py` with a 4-level SSL trust hierarchy:
  1. `AUTOBOT_TLS_CA_PATH` env var — explicit CA cert for production mTLS
  2. `AUTOBOT_SKIP_TLS_VERIFY=true` — disable verification for dev/test only
  3. Project CA fallback at `certs/ca/ca-cert.pem` — covers single-host installs with AutoBot-issued self-signed cert (fixes the production log flooding)
  4. System trust store — default Python SSL behaviour
- Added `slm_client_test.py` with 11 tests covering the SSL trust hierarchy (6) and exponential backoff behaviour (5)

## Tests
- 11/11 new tests passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)