### PR TITLE
fix(frontend): resolve TerminalService.ts TS2352 unsafe cast to SessionInfo[] (#4701)

### DIFF
--- a/autobot-frontend/src/services/TerminalService.ts
+++ b/autobot-frontend/src/services/TerminalService.ts
@@ -854,7 +854,7 @@ class TerminalService {
   async getSessions(): Promise<SessionInfo[]> {
     try {
       const result = await apiClient.getTerminalSessions()
-      return (result || []) as SessionInfo[]
+      return (result || []) as unknown as SessionInfo[]
     } catch (error) {
       logger.error('Error getting sessions:', error)
       return []


### PR DESCRIPTION
Closes #4701

## Summary
- Routes cast through `unknown` intermediary: `(result || []) as unknown as SessionInfo[]` — makes intentional cross-type assertion explicit while satisfying TypeScript

## Test Status
PASS — TS2352 error on TerminalService.ts:857 eliminated; verified via vue-tsc