### PR TITLE
fix(desktop): use correct i18n key for DesktopContextPanel toggle button (#4812)

### DIFF
--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -59,7 +59,7 @@
       <button @click="reconnect" class="control-btn">
         {{ $t('desktop.interface.reconnect') }}
       </button>
-      <button @click="showContextPanel = !showContextPanel" class="control-btn" :title="$t('desktop.interface.contextPanel')">
+      <button @click="showContextPanel = !showContextPanel" class="control-btn" :title="$t('desktop.contextPanel.title')">
         ℹ️
       </button>
       <div class="connection-status">


### PR DESCRIPTION
## Summary

Fixes #4812 — the toggle button for DesktopContextPanel in `DesktopInterface.vue` used the i18n key `desktop.interface.contextPanel`, which resolves to an object (the `contextPanel` namespace), causing the title to render as `[object Object]`.

## Fix

Changed to the correct key path `desktop.contextPanel.title` which resolves to the string `"Desktop Context"`.

## Root Cause

The key was guessed based on component nesting hierarchy rather than looked up in `en.json`. The `contextPanel` namespace sits directly under `desktop`, not under `desktop.interface`.

## Change

```diff
- :title="$t('desktop.interface.contextPanel')"
+ :title="$t('desktop.contextPanel.title')"
```