### PR TITLE
fix(testing): rename test to test_hash_no_args_vs_empty_string_differ (#4875)

### DIFF
--- a/autobot-backend/agent_loop/test_loop_repetition.py
+++ b/autobot-backend/agent_loop/test_loop_repetition.py
@@ -94,11 +94,12 @@ def test_hash_different_non_serializable_types_differ():
 # ---------------------------------------------------------------------------
 
 
-def test_hash_none_vs_empty_string_differ():
-    """None args and empty-string args must produce distinct hashes."""
-    h_none = AgentLoop._compute_tool_call_hash(_make_tool("t", None))
+def test_hash_no_args_vs_empty_string_differ():
+    """A tool with no args key and one with args='' must produce distinct hashes."""
+    # _make_tool("t", None) drops None args key → produces {"tool_name": "t"} (no args key)
+    h_no_args = AgentLoop._compute_tool_call_hash(_make_tool("t", None))
     h_str = AgentLoop._compute_tool_call_hash(_make_tool("t", ""))
-    assert h_none != h_str
+    assert h_no_args != h_str
 
 
 def test_hash_string_args_preserved():


### PR DESCRIPTION
## Summary

- Renames `test_hash_none_vs_empty_string_differ` → `test_hash_no_args_vs_empty_string_differ`
- Renames `h_none` → `h_no_args`
- Updates docstring to accurately describe what is tested
- Adds inline comment explaining `_make_tool("t", None)` drops the args key

`_make_tool("t", None)` produces `{"tool_name": "t"}` (no `args` key at all), not `{"tool_name": "t", "args": None}`. The test was verifying no-args vs empty-string, not None vs empty-string. The name was misleading and could cause future confusion when debugging hash collisions.

Closes #4875

🤖 Generated with Claude Code