### PR TITLE
fix(ui): 3 remaining accessibility gaps — toast icon, status dot, aria-label anti-pattern (#4821)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -17,7 +17,7 @@
               @click="toggleSystemStatus"
               class="flex items-center space-x-3 hover:bg-autobot-bg-tertiary rounded-md px-2 py-1 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-autobot-primary"
               :title="getSystemStatusTooltip()"
-              :aria-label="getSystemStatusTooltip()"
+              :aria-label="getSystemStatusAriaLabel()"
             >
               <div class="relative w-8 h-8 bg-white rounded flex items-center justify-center">
                 <span class="text-slate-800 font-bold text-sm font-mono">AB</span>
@@ -30,6 +30,7 @@
                     'animate-pulse': systemStatus.hasIssues
                   }"
                   class="absolute -top-1 -right-1 w-3 h-3 rounded-full border-2 border-white"
+                  aria-hidden="true"
                 ></div>
               </div>
               <span class="text-autobot-text-primary font-bold text-lg hidden sm:block">AutoBot</span>
@@ -476,6 +477,7 @@ export default {
       systemServices,
       showSystemStatus,
       getSystemStatusTooltip,
+      getSystemStatusAriaLabel,
       getSystemStatusText,
       getSystemStatusDescription,
       toggleSystemStatus,

--- a/autobot-frontend/src/components/ui/ToastContainer.vue
+++ b/autobot-frontend/src/components/ui/ToastContainer.vue
@@ -10,7 +10,7 @@
           :aria-atomic="true"
         >
           <div class="toast-icon">
-            <i :class="getIcon(toast.type)"></i>
+            <i :class="getIcon(toast.type)" aria-hidden="true"></i>
           </div>
           <div class="toast-content">
             <span class="toast-message">{{ toast.message }}</span>

--- a/autobot-frontend/src/composables/useSystemStatus.ts
+++ b/autobot-frontend/src/composables/useSystemStatus.ts
@@ -310,6 +310,15 @@ export function useSystemStatus(): UseSystemStatusReturn {
     return 'Click to view system status - all services operational'
   }
 
+  const getSystemStatusAriaLabel = (): string => {
+    if (systemStatus.value.hasIssues) {
+      return 'System status: issues detected'
+    } else if (!systemStatus.value.isHealthy) {
+      return 'System status: warnings present'
+    }
+    return 'System status: all services operational'
+  }
+
   const getSystemStatusText = (): string => {
     if (systemStatus.value.hasIssues) {
       return 'System Issues Detected'
@@ -435,6 +444,7 @@ export function useSystemStatus(): UseSystemStatusReturn {
 
     // Computed-like getters
     getSystemStatusTooltip,
+    getSystemStatusAriaLabel,
     getSystemStatusText,
     getSystemStatusDescription,
 


### PR DESCRIPTION
Closes #4821

## Summary
- **ToastContainer.vue**: `aria-hidden="true"` on toast type indicator `<i>` — decorative, message conveyed by `role="alert"` content
- **App.vue**: `aria-hidden="true"` on status dot div — state communicated via button aria-label
- **useSystemStatus.ts**: new `getSystemStatusAriaLabel()` getter returns state-describing strings ("System status: issues detected") instead of action-describing strings ("Click to view..."); App.vue updated to use it for `:aria-label`

## Test Status
✅ vue-tsc type check passes (pre-existing baseline errors unaffected)