### PR TITLE
fix(frontend): resolve CacheService.ts TS2352 unsafe Window cast (#4700)

### DIFF
--- a/autobot-frontend/src/services/CacheService.ts
+++ b/autobot-frontend/src/services/CacheService.ts
@@ -199,7 +199,7 @@ export const cacheService = new CacheService();
 
 // Make available globally for debugging
 if (typeof window !== 'undefined') {
-  (window as Record<string, unknown>).cacheService = cacheService;
+  (window as unknown as Record<string, unknown>).cacheService = cacheService;
 }
 
 export default cacheService;


### PR DESCRIPTION
Closes #4700

## Summary
- Changes `(window as Record<string, unknown>)` to `(window as unknown as Record<string, unknown>)` — double cast through `unknown` is the correct TypeScript pattern for intentional cross-type assertions

## Test Status
PASS — vue-tsc confirms zero TS2352 errors in CacheService.ts after fix