### PR TITLE
refactor(components): wire orphaned OperationDetail component (#4270)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -5267,6 +5267,15 @@
       "resume": "Resume",
       "viewDetails": "View Details",
       "showingCount": "Showing {shown} of {total} operations"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "secrets": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -5265,6 +5265,15 @@
       "resume": "Fortsetzen",
       "viewDetails": "Details anzeigen",
       "showingCount": "{shown} von {total} Vorgängen"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "secrets": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -5662,6 +5662,15 @@
       "resume": "Resume",
       "viewDetails": "View Details",
       "showingCount": "Showing {shown} of {total} operations"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "secrets": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -5265,6 +5265,15 @@
       "resume": "Reanudar",
       "viewDetails": "Ver detalles",
       "showingCount": "Mostrando {shown} de {total} operaciones"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "secrets": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -6128,6 +6128,15 @@
       "statusLabel": "Status",
       "allTypes": "All Types",
       "allStatuses": "All Statuses"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "fileBrowser": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -5265,6 +5265,15 @@
       "resume": "Reprendre",
       "viewDetails": "Voir les détails",
       "showingCount": "{shown} sur {total} opérations"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "secrets": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -6128,6 +6128,15 @@
       "statusLabel": "Status",
       "allTypes": "All Types",
       "allStatuses": "All Statuses"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "fileBrowser": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -5265,6 +5265,15 @@
       "resume": "Atsākt",
       "viewDetails": "Skatīt detaļas",
       "showingCount": "Rāda {shown} no {total} operācijām"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "secrets": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -5265,6 +5265,15 @@
       "resume": "Wznów",
       "viewDetails": "Zobacz szczegóły",
       "showingCount": "Wyświetlanie {shown} z {total} operacji"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "secrets": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -5265,6 +5265,15 @@
       "resume": "Retomar",
       "viewDetails": "Ver detalhes",
       "showingCount": "A mostrar {shown} de {total} operações"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "secrets": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -6128,6 +6128,15 @@
       "statusLabel": "Status",
       "allTypes": "All Types",
       "allStatuses": "All Statuses"
+    },
+    "view": {
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
+      "refresh": "Refresh",
+      "loadError": "Failed to load operations"
+    },
+    "panel": {
+      "selectOperation": "Select an operation to view details"
     }
   },
   "fileBrowser": {

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -543,6 +543,18 @@ const routes: RouteRecordRaw[] = [
     redirect: '/',
     meta: { title: 'LLM Configuration' }
   },
+  // Issue #4270: Wire OperationDetail via OperationsView — long-running operations tracker
+  {
+    path: '/operations',
+    name: 'operations',
+    component: () => import('@/views/OperationsView.vue'),
+    meta: {
+      title: 'Operations',
+      icon: 'fas fa-tasks',
+      description: 'Monitor and manage long-running operations',
+      requiresAuth: true
+    }
+  },
   // Issue #4703: Wire AgentRegistryView into router (#1794, #1822)
   {
     path: '/agents/registry',

--- a/autobot-frontend/src/views/OperationsView.vue
+++ b/autobot-frontend/src/views/OperationsView.vue
@@ -1,0 +1,205 @@
+<!--
+  AutoBot - AI-Powered Automation Platform
+  Copyright (c) 2025 mrveiss
+  Author: mrveiss
+
+  Operations View
+  Issue #4270 - Wire orphaned OperationDetail component
+-->
+<template>
+  <div class="operations-view">
+    <div class="page-header">
+      <div class="page-header-content">
+        <h2 class="page-title">{{ $t('operations.view.title') }}</h2>
+        <p class="page-subtitle">{{ $t('operations.view.subtitle') }}</p>
+      </div>
+      <div class="header-actions">
+        <button class="btn-action-secondary" :disabled="loading" @click="loadOperations()">
+          <i class="fas fa-sync-alt" :class="{ 'fa-spin': loading }"></i>
+          {{ $t('operations.view.refresh') }}
+        </button>
+      </div>
+    </div>
+
+    <div v-if="error" class="error-banner">
+      <i class="fas fa-exclamation-circle"></i>
+      <span>{{ error }}</span>
+      <button class="btn-dismiss" @click="error = null">
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
+
+    <OperationsPanel
+      :operations="operations"
+      :total-count="totalCount"
+      :loading="loading"
+      :filter="filter"
+      @cancel="handleCancel"
+      @resume="handleResume"
+      @refresh="handleRefreshOperation"
+      @update:filter="handleFilterChange"
+      @clear-filter="handleClearFilter"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { createLogger } from '@/utils/debugUtils'
+import { useOperationsApi } from '@/composables/useOperationsApi'
+import OperationsPanel from '@/components/operations/OperationsPanel.vue'
+import type { Operation, OperationsFilter } from '@/types/operations'
+
+const { t } = useI18n()
+const logger = createLogger('OperationsView')
+const api = useOperationsApi()
+
+const operations = ref<Operation[]>([])
+const totalCount = ref(0)
+const loading = ref(false)
+const error = ref<string | null>(null)
+const filter = ref<OperationsFilter>({ limit: 50 })
+
+async function loadOperations() {
+  loading.value = true
+  error.value = null
+  try {
+    const result = await api.listOperations(filter.value)
+    if (result) {
+      operations.value = result.operations
+      totalCount.value = result.total_count
+    }
+  } catch (err) {
+    logger.error('Failed to load operations:', err)
+    error.value = t('operations.view.loadError')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleCancel(operationId: string) {
+  await api.cancelOperation(operationId)
+  await loadOperations()
+}
+
+async function handleResume(operationId: string) {
+  await api.resumeOperation(operationId)
+  await loadOperations()
+}
+
+async function handleRefreshOperation(_operationId: string) {
+  await loadOperations()
+}
+
+function handleFilterChange(newFilter: OperationsFilter) {
+  filter.value = newFilter
+  loadOperations()
+}
+
+function handleClearFilter() {
+  filter.value = { limit: 50 }
+  loadOperations()
+}
+
+onMounted(() => {
+  loadOperations()
+})
+</script>
+
+<style scoped>
+/* Issue #704: Migrated to CSS design tokens */
+.operations-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6);
+  padding: var(--spacing-6);
+  height: 100%;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-4);
+}
+
+.page-header-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.page-title {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.page-subtitle {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  margin: 0;
+}
+
+.header-actions {
+  display: flex;
+  gap: var(--spacing-2);
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.btn-action-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-4);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  background-color: var(--bg-card);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--duration-200);
+}
+
+.btn-action-secondary:hover:not(:disabled) {
+  background-color: var(--bg-hover);
+}
+
+.btn-action-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  background-color: var(--color-error-bg);
+  border: 1px solid var(--color-error-border, #fecaca);
+  border-radius: var(--radius-md);
+  color: var(--color-error);
+  font-size: var(--text-sm);
+}
+
+.error-banner i:first-child {
+  flex-shrink: 0;
+}
+
+.error-banner span {
+  flex: 1;
+}
+
+.btn-dismiss {
+  background: none;
+  border: none;
+  color: currentColor;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+}
+</style>


### PR DESCRIPTION
Closes #4270

## Changes
- Creates `autobot-frontend/src/views/OperationsView.vue` — page-level view composing `OperationsPanel` + `useOperationsApi` (load, cancel, resume, refresh, filter)
- Registers `/operations` route in `router/index.ts` (lazy-loaded, requiresAuth)
- Adds `operations.view` and `operations.panel` i18n keys to all 11 locales

## Root cause
`OperationDetail` was already imported inside `OperationsPanel`. The missing link was `OperationsPanel` having no caller in any view or route — wiring the view into the router completes the chain.

## Wiring chain
`router /operations` → `OperationsView.vue` → `OperationsPanel` → `OperationDetail`