### PR TITLE
fix(frontend): remove stale /desktop nav entry and fix chat layout overflow (#4966)

### DIFF
--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -376,7 +376,7 @@
     <OfflineBanner />
 
     <!-- Main Content Area with Router -->
-    <main id="main-content" class="flex-1 overflow-hidden" role="main">
+    <main id="main-content" class="flex-1 min-h-0 overflow-hidden" role="main">
       <!-- Unified Loading System -->
       <UnifiedLoadingView
         loading-key="app-main"
@@ -804,8 +804,7 @@ export default {
       // Issue #4703: Agent Registry — backend + specialized agent dashboard
       { to: '/agents/registry', labelKey: 'nav.agentRegistry', icon: 'M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18', iconStroke: true },
       // Code Intelligence removed from main nav — merged into /analytics/codebase
-      // Issue #4704: Desktop re-wired as /desktop route (DesktopView.vue); nav entry restored here (#4778)
-      { to: '/desktop', labelKey: 'nav.desktop', icon: 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z', iconStroke: true },
+      // Desktop nav removed — noVNC lives in the Chat tab. /desktop redirects to /chat.
       // Issue #902: Dev Tools moved into /analytics/dev-tools tab
       // Issue #4492: Custom Dashboard renamed to /home (removed separate nav entry)
       { to: '/preferences', labelKey: 'nav.preferences', icon: 'M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z', iconRule: 'evenodd' },

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -46,7 +46,7 @@
       </Transition>
 
       <!-- Main Chat Area -->
-      <div class="flex-1 flex flex-col min-w-0 relative">
+      <div class="flex-1 flex flex-col min-w-0 min-h-0 relative overflow-hidden">
 
         <!-- Chat Header (Sticky at top) -->
         <ChatHeader

--- a/autobot-frontend/src/components/chat/ChatTabContent.vue
+++ b/autobot-frontend/src/components/chat/ChatTabContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex-1 flex flex-col relative">
+  <div class="flex-1 flex flex-col min-h-0 relative overflow-hidden">
     <!-- Chat Tab Content - Content scrolls, input stays sticky -->
     <div v-if="activeTab === 'chat'" class="flex-1 flex flex-col min-h-0">
       <div class="flex-1 min-h-0 overflow-y-auto">

--- a/autobot-frontend/src/router/index.ts
+++ b/autobot-frontend/src/router/index.ts
@@ -634,19 +634,9 @@ const routes: RouteRecordRaw[] = [
       admin: true,
     },
   },
-  // Issue #4704: Wire DesktopView.vue as /desktop route — re-enables direct desktop access
-  // Issue #4491 removed from router; re-wired here so DesktopView.vue is not orphaned
-  {
-    path: '/desktop',
-    name: 'desktop',
-    component: () => import('@/views/DesktopView.vue'),
-    meta: {
-      title: 'Desktop',
-      icon: 'fas fa-desktop',
-      description: 'Remote desktop via VNC/noVNC',
-      requiresAuth: true,
-    },
-  },
+  // /desktop removed from nav — noVNC is accessible via the Chat tab's noVNC tab.
+  // Redirect any bookmarked /desktop URLs to /chat.
+  { path: '/desktop', redirect: '/chat' },
   // Issue #3502: Custom Dashboard renamed to /home (see home route above)
 
   // Issue #729: Infrastructure routes redirected to slm-admin


### PR DESCRIPTION
Closes #4966

## Summary
- GUI audit quick fixes (remaining after i18n + Overseer rename already committed)
- Removed `/desktop` nav entry from App.vue navItems — noVNC lives in the Chat tab, the route was stale
- Replaced `/desktop` route in router/index.ts with redirect to `/chat` for bookmarked URLs
- Added `min-h-0 overflow-hidden` to ChatInterface.vue and ChatTabContent.vue to fix flex container overflow