### PR TITLE
fix(rag): wire NeuralMeshRetriever into RAGService at startup (#4724)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -754,6 +754,49 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
             )
             await rag_service.initialize()
 
+
+            # Wire NeuralMeshRetriever now that RAGService and the DB engine are ready.
+            # Issue #4724: was never wired despite the full mesh_brain/ implementation.
+            try:
+                from autobot_shared.redis_client import get_async_redis_client
+                from knowledge.search_components.query_classifier import QueryClassifier
+                from knowledge.search_components.reranking import ResultReranker
+                from services.mesh_brain.edge_learner import EdgeLearner
+                from services.mesh_brain.mesh_db_adapter import create_mesh_db_adapter
+                from services.mesh_brain.ppr import PersonalizedPageRank
+                from services.neural_mesh_retriever import NeuralMeshRetriever
+                from user_management.database import get_async_engine
+
+                _mesh_db = create_mesh_db_adapter(get_async_engine())
+                _redis = get_async_redis_client()
+                _ppr = PersonalizedPageRank(db=_mesh_db)
+                _edge_learner = EdgeLearner(db=_mesh_db, redis=_redis)
+
+                async def _chroma_search(query: str, k: int) -> list:
+                    return await rag_service.optimizer._perform_semantic_search(query, limit=k)
+
+                async def _hybrid_search(query: str, top_k: int = 5) -> list:
+                    from advanced_rag_optimizer import RAGMetrics
+                    results, _ = await rag_service.optimizer._retrieve_hybrid_results(
+                        query, RAGMetrics()
+                    )
+                    return results[:top_k]
+
+                rag_service._mesh_retriever = NeuralMeshRetriever(
+                    chroma_search=_chroma_search,
+                    hybrid_search=_hybrid_search,
+                    ppr=_ppr,
+                    edge_learner=_edge_learner,
+                    reranker=ResultReranker(),
+                    classifier=QueryClassifier(),
+                    mesh_db=_mesh_db,
+                    llm=None,
+                )
+                rag_config.mesh_retriever_enabled = True
+                logger.info("✅ [ 87%] Neural Mesh RAG: NeuralMeshRetriever wired into RAGService (#4724)")
+            except Exception as _mesh_wire_err:
+                logger.warning("Neural Mesh RAG wiring skipped (non-fatal): %s", _mesh_wire_err)
+
             graph_rag_service = GraphRAGService(
                 rag_service=rag_service,
                 memory_graph=memory_graph,

--- a/autobot-backend/services/rag_config.py
+++ b/autobot-backend/services/rag_config.py
@@ -58,6 +58,7 @@ class RAGConfig:
     fallback_to_basic_search: bool = True
 
     # Neural Mesh RAG feature flags (Phase 3, Issue #2059)
+    mesh_retriever_enabled: bool = False
     mesh_seed_edges: bool = True
     mesh_edge_learner: bool = False
     mesh_edge_discoverer: bool = False
@@ -237,6 +238,7 @@ class RAGConfig:
             "rewrite_enabled": self.rewrite_enabled,
             "max_search_iterations": self.max_search_iterations,
             # Neural Mesh RAG feature flags (Issue #2059)
+            "mesh_retriever_enabled": self.mesh_retriever_enabled,
             "mesh_seed_edges": self.mesh_seed_edges,
             "mesh_edge_learner": self.mesh_edge_learner,
             "mesh_edge_discoverer": self.mesh_edge_discoverer,

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -67,6 +67,8 @@ class RAGService:
         self._initialized = False
         self._cache: Dict[str, Tuple[List[SearchResult], float]] = {}
         self._cache_lock = asyncio.Lock()  # CRITICAL: Protect concurrent cache access
+        # Neural Mesh RAG retriever (Issue #2059); injected at startup when Phase 3 is active.
+        self._mesh_retriever: Optional[Any] = None
         logger.info(f"RAGService initialized with {self.kb_adapter.implementation_type}")
 
     async def initialize(self) -> bool:
@@ -513,6 +515,36 @@ class RAGService:
 
         return None
 
+    async def _run_mesh_retriever(
+        self,
+        query: str,
+        max_results: int,
+    ) -> Tuple[List[SearchResult], RAGMetrics]:
+        """Delegate retrieval to NeuralMeshRetriever and emit feedback. Issue #2059.
+
+        Called only when mesh_retriever_enabled=True and _mesh_retriever is set.
+        The mesh retriever returns SearchResult-compatible chunks directly; this
+        helper handles feedback emission so the caller stays clean.
+        """
+        logger.info("Using NeuralMeshRetriever for query (mesh_retriever_enabled=True)")
+        mesh_result = await self._mesh_retriever.retrieve(query, max_results)
+        results: List[SearchResult] = mesh_result.chunks
+        metrics = RAGMetrics()
+        metrics.final_results_count = len(results)
+
+        retrieved_ids = [r.metadata.get("chunk_id", r.source_path) for r in results]
+        await self._emit_retrieval_feedback(
+            query=query,
+            retrieved_ids=retrieved_ids,
+            ranked_ids=retrieved_ids,
+        )
+        await self._store_feedback_in_stream(
+            query=query,
+            retrieved_ids=retrieved_ids,
+            ranked_ids=retrieved_ids,
+        )
+        return results, metrics
+
     async def _emit_ranked_feedback(
         self,
         query: str,
@@ -577,6 +609,10 @@ class RAGService:
         hit = await self._check_cache_tiers(query, max_results, enable_reranking, categories)
         if hit is not None:
             return hit[0], hit[1]
+
+        # Neural Mesh RAG path (Issue #2059)
+        if self.config.mesh_retriever_enabled and self._mesh_retriever is not None:
+            return await self._run_mesh_retriever(query, max_results)
 
         if not await self.initialize():
             logger.warning("RAG init failed, using fallback")

--- a/autobot-backend/services/rag_service_mesh_test.py
+++ b/autobot-backend/services/rag_service_mesh_test.py
@@ -2,67 +2,162 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Unit tests for Neural Mesh RAG feature flags and RAGService mesh path (#2059, #4686).
-
-NOTE: mesh_retriever_enabled and _mesh_retriever were removed from RAGService in
-#4686 — those injection-gate tests are gone. The remaining mesh flags (mesh_seed_edges,
-mesh_edge_learner, etc.) live in RAGConfig and are tested here.
-"""
+"""Unit tests for Neural Mesh RAG feature flags and RAGService mesh path (#2059, #4724)."""
 
 import pytest
+from unittest.mock import AsyncMock, MagicMock
 
 
 # =============================================================================
-# Test: RAGConfig mesh flag defaults
+# Helpers
+# =============================================================================
+
+
+def _make_service(mesh_retriever_enabled: bool = False):
+    """Build a RAGService stub; no Redis or ChromaDB connections."""
+    from advanced_rag_optimizer import RAGMetrics
+    from services.rag_config import RAGConfig
+    from services.rag_service import RAGService
+
+    svc = RAGService.__new__(RAGService)
+    svc._initialized = True
+    svc._cache = {}
+    svc._cache_lock = MagicMock()
+    cfg = RAGConfig()
+    cfg.enable_advanced_rag = True
+    cfg.mesh_retriever_enabled = mesh_retriever_enabled
+    svc.config = cfg
+    svc._mesh_retriever = None
+    opt = MagicMock()
+    opt.advanced_search = AsyncMock(return_value=([], RAGMetrics()))
+    opt.advanced_search_with_refinement = AsyncMock(return_value=([], RAGMetrics(), []))
+    svc.optimizer = opt
+    return svc
+
+
+def _make_mesh_result(chunk_ids):
+    """Return a mock MeshRetrievalResult."""
+    from advanced_rag_optimizer import SearchResult
+
+    chunks = [
+        SearchResult(
+            content=f"content-{cid}",
+            metadata={"chunk_id": cid},
+            semantic_score=0.5,
+            keyword_score=0.0,
+            hybrid_score=0.5,
+            relevance_rank=i + 1,
+            source_path=cid,
+        )
+        for i, cid in enumerate(chunk_ids)
+    ]
+    result = MagicMock()
+    result.chunks = chunks
+    return result
+
+
+# =============================================================================
+# Test: mesh_retriever_enabled default and to_dict
 # =============================================================================
 
 
 class TestMeshFeatureFlagsDefaultValues:
-    """All remaining mesh feature flags must have the correct defaults."""
-
-    def test_mesh_feature_flags_default_values(self):
-        """Verify mesh flags have correct defaults from RAGConfig()."""
+    def test_defaults(self):
         from services.rag_config import RAGConfig
-
         cfg = RAGConfig()
+        assert cfg.mesh_retriever_enabled is False
         assert cfg.mesh_seed_edges is True
         assert cfg.mesh_edge_learner is False
-        assert cfg.mesh_edge_discoverer is False
-        assert cfg.mesh_pruner is False
-        assert cfg.mesh_node_promoter is False
 
-
-# =============================================================================
-# Test: to_dict() includes mesh flags
-# =============================================================================
-
-
-class TestRAGConfigSerializationIncludesMeshFlags:
-    """RAGConfig.to_dict() must expose the mesh flags for YAML round-trips."""
-
-    def test_rag_config_serialization_includes_mesh_flags(self):
-        """to_dict() contains mesh flag keys with correct default values."""
+    def test_to_dict_includes_mesh_retriever_enabled(self):
         from services.rag_config import RAGConfig
-
         d = RAGConfig().to_dict()
-        assert d["mesh_seed_edges"] is True
-        assert d["mesh_edge_learner"] is False
-        assert d["mesh_edge_discoverer"] is False
-        assert d["mesh_pruner"] is False
-        assert d["mesh_node_promoter"] is False
-        # mesh_retriever_enabled was removed in #4686
-        assert "mesh_retriever_enabled" not in d
+        assert "mesh_retriever_enabled" in d
+        assert d["mesh_retriever_enabled"] is False
 
-    def test_from_dict_round_trips_mesh_flags(self):
-        """from_dict(to_dict()) preserves non-default mesh flag values."""
+    def test_from_dict_round_trip(self):
         from services.rag_config import RAGConfig
-
         original = RAGConfig()
         original.mesh_edge_learner = True
-        d = original.to_dict()
-
-        restored = RAGConfig.from_dict(d)
+        restored = RAGConfig.from_dict(original.to_dict())
         assert restored.mesh_edge_learner is True
-        # Unmodified flags stay at defaults
-        assert restored.mesh_seed_edges is True
-        assert restored.mesh_edge_discoverer is False
+        assert restored.mesh_retriever_enabled is False
+
+
+# =============================================================================
+# Test: flag disabled — legacy optimizer path is taken
+# =============================================================================
+
+
+class TestMeshFlagDisabled:
+    @pytest.mark.asyncio
+    async def test_legacy_path_when_flag_off(self):
+        from unittest.mock import patch
+
+        svc = _make_service(mesh_retriever_enabled=False)
+
+        with patch("services.rag_service.RAGService._check_cache_tiers",
+                   new_callable=AsyncMock, return_value=None), \
+             patch("services.rag_service.RAGService.initialize",
+                   new_callable=AsyncMock, return_value=True), \
+             patch("services.rag_service.RAGService._emit_ranked_feedback",
+                   new_callable=AsyncMock), \
+             patch("services.rag_service.RAGService._run_mesh_retriever",
+                   new_callable=AsyncMock) as mock_mesh:
+            await svc.advanced_search("test query")
+            mock_mesh.assert_not_called()
+            svc.optimizer.advanced_search.assert_called_once()
+
+
+# =============================================================================
+# Test: flag enabled + retriever set — mesh path is taken
+# =============================================================================
+
+
+class TestMeshFlagEnabled:
+    @pytest.mark.asyncio
+    async def test_mesh_path_when_flag_on_and_retriever_injected(self):
+        from advanced_rag_optimizer import RAGMetrics
+        from unittest.mock import patch
+
+        svc = _make_service(mesh_retriever_enabled=True)
+        svc._mesh_retriever = MagicMock()  # non-None
+
+        expected = _make_mesh_result(["c1", "c2"]).chunks
+        metrics = RAGMetrics()
+
+        with patch("services.rag_service.RAGService._check_cache_tiers",
+                   new_callable=AsyncMock, return_value=None), \
+             patch("services.rag_service.RAGService._emit_ranked_feedback",
+                   new_callable=AsyncMock), \
+             patch("services.rag_service.RAGService._run_mesh_retriever",
+                   new_callable=AsyncMock, return_value=(expected, metrics)) as mock_mesh:
+            results, _ = await svc.advanced_search("test query")
+            mock_mesh.assert_called_once_with("test query", 5)
+            assert results is expected
+
+
+# =============================================================================
+# Test: flag enabled but retriever None — falls through to legacy
+# =============================================================================
+
+
+class TestMeshFlagEnabledRetrieverNone:
+    @pytest.mark.asyncio
+    async def test_falls_through_when_retriever_not_injected(self):
+        from unittest.mock import patch
+
+        svc = _make_service(mesh_retriever_enabled=True)
+        svc._mesh_retriever = None  # not injected yet
+
+        with patch("services.rag_service.RAGService._check_cache_tiers",
+                   new_callable=AsyncMock, return_value=None), \
+             patch("services.rag_service.RAGService.initialize",
+                   new_callable=AsyncMock, return_value=True), \
+             patch("services.rag_service.RAGService._emit_ranked_feedback",
+                   new_callable=AsyncMock), \
+             patch("services.rag_service.RAGService._run_mesh_retriever",
+                   new_callable=AsyncMock) as mock_mesh:
+            await svc.advanced_search("test query")
+            mock_mesh.assert_not_called()
+            svc.optimizer.advanced_search.assert_called_once()


### PR DESCRIPTION
Closes #4724

## Summary

- Reverts removal from #4686 — restores `_mesh_retriever` field, `_run_mesh_retriever()`, and the guard in `advanced_search()`
- Restores `mesh_retriever_enabled` to `RAGConfig` field list and `to_dict()`
- Adds wiring block in `lifespan._init_graph_rag_service()` that builds `NeuralMeshRetriever` from `MeshDBAdapter` / `PersonalizedPageRank` / `EdgeLearner` / `ResultReranker` / `QueryClassifier` and injects it after `rag_service.initialize()`
- Wiring is non-fatal — wrapped in try/except, startup logs warning and continues if a dep is unavailable
- Restores 6 unit tests: flag-off (legacy path), flag-on + retriever injected (mesh path), flag-on + retriever None (falls through) — all pass

## Why #4686 was wrong

All 7 deps exist: `create_mesh_db_adapter(get_async_engine())` factory explicitly says 'use at startup'; PPR/EdgeLearner are in `mesh_brain/`; Reranker/Classifier are in `knowledge/search_components/`; search callables are closures over `rag_service.optimizer`.