### PR TITLE
refactor(typescript): delete parseApiResponse from useKnowledgeVectorization (#5033)

### DIFF
--- a/autobot-frontend/src/composables/useKnowledgeVectorization.ts
+++ b/autobot-frontend/src/composables/useKnowledgeVectorization.ts
@@ -10,7 +10,6 @@ import { ref, computed } from 'vue'
 import { useKnowledgeBase } from './useKnowledgeBase'
 import apiClient from '@/utils/ApiClient'
 import appConfig from '@/config/AppConfig.js'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { useDebounce } from './useTimeout'
@@ -130,11 +129,10 @@ export function useKnowledgeVectorization() {
   const fetchDocumentStatus = async (documentId: string): Promise<VectorizationStatus> => {
     try {
       // Query actual backend status
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorization_status`, {
+      const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/vectorization_status`, {
         fact_ids: [documentId],
         use_cache: true
       })
-      const data = await parseApiResponse<Record<string, any>>(response)
 
       if (data?.statuses?.[documentId]) {
         const status: VectorizationStatus = data.statuses[documentId].vectorized ? 'vectorized' : 'pending'
@@ -191,11 +189,10 @@ export function useKnowledgeVectorization() {
         for (let i = 0; i < documentIds.length; i += batchSize) {
           const batch = documentIds.slice(i, i + batchSize)
 
-          const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorization_status`, {
+          const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/vectorization_status`, {
             fact_ids: batch,
             use_cache: true
           })
-          const data = await parseApiResponse<Record<string, any>>(response)
 
           if (data?.statuses) {
             // Update cache with all statuses, including document names if provided (Issue #165)
@@ -354,13 +351,9 @@ export function useKnowledgeVectorization() {
       const knowledgeTimeout = appConfig.getTimeout('knowledge')
 
       // Call backend API to vectorize the fact with proper timeout
-      // Issue #648: Use parseApiResponse to handle both Response objects and parsed JSON
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorize_fact/${documentId}`, undefined, {
+      const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/vectorize_fact/${documentId}`, undefined, {
         timeout: knowledgeTimeout
       })
-
-      // Parse JSON response (handles both ApiClient parsed JSON)
-      const data = await parseApiResponse<Record<string, any>>(response)
 
       // Check if backend returned success status
       if (data.status !== 'success') {
@@ -379,11 +372,9 @@ export function useKnowledgeVectorization() {
         await new Promise(resolve => setTimeout(resolve, 1000)) // Wait 1 second
 
         // Use knowledge timeout for job status polling as well
-        // Issue #648: Use parseApiResponse to handle both Response objects and parsed JSON
-        const jobResponse = await apiClient.get(`${getApiBase()}/knowledge_base/vectorize_job/${jobId}`, {
+        const jobData = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/vectorize_job/${jobId}`, {
           timeout: knowledgeTimeout
         })
-        const jobData = await parseApiResponse<Record<string, any>>(jobResponse)
 
         // Backend returns: { status: "success", job: { status: "completed", error: null, ... } }
         const job = jobData.job
@@ -428,12 +419,11 @@ export function useKnowledgeVectorization() {
   ): Promise<{ succeeded: string[], failed: string[] }> => {
     const knowledgeTimeout = appConfig.getTimeout('knowledge')
     const batchTimeout = Math.min(knowledgeTimeout * documentIds.length, 300000)
-    const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorize_documents`, {
+    const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/vectorize_documents`, {
       document_ids: documentIds
     }, {
       timeout: batchTimeout
     })
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     const succeeded: string[] = []
     const failed: string[] = []


### PR DESCRIPTION
Addresses #5033 (scoped first-file migration)

## Why

\`ApiClient.get<T>()\` / \`.post<T>()\` already return \`Promise<T>\` (parsed JSON) and throw on HTTP error (ApiClient.ts:337 for GET, :379 for POST). The \`parseApiResponse\` wrapper exists as defensive code for a dual-behavior **that doesn't exist** — ApiClient never returns a raw Response from these methods, so the wrapper is pure noise.

## Change

Deletes all 5 \`parseApiResponse\` call sites in \`useKnowledgeVectorization.ts\` and the \`parseApiResponse\` import. Also removes a stale \`Issue #648\` comment about handling Response objects.

### Pattern

\`\`\`typescript
// BEFORE (3 lines per call site)
const response = await apiClient.post(url, body)
const data = await parseApiResponse<Record<string, any>>(response)
// use data

// AFTER (1 line)
const data = await apiClient.post<Record<string, any>>(url, body)
// use data
\`\`\`

**Stats:** -15 lines, +5 lines. 5 call sites cleaned up.

## Scope

This is the **first file of a gradual migration**. \`useKnowledgeBase.ts\` (24 sites) and ~100 other call sites across the codebase remain for follow-up. Starting here because:
- Smallest high-traffic composable → proves the pattern safely
- All 5 sites share the identical mechanical transform
- Already imports \`apiClient\` typed correctly

After enough files are migrated, the \`parseApiResponse\` function itself and \`apiResponseHelpers.ts\` can be deleted.

## Risk

Low. \`apiClient.get<T>()\`/\`.post<T>()\` have been returning parsed \`Promise<T>\` for many releases — confirmed by reading ApiClient.ts. Any call site that still needs defensive handling can keep using \`parseApiResponse\`; this only touches the 5 sites in one file.