### PR TITLE
fix(rag): apply provenance_adjustment() to hybrid_score in _deduplicate_and_rank (#4914)

### DIFF
--- a/autobot-backend/services/graph_rag_service.py
+++ b/autobot-backend/services/graph_rag_service.py
@@ -56,6 +56,7 @@ from advanced_rag_optimizer import RAGMetrics, SearchResult
 from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import error_boundary
 from autobot_shared.logging_manager import get_llm_logger
+from knowledge.search_components.reranking import provenance_adjustment
 from services.rag_service import RAGService
 
 logger = get_llm_logger("graph_rag_service")
@@ -465,6 +466,16 @@ class GraphRAGService:
         """
         content_hashes = self._build_content_hash_map(results)
         deduplicated = list(content_hashes.values())
+
+        # Issue #4914: apply provenance boost/penalty to hybrid_score before
+        # ranking so that graph-expanded results with "extracted" relations rank
+        # above "ambiguous" ones when base scores are equal.
+        for r in deduplicated:
+            prov = r.metadata.get("source_provenance") if hasattr(r, "metadata") else None
+            adjustment = provenance_adjustment(prov)
+            if adjustment != 0.0:
+                r.hybrid_score = r.hybrid_score + adjustment
+
         final_results = self._assign_relevance_ranks(deduplicated, max_results)
 
         logger.info(

--- a/autobot-backend/services/graph_rag_service_test.py
+++ b/autobot-backend/services/graph_rag_service_test.py
@@ -574,3 +574,97 @@ def test_create_search_result_unknown_origin_defaults_to_inferred():
 
     assert result is not None
     assert result.metadata["source_provenance"] == "inferred"
+
+
+# ============================================================================
+# Provenance Adjustment in _deduplicate_and_rank Tests (#4914)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_deduplicate_and_rank_applies_provenance_boost(graph_rag_service):
+    """extracted > inferred after deduplication when base hybrid_score is equal."""
+    base_score = 0.5
+    extracted = SearchResult(
+        content="Graph entity A",
+        metadata={"source_provenance": "extracted"},
+        semantic_score=0.0,
+        keyword_score=0.0,
+        hybrid_score=base_score,
+        relevance_rank=0,
+        source_path="graph:A",
+        chunk_index=0,
+    )
+    inferred = SearchResult(
+        content="Graph entity B",
+        metadata={"source_provenance": "inferred"},
+        semantic_score=0.0,
+        keyword_score=0.0,
+        hybrid_score=base_score,
+        relevance_rank=0,
+        source_path="graph:B",
+        chunk_index=0,
+    )
+
+    ranked = await graph_rag_service._deduplicate_and_rank(
+        [extracted, inferred], max_results=10
+    )
+
+    # extracted receives +0.05 boost; inferred receives 0.0 adjustment
+    assert ranked[0] is extracted
+    assert ranked[0].hybrid_score > ranked[1].hybrid_score
+
+
+@pytest.mark.asyncio
+async def test_deduplicate_and_rank_applies_provenance_penalty(graph_rag_service):
+    """inferred > ambiguous after deduplication when base hybrid_score is equal."""
+    base_score = 0.5
+    inferred = SearchResult(
+        content="Graph entity C",
+        metadata={"source_provenance": "inferred"},
+        semantic_score=0.0,
+        keyword_score=0.0,
+        hybrid_score=base_score,
+        relevance_rank=0,
+        source_path="graph:C",
+        chunk_index=0,
+    )
+    ambiguous = SearchResult(
+        content="Graph entity D",
+        metadata={"source_provenance": "ambiguous"},
+        semantic_score=0.0,
+        keyword_score=0.0,
+        hybrid_score=base_score,
+        relevance_rank=0,
+        source_path="graph:D",
+        chunk_index=0,
+    )
+
+    ranked = await graph_rag_service._deduplicate_and_rank(
+        [ambiguous, inferred], max_results=10
+    )
+
+    # inferred receives 0.0; ambiguous receives -0.05 penalty
+    assert ranked[0] is inferred
+    assert ranked[0].hybrid_score > ranked[1].hybrid_score
+
+
+@pytest.mark.asyncio
+async def test_deduplicate_and_rank_no_provenance_unchanged(graph_rag_service):
+    """Results without source_provenance are not adjusted (0.0 delta, no mutation)."""
+    result = SearchResult(
+        content="Graph entity E",
+        metadata={},
+        semantic_score=0.0,
+        keyword_score=0.0,
+        hybrid_score=0.7,
+        relevance_rank=0,
+        source_path="graph:E",
+        chunk_index=0,
+    )
+
+    ranked = await graph_rag_service._deduplicate_and_rank([result], max_results=10)
+
+    assert len(ranked) == 1
+    # No adjustment for missing provenance (0.0 delta skipped)
+    assert ranked[0].hybrid_score == 0.7


### PR DESCRIPTION
Closes #4914

## Summary

`source_provenance` was being set on graph-expanded `SearchResult` objects but `provenance_adjustment()` was never called anywhere in the query path — the entire provenance taxonomy from #4818 had zero runtime effect.

**Fix:** In `_deduplicate_and_rank`, after building the dedup map and before `_assign_relevance_ranks`, applies `provenance_adjustment()` additive delta to `hybrid_score` for each result that carries `source_provenance` metadata.

**Tests:** 3 new tests verifying extracted ranks above inferred, inferred above ambiguous, and results without provenance are unaffected. 2 pre-existing unrelated failures unchanged.