### PR TITLE
fix(rag): cache synthesis_schema singleton in _get_kb_synthesis_context (#4654)

### DIFF
--- a/autobot-backend/services/rag_integration_test.py
+++ b/autobot-backend/services/rag_integration_test.py
@@ -381,6 +381,64 @@ class TestCrossEncoderReranking:
         assert reranked[0].rerank_score > reranked[1].rerank_score
 
 
+class TestKBSynthesisSchemaCache:
+    """Tests for module-level synthesis schema caching in RAGService (#4654)."""
+
+    def setup_method(self):
+        """Reset the module-level cache before each test."""
+        import services.rag_service as rag_module
+
+        rag_module._SYNTHESIS_SCHEMA_CACHE = None
+
+    def teardown_method(self):
+        """Reset the module-level cache after each test."""
+        import services.rag_service as rag_module
+
+        rag_module._SYNTHESIS_SCHEMA_CACHE = None
+
+    @pytest.mark.asyncio
+    async def test_load_synthesis_schema_called_only_once_across_multiple_calls(self):
+        """load_synthesis_schema is called exactly once even when _get_kb_synthesis_context
+        is invoked multiple times — schema is cached after the first load (#4654)."""
+        mock_schema = Mock()
+        mock_schema.collections = []
+
+        chromadb_client = AsyncMock()
+        chromadb_client.get_or_create_collection = AsyncMock(side_effect=Exception("no db"))
+
+        with patch(
+            "services.rag_service.load_synthesis_schema", create=True
+        ) as _unused, patch(
+            "services.knowledge.synthesis_schema_loader.load_synthesis_schema",
+            return_value=mock_schema,
+        ) as mock_loader, patch(
+            "utils.chromadb_client.get_async_chromadb_client",
+            AsyncMock(return_value=chromadb_client),
+        ):
+            service = RAGService.__new__(RAGService)
+            await service._get_kb_synthesis_context("query one")
+            await service._get_kb_synthesis_context("query two")
+
+        mock_loader.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_synthesis_schema_returns_same_object_on_repeated_calls(self):
+        """_get_synthesis_schema() returns identical object instance on every call (#4654)."""
+        import services.rag_service as rag_module
+
+        mock_schema = Mock()
+
+        with patch(
+            "services.knowledge.synthesis_schema_loader.load_synthesis_schema",
+            return_value=mock_schema,
+        ):
+            result1 = rag_module._get_synthesis_schema()
+            result2 = rag_module._get_synthesis_schema()
+
+        assert result1 is result2
+        assert result1 is mock_schema
+
+
 class TestAPIEndpoints:
     """Tests for advanced RAG API endpoints."""
 

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -44,6 +44,20 @@ _hash_cache_memo: dict = {}
 _hash_cache_loaded_at: float = 0.0
 _HASH_CACHE_TTL: float = 60.0  # seconds
 
+# Module-level singleton cache for synthesis schema — avoids repeated disk reads on the
+# hot path (_get_kb_synthesis_context is called on every advanced_search). (#4654)
+_SYNTHESIS_SCHEMA_CACHE: "object | None" = None
+
+
+def _get_synthesis_schema() -> "object":
+    """Return the cached SynthesisSchema, loading from disk only on first call."""
+    global _SYNTHESIS_SCHEMA_CACHE
+    if _SYNTHESIS_SCHEMA_CACHE is None:
+        from services.knowledge.synthesis_schema_loader import load_synthesis_schema
+
+        _SYNTHESIS_SCHEMA_CACHE = load_synthesis_schema()
+    return _SYNTHESIS_SCHEMA_CACHE
+
 
 class RAGService:
     """
@@ -809,9 +823,7 @@ class RAGService:
         # Collect all synthesis collection names: default + schema-defined targets.
         collection_names: List[str] = ["kb_synthesis"]
         try:
-            from services.knowledge.synthesis_schema_loader import load_synthesis_schema
-
-            schema = load_synthesis_schema()
+            schema = _get_synthesis_schema()
             for col in schema.collections:
                 target = col.synthesis_target.strip()
                 if target and target not in collection_names:


### PR DESCRIPTION
Closes #4654

## Summary
- `_get_kb_synthesis_context()` called `load_synthesis_schema()` on every invocation (disk I/O on hot path)
- Added `_SYNTHESIS_SCHEMA_CACHE` module-level singleton and `_get_synthesis_schema()` lazy-loader
- Schema now loaded once per process; subsequent calls return the cached instance

## Tests
- 2 new tests in `TestKBSynthesisSchemaCache`: schema loaded exactly once across multiple calls; returns same object instance
- Setup/teardown resets cache to None for test isolation