### PR TITLE
fix(testing): replace deprecated get_event_loop() in test_first_turn_priming.py (#4848)

### DIFF
--- a/autobot-backend/agent_loop/tests/test_first_turn_priming.py
+++ b/autobot-backend/agent_loop/tests/test_first_turn_priming.py
@@ -43,7 +43,7 @@ def _make_loop(first_turn_priming_enabled: bool = True) -> AgentLoop:
 
 
 def _run(coro: Any) -> Any:
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _stub_iteration(loop: AgentLoop, events_context: dict[str, Any]) -> IterationResult:


### PR DESCRIPTION
Closes #4848

## Summary
Replaced `asyncio.get_event_loop().run_until_complete(coro)` with `asyncio.run(coro)` on line 46 of `test_first_turn_priming.py` — the one call missed by the #4717 sweep.

## Test Status
✅ 6/6 tests pass