### PR TITLE
fix(knowledge): O(1) ancestor lookup in LineageService via sorted set (#4788)

### DIFF
--- a/autobot-backend/services/knowledge/lineage_service.py
+++ b/autobot-backend/services/knowledge/lineage_service.py
@@ -128,6 +128,12 @@ class LineageService:
     ) -> Optional[SynthesisRun]:
         """Return the highest-scoring run in the lineage tree for *collection*.
 
+        Uses ``get_best_run_id_for_collection()`` for O(1) sorted-set lookup
+        followed by a single ``get_by_run_id()`` hash fetch — replacing the
+        O(total_runs) full-stream scan.  Falls back to None when no runs exist.
+
+        Issue #4788: O(1) ancestor lookup via Redis sorted set index.
+
         Args:
             collection: ChromaDB collection name to filter by.
             metric: Field to maximise (currently only "score" supported).
@@ -136,15 +142,15 @@ class LineageService:
             The SynthesisRun with the highest metric value, or None when no
             runs exist for the collection.
         """
-        all_entries = await self._provenance_log.get_recent(limit=500)
-        runs = [
-            SynthesisRun.from_provenance_entry(e)
-            for e in all_entries
-            if e.get("collection_name") == collection and e.get("run_id")
-        ]
-        if not runs:
+        best_run_id = await self._provenance_log.get_best_run_id_for_collection(
+            collection
+        )
+        if not best_run_id:
             return None
-        return max(runs, key=lambda r: float(getattr(r, metric, 0.0)))
+        entry = await self._provenance_log.get_by_run_id(best_run_id)
+        if entry is None:
+            return None
+        return SynthesisRun.from_provenance_entry(entry)
 
     # ------------------------------------------------------------------
     # Entity version history (ChromaDB)

--- a/autobot-backend/services/knowledge/synthesis_provenance.py
+++ b/autobot-backend/services/knowledge/synthesis_provenance.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 _STREAM_KEY = "kb:synthesis:log"
 _RUN_KEY_PREFIX = "kb:synthesis:run:"
+_COLLECTION_BEST_KEY_PREFIX = "kb:synthesis:best:"
 
 
 class SynthesisProvenanceLog:
@@ -75,6 +76,11 @@ class SynthesisProvenanceLog:
             pipe = redis.pipeline()
             pipe.xadd(_STREAM_KEY, entry)
             pipe.hset(f"{_RUN_KEY_PREFIX}{run_id}", mapping=entry)
+            if collection_name:
+                pipe.zadd(
+                    f"{_COLLECTION_BEST_KEY_PREFIX}{collection_name}",
+                    {run_id: score},
+                )
             await pipe.execute()
             logger.debug("Provenance logged for run %s (%d insights)", run_id, len(synthesis_ids))
         except Exception:
@@ -126,6 +132,34 @@ class SynthesisProvenanceLog:
         entry.setdefault("prompt_variant", entry.get("prompt_template", ""))
         entry.setdefault("collection_name", "")
         return entry
+
+    async def get_best_run_id_for_collection(
+        self, collection_name: str
+    ) -> Optional[str]:
+        """Return the run_id with the highest score for *collection_name*.
+
+        Uses the ``kb:synthesis:best:{collection_name}`` sorted set for an O(1)
+        lookup instead of scanning the full stream.  Returns None when no runs
+        exist for the collection.
+
+        Issue #4788: O(1) replacement for the 500-entry scan in get_best_ancestor.
+        """
+        try:
+            redis = await get_async_redis_client(database="main")
+            results = await redis.zrevrange(
+                f"{_COLLECTION_BEST_KEY_PREFIX}{collection_name}", 0, 0
+            )
+        except Exception:
+            logger.exception(
+                "get_best_run_id_for_collection: Redis error for collection '%s'",
+                collection_name,
+            )
+            return None
+
+        if not results:
+            return None
+        raw = results[0]
+        return raw.decode("utf-8") if isinstance(raw, bytes) else raw
 
     async def get_best_prompt_variant(
         self,

--- a/autobot-backend/services/knowledge/test_lineage_service.py
+++ b/autobot-backend/services/knowledge/test_lineage_service.py
@@ -73,8 +73,10 @@ def _entry(
 def _make_provenance_log(entries: List[Dict[str, Any]]) -> MagicMock:
     """Build a mock SynthesisProvenanceLog from a flat list of entries.
 
-    - get_recent returns the full list (used by get_best_ancestor).
+    - get_recent returns the full list (retained for other callers).
     - get_by_run_id does an O(1) dict lookup by run_id (used by get_ancestors).
+    - get_best_run_id_for_collection returns the highest-scoring run_id for the
+      collection (used by get_best_ancestor, Issue #4788).
     """
     by_id = {e["run_id"]: e for e in entries if e.get("run_id")}
 
@@ -91,9 +93,22 @@ def _make_provenance_log(entries: List[Dict[str, Any]]) -> MagicMock:
         result.setdefault("collection_name", "")
         return result
 
+    async def _get_best_run_id_for_collection(collection_name: str):
+        candidates = [
+            e for e in entries
+            if e.get("collection_name") == collection_name and e.get("run_id")
+        ]
+        if not candidates:
+            return None
+        best = max(candidates, key=lambda e: float(e.get("score", 0.0)))
+        return best["run_id"]
+
     log = MagicMock()
     log.get_recent = AsyncMock(return_value=entries)
     log.get_by_run_id = AsyncMock(side_effect=_get_by_run_id)
+    log.get_best_run_id_for_collection = AsyncMock(
+        side_effect=_get_best_run_id_for_collection
+    )
     return log
 
 

--- a/autobot-backend/services/knowledge/test_synthesis_provenance.py
+++ b/autobot-backend/services/knowledge/test_synthesis_provenance.py
@@ -373,3 +373,100 @@ class TestSynthesisLogEndpoint:
             client = TestClient(app)
             client.get("/knowledge/synthesis/log?limit=25")
             mock_get_recent.assert_called_once_with(limit=25)
+
+
+# ---------------------------------------------------------------------------
+# get_best_run_id_for_collection tests (Issue #4788)
+# ---------------------------------------------------------------------------
+
+
+class TestGetBestRunIdForCollection:
+    """Tests for SynthesisProvenanceLog.get_best_run_id_for_collection()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_entries(self):
+        """Returns None when the sorted set is empty."""
+        mock_redis = AsyncMock()
+        mock_redis.zrevrange = AsyncMock(return_value=[])
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            result = await svc.get_best_run_id_for_collection("kb_synthesis")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_top_run_id(self):
+        """Returns the decoded run_id at rank 0 of the sorted set."""
+        mock_redis = AsyncMock()
+        mock_redis.zrevrange = AsyncMock(return_value=[b"run-best"])
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            result = await svc.get_best_run_id_for_collection("kb_synthesis")
+        assert result == "run-best"
+        mock_redis.zrevrange.assert_called_once_with(
+            "kb:synthesis:best:kb_synthesis", 0, 0
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_redis_error(self):
+        """Returns None when Redis raises an exception."""
+        mock_redis = AsyncMock()
+        mock_redis.zrevrange = AsyncMock(side_effect=ConnectionError("Redis down"))
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            result = await svc.get_best_run_id_for_collection("kb_synthesis")
+        assert result is None
+
+
+class TestLogRunCollectionIndex:
+    """Tests that log_run maintains the kb:synthesis:best: sorted set."""
+
+    @pytest.mark.asyncio
+    async def test_zadd_called_when_collection_name_provided(self):
+        """log_run writes to the sorted set when collection_name is set."""
+        mock_redis = _make_redis_mock()
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            await svc.log_run(
+                run_id="run-1",
+                source_docs=[],
+                synthesis_ids=[],
+                llm_model="m",
+                prompt_template="t",
+                duration_ms=0,
+                collection_name="kb_synthesis",
+                score=0.75,
+            )
+        mock_redis._pipe.zadd.assert_called_once_with(
+            "kb:synthesis:best:kb_synthesis", {"run-1": 0.75}
+        )
+
+    @pytest.mark.asyncio
+    async def test_zadd_not_called_when_no_collection_name(self):
+        """log_run skips sorted set write when collection_name is empty."""
+        mock_redis = _make_redis_mock()
+        with patch(
+            "services.knowledge.synthesis_provenance.get_async_redis_client",
+            new=AsyncMock(return_value=mock_redis),
+        ):
+            svc = SynthesisProvenanceLog()
+            await svc.log_run(
+                run_id="run-1",
+                source_docs=[],
+                synthesis_ids=[],
+                llm_model="m",
+                prompt_template="t",
+                duration_ms=0,
+            )
+        mock_redis._pipe.zadd.assert_not_called()


### PR DESCRIPTION
Closes #4788

## Summary
- `get_best_ancestor()` was scanning 500 provenance stream entries per call — O(n) full scan
- Added `kb:synthesis:best:{collection_name}` Redis sorted set written atomically in `log_run()` pipeline
- Added `get_best_run_id_for_collection(collection_name)` → single `ZREVRANGE … 0 0` O(1) lookup
- `get_best_ancestor()` now uses two O(1) calls instead of 500-entry scan

## Tests
- 5 new tests: sorted set write in `log_run`, `get_best_run_id_for_collection` reads correct member
- 44 total lineage tests pass