### PR TITLE
style(tokens): replace hardcoded padding/margin/gap with spacing design tokens (#4651)

### DIFF
--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -396,25 +396,25 @@ function statusClass(status: string): string {
 .heartbeat-panel {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-4);
   font-size: var(--text-sm);
   color: var(--text-primary, #e2e8f0);
 }
 .panel-header {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
   flex-wrap: wrap;
 }
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
 }
 .agent-selector {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 .agent-selector label {
   color: var(--text-secondary, #94a3b8);
@@ -438,25 +438,25 @@ function statusClass(status: string): string {
   background: var(--bg-card, #1e293b);
   border: 1px solid var(--border, #334155);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 .card-title {
   font-weight: 600;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 .config-grid {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 .config-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 .config-row .label {
   width: 130px;
@@ -469,10 +469,10 @@ function statusClass(status: string): string {
 .config-actions {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   flex-wrap: wrap;
   border-top: 1px solid var(--border, #334155);
-  padding-top: 0.75rem;
+  padding-top: var(--spacing-3);
 }
 .toggle-label {
   display: flex;
@@ -524,21 +524,21 @@ function statusClass(status: string): string {
 }
 .events-row td {
   background: var(--bg-input, #0f172a);
-  padding: 0;
+  padding: var(--spacing-0);
 }
 .events-container {
   padding: 0.5rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 .error-message {
   color: #fca5a5;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 .event-row {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   align-items: baseline;
 }
 .event-time {

--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -477,7 +477,7 @@ onMounted(() => {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
   display: flex;
   align-items: center;
   gap: var(--spacing-2-5);
@@ -664,7 +664,7 @@ onMounted(() => {
   position: absolute;
   width: 1px;
   height: 1px;
-  padding: 0;
+  padding: var(--spacing-0);
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);

--- a/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/AdvancedAnalytics.vue
@@ -527,7 +527,7 @@ onMounted(() => {
 
 <style scoped>
 .advanced-analytics {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   position: relative;
 }
 
@@ -535,25 +535,25 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .analytics-header h2 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
 }
 
 .header-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .analytics-tabs {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1.5rem;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
-  padding-bottom: 0.5rem;
+  padding-bottom: var(--spacing-2);
 }
 
 .tab-btn {
@@ -576,13 +576,13 @@ onMounted(() => {
 }
 
 .tab-btn i {
-  margin-right: 0.5rem;
+  margin-right: var(--spacing-2);
 }
 
 .metrics-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .metric-value {
@@ -600,7 +600,7 @@ onMounted(() => {
 }
 
 .metric-trend {
-  margin-top: 0.5rem;
+  margin-top: var(--spacing-2);
   font-size: var(--text-sm);
 }
 
@@ -623,7 +623,7 @@ onMounted(() => {
 
 .data-table th,
 .data-table td {
-  padding: 0.75rem;
+  padding: var(--spacing-3);
   text-align: left;
   border-bottom: 1px solid var(--border-default);
 }
@@ -659,18 +659,18 @@ onMounted(() => {
 }
 
 .mt-4 {
-  margin-top: 1rem;
+  margin-top: var(--spacing-4);
 }
 
 .recommendations-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .recommendation-item ul {
   margin: 0.5rem 0 0 1.5rem;
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 .recommendation-item li {
@@ -692,7 +692,7 @@ onMounted(() => {
 .export-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .export-card p {
@@ -703,7 +703,7 @@ onMounted(() => {
 .export-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 /* Issue #704: Migrated to CSS design tokens */
@@ -733,7 +733,7 @@ onMounted(() => {
   border-radius: 50%;
   font-size: var(--text-xs);
   font-weight: 600;
-  margin-right: 0.5rem;
+  margin-right: var(--spacing-2);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
 }
@@ -771,14 +771,14 @@ onMounted(() => {
 .peak-hours-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .peak-hour-item {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.75rem;
+  gap: var(--spacing-4);
+  padding: var(--spacing-3);
   background: var(--bg-secondary);
   border-radius: var(--radius-md);
 }

--- a/autobot-frontend/src/components/analytics/AgentCostPanel.vue
+++ b/autobot-frontend/src/components/analytics/AgentCostPanel.vue
@@ -253,7 +253,7 @@ defineExpose({ fetchAgentCosts })
 }
 
 .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);

--- a/autobot-frontend/src/components/analytics/AnalyticsHeader.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeader.vue
@@ -198,7 +198,7 @@ function handleSourceChange(event: Event) {
 
 .header-content h2 {
   color: var(--color-info);
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xl);
   display: flex;
   align-items: center;

--- a/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsHeaderControls.vue
@@ -129,7 +129,7 @@ const emit = defineEmits<{
 
 .header-controls {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   align-items: center;
   flex-wrap: wrap;
 }
@@ -143,7 +143,7 @@ const emit = defineEmits<{
   transition: var(--transition-all);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-primary {
@@ -184,7 +184,7 @@ const emit = defineEmits<{
   transition: var(--transition-all);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-cancel:hover {
@@ -195,7 +195,7 @@ const emit = defineEmits<{
 .btn-back {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   color: var(--text-secondary);
   text-decoration: none;
   font-size: var(--text-sm);
@@ -211,7 +211,7 @@ const emit = defineEmits<{
 
 .debug-controls {
   width: 100%;
-  padding-top: 12px;
+  padding-top: var(--spacing-3);
   border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 

--- a/autobot-frontend/src/components/analytics/AnalyticsProgressSection.vue
+++ b/autobot-frontend/src/components/analytics/AnalyticsProgressSection.vue
@@ -224,13 +224,13 @@ function getPhaseIcon(status: string): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .progress-title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   color: var(--chart-green);
   font-weight: var(--font-semibold);
 }
@@ -247,7 +247,7 @@ function getPhaseIcon(status: string): string {
   background: var(--bg-tertiary);
   border-radius: var(--radius-default);
   overflow: hidden;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .progress-fill {
@@ -289,9 +289,9 @@ function getPhaseIcon(status: string): string {
 .phase-progress {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 16px;
-  padding: 12px;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
+  padding: var(--spacing-3);
   background: var(--bg-primary);
   border-radius: var(--radius-md);
 }
@@ -299,7 +299,7 @@ function getPhaseIcon(status: string): string {
 .phase-item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   padding: 6px 12px;
   background: var(--bg-secondary);
   border-radius: var(--radius-default);
@@ -331,8 +331,8 @@ function getPhaseIcon(status: string): string {
 
 /* Batch Progress */
 .batch-progress {
-  margin-top: 16px;
-  padding: 12px;
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-3);
   background: var(--bg-primary);
   border-radius: var(--radius-md);
 }
@@ -341,7 +341,7 @@ function getPhaseIcon(status: string): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .batch-label {
@@ -374,9 +374,9 @@ function getPhaseIcon(status: string): string {
 .live-stats {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
-  margin-top: 16px;
-  padding: 12px;
+  gap: var(--spacing-4);
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-3);
   background: var(--bg-card);
   border-radius: var(--radius-md);
 }
@@ -384,7 +384,7 @@ function getPhaseIcon(status: string): string {
 .live-stats .stat-item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   color: var(--text-secondary);
   font-size: 0.85em;
 }

--- a/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
+++ b/autobot-frontend/src/components/analytics/CodeEvolutionTimeline.vue
@@ -521,7 +521,7 @@ watch([selectedGranularity, selectedDays], () => {
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
 .code-evolution-timeline {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
 }
@@ -530,7 +530,7 @@ watch([selectedGranularity, selectedDays], () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .timeline-header h2 {
@@ -538,12 +538,12 @@ watch([selectedGranularity, selectedDays], () => {
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .timeline-controls {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   align-items: center;
 }
 
@@ -562,22 +562,22 @@ watch([selectedGranularity, selectedDays], () => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
-  gap: 1rem;
+  padding: var(--spacing-12);
+  gap: var(--spacing-4);
   color: var(--text-secondary);
 }
 
 .trends-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
 }
 
 .trend-card {
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   border: 1px solid var(--border-default);
 }
 
@@ -593,7 +593,7 @@ watch([selectedGranularity, selectedDays], () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .metric-name {
@@ -610,7 +610,7 @@ watch([selectedGranularity, selectedDays], () => {
 
 .trend-change {
   font-size: var(--text-sm);
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
 }
 
 .trend-change .improving {
@@ -623,7 +623,7 @@ watch([selectedGranularity, selectedDays], () => {
 
 .trend-change .percent {
   color: var(--text-secondary);
-  margin-left: 0.25rem;
+  margin-left: var(--spacing-1);
 }
 
 .trend-up {
@@ -637,15 +637,15 @@ watch([selectedGranularity, selectedDays], () => {
 .chart-container {
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
+  padding: var(--spacing-6);
+  margin-bottom: var(--spacing-6);
 }
 
 .chart-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .chart-header h3 {
@@ -655,14 +655,14 @@ watch([selectedGranularity, selectedDays], () => {
 
 .metric-toggles {
   display: flex;
-  gap: 1rem;
+  gap: var(--spacing-4);
   flex-wrap: wrap;
 }
 
 .metric-toggle {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   font-size: var(--text-xs);
   cursor: pointer;
   opacity: 0.6;
@@ -725,7 +725,7 @@ watch([selectedGranularity, selectedDays], () => {
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
-  padding: 0.75rem;
+  padding: var(--spacing-3);
   z-index: var(--z-tooltip);
   pointer-events: none;
 }
@@ -733,12 +733,12 @@ watch([selectedGranularity, selectedDays], () => {
 .tooltip-date {
   font-size: var(--text-xs);
   color: var(--text-secondary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .tooltip-metric {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .tooltip-metric .metric-value {
@@ -749,22 +749,22 @@ watch([selectedGranularity, selectedDays], () => {
 .patterns-section h3 {
   font-size: var(--text-lg);
   color: var(--text-primary);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .patterns-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .pattern-card {
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   border: 1px solid var(--border-default);
 }
 
@@ -772,7 +772,7 @@ watch([selectedGranularity, selectedDays], () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .pattern-name {
@@ -797,8 +797,8 @@ watch([selectedGranularity, selectedDays], () => {
   display: flex;
   align-items: flex-end;
   height: 40px;
-  gap: 2px;
-  margin-bottom: 0.5rem;
+  gap: var(--spacing-0-5);
+  margin-bottom: var(--spacing-2);
 }
 
 .sparkline-bar {
@@ -813,6 +813,6 @@ watch([selectedGranularity, selectedDays], () => {
   color: var(--text-secondary);
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 </style>

--- a/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeGenerationDashboard.vue
@@ -608,7 +608,7 @@ onMounted(() => {
   font-size: var(--text-2xl);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .subtitle {
@@ -926,7 +926,7 @@ onMounted(() => {
 
 .validation-warnings ul,
 .validation-errors ul {
-  margin: 0;
+  margin: var(--spacing-0);
   padding-left: var(--spacing-6);
   font-size: 0.8125rem;
 }
@@ -956,7 +956,7 @@ onMounted(() => {
 }
 
 .changes-list ul {
-  margin: 0;
+  margin: var(--spacing-0);
   padding-left: var(--spacing-6);
   font-size: 0.8125rem;
   color: var(--color-info-light);
@@ -1003,7 +1003,7 @@ onMounted(() => {
 }
 
 .code-block {
-  margin: 0;
+  margin: var(--spacing-0);
   padding: var(--spacing-4);
   background: var(--code-bg);
   border: 1px solid var(--border-subtle);
@@ -1047,7 +1047,7 @@ onMounted(() => {
 }
 
 .diff-block {
-  margin: 0;
+  margin: var(--spacing-0);
   padding: var(--spacing-4);
   background: var(--code-bg);
   border: 1px solid var(--border-subtle);

--- a/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeQualityDashboard.vue
@@ -1079,7 +1079,7 @@ watch(selectedPeriod, () => {
   font-size: var(--text-2xl);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .realtime-status {
@@ -1291,7 +1291,7 @@ watch(selectedPeriod, () => {
 }
 
 .recommendations ul {
-  margin: 0;
+  margin: var(--spacing-0);
   padding-left: var(--spacing-5);
 }
 
@@ -1418,7 +1418,7 @@ watch(selectedPeriod, () => {
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
@@ -1820,7 +1820,7 @@ watch(selectedPeriod, () => {
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   color: var(--text-primary);
 }

--- a/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
+++ b/autobot-frontend/src/components/analytics/CodeReviewDashboard.vue
@@ -788,10 +788,10 @@ onMounted(() => {
 
 <style scoped>
 .code-review-dashboard {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 /* Header */
@@ -800,14 +800,14 @@ onMounted(() => {
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .header-content h2 {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin: 0;
+  gap: var(--spacing-2);
+  margin: var(--spacing-0);
   font-size: var(--text-2xl);
   color: var(--text-primary);
 }
@@ -824,14 +824,14 @@ onMounted(() => {
 
 .header-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 /* Buttons */
 .action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.5rem 1rem;
   border: none;
   border-radius: var(--radius-md);
@@ -888,8 +888,8 @@ onMounted(() => {
 .path-selection {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 1rem;
-  padding: 1rem;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
@@ -898,7 +898,7 @@ onMounted(() => {
 .input-group {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .input-group label {
@@ -930,7 +930,7 @@ onMounted(() => {
 .language-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .chip {
@@ -953,14 +953,14 @@ onMounted(() => {
 .summary-cards {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .summary-card {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
@@ -990,7 +990,7 @@ onMounted(() => {
 .content-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 /* Panels */
@@ -1005,18 +1005,18 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem;
+  padding: var(--spacing-4);
   border-bottom: 1px solid var(--border-color);
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
 
 .panel-content {
-  padding: 1rem;
+  padding: var(--spacing-4);
   max-height: 400px;
   overflow-y: auto;
 }
@@ -1032,14 +1032,14 @@ onMounted(() => {
 /* Filter Tabs */
 .filter-tabs {
   display: flex;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   flex-wrap: wrap;
 }
 
 .filter-tab {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   padding: 0.25rem 0.5rem;
   background: transparent;
   border: none;
@@ -1065,11 +1065,11 @@ onMounted(() => {
 .issues-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .issue-card {
-  padding: 0.875rem;
+  padding: var(--spacing-3-5);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   border-left: 3px solid;
@@ -1101,8 +1101,8 @@ onMounted(() => {
 .issue-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .severity-badge {
@@ -1136,10 +1136,10 @@ onMounted(() => {
 
 .issue-location {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: var(--text-xs);
   color: var(--text-secondary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .file-path {
@@ -1151,7 +1151,7 @@ onMounted(() => {
 }
 
 .issue-message {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: 0.8125rem;
   color: var(--text-secondary);
   line-height: 1.4;
@@ -1159,7 +1159,7 @@ onMounted(() => {
 
 /* Detail Panel */
 .detail-section {
-  margin-bottom: 1.25rem;
+  margin-bottom: var(--spacing-5);
 }
 
 .detail-section label {
@@ -1169,17 +1169,17 @@ onMounted(() => {
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .detail-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .detail-title h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
@@ -1192,19 +1192,19 @@ onMounted(() => {
 
 .line-info {
   color: var(--text-secondary);
-  margin-left: 0.5rem;
+  margin-left: var(--spacing-2);
 }
 
 .description {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   line-height: 1.5;
 }
 
 .suggestion-box {
   display: flex;
-  gap: 0.75rem;
-  padding: 0.875rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3-5);
   background: rgba(16, 185, 129, 0.1);
   border-radius: var(--radius-md);
   border: 1px solid rgba(16, 185, 129, 0.3);
@@ -1215,7 +1215,7 @@ onMounted(() => {
 }
 
 .suggestion-box p {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
   line-height: 1.4;
 }
@@ -1227,8 +1227,8 @@ onMounted(() => {
 }
 
 .code-snippet pre {
-  margin: 0;
-  padding: 0.875rem;
+  margin: var(--spacing-0);
+  padding: var(--spacing-3-5);
   overflow-x: auto;
 }
 
@@ -1240,8 +1240,8 @@ onMounted(() => {
 
 .detail-actions {
   display: flex;
-  gap: 0.75rem;
-  padding-top: 1rem;
+  gap: var(--spacing-3);
+  padding-top: var(--spacing-4);
   border-top: 1px solid var(--border-color);
 }
 
@@ -1280,14 +1280,14 @@ onMounted(() => {
 .chart-legend {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0 1rem;
 }
 
 .legend-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .legend-color {
@@ -1315,7 +1315,7 @@ onMounted(() => {
 .history-list {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .history-item {
@@ -1336,7 +1336,7 @@ onMounted(() => {
 .history-info {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .history-path {
@@ -1352,7 +1352,7 @@ onMounted(() => {
 
 .history-stats {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .stat {
@@ -1393,11 +1393,11 @@ onMounted(() => {
 
 .empty-icon {
   font-size: 2.5rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 
@@ -1432,17 +1432,17 @@ onMounted(() => {
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
 }
 
 .modal-content {
-  padding: 1.25rem;
+  padding: var(--spacing-5);
   overflow-y: auto;
 }
 
 .pattern-category {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .pattern-category h4 {
@@ -1454,13 +1454,13 @@ onMounted(() => {
 .pattern-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .pattern-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.625rem 0.875rem;
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
@@ -1480,7 +1480,7 @@ onMounted(() => {
 .pattern-info {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   flex: 1;
 }
 

--- a/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
+++ b/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
@@ -429,7 +429,7 @@ const getItemSeverityClass = (severity: string): string => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   transition: all var(--duration-150) var(--ease-out);
 }
 

--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -976,7 +976,7 @@ onUnmounted(() => {
 <style scoped>
 /* Issue #704: Uses CSS design tokens via getCssVar() helper */
 .codebase-analytics {
-  padding: 20px;
+  padding: var(--spacing-5);
   background: var(--bg-primary);
   color: var(--text-primary);
   min-height: 100vh;
@@ -1031,7 +1031,7 @@ onUnmounted(() => {
   transition: var(--transition-all);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   background: var(--chart-green);
   color: var(--text-on-success);
 }
@@ -1061,8 +1061,8 @@ onUnmounted(() => {
 
 /* Traditional Analytics Section */
 .analytics-section {
-  margin-top: 24px;
-  padding: 20px;
+  margin-top: var(--spacing-6);
+  padding: var(--spacing-5);
   background: var(--bg-secondary);
   border-radius: var(--radius-xl);
   border: 1px solid var(--bg-tertiary);
@@ -1072,15 +1072,15 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 24px;
-  padding-bottom: 16px;
+  margin-bottom: var(--spacing-6);
+  padding-bottom: var(--spacing-4);
   border-bottom: 1px solid var(--bg-tertiary);
 }
 
 .toggle-switch {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   cursor: pointer;
   color: var(--text-secondary);
 }
@@ -1128,7 +1128,7 @@ onUnmounted(() => {
   transition: all var(--duration-200);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .refresh-all-btn:hover {
@@ -1172,7 +1172,7 @@ onUnmounted(() => {
 .kb-optin-text strong {
   display: block;
   color: var(--text-primary);
-  margin-bottom: 2px;
+  margin-bottom: var(--spacing-0-5);
 }
 
 .kb-optin-btn {
@@ -1186,7 +1186,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   white-space: nowrap;
   flex-shrink: 0;
   transition: opacity var(--duration-200);
@@ -1206,7 +1206,7 @@ onUnmounted(() => {
   border: none;
   color: var(--text-muted);
   cursor: pointer;
-  padding: 4px;
+  padding: var(--spacing-1);
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
@@ -1221,13 +1221,13 @@ onUnmounted(() => {
 
 /* Issue #3436: Per-project sub-tab bar */
 .project-sub-tabs-container {
-  margin-top: 24px;
+  margin-top: var(--spacing-6);
   border-top: 1px solid var(--border-default);
 }
 
 .project-sub-tabs {
   display: flex;
-  gap: 2px;
+  gap: var(--spacing-0-5);
   padding: 0 0 0 0;
   overflow-x: auto;
   border-bottom: 1px solid var(--border-default);
@@ -1237,7 +1237,7 @@ onUnmounted(() => {
 .project-sub-tab {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   padding: 10px 16px;
   font-size: var(--text-sm);
   font-weight: 500;
@@ -1273,6 +1273,6 @@ onUnmounted(() => {
 }
 
 .project-sub-tab-view {
-  margin-top: 16px;
+  margin-top: var(--spacing-4);
 }
 </style>

--- a/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
@@ -463,7 +463,7 @@ onUnmounted(() => {
 .landing-subtitle {
   font-size: var(--text-sm);
   color: var(--text-muted);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Loading */
@@ -576,7 +576,7 @@ onUnmounted(() => {
   border-radius: var(--radius-full);
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   text-transform: capitalize;
 }
 

--- a/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseDependenciesPanel.vue
@@ -336,7 +336,7 @@ const emit = defineEmits<{
   transition: var(--transition-all);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   background: var(--chart-green);
   color: var(--text-on-success);
 }
@@ -389,7 +389,7 @@ const emit = defineEmits<{
   align-items: center;
   justify-content: center;
   min-height: 200px;
-  gap: 12px;
+  gap: var(--spacing-3);
   color: var(--text-muted);
 }
 
@@ -411,14 +411,14 @@ const emit = defineEmits<{
 .chart-summary {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin-bottom: 16px;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
 }
 
 .summary-stat {
   background: rgba(51, 65, 85, 0.5);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
   text-align: center;
   border: 1px solid rgba(71, 85, 105, 0.5);
   transition: all var(--duration-200) var(--ease-out);
@@ -452,7 +452,7 @@ const emit = defineEmits<{
 .summary-label {
   font-size: 0.85rem;
   color: var(--text-muted);
-  margin-top: 4px;
+  margin-top: var(--spacing-1);
   display: block;
 }
 
@@ -460,7 +460,7 @@ const emit = defineEmits<{
 .charts-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 .chart-item {
@@ -470,7 +470,7 @@ const emit = defineEmits<{
 .chart-empty-slot {
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
   border: 1px solid rgba(71, 85, 105, 0.5);
   min-height: 350px;
   display: flex;
@@ -503,8 +503,8 @@ const emit = defineEmits<{
 
 /* Dependency Section */
 .dependency-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -514,19 +514,19 @@ const emit = defineEmits<{
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
-  padding-bottom: 12px;
+  margin-bottom: var(--spacing-5);
+  padding-bottom: var(--spacing-3);
   border-bottom: 1px solid rgba(71, 85, 105, 0.5);
 }
 
 .dependency-section .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: var(--text-xl);
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .dependency-section .section-header h3 i {
@@ -536,7 +536,7 @@ const emit = defineEmits<{
 .dependency-grid {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--spacing-6);
 }
 
 /* Circular Dependencies Warning */
@@ -544,16 +544,16 @@ const emit = defineEmits<{
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
 }
 
 .circular-deps-warning .warning-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   font-weight: 600;
   color: var(--color-error-light);
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .circular-deps-warning .warning-header i {
@@ -563,13 +563,13 @@ const emit = defineEmits<{
 .circular-deps-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .circular-dep-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 8px 12px;
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-default);
@@ -584,10 +584,10 @@ const emit = defineEmits<{
 
 .show-more {
   text-align: center;
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-secondary);
   border-radius: var(--radius-md);
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
 }
 
 .muted {
@@ -599,7 +599,7 @@ const emit = defineEmits<{
 .external-deps-table {
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
 
@@ -610,7 +610,7 @@ const emit = defineEmits<{
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .external-deps-table h4 i {
@@ -620,7 +620,7 @@ const emit = defineEmits<{
 .deps-table-content {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .dep-row {
@@ -653,8 +653,8 @@ const emit = defineEmits<{
 
 /* Import Tree Section */
 .import-tree-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -664,17 +664,17 @@ const emit = defineEmits<{
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .import-tree-section .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: 1.1rem;
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .import-tree-section .section-header h3 i {
@@ -684,8 +684,8 @@ const emit = defineEmits<{
 .import-tree-section .section-error {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-3);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: var(--radius-lg);
@@ -697,13 +697,13 @@ const emit = defineEmits<{
 }
 
 .import-tree-content {
-  margin-top: 16px;
+  margin-top: var(--spacing-4);
 }
 
 /* Call Graph Section */
 .call-graph-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -713,17 +713,17 @@ const emit = defineEmits<{
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .call-graph-section .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: 1.1rem;
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .call-graph-section .section-header h3 i {
@@ -733,8 +733,8 @@ const emit = defineEmits<{
 .call-graph-section .section-error {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-3);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: var(--radius-lg);
@@ -746,7 +746,7 @@ const emit = defineEmits<{
 }
 
 .call-graph-content {
-  margin-top: 16px;
+  margin-top: var(--spacing-4);
 }
 
 /* Loading Skeleton */
@@ -754,8 +754,8 @@ const emit = defineEmits<{
   min-height: 500px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 24px;
+  gap: var(--spacing-4);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.3);
   border-radius: var(--radius-lg);
   border: 1px solid rgba(71, 85, 105, 0.3);

--- a/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseOverviewPanel.vue
@@ -242,8 +242,8 @@ const getQualityClass = (score: number): string => {
 .enhanced-analytics-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 20px;
-  margin-bottom: 32px;
+  gap: var(--spacing-5);
+  margin-bottom: var(--spacing-8);
 }
 
 .card-header-content {
@@ -254,7 +254,7 @@ const getQualityClass = (score: number): string => {
 }
 
 .card-header-content h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
   font-size: 1.1em;
   font-weight: 600;
@@ -263,7 +263,7 @@ const getQualityClass = (score: number): string => {
 .refresh-indicator {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   font-size: 0.8em;
   color: var(--text-muted);
 }
@@ -294,8 +294,8 @@ const getQualityClass = (score: number): string => {
 /* Issue #609: Section Export Buttons */
 .section-export-buttons {
   display: inline-flex;
-  gap: 4px;
-  margin-left: 10px;
+  gap: var(--spacing-1);
+  margin-left: var(--spacing-2-5);
 }
 
 .export-btn {
@@ -309,7 +309,7 @@ const getQualityClass = (score: number): string => {
   transition: all var(--duration-200);
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .export-btn:hover {
@@ -325,7 +325,7 @@ const getQualityClass = (score: number): string => {
 .metrics-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .metric-item {
@@ -335,7 +335,7 @@ const getQualityClass = (score: number): string => {
 .metric-label {
   font-size: 0.8em;
   color: var(--text-muted);
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
 }
 
 .metric-value {
@@ -354,7 +354,7 @@ const getQualityClass = (score: number): string => {
 .quality-details {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .pattern-item,
@@ -390,8 +390,8 @@ const getQualityClass = (score: number): string => {
 .quality-score,
 .performance-gauge {
   text-align: center;
-  margin-bottom: 16px;
-  padding: 16px;
+  margin-bottom: var(--spacing-4);
+  padding: var(--spacing-4);
   border-radius: var(--radius-lg);
 }
 
@@ -399,7 +399,7 @@ const getQualityClass = (score: number): string => {
 .gauge-value {
   font-size: 2.5em;
   font-weight: 700;
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
 }
 
 .score-label,
@@ -443,7 +443,7 @@ const getQualityClass = (score: number): string => {
 .analytics-section {
   background: var(--bg-secondary);
   border-radius: var(--radius-xl);
-  padding: 24px;
+  padding: var(--spacing-6);
   border: 1px solid var(--bg-tertiary);
 }
 
@@ -451,15 +451,15 @@ const getQualityClass = (score: number): string => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 24px;
-  padding-bottom: 16px;
+  margin-bottom: var(--spacing-6);
+  padding-bottom: var(--spacing-4);
   border-bottom: 1px solid var(--bg-tertiary);
 }
 
 .toggle-switch {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   cursor: pointer;
   color: var(--text-secondary);
 }
@@ -507,7 +507,7 @@ const getQualityClass = (score: number): string => {
   transition: all var(--duration-200);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .refresh-all-btn:hover {
@@ -515,12 +515,12 @@ const getQualityClass = (score: number): string => {
 }
 
 .stats-section {
-  margin-bottom: 32px;
+  margin-bottom: var(--spacing-8);
 }
 
 .stats-section h3 {
   color: var(--text-primary);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
   font-size: 1.2em;
   font-weight: 600;
 }
@@ -528,14 +528,14 @@ const getQualityClass = (score: number): string => {
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .stat-value {
   font-size: 2em;
   font-weight: 700;
   color: var(--chart-green);
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
   text-align: center;
 }
 
@@ -561,7 +561,7 @@ const getQualityClass = (score: number): string => {
 
   .real-time-controls {
     flex-direction: column;
-    gap: 12px;
+    gap: var(--spacing-3);
     align-items: stretch;
   }
 

--- a/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseSecurityPanel.vue
@@ -167,13 +167,13 @@ const getTabCount = (tabId: string): number => {
 .code-intelligence-section h3 {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   flex-wrap: wrap;
 }
 
 .code-intelligence-section .section-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   margin-left: auto;
 }
 
@@ -187,7 +187,7 @@ const getTabCount = (tabId: string): number => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   transition: all var(--duration-150) var(--ease-out);
 }
 
@@ -213,14 +213,14 @@ const getTabCount = (tabId: string): number => {
 
 /* Code Intelligence Tabs */
 .code-intel-tabs {
-  margin-top: 16px;
+  margin-top: var(--spacing-4);
 }
 
 .code-intel-tabs .tabs-header {
   display: flex;
-  gap: 4px;
+  gap: var(--spacing-1);
   border-bottom: 1px solid var(--border-primary);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
 }
 
 .code-intel-tabs .tab-btn {
@@ -232,7 +232,7 @@ const getTabCount = (tabId: string): number => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   font-size: 0.9em;
   transition: all var(--duration-150) var(--ease-out);
 }

--- a/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
+++ b/autobot-frontend/src/components/analytics/ConversationFlowDashboard.vue
@@ -400,7 +400,7 @@ onMounted(() => {
 }
 
 .header-content h2 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-2xl);
   color: var(--text-primary);
 }
@@ -549,7 +549,7 @@ onMounted(() => {
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
@@ -797,7 +797,7 @@ onMounted(() => {
   display: flex;
   align-items: flex-end;
   height: 120px;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding-top: var(--spacing-4);
 }
 
@@ -892,7 +892,7 @@ onMounted(() => {
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
 }
 

--- a/autobot-frontend/src/components/analytics/DeclarationsSection.vue
+++ b/autobot-frontend/src/components/analytics/DeclarationsSection.vue
@@ -354,7 +354,7 @@ const getDeclarationTypeClass = (type: string): string => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   transition: all var(--duration-150) var(--ease-out);
 }
 

--- a/autobot-frontend/src/components/analytics/DuplicatesSection.vue
+++ b/autobot-frontend/src/components/analytics/DuplicatesSection.vue
@@ -358,7 +358,7 @@ const formatSimilarityGroup = (similarity: string): string => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   transition: all var(--duration-150) var(--ease-out);
 }
 

--- a/autobot-frontend/src/components/analytics/EnhancedAnalyticsGrid.vue
+++ b/autobot-frontend/src/components/analytics/EnhancedAnalyticsGrid.vue
@@ -249,7 +249,7 @@ const getEfficiencyClass = (score: number): string => {
 }
 
 .card-header-content h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--color-info);
   font-size: var(--text-base);
   display: flex;

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -577,21 +577,21 @@ onMounted(() => {
 /* Issue #704: Migrated to CSS design tokens */
 
 .llm-pattern-dashboard {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   background: var(--bg-primary);
   min-height: 100vh;
   color: var(--text-primary);
 }
 
 .dashboard-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .dashboard-header h2 {
   font-size: var(--text-2xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .subtitle {
@@ -604,18 +604,18 @@ onMounted(() => {
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
 }
 
 .stat-card {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
   background: var(--bg-surface);
   border: 1px solid var(--border-secondary);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .stat-icon {
@@ -657,15 +657,15 @@ onMounted(() => {
 .content-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
-  margin-bottom: 1.5rem;
+  gap: var(--spacing-6);
+  margin-bottom: var(--spacing-6);
 }
 
 .left-column,
 .right-column {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 /* Panels */
@@ -679,7 +679,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem;
+  padding: var(--spacing-4);
   border-bottom: 1px solid var(--border-secondary);
 }
 
@@ -687,17 +687,17 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .panel-content {
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .empty-state {
   text-align: center;
   color: var(--text-tertiary);
-  padding: 2rem;
+  padding: var(--spacing-8);
 }
 
 .refresh-btn {
@@ -705,7 +705,7 @@ onMounted(() => {
   border: none;
   color: var(--text-secondary);
   cursor: pointer;
-  padding: 0.25rem;
+  padding: var(--spacing-1);
 }
 
 .refresh-btn:hover {
@@ -719,13 +719,13 @@ onMounted(() => {
 
 /* Prompt Analyzer */
 .form-group {
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .form-group textarea,
 .form-row select {
   width: 100%;
-  padding: 0.75rem;
+  padding: var(--spacing-3);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -747,7 +747,7 @@ onMounted(() => {
 
 .form-row {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .form-row select {
@@ -776,8 +776,8 @@ onMounted(() => {
 
 /* Analysis Result */
 .analysis-result {
-  margin-top: 1rem;
-  padding: 1rem;
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-4);
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
   border-radius: var(--radius-md);
@@ -785,9 +785,9 @@ onMounted(() => {
 
 .result-header {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   flex-wrap: wrap;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .category-badge,
@@ -816,14 +816,14 @@ onMounted(() => {
 
 .issues-list,
 .recommendations-list {
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .issue-item {
-  padding: 0.5rem;
+  padding: var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: 0.8125rem;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .issue-item.warning {
@@ -837,16 +837,16 @@ onMounted(() => {
 }
 
 .recommendation-item {
-  padding: 0.5rem;
+  padding: var(--spacing-2);
   background: var(--color-success-alpha-10);
   border-radius: var(--radius-default);
   font-size: 0.8125rem;
   color: var(--chart-green-light);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .cache-indicator {
-  padding: 0.5rem;
+  padding: var(--spacing-2);
   background: rgba(168, 85, 247, 0.1);
   border-radius: var(--radius-default);
   font-size: 0.8125rem;
@@ -858,11 +858,11 @@ onMounted(() => {
 .recommendations-grid {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .recommendation-card {
-  padding: 1rem;
+  padding: var(--spacing-4);
   background: var(--bg-primary);
   border: 1px solid var(--border-secondary);
   border-radius: var(--radius-md);
@@ -876,7 +876,7 @@ onMounted(() => {
 .rec-header {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .rec-type {
@@ -907,7 +907,7 @@ onMounted(() => {
 .rec-meta {
   font-size: var(--text-xs);
   color: var(--text-tertiary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .expand-btn {
@@ -926,31 +926,31 @@ onMounted(() => {
 }
 
 .rec-steps {
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
+  margin-top: var(--spacing-3);
+  padding-top: var(--spacing-3);
   border-top: 1px solid var(--border-secondary);
 }
 
 .rec-steps ol {
-  margin: 0;
-  padding-left: 1.25rem;
+  margin: var(--spacing-0);
+  padding-left: var(--spacing-5);
   font-size: 0.8125rem;
   color: var(--text-tertiary);
 }
 
 .rec-steps li {
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 /* Model List */
 .model-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .model-item {
-  padding: 0.75rem;
+  padding: var(--spacing-3);
   background: var(--bg-primary);
   border-radius: var(--radius-md);
 }
@@ -958,7 +958,7 @@ onMounted(() => {
 .model-header {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .model-name {
@@ -974,10 +974,10 @@ onMounted(() => {
 
 .model-stats {
   display: flex;
-  gap: 1rem;
+  gap: var(--spacing-4);
   font-size: var(--text-xs);
   color: var(--text-secondary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .model-bar {
@@ -998,7 +998,7 @@ onMounted(() => {
 .category-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .category-item {
@@ -1008,7 +1008,7 @@ onMounted(() => {
 .category-header {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .category-name {
@@ -1026,7 +1026,7 @@ onMounted(() => {
   background: var(--border-secondary);
   border-radius: var(--radius-xs);
   overflow: hidden;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .category-bar-fill {
@@ -1047,11 +1047,11 @@ onMounted(() => {
 .cache-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .cache-item {
-  padding: 0.75rem;
+  padding: var(--spacing-3);
   background: var(--bg-primary);
   border-radius: var(--radius-md);
 }
@@ -1059,7 +1059,7 @@ onMounted(() => {
 .cache-header {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .cache-count {
@@ -1076,7 +1076,7 @@ onMounted(() => {
 .cache-preview {
   font-size: 0.8125rem;
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1084,11 +1084,11 @@ onMounted(() => {
 
 /* Trend Panel */
 .trend-panel {
-  margin-top: 1.5rem;
+  margin-top: var(--spacing-6);
 }
 
 .trend-chart {
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .chart-svg {
@@ -1118,14 +1118,14 @@ onMounted(() => {
 .trend-legend {
   display: flex;
   justify-content: center;
-  gap: 1rem;
-  margin-top: 0.5rem;
+  gap: var(--spacing-4);
+  margin-top: var(--spacing-2);
 }
 
 .legend-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: var(--text-xs);
   color: var(--text-secondary);
 }

--- a/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
@@ -443,7 +443,7 @@ onUnmounted(() => {
 }
 
 .header-content h2 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-2xl);
   color: var(--text-primary);
 }
@@ -580,7 +580,7 @@ onUnmounted(() => {
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
@@ -802,7 +802,7 @@ onUnmounted(() => {
 }
 
 .anomaly-description {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -893,7 +893,7 @@ onUnmounted(() => {
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Modal */
@@ -926,7 +926,7 @@ onUnmounted(() => {
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
 }
 

--- a/autobot-frontend/src/components/analytics/PatternAnalysis.vue
+++ b/autobot-frontend/src/components/analytics/PatternAnalysis.vue
@@ -790,7 +790,7 @@ defineExpose({
 }
 
 .code-block pre {
-  margin: 0;
+  margin: var(--spacing-0);
   white-space: pre-wrap;
   word-break: break-all;
 }

--- a/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PerformanceAnalysisDashboard.vue
@@ -600,10 +600,10 @@ onMounted(() => {
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
 .performance-dashboard {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 /* Header */
@@ -612,14 +612,14 @@ onMounted(() => {
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .header-content h2 {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin: 0;
+  gap: var(--spacing-2);
+  margin: var(--spacing-0);
   font-size: var(--text-2xl);
   color: var(--text-primary);
 }
@@ -632,14 +632,14 @@ onMounted(() => {
 
 .header-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 /* Buttons */
 .action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.5rem 1rem;
   border: none;
   border-radius: var(--radius-md);
@@ -684,7 +684,7 @@ onMounted(() => {
 
 /* Path Selection */
 .path-selection {
-  padding: 1rem;
+  padding: var(--spacing-4);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
@@ -693,8 +693,8 @@ onMounted(() => {
 .input-group {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-3);
 }
 
 .input-group label {
@@ -725,7 +725,7 @@ onMounted(() => {
 .quick-paths {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .quick-path-btn {
@@ -749,8 +749,8 @@ onMounted(() => {
 .score-section {
   display: flex;
   align-items: center;
-  gap: 2rem;
-  padding: 1.5rem;
+  gap: var(--spacing-8);
+  padding: var(--spacing-6);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
@@ -786,14 +786,14 @@ onMounted(() => {
 .summary-stats {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 .stat-item {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .stat-icon {
@@ -816,7 +816,7 @@ onMounted(() => {
 .content-grid {
   display: grid;
   grid-template-columns: 1.5fr 1fr;
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 /* Panels */
@@ -831,18 +831,18 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem;
+  padding: var(--spacing-4);
   border-bottom: 1px solid var(--border-color);
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
 
 .panel-content {
-  padding: 1rem;
+  padding: var(--spacing-4);
   max-height: 400px;
   overflow-y: auto;
 }
@@ -858,14 +858,14 @@ onMounted(() => {
 /* Category Tabs */
 .category-tabs {
   display: flex;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   flex-wrap: wrap;
 }
 
 .cat-tab {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   padding: 0.25rem 0.5rem;
   background: transparent;
   border: none;
@@ -890,11 +890,11 @@ onMounted(() => {
 .issues-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .issue-card {
-  padding: 0.875rem;
+  padding: var(--spacing-3-5);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   border-left: 3px solid;
@@ -914,8 +914,8 @@ onMounted(() => {
 .issue-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .impact-badge {
@@ -953,7 +953,7 @@ onMounted(() => {
   font-size: var(--text-xs);
   font-family: monospace;
   color: var(--text-secondary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .issue-desc {
@@ -964,7 +964,7 @@ onMounted(() => {
 
 .issue-impact {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: var(--text-xs);
 }
 
@@ -981,18 +981,18 @@ onMounted(() => {
 .detail-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1.25rem;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-5);
 }
 
 .detail-title h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
 
 .detail-section {
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .detail-section label {
@@ -1001,7 +1001,7 @@ onMounted(() => {
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .location-info {
@@ -1011,11 +1011,11 @@ onMounted(() => {
 
 .line-info {
   color: var(--text-secondary);
-  margin-left: 0.5rem;
+  margin-left: var(--spacing-2);
 }
 
 .description {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   line-height: 1.5;
 }
@@ -1027,8 +1027,8 @@ onMounted(() => {
 }
 
 .code-snippet pre {
-  margin: 0;
-  padding: 0.875rem;
+  margin: var(--spacing-0);
+  padding: var(--spacing-3-5);
   font-size: var(--text-xs);
   overflow-x: auto;
 }
@@ -1036,8 +1036,8 @@ onMounted(() => {
 .impact-box {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
   background: rgba(245, 158, 11, 0.1);
   border-radius: var(--radius-md);
   border: 1px solid rgba(245, 158, 11, 0.3);
@@ -1054,8 +1054,8 @@ onMounted(() => {
 
 .suggestion-box {
   display: flex;
-  gap: 0.75rem;
-  padding: 0.875rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3-5);
   background: rgba(16, 185, 129, 0.1);
   border-radius: var(--radius-md);
   border: 1px solid rgba(16, 185, 129, 0.3);
@@ -1066,7 +1066,7 @@ onMounted(() => {
 }
 
 .suggestion-box p {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
   line-height: 1.4;
 }
@@ -1075,11 +1075,11 @@ onMounted(() => {
 .hotspots-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .hotspot-item {
-  padding: 0.75rem;
+  padding: var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
 }
@@ -1087,8 +1087,8 @@ onMounted(() => {
 .hotspot-info {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  margin-bottom: 0.5rem;
+  gap: var(--spacing-1);
+  margin-bottom: var(--spacing-2);
 }
 
 .hotspot-file {
@@ -1104,7 +1104,7 @@ onMounted(() => {
 
 .hotspot-stats {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .hotspot-stats .stat {
@@ -1137,19 +1137,19 @@ onMounted(() => {
 .category-bars {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .category-bar-item {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .bar-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   width: 100px;
 }
 
@@ -1199,12 +1199,12 @@ onMounted(() => {
 }
 
 .empty-state.small {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
 }
 
 .empty-icon {
   font-size: 2.5rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 /* Modal */
@@ -1238,12 +1238,12 @@ onMounted(() => {
 }
 
 .modal-content {
-  padding: 1.25rem;
+  padding: var(--spacing-5);
   overflow-y: auto;
 }
 
 .pattern-category {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .pattern-category h4 {
@@ -1255,13 +1255,13 @@ onMounted(() => {
 .pattern-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .pattern-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.5rem 0.75rem;
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
@@ -615,10 +615,10 @@ onMounted(() => {
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
 .precommit-dashboard {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 /* Header */
@@ -627,14 +627,14 @@ onMounted(() => {
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .header-content h2 {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin: 0;
+  gap: var(--spacing-2);
+  margin: var(--spacing-0);
   font-size: var(--text-2xl);
   color: var(--text-primary);
 }
@@ -651,14 +651,14 @@ onMounted(() => {
 
 .header-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 /* Buttons */
 .action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.5rem 1rem;
   border: none;
   border-radius: var(--radius-md);
@@ -724,7 +724,7 @@ onMounted(() => {
 .status-banner {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
   padding: 1rem 1.25rem;
   border-radius: var(--radius-lg);
   border: 1px solid;
@@ -763,14 +763,14 @@ onMounted(() => {
 .summary-cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .summary-card {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
@@ -812,7 +812,7 @@ onMounted(() => {
 .content-grid {
   display: grid;
   grid-template-columns: 1.5fr 1fr;
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 /* Panels */
@@ -827,18 +827,18 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem;
+  padding: var(--spacing-4);
   border-bottom: 1px solid var(--border-color);
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
 
 .panel-content {
-  padding: 1rem;
+  padding: var(--spacing-4);
   max-height: 400px;
   overflow-y: auto;
 }
@@ -846,7 +846,7 @@ onMounted(() => {
 /* Severity Filters */
 .severity-filters {
   display: flex;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .filter-btn {
@@ -868,11 +868,11 @@ onMounted(() => {
 .results-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .result-card {
-  padding: 0.875rem;
+  padding: var(--spacing-3-5);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   border-left: 3px solid;
@@ -893,8 +893,8 @@ onMounted(() => {
 .result-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .severity-badge {
@@ -919,7 +919,7 @@ onMounted(() => {
   font-size: var(--text-xs);
   font-family: monospace;
   color: var(--text-secondary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .result-message {
@@ -931,12 +931,12 @@ onMounted(() => {
 .result-snippet {
   background: var(--bg-quaternary);
   border-radius: var(--radius-default);
-  padding: 0.5rem;
-  margin-bottom: 0.5rem;
+  padding: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .result-snippet pre {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xs);
   color: var(--text-primary);
   overflow-x: auto;
@@ -945,7 +945,7 @@ onMounted(() => {
 .result-suggestion {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: var(--text-xs);
   color: var(--color-success);
 }
@@ -957,14 +957,14 @@ onMounted(() => {
 }
 
 .category-section {
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .category-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2);
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -997,7 +997,7 @@ onMounted(() => {
 .check-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.5rem 0;
   opacity: 0.6;
 }
@@ -1094,13 +1094,13 @@ onMounted(() => {
 .history-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .history-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.625rem 0.875rem;
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
@@ -1142,7 +1142,7 @@ onMounted(() => {
 
 .history-stats {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .stat {
@@ -1170,8 +1170,8 @@ onMounted(() => {
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
 }
 
 .stat-item {
@@ -1199,13 +1199,13 @@ onMounted(() => {
 .issue-bar-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .issue-bar-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .issue-label {
@@ -1254,11 +1254,11 @@ onMounted(() => {
 
 .empty-icon {
   font-size: 2.5rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -297,7 +297,7 @@ watch(() => props.source, (source) => {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
   display: flex;
   align-items: center;
   gap: var(--spacing-2-5);
@@ -471,7 +471,7 @@ watch(() => props.source, (source) => {
   position: absolute;
   width: 1px;
   height: 1px;
-  padding: 0;
+  padding: var(--spacing-0);
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);

--- a/autobot-frontend/src/components/analytics/SourceManager.vue
+++ b/autobot-frontend/src/components/analytics/SourceManager.vue
@@ -541,7 +541,7 @@ defineExpose({ loadSources })
 }
 
 .panel-empty p {
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .panel-empty-hint {
@@ -686,7 +686,7 @@ defineExpose({ loadSources })
   border-radius: var(--radius-full);
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   text-transform: capitalize;
 }
 

--- a/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
+++ b/autobot-frontend/src/components/analytics/TechnicalDebtDashboard.vue
@@ -956,7 +956,7 @@ watch(selectedPeriod, () => {
   font-size: var(--text-2xl);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .dashboard-subtitle {
@@ -1146,7 +1146,7 @@ watch(selectedPeriod, () => {
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
@@ -1853,7 +1853,7 @@ watch(selectedPeriod, () => {
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   color: var(--text-primary);
 }

--- a/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FileScanModal.vue
@@ -136,7 +136,7 @@ async function handleScan() {
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
@@ -205,7 +205,7 @@ async function handleScan() {
 .note {
   color: var(--text-tertiary);
   font-size: var(--text-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .modal-footer {

--- a/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
@@ -373,7 +373,7 @@ code {
 }
 
 .detail-row td {
-  padding: 0;
+  padding: var(--spacing-0);
   background: var(--bg-tertiary);
 }
 
@@ -397,7 +397,7 @@ code {
 
 .detail-section p {
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Issue #901: Electric blue for OWASP tags */
@@ -434,7 +434,7 @@ code {
   transition: all var(--duration-150) var(--ease-in-out);
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .btn-small:hover {

--- a/autobot-frontend/src/components/analytics/code-intelligence/PerformanceFindingsPanel.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/PerformanceFindingsPanel.vue
@@ -41,7 +41,7 @@ defineProps<{
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: var(--font-medium);
   color: var(--text-primary);

--- a/autobot-frontend/src/components/analytics/code-intelligence/RedisFindingsPanel.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/RedisFindingsPanel.vue
@@ -41,7 +41,7 @@ defineProps<{
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: var(--font-medium);
   color: var(--text-primary);

--- a/autobot-frontend/src/components/analytics/code-intelligence/SecurityFindingsPanel.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/SecurityFindingsPanel.vue
@@ -41,7 +41,7 @@ defineProps<{
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: var(--font-medium);
   color: var(--text-primary);

--- a/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
@@ -306,7 +306,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .accordion-groups {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .accordion-group {
@@ -333,7 +333,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .header-info {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .header-info i {
@@ -354,7 +354,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 
 .header-badges {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   flex-wrap: wrap;
 }
 
@@ -375,11 +375,11 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 
 /* Accordion Items Container */
 .accordion-items {
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-primary);
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 /* Accordion Transition */
@@ -425,10 +425,10 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Show More / Muted Utilities */
 .show-more {
   text-align: center;
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-secondary);
   border-radius: var(--radius-md);
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
 }
 
 .muted {
@@ -441,7 +441,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .item-name {
@@ -468,23 +468,23 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .item-description {
   color: var(--text-secondary);
   font-size: 0.9em;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .item-location {
   color: var(--text-muted);
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.8em;
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
 }
 
 .item-suggestion {
   color: var(--chart-green);
   font-size: 0.85em;
-  padding: 8px;
+  padding: var(--spacing-2);
   background: rgba(34, 197, 94, 0.1);
   border-radius: var(--radius-default);
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
 }
 
 /* Duplicate-specific Styles */
@@ -507,7 +507,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .item-files {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .item-file {
@@ -519,7 +519,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Responsive Design */
 @media (max-width: 768px) {
   .codebase-analytics {
-    padding: 12px;
+    padding: var(--spacing-3);
   }
 
   .header-controls {
@@ -534,7 +534,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 
   .debug-controls {
     flex-direction: column;
-    gap: 8px;
+    gap: var(--spacing-2);
   }
 
   .btn-debug {
@@ -552,7 +552,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 
   .real-time-controls {
     flex-direction: column;
-    gap: 12px;
+    gap: var(--spacing-3);
     align-items: stretch;
   }
 
@@ -569,15 +569,15 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   .problem-header, .duplicate-header {
     flex-direction: column;
     align-items: flex-start;
-    gap: 4px;
+    gap: var(--spacing-1);
   }
 }
 
 /* Charts Section Styles */
 
 .api-endpoints-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -586,7 +586,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .api-endpoints-section h3 {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   margin: 0 0 20px 0;
   color: var(--text-secondary);
   font-size: 1.1rem;
@@ -601,8 +601,8 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 .api-endpoints-section .error-state {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 16px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-4);
   border-radius: var(--radius-lg);
 }
 
@@ -621,7 +621,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 /* Coverage Bar */
 .coverage-bar-container {
   margin: 20px 0;
-  padding: 16px;
+  padding: var(--spacing-4);
   background: rgba(30, 41, 59, 0.8);
   border-radius: var(--radius-lg);
 }
@@ -630,7 +630,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
   color: var(--text-muted);
   font-size: 0.9rem;
 }
@@ -671,7 +671,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
-  margin-right: 8px;
+  margin-right: var(--spacing-2);
 }
 
 .method-badge.get { background: var(--chart-green)20; color: var(--chart-green); border: 1px solid var(--chart-green)40; }
@@ -702,7 +702,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 
 /* Item Details */
 .item-details {
-  margin-top: 4px;
+  margin-top: var(--spacing-1);
   padding: 6px 10px;
   background: rgba(0, 0, 0, 0.2);
   border-radius: var(--radius-default);
@@ -770,7 +770,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
 
 /* Scan Timestamp */
 .scan-timestamp {
-  margin-top: 16px;
+  margin-top: var(--spacing-4);
   padding: 8px 12px;
   background: rgba(30, 41, 59, 0.8);
   border-radius: var(--radius-md);
@@ -778,7 +778,7 @@ function formatTimestamp(timestamp: string | number | Date | undefined): string 
   font-size: 0.8rem;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .scan-timestamp i {

--- a/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
@@ -505,8 +505,8 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 <style scoped>
 .bug-prediction-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -515,9 +515,9 @@ function formatTimestamp(timestamp: string | undefined): string {
 .bug-prediction-section h3 {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   color: var(--text-primary);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
   font-size: 1.2em;
   font-weight: 600;
 }
@@ -531,8 +531,8 @@ function formatTimestamp(timestamp: string | undefined): string {
 .bug-prediction-section .success-state {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 16px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-4);
   border-radius: var(--radius-lg);
 }
 
@@ -560,21 +560,21 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 /* Risk Files List */
 .bug-prediction-section .risk-files-list {
-  margin-top: 20px;
+  margin-top: var(--spacing-5);
 }
 
 .bug-prediction-section .risk-files-list h4 {
   color: var(--text-secondary);
   font-size: 1em;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
   font-weight: 600;
 }
 
 .bug-prediction-section .list-item {
-  padding: 16px;
+  padding: var(--spacing-4);
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-lg);
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
   border-left: 4px solid var(--text-tertiary);
   transition: all var(--duration-200) var(--ease-out);
 }
@@ -602,8 +602,8 @@ function formatTimestamp(timestamp: string | undefined): string {
 .bug-prediction-section .item-header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 10px;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-2-5);
   flex-wrap: wrap;
 }
 
@@ -672,8 +672,8 @@ function formatTimestamp(timestamp: string | undefined): string {
 .bug-prediction-section .risk-factors {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 10px;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2-5);
 }
 
 .bug-prediction-section .factor-badge {
@@ -688,7 +688,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .bug-prediction-section .prevention-tips {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 10px 12px;
   background: rgba(59, 130, 246, 0.1);
   border-radius: var(--radius-md);
@@ -697,7 +697,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 .bug-prediction-section .prevention-tips i {
   color: var(--color-warning-light);
-  margin-top: 2px;
+  margin-top: var(--spacing-0-5);
 }
 
 .bug-prediction-section .prevention-tips span {
@@ -708,7 +708,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 .bug-prediction-section .show-more {
   text-align: center;
-  padding: 10px;
+  padding: var(--spacing-2-5);
 }
 
 .bug-prediction-section .show-more .muted {
@@ -719,11 +719,11 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Enhanced Bug Prediction Styles */
 .summary-card.clickable { cursor: pointer; transition: transform 0.2s; }
 .summary-card.clickable:hover { transform: translateY(-2px); }
-.top-risk-factors-summary { margin: 20px 0; padding: 16px; background: rgba(17, 24, 39, 0.6); border-radius: var(--radius-xl); border: 1px solid rgba(239, 68, 68, 0.2); }
-.top-risk-factors-summary h4 { color: var(--color-error-light); font-size: 1em; margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }
+.top-risk-factors-summary { margin: 20px 0; padding: var(--spacing-4); background: rgba(17, 24, 39, 0.6); border-radius: var(--radius-xl); border: 1px solid rgba(239, 68, 68, 0.2); }
+.top-risk-factors-summary h4 { color: var(--color-error-light); font-size: 1em; margin-bottom: var(--spacing-4); display: flex; align-items: center; gap: var(--spacing-2); }
 .top-risk-factors-summary h4 i { color: var(--color-error); }
-.risk-factors-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; }
-.risk-factor-card { display: flex; align-items: flex-start; gap: 12px; padding: 14px; background: rgba(30, 41, 59, 0.5); border-radius: var(--radius-lg); border-left: 3px solid var(--text-tertiary); }
+.risk-factors-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: var(--spacing-3); }
+.risk-factor-card { display: flex; align-items: flex-start; gap: var(--spacing-3); padding: var(--spacing-3-5); background: rgba(30, 41, 59, 0.5); border-radius: var(--radius-lg); border-left: 3px solid var(--text-tertiary); }
 .risk-factor-card.critical { border-left-color: var(--color-error); background: rgba(239, 68, 68, 0.1); }
 .risk-factor-card.high { border-left-color: var(--chart-orange); background: rgba(249, 115, 22, 0.1); }
 .risk-factor-card.medium { border-left-color: var(--color-warning); background: rgba(234, 179, 8, 0.1); }
@@ -732,18 +732,18 @@ function formatTimestamp(timestamp: string | undefined): string {
 .risk-factor-card.critical .factor-icon i { color: var(--color-error-light); }
 .risk-factor-card.high .factor-icon i { color: var(--chart-orange-light); }
 .risk-factor-card .factor-details { flex: 1; }
-.risk-factor-card .factor-name { color: var(--text-primary); font-weight: 600; font-size: 0.95em; margin-bottom: 4px; }
-.risk-factor-card .factor-count { color: var(--color-warning-light); font-size: 0.85em; font-weight: 500; margin-bottom: 4px; }
+.risk-factor-card .factor-name { color: var(--text-primary); font-weight: 600; font-size: 0.95em; margin-bottom: var(--spacing-1); }
+.risk-factor-card .factor-count { color: var(--color-warning-light); font-size: 0.85em; font-weight: 500; margin-bottom: var(--spacing-1); }
 .risk-factor-card .factor-description { color: var(--text-muted); font-size: 0.8em; line-height: 1.4; }
-.risk-filter-tabs { display: flex; gap: 8px; margin: 20px 0 16px; flex-wrap: wrap; }
+.risk-filter-tabs { display: flex; gap: var(--spacing-2); margin: 20px 0 16px; flex-wrap: wrap; }
 .risk-filter-tabs button { padding: 8px 16px; border: 1px solid rgba(71, 85, 105, 0.5); background: rgba(30, 41, 59, 0.5); color: var(--text-muted); border-radius: var(--radius-md); font-size: 0.85em; cursor: pointer; transition: all 0.2s; }
 .risk-filter-tabs button:hover:not(:disabled) { background: rgba(71, 85, 105, 0.5); color: var(--text-secondary); }
 .risk-filter-tabs button.active { background: rgba(59, 130, 246, 0.2); border-color: rgba(59, 130, 246, 0.5); color: var(--color-info-light); }
 .risk-filter-tabs button:disabled { opacity: 0.5; cursor: not-allowed; }
-.risk-files-list.detailed h4 { display: flex; align-items: center; gap: 8px; color: var(--text-secondary); margin-bottom: 12px; }
+.risk-files-list.detailed h4 { display: flex; align-items: center; gap: var(--spacing-2); color: var(--text-secondary); margin-bottom: var(--spacing-3); }
 .risk-files-list.detailed h4 .file-count { color: var(--text-tertiary); font-weight: normal; font-size: 0.9em; }
-.risk-files-list .no-files-message { padding: 20px; text-align: center; color: var(--color-success-light); background: rgba(34, 197, 94, 0.1); border-radius: var(--radius-lg); }
-.risk-file-item { background: rgba(17, 24, 39, 0.5); border-radius: var(--radius-lg); margin-bottom: 10px; border-left: 4px solid var(--text-tertiary); overflow: hidden; transition: all 0.2s; }
+.risk-files-list .no-files-message { padding: var(--spacing-5); text-align: center; color: var(--color-success-light); background: rgba(34, 197, 94, 0.1); border-radius: var(--radius-lg); }
+.risk-file-item { background: rgba(17, 24, 39, 0.5); border-radius: var(--radius-lg); margin-bottom: var(--spacing-2-5); border-left: 4px solid var(--text-tertiary); overflow: hidden; transition: all 0.2s; }
 .risk-file-item.item-critical { border-left-color: var(--color-error); }
 .risk-file-item.item-warning { border-left-color: var(--color-warning); }
 .risk-file-item.item-info { border-left-color: var(--chart-blue); }
@@ -751,7 +751,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .risk-file-item.expanded { background: rgba(17, 24, 39, 0.8); }
 .risk-file-item .file-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; cursor: pointer; transition: background 0.2s; }
 .risk-file-item .file-header:hover { background: rgba(71, 85, 105, 0.2); }
-.risk-file-item .file-info { display: flex; align-items: center; gap: 10px; flex: 1; flex-wrap: wrap; }
+.risk-file-item .file-info { display: flex; align-items: center; gap: var(--spacing-2-5); flex: 1; flex-wrap: wrap; }
 .risk-file-item .risk-score-badge { padding: 4px 10px; border-radius: var(--radius-default); font-weight: 700; font-size: 0.85em; min-width: 40px; text-align: center; }
 .risk-file-item .risk-score-badge.item-critical { background: rgba(239, 68, 68, 0.3); color: var(--color-error-light); }
 .risk-file-item .risk-score-badge.item-warning { background: rgba(245, 158, 11, 0.3); color: var(--color-warning-light); }
@@ -763,21 +763,21 @@ function formatTimestamp(timestamp: string | undefined): string {
 .risk-file-item .risk-level-tag.medium { background: rgba(245, 158, 11, 0.2); color: var(--color-warning-light); }
 .risk-file-item .risk-level-tag.low, .risk-file-item .risk-level-tag.minimal { background: rgba(34, 197, 94, 0.2); color: var(--color-success-light); }
 .risk-file-item .expand-icon { color: var(--text-tertiary); padding: 4px 8px; }
-.quick-risk-indicators { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 16px 12px; }
-.quick-risk-indicators .indicator { display: flex; align-items: center; gap: 4px; padding: 3px 8px; border-radius: var(--radius-default); font-size: 0.75em; font-weight: 500; }
+.quick-risk-indicators { display: flex; flex-wrap: wrap; gap: var(--spacing-1-5); padding: 0 16px 12px; }
+.quick-risk-indicators .indicator { display: flex; align-items: center; gap: var(--spacing-1); padding: 3px 8px; border-radius: var(--radius-default); font-size: 0.75em; font-weight: 500; }
 .quick-risk-indicators .indicator.critical { background: rgba(239, 68, 68, 0.2); color: var(--color-error-light); }
 .quick-risk-indicators .indicator.high { background: rgba(249, 115, 22, 0.2); color: var(--chart-orange-light); }
 .quick-risk-indicators .indicator.warning { background: rgba(234, 179, 8, 0.2); color: var(--color-warning-light); }
 .quick-risk-indicators .indicator.info { background: rgba(59, 130, 246, 0.2); color: var(--color-info-light); }
 .quick-risk-indicators .indicator.muted { background: rgba(100, 116, 139, 0.2); color: var(--text-muted); }
-.file-details { padding: 16px; background: rgba(15, 23, 42, 0.5); border-top: 1px solid rgba(71, 85, 105, 0.3); }
-.file-details .detail-section { margin-bottom: 16px; }
-.file-details .detail-section:last-child { margin-bottom: 0; }
-.file-details h5 { color: var(--text-secondary); font-size: 0.9em; margin-bottom: 10px; display: flex; align-items: center; gap: 6px; }
+.file-details { padding: var(--spacing-4); background: rgba(15, 23, 42, 0.5); border-top: 1px solid rgba(71, 85, 105, 0.3); }
+.file-details .detail-section { margin-bottom: var(--spacing-4); }
+.file-details .detail-section:last-child { margin-bottom: var(--spacing-0); }
+.file-details h5 { color: var(--text-secondary); font-size: 0.9em; margin-bottom: var(--spacing-2-5); display: flex; align-items: center; gap: var(--spacing-1-5); }
 .file-details h5 i { color: var(--text-tertiary); }
-.factors-breakdown { display: flex; flex-direction: column; gap: 8px; }
-.factor-row { display: flex; align-items: center; gap: 12px; }
-.factor-row .factor-label { width: 140px; color: var(--text-muted); font-size: 0.85em; display: flex; align-items: center; gap: 6px; }
+.factors-breakdown { display: flex; flex-direction: column; gap: var(--spacing-2); }
+.factor-row { display: flex; align-items: center; gap: var(--spacing-3); }
+.factor-row .factor-label { width: 140px; color: var(--text-muted); font-size: 0.85em; display: flex; align-items: center; gap: var(--spacing-1-5); }
 .factor-row .factor-label i { width: 16px; text-align: center; color: var(--text-tertiary); }
 .factor-row.high-value .factor-label { color: var(--color-error-light); }
 .factor-row.high-value .factor-label i { color: var(--color-error); }
@@ -790,14 +790,14 @@ function formatTimestamp(timestamp: string | undefined): string {
 .factor-row .factor-value { width: 40px; text-align: right; font-weight: 600; font-size: 0.85em; color: var(--text-secondary); }
 .factor-row.high-value .factor-value { color: var(--color-error-light); }
 .factor-row.medium-value .factor-value { color: var(--color-warning-light); }
-.tips-list, .tests-list { list-style: none; padding: 0; margin: 0; }
-.tips-list li, .tests-list li { display: flex; align-items: flex-start; gap: 10px; padding: 10px 12px; background: rgba(30, 41, 59, 0.5); border-radius: var(--radius-md); margin-bottom: 6px; font-size: 0.85em; line-height: 1.4; }
-.tips-list li i { color: var(--color-warning-light); margin-top: 2px; }
+.tips-list, .tests-list { list-style: none; padding: var(--spacing-0); margin: var(--spacing-0); }
+.tips-list li, .tests-list li { display: flex; align-items: flex-start; gap: var(--spacing-2-5); padding: 10px 12px; background: rgba(30, 41, 59, 0.5); border-radius: var(--radius-md); margin-bottom: var(--spacing-1-5); font-size: 0.85em; line-height: 1.4; }
+.tips-list li i { color: var(--color-warning-light); margin-top: var(--spacing-0-5); }
 .tips-list li { color: var(--text-secondary); border-left: 3px solid var(--color-warning-light); }
-.tests-list li i { color: var(--chart-purple-light); margin-top: 2px; }
+.tests-list li i { color: var(--chart-purple-light); margin-top: var(--spacing-0-5); }
 .tests-list li { color: var(--chart-purple-light); border-left: 3px solid var(--chart-purple-light); }
-.show-more-container { text-align: center; margin-top: 16px; }
-.show-more-btn { padding: 10px 24px; background: rgba(59, 130, 246, 0.2); border: 1px solid rgba(59, 130, 246, 0.4); color: var(--color-info-light); border-radius: var(--radius-md); cursor: pointer; font-size: 0.9em; display: inline-flex; align-items: center; gap: 8px; transition: all 0.2s; }
+.show-more-container { text-align: center; margin-top: var(--spacing-4); }
+.show-more-btn { padding: 10px 24px; background: rgba(59, 130, 246, 0.2); border: 1px solid rgba(59, 130, 246, 0.4); color: var(--color-info-light); border-radius: var(--radius-md); cursor: pointer; font-size: 0.9em; display: inline-flex; align-items: center; gap: var(--spacing-2); transition: all 0.2s; }
 .show-more-btn:hover { background: rgba(59, 130, 246, 0.3); }
 
 /* Issue #538: Code Intelligence Scores Section */

--- a/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseChartsSection.vue
@@ -323,8 +323,8 @@ function getCategoryIcon(categoryId: string): string {
 <style scoped>
 /* Codebase Statistics Section (#4063: Fix rendering gaps) */
 .stats-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -338,7 +338,7 @@ function getCategoryIcon(categoryId: string): string {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .stats-section h3 i {
@@ -348,12 +348,12 @@ function getCategoryIcon(categoryId: string): string {
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .section-export-buttons {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   align-items: center;
 }
 
@@ -369,7 +369,7 @@ function getCategoryIcon(categoryId: string): string {
   transition: all var(--duration-200) var(--ease-out);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .export-btn:hover:not(:disabled) {
@@ -397,8 +397,8 @@ function getCategoryIcon(categoryId: string): string {
 }
 
 .charts-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -408,19 +408,19 @@ function getCategoryIcon(categoryId: string): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
-  padding-bottom: 12px;
+  margin-bottom: var(--spacing-5);
+  padding-bottom: var(--spacing-3);
   border-bottom: 1px solid rgba(71, 85, 105, 0.5);
 }
 
 .charts-section .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: var(--text-xl);
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .charts-section .section-header h3 i {
@@ -429,7 +429,7 @@ function getCategoryIcon(categoryId: string): string {
 
 .section-header-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   align-items: center;
 }
 
@@ -437,9 +437,9 @@ function getCategoryIcon(categoryId: string): string {
 .category-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 20px;
-  padding: 12px;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-5);
+  padding: var(--spacing-3);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-lg);
   border: 1px solid rgba(71, 85, 105, 0.3);
@@ -448,7 +448,7 @@ function getCategoryIcon(categoryId: string): string {
 .category-tab {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 8px 16px;
   background: rgba(51, 65, 85, 0.5);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -500,7 +500,7 @@ function getCategoryIcon(categoryId: string): string {
   align-items: center;
   justify-content: center;
   min-height: 200px;
-  gap: 12px;
+  gap: var(--spacing-3);
   color: var(--text-muted);
 }
 
@@ -521,20 +521,20 @@ function getCategoryIcon(categoryId: string): string {
 .charts-grid {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--spacing-6);
 }
 
 .chart-summary {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin-bottom: 16px;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
 }
 
 .summary-stat {
   background: rgba(51, 65, 85, 0.5);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
   text-align: center;
   border: 1px solid rgba(71, 85, 105, 0.5);
   transition: all var(--duration-200) var(--ease-out);
@@ -568,14 +568,14 @@ function getCategoryIcon(categoryId: string): string {
 .summary-label {
   font-size: 0.85rem;
   color: var(--text-muted);
-  margin-top: 4px;
+  margin-top: var(--spacing-1);
   display: block;
 }
 
 .charts-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 /* Chart items (BaseChart components) - minimal layout adjustment */
@@ -587,7 +587,7 @@ function getCategoryIcon(categoryId: string): string {
 .chart-empty-slot {
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
   border: 1px solid rgba(71, 85, 105, 0.5);
   min-height: 350px;
   display: flex;
@@ -620,8 +620,8 @@ function getCategoryIcon(categoryId: string): string {
 
 /* Dependency Section Styles */
 .dependency-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -631,19 +631,19 @@ function getCategoryIcon(categoryId: string): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
-  padding-bottom: 12px;
+  margin-bottom: var(--spacing-5);
+  padding-bottom: var(--spacing-3);
   border-bottom: 1px solid rgba(71, 85, 105, 0.5);
 }
 
 .dependency-section .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: var(--text-xl);
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .dependency-section .section-header h3 i {
@@ -653,7 +653,7 @@ function getCategoryIcon(categoryId: string): string {
 .dependency-grid {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--spacing-6);
 }
 
 /* Circular Dependencies Warning */
@@ -661,16 +661,16 @@ function getCategoryIcon(categoryId: string): string {
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
 }
 
 .circular-deps-warning .warning-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   font-weight: 600;
   color: var(--color-error-light);
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .circular-deps-warning .warning-header i {
@@ -680,13 +680,13 @@ function getCategoryIcon(categoryId: string): string {
 .circular-deps-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .circular-dep-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 8px 12px;
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-default);
@@ -703,7 +703,7 @@ function getCategoryIcon(categoryId: string): string {
 .external-deps-table {
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
   border: 1px solid rgba(71, 85, 105, 0.3);
 }
 
@@ -714,7 +714,7 @@ function getCategoryIcon(categoryId: string): string {
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .external-deps-table h4 i {
@@ -724,7 +724,7 @@ function getCategoryIcon(categoryId: string): string {
 .deps-table-content {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .dep-row {
@@ -757,8 +757,8 @@ function getCategoryIcon(categoryId: string): string {
 
 /* Import Tree Section */
 .import-tree-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -768,17 +768,17 @@ function getCategoryIcon(categoryId: string): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .import-tree-section .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: 1.1rem;
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .import-tree-section .section-header h3 i {
@@ -788,8 +788,8 @@ function getCategoryIcon(categoryId: string): string {
 .import-tree-section .section-error {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-3);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: var(--radius-lg);
@@ -801,13 +801,13 @@ function getCategoryIcon(categoryId: string): string {
 }
 
 .import-tree-content {
-  margin-top: 16px;
+  margin-top: var(--spacing-4);
 }
 
 /* Call Graph Section */
 .call-graph-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -817,17 +817,17 @@ function getCategoryIcon(categoryId: string): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .call-graph-section .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: 1.1rem;
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .call-graph-section .section-header h3 i {
@@ -837,8 +837,8 @@ function getCategoryIcon(categoryId: string): string {
 .call-graph-section .section-error {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-3);
   background: rgba(239, 68, 68, 0.1);
   border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: var(--radius-lg);
@@ -850,7 +850,7 @@ function getCategoryIcon(categoryId: string): string {
 }
 
 .call-graph-content {
-  margin-top: 16px;
+  margin-top: var(--spacing-4);
 }
 
 /* Issue #527: API Endpoint Checker Section */

--- a/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseConfigDuplicatesPanel.vue
@@ -147,8 +147,8 @@ function truncateValue(value: string, maxLength = 50): string {
 
 <style scoped>
 .config-duplicates-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -157,9 +157,9 @@ function truncateValue(value: string, maxLength = 50): string {
 .config-duplicates-section h3 {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   color: var(--text-primary);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
   font-size: 1.2em;
   font-weight: 600;
 }
@@ -173,8 +173,8 @@ function truncateValue(value: string, maxLength = 50): string {
 .config-duplicates-section .success-state {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 16px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-4);
   border-radius: var(--radius-lg);
 }
 
@@ -203,15 +203,15 @@ function truncateValue(value: string, maxLength = 50): string {
 .config-duplicates-section .duplicates-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  margin-top: 16px;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-4);
 }
 
 .config-duplicates-section .item-header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 8px;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-2);
 }
 
 .config-duplicates-section .config-value-badge {
@@ -229,7 +229,7 @@ function truncateValue(value: string, maxLength = 50): string {
 }
 
 .config-duplicates-section .item-locations {
-  padding-left: 12px;
+  padding-left: var(--spacing-3);
   border-left: 2px solid rgba(245, 158, 11, 0.3);
 }
 
@@ -243,11 +243,11 @@ function truncateValue(value: string, maxLength = 50): string {
   color: var(--text-tertiary);
   font-size: 0.8em;
   font-style: italic;
-  padding-top: 4px;
+  padding-top: var(--spacing-1);
 }
 
 .config-duplicates-section .recommendation-box {
-  margin-top: 20px;
+  margin-top: var(--spacing-5);
   padding: 12px 16px;
   background: rgba(59, 130, 246, 0.1);
   border: 1px solid rgba(59, 130, 246, 0.3);
@@ -255,7 +255,7 @@ function truncateValue(value: string, maxLength = 50): string {
   color: var(--color-info-light);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .config-duplicates-section .recommendation-box i {

--- a/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
@@ -415,7 +415,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .accordion-groups {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .accordion-group {
@@ -442,7 +442,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .header-info {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .header-info i {
@@ -463,7 +463,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 .header-badges {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   flex-wrap: wrap;
 }
 
@@ -484,11 +484,11 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 /* Accordion Items Container */
 .accordion-items {
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-primary);
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 /* Accordion Transition */
@@ -534,10 +534,10 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Show More / Muted Utilities */
 .show-more {
   text-align: center;
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-secondary);
   border-radius: var(--radius-md);
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
 }
 
 .muted {
@@ -550,7 +550,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .item-name {
@@ -577,23 +577,23 @@ function formatTimestamp(timestamp: string | undefined): string {
 .item-description {
   color: var(--text-secondary);
   font-size: 0.9em;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .item-location {
   color: var(--text-muted);
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.8em;
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
 }
 
 .item-suggestion {
   color: var(--chart-green);
   font-size: 0.85em;
-  padding: 8px;
+  padding: var(--spacing-2);
   background: rgba(34, 197, 94, 0.1);
   border-radius: var(--radius-default);
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
 }
 
 /* Duplicate-specific Styles */
@@ -616,7 +616,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .item-files {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .item-file {
@@ -628,7 +628,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 /* Responsive Design */
 @media (max-width: 768px) {
   .codebase-analytics {
-    padding: 12px;
+    padding: var(--spacing-3);
   }
 
   .header-controls {
@@ -643,7 +643,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
   .debug-controls {
     flex-direction: column;
-    gap: 8px;
+    gap: var(--spacing-2);
   }
 
   .btn-debug {
@@ -661,7 +661,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
   .real-time-controls {
     flex-direction: column;
-    gap: 12px;
+    gap: var(--spacing-3);
     align-items: stretch;
   }
 
@@ -678,15 +678,15 @@ function formatTimestamp(timestamp: string | undefined): string {
   .problem-header, .duplicate-header {
     flex-direction: column;
     align-items: flex-start;
-    gap: 4px;
+    gap: var(--spacing-1);
   }
 }
 
 /* Charts Section Styles */
 
 .cross-language-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -695,7 +695,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .cross-language-section h3 {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   margin: 0 0 20px 0;
   color: var(--text-secondary);
   font-size: 1.1rem;
@@ -710,8 +710,8 @@ function formatTimestamp(timestamp: string | undefined): string {
 .cross-language-section .error-state {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 16px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-4);
   border-radius: var(--radius-lg);
 }
 
@@ -731,9 +731,9 @@ function formatTimestamp(timestamp: string | undefined): string {
 .language-breakdown {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--spacing-3);
   margin: 16px 0;
-  padding: 12px;
+  padding: var(--spacing-3);
   background: rgba(30, 41, 59, 0.8);
   border-radius: var(--radius-lg);
 }
@@ -741,7 +741,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .language-badge {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   padding: 6px 12px;
   border-radius: var(--radius-md);
   font-size: 0.85rem;
@@ -774,7 +774,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   font-size: var(--text-xs);
   font-weight: 500;
   text-transform: uppercase;
-  margin-right: 8px;
+  margin-right: var(--spacing-2);
   background: rgba(139, 92, 246, 0.2);
   color: var(--chart-purple-light);
   border: 1px solid rgba(139, 92, 246, 0.3);
@@ -799,7 +799,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   font-weight: 500;
-  margin-right: 8px;
+  margin-right: var(--spacing-2);
   background: rgba(59, 130, 246, 0.2);
   color: var(--color-info-light);
   border: 1px solid rgba(59, 130, 246, 0.3);
@@ -827,7 +827,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .match-type {
   display: inline-block;
   padding: 2px 8px;
-  margin-left: 8px;
+  margin-left: var(--spacing-2);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
   font-weight: 500;
@@ -840,8 +840,8 @@ function formatTimestamp(timestamp: string | undefined): string {
 .item-locations {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 6px;
+  gap: var(--spacing-2);
+  margin-top: var(--spacing-1-5);
   align-items: center;
 }
 
@@ -866,7 +866,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 /* Item Field */
 .item-field {
-  margin-top: 4px;
+  margin-top: var(--spacing-1);
   font-size: 0.85rem;
   color: var(--text-muted);
 }
@@ -887,7 +887,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 
 /* Item Recommendation */
 .item-recommendation {
-  margin-top: 6px;
+  margin-top: var(--spacing-1-5);
   padding: 8px 12px;
   background: rgba(59, 130, 246, 0.1);
   border-radius: var(--radius-md);
@@ -900,7 +900,7 @@ function formatTimestamp(timestamp: string | undefined): string {
 .analysis-time {
   color: var(--text-tertiary);
   font-size: var(--text-xs);
-  margin-left: 4px;
+  margin-left: var(--spacing-1);
 }
 
 /* Scan Button */
@@ -914,7 +914,7 @@ function formatTimestamp(timestamp: string | undefined): string {
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   transition: background var(--duration-200);
 }
 

--- a/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
@@ -283,8 +283,8 @@ function formatFactorName(factor: string): string {
 
 <style scoped>
 .environment-analysis-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -293,9 +293,9 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section h3 {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   color: var(--text-primary);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
   font-size: 1.2em;
   font-weight: 600;
 }
@@ -309,8 +309,8 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .success-state {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 16px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-4);
   border-radius: var(--radius-lg);
 }
 
@@ -338,19 +338,19 @@ function formatFactorName(factor: string): string {
 
 /* Categories Breakdown */
 .environment-analysis-section .categories-breakdown {
-  margin-top: 20px;
+  margin-top: var(--spacing-5);
 }
 
 .environment-analysis-section .categories-breakdown h4 {
   color: var(--text-secondary);
   font-size: 1em;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .environment-analysis-section .category-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .environment-analysis-section .category-badge {
@@ -363,20 +363,20 @@ function formatFactorName(factor: string): string {
 
 /* Recommendations List */
 .environment-analysis-section .recommendations-list {
-  margin-top: 20px;
+  margin-top: var(--spacing-5);
 }
 
 .environment-analysis-section .recommendations-list h4 {
   color: var(--text-secondary);
   font-size: 1em;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .environment-analysis-section .recommendation-item {
-  padding: 14px;
+  padding: var(--spacing-3-5);
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-lg);
-  margin-bottom: 10px;
+  margin-bottom: var(--spacing-2-5);
   border-left: 4px solid var(--text-tertiary);
 }
 
@@ -395,8 +395,8 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .rec-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 8px;
+  gap: var(--spacing-2-5);
+  margin-bottom: var(--spacing-2);
 }
 
 .environment-analysis-section .env-var-name {
@@ -433,7 +433,7 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .rec-description {
   color: var(--text-secondary);
   font-size: 0.9em;
-  margin-bottom: 6px;
+  margin-bottom: var(--spacing-1-5);
 }
 
 .environment-analysis-section .rec-default {
@@ -449,13 +449,13 @@ function formatFactorName(factor: string): string {
 
 /* Hardcoded Values Preview */
 .environment-analysis-section .hardcoded-preview {
-  margin-top: 20px;
+  margin-top: var(--spacing-5);
 }
 
 .environment-analysis-section .hardcoded-preview h4 {
   color: var(--text-secondary);
   font-size: 1em;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 /* Issue #631: Truncation warning style */
@@ -463,14 +463,14 @@ function formatFactorName(factor: string): string {
   font-size: 0.85em;
   color: var(--color-warning);
   font-weight: normal;
-  margin-left: 8px;
+  margin-left: var(--spacing-2);
 }
 
 .environment-analysis-section .hardcoded-item {
-  padding: 12px;
+  padding: var(--spacing-3);
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-md);
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
   border-left: 3px solid var(--text-tertiary);
 }
 
@@ -487,7 +487,7 @@ function formatFactorName(factor: string): string {
 }
 
 .environment-analysis-section .hv-location {
-  margin-bottom: 6px;
+  margin-bottom: var(--spacing-1-5);
 }
 
 .environment-analysis-section .file-path {
@@ -504,8 +504,8 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .hv-value {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-1-5);
 }
 
 .environment-analysis-section .hv-value code {
@@ -525,7 +525,7 @@ function formatFactorName(factor: string): string {
 .environment-analysis-section .hv-suggestion {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   padding: 6px 10px;
   background: rgba(59, 130, 246, 0.1);
   border-radius: var(--radius-default);

--- a/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
@@ -769,8 +769,8 @@ function formatTimestamp(timestamp: string): string {
 
 <style scoped>
 .code-intelligence-scores-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -779,9 +779,9 @@ function formatTimestamp(timestamp: string): string {
 .code-intelligence-scores-section h3 {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   color: var(--text-primary);
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
   font-size: 1.2em;
   font-weight: 600;
 }
@@ -794,13 +794,13 @@ function formatTimestamp(timestamp: string): string {
 .scores-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 .score-card {
   background: rgba(17, 24, 39, 0.6);
   border-radius: var(--radius-xl);
-  padding: 20px;
+  padding: var(--spacing-5);
   border: 1px solid rgba(71, 85, 105, 0.4);
   transition: all var(--duration-200) var(--ease-out);
 }
@@ -813,8 +813,8 @@ function formatTimestamp(timestamp: string): string {
 .score-card .score-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 16px;
+  gap: var(--spacing-2-5);
+  margin-bottom: var(--spacing-4);
   font-size: 1.1em;
   font-weight: 600;
   color: var(--text-secondary);
@@ -860,8 +860,8 @@ function formatTimestamp(timestamp: string): string {
 .score-card .score-error {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
   background: rgba(239, 68, 68, 0.1);
   border-radius: var(--radius-lg);
   color: var(--color-error-light);
@@ -880,15 +880,15 @@ function formatTimestamp(timestamp: string): string {
 .score-card .score-details {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--spacing-2);
   justify-content: center;
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
 }
 
 .score-card .detail-item {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 4px 10px;
   border-radius: var(--radius-default);
   font-size: 0.8em;
@@ -920,14 +920,14 @@ function formatTimestamp(timestamp: string): string {
 /* Quality Metrics (#3073) */
 .quality-metrics {
   width: 100%;
-  margin-top: 12px;
+  margin-top: var(--spacing-3);
 }
 
 .quality-metric {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-1-5);
 }
 
 .quality-metric .metric-label {
@@ -963,14 +963,14 @@ function formatTimestamp(timestamp: string): string {
 }
 
 .quality-trend {
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
   padding: 4px 12px;
   border-radius: var(--radius-default);
   font-size: 0.8em;
   font-weight: 500;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .quality-trend.trend-improving {
@@ -990,8 +990,8 @@ function formatTimestamp(timestamp: string): string {
 
 /* Suggestions Section (#3073) */
 .suggestions-section {
-  margin-top: 24px;
-  padding: 20px;
+  margin-top: var(--spacing-6);
+  padding: var(--spacing-5);
   background: rgba(30, 41, 59, 0.4);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.3);
@@ -1000,9 +1000,9 @@ function formatTimestamp(timestamp: string): string {
 .suggestions-section h4 {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   color: var(--text-primary);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
   font-size: 1.05em;
   font-weight: 600;
 }
@@ -1020,7 +1020,7 @@ function formatTimestamp(timestamp: string): string {
 .suggestions-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .suggestion-item {
@@ -1037,8 +1037,8 @@ function formatTimestamp(timestamp: string): string {
 .suggestion-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-1-5);
 }
 
 .suggestion-type-badge {
@@ -1077,14 +1077,14 @@ function formatTimestamp(timestamp: string): string {
   font-weight: 600;
   color: var(--text-primary);
   font-size: 0.95em;
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
 }
 
 .suggestion-description {
   color: var(--text-secondary);
   font-size: 0.85em;
   line-height: 1.5;
-  margin-bottom: 6px;
+  margin-bottom: var(--spacing-1-5);
 }
 
 .suggestion-impact {
@@ -1094,13 +1094,13 @@ function formatTimestamp(timestamp: string): string {
 
 .suggestion-impact i {
   color: var(--chart-green);
-  margin-right: 4px;
+  margin-right: var(--spacing-1);
 }
 
 /* Analysis History Section (#3073) */
 .analysis-history-section {
-  margin-top: 24px;
-  padding: 20px;
+  margin-top: var(--spacing-6);
+  padding: var(--spacing-5);
   background: rgba(30, 41, 59, 0.4);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.3);
@@ -1109,9 +1109,9 @@ function formatTimestamp(timestamp: string): string {
 .analysis-history-section h4 {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   color: var(--text-primary);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
   font-size: 1.05em;
   font-weight: 600;
 }
@@ -1121,7 +1121,7 @@ function formatTimestamp(timestamp: string): string {
 .history-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
   max-height: 300px;
   overflow-y: auto;
 }
@@ -1129,7 +1129,7 @@ function formatTimestamp(timestamp: string): string {
 .history-item {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 10px 14px;
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-md);
@@ -1144,7 +1144,7 @@ function formatTimestamp(timestamp: string): string {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
 }
 
 .history-language {
@@ -1180,7 +1180,7 @@ function formatTimestamp(timestamp: string): string {
 /* View Details Button */
 .view-details-btn {
   width: 100%;
-  margin-top: 12px;
+  margin-top: var(--spacing-3);
   padding: 8px 16px;
   background: rgba(99, 102, 241, 0.2);
   border: 1px solid rgba(99, 102, 241, 0.4);
@@ -1193,7 +1193,7 @@ function formatTimestamp(timestamp: string): string {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .view-details-btn:hover:not(:disabled) {
@@ -1209,7 +1209,7 @@ function formatTimestamp(timestamp: string): string {
 
 /* Findings Panel Styles */
 .findings-panel {
-  margin-top: 16px;
+  margin-top: var(--spacing-4);
   background: rgba(30, 41, 59, 0.6);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -1240,10 +1240,10 @@ function formatTimestamp(timestamp: string): string {
 }
 
 .findings-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   color: var(--text-primary);
   font-size: 1.1em;
   font-weight: 600;
@@ -1267,7 +1267,7 @@ function formatTimestamp(timestamp: string): string {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   padding: 40px 20px;
   color: var(--text-muted);
   font-size: 0.95em;
@@ -1279,7 +1279,7 @@ function formatTimestamp(timestamp: string): string {
 }
 
 .findings-list {
-  padding: 12px;
+  padding: var(--spacing-3);
   max-height: 500px;
   overflow-y: auto;
 }
@@ -1288,12 +1288,12 @@ function formatTimestamp(timestamp: string): string {
   background: rgba(15, 23, 42, 0.6);
   border-radius: var(--radius-lg);
   padding: 14px 16px;
-  margin-bottom: 10px;
+  margin-bottom: var(--spacing-2-5);
   border-left: 4px solid var(--text-tertiary);
   transition: all var(--duration-200) var(--ease-out);
 }
 
-.finding-item:last-child { margin-bottom: 0; }
+.finding-item:last-child { margin-bottom: var(--spacing-0); }
 .finding-item:hover { background: rgba(15, 23, 42, 0.8); }
 
 .finding-item.severity-critical {
@@ -1324,8 +1324,8 @@ function formatTimestamp(timestamp: string): string {
 .finding-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 8px;
+  gap: var(--spacing-2-5);
+  margin-bottom: var(--spacing-2);
   flex-wrap: wrap;
 }
 
@@ -1381,13 +1381,13 @@ function formatTimestamp(timestamp: string): string {
   color: var(--text-secondary);
   font-size: 0.9em;
   line-height: 1.5;
-  margin-bottom: 10px;
+  margin-bottom: var(--spacing-2-5);
 }
 
 .finding-location {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   color: var(--text-tertiary);
   font-size: 0.85em;
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
@@ -1401,7 +1401,7 @@ function formatTimestamp(timestamp: string): string {
 }
 
 .finding-recommendation {
-  margin-top: 10px;
+  margin-top: var(--spacing-2-5);
   padding: 10px 12px;
   background: rgba(34, 197, 94, 0.1);
   border-radius: var(--radius-md);
@@ -1413,17 +1413,17 @@ function formatTimestamp(timestamp: string): string {
 
 .finding-recommendation i {
   color: var(--chart-green);
-  margin-right: 6px;
+  margin-right: var(--spacing-1-5);
 }
 
 .finding-owasp {
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
   color: var(--text-muted);
   font-size: 0.8em;
 }
 
 .finding-owasp i {
   color: var(--chart-orange);
-  margin-right: 4px;
+  margin-right: var(--spacing-1);
 }
 </style>

--- a/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseOwnershipPanel.vue
@@ -439,8 +439,8 @@ function formatFactorName(factor: string): string {
 
 <style scoped>
 .ownership-section {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-6);
   background: rgba(30, 41, 59, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.5);
@@ -449,9 +449,9 @@ function formatFactorName(factor: string): string {
 .ownership-section h3 {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   color: var(--text-primary);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
   font-size: 1.2em;
   font-weight: 600;
 }
@@ -465,8 +465,8 @@ function formatFactorName(factor: string): string {
 .ownership-section .success-state {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 16px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-4);
   border-radius: var(--radius-lg);
 }
 
@@ -491,10 +491,10 @@ function formatFactorName(factor: string): string {
 /* Ownership Tabs */
 .ownership-tabs {
   display: flex;
-  gap: 8px;
-  margin-bottom: 20px;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-5);
   border-bottom: 1px solid rgba(71, 85, 105, 0.5);
-  padding-bottom: 12px;
+  padding-bottom: var(--spacing-3);
 }
 
 .ownership-tabs .tab-btn {
@@ -506,7 +506,7 @@ function formatFactorName(factor: string): string {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   font-size: 0.9em;
   transition: all var(--duration-200) var(--ease-out);
 }
@@ -536,17 +536,17 @@ function formatFactorName(factor: string): string {
 
 /* Ownership Overview */
 .ownership-overview .ownership-metrics {
-  margin-top: 20px;
+  margin-top: var(--spacing-5);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .ownership-metrics .metric-item {
   display: grid;
   grid-template-columns: 180px 80px 1fr;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .ownership-metrics .metric-label {
@@ -590,16 +590,16 @@ function formatFactorName(factor: string): string {
 
 /* Top Contributors Preview */
 .top-contributors-preview {
-  margin-top: 24px;
+  margin-top: var(--spacing-6);
 }
 
 .top-contributors-preview h4 {
   color: var(--text-secondary);
   font-size: 1em;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .top-contributors-preview h4 i {
@@ -609,7 +609,7 @@ function formatFactorName(factor: string): string {
 .contributor-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .contributor-item {
@@ -646,22 +646,22 @@ function formatFactorName(factor: string): string {
 
 /* Risk Distribution */
 .risk-distribution {
-  margin-top: 24px;
+  margin-top: var(--spacing-6);
 }
 
 .risk-distribution h4 {
   color: var(--text-secondary);
   font-size: 1em;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .risk-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .risk-badge {
@@ -699,11 +699,11 @@ function formatFactorName(factor: string): string {
 .ownership-contributors {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .expert-card {
-  padding: 16px;
+  padding: var(--spacing-4);
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-xl);
   border: 1px solid rgba(71, 85, 105, 0.3);
@@ -712,8 +712,8 @@ function formatFactorName(factor: string): string {
 .expert-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 12px;
+  gap: var(--spacing-2-5);
+  margin-bottom: var(--spacing-3);
 }
 
 .expert-rank {
@@ -739,15 +739,15 @@ function formatFactorName(factor: string): string {
 
 .expert-stats {
   display: flex;
-  gap: 16px;
-  margin-bottom: 12px;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-3);
   flex-wrap: wrap;
 }
 
 .expert-stats .stat {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   color: var(--text-muted);
   font-size: 0.85em;
 }
@@ -759,14 +759,14 @@ function formatFactorName(factor: string): string {
 .expert-scores {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .score-bar {
   display: grid;
   grid-template-columns: 60px 1fr 40px;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .score-label {
@@ -801,10 +801,10 @@ function formatFactorName(factor: string): string {
 }
 
 .expertise-areas {
-  margin-top: 10px;
+  margin-top: var(--spacing-2-5);
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .area-tag {
@@ -818,16 +818,16 @@ function formatFactorName(factor: string): string {
 /* Files Tab */
 .ownership-files .directories-section,
 .ownership-files .files-section {
-  margin-bottom: 24px;
+  margin-bottom: var(--spacing-6);
 }
 
 .ownership-files h4 {
   color: var(--text-secondary);
   font-size: 1em;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .ownership-files h4 i {
@@ -838,7 +838,7 @@ function formatFactorName(factor: string): string {
 .file-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .directory-item,
@@ -869,14 +869,14 @@ function formatFactorName(factor: string): string {
   color: var(--text-secondary);
   font-family: 'Monaco', 'Menlo', monospace;
   font-size: 0.9em;
-  margin-bottom: 6px;
+  margin-bottom: var(--spacing-1-5);
 }
 
 .dir-meta,
 .file-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--spacing-3);
   font-size: 0.85em;
 }
 
@@ -910,11 +910,11 @@ function formatFactorName(factor: string): string {
 .ownership-gaps .gaps-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .gap-item {
-  padding: 16px;
+  padding: var(--spacing-4);
   background: rgba(17, 24, 39, 0.5);
   border-radius: var(--radius-xl);
   border-left: 4px solid var(--color-error-light);
@@ -936,8 +936,8 @@ function formatFactorName(factor: string): string {
 .gap-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 10px;
+  gap: var(--spacing-2-5);
+  margin-bottom: var(--spacing-2-5);
 }
 
 .gap-risk-badge {
@@ -983,10 +983,10 @@ function formatFactorName(factor: string): string {
   color: var(--chart-purple-light);
   font-family: 'Monaco', 'Menlo', monospace;
   font-size: 0.9em;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .gap-area i {
@@ -997,7 +997,7 @@ function formatFactorName(factor: string): string {
   color: var(--text-secondary);
   font-size: 0.9em;
   line-height: 1.4;
-  margin-bottom: 10px;
+  margin-bottom: var(--spacing-2-5);
 }
 
 .gap-recommendation {
@@ -1005,15 +1005,15 @@ function formatFactorName(factor: string): string {
   font-size: 0.85em;
   display: flex;
   align-items: flex-start;
-  gap: 6px;
-  padding: 10px;
+  gap: var(--spacing-1-5);
+  padding: var(--spacing-2-5);
   background: rgba(34, 197, 94, 0.1);
   border-radius: var(--radius-md);
 }
 
 .gap-recommendation i {
   color: var(--color-warning-light);
-  margin-top: 2px;
+  margin-top: var(--spacing-0-5);
 }
 
 /* Issue #566: Code Intelligence Section Styles */

--- a/autobot-frontend/src/components/audit/AuditLogTable.vue
+++ b/autobot-frontend/src/components/audit/AuditLogTable.vue
@@ -557,7 +557,7 @@ th span {
   color: var(--color-info);
   font-size: inherit;
   cursor: pointer;
-  padding: 0;
+  padding: var(--spacing-0);
   text-decoration: underline;
   font-family: var(--font-sans);
 }
@@ -689,7 +689,7 @@ th span {
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
 }
@@ -751,7 +751,7 @@ th span {
   padding: var(--spacing-3);
   border-radius: var(--radius-xs);
   overflow-x: auto;
-  margin: 0;
+  margin: var(--spacing-0);
   white-space: pre-wrap;
   word-break: break-word;
   letter-spacing: -0.02em;

--- a/autobot-frontend/src/components/audit/AuditTimeline.vue
+++ b/autobot-frontend/src/components/audit/AuditTimeline.vue
@@ -210,7 +210,7 @@ function toggleDetails(id: string) {
 }
 
 .header-content h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
   display: flex;
@@ -415,7 +415,7 @@ function toggleDetails(id: string) {
   color: var(--color-primary);
   font-size: var(--text-xs);
   cursor: pointer;
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 .details-toggle:hover {
@@ -433,7 +433,7 @@ function toggleDetails(id: string) {
   padding: var(--spacing-2);
   border-radius: var(--radius-default);
   overflow-x: auto;
-  margin: 0;
+  margin: var(--spacing-0);
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/autobot-frontend/src/components/auth/LoginForm.vue
+++ b/autobot-frontend/src/components/auth/LoginForm.vue
@@ -310,7 +310,7 @@ onMounted(async () => {
   font-size: var(--text-3xl);
   font-weight: var(--font-bold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .subtitle {
@@ -379,7 +379,7 @@ onMounted(async () => {
 }
 
 .password-input-wrapper .form-input {
-  padding-right: 2.5rem;
+  padding-right: var(--spacing-10);
 }
 
 .password-toggle {
@@ -391,7 +391,7 @@ onMounted(async () => {
   border: none;
   color: var(--text-secondary);
   cursor: pointer;
-  padding: 0;
+  padding: var(--spacing-0);
   font-size: var(--text-lg);
   transition: color var(--duration-150) var(--ease-in-out);
 }
@@ -460,7 +460,7 @@ onMounted(async () => {
   color: var(--text-on-primary);
   opacity: 0.8;
   font-size: var(--text-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Icon classes for basic icons */

--- a/autobot-frontend/src/components/base/BaseBadge.vue
+++ b/autobot-frontend/src/components/base/BaseBadge.vue
@@ -68,7 +68,7 @@ const handleRemove = (event: MouseEvent) => {
 .base-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   font-weight: 500;
   white-space: nowrap;
   transition: all var(--duration-150) var(--ease-out);
@@ -212,14 +212,14 @@ const handleRemove = (event: MouseEvent) => {
 
 /* Removable Badge */
 .badge-removable {
-  padding-right: 4px;
+  padding-right: var(--spacing-1);
 }
 
 .badge-remove {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2px;
+  padding: var(--spacing-0-5);
   background: transparent;
   border: none;
   color: currentColor;

--- a/autobot-frontend/src/components/base/BaseButton.vue
+++ b/autobot-frontend/src/components/base/BaseButton.vue
@@ -308,8 +308,8 @@ const createRipple = (event: TouchEvent) => {
   background-color: transparent;
   color: var(--color-primary);
   text-decoration: none;
-  padding-left: 0;
-  padding-right: 0;
+  padding-left: var(--spacing-0);
+  padding-right: var(--spacing-0);
   border: none;
 }
 
@@ -342,7 +342,7 @@ const createRipple = (event: TouchEvent) => {
   display: inline-block;
   width: 1rem;
   height: 1rem;
-  margin-right: 0.5rem;
+  margin-right: var(--spacing-2);
   border: 2px solid currentColor;
   border-top-color: transparent;
   border-radius: 50%;
@@ -357,7 +357,7 @@ const createRipple = (event: TouchEvent) => {
 .button-content {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 /* Icon spacing */

--- a/autobot-frontend/src/components/base/BaseCard.vue
+++ b/autobot-frontend/src/components/base/BaseCard.vue
@@ -131,13 +131,13 @@ const footerClasses = computed(() => ({
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  padding: 16px;
+  padding: var(--spacing-4);
   border-bottom: 1px solid var(--border-default);
   background-color: var(--bg-card);
 }
 
 .header-no-padding {
-  padding: 0;
+  padding: var(--spacing-0);
   border-bottom: none;
 }
 
@@ -147,7 +147,7 @@ const footerClasses = computed(() => ({
 }
 
 .card-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -165,18 +165,18 @@ const footerClasses = computed(() => ({
 .card-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-left: 12px;
+  gap: var(--spacing-2);
+  margin-left: var(--spacing-3);
 }
 
 /* Card Body */
 .card-body {
-  padding: 16px;
+  padding: var(--spacing-4);
   color: var(--text-primary);
 }
 
 .body-no-padding {
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 /* Card Footer */
@@ -187,11 +187,11 @@ const footerClasses = computed(() => ({
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .footer-no-padding {
-  padding: 0;
+  padding: var(--spacing-0);
   border-top: none;
   background-color: transparent;
 }
@@ -225,16 +225,16 @@ const footerClasses = computed(() => ({
   .card-header {
     flex-direction: column;
     align-items: stretch;
-    gap: 12px;
+    gap: var(--spacing-3);
   }
 
   .card-actions {
-    margin-left: 0;
-    margin-top: 8px;
+    margin-left: var(--spacing-0);
+    margin-top: var(--spacing-2);
   }
 
   .card-body {
-    padding: 12px;
+    padding: var(--spacing-3);
   }
 
   .card-footer {

--- a/autobot-frontend/src/components/base/BaseInput.vue
+++ b/autobot-frontend/src/components/base/BaseInput.vue
@@ -160,7 +160,7 @@ defineExpose({
 .base-input-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 /* Label */
@@ -169,13 +169,13 @@ defineExpose({
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-primary);
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
   font-family: var(--font-sans);
 }
 
 .label-asterisk {
   color: var(--color-error);
-  margin-left: 2px;
+  margin-left: var(--spacing-0-5);
 }
 
 /* Input Container */
@@ -272,19 +272,19 @@ defineExpose({
 }
 
 .input-prefix {
-  margin-right: 8px;
+  margin-right: var(--spacing-2);
 }
 
 .input-suffix {
-  margin-left: 8px;
-  gap: 4px;
+  margin-left: var(--spacing-2);
+  gap: var(--spacing-1);
 }
 
 .clear-button {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 4px;
+  padding: var(--spacing-1);
   background: transparent;
   border: none;
   color: var(--text-muted);
@@ -306,14 +306,14 @@ defineExpose({
 .helper-text {
   font-size: var(--text-xs);
   color: var(--text-muted);
-  margin: 0;
+  margin: var(--spacing-0);
   font-family: var(--font-sans);
 }
 
 .error-text {
   font-size: var(--text-xs);
   color: var(--color-error);
-  margin: 0;
+  margin: var(--spacing-0);
   font-family: var(--font-sans);
   font-weight: 500;
 }
@@ -322,7 +322,7 @@ defineExpose({
 .base-input[type="number"]::-webkit-inner-spin-button,
 .base-input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .base-input[type="number"] {

--- a/autobot-frontend/src/components/base/BasePanel.vue
+++ b/autobot-frontend/src/components/base/BasePanel.vue
@@ -140,7 +140,7 @@ const toggleCollapse = () => {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .panel-actions {

--- a/autobot-frontend/src/components/base/BaseTable.vue
+++ b/autobot-frontend/src/components/base/BaseTable.vue
@@ -318,7 +318,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 .header-content {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .sort-indicator {
@@ -393,7 +393,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 /* Selection Cells */
 .select-cell {
   width: 40px;
-  padding: 8px;
+  padding: var(--spacing-2);
   text-align: center;
 }
 
@@ -409,7 +409,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 .actions-cell {
   width: 120px;
   text-align: right;
-  padding-right: 16px;
+  padding-right: var(--spacing-4);
 }
 
 .actions-cell {
@@ -435,7 +435,7 @@ const formatCellValue = (value: any, column: TableColumn) => {
 }
 
 .empty-text {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 

--- a/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
+++ b/autobot-frontend/src/components/browser/InteractiveScreenshot.vue
@@ -242,7 +242,7 @@ function submitType() {
 
 .toolbar {
   display: flex;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 4px 8px;
   background: var(--color-surface, #1e1e2e);
   border-top: 1px solid var(--color-border, #333);
@@ -275,7 +275,7 @@ function submitType() {
 
 .type-overlay {
   display: flex;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 4px 8px;
   background: var(--color-surface, #1e1e2e);
   border-top: 1px solid var(--color-border, #333);

--- a/autobot-frontend/src/components/charts/BaseChart.vue
+++ b/autobot-frontend/src/components/charts/BaseChart.vue
@@ -469,7 +469,7 @@ watch(
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .chart-subtitle {

--- a/autobot-frontend/src/components/charts/EvolutionTimelineChart.vue
+++ b/autobot-frontend/src/components/charts/EvolutionTimelineChart.vue
@@ -137,6 +137,6 @@ function formatMetricName(metric: string): string {
 .base-chart {
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 </style>

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -1877,7 +1877,7 @@ watch(viewMode, async (newMode) => {
 }
 
 .detail-row:last-child {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .detail-label {

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -833,7 +833,7 @@ onUnmounted(() => {
 }
 
 .chart-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
@@ -843,7 +843,7 @@ onUnmounted(() => {
   display: block;
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin-top: 4px;
+  margin-top: var(--spacing-1);
 }
 
 .chart-loading,
@@ -908,7 +908,7 @@ onUnmounted(() => {
   cursor: pointer;
   text-decoration: underline;
   font-size: var(--text-sm);
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 .tree-container {
@@ -958,7 +958,7 @@ onUnmounted(() => {
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   background: var(--bg-primary);
-  padding: 2px;
+  padding: var(--spacing-0-5);
 }
 
 .view-toggle button {
@@ -1124,7 +1124,7 @@ onUnmounted(() => {
   color: var(--text-secondary);
   cursor: pointer;
   font-size: var(--text-lg);
-  padding: 0;
+  padding: var(--spacing-0);
   width: 24px;
   height: 24px;
   display: flex;
@@ -1146,7 +1146,7 @@ onUnmounted(() => {
 .detail-row {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .detail-label {
@@ -1292,7 +1292,7 @@ onUnmounted(() => {
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
 }
 
 .section-icon {
@@ -1302,7 +1302,7 @@ onUnmounted(() => {
 .import-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding-left: var(--spacing-2);
 }
 

--- a/autobot-frontend/src/components/charts/PatternEvolutionChart.vue
+++ b/autobot-frontend/src/components/charts/PatternEvolutionChart.vue
@@ -151,6 +151,6 @@ function formatPatternName(pattern: string): string {
 .base-chart {
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 </style>

--- a/autobot-frontend/src/components/chat/DocumentationCategoryFilter.vue
+++ b/autobot-frontend/src/components/chat/DocumentationCategoryFilter.vue
@@ -242,7 +242,7 @@ const selectDocumentation = () => {
   color: var(--text-tertiary);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wider);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .clear-btn {

--- a/autobot-frontend/src/components/chat/DocumentationResultCard.vue
+++ b/autobot-frontend/src/components/chat/DocumentationResultCard.vue
@@ -311,7 +311,7 @@ const openDocument = () => {
   justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
-  padding: 0;
+  padding: var(--spacing-0);
   background: none;
   border: none;
   border-radius: var(--radius-default);
@@ -348,7 +348,7 @@ const openDocument = () => {
   font-size: 0.8125rem;
   color: var(--text-secondary);
   line-height: var(--leading-relaxed);
-  margin: 0;
+  margin: var(--spacing-0);
   white-space: pre-wrap;
 }
 
@@ -390,7 +390,7 @@ const openDocument = () => {
   justify-content: center;
   width: 1.75rem;
   height: 1.75rem;
-  padding: 0;
+  padding: var(--spacing-0);
   background: none;
   border: 1px solid transparent;
   border-radius: var(--radius-default);

--- a/autobot-frontend/src/components/chat/DocumentationSearchSidebar.vue
+++ b/autobot-frontend/src/components/chat/DocumentationSearchSidebar.vue
@@ -535,7 +535,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .close-btn {
@@ -544,7 +544,7 @@ onMounted(() => {
   justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
-  padding: 0;
+  padding: var(--spacing-0);
   background: none;
   border: none;
   border-radius: var(--radius-default);
@@ -610,7 +610,7 @@ onMounted(() => {
   justify-content: center;
   width: 1.25rem;
   height: 1.25rem;
-  padding: 0;
+  padding: var(--spacing-0);
   background: none;
   border: none;
   border-radius: var(--radius-full);

--- a/autobot-frontend/src/components/chat/DocumentationSuggestionChip.vue
+++ b/autobot-frontend/src/components/chat/DocumentationSuggestionChip.vue
@@ -237,7 +237,7 @@ const handleClick = () => {
   justify-content: center;
   width: var(--spacing-4);
   height: var(--spacing-4);
-  padding: 0;
+  padding: var(--spacing-0);
   background: none;
   border: none;
   border-radius: var(--radius-full);

--- a/autobot-frontend/src/components/chat/MessageItem.vue
+++ b/autobot-frontend/src/components/chat/MessageItem.vue
@@ -590,20 +590,20 @@ const formattedContent = computed(() => {
 
 /* RTL layout support (#1337) */
 :global([dir="rtl"]) .message-wrapper.user-message {
-  margin-left: 0;
+  margin-left: var(--spacing-0);
   margin-right: auto;
   border-radius: 18px 18px 18px 4px;
 }
 
 :global([dir="rtl"]) .message-wrapper.assistant-message {
-  margin-right: 0;
+  margin-right: var(--spacing-0);
   margin-left: auto;
   border-radius: 18px 18px 4px 18px;
 }
 
 :global([dir="rtl"]) .message-info {
-  margin-left: 0;
-  margin-right: 0.375rem;
+  margin-left: var(--spacing-0);
+  margin-right: var(--spacing-1-5);
 }
 
 :global([dir="rtl"]) .message-status-container {
@@ -620,13 +620,13 @@ const formattedContent = computed(() => {
 
 @media (max-width: 768px) {
   :global([dir="rtl"]) .message-wrapper.user-message {
-    margin-left: 0;
-    margin-right: 0.125rem;
+    margin-left: var(--spacing-0);
+    margin-right: var(--spacing-0-5);
   }
 
   :global([dir="rtl"]) .message-wrapper.assistant-message {
-    margin-right: 0;
-    margin-left: 0.125rem;
+    margin-right: var(--spacing-0);
+    margin-left: var(--spacing-0-5);
   }
 }
 </style>

--- a/autobot-frontend/src/components/chat/ReasoningTrace.vue
+++ b/autobot-frontend/src/components/chat/ReasoningTrace.vue
@@ -112,7 +112,7 @@ function formatDuration(ms: number): string {
 .reasoning-trace {
   border: 1px solid var(--color-border, #334155);
   border-radius: var(--radius-lg);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   background: var(--color-bg-subtle, #0f172a);
   overflow: hidden;
   font-size: var(--text-xs);
@@ -126,7 +126,7 @@ function formatDuration(ms: number): string {
 .reasoning-trace__header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   width: 100%;
   padding: 0.4rem 0.75rem;
   background: none;
@@ -183,7 +183,7 @@ function formatDuration(ms: number): string {
 .reasoning-trace__entry {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.2rem 0.75rem;
   line-height: 1.5;
   border-left: 2px solid transparent;
@@ -246,13 +246,13 @@ function formatDuration(ms: number): string {
   flex-shrink: 0;
   font-size: 0.7rem;
   margin-left: auto;
-  padding-left: 0.25rem;
+  padding-left: var(--spacing-1);
 }
 
 .reasoning-trace__entry-status {
   flex-shrink: 0;
   font-size: 0.7rem;
-  padding-left: 0.25rem;
+  padding-left: var(--spacing-1);
 }
 
 .reasoning-trace__entry-status--ok {

--- a/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
+++ b/autobot-frontend/src/components/chat/VisionAnalysisModal.vue
@@ -379,7 +379,7 @@ onUnmounted(() => {
 .header-title {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .header-title i {
@@ -388,14 +388,14 @@ onUnmounted(() => {
 }
 
 .header-title h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .btn-close {
-  padding: 8px;
+  padding: var(--spacing-2);
   background: none;
   border: none;
   color: var(--text-tertiary);
@@ -413,17 +413,17 @@ onUnmounted(() => {
 .modal-body {
   flex: 1;
   overflow-y: auto;
-  padding: 20px;
+  padding: var(--spacing-5);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 /* Drop zone */
 .drop-zone {
   border: 2px dashed var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 32px;
+  padding: var(--spacing-8);
   text-align: center;
   cursor: pointer;
   transition: all var(--duration-200);
@@ -440,14 +440,14 @@ onUnmounted(() => {
 
 .drop-zone.has-file {
   border-style: solid;
-  padding: 16px;
+  padding: var(--spacing-4);
 }
 
 .drop-placeholder {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   color: var(--text-tertiary);
 }
 
@@ -457,7 +457,7 @@ onUnmounted(() => {
 }
 
 .drop-placeholder p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -470,7 +470,7 @@ onUnmounted(() => {
 .file-preview {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: var(--spacing-3-5);
   width: 100%;
 }
 
@@ -486,7 +486,7 @@ onUnmounted(() => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
   text-align: left;
 }
 
@@ -503,7 +503,7 @@ onUnmounted(() => {
 }
 
 .btn-clear {
-  padding: 8px;
+  padding: var(--spacing-2);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;
@@ -519,14 +519,14 @@ onUnmounted(() => {
 /* Options */
 .options-row {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   flex-wrap: wrap;
 }
 
 .option-group {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   min-width: 160px;
 }
 
@@ -570,7 +570,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   align-self: center;
 }
 
@@ -587,7 +587,7 @@ onUnmounted(() => {
 .error-banner {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 10px 14px;
   background: var(--color-error-bg);
   border: 1px solid var(--color-error-border, var(--color-error));
@@ -620,18 +620,18 @@ onUnmounted(() => {
 }
 
 .results-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--color-success);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .results-meta {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .meta-badge {
@@ -643,16 +643,16 @@ onUnmounted(() => {
 }
 
 .results-content {
-  padding: 16px;
+  padding: var(--spacing-4);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .result-item {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .result-label {
@@ -663,7 +663,7 @@ onUnmounted(() => {
 }
 
 .result-value {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-primary);
   line-height: 1.5;
@@ -672,7 +672,7 @@ onUnmounted(() => {
 .tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .tag {
@@ -686,7 +686,7 @@ onUnmounted(() => {
 .objects-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .object-row {
@@ -713,7 +713,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .btn-toggle-json:hover {
@@ -721,14 +721,14 @@ onUnmounted(() => {
 }
 
 .json-display {
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-secondary);
   border-radius: var(--radius-md);
   font-size: var(--text-xs);
   color: var(--text-secondary);
   overflow-x: auto;
   max-height: 200px;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Footer */
@@ -742,7 +742,7 @@ onUnmounted(() => {
 
 .footer-right {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-primary {
@@ -756,7 +756,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .btn-primary:hover:not(:disabled) {
@@ -779,7 +779,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .btn-secondary:hover:not(:disabled) {

--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -537,14 +537,14 @@ onMounted(() => {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .viewport-msg {
   font-size: var(--text-sm);
   color: var(--text-muted);
   max-width: 360px;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .capture-btn {

--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -382,7 +382,7 @@ onBeforeUnmount(() => {
   width: 100%;
   max-width: 480px;
   max-height: 85vh;
-  margin: 1rem;
+  margin: var(--spacing-4);
   border-radius: 1.25rem;
   background: var(--bg-card, #0f172a);
   border: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.1));
@@ -493,7 +493,7 @@ onBeforeUnmount(() => {
 .voice-overlay__conversation {
   flex: 1;
   overflow-y: auto;
-  padding: 1.25rem;
+  padding: var(--spacing-5);
   min-height: 200px;
   max-height: 40vh;
   scroll-behavior: smooth;
@@ -504,7 +504,7 @@ onBeforeUnmount(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   height: 100%;
   min-height: 120px;
   color: var(--text-muted, #64748b);
@@ -514,7 +514,7 @@ onBeforeUnmount(() => {
 /* Bubbles */
 .voice-overlay__bubble {
   display: flex;
-  gap: 0.625rem;
+  gap: var(--spacing-2-5);
   align-items: flex-start;
 }
 
@@ -570,13 +570,13 @@ onBeforeUnmount(() => {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 0.125rem;
+  margin-bottom: var(--spacing-0-5);
   opacity: 0.6;
 }
 
 /* Live transcript */
 .voice-overlay__live-transcript {
-  margin-top: 0.75rem;
+  margin-top: var(--spacing-3);
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-lg);
   background: rgba(37, 99, 235, 0.06);
@@ -621,11 +621,11 @@ onBeforeUnmount(() => {
 }
 
 .voice-overlay__cert-warning-steps {
-  padding-left: 1.25rem;
+  padding-left: var(--spacing-5);
   list-style: decimal;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .voice-overlay__cert-warning-steps code {
@@ -639,7 +639,7 @@ onBeforeUnmount(() => {
 .voice-overlay__cert-warning-fallback {
   color: #94a3b8;
   font-size: var(--text-xs);
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
 }
 
 /* Controls area */
@@ -647,7 +647,7 @@ onBeforeUnmount(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 1.5rem 1.25rem 2rem;
   border-top: 1px solid var(--border-subtle, rgba(148, 163, 184, 0.08));
   background: linear-gradient(
@@ -774,7 +774,7 @@ onBeforeUnmount(() => {
   padding: 0.75rem 1.25rem 0;
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: var(--spacing-2-5);
 }
 
 /* Amplitude meter */
@@ -797,7 +797,7 @@ onBeforeUnmount(() => {
 .voice-overlay__threshold {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .voice-overlay__threshold-label {

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -404,7 +404,7 @@ onBeforeUnmount(() => {
   font-size: var(--text-xs);
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 /* Hands-free controls */
@@ -412,7 +412,7 @@ onBeforeUnmount(() => {
   padding: 0.5rem 0.75rem 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .voice-panel__amplitude {

--- a/autobot-frontend/src/components/common/PermissionDenied.vue
+++ b/autobot-frontend/src/components/common/PermissionDenied.vue
@@ -207,7 +207,7 @@ function goHome(): void {
 }
 
 .permission-denied__contact {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -529,7 +529,7 @@ onUnmounted(() => {
   border-top: 1px solid var(--border-default);
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .actions-label {
@@ -539,7 +539,7 @@ onUnmounted(() => {
 .actions-buttons {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   flex-wrap: wrap;
 }
 
@@ -560,7 +560,7 @@ onUnmounted(() => {
 
 /* Touch-friendly button variant for desktop actions */
 .touch-action-btn {
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Screenshot Modal (Issue #74) */
@@ -593,7 +593,7 @@ onUnmounted(() => {
 }
 
 .screenshot-body {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   overflow: auto;
   flex: 1;
 }
@@ -611,7 +611,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .download-btn {
@@ -683,7 +683,7 @@ onUnmounted(() => {
 }
 
 .type-dialog-body {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
 }
 
 .type-textarea {
@@ -713,7 +713,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .type-btn {
@@ -744,7 +744,7 @@ onUnmounted(() => {
   height: 100%;
   overflow-y: auto;
   z-index: 10;
-  padding: 1rem;
+  padding: var(--spacing-4);
   background-color: var(--bg-card);
   border-left: 1px solid var(--border-default);
   box-shadow: var(--shadow-lg, -2px 0 8px rgba(0, 0, 0, 0.15));

--- a/autobot-frontend/src/components/documents/AIDocumentEditor.vue
+++ b/autobot-frontend/src/components/documents/AIDocumentEditor.vue
@@ -272,7 +272,7 @@ const formattedUpdatedAt = computed(() => {
   justify-content: space-between;
   padding: 12px 16px;
   border-bottom: 1px solid var(--color-border, #333);
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .title-row {
@@ -281,7 +281,7 @@ const formattedUpdatedAt = computed(() => {
 }
 
 .document-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: 1.1rem;
   font-weight: 600;
   cursor: pointer;
@@ -320,7 +320,7 @@ const formattedUpdatedAt = computed(() => {
 
 .header-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   flex-shrink: 0;
 }
 
@@ -338,7 +338,7 @@ const formattedUpdatedAt = computed(() => {
   background: var(--color-background-secondary, #252525);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .refine-textarea {
@@ -348,7 +348,7 @@ const formattedUpdatedAt = computed(() => {
   color: inherit;
   border: 1px solid var(--color-border, #444);
   border-radius: var(--radius-default);
-  padding: 8px;
+  padding: var(--spacing-2);
   font-size: 0.9rem;
   font-family: inherit;
   outline: none;
@@ -365,7 +365,7 @@ const formattedUpdatedAt = computed(() => {
 
 .refine-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .editor-body {
@@ -380,7 +380,7 @@ const formattedUpdatedAt = computed(() => {
   background: transparent;
   color: inherit;
   border: none;
-  padding: 16px;
+  padding: var(--spacing-4);
   font-size: 0.95rem;
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
   line-height: 1.6;
@@ -396,7 +396,7 @@ const formattedUpdatedAt = computed(() => {
 .editor-footer {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--spacing-4);
   padding: 6px 16px;
   font-size: var(--text-xs);
   color: var(--color-text-muted, #888);

--- a/autobot-frontend/src/components/examples/AsyncOperationExample.vue
+++ b/autobot-frontend/src/components/examples/AsyncOperationExample.vue
@@ -781,8 +781,8 @@ const loadAnalytics = () => analytics.execute(async () => {
 .example-card {
   background: var(--bg-card);
   border-radius: var(--radius-lg);
-  padding: 24px;
-  margin-bottom: 24px;
+  padding: var(--spacing-6);
+  margin-bottom: var(--spacing-6);
   box-shadow: var(--shadow-sm);
 }
 
@@ -790,8 +790,8 @@ const loadAnalytics = () => analytics.execute(async () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
-  padding-bottom: 16px;
+  margin-bottom: var(--spacing-4);
+  padding-bottom: var(--spacing-4);
   border-bottom: 2px solid var(--border-default);
 }
 
@@ -812,11 +812,11 @@ const loadAnalytics = () => analytics.execute(async () => {
 
 .example-description {
   color: var(--text-tertiary);
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .example-content {
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 /* Buttons */
@@ -829,7 +829,7 @@ const loadAnalytics = () => analytics.execute(async () => {
   border: none;
   cursor: pointer;
   transition: all var(--duration-200);
-  margin-right: 8px;
+  margin-right: var(--spacing-2);
 }
 
 .btn-primary:hover:not(:disabled) {
@@ -860,12 +860,12 @@ const loadAnalytics = () => analytics.execute(async () => {
 .loading-indicator {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 16px;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
   background: var(--color-info-bg);
   border: 1px solid var(--color-info-light);
   border-radius: var(--radius-md);
-  margin-top: 12px;
+  margin-top: var(--spacing-3);
   color: var(--color-info-dark);
 }
 
@@ -884,30 +884,30 @@ const loadAnalytics = () => analytics.execute(async () => {
 
 /* Error Messages */
 .error-message {
-  padding: 16px;
+  padding: var(--spacing-4);
   background: var(--color-error-bg);
   border: 1px solid var(--color-error-light);
   border-radius: var(--radius-md);
-  margin-top: 12px;
+  margin-top: var(--spacing-3);
   color: var(--color-error-dark);
 }
 
 /* Success Messages */
 .success-message {
-  padding: 16px;
+  padding: var(--spacing-4);
   background: var(--color-success-bg);
   border: 1px solid var(--color-success-light);
   border-radius: var(--radius-md);
-  margin-top: 12px;
+  margin-top: var(--spacing-3);
   color: var(--color-success-dark);
 }
 
 .success-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   font-weight: 500;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .success-icon {
@@ -920,27 +920,27 @@ const loadAnalytics = () => analytics.execute(async () => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
-  padding: 12px;
-  margin-top: 12px;
+  padding: var(--spacing-3);
+  margin-top: var(--spacing-3);
   overflow-x: auto;
 }
 
 .data-display pre {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
 
 /* Form Elements */
 .form-group {
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
 }
 
 .form-group label {
   display: block;
   font-weight: 500;
   color: var(--text-secondary);
-  margin-bottom: 6px;
+  margin-bottom: var(--spacing-1-5);
 }
 
 .form-input {
@@ -994,8 +994,8 @@ const loadAnalytics = () => analytics.execute(async () => {
 
 /* Error Log */
 .error-log {
-  margin-top: 16px;
-  padding: 16px;
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-4);
   background: var(--color-error-bg);
   border: 1px solid var(--color-error-light);
   border-radius: var(--radius-md);
@@ -1008,12 +1008,12 @@ const loadAnalytics = () => analytics.execute(async () => {
 
 .error-log ul {
   list-style: none;
-  padding: 0;
-  margin: 0;
+  padding: var(--spacing-0);
+  margin: var(--spacing-0);
 }
 
 .error-log li {
-  padding: 8px;
+  padding: var(--spacing-2);
   border-bottom: 1px solid var(--color-error-light);
 }
 
@@ -1024,7 +1024,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 .log-timestamp {
   font-size: var(--text-xs);
   color: var(--color-error-dark);
-  margin-right: 12px;
+  margin-right: var(--spacing-3);
 }
 
 .log-message {
@@ -1035,15 +1035,15 @@ const loadAnalytics = () => analytics.execute(async () => {
 .data-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 20px;
-  margin-top: 20px;
+  gap: var(--spacing-5);
+  margin-top: var(--spacing-5);
 }
 
 .data-section {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
 }
 
 .data-section h3 {
@@ -1056,14 +1056,14 @@ const loadAnalytics = () => analytics.execute(async () => {
 .analytics-display {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
-  margin-top: 16px;
+  gap: var(--spacing-4);
+  margin-top: var(--spacing-4);
 }
 
 .analytics-card {
   background: var(--chart-purple);
   color: white;
-  padding: 20px;
+  padding: var(--spacing-5);
   border-radius: var(--radius-lg);
   text-align: center;
 }
@@ -1082,13 +1082,13 @@ const loadAnalytics = () => analytics.execute(async () => {
 
 /* Code Comparison */
 .code-comparison {
-  margin-top: 20px;
+  margin-top: var(--spacing-5);
 }
 
 .code-comparison details {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-secondary);
 }
 
@@ -1106,8 +1106,8 @@ const loadAnalytics = () => analytics.execute(async () => {
 .code-blocks {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 20px;
-  margin-top: 16px;
+  gap: var(--spacing-5);
+  margin-top: var(--spacing-4);
 }
 
 @media (max-width: 1024px) {
@@ -1124,7 +1124,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 }
 
 .code-block h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   padding: 12px 16px;
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border-default);
@@ -1132,8 +1132,8 @@ const loadAnalytics = () => analytics.execute(async () => {
 }
 
 .code-block pre {
-  margin: 0;
-  padding: 16px;
+  margin: var(--spacing-0);
+  padding: var(--spacing-4);
   overflow-x: auto;
 }
 
@@ -1148,8 +1148,8 @@ const loadAnalytics = () => analytics.execute(async () => {
   background: var(--chart-purple);
   color: white;
   border-radius: var(--radius-lg);
-  padding: 32px;
-  margin-top: 32px;
+  padding: var(--spacing-8);
+  margin-top: var(--spacing-8);
 }
 
 .summary-title {
@@ -1162,16 +1162,16 @@ const loadAnalytics = () => analytics.execute(async () => {
 .benefits-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 .benefit-item {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
   border-radius: var(--radius-lg);
-  padding: 20px;
+  padding: var(--spacing-5);
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-4);
   transition: transform var(--duration-200);
 }
 
@@ -1190,7 +1190,7 @@ const loadAnalytics = () => analytics.execute(async () => {
 }
 
 .benefit-content p {
-  margin: 0;
+  margin: var(--spacing-0);
   opacity: 0.9;
   font-size: var(--text-sm);
 }

--- a/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
+++ b/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
@@ -309,18 +309,18 @@ const formatTime = (timestamp: number) => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .access-metrics.compact {
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .section-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .header-info h3 {
@@ -330,7 +330,7 @@ const formatTime = (timestamp: number) => {
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .header-info h3 i {
@@ -338,14 +338,14 @@ const formatTime = (timestamp: number) => {
 }
 
 .header-info .description {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }
 
 .header-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   align-items: center;
 }
 
@@ -389,7 +389,7 @@ const formatTime = (timestamp: number) => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 40px;
+  padding: var(--spacing-10);
   color: var(--text-tertiary);
 }
 
@@ -403,7 +403,7 @@ const formatTime = (timestamp: number) => {
   align-items: center;
   justify-content: center;
   font-size: 28px;
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
 }
 
 .no-data-state h4 {
@@ -414,7 +414,7 @@ const formatTime = (timestamp: number) => {
 }
 
 .no-data-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -423,19 +423,19 @@ const formatTime = (timestamp: number) => {
 .summary-stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 16px;
-  margin-bottom: 24px;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
 }
 
 .compact .summary-stats {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .summary-card {
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 16px;
+  gap: var(--spacing-3-5);
+  padding: var(--spacing-4);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -490,7 +490,7 @@ const formatTime = (timestamp: number) => {
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .trend-up {
@@ -514,14 +514,14 @@ const formatTime = (timestamp: number) => {
 .breakdowns {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 24px;
+  gap: var(--spacing-6);
 }
 
 .breakdown-section {
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 16px;
+  padding: var(--spacing-4);
 }
 
 .breakdown-section.full-width {
@@ -535,12 +535,12 @@ const formatTime = (timestamp: number) => {
   color: var(--text-secondary);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .empty-breakdown {
   text-align: center;
-  padding: 20px;
+  padding: var(--spacing-5);
   color: var(--text-muted);
   font-size: var(--text-sm);
 }
@@ -548,7 +548,7 @@ const formatTime = (timestamp: number) => {
 .breakdown-list {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   max-height: 250px;
   overflow-y: auto;
 }
@@ -556,12 +556,12 @@ const formatTime = (timestamp: number) => {
 .breakdown-item {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .breakdown-item.clickable {
   cursor: pointer;
-  padding: 8px;
+  padding: var(--spacing-2);
   margin: -8px;
   border-radius: var(--radius-md);
   transition: background var(--duration-150);
@@ -583,7 +583,7 @@ const formatTime = (timestamp: number) => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
 }
 
 code.item-label {
@@ -616,10 +616,10 @@ code.item-label {
 /* Daily Chart */
 .daily-chart {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   align-items: flex-end;
   height: 150px;
-  padding-top: 20px;
+  padding-top: var(--spacing-5);
 }
 
 .day-bar {
@@ -627,7 +627,7 @@ code.item-label {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   min-width: 40px;
 }
 
@@ -666,19 +666,19 @@ code.item-label {
 .table-header {
   display: grid;
   grid-template-columns: 120px 100px 1fr 100px;
-  gap: 16px;
+  gap: var(--spacing-4);
   padding: 10px 12px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-md);
   font-weight: 600;
   color: var(--text-secondary);
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .table-row {
   display: grid;
   grid-template-columns: 120px 100px 1fr 100px;
-  gap: 16px;
+  gap: var(--spacing-4);
   padding: 10px 12px;
   border-bottom: 1px solid var(--border-subtle);
 }

--- a/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
+++ b/autobot-frontend/src/components/feature-flags/EndpointEnforcement.vue
@@ -275,14 +275,14 @@ const closeModal = () => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .section-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .header-info h3 {
@@ -292,7 +292,7 @@ const closeModal = () => {
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .header-info h3 i {
@@ -300,7 +300,7 @@ const closeModal = () => {
 }
 
 .header-info .description {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
   max-width: 500px;
@@ -317,7 +317,7 @@ const closeModal = () => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -361,19 +361,19 @@ const closeModal = () => {
 .overrides-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .global-mode-banner {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   padding: 12px 16px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .global-mode-banner i {
@@ -384,7 +384,7 @@ const closeModal = () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px;
+  padding: var(--spacing-4);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -398,7 +398,7 @@ const closeModal = () => {
 .override-info {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .endpoint-path code {
@@ -413,13 +413,13 @@ const closeModal = () => {
 .override-mode {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .mode-badge {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   padding: 4px 10px;
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
@@ -448,7 +448,7 @@ const closeModal = () => {
 
 .override-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .action-btn {
@@ -479,13 +479,13 @@ const closeModal = () => {
 .override-form {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .form-group label {
@@ -499,7 +499,7 @@ const closeModal = () => {
 }
 
 .form-input {
-  padding: 12px;
+  padding: var(--spacing-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -531,7 +531,7 @@ const closeModal = () => {
 
 .mode-selector {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .mode-selector .mode-option {
@@ -539,8 +539,8 @@ const closeModal = () => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
-  padding: 16px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-4);
   border: 2px solid var(--border-default);
   border-radius: var(--radius-xl);
   cursor: pointer;
@@ -600,7 +600,7 @@ const closeModal = () => {
   display: block;
   font-size: var(--text-xs);
   color: var(--text-tertiary);
-  margin-top: 4px;
+  margin-top: var(--spacing-1);
 }
 
 /* Remove Modal */
@@ -630,7 +630,7 @@ const closeModal = () => {
 }
 
 .remove-content p {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
 }
 
@@ -654,7 +654,7 @@ const closeModal = () => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -687,7 +687,7 @@ const closeModal = () => {
 @media (max-width: 600px) {
   .section-header {
     flex-direction: column;
-    gap: 16px;
+    gap: var(--spacing-4);
   }
 
   .mode-selector {

--- a/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.vue
+++ b/autobot-frontend/src/components/feature-flags/EnforcementModeSelector.vue
@@ -133,11 +133,11 @@ const selectMode = (mode: EnforcementMode) => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .selector-header {
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .selector-header h3 {
@@ -147,7 +147,7 @@ const selectMode = (mode: EnforcementMode) => {
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .selector-header h3 i {
@@ -155,7 +155,7 @@ const selectMode = (mode: EnforcementMode) => {
 }
 
 .selector-header .description {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }
@@ -163,14 +163,14 @@ const selectMode = (mode: EnforcementMode) => {
 .mode-options {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .mode-option {
   display: flex;
   align-items: flex-start;
-  gap: 16px;
-  padding: 16px;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
   background: var(--bg-primary);
   border: 2px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -225,8 +225,8 @@ const selectMode = (mode: EnforcementMode) => {
 .option-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 4px;
+  gap: var(--spacing-2-5);
+  margin-bottom: var(--spacing-1);
 }
 
 .option-title {
@@ -253,14 +253,14 @@ const selectMode = (mode: EnforcementMode) => {
 
 .option-details {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-4);
   flex-wrap: wrap;
 }
 
 .detail-item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   font-size: var(--text-xs);
 }
 
@@ -283,7 +283,7 @@ const selectMode = (mode: EnforcementMode) => {
 .option-radio {
   display: flex;
   align-items: center;
-  padding-top: 12px;
+  padding-top: var(--spacing-3);
 }
 
 .radio-outer {
@@ -311,9 +311,9 @@ const selectMode = (mode: EnforcementMode) => {
 .mode-warning,
 .mode-info {
   display: flex;
-  gap: 12px;
-  margin-top: 16px;
-  padding: 14px;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-4);
+  padding: var(--spacing-3-5);
   border-radius: var(--radius-lg);
 }
 
@@ -331,18 +331,18 @@ const selectMode = (mode: EnforcementMode) => {
 .mode-info i {
   font-size: var(--text-lg);
   flex-shrink: 0;
-  margin-top: 2px;
+  margin-top: var(--spacing-0-5);
 }
 
 .warning-content strong,
 .info-content strong {
   display: block;
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
 }
 
 .warning-content p,
 .info-content p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   opacity: 0.9;
 }

--- a/autobot-frontend/src/components/feature-flags/FlagChangeHistory.vue
+++ b/autobot-frontend/src/components/feature-flags/FlagChangeHistory.vue
@@ -161,11 +161,11 @@ const formatRelativeTime = (timestamp: string) => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .section-header {
-  margin-bottom: 24px;
+  margin-bottom: var(--spacing-6);
 }
 
 .section-header h3 {
@@ -175,7 +175,7 @@ const formatRelativeTime = (timestamp: string) => {
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .section-header h3 i {
@@ -183,7 +183,7 @@ const formatRelativeTime = (timestamp: string) => {
 }
 
 .section-header .description {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }
@@ -195,7 +195,7 @@ const formatRelativeTime = (timestamp: string) => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 40px;
+  padding: var(--spacing-10);
   color: var(--text-tertiary);
 }
 
@@ -209,7 +209,7 @@ const formatRelativeTime = (timestamp: string) => {
   align-items: center;
   justify-content: center;
   font-size: var(--text-2xl);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
 }
 
 .empty-state h4 {
@@ -220,7 +220,7 @@ const formatRelativeTime = (timestamp: string) => {
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -233,7 +233,7 @@ const formatRelativeTime = (timestamp: string) => {
 
 .timeline-entry {
   display: flex;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 .timeline-marker {
@@ -278,18 +278,18 @@ const formatRelativeTime = (timestamp: string) => {
 
 .timeline-content {
   flex: 1;
-  padding-bottom: 32px;
+  padding-bottom: var(--spacing-8);
 }
 
 .timeline-entry:last-child .timeline-content {
-  padding-bottom: 0;
+  padding-bottom: var(--spacing-0);
 }
 
 .entry-header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 8px;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-2);
 }
 
 .mode-badge {
@@ -322,7 +322,7 @@ const formatRelativeTime = (timestamp: string) => {
 }
 
 .entry-details {
-  padding: 14px;
+  padding: var(--spacing-3-5);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -336,7 +336,7 @@ const formatRelativeTime = (timestamp: string) => {
 
 .meta-info {
   display: flex;
-  gap: 20px;
+  gap: var(--spacing-5);
   font-size: var(--text-xs);
   color: var(--text-tertiary);
 }
@@ -344,7 +344,7 @@ const formatRelativeTime = (timestamp: string) => {
 .changed-by {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .relative-time {
@@ -353,12 +353,12 @@ const formatRelativeTime = (timestamp: string) => {
 
 /* Legend */
 .legend {
-  margin-top: 24px;
-  padding-top: 20px;
+  margin-top: var(--spacing-6);
+  padding-top: var(--spacing-5);
   border-top: 1px solid var(--border-default);
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 .legend-title {
@@ -368,13 +368,13 @@ const formatRelativeTime = (timestamp: string) => {
 
 .legend-items {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .legend-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   font-size: var(--text-xs);
   color: var(--text-secondary);
 }
@@ -404,13 +404,13 @@ const formatRelativeTime = (timestamp: string) => {
   }
 
   .timeline-entry {
-    gap: 0;
+    gap: var(--spacing-0);
   }
 
   .legend {
     flex-direction: column;
     align-items: flex-start;
-    gap: 12px;
+    gap: var(--spacing-3);
   }
 }
 </style>

--- a/autobot-frontend/src/components/file-browser/FileBrowser.vue
+++ b/autobot-frontend/src/components/file-browser/FileBrowser.vue
@@ -589,7 +589,7 @@ onMounted(() => {
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   color: var(--text-primary);
   word-break: break-all;
@@ -601,7 +601,7 @@ onMounted(() => {
   font-size: var(--text-2xl);
   color: var(--text-muted);
   cursor: pointer;
-  padding: 0;
+  padding: var(--spacing-0);
   width: 30px;
   height: 30px;
   display: flex;
@@ -641,7 +641,7 @@ onMounted(() => {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 20px;
+  padding: var(--spacing-5);
   background-color: var(--bg-secondary);
 }
 
@@ -657,11 +657,11 @@ onMounted(() => {
 .text-preview, .json-preview {
   flex: 1;
   overflow: auto;
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .text-preview pre, .json-preview pre {
-  margin: 0;
+  margin: var(--spacing-0);
   font-family: 'Courier New', Courier, monospace;
   font-size: var(--text-sm);
   line-height: 1.5;
@@ -669,7 +669,7 @@ onMounted(() => {
   word-break: break-word;
   background-color: var(--bg-secondary);
   color: var(--text-primary);
-  padding: 16px;
+  padding: var(--spacing-4);
   border-radius: var(--radius-default);
   border: 1px solid var(--border-default);
 }
@@ -694,7 +694,7 @@ onMounted(() => {
 /* File Info */
 .file-info {
   flex: 1;
-  padding: 40px;
+  padding: var(--spacing-10);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -714,7 +714,7 @@ onMounted(() => {
 }
 
 .download-btn {
-  margin-top: 20px;
+  margin-top: var(--spacing-5);
   padding: 10px 20px;
   background-color: var(--color-electric-600, #2563eb);
   color: white;
@@ -745,12 +745,12 @@ onMounted(() => {
   }
 
   .text-preview, .json-preview {
-    padding: 16px;
+    padding: var(--spacing-4);
   }
 
   .text-preview pre, .json-preview pre {
     font-size: var(--text-xs);
-    padding: 12px;
+    padding: var(--spacing-3);
   }
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/BackupManager.vue
+++ b/autobot-frontend/src/components/knowledge/BackupManager.vue
@@ -347,7 +347,7 @@ onMounted(() => {
 
 .header-description {
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 
@@ -437,7 +437,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .list-header {
@@ -506,7 +506,7 @@ onMounted(() => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: var(--spacing-0-5);
 }
 
 .backup-name {

--- a/autobot-frontend/src/components/knowledge/CleanupStatistics.vue
+++ b/autobot-frontend/src/components/knowledge/CleanupStatistics.vue
@@ -300,7 +300,7 @@ const runCleanup = async () => {
 
 .header-description {
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 

--- a/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
+++ b/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
@@ -370,7 +370,7 @@ const cleanupOrphans = async () => {
 }
 
 .manager-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xl);
   color: var(--text-primary);
   display: flex;
@@ -422,7 +422,7 @@ const cleanupOrphans = async () => {
 }
 
 .section-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   color: var(--text-primary);
   display: flex;

--- a/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
+++ b/autobot-frontend/src/components/knowledge/DocumentChangeFeed.vue
@@ -328,32 +328,32 @@ onUnmounted(() => {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
+  padding: var(--spacing-6);
+  margin-bottom: var(--spacing-6);
 }
 
 .feed-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
-  padding-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
+  padding-bottom: var(--spacing-4);
   border-bottom: 1px solid var(--border-default);
 }
 
 .feed-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .change-badges {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .badge {
@@ -363,7 +363,7 @@ onUnmounted(() => {
   font-weight: 500;
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
 }
 
 .badge-success {
@@ -389,8 +389,8 @@ onUnmounted(() => {
 .feed-controls {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
   flex-wrap: wrap;
 }
 
@@ -398,13 +398,13 @@ onUnmounted(() => {
 .section-filter {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .filter-label {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   font-size: var(--text-sm);
   color: var(--text-secondary);
   white-space: nowrap;
@@ -444,7 +444,7 @@ onUnmounted(() => {
 .toggle-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   cursor: pointer;
   user-select: none;
 }
@@ -459,7 +459,7 @@ onUnmounted(() => {
   font-size: var(--text-sm);
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
 }
 
 .vectorization-status {
@@ -467,28 +467,28 @@ onUnmounted(() => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .status-header {
   font-weight: 600;
   color: var(--text-secondary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .status-stats {
   display: flex;
-  gap: 1rem;
+  gap: var(--spacing-4);
   flex-wrap: wrap;
 }
 
 .stat-item {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   font-size: var(--text-sm);
   font-weight: 500;
 }
@@ -507,25 +507,25 @@ onUnmounted(() => {
 
 .change-filters {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-4);
   flex-wrap: wrap;
 }
 
 .change-list {
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .change-items {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .change-item {
   display: flex;
-  gap: 0.75rem;
-  padding: 0.75rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
   border-radius: var(--radius-md);
   transition: all var(--duration-200);
 }
@@ -564,7 +564,7 @@ onUnmounted(() => {
 .change-title {
   font-weight: 500;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
   word-break: break-word;
 }
 
@@ -576,7 +576,7 @@ onUnmounted(() => {
 
 .change-meta {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   font-size: 0.8125rem;
   color: var(--text-tertiary);
   flex-wrap: wrap;
@@ -589,8 +589,8 @@ onUnmounted(() => {
 
 .feed-actions {
   display: flex;
-  gap: 0.75rem;
-  padding-top: 1rem;
+  gap: var(--spacing-3);
+  padding-top: var(--spacing-4);
   border-top: 1px solid var(--border-default);
 }
 

--- a/autobot-frontend/src/components/knowledge/EntityExtractor.vue
+++ b/autobot-frontend/src/components/knowledge/EntityExtractor.vue
@@ -372,7 +372,7 @@ function formatTime(timestamp?: number): string {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .extractor-header h4 i {
@@ -551,7 +551,7 @@ function formatTime(timestamp?: number): string {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .processing-time {
@@ -627,8 +627,8 @@ function formatTime(timestamp?: number): string {
 
 .error-list {
   list-style: none;
-  padding: 0;
-  margin: 0;
+  padding: var(--spacing-0);
+  margin: var(--spacing-0);
 }
 
 .error-list li {

--- a/autobot-frontend/src/components/knowledge/EntityGraphManager.vue
+++ b/autobot-frontend/src/components/knowledge/EntityGraphManager.vue
@@ -404,7 +404,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .header-content h3 i {
@@ -519,7 +519,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .stats-section h4 i,
@@ -720,7 +720,7 @@ onMounted(() => {
 .activity-main {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
 }
 
 .activity-id {

--- a/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
+++ b/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
@@ -235,7 +235,7 @@ onMounted(() => {
 }
 
 .manager-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xl);
   color: var(--color-error);
   display: flex;

--- a/autobot-frontend/src/components/knowledge/GraphRAGQuery.vue
+++ b/autobot-frontend/src/components/knowledge/GraphRAGQuery.vue
@@ -374,7 +374,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
   flex: 1;
 }
 
@@ -426,7 +426,7 @@ onMounted(() => {
 }
 
 .form-group.compact {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .form-group label {
@@ -499,7 +499,7 @@ onMounted(() => {
 
 .toggle-label input[type="checkbox"] {
   width: auto;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .toggle-text {
@@ -583,7 +583,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .metrics-badges {
@@ -663,7 +663,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   color: var(--text-primary);
   line-height: 1.6;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .result-source {
@@ -703,7 +703,7 @@ onMounted(() => {
 }
 
 .no-results p {
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .no-results .hint {

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -498,21 +498,21 @@ onMounted(() => {
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
 .knowledge-advanced {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   max-width: 1200px;
   margin: 0 auto;
 }
 
 .advanced-header {
   text-align: center;
-  margin-bottom: 2rem;
+  margin-bottom: var(--spacing-8);
 }
 
 .advanced-header h3 {
   font-size: var(--text-2xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .header-description {
@@ -523,7 +523,7 @@ onMounted(() => {
 .advanced-sections {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: var(--spacing-8);
 }
 
 .section-card {
@@ -534,7 +534,7 @@ onMounted(() => {
 }
 
 .section-header {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-secondary);
 }
@@ -543,32 +543,32 @@ onMounted(() => {
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .section-header p {
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .action-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
-  padding: 1.5rem;
+  gap: var(--spacing-6);
+  padding: var(--spacing-6);
 }
 
 .management-actions {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
 }
 
 .action-card {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 1.25rem;
+  padding: var(--spacing-5);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -602,7 +602,7 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   font-size: var(--text-xl);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .action-icon.system-commands {
@@ -629,12 +629,12 @@ onMounted(() => {
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .action-card p {
   color: var(--text-secondary);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
   line-height: 1.5;
 }
 
@@ -642,7 +642,7 @@ onMounted(() => {
   color: var(--text-tertiary);
   font-size: var(--text-xs);
   display: block;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 /* Action button layout */
@@ -652,20 +652,20 @@ onMounted(() => {
 
 /* Progress Styles */
 .progress-container {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
 }
 
 .progress-info {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .progress-text {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .progress-operation {
@@ -690,7 +690,7 @@ onMounted(() => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-full);
   overflow: hidden;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .progress-fill {
@@ -714,7 +714,7 @@ onMounted(() => {
   z-index: var(--z-modal);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   max-width: 400px;
 }
 
@@ -722,11 +722,11 @@ onMounted(() => {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   box-shadow: var(--shadow-md);
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   position: relative;
 }
 
@@ -752,7 +752,7 @@ onMounted(() => {
 
 .status-message i {
   flex-shrink: 0;
-  margin-top: 0.125rem;
+  margin-top: var(--spacing-0-5);
 }
 
 .status-message.success i {
@@ -778,7 +778,7 @@ onMounted(() => {
 .message-title {
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .message-details {
@@ -796,13 +796,13 @@ onMounted(() => {
 /* Responsive */
 @media (max-width: 768px) {
   .knowledge-advanced {
-    padding: 1rem;
+    padding: var(--spacing-4);
   }
 
   .action-grid {
     grid-template-columns: 1fr;
-    gap: 1rem;
-    padding: 1rem;
+    gap: var(--spacing-4);
+    padding: var(--spacing-4);
   }
 
   .action-card {
@@ -817,12 +817,12 @@ onMounted(() => {
 
   .progress-info {
     flex-direction: column;
-    gap: 0.5rem;
+    gap: var(--spacing-2);
   }
 
   .progress-stats {
     flex-direction: column;
-    gap: 0.25rem;
+    gap: var(--spacing-1);
   }
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -1105,11 +1105,11 @@ watch(() => props.mode, () => {
 /* Header */
 .browser-header {
   background: var(--bg-card);
-  padding: 1rem;
+  padding: var(--spacing-4);
   border-bottom: 2px solid var(--border-default);
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
   flex-wrap: wrap;
 }
 
@@ -1117,7 +1117,7 @@ watch(() => props.mode, () => {
 .category-tabs-container {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   flex: 1;
   min-width: 0;
 }
@@ -1125,10 +1125,10 @@ watch(() => props.mode, () => {
 /* Category Tabs */
 .category-tabs {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   overflow-x: auto;
   flex: 0 0 auto;
-  padding-bottom: 0.25rem;
+  padding-bottom: var(--spacing-1);
   scrollbar-width: thin;
   scrollbar-color: var(--color-primary-alpha-30) transparent;
 }
@@ -1157,7 +1157,7 @@ watch(() => props.mode, () => {
 }
 
 .category-tab-icon {
-  margin-right: 0.25rem;
+  margin-right: var(--spacing-1);
   transition: transform var(--duration-200) var(--ease-out);
 }
 
@@ -1180,7 +1180,7 @@ watch(() => props.mode, () => {
   border-radius: var(--radius-xl);
   font-size: var(--text-xs);
   font-weight: 600;
-  margin-left: 0.375rem;
+  margin-left: var(--spacing-1-5);
   transition: all var(--duration-200) var(--ease-out);
 }
 
@@ -1192,7 +1192,7 @@ watch(() => props.mode, () => {
 .active-filter-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.375rem 0.75rem;
   background: var(--color-primary-bg);
   border: 1px solid var(--color-primary-light);
@@ -1214,7 +1214,7 @@ watch(() => props.mode, () => {
   justify-content: center;
   width: 1.25rem;
   height: 1.25rem;
-  padding: 0;
+  padding: var(--spacing-0);
   background: transparent;
   border: none;
   border-radius: 50%;
@@ -1264,7 +1264,7 @@ watch(() => props.mode, () => {
 .refresh-status-btn {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -1295,7 +1295,7 @@ watch(() => props.mode, () => {
 .toolbar-info {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   color: var(--bg-card);
   font-weight: 500;
 }
@@ -1306,7 +1306,7 @@ watch(() => props.mode, () => {
 
 .toolbar-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 /* Toolbar button custom styling */
@@ -1376,7 +1376,7 @@ watch(() => props.mode, () => {
 .breadcrumb {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.75rem 1.5rem;
   background: var(--bg-card);
   border-bottom: 1px solid var(--border-default);
@@ -1399,7 +1399,7 @@ watch(() => props.mode, () => {
   grid-template-columns: 30% 70%;
   flex: 1;
   overflow: hidden;
-  gap: 0;
+  gap: var(--spacing-0);
 }
 
 .tree-pane {
@@ -1416,23 +1416,23 @@ watch(() => props.mode, () => {
 
 /* Tree container */
 .tree-container {
-  padding: 0.5rem;
+  padding: var(--spacing-2);
 }
 
 /* Load More button container */
 .load-more-container {
   display: flex;
   justify-content: center;
-  padding: 1rem;
-  margin-top: 0.5rem;
+  padding: var(--spacing-4);
+  margin-top: var(--spacing-2);
 }
 
 .loading-more {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 1rem;
+  gap: var(--spacing-2);
+  padding: var(--spacing-4);
   color: var(--text-tertiary);
   font-size: var(--text-sm);
 }
@@ -1458,7 +1458,7 @@ watch(() => props.mode, () => {
 .error-state i,
 .placeholder-state i {
   font-size: var(--text-5xl);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
   opacity: 0.5;
 }
 
@@ -1467,7 +1467,7 @@ watch(() => props.mode, () => {
 }
 
 .retry-btn {
-  margin-top: 1rem;
+  margin-top: var(--spacing-4);
 }
 
 /* File viewer */
@@ -1481,7 +1481,7 @@ watch(() => props.mode, () => {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   background: var(--bg-card);
   border-bottom: 2px solid var(--border-default);
 }
@@ -1489,21 +1489,21 @@ watch(() => props.mode, () => {
 .file-info {
   display: flex;
   align-items: flex-start;
-  gap: 1rem;
+  gap: var(--spacing-4);
   flex: 1;
 }
 
 .file-info > i {
   font-size: 2rem;
   color: var(--color-primary);
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
 }
 
 .file-info h4 {
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .file-meta {
@@ -1523,7 +1523,7 @@ watch(() => props.mode, () => {
   flex: 1;
   overflow-y: auto;
   background: var(--bg-card);
-  margin: 1rem;
+  margin: var(--spacing-4);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
 }
@@ -1534,7 +1534,7 @@ watch(() => props.mode, () => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 3rem;
+  padding: var(--spacing-12);
   color: var(--text-tertiary);
 }
 
@@ -1543,14 +1543,14 @@ watch(() => props.mode, () => {
 }
 
 .content-display {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
   font-size: var(--text-sm);
   line-height: 1.6;
   color: var(--text-primary);
   white-space: pre-wrap;
   word-wrap: break-word;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Scrollbar styling */

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.vue
@@ -181,7 +181,7 @@ defineEmits<Emits>()
 
   .category-tabs {
     overflow-x: auto;
-    padding-bottom: 0.5rem;
+    padding-bottom: var(--spacing-2);
     margin-bottom: -0.5rem;
   }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -378,7 +378,7 @@ onUnmounted(() => {
 
 <style scoped>
 .knowledge-categories {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   max-width: 1400px;
   margin: 0 auto;
   min-height: calc(100vh - 200px);
@@ -391,14 +391,14 @@ onUnmounted(() => {
 
 .selection-header {
   text-align: center;
-  margin-bottom: 3rem;
+  margin-bottom: var(--spacing-12);
 }
 
 .selection-header h2 {
   font-size: 2.5rem;
   font-weight: 700;
   color: var(--text-primary);
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .selection-header .subtitle {
@@ -410,7 +410,7 @@ onUnmounted(() => {
 .main-categories-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  gap: 2rem;
+  gap: var(--spacing-8);
   max-width: 1200px;
   margin: 0 auto;
 }
@@ -419,7 +419,7 @@ onUnmounted(() => {
   background: var(--bg-card);
   border: 3px solid var(--border-default);
   border-radius: var(--radius-2xl);
-  padding: 2rem;
+  padding: var(--spacing-8);
   cursor: pointer;
   transition: all var(--duration-300) var(--ease-in-out);
   display: flex;
@@ -489,7 +489,7 @@ onUnmounted(() => {
   justify-content: center;
   color: var(--text-on-primary);
   font-size: 2.5rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
   transition: all var(--duration-300);
 }
 
@@ -506,13 +506,13 @@ onUnmounted(() => {
   font-size: var(--text-2xl);
   font-weight: 700;
   color: var(--text-primary);
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .category-description {
   color: var(--text-secondary);
   font-size: var(--text-base);
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
   line-height: 1.6;
 }
 
@@ -520,8 +520,8 @@ onUnmounted(() => {
   color: var(--text-tertiary);
   font-size: var(--text-sm);
   font-style: italic;
-  margin-bottom: 1.5rem;
-  padding: 0.75rem;
+  margin-bottom: var(--spacing-6);
+  padding: var(--spacing-3);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
 }
@@ -529,14 +529,14 @@ onUnmounted(() => {
 .category-stats {
   display: flex;
   justify-content: center;
-  gap: 1.5rem;
-  margin-top: 1rem;
+  gap: var(--spacing-6);
+  margin-top: var(--spacing-4);
 }
 
 .category-stats .stat {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   color: var(--text-secondary);
   font-size: var(--text-sm);
   font-weight: 500;
@@ -547,7 +547,7 @@ onUnmounted(() => {
 }
 
 .browse-arrow {
-  margin-top: 1.5rem;
+  margin-top: var(--spacing-6);
   color: var(--color-info);
   font-size: var(--text-2xl);
   transition: transform var(--duration-300);
@@ -576,9 +576,9 @@ onUnmounted(() => {
 .browser-header-bar {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
-  margin-bottom: 1.5rem;
-  padding: 1rem;
+  gap: var(--spacing-6);
+  margin-bottom: var(--spacing-6);
+  padding: var(--spacing-4);
   background: var(--bg-card);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-sm);
@@ -590,20 +590,20 @@ onUnmounted(() => {
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Page Header */
 .page-header {
   text-align: center;
-  margin-bottom: 2rem;
+  margin-bottom: var(--spacing-8);
 }
 
 .page-header h2 {
   font-size: 2rem;
   font-weight: 700;
   color: var(--text-primary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .page-header .subtitle {
@@ -614,10 +614,10 @@ onUnmounted(() => {
 /* Tab Selection */
 .category-tabs {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 2rem;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-8);
   border-bottom: 2px solid var(--border-default);
-  padding-bottom: 0;
+  padding-bottom: var(--spacing-0);
 }
 
 .tab-btn {
@@ -647,8 +647,8 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 2rem;
-  padding: 1.5rem;
+  margin-bottom: var(--spacing-8);
+  padding: var(--spacing-6);
   background: var(--bg-card);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-sm);
@@ -658,19 +658,19 @@ onUnmounted(() => {
   font-size: var(--text-2xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .view-description {
   color: var(--text-secondary);
   font-size: 0.95rem;
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
 }
 
 .manage-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.625rem 1.25rem;
   background: var(--color-info);
   color: var(--text-on-primary);
@@ -689,17 +689,17 @@ onUnmounted(() => {
 .stats-overview {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
-  margin-bottom: 2rem;
+  gap: var(--spacing-6);
+  margin-bottom: var(--spacing-8);
 }
 
 .stat-card {
   background: var(--bg-card);
   border-radius: var(--radius-xl);
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
   box-shadow: var(--shadow-sm);
   transition: all var(--duration-200);
 }
@@ -735,24 +735,24 @@ onUnmounted(() => {
 .stat-label {
   color: var(--text-secondary);
   font-size: var(--text-sm);
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
 }
 
 /* Category Browse Grid */
 .category-browse-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: 1.5rem;
-  margin-bottom: 2rem;
+  gap: var(--spacing-6);
+  margin-bottom: var(--spacing-8);
 }
 
 .category-browse-card {
   background: var(--bg-card);
   border-radius: var(--radius-xl);
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
   cursor: pointer;
   border: 2px solid var(--border-default);
   transition: all var(--duration-200);
@@ -784,7 +784,7 @@ onUnmounted(() => {
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .category-browse-card .category-info p {
@@ -810,15 +810,15 @@ onUnmounted(() => {
 .population-controls {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 2rem;
-  margin-top: 1.5rem;
+  gap: var(--spacing-8);
+  margin-top: var(--spacing-6);
 }
 
 .category-tree-container {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   max-height: 500px;
   overflow-y: auto;
 }
@@ -826,12 +826,12 @@ onUnmounted(() => {
 .population-actions {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .selected-category-info {
   background: var(--color-info-bg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-info);
 }
@@ -840,7 +840,7 @@ onUnmounted(() => {
   font-weight: 500;
   color: var(--text-primary);
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .selected-path {
@@ -850,7 +850,7 @@ onUnmounted(() => {
 
 .action-buttons {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .action-button {
@@ -864,7 +864,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .action-button.primary {
@@ -894,7 +894,7 @@ onUnmounted(() => {
 .kb-stats {
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
-  padding: 1.25rem;
+  padding: var(--spacing-5);
   border: 1px solid var(--border-default);
 }
 
@@ -902,19 +902,19 @@ onUnmounted(() => {
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .stat-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .stat-item {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .stat-label {
@@ -953,7 +953,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .categories-header h3 {
@@ -966,7 +966,7 @@ onUnmounted(() => {
 
 .loading-state {
   text-align: center;
-  padding: 3rem;
+  padding: var(--spacing-12);
   color: var(--text-secondary);
 }
 
@@ -983,13 +983,13 @@ onUnmounted(() => {
 
 .categories-error-state i {
   font-size: 2.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
   display: block;
 }
 
 .categories-error-state p {
   font-size: var(--text-base);
-  margin-bottom: 1.25rem;
+  margin-bottom: var(--spacing-5);
 }
 
 .retry-btn {
@@ -1010,14 +1010,14 @@ onUnmounted(() => {
 .categories-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 .category-card {
   background: var(--bg-card);
   border: 2px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   cursor: pointer;
   transition: all var(--duration-200);
 }
@@ -1036,7 +1036,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .category-icon {
@@ -1052,7 +1052,7 @@ onUnmounted(() => {
 
 .category-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 /* Button styling handled by BaseButton component */
@@ -1061,19 +1061,19 @@ onUnmounted(() => {
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .category-description {
   color: var(--text-secondary);
   font-size: var(--text-sm);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .category-stats {
   display: flex;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -1081,7 +1081,7 @@ onUnmounted(() => {
 .stat-item {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 /* Button styling handled by BaseButton component */
@@ -1089,12 +1089,12 @@ onUnmounted(() => {
 /* Form styles (used in modals) */
 
 .form-group {
-  margin-bottom: 1.25rem;
+  margin-bottom: var(--spacing-5);
 }
 
 .form-group label {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   font-weight: 500;
   color: var(--text-primary);
 }
@@ -1102,7 +1102,7 @@ onUnmounted(() => {
 .form-input,
 .form-textarea {
   width: 100%;
-  padding: 0.625rem;
+  padding: var(--spacing-2-5);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -1124,7 +1124,7 @@ onUnmounted(() => {
 
 .color-picker {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   flex-wrap: wrap;
 }
 
@@ -1171,7 +1171,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -1180,17 +1180,17 @@ onUnmounted(() => {
 .documents-list {
   flex: 1;
   overflow-y: auto;
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .document-item {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.75rem;
+  gap: var(--spacing-4);
+  padding: var(--spacing-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   cursor: pointer;
   transition: all var(--duration-200);
 }
@@ -1214,7 +1214,7 @@ onUnmounted(() => {
 .doc-info h5 {
   font-weight: 500;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .doc-meta {
@@ -1224,7 +1224,7 @@ onUnmounted(() => {
 
 /* View Documents Button */
 .view-docs-button {
-  margin-top: 0.75rem;
+  margin-top: var(--spacing-3);
   padding: 0.5rem 1rem;
   background: var(--color-success);
   color: var(--text-on-success);
@@ -1235,7 +1235,7 @@ onUnmounted(() => {
   transition: all var(--duration-200);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .view-docs-button:hover:not(:disabled) {
@@ -1259,7 +1259,7 @@ onUnmounted(() => {
   align-items: center;
   justify-content: center;
   z-index: var(--z-modal);
-  padding: 2rem;
+  padding: var(--spacing-8);
 }
 
 .category-documents-modal {
@@ -1287,7 +1287,7 @@ onUnmounted(() => {
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .modal-content {
@@ -1299,14 +1299,14 @@ onUnmounted(() => {
 .documents-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .document-card {
   background: var(--bg-card);
   border: 2px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 1.25rem;
+  padding: var(--spacing-5);
   cursor: pointer;
   transition: all var(--duration-200);
 }
@@ -1320,8 +1320,8 @@ onUnmounted(() => {
 .doc-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
 }
 
 .doc-icon {
@@ -1343,13 +1343,13 @@ onUnmounted(() => {
 }
 
 .doc-info {
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .doc-source {
   font-size: var(--text-xs);
   color: var(--color-info);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   font-family: var(--font-mono);
 }
 
@@ -1367,7 +1367,7 @@ onUnmounted(() => {
   display: flex;
   justify-content: between;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
   font-size: var(--text-xs);
   color: var(--text-muted);
 }
@@ -1392,7 +1392,7 @@ onUnmounted(() => {
   align-items: center;
   justify-content: center;
   z-index: var(--z-modal);
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .document-viewer-modal {
@@ -1420,13 +1420,13 @@ onUnmounted(() => {
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .document-source {
@@ -1441,17 +1441,17 @@ onUnmounted(() => {
 .viewer-content {
   flex: 1;
   overflow-y: auto;
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 .document-content {
-  padding: 2rem;
+  padding: var(--spacing-8);
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   line-height: 1.6;
   white-space: pre-wrap;
   word-wrap: break-word;
-  margin: 0;
+  margin: var(--spacing-0);
   background: var(--code-bg);
   color: var(--code-text);
 }
@@ -1459,9 +1459,9 @@ onUnmounted(() => {
 /* System Tabs */
 .system-tabs {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   border-bottom: 2px solid var(--border-default);
-  padding-bottom: 0.5rem;
+  padding-bottom: var(--spacing-2);
 }
 
 .system-tab-btn {
@@ -1490,32 +1490,32 @@ onUnmounted(() => {
 
 /* AutoBot Categories */
 .autobot-categories {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
 }
 
 .subtitle {
   color: var(--text-secondary);
   font-size: var(--text-sm);
-  margin-top: 0.5rem;
+  margin-top: var(--spacing-2);
 }
 
 /* Documents Grid */
 .documents-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+  gap: var(--spacing-4);
+  margin-top: var(--spacing-4);
 }
 
 .document-card {
   background: var(--bg-card);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   cursor: pointer;
   transition: all var(--duration-200);
   display: flex;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .document-card:hover {
@@ -1546,7 +1546,7 @@ onUnmounted(() => {
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1555,7 +1555,7 @@ onUnmounted(() => {
 .doc-path {
   font-size: var(--text-xs);
   color: var(--text-secondary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1563,7 +1563,7 @@ onUnmounted(() => {
 
 .doc-meta {
   display: flex;
-  gap: 1rem;
+  gap: var(--spacing-4);
   font-size: var(--text-xs);
   color: var(--text-muted);
 }
@@ -1571,48 +1571,48 @@ onUnmounted(() => {
 .doc-meta span {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 /* Document Metadata */
 .document-metadata {
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
-  padding: 1rem;
-  margin-bottom: 1rem;
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
 }
 
 .meta-item {
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   font-size: var(--text-sm);
 }
 
 .meta-item:last-child {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .meta-item strong {
   color: var(--text-primary);
-  margin-right: 0.5rem;
+  margin-right: var(--spacing-2);
 }
 
 /* Document Content */
 .document-content {
-  margin-top: 1rem;
+  margin-top: var(--spacing-4);
 }
 
 .document-content h4 {
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .document-content pre {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   font-size: var(--text-sm);
   overflow-x: auto;
   white-space: pre-wrap;

--- a/autobot-frontend/src/components/knowledge/KnowledgeContentViewer.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeContentViewer.vue
@@ -173,7 +173,7 @@ const fileIcon = computed(() => {
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .file-meta {
@@ -194,7 +194,7 @@ const fileIcon = computed(() => {
 .file-content {
   flex: 1;
   overflow: auto;
-  padding: 1.5rem;
+  padding: var(--spacing-6);
 }
 
 .loading-content,
@@ -218,7 +218,7 @@ const fileIcon = computed(() => {
 }
 
 .content-display {
-  margin: 0;
+  margin: var(--spacing-0);
   padding: var(--spacing-4);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -1736,8 +1736,8 @@ watch(layoutMode, () => {
 
 .observations-list {
   list-style: none;
-  padding: 0;
-  margin: 0;
+  padding: var(--spacing-0);
+  margin: var(--spacing-0);
 }
 
 .observations-list li {
@@ -1751,8 +1751,8 @@ watch(layoutMode, () => {
 
 .relations-list {
   list-style: none;
-  padding: 0;
-  margin: 0;
+  padding: var(--spacing-0);
+  margin: var(--spacing-0);
 }
 
 .relations-list li {
@@ -1986,7 +1986,7 @@ watch(layoutMode, () => {
   }
 
   .stats-summary {
-    margin-left: 0;
+    margin-left: var(--spacing-0);
     justify-content: center;
   }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraphView.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraphView.vue
@@ -166,7 +166,7 @@ function navigateTo(path: string): void {
 }
 
 .sidebar-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: var(--font-bold);
   color: var(--text-primary);
@@ -351,7 +351,7 @@ function navigateTo(path: string): void {
 .feature-card p {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: 1.5;
 }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
@@ -322,7 +322,7 @@ onMounted(() => {
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
 .knowledge-maintenance {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   max-width: 1400px;
   margin: 0 auto;
 }
@@ -332,8 +332,8 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 2rem;
-  padding-bottom: 1rem;
+  margin-bottom: var(--spacing-8);
+  padding-bottom: var(--spacing-4);
   border-bottom: 2px solid var(--border-default);
 }
 
@@ -344,7 +344,7 @@ onMounted(() => {
   margin: 0 0 0.5rem 0;
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .header-content h2 i {
@@ -353,7 +353,7 @@ onMounted(() => {
 
 .header-subtitle {
   color: var(--text-tertiary);
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: 0.95rem;
 }
 
@@ -361,8 +361,8 @@ onMounted(() => {
 .health-dashboard {
   background: var(--bg-card);
   border-radius: var(--radius-xl);
-  padding: 1.5rem;
-  margin-bottom: 2rem;
+  padding: var(--spacing-6);
+  margin-bottom: var(--spacing-8);
   box-shadow: var(--shadow-sm);
 }
 
@@ -370,17 +370,17 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .section-title h3 {
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .health-status-badge {
@@ -414,14 +414,14 @@ onMounted(() => {
 .loading-state,
 .empty-state {
   text-align: center;
-  padding: 3rem;
+  padding: var(--spacing-12);
   color: var(--text-tertiary);
 }
 
 .loading-state i,
 .empty-state i {
   font-size: 2.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
   display: block;
 }
 
@@ -429,14 +429,14 @@ onMounted(() => {
 .health-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 .health-card {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 1rem;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-default);
@@ -502,7 +502,7 @@ onMounted(() => {
   grid-column: span 2;
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   border: 1px solid var(--border-default);
 }
 
@@ -516,13 +516,13 @@ onMounted(() => {
 .dimension-bars {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .dimension-item {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .dimension-header {
@@ -569,7 +569,7 @@ onMounted(() => {
 .issues-summary {
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   border: 1px solid var(--border-default);
 }
 
@@ -582,13 +582,13 @@ onMounted(() => {
 
 .issues-counts {
   display: flex;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .issue-count {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: var(--text-sm);
   font-weight: 500;
 }
@@ -606,7 +606,7 @@ onMounted(() => {
   grid-column: span 4;
   background: var(--color-info-bg);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   border: 1px solid var(--color-info-light);
 }
 
@@ -618,33 +618,33 @@ onMounted(() => {
 }
 
 .recommendation-list {
-  margin: 0;
-  padding: 0;
+  margin: var(--spacing-0);
+  padding: var(--spacing-0);
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .recommendation-list li {
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: var(--text-sm);
   color: var(--color-info-dark);
 }
 
 .recommendation-list li i {
   color: var(--color-primary);
-  margin-top: 0.125rem;
+  margin-top: var(--spacing-0-5);
 }
 
 /* Maintenance Sections */
 .maintenance-sections {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
-  margin-bottom: 2rem;
+  gap: var(--spacing-6);
+  margin-bottom: var(--spacing-8);
 }
 
 .maintenance-section {
@@ -658,40 +658,40 @@ onMounted(() => {
 .maintenance-history {
   background: var(--bg-card);
   border-radius: var(--radius-xl);
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   box-shadow: var(--shadow-sm);
 }
 
 .history-content {
-  margin-top: 1rem;
+  margin-top: var(--spacing-4);
 }
 
 .empty-history {
   text-align: center;
-  padding: 2rem;
+  padding: var(--spacing-8);
   color: var(--text-muted);
 }
 
 .empty-history i {
   font-size: 2rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
   display: block;
 }
 
 .empty-history p {
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .history-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .history-item {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
   padding: 0.75rem 1rem;
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
@@ -763,7 +763,7 @@ onMounted(() => {
 @media (max-width: 768px) {
   .maintenance-header {
     flex-direction: column;
-    gap: 1rem;
+    gap: var(--spacing-4);
   }
 
   .header-actions {

--- a/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePersistenceDialog.vue
@@ -514,7 +514,7 @@ watch(() => props.visible, (newVal) => {
 }
 
 .dialog-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xl);
   font-weight: var(--font-semibold);
 }
@@ -670,7 +670,7 @@ watch(() => props.visible, (newVal) => {
 }
 
 .content-preview pre {
-  margin: 0;
+  margin: var(--spacing-0);
   white-space: pre-wrap;
   word-wrap: break-word;
   font-family: var(--font-mono);
@@ -719,7 +719,7 @@ watch(() => props.visible, (newVal) => {
 .option-description {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin-left: 28px;
+  margin-left: var(--spacing-7);
 }
 
 .item-metadata {

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -535,7 +535,7 @@ onBeforeUnmount(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-card);
 }
@@ -544,7 +544,7 @@ onBeforeUnmount(() => {
   font-size: var(--text-2xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .header-left .subtitle {
@@ -554,7 +554,7 @@ onBeforeUnmount(() => {
 
 .header-actions {
   display: flex;
-  gap: 1rem;
+  gap: var(--spacing-4);
   align-items: center;
 }
 
@@ -594,7 +594,7 @@ onBeforeUnmount(() => {
 .alert {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.75rem 1rem;
   font-size: var(--text-sm);
 }
@@ -613,7 +613,7 @@ onBeforeUnmount(() => {
 
 .alert .close-btn {
   margin-left: auto;
-  padding: 0.25rem;
+  padding: var(--spacing-1);
   background: none;
   border: none;
   color: inherit;
@@ -636,17 +636,17 @@ onBeforeUnmount(() => {
 }
 
 .prompt-list {
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .prompt-category {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .category-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.5rem 0;
   font-size: var(--text-xs);
   font-weight: 600;
@@ -666,7 +666,7 @@ onBeforeUnmount(() => {
 .category-prompts {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .prompt-item {
@@ -695,7 +695,7 @@ onBeforeUnmount(() => {
   display: block;
   font-size: var(--text-xs);
   color: var(--text-muted);
-  margin-top: 0.125rem;
+  margin-top: var(--spacing-0-5);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -715,7 +715,7 @@ onBeforeUnmount(() => {
   align-items: center;
   justify-content: center;
   color: var(--text-muted);
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .editor-empty i {
@@ -736,7 +736,7 @@ onBeforeUnmount(() => {
 .toolbar-left {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .toolbar-left h3 {
@@ -764,20 +764,20 @@ onBeforeUnmount(() => {
 
 .toolbar-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 /* Editor Wrapper */
 .editor-wrapper {
   flex: 1;
-  padding: 1rem;
+  padding: var(--spacing-4);
   overflow: hidden;
 }
 
 .prompt-textarea {
   width: 100%;
   height: 100%;
-  padding: 1rem;
+  padding: var(--spacing-4);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
   font-family: var(--font-mono);
@@ -807,18 +807,18 @@ onBeforeUnmount(() => {
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .footer-stats {
   display: flex;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .footer-stats .stat {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   font-size: var(--text-xs);
   color: var(--text-secondary);
 }
@@ -830,7 +830,7 @@ onBeforeUnmount(() => {
 .variable-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
 }
 
 .variable-tag {
@@ -847,8 +847,8 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
-  padding: 2rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-8);
   color: var(--text-secondary);
 }
 
@@ -860,8 +860,8 @@ onBeforeUnmount(() => {
 .history-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-bottom: 1.5rem;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-6);
 }
 
 .history-item {
@@ -887,7 +887,7 @@ onBeforeUnmount(() => {
 .version-info {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: var(--spacing-0-5);
 }
 
 .version-number {
@@ -902,20 +902,20 @@ onBeforeUnmount(() => {
 
 .version-preview {
   border-top: 1px solid var(--border-default);
-  padding-top: 1rem;
+  padding-top: var(--spacing-4);
 }
 
 .version-preview h4 {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .version-content {
   max-height: 200px;
   overflow-y: auto;
-  padding: 1rem;
+  padding: var(--spacing-4);
   background: var(--bg-secondary);
   border-radius: var(--radius-md);
   font-family: var(--font-mono);

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
@@ -764,7 +764,7 @@ onUnmounted(() => {
   border: none;
   color: inherit;
   cursor: pointer;
-  padding: 2px;
+  padding: var(--spacing-0-5);
   display: flex;
   align-items: center;
 }
@@ -877,7 +877,7 @@ onUnmounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: 1.4;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -888,7 +888,7 @@ onUnmounted(() => {
 .card-snippet {
   font-size: var(--text-xs);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: 1.5;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -907,7 +907,7 @@ onUnmounted(() => {
 .card-link {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   font-size: var(--text-xs);
   color: var(--text-muted);
   text-decoration: none;
@@ -927,7 +927,7 @@ onUnmounted(() => {
 .btn-reject {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 3px 10px;
   border-radius: var(--radius-sm);
   font-size: var(--text-xs);
@@ -1082,7 +1082,7 @@ onUnmounted(() => {
 .viewport-empty p {
   font-size: var(--text-sm);
   max-width: 320px;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* ── Status bar ──────────────────────────────────────────────────────────── */

--- a/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeScopeSelector.vue
@@ -155,13 +155,13 @@ const handleGroupChange = () => {
 .scope-selector {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .scope-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-weight: 500;
   color: var(--text-secondary);
 }
@@ -176,7 +176,7 @@ const handleGroupChange = () => {
 }
 
 .scope-dropdown {
-  padding: 0.5rem;
+  padding: var(--spacing-2);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -207,8 +207,8 @@ const handleGroupChange = () => {
 }
 
 .scope-help {
-  margin-top: 0.5rem;
-  padding: 0.75rem;
+  margin-top: var(--spacing-2);
+  padding: var(--spacing-3);
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -216,11 +216,11 @@ const handleGroupChange = () => {
 }
 
 .help-item {
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .help-item:last-child {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .help-item strong {
@@ -228,8 +228,8 @@ const handleGroupChange = () => {
 }
 
 .group-selector {
-  margin-top: 0.75rem;
-  padding: 0.75rem;
+  margin-top: var(--spacing-3);
+  padding: var(--spacing-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   background-color: var(--bg-secondary);
@@ -237,7 +237,7 @@ const handleGroupChange = () => {
 
 .group-selector label {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   font-weight: 500;
   color: var(--text-secondary);
 }
@@ -245,14 +245,14 @@ const handleGroupChange = () => {
 .group-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .group-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2);
   border-radius: var(--radius-default);
   cursor: pointer;
   transition: background-color var(--duration-200);

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
@@ -524,7 +524,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-card);
 }
@@ -533,7 +533,7 @@ onMounted(() => {
   font-size: var(--text-2xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .header-left .subtitle {
@@ -543,7 +543,7 @@ onMounted(() => {
 
 .header-actions {
   display: flex;
-  gap: 1rem;
+  gap: var(--spacing-4);
   align-items: center;
 }
 
@@ -588,7 +588,7 @@ onMounted(() => {
   position: absolute;
   top: 100%;
   right: 0;
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
   background: var(--bg-card);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
@@ -605,7 +605,7 @@ onMounted(() => {
 .dropdown-menu button {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   width: 100%;
   padding: 0.625rem 1rem;
   border: none;
@@ -624,7 +624,7 @@ onMounted(() => {
 .error-banner {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.75rem 1rem;
   background: var(--color-error-bg);
   color: var(--color-error-dark);
@@ -633,7 +633,7 @@ onMounted(() => {
 
 .error-banner .close-btn {
   margin-left: auto;
-  padding: 0.25rem;
+  padding: var(--spacing-1);
   background: none;
   border: none;
   color: inherit;
@@ -660,13 +660,13 @@ onMounted(() => {
 }
 
 .category-item {
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .category-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -683,7 +683,7 @@ onMounted(() => {
 }
 
 .category-header.child {
-  padding-left: 2rem;
+  padding-left: var(--spacing-8);
 }
 
 .expand-btn {
@@ -692,7 +692,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0;
+  padding: var(--spacing-0);
   border: none;
   background: none;
   color: var(--text-muted);
@@ -720,27 +720,27 @@ onMounted(() => {
 }
 
 .category-children {
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
 }
 
 /* Document List */
 .docs-list {
   border-right: 1px solid var(--border-default);
   overflow-y: auto;
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .doc-items {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .doc-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -777,7 +777,7 @@ onMounted(() => {
   display: block;
   font-weight: 500;
   color: var(--text-primary);
-  margin-bottom: 0.125rem;
+  margin-bottom: var(--spacing-0-5);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -805,7 +805,7 @@ onMounted(() => {
   justify-content: center;
   height: 100%;
   color: var(--text-muted);
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .preview-empty i {
@@ -836,7 +836,7 @@ onMounted(() => {
 
 .preview-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .preview-actions .success {
@@ -845,7 +845,7 @@ onMounted(() => {
 
 .preview-meta {
   display: flex;
-  gap: 1.5rem;
+  gap: var(--spacing-6);
   padding: 0.75rem 1.5rem;
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-card);
@@ -854,14 +854,14 @@ onMounted(() => {
 .meta-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: var(--text-xs);
   color: var(--text-secondary);
 }
 
 .preview-body {
   flex: 1;
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   overflow-y: auto;
 }
 
@@ -871,7 +871,7 @@ onMounted(() => {
   line-height: 1.6;
   white-space: pre-wrap;
   word-wrap: break-word;
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
 }
 
@@ -880,8 +880,8 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.75rem;
-  padding: 2rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-8);
   color: var(--text-secondary);
 }
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
@@ -1180,11 +1180,11 @@ onMounted(() => {
 }
 
 .drop-zone-content.compact .drop-icon-wrapper {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .drop-zone-content.compact .drop-text {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .drop-zone-content.compact .drop-hint {
@@ -1253,7 +1253,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .files-header h5 i {
@@ -1501,7 +1501,7 @@ onMounted(() => {
   word-wrap: break-word;
   max-height: 200px;
   overflow-y: auto;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .preview-truncated {
@@ -1588,8 +1588,8 @@ onMounted(() => {
 .slide-leave-to {
   opacity: 0;
   max-height: 0;
-  padding-top: 0;
-  padding-bottom: 0;
+  padding-top: var(--spacing-0);
+  padding-bottom: var(--spacing-0);
 }
 
 .slide-enter-to,

--- a/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
@@ -481,14 +481,14 @@ onMounted(() => {
 }
 
 .header-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
   font-family: var(--font-sans);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .header-icon {
@@ -556,7 +556,7 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
+  gap: var(--spacing-0-5);
   min-width: 80px;
 }
 
@@ -683,7 +683,7 @@ onMounted(() => {
   align-items: center;
   gap: var(--spacing-3);
   margin-bottom: var(--spacing-3);
-  margin-left: 28px;
+  margin-left: var(--spacing-7);
   flex-wrap: wrap;
 }
 
@@ -756,7 +756,7 @@ onMounted(() => {
 .card-actions {
   display: flex;
   gap: var(--spacing-2);
-  margin-left: 28px;
+  margin-left: var(--spacing-7);
 }
 
 /* Pagination */
@@ -794,19 +794,19 @@ onMounted(() => {
   }
 
   .card-meta {
-    margin-left: 0;
+    margin-left: var(--spacing-0);
   }
 
   .card-content {
-    margin-left: 0;
+    margin-left: var(--spacing-0);
   }
 
   .card-url {
-    margin-left: 0;
+    margin-left: var(--spacing-0);
   }
 
   .card-actions {
-    margin-left: 0;
+    margin-left: var(--spacing-0);
   }
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/MemoryOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/MemoryOrphanManager.vue
@@ -314,7 +314,7 @@ const cleanupOrphans = async () => {
 
 .header-description {
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 

--- a/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
+++ b/autobot-frontend/src/components/knowledge/SessionOrphanManager.vue
@@ -265,12 +265,12 @@ const cleanupSessionOrphans = async () => {
 .session-orphan-manager {
   background: var(--bg-card);
   border-radius: var(--radius-lg);
-  margin: 1rem;
+  margin: var(--spacing-4);
   box-shadow: var(--shadow-sm);
 }
 
 .section-header {
-  padding: 1.25rem;
+  padding: var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-secondary);
 }
@@ -282,33 +282,33 @@ const cleanupSessionOrphans = async () => {
   margin: 0 0 0.25rem 0;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .header-description {
   color: var(--text-tertiary);
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 
 .orphan-content {
-  padding: 1.25rem;
+  padding: var(--spacing-5);
 }
 
 .orphan-summary {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .summary-stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
 }
 
 .stat-item {
   text-align: center;
-  padding: 1rem;
+  padding: var(--spacing-4);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-default);
@@ -334,14 +334,14 @@ const cleanupSessionOrphans = async () => {
   display: block;
   font-size: var(--text-xs);
   color: var(--text-tertiary);
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
 }
 
 .orphan-preview {
   background: var(--color-warning-bg-light);
   border: 1px solid var(--color-warning-light);
   border-radius: var(--radius-lg);
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .orphan-preview h5 {
@@ -354,7 +354,7 @@ const cleanupSessionOrphans = async () => {
 .orphan-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   max-height: 300px;
   overflow-y: auto;
 }
@@ -363,13 +363,13 @@ const cleanupSessionOrphans = async () => {
   background: var(--bg-card);
   border: 1px solid var(--color-warning-light);
   border-radius: var(--radius-md);
-  padding: 0.75rem;
+  padding: var(--spacing-3);
 }
 
 .orphan-meta {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .orphan-category {
@@ -414,13 +414,13 @@ const cleanupSessionOrphans = async () => {
 .orphan-actions {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
+  gap: var(--spacing-6);
 }
 
 .action-card {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 1.25rem;
+  padding: var(--spacing-5);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -454,7 +454,7 @@ const cleanupSessionOrphans = async () => {
   align-items: center;
   justify-content: center;
   font-size: var(--text-xl);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .action-icon.scan {
@@ -484,7 +484,7 @@ const cleanupSessionOrphans = async () => {
   color: var(--text-muted);
   font-size: var(--text-xs);
   display: block;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .action-btn {
@@ -495,10 +495,10 @@ const cleanupSessionOrphans = async () => {
 .status-message {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
   border-radius: var(--radius-lg);
-  margin-top: 1.5rem;
+  margin-top: var(--spacing-6);
 }
 
 .status-message.success {
@@ -533,7 +533,7 @@ const cleanupSessionOrphans = async () => {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0.25rem;
+  padding: var(--spacing-1);
   color: inherit;
   opacity: 0.7;
 }

--- a/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
+++ b/autobot-frontend/src/components/knowledge/ShareKnowledgeDialog.vue
@@ -386,7 +386,7 @@ const closeDialog = () => {
 }
 
 .modal-header {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
   display: flex;
   justify-content: space-between;
@@ -394,7 +394,7 @@ const closeDialog = () => {
 }
 
 .modal-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
@@ -406,7 +406,7 @@ const closeDialog = () => {
   font-size: var(--text-2xl);
   cursor: pointer;
   color: var(--text-muted);
-  padding: 0;
+  padding: var(--spacing-0);
   width: 2rem;
   height: 2rem;
   display: flex;
@@ -422,18 +422,18 @@ const closeDialog = () => {
 }
 
 .modal-body {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   overflow-y: auto;
   flex: 1;
 }
 
 .search-section {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .search-section label {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   font-weight: 500;
   color: var(--text-secondary);
 }
@@ -471,7 +471,7 @@ const closeDialog = () => {
 }
 
 .search-results {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
   max-height: 200px;
@@ -479,14 +479,14 @@ const closeDialog = () => {
 }
 
 .search-status {
-  padding: 0.75rem;
+  padding: var(--spacing-3);
   text-align: center;
   color: var(--text-muted);
   font-size: var(--text-sm);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .search-status--error {
@@ -494,10 +494,10 @@ const closeDialog = () => {
 }
 
 .search-result-item {
-  padding: 0.75rem;
+  padding: var(--spacing-3);
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   cursor: pointer;
   transition: background-color var(--duration-200);
 }
@@ -530,7 +530,7 @@ const closeDialog = () => {
 }
 
 .empty-state {
-  padding: 2rem;
+  padding: var(--spacing-8);
   text-align: center;
   color: var(--text-muted);
   font-style: italic;
@@ -542,7 +542,7 @@ const closeDialog = () => {
 }
 
 .access-item {
-  padding: 0.75rem;
+  padding: var(--spacing-3);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -556,7 +556,7 @@ const closeDialog = () => {
 .access-info {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   flex: 1;
 }
 
@@ -578,7 +578,7 @@ const closeDialog = () => {
 .access-controls {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .permission-select {
@@ -594,7 +594,7 @@ const closeDialog = () => {
 .remove-button {
   background: none;
   border: none;
-  padding: 0.5rem;
+  padding: var(--spacing-2);
   cursor: pointer;
   color: #ef4444;
   border-radius: var(--radius-default);
@@ -606,11 +606,11 @@ const closeDialog = () => {
 }
 
 .modal-footer {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   border-top: 1px solid var(--border-default);
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .btn {
@@ -621,7 +621,7 @@ const closeDialog = () => {
   transition: all var(--duration-200);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .btn-secondary {

--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
@@ -757,7 +757,7 @@ export default {
 }
 
 .subtitle {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: var(--text-sm);
 }
@@ -825,7 +825,7 @@ export default {
 }
 
 .status-content p {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: var(--text-xs);
 }

--- a/autobot-frontend/src/components/knowledge/TreeNodeComponent.vue
+++ b/autobot-frontend/src/components/knowledge/TreeNodeComponent.vue
@@ -243,7 +243,7 @@ const formatSize = (bytes: number): string => {
   border: none;
   color: var(--text-secondary);
   cursor: pointer;
-  padding: 0;
+  padding: var(--spacing-0);
   transition: transform var(--duration-200) var(--ease-in-out);
 }
 
@@ -268,7 +268,7 @@ const formatSize = (bytes: number): string => {
   justify-content: center;
   background: none;
   border: none;
-  padding: 0;
+  padding: var(--spacing-0);
   cursor: pointer;
   color: var(--color-primary);
   transition: all var(--duration-150) var(--ease-in-out);
@@ -300,7 +300,7 @@ const formatSize = (bytes: number): string => {
   cursor: pointer;
   background: none;
   border: none;
-  padding: 0;
+  padding: var(--spacing-0);
   font-family: inherit;
   text-align: left;
   transition: all var(--duration-150) var(--ease-in-out);

--- a/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
+++ b/autobot-frontend/src/components/knowledge/VectorizationProgressModal.vue
@@ -202,7 +202,7 @@ const allCompleted = computed(() => {
   align-items: center;
   justify-content: center;
   z-index: var(--z-modal);
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .modal-container {
@@ -221,14 +221,14 @@ const allCompleted = computed(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   border-bottom: 2px solid var(--border-default);
 }
 
 .header-content {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .header-content i {
@@ -240,7 +240,7 @@ const allCompleted = computed(() => {
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .close-btn {
@@ -264,7 +264,7 @@ const allCompleted = computed(() => {
 
 /* Progress Summary */
 .progress-summary {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-default);
 }
@@ -272,15 +272,15 @@ const allCompleted = computed(() => {
 .summary-stats {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
 }
 
 .stat-item {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1rem;
+  padding: var(--spacing-4);
   background: var(--bg-card);
   border-radius: var(--radius-lg);
   border: 2px solid var(--border-default);
@@ -296,7 +296,7 @@ const allCompleted = computed(() => {
   font-size: var(--text-xs);
   color: var(--text-tertiary);
   font-weight: 500;
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
 }
 
 .stat-completed .stat-value {
@@ -315,7 +315,7 @@ const allCompleted = computed(() => {
 .overall-progress {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .progress-bar {
@@ -345,7 +345,7 @@ const allCompleted = computed(() => {
 .document-list {
   flex: 1;
   overflow-y: auto;
-  padding: 1rem;
+  padding: var(--spacing-4);
   max-height: 400px;
 }
 
@@ -353,8 +353,8 @@ const allCompleted = computed(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem;
-  margin-bottom: 0.5rem;
+  padding: var(--spacing-3);
+  margin-bottom: var(--spacing-2);
   background: var(--bg-card);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -369,7 +369,7 @@ const allCompleted = computed(() => {
 .document-info {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   flex: 1;
   min-width: 0;
 }
@@ -413,7 +413,7 @@ const allCompleted = computed(() => {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .document-name {
@@ -437,8 +437,8 @@ const allCompleted = computed(() => {
 .document-progress {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-right: 0.75rem;
+  gap: var(--spacing-2);
+  margin-right: var(--spacing-3);
 }
 
 .mini-progress-bar {
@@ -467,8 +467,8 @@ const allCompleted = computed(() => {
 .modal-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
-  padding: 1.5rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-6);
   border-top: 2px solid var(--border-default);
   background: var(--bg-secondary);
 }
@@ -476,7 +476,7 @@ const allCompleted = computed(() => {
 .action-btn {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.625rem 1.25rem;
   border-radius: var(--radius-lg);
   font-weight: 500;

--- a/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
+++ b/autobot-frontend/src/components/knowledge/WebResearchSettings.vue
@@ -610,7 +610,7 @@ onMounted(() => {
 .header-subtitle {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: var(--leading-normal);
 }
 
@@ -644,7 +644,7 @@ onMounted(() => {
   border: none;
   cursor: pointer;
   color: inherit;
-  padding: 0;
+  padding: var(--spacing-0);
   display: flex;
   align-items: center;
 }
@@ -705,7 +705,7 @@ onMounted(() => {
 .status-card-body {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
   min-width: 0;
 }
 
@@ -749,7 +749,7 @@ onMounted(() => {
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-tertiary);
-  margin: 0;
+  margin: var(--spacing-0);
   padding: var(--spacing-md) var(--spacing-lg);
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border-default);
@@ -778,14 +778,14 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-primary);
-  margin-bottom: 2px;
+  margin-bottom: var(--spacing-0-5);
   cursor: pointer;
 }
 
 .field-hint {
   font-size: var(--text-xs, 12px);
   color: var(--text-tertiary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: var(--leading-normal);
 }
 
@@ -876,7 +876,7 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: var(--spacing-sm) var(--spacing-md);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
@@ -1041,7 +1041,7 @@ onMounted(() => {
   }
 
   .form-actions-right {
-    margin-left: 0;
+    margin-left: var(--spacing-0);
     flex-direction: column;
   }
 }

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
@@ -893,7 +893,7 @@ function closeModal() {
   display: block;
   font-size: var(--text-xs);
   color: var(--text-tertiary);
-  margin-top: 4px;
+  margin-top: var(--spacing-1);
   font-family: var(--font-sans);
 }
 
@@ -937,7 +937,7 @@ function closeModal() {
   position: absolute;
   width: 1px;
   height: 1px;
-  padding: 0;
+  padding: var(--spacing-0);
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
@@ -349,14 +349,14 @@ onMounted(() => {
 }
 
 .header-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
   font-family: var(--font-sans);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .header-icon {
@@ -487,7 +487,7 @@ onMounted(() => {
   margin-top: var(--spacing-2);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
 }
 
 .history-error {

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
@@ -293,13 +293,13 @@ defineExpose({ resetSyncing })
   height: 20px;
   color: var(--color-info);
   flex-shrink: 0;
-  margin-top: 2px;
+  margin-top: var(--spacing-0-5);
 }
 
 .header-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .name-row {
@@ -357,7 +357,7 @@ defineExpose({ resetSyncing })
 .stat {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
 }
 
 .stat-label {
@@ -398,7 +398,7 @@ defineExpose({ resetSyncing })
   height: 14px;
   color: var(--color-error);
   flex-shrink: 0;
-  margin-top: 1px;
+  margin-top: var(--spacing-px);
 }
 
 .error-text {

--- a/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
+++ b/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
@@ -237,7 +237,7 @@ onMounted(async () => {
   font-size: var(--text-lg);
   font-weight: var(--font-bold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -335,7 +335,7 @@ onMounted(async () => {
   font-size: var(--text-sm);
   color: var(--text-secondary);
   line-height: 1.6;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Properties */

--- a/autobot-frontend/src/components/knowledge/graph/KnowledgeGraphExplorer.vue
+++ b/autobot-frontend/src/components/knowledge/graph/KnowledgeGraphExplorer.vue
@@ -199,7 +199,7 @@ function handleViewTimeline(entityName: string): void {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .explorer-header h4 i {
@@ -278,7 +278,7 @@ function handleViewTimeline(entityName: string): void {
 .type-checkbox {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   cursor: pointer;
 }
 
@@ -398,7 +398,7 @@ function handleViewTimeline(entityName: string): void {
 }
 
 .entity-meta i {
-  margin-right: 4px;
+  margin-right: var(--spacing-1);
 }
 
 .confidence-score,

--- a/autobot-frontend/src/components/knowledge/graph/RelationshipViewer.vue
+++ b/autobot-frontend/src/components/knowledge/graph/RelationshipViewer.vue
@@ -162,7 +162,7 @@ watch(() => props.entityId, fetchRelationships)
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .viewer-header h4 i {
@@ -283,7 +283,7 @@ watch(() => props.entityId, fetchRelationships)
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
+  gap: var(--spacing-0-5);
   min-width: 80px;
 }
 
@@ -330,7 +330,7 @@ watch(() => props.entityId, fetchRelationships)
 .rel-confidence {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .viewer-summary {

--- a/autobot-frontend/src/components/knowledge/modals/BulkEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/BulkEditModal.vue
@@ -403,7 +403,7 @@ watch(() => props.modelValue, (newValue) => {
 .edit-description {
   color: var(--text-secondary);
   font-size: var(--text-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Selected Preview */
@@ -519,7 +519,7 @@ watch(() => props.modelValue, (newValue) => {
 .form-hint {
   font-size: var(--text-xs);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Existing Tags */

--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -444,17 +444,17 @@ function selectIcon(icon: string): void {
 
 <style scoped>
 .category-edit-modal {
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 /* Alerts */
 .alert {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.875rem 1rem;
   border-radius: var(--radius-lg);
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
   font-size: var(--text-sm);
 }
 
@@ -475,7 +475,7 @@ function selectIcon(icon: string): void {
   background: var(--bg-secondary);
   padding: 0.75rem 1rem;
   border-radius: var(--radius-lg);
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .category-path label {
@@ -484,7 +484,7 @@ function selectIcon(icon: string): void {
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .path-value {
@@ -495,12 +495,12 @@ function selectIcon(icon: string): void {
 
 /* Form Groups */
 .form-group {
-  margin-bottom: 1.25rem;
+  margin-bottom: var(--spacing-5);
 }
 
 .form-group label {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   font-weight: 500;
   color: var(--text-primary);
   font-size: var(--text-sm);
@@ -545,7 +545,7 @@ function selectIcon(icon: string): void {
 .icon-picker {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .icon-option {
@@ -583,7 +583,7 @@ function selectIcon(icon: string): void {
 .color-picker {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .color-option {
@@ -626,8 +626,8 @@ function selectIcon(icon: string): void {
 .category-preview {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-default);
@@ -654,22 +654,22 @@ function selectIcon(icon: string): void {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
+  margin-top: var(--spacing-6);
+  padding-top: var(--spacing-6);
   border-top: 1px solid var(--border-default);
 }
 
 .left-actions,
 .right-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   align-items: center;
 }
 
 .delete-disabled-hint {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: var(--text-xs);
   color: var(--text-muted);
 }
@@ -677,57 +677,57 @@ function selectIcon(icon: string): void {
 /* Delete Confirmation */
 .delete-confirm {
   text-align: center;
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 .delete-warning {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   background: var(--color-warning-bg);
   border: 1px solid var(--color-warning-border);
   border-radius: var(--radius-xl);
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .delete-warning i.fa-exclamation-triangle {
   font-size: 2.5rem;
   color: var(--color-warning);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .delete-warning h3 {
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .delete-warning p {
   color: var(--text-secondary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .fact-warning {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.75rem;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
   background: var(--color-error-bg);
   border-radius: var(--radius-md);
   color: var(--color-error-dark);
-  margin-top: 1rem;
+  margin-top: var(--spacing-4);
 }
 
 .delete-note {
   font-size: var(--text-xs);
   color: var(--text-muted);
   font-style: italic;
-  margin-top: 0.75rem;
+  margin-top: var(--spacing-3);
 }
 
 .delete-actions {
   display: flex;
   justify-content: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
@@ -283,17 +283,17 @@ watch(() => props.modelValue, (isOpen) => {
 
 <style scoped>
 .export-modal {
-  padding: 0.5rem;
+  padding: var(--spacing-2);
 }
 
 /* Alert */
 .alert {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.75rem 1rem;
   border-radius: var(--radius-md);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
   font-size: var(--text-sm);
 }
 
@@ -307,11 +307,11 @@ watch(() => props.modelValue, (isOpen) => {
 .export-summary {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1rem;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
   background: var(--bg-secondary);
   border-radius: var(--radius-lg);
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
   color: var(--text-secondary);
   font-size: var(--text-sm);
 }
@@ -323,12 +323,12 @@ watch(() => props.modelValue, (isOpen) => {
 
 /* Form Groups */
 .form-group {
-  margin-bottom: 1.25rem;
+  margin-bottom: var(--spacing-5);
 }
 
 .form-group > label {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
   font-weight: 500;
   color: var(--text-primary);
   font-size: var(--text-sm);
@@ -338,13 +338,13 @@ watch(() => props.modelValue, (isOpen) => {
 .format-options {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .format-option {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.875rem 1rem;
   border: 2px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -387,7 +387,7 @@ watch(() => props.modelValue, (isOpen) => {
   display: block;
   font-weight: 500;
   color: var(--text-primary);
-  margin-bottom: 0.125rem;
+  margin-bottom: var(--spacing-0-5);
 }
 
 .format-desc {
@@ -404,7 +404,7 @@ watch(() => props.modelValue, (isOpen) => {
 .checkbox-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   cursor: pointer;
   font-size: var(--text-sm);
   color: var(--text-primary);
@@ -421,7 +421,7 @@ watch(() => props.modelValue, (isOpen) => {
   position: absolute;
   width: 1px;
   height: 1px;
-  padding: 0;
+  padding: var(--spacing-0);
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
@@ -433,9 +433,9 @@ watch(() => props.modelValue, (isOpen) => {
 .modal-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
-  margin-top: 1.5rem;
-  padding-top: 1rem;
+  gap: var(--spacing-3);
+  margin-top: var(--spacing-6);
+  padding-top: var(--spacing-4);
   border-top: 1px solid var(--border-default);
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
+++ b/autobot-frontend/src/components/knowledge/panels/SourcePreviewPanel.vue
@@ -326,7 +326,7 @@ onUnmounted(() => {
 
 .header-content {
   display: flex;
-  gap: 0.875rem;
+  gap: var(--spacing-3-5);
   flex: 1;
   min-width: 0;
 }
@@ -353,7 +353,7 @@ onUnmounted(() => {
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -404,7 +404,7 @@ onUnmounted(() => {
   align-items: center;
   justify-content: center;
   color: var(--text-muted);
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .empty-state i {
@@ -416,7 +416,7 @@ onUnmounted(() => {
 .metadata-bar {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: var(--spacing-4);
   padding: 0.75rem 1.5rem;
   border-bottom: 1px solid var(--border-default);
   background: var(--bg-secondary);
@@ -425,7 +425,7 @@ onUnmounted(() => {
 .meta-item {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   font-size: var(--text-xs);
   color: var(--text-secondary);
 }
@@ -445,7 +445,7 @@ onUnmounted(() => {
 /* Content */
 .content-area {
   flex: 1;
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   overflow-y: auto;
 }
 
@@ -455,7 +455,7 @@ onUnmounted(() => {
   line-height: 1.7;
   white-space: pre-wrap;
   word-wrap: break-word;
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
 }
 
@@ -463,7 +463,7 @@ onUnmounted(() => {
 .panel-footer {
   display: flex;
   justify-content: space-between;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 1rem 1.5rem;
   border-top: 1px solid var(--border-default);
   background: var(--bg-card);

--- a/autobot-frontend/src/components/knowledge/pipeline/PipelineConfig.vue
+++ b/autobot-frontend/src/components/knowledge/pipeline/PipelineConfig.vue
@@ -256,7 +256,7 @@ function emitConfig(): void {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .config-header h4 i {
@@ -419,7 +419,7 @@ h5 i {
   font-size: var(--text-xs);
   color: var(--text-primary);
   overflow-x: auto;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Actions */

--- a/autobot-frontend/src/components/knowledge/pipeline/PipelineRunner.vue
+++ b/autobot-frontend/src/components/knowledge/pipeline/PipelineRunner.vue
@@ -228,7 +228,7 @@ async function handleSubmit(): Promise<void> {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .runner-header h4 i {
@@ -327,7 +327,7 @@ async function handleSubmit(): Promise<void> {
 .field-error {
   color: var(--color-error);
   font-size: var(--text-xs);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .submit-btn {
@@ -403,7 +403,7 @@ async function handleSubmit(): Promise<void> {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .result-duration {

--- a/autobot-frontend/src/components/knowledge/summaries/DocumentOverview.vue
+++ b/autobot-frontend/src/components/knowledge/summaries/DocumentOverview.vue
@@ -200,7 +200,7 @@ watch(() => props.documentId, loadOverview)
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .overview-header h4 i {
@@ -217,7 +217,7 @@ watch(() => props.documentId, loadOverview)
   color: var(--text-secondary);
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .header-stat i {
@@ -332,7 +332,7 @@ watch(() => props.documentId, loadOverview)
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .sections-list h5 i {

--- a/autobot-frontend/src/components/knowledge/summaries/DrillDownViewer.vue
+++ b/autobot-frontend/src/components/knowledge/summaries/DrillDownViewer.vue
@@ -229,7 +229,7 @@ watch(() => props.summaryId, (newId) => loadDrillDown(newId))
   color: var(--color-primary);
   font-size: var(--text-sm);
   cursor: pointer;
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 .breadcrumb-link:hover {
@@ -331,7 +331,7 @@ watch(() => props.summaryId, (newId) => loadDrillDown(newId))
   font-size: var(--text-sm);
   color: var(--text-primary);
   line-height: 1.7;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Sections */
@@ -342,7 +342,7 @@ h5 {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 h5 i {

--- a/autobot-frontend/src/components/knowledge/summaries/SummariesPage.vue
+++ b/autobot-frontend/src/components/knowledge/summaries/SummariesPage.vue
@@ -145,7 +145,7 @@ function handleDrillDown(summaryId: string): void {
 
 .doc-id-input {
   padding: var(--spacing-lg);
-  padding-bottom: 0;
+  padding-bottom: var(--spacing-0);
 }
 
 .doc-id-input label {

--- a/autobot-frontend/src/components/knowledge/summaries/SummarySearch.vue
+++ b/autobot-frontend/src/components/knowledge/summaries/SummarySearch.vue
@@ -200,7 +200,7 @@ async function handleSearch(): Promise<void> {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .search-header h4 i {

--- a/autobot-frontend/src/components/knowledge/temporal/CausalChainViewer.vue
+++ b/autobot-frontend/src/components/knowledge/temporal/CausalChainViewer.vue
@@ -162,7 +162,7 @@ watch(() => props.eventId, loadChain)
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .chain-header h4 i {
@@ -288,7 +288,7 @@ watch(() => props.eventId, loadChain)
 .event-desc {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: 1.5;
 }
 

--- a/autobot-frontend/src/components/knowledge/temporal/EventTimeline.vue
+++ b/autobot-frontend/src/components/knowledge/temporal/EventTimeline.vue
@@ -201,7 +201,7 @@ function toggleExpand(eventId: string): void {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .timeline-header h4 i {
@@ -240,7 +240,7 @@ function toggleExpand(eventId: string): void {
 /* Timeline */
 .timeline-container {
   position: relative;
-  padding-left: 40px;
+  padding-left: var(--spacing-10);
 }
 
 .timeline-line {
@@ -260,7 +260,7 @@ function toggleExpand(eventId: string): void {
 .date-marker {
   margin-bottom: var(--spacing-sm);
   margin-left: -40px;
-  padding-left: 40px;
+  padding-left: var(--spacing-10);
 }
 
 .date-marker span {
@@ -342,7 +342,7 @@ function toggleExpand(eventId: string): void {
 .event-description {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: 1.5;
 }
 
@@ -402,7 +402,7 @@ function toggleExpand(eventId: string): void {
 
 @media (max-width: 768px) {
   .timeline-container {
-    padding-left: 32px;
+    padding-left: var(--spacing-8);
   }
 
   .timeline-line {

--- a/autobot-frontend/src/components/knowledge/temporal/TemporalFilter.vue
+++ b/autobot-frontend/src/components/knowledge/temporal/TemporalFilter.vue
@@ -143,7 +143,7 @@ h5 {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 h5 i {

--- a/autobot-frontend/src/components/layout/LanguageSwitcher.vue
+++ b/autobot-frontend/src/components/layout/LanguageSwitcher.vue
@@ -162,7 +162,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
   z-index: var(--z-popover);
   padding: var(--spacing-xs) 0;
   list-style: none;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .lang-option {

--- a/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
+++ b/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
@@ -206,7 +206,7 @@ const { formatDate } = useKnowledgeBase()
 .command-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .command-tag {
@@ -223,7 +223,7 @@ const { formatDate } = useKnowledgeBase()
   align-items: center;
   justify-content: center;
   gap: 15px;
-  padding: 40px;
+  padding: var(--spacing-10);
   color: var(--text-muted);
   font-style: italic;
 }

--- a/autobot-frontend/src/components/operations/OperationDetail.vue
+++ b/autobot-frontend/src/components/operations/OperationDetail.vue
@@ -248,7 +248,7 @@ async function copyId() {
 .type-icon {
   font-size: var(--text-2xl);
   color: var(--color-info);
-  margin-top: 0.125rem;
+  margin-top: var(--spacing-0-5);
 }
 
 .header-info {
@@ -260,7 +260,7 @@ async function copyId() {
   font-size: var(--text-xl);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .operation-type {
@@ -330,27 +330,27 @@ async function copyId() {
 .description-section,
 .timing-section,
 .checkpoints-section {
-  padding-top: 0.75rem;
+  padding-top: var(--spacing-3);
   border-top: 1px solid var(--border-subtle);
 }
 
 .description-text {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: 1.5;
 }
 
 .timing-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .timing-item {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: var(--spacing-0-5);
 }
 
 .timing-label {
@@ -364,7 +364,7 @@ async function copyId() {
 }
 
 .error-section {
-  padding: 1rem;
+  padding: var(--spacing-4);
   background-color: #fef2f2;
   border: 1px solid #fecaca;
   border-radius: var(--radius-md);
@@ -373,7 +373,7 @@ async function copyId() {
 .error-title {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   color: #991b1b;
 }
 
@@ -388,7 +388,7 @@ async function copyId() {
 .checkpoints-info {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
   font-size: var(--text-sm);
   color: var(--text-secondary);
 }
@@ -396,22 +396,22 @@ async function copyId() {
 .can-resume {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   color: var(--color-success);
 }
 
 .context-section {
   border-top: 1px solid var(--border-subtle);
-  padding-top: 0.75rem;
+  padding-top: var(--spacing-3);
 }
 
 .context-toggle {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   background: none;
   border: none;
-  padding: 0;
+  padding: var(--spacing-0);
   cursor: pointer;
   color: var(--text-secondary);
 }
@@ -421,33 +421,33 @@ async function copyId() {
 }
 
 .context-toggle .section-title {
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .context-content {
-  margin-top: 0.75rem;
+  margin-top: var(--spacing-3);
 }
 
 .context-json {
   font-size: var(--text-xs);
   background-color: var(--code-bg);
-  padding: 1rem;
+  padding: var(--spacing-4);
   border-radius: var(--radius-md);
   overflow-x: auto;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .actions-section {
   display: flex;
-  gap: 0.75rem;
-  padding-top: 1rem;
+  gap: var(--spacing-3);
+  padding-top: var(--spacing-4);
   border-top: 1px solid var(--border-default);
 }
 
 .action-btn {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   padding: 0.5rem 1rem;
   font-size: var(--text-sm);
   font-weight: 500;
@@ -495,7 +495,7 @@ async function copyId() {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-top: 0.75rem;
+  padding-top: var(--spacing-3);
   border-top: 1px solid var(--border-subtle);
 }
 

--- a/autobot-frontend/src/components/operations/OperationFilters.vue
+++ b/autobot-frontend/src/components/operations/OperationFilters.vue
@@ -145,8 +145,8 @@ function clearFilters() {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
-  gap: 1rem;
-  padding: 1rem;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
   background-color: var(--bg-secondary);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-default);
@@ -155,7 +155,7 @@ function clearFilters() {
 .filter-group {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .filter-label {
@@ -196,7 +196,7 @@ function clearFilters() {
 .clear-filters-btn {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   padding: 0.5rem 0.75rem;
   font-size: var(--text-sm);
   font-weight: 500;

--- a/autobot-frontend/src/components/operations/OperationsList.vue
+++ b/autobot-frontend/src/components/operations/OperationsList.vue
@@ -206,7 +206,7 @@ function canResumeOperation(operation: Operation): boolean {
 .empty-text {
   font-size: var(--text-sm);
   color: var(--text-tertiary);
-  margin: 0;
+  margin: var(--spacing-0);
   max-width: 400px;
 }
 
@@ -268,7 +268,7 @@ function canResumeOperation(operation: Operation): boolean {
 .name-cell {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: var(--spacing-0-5);
 }
 
 .operation-name {
@@ -288,7 +288,7 @@ function canResumeOperation(operation: Operation): boolean {
 .progress-cell {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   min-width: 120px;
 }
 
@@ -301,7 +301,7 @@ function canResumeOperation(operation: Operation): boolean {
 .type-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   font-size: var(--text-xs);
   color: var(--text-secondary);
 }
@@ -313,7 +313,7 @@ function canResumeOperation(operation: Operation): boolean {
 
 .action-buttons {
   display: flex;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .action-btn {

--- a/autobot-frontend/src/components/operations/OperationsPanel.vue
+++ b/autobot-frontend/src/components/operations/OperationsPanel.vue
@@ -172,7 +172,7 @@ function handleClearFilter() {
 }
 
 .empty-placeholder p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -362,12 +362,12 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 24px;
+  padding: var(--spacing-6);
   border-bottom: 1px solid var(--border-default);
 }
 
 .modal-header h2 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-2xl);
   font-weight: 600;
   color: var(--text-primary);
@@ -379,7 +379,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   font-size: 32px;
   color: var(--text-muted);
   cursor: pointer;
-  padding: 0;
+  padding: var(--spacing-0);
   width: 32px;
   height: 32px;
   display: flex;
@@ -395,7 +395,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 
 .tab-bar {
   display: flex;
-  gap: 0;
+  gap: var(--spacing-0);
   border-bottom: 1px solid var(--border-default);
   padding: 0 24px;
 }
@@ -403,7 +403,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 .tab-btn {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   padding: 12px 16px;
   border: none;
   background: none;
@@ -430,35 +430,35 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 }
 
 .modal-body {
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .profile-section {
-  margin-bottom: 32px;
+  margin-bottom: var(--spacing-8);
 }
 
 .profile-section:last-child {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .profile-section h3 {
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
 }
 
 .info-grid {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .info-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-secondary);
   border-radius: var(--radius-md);
 }
@@ -485,7 +485,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 .role-viewer { background: var(--bg-tertiary); color: var(--text-secondary); }
 
 .pref-group {
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .pref-label {
@@ -495,12 +495,12 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   font-size: var(--text-sm);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .option-row {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .option-btn {
@@ -527,13 +527,13 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 .toggle-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .toggle-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   font-size: var(--text-sm);
   color: var(--text-primary);
   cursor: pointer;
@@ -547,7 +547,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 }
 
 .save-btn {
-  margin-top: 16px;
+  margin-top: var(--spacing-4);
   padding: 8px 20px;
   background: var(--color-primary, #6366f1);
   color: white;
@@ -571,7 +571,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
 .pw-form {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .pw-input {

--- a/autobot-frontend/src/components/research/CaptchaNotification.vue
+++ b/autobot-frontend/src/components/research/CaptchaNotification.vue
@@ -299,7 +299,7 @@ watch(activeCaptcha, (newVal) => {
 }
 
 .captcha-title h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
 }

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -1623,18 +1623,18 @@ watch(selectedScope, () => {
 }
 
 .sidebar-header {
-  padding: 20px;
+  padding: var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
 .sidebar-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .sidebar-header i {
@@ -1685,7 +1685,7 @@ watch(selectedScope, () => {
   right: 8px;
   background: none;
   border: none;
-  padding: 4px;
+  padding: var(--spacing-1);
   cursor: pointer;
   color: var(--text-muted);
 }
@@ -1708,7 +1708,7 @@ watch(selectedScope, () => {
 .category-item {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 10px 20px;
   cursor: pointer;
   transition: all var(--duration-150);
@@ -1764,7 +1764,7 @@ watch(selectedScope, () => {
 
 .btn-create {
   width: 100%;
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
@@ -1775,7 +1775,7 @@ watch(selectedScope, () => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -1802,7 +1802,7 @@ watch(selectedScope, () => {
 }
 
 .header-left h2 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
@@ -1815,7 +1815,7 @@ watch(selectedScope, () => {
 
 .header-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-icon {
@@ -1844,7 +1844,7 @@ watch(selectedScope, () => {
 /* Stats Bar */
 .stats-bar {
   display: flex;
-  gap: 24px;
+  gap: var(--spacing-6);
   padding: 16px 24px;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-default);
@@ -1853,7 +1853,7 @@ watch(selectedScope, () => {
 .stat-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .stat-item i {
@@ -1887,7 +1887,7 @@ watch(selectedScope, () => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: var(--spacing-4);
   color: var(--text-tertiary);
 }
 
@@ -1895,27 +1895,27 @@ watch(selectedScope, () => {
 .credentials-container {
   flex: 1;
   overflow-y: auto;
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .credentials-container.grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-  gap: 16px;
+  gap: var(--spacing-4);
   align-content: start;
 }
 
 .credentials-container.list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 /* Credential Card */
 .credential-card {
   display: flex;
-  gap: 16px;
-  padding: 16px;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -1958,12 +1958,12 @@ watch(selectedScope, () => {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 8px;
-  margin-bottom: 6px;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-1-5);
 }
 
 .card-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: 15px;
   font-weight: 600;
   color: var(--text-primary);
@@ -1974,7 +1974,7 @@ watch(selectedScope, () => {
 
 .card-badges {
   display: flex;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   flex-shrink: 0;
 }
 
@@ -2001,14 +2001,14 @@ watch(selectedScope, () => {
   color: var(--color-error);
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 /* Issue #685: Visibility badge styles */
 .badge.visibility {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .badge.visibility-private {
@@ -2045,7 +2045,7 @@ watch(selectedScope, () => {
 
 .card-meta {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-4);
   font-size: var(--text-xs);
   color: var(--text-muted);
 }
@@ -2053,7 +2053,7 @@ watch(selectedScope, () => {
 .meta-item {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .meta-item.text-warning {
@@ -2062,8 +2062,8 @@ watch(selectedScope, () => {
 
 .card-tags {
   display: flex;
-  gap: 6px;
-  margin-top: 8px;
+  gap: var(--spacing-1-5);
+  margin-top: var(--spacing-2);
   flex-wrap: wrap;
 }
 
@@ -2082,9 +2082,9 @@ watch(selectedScope, () => {
 .card-workflow-usage {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   flex-wrap: wrap;
-  margin-top: 6px;
+  margin-top: var(--spacing-1-5);
 }
 
 .usage-label {
@@ -2092,7 +2092,7 @@ watch(selectedScope, () => {
   color: var(--text-tertiary);
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .usage-tag {
@@ -2106,7 +2106,7 @@ watch(selectedScope, () => {
 .card-actions {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   opacity: 0;
   transition: opacity var(--duration-150);
 }
@@ -2141,7 +2141,7 @@ watch(selectedScope, () => {
 
 /* Templates Section */
 .templates-section {
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .templates-section h3 {
@@ -2151,7 +2151,7 @@ watch(selectedScope, () => {
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .templates-section h3 i {
@@ -2167,14 +2167,14 @@ watch(selectedScope, () => {
 .templates-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .template-card {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 14px;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3-5);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -2199,7 +2199,7 @@ watch(selectedScope, () => {
 }
 
 .template-info h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
@@ -2215,7 +2215,7 @@ watch(selectedScope, () => {
 .credential-form {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 .template-selection h4 {
@@ -2228,15 +2228,15 @@ watch(selectedScope, () => {
 .type-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .type-option {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
-  padding: 16px;
+  gap: var(--spacing-2-5);
+  padding: var(--spacing-4);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
   cursor: pointer;
@@ -2269,11 +2269,11 @@ watch(selectedScope, () => {
 .selected-type {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-xl);
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .selected-type .type-icon {
@@ -2300,7 +2300,7 @@ watch(selectedScope, () => {
 .selected-type .change-type {
   background: none;
   border: none;
-  padding: 0;
+  padding: var(--spacing-0);
   font-size: var(--text-xs);
   color: var(--color-primary);
   cursor: pointer;
@@ -2309,12 +2309,12 @@ watch(selectedScope, () => {
 .form-fields {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .form-row {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .form-row.two-col > .form-group {
@@ -2324,7 +2324,7 @@ watch(selectedScope, () => {
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   flex: 1;
 }
 
@@ -2393,15 +2393,15 @@ watch(selectedScope, () => {
 
 .scope-selector {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .scope-option {
   flex: 1;
   display: flex;
   align-items: flex-start;
-  gap: 12px;
-  padding: 14px;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3-5);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
   cursor: pointer;
@@ -2424,7 +2424,7 @@ watch(selectedScope, () => {
 .scope-option i {
   font-size: var(--text-xl);
   color: var(--text-muted);
-  margin-top: 2px;
+  margin-top: var(--spacing-0-5);
 }
 
 .scope-option.active i {
@@ -2444,21 +2444,21 @@ watch(selectedScope, () => {
 .scope-option small {
   font-size: var(--text-xs);
   color: var(--text-tertiary);
-  margin-top: 2px;
+  margin-top: var(--spacing-0-5);
 }
 
 /* View Modal */
 .view-credential {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 .view-header {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding-bottom: 16px;
+  gap: var(--spacing-4);
+  padding-bottom: var(--spacing-4);
   border-bottom: 1px solid var(--border-default);
 }
 
@@ -2474,7 +2474,7 @@ watch(selectedScope, () => {
 }
 
 .view-title h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
@@ -2488,7 +2488,7 @@ watch(selectedScope, () => {
 .view-section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .view-section label {
@@ -2500,15 +2500,15 @@ watch(selectedScope, () => {
 }
 
 .view-section p {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
 }
 
 .secret-display {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px;
+  gap: var(--spacing-2);
+  padding: var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
 }
@@ -2523,19 +2523,19 @@ watch(selectedScope, () => {
 
 .secret-actions {
   display: flex;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .view-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .view-item {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .view-item label {
@@ -2554,7 +2554,7 @@ watch(selectedScope, () => {
 .tags-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .text-danger {
@@ -2612,7 +2612,7 @@ watch(selectedScope, () => {
 .delete-warning {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 10px 16px;
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -2641,7 +2641,7 @@ watch(selectedScope, () => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -2682,7 +2682,7 @@ watch(selectedScope, () => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -2698,14 +2698,14 @@ watch(selectedScope, () => {
 /* Infrastructure Host Form Styles */
 .capability-checkboxes {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-4);
   flex-wrap: wrap;
 }
 
 .checkbox-option {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 10px 16px;
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);

--- a/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.vue
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceDashboard.vue
@@ -374,7 +374,7 @@ onMounted(() => {
   font-size: var(--text-2xl);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .dashboard-subtitle {
@@ -493,7 +493,7 @@ onMounted(() => {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .section-header p {

--- a/autobot-frontend/src/components/security/ThreatIntelligenceSettings.vue
+++ b/autobot-frontend/src/components/security/ThreatIntelligenceSettings.vue
@@ -313,7 +313,7 @@ onMounted(() => {
   font-size: var(--text-2xl);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .settings-subtitle {
@@ -379,7 +379,7 @@ onMounted(() => {
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .service-badge {

--- a/autobot-frontend/src/components/services/RedisServiceControl.vue
+++ b/autobot-frontend/src/components/services/RedisServiceControl.vue
@@ -423,7 +423,7 @@ const getHealthCheckCardClass = (status) => {
 .detail-item {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .health-check-card {

--- a/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/FeatureFlagsSettingsPanel.vue
@@ -283,7 +283,7 @@ onMounted(() => {
 .feature-flags-settings-panel {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--spacing-6);
 }
 
 .loading-state,
@@ -307,12 +307,12 @@ onMounted(() => {
   border: 1px solid var(--color-error);
   border-radius: var(--radius-xl);
   min-height: 200px;
-  padding: 40px;
+  padding: var(--spacing-10);
 }
 
 .error-state i {
   font-size: 32px;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .error-state p {
@@ -323,7 +323,7 @@ onMounted(() => {
 .retry-btn {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 10px 16px;
   background: var(--color-error);
   color: var(--text-on-error);
@@ -342,7 +342,7 @@ onMounted(() => {
 .settings-content {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--spacing-6);
 }
 
 .settings-section {

--- a/autobot-frontend/src/components/settings/LanguageSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/LanguageSettingsPanel.vue
@@ -120,7 +120,7 @@ function announceChange(message: string): void {
   position: absolute;
   width: 1px;
   height: 1px;
-  padding: 0;
+  padding: var(--spacing-0);
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
@@ -144,7 +144,7 @@ function announceChange(message: string): void {
   font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .panel-title i {
@@ -163,8 +163,8 @@ function announceChange(message: string): void {
   flex-direction: column;
   gap: var(--spacing-md);
   border: none;
-  padding: 0;
-  margin: 0;
+  padding: var(--spacing-0);
+  margin: var(--spacing-0);
 }
 
 .preference-label {
@@ -186,7 +186,7 @@ function announceChange(message: string): void {
 .preference-hint {
   font-size: var(--font-size-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: var(--leading-normal);
 }
 

--- a/autobot-frontend/src/components/settings/SettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/SettingsPanel.vue
@@ -861,7 +861,7 @@ onMounted(async () => {
   flex: 1;
   min-height: 0; /* Required for flex child to shrink and enable overflow */
   overflow-y: auto;
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .settings-loading {
@@ -961,7 +961,7 @@ onMounted(async () => {
   }
 
   .settings-content-inner {
-    padding: 16px;
+    padding: var(--spacing-4);
   }
 
   .settings-actions {

--- a/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/VoiceSettingsPanel.vue
@@ -306,7 +306,7 @@ async function handleDelete(voiceId: string, name: string) {
   border: none;
   color: var(--text-tertiary, #64748b);
   cursor: pointer;
-  padding: 4px;
+  padding: var(--spacing-1);
   border-radius: var(--radius-sm, 4px);
 }
 
@@ -478,7 +478,7 @@ async function handleDelete(voiceId: string, name: string) {
 .personality-voice-details {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
 }
 
 .personality-voice-hint strong {

--- a/autobot-frontend/src/components/settings/WebResearchSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/WebResearchSettingsPanel.vue
@@ -274,7 +274,7 @@ function clamp(value: number, min: number, max: number): number {
   font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .panel-title i {
@@ -293,8 +293,8 @@ function clamp(value: number, min: number, max: number): number {
   flex-direction: column;
   gap: var(--spacing-md);
   border: none;
-  padding: 0;
-  margin: 0;
+  padding: var(--spacing-0);
+  margin: var(--spacing-0);
 }
 
 .preference-label {
@@ -316,7 +316,7 @@ function clamp(value: number, min: number, max: number): number {
 .preference-hint {
   font-size: var(--font-size-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: var(--leading-normal);
 }
 

--- a/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
+++ b/autobot-frontend/src/components/terminal/AdvancedStepConfirmationModal.vue
@@ -402,7 +402,7 @@ function resetEdit(): void {
 .step-explanation {
   color: var(--text-secondary);
   font-size: var(--text-sm);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: 1.5;
 }
 
@@ -441,7 +441,7 @@ function resetEdit(): void {
 .modified-badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   padding: 0.125rem 0.5rem;
   background: var(--color-warning-bg, rgba(245, 158, 11, 0.15));
   color: var(--color-warning, #f59e0b);
@@ -457,7 +457,7 @@ function resetEdit(): void {
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   padding: 0.125rem 0.5rem;
   background: transparent;
   border: 1px solid var(--border-default);
@@ -522,7 +522,7 @@ function resetEdit(): void {
   gap: var(--spacing-1, 0.25rem);
   font-size: 0.8125rem;
   color: var(--color-danger, #ef4444);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .edit-actions {
@@ -534,7 +534,7 @@ function resetEdit(): void {
 .edit-action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
   padding: 0.3125rem 0.75rem;
   border-radius: var(--radius-sm, 0.25rem);
   font-size: 0.8125rem;
@@ -588,8 +588,8 @@ function resetEdit(): void {
 }
 
 .guide-list {
-  margin: 0;
-  padding-left: 1.25rem;
+  margin: var(--spacing-0);
+  padding-left: var(--spacing-5);
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1, 0.25rem);

--- a/autobot-frontend/src/components/terminal/BaseXTerminal.vue
+++ b/autobot-frontend/src/components/terminal/BaseXTerminal.vue
@@ -812,7 +812,7 @@ onUnmounted(() => {
 /* Ensure xterm.js styles are properly scoped */
 :deep(.xterm) {
   height: 100%;
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 :deep(.xterm-viewport) {

--- a/autobot-frontend/src/components/terminal/CompletionSuggestions.vue
+++ b/autobot-frontend/src/components/terminal/CompletionSuggestions.vue
@@ -74,7 +74,7 @@ const typeIcon = (type: string): string => {
   align-items: center;
   padding: 4px 12px;
   cursor: pointer;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: background-color var(--duration-100);
 }
 

--- a/autobot-frontend/src/components/terminal/SSHTerminal.vue
+++ b/autobot-frontend/src/components/terminal/SSHTerminal.vue
@@ -317,7 +317,7 @@ defineExpose({
 .connection-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 6px 12px;
   font-size: var(--text-xs);
   border-bottom: 1px solid #333;
@@ -380,7 +380,7 @@ defineExpose({
 
 .terminal-viewport {
   flex: 1;
-  padding: 4px;
+  padding: var(--spacing-1);
   overflow: hidden;
 }
 

--- a/autobot-frontend/src/components/terminal/Terminal.vue
+++ b/autobot-frontend/src/components/terminal/Terminal.vue
@@ -666,7 +666,7 @@ onUnmounted(() => {
 }
 
 .terminal-line {
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
   word-wrap: break-word;
 }
 
@@ -705,13 +705,13 @@ onUnmounted(() => {
 .terminal-prompt {
   display: flex;
   align-items: center;
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
   flex-shrink: 0; /* Prevent prompt from shrinking */
 }
 
 .prompt {
   color: #6c757d;
-  margin-right: 8px;
+  margin-right: var(--spacing-2);
   user-select: none;
 }
 
@@ -723,7 +723,7 @@ onUnmounted(() => {
   font-family: inherit;
   font-size: inherit;
   outline: none;
-  padding: 0;
+  padding: var(--spacing-0);
 }
 
 .terminal-input:focus-visible {
@@ -804,7 +804,7 @@ onUnmounted(() => {
   }
 
   .terminal-output {
-    padding: 12px;
+    padding: var(--spacing-3);
     font-size: var(--text-xs);
   }
 }

--- a/autobot-frontend/src/components/terminal/TerminalInput.vue
+++ b/autobot-frontend/src/components/terminal/TerminalInput.vue
@@ -283,7 +283,7 @@ defineExpose({
 .cursor {
   color: var(--terminal-green);
   font-weight: var(--font-bold);
-  margin-left: 2px;
+  margin-left: var(--spacing-0-5);
 }
 
 .cursor.blink {

--- a/autobot-frontend/src/components/terminal/TerminalModals.vue
+++ b/autobot-frontend/src/components/terminal/TerminalModals.vue
@@ -751,7 +751,7 @@ const handleTakeManualControl = async () => {
 }
 
 .option-info ul {
-  margin: 0;
+  margin: var(--spacing-0);
   padding-left: var(--spacing-5);
   color: var(--text-secondary);
 }

--- a/autobot-frontend/src/components/terminal/TerminalOutput.vue
+++ b/autobot-frontend/src/components/terminal/TerminalOutput.vue
@@ -169,8 +169,8 @@ defineExpose({
 }
 
 .terminal-line {
-  margin: 0;
-  padding: 0;
+  margin: var(--spacing-0);
+  padding: var(--spacing-0);
   min-height: 1.4em;
 }
 

--- a/autobot-frontend/src/components/terminal/TerminalWindow.vue
+++ b/autobot-frontend/src/components/terminal/TerminalWindow.vue
@@ -1509,7 +1509,7 @@ export default {
 .window-title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   font-size: var(--text-sm);
   font-weight: 600;
 }
@@ -1520,7 +1520,7 @@ export default {
 
 .window-controls {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .control-button {
@@ -1562,13 +1562,13 @@ export default {
 .status-left, .status-right {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .connection-status {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .status-dot {
@@ -1601,7 +1601,7 @@ export default {
 
 .terminal-output {
   flex: 1;
-  padding: 16px;
+  padding: var(--spacing-4);
   overflow-y: auto;
   font-size: var(--text-sm);
   line-height: 1.4;
@@ -1610,8 +1610,8 @@ export default {
 }
 
 .terminal-line {
-  margin: 0;
-  padding: 0;
+  margin: var(--spacing-0);
+  padding: var(--spacing-0);
   min-height: 1.4em;
 }
 
@@ -1649,7 +1649,7 @@ export default {
 
 .prompt {
   color: #00ff00;
-  margin-right: 8px;
+  margin-right: var(--spacing-2);
   flex-shrink: 0;
 }
 
@@ -1672,7 +1672,7 @@ export default {
 .cursor {
   color: #00ff00;
   font-weight: bold;
-  margin-left: 2px;
+  margin-left: var(--spacing-0-5);
 }
 
 .cursor.blink {
@@ -1695,7 +1695,7 @@ export default {
 
 .footer-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .footer-button {
@@ -1741,7 +1741,7 @@ export default {
 .modal-content {
   background-color: #2d2d2d;
   color: #fff;
-  padding: 24px;
+  padding: var(--spacing-6);
   border-radius: var(--radius-lg);
   max-width: 400px;
   width: 90%;
@@ -1749,15 +1749,15 @@ export default {
 }
 
 .modal-content h3 {
-  margin-top: 0;
+  margin-top: var(--spacing-0);
   color: #ffc107;
 }
 
 .modal-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   justify-content: center;
-  margin-top: 20px;
+  margin-top: var(--spacing-5);
 }
 
 .btn {
@@ -1862,7 +1862,7 @@ export default {
 .confirmation-modal {
   background-color: #2d2d2d;
   color: #fff;
-  padding: 0;
+  padding: var(--spacing-0);
   border-radius: var(--radius-xl);
   max-width: 600px;
   width: 90%;
@@ -1883,13 +1883,13 @@ export default {
 }
 
 .modal-title {
-  margin: 0;
+  margin: var(--spacing-0);
   color: #ffc107;
   font-size: var(--text-lg);
   font-weight: 600;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .confirmation-modal.emergency .modal-title {
@@ -1897,21 +1897,21 @@ export default {
 }
 
 .modal-content {
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .command-preview {
   background-color: #1e1e1e;
   border: 1px solid #444;
   border-radius: var(--radius-lg);
-  padding: 16px;
-  margin-bottom: 20px;
+  padding: var(--spacing-4);
+  margin-bottom: var(--spacing-5);
 }
 
 .command-label {
   font-size: var(--text-xs);
   color: #888;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -1921,7 +1921,7 @@ export default {
   font-size: var(--text-sm);
   color: #87ceeb;
   background-color: #000;
-  padding: 12px;
+  padding: var(--spacing-3);
   border-radius: var(--radius-md);
   border-left: 4px solid #ffc107;
   white-space: pre-wrap;
@@ -1929,7 +1929,7 @@ export default {
 }
 
 .risk-assessment {
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .risk-level {
@@ -1937,7 +1937,7 @@ export default {
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
   font-weight: 600;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .risk-level.low {
@@ -1970,7 +1970,7 @@ export default {
 }
 
 .risk-reason {
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
   font-size: var(--text-sm);
 }
 
@@ -1979,16 +1979,16 @@ export default {
 }
 
 .confirmation-message p {
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .confirmation-message ul {
   margin: 12px 0;
-  padding-left: 20px;
+  padding-left: var(--spacing-5);
 }
 
 .confirmation-message li {
-  margin-bottom: 6px;
+  margin-bottom: var(--spacing-1-5);
   color: #ccc;
 }
 
@@ -1997,7 +1997,7 @@ export default {
 }
 
 .emergency-warning p {
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
   font-weight: 500;
 }
 
@@ -2005,7 +2005,7 @@ export default {
   background-color: #1e1e1e;
   padding: 8px 12px;
   border-radius: var(--radius-default);
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
   font-size: var(--text-sm);
   color: #87ceeb;
@@ -2013,7 +2013,7 @@ export default {
 
 .modal-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   justify-content: flex-end;
   padding: 20px 24px;
   border-top: 1px solid #444;
@@ -2070,7 +2070,7 @@ export default {
   display: inline-block;
   font-size: var(--text-xs);
   font-weight: 600;
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -2092,8 +2092,8 @@ export default {
 .workflow-options {
   background-color: #1e1e1e;
   border-radius: var(--radius-lg);
-  padding: 16px;
-  margin-top: 20px;
+  padding: var(--spacing-4);
+  margin-top: var(--spacing-5);
   border-left: 4px solid #17a2b8;
 }
 
@@ -2104,13 +2104,13 @@ export default {
 }
 
 .option-info ul {
-  margin: 0;
-  padding-left: 20px;
+  margin: var(--spacing-0);
+  padding-left: var(--spacing-5);
   color: #ccc;
 }
 
 .option-info li {
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
   font-size: var(--text-sm);
   line-height: 1.4;
 }
@@ -2162,7 +2162,7 @@ export default {
   font-weight: 500;
   background-color: rgba(23, 162, 184, 0.1);
   border-left: 3px solid #17a2b8;
-  padding-left: 8px;
+  padding-left: var(--spacing-2);
 }
 
 .line-manual_command {
@@ -2170,14 +2170,14 @@ export default {
   font-weight: 500;
   background-color: rgba(40, 167, 69, 0.1);
   border-left: 3px solid #28a745;
-  padding-left: 8px;
+  padding-left: var(--spacing-2);
 }
 
 .line-workflow_info {
   color: #6f42c1;
   background-color: rgba(111, 66, 193, 0.1);
   border-left: 3px solid #6f42c1;
-  padding-left: 8px;
+  padding-left: var(--spacing-2);
   font-style: italic;
 }
 
@@ -2226,7 +2226,7 @@ export default {
   }
 
   .terminal-output {
-    padding: 12px;
+    padding: var(--spacing-3);
     font-size: var(--text-xs);
   }
 

--- a/autobot-frontend/src/components/ui/BaseAlert.vue
+++ b/autobot-frontend/src/components/ui/BaseAlert.vue
@@ -118,7 +118,7 @@ onMounted(() => {
 .base-alert {
   display: flex;
   align-items: flex-start;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 0.75rem 1rem;
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -128,7 +128,7 @@ onMounted(() => {
 
 .alert-icon {
   flex-shrink: 0;
-  margin-top: 0.125rem;
+  margin-top: var(--spacing-0-5);
 }
 
 .alert-content {
@@ -138,7 +138,7 @@ onMounted(() => {
 
 .alert-title {
   font-weight: 600;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .alert-message {
@@ -148,13 +148,13 @@ onMounted(() => {
 .alert-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   flex-shrink: 0;
   margin-left: auto;
 }
 
 .alert-dismiss {
-  padding: 0.25rem;
+  padding: var(--spacing-1);
   border-radius: var(--radius-default);
   transition: background-color var(--duration-200) var(--ease-out);
   background: transparent;

--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -270,7 +270,7 @@ onUnmounted(() => {
   font-size: var(--text-xl);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .close-btn {

--- a/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
+++ b/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
@@ -476,7 +476,7 @@ export default {
 }
 
 .command-subtitle {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--font-size-sm);
   opacity: 0.9;
 }
@@ -512,7 +512,7 @@ export default {
 }
 
 .info-item:last-child {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
 }
 
 .label {

--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -261,7 +261,7 @@ const formatCell = (value: any, column: Column) => {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .header-right {

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -465,7 +465,7 @@ onUnmounted(() => {
 }
 
 .dialog-subtitle {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--font-size-sm);
   opacity: 0.9;
 }

--- a/autobot-frontend/src/components/ui/HostSelector.vue
+++ b/autobot-frontend/src/components/ui/HostSelector.vue
@@ -323,7 +323,7 @@ defineExpose({
 .host-selector-collapsed {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 8px 12px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
@@ -340,7 +340,7 @@ defineExpose({
 .selected-host {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   flex: 1;
 }
 
@@ -377,7 +377,7 @@ defineExpose({
 .no-host-selected {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   flex: 1;
   color: var(--text-muted);
 }
@@ -414,7 +414,7 @@ defineExpose({
 }
 
 .selector-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
@@ -423,7 +423,7 @@ defineExpose({
 .btn-close {
   background: none;
   border: none;
-  padding: 4px;
+  padding: var(--spacing-1);
   cursor: pointer;
   color: var(--text-muted);
 }
@@ -434,7 +434,7 @@ defineExpose({
 
 .capability-filter {
   display: flex;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 8px 16px;
   border-bottom: 1px solid var(--border-default);
 }
@@ -464,13 +464,13 @@ defineExpose({
 .host-list {
   min-height: 200px; max-height: 50vh;
   overflow-y: auto;
-  padding: 8px;
+  padding: var(--spacing-2);
 }
 
 .host-item {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 10px 12px;
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -521,7 +521,7 @@ defineExpose({
 
 .host-capabilities {
   display: flex;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .capability-badge {
@@ -556,18 +556,18 @@ defineExpose({
 .empty-state i,
 .loading-state i {
   font-size: 32px;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
   opacity: 0.5;
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 
 .selector-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 12px 16px;
   border-top: 1px solid var(--border-default);
 }
@@ -584,7 +584,7 @@ defineExpose({
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   transition: all var(--duration-150);
 }
 

--- a/autobot-frontend/src/components/ui/LoadingSpinner.vue
+++ b/autobot-frontend/src/components/ui/LoadingSpinner.vue
@@ -134,7 +134,7 @@ const customStyle = computed(() => ({
 /* Dots Spinner */
 .loading-dots {
   display: flex;
-  gap: 4px;
+  gap: var(--spacing-1);
   align-items: center;
 }
 
@@ -194,7 +194,7 @@ const customStyle = computed(() => ({
 /* Bars Spinner */
 .loading-bars {
   display: flex;
-  gap: 2px;
+  gap: var(--spacing-0-5);
   align-items: center;
   height: 100%;
 }
@@ -231,13 +231,13 @@ const customStyle = computed(() => ({
 }
 
 .label-right {
-  margin-top: 0;
+  margin-top: var(--spacing-0);
   margin-left: var(--spacing-2);
 }
 
 .label-bottom {
   margin-top: var(--spacing-2);
-  margin-left: 0;
+  margin-left: var(--spacing-0);
 }
 
 /* Right-aligned label layout */

--- a/autobot-frontend/src/components/ui/PreferencesPanel.vue
+++ b/autobot-frontend/src/components/ui/PreferencesPanel.vue
@@ -215,7 +215,7 @@ function handleReset() {
   position: absolute;
   width: 1px;
   height: 1px;
-  padding: 0;
+  padding: var(--spacing-0);
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
@@ -243,7 +243,7 @@ function handleReset() {
   font-size: var(--font-size-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .panel-title i {
@@ -295,8 +295,8 @@ function handleReset() {
   flex-direction: column;
   gap: var(--spacing-md);
   border: none;
-  padding: 0;
-  margin: 0;
+  padding: var(--spacing-0);
+  margin: var(--spacing-0);
 }
 
 .preference-label {

--- a/autobot-frontend/src/components/ui/ProgressBar.vue
+++ b/autobot-frontend/src/components/ui/ProgressBar.vue
@@ -221,7 +221,7 @@ const formatTime = (seconds: number): string => {
 
 /* Compact layout adjustments */
 .progress-compact .progress-label {
-  margin-bottom: 0;
+  margin-bottom: var(--spacing-0);
   margin-right: var(--spacing-3);
   flex-shrink: 0;
 }
@@ -231,7 +231,7 @@ const formatTime = (seconds: number): string => {
 }
 
 .progress-compact .progress-details {
-  margin-top: 0;
+  margin-top: var(--spacing-0);
   margin-left: var(--spacing-3);
   flex-shrink: 0;
 }

--- a/autobot-frontend/src/components/ui/SkeletonLoader.vue
+++ b/autobot-frontend/src/components/ui/SkeletonLoader.vue
@@ -161,10 +161,10 @@ const lineClass = computed(() => ({
   height: 1rem;
 }
 
-.skeleton-line.mb-1 { margin-bottom: 0.25rem; }
-.skeleton-line.mb-2 { margin-bottom: 0.5rem; }
-.skeleton-line.mb-3 { margin-bottom: 0.75rem; }
-.skeleton-line.mb-4 { margin-bottom: 1rem; }
+.skeleton-line.mb-1 { margin-bottom: var(--spacing-1); }
+.skeleton-line.mb-2 { margin-bottom: var(--spacing-2); }
+.skeleton-line.mb-3 { margin-bottom: var(--spacing-3); }
+.skeleton-line.mb-4 { margin-bottom: var(--spacing-4); }
 
 .skeleton-line.w-full { width: 100%; }
 .skeleton-line.w-3\/4 { width: 75%; }
@@ -211,7 +211,7 @@ const lineClass = computed(() => ({
 .skeleton-file-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .skeleton-file-item {
@@ -244,7 +244,7 @@ const lineClass = computed(() => ({
 .skeleton-stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .skeleton-stat-card {
@@ -268,7 +268,7 @@ const lineClass = computed(() => ({
 
 /* Custom skeleton */
 .skeleton-custom {
-  padding: 1rem;
+  padding: var(--spacing-4);
 }
 
 /* Dark theme adjustments */
@@ -287,7 +287,7 @@ const lineClass = computed(() => ({
   }
 
   .skeleton-chat-message {
-    padding: 0.75rem;
+    padding: var(--spacing-3);
   }
 
   .skeleton-avatar {
@@ -296,7 +296,7 @@ const lineClass = computed(() => ({
   }
 
   .skeleton-stat-card {
-    padding: 1rem;
+    padding: var(--spacing-4);
   }
 
   .skeleton-stat-icon {

--- a/autobot-frontend/src/components/vision/GUIAutomationControls.vue
+++ b/autobot-frontend/src/components/vision/GUIAutomationControls.vue
@@ -317,7 +317,7 @@ onMounted(() => {
 .gui-automation-controls {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 /* Header Section */
@@ -325,7 +325,7 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
+  padding: var(--spacing-5);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -339,7 +339,7 @@ onMounted(() => {
 }
 
 .header-info p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }
@@ -355,7 +355,7 @@ onMounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -373,7 +373,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 60px 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
@@ -386,20 +386,20 @@ onMounted(() => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .opportunities-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .opportunity-card {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 16px;
+  padding: var(--spacing-4);
   cursor: pointer;
   transition: all var(--duration-200);
 }
@@ -412,8 +412,8 @@ onMounted(() => {
 .card-header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
 }
 
 .element-type-badge {
@@ -431,7 +431,7 @@ onMounted(() => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
 }
 
 .action-name {
@@ -470,13 +470,13 @@ onMounted(() => {
 .card-description {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
   line-height: 1.4;
 }
 
 .card-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-execute,
@@ -490,7 +490,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   transition: all var(--duration-200);
 }
 
@@ -520,7 +520,7 @@ onMounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: var(--spacing-4);
   padding: 60px 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
@@ -540,13 +540,13 @@ onMounted(() => {
 }
 
 .empty-state h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }
@@ -573,13 +573,13 @@ onMounted(() => {
 }
 
 .reference-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-secondary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .reference-header i:last-child {
@@ -593,13 +593,13 @@ onMounted(() => {
 .types-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .type-item {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 10px 12px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
@@ -620,7 +620,7 @@ onMounted(() => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
 }
 
 .type-name {
@@ -637,13 +637,13 @@ onMounted(() => {
 .interactions-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .interaction-item {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   padding: 10px 12px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
@@ -689,14 +689,14 @@ onMounted(() => {
 }
 
 .modal-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .btn-close {
-  padding: 8px;
+  padding: var(--spacing-2);
   background: none;
   border: none;
   color: var(--text-tertiary);
@@ -708,16 +708,16 @@ onMounted(() => {
 }
 
 .modal-content {
-  padding: 20px;
+  padding: var(--spacing-5);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .detail-section {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .detail-section label {
@@ -734,14 +734,14 @@ onMounted(() => {
 
 .modal-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 16px 20px;
   border-top: 1px solid var(--border-default);
 }
 
 .btn-primary {
   flex: 1;
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--color-primary);
   color: var(--text-on-primary);
   border: none;
@@ -752,7 +752,7 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-primary:hover {

--- a/autobot-frontend/src/components/vision/MediaGallery.vue
+++ b/autobot-frontend/src/components/vision/MediaGallery.vue
@@ -302,7 +302,7 @@ onUnmounted(() => {
 .media-gallery {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 /* Header */
@@ -310,12 +310,12 @@ onUnmounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
+  padding: var(--spacing-5);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
   flex-wrap: wrap;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .header-info h3 {
@@ -326,14 +326,14 @@ onUnmounted(() => {
 }
 
 .header-info p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }
 
 .header-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   align-items: center;
 }
 
@@ -357,7 +357,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -375,7 +375,7 @@ onUnmounted(() => {
 .gallery-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .gallery-item {
@@ -428,10 +428,10 @@ onUnmounted(() => {
 }
 
 .item-info {
-  padding: 12px;
+  padding: var(--spacing-3);
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .item-name {
@@ -450,13 +450,13 @@ onUnmounted(() => {
 
 .item-actions {
   display: flex;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 0 12px 12px;
 }
 
 .btn-action {
   flex: 1;
-  padding: 8px;
+  padding: var(--spacing-2);
   background: var(--bg-tertiary);
   border: none;
   border-radius: var(--radius-md);
@@ -481,7 +481,7 @@ onUnmounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: var(--spacing-4);
   padding: 80px 20px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
@@ -501,13 +501,13 @@ onUnmounted(() => {
 }
 
 .empty-state h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
   text-align: center;
@@ -525,7 +525,7 @@ onUnmounted(() => {
   align-items: center;
   justify-content: center;
   z-index: var(--z-modal);
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .detail-modal {
@@ -548,7 +548,7 @@ onUnmounted(() => {
 }
 
 .modal-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -558,7 +558,7 @@ onUnmounted(() => {
 }
 
 .btn-close {
-  padding: 8px;
+  padding: var(--spacing-2);
   background: none;
   border: none;
   color: var(--text-tertiary);
@@ -572,11 +572,11 @@ onUnmounted(() => {
 .modal-content {
   flex: 1;
   overflow-y: auto;
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .preview-section {
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .preview-image {
@@ -602,7 +602,7 @@ onUnmounted(() => {
 .details-section {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .detail-row {
@@ -622,8 +622,8 @@ onUnmounted(() => {
 }
 
 .analysis-section {
-  margin-top: 20px;
-  padding-top: 20px;
+  margin-top: var(--spacing-5);
+  padding-top: var(--spacing-5);
   border-top: 1px solid var(--border-default);
 }
 
@@ -637,8 +637,8 @@ onUnmounted(() => {
 .analysis-data {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-3);
 }
 
 .data-row {
@@ -670,7 +670,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-toggle:hover {
@@ -678,8 +678,8 @@ onUnmounted(() => {
 }
 
 .json-display {
-  margin-top: 12px;
-  padding: 12px;
+  margin-top: var(--spacing-3);
+  padding: var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   font-size: var(--text-xs);
@@ -690,7 +690,7 @@ onUnmounted(() => {
 
 .modal-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 16px 20px;
   border-top: 1px solid var(--border-default);
 }
@@ -708,7 +708,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-primary:hover {
@@ -726,7 +726,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-secondary:hover {
@@ -744,7 +744,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-danger:hover {
@@ -764,13 +764,13 @@ onUnmounted(() => {
   align-items: center;
   justify-content: center;
   z-index: var(--z-popover);
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .confirm-modal {
   background: var(--bg-secondary);
   border-radius: var(--radius-xl);
-  padding: 24px;
+  padding: var(--spacing-6);
   width: 100%;
   max-width: 360px;
   text-align: center;
@@ -804,7 +804,7 @@ onUnmounted(() => {
 
 .confirm-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .btn-cancel {

--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
@@ -389,7 +389,7 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   height: 100%;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 /* Controls Bar */
@@ -402,14 +402,14 @@ onUnmounted(() => {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
   flex-wrap: wrap;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .controls-left,
 .controls-right {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .btn-capture {
@@ -423,7 +423,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -439,13 +439,13 @@ onUnmounted(() => {
 .auto-refresh-toggle {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .toggle-label {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   cursor: pointer;
   font-size: var(--text-sm);
   color: var(--text-secondary);
@@ -497,7 +497,7 @@ onUnmounted(() => {
 .filter-group {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .filter-group label {
@@ -548,11 +548,11 @@ onUnmounted(() => {
   padding: 16px 20px;
   border-bottom: 1px solid var(--border-default);
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .panel-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
@@ -560,7 +560,7 @@ onUnmounted(() => {
 
 .analysis-meta {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .analysis-meta span {
@@ -568,7 +568,7 @@ onUnmounted(() => {
   color: var(--text-tertiary);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 /* Elements Section */
@@ -591,7 +591,7 @@ onUnmounted(() => {
 .elements-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
   max-height: 300px;
   overflow-y: auto;
 }
@@ -599,7 +599,7 @@ onUnmounted(() => {
 .element-item {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 10px 12px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
@@ -631,7 +631,7 @@ onUnmounted(() => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--spacing-0-5);
   min-width: 0;
 }
 
@@ -659,12 +659,12 @@ onUnmounted(() => {
 
 .no-elements {
   text-align: center;
-  padding: 24px;
+  padding: var(--spacing-6);
   color: var(--text-tertiary);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .no-elements i {
@@ -675,7 +675,7 @@ onUnmounted(() => {
 .text-regions {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .text-region {
@@ -691,8 +691,8 @@ onUnmounted(() => {
 
 /* Layout Section */
 .layout-info pre {
-  margin: 0;
-  padding: 12px;
+  margin: var(--spacing-0);
+  padding: var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   font-size: var(--text-xs);
@@ -708,7 +708,7 @@ onUnmounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: var(--spacing-4);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -727,13 +727,13 @@ onUnmounted(() => {
 }
 
 .empty-state h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   color: var(--text-primary);
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }
@@ -772,14 +772,14 @@ onUnmounted(() => {
 }
 
 .modal-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .btn-close {
-  padding: 8px;
+  padding: var(--spacing-2);
   background: none;
   border: none;
   color: var(--text-tertiary);
@@ -791,17 +791,17 @@ onUnmounted(() => {
 }
 
 .modal-content {
-  padding: 20px;
+  padding: var(--spacing-5);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .detail-row {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .detail-row .label {
@@ -819,7 +819,7 @@ onUnmounted(() => {
 .interactions-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .interaction-tag {

--- a/autobot-frontend/src/components/vision/VideoProcessor.vue
+++ b/autobot-frontend/src/components/vision/VideoProcessor.vue
@@ -524,7 +524,7 @@ onUnmounted(() => {
 .video-processor {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--spacing-6);
 }
 
 /* Upload Section */
@@ -532,13 +532,13 @@ onUnmounted(() => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .drop-zone {
   border: 2px dashed var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 40px;
+  padding: var(--spacing-10);
   text-align: center;
   cursor: pointer;
   transition: all var(--duration-200);
@@ -556,14 +556,14 @@ onUnmounted(() => {
 
 .drop-zone.has-file {
   border-style: solid;
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .drop-placeholder {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   color: var(--text-tertiary);
 }
 
@@ -573,7 +573,7 @@ onUnmounted(() => {
 }
 
 .drop-placeholder p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-secondary);
 }
@@ -581,13 +581,13 @@ onUnmounted(() => {
 .supported-formats {
   font-size: var(--text-xs);
   color: var(--text-muted);
-  margin-top: 8px;
+  margin-top: var(--spacing-2);
 }
 
 .file-preview {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--spacing-4);
   width: 100%;
 }
 
@@ -603,7 +603,7 @@ onUnmounted(() => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
   text-align: left;
 }
 
@@ -620,7 +620,7 @@ onUnmounted(() => {
 }
 
 .btn-clear {
-  padding: 8px;
+  padding: var(--spacing-2);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;
@@ -637,17 +637,17 @@ onUnmounted(() => {
 .options-section {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
+  gap: var(--spacing-4);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .option-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .option-group label {
@@ -683,7 +683,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .btn-process:hover:not(:disabled) {
@@ -700,7 +700,7 @@ onUnmounted(() => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .progress-bar {
@@ -708,7 +708,7 @@ onUnmounted(() => {
   background: var(--bg-tertiary);
   border-radius: var(--radius-default);
   overflow: hidden;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .progress-fill {
@@ -742,13 +742,13 @@ onUnmounted(() => {
 }
 
 .results-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--color-success);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .frame-count {
@@ -759,15 +759,15 @@ onUnmounted(() => {
 .frames-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
-  gap: 12px;
-  padding: 20px;
+  gap: var(--spacing-3);
+  padding: var(--spacing-5);
 }
 
 .frame-card {
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 12px;
+  padding: var(--spacing-3);
   cursor: pointer;
   transition: all var(--duration-150);
 }
@@ -780,13 +780,13 @@ onUnmounted(() => {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .frame-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .frame-info .confidence,
@@ -796,7 +796,7 @@ onUnmounted(() => {
 }
 
 .selected-frame {
-  padding: 20px;
+  padding: var(--spacing-5);
   border-top: 1px solid var(--border-default);
 }
 
@@ -810,14 +810,14 @@ onUnmounted(() => {
 .frame-details {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 12px;
-  margin-bottom: 16px;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-4);
 }
 
 .detail-item {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .detail-item .label {
@@ -840,12 +840,12 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .json-display {
-  margin-top: 12px;
-  padding: 12px;
+  margin-top: var(--spacing-3);
+  padding: var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   font-size: var(--text-xs);
@@ -856,7 +856,7 @@ onUnmounted(() => {
 
 .results-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 16px 20px;
   border-top: 1px solid var(--border-default);
 }
@@ -872,7 +872,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .btn-secondary:hover {
@@ -893,7 +893,7 @@ onUnmounted(() => {
 .error-content {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   color: var(--color-error);
 }
 

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
@@ -553,7 +553,7 @@ defineExpose({
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .header-controls {
@@ -817,7 +817,7 @@ defineExpose({
 
 .task-list {
   list-style: none;
-  padding: 0;
+  padding: var(--spacing-0);
   margin: 0 0 var(--spacing-3) 0;
 }
 

--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
@@ -465,7 +465,7 @@ defineExpose({
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .header-actions {

--- a/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.vue
+++ b/autobot-frontend/src/components/visualizations/ServiceMessageTimeline.vue
@@ -161,32 +161,32 @@ onMounted(() => refresh())
 <style scoped>
 .smt { display:flex; flex-direction:column; height:100%; background:var(--bg-primary,#1a1a2e); border-radius: var(--radius-lg); overflow:hidden; }
 .smt-header { display:flex; justify-content:space-between; align-items:center; padding:12px 16px; border-bottom:1px solid var(--border-color,#2a2a4a); }
-.smt-header h3 { margin:0; font-size: var(--text-sm); font-weight:600; color:var(--text-primary,#e0e0ff); }
-.smt-controls { display:flex; gap:4px; align-items:center; }
+.smt-header h3 { margin:var(--spacing-0); font-size: var(--text-sm); font-weight:600; color:var(--text-primary,#e0e0ff); }
+.smt-controls { display:flex; gap:var(--spacing-1); align-items:center; }
 .smt-select { background:var(--bg-secondary,#16213e); color:var(--text-secondary,#a0a0c0); border:1px solid var(--border-color,#2a2a4a); border-radius: var(--radius-default); padding:4px 8px; font-size: var(--text-xs); }
 .smt-btn { background:none; border:1px solid var(--border-color,#2a2a4a); color:var(--text-secondary,#a0a0c0); border-radius: var(--radius-default); padding:4px 8px; cursor:pointer; font-size: var(--text-xs); transition:all .2s; }
 .smt-btn:hover { background:var(--bg-hover,#2a2a4a); color:var(--text-primary,#e0e0ff); }
 .smt-btn.active { background:var(--accent-color,#4a90d9); color:#fff; border-color:var(--accent-color,#4a90d9); }
-.smt-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:40px; color:var(--text-secondary,#a0a0c0); gap:8px; }
+.smt-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; padding:var(--spacing-10); color:var(--text-secondary,#a0a0c0); gap:var(--spacing-2); }
 .smt-body { flex:1; overflow-y:auto; padding:4px 12px; }
-.smt-entry { display:flex; gap:10px; padding:8px 4px; cursor:pointer; border-radius: var(--radius-default); transition:background .15s; align-items:flex-start; }
+.smt-entry { display:flex; gap:var(--spacing-2-5); padding:8px 4px; cursor:pointer; border-radius: var(--radius-default); transition:background .15s; align-items:flex-start; }
 .smt-entry:hover { background:rgba(255,255,255,.03); }
 .smt-entry.selected { background:rgba(74,144,217,.1); }
-.smt-dot { width:10px; height:10px; border-radius:50%; margin-top:4px; flex-shrink:0; }
+.smt-dot { width:10px; height:10px; border-radius:50%; margin-top:var(--spacing-1); flex-shrink:0; }
 .smt-dot.t-task { background:#4a90d9; } .smt-dot.t-result { background:#4caf50; } .smt-dot.t-error { background:#f44336; }
 .smt-dot.t-health { background:#8bc34a; } .smt-dot.t-deploy { background:#ff9800; } .smt-dot.t-workflow_step { background:#9c27b0; }
 .smt-dot.t-notification { background:#00bcd4; }
 .smt-info { flex:1; min-width:0; }
-.smt-route { display:flex; align-items:center; gap:4px; font-size: var(--text-sm); font-weight:500; color:var(--text-primary,#e0e0ff); }
+.smt-route { display:flex; align-items:center; gap:var(--spacing-1); font-size: var(--text-sm); font-weight:500; color:var(--text-primary,#e0e0ff); }
 .smt-route i { font-size: var(--text-xs); color:var(--text-secondary,#a0a0c0); }
-.smt-meta { font-size: var(--text-xs); color:var(--text-muted,#707090); margin-top:2px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.smt-meta { font-size: var(--text-xs); color:var(--text-muted,#707090); margin-top:var(--spacing-0-5); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .smt-badge { font-size: var(--text-xs); padding:1px 6px; border-radius: var(--radius-default); font-weight:500; margin-left:auto; }
 .smt-badge.t-task { background:rgba(74,144,217,.2); color:#4a90d9; } .smt-badge.t-result { background:rgba(76,175,80,.2); color:#4caf50; }
 .smt-badge.t-error { background:rgba(244,67,54,.2); color:#f44336; } .smt-badge.t-health { background:rgba(139,195,74,.2); color:#8bc34a; }
 .smt-badge.t-deploy { background:rgba(255,152,0,.2); color:#ff9800; } .smt-badge.t-workflow_step { background:rgba(156,39,176,.2); color:#9c27b0; }
 .smt-badge.t-notification { background:rgba(0,188,212,.2); color:#00bcd4; }
 .smt-detail { border-top:1px solid var(--border-color,#2a2a4a); background:var(--bg-secondary,#16213e); max-height:50%; overflow-y:auto; padding:12px 16px; }
-.smt-detail-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:8px; color:var(--text-primary,#e0e0ff); font-size: var(--text-sm); }
+.smt-detail-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--spacing-2); color:var(--text-primary,#e0e0ff); font-size: var(--text-sm); }
 .smt-table { width:100%; font-size: var(--text-xs); border-collapse:collapse; }
 .smt-table td { padding:3px 0; }
 .smt-table td:first-child { color:var(--text-muted,#707090); font-weight:500; width:120px; }
@@ -194,9 +194,9 @@ onMounted(() => refresh())
 .smt-table code { font-family:'JetBrains Mono',monospace; font-size: var(--text-xs); background:var(--bg-primary,#1a1a2e); padding:2px 6px; border-radius: var(--radius-default); }
 .smt-link { cursor:pointer; } .smt-link:hover { color:var(--accent-color,#4a90d9)!important; }
 .smt-pre { background:var(--bg-primary,#1a1a2e); padding:8px 12px; border-radius: var(--radius-default); font-size: var(--text-xs); font-family:'JetBrains Mono',monospace; color:var(--text-secondary,#a0a0c0); overflow-x:auto; max-height:120px; margin:8px 0 0; }
-.smt-chain { margin-top:12px; border-top:1px solid var(--border-color,#2a2a4a); padding-top:8px; }
+.smt-chain { margin-top:var(--spacing-3); border-top:1px solid var(--border-color,#2a2a4a); padding-top:var(--spacing-2); }
 .smt-chain strong { font-size: var(--text-sm); color:var(--text-primary,#e0e0ff); }
-.smt-chain-row { display:flex; align-items:center; gap:8px; padding:3px 8px; font-size: var(--text-xs); border-radius: var(--radius-default); color:var(--text-primary,#e0e0ff); }
+.smt-chain-row { display:flex; align-items:center; gap:var(--spacing-2); padding:3px 8px; font-size: var(--text-xs); border-radius: var(--radius-default); color:var(--text-primary,#e0e0ff); }
 .smt-chain-row.current { background:rgba(74,144,217,.15); }
 .smt-chain-idx { color:var(--text-muted,#707090); font-weight:600; min-width:18px; }
 .smt-muted { color:var(--text-muted,#707090); font-size: var(--text-xs); margin-left:auto; }

--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
@@ -1705,8 +1705,8 @@ watch(() => currentView.value, () => {
 
 .connections-list {
   list-style: none;
-  padding: 0;
-  margin: 0;
+  padding: var(--spacing-0);
+  margin: var(--spacing-0);
 }
 
 .connections-list li {

--- a/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/WorkflowVisualization.vue
@@ -588,7 +588,7 @@ defineExpose({
 .workflow-visualization {
   background: var(--bg-secondary-alpha);
   border-radius: var(--radius-xl);
-  padding: 20px;
+  padding: var(--spacing-5);
   border: 1px solid var(--border-subtle);
   position: relative;
 }
@@ -597,8 +597,8 @@ defineExpose({
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
-  padding-bottom: 12px;
+  margin-bottom: var(--spacing-4);
+  padding-bottom: var(--spacing-3);
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -606,7 +606,7 @@ defineExpose({
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .workflow-id {
@@ -616,14 +616,14 @@ defineExpose({
 
 .header-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   align-items: center;
 }
 
 .status-badge {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   padding: 6px 12px;
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
@@ -806,9 +806,9 @@ defineExpose({
   right: 16px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   background: rgba(30, 41, 59, 0.9);
-  padding: 8px;
+  padding: var(--spacing-2);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-subtle);
 }
@@ -885,8 +885,8 @@ defineExpose({
 .details-header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 16px;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
   background: var(--bg-tertiary-alpha);
   border-bottom: 1px solid var(--border-subtle);
 }
@@ -919,7 +919,7 @@ defineExpose({
 }
 
 .details-title h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
@@ -931,7 +931,7 @@ defineExpose({
 }
 
 .close-btn {
-  padding: 6px;
+  padding: var(--spacing-1-5);
   background: transparent;
   border: none;
   color: var(--text-tertiary);
@@ -946,7 +946,7 @@ defineExpose({
 }
 
 .details-content {
-  padding: 16px;
+  padding: var(--spacing-4);
 }
 
 .detail-row {
@@ -979,9 +979,9 @@ defineExpose({
 .detail-row .output {
   font-size: var(--text-xs);
   background: rgba(15, 23, 42, 0.5);
-  padding: 8px;
+  padding: var(--spacing-2);
   border-radius: var(--radius-default);
-  margin-top: 4px;
+  margin-top: var(--spacing-1);
   overflow-x: auto;
   max-width: 200px;
 }
@@ -1002,7 +1002,7 @@ defineExpose({
 @media (max-width: 768px) {
   .workflow-header {
     flex-direction: column;
-    gap: 12px;
+    gap: var(--spacing-3);
     align-items: stretch;
   }
 

--- a/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
+++ b/autobot-frontend/src/components/workflow/AgentObservabilityPanel.vue
@@ -178,7 +178,7 @@ function formatDuration(seconds: number): string {
 .agent-observability-panel {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .panel-header {
@@ -188,12 +188,12 @@ function formatDuration(seconds: number): string {
 }
 
 .panel-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: 15px;
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .panel-header h3 i {
@@ -238,7 +238,7 @@ function formatDuration(seconds: number): string {
 .empty-state i,
 .loading-state i {
   font-size: var(--text-4xl);
-  margin-bottom: 10px;
+  margin-bottom: var(--spacing-2-5);
 }
 
 .empty-state h4 {
@@ -248,7 +248,7 @@ function formatDuration(seconds: number): string {
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xs);
 }
 
@@ -256,7 +256,7 @@ function formatDuration(seconds: number): string {
 .agents-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 14px;
+  gap: var(--spacing-3-5);
 }
 
 /* Agent Card */
@@ -264,10 +264,10 @@ function formatDuration(seconds: number): string {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 16px;
+  padding: var(--spacing-4);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
   transition: border-color var(--duration-200);
 }
 
@@ -279,13 +279,13 @@ function formatDuration(seconds: number): string {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .agent-identity {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   flex: 1;
   min-width: 0;
 }
@@ -362,7 +362,7 @@ function formatDuration(seconds: number): string {
 /* Metrics */
 .metrics-row {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .metric {
@@ -389,7 +389,7 @@ function formatDuration(seconds: number): string {
   color: var(--text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin-top: 2px;
+  margin-top: var(--spacing-0-5);
 }
 
 /* Reliability Bar */
@@ -418,7 +418,7 @@ function formatDuration(seconds: number): string {
 .capabilities-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .capability-tag {

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
@@ -271,12 +271,12 @@ async function handleSave(): Promise<void> {
 }
 
 .notif-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .notif-header h3 i { color: var(--color-primary); }
@@ -293,21 +293,21 @@ async function handleSave(): Promise<void> {
 .btn-close:hover { background: var(--bg-hover); color: var(--text-primary); }
 
 .notif-loading {
-  padding: 48px;
+  padding: var(--spacing-12);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   color: var(--text-tertiary);
 }
 
 .notif-body {
   flex: 1;
   overflow-y: auto;
-  padding: 20px;
+  padding: var(--spacing-5);
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--spacing-5);
 }
 
 .notif-error {
@@ -318,14 +318,14 @@ async function handleSave(): Promise<void> {
   font-size: var(--text-sm);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .notif-field {
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
-  padding: 14px;
-  margin: 0;
+  padding: var(--spacing-3-5);
+  margin: var(--spacing-0);
 }
 
 .notif-field legend {
@@ -351,19 +351,19 @@ async function handleSave(): Promise<void> {
 .tag-input-wrapper {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .tag-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .tag {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
   padding: 4px 10px;
   background: var(--color-primary-bg);
   color: var(--color-primary);
@@ -373,7 +373,7 @@ async function handleSave(): Promise<void> {
 }
 
 .tag-remove {
-  padding: 0;
+  padding: var(--spacing-0);
   background: transparent;
   border: none;
   color: inherit;
@@ -411,7 +411,7 @@ async function handleSave(): Promise<void> {
 .channel-grid {
   display: grid;
   grid-template-columns: 1fr repeat(4, 64px);
-  gap: 4px;
+  gap: var(--spacing-1);
   align-items: center;
 }
 
@@ -421,7 +421,7 @@ async function handleSave(): Promise<void> {
   color: var(--text-tertiary);
   text-align: center;
   text-transform: uppercase;
-  padding: 4px;
+  padding: var(--spacing-1);
 }
 
 .event-label {
@@ -446,7 +446,7 @@ async function handleSave(): Promise<void> {
 .notif-footer {
   display: flex;
   justify-content: flex-end;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   padding: 14px 20px;
   border-top: 1px solid var(--border-default);
 }
@@ -462,7 +462,7 @@ async function handleSave(): Promise<void> {
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 .btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/autobot-frontend/src/components/workflow/OrchestrationVisualizer.vue
+++ b/autobot-frontend/src/components/workflow/OrchestrationVisualizer.vue
@@ -171,53 +171,53 @@ function getStrategyIcon(strategy: string): string {
 </script>
 
 <style scoped>
-.orchestration-visualizer { display: flex; flex-direction: column; gap: 24px; height: 100%; overflow-y: auto; }
+.orchestration-visualizer { display: flex; flex-direction: column; gap: var(--spacing-6); height: 100%; overflow-y: auto; }
 
 .status-panel h3, .capabilities-panel h4, .strategies-panel h4, .visualization-panel h4 {
-  margin: 0 0 16px; font-size: 15px; color: var(--text-primary); display: flex; align-items: center; gap: 10px;
+  margin: 0 0 16px; font-size: 15px; color: var(--text-primary); display: flex; align-items: center; gap: var(--spacing-2-5);
 }
 .status-panel h3 i, .capabilities-panel h4 i, .strategies-panel h4 i, .visualization-panel h4 i { color: var(--color-primary); }
 
-.status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; }
-.status-card { display: flex; align-items: center; gap: 14px; padding: 16px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); }
+.status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--spacing-4); }
+.status-card { display: flex; align-items: center; gap: var(--spacing-3-5); padding: var(--spacing-4); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); }
 .status-card.healthy { border-color: var(--color-success); }
 .card-icon { width: 44px; height: 44px; border-radius: var(--radius-xl); background: var(--bg-tertiary); display: flex; align-items: center; justify-content: center; font-size: var(--text-lg); color: var(--text-secondary); }
 .status-card.healthy .card-icon { background: var(--color-success-bg); color: var(--color-success); }
 .card-value { display: block; font-size: var(--text-lg); font-weight: 600; color: var(--text-primary); text-transform: capitalize; }
 .card-label { font-size: var(--text-xs); color: var(--text-tertiary); }
 
-.capabilities-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: 20px; }
-.capabilities-list { display: flex; flex-wrap: wrap; gap: 12px; }
-.capability-item { display: flex; align-items: center; gap: 8px; padding: 8px 14px; background: var(--bg-tertiary); border-radius: var(--radius-2xl); font-size: var(--text-sm); color: var(--text-muted); }
+.capabilities-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: var(--spacing-5); }
+.capabilities-list { display: flex; flex-wrap: wrap; gap: var(--spacing-3); }
+.capability-item { display: flex; align-items: center; gap: var(--spacing-2); padding: 8px 14px; background: var(--bg-tertiary); border-radius: var(--radius-2xl); font-size: var(--text-sm); color: var(--text-muted); }
 .capability-item.enabled { background: var(--color-success-bg); color: var(--color-success); }
 .capability-item i { font-size: var(--text-sm); }
 
-.strategies-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: 20px; }
+.strategies-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: var(--spacing-5); }
 .loading { color: var(--text-tertiary); font-size: var(--text-sm); }
-.strategies-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; }
-.strategy-card { display: flex; gap: 12px; padding: 14px; background: var(--bg-tertiary); border: 1px solid transparent; border-radius: var(--radius-lg); transition: all 0.2s; }
+.strategies-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--spacing-4); }
+.strategy-card { display: flex; gap: var(--spacing-3); padding: var(--spacing-3-5); background: var(--bg-tertiary); border: 1px solid transparent; border-radius: var(--radius-lg); transition: all 0.2s; }
 .strategy-card.active { border-color: var(--color-primary); background: var(--color-primary-bg); }
 .strategy-icon { width: 36px; height: 36px; border-radius: var(--radius-lg); background: var(--bg-secondary); display: flex; align-items: center; justify-content: center; color: var(--text-secondary); flex-shrink: 0; }
 .strategy-card.active .strategy-icon { background: var(--color-primary); color: white; }
-.strategy-name { display: block; font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); margin-bottom: 4px; }
+.strategy-name { display: block; font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); margin-bottom: var(--spacing-1); }
 .strategy-desc { margin: 0 0 6px; font-size: var(--text-xs); color: var(--text-secondary); line-height: 1.4; }
 .strategy-best { font-size: var(--text-xs); color: var(--text-muted); font-style: italic; }
 
-.visualization-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: 20px; }
-.workflow-viz { display: flex; flex-direction: column; gap: 20px; }
-.viz-timeline { display: flex; align-items: flex-start; gap: 0; overflow-x: auto; padding: 16px 0; }
+.visualization-panel { background: var(--bg-secondary); border-radius: var(--radius-xl); padding: var(--spacing-5); }
+.workflow-viz { display: flex; flex-direction: column; gap: var(--spacing-5); }
+.viz-timeline { display: flex; align-items: flex-start; gap: var(--spacing-0); overflow-x: auto; padding: 16px 0; }
 .viz-step { display: flex; align-items: center; }
-.viz-node { display: flex; flex-direction: column; align-items: center; gap: 8px; min-width: 80px; }
+.viz-node { display: flex; flex-direction: column; align-items: center; gap: var(--spacing-2); min-width: 80px; }
 .node-circle { width: 40px; height: 40px; border-radius: 50%; background: var(--bg-tertiary); display: flex; align-items: center; justify-content: center; font-size: var(--text-sm); font-weight: 600; color: var(--text-tertiary); border: 2px solid var(--border-default); }
 .viz-step.completed .node-circle { background: var(--color-success); color: white; border-color: var(--color-success); }
 .viz-step.failed .node-circle { background: var(--color-error); color: white; border-color: var(--color-error); }
 .viz-step.executing .node-circle { background: var(--color-primary); color: white; border-color: var(--color-primary); }
 .node-label { font-size: var(--text-xs); color: var(--text-secondary); text-align: center; max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.viz-connector { width: 40px; height: 2px; background: var(--border-default); margin-top: 20px; }
+.viz-connector { width: 40px; height: 2px; background: var(--border-default); margin-top: var(--spacing-5); }
 .viz-connector.completed { background: var(--color-success); }
 
-.viz-details { display: flex; gap: 24px; padding: 16px; background: var(--bg-tertiary); border-radius: var(--radius-lg); }
-.detail-item { display: flex; flex-direction: column; gap: 4px; }
+.viz-details { display: flex; gap: var(--spacing-6); padding: var(--spacing-4); background: var(--bg-tertiary); border-radius: var(--radius-lg); }
+.detail-item { display: flex; flex-direction: column; gap: var(--spacing-1); }
 .detail-item .label { font-size: var(--text-xs); color: var(--text-tertiary); text-transform: uppercase; }
 .detail-item .value { font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); }
 .status-badge { padding: 2px 10px; border-radius: var(--radius-xl); font-size: var(--text-xs); }
@@ -227,8 +227,8 @@ function getStrategyIcon(strategy: string): string {
 .status-badge.cancelled { background: var(--color-error-bg); color: var(--color-error); }
 
 .no-workflow { flex: 1; display: flex; align-items: center; justify-content: center; }
-.empty-viz { text-align: center; padding: 40px; }
-.empty-viz i { font-size: var(--text-5xl); color: var(--text-muted); margin-bottom: 16px; }
+.empty-viz { text-align: center; padding: var(--spacing-10); }
+.empty-viz i { font-size: var(--text-5xl); color: var(--text-muted); margin-bottom: var(--spacing-4); }
 .empty-viz h3 { margin: 0 0 8px; color: var(--text-primary); }
-.empty-viz p { margin: 0; color: var(--text-tertiary); }
+.empty-viz p { margin: var(--spacing-0); color: var(--text-tertiary); }
 </style>

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -350,8 +350,8 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 <style scoped>
 .workflow-canvas-container { display: flex; flex-direction: column; height: 100%; background: var(--bg-primary); border-radius: var(--radius-lg); overflow: hidden; }
 .canvas-toolbar { display: flex; justify-content: space-between; padding: 12px 16px; background: var(--bg-secondary); border-bottom: 1px solid var(--border-default); }
-.toolbar-left, .toolbar-right { display: flex; align-items: center; gap: 8px; }
-.tool-btn { display: flex; align-items: center; gap: 6px; padding: 8px 12px; background: var(--bg-tertiary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; }
+.toolbar-left, .toolbar-right { display: flex; align-items: center; gap: var(--spacing-2); }
+.tool-btn { display: flex; align-items: center; gap: var(--spacing-1-5); padding: 8px 12px; background: var(--bg-tertiary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; }
 .tool-btn:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
 .tool-btn.primary { background: var(--color-primary); color: var(--text-on-primary); border-color: var(--color-primary); }
 .tool-btn.primary:hover:not(:disabled) { filter: brightness(1.1); }
@@ -377,24 +377,24 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 
 .dropdown-container { position: relative; display: inline-block; }
 .dropdown-menu { position: absolute; top: 100%; left: 0; z-index: 10; background: var(--bg-secondary, #1e293b); border: 1px solid var(--border-color, #334155); border-radius: var(--radius-md); padding: 4px 0; min-width: 180px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
-.dropdown-menu button { display: flex; align-items: center; gap: 8px; width: 100%; padding: 8px 12px; border: none; background: none; color: var(--text-primary, #e2e8f0); cursor: pointer; font-size: 0.85rem; }
+.dropdown-menu button { display: flex; align-items: center; gap: var(--spacing-2); width: 100%; padding: 8px 12px; border: none; background: none; color: var(--text-primary, #e2e8f0); cursor: pointer; font-size: 0.85rem; }
 .dropdown-menu button:hover { background: var(--bg-tertiary, #334155); }
 .target-label { font-size: var(--text-xs); color: var(--text-secondary, #94a3b8); }
 .hint { font-size: var(--text-xs); color: var(--text-secondary, #94a3b8); font-style: italic; }
 
-.node-header { display: flex; align-items: center; gap: 8px; padding: 8px 12px; color: var(--text-on-primary); border-radius: var(--radius-lg) 8px 0 0; font-size: var(--text-sm); font-weight: 600; }
+.node-header { display: flex; align-items: center; gap: var(--spacing-2); padding: 8px 12px; color: var(--text-on-primary); border-radius: var(--radius-lg) 8px 0 0; font-size: var(--text-sm); font-weight: 600; }
 .node-header span { flex: 1; }
-.delete-btn { padding: 4px; background: transparent; border: none; color: inherit; cursor: pointer; opacity: 0.7; border-radius: var(--radius-default); }
+.delete-btn { padding: var(--spacing-1); background: transparent; border: none; color: inherit; cursor: pointer; opacity: 0.7; border-radius: var(--radius-default); }
 .delete-btn:hover { opacity: 1; background: rgba(255,255,255,0.2); }
 
-.node-body { padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+.node-body { padding: var(--spacing-3); display: flex; flex-direction: column; gap: var(--spacing-2); }
 .node-body input, .node-body select { width: 100%; padding: 6px 8px; background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-default); color: var(--text-primary); font-size: var(--text-xs); }
 .node-body input:focus, .node-body select:focus { outline: none; border-color: var(--color-primary); }
 .node-body input:focus-visible, .node-body select:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .node-body input.mono { font-family: monospace; }
-.node-row { display: flex; gap: 8px; align-items: center; }
+.node-row { display: flex; gap: var(--spacing-2); align-items: center; }
 .node-row select { flex: 1; }
-.checkbox { display: flex; align-items: center; gap: 4px; font-size: var(--text-xs); color: var(--text-secondary); white-space: nowrap; }
+.checkbox { display: flex; align-items: center; gap: var(--spacing-1); font-size: var(--text-xs); color: var(--text-secondary); white-space: nowrap; }
 .checkbox input { width: 14px; height: 14px; }
 
 .port { position: absolute; width: 12px; height: 12px; background: var(--bg-secondary); border: 2px solid var(--color-primary); border-radius: 50%; cursor: crosshair; top: 50%; transform: translateY(-50%); }
@@ -402,21 +402,21 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .port-in { left: -6px; }
 .port-out { right: -6px; }
 
-.empty-state { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; padding: 40px; }
-.empty-state i { font-size: var(--text-5xl); color: var(--text-muted); margin-bottom: 16px; }
+.empty-state { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; padding: var(--spacing-10); }
+.empty-state i { font-size: var(--text-5xl); color: var(--text-muted); margin-bottom: var(--spacing-4); }
 .empty-state h3 { margin: 0 0 8px; color: var(--text-primary); }
 .empty-state p { margin: 0 0 20px; color: var(--text-tertiary); }
 
 .dialog-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: var(--z-modal-backdrop); }
-.dialog { width: 400px; background: var(--bg-secondary); border-radius: var(--radius-xl); padding: 24px; }
-.dialog h3 { margin: 0 0 20px; display: flex; align-items: center; gap: 10px; color: var(--text-primary); }
+.dialog { width: 400px; background: var(--bg-secondary); border-radius: var(--radius-xl); padding: var(--spacing-6); }
+.dialog h3 { margin: 0 0 20px; display: flex; align-items: center; gap: var(--spacing-2-5); color: var(--text-primary); }
 .dialog h3 i { color: var(--color-primary); }
-.dialog input, .dialog textarea { width: 100%; padding: 10px 12px; margin-bottom: 12px; background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-primary); font-size: var(--text-sm); font-family: inherit; }
+.dialog input, .dialog textarea { width: 100%; padding: 10px 12px; margin-bottom: var(--spacing-3); background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-primary); font-size: var(--text-sm); font-family: inherit; }
 .dialog input:focus, .dialog textarea:focus { outline: none; border-color: var(--color-primary); }
 .dialog input:focus-visible, .dialog textarea:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
-.dialog-actions { display: flex; justify-content: flex-end; gap: 12px; margin-top: 12px; }
+.dialog-actions { display: flex; justify-content: flex-end; gap: var(--spacing-3); margin-top: var(--spacing-3); }
 
-.btn-primary { padding: 10px 20px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
+.btn-primary { padding: 10px 20px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-2); }
 .btn-primary:hover:not(:disabled) { filter: brightness(1.1); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 .btn-secondary { padding: 10px 20px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; }

--- a/autobot-frontend/src/components/workflow/WorkflowHistory.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowHistory.vue
@@ -184,20 +184,20 @@ function formatDate(date?: string): string {
 <style scoped>
 .workflow-history { height: 100%; display: flex; flex-direction: column; }
 
-.history-filters { display: flex; justify-content: space-between; align-items: center; gap: 16px; margin-bottom: 20px; flex-wrap: wrap; }
-.search-box { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); flex: 1; min-width: 200px; }
+.history-filters { display: flex; justify-content: space-between; align-items: center; gap: var(--spacing-4); margin-bottom: var(--spacing-5); flex-wrap: wrap; }
+.search-box { display: flex; align-items: center; gap: var(--spacing-2-5); padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); flex: 1; min-width: 200px; }
 .search-box i { color: var(--text-muted); }
 .search-box input { flex: 1; background: none; border: none; color: var(--text-primary); font-size: var(--text-sm); outline: none; }
 .search-box input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
-.filter-group { display: flex; gap: 8px; }
+.filter-group { display: flex; gap: var(--spacing-2); }
 .filter-group select { padding: 10px 12px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); color: var(--text-primary); font-size: var(--text-sm); cursor: pointer; }
 
-.empty-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-tertiary); padding: 40px; }
-.empty-state i { font-size: var(--text-5xl); margin-bottom: 16px; }
+.empty-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-tertiary); padding: var(--spacing-10); }
+.empty-state i { font-size: var(--text-5xl); margin-bottom: var(--spacing-4); }
 .empty-state h3 { margin: 0 0 8px; color: var(--text-primary); }
 
-.history-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; }
-.history-item { display: flex; align-items: center; gap: 16px; padding: 16px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); cursor: pointer; transition: all 0.2s; }
+.history-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: var(--spacing-3); }
+.history-item { display: flex; align-items: center; gap: var(--spacing-4); padding: var(--spacing-4); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); cursor: pointer; transition: all 0.2s; }
 .history-item:hover { border-color: var(--color-primary); box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
 
 .item-status { width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: var(--text-base); flex-shrink: 0; }
@@ -206,23 +206,23 @@ function formatDate(date?: string): string {
 .item-status.cancelled { background: var(--color-warning-bg); color: var(--color-warning); }
 
 .item-info { flex: 1; min-width: 0; }
-.item-name { display: block; font-size: 15px; font-weight: 500; color: var(--text-primary); margin-bottom: 2px; }
-.item-desc { display: block; font-size: var(--text-sm); color: var(--text-secondary); margin-bottom: 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.item-meta { display: flex; gap: 16px; font-size: var(--text-xs); color: var(--text-tertiary); }
-.item-meta span { display: flex; align-items: center; gap: 4px; }
+.item-name { display: block; font-size: 15px; font-weight: 500; color: var(--text-primary); margin-bottom: var(--spacing-0-5); }
+.item-desc { display: block; font-size: var(--text-sm); color: var(--text-secondary); margin-bottom: var(--spacing-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.item-meta { display: flex; gap: var(--spacing-4); font-size: var(--text-xs); color: var(--text-tertiary); }
+.item-meta span { display: flex; align-items: center; gap: var(--spacing-1); }
 
-.item-stats { display: flex; gap: 12px; }
+.item-stats { display: flex; gap: var(--spacing-3); }
 .item-stats .stat { font-size: var(--text-xs); padding: 4px 10px; border-radius: var(--radius-xl); }
 .item-stats .stat span { font-weight: 600; }
 .item-stats .success { background: var(--color-success-bg); color: var(--color-success); }
 .item-stats .failed { background: var(--color-error-bg); color: var(--color-error); }
 .item-stats .skipped { background: var(--bg-tertiary); color: var(--text-tertiary); }
 
-.item-actions { display: flex; gap: 8px; }
+.item-actions { display: flex; gap: var(--spacing-2); }
 .btn-icon { width: 32px; height: 32px; background: var(--bg-tertiary); border: none; border-radius: var(--radius-md); color: var(--text-secondary); cursor: pointer; transition: all 0.15s; }
 .btn-icon:hover { background: var(--bg-hover); color: var(--text-primary); }
 
-.pagination { display: flex; justify-content: center; align-items: center; gap: 16px; padding: 16px 0; margin-top: auto; }
+.pagination { display: flex; justify-content: center; align-items: center; gap: var(--spacing-4); padding: 16px 0; margin-top: auto; }
 .pagination button { padding: 8px 12px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); color: var(--text-secondary); cursor: pointer; }
 .pagination button:hover:not(:disabled) { background: var(--bg-hover); }
 .pagination button:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -330,7 +330,7 @@ onUnmounted(() => {
 .workflow-live-dashboard {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--spacing-5);
   height: 100%;
   overflow-y: auto;
 }
@@ -339,7 +339,7 @@ onUnmounted(() => {
 .connection-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 8px 14px;
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -375,7 +375,7 @@ onUnmounted(() => {
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .btn-reconnect:hover:not(:disabled) {
@@ -390,14 +390,14 @@ onUnmounted(() => {
 /* Stats Bar */
 .stats-bar {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   flex-wrap: wrap;
 }
 
 .stat-chip {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 10px 16px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
@@ -432,16 +432,16 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  margin-bottom: var(--spacing-4);
 }
 
 .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: 15px;
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .section-header h3 i {
@@ -486,7 +486,7 @@ onUnmounted(() => {
 .empty-state i,
 .loading-state i {
   font-size: 40px;
-  margin-bottom: 12px;
+  margin-bottom: var(--spacing-3);
 }
 
 .empty-state h4 {
@@ -496,7 +496,7 @@ onUnmounted(() => {
 }
 
 .empty-state p {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-sm);
 }
 
@@ -504,7 +504,7 @@ onUnmounted(() => {
 .execution-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 /* Execution Card */
@@ -517,7 +517,7 @@ onUnmounted(() => {
   transition: border-color var(--duration-200), box-shadow var(--duration-200);
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: var(--spacing-3-5);
 }
 
 .execution-card:hover {
@@ -534,14 +534,14 @@ onUnmounted(() => {
 .card-header {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .card-title-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .card-name {
@@ -566,7 +566,7 @@ onUnmounted(() => {
 .status-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 3px 10px;
   border-radius: var(--radius-xl);
   font-size: var(--text-xs);
@@ -586,7 +586,7 @@ onUnmounted(() => {
 .card-progress {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .progress-track {
@@ -618,7 +618,7 @@ onUnmounted(() => {
 .step-timeline {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   flex-wrap: wrap;
 }
 
@@ -674,7 +674,7 @@ onUnmounted(() => {
 .timeline-overflow {
   font-size: var(--text-xs);
   color: var(--text-muted);
-  padding-left: 4px;
+  padding-left: var(--spacing-1);
 }
 
 /* Card Footer */
@@ -682,19 +682,19 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .footer-meta {
   display: flex;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .mode-tag,
 .phase-tag {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 2px 8px;
   background: var(--bg-tertiary);
   border-radius: var(--radius-default);
@@ -706,7 +706,7 @@ onUnmounted(() => {
 .footer-time {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   font-size: var(--text-xs);
   color: var(--text-tertiary);
 }

--- a/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowNotificationConfig.vue
@@ -338,14 +338,14 @@ watch(saveSuccess, (val) => {
 .notification-config {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-4);
   max-width: 48rem;
 }
 
 .config-section {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
 }
 
 .field-label {
@@ -386,7 +386,7 @@ watch(saveSuccess, (val) => {
 .toggle-label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   cursor: pointer;
   user-select: none;
 }
@@ -405,11 +405,11 @@ watch(saveSuccess, (val) => {
 
 .config-fieldset {
   border: none;
-  padding: 0;
-  margin: 0;
+  padding: var(--spacing-0);
+  margin: var(--spacing-0);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 .config-fieldset:disabled {
   opacity: 0.45;
@@ -420,7 +420,7 @@ watch(saveSuccess, (val) => {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--color-text-primary, #e2e8f0);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Routing matrix */
@@ -430,7 +430,7 @@ watch(saveSuccess, (val) => {
   border: 1px solid var(--color-border, #374151);
   border-radius: var(--radius-md);
   overflow: hidden;
-  margin-top: 0.5rem;
+  margin-top: var(--spacing-2);
 }
 
 .matrix-row {
@@ -480,14 +480,14 @@ watch(saveSuccess, (val) => {
 .config-actions {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding-top: 0.5rem;
+  gap: var(--spacing-3);
+  padding-top: var(--spacing-2);
 }
 
 .btn-save {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   padding: 0.5rem 1.25rem;
   border: none;
   border-radius: var(--radius-md);
@@ -516,7 +516,7 @@ watch(saveSuccess, (val) => {
 .loading-indicator {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: var(--text-sm);
   color: var(--color-text-secondary, #94a3b8);
   padding: 0.75rem 0;

--- a/autobot-frontend/src/components/workflow/WorkflowRunner.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowRunner.vue
@@ -206,25 +206,25 @@ function formatResult(result: Record<string, unknown>): string {
 </script>
 
 <style scoped>
-.workflow-runner { display: flex; height: 100%; gap: 0; background: var(--bg-primary); border-radius: var(--radius-lg); overflow: hidden; }
+.workflow-runner { display: flex; height: 100%; gap: var(--spacing-0); background: var(--bg-primary); border-radius: var(--radius-lg); overflow: hidden; }
 
 .runner-sidebar { width: 300px; min-width: 300px; background: var(--bg-secondary); border-right: 1px solid var(--border-default); display: flex; flex-direction: column; }
-.sidebar-header { display: flex; justify-content: space-between; align-items: center; padding: 16px; border-bottom: 1px solid var(--border-default); }
-.sidebar-header h4 { margin: 0; font-size: var(--text-sm); color: var(--text-primary); display: flex; align-items: center; gap: 8px; }
+.sidebar-header { display: flex; justify-content: space-between; align-items: center; padding: var(--spacing-4); border-bottom: 1px solid var(--border-default); }
+.sidebar-header h4 { margin: var(--spacing-0); font-size: var(--text-sm); color: var(--text-primary); display: flex; align-items: center; gap: var(--spacing-2); }
 .sidebar-header h4 i { color: var(--color-primary); }
-.btn-refresh { padding: 6px; background: transparent; border: none; color: var(--text-tertiary); cursor: pointer; border-radius: var(--radius-default); }
+.btn-refresh { padding: var(--spacing-1-5); background: transparent; border: none; color: var(--text-tertiary); cursor: pointer; border-radius: var(--radius-default); }
 .btn-refresh:hover:not(:disabled) { background: var(--bg-hover); }
 .btn-refresh:disabled { opacity: 0.5; }
 
-.empty-list { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-muted); padding: 20px; }
-.empty-list i { font-size: 32px; margin-bottom: 12px; }
+.empty-list { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-muted); padding: var(--spacing-5); }
+.empty-list i { font-size: 32px; margin-bottom: var(--spacing-3); }
 
-.workflow-list { flex: 1; overflow-y: auto; padding: 8px; }
-.workflow-item { padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-lg); margin-bottom: 8px; cursor: pointer; transition: all 0.15s; }
+.workflow-list { flex: 1; overflow-y: auto; padding: var(--spacing-2); }
+.workflow-item { padding: var(--spacing-3); background: var(--bg-tertiary); border-radius: var(--radius-lg); margin-bottom: var(--spacing-2); cursor: pointer; transition: all 0.15s; }
 .workflow-item:hover { background: var(--bg-hover); }
 .workflow-item.active { background: var(--color-primary-bg); border: 1px solid var(--color-primary); }
 .workflow-item.paused { opacity: 0.7; }
-.workflow-item { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
+.workflow-item { display: flex; flex-wrap: wrap; align-items: center; gap: var(--spacing-2-5); }
 .wf-status { width: 28px; height: 28px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: var(--text-xs); }
 .wf-status.running { background: var(--color-success-bg); color: var(--color-success); }
 .wf-status.paused { background: var(--color-warning-bg); color: var(--color-warning); }
@@ -237,15 +237,15 @@ function formatResult(result: Record<string, unknown>): string {
 .wf-progress-bar .progress-fill { height: 100%; background: var(--color-primary); transition: width 0.3s; }
 
 .runner-main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
-.no-selection { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-tertiary); padding: 40px; }
-.no-selection i { font-size: var(--text-5xl); margin-bottom: 16px; }
+.no-selection { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; color: var(--text-tertiary); padding: var(--spacing-10); }
+.no-selection i { font-size: var(--text-5xl); margin-bottom: var(--spacing-4); }
 .no-selection h3 { margin: 0 0 8px; color: var(--text-primary); }
 
-.workflow-header { display: flex; justify-content: space-between; align-items: flex-start; padding: 20px; background: var(--bg-secondary); border-bottom: 1px solid var(--border-default); }
+.workflow-header { display: flex; justify-content: space-between; align-items: flex-start; padding: var(--spacing-5); background: var(--bg-secondary); border-bottom: 1px solid var(--border-default); }
 .header-info h2 { margin: 0 0 4px; font-size: var(--text-lg); color: var(--text-primary); }
 .header-info p { margin: 0 0 10px; font-size: var(--text-sm); color: var(--text-secondary); }
-.header-meta { display: flex; gap: 16px; font-size: var(--text-xs); color: var(--text-tertiary); flex-wrap: wrap; }
-.header-meta span { display: flex; align-items: center; gap: 6px; }
+.header-meta { display: flex; gap: var(--spacing-4); font-size: var(--text-xs); color: var(--text-tertiary); flex-wrap: wrap; }
+.header-meta span { display: flex; align-items: center; gap: var(--spacing-1-5); }
 .phase-badge { padding: 2px 8px; border-radius: var(--radius-xl); font-weight: 500; background: var(--bg-tertiary); }
 .phase-badge.planning { background: var(--color-info-bg); color: var(--color-info); }
 .phase-badge.executing { background: var(--color-primary-bg); color: var(--color-primary); }
@@ -253,7 +253,7 @@ function formatResult(result: Record<string, unknown>): string {
 .phase-badge.complete { background: var(--color-success-bg); color: var(--color-success); }
 .phase-badge.failed { background: var(--color-error-bg); color: var(--color-error); }
 .service-badge { padding: 2px 8px; border-radius: var(--radius-xl); background: var(--bg-tertiary); color: var(--text-secondary); font-family: monospace; }
-.header-actions { display: flex; gap: 10px; align-items: center; }
+.header-actions { display: flex; gap: var(--spacing-2-5); align-items: center; }
 
 .btn-notif {
   padding: 8px 10px;
@@ -269,20 +269,20 @@ function formatResult(result: Record<string, unknown>): string {
 }
 .btn-notif:hover { background: var(--bg-hover); color: var(--color-primary); }
 
-.progress-overview { padding: 20px; background: var(--bg-secondary); }
-.progress-bar-large { height: 8px; background: var(--bg-tertiary); border-radius: var(--radius-default); overflow: hidden; margin-bottom: 16px; }
+.progress-overview { padding: var(--spacing-5); background: var(--bg-secondary); }
+.progress-bar-large { height: 8px; background: var(--bg-tertiary); border-radius: var(--radius-default); overflow: hidden; margin-bottom: var(--spacing-4); }
 .progress-bar-large .progress-fill { height: 100%; background: var(--color-primary); transition: width 0.3s; }
 .progress-stats { display: flex; justify-content: space-around; }
 .progress-stats .stat { text-align: center; }
 .progress-stats .value { display: block; font-size: var(--text-2xl); font-weight: 600; color: var(--text-primary); }
 .progress-stats .label { font-size: var(--text-xs); color: var(--text-tertiary); }
 
-.steps-container { flex: 1; overflow-y: auto; padding: 20px; }
-.steps-container h4 { margin: 0 0 16px; font-size: var(--text-sm); color: var(--text-primary); display: flex; align-items: center; gap: 8px; }
+.steps-container { flex: 1; overflow-y: auto; padding: var(--spacing-5); }
+.steps-container h4 { margin: 0 0 16px; font-size: var(--text-sm); color: var(--text-primary); display: flex; align-items: center; gap: var(--spacing-2); }
 .steps-container h4 i { color: var(--color-primary); }
 
 .steps-list { display: flex; flex-direction: column; }
-.step-item { display: flex; gap: 16px; padding-bottom: 16px; }
+.step-item { display: flex; gap: var(--spacing-4); padding-bottom: var(--spacing-4); }
 .step-indicator { display: flex; flex-direction: column; align-items: center; }
 .step-icon { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: var(--text-xs); font-weight: 600; background: var(--bg-tertiary); color: var(--text-tertiary); }
 .step-icon.completed { background: var(--color-success); color: white; }
@@ -290,7 +290,7 @@ function formatResult(result: Record<string, unknown>): string {
 .step-icon.executing { background: var(--color-primary); color: white; }
 .step-icon.waiting_approval { background: var(--color-warning); color: white; }
 .step-icon.skipped { background: var(--bg-tertiary); color: var(--text-muted); }
-.step-line { width: 2px; flex: 1; min-height: 20px; background: var(--border-default); margin-top: 4px; }
+.step-line { width: 2px; flex: 1; min-height: 20px; background: var(--border-default); margin-top: var(--spacing-1); }
 .step-line.completed { background: var(--color-success); }
 
 .step-content { flex: 1; padding: 8px 16px; background: var(--bg-secondary); border-radius: var(--radius-lg); border-left: 3px solid var(--border-default); }
@@ -299,7 +299,7 @@ function formatResult(result: Record<string, unknown>): string {
 .step-item.executing .step-content { border-left-color: var(--color-primary); }
 .step-item.waiting_approval .step-content { border-left-color: var(--color-warning); }
 
-.step-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+.step-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--spacing-2); }
 .step-desc { font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); }
 .step-status { font-size: var(--text-xs); padding: 2px 8px; border-radius: var(--radius-xl); background: var(--bg-tertiary); color: var(--text-tertiary); }
 .step-status.completed { background: var(--color-success-bg); color: var(--color-success); }
@@ -307,26 +307,26 @@ function formatResult(result: Record<string, unknown>): string {
 .step-status.executing { background: var(--color-primary-bg); color: var(--color-primary); }
 .step-status.waiting_approval { background: var(--color-warning-bg); color: var(--color-warning); }
 
-.step-command { display: block; padding: 8px 10px; background: var(--bg-tertiary); border-radius: var(--radius-default); font-size: var(--text-xs); color: var(--text-secondary); margin-bottom: 8px; overflow-x: auto; }
-.step-meta { display: flex; gap: 12px; font-size: var(--text-xs); color: var(--text-tertiary); }
-.step-meta span { display: flex; align-items: center; gap: 4px; }
+.step-command { display: block; padding: 8px 10px; background: var(--bg-tertiary); border-radius: var(--radius-default); font-size: var(--text-xs); color: var(--text-secondary); margin-bottom: var(--spacing-2); overflow-x: auto; }
+.step-meta { display: flex; gap: var(--spacing-3); font-size: var(--text-xs); color: var(--text-tertiary); }
+.step-meta span { display: flex; align-items: center; gap: var(--spacing-1); }
 .step-meta .risk { padding: 2px 6px; border-radius: var(--radius-lg); }
 .step-meta .risk.low { background: var(--color-success-bg); color: var(--color-success); }
 .step-meta .risk.medium { background: var(--color-warning-bg); color: var(--color-warning); }
 .step-meta .risk.high { background: var(--color-error-bg); color: var(--color-error); }
 
-.step-actions { display: flex; gap: 8px; margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border-default); }
-.step-result { margin-top: 12px; padding: 10px; background: var(--bg-tertiary); border-radius: var(--radius-default); }
+.step-actions { display: flex; gap: var(--spacing-2); margin-top: var(--spacing-3); padding-top: var(--spacing-3); border-top: 1px solid var(--border-default); }
+.step-result { margin-top: var(--spacing-3); padding: var(--spacing-2-5); background: var(--bg-tertiary); border-radius: var(--radius-default); }
 .step-result.error { background: var(--color-error-bg); }
-.step-result pre { margin: 0; font-size: var(--text-xs); color: var(--text-secondary); white-space: pre-wrap; word-break: break-all; max-height: 150px; overflow-y: auto; }
+.step-result pre { margin: var(--spacing-0); font-size: var(--text-xs); color: var(--text-secondary); white-space: pre-wrap; word-break: break-all; max-height: 150px; overflow-y: auto; }
 
-.btn-success { padding: 8px 16px; background: var(--color-success); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+.btn-success { padding: 8px 16px; background: var(--color-success); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
 .btn-success:hover { filter: brightness(1.1); }
-.btn-warning { padding: 8px 16px; background: var(--color-warning); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+.btn-warning { padding: 8px 16px; background: var(--color-warning); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
 .btn-warning:hover { filter: brightness(1.1); }
-.btn-danger { padding: 8px 16px; background: var(--color-error); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+.btn-danger { padding: 8px 16px; background: var(--color-error); color: white; border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
 .btn-danger:hover { filter: brightness(1.1); }
-.btn-secondary { padding: 8px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+.btn-secondary { padding: 8px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-1-5); }
 .btn-secondary:hover { background: var(--bg-hover); }
 .btn-sm { padding: 6px 12px; font-size: var(--text-xs); }
 </style>

--- a/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowTemplateGallery.vue
@@ -321,24 +321,24 @@ onMounted(async () => {
 
 <style scoped>
 .template-gallery { height: 100%; display: flex; flex-direction: column; }
-.gallery-header { padding: 0 0 20px; display: flex; flex-direction: column; gap: 16px; }
-.search-box { display: flex; align-items: center; gap: 10px; padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); }
+.gallery-header { padding: 0 0 20px; display: flex; flex-direction: column; gap: var(--spacing-4); }
+.search-box { display: flex; align-items: center; gap: var(--spacing-2-5); padding: 10px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-lg); }
 .search-box i { color: var(--text-muted); }
 .search-box input { flex: 1; background: none; border: none; color: var(--text-primary); font-size: var(--text-sm); outline: none; }
 .search-box input:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
-.category-filters { display: flex; gap: 8px; flex-wrap: wrap; }
-.filter-btn { padding: 6px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-2xl); color: var(--text-secondary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; display: flex; align-items: center; gap: 6px; }
+.category-filters { display: flex; gap: var(--spacing-2); flex-wrap: wrap; }
+.filter-btn { padding: 6px 14px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-2xl); color: var(--text-secondary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; display: flex; align-items: center; gap: var(--spacing-1-5); }
 .filter-btn:hover { background: var(--bg-hover); }
 .filter-btn.active { background: var(--color-primary); color: var(--text-on-primary); border-color: var(--color-primary); }
 .count-badge { font-size: var(--text-xs); padding: 1px 6px; background: rgba(255,255,255,0.2); border-radius: var(--radius-xl); }
 
-.loading-state, .empty-state, .error-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; color: var(--text-tertiary); }
+.loading-state, .empty-state, .error-state { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--spacing-3); color: var(--text-tertiary); }
 .empty-state i, .error-state i { font-size: var(--text-5xl); }
 .error-state { color: var(--color-error); }
 .error-state p { color: var(--text-secondary); }
 
-.templates-grid { flex: 1; display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; overflow-y: auto; padding-bottom: 20px; }
-.template-card { display: flex; gap: 16px; padding: 16px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); cursor: pointer; transition: all 0.2s; }
+.templates-grid { flex: 1; display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: var(--spacing-4); overflow-y: auto; padding-bottom: var(--spacing-5); }
+.template-card { display: flex; gap: var(--spacing-4); padding: var(--spacing-4); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-xl); cursor: pointer; transition: all 0.2s; }
 .template-card:hover { border-color: var(--color-primary); box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
 
 .template-icon { width: 48px; height: 48px; border-radius: var(--radius-xl); display: flex; align-items: center; justify-content: center; font-size: var(--text-xl); background: var(--bg-tertiary); color: var(--text-secondary); flex-shrink: 0; }
@@ -353,31 +353,31 @@ onMounted(async () => {
 .template-info { flex: 1; min-width: 0; }
 .template-info h4 { margin: 0 0 4px; font-size: 15px; color: var(--text-primary); }
 .template-info p { margin: 0 0 10px; font-size: var(--text-sm); color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.template-meta { display: flex; gap: 12px; font-size: var(--text-xs); flex-wrap: wrap; }
+.template-meta { display: flex; gap: var(--spacing-3); font-size: var(--text-xs); flex-wrap: wrap; }
 .category-badge { padding: 2px 8px; background: var(--bg-tertiary); color: var(--text-tertiary); border-radius: var(--radius-xl); }
-.steps-count, .duration { color: var(--text-tertiary); display: flex; align-items: center; gap: 4px; }
+.steps-count, .duration { color: var(--text-tertiary); display: flex; align-items: center; gap: var(--spacing-1); }
 
-.template-actions { display: flex; flex-direction: column; gap: 8px; }
+.template-actions { display: flex; flex-direction: column; gap: var(--spacing-2); }
 .btn-icon { width: 32px; height: 32px; background: var(--bg-tertiary); border: none; border-radius: var(--radius-md); color: var(--text-secondary); cursor: pointer; }
 .btn-icon:hover { background: var(--bg-hover); color: var(--text-primary); }
 .btn-run { width: 32px; height: 32px; background: var(--color-success); border: none; border-radius: var(--radius-md); color: white; cursor: pointer; }
 .btn-run:hover { filter: brightness(1.1); }
 
 .preview-panel { position: fixed; right: 0; top: 0; bottom: 0; width: 400px; background: var(--bg-secondary); border-left: 1px solid var(--border-default); display: flex; flex-direction: column; z-index: 50; box-shadow: -4px 0 20px rgba(0,0,0,0.1); }
-.preview-header { display: flex; justify-content: space-between; align-items: center; padding: 20px; border-bottom: 1px solid var(--border-default); }
-.preview-header h3 { margin: 0; font-size: var(--text-base); color: var(--text-primary); }
-.preview-header button { padding: 6px; background: transparent; border: none; color: var(--text-tertiary); cursor: pointer; }
-.preview-body { flex: 1; overflow-y: auto; padding: 20px; }
+.preview-header { display: flex; justify-content: space-between; align-items: center; padding: var(--spacing-5); border-bottom: 1px solid var(--border-default); }
+.preview-header h3 { margin: var(--spacing-0); font-size: var(--text-base); color: var(--text-primary); }
+.preview-header button { padding: var(--spacing-1-5); background: transparent; border: none; color: var(--text-tertiary); cursor: pointer; }
+.preview-body { flex: 1; overflow-y: auto; padding: var(--spacing-5); }
 .preview-desc { margin: 0 0 20px; color: var(--text-secondary); }
 .preview-body h4 { margin: 0 0 12px; font-size: var(--text-sm); color: var(--text-tertiary); text-transform: uppercase; }
 
-.preview-agents { margin-bottom: 20px; }
-.agent-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+.preview-agents { margin-bottom: var(--spacing-5); }
+.agent-tags { display: flex; flex-wrap: wrap; gap: var(--spacing-1-5); }
 .agent-tag { padding: 4px 10px; background: var(--color-primary-bg); color: var(--color-primary); border-radius: var(--radius-xl); font-size: var(--text-xs); }
 
-.preview-secrets { margin-bottom: 20px; }
-.secret-items { display: flex; flex-direction: column; gap: 8px; }
-.secret-item { display: flex; align-items: center; gap: 10px; padding: 8px 12px; background: var(--bg-tertiary); border-radius: var(--radius-lg); font-size: var(--text-sm); }
+.preview-secrets { margin-bottom: var(--spacing-5); }
+.secret-items { display: flex; flex-direction: column; gap: var(--spacing-2); }
+.secret-item { display: flex; align-items: center; gap: var(--spacing-2-5); padding: 8px 12px; background: var(--bg-tertiary); border-radius: var(--radius-lg); font-size: var(--text-sm); }
 .secret-item i { color: var(--text-tertiary); font-size: var(--text-xs); }
 .secret-info { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 .secret-name { font-weight: 600; color: var(--text-primary); font-size: var(--text-xs); }
@@ -386,24 +386,24 @@ onMounted(async () => {
 .secret-scope.write { background: var(--color-warning-bg); color: var(--color-warning); }
 .secret-scope.read { background: var(--color-success-bg); color: var(--color-success); }
 
-.preview-steps { display: flex; flex-direction: column; gap: 12px; }
-.preview-step { display: flex; gap: 12px; padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-lg); }
+.preview-steps { display: flex; flex-direction: column; gap: var(--spacing-3); }
+.preview-step { display: flex; gap: var(--spacing-3); padding: var(--spacing-3); background: var(--bg-tertiary); border-radius: var(--radius-lg); }
 .step-num { width: 24px; height: 24px; background: var(--color-primary); color: white; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: var(--text-xs); font-weight: 600; flex-shrink: 0; }
 .step-content { flex: 1; min-width: 0; }
-.step-desc { display: block; font-size: var(--text-sm); color: var(--text-primary); margin-bottom: 4px; }
+.step-desc { display: block; font-size: var(--text-sm); color: var(--text-primary); margin-bottom: var(--spacing-1); }
 .step-content code { display: block; padding: 6px 8px; background: var(--bg-primary); border-radius: var(--radius-default); font-size: var(--text-xs); color: var(--text-secondary); overflow-x: auto; }
-.step-meta { display: flex; gap: 10px; margin-top: 8px; font-size: var(--text-xs); }
+.step-meta { display: flex; gap: var(--spacing-2-5); margin-top: var(--spacing-2); font-size: var(--text-xs); }
 .step-meta .risk { padding: 2px 6px; border-radius: var(--radius-lg); }
 .step-meta .risk.low { background: var(--color-success-bg); color: var(--color-success); }
 .step-meta .risk.medium { background: var(--color-warning-bg); color: var(--color-warning); }
 .step-meta .risk.high, .step-meta .risk.critical { background: var(--color-error-bg); color: var(--color-error); }
-.step-meta span { color: var(--text-tertiary); display: flex; align-items: center; gap: 4px; }
-.preview-actions { padding: 16px 20px; border-top: 1px solid var(--border-default); display: flex; gap: 12px; }
+.step-meta span { color: var(--text-tertiary); display: flex; align-items: center; gap: var(--spacing-1); }
+.preview-actions { padding: 16px 20px; border-top: 1px solid var(--border-default); display: flex; gap: var(--spacing-3); }
 .preview-actions .btn-secondary, .preview-actions .btn-primary { flex: 1; justify-content: center; }
 
-.btn-primary { padding: 10px 16px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
+.btn-primary { padding: 10px 16px; background: var(--color-primary); color: var(--text-on-primary); border: none; border-radius: var(--radius-md); font-size: var(--text-sm); font-weight: 500; cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-2); }
 .btn-primary:hover { filter: brightness(1.1); }
-.btn-secondary { padding: 10px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
+.btn-secondary { padding: 10px 16px; background: var(--bg-tertiary); color: var(--text-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); font-size: var(--text-sm); cursor: pointer; display: inline-flex; align-items: center; gap: var(--spacing-2); }
 .btn-secondary:hover { background: var(--bg-hover); }
 
 .slide-enter-active, .slide-leave-active { transition: transform 0.25s ease; }

--- a/autobot-frontend/src/views/AdminUsersView.vue
+++ b/autobot-frontend/src/views/AdminUsersView.vue
@@ -373,7 +373,7 @@ onMounted(loadUsers)
 
 <style scoped>
 .admin-users-view {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   max-width: 1200px;
   margin: 0 auto;
 }
@@ -382,8 +382,8 @@ onMounted(loadUsers)
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: 1.5rem;
-  gap: 1rem;
+  margin-bottom: var(--spacing-6);
+  gap: var(--spacing-4);
   flex-wrap: wrap;
 }
 
@@ -396,23 +396,23 @@ onMounted(loadUsers)
 .page-subtitle {
   font-size: var(--text-sm);
   color: var(--color-text-secondary, #6b7280);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .header-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .error-banner {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.75rem 1rem;
   background: var(--color-error-bg, #fef2f2);
   border: 1px solid var(--color-error-border, #fca5a5);
   border-radius: var(--radius-lg);
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
   color: var(--color-error, #dc2626);
 }
 
@@ -426,7 +426,7 @@ onMounted(loadUsers)
 
 .search-bar {
   position: relative;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .search-icon {
@@ -454,7 +454,7 @@ onMounted(loadUsers)
 }
 
 .loading-state {
-  padding: 2rem;
+  padding: var(--spacing-8);
   text-align: center;
   color: var(--color-text-secondary, #6b7280);
 }
@@ -489,7 +489,7 @@ onMounted(loadUsers)
 .username-cell {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .username {
@@ -529,7 +529,7 @@ onMounted(loadUsers)
 
 .actions-cell {
   display: flex;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .btn-icon {
@@ -569,8 +569,8 @@ onMounted(loadUsers)
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
-  padding: 0.75rem;
+  gap: var(--spacing-4);
+  padding: var(--spacing-3);
   border-top: 1px solid var(--color-border, #e5e7eb);
 }
 
@@ -597,7 +597,7 @@ onMounted(loadUsers)
 .btn-action-danger {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--spacing-1-5);
   padding: 0.5rem 1rem;
   border-radius: var(--radius-lg);
   font-size: var(--text-sm);
@@ -659,7 +659,7 @@ onMounted(loadUsers)
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
 }
@@ -673,16 +673,16 @@ onMounted(loadUsers)
 }
 
 .modal-body {
-  padding: 1.25rem;
+  padding: var(--spacing-5);
 }
 
 .form-group {
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .form-group label {
   display: block;
-  margin-bottom: 0.375rem;
+  margin-bottom: var(--spacing-1-5);
   font-size: var(--text-sm);
   font-weight: 500;
 }
@@ -699,13 +699,13 @@ onMounted(loadUsers)
 .error-inline {
   color: var(--color-error, #dc2626);
   font-size: 0.8125rem;
-  margin-top: 0.5rem;
+  margin-top: var(--spacing-2);
 }
 
 .modal-footer {
   display: flex;
   justify-content: flex-end;
-  gap: 0.5rem;
-  padding-top: 1rem;
+  gap: var(--spacing-2);
+  padding-top: var(--spacing-4);
 }
 </style>

--- a/autobot-frontend/src/views/AnalyticsView.vue
+++ b/autobot-frontend/src/views/AnalyticsView.vue
@@ -157,7 +157,7 @@ const isDevToolsActive = computed(() => {
 }
 
 .page-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-2xl);
   font-weight: 600;
   color: var(--text-primary);
@@ -183,7 +183,7 @@ const isDevToolsActive = computed(() => {
 
 .nav-tabs {
   display: flex;
-  gap: 2px;
+  gap: var(--spacing-0-5);
   padding: 0 32px;
   max-width: 1400px;
   margin: 0 auto;
@@ -193,7 +193,7 @@ const isDevToolsActive = computed(() => {
 .nav-tab {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 12px 16px;
   font-size: var(--text-sm);
   font-weight: 500;
@@ -251,13 +251,13 @@ const isDevToolsActive = computed(() => {
 
   .nav-tabs {
     padding: 0 16px;
-    gap: 0;
+    gap: var(--spacing-0);
   }
 
   .nav-tab {
     padding: 10px 12px;
     font-size: var(--text-sm);
-    gap: 6px;
+    gap: var(--spacing-1-5);
   }
 
   .tab-icon {
@@ -266,7 +266,7 @@ const isDevToolsActive = computed(() => {
   }
 
   .analytics-router-view {
-    padding: 16px;
+    padding: var(--spacing-4);
   }
 }
 

--- a/autobot-frontend/src/views/AuditLogsView.vue
+++ b/autobot-frontend/src/views/AuditLogsView.vue
@@ -520,7 +520,7 @@ async function performCleanup() {
 }
 
 .modal-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);

--- a/autobot-frontend/src/views/BrowserAutomationView.vue
+++ b/autobot-frontend/src/views/BrowserAutomationView.vue
@@ -353,13 +353,13 @@ function selectSession(session: typeof sessions.value[0]) {
 .cell-mono { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--text-secondary); }
 .cell-url { max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cell-actions { display: flex; gap: var(--spacing-3); }
-.btn-link { background: none; border: none; color: var(--color-primary); cursor: pointer; font-size: var(--text-sm); padding: 0; transition: color var(--duration-150) var(--ease-in-out); }
+.btn-link { background: none; border: none; color: var(--color-primary); cursor: pointer; font-size: var(--text-sm); padding: var(--spacing-0); transition: color var(--duration-150) var(--ease-in-out); }
 .btn-link:hover { color: var(--color-primary-hover); }
 .btn-link-danger { color: var(--color-error); }
 .btn-link-danger:hover { color: var(--color-error-hover); }
 .empty-state { text-align: center; padding: var(--spacing-12) var(--spacing-4); color: var(--text-secondary); }
 .empty-state i { font-size: var(--text-3xl); margin-bottom: var(--spacing-3); display: block; color: var(--text-muted); }
-.empty-state p { margin: 0; font-size: var(--text-sm); }
+.empty-state p { margin: var(--spacing-0); font-size: var(--text-sm); }
 @media (max-width: 768px) {
   .input-action-row { flex-direction: column; }
   .screenshots-grid { grid-template-columns: 1fr 1fr; }

--- a/autobot-frontend/src/views/BusinessIntelligenceView.vue
+++ b/autobot-frontend/src/views/BusinessIntelligenceView.vue
@@ -598,7 +598,7 @@ onMounted(() => {
 }
 
 .section-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
@@ -855,7 +855,7 @@ onMounted(() => {
 }
 
 .report-card p {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
   font-size: var(--text-sm);
 }
@@ -875,7 +875,7 @@ onMounted(() => {
 }
 
 .report-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   text-transform: capitalize;
   color: var(--text-primary);
 }

--- a/autobot-frontend/src/views/ComponentShowcaseView.vue
+++ b/autobot-frontend/src/views/ComponentShowcaseView.vue
@@ -330,25 +330,25 @@ const handleRemove = () => {
 </script>
 
 <style scoped>
-.showcase-container { padding: 24px; max-width: 1400px; margin: 0 auto; background-color: var(--bg-primary); min-height: 100%; overflow-y: auto; }
-.showcase-header { margin-bottom: 32px; }
+.showcase-container { padding: var(--spacing-6); max-width: 1400px; margin: 0 auto; background-color: var(--bg-primary); min-height: 100%; overflow-y: auto; }
+.showcase-header { margin-bottom: var(--spacing-8); }
 .showcase-title { font-size: 32px; font-weight: 600; color: var(--text-primary); margin: 0 0 8px 0; font-family: var(--font-sans); }
-.showcase-subtitle { font-size: var(--text-base); color: var(--text-secondary); margin: 0; }
-.showcase-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 24px; }
+.showcase-subtitle { font-size: var(--text-base); color: var(--text-secondary); margin: var(--spacing-0); }
+.showcase-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: var(--spacing-6); }
 .showcase-full-width { grid-column: 1 / -1; }
-.component-section { display: flex; flex-direction: column; gap: 20px; }
-.section-heading { font-size: var(--text-sm); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-secondary); margin: 0; padding-bottom: 8px; border-bottom: 1px solid var(--border-subtle); }
-.button-group { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
-.input-stack { display: flex; flex-direction: column; gap: 12px; }
-.badge-group { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
-.card-stack { display: flex; flex-direction: column; gap: 16px; }
-.color-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 12px; }
-.color-swatch { aspect-ratio: 1; border-radius: var(--radius-default); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; padding: 12px; box-shadow: var(--shadow-md); }
+.component-section { display: flex; flex-direction: column; gap: var(--spacing-5); }
+.section-heading { font-size: var(--text-sm); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-secondary); margin: var(--spacing-0); padding-bottom: var(--spacing-2); border-bottom: 1px solid var(--border-subtle); }
+.button-group { display: flex; flex-wrap: wrap; gap: var(--spacing-3); align-items: center; }
+.input-stack { display: flex; flex-direction: column; gap: var(--spacing-3); }
+.badge-group { display: flex; flex-wrap: wrap; gap: var(--spacing-2); align-items: center; }
+.card-stack { display: flex; flex-direction: column; gap: var(--spacing-4); }
+.color-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: var(--spacing-3); }
+.color-swatch { aspect-ratio: 1; border-radius: var(--radius-default); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--spacing-1); padding: var(--spacing-3); box-shadow: var(--shadow-md); }
 .swatch-label { font-size: var(--text-xs); font-weight: 600; color: white; text-transform: uppercase; letter-spacing: 0.05em; }
 .swatch-hex { font-size: var(--text-xs); font-family: var(--font-mono); color: rgba(255, 255, 255, 0.8); }
-.type-samples { padding: 16px; background-color: var(--bg-secondary); border-radius: var(--radius-default); border: 1px solid var(--border-default); }
+.type-samples { padding: var(--spacing-4); background-color: var(--bg-secondary); border-radius: var(--radius-default); border: 1px solid var(--border-default); }
 @media (max-width: 768px) {
   .showcase-grid { grid-template-columns: 1fr; }
-  .showcase-container { padding: 16px; }
+  .showcase-container { padding: var(--spacing-4); }
 }
 </style>

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -642,7 +642,7 @@ onMounted(() => {
 .header-content h1 {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   font-size: var(--text-2xl);
   font-weight: 700;
   color: var(--text-primary);
@@ -655,19 +655,19 @@ onMounted(() => {
 .header-description {
   color: var(--text-secondary);
   font-size: var(--text-sm);
-  margin-top: 0.25rem;
+  margin-top: var(--spacing-1);
 }
 
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .action-btn {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.625rem 1rem;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
@@ -702,7 +702,7 @@ onMounted(() => {
 .dashboard-selector {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
 }
 
 .dashboard-selector select {
@@ -745,19 +745,19 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-secondary);
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--spacing-3);
 }
 
 .palette-widgets {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
 }
 
 .palette-widget {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   padding: 0.5rem 1rem;
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
@@ -782,7 +782,7 @@ onMounted(() => {
   flex: 1;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1.5rem;
+  gap: var(--spacing-6);
   padding: 1.5rem 2rem;
   overflow-y: auto;
 }
@@ -845,7 +845,7 @@ onMounted(() => {
 .widget-header h3 {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--spacing-2);
   font-size: 0.9375rem;
   font-weight: 600;
   color: var(--text-primary);
@@ -857,7 +857,7 @@ onMounted(() => {
 
 .widget-actions {
   display: flex;
-  gap: 0.25rem;
+  gap: var(--spacing-1);
 }
 
 .widget-actions button {
@@ -896,7 +896,7 @@ onMounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 4rem;
+  padding: var(--spacing-16);
   text-align: center;
 }
 
@@ -910,19 +910,19 @@ onMounted(() => {
   justify-content: center;
   font-size: 2rem;
   color: var(--color-primary);
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 .empty-dashboard h3 {
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-2);
 }
 
 .empty-dashboard p {
   color: var(--text-secondary);
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-6);
 }
 
 /* Modals */
@@ -964,7 +964,7 @@ onMounted(() => {
 .modal-header h4 {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
@@ -979,7 +979,7 @@ onMounted(() => {
   border: none;
   color: var(--text-secondary);
   cursor: pointer;
-  padding: 0.25rem;
+  padding: var(--spacing-1);
 }
 
 .close-btn:hover {
@@ -987,13 +987,13 @@ onMounted(() => {
 }
 
 .modal-body {
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   overflow-y: auto;
   flex: 1;
 }
 
 .form-group {
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-4);
 }
 
 .form-group label {
@@ -1001,7 +1001,7 @@ onMounted(() => {
   font-size: var(--text-sm);
   font-weight: 500;
   color: var(--text-primary);
-  margin-bottom: 0.375rem;
+  margin-bottom: var(--spacing-1-5);
 }
 
 .form-group input,
@@ -1029,7 +1029,7 @@ onMounted(() => {
 .modal-footer {
   display: flex;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: var(--spacing-3);
   padding: 1rem 1.5rem;
   background: var(--bg-primary);
   border-top: 1px solid var(--border-default);
@@ -1039,14 +1039,14 @@ onMounted(() => {
 .widget-gallery {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
+  gap: var(--spacing-4);
 }
 
 .widget-option {
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 1.5rem;
+  padding: var(--spacing-6);
   text-align: center;
   cursor: pointer;
   transition: all var(--duration-200);
@@ -1074,7 +1074,7 @@ onMounted(() => {
   font-size: 0.9375rem;
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--spacing-1);
 }
 
 .widget-option p {
@@ -1105,8 +1105,8 @@ onMounted(() => {
 @media (max-width: 768px) {
   .dashboard-header {
     flex-direction: column;
-    gap: 1rem;
-    padding: 1rem;
+    gap: var(--spacing-4);
+    padding: var(--spacing-4);
   }
 
   .header-actions {
@@ -1116,7 +1116,7 @@ onMounted(() => {
 
   .dashboard-grid {
     grid-template-columns: 1fr;
-    padding: 1rem;
+    padding: var(--spacing-4);
   }
 
   .widget-container {

--- a/autobot-frontend/src/views/DevSpeedupView.vue
+++ b/autobot-frontend/src/views/DevSpeedupView.vue
@@ -470,7 +470,7 @@ const templateCategories = computed(() => {
   font-weight: var(--font-medium);
   font-family: var(--font-mono);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .result-line {
@@ -533,7 +533,7 @@ const templateCategories = computed(() => {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .snippet-desc,
@@ -578,7 +578,7 @@ const templateCategories = computed(() => {
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: var(--text-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .code-sm { padding: var(--spacing-3); font-size: var(--text-xs); }
@@ -646,7 +646,7 @@ const templateCategories = computed(() => {
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Empty state */
@@ -663,7 +663,7 @@ const templateCategories = computed(() => {
   color: var(--text-muted);
 }
 
-.empty-state p { margin: 0; font-size: var(--text-sm); }
+.empty-state p { margin: var(--spacing-0); font-size: var(--text-sm); }
 
 @media (max-width: 768px) {
   .search-row { flex-direction: column; }

--- a/autobot-frontend/src/views/DocumentsView.vue
+++ b/autobot-frontend/src/views/DocumentsView.vue
@@ -285,7 +285,7 @@ function showError(msg: string) {
 }
 
 .sidebar-title {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
 }
@@ -298,8 +298,8 @@ function showError(msg: string) {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 24px;
+  gap: var(--spacing-2);
+  padding: var(--spacing-6);
   text-align: center;
   color: var(--color-text-muted, #888);
   font-size: 0.9rem;
@@ -307,7 +307,7 @@ function showError(msg: string) {
 
 .empty-icon {
   font-size: 2rem;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
   color: var(--color-text-muted, #555);
 }
 
@@ -328,8 +328,8 @@ function showError(msg: string) {
 /* Document list */
 .document-list {
   list-style: none;
-  margin: 0;
-  padding: 0;
+  margin: var(--spacing-0);
+  padding: var(--spacing-0);
   overflow-y: auto;
   flex: 1;
 }
@@ -340,7 +340,7 @@ function showError(msg: string) {
   padding: 10px 16px;
   cursor: pointer;
   border-bottom: 1px solid var(--color-border, #2a2a2a);
-  gap: 2px;
+  gap: var(--spacing-0-5);
   position: relative;
   transition: background 0.12s;
 }
@@ -360,7 +360,7 @@ function showError(msg: string) {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding-right: 28px;
+  padding-right: var(--spacing-7);
 }
 
 .doc-meta {
@@ -411,7 +411,7 @@ function showError(msg: string) {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   color: var(--color-text-muted, #888);
   font-size: 0.95rem;
 }
@@ -441,7 +441,7 @@ function showError(msg: string) {
   background: var(--color-background-secondary, #252525);
   border: 1px solid var(--color-border, #444);
   border-radius: var(--radius-lg);
-  padding: 24px;
+  padding: var(--spacing-6);
   width: 360px;
   max-width: 90vw;
 }
@@ -462,7 +462,7 @@ function showError(msg: string) {
 .modal-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 /* Error toast */

--- a/autobot-frontend/src/views/EvolutionView.vue
+++ b/autobot-frontend/src/views/EvolutionView.vue
@@ -837,7 +837,7 @@ onMounted(async () => {
 
 @media (max-width: 768px) {
   .filter-row { flex-direction: column; }
-  .filter-actions { margin-left: 0; width: 100%; }
+  .filter-actions { margin-left: var(--spacing-0); width: 100%; }
   .form-row { grid-template-columns: 1fr; }
   .analysis-summary { grid-template-columns: 1fr 1fr; }
 }

--- a/autobot-frontend/src/views/KnowledgeView.vue
+++ b/autobot-frontend/src/views/KnowledgeView.vue
@@ -212,19 +212,19 @@
 }
 
 .sidebar-header {
-  padding: 20px;
+  padding: var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
 .sidebar-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
   font-family: var(--font-sans);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   line-height: 1.5;
 }
 
@@ -258,7 +258,7 @@
 .category-item {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 10px 20px;
   cursor: pointer;
   transition: all var(--duration-150) var(--ease-in-out);

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -355,7 +355,7 @@ onMounted(async () => {
 .page-subtitle {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .btn-refresh {
@@ -554,14 +554,14 @@ onMounted(async () => {
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .empty-subtitle {
   font-size: var(--text-sm);
   text-align: center;
   max-width: 380px;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* ---- Grid ---- */
@@ -641,13 +641,13 @@ onMounted(async () => {
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .plugin-desc {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: var(--leading-relaxed);
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -658,7 +658,7 @@ onMounted(async () => {
 .plugin-meta {
   font-size: var(--text-xs);
   color: var(--text-tertiary, var(--text-secondary));
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .plugin-stats {
@@ -697,7 +697,7 @@ onMounted(async () => {
 .tags-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--spacing-1);
 }
 
 .tag-chip {
@@ -723,7 +723,7 @@ onMounted(async () => {
 .action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 4px 12px;
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);

--- a/autobot-frontend/src/views/OperationsView.vue
+++ b/autobot-frontend/src/views/OperationsView.vue
@@ -134,13 +134,13 @@ onMounted(() => {
   font-size: var(--text-2xl);
   font-weight: var(--font-semibold);
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .page-subtitle {
   font-size: var(--text-sm);
   color: var(--text-tertiary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .header-actions {
@@ -199,7 +199,7 @@ onMounted(() => {
   border: none;
   color: currentColor;
   cursor: pointer;
-  padding: 0;
+  padding: var(--spacing-0);
   flex-shrink: 0;
 }
 </style>

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -524,7 +524,7 @@ onMounted(async () => {
 .page-subtitle {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .btn-refresh {
@@ -660,14 +660,14 @@ onMounted(async () => {
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .empty-subtitle {
   font-size: var(--text-sm);
   text-align: center;
   max-width: 380px;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* ---- Plugin Grid ---- */
@@ -779,13 +779,13 @@ onMounted(async () => {
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .plugin-desc {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: var(--leading-relaxed);
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -796,14 +796,14 @@ onMounted(async () => {
 .plugin-meta {
   font-size: var(--text-xs);
   color: var(--text-tertiary, var(--text-secondary));
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .hooks-list,
 .deps-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--spacing-1);
   align-items: center;
 }
 
@@ -835,7 +835,7 @@ onMounted(async () => {
 .action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--spacing-1);
   padding: 4px 12px;
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);
@@ -944,7 +944,7 @@ onMounted(async () => {
   font-size: var(--text-lg);
   font-weight: 700;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .modal-close {
@@ -981,7 +981,7 @@ onMounted(async () => {
   grid-template-columns: max-content 1fr;
   gap: var(--spacing-xs) var(--spacing-md);
   font-size: var(--text-sm);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .info-grid dt {
@@ -991,10 +991,10 @@ onMounted(async () => {
 
 .info-grid dd {
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--spacing-1);
   align-items: center;
 }
 
@@ -1002,7 +1002,7 @@ onMounted(async () => {
   font-size: var(--text-sm);
   color: var(--text-secondary);
   line-height: var(--leading-relaxed);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* ---- Config Editor ---- */
@@ -1022,7 +1022,7 @@ onMounted(async () => {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .config-edit-btn {
@@ -1057,7 +1057,7 @@ onMounted(async () => {
   color: var(--text-primary);
   overflow-x: auto;
   white-space: pre-wrap;
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .config-editor {
@@ -1096,7 +1096,7 @@ onMounted(async () => {
 .config-empty {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   font-style: italic;
 }
 

--- a/autobot-frontend/src/views/SecretsView.vue
+++ b/autobot-frontend/src/views/SecretsView.vue
@@ -60,7 +60,7 @@ const { t } = useI18n()
   font-size: var(--text-lg);
   color: var(--color-warning);
   flex-shrink: 0;
-  margin-top: 2px;
+  margin-top: var(--spacing-0-5);
 }
 
 .notice-content {
@@ -77,7 +77,7 @@ const { t } = useI18n()
 .notice-text {
   font-size: var(--text-sm);
   color: var(--color-warning);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: var(--leading-relaxed);
 }
 

--- a/autobot-frontend/src/views/SettingsView.vue
+++ b/autobot-frontend/src/views/SettingsView.vue
@@ -237,7 +237,7 @@ function onApiKeysSaved(): void {
   font-size: var(--text-3xl);
   font-weight: 700;
   color: var(--text-primary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .page-title i {
@@ -248,7 +248,7 @@ function onApiKeysSaved(): void {
 .page-description {
   font-size: var(--text-base);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: var(--leading-relaxed);
 }
 
@@ -291,7 +291,7 @@ function onApiKeysSaved(): void {
 .section-description {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
   line-height: var(--leading-normal);
 }
 

--- a/autobot-frontend/src/views/UsageView.vue
+++ b/autobot-frontend/src/views/UsageView.vue
@@ -262,7 +262,7 @@ onMounted(load)
   font-weight: var(--font-semibold);
   color: var(--text-primary);
   border-bottom: 1px solid var(--border-default);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 .usage-table {

--- a/autobot-frontend/src/views/WorkflowBuilderView.vue
+++ b/autobot-frontend/src/views/WorkflowBuilderView.vue
@@ -1190,19 +1190,19 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .sidebar-header {
-  padding: 20px;
+  padding: var(--spacing-5);
   border-bottom: 1px solid var(--border-default);
 }
 
 .sidebar-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
   font-family: var(--font-sans);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
   line-height: 1.5;
 }
 
@@ -1261,7 +1261,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .category-item {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--spacing-3);
   padding: 10px 20px;
   cursor: pointer;
   transition: all var(--duration-150) var(--ease-in-out);
@@ -1340,7 +1340,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-150) var(--ease-in-out);
 }
 
@@ -1391,7 +1391,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .header-left h2 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
@@ -1404,14 +1404,14 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .header-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   align-items: center;
 }
 
 .status-badge {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   padding: 8px 14px;
   border-radius: var(--radius-2xl);
   font-size: var(--text-sm);
@@ -1441,9 +1441,9 @@ watch(hasActiveWorkflows, (hasActive) => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: var(--spacing-4);
   color: var(--text-tertiary);
-  padding: 40px;
+  padding: var(--spacing-10);
 }
 
 .error-container .error-icon {
@@ -1459,12 +1459,12 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .error-container h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
 }
 
 .error-container p {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-secondary);
 }
 
@@ -1472,22 +1472,22 @@ watch(hasActiveWorkflows, (hasActive) => {
 .content-body {
   flex: 1;
   overflow-y: auto;
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 /* Overview Stats Grid */
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
-  margin-bottom: 24px;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-6);
 }
 
 .stat-card {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 20px;
+  gap: var(--spacing-4);
+  padding: var(--spacing-5);
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
@@ -1540,14 +1540,14 @@ watch(hasActiveWorkflows, (hasActive) => {
 .overview-sections {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--spacing-6);
 }
 
 .overview-card {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .overview-card h4 {
@@ -1557,7 +1557,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .overview-card h4 i {
@@ -1568,15 +1568,15 @@ watch(hasActiveWorkflows, (hasActive) => {
 .quick-actions-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .quick-action {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 16px;
+  gap: var(--spacing-2);
+  padding: var(--spacing-4);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -1604,11 +1604,11 @@ watch(hasActiveWorkflows, (hasActive) => {
 .strategies-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .strategy-item {
-  padding: 16px;
+  padding: var(--spacing-4);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
 }
@@ -1616,8 +1616,8 @@ watch(hasActiveWorkflows, (hasActive) => {
 .strategy-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 8px;
+  gap: var(--spacing-2-5);
+  margin-bottom: var(--spacing-2);
 }
 
 .strategy-header i {
@@ -1645,7 +1645,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .examples-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--spacing-3);
 }
 
 .example-item {
@@ -1664,7 +1664,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 4px;
+  margin-bottom: var(--spacing-1);
 }
 
 .example-name {
@@ -1684,7 +1684,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .example-description {
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin: 0;
+  margin: var(--spacing-0);
 }
 
 /* Natural Language Section */
@@ -1695,18 +1695,18 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .nl-header {
   text-align: center;
-  margin-bottom: 24px;
+  margin-bottom: var(--spacing-6);
 }
 
 .nl-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-lg);
   font-weight: 600;
   color: var(--text-primary);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .nl-header h3 i {
@@ -1722,12 +1722,12 @@ watch(hasActiveWorkflows, (hasActive) => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .nl-input-area textarea {
   width: 100%;
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-primary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -1760,7 +1760,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 .checkbox-option {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   cursor: pointer;
   color: var(--text-secondary);
   font-size: var(--text-sm);
@@ -1787,18 +1787,18 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 /* Approval Panel */
 .approval-panel {
-  margin-top: 24px;
+  margin-top: var(--spacing-6);
   background: var(--bg-secondary);
   border: 1px solid var(--color-warning);
   border-radius: var(--radius-xl);
-  padding: 20px;
+  padding: var(--spacing-5);
 }
 
 .approval-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 16px;
+  gap: var(--spacing-2-5);
+  margin-bottom: var(--spacing-4);
 }
 
 .approval-header i {
@@ -1807,7 +1807,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .approval-header h4 {
-  margin: 0;
+  margin: var(--spacing-0);
   color: var(--text-primary);
 }
 
@@ -1818,7 +1818,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .approval-meta {
   display: flex;
-  gap: 16px;
+  gap: var(--spacing-4);
   font-size: var(--text-sm);
   color: var(--text-tertiary);
 }
@@ -1826,18 +1826,18 @@ watch(hasActiveWorkflows, (hasActive) => {
 .approval-meta span {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--spacing-1-5);
 }
 
 .approval-steps {
   margin: 16px 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .approval-step {
-  padding: 12px;
+  padding: var(--spacing-3);
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
   border-left: 3px solid var(--border-default);
@@ -1851,7 +1851,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-2);
 }
 
 .step-description {
@@ -1884,7 +1884,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .step-command {
   display: block;
-  padding: 8px;
+  padding: var(--spacing-2);
   background: var(--bg-primary);
   border-radius: var(--radius-default);
   font-size: var(--text-xs);
@@ -1894,7 +1894,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 
 .approval-actions {
   display: flex;
-  gap: 12px;
+  gap: var(--spacing-3);
   justify-content: flex-end;
 }
 
@@ -1903,24 +1903,24 @@ watch(hasActiveWorkflows, (hasActive) => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 24px;
+  padding: var(--spacing-6);
 }
 
 .agents-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-5);
 }
 
 .agents-header h3 {
-  margin: 0;
+  margin: var(--spacing-0);
   font-size: var(--text-base);
   font-weight: 600;
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-2-5);
 }
 
 .agents-header h3 i {
@@ -1928,7 +1928,7 @@ watch(hasActiveWorkflows, (hasActive) => {
 }
 
 .btn-refresh-sm {
-  padding: 8px;
+  padding: var(--spacing-2);
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border: none;
@@ -1949,28 +1949,28 @@ watch(hasActiveWorkflows, (hasActive) => {
 .loading-inline {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 20px;
+  gap: var(--spacing-3);
+  padding: var(--spacing-5);
   color: var(--text-tertiary);
 }
 
 .agents-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 16px;
+  gap: var(--spacing-4);
 }
 
 .agent-card {
   background: var(--bg-tertiary);
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: var(--spacing-4);
 }
 
 .agent-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 12px;
+  gap: var(--spacing-2-5);
+  margin-bottom: var(--spacing-3);
 }
 
 .agent-header i {
@@ -1986,8 +1986,8 @@ watch(hasActiveWorkflows, (hasActive) => {
 .agent-capabilities {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  margin-bottom: 12px;
+  gap: var(--spacing-1-5);
+  margin-bottom: var(--spacing-3);
 }
 
 .capability-tag {
@@ -2001,13 +2001,13 @@ watch(hasActiveWorkflows, (hasActive) => {
 .agent-performance {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .agent-performance .perf-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
 }
 
 .agent-performance .label {
@@ -2052,7 +2052,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -2076,7 +2076,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 
@@ -2095,7 +2095,7 @@ watch(hasActiveWorkflows, (hasActive) => {
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--spacing-2);
   transition: all var(--duration-200);
 }
 

--- a/scripts/migrate_spacing_tokens.py
+++ b/scripts/migrate_spacing_tokens.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Migrate hardcoded padding/margin/gap values in Vue <style> blocks to spacing design tokens.
+
+Covers only single-value declarations (e.g. `padding: 16px`) — multi-value shorthands
+(e.g. `padding: 8px 16px`) are skipped per issue #4651 scope.
+
+Usage:
+    python scripts/migrate_spacing_tokens.py <src_dir>
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Mapping from raw value to CSS custom property token
+SPACING_MAP = {
+    # px values
+    "0px": "var(--spacing-0)",
+    "1px": "var(--spacing-px)",
+    "2px": "var(--spacing-0-5)",
+    "4px": "var(--spacing-1)",
+    "6px": "var(--spacing-1-5)",
+    "8px": "var(--spacing-2)",
+    "10px": "var(--spacing-2-5)",
+    "12px": "var(--spacing-3)",
+    "14px": "var(--spacing-3-5)",
+    "16px": "var(--spacing-4)",
+    "20px": "var(--spacing-5)",
+    "24px": "var(--spacing-6)",
+    "28px": "var(--spacing-7)",
+    "32px": "var(--spacing-8)",
+    "36px": "var(--spacing-9)",
+    "40px": "var(--spacing-10)",
+    "48px": "var(--spacing-12)",
+    "56px": "var(--spacing-14)",
+    "64px": "var(--spacing-16)",
+    "80px": "var(--spacing-20)",
+    "96px": "var(--spacing-24)",
+    "128px": "var(--spacing-32)",
+    # rem values
+    "0rem": "var(--spacing-0)",
+    "0.125rem": "var(--spacing-0-5)",
+    "0.25rem": "var(--spacing-1)",
+    "0.375rem": "var(--spacing-1-5)",
+    "0.5rem": "var(--spacing-2)",
+    "0.625rem": "var(--spacing-2-5)",
+    "0.75rem": "var(--spacing-3)",
+    "0.875rem": "var(--spacing-3-5)",
+    "1rem": "var(--spacing-4)",
+    "1.25rem": "var(--spacing-5)",
+    "1.5rem": "var(--spacing-6)",
+    "1.75rem": "var(--spacing-7)",
+    "2rem": "var(--spacing-8)",
+    "2.25rem": "var(--spacing-9)",
+    "2.5rem": "var(--spacing-10)",
+    "3rem": "var(--spacing-12)",
+    "3.5rem": "var(--spacing-14)",
+    "4rem": "var(--spacing-16)",
+    "5rem": "var(--spacing-20)",
+    "6rem": "var(--spacing-24)",
+    "8rem": "var(--spacing-32)",
+    # zero without unit
+    "0": "var(--spacing-0)",
+}
+
+# Properties to migrate
+SPACING_PROPS = [
+    "padding",
+    "padding-top",
+    "padding-right",
+    "padding-bottom",
+    "padding-left",
+    "margin",
+    "margin-top",
+    "margin-right",
+    "margin-bottom",
+    "margin-left",
+    "gap",
+    "row-gap",
+    "column-gap",
+]
+
+_PROPS_RE = "|".join(re.escape(p) for p in SPACING_PROPS)
+
+# Matches single-value spacing declarations only (no multi-value shorthands).
+# Value must be a single token (digits + optional unit), nothing after before `;`.
+DECL_RE = re.compile(
+    r"(?P<indent>[ \t]*)(?P<prop>" + _PROPS_RE + r")(?P<colon>\s*:\s*)"
+    r"(?P<value>-?[\d.]+(?:px|rem)|0)(?P<tail>\s*;)",
+    re.MULTILINE,
+)
+
+
+def migrate_style_block(style_block: str) -> tuple[str, int]:
+    """Replace single-value spacing declarations inside a <style> block."""
+    replacements = 0
+
+    def replacer(m: re.Match) -> str:
+        nonlocal replacements
+        raw_val = m.group("value")
+        token = SPACING_MAP.get(raw_val)
+        if token is None:
+            return m.group(0)  # no mapping — leave unchanged
+        replacements += 1
+        return m.group("indent") + m.group("prop") + m.group("colon") + token + m.group("tail")
+
+    new_block = DECL_RE.sub(replacer, style_block)
+    return new_block, replacements
+
+
+# Matches <style ...>...</style> (including scoped/lang attrs)
+STYLE_BLOCK_RE = re.compile(r"(<style\b[^>]*>)(.*?)(</style>)", re.DOTALL)
+
+
+def migrate_file(path: Path) -> int:
+    """Migrate a single Vue file. Returns number of replacements made."""
+    content = path.read_text(encoding="utf-8")
+    total = 0
+
+    def style_replacer(m: re.Match) -> str:
+        nonlocal total
+        open_tag, body, close_tag = m.group(1), m.group(2), m.group(3)
+        new_body, count = migrate_style_block(body)
+        total += count
+        return open_tag + new_body + close_tag
+
+    new_content = STYLE_BLOCK_RE.sub(style_replacer, content)
+
+    if new_content != content:
+        path.write_text(new_content, encoding="utf-8")
+
+    return total
+
+
+def main(src_dir: str) -> None:
+    root = Path(src_dir).resolve()
+    if not root.is_dir():
+        print(f"ERROR: {src_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    vue_files = sorted(root.rglob("*.vue"))
+    print(f"Scanning {len(vue_files)} Vue files in {root}...")
+
+    total_files = 0
+    total_replacements = 0
+    changed_files: list[str] = []
+
+    for path in vue_files:
+        count = migrate_file(path)
+        if count > 0:
+            total_files += 1
+            total_replacements += count
+            changed_files.append(f"  {path.relative_to(root)}: {count}")
+
+    print(f"\nMigrated {total_replacements} declarations across {total_files} files.")
+    if changed_files:
+        print("Changed files:")
+        for line in changed_files:
+            print(line)
+    else:
+        print("No changes made.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <src_dir>", file=sys.stderr)
+        sys.exit(1)
+    main(sys.argv[1])


### PR DESCRIPTION
Closes #4651

## Summary

- Migrates **2,328** single-value `padding`/`margin`/`gap` declarations in Vue `<style>` blocks to `--spacing-*` design tokens
- Covers **197 files** across all frontend components, views, and layouts
- Multi-value shorthands (e.g. `padding: 8px 16px`) are intentionally deferred — same approach as prior migrations (#4638 for border-radius)
- Includes `scripts/migrate_spacing_tokens.py` for reproducibility and future partial migrations

## Token mapping applied

Values replaced: `0`, `1px`, `2px`, `4px`, `6px`, `8px`, `10px`, `12px`, `14px`, `16px`, `20px`, `24px`, `28px`, `32px`, `36px`, `40px`, `48px`, `56px`, `64px`, `80px`, `96px`, `128px` (and rem equivalents) → `var(--spacing-*)`.

## Remaining violations (~244)

- Multi-value shorthands: `padding: 8px 16px` (deferred, same as issue scope)
- Inline `style=""` attributes in templates (out of scope for `<style>`-block migration)
- Non-standard values (e.g. `gap: 3px`, `gap: 15px`) with no token equivalent

## Test status

TypeScript errors in `WorkflowBuilderView.vue` are pre-existing (verified via `git stash` check — identical errors on base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)