### PR TITLE
fix(knowledge): recursive oversized chunk split up to depth 4 (#4702)

### DIFF
--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -767,6 +767,65 @@ class DocIndexerService:
             metadatas=[metadata],
         )
 
+    def _split_and_embed(
+        self,
+        content: str,
+        chunk_id: str,
+        metadata: Dict[str, Any],
+        rel_path: str,
+        depth: int = 0,
+        max_depth: int = 4,
+    ) -> bool:
+        """Recursively split oversized content and embed each piece (#4702).
+
+        Attempts to embed *content* directly.  If the model rejects it as
+        oversized and *depth* < *max_depth*, the content is split in half and
+        each half is retried recursively (up to 1/16th of the original at
+        depth 4).  Returns True when at least one sub-chunk is stored.
+        """
+        try:
+            self._embed_and_upsert(content, chunk_id, metadata)
+            return True
+        except Exception as e:
+            if not self._is_oversized_error(e) or depth >= max_depth:
+                logger.warning(
+                    "Dropping chunk %s (depth=%d, chars=%d): %s",
+                    chunk_id,
+                    depth,
+                    len(content),
+                    e,
+                )
+                return False
+
+        logger.warning(
+            "Oversized chunk — splitting at depth %d "
+            "(doc=%s, chunk_id=%s, chars=%d)",
+            depth,
+            rel_path,
+            chunk_id,
+            len(content),
+        )
+        mid = len(content) // 2
+        left = content[:mid].strip()
+        right = content[mid:].strip()
+        left_ok = self._split_and_embed(
+            left,
+            f"{chunk_id}_L{depth}",
+            {**metadata, "chunk_id_parent": chunk_id, "split_depth": depth},
+            rel_path,
+            depth + 1,
+            max_depth,
+        )
+        right_ok = self._split_and_embed(
+            right,
+            f"{chunk_id}_R{depth}",
+            {**metadata, "chunk_id_parent": chunk_id, "split_depth": depth},
+            rel_path,
+            depth + 1,
+            max_depth,
+        )
+        return left_ok or right_ok
+
     def _index_chunk(
         self,
         chunk: Dict[str, Any],
@@ -779,9 +838,10 @@ class DocIndexerService:
         """Index a single chunk into ChromaDB.
 
         If the embedding model rejects the chunk as oversized, the content is
-        split in half and each half is retried once.  A WARNING is logged when
-        splitting occurs so the failure is always visible (fixes #4665 — chunks
-        were previously dropped silently with no diagnostic).
+        split recursively up to max_depth=4 (at most 1/16th of original size).
+        A WARNING is logged when splitting occurs so the failure is always
+        visible (fixes #4665 — chunks were previously dropped silently with no
+        diagnostic; #4702 — single-level split could still drop large halves).
 
         Returns True when at least one (sub-)chunk was stored successfully.
         """
@@ -813,50 +873,7 @@ class DocIndexerService:
             "lineage_source_run_id": "",
         }
 
-        content = chunk["content"]
-        _oversized_exc: Optional[Exception] = None
-        try:
-            self._embed_and_upsert(content, chunk_id, metadata)
-            return True
-        except Exception as e:
-            if not self._is_oversized_error(e):
-                logger.error("Failed to index chunk %s: %s", chunk_id, e)
-                return False
-            # Capture before Python deletes the name at except-block exit.
-            _oversized_exc = e
-
-        # Oversized chunk: split in half and retry each part once (#4665).
-        char_count = len(content)
-        logger.warning(
-            "Oversized chunk detected — splitting and retrying "
-            "(doc=%s, chunk_id=%s, chars=%d): %s",
-            rel_path,
-            chunk_id,
-            char_count,
-            _oversized_exc,
-        )
-        mid = char_count // 2
-        halves = [content[:mid].strip(), content[mid:].strip()]
-        any_ok = False
-        for part_idx, half in enumerate(halves):
-            if not half:
-                continue
-            half_id = f"{chunk_id}_{part_idx}"
-            half_meta = {**metadata, "chunk_id_parent": chunk_id, "split_part": part_idx}
-            try:
-                self._embed_and_upsert(half, half_id, half_meta)
-                any_ok = True
-            except Exception as split_err:
-                logger.warning(
-                    "Oversized chunk half still too large — dropping "
-                    "(doc=%s, chunk_id=%s, part=%d, chars=%d): %s",
-                    rel_path,
-                    half_id,
-                    part_idx,
-                    len(half),
-                    split_err,
-                )
-        return any_ok
+        return self._split_and_embed(chunk["content"], chunk_id, metadata, rel_path)
 
     def _check_hash_and_update_cache(self, file_str: str, force: bool) -> bool:
         """Check incremental hash cache; update cache entry if changed. Issue #2735.

--- a/autobot-backend/services/knowledge/test_doc_indexer.py
+++ b/autobot-backend/services/knowledge/test_doc_indexer.py
@@ -930,8 +930,13 @@ class TestIndexChunkOversized4665:
     # _index_chunk: oversized → split, one half fails (still non-silent)
     # ------------------------------------------------------------------
 
-    def test_index_chunk_splits_on_oversized_one_half_fails(self):
-        """Oversized: first half embeds OK, second half also oversized → True (partial)."""
+    def test_index_chunk_splits_on_oversized_one_half_still_oversized(self):
+        """Oversized: first half OK, second half oversized → recursion splits second half further.
+
+        With multi-level splitting (#4702), a still-oversized half is split
+        recursively rather than dropped.  This test verifies that the second
+        half is split into quarters (depth 1) which then succeed.
+        """
         svc = _make_service()
 
         content = "B" * 400
@@ -943,7 +948,7 @@ class TestIndexChunkOversized4665:
                 # Full chunk too large
                 raise ValueError("token limit exceeded")
             if call_count[0] == 3:
-                # Second half also too large
+                # Second half at depth 0 also too large → recursion continues
                 raise ValueError("token limit exceeded")
             return [0.2] * 128
 
@@ -951,9 +956,9 @@ class TestIndexChunkOversized4665:
         chunk = self._make_chunk(content)
         ok = svc._index_chunk(chunk, 0, 1, "docs/test.md", [], 2)
 
-        # Partial success (first half OK)
+        # Full success: first half (call 2) + two quarters of second half (calls 4+5)
         assert ok is True
-        assert svc._collection.upsert.call_count == 1
+        assert svc._collection.upsert.call_count == 3
 
     # ------------------------------------------------------------------
     # _index_chunk: oversized → split, BOTH halves fail → returns False
@@ -1001,6 +1006,156 @@ class TestIndexChunkOversized4665:
         assert any(
             "docs/oversized.md" in r.getMessage() for r in caplog.records
         ), "WARNING must include the document path"
+
+
+class TestIndexChunkMultiLevelSplit4702:
+    """Tests for multi-level recursive oversized-chunk split — Issue #4702."""
+
+    def _make_chunk(self, content: str) -> Dict[str, Any]:
+        return {
+            "content": content,
+            "section": "Section",
+            "subsection": None,
+            "file_path": "docs/test.md",
+            "doc_type": "documentation",
+            "category": "general",
+            "title": "Test Doc",
+        }
+
+    # ------------------------------------------------------------------
+    # Two-level split: halves are still too large, quarters succeed
+    # ------------------------------------------------------------------
+
+    def test_two_level_split_all_quarters_succeed(self):
+        """Chunk too large → halves too large → quarters succeed → returns True."""
+        svc = _make_service()
+
+        # Track calls to identify which content sizes fail
+        call_count = [0]
+
+        def _fake_embed(text):
+            call_count[0] += 1
+            # First 3 calls (original + 2 halves) raise oversized;
+            # subsequent calls (4 quarters) succeed.
+            if call_count[0] <= 3:
+                raise ValueError("input too large for model context length")
+            return [0.1] * 128
+
+        svc._embed_model.get_text_embedding.side_effect = _fake_embed
+        chunk = self._make_chunk("A" * 800)
+        ok = svc._index_chunk(chunk, 0, 1, "docs/test.md", [], 2)
+
+        assert ok is True
+        # 3 failed + 4 successful = 7 total embed calls
+        assert call_count[0] == 7
+        assert svc._collection.upsert.call_count == 4
+
+    # ------------------------------------------------------------------
+    # Three-level split: only some leaf nodes succeed
+    # ------------------------------------------------------------------
+
+    def test_three_level_split_partial_success(self):
+        """Three-level split where some deepest pieces succeed → True (partial)."""
+        svc = _make_service()
+
+        call_count = [0]
+
+        def _fake_embed(text):
+            call_count[0] += 1
+            # Calls 1–7 (original + 2 halves + 4 quarters) raise oversized;
+            # 8 of the 8 depth-3 pieces: first 4 succeed, last 4 fail.
+            if call_count[0] <= 7:
+                raise ValueError("token limit exceeded")
+            if call_count[0] <= 11:
+                return [0.1] * 128
+            raise ValueError("token limit exceeded")
+
+        svc._embed_model.get_text_embedding.side_effect = _fake_embed
+        chunk = self._make_chunk("B" * 1600)
+        ok = svc._index_chunk(chunk, 0, 1, "docs/test.md", [], 2)
+
+        assert ok is True
+        # At least one piece stored
+        assert svc._collection.upsert.call_count >= 1
+
+    # ------------------------------------------------------------------
+    # max_depth=4 cap: beyond depth 4, chunk is dropped (returns False
+    # only if no sibling succeeded)
+    # ------------------------------------------------------------------
+
+    def test_always_oversized_drops_at_max_depth(self):
+        """If every embed call raises oversized, chunk is dropped at max_depth → False."""
+        svc = _make_service()
+        svc._embed_model.get_text_embedding.side_effect = ValueError(
+            "input too large for model context length"
+        )
+        chunk = self._make_chunk("C" * 3200)
+        ok = svc._index_chunk(chunk, 0, 1, "docs/test.md", [], 2)
+
+        assert ok is False
+        svc._collection.upsert.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Chunk IDs at each depth carry the _L/_R suffix chain
+    # ------------------------------------------------------------------
+
+    def test_split_chunk_ids_carry_depth_suffix(self):
+        """Sub-chunk IDs at depth 1 must end with _L0 or _R0."""
+        svc = _make_service()
+
+        call_count = [0]
+        upserted_ids = []
+
+        def _fake_embed(text):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise ValueError("too large")
+            return [0.1] * 128
+
+        def _fake_upsert(ids, embeddings, documents, metadatas):
+            upserted_ids.extend(ids)
+
+        svc._embed_model.get_text_embedding.side_effect = _fake_embed
+        svc._collection.upsert.side_effect = _fake_upsert
+
+        chunk = self._make_chunk("D" * 400)
+        svc._index_chunk(chunk, 0, 1, "docs/test.md", [], 2)
+
+        # Both sub-IDs must end with the depth-0 suffix
+        assert any(uid.endswith("_L0") for uid in upserted_ids), (
+            f"Expected _L0 suffix in {upserted_ids}"
+        )
+        assert any(uid.endswith("_R0") for uid in upserted_ids), (
+            f"Expected _R0 suffix in {upserted_ids}"
+        )
+
+    # ------------------------------------------------------------------
+    # Non-oversized error at any depth stops recursion immediately
+    # ------------------------------------------------------------------
+
+    def test_non_oversized_error_at_depth_1_drops_that_branch(self):
+        """Non-oversized error at depth 1 → that branch is dropped, no deeper recursion."""
+        svc = _make_service()
+
+        call_count = [0]
+
+        def _fake_embed(text):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # Original chunk: oversized
+                raise ValueError("input too large")
+            if call_count[0] == 2:
+                # Left half: non-oversized error
+                raise ConnectionError("network error")
+            return [0.1] * 128
+
+        svc._embed_model.get_text_embedding.side_effect = _fake_embed
+        chunk = self._make_chunk("E" * 400)
+        ok = svc._index_chunk(chunk, 0, 1, "docs/test.md", [], 2)
+
+        # Right half succeeded → partial success
+        assert ok is True
+        assert svc._collection.upsert.call_count == 1
 
 
 class TestGetDocIndexerService:


### PR DESCRIPTION
Closes #4702

## Summary
- Replaces single-level bisect-and-retry in `_index_chunk` with a new `_split_and_embed()` recursive helper
- Splits up to `max_depth=4` levels (chunks shrink to at most 1/16th of original), logging a warning only at the leaf when still oversized
- Non-oversized errors stop recursion immediately

## Test Status
70/70 tests pass (5 new tests in `TestIndexChunkMultiLevelSplit4702` covering 2-level, 3-level, max_depth drop, depth suffix chaining)