### PR TITLE
fix(backend): remove duplicate api.user_management router registration (#4708)

### DIFF
--- a/autobot-backend/initialization/router_registry/feature_routers.py
+++ b/autobot-backend/initialization/router_registry/feature_routers.py
@@ -461,13 +461,6 @@ FEATURE_ROUTER_CONFIGS: List[Tuple[str, str, List[str], str]] = [
         ["resilience", "monitoring"],
         "error_resilience",
     ),
-    # User management (users, teams, organizations) — router defines /user-management internally
-    (
-        "api.user_management",
-        "",
-        ["user-management", "users"],
-        "user_management",
-    ),
     # Issue #1803: Plugin manager endpoints (list, discover, load/unload/enable/disable, config)
     ("plugin_manager", "", ["plugins"], "plugin_manager"),
     # Issue #1803: Plugin and agent marketplace — community catalog


### PR DESCRIPTION
Closes #4708. Removed duplicate api.user_management entry from feature_routers.py. Authoritative registration kept in core_routers.py for fail-fast behavior.