### PR TITLE
fix(media): add pytest.importorskip guard for bs4 in pipeline_test.py (#4533)

### DIFF
--- a/autobot-backend/media/link/pipeline_test.py
+++ b/autobot-backend/media/link/pipeline_test.py
@@ -14,6 +14,9 @@ import pytest
 from media.core.types import MediaInput, MediaType, ProcessingIntent
 from media.link.pipeline import LinkPipeline
 
+bs4 = pytest.importorskip("bs4", reason="beautifulsoup4 not installed")
+BeautifulSoup = bs4.BeautifulSoup
+
 
 def _make_input(url, metadata=None):
     return MediaInput(
@@ -53,8 +56,6 @@ class TestLinkPipelineHtmlParsing:
         self.pipe = LinkPipeline()
 
     def _soup(self, html):
-        from bs4 import BeautifulSoup
-
         return BeautifulSoup(html, "html.parser")
 
     def test_extract_title_from_title_tag(self):


### PR DESCRIPTION
Closes #4533

## Summary
- Added `bs4 = pytest.importorskip("bs4", reason="beautifulsoup4 not installed")` at module level in `pipeline_test.py`
- Replaced the lazy `from bs4 import BeautifulSoup` import inside `_soup()` with the module-level `BeautifulSoup = bs4.BeautifulSoup`
- In environments without `beautifulsoup4`, the entire `TestLinkPipelineHtmlParsing` class now gracefully skips instead of raising `ModuleNotFoundError`

## Test Status
All 16 tests PASS (bs4 is installed in CI). In environments without bs4, tests skip with a clear reason message.