### PR TITLE
fix(ui): add getSystemStatusAriaLabel to App.vue setup() return (#4862)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -859,6 +859,7 @@ export default {
       // System status methods (from composable)
       toggleSystemStatus,
       getSystemStatusTooltip,
+      getSystemStatusAriaLabel,
       getSystemStatusText,
       getSystemStatusDescription,
       refreshSystemStatus,


### PR DESCRIPTION
## Summary

- Adds `getSystemStatusAriaLabel` to the `setup()` return object in `App.vue`

## Root Cause

#4821 added `getSystemStatusAriaLabel()` to `useSystemStatus.ts` and wired it into the template at line 20 (`:aria-label="getSystemStatusAriaLabel()"`), but omitted it from the `setup()` return block. In Vue Options API, any function not in the return object is `undefined` in the template — calling it throws `TypeError: getSystemStatusAriaLabel is not a function`, breaking the status button on load.

## Test Plan
- [ ] Verify status button renders without console errors
- [ ] Screen reader announces system status state (not action instruction)

Closes #4862

🤖 Generated with Claude Code