### PR TITLE
fix(mesh): add fetch_edges + promote_to_anchor forwarding to MeshDBAdapter (#4837)

### DIFF
--- a/autobot-backend/services/mesh_brain/mesh_db_adapter.py
+++ b/autobot-backend/services/mesh_brain/mesh_db_adapter.py
@@ -76,6 +76,14 @@ class MeshDBAdapter:
         """Return IDs of anchor nodes adjacent to any seed_id (#4819)."""
         return await self._db.get_anchor_neighbors(seed_ids)
 
+    async def fetch_edges(self, min_weight: float = 0.5) -> list[dict]:
+        """Return all edges above min_weight. Satisfies MeshEdgeSync Protocol (#4837)."""
+        return await self._db.fetch_edges(min_weight=min_weight)
+
+    async def promote_to_anchor(self, node_id: str) -> None:
+        """Set is_anchor=True for node_id. Forwards to MeshDB (#4837)."""
+        await self._db.promote_to_anchor(node_id)
+
     # ------------------------------------------------------------------
     # MeshGraph protocol — StalenessPropagor surface
     # ------------------------------------------------------------------

--- a/autobot-backend/services/mesh_brain/mesh_db_adapter_test.py
+++ b/autobot-backend/services/mesh_brain/mesh_db_adapter_test.py
@@ -149,6 +149,47 @@ class TestUpdateAccessCount:
 
 
 # =============================================================================
+# CommunityClusterer protocol surface — fetch_edges + promote_to_anchor
+# =============================================================================
+
+
+class TestFetchEdges:
+    """MeshDBAdapter.fetch_edges delegates to inner MeshDB and returns list[dict]."""
+
+    @pytest.mark.asyncio
+    async def test_forwards_min_weight_and_returns_rows(self):
+        edge_rows = [
+            {"id": _EDGE_ID, "from_node": _NODE_A, "to_node": _NODE_B, "weight": 0.8},
+        ]
+        adapter, mock_db = _make_adapter(fetch_edges=edge_rows)
+
+        result = await adapter.fetch_edges(min_weight=0.7)
+
+        assert result == edge_rows
+        mock_db.fetch_edges.assert_awaited_once_with(min_weight=0.7)
+
+    @pytest.mark.asyncio
+    async def test_default_min_weight_is_forwarded(self):
+        adapter, mock_db = _make_adapter(fetch_edges=[])
+
+        await adapter.fetch_edges()
+
+        mock_db.fetch_edges.assert_awaited_once_with(min_weight=0.5)
+
+
+class TestPromoteToAnchor:
+    """MeshDBAdapter.promote_to_anchor delegates to inner MeshDB."""
+
+    @pytest.mark.asyncio
+    async def test_forwards_node_id(self):
+        adapter, mock_db = _make_adapter(promote_to_anchor=None)
+
+        await adapter.promote_to_anchor(_NODE_A)
+
+        mock_db.promote_to_anchor.assert_awaited_once_with(_NODE_A)
+
+
+# =============================================================================
 # MeshGraph protocol surface
 # =============================================================================
 


### PR DESCRIPTION
Closes #4837

## Summary
Added two forwarding methods to `MeshDBAdapter` that were called by `CommunityClusterer.run()` but missing, causing `AttributeError` at runtime:
- `fetch_edges(min_weight=0.5)` → forwards to `self._db.fetch_edges()`
- `promote_to_anchor(node_id)` → forwards to `self._db.promote_to_anchor()`

Added 3 tests in `mesh_db_adapter_test.py` covering default/custom min_weight and node_id forwarding.

## Test Status
✅ 19/19 tests pass (16 pre-existing + 3 new)