### PR TITLE
fix(agent_loop): resolve _compute_tool_call_hash type collision (#4847)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -788,7 +788,7 @@ Duration: {self._current_context.get_duration_ms():.0f}ms
         # Issue #3874: preserve non-dict arg identity; {} would alias all
         # non-dict calls to the same bucket
         if not isinstance(args, dict):
-            args = {"_raw": str(args)}
+            args = {"_raw": str(args), "_type": type(args).__name__}
         try:
             # Issue #3868: default=str handles datetime, bytes, custom objects
             canonical = json.dumps({"n": tool_name, "a": args}, sort_keys=True, default=str)

--- a/autobot-backend/agent_loop/test_loop_repetition.py
+++ b/autobot-backend/agent_loop/test_loop_repetition.py
@@ -118,7 +118,7 @@ def test_hash_int_args_vs_string_args_differ():
 def test_hash_missing_args_vs_none_differ():
     """A tool with no args key and one with args=None must hash differently."""
     tool_no_args = {"tool_name": "t"}  # no "args" key at all — falls back to {}
-    tool_none = _make_tool("t", None)
+    tool_none = {"tool_name": "t", "args": None}  # explicit None; _make_tool drops None args
     h_no_args = AgentLoop._compute_tool_call_hash(tool_no_args)
     h_none = AgentLoop._compute_tool_call_hash(tool_none)
     assert h_no_args != h_none


### PR DESCRIPTION
Closes #4847

## Summary
Two fixes:

1. **`loop.py` line 791** — Add `_type` to non-dict arg canonical so `int 42` and `str "42"` hash differently:
   ```python
   # Before
   args = {"_raw": str(args)}
   # After
   args = {"_raw": str(args), "_type": type(args).__name__}
   ```

2. **`test_loop_repetition.py` line 121** — Fix `test_hash_missing_args_vs_none_differ` to use an explicit dict instead of `_make_tool("t", None)` which silently omits the args key (making both inputs identical):
   ```python
   # Before — _make_tool drops None, so both dicts are {"tool_name": "t"}
   tool_none = _make_tool("t", None)
   # After — explicit None preserved
   tool_none = {"tool_name": "t", "args": None}
   ```

## Test Status
✅ `test_hash_int_args_vs_string_args_differ` — PASS
✅ `test_hash_missing_args_vs_none_differ` — PASS