### PR TITLE
feat(nav): responsive desktop nav with More ▾ overflow dropdown

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -57,6 +57,7 @@
         "@types/sinonjs__fake-timers": "^15.0.1",
         "@types/sizzle": "^2.3.10",
         "@types/statuses": "^2.0.6",
+        "@types/three": "^0.183.0",
         "@types/tough-cookie": "^4.0.5",
         "@vitejs/plugin-vue": "^6.0.5",
         "@vitejs/plugin-vue-jsx": "^5.1.5",
@@ -851,6 +852,13 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
@@ -3295,10 +3303,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.183.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
+      "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.0.1"
+      }
+    },
+    "node_modules/@types/three/node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3322,6 +3360,13 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
@@ -4614,6 +4659,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
@@ -9123,6 +9175,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
+      "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",

--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -40,10 +40,9 @@
           <!-- Desktop Navigation -->
           <nav id="navigation" class="hidden lg:block" role="navigation" :aria-label="$t('nav.mainNavigation')">
             <div class="hidden lg:flex items-center space-x-8">
-              <div ref="navContainerRef" class="flex items-center space-x-4 overflow-hidden">
+              <div ref="navContainerRef" class="flex items-center space-x-4">
                 <template v-for="item in visibleNavItems" :key="item.to">
                 <router-link
-                  v-if="!item.adminOnly || userStore.isAdmin"
                   :to="item.to"
                   data-nav-item
                   :class="{

--- a/autobot-frontend/src/App.vue
+++ b/autobot-frontend/src/App.vue
@@ -40,16 +40,17 @@
           <!-- Desktop Navigation -->
           <nav id="navigation" class="hidden lg:block" role="navigation" :aria-label="$t('nav.mainNavigation')">
             <div class="hidden lg:flex items-center space-x-8">
-                            <div class="flex items-center space-x-4">
-                <template v-for="item in navItems" :key="item.to">
+              <div ref="navContainerRef" class="flex items-center space-x-4 overflow-hidden">
+                <template v-for="item in visibleNavItems" :key="item.to">
                 <router-link
                   v-if="!item.adminOnly || userStore.isAdmin"
                   :to="item.to"
+                  data-nav-item
                   :class="{
                     'bg-autobot-primary text-white': $route.path.startsWith(item.to),
                     'text-autobot-text-primary hover:bg-autobot-bg-tertiary': !$route.path.startsWith(item.to)
                   }"
-                  class="px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200"
+                  class="px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 shrink-0"
                 >
                   <div class="flex items-center space-x-1">
                     <svg class="w-4 h-4" :fill="item.iconStroke ? 'none' : 'currentColor'" :stroke="item.iconStroke ? 'currentColor' : undefined" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
@@ -63,12 +64,17 @@
                 </router-link>
                 </template>
 
+                <NavOverflowMenu
+                  v-if="overflowNavItems.length > 0"
+                  :items="overflowNavItems"
+                />
+
                 <!-- SLM Admin: external link (Issue #729) -->
                 <a
                   :href="slmAdminUrl"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="px-3 py-2 rounded text-sm font-medium transition-colors duration-150 text-autobot-text-primary hover:bg-autobot-bg-tertiary"
+                  class="px-3 py-2 rounded text-sm font-medium transition-colors duration-150 text-autobot-text-primary hover:bg-autobot-bg-tertiary shrink-0"
                   :title="$t('nav.slmAdminTitle')"
                   :aria-label="$t('nav.slmAdminTitle')"
                 >
@@ -410,6 +416,8 @@ import { useChatStore } from '@/stores/useChatStore'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import { useSystemStatus } from '@/composables/useSystemStatus'
 import { useHostSelection } from '@/composables/useHostSelection';
+import { useNavOverflow } from '@/composables/useNavOverflow'
+import NavOverflowMenu from '@/components/layout/NavOverflowMenu.vue'
 import { createLogger } from '@/utils/debugUtils'
 import { cacheBuster } from '@/utils/CacheBuster.js';
 import { optimizedHealthMonitor } from '@/utils/OptimizedHealthMonitor.js';
@@ -440,6 +448,7 @@ export default {
     UnifiedLoadingView,
     ProfileModal,
     ErrorBoundary,
+    NavOverflowMenu,
     DarkModeToggle: defineAsyncComponent(() => import('@/components/ui/DarkModeToggle.vue')),
     LanguageSwitcher: defineAsyncComponent(() => import('@/components/layout/LanguageSwitcher.vue')),
   },
@@ -814,6 +823,21 @@ export default {
       { to: '/experiments', labelKey: 'nav.experiments', adminOnly: true, icon: 'M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z' },
     ];
 
+    // Nav overflow: ref for container, filtered/visible/overflow computed slices
+    const navContainerRef = ref<HTMLElement | null>(null)
+
+    const filteredNavItems = computed(() =>
+      navItems.filter(item => !item.adminOnly || userStore.isAdmin)
+    )
+
+    const { visibleCount } = useNavOverflow(
+      navContainerRef,
+      computed(() => filteredNavItems.value.length)
+    )
+
+    const visibleNavItems = computed(() => filteredNavItems.value.slice(0, visibleCount.value))
+    const overflowNavItems = computed(() => filteredNavItems.value.slice(visibleCount.value))
+
     // Issue #973: Guard against Promise objects being rendered as username
     const displayUsername = computed(() => {
       const username = userStore.currentUser?.username
@@ -843,6 +867,11 @@ export default {
       navItems,
       slmAdminUrl,
       displayUsername,
+
+      // Nav overflow
+      navContainerRef,
+      visibleNavItems,
+      overflowNavItems,
 
       // Methods
       toggleMobileNav,

--- a/autobot-frontend/src/components/layout/NavOverflowMenu.vue
+++ b/autobot-frontend/src/components/layout/NavOverflowMenu.vue
@@ -34,6 +34,7 @@
         class="fixed z-50 bg-autobot-bg-secondary border border-autobot-border rounded-md shadow-lg py-1 min-w-40"
         role="menu"
         :aria-label="$t('nav.moreItems')"
+        @keydown.escape="close"
       >
         <router-link
           v-for="item in items"

--- a/autobot-frontend/src/components/layout/NavOverflowMenu.vue
+++ b/autobot-frontend/src/components/layout/NavOverflowMenu.vue
@@ -1,8 +1,8 @@
 <template>
-  <div ref="triggerRef" class="relative">
+  <div v-if="items.length > 0" ref="triggerRef" class="relative">
     <button
       :aria-expanded="open"
-      aria-haspopup="true"
+      aria-haspopup="menu"
       :aria-label="$t('nav.moreItems')"
       :class="[
         'px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center space-x-1',
@@ -41,8 +41,9 @@
           :key="item.to"
           :to="item.to"
           role="menuitem"
-          class="flex items-center space-x-2 px-3 py-2 text-sm transition-colors duration-150 hover:bg-autobot-bg-tertiary"
-          :class="$route.path.startsWith(item.to) ? 'text-autobot-primary' : 'text-autobot-text-primary'"
+          active-class=""
+          exact-active-class="text-autobot-primary"
+          class="flex items-center space-x-2 px-3 py-2 text-sm transition-colors duration-150 hover:bg-autobot-bg-tertiary text-autobot-text-primary"
           @click="close"
         >
           <svg
@@ -79,7 +80,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 
 type SvgFillRule = 'evenodd' | 'nonzero' | 'inherit'
@@ -108,19 +109,34 @@ const hasActiveItem = computed(() =>
 function positionDropdown() {
   if (!triggerRef.value) return
   const rect = triggerRef.value.getBoundingClientRect()
+  const menuWidth = 160  // min-w-40 = 10rem
+  const spaceRight = window.innerWidth - rect.left
+  const left = spaceRight < menuWidth ? rect.right - menuWidth : rect.left
   dropdownStyle.value = {
     top: `${rect.bottom + 4}px`,
-    left: `${rect.left}px`,
+    left: `${Math.max(0, left)}px`,
   }
 }
 
-function toggle() {
-  if (!open.value) positionDropdown()
-  open.value = !open.value
+function handleResize() {
+  if (open.value) positionDropdown()
+}
+
+async function toggle() {
+  if (!open.value) {
+    positionDropdown()
+    open.value = true
+    await nextTick()
+    const firstItem = dropdownRef.value?.querySelector<HTMLElement>('[role="menuitem"]')
+    firstItem?.focus()
+  } else {
+    close()
+  }
 }
 
 function close() {
   open.value = false
+  triggerRef.value?.focus()
 }
 
 function onClickOutside(event: MouseEvent) {
@@ -130,6 +146,13 @@ function onClickOutside(event: MouseEvent) {
   }
 }
 
-onMounted(() => document.addEventListener('click', onClickOutside, true))
-onUnmounted(() => document.removeEventListener('click', onClickOutside, true))
+onMounted(() => {
+  document.addEventListener('click', onClickOutside, true)
+  window.addEventListener('resize', handleResize)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', onClickOutside, true)
+  window.removeEventListener('resize', handleResize)
+})
 </script>

--- a/autobot-frontend/src/components/layout/NavOverflowMenu.vue
+++ b/autobot-frontend/src/components/layout/NavOverflowMenu.vue
@@ -11,7 +11,7 @@
           : 'text-autobot-text-primary hover:bg-autobot-bg-tertiary'
       ]"
       @click="toggle"
-      @keydown.escape="close"
+      @keydown.escape="close(true)"
     >
       <span>{{ $t('nav.more') }}</span>
       <svg
@@ -34,7 +34,7 @@
         class="fixed z-50 bg-autobot-bg-secondary border border-autobot-border rounded-md shadow-lg py-1 min-w-40"
         role="menu"
         :aria-label="$t('nav.moreItems')"
-        @keydown.escape="close"
+        @keydown.escape="close(true)"
       >
         <router-link
           v-for="item in items"
@@ -109,7 +109,7 @@ const hasActiveItem = computed(() =>
 function positionDropdown() {
   if (!triggerRef.value) return
   const rect = triggerRef.value.getBoundingClientRect()
-  const menuWidth = 160  // min-w-40 = 10rem
+  const menuWidth = dropdownRef.value?.getBoundingClientRect().width || 160
   const spaceRight = window.innerWidth - rect.left
   const left = spaceRight < menuWidth ? rect.right - menuWidth : rect.left
   dropdownStyle.value = {
@@ -129,14 +129,16 @@ async function toggle() {
     await nextTick()
     const firstItem = dropdownRef.value?.querySelector<HTMLElement>('[role="menuitem"]')
     firstItem?.focus()
+    // Re-position now that the dropdown is rendered and its real width is known
+    positionDropdown()
   } else {
     close()
   }
 }
 
-function close() {
+function close(restoreFocus = false) {
   open.value = false
-  triggerRef.value?.focus()
+  if (restoreFocus) triggerRef.value?.focus()
 }
 
 function onClickOutside(event: MouseEvent) {

--- a/autobot-frontend/src/components/layout/NavOverflowMenu.vue
+++ b/autobot-frontend/src/components/layout/NavOverflowMenu.vue
@@ -1,0 +1,134 @@
+<template>
+  <div ref="triggerRef" class="relative">
+    <button
+      :aria-expanded="open"
+      aria-haspopup="true"
+      :aria-label="$t('nav.moreItems')"
+      :class="[
+        'px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 flex items-center space-x-1',
+        hasActiveItem
+          ? 'bg-autobot-primary text-white'
+          : 'text-autobot-text-primary hover:bg-autobot-bg-tertiary'
+      ]"
+      @click="toggle"
+      @keydown.escape="close"
+    >
+      <span>{{ $t('nav.more') }}</span>
+      <svg
+        class="w-3 h-3 transition-transform duration-150"
+        :class="open ? 'rotate-180' : ''"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 20 20"
+        aria-hidden="true"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8l5 5 5-5" />
+      </svg>
+    </button>
+
+    <Teleport to="body">
+      <div
+        v-if="open"
+        ref="dropdownRef"
+        :style="dropdownStyle"
+        class="fixed z-50 bg-autobot-bg-secondary border border-autobot-border rounded-md shadow-lg py-1 min-w-40"
+        role="menu"
+        :aria-label="$t('nav.moreItems')"
+      >
+        <router-link
+          v-for="item in items"
+          :key="item.to"
+          :to="item.to"
+          role="menuitem"
+          class="flex items-center space-x-2 px-3 py-2 text-sm transition-colors duration-150 hover:bg-autobot-bg-tertiary"
+          :class="$route.path.startsWith(item.to) ? 'text-autobot-primary' : 'text-autobot-text-primary'"
+          @click="close"
+        >
+          <svg
+            class="w-4 h-4 shrink-0"
+            :fill="item.iconStroke ? 'none' : 'currentColor'"
+            :stroke="item.iconStroke ? 'currentColor' : undefined"
+            viewBox="0 0 20 20"
+            aria-hidden="true"
+          >
+            <template v-if="item.iconPaths">
+              <path
+                v-for="(p, pi) in item.iconPaths"
+                :key="pi"
+                :d="p"
+                :fill-rule="item.iconRule"
+                :clip-rule="item.iconRule"
+              />
+            </template>
+            <path
+              v-else
+              :d="item.icon"
+              :fill-rule="item.iconRule"
+              :clip-rule="item.iconRule"
+              :stroke-linecap="item.iconStroke ? 'round' : undefined"
+              :stroke-linejoin="item.iconStroke ? 'round' : undefined"
+              :stroke-width="item.iconStroke ? '2' : undefined"
+            />
+          </svg>
+          <span>{{ $t(item.labelKey) }}</span>
+        </router-link>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useRoute } from 'vue-router'
+
+type SvgFillRule = 'evenodd' | 'nonzero' | 'inherit'
+
+interface NavItem {
+  to: string
+  labelKey: string
+  icon?: string
+  iconPaths?: string[]
+  iconRule?: SvgFillRule
+  iconStroke?: boolean
+}
+
+const props = defineProps<{ items: NavItem[] }>()
+
+const route = useRoute()
+const open = ref(false)
+const triggerRef = ref<HTMLElement | null>(null)
+const dropdownRef = ref<HTMLElement | null>(null)
+const dropdownStyle = ref<Record<string, string>>({})
+
+const hasActiveItem = computed(() =>
+  props.items.some(item => route.path.startsWith(item.to))
+)
+
+function positionDropdown() {
+  if (!triggerRef.value) return
+  const rect = triggerRef.value.getBoundingClientRect()
+  dropdownStyle.value = {
+    top: `${rect.bottom + 4}px`,
+    left: `${rect.left}px`,
+  }
+}
+
+function toggle() {
+  if (!open.value) positionDropdown()
+  open.value = !open.value
+}
+
+function close() {
+  open.value = false
+}
+
+function onClickOutside(event: MouseEvent) {
+  const target = event.target as Node
+  if (!triggerRef.value?.contains(target) && !dropdownRef.value?.contains(target)) {
+    close()
+  }
+}
+
+onMounted(() => document.addEventListener('click', onClickOutside, true))
+onUnmounted(() => document.removeEventListener('click', onClickOutside, true))
+</script>

--- a/autobot-frontend/src/composables/__tests__/useNavOverflow.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useNavOverflow.test.ts
@@ -36,12 +36,12 @@ function useComposableInComponent(container: HTMLElement, itemCount: number) {
     },
     render: () => null
   })
-  
+
   const app = createApp(Comp)
   const root = document.createElement('div')
   document.body.appendChild(root)
   app.mount(root)
-  
+
   return {
     get visibleCount() { return result.visibleCount.value },
     dispose: () => { app.unmount() }
@@ -88,5 +88,47 @@ describe('useNavOverflow', () => {
     await nextTick()
     expect(test.visibleCount).toBe(1)
     test.dispose()
+  })
+
+  it('shows all items at exact fit boundary (no trailing-gap false overflow)', async () => {
+    // 4 items × 80px + 3 gaps × 16px = 368px; container = 368px exactly — should show all 4
+    const container = makeContainer(368, [80, 80, 80, 80])
+    const test = useComposableInComponent(container, 4)
+    await nextTick()
+    expect(test.visibleCount).toBe(4)
+    test.dispose()
+  })
+
+  it('re-measures when itemCount changes', async () => {
+    const container = makeContainer(800, [80, 80])
+    const itemCountRef = ref(2)
+    let result: any
+    const Comp = defineComponent({
+      setup() {
+        result = useNavOverflow(ref(container), itemCountRef)
+        return result
+      },
+      render: () => null
+    })
+
+    const app = createApp(Comp)
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app.mount(root)
+
+    await nextTick()
+    expect(result.visibleCount.value).toBe(2)
+
+    // Add a third item to the container and update itemCount
+    const el = document.createElement('a')
+    el.setAttribute('data-nav-item', '')
+    el.getBoundingClientRect = () => ({ width: 80 } as DOMRect)
+    container.appendChild(el)
+    itemCountRef.value = 3
+    await nextTick()
+    await nextTick()  // second tick for watch + remeasure
+    expect(result.visibleCount.value).toBe(3)
+
+    app.unmount()
   })
 })

--- a/autobot-frontend/src/composables/__tests__/useNavOverflow.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useNavOverflow.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, nextTick, createApp, defineComponent } from 'vue'
+import { useNavOverflow } from '../useNavOverflow'
+
+let observeCallback: ((entries: any[]) => void) | null = null
+
+beforeEach(() => {
+  observeCallback = null
+  vi.stubGlobal('ResizeObserver', class {
+    constructor(cb: (entries: any[]) => void) {
+      observeCallback = cb
+    }
+    observe() { }
+    disconnect() { }
+  })
+})
+
+function makeContainer(width: number, itemWidths: number[]): HTMLElement {
+  const container = document.createElement('div')
+  Object.defineProperty(container, 'clientWidth', { get: () => width, configurable: true })
+  itemWidths.forEach(w => {
+    const el = document.createElement('a')
+    el.setAttribute('data-nav-item', '')
+    el.getBoundingClientRect = () => ({ width: w } as DOMRect)
+    container.appendChild(el)
+  })
+  return container
+}
+
+function useComposableInComponent(container: HTMLElement, itemCount: number) {
+  let result: any
+  const Comp = defineComponent({
+    setup() {
+      result = useNavOverflow(ref(container), ref(itemCount))
+      return result
+    },
+    render: () => null
+  })
+  
+  const app = createApp(Comp)
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  app.mount(root)
+  
+  return {
+    get visibleCount() { return result.visibleCount.value },
+    dispose: () => { app.unmount() }
+  }
+}
+
+describe('useNavOverflow', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
+  })
+
+  it('shows all items when they fit', async () => {
+    const container = makeContainer(800, [80, 80, 80, 80])
+    const test = useComposableInComponent(container, 4)
+    await nextTick()
+    expect(test.visibleCount).toBe(4)
+    test.dispose()
+  })
+
+  it('clamps when container is narrow', async () => {
+    const container = makeContainer(250, [80, 80, 80, 80])
+    const test = useComposableInComponent(container, 4)
+    await nextTick()
+    expect(test.visibleCount).toBe(1)
+    test.dispose()
+  })
+
+  it('recalculates when ResizeObserver fires', async () => {
+    const container = makeContainer(250, [80, 80, 80, 80])
+    const test = useComposableInComponent(container, 4)
+    await nextTick()
+    expect(test.visibleCount).toBe(1)
+    Object.defineProperty(container, 'clientWidth', { get: () => 800, configurable: true })
+    observeCallback?.([])
+    await nextTick()
+    expect(test.visibleCount).toBe(4)
+    test.dispose()
+  })
+
+  it('always shows at least 1 item', async () => {
+    const container = makeContainer(50, [200, 200, 200])
+    const test = useComposableInComponent(container, 3)
+    await nextTick()
+    expect(test.visibleCount).toBe(1)
+    test.dispose()
+  })
+})

--- a/autobot-frontend/src/composables/useNavOverflow.ts
+++ b/autobot-frontend/src/composables/useNavOverflow.ts
@@ -1,4 +1,4 @@
-import { ref, onMounted, onUnmounted, nextTick, type Ref } from 'vue'
+import { ref, watch, onMounted, onUnmounted, nextTick, type Ref } from 'vue'
 
 const MORE_BUTTON_WIDTH = 90
 const GAP = 16
@@ -25,7 +25,7 @@ export function useNavOverflow(
     if (naturalWidths.length === 0) measureNaturalWidths()
     if (naturalWidths.length === 0) return
 
-    const totalNatural = naturalWidths.reduce((s, w) => s + w + GAP, 0)
+    const totalNatural = naturalWidths.reduce((s, w) => s + w, 0) + GAP * Math.max(0, naturalWidths.length - 1)
     const available = container.clientWidth
 
     if (totalNatural <= available) {
@@ -36,8 +36,8 @@ export function useNavOverflow(
     const budget = available - MORE_BUTTON_WIDTH
     let consumed = 0
     let count = 0
-    for (const w of naturalWidths) {
-      consumed += w + GAP
+    for (let i = 0; i < naturalWidths.length; i++) {
+      consumed += naturalWidths[i] + (i > 0 ? GAP : 0)
       if (consumed > budget) break
       count++
     }
@@ -50,6 +50,13 @@ export function useNavOverflow(
     recalculate()
     ro = new ResizeObserver(recalculate)
     if (containerRef.value) ro.observe(containerRef.value)
+  })
+
+  watch(itemCount, async () => {
+    await nextTick()
+    naturalWidths = []
+    measureNaturalWidths()
+    recalculate()
   })
 
   onUnmounted(() => ro?.disconnect())

--- a/autobot-frontend/src/composables/useNavOverflow.ts
+++ b/autobot-frontend/src/composables/useNavOverflow.ts
@@ -1,0 +1,58 @@
+import { ref, onMounted, onUnmounted, nextTick, type Ref } from 'vue'
+
+const MORE_BUTTON_WIDTH = 90
+const GAP = 16
+
+export function useNavOverflow(
+  containerRef: Ref<HTMLElement | null>,
+  itemCount: Ref<number>
+) {
+  const visibleCount = ref(itemCount.value)
+  let naturalWidths: number[] = []
+  let ro: ResizeObserver | null = null
+
+  function measureNaturalWidths() {
+    const container = containerRef.value
+    if (!container) return
+    naturalWidths = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-nav-item]')
+    ).map(el => el.getBoundingClientRect().width)
+  }
+
+  function recalculate() {
+    const container = containerRef.value
+    if (!container) return
+    if (naturalWidths.length === 0) measureNaturalWidths()
+    if (naturalWidths.length === 0) return
+
+    const totalNatural = naturalWidths.reduce((s, w) => s + w + GAP, 0)
+    const available = container.clientWidth
+
+    if (totalNatural <= available) {
+      visibleCount.value = naturalWidths.length
+      return
+    }
+
+    const budget = available - MORE_BUTTON_WIDTH
+    let consumed = 0
+    let count = 0
+    for (const w of naturalWidths) {
+      consumed += w + GAP
+      if (consumed > budget) break
+      count++
+    }
+    visibleCount.value = Math.max(1, count)
+  }
+
+  onMounted(async () => {
+    await nextTick()
+    measureNaturalWidths()
+    recalculate()
+    ro = new ResizeObserver(recalculate)
+    if (containerRef.value) ro.observe(containerRef.value)
+  })
+
+  onUnmounted(() => ro?.disconnect())
+
+  return { visibleCount }
+}

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -5644,8 +5644,8 @@
   },
   "operations": {
     "view": {
-      "title": "Operations",
-      "subtitle": "Monitor and manage ongoing operations",
+      "title": "Long-Running Operations",
+      "subtitle": "Monitor and manage background tasks",
       "refresh": "Refresh",
       "loadError": "Failed to load operations"
     },
@@ -5694,12 +5694,6 @@
       "resume": "Resume",
       "viewDetails": "View Details",
       "showingCount": "Showing {shown} of {total} operations"
-    },
-    "view": {
-      "title": "Long-Running Operations",
-      "subtitle": "Monitor and manage background tasks",
-      "refresh": "Refresh",
-      "loadError": "Failed to load operations"
     },
     "panel": {
       "selectOperation": "Select an operation to view details"
@@ -6851,7 +6845,9 @@
     "applicationError": "Application Error",
     "unexpectedError": "An unexpected error occurred",
     "loadingTimeout": "Loading Timed Out",
-    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing.",
+    "more": "More",
+    "moreItems": "More navigation items"
   },
   "reasoningTrace": {
     "title": "Reasoning trace",


### PR DESCRIPTION
## Summary

- Adds `useNavOverflow` composable — `ResizeObserver` watches the nav container and computes `visibleCount` based on measured item widths, with correct gap arithmetic (`sum(widths) + GAP*(n-1)`) and a reserved budget for the More button
- Adds `NavOverflowMenu.vue` — teleported dropdown with active-route highlight on trigger, viewport edge clamping, resize repositioning, keyboard focus management, click-outside close, and full ARIA attributes
- Wires both into `App.vue` desktop nav — admin items pre-filtered before the overflow split; mobile nav unchanged

## Test Plan

- [ ] Run `npx vitest run src/composables/__tests__/useNavOverflow.test.ts` — 6 tests pass
- [ ] Narrow browser window (>1024px but tight) — overflow items collapse into More ▾ button
- [ ] More ▾ button highlights when current route is in overflow set
- [ ] Escape key closes dropdown whether focus is on trigger or inside menu items
- [ ] Click outside closes dropdown without stealing focus from clicked element
- [ ] Dropdown flips left when More button is near right viewport edge
- [ ] Non-admin users do not see Usage/Experiments in overflow menu
- [ ] Mobile nav (hamburger) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)