### PR TITLE
fix(scheduler): normalize cron 7=Sunday in _parse_cron_field (#4888)

### DIFF
--- a/autobot-backend/services/trigger_service.py
+++ b/autobot-backend/services/trigger_service.py
@@ -254,13 +254,22 @@ def _parse_cron_field(field_str: str, min_val: int, max_val: int) -> List[int]:
     return out
 
 
+def _normalize_dow_field(field: str) -> str:
+    """Normalize day-of-week field: replace standalone '7' tokens with '0' (both mean Sunday)."""
+    import re
+
+    return re.sub(r"(?<![0-9])7(?![0-9])", "0", field)
+
+
 def validate_cron_expression(expression: str) -> bool:
     """Return True when *expression* is a valid 5-field cron string."""
     try:
         parts = expression.split()
         if len(parts) != 5:
             return False
-        for part, (lo, hi) in zip(parts, _CRON_RANGES):
+        for i, (part, (lo, hi)) in enumerate(zip(parts, _CRON_RANGES)):
+            if i == 4:
+                part = _normalize_dow_field(part)
             _parse_cron_field(part, lo, hi)
         return True
     except (ValueError, TypeError):
@@ -284,7 +293,7 @@ def next_cron_run(expression: str, after: Optional[datetime] = None) -> datetime
     hours = _parse_cron_field(parts[1], 0, 23)
     days = _parse_cron_field(parts[2], 1, 31)
     months = _parse_cron_field(parts[3], 1, 12)
-    weekdays = _parse_cron_field(parts[4], 0, 6)
+    weekdays = _parse_cron_field(_normalize_dow_field(parts[4]), 0, 6)
 
     base = after or datetime.now(timezone.utc)
     # Advance by at least one minute

--- a/autobot-backend/services/trigger_service_test.py
+++ b/autobot-backend/services/trigger_service_test.py
@@ -159,6 +159,13 @@ class TestValidateCronExpression:
     def test_empty_string(self) -> None:
         assert validate_cron_expression("") is False
 
+    def test_dow_7_sunday_accepted(self) -> None:
+        # Standard cron: 7 is an alias for Sunday (same as 0); must not raise
+        assert validate_cron_expression("0 0 * * 7") is True
+
+    def test_dow_0_sunday_accepted(self) -> None:
+        assert validate_cron_expression("0 0 * * 0") is True
+
 
 class TestNextCronRun:
     def test_every_minute_advances_by_one(self) -> None:
@@ -188,6 +195,14 @@ class TestNextCronRun:
     def test_invalid_expression_raises(self) -> None:
         with pytest.raises(ValueError):
             next_cron_run("bad expression")
+
+    def test_dow_7_sunday_fires_same_day_as_dow_0(self) -> None:
+        # Both "0 0 * * 7" and "0 0 * * 0" should fire on the same Sunday
+        # Use a Saturday base so the next Sunday is one day away for both
+        base = datetime(2025, 6, 7, 23, 0, 0, tzinfo=timezone.utc)  # Saturday
+        nxt_7 = next_cron_run("0 0 * * 7", after=base)
+        nxt_0 = next_cron_run("0 0 * * 0", after=base)
+        assert nxt_7 == nxt_0, f"7=Sunday and 0=Sunday must fire at same time: {nxt_7} vs {nxt_0}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4888

Normalizes day-of-week value 7 to 0 (both mean Sunday) in `_parse_cron_field` to match standard cron convention.