### PR TITLE
fix(knowledge): wire KBSynthesizer.synthesize_docs to SynthesisProvenanceLog (#4656)

### DIFF
--- a/autobot-backend/services/knowledge/kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/kb_synthesizer.py
@@ -15,6 +15,7 @@ import asyncio
 import hashlib
 import logging
 import time
+import uuid
 from typing import TYPE_CHECKING, Any, List, Optional
 
 if TYPE_CHECKING:
@@ -46,11 +47,21 @@ class KBSynthesizer:
 
     COLLECTION_NAME = _KB_SYNTHESIS_COLLECTION
 
-    def __init__(self, llm_service: Any) -> None:
+    def __init__(
+        self,
+        llm_service: Any,
+        provenance_log: "Optional[Any]" = None,
+    ) -> None:
         self._llm = llm_service
         self._collection: Optional[Any] = None
         # Cache of named collections keyed by collection name.
         self._named_collections: dict[str, Any] = {}
+        # Lazy import to avoid circular deps at module load time.
+        if provenance_log is None:
+            from services.knowledge.synthesis_provenance import SynthesisProvenanceLog
+
+            provenance_log = SynthesisProvenanceLog()
+        self._provenance_log = provenance_log
 
     # ------------------------------------------------------------------
     # BaseSynthesizer ABC interface
@@ -250,7 +261,21 @@ class KBSynthesizer:
                     "KBSynthesizer: writing cluster to synthesis_target '%s'",
                     target_collection,
                 )
+        start = time.monotonic()
         await self._index_documents([page], collection_name=target_collection)
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        prompt_name = (
+            collection_config.name if collection_config is not None else "default"
+        )
+        await self._provenance_log.log_run(
+            run_id=cluster_id,
+            source_docs=file_paths[:_MAX_DOCS_PER_CLUSTER],
+            synthesis_ids=[cluster_id],
+            llm_model=getattr(self._llm, "model", "unknown"),
+            prompt_template=prompt_name,
+            duration_ms=duration_ms,
+        )
 
     @staticmethod
     def _read_docs(file_paths: List[str]) -> str:

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -240,6 +240,51 @@ async def test_synthesize_docs_llm_error_is_swallowed(tmp_path):
     col.upsert.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_synthesize_docs_calls_provenance_log_run(tmp_path):
+    """After a successful synthesis, log_run must be called on the provenance log (#4656)."""
+    f = tmp_path / "doc.md"
+    f.write_text("# Topic\nContent here.", encoding="utf-8")
+
+    col = _make_collection()
+    llm = _make_llm("Synthesized summary")
+    provenance_log = MagicMock()
+    provenance_log.log_run = AsyncMock()
+
+    synth = KBSynthesizer(llm_service=llm, provenance_log=provenance_log)
+    synth._collection = col
+
+    await synth.synthesize_docs([str(f)])
+
+    provenance_log.log_run.assert_awaited_once()
+    call_kwargs = provenance_log.log_run.call_args.kwargs
+    assert call_kwargs["source_docs"] == [str(f)]
+    assert len(call_kwargs["synthesis_ids"]) == 1
+    assert call_kwargs["synthesis_ids"][0].startswith("kb_syn_")
+    assert call_kwargs["run_id"] == call_kwargs["synthesis_ids"][0]
+    assert isinstance(call_kwargs["duration_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_synthesize_docs_provenance_log_not_called_on_llm_error(tmp_path):
+    """When LLM fails, log_run must NOT be called (#4656)."""
+    f = tmp_path / "doc.md"
+    f.write_text("content", encoding="utf-8")
+
+    llm = MagicMock()
+    llm.chat = AsyncMock(side_effect=RuntimeError("LLM down"))
+    col = _make_collection()
+    provenance_log = MagicMock()
+    provenance_log.log_run = AsyncMock()
+
+    synth = KBSynthesizer(llm_service=llm, provenance_log=provenance_log)
+    synth._collection = col
+
+    await synth.synthesize_docs([str(f)])  # must not raise
+
+    provenance_log.log_run.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Tests: KBSynthesizer.get_relevant_context
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4656

## Summary
- Injected `SynthesisProvenanceLog` into `KBSynthesizer.__init__` (same pattern as `KnowledgeSynthesizer`)
- Called `log_run()` in `_synthesize_cluster()` after `_index_documents()` succeeds
- `GET /knowledge/synthesis/log` now returns KB synthesis runs instead of always being empty
- Added 2 new tests: `test_synthesize_docs_calls_provenance_log_run` and `test_synthesize_docs_provenance_log_not_called_on_llm_error`

## Test Status
✅ 31/31 passed