### PR TITLE
feat(slm-frontend): wire InfrastructureSettings.vue into router (#4705)

### DIFF
--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -153,10 +153,10 @@ const router = createRouter({
           meta: { title: 'General Settings', parent: 'settings' }
         },
         {
-          // Issue #850: Consolidated into unified orchestration view (Tab 5)
+          // Issue #4705: Wire InfrastructureSettings view into settings router
           path: 'infrastructure',
           name: 'settings-infrastructure',
-          redirect: '/orchestration/infrastructure',
+          component: () => import('@/views/settings/InfrastructureSettings.vue'),
           meta: { title: 'Infrastructure', parent: 'settings' }
         },
         {

--- a/autobot-slm-frontend/src/views/SettingsView.vue
+++ b/autobot-slm-frontend/src/views/SettingsView.vue
@@ -26,8 +26,8 @@ const success = ref<string | null>(null)
 const tabs = [
   { id: 'general', name: 'General', path: '/settings/general', icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z' },
   // Issue #737: Nodes tab removed - consolidated to Fleet Overview
-  // Issue #786: Infrastructure tab removed - consolidated to Fleet Overview /fleet/infrastructure
-  // { id: 'nodes', name: 'Nodes', path: '/settings/nodes', icon: '...' },
+  // Issue #4705: Infrastructure tab restored — InfrastructureSettings.vue now wired into router
+  { id: 'infrastructure', name: 'Infrastructure', path: '/settings/infrastructure', icon: 'M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10' },
   { id: 'monitoring', name: 'Monitoring', path: '/settings/monitoring', icon: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z' },
   { id: 'notifications', name: 'Notifications', path: '/settings/notifications', icon: 'M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9' },
   { id: 'security', name: 'Security', path: '/settings/security', icon: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z' },


### PR DESCRIPTION
Closes #4705

Fixes the `/settings/infrastructure` route which previously redirected to `/orchestration/infrastructure` (a leftover from Issue #850) instead of serving `InfrastructureSettings.vue`.

**Changes:**
- `router/index.ts`: changed `settings-infrastructure` from redirect to lazy-loaded `InfrastructureSettings.vue`
- `views/SettingsView.vue`: added Infrastructure tab to settings sidebar nav