### PR TITLE
feat(agents): add circuit breaker for unhealthy distributed agents (#4694)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/distributed_management.py
+++ b/autobot-backend/agents/agent_orchestration/distributed_management.py
@@ -10,12 +10,12 @@ Contains distributed agent registration, health monitoring, and lifecycle manage
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from constants.threshold_constants import TimingConstants, WorkStealingConfig
 
-from .types import DistributedAgentInfo
+from .types import CircuitState, DistributedAgentInfo
 
 if TYPE_CHECKING:
     from agents.base_agent import AgentHealth, BaseAgent
@@ -34,6 +34,8 @@ class DistributedAgentManager:
         grace_period_seconds: int = WorkStealingConfig.GRACE_PERIOD_SECONDS,
         max_reassignments: int = WorkStealingConfig.MAX_REASSIGNMENTS,
         progress_ttl_seconds: int = WorkStealingConfig.PROGRESS_TTL_SECONDS,
+        circuit_failure_threshold: int = 3,
+        circuit_recovery_timeout_seconds: int = 300,
     ):
         """
         Initialize the distributed agent manager.
@@ -45,8 +47,11 @@ class DistributedAgentManager:
             grace_period_seconds: Minimum task age before it is eligible for stealing
             max_reassignments: Hard cap on how many times one task may be stolen
             progress_ttl_seconds: Recent-progress window that marks a task as alive
+            circuit_failure_threshold: Consecutive unhealthy results before opening circuit
+            circuit_recovery_timeout_seconds: Seconds before a half-open probe is attempted
 
         Issue #2109: work-stealing parameters added.
+        Issue #4694: circuit breaker parameters added.
         """
         self.distributed_agents: Dict[str, DistributedAgentInfo] = {}
         self.builtin_distributed_agents = builtin_agents
@@ -59,6 +64,10 @@ class DistributedAgentManager:
         self.grace_period_seconds = grace_period_seconds
         self.max_reassignments = max_reassignments
         self.progress_ttl_seconds = progress_ttl_seconds
+
+        # Circuit breaker configuration (Issue #4694)
+        self.circuit_failure_threshold = circuit_failure_threshold
+        self.circuit_recovery_timeout_seconds = circuit_recovery_timeout_seconds
 
         # task_id -> assigned_at (UTC) — set when add_active_task is called
         self._task_assigned_at: Dict[str, datetime] = {}
@@ -189,26 +198,90 @@ class DistributedAgentManager:
         health: Optional["AgentHealth"],
         error: Optional[Exception],
     ) -> None:
-        """Process a single health check result (Issue #334 - extracted helper)."""
+        """Process a single health check result and update circuit breaker state.
+
+        Issue #334: extracted helper.
+        Issue #4694: circuit breaker transitions added.
+
+        State machine:
+        - CLOSED  → OPEN      when circuit_failure_count reaches circuit_failure_threshold
+        - OPEN    → HALF_OPEN when circuit_recovery_timeout_seconds has elapsed
+        - HALF_OPEN → CLOSED  on a healthy result
+        - HALF_OPEN → OPEN    on an unhealthy result (reset opened_at for new backoff)
+        """
         agent_info = self.distributed_agents.get(agent_id)
         if not agent_info:
             return
 
+        now = datetime.now(tz=timezone.utc)
+
         if error:
             logger.error(
-                f"Health check failed for distributed agent {agent_id}: {error}"
+                "Health check failed for distributed agent %s: %s", agent_id, error
             )
+            self._on_agent_failure(agent_id, agent_info, now)
             return
 
         if not health:
             return
 
         agent_info.health = health
-        agent_info.last_health_check = datetime.now(tz=timezone.utc)
+        agent_info.last_health_check = now
 
-        if health.status.value != "healthy":
+        is_healthy = health.status.value == "healthy"
+
+        if is_healthy:
+            self._on_agent_success(agent_id, agent_info)
+        else:
             logger.warning(
-                f"Distributed agent {agent_id} health issue: {health.status.value}"
+                "Distributed agent %s health issue: %s", agent_id, health.status.value
+            )
+            self._on_agent_failure(agent_id, agent_info, now)
+
+    def _on_agent_success(self, agent_id: str, agent_info: DistributedAgentInfo) -> None:
+        """Handle a successful health check — reset failure counter and close circuit."""
+        prev_state = agent_info.circuit_state
+        agent_info.circuit_failure_count = 0
+        agent_info.circuit_state = CircuitState.CLOSED
+        agent_info.circuit_opened_at = None
+        agent_info.circuit_probe_dispatched_at = None
+
+        if prev_state != CircuitState.CLOSED:
+            logger.info(
+                "Circuit breaker CLOSED for agent %s (recovered from %s)",
+                agent_id,
+                prev_state.value,
+            )
+
+    def _on_agent_failure(
+        self, agent_id: str, agent_info: DistributedAgentInfo, now: datetime
+    ) -> None:
+        """Handle an unhealthy health check — increment failure count; open if threshold met."""
+        agent_info.circuit_failure_count += 1
+
+        if agent_info.circuit_state == CircuitState.HALF_OPEN:
+            # Probe failed → extend backoff, re-open circuit.
+            agent_info.circuit_state = CircuitState.OPEN
+            agent_info.circuit_opened_at = now
+            agent_info.circuit_probe_dispatched_at = None
+            logger.warning(
+                "Circuit breaker re-OPENED for agent %s (half-open probe failed, "
+                "failure count=%d)",
+                agent_id,
+                agent_info.circuit_failure_count,
+            )
+            return
+
+        if (
+            agent_info.circuit_state == CircuitState.CLOSED
+            and agent_info.circuit_failure_count >= self.circuit_failure_threshold
+        ):
+            agent_info.circuit_state = CircuitState.OPEN
+            agent_info.circuit_opened_at = now
+            logger.warning(
+                "Circuit breaker OPENED for agent %s after %d consecutive failures",
+                agent_id,
+                agent_info.circuit_failure_count,
             )
 
     async def _run_health_checks(self, agents_snapshot: list) -> None:
@@ -254,12 +327,48 @@ class DistributedAgentManager:
                 await asyncio.sleep(TimingConstants.ERROR_RECOVERY_DELAY)
 
     def get_healthy_agents(self) -> list:
-        """Get list of healthy distributed agents."""
-        return [
-            info.agent
-            for info in self.distributed_agents.values()
-            if info.health.status.value == "healthy"
-        ]
+        """Return agents available for task routing, respecting circuit breaker state.
+
+        Issue #4694: circuit breaker — OPEN agents are excluded; HALF_OPEN agents
+        are included for a single probe dispatch then re-excluded until the probe
+        resolves (tracked via circuit_probe_dispatched_at).
+        """
+        now = datetime.now(tz=timezone.utc)
+        available = []
+        for agent_id, info in self.distributed_agents.items():
+            if info.circuit_state == CircuitState.OPEN:
+                # Promote to HALF_OPEN once the recovery timeout has elapsed.
+                if (
+                    info.circuit_opened_at is not None
+                    and (now - info.circuit_opened_at).total_seconds()
+                    >= self.circuit_recovery_timeout_seconds
+                ):
+                    info.circuit_state = CircuitState.HALF_OPEN
+                    info.circuit_probe_dispatched_at = None
+                    logger.info(
+                        "Circuit breaker HALF_OPEN for agent %s — probe allowed",
+                        agent_id,
+                    )
+                else:
+                    # Still in backoff window — skip agent entirely.
+                    continue
+
+            if info.circuit_state == CircuitState.HALF_OPEN:
+                # Allow only one probe task at a time.
+                if info.circuit_probe_dispatched_at is not None:
+                    continue
+                info.circuit_probe_dispatched_at = now
+                logger.info(
+                    "Circuit breaker half-open probe dispatched for agent %s", agent_id
+                )
+                available.append(info.agent)
+                continue
+
+            # CLOSED: include only if underlying health status is healthy.
+            if info.health.status.value == "healthy":
+                available.append(info.agent)
+
+        return available
 
     def get_agent_info(self, agent_id: str) -> Optional[DistributedAgentInfo]:
         """Get info for a specific agent."""
@@ -430,9 +539,10 @@ class DistributedAgentManager:
         return reassigned
 
     def get_statistics(self) -> Dict[str, Any]:
-        """Get distributed agent statistics, including work-stealing counters.
+        """Get distributed agent statistics, including work-stealing and circuit breaker state.
 
         Issue #2109: reassignment_counts added to per-agent task entries.
+        Issue #4694: circuit breaker fields added per agent.
         """
         stats: Dict[str, Any] = {}
         for agent_id, agent_info in self.distributed_agents.items():
@@ -446,6 +556,14 @@ class DistributedAgentManager:
                 "task_reassignment_counts": {
                     t: self._task_reassignment_count.get(t, 0) for t in task_list
                 },
+                # Circuit breaker state (Issue #4694)
+                "circuit_state": agent_info.circuit_state.value,
+                "circuit_failure_count": agent_info.circuit_failure_count,
+                "circuit_opened_at": (
+                    agent_info.circuit_opened_at.isoformat()
+                    if agent_info.circuit_opened_at
+                    else None
+                ),
             }
         stats["_work_stealing"] = {
             "stale_task_timeout_seconds": self.stale_task_timeout_seconds,
@@ -453,5 +571,9 @@ class DistributedAgentManager:
             "max_reassignments": self.max_reassignments,
             "progress_ttl_seconds": self.progress_ttl_seconds,
             "total_tracked_tasks": len(self._task_assigned_at),
+        }
+        stats["_circuit_breaker"] = {
+            "failure_threshold": self.circuit_failure_threshold,
+            "recovery_timeout_seconds": self.circuit_recovery_timeout_seconds,
         }
         return stats

--- a/autobot-backend/agents/agent_orchestration/distributed_management_test.py
+++ b/autobot-backend/agents/agent_orchestration/distributed_management_test.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Tests for DistributedAgentManager work-stealing logic (Issue #2109).
+Tests for DistributedAgentManager work-stealing logic (Issue #2109) and
+circuit breaker logic (Issue #4694).
 
 All tests are pure in-memory; no Redis, no actual agents, no network I/O.
 """
@@ -13,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from .distributed_management import DistributedAgentManager
-from .types import DistributedAgentInfo
+from .types import CircuitState, DistributedAgentInfo
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -360,3 +361,176 @@ class TestGetStatisticsWorkStealing:
         mgr._task_reassignment_count["t1"] = 2
         stats = mgr.get_statistics()
         assert stats["a1"]["task_reassignment_counts"]["t1"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cb_manager(
+    failure_threshold: int = 3,
+    recovery_timeout_seconds: int = 300,
+) -> DistributedAgentManager:
+    """Return a manager configured for circuit breaker tests."""
+    return DistributedAgentManager(
+        builtin_agents={},
+        health_check_interval=30.0,
+        circuit_failure_threshold=failure_threshold,
+        circuit_recovery_timeout_seconds=recovery_timeout_seconds,
+    )
+
+
+def _make_health_stub(status: str = "healthy") -> MagicMock:
+    """Return a minimal AgentHealth stub."""
+    h = MagicMock()
+    h.status.value = status
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker — _process_health_result / state transitions (Issue #4694)
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerHealthTransitions:
+    def test_healthy_result_resets_failure_count(self):
+        mgr = _make_cb_manager(failure_threshold=3)
+        _register_agent(mgr, "a1")
+        mgr.distributed_agents["a1"].circuit_failure_count = 2
+        mgr._process_health_result("a1", _make_health_stub("healthy"), None)
+        assert mgr.distributed_agents["a1"].circuit_failure_count == 0
+
+    def test_consecutive_failures_open_circuit(self):
+        mgr = _make_cb_manager(failure_threshold=3)
+        _register_agent(mgr, "a1")
+        for _ in range(3):
+            mgr._process_health_result("a1", _make_health_stub("unhealthy"), None)
+        info = mgr.distributed_agents["a1"]
+        assert info.circuit_state == CircuitState.OPEN
+        assert info.circuit_opened_at is not None
+
+    def test_failure_below_threshold_does_not_open_circuit(self):
+        mgr = _make_cb_manager(failure_threshold=3)
+        _register_agent(mgr, "a1")
+        for _ in range(2):
+            mgr._process_health_result("a1", _make_health_stub("unhealthy"), None)
+        assert mgr.distributed_agents["a1"].circuit_state == CircuitState.CLOSED
+
+    def test_exception_in_health_check_counts_as_failure(self):
+        mgr = _make_cb_manager(failure_threshold=2)
+        _register_agent(mgr, "a1")
+        mgr._process_health_result("a1", None, RuntimeError("timeout"))
+        mgr._process_health_result("a1", None, RuntimeError("timeout"))
+        assert mgr.distributed_agents["a1"].circuit_state == CircuitState.OPEN
+
+    def test_healthy_after_open_half_open_closes_circuit(self):
+        mgr = _make_cb_manager(failure_threshold=3)
+        _register_agent(mgr, "a1")
+        info = mgr.distributed_agents["a1"]
+        info.circuit_state = CircuitState.HALF_OPEN
+        info.circuit_failure_count = 3
+        mgr._process_health_result("a1", _make_health_stub("healthy"), None)
+        assert info.circuit_state == CircuitState.CLOSED
+        assert info.circuit_failure_count == 0
+        assert info.circuit_opened_at is None
+
+    def test_failure_in_half_open_reopens_circuit(self):
+        mgr = _make_cb_manager(failure_threshold=3)
+        _register_agent(mgr, "a1")
+        info = mgr.distributed_agents["a1"]
+        info.circuit_state = CircuitState.HALF_OPEN
+        info.circuit_failure_count = 3
+        original_opened_at = datetime.now(timezone.utc) - timedelta(seconds=600)
+        info.circuit_opened_at = original_opened_at
+        mgr._process_health_result("a1", _make_health_stub("degraded"), None)
+        assert info.circuit_state == CircuitState.OPEN
+        # opened_at must be reset (new backoff window)
+        assert info.circuit_opened_at is not None
+        assert info.circuit_opened_at > original_opened_at
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker — get_healthy_agents routing exclusion (Issue #4694)
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerRouting:
+    def test_closed_healthy_agent_is_included(self):
+        mgr = _make_cb_manager()
+        _register_agent(mgr, "a1")
+        agents = mgr.get_healthy_agents()
+        assert len(agents) == 1
+
+    def test_open_agent_excluded_from_routing(self):
+        mgr = _make_cb_manager(recovery_timeout_seconds=300)
+        _register_agent(mgr, "a1")
+        info = mgr.distributed_agents["a1"]
+        info.circuit_state = CircuitState.OPEN
+        info.circuit_opened_at = datetime.now(timezone.utc)
+        assert mgr.get_healthy_agents() == []
+
+    def test_open_agent_promoted_to_half_open_after_backoff(self):
+        mgr = _make_cb_manager(recovery_timeout_seconds=60)
+        _register_agent(mgr, "a1")
+        info = mgr.distributed_agents["a1"]
+        info.circuit_state = CircuitState.OPEN
+        info.circuit_opened_at = datetime.now(timezone.utc) - timedelta(seconds=120)
+        agents = mgr.get_healthy_agents()
+        assert info.circuit_state == CircuitState.HALF_OPEN
+        assert len(agents) == 1
+
+    def test_half_open_allows_single_probe_then_blocks(self):
+        mgr = _make_cb_manager()
+        _register_agent(mgr, "a1")
+        info = mgr.distributed_agents["a1"]
+        info.circuit_state = CircuitState.HALF_OPEN
+
+        # First call: probe dispatched.
+        agents_first = mgr.get_healthy_agents()
+        assert len(agents_first) == 1
+        assert info.circuit_probe_dispatched_at is not None
+
+        # Second call: probe already dispatched — excluded.
+        agents_second = mgr.get_healthy_agents()
+        assert agents_second == []
+
+    def test_unhealthy_closed_agent_excluded(self):
+        mgr = _make_cb_manager()
+        _register_agent(mgr, "a1")
+        mgr.distributed_agents["a1"].health.status.value = "degraded"
+        assert mgr.get_healthy_agents() == []
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker — get_statistics exposes circuit state (Issue #4694)
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerStatistics:
+    def test_circuit_state_in_agent_stats(self):
+        mgr = _make_cb_manager(failure_threshold=2, recovery_timeout_seconds=120)
+        _register_agent(mgr, "a1")
+        stats = mgr.get_statistics()
+        a1_stats = stats["a1"]
+        assert a1_stats["circuit_state"] == "closed"
+        assert a1_stats["circuit_failure_count"] == 0
+        assert a1_stats["circuit_opened_at"] is None
+
+    def test_circuit_breaker_section_present(self):
+        mgr = _make_cb_manager(failure_threshold=4, recovery_timeout_seconds=600)
+        stats = mgr.get_statistics()
+        cb = stats["_circuit_breaker"]
+        assert cb["failure_threshold"] == 4
+        assert cb["recovery_timeout_seconds"] == 600
+
+    def test_open_circuit_exposes_opened_at(self):
+        mgr = _make_cb_manager()
+        _register_agent(mgr, "a1")
+        opened_at = datetime.now(timezone.utc)
+        info = mgr.distributed_agents["a1"]
+        info.circuit_state = CircuitState.OPEN
+        info.circuit_opened_at = opened_at
+        stats = mgr.get_statistics()
+        assert stats["a1"]["circuit_state"] == "open"
+        assert stats["a1"]["circuit_opened_at"] == opened_at.isoformat()

--- a/autobot-backend/agents/agent_orchestration/types.py
+++ b/autobot-backend/agents/agent_orchestration/types.py
@@ -8,10 +8,10 @@ Issue #381: Extracted from agent_orchestrator.py god class refactoring.
 Contains type definitions, enums, and routing pattern constants.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, List, Set
+from typing import TYPE_CHECKING, List, Optional, Set
 
 if TYPE_CHECKING:
     from agents.base_agent import AgentHealth, BaseAgent
@@ -155,6 +155,14 @@ class AgentCapability:
     resource_usage: str
 
 
+class CircuitState(Enum):
+    """Circuit breaker state for a distributed agent (Issue #4694)."""
+
+    CLOSED = "closed"      # Normal operation — agent receives tasks.
+    OPEN = "open"          # Agent quarantined — excluded from routing.
+    HALF_OPEN = "half_open"  # Recovery probe: one task allowed; result decides next state.
+
+
 @dataclass
 class DistributedAgentInfo:
     """Information about a distributed agent."""
@@ -163,6 +171,13 @@ class DistributedAgentInfo:
     health: "AgentHealth"
     last_health_check: datetime
     active_tasks: Set[str]
+
+    # Circuit breaker fields (Issue #4694)
+    circuit_state: CircuitState = field(default=CircuitState.CLOSED)
+    circuit_failure_count: int = field(default=0)
+    circuit_opened_at: Optional[datetime] = field(default=None)
+    # Timestamp of the last half-open probe task dispatch.
+    circuit_probe_dispatched_at: Optional[datetime] = field(default=None)
 
 
 # Default agent capabilities configuration


### PR DESCRIPTION
Closes #4694

Adds consecutive-failure counter and circuit-breaker pattern to DistributedAgentManager so flapping agents stop receiving tasks between health check intervals.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)