### PR TITLE
fix(mobile): improve responsive layout for Dashboard, Agents, Knowledge, Settings views (#4445)

### DIFF
--- a/autobot-frontend/src/views/AgentRegistryView.vue
+++ b/autobot-frontend/src/views/AgentRegistryView.vue
@@ -420,3 +420,42 @@ onMounted(async () => {
     </Teleport>
   </div>
 </template>
+
+<style scoped>
+/* Mobile responsive overrides — Tailwind utility classes handle desktop layout,
+   scoped styles handle mobile stacking that Tailwind responsive prefixes can't
+   express without overriding third-party class output. */
+
+@media (max-width: 640px) {
+  /* Stack header title + refresh button vertically */
+  .p-6 > .flex.items-center.justify-between:first-child {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  /* Scrollable tab nav instead of wrapping */
+  .border-b > nav.-mb-px {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    -webkit-overflow-scrolling: touch;
+    /* Hide scrollbar visually but keep functionality */
+    scrollbar-width: none;
+  }
+
+  .border-b > nav.-mb-px::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Ensure tab buttons don't shrink below readable size */
+  .border-b > nav.-mb-px > button {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  /* Category filter buttons: allow wrap on mobile */
+  .mb-4.flex.flex-wrap {
+    gap: 0.5rem;
+  }
+}
+</style>

--- a/autobot-frontend/src/views/CustomDashboard.vue
+++ b/autobot-frontend/src/views/CustomDashboard.vue
@@ -716,8 +716,8 @@ onMounted(() => {
 }
 
 .icon-btn {
-  width: 36px;
-  height: 36px;
+  width: 44px;
+  height: 44px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-lg);
@@ -861,8 +861,8 @@ onMounted(() => {
 }
 
 .widget-actions button {
-  width: 28px;
-  height: 28px;
+  width: 44px;
+  height: 44px;
   background: transparent;
   border: none;
   color: var(--text-tertiary);

--- a/autobot-frontend/src/views/KnowledgeView.vue
+++ b/autobot-frontend/src/views/KnowledgeView.vue
@@ -313,7 +313,6 @@
 
 @media (max-width: 768px) {
   .knowledge-view {
-  contain: layout style paint;
     flex-direction: column;
   }
 
@@ -336,7 +335,8 @@
   }
 
   .category-item {
-    padding: 8px 16px;
+    padding: 12px 16px;
+    min-height: 44px;
   }
 
   .category-item span {

--- a/autobot-frontend/src/views/SettingsView.vue
+++ b/autobot-frontend/src/views/SettingsView.vue
@@ -372,6 +372,22 @@ function onApiKeysSaved(): void {
   .section-content {
     padding: var(--spacing-md);
   }
+
+  /* Prevent tab bar overflow on narrow screens */
+  .settings-tabs {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    -webkit-overflow-scrolling: touch;
+    gap: 0;
+  }
+
+  .settings-tab {
+    white-space: nowrap;
+    flex-shrink: 0;
+    /* Ensure min 44px touch target height */
+    min-height: 44px;
+    padding: var(--spacing-2) var(--spacing-3);
+  }
 }
 .open-wizard-btn {
   display: inline-flex;


### PR DESCRIPTION
Closes #4445

## Summary
- **CustomDashboard.vue**: raised widget-actions and icon-btn touch targets to ≥44px
- **KnowledgeView.vue**: fixed duplicate CSS property in media query; raised category-item mobile touch target to 44px
- **SettingsView.vue**: settings-tabs scrolls horizontally on mobile (overflow-x: auto + flex-wrap: nowrap); tabs get white-space: nowrap + min-height: 44px
- **AgentRegistryView.vue**: added scoped styles block; header stacks vertically at ≤640px; tab nav scrolls horizontally with hidden scrollbar

## Test Status
PASS — 0 new TS errors