### PR TITLE
fix(mesh): add 5-minute startup delay before first Leiden clustering run (#4919)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1270,6 +1270,8 @@ async def _start_community_clustering_loop(app: FastAPI) -> None:
     _CLUSTER_INTERVAL_SECONDS = 6 * 3600  # 6 hours
 
     async def _loop() -> None:
+        # Allow startup to complete before first expensive Leiden pass
+        await asyncio.sleep(300)  # 5 minutes
         while True:
             try:
                 promoted = await CommunityClusterer(mesh_db).run()


### PR DESCRIPTION
Closes #4919

## Summary
- `_start_community_clustering_loop` in `lifespan.py` ran Leiden clustering immediately on startup
- Added `await asyncio.sleep(300)` before the `while True` loop to match the pattern used by all other periodic loops (backup scheduler, autonomous loop)
- Prevents CPU-intensive Leiden algorithm from competing with startup initialization

## Test Status
No new tests — single-line behavioral fix matching existing loop patterns.