### PR TITLE
refactor(frontend): add TypeScript stubs for Options API Vue components (#4534)

### DIFF
--- a/autobot-frontend/src/components/manpage/ManPageManager.vue.d.ts
+++ b/autobot-frontend/src/components/manpage/ManPageManager.vue.d.ts
@@ -1,0 +1,4 @@
+import { DefineComponent } from 'vue';
+
+declare const ManPageManager: DefineComponent<{}, {}, any>;
+export default ManPageManager;

--- a/autobot-frontend/src/components/manpage/index.ts
+++ b/autobot-frontend/src/components/manpage/index.ts
@@ -11,6 +11,7 @@
  * Issue #184: Split oversized Vue components
  */
 
+export { default as ManPageManager } from './ManPageManager.vue'
 export { default as MachineProfilePanel } from './MachineProfilePanel.vue'
 export { default as IntegrationStatusPanel } from './IntegrationStatusPanel.vue'
 export { default as IntegrationActionsPanel } from './IntegrationActionsPanel.vue'

--- a/autobot-frontend/src/components/ui/index.ts
+++ b/autobot-frontend/src/components/ui/index.ts
@@ -1,0 +1,33 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * UI Components Barrel
+ *
+ * Barrel exports for reusable UI components.
+ * CommandPermissionDialog uses Options API with .vue.d.ts stub for TS7016 compatibility.
+ *
+ * Issue #4534: Options API components without TypeScript stubs
+ */
+
+export { default as BaseAlert } from './BaseAlert.vue'
+export { default as BaseModal } from './BaseModal.vue'
+export { default as CommandPermissionDialog } from './CommandPermissionDialog.vue'
+export { default as DarkModeToggle } from './DarkModeToggle.vue'
+export { default as DataTable } from './DataTable.vue'
+export { default as EmptyState } from './EmptyState.vue'
+export { default as HostSelectionDialog } from './HostSelectionDialog.vue'
+export { default as HostSelector } from './HostSelector.vue'
+export { default as LoadingSpinner } from './LoadingSpinner.vue'
+export { default as MessageStatus } from './MessageStatus.vue'
+export { default as OfflineBanner } from './OfflineBanner.vue'
+export { default as PreferencesPanel } from './PreferencesPanel.vue'
+export { default as ProgressBar } from './ProgressBar.vue'
+export { default as SkeletonLoader } from './SkeletonLoader.vue'
+export { default as StableLoadingState } from './StableLoadingState.vue'
+export { default as StatusBadge } from './StatusBadge.vue'
+export { default as SystemStatusNotification } from './SystemStatusNotification.vue'
+export { default as ThemeToggle } from './ThemeToggle.vue'
+export { default as ToastContainer } from './ToastContainer.vue'
+export { default as TouchFriendlyButton } from './TouchFriendlyButton.vue'
+export { default as UnifiedLoadingView } from './UnifiedLoadingView.vue'


### PR DESCRIPTION
Closes #4534

## Summary
- Created `ManPageManager.vue.d.ts` stub (was missing — the only component of the 3 without a stub)
- Added `ManPageManager` export to `manpage/index.ts` barrel
- Created `ui/index.ts` barrel exporting all 21 ui components
- `CommandPermissionDialog.vue.d.ts` and `TerminalWindow.vue.d.ts` stubs were already present
- Used `.vue.d.ts` stub approach (per issue acceptance criteria) rather than full Composition API conversion, which would introduce 356 new template errors from pre-existing `$t` binding issues

## Test Status
PASS — 0 new TS errors; vue-tsc total error count unchanged at 1939 (all pre-existing)