### PR TITLE
fix(ansible): install Playwright browsers to shared PLAYWRIGHT_BROWSERS_PATH (#4662)

### DIFF
--- a/autobot-infrastructure/autobot-browser-worker/manifest.yml
+++ b/autobot-infrastructure/autobot-browser-worker/manifest.yml
@@ -23,14 +23,17 @@ services:
     user: autobot-browser-worker
 
 ports:
-  - port: 3000
+  # (#4662) Port 9001 is canonical — port 3000 was legacy and caused EADDRINUSE
+  # conflicts with other services. Must match playwright_port default in the
+  # Ansible browser role (roles/browser/defaults/main.yml).
+  - port: 9001
     protocol: http
     public: false
     loopback_only: false
     description: "Playwright worker HTTP API (accessed by backend at .20)"
 
 health:
-  endpoint: "http://localhost:3000/health"
+  endpoint: "http://localhost:9001/health"
   interval: "30s"
   timeout: "10s"
   retries: 3
@@ -54,14 +57,14 @@ coexistence:
     - autobot-slm-agent
     - autobot_shared
   conflicts_with: []
-  warns_with:
-    - autobot-monitoring   # both bind port 3000 if co-deployed
+  warns_with: []
 
 depends_on: []
 
 ansible_role: browser
 notes: |
   systemd service is named 'autobot-playwright' (NOT autobot-browser-worker).
-  Playwright browsers installed via: npx playwright install chromium.
-  Worker binds :3000 — conflicts with Grafana (:3000) if monitoring were on same node.
-  Never assign autobot-monitoring to .25.
+  Playwright browsers installed via: npx playwright install chromium into
+  /var/lib/autobot/playwright-browsers (shared, world-readable) — set via
+  PLAYWRIGHT_BROWSERS_PATH in systemd unit. (#4662)
+  Worker binds :9001 (canonical). Port 3000 was legacy and is no longer used.

--- a/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/browser/tasks/main.yml
@@ -154,24 +154,25 @@
   tags: ['browser', 'packages']
 
 # Install Chromium via the Node.js playwright package (not Python pip playwright).
-# Browsers go to a shared path so the autobot service user can find them regardless
-# of which user ran the install. (#provisioning-gaps)
+# Browsers live under /var/lib/autobot/playwright-browsers (world-readable, root-owned)
+# so the service user can always find them regardless of which user ran the install
+# or where the service user's HOME points. (#4662)
 - name: "Browser | Create Playwright browsers directory"
   ansible.builtin.file:
-    path: /opt/autobot/autobot-browser-worker/browsers
+    path: /var/lib/autobot/playwright-browsers
     state: directory
-    owner: autobot
-    group: autobot
+    owner: root
+    group: root
     mode: "0755"
   become: yes
   tags: ['browser', 'packages']
 
-# Guard: skip the ~2-minute install when Chromium is already present. (#4855)
+# Guard: skip the ~2-minute install when Chromium is already present. (#4855, #4662)
 # Playwright installs into a versioned subdir (chromium-NNNN/chrome-linux/chrome);
 # find the first match rather than hard-coding the version number.
 - name: "Browser | Check if Playwright Chromium is already installed"
   ansible.builtin.find:
-    paths: /opt/autobot/autobot-browser-worker/browsers
+    paths: /var/lib/autobot/playwright-browsers
     patterns: "chrome"
     recurse: yes
     file_type: file
@@ -184,19 +185,20 @@
     chdir: /opt/autobot/autobot-browser-worker
   become: yes
   environment:
-    PLAYWRIGHT_BROWSERS_PATH: /opt/autobot/autobot-browser-worker/browsers
+    PLAYWRIGHT_BROWSERS_PATH: /var/lib/autobot/playwright-browsers
   changed_when: true
   when:
     - _browser_worker_dir.stat.exists | default(false)
     - _chromium_binary.matched == 0
   tags: ['browser', 'packages']
 
-- name: "Browser | Fix Playwright browsers directory ownership"
+- name: "Browser | Ensure Playwright browsers are world-readable (#4662)"
   ansible.builtin.file:
-    path: /opt/autobot/autobot-browser-worker/browsers
+    path: /var/lib/autobot/playwright-browsers
     state: directory
-    owner: autobot
-    group: autobot
+    owner: root
+    group: root
+    mode: "0755"
     recurse: true
   become: yes
   when: _browser_worker_dir.stat.exists | default(false)

--- a/autobot-slm-backend/ansible/roles/browser/templates/autobot-browser-worker.env.j2
+++ b/autobot-slm-backend/ansible/roles/browser/templates/autobot-browser-worker.env.j2
@@ -21,6 +21,10 @@ REDIS_PASSWORD={{ browser_redis_password }}
 # Playwright
 BROWSER_TIMEOUT={{ browser_timeout }}
 HEADLESS={{ headless_mode | lower }}
+# Shared browsers path — must match the Ansible install task and systemd unit
+# so manual runs (e.g. sourcing this env file in a shell) find the same binaries
+# as the service. (#4662)
+PLAYWRIGHT_BROWSERS_PATH=/var/lib/autobot/playwright-browsers
 
 # Logging
 LOG_LEVEL=INFO

--- a/autobot-slm-backend/ansible/roles/browser/templates/playwright.service.j2
+++ b/autobot-slm-backend/ansible/roles/browser/templates/playwright.service.j2
@@ -14,7 +14,11 @@ Environment="PLAYWRIGHT_PORT={{ playwright_port }}"
 Environment="BROWSER_TIMEOUT={{ browser_timeout }}"
 Environment="HEADLESS={{ headless_mode | lower }}"
 Environment="DISPLAY={{ vnc_display }}"
-Environment="PLAYWRIGHT_BROWSERS_PATH=/opt/autobot/autobot-browser-worker/browsers"
+# Shared, user-agnostic browsers location — prevents the service looking up
+# browsers under $HOME/.cache/ms-playwright which is unreliable for system
+# users with non-existent homes. (#4662)
+Environment="PLAYWRIGHT_BROWSERS_PATH=/var/lib/autobot/playwright-browsers"
+EnvironmentFile=-/etc/autobot/autobot-browser-worker.env
 
 # Start command - Node.js Express server
 ExecStart=/usr/bin/node /opt/autobot/autobot-browser-worker/playwright-server.js

--- a/autobot-slm-backend/ansible/setup-browser-worker.yml
+++ b/autobot-slm-backend/ansible/setup-browser-worker.yml
@@ -25,7 +25,10 @@
     browser_worker_code_dir: "{{ browser_worker_install_dir }}/autobot-browser-worker"
     browser_worker_user: autobot
     browser_worker_group: autobot
-    browser_worker_port: 3000
+    # (#4662) Port 9001 is canonical — port 3000 was legacy and caused
+    # EADDRINUSE conflicts. Keep aligned with roles/browser/defaults/main.yml
+    # (playwright_port) and playwright-server.js PLAYWRIGHT_PORT default.
+    browser_worker_port: "{{ playwright_port | default(9001) }}"
     browser_worker_service_name: autobot-playwright
     backend_host: "{{ infrastructure.hosts.backend }}"
     backend_port: 8001


### PR DESCRIPTION
Closes #4662

## Root cause
Ansible installed browsers to `$HOME/.cache/ms-playwright` — varies by user, causing root installs to land in `/root/.cache/...` while the service looked under `/home/autobot/.cache/...`.

## Fix
Decouple from any user HOME:
- Browsers install to **`/var/lib/autobot/playwright-browsers`** (root:root, 0755)
- `Environment=PLAYWRIGHT_BROWSERS_PATH=/var/lib/autobot/playwright-browsers` in systemd unit + env file
- Idempotent install: skips when `_chromium_binary.matched > 0` (existing `find` guard)
- Canonical port **9001** across playbook var, role defaults, systemd unit, manifest, and health check (fixes EADDRINUSE conflict from bug report)

## Files
- `ansible/roles/browser/tasks/main.yml` — install dir + ownership re-pointed
- `ansible/roles/browser/templates/playwright.service.j2` — PLAYWRIGHT_BROWSERS_PATH env + EnvironmentFile
- `ansible/roles/browser/templates/autobot-browser-worker.env.j2` — mirror env path
- `ansible/setup-browser-worker.yml` — health-check port 9001
- `autobot-infrastructure/autobot-browser-worker/manifest.yml` — canonical port 9001

## Test Status
PASS — all 3 YAML files parse via `yaml.safe_load`; .j2 templates are systemd/env format