### PR TITLE
fix(rag): memoize hash cache in _filter_stale_chunks with 60s TTL (#4723)

### DIFF
--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -37,6 +37,13 @@ logger = get_llm_logger("rag_service")
 
 _STREAM_TTL_SECONDS = TTL_30_DAYS
 
+# In-process cache for the DocIndexer hash cache file (Issue #4723).
+# The file is only rewritten when indexing completes (infrequent), so reading
+# it on every advanced_search() call is unnecessary I/O.
+_hash_cache_memo: dict = {}
+_hash_cache_loaded_at: float = 0.0
+_HASH_CACHE_TTL: float = 60.0  # seconds
+
 
 class RAGService:
     """
@@ -952,7 +959,12 @@ class RAGService:
                 return {}
 
         try:
-            hash_cache: dict = await asyncio.to_thread(_load)
+            global _hash_cache_memo, _hash_cache_loaded_at
+            now = time.monotonic()
+            if now - _hash_cache_loaded_at > _HASH_CACHE_TTL:
+                _hash_cache_memo = await asyncio.to_thread(_load)
+                _hash_cache_loaded_at = now
+            hash_cache: dict = _hash_cache_memo
         except Exception as exc:
             logger.debug("Hash cache load failed (skipping provenance check): %s", exc)
             return results

--- a/autobot-backend/tests/services/rag_service_events_test.py
+++ b/autobot-backend/tests/services/rag_service_events_test.py
@@ -3,7 +3,9 @@
 # Author: mrveiss
 """Unit tests for RAGService retrieval feedback event emission (#1516)."""
 
+import asyncio
 import json
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -729,6 +731,17 @@ class TestRetrievedVsRankedIdsSeparation:
 class TestFilterStaleChunks:
     """Tests for RAGService._filter_stale_chunks() — provenance validation."""
 
+    @pytest.fixture(autouse=True)
+    def reset_hash_cache_memo(self):
+        """Reset module-level TTL cache before each test to ensure isolation."""
+        import services.rag_service as rag_mod
+
+        rag_mod._hash_cache_memo = {}
+        rag_mod._hash_cache_loaded_at = 0.0
+        yield
+        rag_mod._hash_cache_memo = {}
+        rag_mod._hash_cache_loaded_at = 0.0
+
     def _make_service(self):
         from services.rag_service import RAGService
 
@@ -834,6 +847,99 @@ class TestFilterStaleChunks:
 
         assert result == [chunk]
 
+    # ------------------------------------------------------------------
+    # TTL memo-cache tests (Issue #4723)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_first_call_loads_from_disk(self, tmp_path):
+        """First call triggers a disk read via asyncio.to_thread."""
+        import services.rag_service as rag_mod
+
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text('{"docs/guide.md": "abc"}', encoding="utf-8")
+
+        svc = self._make_service()
+        chunk = self._make_chunk("docs/guide.md")
+
+        # Reset module-level state so we always start cold.
+        rag_mod._hash_cache_loaded_at = 0.0
+        rag_mod._hash_cache_memo = {}
+
+        load_call_count = 0
+        original_to_thread = asyncio.to_thread
+
+        async def counting_to_thread(fn, *args, **kwargs):
+            nonlocal load_call_count
+            load_call_count += 1
+            return await original_to_thread(fn, *args, **kwargs)
+
+        with patch("services.knowledge.doc_indexer.HASH_CACHE_FILE", cache_file):
+            with patch("services.rag_service.asyncio.to_thread", side_effect=counting_to_thread):
+                await svc._filter_stale_chunks([chunk])
+
+        assert load_call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_second_call_within_ttl_skips_disk(self, tmp_path):
+        """Second call within TTL window uses the in-process memo — no disk read."""
+        import services.rag_service as rag_mod
+
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text('{"docs/guide.md": "abc"}', encoding="utf-8")
+
+        svc = self._make_service()
+        chunk = self._make_chunk("docs/guide.md")
+
+        # Seed memo as if we already loaded recently.
+        rag_mod._hash_cache_memo = {"docs/guide.md": "abc"}
+        rag_mod._hash_cache_loaded_at = time.monotonic()  # just now — within TTL
+
+        load_call_count = 0
+        original_to_thread = asyncio.to_thread
+
+        async def counting_to_thread(fn, *args, **kwargs):
+            nonlocal load_call_count
+            load_call_count += 1
+            return await original_to_thread(fn, *args, **kwargs)
+
+        with patch("services.knowledge.doc_indexer.HASH_CACHE_FILE", cache_file):
+            with patch("services.rag_service.asyncio.to_thread", side_effect=counting_to_thread):
+                result = await svc._filter_stale_chunks([chunk])
+
+        assert load_call_count == 0, "Should not re-read disk within TTL"
+        assert result == [chunk]
+
+    @pytest.mark.asyncio
+    async def test_call_after_ttl_expiry_reloads(self, tmp_path):
+        """A call made after the TTL expires triggers a fresh disk read."""
+        import services.rag_service as rag_mod
+
+        cache_file = tmp_path / ".doc_index_hashes.json"
+        cache_file.write_text('{"docs/guide.md": "abc"}', encoding="utf-8")
+
+        svc = self._make_service()
+        chunk = self._make_chunk("docs/guide.md")
+
+        # Simulate an expired memo: loaded_at is older than TTL.
+        rag_mod._hash_cache_memo = {"docs/guide.md": "abc"}
+        rag_mod._hash_cache_loaded_at = time.monotonic() - rag_mod._HASH_CACHE_TTL - 1.0
+
+        load_call_count = 0
+        original_to_thread = asyncio.to_thread
+
+        async def counting_to_thread(fn, *args, **kwargs):
+            nonlocal load_call_count
+            load_call_count += 1
+            return await original_to_thread(fn, *args, **kwargs)
+
+        with patch("services.knowledge.doc_indexer.HASH_CACHE_FILE", cache_file):
+            with patch("services.rag_service.asyncio.to_thread", side_effect=counting_to_thread):
+                result = await svc._filter_stale_chunks([chunk])
+
+        assert load_call_count == 1, "Should reload disk after TTL expiry"
+        assert result == [chunk]
+
 
 # =============================================================================
 # _fallback_basic_search stale-chunk filtering tests (#4721)
@@ -846,6 +952,17 @@ class TestFallbackBasicSearchFiltersStaleChunks:
     Issue #4721: the fallback path previously returned results without calling
     _filter_stale_chunks(), silently returning stale/moved source paths.
     """
+
+    @pytest.fixture(autouse=True)
+    def reset_hash_cache_memo(self):
+        """Reset module-level TTL cache before each test to ensure isolation."""
+        import services.rag_service as rag_mod
+
+        rag_mod._hash_cache_memo = {}
+        rag_mod._hash_cache_loaded_at = 0.0
+        yield
+        rag_mod._hash_cache_memo = {}
+        rag_mod._hash_cache_loaded_at = 0.0
 
     def _make_service(self):
         from services.rag_service import RAGService


### PR DESCRIPTION
Closes #4723

## Summary
- `_filter_stale_chunks()` was reading the DocIndexer hash cache JSON from disk on every `advanced_search()` call (hot path)
- Added module-level `_hash_cache_memo` + 60s TTL: disk read only fires when cache is stale
- `autouse` reset fixture added to test classes to isolate module-level state between tests

## Tests
- 3 new TTL tests: first call loads from disk, second call within TTL skips disk, call after TTL expiry reloads
- 38 total rag_service tests pass (9 `TestFilterStaleChunks` + all existing)