### PR TITLE
fix(testing): mock _run_analyzer in test_synthesize_docs_happy_path to isolate LLM calls (#4785)

### DIFF
--- a/autobot-backend/services/knowledge/test_kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/test_kb_synthesizer.py
@@ -209,6 +209,9 @@ async def test_synthesize_docs_happy_path(tmp_path):
     llm = _make_llm("Synthesized summary")
     synth = KBSynthesizer(llm_service=llm)
     synth._collection = col
+    # Issue #4785: AnalyzerService (#4678) makes a second llm.chat call; patch it
+    # out so the synthesis-only assertion on assert_awaited_once() stays valid.
+    synth._run_analyzer = AsyncMock()
 
     await synth.synthesize_docs([str(f)])
 


### PR DESCRIPTION
Closes #4785. Added AsyncMock for _run_analyzer to prevent AnalyzerService's LLM call from breaking assert_awaited_once(). All 34 tests in test_kb_synthesizer.py pass.