### PR TITLE
feat(i18n): add CI check script for missing i18n keys (#4826)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,11 @@ jobs:
         cd autobot-frontend
         npm run lint
 
+    - name: Check i18n keys
+      run: |
+        cd autobot-frontend
+        npm run check:i18n
+
     - name: Run frontend type checking
       run: |
         cd autobot-frontend

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -53,6 +53,10 @@ jobs:
         working-directory: autobot-frontend
         run: npm run lint
 
+      - name: Check i18n keys
+        working-directory: autobot-frontend
+        run: npm run check:i18n
+
       - name: Run unit tests
         working-directory: autobot-frontend
         run: npm run test:unit

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -29,6 +29,7 @@
     "test:all": "run-s test:unit test:integration test:playwright",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.app.json",
+    "check:i18n": "node scripts/check-i18n-keys.mjs",
     "lint:oxlint": "oxlint . --fix -D correctness --ignore-path .gitignore",
     "lint:eslint": "eslint . --fix",
     "lint": "run-s lint:*",

--- a/autobot-frontend/scripts/check-i18n-keys.mjs
+++ b/autobot-frontend/scripts/check-i18n-keys.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * check-i18n-keys.mjs
+ *
+ * Extracts all $t('key') and t('key') usages from .vue and .ts source files,
+ * then checks each key against en.json.  Exits with code 1 if any keys used
+ * in code are missing from the locale file.
+ *
+ * Usage:  node scripts/check-i18n-keys.mjs [--quiet]
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const SRC = join(ROOT, 'src');
+const EN_JSON = join(ROOT, 'src', 'i18n', 'locales', 'en.json');
+
+const quiet = process.argv.includes('--quiet');
+
+// ---------------------------------------------------------------------------
+// 1. Load en.json and build a flat set of dot-joined keys
+// ---------------------------------------------------------------------------
+function flattenKeys(obj, prefix = '') {
+  const result = new Set();
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      for (const nested of flattenKeys(v, key)) result.add(nested);
+    } else {
+      result.add(key);
+    }
+  }
+  return result;
+}
+
+const enJson = JSON.parse(readFileSync(EN_JSON, 'utf8'));
+const definedKeys = flattenKeys(enJson);
+
+// ---------------------------------------------------------------------------
+// 2. Walk src/ and collect all .vue / .ts files (exclude test and node_modules)
+// ---------------------------------------------------------------------------
+const EXTENSIONS = new Set(['.vue', '.ts']);
+const EXCLUDE_DIRS = new Set(['node_modules', 'dist', '__tests__', 'coverage', 'cypress', 'playwright']);
+
+function walkFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    if (EXCLUDE_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      results.push(...walkFiles(full));
+    } else if (EXTENSIONS.has(extname(entry))) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const sourceFiles = walkFiles(SRC);
+
+// ---------------------------------------------------------------------------
+// 3. Extract translation key strings from source files
+//
+//    Patterns matched:
+//      $t('key')          $t("key")          $t(`key`)
+//      t('key')           t("key")           t(`key`)
+//    Keys with dynamic parts (template literals containing ${...}) are skipped
+//    with a warning since they cannot be statically analysed.
+// ---------------------------------------------------------------------------
+
+// Matches $t('key') or standalone t('key') with single/double/backtick quotes.
+//
+// To avoid false positives from other functions ending in "t" (e.g. mount(),
+// split(), parseInt()), we require that the "t(" is preceded by one of:
+//   - "$"  → template $t(...)
+//   - "{"  → object literal / JSX  { t('...') }
+//   - whitespace / start-of-line
+//   - "," or "(" or "=" or ";" or ":"  → common statement starters
+//
+// Group 1 = quote char, group 2 = key string.
+//
+// Additionally, we only accept keys that look like i18n dot-path strings
+// (letters, digits, dots, underscores, hyphens) to filter out accidental
+// matches on punctuation, CSS selectors, etc.
+const KEY_RE = /(?<![a-zA-Z0-9_])\$?t\(\s*(['"`])((?:[^'"`\\]|\\.)*?)\1/g;
+const VALID_KEY_RE = /^[a-zA-Z_][\w.]*[\w]$/;
+// A dynamic key contains an unescaped ${ inside a backtick string.
+const DYNAMIC_RE = /\$\{/;
+
+const usedKeys = new Map(); // key -> Set<file>
+const dynamicUsages = []; // { file, raw } for dynamic keys we can't check
+
+for (const file of sourceFiles) {
+  const src = readFileSync(file, 'utf8');
+  for (const match of src.matchAll(KEY_RE)) {
+    const quote = match[1];
+    const raw = match[2];
+    // Skip interpolated template literals  (e.g.  t(`prefix.${var}`) )
+    if (quote === '`' && DYNAMIC_RE.test(raw)) {
+      dynamicUsages.push({ file, raw: match[0] });
+      continue;
+    }
+    // Skip strings that don't look like i18n dot-path keys
+    if (!VALID_KEY_RE.test(raw)) continue;
+    if (!usedKeys.has(raw)) usedKeys.set(raw, new Set());
+    usedKeys.get(raw).add(file.replace(ROOT + '/', ''));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Compare: used keys vs defined keys
+// ---------------------------------------------------------------------------
+
+// A key is "missing" if neither the key itself nor any of its ancestors exist
+// in en.json.  (This handles pluralisation keys such as `foo.bar` when the
+// locale only defines `foo.bar.one` / `foo.bar.other`.)
+function isMissingFromLocale(key) {
+  if (definedKeys.has(key)) return false;
+  // Accept if the key is a namespace prefix of any defined key
+  const prefix = key + '.';
+  for (const defined of definedKeys) {
+    if (defined.startsWith(prefix)) return false;
+  }
+  return true;
+}
+
+const missing = [];
+for (const [key, files] of [...usedKeys.entries()].sort()) {
+  if (isMissingFromLocale(key)) {
+    missing.push({ key, files: [...files].sort() });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Report
+// ---------------------------------------------------------------------------
+const relativeEN = EN_JSON.replace(ROOT + '/', '');
+
+if (!quiet) {
+  console.log(`i18n key check — locale: ${relativeEN}`);
+  console.log(`  Source files scanned : ${sourceFiles.length}`);
+  console.log(`  Keys in en.json      : ${definedKeys.size}`);
+  console.log(`  Unique keys used     : ${usedKeys.size}`);
+  if (dynamicUsages.length) {
+    console.log(`  Dynamic keys skipped : ${dynamicUsages.length} (cannot be statically analysed)`);
+  }
+  console.log('');
+}
+
+if (missing.length === 0) {
+  if (!quiet) console.log('All translation keys found in en.json.');
+  process.exit(0);
+}
+
+console.error(`Missing i18n keys: ${missing.length} key(s) used in source but absent from en.json\n`);
+for (const { key, files } of missing) {
+  console.error(`  MISSING: "${key}"`);
+  if (!quiet) {
+    for (const f of files) {
+      console.error(`    in ${f}`);
+    }
+  }
+}
+console.error('');
+console.error('Fix: add the missing keys to src/i18n/locales/en.json');
+process.exit(1);


### PR DESCRIPTION
Closes #4826

## Summary
- New `autobot-frontend/scripts/check-i18n-keys.mjs` — pure Node ESM, no new dependencies
  - Scans all 545 `.vue`/`.ts` source files for `$t()`/`t()` calls
  - Flattens `en.json` (5769 keys) into a Set and reports mismatches
  - Exits 1 if any missing keys found
- Added `"check:i18n": "node scripts/check-i18n-keys.mjs"` to `package.json`
- Added "Check i18n keys" step to `ci.yml` (frontend-tests job) and `frontend-test.yml` (unit-tests job)
- Found 81 genuinely missing keys in existing code — filed as separate discovery issue

## Test Status
PASS — script runs cleanly, exits 1 with 81 real missing keys as expected