### PR TITLE
feat(knowledge): per-collection synthesis_model override in synthesis_schema.yaml (#4688)

### DIFF
--- a/autobot-backend/resources/knowledge/synthesis_schema.yaml
+++ b/autobot-backend/resources/knowledge/synthesis_schema.yaml
@@ -14,6 +14,7 @@ collections:
       - docs/architecture
       - docs/adr
     synthesis_target: autobot_synthesis_architecture
+    # synthesis_model: claude-opus-4-6  # optional: override the default LLM for this collection
     prompt_template: |
       You are an AutoBot architecture assistant. Given the following architecture
       documentation and Architecture Decision Records (ADRs), produce a concise

--- a/autobot-backend/services/knowledge/kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/kb_synthesizer.py
@@ -220,12 +220,21 @@ class KBSynthesizer:
                 {"role": "system", "content": prompt},
                 {"role": "user", "content": docs_text},
             ]
-        try:
-            response = await self._llm.chat(
-                messages=messages,
-                temperature=0.3,
-                max_tokens=600,
+        override_model: Optional[str] = (
+            collection_config.synthesis_model
+            if collection_config is not None
+            else None
+        )
+        chat_kwargs: dict = {"messages": messages, "temperature": 0.3, "max_tokens": 600}
+        if override_model:
+            chat_kwargs["model"] = override_model
+            logger.debug(
+                "KBSynthesizer: using synthesis_model override '%s' for collection '%s'",
+                override_model,
+                collection_config.name if collection_config else "<default>",  # type: ignore[union-attr]
             )
+        try:
+            response = await self._llm.chat(**chat_kwargs)
         except Exception:
             logger.exception("KBSynthesizer: LLM call failed")
             return

--- a/autobot-backend/services/knowledge/synthesis_schema_loader.py
+++ b/autobot-backend/services/knowledge/synthesis_schema_loader.py
@@ -18,7 +18,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 _REQUIRED_KEYS = {"name", "paths", "synthesis_target", "prompt_template"}
-_ALLOWED_KEYS = _REQUIRED_KEYS
+_ALLOWED_KEYS = _REQUIRED_KEYS | {"synthesis_model"}
 
 
 @dataclass
@@ -29,6 +29,7 @@ class CollectionConfig:
     paths: List[str]
     synthesis_target: str
     prompt_template: str
+    synthesis_model: Optional[str] = None
 
 
 @dataclass
@@ -58,11 +59,21 @@ def _parse_collection(raw: dict, index: int, repo_root: Optional[Path] = None) -
         raise ValueError(
             f"Collection[{index}] is missing required keys: {sorted(missing)}"
         )
+    synthesis_model: Optional[str] = None
+    if "synthesis_model" in raw:
+        model_val = str(raw["synthesis_model"]).strip()
+        if not model_val:
+            raise ValueError(
+                f"Collection[{index}] 'synthesis_model' must be a non-empty string when present"
+            )
+        synthesis_model = model_val
+
     config = CollectionConfig(
         name=str(raw["name"]),
         paths=[str(p) for p in raw["paths"]],
         synthesis_target=str(raw["synthesis_target"]),
         prompt_template=str(raw["prompt_template"]),
+        synthesis_model=synthesis_model,
     )
     if repo_root is not None:
         for p in config.paths:

--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -610,3 +610,85 @@ async def test_get_relevant_context_deduplicates_default_collection():
 
     # Default collection queried exactly once (not twice).
     assert col.query.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: synthesis_model override (#4688)
+# ---------------------------------------------------------------------------
+
+
+def _make_collection_config_with_model(
+    name: str = "test_col",
+    prompt_template: str = "Custom prompt: {documents}",
+    synthesis_target: str = "",
+    synthesis_model: str | None = None,
+):
+    """Return a CollectionConfig-like mock with synthesis_model support."""
+    cfg = MagicMock()
+    cfg.name = name
+    cfg.prompt_template = prompt_template
+    cfg.synthesis_target = synthesis_target
+    cfg.paths = ["docs/test"]
+    cfg.synthesis_model = synthesis_model
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_synthesize_docs_passes_model_override_to_llm(tmp_path):
+    """When synthesis_model is set, llm.chat() receives model= kwarg."""
+    f = tmp_path / "doc.md"
+    f.write_text("Architecture notes.", encoding="utf-8")
+
+    col = _make_collection()
+    llm = _make_llm("Summary")
+    synth = KBSynthesizer(llm_service=llm)
+    synth._collection = col
+
+    cfg = _make_collection_config_with_model(
+        name="hq_col",
+        synthesis_model="claude-opus-4-6",
+    )
+
+    await synth.synthesize_docs([str(f)], collection_config=cfg)
+
+    llm.chat.assert_awaited_once()
+    call_kwargs = llm.chat.call_args.kwargs
+    assert call_kwargs.get("model") == "claude-opus-4-6"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_docs_no_model_override_omits_model_kwarg(tmp_path):
+    """When synthesis_model is None, llm.chat() is NOT passed a model= kwarg."""
+    f = tmp_path / "doc.md"
+    f.write_text("Some content.", encoding="utf-8")
+
+    col = _make_collection()
+    llm = _make_llm("Summary")
+    synth = KBSynthesizer(llm_service=llm)
+    synth._collection = col
+
+    cfg = _make_collection_config_with_model(name="default_col", synthesis_model=None)
+
+    await synth.synthesize_docs([str(f)], collection_config=cfg)
+
+    llm.chat.assert_awaited_once()
+    call_kwargs = llm.chat.call_args.kwargs
+    assert "model" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_synthesize_docs_no_collection_config_omits_model_kwarg(tmp_path):
+    """When collection_config is None, llm.chat() is NOT passed a model= kwarg."""
+    f = tmp_path / "doc.md"
+    f.write_text("Content.", encoding="utf-8")
+
+    col = _make_collection()
+    llm = _make_llm("Summary")
+    synth = KBSynthesizer(llm_service=llm)
+    synth._collection = col
+
+    await synth.synthesize_docs([str(f)], collection_config=None)
+
+    llm.chat.assert_awaited_once()
+    call_kwargs = llm.chat.call_args.kwargs
+    assert "model" not in call_kwargs

--- a/autobot-backend/services/knowledge/test_synthesis_schema_loader.py
+++ b/autobot-backend/services/knowledge/test_synthesis_schema_loader.py
@@ -146,6 +146,78 @@ class TestValidationError:
             load_synthesis_schema(path)
 
 
+class TestSynthesisModelOverride:
+    """synthesis_model is optional; validates non-empty when present."""
+
+    def test_synthesis_model_omitted_defaults_to_none(self, tmp_path):
+        path = _write_yaml(tmp_path, VALID_YAML)
+        schema = load_synthesis_schema(path)
+        for col in schema.collections:
+            assert col.synthesis_model is None
+
+    def test_synthesis_model_parsed_when_present(self, tmp_path):
+        yaml_with_model = """\
+            collections:
+              - name: high_quality_col
+                paths:
+                  - docs/hq
+                synthesis_target: autobot_synthesis_hq
+                synthesis_model: claude-opus-4-6
+                prompt_template: "Summarize: {documents}"
+        """
+        path = _write_yaml(tmp_path, yaml_with_model)
+        schema = load_synthesis_schema(path)
+        assert schema.collections[0].synthesis_model == "claude-opus-4-6"
+
+    def test_synthesis_model_empty_string_raises(self, tmp_path):
+        yaml_empty_model = """\
+            collections:
+              - name: bad_col
+                paths:
+                  - docs/bad
+                synthesis_target: autobot_synthesis_bad
+                synthesis_model: ""
+                prompt_template: "Summarize: {documents}"
+        """
+        path = _write_yaml(tmp_path, yaml_empty_model)
+        with pytest.raises(ValueError, match="non-empty string"):
+            load_synthesis_schema(path)
+
+    def test_synthesis_model_whitespace_raises(self, tmp_path):
+        yaml_ws_model = """\
+            collections:
+              - name: bad_col
+                paths:
+                  - docs/bad
+                synthesis_target: autobot_synthesis_bad
+                synthesis_model: "   "
+                prompt_template: "Summarize: {documents}"
+        """
+        path = _write_yaml(tmp_path, yaml_ws_model)
+        with pytest.raises(ValueError, match="non-empty string"):
+            load_synthesis_schema(path)
+
+    def test_mixed_collections_some_with_model(self, tmp_path):
+        mixed_yaml = """\
+            collections:
+              - name: col_with_model
+                paths:
+                  - docs/a
+                synthesis_target: target_a
+                synthesis_model: claude-opus-4-6
+                prompt_template: "Docs: {documents}"
+              - name: col_without_model
+                paths:
+                  - docs/b
+                synthesis_target: target_b
+                prompt_template: "Docs: {documents}"
+        """
+        path = _write_yaml(tmp_path, mixed_yaml)
+        schema = load_synthesis_schema(path)
+        assert schema.collections[0].synthesis_model == "claude-opus-4-6"
+        assert schema.collections[1].synthesis_model is None
+
+
 class TestPathExistenceWarnings:
     """load_synthesis_schema warns on missing paths but does not raise."""
 


### PR DESCRIPTION
Closes #4688

## Summary
- Added optional `synthesis_model` field to `CollectionConfig` and `synthesis_schema.yaml`
- Schema loader validates it is non-empty when present
- `KBSynthesizer._synthesize_cluster` passes `model=` to `llm.chat()` when override is set, falls back to injected LLM default when omitted
- Allows per-collection model selection (e.g., use a larger model for high-value collections)
- Added 5 new schema loader tests and 3 new kb_synthesizer model-override tests

## Test Status
✅ 49/49 passed