### PR TITLE
style(tokens): delete pixel-value spacing tokens; round call sites to rem scale (#5036)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -267,14 +267,6 @@
   --spacing-micro-5: 0.4rem;   /* ~6.4px */
   --spacing-micro-6: 0.45rem;  /* ~7.2px */
 
-  /* Pixel-value tokens for values that don't fit the rem scale.
-   * See #5036 for audit of whether each of these values is intentional
-   * or represents a design error that should be rounded to the scale. */
-  --spacing-3px: 3px;   /* dense chip/badge padding; nearest rem token is --spacing-1 (4px) */
-  --spacing-15px: 15px; /* mid-point between --spacing-3 (12px) and --spacing-4 (16px) */
-  --spacing-18px: 18px; /* mid-point between --spacing-4 (16px) and --spacing-5 (20px) */
-  --spacing-30px: 30px; /* mid-point between --spacing-7 (28px) and --spacing-8 (32px) */
-
   /* Semantic accessibility tokens */
   --touch-target-min: 44px; /* WCAG 2.5.8 minimum touch target size */
 

--- a/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
@@ -39,8 +39,8 @@
     <!-- AI Filtering Toggle (#633) -->
     <div
       class="ai-filter-controls"
-      style="margin-bottom: var(--spacing-15px); padding: 10px; background: rgba(0,0,0,0.2);
-             border-radius: 6px; display: flex; align-items: center; gap: var(--spacing-15px); flex-wrap: wrap;"
+      style="margin-bottom: var(--spacing-4); padding: 10px; background: rgba(0,0,0,0.2);
+             border-radius: 6px; display: flex; align-items: center; gap: var(--spacing-4); flex-wrap: wrap;"
     >
       <label
         class="toggle-label"

--- a/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseIntelligenceScoresPanel.vue
@@ -852,7 +852,7 @@ function formatTimestamp(timestamp: string): string {
 .score-card .score-loading {
   display: flex;
   justify-content: center;
-  padding: var(--spacing-30px);
+  padding: var(--spacing-8);
   color: var(--color-info-light);
   font-size: 1.5em;
 }
@@ -912,7 +912,7 @@ function formatTimestamp(timestamp: string): string {
 .score-card .score-empty {
   display: flex;
   justify-content: center;
-  padding: var(--spacing-30px);
+  padding: var(--spacing-8);
   color: var(--text-tertiary);
   font-style: italic;
 }

--- a/autobot-frontend/src/components/chat/MessageAttachments.vue
+++ b/autobot-frontend/src/components/chat/MessageAttachments.vue
@@ -196,7 +196,7 @@ const formatSize = (bytes: number): string => {
 
   .attachment-size {
     width: 100%;
-    margin-left: var(--spacing-30px);
+    margin-left: var(--spacing-8);
     margin-top: var(--spacing-neg-4px);
   }
 }

--- a/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
@@ -654,7 +654,7 @@ onMounted(() => {
 }
 
 .card-checkbox {
-  margin-top: var(--spacing-3px);
+  margin-top: var(--spacing-1);
   flex-shrink: 0;
 }
 

--- a/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
+++ b/autobot-frontend/src/components/manpage/IntegrationStatusPanel.vue
@@ -222,7 +222,7 @@ const { formatDate } = useKnowledgeBase()
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--spacing-15px);
+  gap: var(--spacing-4);
   padding: var(--spacing-10);
   color: var(--text-muted);
   font-style: italic;

--- a/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowLiveDashboard.vue
@@ -512,7 +512,7 @@ onUnmounted(() => {
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-xl);
-  padding: var(--spacing-18px);
+  padding: var(--spacing-5);
   cursor: pointer;
   transition: border-color var(--duration-200), box-shadow var(--duration-200);
   display: flex;

--- a/autobot-frontend/src/views/MarketplaceView.vue
+++ b/autobot-frontend/src/views/MarketplaceView.vue
@@ -672,7 +672,7 @@ onMounted(async () => {
 .stat-item {
   display: flex;
   align-items: center;
-  gap: var(--spacing-3px);
+  gap: var(--spacing-1);
 }
 
 .stat-icon {


### PR DESCRIPTION
Closes #5036

## Problem
PR #5009 (#4948) added pixel-value spacing tokens (\`--spacing-3px\`, \`--spacing-15px\`, \`--spacing-18px\`, \`--spacing-30px\`) without auditing whether the values were intentional or design errors. Pixel tokens defeat the rem-scale accessibility benefit — users who increase their base font size don't get proportional spacing at these call sites.

## Audit

Audited all 9 call sites and rounded each to the nearest rem-scale token. All deltas are 1–2px, visually imperceptible:

| Token | Uses | Rounded to | Delta |
|---|---|---|---|
| \`--spacing-3px\` | 2 | \`--spacing-1\` (4px) | +1px |
| \`--spacing-15px\` | 3 | \`--spacing-4\` (16px) | +1px |
| \`--spacing-18px\` | 1 | \`--spacing-5\` (20px) | +2px |
| \`--spacing-30px\` | 3 | \`--spacing-8\` (32px) | +2px |

The 4 pixel tokens are then deleted from \`design-tokens.css\`. \`--touch-target-min\` (44px, semantic WCAG token) and the pre-existing \`--spacing-micro-*\` / \`--spacing-neg-*\` families remain.

## Files updated

- \`MarketplaceView.vue\`, \`KnowledgeVerificationQueue.vue\` (3px)
- \`IntegrationStatusPanel.vue\`, \`CodebaseEnvironmentPanel.vue\` (15px, 3 uses)
- \`WorkflowLiveDashboard.vue\` (18px)
- \`CodebaseIntelligenceScoresPanel.vue\`, \`MessageAttachments.vue\` (30px)
- \`design-tokens.css\` (deletions)