### PR TITLE
fix(i18n): add 4 missing nav error keys to 10 non-English locale files (#4965)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -6415,7 +6415,11 @@
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
     "systemStatus": "System Status",
-    "operations": "العمليات"
+    "operations": "العمليات",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "reasoningTrace": {
     "title": "Reasoning trace",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -6413,7 +6413,11 @@
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
     "systemStatus": "System Status",
-    "operations": "Operationen"
+    "operations": "Operationen",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "reasoningTrace": {
     "title": "Reasoning-Trace",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -6413,7 +6413,11 @@
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
     "systemStatus": "System Status",
-    "operations": "Operaciones"
+    "operations": "Operaciones",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "reasoningTrace": {
     "title": "Traza de razonamiento",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -119,7 +119,11 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "openMainMenu": "Open main menu",
-    "operations": "عملیات"
+    "operations": "عملیات",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "agent": {
     "registry": {

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -6413,7 +6413,11 @@
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
     "systemStatus": "System Status",
-    "operations": "Opérations"
+    "operations": "Opérations",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "reasoningTrace": {
     "title": "Trace de raisonnement",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -119,7 +119,11 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "openMainMenu": "Open main menu",
-    "operations": "פעולות"
+    "operations": "פעולות",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "agent": {
     "registry": {

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -6413,7 +6413,11 @@
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
     "systemStatus": "System Status",
-    "operations": "Darbības"
+    "operations": "Darbības",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "reasoningTrace": {
     "title": "Reasoning trace",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -6413,7 +6413,11 @@
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
     "systemStatus": "System Status",
-    "operations": "Operacje"
+    "operations": "Operacje",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "reasoningTrace": {
     "title": "Slad rozumowania",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -6413,7 +6413,11 @@
     "skipToNavigation": "Skip to navigation",
     "profile": "Profile",
     "systemStatus": "System Status",
-    "operations": "Operações"
+    "operations": "Operações",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "reasoningTrace": {
     "title": "Rastro de raciocinio",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -119,7 +119,11 @@
     "services": "Services",
     "skipToNavigation": "Skip to navigation",
     "openMainMenu": "Open main menu",
-    "operations": "آپریشنز"
+    "operations": "آپریشنز",
+    "applicationError": "Application Error",
+    "unexpectedError": "An unexpected error occurred",
+    "loadingTimeout": "Loading Timed Out",
+    "loadingTimeoutMessage": "Some content took too long to load. Try refreshing."
   },
   "agent": {
     "registry": {


### PR DESCRIPTION
## Summary
- Adds `nav.applicationError`, `nav.unexpectedError`, `nav.loadingTimeout`, `nav.loadingTimeoutMessage` to all 10 non-English locale files (de, es, fr, pt, ar, fa, he, lv, pl, ur)
- These keys were added to `en.json` in commit `1b47abdfd` but never propagated; users in those locales saw raw key strings instead of English fallback toasts
- English strings used as placeholder pending proper translations (#4826 tracks CI parity check)

## Test Plan
- [ ] Build frontend — no missing-key warnings in console
- [ ] Switch to any non-English locale and trigger an error toast — text displays in English (placeholder) rather than raw key string

Closes #4965

🤖 Generated with [Claude Code](https://claude.com/claude-code)