### PR TITLE
refactor(knowledge): add ConnectorRegistry public API; replace 3 _connectors private accesses (#5057)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -267,7 +267,7 @@ async def list_connector_types():
     the class attribute on each registered connector.
     """
     types = []
-    for type_name, klass in ConnectorRegistry._connectors.items():
+    for type_name, klass in ConnectorRegistry.registered_types().items():
         types.append(
             {
                 "connector_type": type_name,
@@ -305,7 +305,12 @@ async def create_connector(request: CreateConnectorRequest):
             detail="connector_type must be one of: %s" % _SUPPORTED_TYPES,
         )
     connector_id = str(uuid.uuid4())
-    klass = ConnectorRegistry._connectors.get(request.connector_type)
+    klass = ConnectorRegistry.get_registered_class(request.connector_type)
+    if klass is None:
+        raise HTTPException(
+            status_code=422,
+            detail="connector_type '%s' is not registered" % request.connector_type,
+        )
     cfg = ConnectorConfig(
         connector_id=connector_id,
         connector_type=request.connector_type,
@@ -316,7 +321,7 @@ async def create_connector(request: CreateConnectorRequest):
         schedule_cron=request.schedule_cron,
         include_patterns=request.include_patterns,
         exclude_patterns=request.exclude_patterns,
-        tier=int(getattr(klass, "tier", 0)) if klass is not None else 0,
+        tier=int(getattr(klass, "tier", 0)),
     )
     instance = _load_or_create_instance(cfg)
     healthy = await instance.test_connection()
@@ -533,7 +538,7 @@ def _resolve_tier(cfg: ConnectorConfig) -> int:
     connector is the source of truth — fall back to ``cfg.tier`` only when the
     type isn't registered.
     """
-    klass = ConnectorRegistry._connectors.get(cfg.connector_type)
+    klass = ConnectorRegistry.get_registered_class(cfg.connector_type)
     if klass is not None:
         return int(getattr(klass, "tier", 0))
     return int(getattr(cfg, "tier", 0))

--- a/autobot-backend/knowledge/connectors/registry.py
+++ b/autobot-backend/knowledge/connectors/registry.py
@@ -22,7 +22,8 @@ Usage:
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Type
+from types import MappingProxyType
+from typing import Any, Dict, List, Mapping, Optional, Type
 
 from knowledge.connectors.models import ConnectorConfig
 
@@ -99,6 +100,27 @@ class ConnectorRegistry:
     def list_types(cls) -> List[str]:
         """Return all registered connector type strings."""
         return list(cls._connectors.keys())
+
+    @classmethod
+    def registered_types(cls) -> Mapping[str, Type["AbstractConnector"]]:
+        """Immutable view of all registered connector classes by type name (Issue #5057).
+
+        Callers iterating over the type→class mapping should use this method
+        instead of reading the private ``_connectors`` dict so internal storage
+        can be refactored without breaking them.
+        """
+        return MappingProxyType(cls._connectors)
+
+    @classmethod
+    def get_registered_class(
+        cls, type_name: str
+    ) -> Optional[Type["AbstractConnector"]]:
+        """Return the registered connector class for *type_name*, or None (Issue #5057).
+
+        Public accessor that replaces ``ConnectorRegistry._connectors.get(...)``
+        at call sites outside the registry module.
+        """
+        return cls._connectors.get(type_name)
 
     @classmethod
     def list_instances(cls) -> List[str]:

--- a/autobot-backend/knowledge/connectors/registry_public_api_test.py
+++ b/autobot-backend/knowledge/connectors/registry_public_api_test.py
@@ -1,0 +1,86 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""
+Tests for ConnectorRegistry public API — Issue #5057.
+
+Verifies:
+  - ``registered_types()`` returns an immutable view containing every
+    registered connector class.
+  - ``get_registered_class(known)`` returns the correct class.
+  - ``get_registered_class(unknown)`` returns ``None`` (no KeyError).
+"""
+
+import os
+import sys
+from types import MappingProxyType
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the autobot-backend package root is on sys.path
+# ---------------------------------------------------------------------------
+_BACKEND_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# Importing the connector modules triggers their @ConnectorRegistry.register
+# decorators so the registry is populated for these tests.
+from knowledge.connectors import (  # noqa: E402,F401
+    audio_connector,
+    database,
+    file_server,
+    notion,
+    web_crawler,
+)
+from knowledge.connectors.registry import ConnectorRegistry  # noqa: E402
+
+
+class TestRegisteredTypes:
+    """``registered_types()`` exposes all registered classes."""
+
+    def test_returns_mapping_proxy(self):
+        view = ConnectorRegistry.registered_types()
+        assert isinstance(view, MappingProxyType)
+
+    def test_view_is_read_only(self):
+        view = ConnectorRegistry.registered_types()
+        with pytest.raises(TypeError):
+            view["new_type"] = object  # type: ignore[index]
+
+    def test_contains_every_builtin(self):
+        view = ConnectorRegistry.registered_types()
+        for type_name in (
+            "file_server",
+            "web_crawler",
+            "audio",
+            "notion",
+            "database",
+        ):
+            assert type_name in view, (
+                "registered_types() missing built-in %s" % type_name
+            )
+
+    def test_classes_match_private_dict(self):
+        # Source of truth inside this test is the private dict — the public
+        # API must surface the same objects.
+        view = ConnectorRegistry.registered_types()
+        for type_name, klass in ConnectorRegistry._connectors.items():
+            assert view[type_name] is klass
+
+
+class TestGetRegisteredClass:
+    """``get_registered_class()`` is a safe lookup with None fallback."""
+
+    def test_known_type_returns_class(self):
+        klass = ConnectorRegistry.get_registered_class("notion")
+        assert klass is not None
+        assert klass is ConnectorRegistry._connectors["notion"]
+
+    def test_unknown_type_returns_none(self):
+        assert ConnectorRegistry.get_registered_class("no_such_type") is None
+
+    def test_empty_string_returns_none(self):
+        assert ConnectorRegistry.get_registered_class("") is None


### PR DESCRIPTION
Closes #5057

## Summary
- \`ConnectorRegistry.registered_types()\` → returns \`MappingProxyType\` (immutable view)
- \`ConnectorRegistry.get_registered_class(type_name)\` → returns class or \`None\`
- Replaced 3 \`_connectors\` private accesses in \`api/knowledge_connectors.py\`:
  - \`list_connector_types\` → iterates \`registered_types().items()\`
  - \`create_connector\` → uses \`get_registered_class()\` with explicit None-check raising HTTP 422 for unknown types
  - \`_resolve_tier\` → uses \`get_registered_class()\`

## Tests
7 new tests: MappingProxyType type, read-only enforcement, built-in coverage, parity with private dict, known/unknown/empty-string lookups.

## Status
PASS — 28/28