### PR TITLE
fix(media): add circuit breaker, pooled session, and correct title parsing to Jina Reader fast-path (#5022)

### DIFF
--- a/autobot-backend/media/link/pipeline.py
+++ b/autobot-backend/media/link/pipeline.py
@@ -13,7 +13,8 @@ import ipaddress
 import logging
 import re
 import socket
-from typing import Any, Dict, List
+import time
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
 from media.core.pipeline import BasePipeline
@@ -50,6 +51,21 @@ _PRIVATE_TLDS = (".onion", ".internal", ".local", ".localhost", ".lan", ".home",
 _IPV6_ULA = ipaddress.ip_network("fc00::/7")
 # Short DNS timeout to prevent the SSRF check itself from becoming a DoS vector.
 _DNS_TIMEOUT_SECONDS = 2.0
+
+# Jina Reader circuit breaker: open after N failures in a rolling window,
+# stay open for _JINA_COOLDOWN_SECONDS, then retry. Prevents paying the
+# full timeout cost on every URL during a Jina outage.
+_JINA_COOLDOWN_SECONDS = 60.0
+_JINA_FAILURE_THRESHOLD = 3
+_JINA_FAILURE_WINDOW_SECONDS = 60.0
+_jina_cooldown_until: float = 0.0
+_jina_failures_in_window: List[float] = []
+
+# Pooled aiohttp session for Jina Reader (reused across calls for connection
+# pooling). Lazy-created under _jina_session_lock to serialize the first-
+# creation race. Close via close_jina_session() during app shutdown.
+_jina_session: Optional["aiohttp.ClientSession"] = None
+_jina_session_lock: Optional[asyncio.Lock] = None
 
 
 class LinkPipeline(BasePipeline):
@@ -169,29 +185,52 @@ class LinkPipeline(BasePipeline):
         return await loop.run_in_executor(None, self._is_public_url, url)
 
     async def _try_jina(self, url: str) -> str | None:
-        """Attempt to fetch URL via Jina Reader. Returns text content or None on failure."""
+        """Attempt to fetch URL via Jina Reader. Returns text content or None on failure.
+
+        Uses a pooled ClientSession and a circuit breaker: after
+        _JINA_FAILURE_THRESHOLD failures within _JINA_FAILURE_WINDOW_SECONDS,
+        the circuit opens for _JINA_COOLDOWN_SECONDS and all calls short-
+        circuit to None immediately.
+        """
+        global _jina_cooldown_until
+
+        # Circuit open? Skip the call entirely.
+        if time.monotonic() < _jina_cooldown_until:
+            return None
+
         jina_url = f"{_JINA_BASE_URL}{url}"
         try:
-            async with aiohttp.ClientSession(timeout=_JINA_TIMEOUT) as session:
-                async with session.get(jina_url, allow_redirects=True) as response:
-                    if response.status == 200:
-                        return await response.text(encoding="utf-8", errors="replace")
+            session = await _get_jina_session()
+            async with session.get(
+                jina_url, allow_redirects=True, timeout=_JINA_TIMEOUT
+            ) as response:
+                if response.status == 200:
+                    text = await response.text(encoding="utf-8", errors="replace")
+                    _record_jina_success()
+                    return text
+                # Non-200 counts as a failure for circuit-breaker purposes.
+                _record_jina_failure()
         except Exception as exc:
             logger.debug("Jina Reader fast-path failed for %s: %s", url, exc)
+            _record_jina_failure()
         return None
 
     def _jina_result(self, url: str, content: str, metadata: Dict) -> Dict[str, Any]:
-        """Build a result dict from Jina Reader plain-text response."""
-        word_count = len(content.split()) if content else 0
-        # Extract a title from the first non-empty line if present
-        first_line = next((ln.strip() for ln in content.splitlines() if ln.strip()), "")
-        title = first_line[:200] if first_line else ""
+        """Build a result dict from Jina Reader plain-text response.
+
+        Jina Reader prepends metadata lines like ``Title: ...`` and
+        ``URL Source: ...`` before a blank line and the markdown body. We
+        parse the title from the ``Title:`` prefix and strip the metadata
+        header from the body returned to callers.
+        """
+        title, body = _parse_jina_output(content)
+        word_count = len(body.split()) if body else 0
         return {
             "type": "link_fetch",
             "url": url,
             "title": title,
             "description": "",
-            "content": content,
+            "content": body,
             "word_count": word_count,
             "links": [],
             "open_graph": {},
@@ -375,3 +414,108 @@ class LinkPipeline(BasePipeline):
     def _calculate_confidence(self, result_data: Dict[str, Any]) -> float:
         """Calculate confidence score from result data."""
         return result_data.get("confidence", 0.5)
+
+
+# ----------------------------------------------------------------------
+# Module-level helpers: pooled session, circuit breaker, title parsing
+# ----------------------------------------------------------------------
+
+
+async def _get_jina_session() -> "aiohttp.ClientSession":
+    """Return the shared Jina Reader aiohttp.ClientSession, creating on first call.
+
+    Lazy-created under an asyncio.Lock so concurrent first calls don't each
+    create their own session. Closed at app shutdown via close_jina_session().
+    """
+    global _jina_session, _jina_session_lock
+    if _jina_session_lock is None:
+        _jina_session_lock = asyncio.Lock()
+    if _jina_session is None or _jina_session.closed:
+        async with _jina_session_lock:
+            if _jina_session is None or _jina_session.closed:
+                _jina_session = aiohttp.ClientSession()
+    return _jina_session
+
+
+async def close_jina_session() -> None:
+    """Close the pooled Jina Reader session. Call from app shutdown hook."""
+    global _jina_session
+    if _jina_session is not None and not _jina_session.closed:
+        await _jina_session.close()
+    _jina_session = None
+
+
+def _record_jina_failure() -> None:
+    """Record a Jina Reader failure and open the circuit if threshold reached."""
+    global _jina_cooldown_until
+    now = time.monotonic()
+    cutoff = now - _JINA_FAILURE_WINDOW_SECONDS
+    # Drop entries older than the window.
+    _jina_failures_in_window[:] = [t for t in _jina_failures_in_window if t > cutoff]
+    _jina_failures_in_window.append(now)
+    if len(_jina_failures_in_window) >= _JINA_FAILURE_THRESHOLD:
+        _jina_cooldown_until = now + _JINA_COOLDOWN_SECONDS
+        logger.info(
+            "Jina Reader circuit opened for %.0fs after %d failures",
+            _JINA_COOLDOWN_SECONDS,
+            len(_jina_failures_in_window),
+        )
+        _jina_failures_in_window.clear()
+
+
+def _record_jina_success() -> None:
+    """Record a Jina Reader success, clearing the failure window."""
+    _jina_failures_in_window.clear()
+
+
+def _parse_jina_output(content: str) -> Tuple[str, str]:
+    """Parse Jina Reader output into (title, body).
+
+    Jina Reader output format::
+
+        Title: Actual Page Title Here
+        URL Source: https://...
+
+        Markdown body starts here...
+
+    We scan the first ~10 lines for a ``Title:`` prefix, then strip the
+    metadata header (everything up to and including the first blank line
+    after the metadata block) from the body. If no ``Title:`` prefix is
+    found, title falls back to the first non-empty line of the body and
+    no header is stripped.
+    """
+    if not content:
+        return "", ""
+
+    lines = content.splitlines()
+    title = ""
+    metadata_end_idx = -1  # index of the blank line after metadata block
+
+    # Scan up to the first 10 lines for a Title: prefix and the metadata block end.
+    scan_limit = min(len(lines), 10)
+    for idx in range(scan_limit):
+        line = lines[idx]
+        stripped = line.strip()
+        if not stripped and title:
+            # Blank line AFTER a Title line — end of metadata header.
+            metadata_end_idx = idx
+            break
+        match = re.match(r"^([A-Za-z][A-Za-z0-9 _-]*):\s*(.+)$", stripped)
+        if match:
+            key = match.group(1).strip().lower()
+            if key == "title" and not title:
+                title = match.group(2).strip()[:200]
+            # Continue scanning — could be Title, URL Source, etc.
+
+    if title and metadata_end_idx >= 0:
+        # Strip metadata header (header lines + the blank separator).
+        body = "\n".join(lines[metadata_end_idx + 1 :]).lstrip("\n")
+        return title, body
+
+    if title:
+        # Title found but no blank-line separator — return title + full content.
+        return title, content
+
+    # Fallback: no Title: prefix. Use first non-empty line as title.
+    first_nonempty = next((ln.strip() for ln in lines if ln.strip()), "")
+    return first_nonempty[:200], content

--- a/autobot-backend/media/link/pipeline_test.py
+++ b/autobot-backend/media/link/pipeline_test.py
@@ -532,3 +532,228 @@ class TestLinkPipelineJina:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=False)
         return mock_session
+
+
+# ----------------------------------------------------------------------
+# Circuit breaker, pooled session, title parsing (issue #5022)
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=False)
+def _reset_jina_state():
+    """Reset module-level circuit-breaker + pooled session state between tests."""
+    from media.link import pipeline as pl
+
+    pl._jina_cooldown_until = 0.0
+    pl._jina_failures_in_window.clear()
+    # Force re-creation of pooled session on next use
+    pl._jina_session = None
+    yield
+    pl._jina_cooldown_until = 0.0
+    pl._jina_failures_in_window.clear()
+    pl._jina_session = None
+
+
+class TestJinaCircuitBreaker:
+    """Circuit breaker opens after N failures in rolling window (#5022)."""
+
+    @pytest.mark.asyncio
+    async def test_circuit_opens_after_threshold_failures(self, _reset_jina_state):
+        """After _JINA_FAILURE_THRESHOLD failures, subsequent calls short-circuit."""
+        from media.link import pipeline as pl
+
+        pipe = LinkPipeline()
+
+        # First N calls raise → circuit opens
+        async def _always_raise(*args, **kwargs):
+            raise RuntimeError("simulated Jina outage")
+
+        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(side_effect=_always_raise)):
+            for _ in range(pl._JINA_FAILURE_THRESHOLD):
+                result = await pipe._try_jina("https://example.com/a")
+                assert result is None
+
+        # Circuit should now be open
+        assert pl._jina_cooldown_until > 0
+        assert pl._jina_cooldown_until > __import__("time").monotonic()
+
+        # Subsequent call must NOT invoke _get_jina_session (short-circuit)
+        called = AsyncMock()
+        with patch("media.link.pipeline._get_jina_session", new=called):
+            result = await pipe._try_jina("https://example.com/b")
+        assert result is None
+        called.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_circuit_expires_after_cooldown(self, _reset_jina_state):
+        """After cooldown expires, Jina is tried again."""
+        from media.link import pipeline as pl
+
+        pipe = LinkPipeline()
+
+        # Manually open the circuit in the past (already-expired cooldown)
+        import time as _time
+
+        pl._jina_cooldown_until = _time.monotonic() - 1.0  # expired
+
+        # Mock a successful Jina call; circuit should NOT short-circuit
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value="Title: Foo\n\nBody")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+
+        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(return_value=mock_session)):
+            result = await pipe._try_jina("https://example.com/c")
+
+        assert result == "Title: Foo\n\nBody"
+
+    @pytest.mark.asyncio
+    async def test_success_clears_failure_window(self, _reset_jina_state):
+        """A successful call resets the failure counter so the circuit stays closed."""
+        from media.link import pipeline as pl
+
+        pipe = LinkPipeline()
+
+        # Two failures (below threshold)
+        async def _raise(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(side_effect=_raise)):
+            await pipe._try_jina("https://example.com/x")
+            await pipe._try_jina("https://example.com/y")
+
+        assert len(pl._jina_failures_in_window) == 2
+
+        # One success — window clears
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value="ok")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+
+        with patch("media.link.pipeline._get_jina_session", new=AsyncMock(return_value=mock_session)):
+            await pipe._try_jina("https://example.com/z")
+
+        assert len(pl._jina_failures_in_window) == 0
+
+
+class TestJinaPooledSession:
+    """Pooled ClientSession is reused across sequential calls (#5022)."""
+
+    @pytest.mark.asyncio
+    async def test_pooled_session_reused_across_calls(self, _reset_jina_state):
+        """Two sequential _try_jina calls reuse the same _jina_session instance."""
+        from media.link import pipeline as pl
+
+        pipe = LinkPipeline()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value="Title: Hi\n\nBody")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        # Patch aiohttp.ClientSession to return a tracked MagicMock (not AsyncMock,
+        # so `.closed` is a truthy-free MagicMock attribute; we set it explicitly).
+        created_session = MagicMock()
+        created_session.closed = False
+        created_session.get = MagicMock(return_value=mock_response)
+
+        call_count = MagicMock(return_value=created_session)
+
+        with patch("media.link.pipeline.aiohttp.ClientSession", call_count):
+            await pipe._try_jina("https://example.com/1")
+            first_id = id(pl._jina_session)
+            await pipe._try_jina("https://example.com/2")
+            second_id = id(pl._jina_session)
+
+        assert first_id == second_id, "Pooled session must be the same instance across calls"
+        # aiohttp.ClientSession() constructor should have been called exactly once
+        assert call_count.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_close_jina_session_allows_recreation(self, _reset_jina_state):
+        """close_jina_session() closes the pooled session; next call creates a new one."""
+        from media.link import pipeline as pl
+
+        pipe = LinkPipeline()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value="ok")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        session_a = MagicMock()
+        session_a.closed = False
+        session_a.get = MagicMock(return_value=mock_response)
+        session_a.close = AsyncMock()
+        session_b = MagicMock()
+        session_b.closed = False
+        session_b.get = MagicMock(return_value=mock_response)
+
+        with patch("media.link.pipeline.aiohttp.ClientSession", side_effect=[session_a, session_b]):
+            await pipe._try_jina("https://example.com/1")
+            assert pl._jina_session is session_a
+            await pl.close_jina_session()
+            assert pl._jina_session is None
+            await pipe._try_jina("https://example.com/2")
+            assert pl._jina_session is session_b
+
+        session_a.close.assert_awaited_once()
+
+
+class TestJinaTitleExtraction:
+    """Title is parsed from `Title:` prefix; metadata is stripped from body (#5022)."""
+
+    def test_parse_title_prefix_and_strip_metadata(self):
+        """`Title: Foo\\nURL Source: ...\\n\\nBody` yields title=Foo and clean body."""
+        from media.link.pipeline import _parse_jina_output
+
+        raw = "Title: Foo\nURL Source: https://example.com\n\nBody paragraph here."
+        title, body = _parse_jina_output(raw)
+        assert title == "Foo"
+        assert "Title:" not in body
+        assert "URL Source:" not in body
+        assert body.strip() == "Body paragraph here."
+
+    def test_jina_result_strips_metadata_from_content(self):
+        """_jina_result's content field must not contain Title: or URL Source: lines."""
+        pipe = LinkPipeline()
+        raw = "Title: My Article\nURL Source: https://example.com\n\nThe actual article body."
+        result = pipe._jina_result("https://example.com", raw, {})
+        assert result["title"] == "My Article"
+        assert "Title:" not in result["content"]
+        assert "URL Source:" not in result["content"]
+        assert "The actual article body." in result["content"]
+
+    def test_parse_fallback_when_no_title_prefix(self):
+        """Without a Title: prefix, first non-empty body line is used as title."""
+        from media.link.pipeline import _parse_jina_output
+
+        raw = "Just a plain first line\n\nSecond paragraph."
+        title, body = _parse_jina_output(raw)
+        assert title == "Just a plain first line"
+        # Fallback preserves the full content
+        assert body == raw
+
+    def test_parse_empty_content(self):
+        """Empty or None content returns empty title and body."""
+        from media.link.pipeline import _parse_jina_output
+
+        assert _parse_jina_output("") == ("", "")
+
+    def test_parse_title_truncated_to_200_chars(self):
+        """Title longer than 200 chars is truncated."""
+        from media.link.pipeline import _parse_jina_output
+
+        long_title = "X" * 300
+        raw = f"Title: {long_title}\n\nBody"
+        title, _ = _parse_jina_output(raw)
+        assert len(title) == 200


### PR DESCRIPTION
Closes #5022

## Summary
1. **Circuit breaker** — opens after 3 failures in 60s window; short-circuits `_try_jina` to None for next 60s; successes clear the window. Logs at INFO when opened.
2. **Pooled aiohttp session** — lazy-created once via double-checked locking (`_jina_session_lock`); `close_jina_session()` exposed for app shutdown.
3. **Correct title extraction** — new `_parse_jina_output()` scans first 10 lines for `Title:` prefix; strips the entire metadata header (Title, URL Source, etc.) from the body before returning to consumers. Falls back to first non-empty body line when no `Title:` prefix found.

Tests:
- `TestJinaCircuitBreaker`: opens after threshold, expires after cooldown, success resets window (3)
- `TestJinaPooledSession`: reused across calls, `close_jina_session()` allows recreation (2)
- `TestJinaTitleExtraction`: prefix + metadata stripping, fallback, empty input, 200-char truncation (5)

## Test Status
PASS — 34/34 (24 existing + 10 new)