### PR TITLE
fix(backend): update startup_validator.py minimum Python version to 3.12 (#4718)

### DIFF
--- a/autobot-backend/startup_validator.py
+++ b/autobot-backend/startup_validator.py
@@ -315,8 +315,8 @@ class StartupValidator:
         logger.info("Validating system requirements...")
 
         # Check Python version
-        if sys.version_info < (3, 8):
-            self.result.add_error(f"Python 3.8+ required, found {sys.version}")
+        if sys.version_info < (3, 12):
+            self.result.add_error(f"Python 3.12+ required, found {sys.version}")
 
         # Check disk space for logs and data
         try:


### PR DESCRIPTION
Closes #4718. Changed sys.version_info check from (3, 8) to (3, 12) with updated error message.