### PR TITLE
refactor(extensions): register LoggingExtension builtin extension (#4182)

### DIFF
--- a/autobot-backend/extensions/hook_invoker.py
+++ b/autobot-backend/extensions/hook_invoker.py
@@ -122,6 +122,9 @@ class HookInvoker:
         self._configs[HookPoint.BEFORE_MESSAGE_PROCESS] = HookInvocationConfig(
             mode=InvocationMode.COLLECT
         )
+        self._configs[HookPoint.BEFORE_PROMPT_BUILD] = HookInvocationConfig(
+            mode=InvocationMode.COLLECT
+        )
         self._configs[HookPoint.AFTER_PROMPT_BUILD] = HookInvocationConfig(
             mode=InvocationMode.TRANSFORM,
             transform_key="prompt",


### PR DESCRIPTION
Closes #4182

## Summary

- Investigated startup registration: `_init_builtin_extensions` in `lifespan.py` already registers all three builtin extensions (LoggingExtension, SecretMaskingExtension, PermissionEnforcementExtension) — prior session already wired these in
- Found related gap: `HookPoint.BEFORE_PROMPT_BUILD` was defined in the `HookPoint` enum (25 values) but missing from `HookInvoker._register_default_configs()`, which only registered 24 configs — causing `test_default_configs_registered` to fail
- Fixed by adding the missing `BEFORE_PROMPT_BUILD` config as `InvocationMode.COLLECT` in `hook_invoker.py`

## Test Status

✅ 96 extension tests pass
✅ Flake8 clean on modified files