### PR TITLE
feat(slm-frontend): wire ServicesView.vue as direct /services route (#4762)

### DIFF
--- a/autobot-slm-frontend/src/components/common/Sidebar.vue
+++ b/autobot-slm-frontend/src/components/common/Sidebar.vue
@@ -51,6 +51,8 @@ const navItems = [
   { name: 'Orchestration', path: '/orchestration', icon: 'orchestration' },
   // Issue #4706: Wire RolesView into router
   { name: 'Roles', path: '/roles', icon: 'roles' },
+  // Issue #4762: Wire ServicesView as direct /services route
+  { name: 'Services', path: '/services', icon: 'services' },
   { name: 'Deployments', path: '/deployments', icon: 'rocket' },
   { name: 'Backups', path: '/backups', icon: 'database' },
   { name: 'Replication', path: '/replications', icon: 'replicate' },
@@ -280,6 +282,10 @@ onUnmounted(() => {
               <!-- Issue #841: Roles icon (identification/tag) -->
               <svg v-else-if="item.icon === 'roles'" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+              </svg>
+              <!-- Issue #4762: Services icon (server stack with list) -->
+              <svg v-else-if="item.icon === 'services'" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" />
               </svg>
               <svg v-else-if="item.icon === 'wrench'" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />

--- a/autobot-slm-frontend/src/router/index.ts
+++ b/autobot-slm-frontend/src/router/index.ts
@@ -55,10 +55,10 @@ const router = createRouter({
       },
     },
     {
-      // Issue #850: Consolidated into unified orchestration view
+      // Issue #4762: Wire ServicesView as direct route (was redirect to /orchestration/per-node)
       path: '/services',
       name: 'services',
-      redirect: '/orchestration/per-node',
+      component: () => import('@/views/ServicesView.vue'),
       meta: { title: 'Services' }
     },
     {


### PR DESCRIPTION
Closes #4762

## Changes
- `autobot-slm-frontend/src/router/index.ts` — replaced the redirect stub `{ redirect: '/orchestration/per-node' }` with lazy-loaded `ServicesView.vue`
- `autobot-slm-frontend/src/components/common/Sidebar.vue` — added Services nav entry with server icon, same pattern as #4705/#4706

## Root cause
Issue #850 added a redirect to `/orchestration/per-node` that bypassed ServicesView.vue's 929-line per-service control implementation. Same pattern already fixed for InfrastructureSettings (#4705) and RolesView (#4706).

## Wiring chain
`router /services` → `ServicesView.vue` (929 lines, per-host service control with start/stop/restart)