### PR TITLE
refactor(docs): remove incorrect ON_ prefix from HookPoint docstring examples (#4391)

### DIFF
--- a/autobot-backend/extensions/hooks.py
+++ b/autobot-backend/extensions/hooks.py
@@ -20,11 +20,11 @@ class HookPoint(Enum):
     - LLM interaction (BEFORE_LLM_CALL, DURING_LLM_STREAMING, etc.)
     - Tool execution (BEFORE_TOOL_PARSE, BEFORE_TOOL_EXECUTE, etc.)
     - Continuation loop (BEFORE_CONTINUATION, AFTER_CONTINUATION, etc.)
-    - Error handling (ON_REPAIRABLE_ERROR, ON_CRITICAL_ERROR)
+    - Error handling (REPAIRABLE_ERROR, CRITICAL_ERROR)
     - Response (BEFORE_RESPONSE_SEND, AFTER_RESPONSE_SEND)
-    - Session lifecycle (ON_SESSION_CREATE, ON_SESSION_DESTROY)
+    - Session lifecycle (SESSION_CREATE, SESSION_DESTROY)
     - Knowledge integration (BEFORE_RAG_QUERY, AFTER_RAG_RESULTS)
-    - Approval flow (ON_APPROVAL_REQUIRED, ON_APPROVAL_RECEIVED)
+    - Approval flow (APPROVAL_REQUIRED, APPROVAL_RECEIVED)
 
     Usage:
         from extensions.hooks import HookPoint

--- a/autobot-backend/extensions/manager.py
+++ b/autobot-backend/extensions/manager.py
@@ -41,7 +41,7 @@ class ExtensionManager:
 
         # Or invoke until one extension handles
         result = await manager.invoke_until_handled(
-            HookPoint.ON_APPROVAL_REQUIRED,
+            HookPoint.APPROVAL_REQUIRED,
             ctx
         )
     """


### PR DESCRIPTION
Closes #4391

## Summary
Removed incorrect `ON_` prefix from HookPoint enum examples in docstrings:

- `extensions/hooks.py`: fixed `ON_REPAIRABLE_ERROR`, `ON_CRITICAL_ERROR`, `ON_SESSION_CREATE`, `ON_SESSION_DESTROY`, `ON_APPROVAL_REQUIRED`, `ON_APPROVAL_RECEIVED` → correct names without prefix
- `extensions/manager.py`: fixed `HookPoint.ON_APPROVAL_REQUIRED` → `HookPoint.APPROVAL_REQUIRED`

Documentation-only changes — no runtime code modified.

## Test Status
✅ py_compile passes on both files