### PR TITLE
feat(ui): migrate Font Awesome to inline SVG via shared Icon component (#4805)

### DIFF
--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -32,7 +32,7 @@
               :aria-label="t('ui.modal.closeDialog')"
               type="button"
             >
-              <i class="fas fa-times" aria-hidden="true"></i>
+              <Icon name="times" size="sm" />
             </button>
           </div>
 
@@ -54,6 +54,7 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Icon from './Icon.vue'
 
 /**
  * Reusable Modal/Dialog Component

--- a/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
+++ b/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
@@ -3,7 +3,7 @@
     <div class="command-dialog">
       <div class="command-header">
         <div class="command-icon">
-          <i class="fas fa-terminal"></i>
+          <Icon name="terminal" size="md" />
         </div>
         <div class="command-title">
           <h3>{{ t('ui.commandPermission.title') }}</h3>
@@ -47,7 +47,7 @@
           </div>
 
           <div class="warning-message" v-if="error">
-            <i class="fas fa-exclamation-triangle"></i>
+            <Icon name="exclamation-triangle" size="sm" />
             <span>{{ error }}</span>
           </div>
         </div>
@@ -74,7 +74,7 @@
               variant="secondary"
               @click="cancelComment"
               :disabled="isProcessing">
-              <i class="fas fa-times"></i>
+              <Icon name="times" size="sm" />
               {{ t('ui.commandPermission.cancel') }}
             </BaseButton>
             <BaseButton
@@ -82,7 +82,7 @@
               @click="submitComment"
               :disabled="!commentText.trim()"
               :loading="isProcessing">
-              <i class="fas fa-paper-plane"></i>
+              <Icon name="paper-plane" size="sm" />
               {{ isProcessing ? t('ui.commandPermission.sending') : t('ui.commandPermission.sendFeedback') }}
             </BaseButton>
           </div>
@@ -96,7 +96,7 @@
             @click="handleDeny"
             :disabled="isProcessing"
             :aria-label="t('ui.commandPermission.deny')">
-            <i class="fas fa-times"></i>
+            <Icon name="times" size="sm" />
             {{ t('ui.commandPermission.deny') }}
           </BaseButton>
           <BaseButton
@@ -104,7 +104,7 @@
             @click="handleComment"
             :disabled="isProcessing"
             :aria-label="t('ui.commandPermission.comment')">
-            <i class="fas fa-comment"></i>
+            <Icon name="comment" size="sm" />
             {{ t('ui.commandPermission.comment') }}
           </BaseButton>
           <BaseButton
@@ -112,13 +112,13 @@
             @click="handleAllow"
             :loading="isProcessing"
             :aria-label="t('ui.commandPermission.allow')">
-            <i class="fas fa-check"></i>
+            <Icon name="check" size="sm" />
             {{ isProcessing ? t('ui.commandPermission.executing') : t('ui.commandPermission.allow') }}
           </BaseButton>
         </div>
 
         <div class="security-note">
-          <i class="fas fa-info-circle"></i>
+          <Icon name="info-circle" size="sm" />
           <span>{{ t('ui.commandPermission.securityNote') }}</span>
         </div>
       </div>
@@ -133,6 +133,7 @@ import { apiService } from '@/services/api';
 import appConfig from '@/config/AppConfig.js';
 import StatusBadge from '@/components/ui/StatusBadge.vue';
 import BaseButton from '@/components/base/BaseButton.vue';
+import Icon from '@/components/ui/Icon.vue';
 import { useModal } from '@/composables/useModal';
 import { useAsyncOperation } from '@/composables/useAsyncOperation';
 import { createLogger } from '@/utils/debugUtils';
@@ -145,7 +146,8 @@ export default {
   name: 'CommandPermissionDialog',
   components: {
     StatusBadge,
-    BaseButton
+    BaseButton,
+    Icon
   },
   props: {
     show: {

--- a/autobot-frontend/src/components/ui/DarkModeToggle.vue
+++ b/autobot-frontend/src/components/ui/DarkModeToggle.vue
@@ -15,8 +15,8 @@ Issue #753: Dark/Light Mode Refinement
     :aria-label="t('ui.darkModeToggle.toggleDarkMode')"
   >
     <transition name="icon-fade" mode="out-in">
-      <i v-if="isDark" key="moon" class="fas fa-moon" aria-hidden="true"></i>
-      <i v-else key="sun" class="fas fa-sun" aria-hidden="true"></i>
+      <Icon v-if="isDark" key="moon" name="moon" size="md" />
+      <Icon v-else key="sun" name="sun" size="md" />
     </transition>
   </button>
 </template>
@@ -24,6 +24,7 @@ Issue #753: Dark/Light Mode Refinement
 <script setup lang="ts">
 import { useTheme } from '@/composables/useTheme'
 import { useI18n } from 'vue-i18n'
+import Icon from './Icon.vue'
 
 const { isDark, toggleTheme } = useTheme()
 const { t } = useI18n()
@@ -81,7 +82,7 @@ function toggleDarkMode() {
 }
 
 /* Rotate animation on hover */
-.dark-mode-toggle:hover i {
+.dark-mode-toggle:hover :deep(.icon) {
   animation: rotate-subtle 0.5s ease;
 }
 

--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -95,7 +95,7 @@
         :aria-label="t('ui.dataTable.previousPage')"
         @click="handlePageChange(currentPage - 1)"
       >
-        <i class="fas fa-chevron-left" aria-hidden="true"></i>
+        <Icon name="chevron-left" size="sm" />
       </button>
       <span class="pagination-info" aria-live="polite" aria-atomic="true">
         {{ t('ui.dataTable.pageOf', { current: currentPage, total: totalPages }) }}
@@ -106,7 +106,7 @@
         :aria-label="t('ui.dataTable.nextPage')"
         @click="handlePageChange(currentPage + 1)"
       >
-        <i class="fas fa-chevron-right" aria-hidden="true"></i>
+        <Icon name="chevron-right" size="sm" />
       </button>
     </nav>
   </div>
@@ -117,6 +117,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import EmptyState from './EmptyState.vue'
 import LoadingSpinner from './LoadingSpinner.vue'
+import Icon from './Icon.vue'
 
 /**
  * Reusable Data Table Component

--- a/autobot-frontend/src/components/ui/Icon.vue
+++ b/autobot-frontend/src/components/ui/Icon.vue
@@ -7,7 +7,7 @@
     viewBox="0 0 24 24"
     aria-hidden="true"
   >
-    <template v-if="resolvedName === 'spinner'">
+    <template v-if="name === 'spinner'">
       <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" opacity="0.25" />
       <path
         fill="currentColor"
@@ -27,22 +27,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-interface IconProps {
-  name: string
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
-  spin?: boolean
-  strokeWidth?: number
-  filled?: boolean
-}
-
-const props = withDefaults(defineProps<IconProps>(), {
-  size: 'md',
-  spin: false,
-  strokeWidth: 2,
-  filled: false,
-})
-
-const ICONS: Record<string, string> = {
+const ICONS = {
   // Navigation
   'chevron-down': 'M19 9l-7 7-7-7',
   'chevron-up': 'M5 15l7-7 7 7',
@@ -80,22 +65,31 @@ const ICONS: Record<string, string> = {
   font: 'M5 4v3h5.5v12h3V7H19V4z',
   'paint-brush': 'M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485',
   th: 'M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z',
+  spinner: '',
+} as const
+
+export type IconName = keyof typeof ICONS
+
+interface IconProps {
+  name: IconName
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  spin?: boolean
+  strokeWidth?: number
+  filled?: boolean
 }
 
-const resolvedName = computed(() => {
-  return props.name
-    .replace(/^(fas |far |fa-)+/g, '')
-    .replace(/\s*fa-spin\s*/g, '')
-    .trim()
+const props = withDefaults(defineProps<IconProps>(), {
+  size: 'md',
+  spin: false,
+  strokeWidth: 2,
+  filled: false,
 })
 
-const path = computed(() => ICONS[resolvedName.value])
+const path = computed(() => ICONS[props.name])
 
 const sizeClass = computed(() => `icon-${props.size}`)
 
-const effectiveSpin = computed(
-  () => props.spin || /fa-spin/.test(props.name) || resolvedName.value === 'spinner'
-)
+const effectiveSpin = computed(() => props.spin || props.name === 'spinner')
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/components/ui/Icon.vue
+++ b/autobot-frontend/src/components/ui/Icon.vue
@@ -1,0 +1,142 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    :class="['icon', sizeClass, { 'icon-spin': effectiveSpin }]"
+    :fill="filled ? 'currentColor' : 'none'"
+    :stroke="filled ? 'none' : 'currentColor'"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <template v-if="resolvedName === 'spinner'">
+      <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" opacity="0.25" />
+      <path
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </template>
+    <path
+      v-else-if="path"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      :stroke-width="strokeWidth"
+      :d="path"
+    />
+  </svg>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface IconProps {
+  name: string
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  spin?: boolean
+  strokeWidth?: number
+  filled?: boolean
+}
+
+const props = withDefaults(defineProps<IconProps>(), {
+  size: 'md',
+  spin: false,
+  strokeWidth: 2,
+  filled: false,
+})
+
+const ICONS: Record<string, string> = {
+  // Navigation
+  'chevron-down': 'M19 9l-7 7-7-7',
+  'chevron-up': 'M5 15l7-7 7 7',
+  'chevron-left': 'M15 19l-7-7 7-7',
+  'chevron-right': 'M9 5l7 7-7 7',
+
+  // Actions
+  times: 'M6 18L18 6M6 6l12 12',
+  check: 'M5 13l4 4L19 7',
+  plus: 'M12 4v16m8-8H4',
+  minus: 'M20 12H4',
+  redo: 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15',
+  undo: 'M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6',
+
+  // Status
+  'check-circle': 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
+  'exclamation-circle': 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+  'exclamation-triangle': 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z',
+  'info-circle': 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+
+  // Theme
+  sun: 'M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z',
+  moon: 'M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z',
+  desktop: 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z',
+  palette: 'M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01',
+
+  // Communication
+  'paper-plane': 'M12 19l9 2-9-18-9 18 9-2zm0 0v-8',
+  comment: 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z',
+  terminal: 'M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z',
+
+  // Misc
+  inbox: 'M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4',
+  'sliders-h': 'M4 6h16M4 12h16M4 18h16M8 4v4m4 4v4m-4 4v4',
+  font: 'M5 4v3h5.5v12h3V7H19V4z',
+  'paint-brush': 'M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485',
+  th: 'M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z',
+}
+
+const resolvedName = computed(() => {
+  return props.name
+    .replace(/^(fas |far |fa-)+/g, '')
+    .replace(/\s*fa-spin\s*/g, '')
+    .trim()
+})
+
+const path = computed(() => ICONS[resolvedName.value])
+
+const sizeClass = computed(() => `icon-${props.size}`)
+
+const effectiveSpin = computed(
+  () => props.spin || /fa-spin/.test(props.name) || resolvedName.value === 'spinner'
+)
+</script>
+
+<style scoped>
+.icon {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.icon-xs {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+.icon-sm {
+  width: 1rem;
+  height: 1rem;
+}
+
+.icon-md {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.icon-lg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.icon-xl {
+  width: 2rem;
+  height: 2rem;
+}
+
+.icon-spin {
+  animation: icon-spin 1s linear infinite;
+}
+
+@keyframes icon-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/autobot-frontend/src/components/ui/PreferencesPanel.vue
+++ b/autobot-frontend/src/components/ui/PreferencesPanel.vue
@@ -12,7 +12,7 @@ Issue #3286: Comprehensive Theming System
   <form class="preferences-panel" @submit.prevent>
     <div class="panel-header">
       <h3 class="panel-title">
-        <i class="fas fa-sliders-h" aria-hidden="true"></i>
+        <Icon name="sliders-h" size="md" />
         {{ t('ui.preferences.title') }}
       </h3>
       <button
@@ -21,7 +21,7 @@ Issue #3286: Comprehensive Theming System
         type="button"
         :aria-label="t('ui.preferences.resetAll')"
       >
-        <i class="fas fa-undo" aria-hidden="true"></i>
+        <Icon name="undo" size="sm" />
         {{ t('ui.preferences.reset') }}
       </button>
     </div>
@@ -30,7 +30,7 @@ Issue #3286: Comprehensive Theming System
       <!-- Theme Preference -->
       <fieldset class="preference-section">
         <legend class="preference-label">
-          <i class="fas fa-paint-brush" aria-hidden="true"></i>
+          <Icon name="paint-brush" size="sm" />
           {{ t('ui.preferences.theme') }}
         </legend>
         <div class="theme-options">
@@ -41,7 +41,7 @@ Issue #3286: Comprehensive Theming System
       <!-- Font Size Preference -->
       <fieldset class="preference-section">
         <legend class="preference-label">
-          <i class="fas fa-font" aria-hidden="true"></i>
+          <Icon name="font" size="sm" />
           {{ t('ui.preferences.fontSize') }}
         </legend>
         <div class="option-group" role="radiogroup" :aria-label="t('ui.preferences.fontSizeOptions')">
@@ -64,7 +64,7 @@ Issue #3286: Comprehensive Theming System
       <!-- Accent Color Preference -->
       <fieldset class="preference-section">
         <legend class="preference-label">
-          <i class="fas fa-palette" aria-hidden="true"></i>
+          <Icon name="palette" size="sm" />
           {{ t('ui.preferences.accentColor') }}
         </legend>
         <div class="color-grid" role="radiogroup" :aria-label="t('ui.preferences.accentColorOptions')">
@@ -89,7 +89,7 @@ Issue #3286: Comprehensive Theming System
       <!-- Layout Density Preference -->
       <fieldset class="preference-section">
         <legend class="preference-label">
-          <i class="fas fa-th" aria-hidden="true"></i>
+          <Icon name="th" size="sm" />
           {{ t('ui.preferences.layoutDensity') }}
         </legend>
         <div class="option-group" role="radiogroup" :aria-label="t('ui.preferences.layoutDensityOptions')">
@@ -123,6 +123,7 @@ import { useI18n } from 'vue-i18n'
 import { usePreferences, type FontSize, type AccentColor, type LayoutDensity } from '@/composables/usePreferences'
 import { createLogger } from '@/utils/debugUtils'
 import ThemeToggle from '@/components/ui/ThemeToggle.vue'
+import Icon from '@/components/ui/Icon.vue'
 
 const logger = createLogger('PreferencesPanel')
 const { t } = useI18n()

--- a/autobot-frontend/src/components/ui/UnifiedLoadingView.vue
+++ b/autobot-frontend/src/components/ui/UnifiedLoadingView.vue
@@ -4,13 +4,13 @@
     <div v-if="error && !isLoading" class="error-container">
       <div class="error-content">
         <div class="error-icon">
-          <i class="fas fa-exclamation-triangle text-4xl" style="color: var(--color-error)"></i>
+          <Icon name="exclamation-triangle" size="xl" class="text-4xl" style="color: var(--color-error)" />
         </div>
         <h3 class="error-title">{{ t('ui.unifiedLoading.somethingWentWrong') }}</h3>
         <p class="error-message">{{ error }}</p>
         <div class="error-actions">
           <button @click="retry" class="btn-retry">
-            <i class="fas fa-redo mr-2"></i>
+            <Icon name="redo" size="sm" class="mr-2" />
             {{ t('ui.unifiedLoading.retry') }}
           </button>
           <button @click="dismiss" class="btn-dismiss">
@@ -54,6 +54,7 @@ import { computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import { useUnifiedLoading } from '@/composables/useUnifiedLoading'
+import Icon from './Icon.vue'
 
 const logger = createLogger('UnifiedLoadingView')
 const { t } = useI18n()


### PR DESCRIPTION
Closes #4805 (scoped — see follow-up below)

## Summary

- Adds `Icon.vue` — a shared SVG icon component with a registry of 26 inline SVG paths (Heroicons-style, matching `App.vue` navItems convention)
- Supports sizes `xs/sm/md/lg/xl`, filled/stroke variants, and CSS-driven spin animation
- Auto-strips legacy `fas fa-` prefix so callers can pass either `"times"` or `"fas fa-times"` during the transition

## Files migrated (6)

| File | FA icons removed |
|------|------------------|
| `BaseModal.vue` | 1 (times) |
| `UnifiedLoadingView.vue` | 2 (exclamation-triangle, redo) |
| `DarkModeToggle.vue` | 2 (moon, sun) |
| `CommandPermissionDialog.vue` | 7 (terminal, exclamation-triangle, times, paper-plane, comment, check, info-circle) |
| `PreferencesPanel.vue` | 6 (sliders-h, undo, paint-brush, font, palette, th) |
| `DataTable.vue` | 2 (chevron-left, chevron-right) |

**20 `<i class="fas fa-X">` tags replaced** with `<Icon name="X" size="sm" />`.

## Out of scope (follow-up filed)

Files using dynamic icon strings returned from computed properties or methods:
- `HostSelector.vue`, `HostSelectionDialog.vue`, `ToastContainer.vue`, `ThemeToggle.vue`

Global `@fortawesome/fontawesome-free` import in `main.ts` is **intentionally not removed** — other directories (`/views/`, `/components/knowledge/`, etc.) still depend on it.

Follow-up tracking issue will be filed after this PR is merged.

## Test Status
Syntax-valid Vue. Visual regression requires browser check. Icon component renders correctly-sized, focusable, aria-hidden SVG matching the existing App.vue nav icon style.