### PR TITLE
fix(testing): update test_total_hook_count_increased to 25 HookPoints (#4740)

### DIFF
--- a/autobot-backend/chat_workflow/prompt_hooks_test.py
+++ b/autobot-backend/chat_workflow/prompt_hooks_test.py
@@ -87,8 +87,8 @@ class TestNewHookPoints:
         assert HookPoint.FULL_PROMPT_READY is not None
 
     def test_total_hook_count_increased(self):
-        # Original 22 hooks + 2 new ones = 24
-        assert len(HookPoint) == 24
+        # Original 22 hooks + 3 new ones = 25
+        assert len(HookPoint) == 25
 
 
 class TestEmitSystemPromptReady:


### PR DESCRIPTION
Closes #4740. Updated expected count from 24 to 25 in prompt_hooks_test.py. Enum has 25 members.