### PR TITLE
fix(ui): expose getSystemStatusAriaLabel in App.vue Options API return (#4862)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -859,6 +859,7 @@ export default {
       // System status methods (from composable)
       toggleSystemStatus,
       getSystemStatusTooltip,
+      getSystemStatusAriaLabel,
       getSystemStatusText,
       getSystemStatusDescription,
       refreshSystemStatus,


### PR DESCRIPTION
Closes #4862

## Summary

- Exposes `getSystemStatusAriaLabel` in the Options API `setup()` return in `App.vue`
- Without this, the composable function was available in the Composition API section but missing from the Options API compatibility layer, causing it to be undefined in that context

## Test

Manual verification that the status button aria-label now correctly describes the status (e.g. "System status: all services operational") rather than using the tooltip "Click to view..." text.