### PR TITLE
feat(frontend): wire DesktopView.vue as /desktop route — re-enables direct desktop access (#4704)

### DIFF
--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -634,7 +634,19 @@ const routes: RouteRecordRaw[] = [
       admin: true,
     },
   },
-  // Issue #4491: Desktop removed — VNC is the noVNC tab in /chat
+  // Issue #4704: Wire DesktopView.vue as /desktop route — re-enables direct desktop access
+  // Issue #4491 removed from router; re-wired here so DesktopView.vue is not orphaned
+  {
+    path: '/desktop',
+    name: 'desktop',
+    component: () => import('@/views/DesktopView.vue'),
+    meta: {
+      title: 'Desktop',
+      icon: 'fas fa-desktop',
+      description: 'Remote desktop via VNC/noVNC',
+      requiresAuth: true,
+    },
+  },
   // Issue #3502: Custom Dashboard renamed to /home (see home route above)
 
   // Issue #729: Infrastructure routes redirected to slm-admin


### PR DESCRIPTION
Closes #4704

## Changes
- `autobot-frontend/src/router/index.ts` — replaced the `// Issue #4491: Desktop removed` comment with live `/desktop` route pointing to `DesktopView.vue` (lazy-loaded, requiresAuth)

## Analysis
`DesktopInterface.vue` has **zero callers** outside `DesktopView.vue` — both were orphaned together when issue #4491 removed the route. Wiring the route back gives users direct URL access to the VNC desktop feature.

**No-deletion policy applied:** The view and component are preserved and re-connected, not deleted.