### PR TITLE
docs(rag): update get_weights() docstring to reflect 60s eviction throttle (#4833)

### DIFF
--- a/autobot-backend/services/session_adaptive_reranker.py
+++ b/autobot-backend/services/session_adaptive_reranker.py
@@ -104,8 +104,8 @@ class SessionAdaptiveReranker:
     def get_weights(self, session_id: str) -> tuple:
         """Return (semantic_weight, keyword_weight) for this session.
 
-        Creates default state for new sessions.  Evicts stale sessions before
-        returning.  Thread-safe.
+        Creates default state for new sessions.  Evicts stale sessions at most
+        once per 60 seconds (_EVICTION_INTERVAL).  Thread-safe.
 
         Returns:
             Tuple[float, float] — normalised to sum ≤ 1.0, each in [0.1, 0.9].


### PR DESCRIPTION
Closes #4833

## Summary
Updated `get_weights()` docstring in `session_adaptive_reranker.py` — "Evicts stale sessions before returning" → "Evicts stale sessions at most once per 60 seconds (_EVICTION_INTERVAL)" to reflect the throttle added in #4827.

## Test Status
✅ py_compile OK