### PR TITLE
perf(knowledge): refactor LineageService.get_ancestors() to O(depth) via per-ID lookup (#4788)

### DIFF
--- a/autobot-backend/services/knowledge/lineage_service.py
+++ b/autobot-backend/services/knowledge/lineage_service.py
@@ -107,21 +107,16 @@ class LineageService:
         Returns:
             List of SynthesisRun from oldest ancestor to run_id, inclusive.
         """
-        all_entries = await self._provenance_log.get_recent(limit=500)
-        by_id: Dict[str, SynthesisRun] = {
-            e["run_id"]: SynthesisRun.from_provenance_entry(e)
-            for e in all_entries
-            if e.get("run_id")
-        }
         chain: List[SynthesisRun] = []
         current_id: Optional[str] = run_id
         seen: set = set()
         for _ in range(depth + 1):
             if current_id is None or current_id in seen:
                 break
-            run = by_id.get(current_id)
-            if run is None:
+            entry = await self._provenance_log.get_by_run_id(current_id)
+            if entry is None:
                 break
+            run = SynthesisRun.from_provenance_entry(entry)
             seen.add(current_id)
             chain.append(run)
             current_id = run.parent_run_id

--- a/autobot-backend/services/knowledge/synthesis_provenance.py
+++ b/autobot-backend/services/knowledge/synthesis_provenance.py
@@ -21,6 +21,7 @@ from autobot_shared.redis_client import get_async_redis_client
 logger = logging.getLogger(__name__)
 
 _STREAM_KEY = "kb:synthesis:log"
+_RUN_KEY_PREFIX = "kb:synthesis:run:"
 
 
 class SynthesisProvenanceLog:
@@ -72,10 +73,58 @@ class SynthesisProvenanceLog:
         try:
             redis = await get_async_redis_client(database="main")
             await redis.xadd(_STREAM_KEY, entry)
+            await redis.hset(f"{_RUN_KEY_PREFIX}{run_id}", mapping=entry)
             logger.debug("Provenance logged for run %s (%d insights)", run_id, len(synthesis_ids))
         except Exception:
             logger.exception("Failed to write provenance log for run %s", run_id)
 
+
+    async def get_by_run_id(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """Return the provenance entry for a single run by its ID.
+
+        Uses a Redis hash key (O(1)) instead of scanning the full stream.
+        Returns None when the run does not exist.
+
+        Issue #4788: replaces O(total_runs) stream scan in get_ancestors().
+        """
+        try:
+            redis = await get_async_redis_client(database="main")
+            raw = await redis.hgetall(f"{_RUN_KEY_PREFIX}{run_id}")
+        except Exception:
+            logger.exception("get_by_run_id: Redis error for run_id '%s'", run_id)
+            return None
+
+        if not raw:
+            return None
+
+        entry = {
+            k.decode("utf-8") if isinstance(k, bytes) else k: (
+                v.decode("utf-8") if isinstance(v, bytes) else v
+            )
+            for k, v in raw.items()
+        }
+        for list_field in ("source_docs", "synthesis_ids", "source_doc_ids"):
+            if list_field in entry:
+                try:
+                    entry[list_field] = json.loads(entry[list_field])
+                except (json.JSONDecodeError, TypeError):
+                    entry[list_field] = []
+        if "duration_ms" in entry:
+            try:
+                entry["duration_ms"] = int(entry["duration_ms"])
+            except (ValueError, TypeError):
+                pass
+        if "score" in entry:
+            try:
+                entry["score"] = float(entry["score"])
+            except (ValueError, TypeError):
+                entry["score"] = 0.0
+        entry.setdefault("parent_run_id", None)
+        if entry["parent_run_id"] == "":
+            entry["parent_run_id"] = None
+        entry.setdefault("prompt_variant", entry.get("prompt_template", ""))
+        entry.setdefault("collection_name", "")
+        return entry
 
     async def get_best_prompt_variant(
         self,

--- a/autobot-backend/services/knowledge/test_lineage_service.py
+++ b/autobot-backend/services/knowledge/test_lineage_service.py
@@ -71,8 +71,29 @@ def _entry(
 
 
 def _make_provenance_log(entries: List[Dict[str, Any]]) -> MagicMock:
+    """Build a mock SynthesisProvenanceLog from a flat list of entries.
+
+    - get_recent returns the full list (used by get_best_ancestor).
+    - get_by_run_id does an O(1) dict lookup by run_id (used by get_ancestors).
+    """
+    by_id = {e["run_id"]: e for e in entries if e.get("run_id")}
+
+    async def _get_by_run_id(run_id: str):
+        entry = by_id.get(run_id)
+        if entry is None:
+            return None
+        # Normalise parent_run_id the same way SynthesisProvenanceLog does.
+        result = dict(entry)
+        result.setdefault("parent_run_id", None)
+        if result["parent_run_id"] == "":
+            result["parent_run_id"] = None
+        result.setdefault("prompt_variant", result.get("prompt_template", ""))
+        result.setdefault("collection_name", "")
+        return result
+
     log = MagicMock()
     log.get_recent = AsyncMock(return_value=entries)
+    log.get_by_run_id = AsyncMock(side_effect=_get_by_run_id)
     return log
 
 


### PR DESCRIPTION
Closes #4788

## Summary
`get_ancestors()` previously called `get_recent(limit=500)` and filtered in Python — O(total_runs). Now uses a new `get_by_run_id()` method for O(depth) Redis operations.

**Changes:**
- `synthesis_provenance.py`: `log_run()` now also writes `hset(kb:synthesis:run:{run_id})` alongside the stream; new `get_by_run_id(run_id)` does O(1) `hgetall` lookup with same deserialization as `get_recent()`
- `lineage_service.py`: `get_ancestors()` walks chain hop-by-hop via `get_by_run_id()` — O(depth) instead of O(total_runs). `get_best_ancestor()` unchanged (needs full scan for collection filter)
- `test_lineage_service.py`: updated mock to include `get_by_run_id` dict lookup

## Test Status
✅ 24/24 lineage tests pass