### PR TITLE
feat(knowledge): add /connectors/health endpoint aggregating test_connection() across registry (#4420)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -308,6 +308,37 @@ async def create_connector(request: CreateConnectorRequest):
     return {"connector_id": connector_id, "config": _cfg_to_dict(cfg)}
 
 
+@router.get("/knowledge_base/connectors/health")
+async def connectors_health():
+    """Aggregate test_connection() across all live connectors (Issue #4420).
+
+    Ensures every live instance is hydrated from Redis first so the registry
+    reflects every configured connector, then runs all ``test_connection()``
+    calls concurrently via ``ConnectorRegistry.health_check_all``.
+
+    Returns:
+        Dict with keys ``healthy``, ``unavailable``, ``errors``, ``checked_at``.
+    """
+    await _hydrate_all_instances()
+    return await ConnectorRegistry.health_check_all()
+
+
+async def _hydrate_all_instances() -> None:
+    """Load every persisted connector config into the live registry (Issue #4420).
+
+    The registry only holds instances created via API calls; on cold start or
+    after a restart, the instance map may be empty even though configs exist
+    in Redis.  The health endpoint needs every configured connector to appear
+    in the report, so we hydrate from Redis before aggregating.
+    """
+    ids = await _list_connector_ids()
+    for cid in ids:
+        cfg = await _load_connector(cid)
+        if cfg is None:
+            continue
+        _load_or_create_instance(cfg)
+
+
 @router.get("/knowledge_base/connectors/{connector_id}")
 async def get_connector(connector_id: str):
     """Return config and status for a single connector."""

--- a/autobot-backend/api/knowledge_connectors_health_test.py
+++ b/autobot-backend/api/knowledge_connectors_health_test.py
@@ -1,0 +1,127 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""
+Tests for GET /api/knowledge_base/connectors/health — Issue #4420.
+
+Covers:
+  - empty registry returns empty structure
+  - healthy + unhealthy aggregation with realistic labels
+  - exceptions surfaced in ``errors``
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.knowledge_connectors import router
+from auth_middleware import check_admin_permission
+from knowledge.connectors.models import ConnectorConfig
+from knowledge.connectors.registry import ConnectorRegistry
+
+
+class _FakeConnector:
+    def __init__(self, config: ConnectorConfig, result=True):
+        self.config = config
+        self._result = result
+
+    async def test_connection(self):
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    # Skip auth for unit tests
+    app.dependency_overrides[check_admin_permission] = lambda: None
+    app.include_router(router, prefix="/api")
+    return app
+
+
+def _make_cfg(connector_id: str, connector_type: str, name: str) -> ConnectorConfig:
+    return ConnectorConfig(
+        connector_id=connector_id,
+        connector_type=connector_type,
+        name=name,
+        config={},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    ConnectorRegistry._instances.clear()
+    yield
+    ConnectorRegistry._instances.clear()
+
+
+def test_health_endpoint_empty_registry():
+    app = _make_app()
+    client = TestClient(app)
+
+    async def _no_op():
+        return None
+
+    # Bypass Redis hydration entirely for this unit test.
+    with patch("api.knowledge_connectors._hydrate_all_instances", new=_no_op):
+        resp = client.get("/api/knowledge_base/connectors/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["healthy"] == []
+    assert body["unavailable"] == []
+    assert body["errors"] == {}
+    assert "checked_at" in body
+
+
+def test_health_endpoint_aggregates_mixed_results():
+    app = _make_app()
+    client = TestClient(app)
+
+    ConnectorRegistry.add_instance(
+        _FakeConnector(_make_cfg("a", "file_server", "docs-nfs"), result=True)
+    )
+    ConnectorRegistry.add_instance(
+        _FakeConnector(_make_cfg("b", "web_crawler", "internal-wiki"), result=True)
+    )
+    ConnectorRegistry.add_instance(
+        _FakeConnector(
+            _make_cfg("c", "notion", "workspace-1"),
+            result=RuntimeError("401 Unauthorized"),
+        )
+    )
+
+    async def _no_op():
+        return None
+
+    with patch("api.knowledge_connectors._hydrate_all_instances", new=_no_op):
+        resp = client.get("/api/knowledge_base/connectors/health")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert sorted(body["healthy"]) == [
+        "file_server:docs-nfs",
+        "web_crawler:internal-wiki",
+    ]
+    assert body["unavailable"] == ["notion:workspace-1"]
+    assert "401 Unauthorized" in body["errors"]["notion:workspace-1"]
+    assert "checked_at" in body
+
+
+def test_health_route_matched_before_connector_id_path():
+    """Ensure FastAPI dispatches /health to the aggregate endpoint,
+    not /{connector_id} (Issue #4420 route-ordering guard)."""
+    app = _make_app()
+    client = TestClient(app)
+
+    async def _no_op():
+        return None
+
+    with patch("api.knowledge_connectors._hydrate_all_instances", new=_no_op):
+        resp = client.get("/api/knowledge_base/connectors/health")
+
+    # If dispatched to GET /{connector_id}, we'd get 404 "connector not found".
+    assert resp.status_code == 200
+    assert "healthy" in resp.json()

--- a/autobot-backend/knowledge/connectors/registry.py
+++ b/autobot-backend/knowledge/connectors/registry.py
@@ -19,8 +19,10 @@ Usage:
     running = ConnectorRegistry.get("my-connector-id")
 """
 
+import asyncio
 import logging
-from typing import Dict, List, Optional, Type
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Type
 
 from knowledge.connectors.models import ConnectorConfig
 
@@ -102,3 +104,74 @@ class ConnectorRegistry:
     def list_instances(cls) -> List[str]:
         """Return IDs of all currently registered instances."""
         return list(cls._instances.keys())
+
+    @classmethod
+    async def health_check_all(cls) -> Dict[str, Any]:
+        """Aggregate ``test_connection()`` results across all live instances (Issue #4420).
+
+        Runs every connector's ``test_connection()`` concurrently so one slow
+        or failing connector never blocks the rest.  Exceptions are caught
+        per-connector and surfaced in the ``errors`` map.
+
+        Returns:
+            Dict with keys:
+                healthy: sorted list of instance labels whose test_connection() returned truthy
+                unavailable: sorted list of labels that returned falsy or raised
+                errors: map of label -> error string (only for those that raised)
+                checked_at: UTC ISO-8601 timestamp of the check
+        """
+        instances = list(cls._instances.values())
+        if not instances:
+            return {
+                "healthy": [],
+                "unavailable": [],
+                "errors": {},
+                "checked_at": datetime.now(timezone.utc).isoformat(),
+            }
+
+        results = await asyncio.gather(
+            *[cls._check_one(instance) for instance in instances],
+            return_exceptions=False,
+        )
+
+        healthy: List[str] = []
+        unavailable: List[str] = []
+        errors: Dict[str, str] = {}
+        for label, ok, err in results:
+            if ok:
+                healthy.append(label)
+            else:
+                unavailable.append(label)
+                if err is not None:
+                    errors[label] = err
+
+        return {
+            "healthy": sorted(healthy),
+            "unavailable": sorted(unavailable),
+            "errors": errors,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    @classmethod
+    async def _check_one(cls, instance: Any) -> tuple:
+        """Run test_connection() on a single instance, never raising (Issue #4420)."""
+        label = cls._label_for(instance)
+        try:
+            ok = await instance.test_connection()
+            return label, bool(ok), None
+        except Exception as exc:
+            logger.warning("Connector %s health check raised: %s", label, exc)
+            return label, False, str(exc)
+
+    @staticmethod
+    def _label_for(instance: Any) -> str:
+        """Build a human-readable label ``{connector_type}:{name}`` (Issue #4420).
+
+        Falls back to connector_id if type or name is missing.
+        """
+        cfg = getattr(instance, "config", None)
+        if cfg is None:
+            return "unknown"
+        connector_type = getattr(cfg, "connector_type", "") or "unknown"
+        name = getattr(cfg, "name", "") or getattr(cfg, "connector_id", "unknown")
+        return "%s:%s" % (connector_type, name)

--- a/autobot-backend/knowledge/connectors/registry_health_test.py
+++ b/autobot-backend/knowledge/connectors/registry_health_test.py
@@ -1,0 +1,205 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""
+Unit tests for ConnectorRegistry.health_check_all() — Issue #4420.
+
+Covers:
+  - empty registry returns empty lists
+  - all connectors healthy
+  - mixed healthy / unhealthy
+  - one connector raises → captured in errors
+  - concurrent execution (total runtime << sum of individual delays)
+  - label format: {connector_type}:{name}
+"""
+
+import asyncio
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the autobot-backend package root is on sys.path
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from knowledge.connectors.models import ConnectorConfig
+from knowledge.connectors.registry import ConnectorRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(connector_id: str, connector_type: str, name: str) -> ConnectorConfig:
+    return ConnectorConfig(
+        connector_id=connector_id,
+        connector_type=connector_type,
+        name=name,
+        config={},
+    )
+
+
+class _FakeConnector:
+    """Minimal stand-in for an AbstractConnector instance (Issue #4420)."""
+
+    def __init__(self, config: ConnectorConfig, result=True, delay: float = 0.0):
+        self.config = config
+        self._result = result
+        self._delay = delay
+
+    async def test_connection(self):
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    """Guarantee clean registry state between tests (Issue #4420)."""
+    ConnectorRegistry._instances.clear()
+    yield
+    ConnectorRegistry._instances.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_registry_returns_empty_structure():
+    result = await ConnectorRegistry.health_check_all()
+    assert result["healthy"] == []
+    assert result["unavailable"] == []
+    assert result["errors"] == {}
+    assert "checked_at" in result
+    # Validate timestamp parses as ISO 8601 UTC
+    parsed = datetime.fromisoformat(result["checked_at"])
+    assert parsed.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_all_connectors_healthy():
+    for i in range(3):
+        cfg = _make_config(f"id-{i}", "file_server", f"src-{i}")
+        ConnectorRegistry.add_instance(_FakeConnector(cfg, result=True))
+
+    result = await ConnectorRegistry.health_check_all()
+    assert sorted(result["healthy"]) == [
+        "file_server:src-0",
+        "file_server:src-1",
+        "file_server:src-2",
+    ]
+    assert result["unavailable"] == []
+    assert result["errors"] == {}
+
+
+@pytest.mark.asyncio
+async def test_mixed_healthy_and_unhealthy():
+    ConnectorRegistry.add_instance(
+        _FakeConnector(_make_config("a", "file_server", "docs-nfs"), result=True)
+    )
+    ConnectorRegistry.add_instance(
+        _FakeConnector(_make_config("b", "web_crawler", "internal-wiki"), result=True)
+    )
+    ConnectorRegistry.add_instance(
+        _FakeConnector(_make_config("c", "notion", "workspace-1"), result=False)
+    )
+
+    result = await ConnectorRegistry.health_check_all()
+    assert result["healthy"] == ["file_server:docs-nfs", "web_crawler:internal-wiki"]
+    assert result["unavailable"] == ["notion:workspace-1"]
+    # False (not exception) → no error string
+    assert result["errors"] == {}
+
+
+@pytest.mark.asyncio
+async def test_connector_exception_captured_in_errors():
+    ConnectorRegistry.add_instance(
+        _FakeConnector(_make_config("a", "file_server", "good"), result=True)
+    )
+    ConnectorRegistry.add_instance(
+        _FakeConnector(
+            _make_config("b", "notion", "workspace-1"),
+            result=RuntimeError("401 Unauthorized"),
+        )
+    )
+
+    result = await ConnectorRegistry.health_check_all()
+    assert result["healthy"] == ["file_server:good"]
+    assert result["unavailable"] == ["notion:workspace-1"]
+    assert "notion:workspace-1" in result["errors"]
+    assert "401 Unauthorized" in result["errors"]["notion:workspace-1"]
+
+
+@pytest.mark.asyncio
+async def test_one_failure_does_not_block_others():
+    """Verify asyncio.gather(return_exceptions=False) path: _check_one never raises."""
+    ConnectorRegistry.add_instance(
+        _FakeConnector(_make_config("a", "t", "one"), result=ValueError("boom"))
+    )
+    ConnectorRegistry.add_instance(
+        _FakeConnector(_make_config("b", "t", "two"), result=True)
+    )
+    ConnectorRegistry.add_instance(
+        _FakeConnector(_make_config("c", "t", "three"), result=True)
+    )
+
+    result = await ConnectorRegistry.health_check_all()
+    assert sorted(result["healthy"]) == ["t:three", "t:two"]
+    assert result["unavailable"] == ["t:one"]
+    assert "boom" in result["errors"]["t:one"]
+
+
+@pytest.mark.asyncio
+async def test_checks_run_concurrently():
+    """Total runtime should be ~max(delays), not sum(delays) (Issue #4420)."""
+    delay = 0.15
+    for i in range(5):
+        cfg = _make_config(f"id-{i}", "slow", f"n-{i}")
+        ConnectorRegistry.add_instance(
+            _FakeConnector(cfg, result=True, delay=delay)
+        )
+
+    start = time.monotonic()
+    result = await ConnectorRegistry.health_check_all()
+    elapsed = time.monotonic() - start
+
+    assert len(result["healthy"]) == 5
+    # Sequential would be 5 * 0.15 = 0.75s. Concurrent should be ~0.15s.
+    # Allow generous overhead but still catch sequential execution.
+    assert elapsed < 0.5, f"health_check_all took {elapsed:.3f}s — not concurrent"
+
+
+@pytest.mark.asyncio
+async def test_label_falls_back_to_connector_id_when_name_missing():
+    cfg = _make_config("only-id", "file_server", "")
+    ConnectorRegistry.add_instance(_FakeConnector(cfg, result=True))
+
+    result = await ConnectorRegistry.health_check_all()
+    assert result["healthy"] == ["file_server:only-id"]
+
+
+@pytest.mark.asyncio
+async def test_async_mock_connector():
+    """Verify health check works against AsyncMock-style connectors too."""
+    cfg = _make_config("am", "file_server", "mock")
+    instance = _FakeConnector(cfg, result=True)
+    instance.test_connection = AsyncMock(return_value=True)
+    ConnectorRegistry.add_instance(instance)
+
+    result = await ConnectorRegistry.health_check_all()
+    assert result["healthy"] == ["file_server:mock"]
+    instance.test_connection.assert_awaited_once()


### PR DESCRIPTION
Closes #4420

## Summary
- `ConnectorRegistry.health_check_all()` runs `test_connection()` concurrently via `asyncio.gather` with per-connector exception capture (`_check_one` never raises)
- `GET /api/knowledge_base/connectors/health` endpoint returns:
  ```json
  {"healthy": [...], "unavailable": [...], "errors": {...}, "checked_at": "..."}
  ```
- Route registered **before** `/{connector_id}` so FastAPI matches the literal path
- `_hydrate_all_instances()` loads every persisted config from Redis before aggregating (cold-start correctness)
- Admin-gated via inherited `Depends(check_admin_permission)`
- 11 new tests: empty, all-healthy, mixed, exception-capture, concurrency timing (5×150ms completes in <500ms), label fallback, route-ordering guard

## Test Status
PASS — 11/11 new + 30/30 including pre-existing connector tests