### PR TITLE
refactor(config): complete ConfigManager → get_config_manager() migration (#4047)

### DIFF
--- a/autobot-backend/llm_interface.py
+++ b/autobot-backend/llm_interface.py
@@ -15,7 +15,7 @@ For new code, import directly from llm_interface_pkg:
 """
 
 # Import additional dependencies that may be expected by consumers
-from config.manager import ConfigManager, get_config_manager
+from config.manager import get_config_manager
 
 # Re-export everything from the refactored package
 from llm_interface_pkg import (  # Types; Models; Hardware; Streaming; Mock providers; Main interface; Providers


### PR DESCRIPTION
Closes #4047

## Summary

Completes the ConfigManager → `get_config_manager()` migration (continuation of #3829).

**Fix:** `autobot-backend/llm_interface.py` — removed unused `ConfigManager` from import; only `get_config_manager` was being used.

**All other listed files were already correct:**
- `dependencies.py` — uses `ConfigManager` as FastAPI DI return type annotation (legitimate)
- `dependency_container.py` — uses `ConfigManager` as `service_type=` in descriptor; factory already calls `get_config_manager()`
- `enhanced_security_layer.py` — already uses `from config import config as global_config_manager`
- `worker_node.py` — already uses `from config import config as global_config_manager`
- `llm_providers/openai_provider.py` — no `ConfigManager` import; only in docstring
- `constants/model_constants.py` — only in comments explaining circular import avoidance
- `utils/distributed_service_discovery.py` — only in comments documenting prior migration
- `config/__init__.py` — already correct; lazy-imports and re-exports `get_config_manager`
- `config/manager.py` — definition file; the one `ConfigManager()` call inside `get_config_manager()` is the legitimate factory

**Remaining `ConfigManager()` instantiations in production code: 0**

## Test Status
PASS — 60 config module tests pass; 14 failures are pre-existing IP/port mismatches from local env