### PR TITLE
fix(rag): guard metadata None and clamp hybrid_score to [0,1] in _deduplicate_and_rank (#4939 #4943)

### DIFF
--- a/autobot-backend/services/graph_rag_service.py
+++ b/autobot-backend/services/graph_rag_service.py
@@ -471,10 +471,10 @@ class GraphRAGService:
         # ranking so that graph-expanded results with "extracted" relations rank
         # above "ambiguous" ones when base scores are equal.
         for r in deduplicated:
-            prov = r.metadata.get("source_provenance") if hasattr(r, "metadata") else None
+            prov = r.metadata.get("source_provenance") if r.metadata else None
             adjustment = provenance_adjustment(prov)
             if adjustment != 0.0:
-                r.hybrid_score = r.hybrid_score + adjustment
+                r.hybrid_score = min(1.0, max(0.0, r.hybrid_score + adjustment))
 
         final_results = self._assign_relevance_ranks(deduplicated, max_results)
 

--- a/autobot-backend/services/graph_rag_service_test.py
+++ b/autobot-backend/services/graph_rag_service_test.py
@@ -668,3 +668,65 @@ async def test_deduplicate_and_rank_no_provenance_unchanged(graph_rag_service):
     assert len(ranked) == 1
     # No adjustment for missing provenance (0.0 delta skipped)
     assert ranked[0].hybrid_score == 0.7
+
+
+@pytest.mark.asyncio
+async def test_metadata_none_does_not_raise(graph_rag_service):
+    """Result with metadata=None passes through _deduplicate_and_rank without AttributeError (#4939)."""
+    result = SearchResult(
+        content="Graph entity F",
+        metadata=None,
+        semantic_score=0.0,
+        keyword_score=0.0,
+        hybrid_score=0.5,
+        relevance_rank=0,
+        source_path="graph:F",
+        chunk_index=0,
+    )
+
+    # Must not raise AttributeError
+    ranked = await graph_rag_service._deduplicate_and_rank([result], max_results=10)
+
+    assert len(ranked) == 1
+    # No provenance adjustment applied when metadata is None
+    assert ranked[0].hybrid_score == 0.5
+
+
+@pytest.mark.asyncio
+async def test_hybrid_score_clamped_at_1_0(graph_rag_service):
+    """hybrid_score + provenance boost is clamped at 1.0 (#4943)."""
+    result = SearchResult(
+        content="Graph entity G",
+        metadata={"source_provenance": "extracted"},
+        semantic_score=0.0,
+        keyword_score=0.0,
+        hybrid_score=0.98,
+        relevance_rank=0,
+        source_path="graph:G",
+        chunk_index=0,
+    )
+
+    ranked = await graph_rag_service._deduplicate_and_rank([result], max_results=10)
+
+    assert len(ranked) == 1
+    assert ranked[0].hybrid_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_hybrid_score_clamped_at_0_0(graph_rag_service):
+    """hybrid_score + provenance penalty is clamped at 0.0 (#4943)."""
+    result = SearchResult(
+        content="Graph entity H",
+        metadata={"source_provenance": "ambiguous"},
+        semantic_score=0.0,
+        keyword_score=0.0,
+        hybrid_score=0.02,
+        relevance_rank=0,
+        source_path="graph:H",
+        chunk_index=0,
+    )
+
+    ranked = await graph_rag_service._deduplicate_and_rank([result], max_results=10)
+
+    assert len(ranked) == 1
+    assert ranked[0].hybrid_score >= 0.0


### PR DESCRIPTION
Closes #4939
Closes #4943

## Summary
Two bugs in `_deduplicate_and_rank` from the #4914 provenance fix:

**Bug 1 (#4939):** `r.metadata.get('source_provenance')` raised `AttributeError` when `r.metadata is None` — the `hasattr` guard was always True (field always exists). Fixed to `if r.metadata else None`.

**Bug 2 (#4943):** `r.hybrid_score + adjustment` (±0.05) could exceed [0.0, 1.0]. Fixed with `min(1.0, max(0.0, ...))`.

## Tests
- `test_metadata_none_does_not_raise` — metadata=None passes through without error
- `test_hybrid_score_clamped_at_1_0` — score 0.98 + 0.05 clamps to 1.0
- `test_hybrid_score_clamped_at_0_0` — score 0.02 - 0.05 clamps to 0.0
- 8/8 provenance tests pass