### PR TITLE
fix(agent_loop): set _halted_on_repetition=True on repetition halt (#4846)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -577,6 +577,7 @@ class AgentLoop:
             for tool in tools:
                 t_name = tool.get("tool_name", "unknown")
                 halt_results[t_name] = {"error": halt_msg}
+            self._halted_on_repetition = True
             return halt_results
 
         # Issue #4092: Gate sensitive operations behind user approval.

--- a/autobot-backend/agent_loop/test_loop_repetition.py
+++ b/autobot-backend/agent_loop/test_loop_repetition.py
@@ -192,6 +192,7 @@ def test_loop_stops_after_repetition_halt():
         think_on_completion=False,
         mandatory_think_enabled=False,
         log_iterations=False,
+        require_approval_for_sensitive=False,  # disable approval gate — test focuses on repetition
     )
     loop = AgentLoop(event_stream=event_stream, config=config)
 


### PR DESCRIPTION
Closes #4846

## Summary
- Added `self._halted_on_repetition = True` before `return halt_results` in `_execute_tools` (loop.py line ~580)
- Fixed `test_loop_stops_after_repetition_halt` to set `require_approval_for_sensitive=False` — the `bash` tool was hitting the approval gate before repetition detection could reach threshold, causing the loop to exit via denial instead of halt

## Root Cause
The comment at line 558 explicitly stated: *"Setting `_halted_on_repetition=True` ensures `_should_continue()` terminates the main while-loop"* — but the assignment was never made.

## Test Status
✅ `test_halted_on_repetition_flag_set` — PASS
✅ `test_loop_stops_after_repetition_halt` — PASS (1.95s vs 305s before — no approval timeout)