### PR TITLE
refactor(tokens): rename --spacing-44px to --touch-target-min, inline --spacing-140px (#5036)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -267,13 +267,16 @@
   --spacing-micro-5: 0.4rem;   /* ~6.4px */
   --spacing-micro-6: 0.45rem;  /* ~7.2px */
 
-  /* Pixel-value tokens for values that don't fit the rem scale */
+  /* Pixel-value tokens for values that don't fit the rem scale.
+   * See #5036 for audit of whether each of these values is intentional
+   * or represents a design error that should be rounded to the scale. */
   --spacing-3px: 3px;   /* dense chip/badge padding; nearest rem token is --spacing-1 (4px) */
   --spacing-15px: 15px; /* mid-point between --spacing-3 (12px) and --spacing-4 (16px) */
   --spacing-18px: 18px; /* mid-point between --spacing-4 (16px) and --spacing-5 (20px) */
   --spacing-30px: 30px; /* mid-point between --spacing-7 (28px) and --spacing-8 (32px) */
-  --spacing-44px: 44px; /* touch-target minimum (WCAG 2.5.8) */
-  --spacing-140px: 140px; /* fixed layout offset (AgentActivityVisualization timeline) */
+
+  /* Semantic accessibility tokens */
+  --touch-target-min: 44px; /* WCAG 2.5.8 minimum touch target size */
 
   /* Negative spacing tokens — used for border-overlap, tab underline alignment */
   --spacing-neg-px: -1px;

--- a/autobot-frontend/src/components/security/SecretsManager.vue
+++ b/autobot-frontend/src/components/security/SecretsManager.vue
@@ -2364,7 +2364,7 @@ watch(selectedScope, () => {
 }
 
 .secret-input {
-  padding-right: var(--spacing-44px);
+  padding-right: var(--touch-target-min);
   font-family: var(--font-mono);
   font-size: var(--text-sm);
 }

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
@@ -890,7 +890,8 @@ defineExpose({
 .time-labels {
   display: flex;
   justify-content: space-between;
-  padding-left: var(--spacing-140px);
+  /* 140px is a fixed timeline-layout offset, not a spacing-scale value */
+  padding-left: 140px;
 }
 
 .time-label {


### PR DESCRIPTION
Closes #5036

Follow-up to #4948 (merged as PR #5009). That PR added 18 tokens including some pixel values whose intent wasn't captured by the name.

## Changes

- **Renamed \`--spacing-44px\` to \`--touch-target-min\`** — 44px is the WCAG 2.5.8 minimum touch-target size. The semantic name makes the intent obvious; any future touch-target change (e.g., to 48px for larger touch-friendly mode) becomes a one-line token edit. Updated its sole usage in \`SecretsManager.vue\`.
- **Inlined \`--spacing-140px\` as a literal \`140px\`** in \`AgentActivityVisualization.vue\` with a comment. It was used exactly once as a layout-specific timeline offset — not a spacing-scale concern — so it doesn't belong as a reusable token.
- **Added a comment** in \`design-tokens.css\` above the remaining pixel-value tokens (\`3px\`, \`15px\`, \`18px\`, \`30px\`) linking to #5036 so reviewers know the audit of those values is still open.

## Out of scope for this PR

\`--spacing-3px\`, \`--spacing-15px\`, \`--spacing-18px\`, \`--spacing-30px\` still exist. Deciding whether each is intentional or a design error needs visual inspection of the affected components — tracked in #5036 and done separately to keep this PR mechanical.