### PR TITLE
fix(scheduler): handle range+step expressions in _normalize_dow_field — 1-7 no longer raises ValueError (#4918)

### DIFF
--- a/autobot-backend/services/trigger_service.py
+++ b/autobot-backend/services/trigger_service.py
@@ -255,10 +255,31 @@ def _parse_cron_field(field_str: str, min_val: int, max_val: int) -> List[int]:
 
 
 def _normalize_dow_field(field: str) -> str:
-    """Normalize day-of-week field: replace standalone '7' tokens with '0' (both mean Sunday)."""
+    """Normalize day-of-week: replace 7 with 0 (both mean Sunday).
+
+    Handles scalars (7->0), lists (0,7->0,0), ranges (1-7->1-6,0),
+    and steps (*/7 left unchanged -- step-of-7 is unusual but valid).
+    """
     import re
 
-    return re.sub(r"(?<![0-9])7(?![0-9])", "0", field)
+    def _replace_token(token: str) -> str:
+        # Range like "1-7" or "0-7"
+        m = re.fullmatch(r"(\d+)-(\d+)", token)
+        if m:
+            lo, hi = int(m.group(1)), int(m.group(2))
+            if hi == 7:
+                if lo == 0:
+                    return "0-6"
+                return f"{lo}-6,0"  # wrap: Mon-Sun = Mon-Sat + Sun(0)
+            return token
+        # Step like "*/7" -- leave as-is (unusual but not invalid)
+        if re.fullmatch(r"\*/\d+", token):
+            return token
+        # Scalar
+        return "0" if token == "7" else token
+
+    # Split on comma, normalize each part, rejoin
+    return ",".join(_replace_token(part) for part in field.split(","))
 
 
 def validate_cron_expression(expression: str) -> bool:

--- a/autobot-backend/services/trigger_service_test.py
+++ b/autobot-backend/services/trigger_service_test.py
@@ -166,6 +166,14 @@ class TestValidateCronExpression:
     def test_dow_0_sunday_accepted(self) -> None:
         assert validate_cron_expression("0 0 * * 0") is True
 
+    def test_dow_range_1_to_7_accepted(self) -> None:
+        # "1-7" used to corrupt to "1-0" (empty range -> ValueError); must now return True
+        assert validate_cron_expression("0 0 * * 1-7") is True
+
+    def test_dow_comma_list_with_7_accepted(self) -> None:
+        # "0,7" should be normalised to "0,0" (both Sunday) and accepted
+        assert validate_cron_expression("0 0 * * 0,7") is True
+
 
 class TestNextCronRun:
     def test_every_minute_advances_by_one(self) -> None:
@@ -203,6 +211,16 @@ class TestNextCronRun:
         nxt_7 = next_cron_run("0 0 * * 7", after=base)
         nxt_0 = next_cron_run("0 0 * * 0", after=base)
         assert nxt_7 == nxt_0, f"7=Sunday and 0=Sunday must fire at same time: {nxt_7} vs {nxt_0}"
+
+    def test_dow_range_1_to_7_fires_on_sunday(self) -> None:
+        # "0 0 * * 1-7" should fire Mon-Sun; verify it fires on Sunday (weekday 6)
+        # Use Saturday 2025-06-07 23:00 UTC -- next fire should be Sunday 2025-06-08 00:00 UTC
+        base = datetime(2025, 6, 7, 23, 0, 0, tzinfo=timezone.utc)  # Saturday
+        nxt = next_cron_run("0 0 * * 1-7", after=base)
+        assert nxt == datetime(2025, 6, 8, 0, 0, 0, tzinfo=timezone.utc), (
+            f"1-7 range should include Sunday; got {nxt}"
+        )
+        assert nxt.weekday() == 6, f"Expected Sunday (weekday=6), got weekday={nxt.weekday()}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4918

## Summary

Replaced `_normalize_dow_field` regex with a token-aware implementation handling:
- Ranges: `1-7` → `1-6,0` (Mon-Sat + Sunday-as-0)
- Scalars: `7` → `0`
- Step expressions: `*/7` left unchanged (not `*/0`)
- Comma lists: each part normalized independently

Previously `validate_cron_expression("0 0 * * 1-7")` returned `False` (ValueError). Now returns `True`.

## Tests
53/53 pass, including 3 new tests for range, comma-list, and next-run-on-Sunday cases