### PR TITLE
fix(knowledge): cap AutonomousLoopOrchestrator._history at 100 entries (#4795)

### DIFF
--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -32,9 +32,10 @@ import json
 import logging
 import time
 import uuid
+from collections import deque
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Deque, Dict, List, Optional
 
 # Module-level imports for patchability in tests.
 # Deferred via try/except to survive environments where these aren't installed yet.
@@ -285,7 +286,7 @@ class AutonomousLoopOrchestrator:
         self.max_no_improvement_rounds = max_no_improvement_rounds
 
         self._evaluator = _RAGEvaluator()
-        self._history: List[LoopRunRecord] = []
+        self._history: Deque[LoopRunRecord] = deque(maxlen=100)
         self._pending_approval: Optional[Dict[str, Any]] = None
         self._no_improvement_count: int = 0
         self._running = False


### PR DESCRIPTION
Closes #4795

## Summary
- Added `from collections import deque` to imports
- Changed `self._history: List[LoopRunRecord] = []` to `deque(maxlen=100)`
- After 150 appends, len stays at 100 — prevents unbounded memory growth
- All call sites (`list(self._history)`, `[-1]` indexing, iteration) are deque-compatible — no call site changes needed

## Test Status
No dedicated autonomous_loop tests exist. Syntax check passes; deque maxlen behavior verified.