### PR TITLE
feat(knowledge): cleanup_orphan_documents + cleanup_generated_files scheduled tasks (#4455)

### DIFF
--- a/autobot-backend/celery_app.py
+++ b/autobot-backend/celery_app.py
@@ -16,6 +16,7 @@ import urllib.parse
 from pathlib import Path
 
 from celery import Celery
+from celery.schedules import crontab
 
 from autobot_shared.redis_management.types import DATABASE_MAPPING
 from autobot_shared.ssot_config import config as ssot_config
@@ -139,3 +140,52 @@ celery_app.conf.update(
 
 # Auto-discover tasks from tasks module
 celery_app.autodiscover_tasks(["tasks"])
+
+
+# =========================================================================
+# Issue #4455: Periodic knowledge-base cleanup schedule
+# =========================================================================
+
+
+def _crontab_from_string(cron_expr: str) -> crontab:
+    """Parse a 5-field cron string ('m h dom mon dow') into a Celery crontab.
+
+    Falls back to a daily 03:00 UTC schedule if the expression is malformed,
+    logging a warning so misconfiguration does not prevent Beat from starting.
+    """
+    import logging as _logging
+
+    _log = _logging.getLogger(__name__)
+    parts = cron_expr.strip().split()
+    if len(parts) != 5:
+        _log.warning(
+            "Invalid cron expression %r (expected 5 fields); falling back to '0 3 * * *'",
+            cron_expr,
+        )
+        parts = ["0", "3", "*", "*", "*"]
+    minute, hour, day_of_month, month_of_year, day_of_week = parts
+    return crontab(
+        minute=minute,
+        hour=hour,
+        day_of_month=day_of_month,
+        month_of_year=month_of_year,
+        day_of_week=day_of_week,
+    )
+
+
+celery_app.conf.beat_schedule = {
+    "knowledge-cleanup-orphan-documents": {
+        "task": "tasks.cleanup_orphan_documents",
+        "schedule": _crontab_from_string(
+            ssot_config.knowledge_orphan_cleanup_schedule
+        ),
+        "kwargs": {"dry_run": False},
+    },
+    "knowledge-cleanup-generated-files": {
+        "task": "tasks.cleanup_generated_files",
+        "schedule": _crontab_from_string(
+            ssot_config.knowledge_generated_files_cleanup_schedule
+        ),
+        "kwargs": {"dry_run": False},
+    },
+}

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -75,6 +75,50 @@ for _mod in _SIMPLE_STUBS:
         except ImportError:
             sys.modules[_mod] = MagicMock()
 
+# Celery stub — issue #4455. When celery isn't installed in the dev venv,
+# provide a tiny shim so modules that do ``@celery_app.task`` import cleanly.
+# The real package is used on production nodes; tests never rely on Beat.
+try:
+    import celery as _celery_real  # noqa: F401
+except ImportError:
+    _celery_stub = types.ModuleType("celery")
+
+    class _StubCelery:
+        def __init__(self, *args, **kwargs) -> None:
+            self.conf = types.SimpleNamespace(
+                update=lambda **_k: None,
+                beat_schedule={},
+            )
+
+        def task(self, *_args, **_kwargs):
+            def decorator(fn):
+                fn.update_state = lambda *a, **k: None
+                return fn
+
+            return decorator
+
+        def autodiscover_tasks(self, *_args, **_kwargs) -> None:
+            return None
+
+    _celery_stub.Celery = _StubCelery
+    sys.modules["celery"] = _celery_stub
+
+    _schedules_stub = types.ModuleType("celery.schedules")
+
+    class _StubCrontab:
+        def __init__(self, **fields) -> None:
+            def _parse(v):
+                try:
+                    return {int(v)}
+                except (TypeError, ValueError):
+                    return set()
+
+            self.minute = _parse(fields.get("minute", 0))
+            self.hour = _parse(fields.get("hour", 0))
+
+    _schedules_stub.crontab = _StubCrontab
+    sys.modules["celery.schedules"] = _schedules_stub
+
 # Package stubs for SQLAlchemy and alembic sub-packages (need __path__ so
 # dotted sub-module imports like ``sqlalchemy.dialects.postgresql`` resolve).
 _PKG_STUBS = [

--- a/autobot-backend/tasks/knowledge_tasks.py
+++ b/autobot-backend/tasks/knowledge_tasks.py
@@ -11,8 +11,10 @@ Issue #424: Added periodic task for incremental man page updates.
 
 import asyncio
 import logging
+import os
 import subprocess  # nosec B404 - used for internal script execution only
 import sys
+import time
 
 from celery_app import celery_app
 from type_defs.common import Metadata
@@ -470,6 +472,300 @@ def full_man_page_index(
             "status": "failed",
             "error": "Full man page index failed",
             "message": "Index failed",
+        }
+
+
+# =========================================================================
+# Issue #4455: Knowledge cleanup tasks (orphan documents + generated files)
+# =========================================================================
+
+
+def _collect_orphan_doc_ids(collection) -> tuple[list[str], list[str], int]:
+    """Scan ChromaDB collection and return IDs whose file paths no longer exist.
+
+    Args:
+        collection: ChromaDB collection object.
+
+    Returns:
+        Tuple of (orphan_ids, orphan_paths, scanned_count).
+    """
+    from utils.chromadb_client import get_all_paginated
+
+    page = get_all_paginated(collection, include=["metadatas"])
+    ids = page.get("ids") or []
+    metadatas = page.get("metadatas") or []
+    scanned = len(ids)
+
+    orphan_ids: list[str] = []
+    orphan_paths: list[str] = []
+
+    for doc_id, meta in zip(ids, metadatas):
+        if not meta:
+            continue
+        # Accept either "file_path" (DocIndexerService) or legacy "path" keys
+        path = meta.get("file_path") or meta.get("path")
+        if not path:
+            continue
+        try:
+            if not os.path.exists(path):
+                orphan_ids.append(doc_id)
+                orphan_paths.append(path)
+        except (OSError, ValueError) as e:
+            logger.warning("Path check failed for %s: %s", path, e)
+
+    return orphan_ids, orphan_paths, scanned
+
+
+async def _cleanup_orphan_documents_async(dry_run: bool) -> dict:
+    """Async core for cleanup_orphan_documents Celery task."""
+    from services.knowledge.doc_indexer import get_doc_indexer_service
+
+    service = get_doc_indexer_service()
+    if not getattr(service, "_initialized", False):
+        await service.initialize()
+
+    collection = getattr(service, "_collection", None)
+    if collection is None:
+        logger.warning("DocIndexerService collection unavailable; skipping orphan cleanup")
+        return {
+            "status": "skipped",
+            "reason": "collection_unavailable",
+            "scanned": 0,
+            "removed": 0,
+            "dry_run": dry_run,
+            "sample_removed_paths": [],
+        }
+
+    orphan_ids, orphan_paths, scanned = _collect_orphan_doc_ids(collection)
+
+    if dry_run:
+        for path in orphan_paths:
+            logger.info("[dry_run] Would remove orphan document: %s", path)
+        return {
+            "status": "success",
+            "scanned": scanned,
+            "removed": 0,
+            "dry_run": True,
+            "sample_removed_paths": orphan_paths[:10],
+        }
+
+    removed = 0
+    batch_size = 500
+    for i in range(0, len(orphan_ids), batch_size):
+        batch = orphan_ids[i : i + batch_size]
+        try:
+            collection.delete(ids=batch)
+            removed += len(batch)
+        except Exception as e:
+            logger.error("Failed to delete orphan batch (size=%d): %s", len(batch), e)
+
+    logger.info(
+        "cleanup_orphan_documents: scanned=%d removed=%d",
+        scanned,
+        removed,
+    )
+    return {
+        "status": "success",
+        "scanned": scanned,
+        "removed": removed,
+        "dry_run": False,
+        "sample_removed_paths": orphan_paths[:10],
+    }
+
+
+@celery_app.task(bind=True, name="tasks.cleanup_orphan_documents")
+def cleanup_orphan_documents(self, dry_run: bool = False) -> Metadata:
+    """
+    Remove ChromaDB document entries whose source file no longer exists.
+
+    Issue #4455: Scheduled nightly cleanup of dangling vectors left behind by
+    deleted or moved source files. Metadata field ``file_path`` (or legacy
+    ``path``) is used to resolve the on-disk location.
+
+    Args:
+        self: Celery task instance.
+        dry_run: If True, log orphan entries without deleting them.
+
+    Returns:
+        Dict with cleanup statistics:
+            - status: 'success' | 'skipped' | 'failed'
+            - scanned: Number of documents inspected
+            - removed: Number of documents deleted
+            - dry_run: Whether this was a preview run
+            - sample_removed_paths: Up to 10 sample orphan paths
+    """
+    try:
+        self.update_state(
+            state="PROGRESS",
+            meta={
+                "current": 0,
+                "total": 100,
+                "status": "Scanning ChromaDB for orphan documents...",
+            },
+        )
+        logger.info("Starting orphan document cleanup (dry_run=%s)...", dry_run)
+        return _run_async_in_loop(_cleanup_orphan_documents_async(dry_run))
+    except Exception as e:
+        logger.exception("cleanup_orphan_documents failed: %s", e)
+        return {
+            "status": "failed",
+            "error": str(e),
+            "scanned": 0,
+            "removed": 0,
+            "dry_run": dry_run,
+            "sample_removed_paths": [],
+        }
+
+
+def _resolve_cache_directories() -> list:
+    """Return list of cache/temp directory Paths that cleanup_generated_files manages.
+
+    Only directories that actually exist are returned; the task silently skips
+    missing paths to avoid errors in fresh installs.
+    """
+    from pathlib import Path
+
+    from constants.path_constants import PATH
+
+    candidates = [
+        PATH.DATA_DIR / "cache",
+        PATH.DATA_DIR / "embeddings_cache",
+        PATH.DATA_DIR / "chunks_temp",
+        PATH.DATA_DIR / "exports",
+        PATH.TEMP_DIR,
+    ]
+    # Include legacy hash-cache json file's parent only if explicit dir exists.
+    return [p for p in candidates if isinstance(p, Path) and p.exists()]
+
+
+def _cleanup_files_older_than(
+    directories: list,
+    cutoff_ts: float,
+    dry_run: bool,
+) -> tuple[int, int, int]:
+    """Walk directories, delete files older than cutoff_ts (mtime).
+
+    Args:
+        directories: List of Path objects to walk.
+        cutoff_ts: Unix timestamp; files with mtime < cutoff_ts are stale.
+        dry_run: If True, log what would be deleted without removing.
+
+    Returns:
+        Tuple of (scanned_count, removed_count, bytes_freed).
+    """
+    scanned = 0
+    removed = 0
+    bytes_freed = 0
+
+    for directory in directories:
+        if not directory.exists():
+            continue
+        for file_path in directory.rglob("*"):
+            if not file_path.is_file():
+                continue
+            scanned += 1
+            try:
+                stat = file_path.stat()
+            except OSError as e:
+                logger.warning("Stat failed for %s: %s", file_path, e)
+                continue
+            if stat.st_mtime >= cutoff_ts:
+                continue
+            if dry_run:
+                logger.info(
+                    "[dry_run] Would remove stale cache file: %s (%d bytes)",
+                    file_path,
+                    stat.st_size,
+                )
+                continue
+            try:
+                file_path.unlink()
+                removed += 1
+                bytes_freed += stat.st_size
+            except OSError as e:
+                logger.warning("Failed to delete %s: %s", file_path, e)
+
+    return scanned, removed, bytes_freed
+
+
+@celery_app.task(bind=True, name="tasks.cleanup_generated_files")
+def cleanup_generated_files(
+    self,
+    dry_run: bool = False,
+    ttl_days: int | None = None,
+) -> Metadata:
+    """
+    Delete stale generated cache/temp files older than the configured TTL.
+
+    Issue #4455: Scheduled nightly cleanup of cached embeddings, chunk
+    intermediates, export artefacts, and other generated files that accumulate
+    indefinitely under ``PATH.DATA_DIR`` and ``PATH.TEMP_DIR``.
+
+    Args:
+        self: Celery task instance.
+        dry_run: If True, log removal candidates without deleting them.
+        ttl_days: Override for ``KNOWLEDGE_CACHE_TTL_DAYS`` from ssot_config.
+
+    Returns:
+        Dict with cleanup statistics:
+            - status: 'success' | 'failed'
+            - scanned: Number of files inspected
+            - removed: Number of files deleted
+            - bytes_freed: Total bytes reclaimed
+            - dry_run: Whether this was a preview run
+            - ttl_days: Effective TTL applied
+    """
+    from autobot_shared.ssot_config import config as ssot_config
+
+    effective_ttl = ttl_days if ttl_days is not None else ssot_config.knowledge_cache_ttl_days
+    try:
+        self.update_state(
+            state="PROGRESS",
+            meta={
+                "current": 0,
+                "total": 100,
+                "status": f"Scanning generated files older than {effective_ttl} days...",
+            },
+        )
+        logger.info(
+            "Starting generated-file cleanup (dry_run=%s, ttl_days=%d)...",
+            dry_run,
+            effective_ttl,
+        )
+
+        directories = _resolve_cache_directories()
+        cutoff_ts = time.time() - (effective_ttl * 86400)
+
+        scanned, removed, bytes_freed = _cleanup_files_older_than(
+            directories,
+            cutoff_ts,
+            dry_run,
+        )
+
+        logger.info(
+            "cleanup_generated_files: scanned=%d removed=%d bytes_freed=%d",
+            scanned,
+            removed,
+            bytes_freed,
+        )
+        return {
+            "status": "success",
+            "scanned": scanned,
+            "removed": removed,
+            "bytes_freed": bytes_freed,
+            "dry_run": dry_run,
+            "ttl_days": effective_ttl,
+        }
+    except Exception as e:
+        logger.exception("cleanup_generated_files failed: %s", e)
+        return {
+            "status": "failed",
+            "error": str(e),
+            "scanned": 0,
+            "removed": 0,
+            "bytes_freed": 0,
+            "dry_run": dry_run,
+            "ttl_days": effective_ttl,
         }
 
 

--- a/autobot-backend/tasks/knowledge_tasks_test.py
+++ b/autobot-backend/tasks/knowledge_tasks_test.py
@@ -1,0 +1,264 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Tests for knowledge-base cleanup Celery tasks (Issue #4455).
+
+Covers:
+- cleanup_orphan_documents: dry-run, orphan detection, batch deletion.
+- cleanup_generated_files: TTL filtering, dry-run, bytes_freed accounting.
+- _crontab_from_string: malformed cron fallback.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# conftest.py stubs celery when it isn't installed in the dev venv.
+from tasks.knowledge_tasks import (
+    _cleanup_files_older_than,
+    _cleanup_orphan_documents_async,
+    _collect_orphan_doc_ids,
+    _run_async_in_loop,
+)
+
+
+# ---------------------------------------------------------------------------
+# _collect_orphan_doc_ids
+# ---------------------------------------------------------------------------
+
+
+def _fake_collection(ids: list[str], metadatas: list[dict]) -> MagicMock:
+    """Build a MagicMock ChromaDB collection whose get_all_paginated returns data."""
+    coll = MagicMock()
+    coll.get.return_value = {"ids": ids, "metadatas": metadatas}
+    return coll
+
+
+def test_collect_orphan_doc_ids_identifies_missing_paths(tmp_path):
+    existing = tmp_path / "present.md"
+    existing.write_text("hello", encoding="utf-8")
+    missing = tmp_path / "gone.md"  # never created
+
+    ids = ["doc-present", "doc-missing"]
+    metadatas = [
+        {"file_path": str(existing)},
+        {"file_path": str(missing)},
+    ]
+    coll = _fake_collection(ids, metadatas)
+
+    orphan_ids, orphan_paths, scanned = _collect_orphan_doc_ids(coll)
+
+    assert scanned == 2
+    assert orphan_ids == ["doc-missing"]
+    assert orphan_paths == [str(missing)]
+
+
+def test_collect_orphan_doc_ids_handles_legacy_path_key(tmp_path):
+    missing = tmp_path / "legacy-gone.md"
+    ids = ["legacy-doc"]
+    metadatas = [{"path": str(missing)}]  # legacy key, not file_path
+    coll = _fake_collection(ids, metadatas)
+
+    orphan_ids, orphan_paths, scanned = _collect_orphan_doc_ids(coll)
+
+    assert scanned == 1
+    assert orphan_ids == ["legacy-doc"]
+    assert orphan_paths == [str(missing)]
+
+
+def test_collect_orphan_doc_ids_skips_entries_without_path():
+    ids = ["no-meta", "empty-meta"]
+    metadatas = [None, {}]
+    coll = _fake_collection(ids, metadatas)
+
+    orphan_ids, orphan_paths, scanned = _collect_orphan_doc_ids(coll)
+
+    assert scanned == 2
+    assert orphan_ids == []
+    assert orphan_paths == []
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_orphan_documents_async
+# ---------------------------------------------------------------------------
+
+
+def _make_service_with_collection(collection: MagicMock) -> MagicMock:
+    """Return a MagicMock DocIndexerService exposing an initialised collection."""
+    svc = MagicMock()
+    svc._initialized = True
+    svc._collection = collection
+    return svc
+
+
+def test_cleanup_orphan_documents_async_dry_run_does_not_delete(tmp_path):
+    missing = tmp_path / "missing.md"
+    ids = ["orphan-1"]
+    metadatas = [{"file_path": str(missing)}]
+    coll = _fake_collection(ids, metadatas)
+    svc = _make_service_with_collection(coll)
+
+    with patch(
+        "services.knowledge.doc_indexer.get_doc_indexer_service",
+        return_value=svc,
+    ):
+        result = _run_async_in_loop(_cleanup_orphan_documents_async(dry_run=True))
+
+    assert result["status"] == "success"
+    assert result["dry_run"] is True
+    assert result["scanned"] == 1
+    assert result["removed"] == 0
+    assert result["sample_removed_paths"] == [str(missing)]
+    coll.delete.assert_not_called()
+
+
+def test_cleanup_orphan_documents_async_deletes_orphans(tmp_path):
+    kept = tmp_path / "kept.md"
+    kept.write_text("ok", encoding="utf-8")
+    gone = tmp_path / "gone.md"
+
+    ids = ["keeper", "orphan"]
+    metadatas = [{"file_path": str(kept)}, {"file_path": str(gone)}]
+    coll = _fake_collection(ids, metadatas)
+    svc = _make_service_with_collection(coll)
+
+    with patch(
+        "services.knowledge.doc_indexer.get_doc_indexer_service",
+        return_value=svc,
+    ):
+        result = _run_async_in_loop(_cleanup_orphan_documents_async(dry_run=False))
+
+    assert result["status"] == "success"
+    assert result["dry_run"] is False
+    assert result["scanned"] == 2
+    assert result["removed"] == 1
+    coll.delete.assert_called_once_with(ids=["orphan"])
+
+
+def test_cleanup_orphan_documents_async_skipped_when_collection_none():
+    svc = MagicMock()
+    svc._initialized = True
+    svc._collection = None
+
+    with patch(
+        "services.knowledge.doc_indexer.get_doc_indexer_service",
+        return_value=svc,
+    ):
+        result = _run_async_in_loop(_cleanup_orphan_documents_async(dry_run=False))
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "collection_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_files_older_than
+# ---------------------------------------------------------------------------
+
+
+def _touch(path: Path, content: str, age_seconds: float) -> None:
+    """Create a file and backdate its mtime by age_seconds."""
+    path.write_text(content, encoding="utf-8")
+    past = time.time() - age_seconds
+    import os as _os
+
+    _os.utime(path, (past, past))
+
+
+def test_cleanup_files_older_than_filters_by_mtime(tmp_path):
+    old_file = tmp_path / "old.bin"
+    new_file = tmp_path / "new.bin"
+    _touch(old_file, "old" * 100, age_seconds=10 * 86400)  # 10 days old
+    _touch(new_file, "new" * 100, age_seconds=1 * 3600)  # 1 hour old
+
+    cutoff = time.time() - (7 * 86400)  # 7-day TTL
+    scanned, removed, bytes_freed = _cleanup_files_older_than(
+        [tmp_path], cutoff, dry_run=False
+    )
+
+    assert scanned == 2
+    assert removed == 1
+    assert bytes_freed > 0
+    assert not old_file.exists()
+    assert new_file.exists()
+
+
+def test_cleanup_files_older_than_dry_run_preserves_files(tmp_path):
+    old_file = tmp_path / "old.bin"
+    _touch(old_file, "old" * 100, age_seconds=10 * 86400)
+
+    cutoff = time.time() - (7 * 86400)
+    scanned, removed, bytes_freed = _cleanup_files_older_than(
+        [tmp_path], cutoff, dry_run=True
+    )
+
+    assert scanned == 1
+    assert removed == 0
+    assert bytes_freed == 0
+    assert old_file.exists()
+
+
+def test_cleanup_files_older_than_skips_missing_directory(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    scanned, removed, bytes_freed = _cleanup_files_older_than(
+        [missing], time.time(), dry_run=False
+    )
+    assert (scanned, removed, bytes_freed) == (0, 0, 0)
+
+
+def test_cleanup_files_older_than_recurses_subdirectories(tmp_path):
+    subdir = tmp_path / "nested"
+    subdir.mkdir()
+    old_file = subdir / "deep-old.bin"
+    _touch(old_file, "x" * 50, age_seconds=30 * 86400)
+
+    cutoff = time.time() - (7 * 86400)
+    scanned, removed, _ = _cleanup_files_older_than([tmp_path], cutoff, dry_run=False)
+
+    assert scanned == 1
+    assert removed == 1
+    assert not old_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# _crontab_from_string
+# ---------------------------------------------------------------------------
+
+
+def _have_real_celery() -> bool:
+    try:
+        import celery
+
+        # Real celery's Celery class lives in celery.app module, not a stub shim.
+        return celery.Celery.__module__.startswith("celery")
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _have_real_celery(),
+    reason="requires real celery package (test stub cannot parse cron expressions)",
+)
+def test_crontab_from_string_accepts_valid_expression():
+    from celery_app import _crontab_from_string
+
+    cron = _crontab_from_string("30 4 * * *")
+    # crontab stores minute/hour as sets of ints
+    assert 30 in cron.minute
+    assert 4 in cron.hour
+
+
+@pytest.mark.skipif(
+    not _have_real_celery(),
+    reason="requires real celery package",
+)
+def test_crontab_from_string_falls_back_on_malformed():
+    from celery_app import _crontab_from_string
+
+    cron = _crontab_from_string("not a cron")
+    assert 0 in cron.minute
+    assert 3 in cron.hour

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -1240,6 +1240,32 @@ class AutoBotConfig(BaseSettings):
         ),
     )
 
+    # Knowledge base cleanup — issue #4455
+    knowledge_orphan_cleanup_schedule: str = Field(
+        default="0 3 * * *",
+        alias="AUTOBOT_KNOWLEDGE_ORPHAN_CLEANUP_SCHEDULE",
+        description=(
+            "Cron schedule for cleanup_orphan_documents task. "
+            "Default 03:00 UTC nightly. 5-field cron: 'm h dom mon dow'."
+        ),
+    )
+    knowledge_generated_files_cleanup_schedule: str = Field(
+        default="0 4 * * *",
+        alias="AUTOBOT_KNOWLEDGE_GENERATED_FILES_CLEANUP_SCHEDULE",
+        description=(
+            "Cron schedule for cleanup_generated_files task. "
+            "Default 04:00 UTC nightly. 5-field cron: 'm h dom mon dow'."
+        ),
+    )
+    knowledge_cache_ttl_days: int = Field(
+        default=7,
+        alias="AUTOBOT_KNOWLEDGE_CACHE_TTL_DAYS",
+        description=(
+            "Max age (days) for generated knowledge cache/temp files before "
+            "cleanup_generated_files deletes them. Default 7 days."
+        ),
+    )
+
     # Issue #858: Handle PORT env var from uvicorn without breaking port config
     @field_validator("port", mode="before")
     @classmethod


### PR DESCRIPTION
Closes #4455

## Summary
Two Celery Beat tasks for KB housekeeping:
- **cleanup_orphan_documents(dry_run=False)** — queries ChromaDB via `get_all_paginated`, deletes entries whose `file_path` no longer exists; returns `{scanned, removed, dry_run, sample_removed_paths}`
- **cleanup_generated_files(dry_run=False, ttl_days=None)** — walks cache/temp dirs (`DATA_DIR/cache`, `embeddings_cache`, `chunks_temp`, `exports`, `TEMP_DIR`); mtime-based TTL filter; returns `{scanned, removed, bytes_freed, dry_run}`

### Config keys (ssot_config)
- `knowledge_orphan_cleanup_schedule` default `"0 3 * * *"`
- `knowledge_generated_files_cleanup_schedule` default `"0 4 * * *"`
- `knowledge_cache_ttl_days` default 7

### Files
- `tasks/knowledge_tasks.py` — task definitions + helpers
- `celery_app.py` — beat_schedule wiring + `_crontab_from_string` parser
- `autobot_shared/ssot_config.py` — 3 new config keys
- `conftest.py` — celery stub for dev venv
- `tasks/knowledge_tasks_test.py` — new tests

## Test Status
PASS — 10 passed, 2 skipped (skipped tests need real celery; they validate the cron parser)