### PR TITLE
fix(knowledge): persist _pending_approval to Redis to survive server restart (#4792)

### DIFF
--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -37,6 +37,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Deque, Dict, List, Optional
 
+from autobot_shared.redis_client import get_async_redis_client
+
 # Module-level imports for patchability in tests.
 # Deferred via try/except to survive environments where these aren't installed yet.
 try:
@@ -56,6 +58,9 @@ except Exception:  # pragma: no cover
     update_rag_config = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
+
+# Redis key for persisting _pending_approval across server restarts (Issue #4792).
+_PENDING_APPROVAL_REDIS_KEY = "autobot:loop:pending_approval"
 
 # How many config variants to generate per loop iteration.
 _DEFAULT_VARIANTS = 5
@@ -292,6 +297,50 @@ class AutonomousLoopOrchestrator:
         self._running = False
 
     # ------------------------------------------------------------------
+    # Redis persistence helpers (Issue #4792)
+    # ------------------------------------------------------------------
+
+    async def restore_state(self) -> None:
+        """Restore _pending_approval from Redis after a server restart.
+
+        Called once by get_loop_orchestrator() immediately after construction.
+        Silently skips if Redis is unavailable.
+        """
+        try:
+            redis = await get_async_redis_client(database="knowledge")
+            if redis is None:
+                return
+            raw = await redis.get(_PENDING_APPROVAL_REDIS_KEY)
+            if raw:
+                self._pending_approval = json.loads(raw)
+                logger.info(
+                    "AutonomousLoop: restored pending_approval from Redis: %s",
+                    self._pending_approval,
+                )
+        except Exception:
+            logger.debug("AutonomousLoop: could not restore pending_approval from Redis (non-fatal)")
+
+    async def _save_pending_approval(self, params: Dict[str, Any]) -> None:
+        """Persist _pending_approval to Redis so it survives restarts."""
+        try:
+            redis = await get_async_redis_client(database="knowledge")
+            if redis is None:
+                return
+            await redis.set(_PENDING_APPROVAL_REDIS_KEY, json.dumps(params))
+        except Exception:
+            logger.debug("AutonomousLoop: could not persist pending_approval to Redis (non-fatal)")
+
+    async def _clear_pending_approval(self) -> None:
+        """Remove the persisted pending_approval from Redis."""
+        try:
+            redis = await get_async_redis_client(database="knowledge")
+            if redis is None:
+                return
+            await redis.delete(_PENDING_APPROVAL_REDIS_KEY)
+        except Exception:
+            logger.debug("AutonomousLoop: could not clear pending_approval from Redis (non-fatal)")
+
+    # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
@@ -400,8 +449,23 @@ class AutonomousLoopOrchestrator:
 
         params = self._pending_approval
         self._pending_approval = None
+        await self._clear_pending_approval()
         await self._apply_params(params, run_id="manual-approve")
         logger.info("AutonomousLoop: pending variant approved and applied: %s", params)
+        return True
+
+    async def reject_pending(self) -> bool:
+        """Discard the staging variant that is awaiting human approval.
+
+        Returns True if a pending variant was cleared, False if none existed.
+        """
+        if self._pending_approval is None:
+            logger.info("AutonomousLoop: no pending variant to reject")
+            return False
+
+        self._pending_approval = None
+        await self._clear_pending_approval()
+        logger.info("AutonomousLoop: pending variant rejected and cleared")
         return True
 
     # ------------------------------------------------------------------
@@ -599,8 +663,9 @@ class AutonomousLoopOrchestrator:
                 relative_improvement * 100,
                 self.promotion_threshold * 100,
             )
-            # Store as pending for human review gate
+            # Store as pending for human review gate; persist to Redis (Issue #4792).
             self._pending_approval = best.params
+            await self._save_pending_approval(best.params)
             return False
 
         if self.dry_run:
@@ -681,13 +746,16 @@ async def get_loop_orchestrator(
         if _loop_orchestrator is None or (
             _loop_orchestrator._llm is None and llm_service is not None
         ):
-            _loop_orchestrator = AutonomousLoopOrchestrator(
+            orchestrator = AutonomousLoopOrchestrator(
                 llm_service,
                 dry_run=dry_run,
                 max_variants=max_variants,
                 promotion_threshold=promotion_threshold,
                 max_no_improvement_rounds=max_no_improvement_rounds,
             )
+            # Restore any pending_approval that survived a server restart (Issue #4792).
+            await orchestrator.restore_state()
+            _loop_orchestrator = orchestrator
     return _loop_orchestrator
 
 

--- a/autobot-backend/services/knowledge/test_autonomous_loop.py
+++ b/autobot-backend/services/knowledge/test_autonomous_loop.py
@@ -326,18 +326,24 @@ async def test_promote_never_promotes_degradation():
 
 @pytest.mark.asyncio
 async def test_approve_pending_applies_and_clears():
-    """approve_pending() applies the staged variant and clears the pending slot."""
+    """approve_pending() applies the staged variant, clears in-memory, and removes Redis key."""
     orch = _make_orchestrator(dry_run=False)
     orch._pending_approval = {"hybrid_weight_semantic": 0.8}
 
+    mock_redis = AsyncMock()
     with patch("services.knowledge.autonomous_loop.update_rag_config") as mock_update, \
-         patch("services.knowledge.autonomous_loop.SynthesisProvenanceLog") as MockPlog:
+         patch("services.knowledge.autonomous_loop.SynthesisProvenanceLog") as MockPlog, \
+         patch(
+             "services.knowledge.autonomous_loop.get_async_redis_client",
+             new=AsyncMock(return_value=mock_redis),
+         ):
         MockPlog.return_value.log_run = AsyncMock()
         result = await orch.approve_pending()
 
     assert result is True
     assert orch._pending_approval is None
     mock_update.assert_called_once()
+    mock_redis.delete.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -445,3 +451,104 @@ async def test_run_once_appends_to_history():
         await orch.run_once()
 
     assert len(orch._history) == 1
+
+
+# ---------------------------------------------------------------------------
+# Redis persistence (Issue #4792)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_promote_stores_pending_in_redis():
+    """_phase_promote persists pending_approval to Redis when below auto-promote threshold."""
+    from services.knowledge.autonomous_loop import VariantResult
+
+    orch = _make_orchestrator(dry_run=False, promotion_threshold=0.5)
+    best = VariantResult("v00", {"hybrid_weight_semantic": 0.75}, 0.6, 0.6, 0.6)
+
+    mock_redis = AsyncMock()
+    with patch("services.knowledge.autonomous_loop.update_rag_config"), \
+         patch(
+             "services.knowledge.autonomous_loop.get_async_redis_client",
+             new=AsyncMock(return_value=mock_redis),
+         ):
+        await orch._phase_promote(best, baseline_score=0.5, run_id="pending-redis")
+
+    assert orch._pending_approval == best.params
+    mock_redis.set.assert_awaited_once()
+    call_args = mock_redis.set.call_args
+    assert call_args[0][0] == "autobot:loop:pending_approval"
+    assert json.loads(call_args[0][1]) == best.params
+
+
+@pytest.mark.asyncio
+async def test_reject_pending_clears_in_memory_and_redis():
+    """reject_pending() clears _pending_approval in-memory and deletes the Redis key."""
+    orch = _make_orchestrator()
+    orch._pending_approval = {"hybrid_weight_semantic": 0.75}
+
+    mock_redis = AsyncMock()
+    with patch(
+        "services.knowledge.autonomous_loop.get_async_redis_client",
+        new=AsyncMock(return_value=mock_redis),
+    ):
+        result = await orch.reject_pending()
+
+    assert result is True
+    assert orch._pending_approval is None
+    mock_redis.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reject_pending_returns_false_when_none():
+    """reject_pending() returns False when there is no pending variant."""
+    orch = _make_orchestrator()
+    result = await orch.reject_pending()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_restore_state_loads_from_redis():
+    """restore_state() reads persisted pending_approval from Redis and restores in-memory."""
+    orch = _make_orchestrator()
+    stored_params = {"hybrid_weight_semantic": 0.8, "diversity_threshold": 0.4}
+
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps(stored_params))
+    with patch(
+        "services.knowledge.autonomous_loop.get_async_redis_client",
+        new=AsyncMock(return_value=mock_redis),
+    ):
+        await orch.restore_state()
+
+    assert orch._pending_approval == stored_params
+
+
+@pytest.mark.asyncio
+async def test_restore_state_no_op_when_redis_empty():
+    """restore_state() leaves _pending_approval as None when Redis key is absent."""
+    orch = _make_orchestrator()
+
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=None)
+    with patch(
+        "services.knowledge.autonomous_loop.get_async_redis_client",
+        new=AsyncMock(return_value=mock_redis),
+    ):
+        await orch.restore_state()
+
+    assert orch._pending_approval is None
+
+
+@pytest.mark.asyncio
+async def test_restore_state_graceful_on_redis_failure():
+    """restore_state() silently skips when Redis is unavailable."""
+    orch = _make_orchestrator()
+
+    with patch(
+        "services.knowledge.autonomous_loop.get_async_redis_client",
+        new=AsyncMock(side_effect=Exception("redis down")),
+    ):
+        await orch.restore_state()  # must not raise
+
+    assert orch._pending_approval is None


### PR DESCRIPTION
Closes #4792

## Summary

`AutonomousLoopOrchestrator._pending_approval` was only held in memory — lost on server restart, leaving experiments stuck at PENDING_APPROVAL status with no way to approve/reject (silent 409).

**Fix:** Added Redis persistence around `_pending_approval`:
- `restore_state()` — reads `autobot:loop:pending_approval` from Redis on startup and restores in-memory state
- `_save_pending_approval()` — writes to Redis when staging a variant for approval
- `_clear_pending_approval()` — deletes from Redis on approve/reject
- Added missing `reject_pending()` public method (operators had no way to discard without approving)
- All Redis calls wrapped in try/except — Redis unavailability is non-fatal

`get_loop_orchestrator()` now calls `await orchestrator.restore_state()` immediately after construction.

## Tests
26/26 pass (includes 6 new Redis persistence tests)