### PR TITLE
feat(api): add OpenAI-compatible /v1/chat/completions and /v1/models endpoints (#4447)

### DIFF
--- a/autobot-backend/api/openai_compat.py
+++ b/autobot-backend/api/openai_compat.py
@@ -1,0 +1,324 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+OpenAI-compatible API endpoints (#4447).
+
+Exposes:
+  POST /v1/chat/completions  — accepts OpenAI-format requests, delegates to
+                               ProviderRegistry, returns OpenAI-format responses
+  GET  /v1/models            — lists available models from ProviderRegistry
+
+Auth: Bearer token in Authorization header, validated via AutoBot's own JWT
+middleware.  Unknown model values fall back to the first available provider's
+default.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, AsyncIterator, Dict, List, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from auth_middleware import get_current_user
+from llm_interface_pkg.models import LLMRequest
+from llm_providers.provider_registry import get_provider_registry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["openai-compat"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response models (OpenAI wire format)
+# ---------------------------------------------------------------------------
+
+
+class OAIMessage(BaseModel):
+    role: str
+    content: str
+    name: Optional[str] = None
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str = "autobot-default"
+    messages: List[OAIMessage]
+    temperature: float = 0.7
+    max_tokens: Optional[int] = None
+    top_p: float = 1.0
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    stop: Optional[List[str]] = None
+    stream: bool = False
+    n: int = Field(default=1, ge=1)
+    user: Optional[str] = None
+
+
+class OAIChoiceMessage(BaseModel):
+    role: str
+    content: str
+
+
+class OAIChoice(BaseModel):
+    index: int
+    message: OAIChoiceMessage
+    finish_reason: str = "stop"
+
+
+class OAIUsage(BaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ChatCompletionResponse(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: List[OAIChoice]
+    usage: OAIUsage
+
+
+class OAIDeltaMessage(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class OAIStreamChoice(BaseModel):
+    index: int
+    delta: OAIDeltaMessage
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletionChunk(BaseModel):
+    id: str
+    object: str = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: List[OAIStreamChoice]
+
+
+class OAIModelCard(BaseModel):
+    id: str
+    object: str = "model"
+    created: int = 0
+    owned_by: str = "autobot"
+
+
+class ModelListResponse(BaseModel):
+    object: str = "list"
+    data: List[OAIModelCard]
+
+
+# ---------------------------------------------------------------------------
+# Auth helper — re-uses AutoBot JWT middleware
+# ---------------------------------------------------------------------------
+
+
+def _get_user(request: Request) -> Dict[str, Any]:
+    """Validate Bearer token and return AutoBot user dict.
+
+    Raises HTTPException 401 if auth fails.
+    """
+    try:
+        return get_current_user(request)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("OpenAI compat auth error: %s", exc)
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_llm_request(body: ChatCompletionRequest) -> LLMRequest:
+    """Convert OpenAI-format request to AutoBot LLMRequest."""
+    messages = [{"role": m.role, "content": m.content} for m in body.messages]
+    return LLMRequest(
+        messages=messages,
+        model_name=body.model if body.model != "autobot-default" else None,
+        temperature=body.temperature,
+        max_tokens=body.max_tokens,
+        top_p=body.top_p,
+        frequency_penalty=body.frequency_penalty,
+        presence_penalty=body.presence_penalty,
+        stop=body.stop,
+        stream=body.stream,
+    )
+
+
+def _make_completion_id() -> str:
+    return f"chatcmpl-{uuid4().hex[:24]}"
+
+
+async def _stream_generator(
+    provider,
+    llm_request: LLMRequest,
+    completion_id: str,
+    model_name: str,
+) -> AsyncIterator[str]:
+    """Yield SSE lines for a streaming completion."""
+    created = int(time.time())
+
+    # Opening chunk — role delta
+    role_chunk = ChatCompletionChunk(
+        id=completion_id,
+        created=created,
+        model=model_name,
+        choices=[
+            OAIStreamChoice(
+                index=0,
+                delta=OAIDeltaMessage(role="assistant"),
+                finish_reason=None,
+            )
+        ],
+    )
+    yield f"data: {role_chunk.model_dump_json()}\n\n"
+
+    async for text_chunk in provider.stream_completion(llm_request):
+        if not text_chunk:
+            continue
+        chunk = ChatCompletionChunk(
+            id=completion_id,
+            created=created,
+            model=model_name,
+            choices=[
+                OAIStreamChoice(
+                    index=0,
+                    delta=OAIDeltaMessage(content=text_chunk),
+                    finish_reason=None,
+                )
+            ],
+        )
+        yield f"data: {chunk.model_dump_json()}\n\n"
+
+    # Terminal chunk
+    final_chunk = ChatCompletionChunk(
+        id=completion_id,
+        created=created,
+        model=model_name,
+        choices=[
+            OAIStreamChoice(
+                index=0,
+                delta=OAIDeltaMessage(),
+                finish_reason="stop",
+            )
+        ],
+    )
+    yield f"data: {final_chunk.model_dump_json()}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/chat/completions", response_model=None)
+async def chat_completions(
+    body: ChatCompletionRequest,
+    request: Request,
+) -> Any:
+    """OpenAI-compatible chat completions endpoint (#4447).
+
+    Accepts Bearer token auth, delegates to ProviderRegistry, returns
+    OpenAI-format response (streaming or non-streaming).
+    """
+    _get_user(request)
+
+    registry = get_provider_registry()
+    llm_request = _build_llm_request(body)
+
+    provider = await registry.get_provider_for_request(request=llm_request)
+    if provider is None:
+        raise HTTPException(status_code=503, detail="No LLM providers available")
+
+    completion_id = _make_completion_id()
+    # Use resolved provider name as model echo when caller sent "autobot-default"
+    resolved_model = body.model if body.model != "autobot-default" else provider.provider_name
+
+    if body.stream:
+        return StreamingResponse(
+            _stream_generator(provider, llm_request, completion_id, resolved_model),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    # Non-streaming path
+    llm_response = await provider.chat_completion(llm_request)
+    if llm_response.error:
+        raise HTTPException(status_code=502, detail=llm_response.error)
+
+    tokens = llm_response.usage or {}
+    usage = OAIUsage(
+        prompt_tokens=tokens.get("prompt_tokens", 0),
+        completion_tokens=tokens.get("completion_tokens", 0),
+        total_tokens=tokens.get("total_tokens", llm_response.tokens_used or 0),
+    )
+
+    return ChatCompletionResponse(
+        id=completion_id,
+        created=int(time.time()),
+        model=resolved_model,
+        choices=[
+            OAIChoice(
+                index=0,
+                message=OAIChoiceMessage(
+                    role="assistant",
+                    content=llm_response.content,
+                ),
+                finish_reason=llm_response.finish_reason or "stop",
+            )
+        ],
+        usage=usage,
+    )
+
+
+@router.get("/models", response_model=ModelListResponse)
+async def list_models(request: Request) -> ModelListResponse:
+    """OpenAI-compatible models list endpoint (#4447).
+
+    Returns all models available across registered providers.
+    """
+    _get_user(request)
+
+    registry = get_provider_registry()
+    created = int(time.time())
+    model_cards: List[OAIModelCard] = []
+    seen: set = set()
+
+    for provider_info in registry.list_providers():
+        provider_name = provider_info["name"]
+        provider = registry._providers.get(str(provider_name))
+        if provider is None:
+            continue
+        try:
+            models = await asyncio.wait_for(provider.list_models(), timeout=5.0)
+            for m in models:
+                if m not in seen:
+                    seen.add(m)
+                    model_cards.append(
+                        OAIModelCard(id=m, created=created, owned_by=str(provider_name))
+                    )
+        except Exception as exc:
+            logger.debug("list_models failed for %s: %s", provider_name, exc)
+
+    # Always include a sentinel entry so the list is non-empty
+    if not model_cards:
+        model_cards.append(OAIModelCard(id="autobot-default", created=created))
+
+    return ModelListResponse(data=model_cards)

--- a/autobot-backend/api/test_openai_compat.py
+++ b/autobot-backend/api/test_openai_compat.py
@@ -1,0 +1,172 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Integration tests for OpenAI-compatible /v1 endpoints (#4447).
+
+Tests:
+  1. POST /v1/chat/completions (non-streaming) returns OpenAI-shaped response
+  2. GET  /v1/models returns a list of model objects
+  3. POST /v1/chat/completions (streaming) returns SSE chunks + [DONE]
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.openai_compat import router
+from auth_middleware import get_current_user
+
+# ---------------------------------------------------------------------------
+# Minimal test app
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+app.include_router(router, prefix="/v1")
+# Bypass auth so tests never need real JWT tokens.
+app.dependency_overrides[get_current_user] = lambda: {"username": "test", "role": "user"}
+
+
+# ---------------------------------------------------------------------------
+# Shared mock helpers
+# ---------------------------------------------------------------------------
+
+_SYNTHETIC_USER = {"username": "test", "role": "user"}
+
+
+def _make_mock_registry(content: str = "Hello from AutoBot", models: list = None):
+    """Return a mocked ProviderRegistry with one provider."""
+    from llm_interface_pkg.models import LLMResponse
+
+    models = models or ["autobot-model-1"]
+
+    mock_provider = MagicMock()
+    mock_provider.provider_name = "mock_provider"
+
+    llm_resp = LLMResponse(
+        content=content,
+        model="autobot-model-1",
+        provider="mock_provider",
+        finish_reason="stop",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+    mock_provider.chat_completion = AsyncMock(return_value=llm_resp)
+
+    async def _fake_stream(request):
+        yield "Hello "
+        yield "from AutoBot"
+
+    mock_provider.stream_completion = MagicMock(side_effect=lambda r: _fake_stream(r))
+    mock_provider.list_models = AsyncMock(return_value=models)
+
+    mock_registry = MagicMock()
+    mock_registry.get_provider_for_request = AsyncMock(return_value=mock_provider)
+    mock_registry.list_providers = MagicMock(
+        return_value=[{"name": "mock_provider"}]
+    )
+    mock_registry._providers = {"mock_provider": mock_provider}
+    return mock_registry
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_non_streaming_returns_oai_shape():
+    """POST /v1/chat/completions (non-streaming) must return OpenAI-shaped JSON."""
+    mock_registry = _make_mock_registry("Hello from AutoBot")
+
+    with patch(
+        "api.openai_compat.get_provider_registry", return_value=mock_registry
+    ), patch("api.openai_compat._get_user", return_value=_SYNTHETIC_USER):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "autobot-model-1",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": False,
+                },
+            )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["object"] == "chat.completion"
+    assert "id" in data
+    assert data["id"].startswith("chatcmpl-")
+    assert "choices" in data
+    assert len(data["choices"]) == 1
+    choice = data["choices"][0]
+    assert choice["message"]["role"] == "assistant"
+    assert "Hello from AutoBot" in choice["message"]["content"]
+    assert "usage" in data
+    assert data["usage"]["total_tokens"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_list_models_returns_model_list():
+    """GET /v1/models must return {object: 'list', data: [{id, object, ...}]}."""
+    mock_registry = _make_mock_registry(models=["gpt-autobot-1", "gpt-autobot-2"])
+
+    with patch(
+        "api.openai_compat.get_provider_registry", return_value=mock_registry
+    ), patch("api.openai_compat._get_user", return_value=_SYNTHETIC_USER):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/v1/models")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["object"] == "list"
+    assert isinstance(data["data"], list)
+    assert len(data["data"]) >= 1
+    for model in data["data"]:
+        assert "id" in model
+        assert model["object"] == "model"
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_returns_sse_done():
+    """POST /v1/chat/completions (stream=true) must return SSE events and [DONE]."""
+    mock_registry = _make_mock_registry()
+
+    with patch(
+        "api.openai_compat.get_provider_registry", return_value=mock_registry
+    ), patch("api.openai_compat._get_user", return_value=_SYNTHETIC_USER):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            async with client.stream(
+                "POST",
+                "/v1/chat/completions",
+                json={
+                    "model": "autobot-model-1",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": True,
+                },
+            ) as response:
+                assert response.status_code == 200
+                raw = await response.aread()
+
+    text = raw.decode("utf-8")
+    # Must end with [DONE]
+    assert "data: [DONE]" in text
+    # All data lines except [DONE] must be valid JSON with expected shape
+    data_lines = [
+        line[len("data: "):].strip()
+        for line in text.splitlines()
+        if line.startswith("data: ") and line.strip() != "data: [DONE]"
+    ]
+    assert len(data_lines) >= 2, "Expected at least role chunk + content chunk"
+    for raw_json in data_lines:
+        chunk = json.loads(raw_json)
+        assert chunk["object"] == "chat.completion.chunk"
+        assert "choices" in chunk

--- a/autobot-backend/app_factory.py
+++ b/autobot-backend/app_factory.py
@@ -59,6 +59,7 @@ def _register_routers(app: FastAPI) -> None:
     Register core and optional routers with the FastAPI app.
 
     Issue #665: Extracted from create_fastapi_app to reduce function length.
+    Issue #4447: Also registers OpenAI-compatible router under /v1.
 
     Args:
         app: FastAPI application instance
@@ -79,6 +80,17 @@ def _register_routers(app: FastAPI) -> None:
             logger.info("✅ Registered optional router: %s at /api%s", name, prefix)
         except Exception as e:
             logger.warning("⚠️ Failed to register optional router %s: %s", name, e)
+
+    # Issue #4447: OpenAI-compatible endpoints at /v1 (not /api/v1) so that
+    # third-party clients (Cursor, Continue, LibreChat, etc.) can point directly
+    # at AutoBot without any path rewriting.
+    try:
+        from api.openai_compat import router as openai_compat_router
+
+        app.include_router(openai_compat_router, prefix="/v1")
+        logger.info("✅ Registered OpenAI-compat router at /v1")
+    except Exception as e:
+        logger.warning("⚠️ Failed to register OpenAI-compat router: %s", e)
 
     logger.info("✅ API routes configured with optional AI Stack integration")
 


### PR DESCRIPTION
Closes #4447

## Summary
- New `autobot-backend/api/openai_compat.py` with OpenAI wire-format Pydantic models
- `POST /v1/chat/completions` — non-streaming returns OpenAI-shaped JSON; streaming returns `text/event-stream` SSE with role delta + content chunks + `data: [DONE]`
- `GET /v1/models` — iterates all registered providers, deduplicates, returns `{object:"list",data:[...]}`
- Auth: Bearer token via `Authorization` header mapped to AutoBot session via `get_current_user`
- Unknown `model` values fall back to first available provider's default
- Registered at `/v1` prefix (not `/api/v1`) so 3rd-party clients work unchanged
- 3 tests: non-streaming response shape, models list shape, streaming SSE termination

## Test Status
PASS — 3/3