### PR TITLE
chore(deps): bump dompurify 3.3.3 → 3.4.0 (rebase of #4817)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -22,7 +22,7 @@
         "apexcharts": "^5.10.4",
         "cytoscape": "^3.33.1",
         "cytoscape-fcose": "^2.2.0",
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.4.0",
         "npm-normalize-package-bin": "^5.0.0",
         "onnxruntime-web": "^1.24.3",
         "pinia": "^3.0.4",
@@ -6190,9 +6190,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -11548,7 +11548,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -51,7 +51,7 @@
     "apexcharts": "^5.10.4",
     "cytoscape": "^3.33.1",
     "cytoscape-fcose": "^2.2.0",
-    "dompurify": "^3.2.4",
+    "dompurify": "^3.4.0",
     "npm-normalize-package-bin": "^5.0.0",
     "onnxruntime-web": "^1.24.3",
     "pinia": "^3.0.4",


### PR DESCRIPTION
Rebase of Dependabot PR #4817 onto `Dev_new_gui` (original targeted `main`).

## Changes
- `autobot-frontend`: dompurify `^3.2.4` → `^3.4.0` (resolves to `3.4.0`)
- `autobot-slm-frontend`: same bump
- TypeScript: `dev` → `devOptional` (lock file metadata only)

Closes original Dependabot PR #4817.