### PR TITLE
fix(mesh): downgrade graspologic ImportError log from CRITICAL to WARNING (#4923)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1277,7 +1277,7 @@ async def _start_community_clustering_loop(app: FastAPI) -> None:
                 promoted = await CommunityClusterer(mesh_db).run()
                 logger.info("CommunityClusterer periodic run: %d anchors promoted", len(promoted))
             except ImportError as exc:
-                logger.critical(
+                logger.warning(
                     "graspologic not installed — community clustering disabled. "
                     "Install with: pip install graspologic. Error: %s",
                     exc,


### PR DESCRIPTION
Closes #4923

## Summary
- `CommunityClusterer` logs `ImportError` for optional `graspologic` at `CRITICAL` level — changed to `WARNING` since the error is non-fatal and the module is optional
- Using `CRITICAL` pollutes log monitoring and causes false-alarm alerts for a non-fatal optional dependency

## Test Status
No tests changed — log-level-only fix. Existing tests pass.