### PR TITLE
feat(slm-frontend): wire RolesView.vue into router (#4706)

### DIFF
--- a/autobot-slm-frontend/src/components/common/Sidebar.vue
+++ b/autobot-slm-frontend/src/components/common/Sidebar.vue
@@ -49,6 +49,8 @@ const navItems = [
   { name: 'Fleet Overview', path: '/fleet', icon: 'grid' },
   // Issue #850: Consolidated Services and Roles into Orchestration
   { name: 'Orchestration', path: '/orchestration', icon: 'orchestration' },
+  // Issue #4706: Wire RolesView into router
+  { name: 'Roles', path: '/roles', icon: 'roles' },
   { name: 'Deployments', path: '/deployments', icon: 'rocket' },
   { name: 'Backups', path: '/backups', icon: 'database' },
   { name: 'Replication', path: '/replications', icon: 'replicate' },

--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -354,10 +354,10 @@ const router = createRouter({
       },
     },
     {
-      // Issue #850: Consolidated into unified orchestration view (Tab 3)
+      // Issue #841/#1129: Role Registry — standalone CRUD view (wired via #4706)
       path: '/roles',
       name: 'roles',
-      redirect: '/orchestration/roles',
+      component: () => import('@/views/RolesView.vue'),
       meta: { title: 'Role Registry' }
     },
     {


### PR DESCRIPTION
Closes #4706

Wires `RolesView.vue` into the SLM router and sidebar nav. Previously `/roles` redirected to `/orchestration/roles` (Issue #850 leftover).

**Changes:**
- `router/index.ts`: replaced redirect with direct lazy-loaded `RolesView.vue` route
- `components/common/Sidebar.vue`: added Roles nav entry using the pre-existing roles SVG icon