### PR TITLE
fix(i18n): translate operations.view.* keys into 10 non-English locales (#4825)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -5223,10 +5223,10 @@
   },
   "operations": {
     "view": {
-      "title": "Operations",
-      "subtitle": "Monitor and manage ongoing operations",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "العمليات طويلة الأمد",
+      "subtitle": "مراقبة المهام الخلفية وإدارتها",
+      "refresh": "تحديث",
+      "loadError": "فشل تحميل العمليات"
     },
     "detail": {
       "close": "إغلاق",
@@ -5273,12 +5273,6 @@
       "resume": "Resume",
       "viewDetails": "View Details",
       "showingCount": "Showing {shown} of {total} operations"
-    },
-    "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -5222,10 +5222,10 @@
   },
   "operations": {
     "view": {
-      "title": "Operations",
-      "subtitle": "Monitor and manage ongoing operations",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "Langläufige Operationen",
+      "subtitle": "Hintergrundaufgaben überwachen und verwalten",
+      "refresh": "Aktualisieren",
+      "loadError": "Operationen konnten nicht geladen werden"
     },
     "detail": {
       "close": "Schließen",
@@ -5271,12 +5271,6 @@
       "resume": "Fortsetzen",
       "viewDetails": "Details anzeigen",
       "showingCount": "{shown} von {total} Vorgängen"
-    },
-    "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -5222,10 +5222,10 @@
   },
   "operations": {
     "view": {
-      "title": "Operations",
-      "subtitle": "Monitor and manage ongoing operations",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "Operaciones de larga duración",
+      "subtitle": "Supervisar y gestionar tareas en segundo plano",
+      "refresh": "Actualizar",
+      "loadError": "Error al cargar las operaciones"
     },
     "detail": {
       "close": "Cerrar",
@@ -5271,12 +5271,6 @@
       "resume": "Reanudar",
       "viewDetails": "Ver detalles",
       "showingCount": "Mostrando {shown} de {total} operaciones"
-    },
-    "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -6131,10 +6131,10 @@
       "allStatuses": "All Statuses"
     },
     "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "عملیات طولانی‌مدت",
+      "subtitle": "نظارت و مدیریت وظایف پس‌زمینه",
+      "refresh": "بازخوانی",
+      "loadError": "بارگذاری عملیات ناموفق بود"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -5222,10 +5222,10 @@
   },
   "operations": {
     "view": {
-      "title": "Operations",
-      "subtitle": "Monitor and manage ongoing operations",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "Opérations de longue durée",
+      "subtitle": "Surveiller et gérer les tâches en arrière-plan",
+      "refresh": "Actualiser",
+      "loadError": "Échec du chargement des opérations"
     },
     "detail": {
       "close": "Fermer",
@@ -5271,12 +5271,6 @@
       "resume": "Reprendre",
       "viewDetails": "Voir les détails",
       "showingCount": "{shown} sur {total} opérations"
-    },
-    "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -6131,10 +6131,10 @@
       "allStatuses": "All Statuses"
     },
     "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "פעולות ממושכות",
+      "subtitle": "ניטור וניהול משימות רקע",
+      "refresh": "רענן",
+      "loadError": "טעינת הפעולות נכשלה"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -5222,10 +5222,10 @@
   },
   "operations": {
     "view": {
-      "title": "Operations",
-      "subtitle": "Monitor and manage ongoing operations",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "Ilgstošas darbības",
+      "subtitle": "Uzraudzīt un pārvaldīt fona uzdevumus",
+      "refresh": "Atjaunināt",
+      "loadError": "Neizdevās ielādēt darbības"
     },
     "detail": {
       "close": "Aizvērt",
@@ -5271,12 +5271,6 @@
       "resume": "Atsākt",
       "viewDetails": "Skatīt detaļas",
       "showingCount": "Rāda {shown} no {total} operācijām"
-    },
-    "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -5222,10 +5222,10 @@
   },
   "operations": {
     "view": {
-      "title": "Operations",
-      "subtitle": "Monitor and manage ongoing operations",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "Długotrwałe operacje",
+      "subtitle": "Monitoruj i zarządzaj zadaniami w tle",
+      "refresh": "Odśwież",
+      "loadError": "Nie udało się załadować operacji"
     },
     "detail": {
       "close": "Zamknij",
@@ -5271,12 +5271,6 @@
       "resume": "Wznów",
       "viewDetails": "Zobacz szczegóły",
       "showingCount": "Wyświetlanie {shown} z {total} operacji"
-    },
-    "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -5222,10 +5222,10 @@
   },
   "operations": {
     "view": {
-      "title": "Operations",
-      "subtitle": "Monitor and manage ongoing operations",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "Operações de longa duração",
+      "subtitle": "Monitorar e gerenciar tarefas em segundo plano",
+      "refresh": "Atualizar",
+      "loadError": "Falha ao carregar operações"
     },
     "detail": {
       "close": "Fechar",
@@ -5271,12 +5271,6 @@
       "resume": "Retomar",
       "viewDetails": "Ver detalhes",
       "showingCount": "A mostrar {shown} de {total} operações"
-    },
-    "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -6131,10 +6131,10 @@
       "allStatuses": "All Statuses"
     },
     "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
+      "title": "طویل مدتی آپریشنز",
+      "subtitle": "پس منظر کے کاموں کی نگرانی اور انتظام کریں",
+      "refresh": "تازہ کریں",
+      "loadError": "آپریشنز لوڈ کرنے میں ناکامی"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"


### PR DESCRIPTION
Closes #4825

## Summary
Translated 4 keys (`operations.view.title`, `.subtitle`, `.refresh`, `.loadError`) from English into all 10 non-English locales: ar, de, es, fa, fr, he, lv, pl, pt, ur.

All 10 locale JSON files validated — no parse errors.

## Test Status
✅ All locale JSON files valid