### PR TITLE
fix(rag): add enable_rlm_refinement and ucb1_exploration_constant to RAGConfig.to_dict() (#4725)

### DIFF
--- a/autobot-backend/services/rag_config.py
+++ b/autobot-backend/services/rag_config.py
@@ -242,6 +242,10 @@ class RAGConfig:
             "enable_agentic_search": self.enable_agentic_search,
             "rewrite_enabled": self.rewrite_enabled,
             "max_search_iterations": self.max_search_iterations,
+            # Issue #4696: RLM-driven refinement loop
+            "enable_rlm_refinement": self.enable_rlm_refinement,
+            # Issue #4674: UCB1 exploration constant for RetrievalLearner
+            "ucb1_exploration_constant": self.ucb1_exploration_constant,
             # Neural Mesh RAG feature flags (Issue #2059)
             "mesh_retriever_enabled": self.mesh_retriever_enabled,
             "mesh_seed_edges": self.mesh_seed_edges,


### PR DESCRIPTION
Closes #4725

## Changes
- `autobot-backend/services/rag_config.py` — adds `enable_rlm_refinement` and `ucb1_exploration_constant` to `to_dict()`

`enable_session_adaptive_reranking` was already present and did not need to be added.