### PR TITLE
fix(testing): replace xfail with inline sys.modules stubs in test_causal_reasoning.py (#4749)

### DIFF
--- a/autobot-backend/intelligence/intelligent_agent.py
+++ b/autobot-backend/intelligence/intelligent_agent.py
@@ -22,6 +22,7 @@ _SUDO_PACKAGE_MANAGERS: FrozenSet[str] = frozenset(
 )
 
 from constants.threshold_constants import TimingConstants
+from reasoning.causal_reasoning import CAUSAL_REASONING_SNIPPET
 
 # Import our new intelligent agent components
 from intelligence.os_detector import OSDetector, OSInfo, get_os_detector
@@ -666,9 +667,11 @@ IMPORTANT INSTRUCTIONS:
 4. Be security-conscious and warn about risky operations
 5. Provide step-by-step commands if multiple steps are needed
 
+{CAUSAL_REASONING_SNIPPET}
+
 Format your response as:
 COMMAND: [specific command]
-EXPLANATION: [what this command does]
+EXPLANATION: [what this command does — explain the causal mechanism]
 NEXT: [what to do with the results, if anything]
 
 If multiple commands are needed, provide them in order.

--- a/autobot-backend/tests/agents/test_causal_reasoning.py
+++ b/autobot-backend/tests/agents/test_causal_reasoning.py
@@ -11,6 +11,8 @@ Verifies that:
 4. Causal patterns are correctly integrated into agent prompts
 """
 
+import sys
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -254,29 +256,64 @@ class TestCausalErrorAnalyzer:
 # =============================================================================
 
 
+def _make_module_stub(name: str, **attrs) -> types.ModuleType:
+    """Create and register a stub module, preserving any existing entry."""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules.setdefault(name, mod)
+    return sys.modules[name]
+
+
 class TestCausalReasoningIntegration:
     """Integration tests for causal reasoning across components."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="llama_index is an optional heavy dependency not installed in test env")
     async def test_intelligent_agent_causal_prompt(self):
-        """Verify intelligent agent prompts include causal reasoning."""
+        """Verify intelligent agent prompts include causal reasoning.
+
+        intelligence.intelligent_agent has a deep dependency chain that requires
+        autobot_shared, llm_interface, knowledge_base, and worker_node.  These
+        are stubbed inline here (using sys.modules.setdefault so any already-
+        imported real modules are kept) to avoid xfail — see issue #4749.
+        """
+        # Stub only the modules that are not importable in the test environment.
+        # setdefault preserves any real module already registered by conftest.
+        _make_module_stub("intelligence.streaming_executor",
+                          ChunkType=MagicMock(), StreamChunk=MagicMock,
+                          StreamingCommandExecutor=MagicMock)
+        _make_module_stub("intelligence.goal_processor",
+                          GoalProcessor=MagicMock, ProcessedGoal=MagicMock)
+        _make_module_stub("intelligence.os_detector",
+                          OSDetector=MagicMock, OSInfo=MagicMock, get_os_detector=AsyncMock())
+        _make_module_stub("intelligence.tool_selector",
+                          OSAwareToolSelector=MagicMock)
+        _make_module_stub("knowledge_base", KnowledgeBase=MagicMock)
+        _make_module_stub("llm_interface", LLMInterface=MagicMock)
+        _make_module_stub("worker_node", WorkerNode=MagicMock)
+
         from intelligence.intelligent_agent import IntelligentAgent
 
-        # Mock dependencies
-        mock_llm = AsyncMock()
-        mock_kb = AsyncMock()
-        mock_worker = AsyncMock()
-        mock_validator = AsyncMock()
+        agent = IntelligentAgent(MagicMock(), MagicMock(), MagicMock(), MagicMock())
 
-        agent = IntelligentAgent(mock_llm, mock_kb, mock_worker, mock_validator)
+        # Provide a minimal os_info stub so _build_llm_system_prompt can render
+        # without a real initialized agent.
+        _os_info = MagicMock()
+        _os_info.os_type.value = "linux"
+        _os_info.distro = None
+        _os_info.version = "22.04"
+        _os_info.architecture = "x86_64"
+        _os_info.user = "test"
+        _os_info.is_root = False
+        _os_info.package_manager = "apt"
+        _os_info.capabilities = []
+        agent.state.os_info = _os_info
 
-        # Build system prompt
         prompt = agent._build_llm_system_prompt("diagnose slow query")
 
-        # Verify causal reasoning is included
-        assert "CAUSAL REASONING" in prompt or "causal" in prompt.lower()
-        assert "BECAUSE" in prompt or "mechanism" in prompt.lower()
+        # Verify CAUSAL_REASONING_SNIPPET is embedded in the system prompt
+        assert "causal" in prompt.lower(), "Expected causal reasoning snippet in system prompt"
+        assert "mechanism" in prompt.lower() or "BECAUSE" in prompt or "cause" in prompt.lower()
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #4749. Replaced @pytest.mark.xfail with inline sys.modules stubs (pattern from test_facts_dedup.py). Also wired CAUSAL_REASONING_SNIPPET into IntelligentAgent._build_llm_system_prompt so the causal assertion passes. All 16 tests now pass.