### PR TITLE
feat(chat): add multi-model comparison fan-out with concurrent SSE streaming (#4414)

### DIFF
--- a/autobot-backend/api/chat_compare.py
+++ b/autobot-backend/api/chat_compare.py
@@ -1,0 +1,189 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Multi-model comparison API endpoint (Issue #4414).
+
+POST /api/chat/compare
+  - Accepts {prompt, models, context?}
+  - Fans out to N providers concurrently via asyncio.gather(return_exceptions=True)
+  - Streams SSE — one stream per model interleaved on the same connection
+  - One model erroring does NOT cancel others
+
+SSE event shapes:
+  {"model": "<provider>/<model>", "delta": "...", "done": false}
+  {"model": "<provider>/<model>", "done": true}
+  {"model": "<provider>/<model>", "error": "...", "done": true}
+"""
+
+import asyncio
+import json
+import logging
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from auth_middleware import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["chat"])
+
+# ---------------------------------------------------------------------------
+# Request model
+# ---------------------------------------------------------------------------
+
+
+class CompareRequest(BaseModel):
+    prompt: str = Field(..., min_length=1, max_length=50000)
+    models: List[str] = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description="List of 'provider/model' strings, e.g. ['ollama/llama3', 'openai/gpt-4o']",
+    )
+    context: Optional[str] = Field(None, max_length=50000)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_provider_model(spec: str) -> tuple[str, str]:
+    """Split 'provider/model' → (provider, model).  Plain strings become (spec, '')."""
+    if "/" in spec:
+        provider, _, model = spec.partition("/")
+        return provider.strip(), model.strip()
+    return spec.strip(), ""
+
+
+async def _stream_single_model(
+    llm_interface: Any,
+    model_spec: str,
+    messages: List[Dict],
+) -> AsyncIterator[str]:
+    """
+    Yield SSE data lines for a single model.
+
+    Uses chat_completion (non-streaming) and emits the content in one delta
+    plus a done event.  This avoids the complexity of per-provider streaming
+    while keeping the SSE protocol consistent for the frontend.
+    """
+    provider, model_name = _parse_provider_model(model_spec)
+    try:
+        kwargs: Dict[str, Any] = {"provider": provider}
+        if model_name:
+            kwargs["model_name"] = model_name
+
+        response = await llm_interface.chat_completion(
+            messages=messages,
+            llm_type="chat",
+            **kwargs,
+        )
+
+        if response.error:
+            yield _sse({"model": model_spec, "error": response.error, "done": True})
+            return
+
+        content: str = response.content or ""
+        # Stream in reasonably-sized chunks so the UI can start rendering early
+        chunk_size = 64
+        for i in range(0, max(1, len(content)), chunk_size):
+            yield _sse({"model": model_spec, "delta": content[i : i + chunk_size], "done": False})
+            await asyncio.sleep(0)  # yield event-loop slot
+
+        yield _sse({"model": model_spec, "done": True})
+
+    except Exception as exc:
+        logger.warning("compare stream error for %s: %s", model_spec, exc)
+        yield _sse({"model": model_spec, "error": str(exc), "done": True})
+
+
+def _sse(payload: Dict) -> str:
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+async def _fan_out_stream(
+    llm_interface: Any,
+    model_specs: List[str],
+    messages: List[Dict],
+) -> AsyncIterator[str]:
+    """
+    Interleave SSE events from all models concurrently using asyncio queues.
+
+    Each model gets its own async generator.  A coordinator task drains all
+    generators round-robin via a shared asyncio.Queue so results are
+    interleaved as they arrive rather than sequentially.
+    """
+    queue: asyncio.Queue[str | None] = asyncio.Queue()
+    n_models = len(model_specs)
+    sentinel_count = 0
+
+    async def _drain(gen: AsyncIterator[str]) -> None:
+        async for item in gen:
+            await queue.put(item)
+        await queue.put(None)  # signal this model is done
+
+    # Launch all model streams concurrently
+    tasks = [
+        asyncio.create_task(_drain(_stream_single_model(llm_interface, spec, messages)))
+        for spec in model_specs
+    ]
+
+    try:
+        while sentinel_count < n_models:
+            item = await queue.get()
+            if item is None:
+                sentinel_count += 1
+            else:
+                yield item
+    finally:
+        for t in tasks:
+            t.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/chat/compare")
+async def compare_models(
+    body: CompareRequest,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> StreamingResponse:
+    """
+    Fan out a prompt to multiple LLM providers/models and stream all responses
+    concurrently as SSE (Issue #4414).
+
+    Each SSE event is a JSON object:
+      {"model": "provider/model", "delta": "text", "done": false}
+      {"model": "provider/model", "done": true}
+      {"model": "provider/model", "error": "message", "done": true}
+    """
+    from llm_interface_pkg.interface import LLMInterface
+
+    llm_interface = getattr(request.app.state, "_compare_llm_interface", None)
+    if llm_interface is None:
+        llm_interface = LLMInterface()
+        request.app.state._compare_llm_interface = llm_interface
+
+    user_content = body.prompt
+    if body.context:
+        user_content = f"{body.context}\n\n{user_content}"
+
+    messages = [{"role": "user", "content": user_content}]
+
+    return StreamingResponse(
+        _fan_out_stream(llm_interface, body.models, messages),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -19,6 +19,7 @@ from api.audit import router as audit_router
 from api.auth import router as auth_router
 from api.browser_mcp import router as browser_mcp_router
 from api.chat import router as chat_router
+from api.chat_compare import router as chat_compare_router  # Issue #4414
 from api.collaboration import router as collaboration_router
 from api.config_revisions import router as config_revisions_router  # #1404
 from api.data_storage import router as data_storage_router
@@ -94,6 +95,7 @@ def _get_system_routers() -> list:
         (auth_router, "/auth", ["auth"], "auth"),
         (service_messages_router, "", ["service-messages"], "service_messages"),
         (chat_router, "", ["chat"], "chat"),
+        (chat_compare_router, "", ["chat", "compare"], "chat_compare"),  # Issue #4414
         (collaboration_router, "", ["collaboration"], "collaboration"),
         (system_router, "/system", ["system"], "system"),
         (settings_router, "/settings", ["settings"], "settings"),

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -89,6 +89,16 @@
             >
               <i class="fas fa-paperclip"></i>
             </button>
+            <!-- Issue #4414: multi-model comparison toggle -->
+            <button
+              @click="showComparePanel = !showComparePanel"
+              class="header-btn"
+              :class="{ 'bg-electric-100 text-electric-600': showComparePanel }"
+              :title="$t('chat.compare.toggleTitle')"
+              :aria-pressed="showComparePanel"
+            >
+              <i class="fas fa-columns" aria-hidden="true"></i>
+            </button>
           </template>
         </ChatHeader>
 
@@ -114,6 +124,11 @@
             v-if="activeTab === 'chat'"
             :entries="cotEntries"
             :is-active="cotIsActive"
+            class="mx-2 mt-1"
+          />
+          <!-- Issue #4414: multi-model comparison panel -->
+          <MultiModelChat
+            v-if="showComparePanel && activeTab === 'chat'"
             class="mx-2 mt-1"
           />
           <ChatTabContent
@@ -285,6 +300,8 @@ import ReasoningTrace from './ReasoningTrace.vue'
 import { useReasoningTrace } from '@/composables/useReasoningTrace'
 // Issue #4952: agent-loop tool approval
 import { useToolApproval, type PendingToolApproval } from '@/composables/useToolApproval'
+// Issue #4414: multi-model comparison
+import MultiModelChat from './MultiModelChat.vue'
 
 // i18n
 const { t } = useI18n()
@@ -395,6 +412,9 @@ const { showToast } = useToast()
 const notify = (message: string, type: 'info' | 'success' | 'warning' | 'error' = 'info') => {
   showToast(message, type, type === 'error' ? 5000 : 3000)
 }
+
+// Issue #4414: multi-model compare panel toggle
+const showComparePanel = ref(false)
 
 // Dialog states
 const showKnowledgeDialog = ref(false)

--- a/autobot-frontend/src/components/chat/MultiModelChat.vue
+++ b/autobot-frontend/src/components/chat/MultiModelChat.vue
@@ -1,0 +1,332 @@
+<template>
+  <!-- Multi-model compare panel (Issue #4414) -->
+  <div class="multi-model-chat" role="region" :aria-label="$t('chat.compare.panelLabel')">
+
+    <!-- Model picker -->
+    <div class="multi-model-chat__picker">
+      <span class="multi-model-chat__picker-label">{{ $t('chat.compare.selectModels') }}</span>
+      <div class="multi-model-chat__checkboxes">
+        <label
+          v-for="model in availableModels"
+          :key="model"
+          class="multi-model-chat__model-checkbox"
+        >
+          <input
+            type="checkbox"
+            :value="model"
+            v-model="selectedModels"
+            :aria-label="model"
+          />
+          <span class="multi-model-chat__model-name">{{ model }}</span>
+        </label>
+      </div>
+    </div>
+
+    <!-- Prompt input + send -->
+    <div class="multi-model-chat__input-row">
+      <textarea
+        v-model="promptText"
+        class="multi-model-chat__textarea"
+        rows="3"
+        :placeholder="$t('chat.compare.promptPlaceholder')"
+        :disabled="isComparing"
+        @keydown.ctrl.enter.prevent="onSend"
+        :aria-label="$t('chat.compare.promptLabel')"
+      />
+      <button
+        class="multi-model-chat__send-btn"
+        :disabled="isComparing || !promptText.trim() || selectedModels.length === 0"
+        @click="onSend"
+        :aria-label="$t('chat.compare.sendLabel')"
+      >
+        <span v-if="isComparing">
+          <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+        </span>
+        <span v-else>{{ $t('chat.compare.send') }}</span>
+      </button>
+    </div>
+
+    <!-- Response columns -->
+    <div
+      v-if="responses.size > 0"
+      class="multi-model-chat__responses"
+      :class="responses.size <= 3 ? 'multi-model-chat__responses--columns' : 'multi-model-chat__responses--stacked'"
+    >
+      <div
+        v-for="[model, state] in responses"
+        :key="model"
+        class="multi-model-chat__response-card"
+        :class="{
+          'multi-model-chat__response-card--done': state.done,
+          'multi-model-chat__response-card--error': !!state.error,
+        }"
+      >
+        <div class="multi-model-chat__response-header">
+          <span class="multi-model-chat__response-model">{{ model }}</span>
+          <span
+            v-if="state.error"
+            class="multi-model-chat__response-badge multi-model-chat__response-badge--error"
+            role="status"
+          >{{ $t('chat.compare.error') }}</span>
+          <span
+            v-else-if="state.done"
+            class="multi-model-chat__response-badge multi-model-chat__response-badge--done"
+            role="status"
+          >{{ $t('chat.compare.done') }}</span>
+          <span
+            v-else
+            class="multi-model-chat__response-badge multi-model-chat__response-badge--streaming"
+            role="status"
+            aria-live="polite"
+          >{{ $t('chat.compare.streaming') }}</span>
+        </div>
+
+        <div class="multi-model-chat__response-body">
+          <p v-if="state.error" class="multi-model-chat__error-msg">{{ state.error }}</p>
+          <pre v-else class="multi-model-chat__response-text">{{ state.content }}<span v-if="!state.done" class="multi-model-chat__cursor" aria-hidden="true">▋</span></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useMultiModelCompare } from '@/composables/useMultiModelCompare'
+
+// ---------------------------------------------------------------------------
+// Defaults — user can change via the picker
+// ---------------------------------------------------------------------------
+const DEFAULT_MODELS = [
+  'ollama/llama3',
+  'ollama/mistral',
+  'openai/gpt-4o-mini',
+]
+
+const { responses, selectedModels, isComparing, compare, reset } = useMultiModelCompare()
+
+const promptText = ref('')
+
+// Populate defaults on first mount if localStorage is empty
+if (selectedModels.value.length === 0) {
+  selectedModels.value = [...DEFAULT_MODELS]
+}
+
+// Available models for the picker: union of defaults + any extra stored choices
+const availableModels = ref<string[]>([...DEFAULT_MODELS])
+
+// Keep availableModels in sync with selectedModels (in case user has stored extras)
+watch(
+  selectedModels,
+  (current) => {
+    for (const m of current) {
+      if (!availableModels.value.includes(m)) {
+        availableModels.value.push(m)
+      }
+    }
+  },
+  { immediate: true },
+)
+
+async function onSend(): Promise<void> {
+  if (!promptText.value.trim() || selectedModels.value.length === 0 || isComparing.value) return
+  await compare(promptText.value)
+}
+
+defineExpose({ reset })
+</script>
+
+<style scoped>
+.multi-model-chat {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3, 0.75rem);
+  padding: var(--spacing-4, 1rem);
+  background: var(--color-bg-card, #1e1e2e);
+  border-radius: var(--radius-lg, 0.5rem);
+  overflow: hidden;
+}
+
+/* ---- Picker ---- */
+.multi-model-chat__picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-2, 0.5rem);
+}
+
+.multi-model-chat__picker-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-muted, #9ca3af);
+  white-space: nowrap;
+}
+
+.multi-model-chat__checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2, 0.5rem);
+}
+
+.multi-model-chat__model-checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1, 0.25rem);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--color-text-primary, #e5e7eb);
+}
+
+.multi-model-chat__model-name {
+  font-family: ui-monospace, monospace;
+  font-size: 0.75rem;
+}
+
+/* ---- Input row ---- */
+.multi-model-chat__input-row {
+  display: flex;
+  gap: var(--spacing-2, 0.5rem);
+}
+
+.multi-model-chat__textarea {
+  flex: 1;
+  resize: vertical;
+  background: var(--color-bg-input, #2a2a3e);
+  color: var(--color-text-primary, #e5e7eb);
+  border: 1px solid var(--color-border, #374151);
+  border-radius: var(--radius-md, 0.375rem);
+  padding: var(--spacing-2, 0.5rem) var(--spacing-3, 0.75rem);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.multi-model-chat__textarea:focus {
+  outline: 2px solid var(--color-electric-500, #6366f1);
+  outline-offset: 1px;
+}
+
+.multi-model-chat__send-btn {
+  align-self: flex-end;
+  padding: var(--spacing-2, 0.5rem) var(--spacing-4, 1rem);
+  background: var(--color-electric-600, #4f46e5);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md, 0.375rem);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.multi-model-chat__send-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.multi-model-chat__send-btn:not(:disabled):hover {
+  background: var(--color-electric-500, #6366f1);
+}
+
+/* ---- Responses ---- */
+.multi-model-chat__responses {
+  display: grid;
+  gap: var(--spacing-3, 0.75rem);
+  overflow-y: auto;
+  max-height: 60vh;
+}
+
+.multi-model-chat__responses--columns {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.multi-model-chat__responses--stacked {
+  grid-template-columns: 1fr;
+}
+
+.multi-model-chat__response-card {
+  background: var(--color-bg-secondary, #13131f);
+  border: 1px solid var(--color-border, #374151);
+  border-radius: var(--radius-md, 0.375rem);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.multi-model-chat__response-card--error {
+  border-color: var(--color-error, #ef4444);
+}
+
+.multi-model-chat__response-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-2, 0.5rem) var(--spacing-3, 0.75rem);
+  background: var(--color-bg-tertiary, #1a1a2e);
+  border-bottom: 1px solid var(--color-border, #374151);
+  gap: var(--spacing-2, 0.5rem);
+}
+
+.multi-model-chat__response-model {
+  font-family: ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #9ca3af);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.multi-model-chat__response-badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-sm, 0.25rem);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.multi-model-chat__response-badge--streaming {
+  background: var(--color-electric-900, #1e1b4b);
+  color: var(--color-electric-300, #a5b4fc);
+}
+
+.multi-model-chat__response-badge--done {
+  background: var(--color-success-900, #14532d);
+  color: var(--color-success-300, #86efac);
+}
+
+.multi-model-chat__response-badge--error {
+  background: var(--color-error-900, #450a0a);
+  color: var(--color-error-300, #fca5a5);
+}
+
+.multi-model-chat__response-body {
+  padding: var(--spacing-3, 0.75rem);
+  flex: 1;
+  overflow: auto;
+}
+
+.multi-model-chat__response-text {
+  margin: 0;
+  font-family: ui-monospace, monospace;
+  font-size: 0.8125rem;
+  color: var(--color-text-primary, #e5e7eb);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+}
+
+.multi-model-chat__error-msg {
+  font-size: 0.8125rem;
+  color: var(--color-error, #ef4444);
+  margin: 0;
+}
+
+.multi-model-chat__cursor {
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
+}
+</style>

--- a/autobot-frontend/src/composables/useMultiModelCompare.ts
+++ b/autobot-frontend/src/composables/useMultiModelCompare.ts
@@ -1,0 +1,188 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * Multi-model comparison composable (Issue #4414).
+ *
+ * Manages fan-out SSE state for N models.  Opens a single SSE connection to
+ * POST /api/chat/compare, then demultiplexes events by model key.
+ *
+ * Usage:
+ *   const { responses, selectedModels, isComparing, compare, reset } = useMultiModelCompare()
+ */
+
+import { ref, type Ref } from 'vue'
+import { getBackendUrl, getApiBase } from '@/config/ssot-config'
+import { getAuthToken } from '@/utils/fetchWithAuth'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useMultiModelCompare')
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ModelResponse {
+  content: string
+  done: boolean
+  error?: string
+}
+
+export interface UseMultiModelCompareReturn {
+  /** Per-model streaming responses keyed by 'provider/model'. */
+  responses: Ref<Map<string, ModelResponse>>
+  /** Currently selected models (persisted in localStorage). */
+  selectedModels: Ref<string[]>
+  /** True while a fan-out comparison is in progress. */
+  isComparing: Ref<boolean>
+  /** Start a new comparison.  Resets responses first. */
+  compare: (prompt: string, models?: string[]) => Promise<void>
+  /** Clear all response state. */
+  reset: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Local-storage persistence
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = 'autobot_compare_models'
+
+function loadStoredModels(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (Array.isArray(parsed)) return parsed as string[]
+  } catch {
+    // ignore
+  }
+  return []
+}
+
+function saveModels(models: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(models))
+  } catch {
+    // ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+export function useMultiModelCompare(): UseMultiModelCompareReturn {
+  const responses = ref<Map<string, ModelResponse>>(new Map())
+  const selectedModels = ref<string[]>(loadStoredModels())
+  const isComparing = ref(false)
+
+  // Persist selected models whenever they change (caller is responsible for
+  // updating selectedModels; we expose a watcher-free API for simplicity)
+  function _persistModels(): void {
+    saveModels(selectedModels.value)
+  }
+
+  function reset(): void {
+    responses.value = new Map()
+    isComparing.value = false
+  }
+
+  async function compare(prompt: string, models?: string[]): Promise<void> {
+    const targetModels = models ?? selectedModels.value
+    if (!prompt.trim() || targetModels.length === 0) return
+
+    _persistModels()
+    reset()
+    isComparing.value = true
+
+    // Initialise placeholders so the UI can render empty cards immediately
+    const initial = new Map<string, ModelResponse>()
+    for (const m of targetModels) {
+      initial.set(m, { content: '', done: false })
+    }
+    responses.value = initial
+
+    const url = `${getBackendUrl()}${getApiBase()}/chat/compare`
+    const token = getAuthToken()
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (token) headers['Authorization'] = `Bearer ${token}`
+
+    let fetchResponse: Response
+    try {
+      fetchResponse = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ prompt, models: targetModels }),
+      })
+    } catch (err) {
+      logger.error('compare fetch failed:', err)
+      for (const m of targetModels) {
+        responses.value.set(m, { content: '', done: true, error: String(err) })
+      }
+      isComparing.value = false
+      return
+    }
+
+    if (!fetchResponse.ok || !fetchResponse.body) {
+      const msg = `HTTP ${fetchResponse.status}`
+      for (const m of targetModels) {
+        responses.value.set(m, { content: '', done: true, error: msg })
+      }
+      isComparing.value = false
+      return
+    }
+
+    const reader = fetchResponse.body.getReader()
+    const decoder = new TextDecoder('utf-8')
+    let buffer = ''
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+
+        // SSE lines are separated by "\n\n"
+        let boundary = buffer.indexOf('\n\n')
+        while (boundary !== -1) {
+          const chunk = buffer.slice(0, boundary)
+          buffer = buffer.slice(boundary + 2)
+
+          for (const line of chunk.split('\n')) {
+            if (!line.startsWith('data: ')) continue
+            try {
+              const event = JSON.parse(line.slice(6)) as {
+                model: string
+                delta?: string
+                done?: boolean
+                error?: string
+              }
+              const current = responses.value.get(event.model) ?? { content: '', done: false }
+              if (event.error) {
+                responses.value.set(event.model, { ...current, done: true, error: event.error })
+              } else if (event.delta !== undefined) {
+                responses.value.set(event.model, {
+                  ...current,
+                  content: current.content + event.delta,
+                })
+              } else if (event.done) {
+                responses.value.set(event.model, { ...current, done: true })
+              }
+            } catch {
+              // malformed JSON — skip
+            }
+          }
+
+          boundary = buffer.indexOf('\n\n')
+        }
+      }
+    } catch (err) {
+      logger.error('compare stream read error:', err)
+    } finally {
+      reader.releaseLock()
+      isComparing.value = false
+    }
+  }
+
+  return { responses, selectedModels, isComparing, compare, reset }
+}

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -218,6 +218,18 @@
       "sessionNoMessages": "Session {sessionId} - No messages yet",
       "sessionInfo": "Session {sessionId} - {count} messages, last at {time}"
     },
+    "compare": {
+      "toggleTitle": "Compare models",
+      "panelLabel": "Multi-model comparison",
+      "selectModels": "Models:",
+      "promptPlaceholder": "Enter a prompt to compare across models…",
+      "promptLabel": "Comparison prompt",
+      "sendLabel": "Send comparison prompt",
+      "send": "Compare",
+      "streaming": "Streaming…",
+      "done": "Done",
+      "error": "Error"
+    },
     "input": {
       "retryUpload": "Retry upload",
       "filesAttached": "{count} files attached",


### PR DESCRIPTION
Closes #4414

## Summary
- New `autobot-backend/api/chat_compare.py` — `POST /api/chat/compare` fans out to N providers concurrently via asyncio tasks + shared queue; SSE events labeled `{model, delta, done}` or `{model, error, done}`; one model failing doesn't cancel others; reuses `LLMInterface.chat_completion()`
- Registered in `core_routers.py`
- New `autobot-frontend/src/composables/useMultiModelCompare.ts` — reactive per-model response state, `selectedModels` persisted to localStorage
- New `autobot-frontend/src/components/chat/MultiModelChat.vue` — model picker (checkboxes), side-by-side columns (≤3) / stacked cards (4+), live streaming cursors, per-model status badges
- Wired into `ChatInterface.vue` via "Compare models" toggle button
- i18n keys added under `chat.compare.*`

## Test Status
PASS — py_compile clean; 0 new TS errors