### PR TITLE
feat(testing): report missing requirements.txt deps in pytest session header (#5032)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -161,6 +161,81 @@ if "models" not in sys.modules:
         setattr(_models_pkg, "infrastructure", _infra_mod)
 
 
+# -- Requirements.txt enforcement (Issue #5032) ----------------------------
+# Tests that use optional parsers like bs4 declare `pytest.importorskip(...)`
+# so they skip gracefully. But a silent skip of ~10% of the suite looks like
+# a passing run to an inattentive reviewer. This session hook reads
+# requirements.txt and reports which declared deps are not importable, so the
+# developer sees a clear "run pip install -r requirements.txt" hint at the
+# top of every test run instead of silent skip messages buried further down.
+
+# Map PyPI distribution names to their importable module name when they differ.
+_DIST_TO_MODULE = {
+    "beautifulsoup4": "bs4",
+    "PyYAML": "yaml",
+    "pyyaml": "yaml",
+    "pillow": "PIL",
+    "opencv-python": "cv2",
+    "scikit-learn": "sklearn",
+    "python-dotenv": "dotenv",
+    "python-multipart": "multipart",
+    "python-dateutil": "dateutil",
+    "python-jose": "jose",
+}
+
+
+def _parse_requirements(path: Path) -> list[str]:
+    """Return package names declared in a requirements.txt file."""
+    names: list[str] = []
+    if not path.exists():
+        return names
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip().split("#", 1)[0].strip()
+        if not line or line.startswith("-"):  # skip comments, blanks, -r/-e flags
+            continue
+        # Strip version specifiers and extras
+        for sep in ("==", ">=", "<=", "~=", ">", "<", "!=", "["):
+            if sep in line:
+                line = line.split(sep, 1)[0].strip()
+        if line:
+            names.append(line)
+    return names
+
+
+def pytest_report_header(config) -> list[str]:
+    """Report missing requirements.txt deps in the pytest session header.
+
+    Does NOT fail the session — stubs in this conftest and `pytest.importorskip`
+    calls in test files still handle graceful degradation. Purpose is to
+    surface the root cause when tests silently skip due to missing deps.
+    """
+    import importlib.util
+
+    req_file = backend_root / "requirements.txt"
+    declared = _parse_requirements(req_file)
+    if not declared:
+        return []
+
+    missing: list[str] = []
+    for dist in declared:
+        module = _DIST_TO_MODULE.get(dist.lower(), dist.replace("-", "_"))
+        try:
+            if importlib.util.find_spec(module) is None:
+                missing.append(dist)
+        except (ImportError, ValueError):
+            missing.append(dist)
+
+    if not missing:
+        return [f"requirements.txt: all {len(declared)} deps importable"]
+
+    preview = ", ".join(missing[:8]) + ("..." if len(missing) > 8 else "")
+    return [
+        f"requirements.txt: {len(missing)}/{len(declared)} deps NOT installed ({preview})",
+        "    Run: pip install -r autobot-backend/requirements.txt",
+        "    Tests using these deps will skip; see importorskip messages below.",
+    ]
+
+
 @pytest.fixture(scope="session")
 def event_loop():
     """Create event loop for async tests."""


### PR DESCRIPTION
Closes #5032

Follow-up to #4533 (merged as PR #5008). That PR added \`pytest.importorskip\` guards so individual tests skip gracefully when optional deps aren't installed — but silent skips hide the root cause from inattentive reviewers.

## Change

Adds a \`pytest_report_header\` hook in \`autobot-backend/conftest.py\` that reads \`requirements.txt\` and reports which declared deps are not importable. Example output at session start:

\`\`\`
requirements.txt: 34/50 deps NOT installed (email-validator, cachetools, celery, sqlalchemy, alembic, openai, anthropic, protobuf...)
    Run: pip install -r autobot-backend/requirements.txt
    Tests using these deps will skip; see importorskip messages below.
\`\`\`

- Does NOT fail the session — existing stubs and importorskip calls still provide graceful degradation for dev environments
- Includes a dist-to-module name map for the common PyPI-name vs. import-name mismatches (\`beautifulsoup4\` → \`bs4\`, \`PyYAML\` → \`yaml\`, etc.)
- Verified locally: header correctly reports \"34/50 deps NOT installed\" in current dev venv

## Test Status
Verified by running \`pytest autobot-backend/media/link/pipeline_test.py --co -q\` — header appears as expected.