### PR TITLE
feat(knowledge): add document_sync_queues with priority-ordered re-indexing worker (#4453)

### DIFF
--- a/autobot-backend/api/knowledge_sync_queue.py
+++ b/autobot-backend/api/knowledge_sync_queue.py
@@ -1,0 +1,65 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Admin API for the document sync queue (#4453).
+
+Exposes introspection endpoints over :class:`DocumentSyncQueue` so operators
+can see what is pending, what failed, and how the worker is keeping up.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, Query
+
+from auth_middleware import check_admin_permission
+from services.knowledge.sync_queue import (
+    SyncStatus,
+    get_document_sync_queue,
+    serialize_entry_for_api,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/knowledge", tags=["knowledge-sync-queue"])
+
+
+@router.get("/sync-queue")
+async def get_sync_queue(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    admin_check: bool = Depends(check_admin_permission),
+) -> Dict[str, Any]:
+    """Return pending and failed entries plus summary counts.
+
+    Pagination (``limit`` / ``offset``) is applied independently to each
+    collection so the caller can page through long-tail failed entries
+    without losing sight of the pending queue.
+    """
+    queue = get_document_sync_queue()
+    pending = await queue.list_entries(SyncStatus.PENDING, limit=limit, offset=offset)
+    failed = await queue.list_entries(SyncStatus.FAILED, limit=limit, offset=offset)
+    counts = await queue.stats()
+    return {
+        "pending": [serialize_entry_for_api(e) for e in pending],
+        "failed": [serialize_entry_for_api(e) for e in failed],
+        "counts": counts,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.post("/sync-queue/prune")
+async def prune_done_entries(
+    older_than_seconds: int = Query(7 * 24 * 3600, ge=60),
+    admin_check: bool = Depends(check_admin_permission),
+) -> Dict[str, int]:
+    """Delete ``done`` entries older than ``older_than_seconds`` (default 7 days)."""
+    queue = get_document_sync_queue()
+    pruned = await queue.prune_done(older_than_seconds=older_than_seconds)
+    return {"pruned": pruned}
+
+
+__all__: List[str] = ["router"]

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -530,6 +530,24 @@ async def _warmup_npu_connection():
         logger.warning("NPU warmup failed: %s", warmup_error)
 
 
+async def _start_doc_sync_queue_worker(app: FastAPI) -> None:
+    """Start the persistent document sync queue worker (#4453).
+
+    The worker drains :class:`DocumentSyncQueue` so re-indexing survives
+    crashes, retries up to MAX_ATTEMPTS, and respects priority ordering.
+    """
+    try:
+        from services.knowledge.sync_queue import SyncQueueWorker
+
+        worker = SyncQueueWorker()
+        task = asyncio.create_task(worker.run())
+        app.state.doc_sync_queue_worker = worker
+        app.state.doc_sync_queue_worker_task = task
+        logger.info("✅ Doc Sync Queue: worker started")
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Doc sync queue worker failed to start: %s", e)
+
+
 async def _init_documentation_watcher():
     """
     Initialize documentation watcher for real-time sync (NON-CRITICAL).
@@ -1389,6 +1407,7 @@ async def initialize_background_services(app: FastAPI):
         await _init_slm_client()
         await _init_background_llm_sync(app)
         await _init_documentation_watcher()
+        await _start_doc_sync_queue_worker(app)
         await _auto_index_documentation()
         await _init_log_forwarding()
         await _init_heartbeat_scheduler(app)
@@ -1446,6 +1465,18 @@ async def cleanup_services(app: FastAPI):
             await stop_documentation_watcher()
         except ImportError:
             pass  # Watcher not available
+
+        # Issue #4453: Stop doc sync queue worker
+        worker = getattr(app.state, "doc_sync_queue_worker", None)
+        task = getattr(app.state, "doc_sync_queue_worker_task", None)
+        if worker is not None:
+            worker.stop()
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
         # Issue #760: Shutdown SLM client
         try:

--- a/autobot-backend/initialization/router_registry/core_routers.py
+++ b/autobot-backend/initialization/router_registry/core_routers.py
@@ -56,6 +56,7 @@ from api.knowledge_grounding import router as knowledge_grounding_router
 from api.knowledge_search_aggregator import (
     router as knowledge_search_aggregator_router,
 )
+from api.knowledge_sync_queue import router as knowledge_sync_queue_router  # Issue #4453
 from api.knowledge_vectorization import router as knowledge_vectorization_router
 from api.llm import router as llm_router
 from api.llm_providers import router as llm_providers_router
@@ -270,6 +271,13 @@ def _get_knowledge_feature_routers() -> list:
             "/knowledge_base",
             ["knowledge-vectorization"],
             "knowledge_vectorization",
+        ),
+        # Issue #4453: document sync queue admin endpoints
+        (
+            knowledge_sync_queue_router,
+            "",
+            ["knowledge-sync-queue"],
+            "knowledge_sync_queue",
         ),
     ]
 

--- a/autobot-backend/services/documentation_watcher.py
+++ b/autobot-backend/services/documentation_watcher.py
@@ -246,34 +246,28 @@ class DocumentationWatcherService:
         Issue #1385: Uses ChromaDB-based DocIndexerService instead of Redis KB.
         Issue #2547: After successful indexing, propagate staleness through the
         mesh graph and enqueue affected nodes for re-embedding.
+        Issue #4453: Enqueue the re-index onto DocumentSyncQueue so a worker
+        crash mid-batch no longer leaves the document silently stale — the
+        persistent queue retries up to MAX_ATTEMPTS with priority ordering.
 
         Args:
             file_path: Path to the updated file
         """
         try:
             from services.knowledge.doc_indexer import get_doc_indexer_service
+            from services.knowledge.sync_queue import SyncReason
 
             indexer = get_doc_indexer_service()
             if not await indexer.initialize():
                 logger.error("DocIndexerService not available for reindexing")
                 return
 
-            # force=True to re-index even if hash matches (file watcher
-            # already debounced, so we trust it actually changed)
-            result = await indexer.index_file(file_path, force=True)
-
-            if result.success > 0:
-                logger.info("Reindexed documentation: %s", file_path.name)
-                doc_id = str(file_path.relative_to(PROJECT_ROOT))
-                await self._propagate_staleness_for_doc(doc_id)
-            elif result.skipped > 0:
-                logger.debug("File unchanged, skipped: %s", file_path.name)
-            else:
-                logger.warning(
-                    "Failed to reindex %s: %s",
-                    file_path.name,
-                    result.errors,
-                )
+            await indexer.enqueue_reindex(
+                str(file_path), reason=SyncReason.CONTENT_CHANGED
+            )
+            logger.info("Enqueued re-index for documentation: %s", file_path.name)
+            doc_id = str(file_path.relative_to(PROJECT_ROOT))
+            await self._propagate_staleness_for_doc(doc_id)
 
         except Exception as e:
             logger.error("Error updating documentation %s: %s", file_path, e)

--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -1160,6 +1160,29 @@ class DocIndexerService:
 
         return total_result
 
+    async def enqueue_reindex(
+        self,
+        document_path: str,
+        reason: "SyncReason | str" = "manual",
+    ) -> "SyncQueueEntry":
+        """Persist a re-indexing work item instead of re-embedding in-line.
+
+        Issue #4453: routing re-indexing through :class:`DocumentSyncQueue`
+        gives us retry, priority ordering, and crash-safety that the old
+        fire-and-forget path lacked.  Callers that need an immediate synchronous
+        index should continue to use :meth:`index_file` directly.
+
+        ``reason`` accepts either a :class:`SyncReason` enum value or the
+        string form (``content_changed`` / ``model_updated`` / ``manual``).
+        """
+        from services.knowledge.sync_queue import (
+            SyncReason,
+            get_document_sync_queue,
+        )
+
+        reason_enum = reason if isinstance(reason, SyncReason) else SyncReason(reason)
+        return await get_document_sync_queue().enqueue_sync(document_path, reason_enum)
+
     async def search(self, query: str, n_results: int = 5) -> List[Any]:
         """Query the autobot_docs ChromaDB collection.
 

--- a/autobot-backend/services/knowledge/sync_queue.py
+++ b/autobot-backend/services/knowledge/sync_queue.py
@@ -43,6 +43,7 @@ _ENTRY_KEY_PREFIX = "doc_sync:entry:"
 _PENDING_KEY = "doc_sync:queue:pending"
 _FAILED_KEY = "doc_sync:queue:failed"
 _DONE_KEY = "doc_sync:queue:done"
+_PENDING_PATH_KEY_PREFIX = "doc_sync:pending_paths:"
 
 MAX_ATTEMPTS = 3
 DONE_TTL_SECONDS = 7 * 24 * 3600  # 7 days
@@ -166,14 +167,18 @@ class DocumentSyncQueue:
         return f"{_ENTRY_KEY_PREFIX}{entry_id}"
 
     @staticmethod
-    def _priority_score(reason: SyncReason) -> float:
-        """Compose a priority score: ``priority.high_bits + monotonic_suffix``.
+    def _pending_path_key(path: str) -> str:
+        return f"{_PENDING_PATH_KEY_PREFIX}{path}"
 
-        The integer priority component dominates so reason ordering is strict;
-        the sub-second suffix (``time.time()`` scaled by 1e-9) preserves FIFO
-        order inside a priority bucket.
+    @staticmethod
+    def _priority_score(reason: SyncReason) -> float:
+        """Compose a priority score: ``priority_bucket + fifo_suffix``.
+
+        Priority bucket uses a 1e12 multiplier so it always dominates the
+        FIFO component (``time.time()`` ~ 1.76e9 today, << 1e12). Within a
+        bucket the raw timestamp preserves FIFO order.
         """
-        return float(reason._priority) + time.time() * 1e-9
+        return float(reason._priority) * 1e12 + time.time()
 
     # ------------------------------------------------------------------
     # Public API
@@ -182,16 +187,40 @@ class DocumentSyncQueue:
     async def enqueue_sync(
         self, document_path: str, reason: SyncReason
     ) -> SyncQueueEntry:
-        """Create a pending entry for ``document_path`` and return it."""
+        """Create a pending entry for ``document_path`` and return it.
+
+        Dedups by ``document_path``: if an entry for this path is already
+        pending (or currently being processed), returns that entry instead
+        of creating a duplicate.  The secondary key is cleared when the
+        entry reaches a terminal state via :meth:`mark_done` or
+        :meth:`mark_failed` (permanent failure only).
+        """
+        redis = await self._redis()
+        path_key = self._pending_path_key(document_path)
+        existing_id = await redis.get(path_key)
+        if existing_id is not None:
+            if isinstance(existing_id, bytes):
+                existing_id = existing_id.decode()
+            raw = await redis.hgetall(self._entry_key(existing_id))
+            if raw:
+                logger.debug(
+                    "enqueue_sync dedup: path=%s already queued as id=%s",
+                    document_path,
+                    existing_id,
+                )
+                return SyncQueueEntry.from_redis_mapping(raw)
+            # Stale secondary key — entry hash was pruned; fall through.
+            await redis.delete(path_key)
+
         entry = SyncQueueEntry(
             id=str(uuid.uuid4()),
             document_path=document_path,
             reason=reason,
         )
-        redis = await self._redis()
         pipe = redis.pipeline()
         pipe.hset(self._entry_key(entry.id), mapping=entry.to_redis_mapping())
         pipe.zadd(_PENDING_KEY, {entry.id: self._priority_score(reason)})
+        pipe.set(path_key, entry.id)
         await pipe.execute()
         logger.info(
             "enqueued sync: path=%s reason=%s id=%s",
@@ -206,6 +235,10 @@ class DocumentSyncQueue:
 
         Uses ``zrange`` with ``withscores=False`` to read the smallest-score
         member (priority 0 before 1 before 2, FIFO inside a bucket).
+
+        Note: this is an inspection helper.  Workers must use
+        :meth:`claim_next_pending` to avoid the read-then-remove race where
+        two workers claim the same entry (#5079).
         """
         redis = await self._redis()
         ids = await redis.zrange(_PENDING_KEY, 0, 0)
@@ -221,8 +254,48 @@ class DocumentSyncQueue:
             return None
         return SyncQueueEntry.from_redis_mapping(raw)
 
+    async def claim_next_pending(self) -> Optional[SyncQueueEntry]:
+        """Atomically claim the highest-priority pending entry.
+
+        Returns the claimed entry (status set to PROCESSING) or ``None`` if
+        the queue is empty or another worker won the race for this id.  The
+        atomic ``zrem`` acts as the claim token — exactly one caller
+        observes ``removed == 1`` for a given id, so double-processing is
+        impossible even with multiple worker processes (#5079).
+        """
+        redis = await self._redis()
+        ids = await redis.zrange(_PENDING_KEY, 0, 0)
+        if not ids:
+            return None
+        entry_id = ids[0]
+        if isinstance(entry_id, bytes):
+            entry_id = entry_id.decode()
+        removed = await redis.zrem(_PENDING_KEY, entry_id)
+        if not removed:
+            return None  # Another worker claimed it first.
+        raw = await redis.hgetall(self._entry_key(entry_id))
+        if not raw:
+            # Orphaned zset member with no hash — nothing to process.
+            return None
+        entry = SyncQueueEntry.from_redis_mapping(raw)
+        now = datetime.now(tz=timezone.utc).isoformat()
+        await redis.hset(
+            self._entry_key(entry_id),
+            mapping={"status": SyncStatus.PROCESSING.value, "updated_at": now},
+        )
+        entry.status = SyncStatus.PROCESSING
+        entry.updated_at = now
+        return entry
+
     async def mark_processing(self, entry_id: str) -> None:
-        """Move an entry out of ``pending`` and set status = processing."""
+        """Move an entry out of ``pending`` and set status = processing.
+
+        Prefer :meth:`claim_next_pending` in worker loops — this helper is
+        retained for tests and admin tooling that want an explicit
+        transition.  The secondary ``pending_paths`` key stays set so a
+        concurrent enqueue for the same path still dedups to this in-flight
+        entry.
+        """
         now = datetime.now(tz=timezone.utc).isoformat()
         redis = await self._redis()
         pipe = redis.pipeline()
@@ -234,11 +307,20 @@ class DocumentSyncQueue:
         await pipe.execute()
 
     async def mark_done(self, entry_id: str) -> None:
-        """Mark an entry complete and place it on the TTL-pruned done zset."""
+        """Mark an entry complete and place it on the TTL-pruned done zset.
+
+        Clears the ``pending_paths`` secondary key so a subsequent re-edit
+        of the same path can be re-enqueued (#5080).
+        """
         now_dt = datetime.now(tz=timezone.utc)
         now_iso = now_dt.isoformat()
         now_ts = now_dt.timestamp()
         redis = await self._redis()
+        # Look up path so we can clear the dedup key alongside the transition.
+        raw = await redis.hgetall(self._entry_key(entry_id))
+        path = None
+        if raw:
+            path = SyncQueueEntry.from_redis_mapping(raw).document_path
         pipe = redis.pipeline()
         pipe.hset(
             self._entry_key(entry_id),
@@ -246,6 +328,8 @@ class DocumentSyncQueue:
         )
         pipe.zrem(_PENDING_KEY, entry_id)
         pipe.zadd(_DONE_KEY, {entry_id: now_ts})
+        if path:
+            pipe.delete(self._pending_path_key(path))
         await pipe.execute()
 
     async def mark_failed(self, entry_id: str, error_msg: str) -> SyncQueueEntry:
@@ -268,6 +352,9 @@ class DocumentSyncQueue:
             pipe.hset(self._entry_key(entry_id), mapping=entry.to_redis_mapping())
             pipe.zrem(_PENDING_KEY, entry_id)
             pipe.zadd(_FAILED_KEY, {entry_id: time.time()})
+            # Terminal failure — free the dedup key so the path can be
+            # re-enqueued by a future edit (#5080).
+            pipe.delete(self._pending_path_key(entry.document_path))
             logger.error(
                 "sync entry %s permanently failed after %d attempts: %s",
                 entry_id,
@@ -361,16 +448,17 @@ class DocumentSyncQueue:
         self,
         processor: Callable[[SyncQueueEntry], Awaitable[None]],
     ) -> Optional[SyncQueueEntry]:
-        """Pop one entry and pass it to ``processor``.
+        """Atomically claim one entry and pass it to ``processor``.
 
-        The processor is expected to be an async callable that raises on
-        failure.  Returns the processed entry (with its final status) or
-        ``None`` if the queue was empty.
+        Uses :meth:`claim_next_pending` so concurrent workers cannot both
+        process the same entry (#5079).  The processor is an async callable
+        that raises on failure.  Returns the processed entry (with its
+        final status) or ``None`` if the queue was empty or another worker
+        won the race.
         """
-        entry = await self.get_next_pending()
+        entry = await self.claim_next_pending()
         if entry is None:
             return None
-        await self.mark_processing(entry.id)
         try:
             await processor(entry)
         except Exception as exc:  # noqa: BLE001 — worker must survive any failure

--- a/autobot-backend/services/knowledge/sync_queue.py
+++ b/autobot-backend/services/knowledge/sync_queue.py
@@ -1,0 +1,480 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Persistent document sync queue for reliable re-indexing (#4453).
+
+Provides a Redis-backed work queue so document re-indexing survives worker
+crashes and gains retry logic, priority ordering, and status tracking.
+
+Design
+------
+Four Redis keys back the queue (DB: ``main``):
+
+* ``doc_sync:entry:{id}``      hash    – serialized :class:`SyncQueueEntry`
+* ``doc_sync:queue:pending``   zset    – entry IDs ordered by priority score
+* ``doc_sync:queue:failed``    zset    – entry IDs of terminally-failed work
+* ``doc_sync:queue:done``      zset    – entry IDs of completed work (TTL pruned)
+
+Priority scores order pending work so that ``content_changed`` entries are
+dequeued before ``model_updated`` which are dequeued before ``manual``.  FIFO
+within a priority is preserved by appending a monotonic fractional component
+to the score at enqueue time.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ENTRY_KEY_PREFIX = "doc_sync:entry:"
+_PENDING_KEY = "doc_sync:queue:pending"
+_FAILED_KEY = "doc_sync:queue:failed"
+_DONE_KEY = "doc_sync:queue:done"
+
+MAX_ATTEMPTS = 3
+DONE_TTL_SECONDS = 7 * 24 * 3600  # 7 days
+
+
+class SyncReason(str, Enum):
+    """Why a document is being re-indexed.
+
+    Priority ordering: lower ``_priority`` is dequeued first.
+    """
+
+    CONTENT_CHANGED = "content_changed"
+    MODEL_UPDATED = "model_updated"
+    MANUAL = "manual"
+
+    @property
+    def _priority(self) -> int:
+        return {
+            SyncReason.CONTENT_CHANGED: 0,
+            SyncReason.MODEL_UPDATED: 1,
+            SyncReason.MANUAL: 2,
+        }[self]
+
+
+class SyncStatus(str, Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    DONE = "done"
+    FAILED = "failed"
+
+
+# ---------------------------------------------------------------------------
+# SyncQueueEntry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SyncQueueEntry:
+    """A single document re-indexing work item."""
+
+    id: str
+    document_path: str
+    reason: SyncReason
+    status: SyncStatus = SyncStatus.PENDING
+    attempts: int = 0
+    last_error: Optional[str] = None
+    created_at: str = field(
+        default_factory=lambda: datetime.now(tz=timezone.utc).isoformat()
+    )
+    updated_at: str = field(
+        default_factory=lambda: datetime.now(tz=timezone.utc).isoformat()
+    )
+
+    def to_redis_mapping(self) -> Dict[str, str]:
+        """Serialize to a flat string mapping suitable for Redis HSET."""
+        return {
+            "id": self.id,
+            "document_path": self.document_path,
+            "reason": self.reason.value,
+            "status": self.status.value,
+            "attempts": str(self.attempts),
+            "last_error": self.last_error or "",
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_redis_mapping(cls, raw: Dict[Any, Any]) -> "SyncQueueEntry":
+        """Build an entry from a Redis ``hgetall`` response (bytes-safe)."""
+
+        def _get(key: str, default: str = "") -> str:
+            for k in (key, key.encode()):
+                if k in raw:
+                    v = raw[k]
+                    return v.decode() if isinstance(v, bytes) else str(v)
+            return default
+
+        return cls(
+            id=_get("id"),
+            document_path=_get("document_path"),
+            reason=SyncReason(_get("reason", SyncReason.MANUAL.value)),
+            status=SyncStatus(_get("status", SyncStatus.PENDING.value)),
+            attempts=int(_get("attempts", "0") or 0),
+            last_error=_get("last_error") or None,
+            created_at=_get("created_at"),
+            updated_at=_get("updated_at"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a plain dict for JSON API responses."""
+        d = asdict(self)
+        d["reason"] = self.reason.value
+        d["status"] = self.status.value
+        return d
+
+
+# ---------------------------------------------------------------------------
+# DocumentSyncQueue
+# ---------------------------------------------------------------------------
+
+
+class DocumentSyncQueue:
+    """Persistent priority-ordered queue of re-indexing work items.
+
+    A thin wrapper over Redis — a single instance is safe to share across
+    callers and across processes because all state lives in Redis.
+    """
+
+    def __init__(self, database: str = "main") -> None:
+        self._database = database
+
+    # ------------------------------------------------------------------
+    # Redis helpers
+    # ------------------------------------------------------------------
+
+    async def _redis(self):
+        return await get_async_redis_client(database=self._database)
+
+    @staticmethod
+    def _entry_key(entry_id: str) -> str:
+        return f"{_ENTRY_KEY_PREFIX}{entry_id}"
+
+    @staticmethod
+    def _priority_score(reason: SyncReason) -> float:
+        """Compose a priority score: ``priority.high_bits + monotonic_suffix``.
+
+        The integer priority component dominates so reason ordering is strict;
+        the sub-second suffix (``time.time()`` scaled by 1e-9) preserves FIFO
+        order inside a priority bucket.
+        """
+        return float(reason._priority) + time.time() * 1e-9
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def enqueue_sync(
+        self, document_path: str, reason: SyncReason
+    ) -> SyncQueueEntry:
+        """Create a pending entry for ``document_path`` and return it."""
+        entry = SyncQueueEntry(
+            id=str(uuid.uuid4()),
+            document_path=document_path,
+            reason=reason,
+        )
+        redis = await self._redis()
+        pipe = redis.pipeline()
+        pipe.hset(self._entry_key(entry.id), mapping=entry.to_redis_mapping())
+        pipe.zadd(_PENDING_KEY, {entry.id: self._priority_score(reason)})
+        await pipe.execute()
+        logger.info(
+            "enqueued sync: path=%s reason=%s id=%s",
+            document_path,
+            reason.value,
+            entry.id,
+        )
+        return entry
+
+    async def get_next_pending(self) -> Optional[SyncQueueEntry]:
+        """Return the highest-priority pending entry without dequeuing it.
+
+        Uses ``zrange`` with ``withscores=False`` to read the smallest-score
+        member (priority 0 before 1 before 2, FIFO inside a bucket).
+        """
+        redis = await self._redis()
+        ids = await redis.zrange(_PENDING_KEY, 0, 0)
+        if not ids:
+            return None
+        entry_id = ids[0]
+        if isinstance(entry_id, bytes):
+            entry_id = entry_id.decode()
+        raw = await redis.hgetall(self._entry_key(entry_id))
+        if not raw:
+            # Orphaned zset member; clean it up so we don't loop forever.
+            await redis.zrem(_PENDING_KEY, entry_id)
+            return None
+        return SyncQueueEntry.from_redis_mapping(raw)
+
+    async def mark_processing(self, entry_id: str) -> None:
+        """Move an entry out of ``pending`` and set status = processing."""
+        now = datetime.now(tz=timezone.utc).isoformat()
+        redis = await self._redis()
+        pipe = redis.pipeline()
+        pipe.hset(
+            self._entry_key(entry_id),
+            mapping={"status": SyncStatus.PROCESSING.value, "updated_at": now},
+        )
+        pipe.zrem(_PENDING_KEY, entry_id)
+        await pipe.execute()
+
+    async def mark_done(self, entry_id: str) -> None:
+        """Mark an entry complete and place it on the TTL-pruned done zset."""
+        now_dt = datetime.now(tz=timezone.utc)
+        now_iso = now_dt.isoformat()
+        now_ts = now_dt.timestamp()
+        redis = await self._redis()
+        pipe = redis.pipeline()
+        pipe.hset(
+            self._entry_key(entry_id),
+            mapping={"status": SyncStatus.DONE.value, "updated_at": now_iso},
+        )
+        pipe.zrem(_PENDING_KEY, entry_id)
+        pipe.zadd(_DONE_KEY, {entry_id: now_ts})
+        await pipe.execute()
+
+    async def mark_failed(self, entry_id: str, error_msg: str) -> SyncQueueEntry:
+        """Record a failure; requeue if under :data:`MAX_ATTEMPTS`, else park.
+
+        Returns the updated entry so callers can inspect the new status.
+        """
+        redis = await self._redis()
+        raw = await redis.hgetall(self._entry_key(entry_id))
+        if not raw:
+            raise KeyError(f"unknown sync entry: {entry_id}")
+        entry = SyncQueueEntry.from_redis_mapping(raw)
+        entry.attempts += 1
+        entry.last_error = error_msg[:1000]  # cap — errors get large fast
+        entry.updated_at = datetime.now(tz=timezone.utc).isoformat()
+
+        pipe = redis.pipeline()
+        if entry.attempts >= MAX_ATTEMPTS:
+            entry.status = SyncStatus.FAILED
+            pipe.hset(self._entry_key(entry_id), mapping=entry.to_redis_mapping())
+            pipe.zrem(_PENDING_KEY, entry_id)
+            pipe.zadd(_FAILED_KEY, {entry_id: time.time()})
+            logger.error(
+                "sync entry %s permanently failed after %d attempts: %s",
+                entry_id,
+                entry.attempts,
+                error_msg,
+            )
+        else:
+            # Re-queue with the same priority class so it retries ahead of
+            # lower-priority work.
+            entry.status = SyncStatus.PENDING
+            pipe.hset(self._entry_key(entry_id), mapping=entry.to_redis_mapping())
+            pipe.zadd(_PENDING_KEY, {entry_id: self._priority_score(entry.reason)})
+            logger.warning(
+                "sync entry %s attempt %d/%d failed: %s (requeued)",
+                entry_id,
+                entry.attempts,
+                MAX_ATTEMPTS,
+                error_msg,
+            )
+        await pipe.execute()
+        return entry
+
+    # ------------------------------------------------------------------
+    # Admin / introspection
+    # ------------------------------------------------------------------
+
+    async def list_entries(
+        self, status: SyncStatus, limit: int = 100, offset: int = 0
+    ) -> List[SyncQueueEntry]:
+        """List entries with the given status, newest first for non-pending.
+
+        For ``pending`` the queue order (priority ascending) is returned so
+        operators can see what is about to run.
+        """
+        redis = await self._redis()
+        key = {
+            SyncStatus.PENDING: _PENDING_KEY,
+            SyncStatus.FAILED: _FAILED_KEY,
+            SyncStatus.DONE: _DONE_KEY,
+        }.get(status)
+        if key is None:
+            return []
+        stop = offset + limit - 1
+        if status == SyncStatus.PENDING:
+            ids = await redis.zrange(key, offset, stop)
+        else:
+            ids = await redis.zrevrange(key, offset, stop)
+        entries: List[SyncQueueEntry] = []
+        for entry_id in ids:
+            if isinstance(entry_id, bytes):
+                entry_id = entry_id.decode()
+            raw = await redis.hgetall(self._entry_key(entry_id))
+            if raw:
+                entries.append(SyncQueueEntry.from_redis_mapping(raw))
+        return entries
+
+    async def prune_done(self, older_than_seconds: int = DONE_TTL_SECONDS) -> int:
+        """Delete done entries older than the cutoff and return the count."""
+        cutoff = time.time() - older_than_seconds
+        redis = await self._redis()
+        old_ids = await redis.zrangebyscore(_DONE_KEY, min=0, max=cutoff)
+        if not old_ids:
+            return 0
+        decoded = [i.decode() if isinstance(i, bytes) else i for i in old_ids]
+        pipe = redis.pipeline()
+        for eid in decoded:
+            pipe.delete(self._entry_key(eid))
+        pipe.zrem(_DONE_KEY, *decoded)
+        await pipe.execute()
+        return len(decoded)
+
+    async def stats(self) -> Dict[str, int]:
+        """Return counts per status for quick admin summaries."""
+        redis = await self._redis()
+        pipe = redis.pipeline()
+        pipe.zcard(_PENDING_KEY)
+        pipe.zcard(_FAILED_KEY)
+        pipe.zcard(_DONE_KEY)
+        pending, failed, done = await pipe.execute()
+        return {
+            "pending": int(pending or 0),
+            "failed": int(failed or 0),
+            "done": int(done or 0),
+        }
+
+    # ------------------------------------------------------------------
+    # Worker loop
+    # ------------------------------------------------------------------
+
+    async def process_one(
+        self,
+        processor: Callable[[SyncQueueEntry], Awaitable[None]],
+    ) -> Optional[SyncQueueEntry]:
+        """Pop one entry and pass it to ``processor``.
+
+        The processor is expected to be an async callable that raises on
+        failure.  Returns the processed entry (with its final status) or
+        ``None`` if the queue was empty.
+        """
+        entry = await self.get_next_pending()
+        if entry is None:
+            return None
+        await self.mark_processing(entry.id)
+        try:
+            await processor(entry)
+        except Exception as exc:  # noqa: BLE001 — worker must survive any failure
+            return await self.mark_failed(entry.id, str(exc))
+        await self.mark_done(entry.id)
+        entry.status = SyncStatus.DONE
+        return entry
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessor
+# ---------------------------------------------------------------------------
+
+
+_queue: Optional[DocumentSyncQueue] = None
+
+
+def get_document_sync_queue() -> DocumentSyncQueue:
+    """Return the process-wide :class:`DocumentSyncQueue` singleton."""
+    global _queue
+    if _queue is None:
+        _queue = DocumentSyncQueue()
+    return _queue
+
+
+# ---------------------------------------------------------------------------
+# Worker that processes queue entries by re-indexing via DocIndexerService
+# ---------------------------------------------------------------------------
+
+
+async def _reindex_processor(entry: SyncQueueEntry) -> None:
+    """Processor that re-indexes the document referenced by ``entry``.
+
+    Imported lazily to avoid circular imports between ``doc_indexer`` and
+    ``sync_queue`` (DocIndexerService enqueues onto this queue).
+    """
+    from pathlib import Path
+
+    from services.knowledge.doc_indexer import get_doc_indexer_service
+
+    indexer = get_doc_indexer_service()
+    if not await indexer.initialize():
+        raise RuntimeError("DocIndexerService initialization failed")
+    result = await indexer.index_file(Path(entry.document_path), force=True)
+    if result.failed:
+        # Surface the underlying reason so mark_failed has a useful message.
+        raise RuntimeError(
+            "; ".join(result.errors) if result.errors else "indexing failed"
+        )
+
+
+class SyncQueueWorker:
+    """Background task that drains :class:`DocumentSyncQueue` continuously."""
+
+    def __init__(
+        self,
+        queue: Optional[DocumentSyncQueue] = None,
+        idle_sleep_seconds: float = 2.0,
+        processor: Optional[Callable[[SyncQueueEntry], Awaitable[None]]] = None,
+    ) -> None:
+        self._queue = queue or get_document_sync_queue()
+        self._idle_sleep = idle_sleep_seconds
+        self._processor = processor or _reindex_processor
+        self._running = False
+        self._task = None
+
+    async def run(self) -> None:
+        """Process entries until stopped.  Intended to be scheduled as a task."""
+        import asyncio
+
+        self._running = True
+        logger.info("SyncQueueWorker started")
+        try:
+            while self._running:
+                try:
+                    processed = await self._queue.process_one(self._processor)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    logger.exception("SyncQueueWorker loop error")
+                    processed = None
+                if processed is None:
+                    await asyncio.sleep(self._idle_sleep)
+        finally:
+            self._running = False
+            logger.info("SyncQueueWorker stopped")
+
+    def stop(self) -> None:
+        self._running = False
+
+
+def serialize_entry_for_api(entry: SyncQueueEntry) -> Dict[str, Any]:
+    """Shape an entry for JSON responses (used by the admin endpoint)."""
+    return entry.to_dict()
+
+
+__all__ = [
+    "DONE_TTL_SECONDS",
+    "DocumentSyncQueue",
+    "MAX_ATTEMPTS",
+    "SyncQueueEntry",
+    "SyncQueueWorker",
+    "SyncReason",
+    "SyncStatus",
+    "get_document_sync_queue",
+    "serialize_entry_for_api",
+]

--- a/autobot-backend/services/knowledge/test_sync_queue.py
+++ b/autobot-backend/services/knowledge/test_sync_queue.py
@@ -1,0 +1,463 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for the document sync queue (#4453).
+
+Uses an in-memory fake Redis so we can exercise the full state machine
+(enqueue → process → mark done/failed, priority ordering, retry cap)
+without a running Redis server or optional fakeredis dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import patch
+
+import pytest
+
+from services.knowledge.sync_queue import (
+    MAX_ATTEMPTS,
+    DocumentSyncQueue,
+    SyncQueueEntry,
+    SyncQueueWorker,
+    SyncReason,
+    SyncStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory async Redis stub
+# ---------------------------------------------------------------------------
+
+
+class _Pipeline:
+    """Accumulates Redis commands and replays them on ``execute()``."""
+
+    def __init__(self, redis: "_FakeAsyncRedis") -> None:
+        self._redis = redis
+        self._ops: List[Tuple[str, tuple, dict]] = []
+
+    def __getattr__(self, name: str):
+        def _op(*args, **kwargs):
+            self._ops.append((name, args, kwargs))
+            return self
+
+        return _op
+
+    async def execute(self) -> List[Any]:
+        out: List[Any] = []
+        for name, args, kwargs in self._ops:
+            method = getattr(self._redis, name)
+            result = method(*args, **kwargs)
+            if asyncio.iscoroutine(result):
+                result = await result
+            out.append(result)
+        return out
+
+
+class _FakeAsyncRedis:
+    """Just enough async Redis surface for :class:`DocumentSyncQueue`."""
+
+    def __init__(self) -> None:
+        self.hashes: Dict[str, Dict[str, str]] = {}
+        self.zsets: Dict[str, Dict[str, float]] = {}
+
+    def pipeline(self) -> _Pipeline:
+        return _Pipeline(self)
+
+    async def hset(self, key: str, mapping: Optional[dict] = None, **kwargs) -> int:
+        payload = mapping or kwargs
+        bucket = self.hashes.setdefault(key, {})
+        added = 0
+        for k, v in payload.items():
+            if k not in bucket:
+                added += 1
+            bucket[k] = str(v)
+        return added
+
+    async def hgetall(self, key: str) -> Dict[str, str]:
+        return dict(self.hashes.get(key, {}))
+
+    async def delete(self, *keys: str) -> int:
+        removed = 0
+        for k in keys:
+            if k in self.hashes:
+                del self.hashes[k]
+                removed += 1
+            if k in self.zsets:
+                del self.zsets[k]
+                removed += 1
+        return removed
+
+    async def zadd(self, key: str, mapping: Dict[str, float]) -> int:
+        bucket = self.zsets.setdefault(key, {})
+        added = 0
+        for m, score in mapping.items():
+            if m not in bucket:
+                added += 1
+            bucket[m] = float(score)
+        return added
+
+    async def zrem(self, key: str, *members: str) -> int:
+        bucket = self.zsets.get(key, {})
+        removed = 0
+        for m in members:
+            if m in bucket:
+                del bucket[m]
+                removed += 1
+        return removed
+
+    async def zrange(self, key: str, start: int, stop: int) -> List[str]:
+        bucket = self.zsets.get(key, {})
+        ordered = sorted(bucket.items(), key=lambda kv: kv[1])
+        # Redis ZRANGE stop is inclusive; -1 means last element.
+        if stop == -1:
+            stop = len(ordered) - 1
+        return [k for k, _ in ordered[start : stop + 1]]
+
+    async def zrevrange(self, key: str, start: int, stop: int) -> List[str]:
+        bucket = self.zsets.get(key, {})
+        ordered = sorted(bucket.items(), key=lambda kv: kv[1], reverse=True)
+        if stop == -1:
+            stop = len(ordered) - 1
+        return [k for k, _ in ordered[start : stop + 1]]
+
+    async def zrangebyscore(
+        self, key: str, min: float, max: float, **kwargs
+    ) -> List[str]:
+        bucket = self.zsets.get(key, {})
+        lo = float("-inf") if min == "-inf" else float(min)
+        hi = float("inf") if max == "+inf" else float(max)
+        return sorted(
+            (m for m, s in bucket.items() if lo <= s <= hi),
+            key=lambda m: bucket[m],
+        )
+
+    async def zcard(self, key: str) -> int:
+        return len(self.zsets.get(key, {}))
+
+
+@pytest.fixture
+def fake_redis() -> _FakeAsyncRedis:
+    return _FakeAsyncRedis()
+
+
+@pytest.fixture
+def queue(fake_redis: _FakeAsyncRedis) -> DocumentSyncQueue:
+    """A :class:`DocumentSyncQueue` patched to return the in-memory fake."""
+
+    async def _return_redis(database: str = "main"):
+        return fake_redis
+
+    q = DocumentSyncQueue()
+    patcher = patch.object(q, "_redis", _return_redis)
+    patcher.start()
+    yield q
+    patcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# Enqueue / dequeue
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueDequeue:
+    @pytest.mark.asyncio
+    async def test_enqueue_returns_pending_entry(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        entry = await queue.enqueue_sync("docs/a.md", SyncReason.CONTENT_CHANGED)
+
+        assert entry.document_path == "docs/a.md"
+        assert entry.reason == SyncReason.CONTENT_CHANGED
+        assert entry.status == SyncStatus.PENDING
+        assert entry.attempts == 0
+
+    @pytest.mark.asyncio
+    async def test_get_next_pending_returns_enqueued_entry(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        enq = await queue.enqueue_sync("docs/a.md", SyncReason.MANUAL)
+
+        nxt = await queue.get_next_pending()
+
+        assert nxt is not None
+        assert nxt.id == enq.id
+        assert nxt.document_path == "docs/a.md"
+
+    @pytest.mark.asyncio
+    async def test_empty_queue_returns_none(self, queue: DocumentSyncQueue) -> None:
+        assert await queue.get_next_pending() is None
+
+
+# ---------------------------------------------------------------------------
+# Priority ordering
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityOrdering:
+    @pytest.mark.asyncio
+    async def test_content_changed_dequeued_before_manual(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        # Enqueue manual FIRST so FIFO would return it without priority.
+        await queue.enqueue_sync("manual.md", SyncReason.MANUAL)
+        # Small await gap so monotonic-suffix does not order them backwards.
+        await asyncio.sleep(0)
+        changed = await queue.enqueue_sync("changed.md", SyncReason.CONTENT_CHANGED)
+
+        nxt = await queue.get_next_pending()
+
+        assert nxt is not None
+        assert nxt.id == changed.id
+        assert nxt.reason == SyncReason.CONTENT_CHANGED
+
+    @pytest.mark.asyncio
+    async def test_model_updated_between_content_and_manual(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        manual = await queue.enqueue_sync("m.md", SyncReason.MANUAL)
+        await asyncio.sleep(0)
+        model = await queue.enqueue_sync("mdl.md", SyncReason.MODEL_UPDATED)
+        await asyncio.sleep(0)
+        content = await queue.enqueue_sync("c.md", SyncReason.CONTENT_CHANGED)
+
+        # Drain in priority order.
+        first = await queue.get_next_pending()
+        assert first.id == content.id
+        await queue.mark_done(first.id)
+
+        second = await queue.get_next_pending()
+        assert second.id == model.id
+        await queue.mark_done(second.id)
+
+        third = await queue.get_next_pending()
+        assert third.id == manual.id
+
+
+# ---------------------------------------------------------------------------
+# State transitions
+# ---------------------------------------------------------------------------
+
+
+class TestStateTransitions:
+    @pytest.mark.asyncio
+    async def test_mark_processing_removes_from_pending(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        entry = await queue.enqueue_sync("a.md", SyncReason.MANUAL)
+
+        await queue.mark_processing(entry.id)
+
+        assert await queue.get_next_pending() is None
+        pending = await queue.list_entries(SyncStatus.PENDING)
+        assert pending == []
+
+    @pytest.mark.asyncio
+    async def test_mark_done_moves_to_done_collection(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        entry = await queue.enqueue_sync("a.md", SyncReason.MANUAL)
+        await queue.mark_processing(entry.id)
+
+        await queue.mark_done(entry.id)
+
+        stats = await queue.stats()
+        assert stats["done"] == 1
+        assert stats["pending"] == 0
+        assert stats["failed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Retry / failure semantics
+# ---------------------------------------------------------------------------
+
+
+class TestFailureAndRetry:
+    @pytest.mark.asyncio
+    async def test_failed_under_limit_requeues(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        entry = await queue.enqueue_sync("a.md", SyncReason.CONTENT_CHANGED)
+        await queue.mark_processing(entry.id)
+
+        updated = await queue.mark_failed(entry.id, "transient embedding error")
+
+        assert updated.status == SyncStatus.PENDING
+        assert updated.attempts == 1
+        assert updated.last_error == "transient embedding error"
+        # The entry should be back on the pending queue for retry.
+        nxt = await queue.get_next_pending()
+        assert nxt is not None and nxt.id == entry.id
+
+    @pytest.mark.asyncio
+    async def test_mark_failed_three_times_terminates_as_failed(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        entry = await queue.enqueue_sync("a.md", SyncReason.CONTENT_CHANGED)
+
+        for attempt in range(MAX_ATTEMPTS):
+            await queue.mark_processing(entry.id)
+            updated = await queue.mark_failed(entry.id, f"attempt {attempt} failed")
+
+        assert updated.status == SyncStatus.FAILED
+        assert updated.attempts == MAX_ATTEMPTS
+        assert updated.last_error == f"attempt {MAX_ATTEMPTS - 1} failed"
+        stats = await queue.stats()
+        assert stats["failed"] == 1
+        assert stats["pending"] == 0
+
+    @pytest.mark.asyncio
+    async def test_failed_entries_appear_in_list_entries(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        entry = await queue.enqueue_sync("a.md", SyncReason.CONTENT_CHANGED)
+        for _ in range(MAX_ATTEMPTS):
+            await queue.mark_processing(entry.id)
+            await queue.mark_failed(entry.id, "boom")
+
+        failed = await queue.list_entries(SyncStatus.FAILED)
+
+        assert len(failed) == 1
+        assert failed[0].id == entry.id
+        assert failed[0].status == SyncStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Worker loop via process_one()
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerLoop:
+    @pytest.mark.asyncio
+    async def test_process_one_runs_processor_and_marks_done(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        entry = await queue.enqueue_sync("a.md", SyncReason.MANUAL)
+        called: List[str] = []
+
+        async def processor(e: SyncQueueEntry) -> None:
+            called.append(e.id)
+
+        processed = await queue.process_one(processor)
+
+        assert processed is not None
+        assert processed.id == entry.id
+        assert called == [entry.id]
+        stats = await queue.stats()
+        assert stats["done"] == 1
+        assert stats["pending"] == 0
+
+    @pytest.mark.asyncio
+    async def test_process_one_records_failure_and_requeues(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        entry = await queue.enqueue_sync("a.md", SyncReason.CONTENT_CHANGED)
+
+        async def processor(_: SyncQueueEntry) -> None:
+            raise RuntimeError("embedding model offline")
+
+        result = await queue.process_one(processor)
+
+        assert result is not None
+        assert result.status == SyncStatus.PENDING  # retry
+        assert result.attempts == 1
+        assert "embedding model offline" in (result.last_error or "")
+        stats = await queue.stats()
+        assert stats["pending"] == 1
+
+    @pytest.mark.asyncio
+    async def test_process_one_empty_queue_returns_none(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        async def processor(_: SyncQueueEntry) -> None:
+            pytest.fail("processor must not run on empty queue")
+
+        assert await queue.process_one(processor) is None
+
+    @pytest.mark.asyncio
+    async def test_sync_queue_worker_drains_pending(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        """SyncQueueWorker.run() processes pending entries and idles otherwise."""
+        processed_ids: List[str] = []
+
+        async def processor(e: SyncQueueEntry) -> None:
+            processed_ids.append(e.id)
+
+        entry = await queue.enqueue_sync("a.md", SyncReason.MANUAL)
+        worker = SyncQueueWorker(
+            queue=queue, idle_sleep_seconds=0.01, processor=processor
+        )
+        task = asyncio.create_task(worker.run())
+
+        # Let the worker pick up the entry.
+        for _ in range(50):
+            await asyncio.sleep(0.01)
+            if processed_ids:
+                break
+
+        worker.stop()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert processed_ids == [entry.id]
+
+
+# ---------------------------------------------------------------------------
+# Pruning
+# ---------------------------------------------------------------------------
+
+
+class TestPrune:
+    @pytest.mark.asyncio
+    async def test_prune_done_removes_expired_entries(
+        self, queue: DocumentSyncQueue, fake_redis: _FakeAsyncRedis
+    ) -> None:
+        entry = await queue.enqueue_sync("a.md", SyncReason.MANUAL)
+        await queue.mark_processing(entry.id)
+        await queue.mark_done(entry.id)
+
+        # Back-date the done-zset score so the entry is "old".
+        fake_redis.zsets["doc_sync:queue:done"][entry.id] = 0.0
+
+        pruned = await queue.prune_done(older_than_seconds=3600)
+
+        assert pruned == 1
+        stats = await queue.stats()
+        assert stats["done"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoint integration (smoke test without FastAPI)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminEndpoint:
+    @pytest.mark.asyncio
+    async def test_admin_endpoint_returns_pending_and_failed(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        from api.knowledge_sync_queue import get_sync_queue
+
+        pending_entry = await queue.enqueue_sync("a.md", SyncReason.CONTENT_CHANGED)
+        failed_entry = await queue.enqueue_sync("b.md", SyncReason.MANUAL)
+        for _ in range(MAX_ATTEMPTS):
+            await queue.mark_processing(failed_entry.id)
+            await queue.mark_failed(failed_entry.id, "nope")
+
+        with patch(
+            "api.knowledge_sync_queue.get_document_sync_queue", return_value=queue
+        ):
+            response = await get_sync_queue(limit=10, offset=0, admin_check=True)
+
+        pending_ids = {e["id"] for e in response["pending"]}
+        failed_ids = {e["id"] for e in response["failed"]}
+        assert pending_entry.id in pending_ids
+        assert failed_entry.id in failed_ids
+        assert response["counts"]["pending"] == 1
+        assert response["counts"]["failed"] == 1

--- a/autobot-backend/services/knowledge/test_sync_queue.py
+++ b/autobot-backend/services/knowledge/test_sync_queue.py
@@ -11,6 +11,7 @@ without a running Redis server or optional fakeredis dependency.
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
@@ -62,6 +63,7 @@ class _FakeAsyncRedis:
     def __init__(self) -> None:
         self.hashes: Dict[str, Dict[str, str]] = {}
         self.zsets: Dict[str, Dict[str, float]] = {}
+        self.strings: Dict[str, str] = {}
 
     def pipeline(self) -> _Pipeline:
         return _Pipeline(self)
@@ -79,6 +81,13 @@ class _FakeAsyncRedis:
     async def hgetall(self, key: str) -> Dict[str, str]:
         return dict(self.hashes.get(key, {}))
 
+    async def get(self, key: str) -> Optional[str]:
+        return self.strings.get(key)
+
+    async def set(self, key: str, value: str) -> bool:
+        self.strings[key] = str(value)
+        return True
+
     async def delete(self, *keys: str) -> int:
         removed = 0
         for k in keys:
@@ -87,6 +96,9 @@ class _FakeAsyncRedis:
                 removed += 1
             if k in self.zsets:
                 del self.zsets[k]
+                removed += 1
+            if k in self.strings:
+                del self.strings[k]
                 removed += 1
         return removed
 
@@ -214,6 +226,33 @@ class TestPriorityOrdering:
         assert nxt.reason == SyncReason.CONTENT_CHANGED
 
     @pytest.mark.asyncio
+    async def test_priority_beats_fifo_across_one_second_gap(
+        self, queue: DocumentSyncQueue, fake_redis: _FakeAsyncRedis
+    ) -> None:
+        """Regression for #5078: FIFO component must not overflow priority bucket.
+
+        With the old ``float(priority) + time.time() * 1e-9`` formula the
+        FIFO component was ~1.76 today — larger than the priority gap of 1
+        — so a MANUAL entry enqueued first would incorrectly come out ahead
+        of a later CONTENT_CHANGED entry.  Simulate the 1-second enqueue
+        gap by back-dating MANUAL's score in the fake zset and verify
+        CONTENT_CHANGED still wins.
+        """
+        manual = await queue.enqueue_sync("manual.md", SyncReason.MANUAL)
+        changed = await queue.enqueue_sync("changed.md", SyncReason.CONTENT_CHANGED)
+
+        # MANUAL was enqueued 1 second earlier than CONTENT_CHANGED.
+        now = time.time()
+        fake_redis.zsets["doc_sync:queue:pending"][manual.id] = 2.0 * 1e12 + (now - 1.0)
+        fake_redis.zsets["doc_sync:queue:pending"][changed.id] = 0.0 * 1e12 + now
+
+        nxt = await queue.get_next_pending()
+
+        assert nxt is not None
+        assert nxt.id == changed.id
+        assert nxt.reason == SyncReason.CONTENT_CHANGED
+
+    @pytest.mark.asyncio
     async def test_model_updated_between_content_and_manual(
         self, queue: DocumentSyncQueue
     ) -> None:
@@ -234,6 +273,99 @@ class TestPriorityOrdering:
 
         third = await queue.get_next_pending()
         assert third.id == manual.id
+
+
+# ---------------------------------------------------------------------------
+# Atomic claim (#5079)
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicClaim:
+    @pytest.mark.asyncio
+    async def test_claim_next_pending_returns_and_removes(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        entry = await queue.enqueue_sync("a.md", SyncReason.MANUAL)
+
+        claimed = await queue.claim_next_pending()
+
+        assert claimed is not None
+        assert claimed.id == entry.id
+        assert claimed.status == SyncStatus.PROCESSING
+        # Queue is now empty — no second claim possible.
+        assert await queue.claim_next_pending() is None
+
+    @pytest.mark.asyncio
+    async def test_claim_next_pending_empty_queue_returns_none(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        assert await queue.claim_next_pending() is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_claims_only_one_wins(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        """Two workers calling claim_next_pending concurrently — exactly one gets it."""
+        await queue.enqueue_sync("a.md", SyncReason.CONTENT_CHANGED)
+
+        results = await asyncio.gather(
+            queue.claim_next_pending(),
+            queue.claim_next_pending(),
+        )
+
+        # Exactly one result is non-None; the other is None.
+        winners = [r for r in results if r is not None]
+        assert len(winners) == 1
+        assert winners[0].status == SyncStatus.PROCESSING
+
+
+# ---------------------------------------------------------------------------
+# Path deduplication (#5080)
+# ---------------------------------------------------------------------------
+
+
+class TestPathDedup:
+    @pytest.mark.asyncio
+    async def test_duplicate_enqueue_returns_existing_entry(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        first = await queue.enqueue_sync("docs/a.md", SyncReason.CONTENT_CHANGED)
+        second = await queue.enqueue_sync("docs/a.md", SyncReason.MANUAL)
+
+        # Same entry returned — not a new one.
+        assert second.id == first.id
+        # Only one pending entry in the queue.
+        stats = await queue.stats()
+        assert stats["pending"] == 1
+
+    @pytest.mark.asyncio
+    async def test_reenqueue_allowed_after_mark_done(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        first = await queue.enqueue_sync("docs/a.md", SyncReason.CONTENT_CHANGED)
+        await queue.mark_processing(first.id)
+        await queue.mark_done(first.id)
+
+        # Path is free again — a fresh enqueue creates a new entry.
+        second = await queue.enqueue_sync("docs/a.md", SyncReason.CONTENT_CHANGED)
+
+        assert second.id != first.id
+        stats = await queue.stats()
+        assert stats["pending"] == 1
+        assert stats["done"] == 1
+
+    @pytest.mark.asyncio
+    async def test_reenqueue_allowed_after_terminal_failure(
+        self, queue: DocumentSyncQueue
+    ) -> None:
+        first = await queue.enqueue_sync("docs/a.md", SyncReason.CONTENT_CHANGED)
+        for _ in range(MAX_ATTEMPTS):
+            await queue.mark_processing(first.id)
+            await queue.mark_failed(first.id, "boom")
+
+        # Terminal failure frees the dedup key.
+        second = await queue.enqueue_sync("docs/a.md", SyncReason.CONTENT_CHANGED)
+        assert second.id != first.id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4453

## Summary
- **Persistence**: Redis-backed (DB=main) — `doc_sync:entry:{id}` hash + `doc_sync:queue:{pending,failed,done}` zsets
- **SyncQueueEntry model**: id, document_path, reason (enum), status (enum), attempts, last_error, created_at, updated_at
- **Priority ordering**: content_changed > model_updated > manual (FIFO within same priority)
- **Retry cap**: 3 attempts → parked in `failed` with `last_error` populated (not silently discarded)
- **DocIndexerService.enqueue_reindex(path, reason)** — new public method
- **documentation_watcher** now enqueues `CONTENT_CHANGED` instead of directly calling `index_file`
- **SyncQueueWorker** started in Phase 2 of `lifespan.py`, cancelled during cleanup
- **Admin endpoint**: `GET /api/knowledge/sync-queue` returns `{pending: [...], failed: [...]}` via new `api/knowledge_sync_queue.py` router

## Test Status
PASS — 16 new + 84 pre-existing doc_indexer tests = 100/100