### PR TITLE
fix(rag): store mesh components on app.state; build per-instance NeuralMeshRetriever (#4765)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -745,7 +745,7 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
     try:
         from services.graph_rag_service import GraphRAGService
         from services.rag_config import RAGConfig
-        from services.rag_service import RAGService, register_shared_mesh_retriever
+        from services.rag_service import RAGService, register_shared_mesh_components
 
         if app.state.knowledge_base:
             rag_config = RAGConfig(enable_advanced_rag=True, timeout_seconds=10.0)
@@ -754,8 +754,9 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
             )
             await rag_service.initialize()
 
-            # Wire NeuralMeshRetriever now that RAGService and the DB engine are ready.
-            # Issue #4724: was never wired despite the full mesh_brain/ implementation.
+            # Build mesh brain components and register them so every RAGService.initialize()
+            # can construct its OWN NeuralMeshRetriever with closures bound to its own
+            # optimizer — eliminating the shared-singleton coupling (#4765).
             try:
                 from autobot_shared.redis_client import get_async_redis_client
                 from knowledge.search_components.query_classifier import QueryClassifier
@@ -763,7 +764,6 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
                 from services.mesh_brain.edge_learner import EdgeLearner
                 from services.mesh_brain.mesh_db_adapter import create_mesh_db_adapter
                 from services.mesh_brain.ppr import PersonalizedPageRank
-                from services.neural_mesh_retriever import NeuralMeshRetriever
                 from user_management.database import get_async_engine
 
                 _mesh_db = create_mesh_db_adapter(get_async_engine())
@@ -771,64 +771,51 @@ async def _init_graph_rag_service(app: FastAPI, memory_graph):
                 _ppr = PersonalizedPageRank(db=_mesh_db)
                 _edge_learner = EdgeLearner(db=_mesh_db, redis=_redis)
 
-                async def _chroma_search(query: str, k: int) -> list:
-                    return await rag_service.optimizer._perform_semantic_search(
-                        query, limit=k
-                    )
+                _mesh_components = {
+                    "mesh_db": _mesh_db,
+                    "ppr": _ppr,
+                    "edge_learner": _edge_learner,
+                    "reranker": ResultReranker(),
+                    "classifier": QueryClassifier(),
+                    "llm": None,
+                }
 
-                async def _hybrid_search(query: str, top_k: int = 5) -> list:
-                    from advanced_rag_optimizer import RAGMetrics
-
-                    results = await rag_service.optimizer._retrieve_hybrid_results(
-                        query, RAGMetrics()
-                    )
-                    return results[:top_k]
-
-                rag_service._mesh_retriever = NeuralMeshRetriever(
-                    chroma_search=_chroma_search,
-                    hybrid_search=_hybrid_search,
-                    ppr=_ppr,
-                    edge_learner=_edge_learner,
-                    reranker=ResultReranker(),
-                    classifier=QueryClassifier(),
-                    mesh_db=_mesh_db,
-                    llm=None,
-                )
-                rag_config.mesh_retriever_enabled = True
-
-                # Register as shared singleton so ALL future RAGService.initialize() calls
-                # auto-wire without changes at each call site (#4757).
-                import services.rag_service as _rag_mod
-
-                register_shared_mesh_retriever(rag_service._mesh_retriever)
-
-                # Back-patch chat_workflow_manager's RAGService — it was created by
-                # set_knowledge_base() before this function ran (Phase 2 ordering).
-                _cwm = getattr(app.state, "chat_workflow_manager", None)
-                if _cwm is not None:
-                    _ks = getattr(_cwm, "knowledge_service", None)
-                    if _ks is not None and hasattr(_ks, "rag_service"):
-                        _ks.rag_service._mesh_retriever = rag_service._mesh_retriever
-                        _ks.rag_service.config.mesh_retriever_enabled = True
-                        logger.info(
-                            "Re-wired NeuralMeshRetriever into chat_workflow_manager RAGService (#4757)"
-                        )
-
-                # Back-patch get_rag_service() singleton if already created.
-                if _rag_mod._rag_service_instance is not None:
-                    _rag_mod._rag_service_instance._mesh_retriever = (
-                        rag_service._mesh_retriever
-                    )
-                    _rag_mod._rag_service_instance.config.mesh_retriever_enabled = True
-                    logger.info(
-                        "Re-wired NeuralMeshRetriever into get_rag_service() singleton (#4757)"
-                    )
+                # Store on app.state for introspection / health checks.
+                app.state.mesh_components = _mesh_components
 
                 # Expose mesh_db on app.state so _start_community_clustering_loop can use it (#4834).
                 app.state.mesh_db = _mesh_db
 
+                # Register components; each future RAGService.initialize() builds its own
+                # retriever from these, binding closures to its own optimizer (#4765).
+                register_shared_mesh_components(_mesh_components)
+
+                # Trigger re-initialization for already-created RAGService instances so they
+                # also build per-instance retrievers (covers chat_workflow_manager and the
+                # get_rag_service() singleton that were created before this point).
+                import services.rag_service as _rag_mod
+
+                for _existing in [
+                    _rag_mod._rag_service_instance,
+                    getattr(
+                        getattr(
+                            getattr(app.state, "chat_workflow_manager", None),
+                            "knowledge_service",
+                            None,
+                        ),
+                        "rag_service",
+                        None,
+                    ),
+                ]:
+                    if _existing is not None and _existing._mesh_retriever is None:
+                        _existing._initialized = False  # force re-init on next call
+                        logger.info(
+                            "Queued per-instance NeuralMeshRetriever build for existing RAGService (#4765)"
+                        )
+
                 logger.info(
-                    "✅ [ 87%] Neural Mesh RAG: NeuralMeshRetriever wired into RAGService (#4724)"
+                    "✅ [ 87%] Neural Mesh RAG: mesh components registered; "
+                    "per-instance NeuralMeshRetriever will build on next initialize() (#4765)"
                 )
             except Exception as _mesh_wire_err:
                 logger.warning(

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -26,6 +26,7 @@ from services.context_sufficiency import (
     SufficiencyVerdict,
     get_context_sufficiency_evaluator,
 )
+from services.neural_mesh_retriever import NeuralMeshRetriever
 from services.knowledge_base_adapter import KnowledgeBaseAdapter
 from services.rag_config import RAGConfig, get_rag_config
 from services.session_adaptive_reranker import get_session_adaptive_reranker
@@ -109,13 +110,36 @@ class RAGService:
 
             self._initialized = True
 
-            # Auto-wire shared NeuralMeshRetriever if registered and not already set (#4757).
-            # Covers per-request instances in knowledge_rag.py / knowledge_search.py and
-            # the chat_workflow manager's set_knowledge_base() path.
-            if self._mesh_retriever is None and _shared_mesh_retriever is not None:
-                self._mesh_retriever = _shared_mesh_retriever
-                self.config.mesh_retriever_enabled = True
-                logger.debug("Auto-wired shared NeuralMeshRetriever into RAGService instance")
+            # Build a per-instance NeuralMeshRetriever from shared components if not already
+            # set (#4765).  Each instance gets its OWN retriever so the search closures bind
+            # to THIS instance's optimizer — not to the GraphRAGService optimizer singleton.
+            if self._mesh_retriever is None and _shared_mesh_components is not None:
+                try:
+                    from advanced_rag_optimizer import RAGMetrics as _RAGMetrics
+
+                    _opt = self.optimizer
+
+                    async def _chroma(q: str, k: int) -> list:
+                        return await _opt._perform_semantic_search(q, limit=k)
+
+                    async def _hybrid(q: str, top_k: int = 5) -> list:
+                        results = await _opt._retrieve_hybrid_results(q, _RAGMetrics())
+                        return results[:top_k]
+
+                    self._mesh_retriever = NeuralMeshRetriever(
+                        chroma_search=_chroma,
+                        hybrid_search=_hybrid,
+                        **_shared_mesh_components,
+                    )
+                    self.config.mesh_retriever_enabled = True
+                    logger.debug(
+                        "Built per-instance NeuralMeshRetriever from shared components (#4765)"
+                    )
+                except Exception as _mesh_err:
+                    logger.warning(
+                        "Per-instance NeuralMeshRetriever build failed (non-fatal): %s",
+                        _mesh_err,
+                    )
 
             logger.info("AdvancedRAGOptimizer initialized successfully")
             return True
@@ -1153,22 +1177,49 @@ class RAGService:
         }
 
 
-# Shared NeuralMeshRetriever singleton — registered by lifespan at startup (#4757).
-# Auto-wired into every RAGService.initialize() call so ALL instances (per-request
-# API deps, chat_workflow manager, get_rag_service singleton) receive the mesh retriever
-# without requiring changes at every call site.
+# Shared mesh components — registered by lifespan at startup (#4765).
+# Each RAGService.initialize() builds its OWN NeuralMeshRetriever from these components so
+# the search closures are bound to THAT instance's optimizer, not to a shared singleton.
+_shared_mesh_components: Optional[Dict[str, Any]] = None
+
+
+def register_shared_mesh_components(components: Dict[str, Any]) -> None:
+    """Register mesh brain components for per-instance NeuralMeshRetriever construction.
+
+    Called once by lifespan._init_graph_rag_service().  Every subsequent
+    RAGService.initialize() builds its own retriever with closures bound to its
+    own optimizer (#4765).
+
+    Args:
+        components: dict with keys mesh_db, ppr, edge_learner, reranker, classifier.
+    """
+    global _shared_mesh_components
+    _shared_mesh_components = components
+    logger.info("Mesh brain components registered for per-instance retriever (#4765)")
+
+
+def get_shared_mesh_components() -> Optional[Dict[str, Any]]:
+    """Return the registered mesh components, or None if not yet registered."""
+    return _shared_mesh_components
+
+
+# ---------------------------------------------------------------------------
+# Legacy singleton kept for backward compatibility — no longer used by
+# RAGService.initialize() (replaced by per-instance build from components above).
+# Retained so external callers importing this symbol don't break.
+# ---------------------------------------------------------------------------
 _shared_mesh_retriever: Optional[Any] = None
 
 
 def register_shared_mesh_retriever(retriever: Any) -> None:
-    """Register NeuralMeshRetriever for auto-wiring into all future RAGService instances.
+    """Deprecated: register a pre-built retriever singleton.
 
-    Called once by lifespan._init_graph_rag_service() after the retriever is built.
-    Every subsequent RAGService.initialize() will pick it up automatically.
+    Kept for backward compatibility.  Prefer register_shared_mesh_components()
+    so each RAGService gets its own retriever bound to its own optimizer (#4765).
     """
     global _shared_mesh_retriever
     _shared_mesh_retriever = retriever
-    logger.info("NeuralMeshRetriever registered as shared singleton (#4757)")
+    logger.info("NeuralMeshRetriever registered as shared singleton (legacy #4757)")
 
 
 # Global service instance (lazily initialized per knowledge base)

--- a/autobot-backend/services/rag_service_mesh_test.py
+++ b/autobot-backend/services/rag_service_mesh_test.py
@@ -195,7 +195,7 @@ class TestSharedMeshComponentsPerInstanceBuild:
         """initialize() builds a fresh NeuralMeshRetriever bound to this instance's optimizer."""
         from services.rag_service import RAGService, register_shared_mesh_components
         from services.rag_config import RAGConfig
-        from unittest.mock import patch, AsyncMock, call
+        from unittest.mock import patch, AsyncMock
 
         register_shared_mesh_components(self._make_components())
 

--- a/autobot-backend/services/rag_service_mesh_test.py
+++ b/autobot-backend/services/rag_service_mesh_test.py
@@ -164,30 +164,40 @@ class TestMeshFlagEnabledRetrieverNone:
 
 
 # =============================================================================
-# Test: register_shared_mesh_retriever auto-wires on initialize() (#4757)
+# Test: register_shared_mesh_components builds per-instance retriever (#4765)
 # =============================================================================
 
 
-class TestSharedMeshRetrieverAutoWire:
+class TestSharedMeshComponentsPerInstanceBuild:
+    """Per-instance NeuralMeshRetriever is built from shared components (#4765)."""
+
     def setup_method(self):
-        """Clear shared singleton before each test to avoid cross-test contamination."""
         import services.rag_service as _mod
-        self._orig = _mod._shared_mesh_retriever
-        _mod._shared_mesh_retriever = None
+        self._orig = _mod._shared_mesh_components
+        _mod._shared_mesh_components = None
 
     def teardown_method(self):
         import services.rag_service as _mod
-        _mod._shared_mesh_retriever = self._orig
+        _mod._shared_mesh_components = self._orig
+
+    def _make_components(self):
+        return {
+            "mesh_db": MagicMock(name="mesh_db"),
+            "ppr": MagicMock(name="ppr"),
+            "edge_learner": MagicMock(name="edge_learner"),
+            "reranker": MagicMock(name="reranker"),
+            "classifier": MagicMock(name="classifier"),
+            "llm": None,
+        }
 
     @pytest.mark.asyncio
-    async def test_register_then_initialize_wires_retriever(self):
-        """RAGService.initialize() picks up the shared singleton when _mesh_retriever is None."""
-        from services.rag_service import RAGService, register_shared_mesh_retriever
+    async def test_builds_per_instance_retriever_on_initialize(self):
+        """initialize() builds a fresh NeuralMeshRetriever bound to this instance's optimizer."""
+        from services.rag_service import RAGService, register_shared_mesh_components
         from services.rag_config import RAGConfig
-        from unittest.mock import patch, AsyncMock
+        from unittest.mock import patch, AsyncMock, call
 
-        sentinel = MagicMock(name="NeuralMeshRetriever")
-        register_shared_mesh_retriever(sentinel)
+        register_shared_mesh_components(self._make_components())
 
         svc = RAGService.__new__(RAGService)
         svc._initialized = False
@@ -198,7 +208,9 @@ class TestSharedMeshRetrieverAutoWire:
         svc.kb_adapter = MagicMock()
         svc.kb_adapter.kb = MagicMock()
 
-        with patch("services.rag_service.AdvancedRAGOptimizer") as MockOpt:
+        built_retriever = MagicMock(name="built_NeuralMeshRetriever")
+        with patch("services.rag_service.AdvancedRAGOptimizer") as MockOpt, \
+             patch("services.rag_service.NeuralMeshRetriever", return_value=built_retriever) as MockNMR:
             mock_opt = MagicMock()
             mock_opt.initialize = AsyncMock(return_value=True)
             MockOpt.return_value = mock_opt
@@ -206,19 +218,68 @@ class TestSharedMeshRetrieverAutoWire:
             result = await svc.initialize()
 
         assert result is True
-        assert svc._mesh_retriever is sentinel
+        assert MockNMR.called, "NeuralMeshRetriever should have been instantiated"
+        # chroma_search and hybrid_search closures must be present
+        kwargs = MockNMR.call_args.kwargs
+        assert callable(kwargs.get("chroma_search")), "chroma_search closure missing"
+        assert callable(kwargs.get("hybrid_search")), "hybrid_search closure missing"
+        assert svc._mesh_retriever is built_retriever
         assert svc.config.mesh_retriever_enabled is True
 
     @pytest.mark.asyncio
-    async def test_already_set_retriever_not_overwritten(self):
-        """An existing _mesh_retriever is not replaced by the shared singleton."""
-        from services.rag_service import RAGService, register_shared_mesh_retriever
+    async def test_two_instances_get_independent_retrievers(self):
+        """Two RAGService instances each get their own NeuralMeshRetriever."""
+        from services.rag_service import RAGService, register_shared_mesh_components
         from services.rag_config import RAGConfig
         from unittest.mock import patch, AsyncMock
 
+        register_shared_mesh_components(self._make_components())
+
+        def _make_svc():
+            svc = RAGService.__new__(RAGService)
+            svc._initialized = False
+            svc._cache = {}
+            svc._cache_lock = MagicMock()
+            svc.config = RAGConfig()
+            svc._mesh_retriever = None
+            svc.kb_adapter = MagicMock()
+            svc.kb_adapter.kb = MagicMock()
+            return svc
+
+        svc1, svc2 = _make_svc(), _make_svc()
+
+        call_count = {"n": 0}
+        retrievers = []
+
+        def _fake_nmr(**kwargs):
+            r = MagicMock(name=f"retriever_{call_count['n']}")
+            call_count["n"] += 1
+            retrievers.append(r)
+            return r
+
+        with patch("services.rag_service.AdvancedRAGOptimizer") as MockOpt, \
+             patch("services.rag_service.NeuralMeshRetriever", side_effect=_fake_nmr):
+            mock_opt = MagicMock()
+            mock_opt.initialize = AsyncMock(return_value=True)
+            MockOpt.return_value = mock_opt
+
+            await svc1.initialize()
+            await svc2.initialize()
+
+        assert len(retrievers) == 2, "Expected two distinct NeuralMeshRetriever instances"
+        assert retrievers[0] is not retrievers[1], "Instances should be independent"
+        assert svc1._mesh_retriever is not svc2._mesh_retriever
+
+    @pytest.mark.asyncio
+    async def test_already_set_retriever_not_overwritten(self):
+        """An existing _mesh_retriever is NOT replaced even when components are registered."""
+        from services.rag_service import RAGService, register_shared_mesh_components
+        from services.rag_config import RAGConfig
+        from unittest.mock import patch, AsyncMock
+
+        register_shared_mesh_components(self._make_components())
+
         existing = MagicMock(name="existing_retriever")
-        shared = MagicMock(name="shared_retriever")
-        register_shared_mesh_retriever(shared)
 
         svc = RAGService.__new__(RAGService)
         svc._initialized = False
@@ -230,11 +291,44 @@ class TestSharedMeshRetrieverAutoWire:
         svc.kb_adapter = MagicMock()
         svc.kb_adapter.kb = MagicMock()
 
-        with patch("services.rag_service.AdvancedRAGOptimizer") as MockOpt:
+        with patch("services.rag_service.AdvancedRAGOptimizer") as MockOpt, \
+             patch("services.rag_service.NeuralMeshRetriever") as MockNMR:
             mock_opt = MagicMock()
             mock_opt.initialize = AsyncMock(return_value=True)
             MockOpt.return_value = mock_opt
 
             await svc.initialize()
 
-        assert svc._mesh_retriever is existing  # not replaced
+        MockNMR.assert_not_called()
+        assert svc._mesh_retriever is existing
+
+    @pytest.mark.asyncio
+    async def test_no_components_no_retriever_built(self):
+        """If components are not registered, no retriever is built."""
+        from services.rag_service import RAGService
+        from services.rag_config import RAGConfig
+        from unittest.mock import patch, AsyncMock
+
+        # _shared_mesh_components is None (cleared in setup_method)
+
+        svc = RAGService.__new__(RAGService)
+        svc._initialized = False
+        svc._cache = {}
+        svc._cache_lock = MagicMock()
+        svc.config = RAGConfig()
+        svc._mesh_retriever = None
+        svc.kb_adapter = MagicMock()
+        svc.kb_adapter.kb = MagicMock()
+
+        with patch("services.rag_service.AdvancedRAGOptimizer") as MockOpt, \
+             patch("services.rag_service.NeuralMeshRetriever") as MockNMR:
+            mock_opt = MagicMock()
+            mock_opt.initialize = AsyncMock(return_value=True)
+            MockOpt.return_value = mock_opt
+
+            result = await svc.initialize()
+
+        assert result is True
+        MockNMR.assert_not_called()
+        assert svc._mesh_retriever is None
+        assert svc.config.mesh_retriever_enabled is False


### PR DESCRIPTION
Closes #4765

## Summary
- Shared `NeuralMeshRetriever` singleton had search closures permanently bound to `GraphRAGService`'s optimizer — breaking per-instance KB semantics
- Refactored: `lifespan.py` now stores mesh **components** on `app.state` via `register_shared_mesh_components()`
- `RAGService.initialize()` builds its own `NeuralMeshRetriever` with closures bound to `self.optimizer` — each instance gets isolated KB search
- Kept `register_shared_mesh_retriever()` as deprecated no-op for backward compat

## Tests
- `TestSharedMeshComponentsPerInstanceBuild`: per-instance build happens, two instances get independent retrievers, existing retriever preserved, no-components leaves retriever None
- 10/10 rag_service_mesh tests pass