### PR TITLE
style(tokens): add missing spacing tokens for negative margins and non-standard sizes (#4948)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -259,6 +259,30 @@
   --spacing-24: 6rem;
   --spacing-32: 8rem;
 
+  /* Sub-half-unit micro spacing — used in dense UI (badges, chips, voice controls) */
+  --spacing-micro-1: 0.1rem;   /* ~1.6px */
+  --spacing-micro-2: 0.15rem;  /* ~2.4px */
+  --spacing-micro-3: 0.2rem;   /* ~3.2px */
+  --spacing-micro-4: 0.3rem;   /* ~4.8px */
+  --spacing-micro-5: 0.4rem;   /* ~6.4px */
+  --spacing-micro-6: 0.45rem;  /* ~7.2px */
+
+  /* Pixel-value tokens for values that don't fit the rem scale */
+  --spacing-3px: 3px;   /* dense chip/badge padding; nearest rem token is --spacing-1 (4px) */
+  --spacing-15px: 15px; /* mid-point between --spacing-3 (12px) and --spacing-4 (16px) */
+  --spacing-18px: 18px; /* mid-point between --spacing-4 (16px) and --spacing-5 (20px) */
+  --spacing-30px: 30px; /* mid-point between --spacing-7 (28px) and --spacing-8 (32px) */
+  --spacing-44px: 44px; /* touch-target minimum (WCAG 2.5.8) */
+  --spacing-140px: 140px; /* fixed layout offset (AgentActivityVisualization timeline) */
+
+  /* Negative spacing tokens — used for border-overlap, tab underline alignment */
+  --spacing-neg-px: -1px;
+  --spacing-neg-2px: -2px;
+  --spacing-neg-4px: -4px;
+  --spacing-neg-8px: -8px;
+  --spacing-neg-40px: -40px;
+  --spacing-neg-0-5: -0.5rem;
+
   /* Semantic spacing aliases */
   --spacing-xs: var(--spacing-1);
   --spacing-sm: var(--spacing-2);

--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -450,7 +450,7 @@ function statusClass(status: string): string {
 .config-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: var(--spacing-micro-5);
   margin-bottom: var(--spacing-4);
 }
 .config-row {
@@ -477,13 +477,13 @@ function statusClass(status: string): string {
 .toggle-label {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--spacing-micro-5);
   cursor: pointer;
 }
 .interval-input {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: var(--spacing-micro-5);
 }
 .interval-input label {
   color: var(--text-secondary, #94a3b8);

--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -665,7 +665,7 @@ onMounted(() => {
   width: 1px;
   height: 1px;
   padding: var(--spacing-0);
-  margin: -1px;
+  margin: var(--spacing-neg-px);
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;

--- a/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
@@ -644,7 +644,7 @@ onUnmounted(() => {
   font-family: var(--font-mono, monospace);
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: var(--spacing-micro-4);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -656,7 +656,7 @@ onUnmounted(() => {
   font-size: var(--text-xs);
   display: flex;
   align-items: center;
-  gap: 0.2rem;
+  gap: var(--spacing-micro-3);
 }
 
 /* Error */

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -472,7 +472,7 @@ watch(() => props.source, (source) => {
   width: 1px;
   height: 1px;
   padding: var(--spacing-0);
-  margin: -1px;
+  margin: var(--spacing-neg-px);
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;

--- a/autobot-frontend/src/components/analytics/SourceManager.vue
+++ b/autobot-frontend/src/components/analytics/SourceManager.vue
@@ -658,7 +658,7 @@ defineExpose({ loadSources })
   font-size: var(--text-xs);
   display: flex;
   align-items: center;
-  gap: 0.2rem;
+  gap: var(--spacing-micro-3);
 }
 
 .source-timestamps {

--- a/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
@@ -39,8 +39,8 @@
     <!-- AI Filtering Toggle (#633) -->
     <div
       class="ai-filter-controls"
-      style="margin-bottom: 15px; padding: 10px; background: rgba(0,0,0,0.2);
-             border-radius: 6px; display: flex; align-items: center; gap: 15px; flex-wrap: wrap;"
+      style="margin-bottom: var(--spacing-15px); padding: 10px; background: rgba(0,0,0,0.2);
+             border-radius: 6px; display: flex; align-items: center; gap: var(--spacing-15px); flex-wrap: wrap;"
     >
       <label
         class="toggle-label"

--- a/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
@@ -852,7 +852,7 @@ function formatTimestamp(timestamp: string): string {
 .score-card .score-loading {
   display: flex;
   justify-content: center;
-  padding: 30px;
+  padding: var(--spacing-30px);
   color: var(--color-info-light);
   font-size: 1.5em;
 }
@@ -912,7 +912,7 @@ function formatTimestamp(timestamp: string): string {
 .score-card .score-empty {
   display: flex;
   justify-content: center;
-  padding: 30px;
+  padding: var(--spacing-30px);
   color: var(--text-tertiary);
   font-style: italic;
 }

--- a/autobot-frontend/src/components/chat/MessageAttachments.vue
+++ b/autobot-frontend/src/components/chat/MessageAttachments.vue
@@ -196,8 +196,8 @@ const formatSize = (bytes: number): string => {
 
   .attachment-size {
     width: 100%;
-    margin-left: 30px;
-    margin-top: -4px;
+    margin-left: var(--spacing-30px);
+    margin-top: var(--spacing-neg-4px);
   }
 }
 </style>

--- a/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationOverlay.vue
@@ -441,7 +441,7 @@ onBeforeUnmount(() => {
 .voice-overlay__lang-badge {
   display: flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: var(--spacing-micro-4);
   padding: 0.15rem 0.5rem;
   border-radius: var(--radius-md);
   background: rgba(37, 99, 235, 0.1);
@@ -608,7 +608,7 @@ onBeforeUnmount(() => {
   font-size: 0.8125rem;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: var(--spacing-micro-5);
 }
 
 .voice-overlay__cert-warning-title {

--- a/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
+++ b/autobot-frontend/src/components/chat/VoiceConversationPanel.vue
@@ -295,7 +295,7 @@ onBeforeUnmount(() => {
 .voice-panel__lang-badge {
   display: flex;
   align-items: center;
-  gap: 0.2rem;
+  gap: var(--spacing-micro-3);
   padding: 0.1rem 0.4rem;
   border-radius: var(--radius-default);
   background: rgba(37, 99, 235, 0.1);

--- a/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
+++ b/autobot-frontend/src/components/feature-flags/AccessMetrics.vue
@@ -562,7 +562,7 @@ const formatTime = (timestamp: number) => {
 .breakdown-item.clickable {
   cursor: pointer;
   padding: var(--spacing-2);
-  margin: -8px;
+  margin: var(--spacing-neg-8px);
   border-radius: var(--radius-md);
   transition: background var(--duration-150);
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowserHeader.vue
@@ -182,7 +182,7 @@ defineEmits<Emits>()
   .category-tabs {
     overflow-x: auto;
     padding-bottom: var(--spacing-2);
-    margin-bottom: -0.5rem;
+    margin-bottom: var(--spacing-neg-0-5);
   }
 
   .search-bar {

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -629,7 +629,7 @@ onUnmounted(() => {
   cursor: pointer;
   transition: all var(--duration-200);
   border-bottom: 2px solid transparent;
-  margin-bottom: -2px;
+  margin-bottom: var(--spacing-neg-2px);
 }
 
 .tab-btn:hover {

--- a/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
@@ -654,7 +654,7 @@ onMounted(() => {
 }
 
 .card-checkbox {
-  margin-top: 3px;
+  margin-top: var(--spacing-3px);
   flex-shrink: 0;
 }
 

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorConfigModal.vue
@@ -938,7 +938,7 @@ function closeModal() {
   width: 1px;
   height: 1px;
   padding: var(--spacing-0);
-  margin: -1px;
+  margin: var(--spacing-neg-px);
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   border: 0;

--- a/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/DocumentExportModal.vue
@@ -422,7 +422,7 @@ watch(() => props.modelValue, (isOpen) => {
   width: 1px;
   height: 1px;
   padding: var(--spacing-0);
-  margin: -1px;
+  margin: var(--spacing-neg-px);
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;

--- a/autobot-frontend/src/components/knowledge/temporal/EventTimeline.vue
+++ b/autobot-frontend/src/components/knowledge/temporal/EventTimeline.vue
@@ -259,7 +259,7 @@ function toggleExpand(eventId: string): void {
 
 .date-marker {
   margin-bottom: var(--spacing-sm);
-  margin-left: -40px;
+  margin-left: var(--spacing-neg-40px);
   padding-left: var(--spacing-10);
 }
 

--- a/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
+++ b/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
@@ -222,7 +222,7 @@ const { formatDate } = useKnowledgeBase()
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 15px;
+  gap: var(--spacing-15px);
   padding: var(--spacing-10);
   color: var(--text-muted);
   font-style: italic;

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -412,7 +412,7 @@ function formatDate(dateValue: Date | string | undefined | null): string {
   font-weight: 500;
   cursor: pointer;
   border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
+  margin-bottom: var(--spacing-neg-px);
   transition: color var(--duration-150), border-color var(--duration-150);
 }
 

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -2364,7 +2364,7 @@ watch(selectedScope, () => {
 }
 
 .secret-input {
-  padding-right: 44px;
+  padding-right: var(--spacing-44px);
   font-family: var(--font-mono);
   font-size: var(--text-sm);
 }

--- a/autobot-frontend/src/components/settings/LanguageSettingsPanel.vue
+++ b/autobot-frontend/src/components/settings/LanguageSettingsPanel.vue
@@ -121,7 +121,7 @@ function announceChange(message: string): void {
   width: 1px;
   height: 1px;
   padding: var(--spacing-0);
-  margin: -1px;
+  margin: var(--spacing-neg-px);
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;

--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -266,7 +266,7 @@ const formatCell = (value: any, column: Column) => {
   width: 1px;
   height: 1px;
   padding: 0;
-  margin: -1px;
+  margin: var(--spacing-neg-px);
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;

--- a/autobot-frontend/src/components/ui/PreferencesPanel.vue
+++ b/autobot-frontend/src/components/ui/PreferencesPanel.vue
@@ -216,7 +216,7 @@ function handleReset() {
   width: 1px;
   height: 1px;
   padding: var(--spacing-0);
-  margin: -1px;
+  margin: var(--spacing-neg-px);
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
@@ -890,7 +890,7 @@ defineExpose({
 .time-labels {
   display: flex;
   justify-content: space-between;
-  padding-left: 140px;
+  padding-left: var(--spacing-140px);
 }
 
 .time-label {

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -512,7 +512,7 @@ onUnmounted(() => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: 18px;
+  padding: var(--spacing-18px);
   cursor: pointer;
   transition: border-color var(--duration-200), box-shadow var(--duration-200);
   display: flex;

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -672,7 +672,7 @@ onMounted(async () => {
 .stat-item {
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: var(--spacing-3px);
 }
 
 .stat-icon {

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -600,7 +600,7 @@ onMounted(async () => {
   font-weight: 500;
   cursor: pointer;
   transition: color var(--duration-150) var(--ease-in-out), border-color var(--duration-150) var(--ease-in-out);
-  margin-bottom: -1px;
+  margin-bottom: var(--spacing-neg-px);
 }
 
 .tab-btn:hover {

--- a/autobot-frontend/src/views/SettingsView.vue
+++ b/autobot-frontend/src/views/SettingsView.vue
@@ -325,7 +325,7 @@ function onApiKeysSaved(): void {
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  margin-bottom: -2px;
+  margin-bottom: var(--spacing-neg-2px);
   cursor: pointer;
   transition: color var(--duration-150), border-color var(--duration-150);
 }


### PR DESCRIPTION
Closes #4948

## Summary
- Added 6 micro-spacing tokens (`--spacing-micro-1` through `--spacing-micro-6`) for sub-half-unit values (0.1rem–0.45rem)
- Added 6 pixel-value tokens (`--spacing-3px`, `--spacing-15px`, `--spacing-18px`, `--spacing-30px`, `--spacing-44px`, `--spacing-140px`) for values that don't fit the rem scale
- Added 6 negative spacing tokens (`--spacing-neg-px` through `--spacing-neg-0-5`) for border-overlap and tab underline alignment patterns
- Migrated 28 Vue files to use the new tokens — these were the 33 occurrences skipped by the #4651 bulk migration

## Test Status
No applicable tests (CSS token declarations). Visual regression should be checked in UI.