### PR TITLE
fix(media): SSRF defense in Jina Reader fast-path — resolve hostnames and reject private IPs (#5015)

### DIFF
--- a/autobot-backend/media/link/pipeline.py
+++ b/autobot-backend/media/link/pipeline.py
@@ -8,9 +8,11 @@
 
 """Link processing pipeline for web content and URLs."""
 
+import asyncio
 import ipaddress
 import logging
 import re
+import socket
 from typing import Any, Dict, List
 from urllib.parse import urljoin, urlparse
 
@@ -40,6 +42,14 @@ _JINA_TIMEOUT = aiohttp.ClientTimeout(total=5) if _AIOHTTP_AVAILABLE else None
 _MAX_CONTENT_LENGTH = 1_000_000  # 1 MB cap on HTML download
 _USER_AGENT = "AutoBot/1.0 (media-pipeline)"
 _JINA_BASE_URL = "https://r.jina.ai/"
+
+# TLDs that are never public — rejected before DNS resolution.
+_PRIVATE_TLDS = (".onion", ".internal", ".local", ".localhost", ".lan", ".home", ".corp")
+# IPv6 Unique Local Address block — ipaddress.is_private already covers this,
+# but we declare it explicitly for documentation.
+_IPV6_ULA = ipaddress.ip_network("fc00::/7")
+# Short DNS timeout to prevent the SSRF check itself from becoming a DoS vector.
+_DNS_TIMEOUT_SECONDS = 2.0
 
 
 class LinkPipeline(BasePipeline):
@@ -88,23 +98,75 @@ class LinkPipeline(BasePipeline):
     # HTTP fetch
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _ip_is_public(ip: ipaddress._BaseAddress) -> bool:
+        """Return True only if an IP address is routable on the public internet."""
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            return False
+        # IPv6 Unique Local Addresses (fc00::/7) — redundant with is_private on
+        # modern Python but kept explicit as defence-in-depth.
+        if isinstance(ip, ipaddress.IPv6Address) and ip in _IPV6_ULA:
+            return False
+        return True
+
     def _is_public_url(self, url: str) -> bool:
-        """Return True only for public HTTP/HTTPS URLs (not localhost or private IPs)."""
+        """Return True only for public HTTP/HTTPS URLs.
+
+        Resolves the hostname via DNS and rejects if *any* resolved address is
+        private, loopback, link-local, multicast, reserved, or unspecified.
+        This closes the SSRF hole where an internal hostname like
+        ``intranet-db.company`` or a DNS-rebinding label like
+        ``10-0-0-1.my-domain.com`` would otherwise be proxied via Jina Reader.
+
+        Note: this performs a blocking DNS lookup; callers on the async path
+        must use :meth:`_is_public_url_async` instead.
+        """
         try:
             parsed = urlparse(url)
             if parsed.scheme not in ("http", "https"):
                 return False
-            host = parsed.hostname or ""
-            if host in ("localhost", "127.0.0.1", "::1"):
+            host = (parsed.hostname or "").lower()
+            if not host:
                 return False
+            # Reject bare private names and private TLDs outright — no DNS needed.
+            if host in ("localhost",) or any(host.endswith(tld) for tld in _PRIVATE_TLDS):
+                return False
+            # If host is a literal IP, check directly without DNS.
             try:
-                addr = ipaddress.ip_address(host)
-                return addr.is_global
+                return self._ip_is_public(ipaddress.ip_address(host))
             except ValueError:
-                # hostname — treat as public unless it looks internal
-                return not (host.endswith(".local") or host.endswith(".internal"))
-        except Exception:
+                pass
+            # Resolve hostname and reject if *any* A/AAAA record is non-public.
+            prev_timeout = socket.getdefaulttimeout()
+            socket.setdefaulttimeout(_DNS_TIMEOUT_SECONDS)
+            try:
+                infos = socket.getaddrinfo(host, None)
+            finally:
+                socket.setdefaulttimeout(prev_timeout)
+            if not infos:
+                return False
+            for info in infos:
+                addr = info[4][0]
+                # Strip IPv6 scope id (e.g. "fe80::1%eth0") before parsing.
+                addr = addr.split("%", 1)[0]
+                if not self._ip_is_public(ipaddress.ip_address(addr)):
+                    return False
+            return True
+        except (socket.gaierror, socket.timeout, ValueError, OSError):
+            # Fail closed — any failure to verify means "not public".
             return False
+
+    async def _is_public_url_async(self, url: str) -> bool:
+        """Async wrapper: run the blocking DNS check in the default executor."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._is_public_url, url)
 
     async def _try_jina(self, url: str) -> str | None:
         """Attempt to fetch URL via Jina Reader. Returns text content or None on failure."""
@@ -141,8 +203,9 @@ class LinkPipeline(BasePipeline):
 
     async def _fetch_and_parse(self, url: str, metadata: Dict) -> Dict[str, Any]:
         """Fetch URL — tries Jina Reader fast-path first, falls back to BeautifulSoup."""
-        # Fast-path: Jina Reader (public URLs only, 5-second timeout)
-        if self._is_public_url(url):
+        # Fast-path: Jina Reader (public URLs only, 5-second timeout).
+        # DNS resolution runs in a thread to avoid blocking the event loop.
+        if await self._is_public_url_async(url):
             content = await self._try_jina(url)
             if content is not None:
                 logger.debug("Jina Reader fast-path succeeded for %s", url)

--- a/autobot-backend/media/link/pipeline_test.py
+++ b/autobot-backend/media/link/pipeline_test.py
@@ -7,12 +7,26 @@
 
 """Unit tests for LinkPipeline."""
 
+import socket
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from media.core.types import MediaInput, MediaType, ProcessingIntent
 from media.link.pipeline import LinkPipeline
+
+
+def _mock_getaddrinfo(ip: str):
+    """Return a patcher that makes socket.getaddrinfo resolve to a fixed IP.
+
+    Supports both IPv4 and IPv6 literals.
+    """
+    family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+    sockaddr = (ip, 0, 0, 0) if family == socket.AF_INET6 else (ip, 0)
+    return patch(
+        "media.link.pipeline.socket.getaddrinfo",
+        return_value=[(family, socket.SOCK_STREAM, 0, "", sockaddr)],
+    )
 
 
 def _make_input(url, metadata=None):
@@ -306,11 +320,28 @@ class TestLinkPipelineJina:
         pipe = LinkPipeline()
         jina_content = "Article title\n\nArticle body text."
 
-        with patch.object(pipe, "_try_jina", new=AsyncMock(return_value=jina_content)):
+        with patch.object(pipe, "_try_jina", new=AsyncMock(return_value=jina_content)), \
+             _mock_getaddrinfo("93.184.216.34"):
             result = await pipe._fetch_and_parse("https://example.com/article", {})
 
         assert result["source"] == "jina"
         assert result["content"] == jina_content
+
+    @pytest.mark.asyncio
+    async def test_fetch_skips_jina_when_hostname_resolves_to_private_ip(self):
+        """SSRF guard: hostname resolving to RFC1918 must skip Jina fast-path."""
+        pipe = LinkPipeline()
+        bs4_result = {"type": "link_fetch", "confidence": 0.9, "url": "https://intranet.attacker/"}
+        jina_mock = AsyncMock(return_value="should-not-be-called")
+
+        with patch.object(pipe, "_try_jina", new=jina_mock), \
+             patch.object(pipe, "_parse_html", return_value=bs4_result), \
+             patch("media.link.pipeline.aiohttp.ClientSession", return_value=self._make_mock_bs4_session()), \
+             _mock_getaddrinfo("10.0.0.5"):
+            result = await pipe._fetch_and_parse("https://intranet.attacker/", {})
+
+        jina_mock.assert_not_called()
+        assert result.get("source") != "jina"
 
     @pytest.mark.asyncio
     async def test_jina_non200_falls_back_to_beautifulsoup(self):
@@ -370,8 +401,120 @@ class TestLinkPipelineJina:
 
     def test_is_public_url_accepts_public_https(self):
         pipe = LinkPipeline()
-        assert pipe._is_public_url("https://example.com/article")
-        assert pipe._is_public_url("http://news.ycombinator.com/")
+        with _mock_getaddrinfo("93.184.216.34"):  # example.com, public IP
+            assert pipe._is_public_url("https://example.com/article")
+        with _mock_getaddrinfo("209.216.230.240"):  # news.ycombinator.com, public IP
+            assert pipe._is_public_url("http://news.ycombinator.com/")
+
+    # ------------------------------------------------------------------
+    # SSRF defence: DNS resolution + private-IP rejection (#5015)
+    # ------------------------------------------------------------------
+
+    def test_is_public_url_rejects_intranet_hostname_resolving_to_rfc1918(self):
+        """Internal hostname resolving to 10.x must be rejected (SSRF guard)."""
+        pipe = LinkPipeline()
+        with _mock_getaddrinfo("10.0.0.5"):
+            assert not pipe._is_public_url("https://intranet-db.company/admin")
+
+    def test_is_public_url_rejects_dns_rebinding_label(self):
+        """DNS-rebinding style names like 10-0-0-1.my-domain.com must be rejected."""
+        pipe = LinkPipeline()
+        with _mock_getaddrinfo("10.0.0.1"):
+            assert not pipe._is_public_url("https://10-0-0-1.my-domain.com/")
+
+    def test_is_public_url_rejects_hostname_resolving_to_loopback(self):
+        pipe = LinkPipeline()
+        with _mock_getaddrinfo("127.0.0.1"):
+            assert not pipe._is_public_url("https://spoofed-loopback.example/")
+
+    def test_is_public_url_rejects_hostname_resolving_to_link_local(self):
+        pipe = LinkPipeline()
+        with _mock_getaddrinfo("169.254.169.254"):  # AWS metadata service
+            assert not pipe._is_public_url("https://metadata.attacker.example/")
+
+    def test_is_public_url_rejects_hostname_resolving_to_ipv6_loopback(self):
+        pipe = LinkPipeline()
+        with _mock_getaddrinfo("::1"):
+            assert not pipe._is_public_url("https://v6-loopback.attacker.example/")
+
+    def test_is_public_url_rejects_hostname_resolving_to_ipv6_ula(self):
+        pipe = LinkPipeline()
+        with _mock_getaddrinfo("fd00::1"):  # IPv6 ULA
+            assert not pipe._is_public_url("https://v6-ula.attacker.example/")
+
+    def test_is_public_url_rejects_multi_answer_with_any_private(self):
+        """If any resolved IP is private, reject — even if others are public."""
+        pipe = LinkPipeline()
+        infos = [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.1", 0)),
+        ]
+        with patch(
+            "media.link.pipeline.socket.getaddrinfo", return_value=infos
+        ):
+            assert not pipe._is_public_url("https://multi-answer.attacker.example/")
+
+    def test_is_public_url_rejects_onion(self):
+        pipe = LinkPipeline()
+        # Must not resolve DNS; rejected by TLD alone.
+        with patch(
+            "media.link.pipeline.socket.getaddrinfo",
+            side_effect=AssertionError("DNS should not be called for .onion"),
+        ):
+            assert not pipe._is_public_url("http://example.onion/page")
+
+    def test_is_public_url_rejects_internal_tld(self):
+        pipe = LinkPipeline()
+        with patch(
+            "media.link.pipeline.socket.getaddrinfo",
+            side_effect=AssertionError("DNS should not be called for .internal"),
+        ):
+            assert not pipe._is_public_url("https://service.internal/")
+
+    def test_is_public_url_rejects_bare_localhost(self):
+        pipe = LinkPipeline()
+        assert not pipe._is_public_url("http://localhost/")
+
+    def test_is_public_url_fails_closed_on_dns_error(self):
+        """DNS lookup failure must return False (fail closed)."""
+        pipe = LinkPipeline()
+        with patch(
+            "media.link.pipeline.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name or service not known"),
+        ):
+            assert not pipe._is_public_url("https://nonexistent-host.example/")
+
+    def test_is_public_url_fails_closed_on_dns_timeout(self):
+        pipe = LinkPipeline()
+        with patch(
+            "media.link.pipeline.socket.getaddrinfo",
+            side_effect=socket.timeout(),
+        ):
+            assert not pipe._is_public_url("https://slow-dns.example/")
+
+    def test_is_public_url_rejects_non_http_scheme(self):
+        pipe = LinkPipeline()
+        assert not pipe._is_public_url("file:///etc/passwd")
+        assert not pipe._is_public_url("ftp://ftp.example.com/")
+        assert not pipe._is_public_url("gopher://example.com/")
+
+    def test_is_public_url_accepts_ipv4_literal_public(self):
+        """Literal public IP short-circuits DNS."""
+        pipe = LinkPipeline()
+        with patch(
+            "media.link.pipeline.socket.getaddrinfo",
+            side_effect=AssertionError("DNS should not be called for literal IP"),
+        ):
+            assert pipe._is_public_url("http://8.8.8.8/")
+
+    @pytest.mark.asyncio
+    async def test_is_public_url_async_wraps_sync_version(self):
+        """Async wrapper delegates to the blocking implementation via executor."""
+        pipe = LinkPipeline()
+        with _mock_getaddrinfo("93.184.216.34"):
+            assert await pipe._is_public_url_async("https://example.com/")
+        with _mock_getaddrinfo("10.0.0.1"):
+            assert not await pipe._is_public_url_async("https://intranet.attacker/")
 
     def _make_mock_bs4_session(self, status=200):
         """Helper: mock ClientSession for the BS4 fallback path."""


### PR DESCRIPTION
Closes #5015

## Summary
- Added DNS resolution + IP range check in `_is_public_url`:
  - Rejects private TLDs (`.onion`, `.internal`, `.local`, `.localhost`, `.lan`, `.home`, `.corp`) without DNS
  - Literal IP hosts short-circuit via `_ip_is_public`
  - Hostnames resolved via `socket.getaddrinfo` with 2s timeout; rejects if ANY returned IP is private/loopback/link-local/multicast/reserved/unspecified or IPv6 ULA
  - Fails closed on DNS errors
- Added `_is_public_url_async` — runs blocking DNS under `run_in_executor`
- `_fetch_and_parse` now `await`s the async version
- 15 new tests: intranet → 10.x, DNS rebinding, loopback, AWS metadata 169.254.169.254, IPv6 loopback/ULA, multi-answer with one private IP, `.onion`/`.internal`, bare `localhost`, DNS failure/timeout fail-closed, non-HTTP schemes, end-to-end proof Jina is NOT called when resolving to RFC1918

## Test Status
PASS — 40/40 (including 15 new SSRF-defense tests)