### PR TITLE
fix(infrastructure): use os.environ.get() instead of unexpanded shell variable in sys.path (#4945)

### DIFF
--- a/autobot-backend/agents/multi_agent_workflow_validation_test.py
+++ b/autobot-backend/agents/multi_agent_workflow_validation_test.py
@@ -7,6 +7,7 @@ Tests the complete multi-agent coordination system for production readiness
 import asyncio
 import json
 import sys
+import os
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -16,7 +17,7 @@ from typing import Dict, List
 import requests
 
 # Add AutoBot paths
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 
 @dataclass

--- a/autobot-backend/agents/security_agents.e2e_test.py
+++ b/autobot-backend/agents/security_agents.e2e_test.py
@@ -5,8 +5,9 @@ Test the new security scanning agent implementations
 
 import asyncio
 import sys
+import os
 
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from agents.network_discovery_agent import network_discovery_agent
 from agents.security_scanner_agent import security_scanner_agent

--- a/autobot-backend/agents/security_agents_research.e2e_test.py
+++ b/autobot-backend/agents/security_agents_research.e2e_test.py
@@ -5,8 +5,9 @@ Test security agents with research-based tool discovery
 
 import asyncio
 import sys
+import os
 
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from agents.security_scanner_agent import security_scanner_agent
 

--- a/autobot-backend/comprehensive_system_validation_test.py
+++ b/autobot-backend/comprehensive_system_validation_test.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 # Add AutoBot paths
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 
 @dataclass

--- a/autobot-backend/knowledge/gpu_kb_integration_test.py
+++ b/autobot-backend/knowledge/gpu_kb_integration_test.py
@@ -5,10 +5,11 @@ Simple test to verify GPU-optimized semantic chunking integration with knowledge
 
 import asyncio
 import sys
+import os
 import time
 
 # Add AutoBot to path
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 
 async def test_chunker_optimization():

--- a/autobot-backend/knowledge/kb_optimization_test.py
+++ b/autobot-backend/knowledge/kb_optimization_test.py
@@ -10,7 +10,7 @@ import sys
 import time
 
 # Add AutoBot to path
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from knowledge_base import get_knowledge_base
 

--- a/autobot-backend/metrics/metrics_system.e2e_test.py
+++ b/autobot-backend/metrics/metrics_system.e2e_test.py
@@ -5,8 +5,9 @@ Test the new metrics and monitoring system
 
 import asyncio
 import sys
+import os
 
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from metrics.system_monitor import system_monitor
 from metrics.workflow_metrics import workflow_metrics

--- a/autobot-backend/monitoring/monitoring_and_alerts_test.py
+++ b/autobot-backend/monitoring/monitoring_and_alerts_test.py
@@ -27,6 +27,7 @@ import logging
 import statistics
 import subprocess
 import sys
+import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -36,7 +37,7 @@ from typing import Dict, List, Optional
 import requests
 
 # Add AutoBot paths
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from tests.test_helpers import get_test_backend_url

--- a/autobot-backend/utils/gpu_performance_test.py
+++ b/autobot-backend/utils/gpu_performance_test.py
@@ -6,13 +6,14 @@ Tests semantic chunking performance and identifies optimization opportunities.
 
 import asyncio
 import sys
+import os
 import time
 
 import psutil
 import torch
 
 # Add AutoBot to path
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from utils.semantic_chunker import AutoBotSemanticChunker
 

--- a/autobot-backend/utils/helpers_reorganization_test.py
+++ b/autobot-backend/utils/helpers_reorganization_test.py
@@ -28,7 +28,8 @@ class TestReorganizeRedisHelpers:
         # Import locally to avoid module-level import issues
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from analysis.reorganize_redis_databases import _decode_key
 
         result = _decode_key(b"test_key")
@@ -38,7 +39,8 @@ class TestReorganizeRedisHelpers:
         """Test _decode_key with string input."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from analysis.reorganize_redis_databases import _decode_key
 
         result = _decode_key("already_string")
@@ -48,7 +50,8 @@ class TestReorganizeRedisHelpers:
         """Test _decode_key with unicode bytes."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from analysis.reorganize_redis_databases import _decode_key
 
         result = _decode_key("unicode_тест".encode("utf-8"))
@@ -58,7 +61,8 @@ class TestReorganizeRedisHelpers:
         """Test _determine_target_db routes facts to DB1."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from analysis.reorganize_redis_databases import _determine_target_db
 
         assert _determine_target_db("fact:user_preferences") == 1
@@ -68,7 +72,8 @@ class TestReorganizeRedisHelpers:
         """Test _determine_target_db routes workflows to DB2."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from analysis.reorganize_redis_databases import _determine_target_db
 
         assert _determine_target_db("workflow_rules") == 2
@@ -78,7 +83,8 @@ class TestReorganizeRedisHelpers:
         """Test _determine_target_db routes other keys to DB3."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from analysis.reorganize_redis_databases import _determine_target_db
 
         assert _determine_target_db("random_key") == 3
@@ -88,7 +94,8 @@ class TestReorganizeRedisHelpers:
         """Test explicit database index to name mapping."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from analysis.reorganize_redis_databases import DB_INDEX_TO_NAME
 
         assert DB_INDEX_TO_NAME[0] == "main"
@@ -105,7 +112,8 @@ class TestMCPClientHelpers:
         """Test error creation for 400 status."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import MCPClient
 
         client = MCPClient(log_requests=False)
@@ -118,7 +126,8 @@ class TestMCPClientHelpers:
         """Test error creation for 404 status."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import MCPClient
 
         client = MCPClient(log_requests=False)
@@ -132,7 +141,8 @@ class TestMCPClientHelpers:
         """Test error creation for 500 status."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import MCPClient
 
         client = MCPClient(log_requests=False)
@@ -145,7 +155,8 @@ class TestMCPClientHelpers:
         """Test NON_RETRYABLE_STATUS_CODES constant."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import NON_RETRYABLE_STATUS_CODES
 
         assert 400 in NON_RETRYABLE_STATUS_CODES
@@ -158,7 +169,8 @@ class TestMCPClientHelpers:
         """Test _RetrySignal exception class exists."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import _RetrySignal
 
         # Should be able to instantiate and raise
@@ -170,7 +182,8 @@ class TestMCPClientHelpers:
         """Test _should_retry returns True on first attempt."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import MCPClient
 
         client = MCPClient(max_retries=3, log_requests=False)
@@ -185,7 +198,8 @@ class TestMCPClientHelpers:
         """Test _should_retry returns False when max attempts exceeded."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import MCPClient
 
         client = MCPClient(max_retries=3, log_requests=False)
@@ -369,7 +383,8 @@ class TestWorkflowResult:
         """Test WorkflowResult initialization."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import WorkflowResult
 
         result = WorkflowResult("test_workflow")
@@ -383,7 +398,8 @@ class TestWorkflowResult:
         """Test adding successful step to WorkflowResult."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import WorkflowResult
 
         result = WorkflowResult("test_workflow")
@@ -399,7 +415,8 @@ class TestWorkflowResult:
         """Test adding error step to WorkflowResult."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import WorkflowResult
 
         result = WorkflowResult("test_workflow")
@@ -413,7 +430,8 @@ class TestWorkflowResult:
         """Test WorkflowResult to_dict conversion."""
         import sys
 
-        sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        import os
+        sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
         from examples.mcp_agent_workflows.base import WorkflowResult
 
         result = WorkflowResult("test_workflow")

--- a/autobot-backend/utils/simple_optimization_test.py
+++ b/autobot-backend/utils/simple_optimization_test.py
@@ -5,10 +5,11 @@ Simple test to verify GPU optimization is working
 
 import asyncio
 import sys
+import os
 import time
 
 # Add AutoBot to path
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 
 async def test_direct_optimization():

--- a/autobot-backend/workflow_scheduler.e2e_test.py
+++ b/autobot-backend/workflow_scheduler.e2e_test.py
@@ -5,9 +5,10 @@ Test the new workflow scheduler and queue management system
 
 import asyncio
 import sys
+import os
 from datetime import datetime, timedelta
 
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from tests.test_helpers import get_test_backend_url
 from workflow_scheduler import WorkflowPriority, WorkflowStatus, workflow_scheduler

--- a/autobot-backend/workflow_templates/workflow_templates.e2e_test.py
+++ b/autobot-backend/workflow_templates/workflow_templates.e2e_test.py
@@ -5,8 +5,9 @@ Test the new workflow templates system
 
 import asyncio
 import sys
+import os
 
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from autobot_types import TaskComplexity
 from tests.test_helpers import get_test_backend_url

--- a/autobot-infrastructure/shared/scripts/analysis/debug_circuit_breaker.py
+++ b/autobot-infrastructure/shared/scripts/analysis/debug_circuit_breaker.py
@@ -9,11 +9,12 @@ Test script to check circuit breaker state
 import asyncio
 import logging
 import sys
+import os
 
 logger = logging.getLogger(__name__)
 
 # Add the src directory to the path
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from circuit_breaker import circuit_breaker_manager
 

--- a/autobot-infrastructure/shared/scripts/analysis/redis_final_analysis.py
+++ b/autobot-infrastructure/shared/scripts/analysis/redis_final_analysis.py
@@ -13,7 +13,7 @@ import os
 import sys
 from typing import Any, Dict, List, Tuple
 
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 from constants import ServiceURLs
 from constants.network_constants import NetworkConstants
 

--- a/autobot-infrastructure/shared/scripts/analysis/redis_vector_analysis.py
+++ b/autobot-infrastructure/shared/scripts/analysis/redis_vector_analysis.py
@@ -11,12 +11,13 @@ import asyncio
 import json
 import logging
 import sys
+import os
 from typing import Any, Dict, List, Tuple
 
 from constants import ServiceURLs
 
 # Add project root to path
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/autobot-infrastructure/shared/scripts/analysis/simple_kb_test.py
+++ b/autobot-infrastructure/shared/scripts/analysis/simple_kb_test.py
@@ -9,8 +9,9 @@ Simple test of current AutoBot knowledge base functionality
 import asyncio
 import logging
 import sys
+import os
 
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_autobot_identity.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_autobot_identity.py
@@ -9,8 +9,9 @@ Test AutoBot identity in knowledge base
 import asyncio
 import logging
 import sys
+import os
 
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_data_layer_debug.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_data_layer_debug.py
@@ -194,7 +194,7 @@ def test_backend_errors():
         # Test Redis database manager import
         import sys
 
-        sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
         from utils.redis_database_manager import RedisDatabaseManager
 

--- a/autobot-infrastructure/shared/scripts/analysis/test_documentation_api.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_documentation_api.py
@@ -9,10 +9,11 @@ Test Documentation API Endpoints (Local Testing)
 import asyncio
 import logging
 import sys
+import os
 from pathlib import Path
 
 # Add project root to Python path
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_kb_documentation.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_kb_documentation.py
@@ -9,8 +9,9 @@ Test knowledge base documentation reading functionality
 import asyncio
 import logging
 import sys
+import os
 
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/test_kb_search.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_kb_search.py
@@ -9,9 +9,10 @@ Test Knowledge Base Documentation Search
 import asyncio
 import logging
 import sys
+import os
 
 # Add the project root to the Python path
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from chat_workflow import ChatWorkflowManager
 from knowledge_base import KnowledgeBase

--- a/autobot-infrastructure/shared/scripts/analysis/test_redis_comparison.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_redis_comparison.py
@@ -19,7 +19,7 @@ from constants import ServiceURLs
 _DB_KNOWLEDGE = int(os.getenv("AUTOBOT_REDIS_DB_KNOWLEDGE", "1"))
 
 # Add the project root to the Python path
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/autobot-infrastructure/shared/scripts/test_llm_awareness.py
+++ b/autobot-infrastructure/shared/scripts/test_llm_awareness.py
@@ -10,10 +10,11 @@ Demonstrates the functionality of the awareness injection system
 import asyncio
 import logging
 import sys
+import os
 
 logger = logging.getLogger(__name__)
 
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 from autobot_shared.network_constants import ServiceURLs
 

--- a/autobot-infrastructure/shared/scripts/test_long_running_operations.py
+++ b/autobot-infrastructure/shared/scripts/test_long_running_operations.py
@@ -26,10 +26,11 @@ import argparse
 import asyncio
 import logging
 import sys
+import os
 from datetime import datetime
 
 # Add AutoBot paths
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")

--- a/autobot-infrastructure/shared/tests/ci_cd_integration.py
+++ b/autobot-infrastructure/shared/tests/ci_cd_integration.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 # Add AutoBot paths
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/tests/performance/test_performance_optimization.py
+++ b/autobot-infrastructure/shared/tests/performance/test_performance_optimization.py
@@ -27,6 +27,7 @@ import logging
 import statistics
 import subprocess
 import sys
+import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -36,7 +37,7 @@ from typing import Dict, List, Optional
 import psutil
 
 # Add AutoBot paths
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/autobot-infrastructure/shared/tests/phase9_comprehensive_test_suite.py
+++ b/autobot-infrastructure/shared/tests/phase9_comprehensive_test_suite.py
@@ -26,6 +26,7 @@ import json
 import logging
 import subprocess
 import sys
+import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -40,7 +41,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger(__name__)
 
 # Add AutoBot paths
-sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
 
 @dataclass

--- a/debug/debug_terminal.py
+++ b/debug/debug_terminal.py
@@ -10,13 +10,14 @@ import asyncio
 import json
 import logging
 import sys
+import os
 from datetime import datetime
 
 import httpx
 import websockets
 
 # Import centralized network configuration
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 from constants.network_constants import NetworkConstants
 
 logger = logging.getLogger(__name__)

--- a/debug/debug_terminal_detailed.py
+++ b/debug/debug_terminal_detailed.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 import sys
+import os
 import time
 from datetime import datetime
 
@@ -19,7 +20,7 @@ import websockets
 logger = logging.getLogger(__name__)
 
 # Import centralized network configuration
-sys.path.insert(0, "${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+sys.path.insert(0, os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 from constants.network_constants import NetworkConstants
 
 # Build URLs from centralized configuration
@@ -197,7 +198,7 @@ def test_system_command_agent_direct():
         # Try to import and test directly
         import sys
 
-        sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")
+        sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))
 
         from agents.system_command_agent import SystemCommandAgent
 


### PR DESCRIPTION
Closes #4945

## Summary
- 30 Python scripts had `sys.path.append("${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}")` — Python never expands shell variable syntax, making the path entry a literal useless string
- Replaced with `sys.path.append(os.environ.get("AUTOBOT_PROJECT_ROOT", "/opt/autobot/code_source"))`
- Added `import os` where missing (24 files)
- All 30 files pass `python3 -m py_compile` syntax check