### PR TITLE
fix(ci): fix ServiceURLs string literals in infrastructure scripts (#4305)

### DIFF
--- a/autobot-infrastructure/shared/scripts/analysis/comprehensive_ui_test.py
+++ b/autobot-infrastructure/shared/scripts/analysis/comprehensive_ui_test.py
@@ -23,7 +23,9 @@ from datetime import datetime
 from pathlib import Path
 
 # Add project root to path
-sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from autobot_shared.network_constants import ServiceURLs
 
 # Import Puppeteer MCP tools
 try:
@@ -48,13 +50,13 @@ class ComprehensiveUITester:
     def __init__(self):
         self.results = UITestResult()
         self.test_urls = [
-            "ServiceURLs.FRONTEND_LOCAL/",
-            "ServiceURLs.FRONTEND_LOCAL/dashboard",
-            "ServiceURLs.FRONTEND_LOCAL/chat",
-            "ServiceURLs.FRONTEND_LOCAL/knowledge",
-            "ServiceURLs.FRONTEND_LOCAL/tools",
-            "ServiceURLs.FRONTEND_LOCAL/monitoring",
-            "ServiceURLs.FRONTEND_LOCAL/settings",
+            f"{ServiceURLs.FRONTEND_LOCAL}/",
+            f"{ServiceURLs.FRONTEND_LOCAL}/dashboard",
+            f"{ServiceURLs.FRONTEND_LOCAL}/chat",
+            f"{ServiceURLs.FRONTEND_LOCAL}/knowledge",
+            f"{ServiceURLs.FRONTEND_LOCAL}/tools",
+            f"{ServiceURLs.FRONTEND_LOCAL}/monitoring",
+            f"{ServiceURLs.FRONTEND_LOCAL}/settings",
         ]
         self.console_messages = []
 

--- a/autobot-infrastructure/shared/scripts/monitoring_dashboard.py
+++ b/autobot-infrastructure/shared/scripts/monitoring_dashboard.py
@@ -19,6 +19,8 @@ from pathlib import Path
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from autobot_shared.network_constants import ServiceURLs
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -220,7 +222,7 @@ class AutoBotMonitor:
         try:
             # Check if backend is running
             result = subprocess.run(
-                ["curl", "-s", "ServiceURLs.BACKEND_LOCAL/api/system/health"],
+                ["curl", "-s", f"{ServiceURLs.BACKEND_LOCAL}/api/system/health"],
                 capture_output=True,
                 timeout=5,
             )

--- a/autobot-infrastructure/shared/scripts/monitoring_system.py
+++ b/autobot-infrastructure/shared/scripts/monitoring_system.py
@@ -465,17 +465,17 @@ class SystemMonitor:
             {
                 "service": "backend",
                 "endpoint": "/api/system/health",
-                "url": "ServiceURLs.BACKEND_LOCAL/api/system/health",
+                "url": f"{ServiceURLs.BACKEND_LOCAL}/api/system/health",
             },
             {
                 "service": "backend",
                 "endpoint": "/api/system/status",
-                "url": "ServiceURLs.BACKEND_LOCAL/api/system/status",
+                "url": f"{ServiceURLs.BACKEND_LOCAL}/api/system/status",
             },
             {
                 "service": "backend",
                 "endpoint": "/api/chat_knowledge/health",
-                "url": "ServiceURLs.BACKEND_LOCAL/api/chat_knowledge/health",
+                "url": f"{ServiceURLs.BACKEND_LOCAL}/api/chat_knowledge/health",
             },
             {"service": "redis", "endpoint": "ping", "url": None},
         ]

--- a/autobot-infrastructure/shared/scripts/test_llm_awareness.py
+++ b/autobot-infrastructure/shared/scripts/test_llm_awareness.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
 
+from autobot_shared.network_constants import ServiceURLs
+
 from llm_self_awareness import get_llm_self_awareness
 from middleware.llm_awareness_middleware import get_awareness_injector
 
@@ -124,9 +126,9 @@ async def test_api_integration():
 
         # Test awareness endpoints
         endpoints_to_test = [
-            "ServiceURLs.BACKEND_LOCAL/api/llm-awareness/status",
-            "ServiceURLs.BACKEND_LOCAL/api/llm-awareness/context",
-            "ServiceURLs.BACKEND_LOCAL/api/llm-awareness/capabilities",
+            f"{ServiceURLs.BACKEND_LOCAL}/api/llm-awareness/status",
+            f"{ServiceURLs.BACKEND_LOCAL}/api/llm-awareness/context",
+            f"{ServiceURLs.BACKEND_LOCAL}/api/llm-awareness/capabilities",
         ]
 
         async with aiohttp.ClientSession() as session:

--- a/autobot-infrastructure/shared/scripts/utilities/system_monitor.py
+++ b/autobot-infrastructure/shared/scripts/utilities/system_monitor.py
@@ -15,6 +15,10 @@ import time
 from datetime import datetime
 from typing import Any, Dict
 
+import requests
+
+from autobot_shared.network_constants import NetworkConstants, ServiceURLs
+
 logger = logging.getLogger(__name__)
 
 
@@ -217,7 +221,7 @@ class AutoBotMonitor:
     def get_ollama_models(self) -> Dict[str, Any]:
         """Get available Ollama models with accessibility testing (Issue #315 - refactored)."""
         try:
-            response = requests.get("ServiceURLs.OLLAMA_LOCAL/api/tags", timeout=10)
+            response = requests.get(f"{ServiceURLs.OLLAMA_LOCAL}/api/tags", timeout=10)
             if response.status_code != 200:
                 return {"available": False, "error": f"HTTP {response.status_code}"}
 
@@ -242,7 +246,7 @@ class AutoBotMonitor:
         """Test if model is accessible (Issue #315 - extracted)."""
         try:
             test_response = requests.post(
-                "ServiceURLs.OLLAMA_LOCAL/api/generate",
+                f"{ServiceURLs.OLLAMA_LOCAL}/api/generate",
                 json={
                     "model": model_name,
                     "prompt": "test",


### PR DESCRIPTION
Closes #4305

## Summary
- Fixed `"ServiceURLs.X/path"` string literals (broken HTTP requests) to `f"{ServiceURLs.X}/path"` f-strings across 5 infrastructure script files
- Added missing `ServiceURLs` and `requests` imports where needed
- 16 broken occurrences fixed across: `system_monitor.py`, `monitoring_dashboard.py`, `monitoring_system.py`, `comprehensive_ui_test.py`, `test_llm_awareness.py`

Note: `phase_validation_system.py` itself was already fixed in a prior commit; this PR fixes the same pattern in the remaining infrastructure scripts.

## Test Status
SKIP — infrastructure scripts, no pytest suite