### PR TITLE
fix(middleware): apply body size check before exemption — /save was unguarded (#4865)

### DIFF
--- a/autobot-backend/middleware/validation_middleware.py
+++ b/autobot-backend/middleware/validation_middleware.py
@@ -116,11 +116,14 @@ _INJECTION_PATTERNS: Final[Sequence[tuple[str, re.Pattern[str]]]] = (
 # ---------------------------------------------------------------------------
 
 
-def _is_exempt(path: str) -> bool:
-    """Return True when *path* should bypass validation."""
-    return any(path.startswith(prefix) for prefix in _EXEMPT_PREFIXES) or bool(
-        _BODY_SCAN_EXEMPT_RE.match(path)
-    )
+def _is_fully_exempt(path: str) -> bool:
+    """Return True when *path* should bypass ALL validation (health probes, docs, static)."""
+    return any(path.startswith(prefix) for prefix in _EXEMPT_PREFIXES)
+
+
+def _is_scan_exempt(path: str) -> bool:
+    """Return True when *path* should skip injection scanning but NOT the size guard."""
+    return bool(_BODY_SCAN_EXEMPT_RE.match(path))
 
 
 def _scan_value(value: str) -> str | None:
@@ -188,24 +191,30 @@ class ValidationMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         path = request.url.path
 
-        if _is_exempt(path):
+        # Health probes, docs, and static assets bypass all checks.
+        if _is_fully_exempt(path):
             return await call_next(request)
 
-        # ── Query-parameter scan ─────────────────────────────────────────
-        label = _scan_query_params(request)
-        if label:
-            logger.warning(
-                "validation_middleware: %s detected in query params path=%s ip=%s",
-                label,
-                path,
-                request.client.host if request.client else "unknown",
-            )
-            return _rejection_response(
-                "VALIDATION_ERROR",
-                f"Request rejected: {label} pattern detected in query parameters.",
-            )
+        # Storage-only paths skip injection scanning but still enforce the size
+        # guard — a crafted oversized payload must be rejected regardless of path.
+        scan_exempt = _is_scan_exempt(path)
 
-        # ── Body scan (POST / PUT / PATCH only) ──────────────────────────
+        if not scan_exempt:
+            # ── Query-parameter scan ─────────────────────────────────────
+            label = _scan_query_params(request)
+            if label:
+                logger.warning(
+                    "validation_middleware: %s detected in query params path=%s ip=%s",
+                    label,
+                    path,
+                    request.client.host if request.client else "unknown",
+                )
+                return _rejection_response(
+                    "VALIDATION_ERROR",
+                    f"Request rejected: {label} pattern detected in query parameters.",
+                )
+
+        # ── Body size guard + optional injection scan (POST / PUT / PATCH) ──
         if request.method in _BODY_METHODS:
             body_bytes = await request.body()
 
@@ -225,25 +234,26 @@ class ValidationMiddleware(BaseHTTPMiddleware):
                     },
                 )
 
-            content_type = request.headers.get("content-type", "")
-            if "application/json" in content_type and body_bytes:
-                try:
-                    payload = json.loads(body_bytes.decode("utf-8"))
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    # Malformed JSON — let FastAPI/Pydantic handle it.
-                    pass
-                else:
-                    label = _scan_body_strings(payload)
-                    if label:
-                        logger.warning(
-                            "validation_middleware: %s detected in body path=%s ip=%s",
-                            label,
-                            path,
-                            request.client.host if request.client else "unknown",
-                        )
-                        return _rejection_response(
-                            "VALIDATION_ERROR",
-                            f"Request rejected: {label} pattern detected in request body.",
-                        )
+            if not scan_exempt:
+                content_type = request.headers.get("content-type", "")
+                if "application/json" in content_type and body_bytes:
+                    try:
+                        payload = json.loads(body_bytes.decode("utf-8"))
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        # Malformed JSON — let FastAPI/Pydantic handle it.
+                        pass
+                    else:
+                        label = _scan_body_strings(payload)
+                        if label:
+                            logger.warning(
+                                "validation_middleware: %s detected in body path=%s ip=%s",
+                                label,
+                                path,
+                                request.client.host if request.client else "unknown",
+                            )
+                            return _rejection_response(
+                                "VALIDATION_ERROR",
+                                f"Request rejected: {label} pattern detected in request body.",
+                            )
 
         return await call_next(request)

--- a/autobot-backend/middleware/validation_middleware_test.py
+++ b/autobot-backend/middleware/validation_middleware_test.py
@@ -296,3 +296,22 @@ def test_non_save_path_still_blocks_injection(client: TestClient) -> None:
         json={"content": "foo; rm -rf /"},
     )
     assert resp.status_code == 400
+
+
+def test_save_path_oversized_body_rejected() -> None:
+    """/save is scan-exempt but must still be rejected when the body exceeds the limit."""
+    app = _make_app(max_body_bytes=10)
+
+    @app.post("/api/chats/{chat_id}/save")
+    async def save_endpoint(chat_id: str):
+        return {"ok": True}
+
+    tc = TestClient(app, raise_server_exceptions=False)
+    chat_id = str(_uuid.uuid4())
+    resp = tc.post(
+        f"/api/chats/{chat_id}/save",
+        content=b"A" * 11,
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 413
+    assert resp.json()["error"] == "PAYLOAD_TOO_LARGE"


### PR DESCRIPTION
## Summary

- Splits `_is_exempt()` into `_is_fully_exempt()` (bypasses everything) and `_is_scan_exempt()` (skips injection scan only)
- Body size guard now runs for ALL POST/PUT/PATCH requests regardless of scan exemption
- Adds test `test_save_path_oversized_body_rejected` verifying 413 on oversized /save body

## Problem

`/api/chats/{uuid}/save` was added to `_BODY_SCAN_EXEMPT_RE` to skip injection scanning, but the early `return` on any exempt match also skipped the body size guard (413 protection). An attacker could POST unlimited bytes to `/save`.

## Fix

Two-tier exemption: health/docs/static bypass everything; `/save` bypasses only the injection scan.

Closes #4865

🤖 Generated with Claude Code