### PR TITLE
feat(agents): add self-critique reflection pass in subagent orchestrator (#4691)

### DIFF
--- a/autobot-backend/services/orchestration/subagent_orchestrator.py
+++ b/autobot-backend/services/orchestration/subagent_orchestrator.py
@@ -1,91 +1,229 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
 """Autonomous subagent spawning for parallel workstreams."""
 import asyncio
+import json
 import logging
-from typing import Any, Callable, List, Optional, Dict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _get_llm_service() -> Any:
+    """Lazy import of get_llm_service to avoid circular imports at module load.
+
+    Exposed as a module-level name so tests can patch it.
+    """
+    from services.llm_service import get_llm_service  # noqa: PLC0415
+
+    return get_llm_service()
+
+
+_REFLECTION_PROMPT = """\
+You are a critical reviewer evaluating whether a subagent result fully addresses its original task.
+
+Original task:
+{task_description}
+
+Result:
+{result}
+
+Respond with a JSON object and nothing else:
+{{
+  "score": <float 0.0-1.0>,
+  "gaps": ["<gap 1>", "<gap 2>"]
+}}
+
+A score of 1.0 means the result completely addresses the task with no gaps.
+"""
+
+_REVISION_PROMPT = """\
+You are a subagent completing a task that was partially addressed. Improve the result to fill all identified gaps.
+
+Original task:
+{task_description}
+
+Previous result:
+{result}
+
+Gaps identified:
+{gaps}
+
+Provide an improved, complete result that addresses all gaps.
+"""
+
 
 @dataclass
 class SubagentTask:
     """Definition of a task for subagent execution."""
+
     task_id: str
     func: Callable
     args: tuple = ()
-    kwargs: dict = None
+    kwargs: dict = field(default_factory=dict)
     timeout: int = 300
-    
-    def __post_init__(self):
+    enable_reflection: bool = False
+    reflection_threshold: float = 0.7
+    task_description: str = ""
+
+    def __post_init__(self) -> None:
         if self.kwargs is None:
             self.kwargs = {}
 
+
 class SubagentOrchestrator:
     """Orchestrates autonomous subagent spawning for parallel workstreams."""
-    
-    def __init__(self, max_parallel: int = 10):
+
+    def __init__(self, max_parallel: int = 10) -> None:
         self.max_parallel = max_parallel
         self.active_subagents: Dict[str, asyncio.Task] = {}
-    
+
     async def spawn_parallel_tasks(self, tasks: List[SubagentTask]) -> Dict[str, Any]:
-<<<<<<< HEAD
-        """
-        Spawn multiple subagents for parallel execution.
-        
+        """Spawn multiple subagents for parallel execution.
+
         Args:
-            tasks: List of SubagentTask objects
-            
+            tasks: List of SubagentTask objects.
+
         Returns:
-            Dictionary with results keyed by task_id
+            Dictionary with results keyed by task_id.
         """
-        results = {}
-        
-        # Create tasks with timeouts
+        results: Dict[str, Any] = {}
         pending = []
-=======
-        """Spawn multiple subagents for parallel execution."""
-        results = {}
-        pending = []
-        
->>>>>>> origin/issue-4348
-        for task in tasks[:self.max_parallel]:
+
+        for task in tasks[: self.max_parallel]:
             try:
                 coro = asyncio.wait_for(
                     self._execute_task(task),
-                    timeout=task.timeout
+                    timeout=task.timeout,
                 )
                 pending.append((task.task_id, coro))
-            except Exception as e:
-                logger.error(f"Error creating task {task.task_id}: {e}")
-                results[task.task_id] = {"error": str(e)}
-        
-<<<<<<< HEAD
-        # Execute all pending tasks concurrently
-        if pending:
-            task_ids, coros = zip(*pending) if pending else ([], [])
-            task_results = await asyncio.gather(*coros, return_exceptions=True)
-            
-=======
+            except Exception as exc:
+                logger.error("Error creating task %s: %s", task.task_id, exc)
+                results[task.task_id] = {"error": str(exc)}
+
         if pending:
             task_ids, coros = zip(*pending)
             task_results = await asyncio.gather(*coros, return_exceptions=True)
->>>>>>> origin/issue-4348
             for task_id, result in zip(task_ids, task_results):
                 results[task_id] = result
-        
+
         return results
-    
+
     async def _execute_task(self, task: SubagentTask) -> Any:
-        """Execute a single subagent task."""
+        """Execute a single subagent task, optionally with a reflection pass."""
         try:
             if asyncio.iscoroutinefunction(task.func):
-                return await task.func(*task.args, **task.kwargs)
+                result = await task.func(*task.args, **task.kwargs)
             else:
-                return task.func(*task.args, **task.kwargs)
-        except Exception as e:
-            logger.error(f"Task {task.task_id} failed: {e}")
+                result = task.func(*task.args, **task.kwargs)
+        except Exception as exc:
+            logger.error("Task %s failed: %s", task.task_id, exc)
             raise
 
+        if task.enable_reflection:
+            result = await self._reflection_pass(task, result)
+
+        return result
+
+    async def _reflection_pass(self, task: SubagentTask, result: Any) -> Any:
+        """Run an optional score-and-revise reflection pass.
+
+        Scores the result against the task description. If the score is below
+        ``task.reflection_threshold``, sends the result and gap list back for
+        one revision pass and returns the revised result. Otherwise returns the
+        original result unchanged.
+        """
+        try:
+            llm = _get_llm_service()
+        except Exception as exc:
+            logger.warning(
+                "Reflection skipped for task %s — LLM service unavailable: %s",
+                task.task_id,
+                exc,
+            )
+            return result
+
+        task_description = task.task_description or str(task.task_id)
+        result_text = result if isinstance(result, str) else json.dumps(result, default=str)
+
+        score, gaps = await self._score_result(llm, task_description, result_text)
+        logger.debug(
+            "Reflection score for task %s: %.2f (threshold=%.2f, gaps=%s)",
+            task.task_id,
+            score,
+            task.reflection_threshold,
+            gaps,
+        )
+
+        if score >= task.reflection_threshold or not gaps:
+            return result
+
+        revised = await self._revise_result(llm, task_description, result_text, gaps)
+        logger.info(
+            "Task %s revised after reflection (score=%.2f < threshold=%.2f)",
+            task.task_id,
+            score,
+            task.reflection_threshold,
+        )
+        return revised
+
+    async def _score_result(
+        self,
+        llm: Any,
+        task_description: str,
+        result_text: str,
+    ) -> tuple[float, List[str]]:
+        """Ask the LLM to score the result and list gaps. Returns (score, gaps)."""
+        prompt = _REFLECTION_PROMPT.format(
+            task_description=task_description,
+            result=result_text,
+        )
+        try:
+            response = await llm.chat(
+                messages=[{"role": "user", "content": prompt}],
+                llm_type="analysis",
+                temperature=0.1,
+                max_tokens=256,
+            )
+            payload = json.loads(response.content.strip())
+            score = float(payload.get("score", 0.0))
+            gaps = [str(g) for g in payload.get("gaps", [])]
+            return max(0.0, min(1.0, score)), gaps
+        except Exception as exc:
+            logger.warning("Reflection scoring failed: %s", exc)
+            return 1.0, []  # assume good to avoid spurious revisions on LLM error
+
+    async def _revise_result(
+        self,
+        llm: Any,
+        task_description: str,
+        result_text: str,
+        gaps: List[str],
+    ) -> Any:
+        """Ask the LLM to produce a revised result that fills the listed gaps."""
+        gaps_text = "\n".join(f"- {g}" for g in gaps)
+        prompt = _REVISION_PROMPT.format(
+            task_description=task_description,
+            result=result_text,
+            gaps=gaps_text,
+        )
+        try:
+            response = await llm.chat(
+                messages=[{"role": "user", "content": prompt}],
+                llm_type="analysis",
+                temperature=0.3,
+                max_tokens=1024,
+            )
+            return response.content.strip()
+        except Exception as exc:
+            logger.warning("Revision LLM call failed: %s — returning original result", exc)
+            return result_text
+
+
 _orchestrator_instance: Optional[SubagentOrchestrator] = None
+
 
 def get_subagent_orchestrator(max_parallel: int = 10) -> SubagentOrchestrator:
     """Get or create global orchestrator instance."""

--- a/autobot-backend/tests/orchestration/test_subagent_orchestrator_reflection.py
+++ b/autobot-backend/tests/orchestration/test_subagent_orchestrator_reflection.py
@@ -1,0 +1,316 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Unit tests for subagent orchestrator reflection pass (#4691).
+
+Covers:
+- Reflection disabled → original result returned unchanged
+- Score >= threshold → original result returned unchanged
+- Score < threshold → revised result returned
+- LLM service unavailable → original result returned (graceful degradation)
+- No regression on existing parallel dispatch flow
+"""
+
+import asyncio
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from services.orchestration.subagent_orchestrator import (
+    SubagentOrchestrator,
+    SubagentTask,
+    get_subagent_orchestrator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_llm_response(content: str) -> MagicMock:
+    resp = MagicMock()
+    resp.content = content
+    return resp
+
+
+def _score_response(score: float, gaps: list) -> MagicMock:
+    return _make_llm_response(json.dumps({"score": score, "gaps": gaps}))
+
+
+# ---------------------------------------------------------------------------
+# SubagentTask defaults
+# ---------------------------------------------------------------------------
+
+class TestSubagentTaskDefaults:
+    def test_reflection_disabled_by_default(self):
+        task = SubagentTask(task_id="t1", func=lambda: None)
+        assert task.enable_reflection is False
+
+    def test_reflection_threshold_default(self):
+        task = SubagentTask(task_id="t1", func=lambda: None)
+        assert task.reflection_threshold == 0.7
+
+    def test_enable_reflection_flag(self):
+        task = SubagentTask(
+            task_id="t1",
+            func=lambda: None,
+            enable_reflection=True,
+            reflection_threshold=0.8,
+        )
+        assert task.enable_reflection is True
+        assert task.reflection_threshold == 0.8
+
+
+# ---------------------------------------------------------------------------
+# Reflection pass disabled → original result
+# ---------------------------------------------------------------------------
+
+class TestReflectionDisabled:
+    @pytest.mark.asyncio
+    async def test_disabled_skips_reflection(self):
+        """enable_reflection=False → _reflection_pass never called."""
+        orch = SubagentOrchestrator()
+
+        async def my_func():
+            return "original"
+
+        task = SubagentTask(task_id="t1", func=my_func, enable_reflection=False)
+
+        with patch.object(orch, "_reflection_pass", new_callable=AsyncMock) as mock_rp:
+            result = await orch._execute_task(task)
+
+        mock_rp.assert_not_called()
+        assert result == "original"
+
+
+# ---------------------------------------------------------------------------
+# Reflection: high score → original returned
+# ---------------------------------------------------------------------------
+
+class TestReflectionHighScore:
+    @pytest.mark.asyncio
+    async def test_high_score_returns_original(self):
+        """Score >= threshold → original result returned unchanged."""
+        orch = SubagentOrchestrator()
+
+        async def my_func():
+            return "original result"
+
+        task = SubagentTask(
+            task_id="t1",
+            func=my_func,
+            enable_reflection=True,
+            reflection_threshold=0.7,
+            task_description="Summarise the document.",
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.chat = AsyncMock(return_value=_score_response(0.9, []))
+
+        with patch("services.orchestration.subagent_orchestrator._get_llm_service", return_value=mock_llm):
+            result = await orch._execute_task(task)
+
+        assert result == "original result"
+        # Only the scoring call should have been made; no revision call.
+        assert mock_llm.chat.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Reflection: low score → revised result returned
+# ---------------------------------------------------------------------------
+
+class TestReflectionLowScore:
+    @pytest.mark.asyncio
+    async def test_low_score_returns_revised(self):
+        """Score < threshold → one revision call, revised result returned."""
+        orch = SubagentOrchestrator()
+
+        async def my_func():
+            return "incomplete result"
+
+        task = SubagentTask(
+            task_id="t1",
+            func=my_func,
+            enable_reflection=True,
+            reflection_threshold=0.7,
+            task_description="Analyse all data points.",
+        )
+
+        mock_llm = MagicMock()
+        score_resp = _score_response(0.4, ["Missing section A", "Missing conclusion"])
+        revision_resp = _make_llm_response("revised and complete result")
+        mock_llm.chat = AsyncMock(side_effect=[score_resp, revision_resp])
+
+        with patch(
+            "services.orchestration.subagent_orchestrator._get_llm_service",
+            return_value=mock_llm,
+        ):
+            result = await orch._execute_task(task)
+
+        assert result == "revised and complete result"
+        assert mock_llm.chat.call_count == 2  # score + revision
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_threshold_is_not_revised(self):
+        """Score == threshold is treated as passing (>= check)."""
+        orch = SubagentOrchestrator()
+
+        async def my_func():
+            return "borderline result"
+
+        task = SubagentTask(
+            task_id="t1",
+            func=my_func,
+            enable_reflection=True,
+            reflection_threshold=0.7,
+            task_description="Write a summary.",
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.chat = AsyncMock(return_value=_score_response(0.7, ["minor gap"]))
+
+        with patch(
+            "services.orchestration.subagent_orchestrator._get_llm_service",
+            return_value=mock_llm,
+        ):
+            result = await orch._execute_task(task)
+
+        assert result == "borderline result"
+        assert mock_llm.chat.call_count == 1  # no revision
+
+
+# ---------------------------------------------------------------------------
+# Reflection: LLM unavailable → graceful degradation
+# ---------------------------------------------------------------------------
+
+class TestReflectionLLMUnavailable:
+    @pytest.mark.asyncio
+    async def test_llm_import_error_returns_original(self):
+        """LLM service unavailable → original result returned without error."""
+        orch = SubagentOrchestrator()
+
+        async def my_func():
+            return "original"
+
+        task = SubagentTask(
+            task_id="t1",
+            func=my_func,
+            enable_reflection=True,
+            task_description="Some task.",
+        )
+
+        with patch(
+            "services.orchestration.subagent_orchestrator._get_llm_service",
+            side_effect=ImportError("no llm"),
+        ):
+            result = await orch._execute_task(task)
+
+        assert result == "original"
+
+    @pytest.mark.asyncio
+    async def test_scoring_exception_returns_original(self):
+        """Scoring LLM call raises → original result returned (score assumed 1.0)."""
+        orch = SubagentOrchestrator()
+
+        async def my_func():
+            return "original"
+
+        task = SubagentTask(
+            task_id="t1",
+            func=my_func,
+            enable_reflection=True,
+            task_description="Some task.",
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.chat = AsyncMock(side_effect=RuntimeError("llm error"))
+
+        with patch(
+            "services.orchestration.subagent_orchestrator._get_llm_service",
+            return_value=mock_llm,
+        ):
+            result = await orch._execute_task(task)
+
+        assert result == "original"
+
+
+# ---------------------------------------------------------------------------
+# No regression: existing parallel dispatch flow
+# ---------------------------------------------------------------------------
+
+class TestParallelDispatchNoRegression:
+    @pytest.mark.asyncio
+    async def test_spawn_parallel_tasks_no_reflection(self):
+        """Parallel dispatch works correctly when reflection is disabled."""
+        orch = SubagentOrchestrator(max_parallel=3)
+        call_order = []
+
+        async def make_func(val):
+            async def func():
+                await asyncio.sleep(0)
+                call_order.append(val)
+                return val
+            return func
+
+        tasks = [
+            SubagentTask(
+                task_id=f"t{i}",
+                func=await make_func(i),
+                enable_reflection=False,
+            )
+            for i in range(3)
+        ]
+
+        results = await orch.spawn_parallel_tasks(tasks)
+
+        assert len(results) == 3
+        assert results["t0"] == 0
+        assert results["t1"] == 1
+        assert results["t2"] == 2
+
+    @pytest.mark.asyncio
+    async def test_spawn_parallel_honours_max_parallel(self):
+        """Tasks beyond max_parallel are dropped (existing behaviour)."""
+        orch = SubagentOrchestrator(max_parallel=2)
+
+        async def my_func():
+            return "ok"
+
+        tasks = [
+            SubagentTask(task_id=f"t{i}", func=my_func) for i in range(4)
+        ]
+        results = await orch.spawn_parallel_tasks(tasks)
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_task_exception_propagates_as_exception_result(self):
+        """A failing task result is stored as an exception (existing behaviour)."""
+        orch = SubagentOrchestrator()
+
+        async def bad_func():
+            raise ValueError("boom")
+
+        task = SubagentTask(task_id="bad", func=bad_func)
+        results = await orch.spawn_parallel_tasks([task])
+        assert isinstance(results["bad"], ValueError)
+
+
+# ---------------------------------------------------------------------------
+# get_subagent_orchestrator singleton
+# ---------------------------------------------------------------------------
+
+class TestGetSubagentOrchestrator:
+    def test_returns_singleton(self):
+        import services.orchestration.subagent_orchestrator as mod
+        mod._orchestrator_instance = None  # reset
+        a = get_subagent_orchestrator()
+        b = get_subagent_orchestrator()
+        assert a is b
+
+    def test_custom_max_parallel(self):
+        import services.orchestration.subagent_orchestrator as mod
+        mod._orchestrator_instance = None
+        orch = get_subagent_orchestrator(max_parallel=5)
+        assert orch.max_parallel == 5
+        mod._orchestrator_instance = None  # clean up


### PR DESCRIPTION
Closes #4691

## Summary
Adds self-critique reflection pass to subagent orchestrator — agents evaluate their own output before returning results.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)