### PR TITLE
feat(rag): add UCB1 sampling to RetrievalLearner pattern selection (#4674)

### DIFF
--- a/autobot-backend/knowledge/search_components/retrieval_learner.py
+++ b/autobot-backend/knowledge/search_components/retrieval_learner.py
@@ -21,6 +21,7 @@ rag:rl:cursors                                   HASH   — last processed strea
 import hashlib
 import json
 import logging
+import math
 import threading
 import time
 from dataclasses import dataclass, field
@@ -379,6 +380,7 @@ class RetrievalLearner:
         complexity: str = "simple",
         categories: Optional[List[str]] = None,
         user_id: Optional[str] = None,
+        exploration_constant: Optional[float] = None,
     ) -> Optional[RetrievalPattern]:
         """Return the best matching historical pattern for a query, or None.
 
@@ -388,17 +390,19 @@ class RetrievalLearner:
         3. Global exact hash — fallback when the user has no patterns yet.
         4. Global complexity-only hash — final fallback.
 
-        Only returns patterns with success_rate >= 0.6 and usage_count >= 3
-        to avoid acting on sparse evidence.
+        Issue #4674: Qualifying candidates (success_rate >= 0.6, usage_count >= 3)
+        are ranked by UCB1 score instead of raw success_rate so that
+        under-sampled patterns are explored rather than permanently ignored.
 
         Args:
-            query:      Raw query string (unused in current implementation but
-                        reserved for future embedding-based matching).
-            complexity: QueryComplexity.value string.
-            categories: Optional category list from the calling context.
-            user_id:    Authenticated user identifier for per-user scope.
-                        Falls back to global patterns when None or when the
-                        user has no qualifying patterns.
+            query:                Raw query string (unused in current implementation but
+                                  reserved for future embedding-based matching).
+            complexity:           QueryComplexity.value string.
+            categories:           Optional category list from the calling context.
+            user_id:              Authenticated user identifier for per-user scope.
+                                  Falls back to global patterns when None or when the
+                                  user has no qualifying patterns.
+            exploration_constant: UCB1 C constant; defaults to RAGConfig value (~sqrt(2)).
 
         Returns:
             Best matching RetrievalPattern or None.
@@ -420,22 +424,41 @@ class RetrievalLearner:
             candidates.append(f"{_PATTERN_KEY_PREFIX}{GLOBAL_USER}:{exact_hash}")
             candidates.append(f"{_PATTERN_KEY_PREFIX}{GLOBAL_USER}:{complexity_hash}")
 
+        if exploration_constant is None:
+            try:
+                from services.rag_config import get_rag_config
+
+                exploration_constant = get_rag_config().ucb1_exploration_constant
+            except Exception:
+                exploration_constant = math.sqrt(2)
+
         try:
             redis = await self._get_redis()
+            qualifying: List[RetrievalPattern] = []
             for redis_key in candidates:
                 raw = await redis.hgetall(redis_key)
                 if not raw:
                     continue
                 pattern = RetrievalPattern.from_redis_mapping(raw)
                 if pattern.success_rate >= 0.6 and pattern.usage_count >= 3:
-                    logger.debug(
-                        "RetrievalLearner: matched pattern %s (rate=%.2f, usage=%d, key=%s)",
-                        pattern.pattern_hash,
-                        pattern.success_rate,
-                        pattern.usage_count,
-                        redis_key,
-                    )
-                    return pattern
+                    qualifying.append(pattern)
+
+            if not qualifying:
+                return None
+
+            # Issue #4674: rank by UCB1 score — explore under-sampled patterns.
+            total_queries = sum(p.usage_count for p in qualifying)
+            best = max(
+                qualifying,
+                key=lambda p: _ucb1_score(p.success_rate, p.usage_count, total_queries, exploration_constant),
+            )
+            logger.debug(
+                "RetrievalLearner: matched pattern %s via UCB1 (rate=%.2f, usage=%d)",
+                best.pattern_hash,
+                best.success_rate,
+                best.usage_count,
+            )
+            return best
         except Exception as exc:
             logger.warning("RetrievalLearner: get_matching_pattern failed: %s", exc)
 
@@ -618,6 +641,37 @@ def get_retrieval_learner() -> RetrievalLearner:
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _ucb1_score(
+    success_rate: float,
+    usage_count: int,
+    total_queries: int,
+    exploration_constant: float,
+) -> float:
+    """Compute UCB1 score for a retrieval pattern.
+
+    Issue #4674: UCB1 balances exploitation (high success_rate) with exploration
+    (patterns with low usage relative to total queries).
+
+    Patterns with usage_count == 0 receive +inf so they are always tried first.
+
+    Args:
+        success_rate:         EMA-smoothed success rate in [0, 1].
+        usage_count:          Number of times this pattern has been matched.
+        total_queries:        Sum of usage_count across all candidate patterns.
+        exploration_constant: UCB1 C constant (sqrt(2) by default).
+
+    Returns:
+        UCB1 score; higher is better.
+    """
+    if usage_count == 0:
+        return float("inf")
+    if total_queries <= 0:
+        return success_rate
+    return success_rate + exploration_constant * math.sqrt(
+        math.log(total_queries) / usage_count
+    )
 
 
 def _compute_pattern_hash(query_type: str, categories: List[str]) -> str:

--- a/autobot-backend/services/rag_config.py
+++ b/autobot-backend/services/rag_config.py
@@ -89,6 +89,11 @@ class RAGConfig:
     # Issue #4696: RLM-driven refinement loop via advanced_search_with_refinement()
     enable_rlm_refinement: bool = False
 
+    # Issue #4674: UCB1 exploration constant for RetrievalLearner pattern selection.
+    # Higher values → more exploration of under-sampled patterns.
+    # sqrt(2) ≈ 1.414 is the classic UCB1 constant.
+    ucb1_exploration_constant: float = 1.414
+
     def __post_init__(self):
         """Validate configuration values and propagate mmr_lambda to rerank_weights.
 

--- a/autobot-backend/tests/knowledge/search_components/retrieval_learner_test.py
+++ b/autobot-backend/tests/knowledge/search_components/retrieval_learner_test.py
@@ -15,6 +15,7 @@ from knowledge.search_components.retrieval_learner import (
     _compute_pattern_hash,
     _extract_categories,
     _jaccard_similarity,
+    _ucb1_score,
     get_retrieval_learner,
 )
 
@@ -476,3 +477,139 @@ class TestSingleton:
 
     def test_singleton_is_retrieval_learner_instance(self):
         assert isinstance(get_retrieval_learner(), RetrievalLearner)
+
+
+# ---------------------------------------------------------------------------
+# UCB1 score helper (Issue #4674)
+# ---------------------------------------------------------------------------
+
+
+import math as _math
+
+
+class TestUcb1Score:
+    def test_zero_usage_returns_inf(self):
+        """Unexplored patterns always score highest."""
+        score = _ucb1_score(0.5, usage_count=0, total_queries=10, exploration_constant=_math.sqrt(2))
+        assert score == float("inf")
+
+    def test_zero_total_queries_returns_success_rate(self):
+        """When total_queries is 0, fall back to success_rate alone."""
+        score = _ucb1_score(0.7, usage_count=5, total_queries=0, exploration_constant=_math.sqrt(2))
+        assert score == pytest.approx(0.7)
+
+    def test_higher_usage_gives_lower_bonus(self):
+        """The exploration bonus shrinks as usage_count grows."""
+        total = 100
+        score_low = _ucb1_score(0.8, usage_count=5, total_queries=total, exploration_constant=_math.sqrt(2))
+        score_high = _ucb1_score(0.8, usage_count=50, total_queries=total, exploration_constant=_math.sqrt(2))
+        assert score_low > score_high
+
+    def test_equal_success_rates_prefer_low_usage(self):
+        """With equal success_rate, the lower-usage pattern has a higher UCB1 score."""
+        total = 20
+        score_a = _ucb1_score(0.75, usage_count=4, total_queries=total, exploration_constant=_math.sqrt(2))
+        score_b = _ucb1_score(0.75, usage_count=16, total_queries=total, exploration_constant=_math.sqrt(2))
+        assert score_a > score_b
+
+    def test_exploration_constant_scales_bonus(self):
+        """Larger C increases the exploration bonus proportionally."""
+        s_low_c = _ucb1_score(0.5, usage_count=3, total_queries=30, exploration_constant=0.5)
+        s_high_c = _ucb1_score(0.5, usage_count=3, total_queries=30, exploration_constant=2.0)
+        assert s_high_c > s_low_c
+
+
+# ---------------------------------------------------------------------------
+# get_matching_pattern — UCB1 ranking (Issue #4674)
+# ---------------------------------------------------------------------------
+
+
+class TestGetMatchingPatternUCB1:
+    def _make_pattern(self, ph, success_rate, usage_count, query_type="simple"):
+        return RetrievalPattern(
+            pattern_hash=ph,
+            query_type=query_type,
+            chunk_categories=[],
+            strategy_hints={},
+            success_rate=success_rate,
+            usage_count=usage_count,
+        )
+
+    @pytest.mark.asyncio
+    async def test_equal_success_rates_prefer_low_usage(self):
+        """With equal success_rates, UCB1 should prefer the less-used pattern."""
+        redis = _make_redis_mock()
+
+        p_high_usage = self._make_pattern("hash_high", success_rate=0.8, usage_count=50)
+        p_low_usage = self._make_pattern("hash_low", success_rate=0.8, usage_count=3)
+
+        # Both patterns match the same complexity-only key — we wire exact key → high,
+        # complexity-only key → low so both qualify for comparison.
+        exact_hash = _compute_pattern_hash("simple", [])
+        complexity_hash = _compute_pattern_hash("simple", [])
+        # exact_hash == complexity_hash when categories=[] → only one lookup happens
+        # so instead we use categories to split them.
+        exact_hash_with_cat = _compute_pattern_hash("simple", ["cat"])
+        complexity_only_hash = _compute_pattern_hash("simple", [])
+
+        from knowledge.search_components.retrieval_learner import _PATTERN_KEY_PREFIX, GLOBAL_USER
+
+        key_exact = f"{_PATTERN_KEY_PREFIX}{GLOBAL_USER}:{exact_hash_with_cat}"
+        key_complexity = f"{_PATTERN_KEY_PREFIX}{GLOBAL_USER}:{complexity_only_hash}"
+
+        # Assign patterns to keys.
+        async def fake_hgetall(key):
+            if key == key_exact:
+                return p_high_usage.to_redis_mapping()
+            if key == key_complexity:
+                return p_low_usage.to_redis_mapping()
+            return {}
+
+        redis.hgetall = AsyncMock(side_effect=fake_hgetall)
+        learner = _make_learner(redis)
+
+        result = await learner.get_matching_pattern(
+            "",
+            complexity="simple",
+            categories=["cat"],
+            exploration_constant=_math.sqrt(2),
+        )
+        # UCB1 should select the low-usage pattern (higher exploration bonus).
+        assert result is not None
+        assert result.pattern_hash == "hash_low"
+
+    @pytest.mark.asyncio
+    async def test_greedy_fallback_when_all_usage_equal(self):
+        """When all usage counts are equal, UCB1 degrades to selecting highest success_rate."""
+        redis = _make_redis_mock()
+
+        p_low_rate = self._make_pattern("hash_low_rate", success_rate=0.65, usage_count=5)
+        p_high_rate = self._make_pattern("hash_high_rate", success_rate=0.90, usage_count=5)
+
+        exact_hash_with_cat = _compute_pattern_hash("simple", ["cat"])
+        complexity_only_hash = _compute_pattern_hash("simple", [])
+
+        from knowledge.search_components.retrieval_learner import _PATTERN_KEY_PREFIX, GLOBAL_USER
+
+        key_exact = f"{_PATTERN_KEY_PREFIX}{GLOBAL_USER}:{exact_hash_with_cat}"
+        key_complexity = f"{_PATTERN_KEY_PREFIX}{GLOBAL_USER}:{complexity_only_hash}"
+
+        async def fake_hgetall(key):
+            if key == key_exact:
+                return p_low_rate.to_redis_mapping()
+            if key == key_complexity:
+                return p_high_rate.to_redis_mapping()
+            return {}
+
+        redis.hgetall = AsyncMock(side_effect=fake_hgetall)
+        learner = _make_learner(redis)
+
+        result = await learner.get_matching_pattern(
+            "",
+            complexity="simple",
+            categories=["cat"],
+            exploration_constant=_math.sqrt(2),
+        )
+        # Equal usage → exploration bonuses cancel → highest success_rate wins.
+        assert result is not None
+        assert result.pattern_hash == "hash_high_rate"


### PR DESCRIPTION
Closes #4674

## Summary
- Added UCB1 sampling to `RetrievalLearner.get_matching_pattern()` — instead of returning the first qualifying pattern, collects all candidates above threshold and selects by highest UCB1 score (`success_rate + C*sqrt(ln(total_queries)/usage_count)`)
- Added `_ucb1_score()` helper method
- Added `ucb1_exploration_constant: float = 1.414` to `RAGConfig`
- Balances exploitation (high success_rate patterns) with exploration (under-tried patterns)
- Added 7 new unit tests covering zero usage, equal usage, exploration constant scaling, greedy fallback

## Test Status
✅ 54/55 passed (1 pre-existing failure unrelated to this change)