### PR TITLE
feat(knowledge): autonomous synthesis prompt evolution — UCB1 variant selection with provenance-based scoring (#4675)

### DIFF
--- a/autobot-backend/services/knowledge/kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/kb_synthesizer.py
@@ -193,6 +193,117 @@ class KBSynthesizer:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # Issue #4675: prompt evolution helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _score_synthesis_output(text: str) -> float:
+        """Score a synthesis output on [0.0, 1.0].
+
+        Combines a token-count score (rewards 50–2000 words) with a
+        uniqueness score (penalises repetitive sentences).
+
+        Issue #4675.
+        """
+        words = text.split()
+        word_count = len(words)
+        if word_count == 0:
+            return 0.0
+
+        # Token-count score — linear decay outside [50, 2000].
+        if 50 <= word_count <= 2000:
+            token_score = 1.0
+        elif word_count < 50:
+            token_score = word_count / 50.0
+        else:
+            token_score = max(0.0, 1.0 - (word_count - 2000) / 2000.0)
+
+        # Uniqueness score — unique sentences / total sentences.
+        sentences = [s.strip() for s in text.replace("!", ".").replace("?", ".").split(".") if s.strip()]
+        total = len(sentences)
+        if total == 0:
+            uniqueness_score = 1.0
+        else:
+            uniqueness_score = len(set(sentences)) / total
+
+        return min(1.0, token_score * 0.6 + uniqueness_score * 0.4)
+
+    async def _select_prompt_variant(
+        self,
+        collection_name: str,
+        variants: list,
+        fallback: str,
+    ) -> tuple:
+        """Select a prompt variant via UCB1 bandit strategy.
+
+        Reads recent provenance entries for ``collection_name`` and applies
+        UCB1 to balance exploration vs. exploitation across ``variants``.
+
+        Args:
+            collection_name: Collection key used for provenance lookup.
+            variants: List of alternate prompt strings from CollectionConfig.
+            fallback: Base prompt text used when no variants are defined.
+
+        Returns:
+            Tuple of (prompt_text, variant_id) where variant_id is one of
+            "base", "variant_0", "variant_1", …
+
+        Issue #4675.
+        """
+        if not variants:
+            return (fallback, "base")
+
+        # Build variant map: id → text
+        all_variants = {"base": fallback}
+        for i, v in enumerate(variants):
+            all_variants[f"variant_{i}"] = v
+
+        # Read recent runs for this collection.
+        try:
+            entries = await self._provenance_log.get_recent(limit=10)
+        except Exception:
+            logger.debug("_select_prompt_variant: provenance read failed, defaulting to base")
+            return (fallback, "base")
+
+        # Accumulate (n_pulls, total_score) per variant.
+        import math
+
+        stats: dict = {vid: [0, 0.0] for vid in all_variants}
+        for entry in entries:
+            if entry.get("prompt_template") != collection_name and entry.get("collection_name") != collection_name:
+                continue
+            vid = str(entry.get("prompt_variant", "base"))
+            if vid not in stats:
+                continue
+            stats[vid][0] += 1
+            stats[vid][1] += float(entry.get("score", 0.0))
+
+        total_runs = sum(s[0] for s in stats.values())
+
+        # Cold-start: pick first untried variant.
+        for vid in all_variants:
+            if stats[vid][0] == 0:
+                logger.debug(
+                    "_select_prompt_variant: cold-start exploration → %s for '%s'",
+                    vid,
+                    collection_name,
+                )
+                return (all_variants[vid], vid)
+
+        # UCB1 selection.
+        log_total = math.log(max(total_runs, 1))
+        best_vid = max(
+            all_variants,
+            key=lambda v: (stats[v][1] / stats[v][0]) + math.sqrt(2 * log_total / stats[v][0]),
+        )
+        logger.debug(
+            "_select_prompt_variant: UCB1 selected %s for '%s'",
+            best_vid,
+            collection_name,
+        )
+        return (all_variants[best_vid], best_vid)
+
     def _resolve_prompt(self, collection_config: "Optional[CollectionConfig]") -> str:
         """Return the synthesis prompt for this cluster.
 
@@ -230,7 +341,15 @@ class KBSynthesizer:
             return
 
         cluster_id = self._cluster_id(file_paths)
-        prompt = self._resolve_prompt(collection_config)
+        # Issue #4675: UCB1 variant selection.
+        base_prompt = self._resolve_prompt(collection_config)
+        variants = collection_config.prompt_variants if collection_config is not None else []
+        collection_key_for_ucb = (
+            collection_config.name if collection_config is not None else "default"
+        )
+        prompt, variant_id = await self._select_prompt_variant(
+            collection_key_for_ucb, variants, base_prompt
+        )
         if "{documents}" in prompt:
             messages = [{"role": "user", "content": prompt.format(documents=docs_text)}]
         else:
@@ -296,8 +415,8 @@ class KBSynthesizer:
             duration_ms=duration_ms,
             parent_run_id=parent_run_id,
             source_doc_ids=file_paths[:_MAX_DOCS_PER_CLUSTER],
-            prompt_variant=prompt,
-            score=min(len(summary_text) / max(len(docs_text), 1), 1.0),
+            prompt_variant=variant_id,
+            score=self._score_synthesis_output(summary_text),
             collection_name=collection_key,
         )
         # Advance lineage pointer for this collection.

--- a/autobot-backend/services/knowledge/synthesis_provenance.py
+++ b/autobot-backend/services/knowledge/synthesis_provenance.py
@@ -76,6 +76,44 @@ class SynthesisProvenanceLog:
         except Exception:
             logger.exception("Failed to write provenance log for run %s", run_id)
 
+
+    async def get_best_prompt_variant(
+        self,
+        collection_name: str,
+        limit: int = 50,
+    ) -> str:
+        """Return the prompt variant with the highest average score for a collection.
+
+        Reads the most recent provenance entries, filters to those whose
+        ``prompt_template`` matches ``collection_name``, then returns the
+        ``prompt_variant`` with the highest mean score.  Returns an empty
+        string when no scored history exists (cold-start).
+
+        Issue #4675.
+
+        Args:
+            collection_name: The collection name used as ``prompt_template`` key.
+            limit: Maximum number of recent entries to consider.
+        """
+        entries = await self.get_recent(limit=limit)
+        # Accumulate scores per variant for this collection.
+        variant_scores: Dict[str, List[float]] = {}
+        for entry in entries:
+            if entry.get("prompt_template") != collection_name:
+                continue
+            variant = str(entry.get("prompt_variant", ""))
+            if not variant or variant == collection_name:
+                # Skip entries where variant == base template name (not a named variant).
+                continue
+            score = float(entry.get("score", 0.0))
+            variant_scores.setdefault(variant, []).append(score)
+
+        if not variant_scores:
+            return ""
+
+        best = max(variant_scores, key=lambda v: sum(variant_scores[v]) / len(variant_scores[v]))
+        return best
+
     async def get_recent(self, limit: int = 50) -> List[Dict[str, Any]]:
         """Return the most recent provenance entries.
 

--- a/autobot-backend/services/knowledge/synthesis_schema_loader.py
+++ b/autobot-backend/services/knowledge/synthesis_schema_loader.py
@@ -18,7 +18,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 _REQUIRED_KEYS = {"name", "paths", "synthesis_target", "prompt_template"}
-_ALLOWED_KEYS = _REQUIRED_KEYS | {"synthesis_model"}
+_ALLOWED_KEYS = _REQUIRED_KEYS | {"synthesis_model", "prompt_variants"}
 
 
 @dataclass
@@ -30,6 +30,8 @@ class CollectionConfig:
     synthesis_target: str
     prompt_template: str
     synthesis_model: Optional[str] = None
+    # Issue #4675: alternate prompt variants for evolutionary selection.
+    prompt_variants: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -68,12 +70,22 @@ def _parse_collection(raw: dict, index: int, repo_root: Optional[Path] = None) -
             )
         synthesis_model = model_val
 
+    prompt_variants: List[str] = []
+    if "prompt_variants" in raw:
+        raw_variants = raw["prompt_variants"]
+        if not isinstance(raw_variants, list):
+            raise ValueError(
+                f"Collection[{index}] 'prompt_variants' must be a list of strings when present"
+            )
+        prompt_variants = [str(v) for v in raw_variants if str(v).strip()]
+
     config = CollectionConfig(
         name=str(raw["name"]),
         paths=[str(p) for p in raw["paths"]],
         synthesis_target=str(raw["synthesis_target"]),
         prompt_template=str(raw["prompt_template"]),
         synthesis_model=synthesis_model,
+        prompt_variants=prompt_variants,
     )
     if repo_root is not None:
         for p in config.paths:

--- a/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
+++ b/autobot-backend/services/knowledge/test_synthesis_prompt_evolution.py
@@ -1,0 +1,140 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for autonomous synthesis prompt evolution (#4675).
+
+Covers:
+- KBSynthesizer._score_synthesis_output
+- KBSynthesizer._select_prompt_variant
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs for optional heavy deps so the module can be imported.
+# ---------------------------------------------------------------------------
+sys.modules.setdefault("utils.chromadb_client", MagicMock())
+sys.modules.setdefault("autobot_shared", MagicMock())
+sys.modules.setdefault("autobot_shared.redis_client", MagicMock())
+
+from services.knowledge.kb_synthesizer import KBSynthesizer  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _score_synthesis_output
+# ---------------------------------------------------------------------------
+
+
+class TestScoreSynthesisOutput:
+    """Tests for KBSynthesizer._score_synthesis_output."""
+
+    def test_empty_text_returns_zero(self) -> None:
+        assert KBSynthesizer._score_synthesis_output("") == 0.0
+        assert KBSynthesizer._score_synthesis_output("   ") == 0.0
+
+    def test_normal_text_returns_high_score(self) -> None:
+        # 100 distinct words, each a unique sentence → near-perfect score.
+        words = " ".join(f"word{i}" for i in range(100))
+        score = KBSynthesizer._score_synthesis_output(words)
+        assert 0.5 < score <= 1.0
+
+    def test_very_long_text_penalised(self) -> None:
+        # 5000 words — well beyond the 2000-word sweet spot.
+        long_text = " ".join(f"word{i}" for i in range(5000))
+        score = KBSynthesizer._score_synthesis_output(long_text)
+        assert score < 1.0
+
+    def test_very_short_text_penalised(self) -> None:
+        # 10 words — below the 50-word minimum.
+        short_text = " ".join(f"word{i}" for i in range(10))
+        score = KBSynthesizer._score_synthesis_output(short_text)
+        assert score < 0.6  # token_score is 10/50 = 0.2; total < 0.52
+
+    def test_repetitive_text_penalised(self) -> None:
+        # 200 copies of the same sentence → uniqueness_score near 1/200.
+        sentence = "This is a repeated sentence"
+        repetitive = ". ".join([sentence] * 200) + "."
+        score = KBSynthesizer._score_synthesis_output(repetitive)
+        # High word count → token_score=1.0; uniqueness near 0 → total < 0.7
+        assert score < 0.7
+
+    def test_score_in_bounds(self) -> None:
+        for text in ["", "a", "word " * 50, "word " * 3000]:
+            score = KBSynthesizer._score_synthesis_output(text)
+            assert 0.0 <= score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# _select_prompt_variant
+# ---------------------------------------------------------------------------
+
+
+def _make_synthesizer(provenance_entries: List[dict]) -> KBSynthesizer:
+    """Create a KBSynthesizer with a mocked provenance log."""
+    mock_log = MagicMock()
+    mock_log.get_recent = AsyncMock(return_value=provenance_entries)
+    synth = KBSynthesizer(llm_service=MagicMock(), provenance_log=mock_log)
+    return synth
+
+
+@pytest.mark.asyncio
+class TestSelectPromptVariant:
+    """Tests for KBSynthesizer._select_prompt_variant."""
+
+    async def test_no_variants_returns_fallback(self) -> None:
+        synth = _make_synthesizer([])
+        prompt, vid = await synth._select_prompt_variant("col", [], "base_text")
+        assert prompt == "base_text"
+        assert vid == "base"
+
+    async def test_cold_start_returns_first_untried(self) -> None:
+        """With no history, should return the first untried variant (base)."""
+        synth = _make_synthesizer([])
+        variants = ["variant_text_A", "variant_text_B"]
+        prompt, vid = await synth._select_prompt_variant("col", variants, "base_text")
+        # Cold-start: base is tried first because it's in all_variants first.
+        assert vid == "base"
+        assert prompt == "base_text"
+
+    async def test_ucb1_picks_best_after_history(self) -> None:
+        """After runs, UCB1 should prefer the variant with the highest avg score."""
+        entries = [
+            # variant_0 ran once with low score.
+            {"prompt_template": "col", "collection_name": "col", "prompt_variant": "base", "score": 0.9},
+            {"prompt_template": "col", "collection_name": "col", "prompt_variant": "variant_0", "score": 0.2},
+            {"prompt_template": "col", "collection_name": "col", "prompt_variant": "variant_1", "score": 0.8},
+        ]
+        synth = _make_synthesizer(entries)
+        variants = ["variant_text_A", "variant_text_B"]
+        # All variants have been tried; UCB1 should favour base or variant_1.
+        prompt, vid = await synth._select_prompt_variant("col", variants, "base_text")
+        # base has score 0.9 and variant_1 has 0.8; base should win UCB1.
+        assert vid in ("base", "variant_1")
+
+    async def test_provenance_read_failure_returns_fallback(self) -> None:
+        """If provenance log throws, fall back to base gracefully."""
+        mock_log = MagicMock()
+        mock_log.get_recent = AsyncMock(side_effect=RuntimeError("redis down"))
+        synth = KBSynthesizer(llm_service=MagicMock(), provenance_log=mock_log)
+        prompt, vid = await synth._select_prompt_variant("col", ["v_text"], "base_text")
+        assert prompt == "base_text"
+        assert vid == "base"
+
+    async def test_entries_filtered_by_collection(self) -> None:
+        """Entries for a different collection must not affect selection."""
+        entries = [
+            # All entries belong to a different collection.
+            {"prompt_template": "other_col", "collection_name": "other_col", "prompt_variant": "variant_0", "score": 0.95},
+        ]
+        synth = _make_synthesizer(entries)
+        variants = ["v_text"]
+        # Cold-start for "col" → should return "base" first.
+        prompt, vid = await synth._select_prompt_variant("col", variants, "base_text")
+        assert vid == "base"


### PR DESCRIPTION
Closes #4675

## Changes
- `kb_synthesizer.py` — adds `_score_synthesis_output()` static method (token-count + uniqueness weighted score), adds `_select_prompt_variant()` async method (UCB1 bandit with cold-start exploration), wires both into `_synthesize_cluster`
- `synthesis_provenance.py` — adds `get_best_prompt_variant()` for UCB1 history reads
- `synthesis_schema_loader.py` — extends `CollectionConfig` with `prompt_variants: List[str]` field; YAML parser handles `prompt_variants` key
- `test_synthesis_prompt_evolution.py` (new) — 11 tests: scoring (empty/normal/long/short/repetitive/bounds) + variant selection (no variants, cold-start, UCB1, provenance failure, cross-collection isolation)

## Acceptance criteria
- ✅ Synthesis output scored after each run (token-count 0.6 + uniqueness 0.4)
- ✅ Score + prompt_variant recorded in provenance log
- ✅ Next synthesis call selects best-scoring prompt variant (UCB1)
- ✅ Falls back to prompt_template when no history exists
- ✅ 11 unit tests pass

## Dependencies
- ✅ #4656 (provenance log wiring) — merged
- ✅ #4674 (UCB1 sampling) — merged