### PR TITLE
fix(scheduler): normalize day-7 in range-step tokens like '1-7/2' in _normalize_dow_field (#4944)

### DIFF
--- a/autobot-backend/services/trigger_service.py
+++ b/autobot-backend/services/trigger_service.py
@@ -258,11 +258,20 @@ def _normalize_dow_field(field: str) -> str:
     """Normalize day-of-week: replace 7 with 0 (both mean Sunday).
 
     Handles scalars (7->0), lists (0,7->0,0), ranges (1-7->1-6,0),
-    and steps (*/7 left unchanged -- step-of-7 is unusual but valid).
+    range-steps (1-7/2->1-6/2,0), and steps (*/7 left unchanged).
     """
     import re
 
     def _replace_token(token: str) -> str:
+        # Range-step like "1-7/2" or "5-7/2"
+        m = re.fullmatch(r"(\d+)-(\d+)/(\d+)", token)
+        if m:
+            lo, hi, step = int(m.group(1)), int(m.group(2)), m.group(3)
+            if hi == 7:
+                if lo == 0:
+                    return f"0-6/{step}"
+                return f"{lo}-6/{step},0"  # wrap: range excludes 7, add Sunday(0)
+            return token
         # Range like "1-7" or "0-7"
         m = re.fullmatch(r"(\d+)-(\d+)", token)
         if m:

--- a/autobot-backend/services/trigger_service_test.py
+++ b/autobot-backend/services/trigger_service_test.py
@@ -174,6 +174,25 @@ class TestValidateCronExpression:
         # "0,7" should be normalised to "0,0" (both Sunday) and accepted
         assert validate_cron_expression("0 0 * * 0,7") is True
 
+    def test_dow_range_step_1_to_7_accepted(self) -> None:
+        # "1-7/2" — range-step spanning Sunday; must be normalised and accepted
+        assert validate_cron_expression("0 0 * * 1-7/2") is True
+
+    def test_dow_range_step_5_to_7_accepted(self) -> None:
+        # "5-7/2" — range-step ending on 7; must be normalised and accepted
+        assert validate_cron_expression("0 0 * * 5-7/2") is True
+
+    def test_dow_range_step_1_to_7_fires_on_sunday(self) -> None:
+        # "0 0 * * 1-7/2" fires Mon(1), Wed(3), Fri(5), Sun(0/7)
+        # Saturday base → next fire should be Sunday
+        base = datetime(2025, 6, 7, 23, 0, 0, tzinfo=timezone.utc)  # Saturday
+        nxt = next_cron_run("0 0 * * 1-7/2", after=base)
+        assert nxt.weekday() == 6, f"Expected Sunday (weekday=6), got weekday={nxt.weekday()}"
+
+    def test_dow_range_step_0_to_7_accepted(self) -> None:
+        # "0-7/2" — range-step from 0 to 7 with step; must be normalised and accepted
+        assert validate_cron_expression("0 0 * * 0-7/2") is True
+
 
 class TestNextCronRun:
     def test_every_minute_advances_by_one(self) -> None:


### PR DESCRIPTION
Closes #4944

## Summary
- `_normalize_dow_field` handled scalars (`7→0`) and pure ranges (`1-7→1-6,0`) but not range-step tokens like `1-7/2` or `5-7/2`
- Added `lo-7/step → lo-6/step,0` rewrite in `_replace_token` for range-step patterns
- `next_cron_run("0 0 * * 1-7/2")` now correctly includes Sunday

## Tests
- 4 new tests: `1-7/2` accepted, `5-7/2` accepted, `0-7/2` accepted, end-to-end Sunday firing
- 57 total trigger_service tests pass