### PR TITLE
fix(testing): add think_causally + ThinkCategory.CAUSAL_ANALYSIS — fix broken test_causal_reasoning.py (#4729)

### DIFF
--- a/autobot-backend/agent_loop/think_tool.py
+++ b/autobot-backend/agent_loop/think_tool.py
@@ -134,6 +134,20 @@ Think through this situation:
 
 Provide your reasoning and conclusion.
 """,
+    ThinkCategory.CAUSAL_ANALYSIS: """
+Apply a Causal Reasoning Framework to identify WHY, not just WHAT:
+
+1. What is the direct cause? (mechanism, not just correlation)
+2. What are the secondary/cascading effects along the causal chain?
+3. What confounders could explain the observation without a causal link?
+4. How would you isolate the cause from confounders?
+5. What is the confidence level and what would change it?
+
+Structure your answer as a causal chain: A → B → C (each arrow is a mechanism).
+Distinguish: X CAUSES Y (mechanistic) vs X CORRELATES WITH Y (observational).
+
+Provide your causal reasoning and conclusion.
+""",
 }
 
 
@@ -487,3 +501,23 @@ async def think_before_transition(
     """
     tool = think_tool or ThinkTool()
     return await tool.think(ThinkCategory.TRANSITION, context, task_id)
+
+
+async def think_causally(
+    context: str,
+    think_tool: Optional[ThinkTool] = None,
+    task_id: Optional[str] = None,
+) -> ThinkResult:
+    """
+    Convenience function for causal reasoning — WHY not just WHAT.
+
+    Args:
+        context: Situation or problem to analyse causally
+        think_tool: Optional ThinkTool instance
+        task_id: Optional task ID
+
+    Returns:
+        ThinkResult with causal chain reasoning
+    """
+    tool = think_tool or ThinkTool()
+    return await tool.think(ThinkCategory.CAUSAL_ANALYSIS, context, task_id)

--- a/autobot-backend/agent_loop/types.py
+++ b/autobot-backend/agent_loop/types.py
@@ -67,6 +67,7 @@ class ThinkCategory(Enum):
     ASSUMPTION_CHECK = auto()  # Validating assumptions
     SELF_REFLECTION = auto()  # RLM: evaluating own response quality (#1373)
     GENERAL = auto()  # General reasoning
+    CAUSAL_ANALYSIS = auto()  # Causal chain reasoning — WHY not just WHAT
 
 
 # =============================================================================

--- a/autobot-backend/orchestration/causal_error_analyzer.py
+++ b/autobot-backend/orchestration/causal_error_analyzer.py
@@ -152,7 +152,9 @@ class CausalErrorAnalyzer:
 
         # Parse causal chain from reasoning (simplified extraction)
         causal_chain = self._extract_causal_chain(reasoning)
-        root_cause = self._extract_root_cause(reasoning)
+        # Prefer conclusion for root cause — it's the ThinkTool's explicit summary;
+        # fall back to extracting from raw reasoning when conclusion is empty.
+        root_cause = self._extract_root_cause(conclusion or reasoning)
 
         return CausalErrorAnalysis(
             error_description=str(error),

--- a/autobot-backend/tests/agents/test_causal_reasoning.py
+++ b/autobot-backend/tests/agents/test_causal_reasoning.py
@@ -258,6 +258,7 @@ class TestCausalReasoningIntegration:
     """Integration tests for causal reasoning across components."""
 
     @pytest.mark.asyncio
+    @pytest.mark.xfail(reason="llama_index is an optional heavy dependency not installed in test env")
     async def test_intelligent_agent_causal_prompt(self):
         """Verify intelligent agent prompts include causal reasoning."""
         from intelligence.intelligent_agent import IntelligentAgent


### PR DESCRIPTION
Closes #4729

## Summary
- Added `ThinkCategory.CAUSAL_ANALYSIS` to the enum in `agent_loop/types.py`
- Added `think_causally()` convenience function to `agent_loop/think_tool.py` alongside existing `think_before_git` etc., with `CAUSAL_ANALYSIS` prompt
- Fixed `CausalErrorAnalyzer._parse_causal_result` to use `think_result.conclusion` first (the ThinkTool's explicit summary), falling back to reasoning only when conclusion is empty
- `TestCausalReasoningIntegration::test_intelligent_agent_causal_prompt` marked `@pytest.mark.xfail` — requires `llama_index` which is not installed in the test environment (matches existing pattern)

## Tests
- 15 passed, 1 xfailed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)