### PR TITLE
fix(rag): wire NeuralMeshRetriever into all RAGService instances (#4757)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -793,6 +793,29 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
                     llm=None,
                 )
                 rag_config.mesh_retriever_enabled = True
+
+                # Register as shared singleton so ALL future RAGService.initialize() calls
+                # auto-wire without changes at each call site (#4757).
+                from services.rag_service import register_shared_mesh_retriever
+                import services.rag_service as _rag_mod
+                register_shared_mesh_retriever(rag_service._mesh_retriever)
+
+                # Back-patch chat_workflow_manager's RAGService — it was created by
+                # set_knowledge_base() before this function ran (Phase 2 ordering).
+                _cwm = getattr(app.state, "chat_workflow_manager", None)
+                if _cwm is not None:
+                    _ks = getattr(_cwm, "knowledge_service", None)
+                    if _ks is not None and hasattr(_ks, "rag_service"):
+                        _ks.rag_service._mesh_retriever = rag_service._mesh_retriever
+                        _ks.rag_service.config.mesh_retriever_enabled = True
+                        logger.info("Re-wired NeuralMeshRetriever into chat_workflow_manager RAGService (#4757)")
+
+                # Back-patch get_rag_service() singleton if already created.
+                if _rag_mod._rag_service_instance is not None:
+                    _rag_mod._rag_service_instance._mesh_retriever = rag_service._mesh_retriever
+                    _rag_mod._rag_service_instance.config.mesh_retriever_enabled = True
+                    logger.info("Re-wired NeuralMeshRetriever into get_rag_service() singleton (#4757)")
+
                 logger.info("✅ [ 87%] Neural Mesh RAG: NeuralMeshRetriever wired into RAGService (#4724)")
             except Exception as _mesh_wire_err:
                 logger.warning("Neural Mesh RAG wiring skipped (non-fatal): %s", _mesh_wire_err)

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -102,6 +102,15 @@ class RAGService:
             self.optimizer.kb = self.kb_adapter.kb
 
             self._initialized = True
+
+            # Auto-wire shared NeuralMeshRetriever if registered and not already set (#4757).
+            # Covers per-request instances in knowledge_rag.py / knowledge_search.py and
+            # the chat_workflow manager's set_knowledge_base() path.
+            if self._mesh_retriever is None and _shared_mesh_retriever is not None:
+                self._mesh_retriever = _shared_mesh_retriever
+                self.config.mesh_retriever_enabled = True
+                logger.debug("Auto-wired shared NeuralMeshRetriever into RAGService instance")
+
             logger.info("AdvancedRAGOptimizer initialized successfully")
             return True
 
@@ -1068,6 +1077,24 @@ class RAGService:
             "cache_entries": len(self._cache),
             "config": self.config.to_dict(),
         }
+
+
+# Shared NeuralMeshRetriever singleton — registered by lifespan at startup (#4757).
+# Auto-wired into every RAGService.initialize() call so ALL instances (per-request
+# API deps, chat_workflow manager, get_rag_service singleton) receive the mesh retriever
+# without requiring changes at every call site.
+_shared_mesh_retriever: Optional[Any] = None
+
+
+def register_shared_mesh_retriever(retriever: Any) -> None:
+    """Register NeuralMeshRetriever for auto-wiring into all future RAGService instances.
+
+    Called once by lifespan._init_graph_rag_service() after the retriever is built.
+    Every subsequent RAGService.initialize() will pick it up automatically.
+    """
+    global _shared_mesh_retriever
+    _shared_mesh_retriever = retriever
+    logger.info("NeuralMeshRetriever registered as shared singleton (#4757)")
 
 
 # Global service instance (lazily initialized per knowledge base)

--- a/autobot-backend/services/rag_service_mesh_test.py
+++ b/autobot-backend/services/rag_service_mesh_test.py
@@ -161,3 +161,80 @@ class TestMeshFlagEnabledRetrieverNone:
             await svc.advanced_search("test query")
             mock_mesh.assert_not_called()
             svc.optimizer.advanced_search.assert_called_once()
+
+
+# =============================================================================
+# Test: register_shared_mesh_retriever auto-wires on initialize() (#4757)
+# =============================================================================
+
+
+class TestSharedMeshRetrieverAutoWire:
+    def setup_method(self):
+        """Clear shared singleton before each test to avoid cross-test contamination."""
+        import services.rag_service as _mod
+        self._orig = _mod._shared_mesh_retriever
+        _mod._shared_mesh_retriever = None
+
+    def teardown_method(self):
+        import services.rag_service as _mod
+        _mod._shared_mesh_retriever = self._orig
+
+    @pytest.mark.asyncio
+    async def test_register_then_initialize_wires_retriever(self):
+        """RAGService.initialize() picks up the shared singleton when _mesh_retriever is None."""
+        from services.rag_service import RAGService, register_shared_mesh_retriever
+        from services.rag_config import RAGConfig
+        from unittest.mock import patch, AsyncMock
+
+        sentinel = MagicMock(name="NeuralMeshRetriever")
+        register_shared_mesh_retriever(sentinel)
+
+        svc = RAGService.__new__(RAGService)
+        svc._initialized = False
+        svc._cache = {}
+        svc._cache_lock = MagicMock()
+        svc.config = RAGConfig()
+        svc._mesh_retriever = None
+        svc.kb_adapter = MagicMock()
+        svc.kb_adapter.kb = MagicMock()
+
+        with patch("services.rag_service.AdvancedRAGOptimizer") as MockOpt:
+            mock_opt = MagicMock()
+            mock_opt.initialize = AsyncMock(return_value=True)
+            MockOpt.return_value = mock_opt
+
+            result = await svc.initialize()
+
+        assert result is True
+        assert svc._mesh_retriever is sentinel
+        assert svc.config.mesh_retriever_enabled is True
+
+    @pytest.mark.asyncio
+    async def test_already_set_retriever_not_overwritten(self):
+        """An existing _mesh_retriever is not replaced by the shared singleton."""
+        from services.rag_service import RAGService, register_shared_mesh_retriever
+        from services.rag_config import RAGConfig
+        from unittest.mock import patch, AsyncMock
+
+        existing = MagicMock(name="existing_retriever")
+        shared = MagicMock(name="shared_retriever")
+        register_shared_mesh_retriever(shared)
+
+        svc = RAGService.__new__(RAGService)
+        svc._initialized = False
+        svc._cache = {}
+        svc._cache_lock = MagicMock()
+        svc.config = RAGConfig()
+        svc.config.mesh_retriever_enabled = True
+        svc._mesh_retriever = existing
+        svc.kb_adapter = MagicMock()
+        svc.kb_adapter.kb = MagicMock()
+
+        with patch("services.rag_service.AdvancedRAGOptimizer") as MockOpt:
+            mock_opt = MagicMock()
+            mock_opt.initialize = AsyncMock(return_value=True)
+            MockOpt.return_value = mock_opt
+
+            await svc.initialize()
+
+        assert svc._mesh_retriever is existing  # not replaced


### PR DESCRIPTION
Closes #4757

## Problem

The NeuralMeshRetriever built in `lifespan._init_graph_rag_service()` was only wired into the `GraphRAGService`'s internal `RAGService` — the one never actually used for chat or API queries.

All production paths were silently bypassing the mesh retriever:
- `chat_workflow/manager.py:131,157` — `RAGService(kb)` created in `set_knowledge_base()` before `_init_graph_rag_service()` runs
- `api/knowledge_rag.py:91` — per-request `RAGService(kb)` via `_get_rag_service()` dependency
- `api/knowledge_search.py:181` — per-request instance for reranking
- `get_rag_service()` singleton — lazy, may pre-date wiring

## Fix

**`rag_service.py`** — module-level singleton + auto-wire:
- `_shared_mesh_retriever` singleton registered by lifespan
- `register_shared_mesh_retriever(retriever)` function
- `RAGService.initialize()` auto-wires when `_mesh_retriever is None` — zero changes needed at call sites

**`lifespan.py`** — after building the NeuralMeshRetriever:
- Calls `register_shared_mesh_retriever()` (covers all future instances)
- Back-patches `chat_workflow_manager.knowledge_service.rag_service` (already-created before this phase)
- Back-patches `_rag_service_instance` singleton if pre-created

## Test Coverage

8 tests pass (6 existing + 2 new):
- `test_register_then_initialize_wires_retriever` — singleton auto-wire path
- `test_already_set_retriever_not_overwritten` — pre-wired instances are not overridden