### PR TITLE
fix(knowledge): surface tree-sitter ImportError to /index/code caller (#4898)

### DIFF
--- a/autobot-backend/services/knowledge/code_indexer.py
+++ b/autobot-backend/services/knowledge/code_indexer.py
@@ -55,7 +55,7 @@ def extract_python(source_path: str, content: bytes) -> dict:
         from tree_sitter import Language, Parser
     except ImportError as exc:
         logger.error("tree-sitter-python not installed: %s", exc)
-        return {"nodes": [], "edges": []}
+        return {"nodes": [], "edges": [], "dep_error": f"tree-sitter-python not installed: {exc}"}
 
     lang = Language(tspython.language())
     parser = Parser(lang)
@@ -208,7 +208,8 @@ def extract_javascript(source_path: str, content: bytes) -> dict:
         from tree_sitter import Language, Parser
     except ImportError as exc:
         logger.error("tree-sitter-javascript not installed: %s", exc)
-        return {"nodes": [], "edges": []}
+        msg = f"tree-sitter-javascript not installed: {exc}"
+        return {"nodes": [], "edges": [], "dep_error": msg}
 
     lang = Language(tsjs.language())
     parser = Parser(lang)
@@ -282,6 +283,11 @@ class CodeIndexer:
             return result
 
         extracted = extractor(file_path, content)
+        dep_error = extracted.get("dep_error")
+        if dep_error:
+            result.failed += 1
+            result.errors.append(dep_error)
+            return result
         nodes = extracted["nodes"]
         edges = extracted["edges"]
 

--- a/autobot-backend/services/knowledge/code_indexer_test.py
+++ b/autobot-backend/services/knowledge/code_indexer_test.py
@@ -88,6 +88,7 @@ async def test_index_python_file_upserts_nodes(tmp_path):
     assert indexer._collection.upsert.called
 
 
+@requires_tree_sitter
 async def test_index_unchanged_file_skips(tmp_path):
     src = tmp_path / "module.py"
     src.write_bytes(SIMPLE_PYTHON)
@@ -279,3 +280,56 @@ async def test_index_code_accepts_subdir_of_project_root(tmp_path):
         response = await index_code({"root_dir": str(subdir)})
 
     assert response["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# dep_error surfacing — tree-sitter missing (#4898)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_file_surfaces_dep_error_when_tree_sitter_missing(tmp_path, monkeypatch):
+    """When tree-sitter is unavailable the dep_error must appear in result.errors."""
+    from services.knowledge import code_indexer as ci
+
+    src = tmp_path / "module.py"
+    src.write_bytes(b"def foo(): pass\n")
+
+    # Patch extract_python to simulate ImportError (dep missing)
+    def _fake_extract(source_path, content):
+        return {"nodes": [], "edges": [], "dep_error": "tree-sitter-python not installed: No module named 'tree_sitter_python'"}
+
+    monkeypatch.setattr(ci, "extract_python", _fake_extract)
+    # Rebuild _EXTRACTORS so index_file picks up the patched extractor
+    monkeypatch.setitem(ci._EXTRACTORS, ".py", _fake_extract)
+
+    indexer = _make_indexer(tmp_path)
+    result = await indexer.index_file(str(src), root_dir=str(tmp_path))
+
+    assert result.failed == 1
+    assert result.success == 0
+    assert len(result.errors) == 1
+    assert "tree-sitter-python not installed" in result.errors[0]
+    assert not indexer._collection.upsert.called
+
+
+@pytest.mark.asyncio
+async def test_index_directory_surfaces_dep_errors_in_aggregate(tmp_path, monkeypatch):
+    """dep_errors from individual files are aggregated into the directory result."""
+    from services.knowledge import code_indexer as ci
+
+    (tmp_path / "a.py").write_bytes(b"def foo(): pass\n")
+    (tmp_path / "b.py").write_bytes(b"def bar(): pass\n")
+
+    def _fake_extract(source_path, content):
+        return {"nodes": [], "edges": [], "dep_error": "tree-sitter-python not installed: No module named 'tree_sitter_python'"}
+
+    monkeypatch.setitem(ci._EXTRACTORS, ".py", _fake_extract)
+
+    indexer = _make_indexer(tmp_path)
+    result = await indexer.index_directory(str(tmp_path))
+
+    assert result.failed == 2
+    assert result.success == 0
+    assert len(result.errors) == 2
+    assert all("tree-sitter-python not installed" in e for e in result.errors)


### PR DESCRIPTION
Closes #4898

## Summary
- `extract_python()` / `extract_javascript()`: on `ImportError`, returns `{"dep_error": "<message>", "nodes": [], "edges": []}` instead of silently returning empty results
- `index_file()`: checks for `dep_error` key — increments `result.failed`, appends message to `result.errors`, returns early (no hash caching so repeated calls keep failing visibly until dep is installed)
- Endpoint already returns `"errors": result.errors[:20]`, so callers now see e.g. `"tree-sitter-python not installed: No module named 'tree_sitter_python'"` instead of silent zeros

## Tests
2 new tests using `monkeypatch` to simulate missing tree-sitter: `test_index_file_surfaces_dep_error_when_tree_sitter_missing` and `test_index_directory_surfaces_dep_errors_in_aggregate`. 4 passed, 10 skipped.