### PR TITLE
fix(mesh): correct graspologic ImportError log message — no restart needed after #4924 (#4936)

### DIFF
--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -1281,8 +1281,8 @@ async def _start_community_clustering_loop(app: FastAPI) -> None:
                 )
             except ImportError as exc:
                 logger.warning(
-                    "graspologic not installed — community clustering disabled. "
-                    "Install graspologic and restart to enable. Retrying in 24h. Error: %s",
+                    "graspologic not installed — community clustering paused. "
+                    "Install with: pip install graspologic. Retrying in 24h. Error: %s",
                     exc,
                 )
                 await asyncio.sleep(

--- a/autobot-backend/services/mesh_brain/community_clusterer_test.py
+++ b/autobot-backend/services/mesh_brain/community_clusterer_test.py
@@ -236,8 +236,8 @@ async def test_loop_body_logs_warning_and_sleeps_on_import_error(caplog):
         except ImportError as exc:
             import logging as _logging
             _logging.getLogger(__name__).warning(
-                "graspologic not installed — community clustering disabled. "
-                "Install graspologic and restart to enable. Retrying in 24h. Error: %s",
+                "graspologic not installed — community clustering paused. "
+                "Install with: pip install graspologic. Retrying in 24h. Error: %s",
                 exc,
             )
             slept_seconds.append(86400)


### PR DESCRIPTION
Closes #4936

## Summary
- After #4924 changed the ImportError handler to retry in 24h instead of permanently exiting, the log message still said "restart to enable" — giving operators incorrect recovery instructions
- Changed to "Install with: pip install graspologic. Retrying in 24h."
- Updated matching string in community_clusterer_test.py

## Tests
- Existing test assertions still pass with updated message