### PR TITLE
fix(rag): correct _hybrid_search closure — remove erroneous tuple unpack

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -777,7 +777,7 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
 
                 async def _hybrid_search(query: str, top_k: int = 5) -> list:
                     from advanced_rag_optimizer import RAGMetrics
-                    results, _ = await rag_service.optimizer._retrieve_hybrid_results(
+                    results = await rag_service.optimizer._retrieve_hybrid_results(
                         query, RAGMetrics()
                     )
                     return results[:top_k]


### PR DESCRIPTION
Bugfix for #4724 wiring.

`_retrieve_hybrid_results()` returns `List[SearchResult]` (changed by #4685), but the `_hybrid_search` closure in the NeuralMeshRetriever wiring block did `results, _ = await ...` — tuple-unpacking a list, which raises `ValueError` at runtime.

Single-char fix: `results = await ...` (no unpacking).