### PR TITLE
fix(knowledge): guard get_loop_orchestrator() against None llm_service race (#4791)

### DIFF
--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -668,10 +668,19 @@ async def get_loop_orchestrator(
 
     Parameters are only applied on first call; subsequent calls return the
     cached instance regardless of arguments.
+
+    Race-condition guard: if the singleton was previously created with
+    ``llm_service=None`` (e.g. an API endpoint called before the background
+    scheduler provides a real service), and the caller now supplies a real
+    service, the None-locked instance is replaced so the orchestrator can
+    actually reach the LLM.  A singleton that already has a real ``_llm``
+    is never replaced.
     """
     global _loop_orchestrator
     async with _loop_lock:
-        if _loop_orchestrator is None:
+        if _loop_orchestrator is None or (
+            _loop_orchestrator._llm is None and llm_service is not None
+        ):
             _loop_orchestrator = AutonomousLoopOrchestrator(
                 llm_service,
                 dry_run=dry_run,


### PR DESCRIPTION
Closes #4791

## Summary

`get_loop_orchestrator()` singleton was locked to `None` when called before the background task provided a real `llm_service`. Subsequent calls with a real service still returned the broken instance.

**Fix:** Allow re-initialization only when the existing singleton was locked to `None` and a real `llm_service` is now available:

```python
if _loop_orchestrator is None or (
    _loop_orchestrator._llm is None and llm_service is not None
):
```

Once a real service is installed, the singleton is never replaced again — singleton semantics preserved for normal operation.

## Tests
20/20 autonomous_loop tests pass