### PR TITLE
fix(knowledge): propagate dep_error so missing tree-sitter counts as failed not skipped (#4938)

### DIFF
--- a/autobot-backend/services/knowledge/code_indexer.py
+++ b/autobot-backend/services/knowledge/code_indexer.py
@@ -67,8 +67,8 @@ def extract_python(source_path: str, content: bytes) -> dict:
         import tree_sitter_python as tspython
         from tree_sitter import Language, Parser
     except ImportError as exc:
-        logger.error("tree-sitter-python not installed: %s", exc)
-        return {"nodes": [], "edges": []}
+        logger.error("tree-sitter-python not installed — AST indexing disabled: %s", exc)
+        return {"nodes": [], "edges": [], "dep_error": str(exc)}
 
     lang = Language(tspython.language())
     parser = Parser(lang)
@@ -226,8 +226,8 @@ def extract_javascript(source_path: str, content: bytes) -> dict:
         import tree_sitter_javascript as tsjs
         from tree_sitter import Language, Parser
     except ImportError as exc:
-        logger.error("tree-sitter-javascript not installed: %s", exc)
-        return {"nodes": [], "edges": []}
+        logger.error("tree-sitter-javascript not installed — AST indexing disabled: %s", exc)
+        return {"nodes": [], "edges": [], "dep_error": str(exc)}
 
     lang = Language(tsjs.language())
     parser = Parser(lang)
@@ -301,6 +301,10 @@ class CodeIndexer:
             return result
 
         extracted = extractor(file_path, content)
+        if extracted.get("dep_error"):
+            result.failed += 1
+            result.errors.append(f"{rel_path}: missing dependency — {extracted['dep_error']}")
+            return result
         nodes = extracted["nodes"]
         edges = extracted["edges"]
 

--- a/autobot-backend/services/knowledge/code_indexer_test.py
+++ b/autobot-backend/services/knowledge/code_indexer_test.py
@@ -88,6 +88,7 @@ async def test_index_python_file_upserts_nodes(tmp_path):
     assert indexer._collection.upsert.called
 
 
+@requires_tree_sitter
 async def test_index_unchanged_file_skips(tmp_path):
     src = tmp_path / "module.py"
     src.write_bytes(SIMPLE_PYTHON)
@@ -367,3 +368,32 @@ async def test_index_code_accepts_subdir_of_project_root(tmp_path):
         response = await index_code({"root_dir": str(subdir)})
 
     assert response["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# dep_error propagation — missing tree-sitter counted as failed (#4938)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_file_dep_error_counts_as_failed(tmp_path):
+    """When an extractor returns dep_error, index_file must record failed=1 not skipped=1."""
+    import services.knowledge.code_indexer as _ci_mod
+
+    src = tmp_path / "module.py"
+    src.write_bytes(SIMPLE_PYTHON)
+    indexer = _make_indexer(tmp_path)
+
+    dep_error_result = {"nodes": [], "edges": [], "dep_error": "tree-sitter-python not installed"}
+    original = _ci_mod._EXTRACTORS[".py"]
+    try:
+        _ci_mod._EXTRACTORS[".py"] = lambda path, content: dep_error_result
+        result = await indexer.index_file(str(src), root_dir=str(tmp_path))
+    finally:
+        _ci_mod._EXTRACTORS[".py"] = original
+
+    assert result.failed == 1
+    assert result.skipped == 0
+    assert result.success == 0
+    assert any("missing dependency" in e for e in result.errors)
+    assert any("tree-sitter-python" in e for e in result.errors)


### PR DESCRIPTION
Closes #4938

## Summary
- `extract_python`/`extract_javascript` returned `{'nodes': [], 'edges': []}` on ImportError — `index_file` counted the file as `skipped` with no diagnostic
- Added `dep_error` key to extractor's ImportError return value
- `index_file` now checks for `dep_error` and records `failed += 1` with descriptive message

## Tests
- `test_index_file_dep_error_counts_as_failed` — patches extractor, asserts `failed=1, skipped=0` and error contains "missing dependency"