### PR TITLE
feat(a2a): add self-evaluation quality gate before COMPLETED state (#4687)

### DIFF
--- a/autobot-backend/a2a/a2a_test.py
+++ b/autobot-backend/a2a/a2a_test.py
@@ -498,3 +498,206 @@ class TestGetTaskTTLSliding:
 
         assert result is None
         self._redis_mock.expire.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #4687: Self-Evaluator unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSelfEvaluator:
+    """Unit tests for a2a.self_evaluator — Issue #4687.
+
+    All tests are pure-Python (no I/O, no network) and verify the heuristic
+    scoring logic and EvalResult dataclass directly.
+    """
+
+    def _run(self, coro):
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_high_confidence_response_passes(self):
+        from a2a.self_evaluator import evaluate_task_output
+
+        result = self._run(
+            evaluate_task_output(
+                input_text="What is 2 + 2?",
+                response_text="The answer is 4. Addition of 2 and 2 yields 4.",
+                metadata={},
+                threshold=0.6,
+            )
+        )
+        assert result.passed is True
+        assert result.confidence >= 0.6
+        assert result.eval_reason == ""
+
+    def test_uncertain_response_fails(self):
+        from a2a.self_evaluator import evaluate_task_output
+
+        # Response with 4+ uncertainty phrases drives confidence below 0.6
+        result = self._run(
+            evaluate_task_output(
+                input_text="What is the capital of France?",
+                response_text=(
+                    "I don't know. I am not sure. I cannot answer this. "
+                    "Unable to provide information here. I have no data on this."
+                ),
+                metadata={},
+                threshold=0.6,
+            )
+        )
+        assert result.passed is False
+        assert result.confidence < 0.6
+        assert result.eval_reason != ""
+
+    def test_empty_response_fails(self):
+        from a2a.self_evaluator import evaluate_task_output
+
+        result = self._run(
+            evaluate_task_output(
+                input_text="Summarise this document.",
+                response_text="   ",
+                metadata={},
+                threshold=0.6,
+            )
+        )
+        assert result.passed is False
+        assert result.confidence == 0.0
+
+    def test_custom_threshold_respected(self):
+        """A response that passes default threshold can fail a stricter one."""
+        from a2a.self_evaluator import evaluate_task_output
+
+        good_response = "Python is a high-level programming language used widely."
+        # Should pass at default 0.6
+        result_default = self._run(
+            evaluate_task_output("Describe Python", good_response, {}, threshold=0.6)
+        )
+        assert result_default.passed is True
+
+        # Force failure with threshold above 1.0 (impossible to pass)
+        result_strict = self._run(
+            evaluate_task_output("Describe Python", good_response, {}, threshold=1.1)
+        )
+        assert result_strict.passed is False
+
+    def test_confidence_is_bounded(self):
+        from a2a.self_evaluator import _score_response
+
+        assert _score_response("x" * 100, "short") <= 1.0
+        assert _score_response("x" * 100, "short") >= 0.0
+        assert _score_response("", "question") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Issue #4687: execute_a2a_task quality-gate integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteA2aTaskEvalGate:
+    """Verify that execute_a2a_task respects the self-eval quality gate.
+
+    Mocks:
+      - get_task_manager() → in-process TaskManager with mock Redis
+      - get_agent_orchestrator() → mock that returns a controllable result
+      - evaluate_task_output() → tested separately; here we mock to control pass/fail
+    """
+
+    def _make_manager(self):
+        with patch("a2a.task_manager.get_redis_client", return_value=_make_redis_mock()):
+            mgr = TaskManager()
+        return mgr
+
+    def _run(self, coro):
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_pass_threshold_transitions_to_completed(self):
+        """When eval passes, task must reach COMPLETED."""
+        import sys
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from a2a.self_evaluator import EvalResult
+        from a2a.task_executor import execute_a2a_task
+        from a2a.types import TaskState
+
+        mgr = self._make_manager()
+        task = mgr.create_task("Describe Python")
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.process_request = AsyncMock(
+            return_value={"response": "Python is a popular programming language."}
+        )
+        # Stub heavy modules so the late import in task_executor succeeds
+        mock_ao_module = MagicMock()
+        mock_ao_module.get_agent_orchestrator = MagicMock(return_value=mock_orchestrator)
+
+        passed_eval = EvalResult(passed=True, confidence=0.9, eval_reason="")
+
+        with (
+            patch("a2a.task_executor.get_task_manager", return_value=mgr),
+            patch(
+                "a2a.task_executor.evaluate_task_output",
+                new=AsyncMock(return_value=passed_eval),
+            ),
+            patch.dict(sys.modules, {"agents.agent_orchestration": mock_ao_module}),
+        ):
+            self._run(execute_a2a_task(task.id, "Describe Python"))
+
+        final = mgr.get_task(task.id)
+        assert final.status.state == TaskState.COMPLETED
+
+    def test_fail_threshold_transitions_to_failed_with_eval_reason(self):
+        """When eval fails, task must reach FAILED with eval_reason artifact."""
+        import sys
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from a2a.self_evaluator import EvalResult
+        from a2a.task_executor import execute_a2a_task
+        from a2a.types import TaskState
+
+        mgr = self._make_manager()
+        task = mgr.create_task("Explain quantum entanglement")
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.process_request = AsyncMock(
+            return_value={"response": "I'm not sure about this."}
+        )
+        mock_ao_module = MagicMock()
+        mock_ao_module.get_agent_orchestrator = MagicMock(return_value=mock_orchestrator)
+
+        failed_eval = EvalResult(
+            passed=False,
+            confidence=0.3,
+            eval_reason="Self-evaluation failed: confidence 0.3000 below threshold 0.6000.",
+        )
+
+        with (
+            patch("a2a.task_executor.get_task_manager", return_value=mgr),
+            patch(
+                "a2a.task_executor.evaluate_task_output",
+                new=AsyncMock(return_value=failed_eval),
+            ),
+            patch.dict(sys.modules, {"agents.agent_orchestration": mock_ao_module}),
+        ):
+            self._run(execute_a2a_task(task.id, "Explain quantum entanglement"))
+
+        final = mgr.get_task(task.id)
+        assert final.status.state == TaskState.FAILED
+        assert final.status.message is not None
+        assert (
+            "eval" in final.status.message.lower()
+            or "confidence" in final.status.message.lower()
+        )
+
+        # eval_reason artifact must be present
+        eval_artifacts = [
+            a
+            for a in final.artifacts
+            if a.artifact_type == "json"
+            and isinstance(a.content, dict)
+            and "eval_reason" in a.content
+        ]
+        assert len(eval_artifacts) == 1, "Expected exactly one eval_reason artifact"

--- a/autobot-backend/a2a/self_evaluator.py
+++ b/autobot-backend/a2a/self_evaluator.py
@@ -1,0 +1,133 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+A2A Self-Evaluation Quality Gate
+
+Issue #4687: Lightweight self-evaluation pass that runs after agent output is
+produced, before a task transitions to COMPLETED.  Scores the response for
+confidence and completeness; if the score falls below a configurable threshold
+the result is a FAILED transition with an eval_reason in metadata.
+
+References:
+    AI Scientist v2 (Sakana AI / Nature 2026) — automated reviewer achieves
+    69% balanced accuracy vs. human reviewers using a similar confidence pass.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Default confidence threshold (0.0 – 1.0).  Tasks whose score falls below
+# this value are marked FAILED instead of COMPLETED.
+DEFAULT_EVAL_THRESHOLD: float = 0.6
+
+# Signals that hint the agent could not answer the question.
+_UNCERTAINTY_PHRASES = frozenset(
+    {
+        "i don't know",
+        "i do not know",
+        "i'm not sure",
+        "i am not sure",
+        "i cannot",
+        "i can't",
+        "unable to",
+        "not able to",
+        "no information",
+        "i have no",
+        "unclear",
+        "uncertain",
+        "sorry, i",
+        "apologies, i",
+    }
+)
+
+# Very short responses (character count) are treated as incomplete.
+_MIN_RESPONSE_CHARS = 20
+
+
+@dataclass
+class EvalResult:
+    """Outcome of a self-evaluation pass."""
+
+    passed: bool
+    confidence: float  # 0.0 – 1.0
+    eval_reason: str
+
+
+def _score_response(response_text: str, input_text: str) -> float:
+    """Return a heuristic confidence score in [0.0, 1.0].
+
+    The heuristic is intentionally cheap (no LLM call) so it adds negligible
+    latency to the task lifecycle.  It penalises:
+      - Very short responses (likely empty / error dumps)
+      - Uncertainty phrase matches in the response
+      - Responses shorter than the input (input ignored, essentially)
+    """
+    text = response_text.strip()
+
+    # Hard floor: near-empty response
+    if len(text) < _MIN_RESPONSE_CHARS:
+        return 0.0
+
+    score = 1.0
+
+    # Penalise each distinct uncertainty phrase found in the lower-cased text
+    lower = text.lower()
+    penalty_per_phrase = 0.2
+    for phrase in _UNCERTAINTY_PHRASES:
+        if phrase in lower:
+            score -= penalty_per_phrase
+            if score <= 0.0:
+                return 0.0
+
+    # Mild penalty when response is shorter than the input (often a sign the
+    # agent side-stepped the question rather than addressing it).
+    if len(text) < len(input_text):
+        score -= 0.1
+
+    return max(0.0, min(1.0, round(score, 4)))
+
+
+async def evaluate_task_output(
+    input_text: str,
+    response_text: str,
+    metadata: Dict[str, Any],
+    threshold: float = DEFAULT_EVAL_THRESHOLD,
+) -> EvalResult:
+    """Run the self-evaluation quality gate.
+
+    Args:
+        input_text: Original task input submitted by the caller.
+        response_text: Primary text artifact produced by the agent.
+        metadata: Routing/execution metadata dict (may be empty).
+        threshold: Minimum confidence required for COMPLETED.
+
+    Returns:
+        EvalResult with passed=True when confidence >= threshold.
+    """
+    confidence = _score_response(response_text, input_text)
+
+    if confidence >= threshold:
+        logger.debug(
+            "Self-eval PASSED (confidence=%.4f, threshold=%.4f)", confidence, threshold
+        )
+        return EvalResult(
+            passed=True,
+            confidence=confidence,
+            eval_reason="",
+        )
+
+    reason = (
+        f"Self-evaluation failed: confidence {confidence:.4f} below threshold "
+        f"{threshold:.4f}. Response may be incomplete or uncertain."
+    )
+    logger.warning(
+        "Self-eval FAILED (confidence=%.4f, threshold=%.4f): %s",
+        confidence,
+        threshold,
+        reason,
+    )
+    return EvalResult(passed=False, confidence=confidence, eval_reason=reason)

--- a/autobot-backend/a2a/task_executor.py
+++ b/autobot-backend/a2a/task_executor.py
@@ -12,6 +12,7 @@ with the task ID while execution continues asynchronously.
 import logging
 from typing import Any, Dict, Optional
 
+from .self_evaluator import DEFAULT_EVAL_THRESHOLD, evaluate_task_output
 from .task_manager import get_task_manager
 from .types import TaskArtifact, TaskState
 
@@ -41,15 +42,25 @@ async def execute_a2a_task(
     task_id: str,
     input_text: str,
     context: Optional[Dict[str, Any]] = None,
+    eval_threshold: float = DEFAULT_EVAL_THRESHOLD,
 ) -> None:
     """
     Execute an A2A task via the existing AgentOrchestrator.
 
     Lifecycle:
-      SUBMITTED → WORKING → (adds text + metadata artifacts) → COMPLETED
-                                                              → FAILED
+      SUBMITTED → WORKING → (adds text + metadata artifacts)
+                          → [self-eval quality gate]
+                          → COMPLETED  (confidence >= eval_threshold)
+                          → FAILED     (confidence < eval_threshold, eval_reason in metadata)
 
     This function is intentionally fire-and-forget (called via BackgroundTasks).
+
+    Args:
+        task_id: Unique A2A task identifier.
+        input_text: Original task input from the caller.
+        context: Optional extra context forwarded to the orchestrator.
+        eval_threshold: Minimum self-eval confidence score required before
+            transitioning to COMPLETED (default: DEFAULT_EVAL_THRESHOLD = 0.6).
     """
     manager = get_task_manager()
     manager.update_state(task_id, TaskState.WORKING)
@@ -86,12 +97,63 @@ async def execute_a2a_task(
                 {"event": "artifact_added", "artifact_type": "json", "task_id": task_id},
             )
 
-        manager.update_state(task_id, TaskState.COMPLETED)
-        manager.publish_event(
-            task_id,
-            {"event": "state_change", "state": "completed", "terminal": True, "task_id": task_id},
+        # Issue #4687: self-evaluation quality gate before COMPLETED transition.
+        eval_result = await evaluate_task_output(
+            input_text=input_text,
+            response_text=response_text,
+            metadata=metadata or {},
+            threshold=eval_threshold,
         )
-        logger.info("A2A task %s completed successfully", task_id)
+
+        if eval_result.passed:
+            manager.update_state(task_id, TaskState.COMPLETED)
+            manager.publish_event(
+                task_id,
+                {
+                    "event": "state_change",
+                    "state": "completed",
+                    "terminal": True,
+                    "task_id": task_id,
+                    "eval_confidence": eval_result.confidence,
+                },
+            )
+            logger.info(
+                "A2A task %s completed (confidence=%.4f)",
+                task_id,
+                eval_result.confidence,
+            )
+        else:
+            eval_artifact = TaskArtifact(
+                artifact_type="json",
+                content={
+                    "eval_reason": eval_result.eval_reason,
+                    "eval_confidence": eval_result.confidence,
+                    "eval_threshold": eval_threshold,
+                },
+            )
+            manager.add_artifact(task_id, eval_artifact)
+            manager.update_state(
+                task_id,
+                TaskState.FAILED,
+                message=eval_result.eval_reason,
+            )
+            manager.publish_event(
+                task_id,
+                {
+                    "event": "state_change",
+                    "state": "failed",
+                    "terminal": True,
+                    "task_id": task_id,
+                    "eval_confidence": eval_result.confidence,
+                    "eval_reason": eval_result.eval_reason,
+                },
+            )
+            logger.warning(
+                "A2A task %s failed self-eval (confidence=%.4f): %s",
+                task_id,
+                eval_result.confidence,
+                eval_result.eval_reason,
+            )
 
     except Exception as exc:
         logger.error("A2A task %s failed: %s", task_id, exc)


### PR DESCRIPTION
Closes #4687

## Summary
Adds self-evaluation quality gate in A2A task handler — tasks must pass a quality check before transitioning to COMPLETED state.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)