### PR TITLE
feat(knowledge): add tier attribute to connectors and readiness badge in ConnectorStatusCard (#4421)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -110,6 +110,7 @@ async def _save_connector(cfg: ConnectorConfig) -> None:
         "last_sync_at": cfg.last_sync_at.isoformat() if cfg.last_sync_at else None,
         "include_patterns": cfg.include_patterns,
         "exclude_patterns": cfg.exclude_patterns,
+        "tier": int(getattr(cfg, "tier", 0)),
     }
     await asyncio.to_thread(
         redis.set,
@@ -144,6 +145,7 @@ def _deserialize_connector(raw: Any) -> ConnectorConfig:
         last_sync_at=_parse_dt(data.get("last_sync_at")),
         include_patterns=data.get("include_patterns", []),
         exclude_patterns=data.get("exclude_patterns", []),
+        tier=int(data.get("tier", 0)),
     )
 
 
@@ -256,6 +258,26 @@ async def _run_sync_background(connector_id: str, incremental: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
+@router.get("/knowledge_base/connector_types")
+async def list_connector_types():
+    """Return all registered connector types with readiness tier (Issue #4421).
+
+    The frontend uses this to show a "Ready / Free key needed / Setup required"
+    badge on each connector card before the user picks one.  Tier is read from
+    the class attribute on each registered connector.
+    """
+    types = []
+    for type_name, klass in ConnectorRegistry._connectors.items():
+        types.append(
+            {
+                "connector_type": type_name,
+                "tier": int(getattr(klass, "tier", 0)),
+            }
+        )
+    types.sort(key=lambda t: (t["tier"], t["connector_type"]))
+    return {"connector_types": types, "total": len(types)}
+
+
 @router.get("/knowledge_base/connectors")
 async def list_connectors():
     """Return all connectors with their current status."""
@@ -283,6 +305,7 @@ async def create_connector(request: CreateConnectorRequest):
             detail="connector_type must be one of: %s" % _SUPPORTED_TYPES,
         )
     connector_id = str(uuid.uuid4())
+    klass = ConnectorRegistry._connectors.get(request.connector_type)
     cfg = ConnectorConfig(
         connector_id=connector_id,
         connector_type=request.connector_type,
@@ -293,6 +316,7 @@ async def create_connector(request: CreateConnectorRequest):
         schedule_cron=request.schedule_cron,
         include_patterns=request.include_patterns,
         exclude_patterns=request.exclude_patterns,
+        tier=int(getattr(klass, "tier", 0)) if klass is not None else 0,
     )
     instance = _load_or_create_instance(cfg)
     healthy = await instance.test_connection()
@@ -466,7 +490,22 @@ def _cfg_to_dict(cfg: ConnectorConfig) -> Dict[str, Any]:
         "last_sync_at": cfg.last_sync_at.isoformat() if cfg.last_sync_at else None,
         "include_patterns": cfg.include_patterns,
         "exclude_patterns": cfg.exclude_patterns,
+        "tier": _resolve_tier(cfg),
     }
+
+
+def _resolve_tier(cfg: ConnectorConfig) -> int:
+    """Return the readiness tier, preferring the registered class attribute.
+
+    Issue #4421: ``ConnectorConfig.tier`` defaults to 0 on old Redis records
+    (before this field existed).  The class attribute on the registered
+    connector is the source of truth — fall back to ``cfg.tier`` only when the
+    type isn't registered.
+    """
+    klass = ConnectorRegistry._connectors.get(cfg.connector_type)
+    if klass is not None:
+        return int(getattr(klass, "tier", 0))
+    return int(getattr(cfg, "tier", 0))
 
 
 def _apply_updates(cfg: ConnectorConfig, req: UpdateConnectorRequest) -> None:

--- a/autobot-backend/knowledge/connectors/audio_connector.py
+++ b/autobot-backend/knowledge/connectors/audio_connector.py
@@ -197,6 +197,9 @@ class AudioConnector(AbstractConnector):
     """
 
     connector_type = "audio"
+    # Issue #4421: zero-config — local files or public YouTube/media URLs; no
+    # credentials required.  Whisper models run on NPU/CPU.
+    tier = 0
 
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)

--- a/autobot-backend/knowledge/connectors/base.py
+++ b/autobot-backend/knowledge/connectors/base.py
@@ -31,9 +31,22 @@ class AbstractConnector(ABC):
     the four abstract methods.  The default ``sync()`` method orchestrates
     change detection → fetch → ingest and can be overridden when a connector
     needs a custom sync strategy.
+
+    Subclasses SHOULD also declare their setup-complexity ``tier`` (Issue #4421):
+
+    * ``tier = 0`` — Zero-config. Works immediately once the target is
+      reachable (local file server, unauthenticated web crawl, local audio).
+    * ``tier = 1`` — Needs a free API key or env var (e.g. Notion integration
+      token, RSS with key).
+    * ``tier = 2`` — Needs credentials, OAuth, a cookie, or a private DB
+      connection string (e.g. database, GitHub private repos).
+
+    The tier is surfaced to the UI via ``/knowledge_base/connector_types`` so
+    users see a readiness badge before they start filling out the config form.
     """
 
     connector_type: str = ""
+    tier: int = 0
 
     def __init__(self, config: ConnectorConfig) -> None:
         self.config = config

--- a/autobot-backend/knowledge/connectors/database.py
+++ b/autobot-backend/knowledge/connectors/database.py
@@ -47,6 +47,8 @@ class DatabaseConnector(AbstractConnector):
     """
 
     connector_type = "database"
+    # Issue #4421: needs a DB connection string with credentials — tier 2.
+    tier = 2
 
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)

--- a/autobot-backend/knowledge/connectors/file_server.py
+++ b/autobot-backend/knowledge/connectors/file_server.py
@@ -65,6 +65,8 @@ class FileServerConnector(AbstractConnector):
     """
 
     connector_type = "file_server"
+    # Issue #4421: zero-config — needs only a mount point, no credentials.
+    tier = 0
 
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)

--- a/autobot-backend/knowledge/connectors/models.py
+++ b/autobot-backend/knowledge/connectors/models.py
@@ -68,6 +68,9 @@ class ConnectorConfig:
     last_sync_at: Optional[datetime] = None
     include_patterns: List[str] = field(default_factory=list)
     exclude_patterns: List[str] = field(default_factory=list)
+    # Issue #4421: readiness tier copied from the connector class at instance-
+    # creation time (0 = zero-config, 1 = free key/env var, 2 = credentials).
+    tier: int = 0
 
 
 @dataclass

--- a/autobot-backend/knowledge/connectors/notion.py
+++ b/autobot-backend/knowledge/connectors/notion.py
@@ -50,6 +50,8 @@ class NotionConnector(AbstractConnector):
     """
 
     connector_type = "notion"
+    # Issue #4421: needs a free Notion integration token (config.token).
+    tier = 1
 
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)

--- a/autobot-backend/knowledge/connectors/tier_test.py
+++ b/autobot-backend/knowledge/connectors/tier_test.py
@@ -1,0 +1,172 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""
+Tests for connector readiness tier (Issue #4421).
+
+Verifies:
+  - Every registered connector class declares a ``tier`` class attribute.
+  - Expected tier values for each built-in connector.
+  - The ``/knowledge_base/connector_types`` endpoint returns tier per type.
+  - ``_cfg_to_dict`` includes the tier in API responses.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the autobot-backend package root is on sys.path
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# Importing the connector modules triggers their @ConnectorRegistry.register
+# decorators so the registry is populated for these tests.
+from knowledge.connectors import (  # noqa: E402,F401
+    audio_connector,
+    database,
+    file_server,
+    notion,
+    web_crawler,
+)
+from knowledge.connectors.base import AbstractConnector  # noqa: E402
+from knowledge.connectors.models import ConnectorConfig  # noqa: E402
+from knowledge.connectors.registry import ConnectorRegistry  # noqa: E402
+
+# Expected tier assignments (Issue #4421)
+_EXPECTED_TIERS = {
+    "file_server": 0,
+    "web_crawler": 0,
+    "audio": 0,
+    "notion": 1,
+    "database": 2,
+}
+
+
+class TestConnectorTierAttribute:
+    """Every registered connector must declare a tier."""
+
+    def test_abstract_base_declares_tier(self):
+        assert hasattr(AbstractConnector, "tier")
+        assert isinstance(AbstractConnector.tier, int)
+
+    def test_every_registered_connector_has_tier(self):
+        # Snapshot the class registry rather than walk instances — we want
+        # the source of truth to be the class attribute.
+        connectors = dict(ConnectorRegistry._connectors)
+        assert connectors, "No connectors registered — imports failed"
+        for type_name, klass in connectors.items():
+            assert hasattr(klass, "tier"), (
+                "Connector %s (%s) missing tier" % (type_name, klass)
+            )
+            assert isinstance(klass.tier, int), (
+                "Connector %s tier must be int, got %r"
+                % (type_name, type(klass.tier))
+            )
+            assert 0 <= klass.tier <= 2, (
+                "Connector %s tier out of range: %d" % (type_name, klass.tier)
+            )
+
+    @pytest.mark.parametrize("connector_type,expected", _EXPECTED_TIERS.items())
+    def test_expected_tier_per_builtin(self, connector_type, expected):
+        klass = ConnectorRegistry._connectors.get(connector_type)
+        assert klass is not None, "Connector %s not registered" % connector_type
+        assert klass.tier == expected, (
+            "Expected %s tier=%d, got %d"
+            % (connector_type, expected, klass.tier)
+        )
+
+
+class TestConnectorConfigTier:
+    """ConnectorConfig carries a tier field that defaults to 0."""
+
+    def test_default_tier_is_zero(self):
+        cfg = ConnectorConfig(
+            connector_id="t-1",
+            connector_type="file_server",
+            name="t",
+            config={},
+        )
+        assert cfg.tier == 0
+
+    def test_explicit_tier_preserved(self):
+        cfg = ConnectorConfig(
+            connector_id="t-2",
+            connector_type="database",
+            name="t",
+            config={},
+            tier=2,
+        )
+        assert cfg.tier == 2
+
+
+class TestApiSerialization:
+    """_cfg_to_dict exposes tier via the registered class attribute."""
+
+    def test_cfg_to_dict_includes_tier_from_class(self):
+        from api.knowledge_connectors import _cfg_to_dict
+
+        cfg = ConnectorConfig(
+            connector_id="api-1",
+            connector_type="notion",
+            name="My Notion",
+            config={"token": "secret", "database_ids": ["x"]},
+            created_at=datetime(2026, 1, 1),
+        )
+        payload = _cfg_to_dict(cfg)
+        assert payload["tier"] == 1, (
+            "notion connector should surface tier=1 in API payload"
+        )
+
+    def test_cfg_to_dict_falls_back_to_cfg_tier_when_type_unknown(self):
+        from api.knowledge_connectors import _cfg_to_dict
+
+        cfg = ConnectorConfig(
+            connector_id="api-2",
+            connector_type="no_such_type",
+            name="Unknown",
+            config={},
+            tier=2,
+            created_at=datetime(2026, 1, 1),
+        )
+        payload = _cfg_to_dict(cfg)
+        assert payload["tier"] == 2
+
+
+class TestConnectorTypesEndpoint:
+    """/knowledge_base/connector_types enumerates types with tier."""
+
+    def test_endpoint_returns_tier_per_type(self):
+        import asyncio
+
+        from api.knowledge_connectors import list_connector_types
+
+        response = asyncio.run(list_connector_types())
+        assert "connector_types" in response
+        assert response["total"] == len(response["connector_types"])
+
+        by_type = {
+            entry["connector_type"]: entry["tier"]
+            for entry in response["connector_types"]
+        }
+        for connector_type, expected in _EXPECTED_TIERS.items():
+            assert by_type.get(connector_type) == expected, (
+                "endpoint tier mismatch for %s: expected %d, got %r"
+                % (connector_type, expected, by_type.get(connector_type))
+            )
+
+    def test_endpoint_sorted_by_tier_then_name(self):
+        import asyncio
+
+        from api.knowledge_connectors import list_connector_types
+
+        response = asyncio.run(list_connector_types())
+        entries = response["connector_types"]
+        keys = [(e["tier"], e["connector_type"]) for e in entries]
+        assert keys == sorted(keys)

--- a/autobot-backend/knowledge/connectors/web_crawler.py
+++ b/autobot-backend/knowledge/connectors/web_crawler.py
@@ -45,6 +45,8 @@ class WebCrawlerConnector(AbstractConnector):
     """
 
     connector_type = "web_crawler"
+    # Issue #4421: zero-config — unauthenticated crawl via Playwright service.
+    tier = 0
 
     def __init__(self, config: ConnectorConfig) -> None:
         super().__init__(config)

--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorStatusCard.vue
@@ -47,6 +47,47 @@ const typeBadgeVariant = computed(() => {
   return map[props.config.connector_type] || 'primary'
 })
 
+/**
+ * Issue #4421: readiness tier badge.
+ *   tier 0 → green   "Ready"
+ *   tier 1 → yellow  "Free key needed"
+ *   tier 2 → orange  "Setup required"
+ */
+const tierValue = computed(() => (typeof props.config.tier === 'number' ? props.config.tier : 0))
+
+const tierBadgeVariant = computed<'success' | 'warning' | 'error'>(() => {
+  switch (tierValue.value) {
+    case 2:
+      return 'error'
+    case 1:
+      return 'warning'
+    default:
+      return 'success'
+  }
+})
+
+const tierLabel = computed(() => {
+  switch (tierValue.value) {
+    case 2:
+      return t('knowledge.connectors.tier.setupRequired')
+    case 1:
+      return t('knowledge.connectors.tier.freeKey')
+    default:
+      return t('knowledge.connectors.tier.ready')
+  }
+})
+
+const tierTooltip = computed(() => {
+  switch (tierValue.value) {
+    case 2:
+      return t('knowledge.connectors.tier.setupRequiredTooltip')
+    case 1:
+      return t('knowledge.connectors.tier.freeKeyTooltip')
+    default:
+      return t('knowledge.connectors.tier.readyTooltip')
+  }
+})
+
 const lastSyncDisplay = computed(() => {
   if (!props.status.last_sync_at) return t('knowledge.connectors.status.never')
   return formatTimeAgo(props.status.last_sync_at)
@@ -141,9 +182,19 @@ defineExpose({ resetSyncing })
               :title="status.is_healthy ? $t('knowledge.connectors.status.healthy') : $t('knowledge.connectors.status.unhealthy')"
             ></span>
           </div>
-          <BaseBadge :variant="typeBadgeVariant" size="xs">
-            {{ typeLabel }}
-          </BaseBadge>
+          <div class="badge-row">
+            <BaseBadge :variant="typeBadgeVariant" size="xs">
+              {{ typeLabel }}
+            </BaseBadge>
+            <BaseBadge
+              :variant="tierBadgeVariant"
+              size="xs"
+              :title="tierTooltip"
+              class="tier-badge"
+            >
+              {{ tierLabel }}
+            </BaseBadge>
+          </div>
         </div>
       </div>
 
@@ -300,6 +351,18 @@ defineExpose({ resetSyncing })
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);
+}
+
+/* Issue #4421: tier badge row */
+.badge-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1-5);
+  flex-wrap: wrap;
+}
+
+.tier-badge {
+  cursor: help;
 }
 
 .name-row {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2831,6 +2831,14 @@
         "confirm": "Confirm",
         "cancel": "Cancel"
       },
+      "tier": {
+        "ready": "Ready",
+        "readyTooltip": "Zero-config connector — works immediately, no credentials required.",
+        "freeKey": "Free key needed",
+        "freeKeyTooltip": "Needs a free API key or environment variable (for example a Notion integration token).",
+        "setupRequired": "Setup required",
+        "setupRequiredTooltip": "Needs credentials, OAuth, a cookie, or a private connection string."
+      },
       "config": {
         "editTitle": "Edit Connector",
         "addTitle": "Add Connector",

--- a/autobot-frontend/src/types/knowledgeBase.ts
+++ b/autobot-frontend/src/types/knowledgeBase.ts
@@ -314,6 +314,13 @@ export interface ConnectorConfig {
   last_sync_at: string | null
   include_patterns: string[]
   exclude_patterns: string[]
+  /**
+   * Issue #4421: readiness tier.
+   *   0 = Zero-config — works immediately.
+   *   1 = Free key / env var needed (e.g. Notion integration token).
+   *   2 = Credentials / OAuth / cookie needed (e.g. database, private GitHub).
+   */
+  tier?: number
 }
 
 /**


### PR DESCRIPTION
Closes #4421

## Summary
Connector tiers declared (0=Ready / 1=Free key / 2=Setup required):
- file_server → 0, web_crawler → 0, audio → 0
- notion → 1
- database → 2

### Backend
- `AbstractConnector.tier: int = 0` class attribute (base)
- `ConnectorConfig.tier` dataclass field (default 0, no migration)
- Per-class tier declarations in file_server/web_crawler/audio/notion/database connectors
- New `GET /api/knowledge_base/connector_types` endpoint; tier propagates through `_cfg_to_dict`, serialization, and creation from the registered class

### Frontend
- `ConnectorConfig.tier?: number` in `types/knowledgeBase.ts`
- `ConnectorStatusCard.vue` shows color-coded `BaseBadge` (success/warning/error) with tooltip next to the existing type badge
- i18n keys under `knowledge.connectors.tier.{ready,freeKey,setupRequired}` + tooltip variants (non-en locales tracked under #5004)

## Test Status
PASS — 13 new tier tests + 22 existing = 35 passed, 0 vue-tsc regressions

## Scope note
Badge placed in `ConnectorStatusCard.vue` (the actual connector UI) rather than `KnowledgeBrowser.vue` (which is the content tree, not connector list). i18n namespace unchanged.