### PR TITLE
fix(mcp): update knowledge-base-mcp requires-python to >=3.12 (#4719)

### DIFF
--- a/autobot-infrastructure/shared/mcp/tools/knowledge-base-mcp/pyproject.toml
+++ b/autobot-infrastructure/shared/mcp/tools/knowledge-base-mcp/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "mrveiss"}
 ]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = {text = "MIT"}
 keywords = ["mcp", "knowledge-base", "autobot", "llm", "vector-search"]
 


### PR DESCRIPTION
Closes #4719. Changed requires-python from >=3.11 to >=3.12 in knowledge-base-mcp/pyproject.toml.