### PR TITLE
fix(config): remove unused ModelManager import from agent_config.py (#4872)

### DIFF
--- a/autobot-backend/api/agent_config.py
+++ b/autobot-backend/api/agent_config.py
@@ -25,7 +25,6 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from services.config_revision_service import ConfigRevisionService
 from services.config_service import ConfigService
 from services.slm_client import get_slm_client
-from utils.connection_utils import ModelManager
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Closes #4872

## Summary

Removes the unused `ModelManager` import from `autobot-backend/api/agent_config.py` (line 28).

`ModelManager` was imported but never referenced in code — only appears in a docstring comment on line 96 referring to `ModelManagerService` (a different class). This was a stale import causing an F401 lint warning.

## Test Status
PASS — lint clean, no F401 warnings on modified file