### PR TITLE
fix(ui): add ARIA roles, labels and focus management to BaseModal, DataTable, HostSelectionDialog (#4806)

### DIFF
--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -119,9 +119,10 @@ const { t } = useI18n()
 const dialogRef = ref<HTMLElement | null>(null)
 let previousActiveElement: HTMLElement | null = null
 
-// Generate unique IDs for ARIA labeling
-const titleId = computed(() => `modal-title-${Math.random().toString(36).substr(2, 9)}`)
-const descriptionId = computed(() => `modal-desc-${Math.random().toString(36).substr(2, 9)}`)
+// Generate stable unique IDs for ARIA labeling (random only once, not per-render)
+const _uid = Math.random().toString(36).substr(2, 9)
+const titleId = computed(() => `modal-title-${_uid}`)
+const descriptionId = computed(() => `modal-desc-${_uid}`)
 
 const sizeClass = computed(() => {
   switch (props.size) {
@@ -290,6 +291,11 @@ onUnmounted(() => {
 .close-btn:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
+}
+
+.close-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 /* Content */

--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -13,16 +13,29 @@
     </div>
 
     <!-- Table -->
+    <div
+      v-if="loading || sortedData.length === 0"
+      aria-live="polite"
+      aria-atomic="true"
+      class="sr-only"
+    >
+      {{ loading ? t('ui.dataTable.loading') : t('ui.dataTable.noDataAvailable') }}
+    </div>
     <div class="table-wrapper">
-      <table class="data-table">
+      <table
+        class="data-table"
+        :aria-label="title || t('ui.dataTable.dataTable')"
+        :aria-busy="loading"
+      >
         <thead>
           <tr>
             <th
               v-for="column in columns"
               :key="column.key"
+              scope="col"
               :class="{ sortable: column.sortable }"
               @click="column.sortable ? handleSort(column.key) : null"
-              :role="column.sortable ? 'button' : undefined"
+              :role="column.sortable ? 'columnheader' : undefined"
               :tabindex="column.sortable ? 0 : undefined"
               :aria-sort="column.sortable && sortKey === column.key ? (sortDirection === 'asc' ? 'ascending' : 'descending') : (column.sortable ? 'none' : undefined)"
               :aria-label="column.sortable ? t('ui.dataTable.sortBy', { column: column.label }) : undefined"
@@ -37,7 +50,7 @@
                 aria-hidden="true"
               ></i>
             </th>
-            <th v-if="$slots.actions" class="actions-column">{{ t('ui.dataTable.actions') }}</th>
+            <th v-if="$slots.actions" scope="col" class="actions-column">{{ t('ui.dataTable.actions') }}</th>
           </tr>
         </thead>
         <tbody>
@@ -71,25 +84,31 @@
     </div>
 
     <!-- Pagination -->
-    <div v-if="pagination && totalPages > 1" class="table-pagination">
+    <nav
+      v-if="pagination && totalPages > 1"
+      class="table-pagination"
+      :aria-label="t('ui.dataTable.pagination')"
+    >
       <button
         class="pagination-btn"
         :disabled="currentPage === 1"
+        :aria-label="t('ui.dataTable.previousPage')"
         @click="handlePageChange(currentPage - 1)"
       >
-        <i class="fas fa-chevron-left"></i>
+        <i class="fas fa-chevron-left" aria-hidden="true"></i>
       </button>
-      <span class="pagination-info">
+      <span class="pagination-info" aria-live="polite" aria-atomic="true">
         {{ t('ui.dataTable.pageOf', { current: currentPage, total: totalPages }) }}
       </span>
       <button
         class="pagination-btn"
         :disabled="currentPage === totalPages"
+        :aria-label="t('ui.dataTable.nextPage')"
         @click="handlePageChange(currentPage + 1)"
       >
-        <i class="fas fa-chevron-right"></i>
+        <i class="fas fa-chevron-right" aria-hidden="true"></i>
       </button>
-    </div>
+    </nav>
   </div>
 </template>
 
@@ -241,6 +260,19 @@ const formatCell = (value: any, column: Column) => {
  * All colors reference CSS custom properties from design-tokens.css
  */
 
+/* Visually hidden but accessible to screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .data-table-container {
   background: var(--bg-card);
   border-radius: var(--radius-default);
@@ -306,6 +338,11 @@ const formatCell = (value: any, column: Column) => {
   color: var(--text-primary);
 }
 
+.data-table th.sortable:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
 .data-table th.sortable i {
   margin-left: var(--spacing-2);
   font-size: var(--text-xs);
@@ -368,6 +405,11 @@ const formatCell = (value: any, column: Column) => {
 .pagination-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.pagination-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 /* Issue #901: Monospace for page numbers */

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -1,21 +1,34 @@
 <template>
-  <div v-if="showDialog" class="host-selection-overlay">
-    <div class="host-selection-dialog">
+  <div
+    v-if="showDialog"
+    class="host-selection-overlay"
+    @click.self="!isProcessing && handleCancel()"
+  >
+    <div
+      ref="dialogRef"
+      class="host-selection-dialog"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="dialogTitleId"
+      :aria-describedby="dialogDescId"
+      tabindex="-1"
+    >
       <div class="dialog-header">
-        <div class="dialog-icon">
+        <div class="dialog-icon" aria-hidden="true">
           <i class="fas fa-server"></i>
         </div>
         <div class="dialog-title">
-          <h3>{{ t('ui.hostSelection.title') }}</h3>
-          <p class="dialog-subtitle">{{ purpose || t('ui.hostSelection.defaultPurpose') }}</p>
+          <h3 :id="dialogTitleId">{{ t('ui.hostSelection.title') }}</h3>
+          <p :id="dialogDescId" class="dialog-subtitle">{{ purpose || t('ui.hostSelection.defaultPurpose') }}</p>
         </div>
         <button
           v-if="!isProcessing"
           class="close-button"
+          type="button"
           @click="handleCancel"
           :aria-label="t('ui.hostSelection.close')"
         >
-          <i class="fas fa-times"></i>
+          <i class="fas fa-times" aria-hidden="true"></i>
         </button>
       </div>
 
@@ -30,25 +43,30 @@
 
         <!-- Host Selection -->
         <div class="host-selection-section">
-          <h4>{{ t('ui.hostSelection.availableHosts') }}:</h4>
+          <h4 :id="hostListLabelId">{{ t('ui.hostSelection.availableHosts') }}</h4>
 
           <!-- Loading State -->
-          <div v-if="loading" class="loading-state">
-            <i class="fas fa-spinner fa-spin"></i>
+          <div v-if="loading" class="loading-state" role="status" aria-live="polite">
+            <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
             <span>{{ t('ui.hostSelection.loadingHosts') }}</span>
           </div>
 
           <!-- No Hosts State -->
           <div v-else-if="hosts.length === 0" class="empty-state">
-            <i class="fas fa-exclamation-circle"></i>
+            <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
             <span>{{ t('ui.hostSelection.noHostsConfigured') }}</span>
-            <button @click="openSecretsManager" class="add-host-link">
-              <i class="fas fa-plus"></i> {{ t('ui.hostSelection.addHost') }}
+            <button type="button" @click="openSecretsManager" class="add-host-link">
+              <i class="fas fa-plus" aria-hidden="true"></i> {{ t('ui.hostSelection.addHost') }}
             </button>
           </div>
 
           <!-- Host List -->
-          <div v-else class="host-list">
+          <div
+            v-else
+            class="host-list"
+            role="radiogroup"
+            :aria-labelledby="hostListLabelId"
+          >
             <div
               v-for="host in hosts"
               :key="host.id"
@@ -66,24 +84,25 @@
                   :value="host.id"
                   v-model="selectedHostId"
                   :disabled="isProcessing"
+                  :aria-label="host.name"
                 />
               </div>
-              <div class="host-icon">
+              <div class="host-icon" aria-hidden="true">
                 <i :class="getHostIcon(host)"></i>
               </div>
               <div class="host-info">
                 <div class="host-name">
                   {{ host.name }}
                   <span v-if="host.id === defaultHostId" class="default-badge">
-                    <i class="fas fa-star"></i> {{ t('ui.hostSelection.default') }}
+                    <i class="fas fa-star" aria-hidden="true"></i> {{ t('ui.hostSelection.default') }}
                   </span>
                 </div>
                 <div class="host-details">
                   <span class="host-connection">
-                    <i class="fas fa-user"></i> {{ host.username || 'root' }}@{{ host.host }}:{{ host.ssh_port || 22 }}
+                    <i class="fas fa-user" aria-hidden="true"></i> {{ host.username || 'root' }}@{{ host.host }}:{{ host.ssh_port || 22 }}
                   </span>
                   <span v-if="host.capabilities?.includes('vnc')" class="host-capability">
-                    <i class="fas fa-desktop"></i> VNC
+                    <i class="fas fa-desktop" aria-hidden="true"></i> VNC
                   </span>
                 </div>
                 <div v-if="host.purpose" class="host-purpose">
@@ -93,12 +112,14 @@
               <div class="host-actions">
                 <button
                   v-if="host.id !== defaultHostId"
+                  type="button"
                   class="set-default-btn"
                   @click.stop="setAsDefault(host)"
+                  :aria-label="t('ui.hostSelection.setAsDefault')"
                   :title="t('ui.hostSelection.setAsDefault')"
                   :disabled="isProcessing"
                 >
-                  <i class="fas fa-star"></i>
+                  <i class="fas fa-star" aria-hidden="true"></i>
                 </button>
               </div>
             </div>
@@ -119,8 +140,8 @@
         </div>
 
         <!-- Error Message -->
-        <div v-if="error" class="error-message">
-          <i class="fas fa-exclamation-triangle"></i>
+        <div v-if="error" class="error-message" role="alert" aria-live="assertive">
+          <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
           <span>{{ error }}</span>
         </div>
       </div>
@@ -128,26 +149,29 @@
       <div class="dialog-footer">
         <div class="button-group">
           <button
+            type="button"
             class="btn btn-secondary"
             @click="handleCancel"
             :disabled="isProcessing"
           >
-            <i class="fas fa-times"></i>
+            <i class="fas fa-times" aria-hidden="true"></i>
             {{ t('ui.hostSelection.cancel') }}
           </button>
           <button
+            type="button"
             class="btn btn-primary"
             @click="handleConfirm"
             :disabled="!selectedHostId || isProcessing"
+            :aria-busy="isProcessing"
           >
-            <i v-if="isProcessing" class="fas fa-spinner fa-spin"></i>
-            <i v-else class="fas fa-check"></i>
+            <i v-if="isProcessing" class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+            <i v-else class="fas fa-check" aria-hidden="true"></i>
             {{ isProcessing ? t('ui.hostSelection.connecting') : t('ui.hostSelection.connectAndExecute') }}
           </button>
         </div>
 
         <div class="security-note">
-          <i class="fas fa-lock"></i>
+          <i class="fas fa-lock" aria-hidden="true"></i>
           <span>{{ t('ui.hostSelection.securityNote') }}</span>
         </div>
       </div>
@@ -156,7 +180,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { secretsApiClient } from '@/utils/SecretsApiClient';
 import { getBackendUrl } from '@/config/ssot-config';
@@ -206,6 +230,16 @@ const emit = defineEmits<{
 
 // #1721: In-memory session host preference (avoids clear-text sessionStorage)
 let _sessionHostChoice: string | null = null;
+
+// Stable IDs for ARIA labeling
+const _uid = Math.random().toString(36).substr(2, 9);
+const dialogTitleId = `host-dialog-title-${_uid}`;
+const dialogDescId = `host-dialog-desc-${_uid}`;
+const hostListLabelId = `host-list-label-${_uid}`;
+
+// Focus management
+const dialogRef = ref<HTMLElement | null>(null);
+let previousActiveElement: HTMLElement | null = null;
 
 // State
 const showDialog = ref(false);
@@ -380,11 +414,33 @@ const handleEscape = (event: KeyboardEvent) => {
   }
 };
 
+// Focus trap helpers
+const trapFocus = (event: FocusEvent) => {
+  if (!dialogRef.value) return;
+  if (!dialogRef.value.contains(event.target as Node)) {
+    const focusable = dialogRef.value.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length > 0) {
+      focusable[0].focus();
+      event.preventDefault();
+    }
+  }
+};
+
 // Watchers
-watch(() => props.show, (newValue) => {
+watch(() => props.show, async (newValue) => {
   showDialog.value = newValue;
   if (newValue) {
+    previousActiveElement = document.activeElement as HTMLElement;
     loadHosts();
+    document.addEventListener('focusin', trapFocus);
+    await nextTick();
+    dialogRef.value?.focus();
+  } else {
+    document.removeEventListener('focusin', trapFocus);
+    previousActiveElement?.focus();
+    previousActiveElement = null;
   }
 }, { immediate: true });
 
@@ -395,6 +451,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   document.removeEventListener('keydown', handleEscape);
+  document.removeEventListener('focusin', trapFocus);
 });
 </script>
 
@@ -484,6 +541,11 @@ onUnmounted(() => {
 
 .close-button:hover {
   opacity: 1;
+}
+
+.close-button:focus-visible {
+  outline: 2px solid var(--text-on-primary);
+  outline-offset: 2px;
 }
 
 /* Body */
@@ -722,6 +784,11 @@ onUnmounted(() => {
   cursor: not-allowed;
 }
 
+.set-default-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 /* Options Section */
 .options-section {
   margin-bottom: var(--spacing-4);
@@ -828,6 +895,11 @@ onUnmounted(() => {
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .security-note {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -4968,7 +4968,12 @@
       "actions": "Actions",
       "noDataAvailable": "No data available",
       "noItemsToDisplay": "No items to display",
-      "pageOf": "Page {current} of {total}"
+      "pageOf": "Page {current} of {total}",
+      "pagination": "Table pagination",
+      "previousPage": "Previous page",
+      "nextPage": "Next page",
+      "dataTable": "Data table",
+      "loading": "Loading data..."
     },
     "hostSelection": {
       "title": "Select Host",
@@ -5645,8 +5650,8 @@
   },
   "operations": {
     "view": {
-      "title": "Operations",
-      "subtitle": "Monitor and manage ongoing operations",
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
       "refresh": "Refresh",
       "loadError": "Failed to load operations"
     },
@@ -5695,12 +5700,6 @@
       "resume": "Resume",
       "viewDetails": "View Details",
       "showingCount": "Showing {shown} of {total} operations"
-    },
-    "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"


### PR DESCRIPTION
Closes #4806

## Summary
- **BaseModal**: stable `_uid`-based IDs, `focus-visible` focus ring on close button
- **DataTable**: `scope="col"` on `<th>`, `role="columnheader"` on sortable headers, `aria-busy`/`aria-live` for loading state, `<nav>` landmark for pagination with descriptive button labels, `aria-hidden` on icons, `.sr-only` utility class
- **HostSelectionDialog**: `role="dialog"` + `aria-modal` + `aria-labelledby/describedby`, focus trap with restore-on-close, `role="radiogroup"`, `role="alert"` on error, `aria-hidden` on all decorative icons, `type="button"` on all buttons, `aria-busy` on submit, `focus-visible` rings

## Test Status
PASS — no new TypeScript errors