### PR TITLE
fix(knowledge): validate root_dir path in /index/code to prevent traversal (#4894)

### DIFF
--- a/autobot-backend/api/knowledge_population.py
+++ b/autobot-backend/api/knowledge_population.py
@@ -23,7 +23,7 @@ import re
 from pathlib import Path as PathLib
 
 import aiofiles
-from fastapi import APIRouter, BackgroundTasks, Depends, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -1171,6 +1171,14 @@ async def index_code(request: dict = None):
     params = request or {}
     root_dir = str(params.get("root_dir") or PATH.PROJECT_ROOT)
     force = bool(params.get("force", False))
+
+    # Issue #4894: Prevent directory traversal — root_dir must be within PROJECT_ROOT.
+    root_dir_path = PathLib(root_dir).resolve()
+    allowed_root = PathLib(PATH.PROJECT_ROOT).resolve()
+    if root_dir_path != allowed_root and not str(root_dir_path).startswith(
+        str(allowed_root) + "/"
+    ):
+        raise HTTPException(status_code=400, detail="root_dir must be within the project root")
 
     doc_svc = get_doc_indexer_service()
     if not await doc_svc.initialize():

--- a/autobot-backend/services/knowledge/code_indexer_test.py
+++ b/autobot-backend/services/knowledge/code_indexer_test.py
@@ -179,3 +179,103 @@ async def test_index_directory_unsupported_extension_skipped(tmp_path):
     assert result.success == 0
     assert result.skipped == 0  # skipped only counts supported-but-hash-match; unsupported = 0
     assert not indexer._collection.upsert.called
+
+
+# ---------------------------------------------------------------------------
+# index_code endpoint — path traversal validation (#4894)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_code_rejects_out_of_root_path(tmp_path):
+    """POST /index/code must return 400 when root_dir is outside PROJECT_ROOT."""
+    from unittest.mock import patch
+
+    import pytest
+    from fastapi import HTTPException
+
+    from api.knowledge_population import index_code
+
+    with patch("constants.path_constants.PATH") as mock_path:
+        mock_path.PROJECT_ROOT = str(tmp_path / "project")
+        with pytest.raises(HTTPException) as exc_info:
+            await index_code({"root_dir": "/etc"})
+    assert exc_info.value.status_code == 400
+    assert "project root" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_index_code_rejects_prefix_confusion_path(tmp_path):
+    """root_dir=/tmp/projectroot_evil must not match /tmp/projectroot."""
+    from unittest.mock import patch
+
+    import pytest
+    from fastapi import HTTPException
+
+    from api.knowledge_population import index_code
+
+    project = tmp_path / "projectroot"
+    evil = tmp_path / "projectroot_evil"
+
+    with patch("constants.path_constants.PATH") as mock_path:
+        mock_path.PROJECT_ROOT = str(project)
+        with pytest.raises(HTTPException) as exc_info:
+            await index_code({"root_dir": str(evil)})
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_index_code_accepts_project_root_itself(tmp_path):
+    """root_dir equal to PROJECT_ROOT is allowed and proceeds to indexing."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from api.knowledge_population import index_code
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    mock_result = MagicMock(success=0, failed=0, skipped=0, errors=[])
+    mock_indexer = MagicMock()
+    mock_indexer.index_directory = AsyncMock(return_value=mock_result)
+
+    mock_doc_svc = MagicMock()
+    mock_doc_svc.initialize = AsyncMock(return_value=True)
+    mock_doc_svc._collection = MagicMock()
+    mock_doc_svc._embed_model = MagicMock()
+
+    with patch("constants.path_constants.PATH") as mock_path, \
+         patch("services.knowledge.doc_indexer.get_doc_indexer_service", return_value=mock_doc_svc), \
+         patch("services.knowledge.code_indexer.CodeIndexer", return_value=mock_indexer):
+        mock_path.PROJECT_ROOT = str(project)
+        response = await index_code({"root_dir": str(project)})
+
+    assert response["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_index_code_accepts_subdir_of_project_root(tmp_path):
+    """root_dir within PROJECT_ROOT is allowed and proceeds to indexing."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from api.knowledge_population import index_code
+
+    project = tmp_path / "project"
+    subdir = project / "autobot-backend" / "services"
+    subdir.mkdir(parents=True)
+
+    mock_result = MagicMock(success=0, failed=0, skipped=0, errors=[])
+    mock_indexer = MagicMock()
+    mock_indexer.index_directory = AsyncMock(return_value=mock_result)
+
+    mock_doc_svc = MagicMock()
+    mock_doc_svc.initialize = AsyncMock(return_value=True)
+    mock_doc_svc._collection = MagicMock()
+    mock_doc_svc._embed_model = MagicMock()
+
+    with patch("constants.path_constants.PATH") as mock_path, \
+         patch("services.knowledge.doc_indexer.get_doc_indexer_service", return_value=mock_doc_svc), \
+         patch("services.knowledge.code_indexer.CodeIndexer", return_value=mock_indexer):
+        mock_path.PROJECT_ROOT = str(project)
+        response = await index_code({"root_dir": str(subdir)})
+
+    assert response["status"] == "ok"


### PR DESCRIPTION
Closes #4894

## Summary
- Resolves `root_dir` and `PATH.PROJECT_ROOT` via `Path.resolve()` in `index_code()`
- Rejects any path that is neither equal to the project root nor a subdirectory of it — uses `str(allowed_root) + "/"` prefix to prevent `/tmp/projectroot_evil` matching `/tmp/projectroot`
- Returns HTTP 400 with actionable message on violation

## Tests
4 new tests: out-of-root rejection, prefix-confusion rejection, exact-root acceptance, subdirectory acceptance. 7 passed, 9 skipped (pre-existing tree-sitter skips).