### PR TITLE
fix(frontend): add @types/three and remove @ts-ignore in KnowledgeGraph3D.vue (#4437)

### DIFF
--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -86,6 +86,7 @@
     "@types/jsdom": "^28.0.1",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^25.5.2",
+    "@types/three": "^0.183.0",
     "@types/sinonjs__fake-timers": "^15.0.1",
     "@types/sizzle": "^2.3.10",
     "@types/statuses": "^2.0.6",

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph3D.vue
@@ -31,8 +31,6 @@
 import { ref, shallowRef, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import ForceGraph3D, { type ForceGraph3DInstance } from '3d-force-graph'
 import SpriteText from 'three-spritetext'
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore – 'three' ships without bundled type declarations in this version; types are provided transitively via 3d-force-graph
 import * as THREE from 'three'
 import { getCssVar } from '@/composables/useCssVars'
 import { createLogger } from '@/utils/debugUtils'


### PR DESCRIPTION
Closes #4437

## Changes
- Added `@types/three` dev dependency to `autobot-frontend/package.json`
- Removed `@ts-ignore` workaround in `KnowledgeGraph3D.vue` — Three.js types are now resolved natively

## Acceptance criteria
- `@types/three` installed → Three.js imports have full type coverage
- No `@ts-ignore` comments remain in KnowledgeGraph3D.vue