### PR TITLE
fix(knowledge): guard against empty-string content in _split_and_embed (#4921)

### DIFF
--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -783,6 +783,8 @@ class DocIndexerService:
         each half is retried recursively (up to 1/16th of the original at
         depth 4).  Returns True when at least one sub-chunk is stored.
         """
+        if not content:
+            return False
         try:
             self._embed_and_upsert(content, chunk_id, metadata)
             return True

--- a/autobot-backend/services/knowledge/test_doc_indexer.py
+++ b/autobot-backend/services/knowledge/test_doc_indexer.py
@@ -979,6 +979,42 @@ class TestIndexChunkOversized4665:
     # Warning is logged (not silently dropped) — #4665 regression guard
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # _split_and_embed: empty-string guard (#4921)
+    # ------------------------------------------------------------------
+
+    def test_split_and_embed_returns_false_on_empty_string(self):
+        """_split_and_embed returns False immediately for empty content (#4921)."""
+        svc = _make_service()
+        ok = svc._split_and_embed("", "chunk_id", {}, "docs/test.md")
+        assert ok is False
+        # No embed call should happen — guard fires before any I/O
+        svc._embed_model.get_text_embedding.assert_not_called()
+
+    def test_split_and_embed_empty_half_after_bisect_does_not_embed(self):
+        """Bisect of whitespace-only content produces empty halves that are skipped (#4921).
+
+        A string like '   ' strips to '' on both sides — both recursive calls
+        must return False without calling the embedding model.
+        """
+        svc = _make_service()
+
+        # Force the initial call to fail with an oversized error so bisect runs
+        call_count = [0]
+
+        def _fake_embed(text):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise ValueError("input too large for model context length")
+            return [0.1] * 128
+
+        svc._embed_model.get_text_embedding.side_effect = _fake_embed
+        # Content that strips to empty on both bisected halves
+        ok = svc._split_and_embed("   ", "chunk_id", {}, "docs/test.md")
+        assert ok is False
+        # Only one embed attempt (the initial oversized call) — halves are empty, skipped
+        assert call_count[0] == 1
+
     def test_index_chunk_logs_warning_on_oversized(self, caplog):
         """Oversized chunk must emit a WARNING with doc path and char count (#4665)."""
         import logging


### PR DESCRIPTION
Closes #4921

## Summary
- `_split_and_embed()` in `doc_indexer.py` could be called with `content=""` after bisect + strip, or from callers passing empty strings
- Added `if not content: return False` as the first line of the method, matching the pre-#4702 guard behavior
- Prevents storing empty embeddings in ChromaDB and misleading WARNING log messages

## Tests
- 2 new tests: direct empty-string call returns False; whitespace-only bisect produces no embed attempt
- 72 total tests pass