### PR TITLE
fix(knowledge): TTL on pending_approval Redis key, POST /loop/reject endpoint, _running guard in re-init (#4915 #4916 #4917)

### DIFF
--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -408,6 +408,37 @@ async def approve_loop_variant(
 
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
+    operation="reject_loop_variant",
+    error_code_prefix="KNOWLEDGE",
+)
+@router.post("/loop/reject")
+async def reject_loop_variant(
+    current_user: dict = Depends(get_current_user),
+):
+    """Discard the pending staging variant without applying it to production RAGConfig.
+
+    The autonomous loop stores a "pending approval" variant when the improvement
+    margin is below the auto-promotion threshold.  This endpoint clears it.
+
+    Returns 409 if no variant is pending.
+
+    Issue #4916.
+    """
+    from services.rag_config import get_rag_config
+    from services.knowledge.autonomous_loop import get_loop_orchestrator
+
+    cfg = get_rag_config()
+    orchestrator = await get_loop_orchestrator(None, dry_run=cfg.autonomous_loop_dry_run)
+    cleared = await orchestrator.reject_pending()
+
+    if not cleared:
+        raise HTTPException(status_code=409, detail="No variant pending approval")
+
+    return {"message": "Pending variant rejected and cleared"}
+
+
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
     operation="get_rag_stats",
     error_code_prefix="KNOWLEDGE",
 )

--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -306,6 +306,7 @@ class AutonomousLoopOrchestrator:
 
         Called once by get_loop_orchestrator() immediately after construction.
         Silently skips if Redis is unavailable.
+        Discards entries older than 7 days (matches TTL on the Redis key).
         """
         try:
             redis = await get_async_redis_client(database="knowledge")
@@ -313,7 +314,17 @@ class AutonomousLoopOrchestrator:
                 return
             raw = await redis.get(_PENDING_APPROVAL_REDIS_KEY)
             if raw:
-                self._pending_approval = json.loads(raw)
+                data = json.loads(raw)
+                staged_at_str = data.pop("staged_at", None)
+                if staged_at_str:
+                    staged_at = datetime.fromisoformat(staged_at_str)
+                    if staged_at.tzinfo is None:
+                        staged_at = staged_at.replace(tzinfo=timezone.utc)
+                    if (datetime.now(timezone.utc) - staged_at).days > 7:
+                        logger.info("restore_state: discarding stale pending_approval (>7 days old)")
+                        await redis.delete(_PENDING_APPROVAL_REDIS_KEY)
+                        return
+                self._pending_approval = data
                 logger.info(
                     "AutonomousLoop: restored pending_approval from Redis: %s",
                     self._pending_approval,
@@ -322,12 +333,18 @@ class AutonomousLoopOrchestrator:
             logger.debug("AutonomousLoop: could not restore pending_approval from Redis (non-fatal)")
 
     async def _save_pending_approval(self, params: Dict[str, Any]) -> None:
-        """Persist _pending_approval to Redis so it survives restarts."""
+        """Persist _pending_approval to Redis so it survives restarts.
+
+        A 7-day TTL is set so stale entries are automatically evicted.
+        A ``staged_at`` timestamp is embedded so restore_state() can
+        skip entries that survived the TTL via a Redis replica lag.
+        """
         try:
             redis = await get_async_redis_client(database="knowledge")
             if redis is None:
                 return
-            await redis.set(_PENDING_APPROVAL_REDIS_KEY, json.dumps(params))
+            params_with_ts = {**params, "staged_at": datetime.now(timezone.utc).isoformat()}
+            await redis.set(_PENDING_APPROVAL_REDIS_KEY, json.dumps(params_with_ts), ex=7 * 24 * 3600)
         except Exception:
             logger.debug("AutonomousLoop: could not persist pending_approval to Redis (non-fatal)")
 
@@ -751,6 +768,9 @@ async def get_loop_orchestrator(
     """
     global _loop_orchestrator
     async with _loop_lock:
+        # Never replace a running instance — it would orphan in-flight experiments.
+        if _loop_orchestrator is not None and getattr(_loop_orchestrator, "_running", False):
+            return _loop_orchestrator
         if _loop_orchestrator is None or (
             _loop_orchestrator._llm is None and llm_service is not None
         ):

--- a/autobot-backend/services/knowledge/test_autonomous_loop.py
+++ b/autobot-backend/services/knowledge/test_autonomous_loop.py
@@ -519,7 +519,12 @@ async def test_promote_stores_pending_in_redis():
     mock_redis.set.assert_awaited_once()
     call_args = mock_redis.set.call_args
     assert call_args[0][0] == "autobot:loop:pending_approval"
-    assert json.loads(call_args[0][1]) == best.params
+    stored = json.loads(call_args[0][1])
+    # staged_at timestamp is injected; strip it before comparing params
+    stored.pop("staged_at", None)
+    assert stored == best.params
+    # 7-day TTL must be set
+    assert call_args[1].get("ex") == 7 * 24 * 3600
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #4915
Closes #4916
Closes #4917

Three fixes in one commit found in stale worktree.