### PR TITLE
fix(knowledge): set _running=True during loop execution so re-init guard is effective (#4937)

### DIFF
--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -371,6 +371,7 @@ class AutonomousLoopOrchestrator:
         started_at = datetime.now(timezone.utc).isoformat()
         logger.info("AutonomousLoop: starting run %s (dry_run=%s)", run_id, self.dry_run)
 
+        self._running = True
         record = LoopRunRecord(
             run_id=run_id,
             started_at=started_at,
@@ -429,6 +430,9 @@ class AutonomousLoopOrchestrator:
         except Exception:
             logger.exception("AutonomousLoop: run %s failed", run_id)
             record.error = "unexpected_error"
+
+        finally:
+            self._running = False
 
         record.finished_at = datetime.now(timezone.utc).isoformat()
         self._history.append(record)

--- a/autobot-backend/services/knowledge/test_autonomous_loop.py
+++ b/autobot-backend/services/knowledge/test_autonomous_loop.py
@@ -23,6 +23,7 @@ from services.knowledge.autonomous_loop import (
     LoopRunRecord,
     LoopStatus,
     _DEFAULT_PROMOTION_THRESHOLD,
+    get_loop_orchestrator,
 )
 
 
@@ -598,3 +599,92 @@ async def test_restore_state_graceful_on_redis_failure():
         await orch.restore_state()  # must not raise
 
     assert orch._pending_approval is None
+
+
+# ---------------------------------------------------------------------------
+# _running flag — Issue #4937
+# ---------------------------------------------------------------------------
+
+
+def test_running_starts_false():
+    """_running is False immediately after construction."""
+    orch = _make_orchestrator()
+    assert orch._running is False
+
+
+@pytest.mark.asyncio
+async def test_running_true_during_run_once(monkeypatch):
+    """_running is True while run_once() is executing."""
+    orch = _make_orchestrator()
+    running_during = []
+
+    async def fake_phase_learn(_run_id):
+        running_during.append(orch._running)
+        raise RuntimeError("stop early")
+
+    monkeypatch.setattr(orch, "_phase_learn", fake_phase_learn)
+    with patch(
+        "services.knowledge.autonomous_loop.get_async_redis_client",
+        new=AsyncMock(return_value=None),
+    ):
+        await orch.run_once()
+
+    assert running_during == [True], "_running must be True inside run_once"
+
+
+@pytest.mark.asyncio
+async def test_running_false_after_run_once():
+    """_running is reset to False after run_once() completes."""
+    orch = _make_orchestrator()
+
+    with patch.object(orch, "_phase_learn", new=AsyncMock(side_effect=RuntimeError("abort"))):
+        with patch(
+            "services.knowledge.autonomous_loop.get_async_redis_client",
+            new=AsyncMock(return_value=None),
+        ):
+            await orch.run_once()
+
+    assert orch._running is False
+
+
+@pytest.mark.asyncio
+async def test_get_loop_orchestrator_returns_singleton_when_running():
+    """get_loop_orchestrator() returns existing instance when _running=True."""
+    import services.knowledge.autonomous_loop as mod
+
+    original = mod._loop_orchestrator
+    try:
+        existing = _make_orchestrator()
+        existing._running = True
+        mod._loop_orchestrator = existing
+
+        result = await get_loop_orchestrator(llm_service=MagicMock())
+        assert result is existing
+    finally:
+        mod._loop_orchestrator = original
+
+
+@pytest.mark.asyncio
+async def test_get_loop_orchestrator_replaces_when_not_running():
+    """get_loop_orchestrator() replaces the singleton when _running=False."""
+    import services.knowledge.autonomous_loop as mod
+
+    original = mod._loop_orchestrator
+    try:
+        existing = _make_orchestrator()
+        existing._running = False
+        existing._llm = None  # triggers the None-llm replacement path
+        mod._loop_orchestrator = existing
+
+        new_llm = MagicMock()
+        with patch.object(
+            AutonomousLoopOrchestrator,
+            "restore_state",
+            new=AsyncMock(),
+        ):
+            result = await get_loop_orchestrator(llm_service=new_llm)
+
+        assert result is not existing
+        assert result._llm is new_llm
+    finally:
+        mod._loop_orchestrator = original


### PR DESCRIPTION
Closes #4937

## Summary
- `_running` flag was never set to `True`, making the `get_loop_orchestrator()` guard from #4917 always ineffective
- `run_once()` now sets `self._running = True` immediately before the run and resets to `False` in a `finally` block
- Guard in `get_loop_orchestrator()` now correctly returns the existing singleton when a run is active

## Tests
- 5 new tests: flag starts False, flag is True during run, flag resets after completion (including exception path), singleton returned when running, replacement allowed when not running
- 32 total tests pass