### PR TITLE
feat(kb): DocIndexerService.search() merges autobot_docs into RAGService (#4953)

### DIFF
--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -1160,6 +1160,64 @@ class DocIndexerService:
 
         return total_result
 
+    async def search(self, query: str, n_results: int = 5) -> List[Any]:
+        """Query the autobot_docs ChromaDB collection.
+
+        Issue #4953: expose doc search so RAGService can merge results with
+        the main KB, giving the agent access to AutoBot's own documentation.
+
+        Returns SearchResult objects (from advanced_rag_optimizer).
+        Returns an empty list if not initialised, collection is empty, or on
+        any error — callers always receive a safe (possibly empty) list.
+        """
+        import asyncio
+
+        from advanced_rag_optimizer import SearchResult
+
+        if not self._initialized or self._collection is None or self._embed_model is None:
+            return []
+
+        doc_count = self._collection.count()
+        if doc_count == 0:
+            return []
+
+        k = min(n_results, doc_count)
+        try:
+            embedding: list = await asyncio.to_thread(
+                self._embed_model.get_text_embedding, query
+            )
+            raw = await asyncio.to_thread(
+                self._collection.query,
+                query_embeddings=[embedding],
+                n_results=k,
+                include=["documents", "metadatas", "distances"],
+            )
+        except Exception as exc:
+            logger.warning("autobot_docs search failed: %s", exc)
+            return []
+
+        documents = raw.get("documents", [[]])[0]
+        metadatas = raw.get("metadatas", [[]])[0]
+        distances = raw.get("distances", [[]])[0]
+
+        results = []
+        for i, (doc, meta, dist) in enumerate(zip(documents, metadatas, distances)):
+            # ChromaDB cosine distance → similarity score
+            score = max(0.0, 1.0 - dist)
+            results.append(
+                SearchResult(
+                    content=doc or "",
+                    metadata={**meta, "source": "autobot_docs"},
+                    semantic_score=score,
+                    keyword_score=0.0,
+                    hybrid_score=score,
+                    relevance_rank=i,
+                    source_path=meta.get("file_path", ""),
+                    chunk_index=int(meta.get("chunk_index", i)),
+                )
+            )
+        return results
+
 
 # ============================================================================
 # SINGLETON

--- a/autobot-backend/services/knowledge/test_doc_indexer.py
+++ b/autobot-backend/services/knowledge/test_doc_indexer.py
@@ -1411,3 +1411,89 @@ class TestFindCollectionConfig:
         svc = self._make_svc([col1, col2])
         result = svc._find_collection_config(["docs/guide.md", "api/ref.md"])
         assert result is col1
+
+
+# ---------------------------------------------------------------------------
+# Tests: DocIndexerService.search() — Issue #4953
+# ---------------------------------------------------------------------------
+
+
+class TestDocIndexerSearch:
+    """search() exposes autobot_docs ChromaDB collection for RAGService merging."""
+
+    @pytest.mark.asyncio
+    async def test_search_not_initialized_returns_empty(self):
+        """Returns [] when service is not initialised."""
+        svc = _make_service(initialized=False, collection_count=0)
+        result = await svc.search("what is autobot")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_search_empty_collection_returns_empty(self):
+        """Returns [] when collection has no documents."""
+        svc = _make_service(initialized=True, collection_count=0)
+        result = await svc.search("what is autobot")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_search_returns_search_results(self):
+        """Happy path: wraps ChromaDB hits into SearchResult objects."""
+        svc = _make_service(initialized=True, collection_count=3)
+        svc._collection.query = MagicMock(
+            return_value={
+                "documents": [["AutoBot is an AI platform.", "CLI usage guide."]],
+                "metadatas": [
+                    [
+                        {"file_path": "docs/overview.md", "chunk_index": 0},
+                        {"file_path": "docs/cli.md", "chunk_index": 1},
+                    ]
+                ],
+                "distances": [[0.1, 0.3]],
+            }
+        )
+
+        stub_mod = MagicMock()
+        stub_mod.SearchResult = MagicMock(side_effect=lambda **kw: kw)
+
+        with patch.dict("sys.modules", {"advanced_rag_optimizer": stub_mod}):
+            results = await svc.search("what is autobot", n_results=2)
+
+        assert len(results) == 2
+        first = results[0]
+        assert first["content"] == "AutoBot is an AI platform."
+        assert first["semantic_score"] == pytest.approx(0.9)
+        assert first["source_path"] == "docs/overview.md"
+        assert first["metadata"]["source"] == "autobot_docs"
+
+    @pytest.mark.asyncio
+    async def test_search_caps_n_results_to_collection_count(self):
+        """n_results is capped to avoid ChromaDB 'n_results > count' error."""
+        svc = _make_service(initialized=True, collection_count=2)
+        svc._collection.query = MagicMock(
+            return_value={
+                "documents": [["doc1", "doc2"]],
+                "metadatas": [[{"file_path": "a.md"}, {"file_path": "b.md"}]],
+                "distances": [[0.2, 0.4]],
+            }
+        )
+
+        stub_mod = MagicMock()
+        stub_mod.SearchResult = MagicMock(side_effect=lambda **kw: kw)
+        with patch.dict("sys.modules", {"advanced_rag_optimizer": stub_mod}):
+            await svc.search("query", n_results=100)
+
+        call_kwargs = svc._collection.query.call_args[1]
+        assert call_kwargs["n_results"] == 2  # capped to collection count
+
+    @pytest.mark.asyncio
+    async def test_search_exception_returns_empty(self):
+        """query() failure returns [] instead of raising."""
+        svc = _make_service(initialized=True, collection_count=5)
+        svc._collection.query = MagicMock(side_effect=RuntimeError("chromadb unavailable"))
+
+        stub_mod = MagicMock()
+        stub_mod.SearchResult = MagicMock(side_effect=lambda **kw: kw)
+        with patch.dict("sys.modules", {"advanced_rag_optimizer": stub_mod}):
+            result = await svc.search("query")
+
+        assert result == []

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -763,6 +763,25 @@ class RAGService:
             self.optimizer.hybrid_weight_semantic = _prev_semantic
             self.optimizer.hybrid_weight_keyword = _prev_keyword  # type: ignore[assignment]
 
+        # Issue #4953: merge autobot_docs results when category is requested or
+        # no category filter is active (search-all).
+        if categories is None or "autobot_docs" in categories:
+            try:
+                from services.knowledge.doc_indexer import get_doc_indexer_service
+
+                doc_svc = get_doc_indexer_service()
+                if doc_svc._initialized:
+                    doc_results = await doc_svc.search(query, n_results=max_results)
+                    if doc_results:
+                        combined = results + doc_results
+                        combined.sort(key=lambda r: r.hybrid_score, reverse=True)
+                        results = combined[:max_results]
+                        logger.debug(
+                            "autobot_docs merged %d result(s) into search", len(doc_results)
+                        )
+            except Exception as _doc_exc:
+                logger.debug("autobot_docs search skipped: %s", _doc_exc)
+
         # Issue #4689: filter chunks whose source_path is absent from the hash cache
         # (file was removed/moved since last index run).
         results = await self._filter_stale_chunks(results)


### PR DESCRIPTION
## Summary

- Adds `DocIndexerService.search(query, n_results)` — embeds query with Ollama `nomic-embed-text`, queries the `autobot_docs` ChromaDB collection, returns `SearchResult` objects (score = 1 − cosine distance)
- Extends `RAGService.advanced_search()` to call `doc_svc.search()` and merge results by `hybrid_score` when `categories=None` or `"autobot_docs"` is in the requested categories
- Doc results are capped to `max_results` after merging and flow through `_filter_stale_chunks` identically to main-KB results
- `source_path` is set from `metadata["file_path"]` so the stale-chunk filter resolves correctly against the DocIndexer hash cache

## Test plan
- [x] 5 new unit tests in `test_doc_indexer.py::TestDocIndexerSearch`: not-initialised guard, empty-collection guard, happy-path SearchResult fields, n_results capping, query-exception fallback
- [x] All 77 tests in `test_doc_indexer.py` pass
- [x] `py_compile` clean on both modified files

Closes #4953