### PR TITLE
fix(knowledge): use asyncio.Lock to prevent hash cache write race in CodeIndexer (#4895)

### DIFF
--- a/autobot-backend/services/knowledge/code_indexer.py
+++ b/autobot-backend/services/knowledge/code_indexer.py
@@ -26,6 +26,19 @@ from constants.path_constants import PATH
 
 logger = logging.getLogger(__name__)
 
+# Process-level locks keyed by cache file path.  Two concurrent index_directory()
+# calls that share the same cache file (same CodeIndexer instance or different
+# instances pointing at the same path) will serialize through this lock so that
+# neither loses the other's cache entries.
+_CACHE_FILE_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _get_cache_lock(path: str) -> asyncio.Lock:
+    """Return (creating if necessary) the asyncio.Lock for *path*."""
+    if path not in _CACHE_FILE_LOCKS:
+        _CACHE_FILE_LOCKS[path] = asyncio.Lock()
+    return _CACHE_FILE_LOCKS[path]
+
 
 @dataclass
 class CodeIndexResult:
@@ -318,25 +331,33 @@ class CodeIndexer:
 
         Skips hidden directories (starting with '.') and node_modules/venv/
         directories to avoid indexing third-party code.
+
+        A process-level asyncio.Lock serialises concurrent calls that share the
+        same cache file, preventing last-write-wins cache corruption (#4895).
         """
-        aggregate = CodeIndexResult()
-        root = Path(root_dir)
-        _SKIP_DIRS = {".git", "node_modules", "venv", ".venv", "__pycache__", ".mypy_cache"}
-        files = await asyncio.to_thread(lambda: sorted(root.rglob("*")))
-        for path in files:
-            if path.is_dir():
-                continue
-            # Skip files inside ignored directories
-            if any(part.startswith(".") or part in _SKIP_DIRS for part in path.parts):
-                continue
-            if path.suffix.lower() not in _EXTRACTORS:
-                continue
-            result = await self.index_file(str(path), root_dir=root_dir, force=force)
-            aggregate.success += result.success
-            aggregate.failed += result.failed
-            aggregate.skipped += result.skipped
-            aggregate.errors.extend(result.errors)
-        return aggregate
+        async with _get_cache_lock(str(self._cache_file)):
+            # Reload cache inside the lock so we start from the freshest snapshot
+            # before this batch begins.
+            self._hash_cache = self._load_cache()
+
+            aggregate = CodeIndexResult()
+            root = Path(root_dir)
+            _SKIP_DIRS = {".git", "node_modules", "venv", ".venv", "__pycache__", ".mypy_cache"}
+            files = await asyncio.to_thread(lambda: sorted(root.rglob("*")))
+            for path in files:
+                if path.is_dir():
+                    continue
+                # Skip files inside ignored directories
+                if any(part.startswith(".") or part in _SKIP_DIRS for part in path.parts):
+                    continue
+                if path.suffix.lower() not in _EXTRACTORS:
+                    continue
+                result = await self.index_file(str(path), root_dir=root_dir, force=force)
+                aggregate.success += result.success
+                aggregate.failed += result.failed
+                aggregate.skipped += result.skipped
+                aggregate.errors.extend(result.errors)
+            return aggregate
 
     async def _upsert_node(self, node: dict, rel_path: str, calls_by_source: dict[str, list[str]]) -> bool:
         content = (

--- a/autobot-backend/services/knowledge/code_indexer_test.py
+++ b/autobot-backend/services/knowledge/code_indexer_test.py
@@ -182,6 +182,57 @@ async def test_index_directory_unsupported_extension_skipped(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Concurrent index_directory — hash cache write-race regression (#4895)
+# ---------------------------------------------------------------------------
+
+
+@requires_tree_sitter
+@pytest.mark.asyncio
+async def test_concurrent_index_directory_preserves_all_cache_entries(tmp_path):
+    """Two concurrent index_directory() calls on disjoint file sets must both
+    have their cache entries persisted — neither must overwrite the other."""
+    import asyncio
+    import json as _json
+
+    # Two source directories, each with one .py file
+    dir_a = tmp_path / "dir_a"
+    dir_b = tmp_path / "dir_b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    (dir_a / "alpha.py").write_bytes(b"def alpha(): pass\n")
+    (dir_b / "beta.py").write_bytes(b"def beta(): pass\n")
+
+    # Both indexers share the same cache file (mirrors production behaviour).
+    cache_file = tmp_path / ".code_index_hashes.json"
+
+    # Clear any stale process-level lock for this cache path before the test.
+    import services.knowledge.code_indexer as _ci_mod
+    _ci_mod._CACHE_FILE_LOCKS.pop(str(cache_file), None)
+
+    indexer_a = CodeIndexer(
+        collection=MagicMock(upsert=MagicMock()),
+        embed_model=MagicMock(get_text_embedding=MagicMock(return_value=[0.1] * 384)),
+        cache_file=cache_file,
+    )
+    indexer_b = CodeIndexer(
+        collection=MagicMock(upsert=MagicMock()),
+        embed_model=MagicMock(get_text_embedding=MagicMock(return_value=[0.1] * 384)),
+        cache_file=cache_file,
+    )
+
+    # Run both concurrently — the lock must serialise the load+index+save cycle.
+    await asyncio.gather(
+        indexer_a.index_directory(str(dir_a)),
+        indexer_b.index_directory(str(dir_b)),
+    )
+
+    cache = _json.loads(cache_file.read_text(encoding="utf-8"))
+    # Both files must appear in the final cache.
+    assert any("alpha" in k for k in cache), f"alpha.py missing from cache: {cache}"
+    assert any("beta" in k for k in cache), f"beta.py missing from cache: {cache}"
+
+
+# ---------------------------------------------------------------------------
 # index_code endpoint — path traversal validation (#4894)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #4895

## Summary
- Two concurrent `POST /index/code` calls created separate `CodeIndexer` instances that both loaded the same cache snapshot and wrote back independently — last write won, silently losing the other's entries
- Added module-level `_CACHE_FILE_LOCKS: dict[str, asyncio.Lock]` + `_get_cache_lock(path)` helper
- `index_directory()` now reloads cache inside the lock before starting its batch, ensuring each concurrent caller sees the freshest snapshot and holds the lock until its final `_save_cache()` completes
- Pre-existing test failures (`test_index_code_accepts_*` asserting "ok" status) are unrelated to this change — the endpoint now returns "queued" after #4912 fix

## Tests
- New `test_concurrent_index_directory_preserves_all_cache_entries` — two concurrent `asyncio.gather` calls on disjoint file sets; asserts both entries present in final cache