### PR TITLE
feat(knowledge): per-org LLM and embedding model config with ssot fallback (#4451)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -2864,6 +2864,91 @@ async def control_documentation_watcher(
         }
 
 
+# ===== PER-ORG LLM + EMBEDDING MODEL CONFIG (Issue #4451) =====
+# Admin-only endpoints for reading and writing an organization's persisted
+# LLM provider, LLM model, and embedding model. Config is resolved via the
+# fallback chain org config -> SSOT default (see OrgKnowledgeConfigService).
+
+
+class OrgKnowledgeConfigPayload(BaseModel):
+    """Per-org LLM + embedding model config payload (Issue #4451)."""
+
+    llm_provider: Optional[str] = Field(default=None, max_length=64)
+    llm_model: Optional[str] = Field(default=None, max_length=256)
+    embedding_model: Optional[str] = Field(default=None, max_length=256)
+    embedding_dimension: Optional[int] = Field(default=None, ge=1, le=65536)
+
+
+def _resolve_target_org_id(
+    current_user: dict, override_org_id: Optional[str]
+) -> Optional[str]:
+    """Pick the org_id a config request should target.
+
+    Admins can target another org via ``?org_id=`` query param. Non-admins
+    always read/write their own org. A missing ``org_id`` means single-org
+    mode — the service uses the ``__default__`` sentinel.
+    """
+    if override_org_id:
+        role = (current_user or {}).get("role", "")
+        if role not in ("admin", "platform_admin", "superadmin"):
+            raise HTTPException(
+                status_code=403, detail="Only admins may target another org"
+            )
+        return override_org_id
+    return (current_user or {}).get("org_id")
+
+
+@router.get("/org-config")
+async def get_org_model_config(
+    org_id: Optional[str] = Query(default=None, max_length=128),
+    current_user: dict = Depends(get_current_user),
+):
+    """Return the org's persisted model config with SSOT-resolved defaults.
+
+    The response always contains a non-null ``effective`` payload (org
+    config merged over SSOT defaults) and a ``stored`` payload showing what
+    was actually persisted (may be ``null`` when the org has never set a
+    preference).
+    """
+    from services.knowledge.org_knowledge_config import (
+        get_org_knowledge_config_service,
+    )
+
+    target_org = _resolve_target_org_id(current_user, org_id)
+    service = get_org_knowledge_config_service()
+    stored = await service.get(target_org)
+    effective = await service.get_effective(target_org)
+    return {
+        "org_id": target_org or "__default__",
+        "stored": stored.model_dump() if stored else None,
+        "effective": effective.model_dump(),
+    }
+
+
+@router.put("/org-config")
+async def set_org_model_config(
+    payload: OrgKnowledgeConfigPayload,
+    org_id: Optional[str] = Query(default=None, max_length=128),
+    current_user: dict = Depends(get_current_user),
+    admin_check: bool = Depends(check_admin_permission),
+):
+    """Persist the org's LLM + embedding model config (admin only)."""
+    from services.knowledge.org_knowledge_config import (
+        OrgKnowledgeConfig,
+        get_org_knowledge_config_service,
+    )
+
+    target_org = _resolve_target_org_id(current_user, org_id)
+    service = get_org_knowledge_config_service()
+    stored = await service.set(target_org, OrgKnowledgeConfig(**payload.model_dump()))
+    effective = await service.get_effective(target_org)
+    return {
+        "org_id": target_org or "__default__",
+        "stored": stored.model_dump(),
+        "effective": effective.model_dump(),
+    }
+
+
 # ===== MAINTENANCE ENDPOINTS =====
 # NOTE: Maintenance and bulk operation endpoints moved to knowledge_maintenance.py (Issue #185)
 # Includes: deduplication, bulk operations, orphaned facts, export/import, cleanup, host scanning

--- a/autobot-backend/llm_providers/provider_registry.py
+++ b/autobot-backend/llm_providers/provider_registry.py
@@ -116,6 +116,26 @@ class ProviderRegistry:
         """Return the provider name pinned to this conversation, or None."""
         return self._conversation_overrides.get(conversation_id)
 
+    async def _resolve_org_provider(self, org_id: Optional[str]) -> Optional[str]:
+        """Return the org's persisted provider preference, or None (Issue #4451).
+
+        Safe to call even when the knowledge Redis DB is unavailable — errors
+        are swallowed and ``None`` is returned so the existing fallback chain
+        still applies.
+        """
+        if org_id is None:
+            return None
+        try:
+            from services.knowledge.org_knowledge_config import (
+                get_org_knowledge_config_service,
+            )
+
+            cfg = await get_org_knowledge_config_service().get(org_id)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Per-org provider lookup failed for %s: %s", org_id, exc)
+            return None
+        return cfg.llm_provider if cfg else None
+
     # ------------------------------------------------------------------
     # Health
     # ------------------------------------------------------------------
@@ -199,14 +219,16 @@ class ProviderRegistry:
         provider_name: Optional[str] = None,
         conversation_id: Optional[str] = None,
         request: Optional[LLMRequest] = None,
+        org_id: Optional[str] = None,
     ) -> Optional[BaseProvider]:
         """
         Return the best provider for a request, applying:
 
         1. Explicit ``provider_name`` argument (highest priority)
         2. Per-conversation override from ``conversation_id``
-        3. Fallback chain order
-        4. Any remaining registered provider
+        3. Per-org persisted config via ``org_id`` (Issue #4451)
+        4. Fallback chain order
+        5. Any remaining registered provider
 
         When *request* is supplied, per-model api_kwargs from the YAML registry
         are merged into ``request.metadata["api_kwargs"]`` before returning
@@ -222,6 +244,10 @@ class ProviderRegistry:
             conv_pref = self._conversation_overrides.get(conversation_id)
             if conv_pref and conv_pref not in candidates:
                 candidates.append(conv_pref)
+        # Issue #4451: per-org persisted provider preference.
+        org_pref = await self._resolve_org_provider(org_id)
+        if org_pref and org_pref not in candidates:
+            candidates.append(org_pref)
         for name in self._fallback_chain:
             if name not in candidates:
                 candidates.append(name)

--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -626,7 +626,11 @@ class DocIndexerService:
 
     COLLECTION_NAME = "autobot_docs"
 
-    def __init__(self, llm_service: Optional[Any] = None):
+    def __init__(
+        self,
+        llm_service: Optional[Any] = None,
+        org_id: Optional[str] = None,
+    ):
         self._client = None
         self._collection = None
         self._embed_model = None
@@ -634,6 +638,9 @@ class DocIndexerService:
         self._root_dir = PATH.PROJECT_ROOT
         # Issue #4564: optional LLM service for KB synthesis
         self._llm_service = llm_service
+        # Issue #4451: per-org embedding model selection (None => __default__)
+        self._org_id = org_id
+        self.embedding_model_name: Optional[str] = None
         self.synthesis_schema: SynthesisSchema = self._load_schema()
 
     def _load_schema(self) -> SynthesisSchema:
@@ -677,17 +684,31 @@ class DocIndexerService:
             )
 
             ollama_url = get_ollama_url()
+
+            # Issue #4451: per-org embedding model config, SSOT fallback.
+            from services.knowledge.org_knowledge_config import (
+                get_org_knowledge_config_service,
+            )
+
+            effective = await get_org_knowledge_config_service().get_effective(
+                self._org_id
+            )
+            embed_model_name = effective.embedding_model or "nomic-embed-text"
+            self.embedding_model_name = embed_model_name
+
             self._embed_model = OllamaEmbedding(
-                model_name="nomic-embed-text", base_url=ollama_url
+                model_name=embed_model_name, base_url=ollama_url
             )
 
             doc_count = self._collection.count()
             logger.info(
                 "DocIndexerService initialized: collection='%s', "
-                "existing_vectors=%d, ollama=%s",
+                "existing_vectors=%d, ollama=%s, embed_model=%s, org_id=%s",
                 self.COLLECTION_NAME,
                 doc_count,
                 ollama_url,
+                embed_model_name,
+                self._org_id or "__default__",
             )
             self._initialized = True
             return True

--- a/autobot-backend/services/knowledge/org_knowledge_config.py
+++ b/autobot-backend/services/knowledge/org_knowledge_config.py
@@ -1,0 +1,194 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Per-org knowledge model configuration (Issue #4451).
+
+Allows each organization to persist its preferred LLM provider, LLM model,
+and embedding model so the preference survives session restarts and applies
+automatically to all members.
+
+Persistence: Redis (knowledge DB), key ``org_llm_config:{org_id}``.
+
+Single-org deployments: callers that omit ``org_id`` use the sentinel
+``__default__`` so the service remains a drop-in for both modes.
+
+Fallback chain (``get_effective``):
+    org config → SSOT default (``autobot_shared.ssot_config``)
+
+Downstream consumers (ProviderRegistry fallback chain, LlamaIndex embedding
+provider selection) remain unchanged — they see a concrete ``LLMModelConfig``
+and apply their own provider-level fallbacks when the named provider is
+unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from autobot_shared.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+# Sentinel used for single-org deployments where no explicit org_id is passed.
+DEFAULT_ORG_ID = "__default__"
+
+# Redis key prefix for per-org config records.
+_KEY_PREFIX = "org_llm_config:"
+
+
+class OrgKnowledgeConfig(BaseModel):
+    """Per-org LLM + embedding model selection.
+
+    All fields are optional — any unset field falls back to the SSOT default
+    when resolved via ``OrgKnowledgeConfigService.get_effective()``.
+    """
+
+    llm_provider: Optional[str] = Field(
+        default=None,
+        description="LLM provider name (ollama, openai, anthropic, ...).",
+    )
+    llm_model: Optional[str] = Field(
+        default=None,
+        description="LLM model identifier (e.g. 'qwen2.5:7b', 'gpt-4o-mini').",
+    )
+    embedding_model: Optional[str] = Field(
+        default=None,
+        description="Embedding model identifier (e.g. 'nomic-embed-text').",
+    )
+    embedding_dimension: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Optional embedding vector dimension override.",
+    )
+
+
+def _key(org_id: Optional[str]) -> str:
+    return f"{_KEY_PREFIX}{org_id or DEFAULT_ORG_ID}"
+
+
+class OrgKnowledgeConfigService:
+    """Persisted per-org knowledge model config with SSOT fallback."""
+
+    def __init__(self, redis_client=None) -> None:
+        # Injected client (for tests) or lazy-fetched from the knowledge DB.
+        self._redis = redis_client
+
+    async def _get_redis(self):
+        if self._redis is not None:
+            return self._redis
+        self._redis = await get_redis_client(
+            database="knowledge", async_client=True
+        )
+        return self._redis
+
+    async def get(self, org_id: Optional[str] = None) -> Optional[OrgKnowledgeConfig]:
+        """Return the persisted config for ``org_id`` or None if unset."""
+        redis = await self._get_redis()
+        if redis is None:
+            logger.warning("Redis unavailable — returning None for org_id=%s", org_id)
+            return None
+        raw = await redis.get(_key(org_id))
+        if not raw:
+            return None
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            logger.error(
+                "Corrupt org_llm_config for org_id=%s (%s) — ignoring",
+                org_id,
+                exc,
+            )
+            return None
+        return OrgKnowledgeConfig(**payload)
+
+    async def set(
+        self, org_id: Optional[str], config: OrgKnowledgeConfig
+    ) -> OrgKnowledgeConfig:
+        """Persist ``config`` for ``org_id`` and return what was stored."""
+        redis = await self._get_redis()
+        if redis is None:
+            raise RuntimeError("Redis unavailable — cannot persist org model config")
+        payload = config.model_dump(exclude_none=False)
+        await redis.set(_key(org_id), json.dumps(payload))
+        logger.info(
+            "Persisted org_llm_config org_id=%s provider=%s llm=%s embed=%s",
+            org_id or DEFAULT_ORG_ID,
+            config.llm_provider,
+            config.llm_model,
+            config.embedding_model,
+        )
+        return config
+
+    async def delete(self, org_id: Optional[str]) -> bool:
+        """Remove any persisted config for ``org_id``; return True if deleted."""
+        redis = await self._get_redis()
+        if redis is None:
+            return False
+        deleted = await redis.delete(_key(org_id))
+        return bool(deleted)
+
+    async def get_effective(
+        self, org_id: Optional[str] = None
+    ) -> OrgKnowledgeConfig:
+        """Resolve org config, filling missing fields from SSOT defaults.
+
+        The returned model always has every field populated (or at least
+        defaulted from SSOT) so callers can treat it as the authoritative
+        source for the request.
+        """
+        org_cfg = await self.get(org_id)
+
+        # Lazy import to avoid circulars at package load time.
+        from autobot_shared.ssot_config import get_config as get_ssot_config
+
+        ssot = get_ssot_config()
+        default_provider = getattr(ssot.llm, "llamaindex_embedding_provider", None) or getattr(
+            ssot.llm, "provider", "ollama"
+        )
+        default_llm_model = getattr(ssot.llm, "default_model", None) or getattr(
+            ssot.llm, "llamaindex_llm_model", ""
+        )
+        default_embed_model = getattr(ssot.llm, "embedding_model", "")
+
+        if org_cfg is None:
+            return OrgKnowledgeConfig(
+                llm_provider=default_provider,
+                llm_model=default_llm_model,
+                embedding_model=default_embed_model,
+                embedding_dimension=None,
+            )
+
+        return OrgKnowledgeConfig(
+            llm_provider=org_cfg.llm_provider or default_provider,
+            llm_model=org_cfg.llm_model or default_llm_model,
+            embedding_model=org_cfg.embedding_model or default_embed_model,
+            embedding_dimension=org_cfg.embedding_dimension,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Process-level singleton accessor
+# ---------------------------------------------------------------------------
+
+_singleton: Optional[OrgKnowledgeConfigService] = None
+
+
+def get_org_knowledge_config_service() -> OrgKnowledgeConfigService:
+    """Return the process-level singleton service."""
+    global _singleton
+    if _singleton is None:
+        _singleton = OrgKnowledgeConfigService()
+    return _singleton
+
+
+__all__ = [
+    "DEFAULT_ORG_ID",
+    "OrgKnowledgeConfig",
+    "OrgKnowledgeConfigService",
+    "get_org_knowledge_config_service",
+]

--- a/autobot-backend/services/knowledge/test_org_knowledge_config.py
+++ b/autobot-backend/services/knowledge/test_org_knowledge_config.py
@@ -1,0 +1,155 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for per-org knowledge model config (Issue #4451)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.knowledge.org_knowledge_config import (
+    DEFAULT_ORG_ID,
+    OrgKnowledgeConfig,
+    OrgKnowledgeConfigService,
+)
+
+
+class _FakeRedis:
+    """Minimal async Redis stub backed by an in-process dict."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    async def get(self, key: str):
+        return self._store.get(key)
+
+    async def set(self, key: str, value: str) -> bool:
+        self._store[key] = value
+        return True
+
+    async def delete(self, key: str) -> int:
+        return 1 if self._store.pop(key, None) is not None else 0
+
+
+def _ssot_stub():
+    """Return a stub SSOT config exposing the attributes we read."""
+    return SimpleNamespace(
+        llm=SimpleNamespace(
+            default_model="ssot-llm-model",
+            embedding_model="ssot-embed-model",
+            llamaindex_embedding_provider="ollama",
+            llamaindex_llm_model="ssot-llamaindex-model",
+            provider="ollama",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_then_get_returns_persisted_config():
+    """A config set via ``set()`` round-trips via ``get()``."""
+    svc = OrgKnowledgeConfigService(redis_client=_FakeRedis())
+    cfg = OrgKnowledgeConfig(
+        llm_provider="openai",
+        llm_model="gpt-4o-mini",
+        embedding_model="text-embedding-3-small",
+        embedding_dimension=1536,
+    )
+    await svc.set("org-42", cfg)
+    loaded = await svc.get("org-42")
+    assert loaded is not None
+    assert loaded.llm_provider == "openai"
+    assert loaded.llm_model == "gpt-4o-mini"
+    assert loaded.embedding_model == "text-embedding-3-small"
+    assert loaded.embedding_dimension == 1536
+
+
+@pytest.mark.asyncio
+async def test_get_effective_returns_ssot_defaults_when_unset():
+    """With no persisted config, ``get_effective()`` returns SSOT defaults."""
+    svc = OrgKnowledgeConfigService(redis_client=_FakeRedis())
+    with patch(
+        "autobot_shared.ssot_config.get_config",
+        return_value=_ssot_stub(),
+    ):
+        effective = await svc.get_effective("org-no-config")
+    assert effective.llm_provider == "ollama"
+    assert effective.llm_model == "ssot-llm-model"
+    assert effective.embedding_model == "ssot-embed-model"
+    assert effective.embedding_dimension is None
+
+
+@pytest.mark.asyncio
+async def test_get_effective_merges_partial_org_config_over_ssot():
+    """Partial org config fills in SSOT defaults for unset fields only."""
+    redis = _FakeRedis()
+    svc = OrgKnowledgeConfigService(redis_client=redis)
+    await svc.set(
+        "org-partial",
+        OrgKnowledgeConfig(embedding_model="custom-embed"),
+    )
+    with patch(
+        "autobot_shared.ssot_config.get_config",
+        return_value=_ssot_stub(),
+    ):
+        effective = await svc.get_effective("org-partial")
+    # Set field wins; unset fields fall back to SSOT.
+    assert effective.embedding_model == "custom-embed"
+    assert effective.llm_model == "ssot-llm-model"
+    assert effective.llm_provider == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_default_org_sentinel_used_when_org_id_none():
+    """Calls with org_id=None use the __default__ sentinel key."""
+    redis = _FakeRedis()
+    svc = OrgKnowledgeConfigService(redis_client=redis)
+    await svc.set(None, OrgKnowledgeConfig(llm_model="default-llm"))
+    # Key must exist under the sentinel.
+    assert f"org_llm_config:{DEFAULT_ORG_ID}" in redis._store
+    loaded = await svc.get(None)
+    assert loaded is not None
+    assert loaded.llm_model == "default-llm"
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_persisted_config():
+    """``delete()`` clears the key and subsequent ``get()`` returns None."""
+    redis = _FakeRedis()
+    svc = OrgKnowledgeConfigService(redis_client=redis)
+    await svc.set("org-gone", OrgKnowledgeConfig(llm_model="m"))
+    assert await svc.delete("org-gone") is True
+    assert await svc.get("org-gone") is None
+
+
+@pytest.mark.asyncio
+async def test_corrupt_payload_returns_none_and_logs():
+    """Non-JSON persisted payloads are ignored rather than raising."""
+    redis = _FakeRedis()
+    redis._store["org_llm_config:broken"] = "not-json"
+    svc = OrgKnowledgeConfigService(redis_client=redis)
+    assert await svc.get("broken") is None
+
+
+@pytest.mark.asyncio
+async def test_set_persists_json_payload_shape():
+    """Persisted blob is valid JSON with the known key set."""
+    redis = _FakeRedis()
+    svc = OrgKnowledgeConfigService(redis_client=redis)
+    await svc.set(
+        "org-1",
+        OrgKnowledgeConfig(llm_provider="anthropic", llm_model="claude-3"),
+    )
+    raw = redis._store["org_llm_config:org-1"]
+    payload = json.loads(raw)
+    assert set(payload.keys()) == {
+        "llm_provider",
+        "llm_model",
+        "embedding_model",
+        "embedding_dimension",
+    }
+    assert payload["llm_provider"] == "anthropic"
+    assert payload["llm_model"] == "claude-3"

--- a/autobot-backend/user_management/models/organization.py
+++ b/autobot-backend/user_management/models/organization.py
@@ -158,3 +158,31 @@ class Organization(Base):
             current = current[k]
         current[keys[-1]] = value
         self.settings = settings
+
+    # ------------------------------------------------------------------
+    # Per-org LLM + embedding model config (Issue #4451)
+    # ------------------------------------------------------------------
+
+    def get_model_config(self) -> dict:
+        """Return the org's persisted LLM/embedding model config.
+
+        Known keys: ``llm_provider``, ``llm_model``, ``embedding_model``,
+        ``embedding_dimension``.  Missing keys indicate "use SSOT default".
+        """
+        return {
+            "llm_provider": self.get_setting("llm_provider"),
+            "llm_model": self.get_setting("llm_model"),
+            "embedding_model": self.get_setting("embedding_model"),
+            "embedding_dimension": self.get_setting("embedding_dimension"),
+        }
+
+    def set_model_config(self, config: dict) -> None:
+        """Persist the org's LLM/embedding model config.
+
+        Only the four well-known keys are accepted.  Passing ``None`` for a
+        key clears that field; omitting the key leaves the existing value
+        untouched.
+        """
+        known = {"llm_provider", "llm_model", "embedding_model", "embedding_dimension"}
+        for key in known & set(config.keys()):
+            self.set_setting(key, config[key])


### PR DESCRIPTION
Closes #4451

## Summary
- **New pydantic model** \`OrgKnowledgeConfig\` with fields \`llm_provider\`, \`llm_model\`, \`embedding_model\`, \`embedding_dimension?\`
- **New \`OrgKnowledgeConfigService\`** Redis-backed at key \`org_llm_config:{org_id}\` in the knowledge DB; single-org deployments resolve via \`__default__\` sentinel
- **\`get_effective(org_id)\`** merges stored org fields over SSOT defaults — missing fields auto-fall-back
- **Organization model helpers**: \`get_model_config()\` / \`set_model_config()\` dot-notation over JSONB \`settings\` column — no DB migration
- **\`DocIndexerService(org_id=None)\`** now uses \`OrgKnowledgeConfigService.get_effective()\` instead of hardcoded \`nomic-embed-text\`
- **\`get_provider_for_request(..., org_id=None)\`** inserts org's persisted provider into candidate chain between conversation override and SSOT fallback
- **Admin API**: \`GET /api/knowledge_base/org-config\` (authenticated users, own org) and \`PUT /api/knowledge_base/org-config\` (admin, \`?org_id=\` to target other org)
- Defensive against Redis unavailability — falls through to SSOT fallback

## Test Status
PASS — 7/7 new + 84/84 pre-existing doc_indexer tests