### PR TITLE
docs(process): add commit-before-subagents rule to pre-flight checklists (#4969)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Before spawning agents or starting worktree work:
 1. **Verify branch isolation:** `git branch --show-current` in main session. Should be `Dev_new_gui`. If on a feature branch, STOP — you'll break parallel worktrees.
 2. **Verify Bash is approved:** Main session must have Bash permission approved — sub-agents inherit from parent. If Bash requires a prompt, approve it once before spawning any agents.
 3. **Create worktrees correctly:** Each issue gets `.worktrees/issue-XXXX/` with dedicated branch. NO shared branches between worktrees.
-4. **Check git status:** `git status` — main session must be clean (no uncommitted changes).
+4. **Check git status:** `git status` — **if any files are dirty, commit or stash them before spawning subagents.** Uncommitted edits are silently discarded when a subagent commits and upstream Dev_new_gui is merged (#4969).
 5. **Verify issue isn't resolved:** Check if issue is already closed or if `Dev_new_gui` already has the fix via `git log origin/Dev_new_gui --oneline --grep="#XXXX"`.
 6. **Confirm approach:** For architectural decisions, state in 1-2 sentences and wait for confirmation.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ After ALL PRs merged:
 **Before spawning agents for issue implementation, verify:**
 
 1. **Main session branch check:** `git branch --show-current` — must be `Dev_new_gui`
-2. **Main session clean:** `git status --porcelain` — no uncommitted changes
+2. **Main session clean:** `git status --porcelain` — **if any files are dirty, commit or stash them before spawning agents.** Uncommitted edits are silently discarded when a subagent commits and upstream is merged (#4969).
 3. **Issue not already resolved:** Check if `#<issue>` is already in `origin/Dev_new_gui` commits
 4. **No stale worktrees:** Clean up any existing `.worktrees/issue-<number>/` directories
 5. **Issue preconditions:** Verify issue dependencies are resolved before starting work

--- a/docs/developer/CLAUDE_WORKFLOW.md
+++ b/docs/developer/CLAUDE_WORKFLOW.md
@@ -58,7 +58,7 @@ Bulk: `scripts/cleanup-worktrees.sh --dry-run` then `scripts/cleanup-worktrees.s
 
 **Pre-Flight Checks (before ANY code changes):**
 1. `git branch --show-current`
-2. `git status`
+2. `git status` — **if any files are dirty, commit or stash them NOW before spawning subagents or starting batch work.** Uncommitted edits are silently discarded when a subagent commits and upstream is merged. (See #4969.)
 3. `git stash list` — if present, ask user
 4. `git fetch origin Dev_new_gui && git log --oneline origin/Dev_new_gui -3`
 


### PR DESCRIPTION
## Summary
- Adds explicit warning to step 4 of the Pre-Flight Checklist in `CLAUDE.md`: commit or stash dirty files before spawning subagents
- Same warning added to `CLAUDE_WORKFLOW.md` Pre-Flight Checks section
- Prevents silent edit loss when a subagent commit + upstream merge discards untracked local edits (incident from session 2026-04-16)

## Test Plan
- [ ] Read both updated sections — rule is clear and actionable

Closes #4969

🤖 Generated with [Claude Code](https://claude.com/claude-code)