### PR TITLE
fix(knowledge): floor regression score at _MIN_SCORE_DELTA not 0.0 (#4794)

### DIFF
--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -42,9 +42,10 @@ from autobot_shared.redis_client import get_async_redis_client
 # Module-level imports for patchability in tests.
 # Deferred via try/except to survive environments where these aren't installed yet.
 try:
-    from services.knowledge.analyzer_service import get_analyzer_service
+    from services.knowledge.analyzer_service import _MIN_SCORE_DELTA, get_analyzer_service
 except Exception:  # pragma: no cover
     get_analyzer_service = None  # type: ignore[assignment]
+    _MIN_SCORE_DELTA = 0.1  # fallback matches analyzer_service default
 
 try:
     from services.knowledge.synthesis_provenance import SynthesisProvenanceLog
@@ -627,9 +628,10 @@ class AutonomousLoopOrchestrator:
                 run_id=f"loop:{run_id}",
                 input_docs=[f"params: {json.dumps(r.params)}" for r in results],
                 output_summary=summary,
-                # Floor at 0.0 so a negative delta still clears the _MIN_SCORE_DELTA guard
-                # and the LLM can produce "what to avoid" lessons from failed experiments.
-                score=max(0.0, score_delta),
+                # For regression runs (delta < 0), floor at _MIN_SCORE_DELTA so the
+                # analyzer's guard passes and the LLM can distil "what to avoid" lessons.
+                # Positive deltas are passed as-is to preserve their magnitude.
+                score=max(_MIN_SCORE_DELTA, score_delta),
             )
             if lessons:
                 await svc.store_lessons(lessons)

--- a/autobot-backend/services/knowledge/test_autonomous_loop.py
+++ b/autobot-backend/services/knowledge/test_autonomous_loop.py
@@ -253,14 +253,16 @@ async def test_analyze_graceful_on_failure():
 async def test_analyze_generates_lessons_when_all_variants_regress():
     """ANALYZE must produce lessons even when every variant scores below baseline.
 
-    Regression path: score_delta < 0 → floored to 0.0 so _MIN_SCORE_DELTA guard
-    is cleared; output_summary prefixed with [REGRESSION] so LLM knows to distil
-    avoidance lessons.
+    Regression path: score_delta < 0 → floored at _MIN_SCORE_DELTA so the
+    analyzer's guard (score < _MIN_SCORE_DELTA → return []) is cleared and the
+    LLM can distil "what to avoid" lessons from failed experiments.
+    output_summary is also prefixed with [REGRESSION].
     """
+    from services.knowledge.analyzer_service import _MIN_SCORE_DELTA
     from services.knowledge.autonomous_loop import VariantResult
 
     orch = _make_orchestrator()
-    # All variants score below the baseline of 0.8
+    # All variants score below the baseline of 0.8 (delta = -0.3)
     results = [
         VariantResult("v00", {"hybrid_weight_semantic": 0.3}, 0.5, 0.5, 0.5),
         VariantResult("v01", {"hybrid_weight_semantic": 0.2}, 0.4, 0.4, 0.4),
@@ -279,9 +281,10 @@ async def test_analyze_generates_lessons_when_all_variants_regress():
     assert count == 1
     mock_svc.store_lessons.assert_awaited_once()
 
-    # Verify the score passed was floored at 0.0 (not the negative delta -0.3)
+    # Score must be >= _MIN_SCORE_DELTA so the analyzer guard passes.
     call_kwargs = mock_svc.analyze_synthesis_run.call_args.kwargs
-    assert call_kwargs["score"] == pytest.approx(0.0)
+    assert call_kwargs["score"] >= _MIN_SCORE_DELTA
+    assert call_kwargs["score"] == pytest.approx(_MIN_SCORE_DELTA)
 
     # Verify the regression context is prepended to the summary
     assert call_kwargs["output_summary"].startswith("[REGRESSION]")


### PR DESCRIPTION
Fixes a broken implementation in PR #4899 — closes #4794 properly.

## Bug in Previous Fix

PR #4899 passed `score=max(0.0, score_delta)` for regression runs. When all variants regress, `score_delta < 0` → `score=0.0`. But `analyzer_service.py` has:

```python
_MIN_SCORE_DELTA = 0.1
if score < _MIN_SCORE_DELTA:   # 0.0 < 0.1 → True
    return []
```

So lessons were still never generated. The test only passed because `analyze_synthesis_run` was mocked.

## Correct Fix

- Import `_MIN_SCORE_DELTA` from `analyzer_service` (with fallback `0.1`)
- Pass `score=max(_MIN_SCORE_DELTA, score_delta)` — regression runs floor at the threshold so the guard passes; positive deltas keep their magnitude
- Fix test assertion from `score == 0.0` to `score >= _MIN_SCORE_DELTA`

## Test Status
27/27 pass