### PR TITLE
fix(frontend): add /operations nav entry and nav.operations i18n key (#4270)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -780,6 +780,7 @@ export default {
       { to: '/knowledge', labelKey: 'nav.knowledge', icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z' },
       { to: '/automation', labelKey: 'nav.automation', icon: 'M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z', iconRule: 'evenodd' },
       { to: '/analytics', labelKey: 'nav.analytics', iconPaths: ['M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z', 'M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z'] },
+      { to: '/operations', labelKey: 'nav.operations', icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01', iconStroke: true },
       { to: '/secrets', labelKey: 'nav.secrets', icon: 'M18 8a6 6 0 01-7.743 5.743L10 14l-1 1-1 1H6v2H2v-4l4.257-4.257A6 6 0 1118 8zm-6-4a1 1 0 100 2 2 2 0 012 2 1 1 0 102 0 4 4 0 00-4-4z', iconRule: 'evenodd' },
       { to: '/plugins', labelKey: 'nav.plugins', icon: 'M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z', iconStroke: true },
       // Issue #1803: Plugin and agent marketplace

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -6414,7 +6414,8 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
-    "systemStatus": "System Status"
+    "systemStatus": "System Status",
+    "operations": "العمليات"
   },
   "reasoningTrace": {
     "title": "Reasoning trace",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -6412,7 +6412,8 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
-    "systemStatus": "System Status"
+    "systemStatus": "System Status",
+    "operations": "Operationen"
   },
   "reasoningTrace": {
     "title": "Reasoning-Trace",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -6814,7 +6814,8 @@
     "skipToNavigation": "Skip to navigation",
     "systemStatus": "System Status",
     "marketplace": "Marketplace",
-    "usage": "Usage & Costs"
+    "usage": "Usage & Costs",
+    "operations": "Operations"
   },
   "reasoningTrace": {
     "title": "Reasoning trace",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -6412,7 +6412,8 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
-    "systemStatus": "System Status"
+    "systemStatus": "System Status",
+    "operations": "Operaciones"
   },
   "reasoningTrace": {
     "title": "Traza de razonamiento",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -118,7 +118,8 @@
     "systemStatus": "System Status",
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
-    "openMainMenu": "Open main menu"
+    "openMainMenu": "Open main menu",
+    "operations": "عملیات"
   },
   "agent": {
     "registry": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -6412,7 +6412,8 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
-    "systemStatus": "System Status"
+    "systemStatus": "System Status",
+    "operations": "Opérations"
   },
   "reasoningTrace": {
     "title": "Trace de raisonnement",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -118,7 +118,8 @@
     "systemStatus": "System Status",
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
-    "openMainMenu": "Open main menu"
+    "openMainMenu": "Open main menu",
+    "operations": "פעולות"
   },
   "agent": {
     "registry": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -6412,7 +6412,8 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
-    "systemStatus": "System Status"
+    "systemStatus": "System Status",
+    "operations": "Darbības"
   },
   "reasoningTrace": {
     "title": "Reasoning trace",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -6412,7 +6412,8 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
-    "systemStatus": "System Status"
+    "systemStatus": "System Status",
+    "operations": "Operacje"
   },
   "reasoningTrace": {
     "title": "Slad rozumowania",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -6412,7 +6412,8 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
-    "systemStatus": "System Status"
+    "systemStatus": "System Status",
+    "operations": "Operações"
   },
   "reasoningTrace": {
     "title": "Rastro de raciocinio",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -118,7 +118,8 @@
     "systemStatus": "System Status",
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
-    "openMainMenu": "Open main menu"
+    "openMainMenu": "Open main menu",
+    "operations": "آپریشنز"
   },
   "agent": {
     "registry": {


### PR DESCRIPTION
Closes #4779

Follow-up to #4270 (OperationsView). The route and view existed but `/operations` was unreachable from the sidebar.

## Changes
- `App.vue` — adds `/operations` to `navItems` after `/analytics` (clipboard icon, `iconStroke: true`)
- All 11 locale files — adds `nav.operations` translation key

## Test Status
PASS — vue-tsc reports no new errors