### PR TITLE
fix(provisioning): add idempotency guard to Playwright install — skip if already installed (#4855)

### DIFF
--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -166,6 +166,18 @@
   become: yes
   tags: ['browser', 'packages']
 
+# Guard: skip the ~2-minute install when Chromium is already present. (#4855)
+# Playwright installs into a versioned subdir (chromium-NNNN/chrome-linux/chrome);
+# find the first match rather than hard-coding the version number.
+- name: "Browser | Check if Playwright Chromium is already installed"
+  ansible.builtin.find:
+    paths: /opt/autobot/autobot-browser-worker/browsers
+    patterns: "chrome"
+    recurse: yes
+    file_type: file
+  register: _chromium_binary
+  tags: ['browser', 'packages']
+
 - name: "Browser | Install Playwright chromium browser via Node.js"
   ansible.builtin.command:
     cmd: node_modules/.bin/playwright install chromium
@@ -173,8 +185,10 @@
   become: yes
   environment:
     PLAYWRIGHT_BROWSERS_PATH: /opt/autobot/autobot-browser-worker/browsers
-  changed_when: false
-  when: _browser_worker_dir.stat.exists | default(false)
+  changed_when: true
+  when:
+    - _browser_worker_dir.stat.exists | default(false)
+    - _chromium_binary.matched == 0
   tags: ['browser', 'packages']
 
 - name: "Browser | Fix Playwright browsers directory ownership"


### PR DESCRIPTION
## Summary

- Adds a `find` task to detect existing Chromium binary before installing
- Install task runs only when `_chromium_binary.matched == 0`
- Fixes `changed_when: false` → `changed_when: true` so real installs are reported correctly

## Problem

Playwright install ran on EVERY provisioning run because it lacked an idempotency check. `changed_when: false` suppressed the "changed" status but didn't prevent re-execution. Each deploy took extra minutes waiting for Playwright to reinstall browsers that were already present.

## Fix

Uses `ansible.builtin.find` to look for `chrome` under the browsers path. Handles the versioned subdirectory pattern (`chromium-NNNN/chrome-linux/chrome`) without hard-coding the version number.

Closes #4855

🤖 Generated with Claude Code