### PR TITLE
fix(ui): accessibility & interaction — focus rings, touch targets, ARIA labels, Escape key (#4803)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -15,8 +15,9 @@
           <div class="shrink-0 flex items-center">
             <button
               @click="toggleSystemStatus"
-              class="flex items-center space-x-3 hover:bg-autobot-bg-tertiary rounded-md px-2 py-1 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-autobot-primary/50"
+              class="flex items-center space-x-3 hover:bg-autobot-bg-tertiary rounded-md px-2 py-1 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-autobot-primary"
               :title="getSystemStatusTooltip()"
+              :aria-label="getSystemStatusTooltip()"
             >
               <div class="relative w-8 h-8 bg-white rounded flex items-center justify-center">
                 <span class="text-slate-800 font-bold text-sm font-mono">AB</span>
@@ -65,8 +66,10 @@
                 <a
                   :href="slmAdminUrl"
                   target="_blank"
+                  rel="noopener noreferrer"
                   class="px-3 py-2 rounded text-sm font-medium transition-colors duration-150 text-autobot-text-primary hover:bg-autobot-bg-tertiary"
                   :title="$t('nav.slmAdminTitle')"
+                  :aria-label="$t('nav.slmAdminTitle')"
                 >
                   <div class="flex items-center space-x-1">
                     <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
@@ -166,8 +169,11 @@
             <!-- SLM Admin: external link (Issue #729) -->
             <a
               :href="slmAdminUrl"
+              target="_blank"
+              rel="noopener noreferrer"
               @click="closeMobileNav"
               class="w-full text-start px-3 py-2 rounded text-sm font-medium transition-colors duration-150 block text-autobot-text-primary hover:bg-autobot-bg-tertiary"
+              :aria-label="`${$t('nav.slmAdmin')} (${$t('nav.opensInNewTab')})`"
             >
               <div class="flex items-center space-x-2">
                 <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
@@ -534,6 +540,12 @@ export default {
       }
     };
 
+    const closeNavbarOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && showMobileNav.value) {
+        showMobileNav.value = false;
+      }
+    };
+
     const clearAllCaches = async () => {
       try {
         // Clear all stores
@@ -687,8 +699,9 @@ export default {
     onMounted(async () => {
       logger.debug('Initializing optimized AutoBot application...');
 
-      // Add global click listener for mobile nav
+      // Add global click and keyboard listeners for mobile nav
       document.addEventListener('click', closeNavbarOnClickOutside);
+      document.addEventListener('keydown', closeNavbarOnEscape);
 
       // Set up global error handling (#2849: use named handlers for cleanup)
       window.addEventListener('error', handleWindowError);
@@ -749,6 +762,7 @@ export default {
 
       // Clean up listeners (#2849: remove all event listeners added in onMounted)
       document.removeEventListener('click', closeNavbarOnClickOutside);
+      document.removeEventListener('keydown', closeNavbarOnEscape);
       window.removeEventListener('error', handleWindowError);
       window.removeEventListener('unhandledrejection', handleUnhandledRejection);
       stopOptimizedNotificationCleanup();

--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -173,7 +173,7 @@
               rel="noopener noreferrer"
               @click="closeMobileNav"
               class="w-full text-start px-3 py-2 rounded text-sm font-medium transition-colors duration-150 block text-autobot-text-primary hover:bg-autobot-bg-tertiary"
-              :aria-label="`${$t('nav.slmAdmin')} (${$t('nav.opensInNewTab')})`"
+              :aria-label="$t('nav.slmAdminTitle')"
             >
               <div class="flex items-center space-x-2">
                 <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">

--- a/autobot-frontend/src/components/ui/DarkModeToggle.vue
+++ b/autobot-frontend/src/components/ui/DarkModeToggle.vue
@@ -15,8 +15,8 @@ Issue #753: Dark/Light Mode Refinement
     :aria-label="t('ui.darkModeToggle.toggleDarkMode')"
   >
     <transition name="icon-fade" mode="out-in">
-      <i v-if="isDark" key="moon" class="fas fa-moon"></i>
-      <i v-else key="sun" class="fas fa-sun"></i>
+      <i v-if="isDark" key="moon" class="fas fa-moon" aria-hidden="true"></i>
+      <i v-else key="sun" class="fas fa-sun" aria-hidden="true"></i>
     </transition>
   </button>
 </template>
@@ -38,8 +38,9 @@ function toggleDarkMode() {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  /* 44×44 minimum touch target (WCAG 2.5.5, Apple HIG) */
+  min-width: 44px;
+  min-height: 44px;
   border-radius: var(--radius-md);
   background-color: var(--bg-hover);
   color: var(--text-primary);

--- a/autobot-frontend/src/components/ui/ToastContainer.vue
+++ b/autobot-frontend/src/components/ui/ToastContainer.vue
@@ -20,7 +20,7 @@
             @click="removeToast(toast.id)"
             :aria-label="t('ui.toastContainer.dismissNotification')"
           >
-            <i class="fas fa-times"></i>
+            <i class="fas fa-times" aria-hidden="true"></i>
           </button>
         </div>
       </TransitionGroup>
@@ -133,17 +133,18 @@ const getIcon = (type: string): string => {
 
 .toast-close {
   flex-shrink: 0;
-  background: var(--bg-hover);
+  background: transparent;
   border: none;
   color: var(--text-secondary);
-  width: 24px;
-  height: 24px;
+  /* 44×44 minimum touch target (WCAG 2.5.5, Apple HIG, Material Design) */
+  min-width: 44px;
+  min-height: 44px;
   border-radius: var(--radius-full);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background var(--duration-200) var(--ease-in-out);
+  transition: background var(--duration-200) var(--ease-in-out), color var(--duration-200) var(--ease-in-out);
 }
 
 .toast-close:hover {
@@ -151,8 +152,8 @@ const getIcon = (type: string): string => {
   color: var(--text-primary);
 }
 
-.toast-close:focus {
-  outline: 2px solid var(--color-primary-bg);
+.toast-close:focus-visible {
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
## Summary

UI/UX Pro Max audit identified 7 CRITICAL accessibility and interaction issues. This PR fixes them across 3 files.

- **ToastContainer**: invisible focus ring, undersized touch target (24px), missing aria-hidden
- **App.vue**: missing aria-label on status button, external links without rel/aria, no Escape-key mobile nav dismiss, weak focus ring opacity
- **DarkModeToggle**: decorative FA icons without aria-hidden, 40×40 button below 44px minimum

## Changes

### `ToastContainer.vue`
- Fix focus ring: `--color-primary-bg` (rgba 10% opacity ≈ invisible) → `--color-primary` (solid)  
- Bump close button from 24×24 to `min-width/min-height: 44px` (WCAG 2.5.5, Apple HIG, Material)
- Use `focus-visible` instead of `focus` (avoids ring on mouse click, preserves keyboard ring)
- Add `aria-hidden="true"` to dismiss icon (button already has aria-label; double-announcement removed)

### `App.vue`
- Add `:aria-label="getSystemStatusTooltip()"` to status button — complements `:title` for screen readers
- Add `rel="noopener noreferrer"` to both SLM Admin `<a target="_blank">` links (security + WCAG)
- Add `:aria-label="$t('nav.slmAdminTitle')"` to both SLM Admin links (reuses existing translation)
- Add `closeNavbarOnEscape` keydown handler: Escape closes mobile nav (standard keyboard pattern)
- Register and clean up `keydown` listener in onMounted/onUnmounted
- Strengthen logo button focus ring: `ring-autobot-primary/50` → `ring-autobot-primary` (removes 50% opacity)

### `DarkModeToggle.vue`
- Add `aria-hidden="true"` to both FA icon variants (button has `aria-label`; icon is decorative)
- Increase from `width/height: 40px` to `min-width/min-height: 44px` (WCAG 2.5.5 minimum)

## Test plan
- [ ] Tab to toast dismiss button — focus ring now fully visible (solid blue)
- [ ] Click toast dismiss on mobile — 44px tap area works without precision tapping
- [ ] Screen reader announces status button label (not just "AB AutoBot")
- [ ] Press Escape with mobile nav open — nav closes
- [ ] Inspect SLM Admin anchor — has `rel="noopener noreferrer"` and `aria-label`
- [ ] Tab to dark mode toggle — focus ring visible, screen reader announces label not icon name

Closes #4803

🤖 Generated with [Claude Code](https://claude.com/claude-code)