### PR TITLE
refactor(tools): move 12 inline _BUILTIN_TOOL_SCHEMAS to authoritative schema constants (#4726)

### DIFF
--- a/autobot-backend/chat_workflow/tool_handler.py
+++ b/autobot-backend/chat_workflow/tool_handler.py
@@ -99,85 +99,114 @@ def validate_tool_arguments(
         return None
 
 
+# Issue #4726: Named schema constants — one per tool, single source of truth.
+# Browser tools and web_search have no dedicated tools/ module; constants are
+# defined here alongside BROWSER_TOOL_NAMES so they stay co-located with the
+# routing logic.  execute_command is also defined here for the same reason.
+EXECUTE_COMMAND_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "command": {"type": "string"},
+        "host": {"type": "string"},
+    },
+    "required": ["command"],
+}
+
+WEB_SEARCH_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string"},
+    },
+    "required": ["query"],
+}
+
+# Browser tool schemas — co-located with BROWSER_TOOL_NAMES (Issue #4726).
+NAVIGATE_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"url": {"type": "string"}},
+    "required": ["url"],
+}
+
+CLICK_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"selector": {"type": "string"}},
+    "required": ["selector"],
+}
+
+FILL_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "selector": {"type": "string"},
+        "value": {"type": "string"},
+    },
+    "required": ["selector", "value"],
+}
+
+SELECT_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "selector": {"type": "string"},
+        "value": {"type": "string"},
+    },
+    "required": ["selector", "value"],
+}
+
+HOVER_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"selector": {"type": "string"}},
+    "required": ["selector"],
+}
+
+SCREENSHOT_SCHEMA: dict = {
+    "type": "object",
+    "properties": {},
+}
+
+EVALUATE_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"script": {"type": "string"}},
+    "required": ["script"],
+}
+
+GET_TEXT_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"selector": {"type": "string"}},
+    "required": ["selector"],
+}
+
+GET_ATTRIBUTE_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "selector": {"type": "string"},
+        "attribute": {"type": "string"},
+    },
+    "required": ["selector", "attribute"],
+}
+
+WAIT_FOR_SELECTOR_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"selector": {"type": "string"}},
+    "required": ["selector"],
+}
+
 # Issue #4529: JSON Schema definitions for built-in tools dispatched directly
 # (not via MCP).  Used by _validate_builtin_tool_arguments() so every dispatch
 # path passes through validate_tool_arguments() before execution.
+# Issue #4726: inline dicts replaced with named constants above; schema content
+# is unchanged.
 _BUILTIN_TOOL_SCHEMAS: dict[str, dict] = {
-    "execute_command": {
-        "type": "object",
-        "properties": {
-            "command": {"type": "string"},
-            "host": {"type": "string"},
-        },
-        "required": ["command"],
-    },
-    "web_search": {
-        "type": "object",
-        "properties": {
-            "query": {"type": "string"},
-        },
-        "required": ["query"],
-    },
-    # Browser tools share a common structure: at minimum one string parameter.
-    # Each tool is registered with its specific required field.
-    "navigate": {
-        "type": "object",
-        "properties": {"url": {"type": "string"}},
-        "required": ["url"],
-    },
-    "click": {
-        "type": "object",
-        "properties": {"selector": {"type": "string"}},
-        "required": ["selector"],
-    },
-    "fill": {
-        "type": "object",
-        "properties": {
-            "selector": {"type": "string"},
-            "value": {"type": "string"},
-        },
-        "required": ["selector", "value"],
-    },
-    "select": {
-        "type": "object",
-        "properties": {
-            "selector": {"type": "string"},
-            "value": {"type": "string"},
-        },
-        "required": ["selector", "value"],
-    },
-    "hover": {
-        "type": "object",
-        "properties": {"selector": {"type": "string"}},
-        "required": ["selector"],
-    },
-    "screenshot": {
-        "type": "object",
-        "properties": {},
-    },
-    "evaluate": {
-        "type": "object",
-        "properties": {"script": {"type": "string"}},
-        "required": ["script"],
-    },
-    "get_text": {
-        "type": "object",
-        "properties": {"selector": {"type": "string"}},
-        "required": ["selector"],
-    },
-    "get_attribute": {
-        "type": "object",
-        "properties": {
-            "selector": {"type": "string"},
-            "attribute": {"type": "string"},
-        },
-        "required": ["selector", "attribute"],
-    },
-    "wait_for_selector": {
-        "type": "object",
-        "properties": {"selector": {"type": "string"}},
-        "required": ["selector"],
-    },
+    "execute_command": EXECUTE_COMMAND_SCHEMA,
+    "web_search": WEB_SEARCH_SCHEMA,
+    "navigate": NAVIGATE_SCHEMA,
+    "click": CLICK_SCHEMA,
+    "fill": FILL_SCHEMA,
+    "select": SELECT_SCHEMA,
+    "hover": HOVER_SCHEMA,
+    "screenshot": SCREENSHOT_SCHEMA,
+    "evaluate": EVALUATE_SCHEMA,
+    "get_text": GET_TEXT_SCHEMA,
+    "get_attribute": GET_ATTRIBUTE_SCHEMA,
+    "wait_for_selector": WAIT_FOR_SELECTOR_SCHEMA,
     # Imported from tools.code_interpreter — single source of truth for the schema.
     # Issue #4561: was missing, causing code_interpreter args to bypass validation
     # (Issue #4562).  All future built-in tool schemas should follow this pattern:


### PR DESCRIPTION
Closes #4726

## Changes
- `autobot-backend/chat_workflow/tool_handler.py` — extracted all 12 inline schema dicts into named module-level constants (`EXECUTE_COMMAND_SCHEMA`, `WEB_SEARCH_SCHEMA`, `NAVIGATE_SCHEMA`, `CLICK_SCHEMA`, `FILL_SCHEMA`, `SELECT_SCHEMA`, `HOVER_SCHEMA`, `SCREENSHOT_SCHEMA`, `EVALUATE_SCHEMA`, `GET_TEXT_SCHEMA`, `GET_ATTRIBUTE_SCHEMA`, `WAIT_FOR_SELECTOR_SCHEMA`). `_BUILTIN_TOOL_SCHEMAS` now references them by name. Schema content is unchanged.

Since the 12 tools have no dedicated module under `tools/`, constants are co-located in `tool_handler.py` per issue guidance.