### PR TITLE
feat: edge provenance, community anchor seeding, AST code indexer (#4818 #4819 #4820)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -31,6 +31,13 @@ vanna>=2.0.2  # Issue #723: Natural language to SQL via Vanna.ai
                # https://pypi.org/project/vanna/#history for a patched release; bump
                # constraint when fix is published. Evaluate removal if no fix by 2026-07-04.
 
+# Graph / AST (Issue #4818, #4819, #4820)
+networkx>=3.3
+graspologic>=3.4
+tree-sitter>=0.23.0
+tree-sitter-python>=0.23.0
+tree-sitter-javascript>=0.23.0
+
 # Include existing requirements
 -r ../requirements.txt
 

--- a/autobot-backend/services/graph_rag_service.py
+++ b/autobot-backend/services/graph_rag_service.py
@@ -652,6 +652,9 @@ class GraphRAGService:
             1.0 - self.graph_weight
         ) * base_score + self.graph_weight * proximity_score
 
+        _origin = relation.get("metadata", {}).get("origin", "inferred")
+        _provenance: str = _origin if _origin in ("extracted", "inferred", "ambiguous") else "inferred"
+
         return SearchResult(
             content=content,
             metadata={
@@ -662,6 +665,7 @@ class GraphRAGService:
                 "relation_type": relation.get("type"),
                 "direction": direction,
                 "graph_distance": max_depth,
+                "source_provenance": _provenance,
             },
             semantic_score=0.0,
             keyword_score=0.0,

--- a/autobot-backend/services/graph_rag_service_test.py
+++ b/autobot-backend/services/graph_rag_service_test.py
@@ -505,3 +505,72 @@ async def test_get_metrics(graph_rag_service):
     assert "graph_weight" in metrics
     assert "entity_extraction_enabled" in metrics
     assert "graph_initialized" in metrics
+
+
+# ============================================================================
+# Source Provenance Tests
+# ============================================================================
+
+
+def test_create_search_result_includes_source_extracted():
+    """source='extracted' propagates into metadata when relation has origin='extracted'."""
+    rag = AsyncMock()
+    graph = AsyncMock()
+    graph.initialized = True
+    svc = GraphRAGService(rag, graph)
+
+    entity = {"id": "e1", "type": "module", "name": "auth", "observations": ["handles login"]}
+    relation = {"type": "imports", "metadata": {"strength": 0.9, "origin": "extracted"}}
+
+    result = svc._create_search_result_from_entity(entity, relation, "outgoing", 1.0, 2)
+
+    assert result is not None
+    assert result.metadata["source_provenance"] == "extracted"
+
+
+def test_create_search_result_includes_source_inferred():
+    """source='inferred' propagates when origin is absent (defaults to inferred)."""
+    rag = AsyncMock()
+    graph = AsyncMock()
+    graph.initialized = True
+    svc = GraphRAGService(rag, graph)
+
+    entity = {"id": "e2", "type": "function", "name": "login", "observations": ["validates token"]}
+    relation = {"type": "calls", "metadata": {"strength": 0.5}}
+
+    result = svc._create_search_result_from_entity(entity, relation, "incoming", 0.8, 2)
+
+    assert result is not None
+    assert result.metadata["source_provenance"] == "inferred"
+
+
+def test_create_search_result_includes_source_ambiguous():
+    """source='ambiguous' passes through when origin='ambiguous'."""
+    rag = AsyncMock()
+    graph = AsyncMock()
+    graph.initialized = True
+    svc = GraphRAGService(rag, graph)
+
+    entity = {"id": "e3", "type": "module", "name": "utils", "observations": ["helpers"]}
+    relation = {"type": "related", "metadata": {"strength": 0.4, "origin": "ambiguous"}}
+
+    result = svc._create_search_result_from_entity(entity, relation, "outgoing", 0.6, 2)
+
+    assert result is not None
+    assert result.metadata["source_provenance"] == "ambiguous"
+
+
+def test_create_search_result_unknown_origin_defaults_to_inferred():
+    """Unknown origin value falls back to 'inferred' via whitelist guard."""
+    rag = AsyncMock()
+    graph = AsyncMock()
+    graph.initialized = True
+    svc = GraphRAGService(rag, graph)
+
+    entity = {"id": "e4", "type": "class", "name": "Config", "observations": ["settings"]}
+    relation = {"type": "uses", "metadata": {"strength": 0.7, "origin": "garbage_value"}}
+
+    result = svc._create_search_result_from_entity(entity, relation, "incoming", 0.9, 2)
+
+    assert result is not None
+    assert result.metadata["source_provenance"] == "inferred"

--- a/autobot-backend/services/knowledge/code_indexer.py
+++ b/autobot-backend/services/knowledge/code_indexer.py
@@ -1,0 +1,349 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""AST-based code indexer using tree-sitter (#4820).
+
+Two-pass extraction per source file:
+  Pass 1 (structural): walk AST for function/class declarations → nodes.
+  Pass 2 (call-graph): walk function bodies for call expressions → edges.
+
+Results are embedded and upserted into ChromaDB following the same
+SHA-256 content-hash cache + upsert pattern as DocIndexer.
+
+Supported languages: Python, JavaScript/TypeScript.
+"""
+
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CodeIndexResult:
+    success: int = 0
+    failed: int = 0
+    skipped: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def _make_node_id(name: str, source_path: str) -> str:
+    """Stable lowercase ID: '<stem>::<safe_name>'."""
+    stem = Path(source_path).stem
+    safe = re.sub(r"[^a-z0-9_]", "", name.lower().replace(".", "_"))
+    return f"{stem}::{safe}"
+
+
+def extract_python(source_path: str, content: bytes) -> dict:
+    """Two-pass tree-sitter extraction for Python.
+
+    Returns {"nodes": [...], "edges": [...]}.
+    """
+    try:
+        import tree_sitter_python as tspython
+        from tree_sitter import Language, Parser
+    except ImportError as exc:
+        logger.error("tree-sitter-python not installed: %s", exc)
+        return {"nodes": [], "edges": []}
+
+    lang = Language(tspython.language())
+    parser = Parser(lang)
+    tree = parser.parse(content)
+
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
+    seen_edges: set[tuple[str, str]] = set()
+
+    _py_structural(tree.root_node, source_path, nodes, parent_scope=None)
+    _py_call_graph(tree.root_node, source_path, nodes, edges, seen_edges, current_scope=None)
+
+    return {"nodes": list(nodes.values()), "edges": edges}
+
+
+def _py_structural(node: Any, source_path: str, nodes: dict, parent_scope: Optional[str]) -> None:
+    if node.type == "function_definition":
+        name_node = node.child_by_field_name("name")
+        if name_node:
+            name = name_node.text.decode("utf-8")
+            nid = _make_node_id(name, source_path)
+            nodes[nid] = {
+                "id": nid,
+                "name": name,
+                "kind": "function",
+                "source_path": source_path,
+                "line": node.start_point[0] + 1,
+                "parent": parent_scope,
+            }
+            for child in node.children:
+                _py_structural(child, source_path, nodes, parent_scope=nid)
+            return
+
+    if node.type == "class_definition":
+        name_node = node.child_by_field_name("name")
+        if name_node:
+            name = name_node.text.decode("utf-8")
+            nid = _make_node_id(name, source_path)
+            nodes[nid] = {
+                "id": nid,
+                "name": name,
+                "kind": "class",
+                "source_path": source_path,
+                "line": node.start_point[0] + 1,
+                "parent": parent_scope,
+            }
+            for child in node.children:
+                _py_structural(child, source_path, nodes, parent_scope=nid)
+            return
+
+    for child in node.children:
+        _py_structural(child, source_path, nodes, parent_scope)
+
+
+def _py_call_graph(
+    node: Any,
+    source_path: str,
+    nodes: dict,
+    edges: list,
+    seen: set,
+    current_scope: Optional[str],
+) -> None:
+    if node.type == "function_definition":
+        name_node = node.child_by_field_name("name")
+        scope = (
+            _make_node_id(name_node.text.decode("utf-8"), source_path)
+            if name_node
+            else current_scope
+        )
+        for child in node.children:
+            _py_call_graph(child, source_path, nodes, edges, seen, scope)
+        return
+
+    if node.type == "call" and current_scope:
+        func_node = node.child_by_field_name("function")
+        if func_node:
+            raw = func_node.text.decode("utf-8").split("(")[0]
+            target_name = raw.split(".")[-1]
+            pair = (current_scope, target_name)
+            if pair not in seen:
+                seen.add(pair)
+                edges.append({
+                    "source": current_scope,
+                    "target_name": target_name,
+                    "kind": "calls",
+                    "source_path": source_path,
+                    "origin": "extracted",
+                })
+
+    for child in node.children:
+        _py_call_graph(child, source_path, nodes, edges, seen, current_scope)
+
+
+def _js_structural(node: Any, source_path: str, nodes: dict, parent_scope: Optional[str]) -> None:
+    """Helper for JS/TS structural extraction."""
+    if node.type in ("function_declaration", "arrow_function", "function_expression"):
+        name_node = node.child_by_field_name("name")
+        name = name_node.text.decode("utf-8") if name_node else f"anon_{node.start_point[0]}"
+        nid = _make_node_id(name, source_path)
+        nodes[nid] = {
+            "id": nid, "name": name, "kind": "function",
+            "source_path": source_path, "line": node.start_point[0] + 1, "parent": parent_scope,
+        }
+        for child in node.children:
+            _js_structural(child, source_path, nodes, parent_scope=nid)
+        return
+    if node.type == "class_declaration":
+        name_node = node.child_by_field_name("name")
+        if name_node:
+            name = name_node.text.decode("utf-8")
+            nid = _make_node_id(name, source_path)
+            nodes[nid] = {
+                "id": nid, "name": name, "kind": "class",
+                "source_path": source_path, "line": node.start_point[0] + 1, "parent": parent_scope,
+            }
+    for child in node.children:
+        _js_structural(child, source_path, nodes, parent_scope)
+
+
+def _js_call_graph(
+    node: Any, source_path: str, nodes: dict, edges: list, seen: set, current_scope: Optional[str],
+) -> None:
+    """Helper for JS/TS call-graph extraction."""
+    if node.type in ("function_declaration", "arrow_function", "function_expression"):
+        name_node = node.child_by_field_name("name")
+        scope = _make_node_id(name_node.text.decode("utf-8"), source_path) if name_node else current_scope
+        for child in node.children:
+            _js_call_graph(child, source_path, nodes, edges, seen, scope)
+        return
+    if node.type == "call_expression" and current_scope:
+        func_node = node.child_by_field_name("function")
+        if func_node:
+            raw = func_node.text.decode("utf-8").split("(")[0]
+            target_name = raw.split(".")[-1]
+            pair = (current_scope, target_name)
+            if pair not in seen:
+                seen.add(pair)
+                edges.append({
+                    "source": current_scope, "target_name": target_name,
+                    "kind": "calls", "source_path": source_path, "origin": "extracted",
+                })
+    for child in node.children:
+        _js_call_graph(child, source_path, nodes, edges, seen, current_scope)
+
+
+def extract_javascript(source_path: str, content: bytes) -> dict:
+    """Two-pass extraction for JavaScript/TypeScript."""
+    try:
+        import tree_sitter_javascript as tsjs
+        from tree_sitter import Language, Parser
+    except ImportError as exc:
+        logger.error("tree-sitter-javascript not installed: %s", exc)
+        return {"nodes": [], "edges": []}
+
+    lang = Language(tsjs.language())
+    parser = Parser(lang)
+    tree = parser.parse(content)
+
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
+    seen_edges: set[tuple[str, str]] = set()
+    _js_structural(tree.root_node, source_path, nodes, parent_scope=None)
+    _js_call_graph(tree.root_node, source_path, nodes, edges, seen_edges, current_scope=None)
+    return {"nodes": list(nodes.values()), "edges": edges}
+
+
+_EXTRACTORS: dict[str, Any] = {
+    ".py": extract_python,
+    ".js": extract_javascript,
+    ".ts": extract_javascript,
+    ".jsx": extract_javascript,
+    ".tsx": extract_javascript,
+    ".vue": extract_javascript,
+}
+
+
+_DEFAULT_CACHE = Path(__file__).parent / ".code_index_hashes.json"
+
+
+class CodeIndexer:
+    """Index source files into ChromaDB using AST extraction.
+
+    Mirrors DocIndexer's SHA-256 hash cache + upsert pattern.
+    Each function/class node becomes one ChromaDB document.
+    """
+
+    def __init__(
+        self,
+        collection: Any,
+        embed_model: Any,
+        cache_file: Path = _DEFAULT_CACHE,
+    ) -> None:
+        self._collection = collection
+        self._embed_model = embed_model
+        self._cache_file = cache_file
+        self._hash_cache: dict[str, str] = self._load_cache()
+
+    def index_file(
+        self,
+        file_path: str,
+        root_dir: str,
+        force: bool = False,
+    ) -> CodeIndexResult:
+        """Extract AST nodes from file_path and upsert into ChromaDB."""
+        result = CodeIndexResult()
+        ext = Path(file_path).suffix.lower()
+        extractor = _EXTRACTORS.get(ext)
+        if extractor is None:
+            result.skipped += 1
+            return result
+
+        rel_path = str(Path(file_path).relative_to(root_dir))
+        if not force:
+            current_hash = self._compute_hash(file_path)
+            if current_hash and self._hash_cache.get(rel_path) == current_hash:
+                result.skipped += 1
+                return result
+
+        try:
+            content = Path(file_path).read_bytes()
+        except OSError as e:
+            result.failed += 1
+            result.errors.append(str(e))
+            return result
+
+        extracted = extractor(file_path, content)
+        nodes = extracted["nodes"]
+        edges = extracted["edges"]
+
+        calls_by_source: dict[str, list[str]] = {}
+        for e in edges:
+            calls_by_source.setdefault(e["source"], []).append(e["target_name"])
+
+        for node in nodes:
+            ok = self._upsert_node(node, rel_path, calls_by_source)
+            if ok:
+                result.success += 1
+            else:
+                result.failed += 1
+
+        new_hash = self._compute_hash(file_path)
+        if new_hash:
+            self._hash_cache[rel_path] = new_hash
+            self._save_cache()
+
+        return result
+
+    def _upsert_node(self, node: dict, rel_path: str, calls_by_source: dict[str, list[str]]) -> bool:
+        content = (
+            f"{node['kind'].upper()} {node['name']}\n"
+            f"File: {rel_path} line {node.get('line', 0)}"
+        )
+        metadata: dict[str, Any] = {
+            "source": "autobot_code",
+            "node_kind": node["kind"],
+            "node_name": node["name"],
+            "source_path": rel_path,
+            "line": str(node.get("line", 0)),
+            "parent": node.get("parent") or "",
+            "calls": ",".join(calls_by_source.get(node["id"], [])),
+            "origin": "extracted",
+        }
+        try:
+            embedding = self._embed_model.get_text_embedding(content)
+            self._collection.upsert(
+                ids=[node["id"]],
+                embeddings=[embedding],
+                documents=[content],
+                metadatas=[metadata],
+            )
+            return True
+        except Exception as e:
+            logger.error("Failed to upsert node %s: %s", node["id"], e)
+            return False
+
+    @staticmethod
+    def _compute_hash(file_path: str) -> str:
+        try:
+            return hashlib.sha256(Path(file_path).read_bytes()).hexdigest()
+        except OSError:
+            return ""
+
+    def _load_cache(self) -> dict[str, str]:
+        if self._cache_file.exists():
+            try:
+                return json.loads(self._cache_file.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        return {}
+
+    def _save_cache(self) -> None:
+        try:
+            self._cache_file.write_text(
+                json.dumps(self._hash_cache, indent=2), encoding="utf-8"
+            )
+        except OSError as e:
+            logger.warning("Could not save code index cache: %s", e)

--- a/autobot-backend/services/knowledge/code_indexer_test.py
+++ b/autobot-backend/services/knowledge/code_indexer_test.py
@@ -1,0 +1,113 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for CodeIndexer (#4820)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+tree_sitter_available = True
+try:
+    import tree_sitter_python  # noqa: F401
+except ImportError:
+    tree_sitter_available = False
+
+requires_tree_sitter = pytest.mark.skipif(
+    not tree_sitter_available,
+    reason="tree-sitter-python not installed"
+)
+
+from services.knowledge.code_indexer import (
+    CodeIndexer,
+    _make_node_id,
+    extract_python,
+)
+
+SIMPLE_PYTHON = b"""
+def greet(name: str) -> str:
+    return "hello " + name
+
+class Greeter:
+    def run(self) -> None:
+        greet("world")
+"""
+
+
+def test_make_node_id_is_stable_and_lowercase():
+    nid = _make_node_id("MyFunc", "src/auth.py")
+    assert nid == "auth::myfunc"
+    assert nid == _make_node_id("MyFunc", "src/auth.py")
+
+
+@requires_tree_sitter
+def test_extract_python_finds_function_nodes():
+    result = extract_python("module.py", SIMPLE_PYTHON)
+    node_names = [n["name"] for n in result["nodes"]]
+    assert "greet" in node_names
+
+
+@requires_tree_sitter
+def test_extract_python_finds_class_nodes():
+    result = extract_python("module.py", SIMPLE_PYTHON)
+    node_names = [n["name"] for n in result["nodes"]]
+    assert "Greeter" in node_names
+
+
+@requires_tree_sitter
+def test_extract_python_finds_call_edge():
+    result = extract_python("module.py", SIMPLE_PYTHON)
+    edge_pairs = [(e["source"], e["target_name"]) for e in result["edges"]]
+    assert any(target == "greet" for _, target in edge_pairs)
+
+
+@requires_tree_sitter
+def test_extract_python_no_duplicate_edges():
+    result = extract_python("module.py", SIMPLE_PYTHON)
+    pairs = [(e["source"], e["target_name"]) for e in result["edges"]]
+    assert len(pairs) == len(set(pairs))
+
+
+def _make_indexer(tmp_path: Path):
+    collection = MagicMock()
+    collection.upsert = MagicMock()
+    embed_model = MagicMock()
+    embed_model.get_text_embedding = MagicMock(return_value=[0.1] * 384)
+    cache_file = tmp_path / ".code_index_hashes.json"
+    return CodeIndexer(collection=collection, embed_model=embed_model, cache_file=cache_file)
+
+
+@requires_tree_sitter
+def test_index_python_file_upserts_nodes(tmp_path):
+    src = tmp_path / "module.py"
+    src.write_bytes(SIMPLE_PYTHON)
+    indexer = _make_indexer(tmp_path)
+    result = indexer.index_file(str(src), root_dir=str(tmp_path))
+    assert result.success > 0
+    assert indexer._collection.upsert.called
+
+
+def test_index_unchanged_file_skips(tmp_path):
+    src = tmp_path / "module.py"
+    src.write_bytes(SIMPLE_PYTHON)
+    indexer = _make_indexer(tmp_path)
+    indexer.index_file(str(src), root_dir=str(tmp_path))
+    call_count_first = indexer._collection.upsert.call_count
+
+    result = indexer.index_file(str(src), root_dir=str(tmp_path))
+    assert result.skipped == 1
+    assert indexer._collection.upsert.call_count == call_count_first
+
+
+@requires_tree_sitter
+def test_force_reindex_bypasses_cache(tmp_path):
+    src = tmp_path / "module.py"
+    src.write_bytes(SIMPLE_PYTHON)
+    indexer = _make_indexer(tmp_path)
+    indexer.index_file(str(src), root_dir=str(tmp_path))
+    call_count_first = indexer._collection.upsert.call_count
+
+    result = indexer.index_file(str(src), root_dir=str(tmp_path), force=True)
+    assert result.success > 0
+    assert indexer._collection.upsert.call_count > call_count_first

--- a/autobot-backend/services/mesh_brain/community_clusterer.py
+++ b/autobot-backend/services/mesh_brain/community_clusterer.py
@@ -86,8 +86,6 @@ def _pick_centroid(subgraph, nodes: list[str]) -> str:
 
 def _split_community(subgraph) -> list[str]:
     """Apply a second Leiden pass to an oversized community subgraph."""
-    import networkx as nx  # lazy import
-
     if subgraph.number_of_nodes() < 2:
         return list(subgraph.nodes)[:1]
 

--- a/autobot-backend/services/mesh_brain/community_clusterer.py
+++ b/autobot-backend/services/mesh_brain/community_clusterer.py
@@ -1,0 +1,150 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Leiden community clustering for anchor seeding in NeuralMeshRetriever (#4819).
+
+Builds a NetworkX graph from MeshDB edges, runs Leiden community detection,
+selects the highest-degree node in each community as centroid, and promotes
+those centroids to anchor nodes via MeshDB.promote_to_anchor().
+
+graspologic is lazy-imported to avoid numba JIT startup overhead on every
+process start. The import only occurs when cluster_graph() is called.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_MAX_COMMUNITY_FRACTION = 0.25
+_MIN_SPLIT_SIZE = 10
+
+
+def cluster_graph(edges: list[dict]) -> list[str]:
+    """Build undirected graph from edge dicts and return centroid node IDs.
+
+    Args:
+        edges: List of dicts with keys 'from_node', 'to_node', 'weight'.
+
+    Returns:
+        One centroid node ID per detected community. Empty list when edges is empty.
+    """
+    if not edges:
+        return []
+
+    import networkx as nx  # lazy import — avoids startup cost when clustering unused
+
+    try:
+        from graspologic.partition import leiden
+    except ImportError as exc:
+        logger.error("graspologic not installed — cannot run Leiden: %s", exc)
+        return []
+
+    G = nx.Graph()
+    for e in edges:
+        G.add_edge(e["from_node"], e["to_node"], weight=float(e["weight"]))
+
+    if G.number_of_nodes() == 0:
+        return []
+
+    try:
+        partition: dict[Any, int] = leiden(G, trials=3)
+    except Exception:
+        logger.exception("Leiden failed — falling back to empty partition")
+        return []
+
+    communities: dict[int, list[str]] = {}
+    for node, comm_id in partition.items():
+        communities.setdefault(comm_id, []).append(str(node))
+
+    total_nodes = G.number_of_nodes()
+    centroids: list[str] = []
+
+    for comm_nodes in communities.values():
+        if (
+            len(comm_nodes) / total_nodes > _MAX_COMMUNITY_FRACTION
+            and len(comm_nodes) >= _MIN_SPLIT_SIZE
+        ):
+            centroids.extend(_split_community(G.subgraph(comm_nodes)))
+        else:
+            centroids.append(_pick_centroid(G.subgraph(comm_nodes), comm_nodes))
+
+    logger.info(
+        "cluster_graph: %d nodes, %d edges → %d communities, %d centroids",
+        G.number_of_nodes(),
+        G.number_of_edges(),
+        len(communities),
+        len(centroids),
+    )
+    return centroids
+
+
+def _pick_centroid(subgraph, nodes: list[str]) -> str:
+    """Return the highest-degree node in nodes within subgraph."""
+    return max(nodes, key=lambda n: subgraph.degree(n))
+
+
+def _split_community(subgraph) -> list[str]:
+    """Apply a second Leiden pass to an oversized community subgraph."""
+    import networkx as nx  # lazy import
+
+    if subgraph.number_of_nodes() < 2:
+        return list(subgraph.nodes)[:1]
+
+    try:
+        from graspologic.partition import leiden
+
+        sub_partition = leiden(subgraph, trials=2)
+    except Exception:
+        logger.warning("_split_community Leiden failed; using single centroid")
+        nodes = list(subgraph.nodes)
+        return [_pick_centroid(subgraph, nodes)]
+
+    sub_communities: dict[int, list[str]] = {}
+    for node, comm_id in sub_partition.items():
+        sub_communities.setdefault(comm_id, []).append(str(node))
+
+    if len(sub_communities) <= 1:
+        nodes = list(subgraph.nodes)
+        return [_pick_centroid(subgraph, nodes)]
+
+    return [
+        _pick_centroid(subgraph.subgraph(sub_nodes), sub_nodes)
+        for sub_nodes in sub_communities.values()
+    ]
+
+
+class CommunityClusterer:
+    """Fetch mesh edges, cluster via Leiden, promote centroids to anchors.
+
+    Usage:
+        clusterer = CommunityClusterer(mesh_db)
+        promoted_ids = await clusterer.run()
+    """
+
+    def __init__(self, db: Any) -> None:
+        self._db = db
+
+    async def run(self, min_weight: float = 0.3) -> list[str]:
+        """Fetch edges, cluster, promote centroids, return promoted node IDs.
+
+        Args:
+            min_weight: Only edges at or above this weight are included.
+
+        Returns:
+            List of node IDs promoted to anchor status.
+        """
+        edges = await self._db.fetch_edges(min_weight=min_weight)
+        if not edges:
+            logger.info("CommunityClusterer.run: no edges above weight=%.2f", min_weight)
+            return []
+
+        centroids = cluster_graph(edges)
+        if not centroids:
+            return []
+
+        for node_id in centroids:
+            await self._db.promote_to_anchor(node_id)
+
+        logger.info("CommunityClusterer.run: promoted %d anchor nodes", len(centroids))
+        return centroids

--- a/autobot-backend/services/mesh_brain/community_clusterer_test.py
+++ b/autobot-backend/services/mesh_brain/community_clusterer_test.py
@@ -1,0 +1,122 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Unit tests for CommunityClusterer (#4819)."""
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.mesh_brain.community_clusterer import CommunityClusterer, cluster_graph
+
+
+def _make_edges(pairs: list[tuple[str, str, float]]) -> list[dict]:
+    return [
+        {
+            "from_node": a,
+            "to_node": b,
+            "weight": w,
+            "id": f"{a}-{b}",
+            "edge_type": "co_access",
+            "origin": "extracted",
+        }
+        for a, b, w in pairs
+    ]
+
+
+def _ensure_graspologic_stub() -> None:
+    """Install a minimal graspologic stub if not present, so tests run without the package."""
+    if "graspologic" not in sys.modules:
+        def _leiden(G, trials=3):
+            # Assign each connected component its own community ID
+            import networkx as nx
+            partition = {}
+            for comm_id, component in enumerate(nx.connected_components(G)):
+                for node in component:
+                    partition[node] = comm_id
+            return partition
+
+        graspologic_mod = ModuleType("graspologic")
+        partition_mod = ModuleType("graspologic.partition")
+        partition_mod.leiden = _leiden
+        graspologic_mod.partition = partition_mod
+        sys.modules["graspologic"] = graspologic_mod
+        sys.modules["graspologic.partition"] = partition_mod
+
+
+# ---------------------------------------------------------------------------
+# cluster_graph (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_graph_empty_returns_empty():
+    assert cluster_graph([]) == []
+
+
+def test_cluster_graph_single_edge_returns_one_centroid():
+    _ensure_graspologic_stub()
+    edges = _make_edges([("n1", "n2", 1.0)])
+    centroids = cluster_graph(edges)
+    assert len(centroids) == 1
+    assert centroids[0] in ("n1", "n2")
+
+
+def test_cluster_graph_triangle_returns_one_centroid():
+    """Three fully-connected nodes → one community → one centroid."""
+    _ensure_graspologic_stub()
+    edges = _make_edges([("n1", "n2", 1.0), ("n2", "n3", 1.0), ("n1", "n3", 1.0)])
+    centroids = cluster_graph(edges)
+    assert len(centroids) == 1
+
+
+def test_cluster_graph_two_components_returns_two_centroids():
+    """Two disconnected triangles → two communities → two centroids."""
+    _ensure_graspologic_stub()
+    edges = _make_edges([
+        ("a1", "a2", 1.0), ("a2", "a3", 1.0), ("a1", "a3", 1.0),
+        ("b1", "b2", 1.0), ("b2", "b3", 1.0), ("b1", "b3", 1.0),
+    ])
+    centroids = cluster_graph(edges)
+    assert len(centroids) == 2
+    assert set(centroids).issubset({"a1", "a2", "a3", "b1", "b2", "b3"})
+
+
+# ---------------------------------------------------------------------------
+# CommunityClusterer (async, uses MeshDB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_seeds_anchors_from_centroids():
+    """run() fetches edges, clusters, and promotes centroid nodes to anchors."""
+    _ensure_graspologic_stub()
+    db = AsyncMock()
+    db.fetch_edges = AsyncMock(
+        return_value=_make_edges([
+            ("n1", "n2", 1.0),
+            ("n2", "n3", 1.0),
+            ("n1", "n3", 1.0),
+        ])
+    )
+    db.promote_to_anchor = AsyncMock()
+
+    clusterer = CommunityClusterer(db)
+    promoted = await clusterer.run()
+
+    assert len(promoted) == 1
+    db.promote_to_anchor.assert_called_once_with(promoted[0])
+
+
+@pytest.mark.asyncio
+async def test_run_empty_graph_promotes_nothing():
+    db = AsyncMock()
+    db.fetch_edges = AsyncMock(return_value=[])
+    db.promote_to_anchor = AsyncMock()
+
+    clusterer = CommunityClusterer(db)
+    promoted = await clusterer.run()
+
+    assert promoted == []
+    db.promote_to_anchor.assert_not_called()

--- a/autobot-backend/services/mesh_brain/mesh_db.py
+++ b/autobot-backend/services/mesh_brain/mesh_db.py
@@ -199,6 +199,24 @@ class MeshDB:
             )
             return [dict(r) for r in rows.mappings()]
 
+    async def get_anchor_neighbors(self, seed_ids: list[str]) -> list[str]:
+        """Return IDs of anchor nodes adjacent to any seed_id. Satisfies _AnchorDB Protocol (#4819)."""
+        if not seed_ids:
+            return []
+        sql = text("""
+            SELECT DISTINCT n.id::text
+            FROM mesh_nodes n
+            JOIN mesh_edges e
+              ON e.from_node = n.id OR e.to_node = n.id
+            WHERE (e.from_node = ANY(:seeds::uuid[])
+               OR  e.to_node   = ANY(:seeds::uuid[]))
+              AND n.is_anchor = TRUE
+              AND n.id != ALL(:seeds::uuid[])
+            """)
+        async with self.engine.connect() as conn:
+            rows = await conn.execute(sql, {"seeds": seed_ids})
+            return [row["id"] for row in rows.mappings()]
+
     async def fetch_candidate_edges(
         self,
         edge_type: str,

--- a/autobot-backend/services/mesh_brain/mesh_db_adapter.py
+++ b/autobot-backend/services/mesh_brain/mesh_db_adapter.py
@@ -72,6 +72,10 @@ class MeshDBAdapter:
         """Increment access_count and set last_accessed for the given node UUIDs."""
         await self._db.update_access_count(node_ids)
 
+    async def get_anchor_neighbors(self, seed_ids: list[str]) -> list[str]:
+        """Return IDs of anchor nodes adjacent to any seed_id (#4819)."""
+        return await self._db.get_anchor_neighbors(seed_ids)
+
     # ------------------------------------------------------------------
     # MeshGraph protocol — StalenessPropagor surface
     # ------------------------------------------------------------------

--- a/autobot-backend/services/mesh_brain/mesh_db_test.py
+++ b/autobot-backend/services/mesh_brain/mesh_db_test.py
@@ -474,3 +474,37 @@ class TestGetGraphDensity:
         density = await db.get_graph_density()
 
         assert density == 0.0
+
+
+# =============================================================================
+# Tests — get_anchor_neighbors
+# =============================================================================
+
+
+class TestGetAnchorNeighbors:
+    """MeshDB.get_anchor_neighbors returns anchor node IDs adjacent to seeds."""
+
+    @pytest.mark.asyncio
+    async def test_get_anchor_neighbors_returns_anchor_nodes_adjacent_to_seeds(self):
+        """get_anchor_neighbors returns UUIDs of anchor nodes reachable from seed_ids."""
+        anchor_id = "aaaaaaaa-0000-0000-0000-000000000001"
+        seed_id = "bbbbbbbb-0000-0000-0000-000000000002"
+
+        rows = [{"id": anchor_id}]
+        engine, _ = _make_engine(mappings=rows)
+        db = MeshDB(engine)
+
+        result = await db.get_anchor_neighbors([seed_id])
+
+        assert result == [anchor_id]
+
+    @pytest.mark.asyncio
+    async def test_get_anchor_neighbors_empty_seeds_returns_empty(self):
+        """get_anchor_neighbors returns [] without touching DB when seed_ids is empty."""
+        engine, conn = _make_engine()
+        db = MeshDB(engine)
+
+        result = await db.get_anchor_neighbors([])
+
+        assert result == []
+        conn.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary

Three mesh/knowledge pipeline improvements:

- **#4818 — Edge provenance taxonomy**: `source_provenance` field (`extracted`/`inferred`/`ambiguous`) propagated in `GraphRAGService` relation metadata, derived from existing `origin` on mesh edges
- **#4819 — Leiden community anchor seeding**: New `CommunityClusterer` service clusters `mesh_nodes` graph via Leiden detection and promotes community centroids to anchors; `MeshDB.get_anchor_neighbors()` added to satisfy `NeuralMeshRetriever._AnchorDB` Protocol
- **#4820 — AST code indexer**: New `CodeIndexer` service uses tree-sitter two-pass extraction (structural declarations + call-graph edges) for Python and JS/TS; SHA-256 hash cache + ChromaDB upsert mirrors `DocIndexer` pattern

## Files changed

- `autobot-backend/requirements.txt` — networkx, graspologic, tree-sitter deps
- `autobot-backend/services/graph_rag_service.py` — `source_provenance` in relation metadata
- `autobot-backend/services/mesh_brain/mesh_db.py` — `get_anchor_neighbors()`
- `autobot-backend/services/mesh_brain/mesh_db_adapter.py` — forward `get_anchor_neighbors()`
- `autobot-backend/services/mesh_brain/community_clusterer.py` — new
- `autobot-backend/services/knowledge/code_indexer.py` — new

## Test plan

- [ ] 61 tests pass across all modified modules
- [ ] 6 tests skip gracefully (tree-sitter not installed in dev env — will pass in CI with deps)
- [ ] 2 pre-existing failures in `graph_rag_service_test.py` remain unchanged (unrelated to this PR)
- [ ] All 5 modified/new files pass `py_compile` syntax check
- [ ] No module-level optional imports (networkx, graspologic, tree-sitter all lazy)