### PR TITLE
fix(testing): lazy-load BROWSER_TOOL_NAMES import in tool_registry — breaks circular import (#4557)

### DIFF
--- a/autobot-backend/tools/tool_registry.py
+++ b/autobot-backend/tools/tool_registry.py
@@ -14,7 +14,6 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from chat_workflow.tool_handler import BROWSER_TOOL_NAMES
 from tools.code_interpreter import execute_code
 
 if TYPE_CHECKING:
@@ -576,4 +575,8 @@ class ToolRegistry:
         ]
         # Issue #1368/#2609: Browser tools are defined once in BROWSER_TOOL_NAMES
         # and imported here so the two lists cannot drift independently.
+        # Lazy import breaks the circular dependency:
+        #   chat_workflow -> tool_handler -> tools -> tool_registry -> chat_workflow
+        # (#4557)
+        from chat_workflow.tool_handler import BROWSER_TOOL_NAMES  # noqa: PLC0415
         return registry_tools + sorted(BROWSER_TOOL_NAMES)


### PR DESCRIPTION
Closes #4557

## Summary
Root cause was a circular import in `tools/tool_registry.py` — the module-level `from chat_workflow.tool_handler import BROWSER_TOOL_NAMES` created a cycle: `chat_workflow.__init__` → `manager` → `tool_handler` → `tools.__init__` → `tool_registry` → `chat_workflow.tool_handler` (partially initialized → `ImportError`).

Fix: moved the import inside `get_available_tools()` as a lazy import. Single-source-of-truth semantics from #2609 fully preserved — import resolves at call time when both modules are fully initialized.

## Tests
- 262 `chat_workflow/` tests pass
- Pre-existing: `prompt_hooks_test.py::test_total_hook_count_increased` asserts 24 HookPoints but finds 25 — unrelated to this change

🤖 Generated with [Claude Code](https://claude.ai/claude-code)