### PR TITLE
fix(cleanup): exclude chromadb/redis/sqlite files from cleanup_generated_files walks (#5083)

### DIFF
--- a/autobot-backend/tasks/knowledge_tasks.py
+++ b/autobot-backend/tasks/knowledge_tasks.py
@@ -10,16 +10,52 @@ Issue #424: Added periodic task for incremental man page updates.
 """
 
 import asyncio
+import fnmatch
 import logging
 import os
 import subprocess  # nosec B404 - used for internal script execution only
 import sys
 import time
+from pathlib import Path
 
 from celery_app import celery_app
 from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
+
+
+# Issue #5083: exclude patterns for cleanup_generated_files. Matches filenames
+# (via fnmatch) or any parent directory name. Prevents accidental deletion of
+# persistent artefacts (ChromaDB sqlite journals, Redis AOF/RDB, WAL files)
+# that may land in cache/temp dirs through operator mistake or future refactor.
+_CLEANUP_EXCLUDE_PATTERNS = (
+    "*.sqlite",
+    "*.sqlite3",
+    "*.sqlite-journal",
+    "*.sqlite-wal",
+    "*.sqlite-shm",
+    "*.wal",
+    "*.aof",
+    "*.rdb",
+    "*chroma*",  # chromadb artefact names (chromadb/, chroma.sqlite, etc.)
+    "*redis*",  # redis data dirs/files (redis-data/, dump.rdb rename, etc.)
+)
+
+
+def _is_excluded(path: Path) -> bool:
+    """Return True if path or any parent dir matches an exclude pattern.
+
+    Issue #5083: guard cleanup_generated_files from deleting persistent
+    artefacts (ChromaDB sqlite journals, Redis AOF fragments, WAL files).
+    """
+    for pattern in _CLEANUP_EXCLUDE_PATTERNS:
+        if fnmatch.fnmatch(path.name, pattern):
+            return True
+        # Check parent directory names too (for *chroma* catching chromadb/)
+        for parent in path.parents:
+            if fnmatch.fnmatch(parent.name, pattern):
+                return True
+    return False
 
 
 def _parse_indexing_output(output: str) -> tuple:
@@ -664,6 +700,11 @@ def _cleanup_files_older_than(
             if not file_path.is_file():
                 continue
             scanned += 1
+            # Issue #5083: skip persistent artefacts (sqlite/WAL/AOF/RDB,
+            # chromadb/, redis-data/) regardless of age.
+            if _is_excluded(file_path):
+                logger.debug("Skipping excluded file: %s", file_path)
+                continue
             try:
                 stat = file_path.stat()
             except OSError as e:

--- a/autobot-backend/tasks/knowledge_tasks_test.py
+++ b/autobot-backend/tasks/knowledge_tasks_test.py
@@ -20,9 +20,11 @@ import pytest
 
 # conftest.py stubs celery when it isn't installed in the dev venv.
 from tasks.knowledge_tasks import (
+    _CLEANUP_EXCLUDE_PATTERNS,
     _cleanup_files_older_than,
     _cleanup_orphan_documents_async,
     _collect_orphan_doc_ids,
+    _is_excluded,
     _run_async_in_loop,
 )
 
@@ -222,6 +224,111 @@ def test_cleanup_files_older_than_recurses_subdirectories(tmp_path):
     assert scanned == 1
     assert removed == 1
     assert not old_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Issue #5083: exclude patterns guard persistent artefacts from cleanup.
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_excludes_sqlite_files(tmp_path):
+    """Stale sqlite/journal/WAL files must be preserved regardless of age."""
+    stale_log = tmp_path / "old.log"
+    stale_sqlite = tmp_path / "chroma.sqlite"
+    stale_journal = tmp_path / "chroma.sqlite-journal"
+    stale_wal = tmp_path / "database.wal"
+    stale_aof = tmp_path / "appendonly.aof"
+    stale_rdb = tmp_path / "dump.rdb"
+    for f in (stale_log, stale_sqlite, stale_journal, stale_wal, stale_aof, stale_rdb):
+        _touch(f, "payload" * 20, age_seconds=30 * 86400)
+
+    cutoff = time.time() - (7 * 86400)
+    scanned, removed, _ = _cleanup_files_older_than(
+        [tmp_path], cutoff, dry_run=False
+    )
+
+    # All 6 files scanned; only .log removed.
+    assert scanned == 6
+    assert removed == 1
+    assert not stale_log.exists()
+    assert stale_sqlite.exists()
+    assert stale_journal.exists()
+    assert stale_wal.exists()
+    assert stale_aof.exists()
+    assert stale_rdb.exists()
+
+
+def test_cleanup_excludes_files_under_chromadb_parent_dir(tmp_path):
+    """Files inside a chromadb/ directory are preserved even if they have
+    an otherwise-deletable name (regression guard for parent-dir matching)."""
+    chroma_dir = tmp_path / "chromadb"
+    chroma_dir.mkdir()
+    protected = chroma_dir / "segment.bin"
+    _touch(protected, "payload", age_seconds=30 * 86400)
+
+    other_dir = tmp_path / "embeddings_cache"
+    other_dir.mkdir()
+    stale = other_dir / "old.pkl"
+    _touch(stale, "stale", age_seconds=30 * 86400)
+
+    cutoff = time.time() - (7 * 86400)
+    scanned, removed, _ = _cleanup_files_older_than(
+        [tmp_path], cutoff, dry_run=False
+    )
+
+    assert scanned == 2
+    assert removed == 1
+    assert protected.exists()
+    assert not stale.exists()
+
+
+def test_cleanup_excludes_files_under_redis_parent_dir(tmp_path):
+    """Files under a redis-data/ directory are preserved."""
+    redis_dir = tmp_path / "redis-data"
+    redis_dir.mkdir()
+    protected = redis_dir / "dump.bin"
+    _touch(protected, "payload", age_seconds=30 * 86400)
+
+    cutoff = time.time() - (7 * 86400)
+    scanned, removed, _ = _cleanup_files_older_than(
+        [tmp_path], cutoff, dry_run=False
+    )
+
+    assert scanned == 1
+    assert removed == 0
+    assert protected.exists()
+
+
+def test_is_excluded_matches_filename_patterns(tmp_path):
+    assert _is_excluded(tmp_path / "foo.sqlite")
+    assert _is_excluded(tmp_path / "foo.sqlite3")
+    assert _is_excluded(tmp_path / "foo.sqlite-journal")
+    assert _is_excluded(tmp_path / "foo.sqlite-wal")
+    assert _is_excluded(tmp_path / "foo.sqlite-shm")
+    assert _is_excluded(tmp_path / "db.wal")
+    assert _is_excluded(tmp_path / "appendonly.aof")
+    assert _is_excluded(tmp_path / "dump.rdb")
+    assert _is_excluded(tmp_path / "my-chroma-file.bin")
+    assert _is_excluded(tmp_path / "redis-dump.bin")
+
+
+def test_is_excluded_matches_parent_dir_patterns(tmp_path):
+    nested = tmp_path / "chromadb" / "nested" / "file.bin"
+    assert _is_excluded(nested)
+    nested_redis = tmp_path / "redis-data" / "file.bin"
+    assert _is_excluded(nested_redis)
+
+
+def test_is_excluded_allows_unrelated_files(tmp_path):
+    assert not _is_excluded(tmp_path / "cache" / "embedding.pkl")
+    assert not _is_excluded(tmp_path / "exports" / "report.json")
+    assert not _is_excluded(tmp_path / "chunks_temp" / "chunk-42.bin")
+
+
+def test_cleanup_exclude_patterns_is_tuple():
+    # Immutable constant guard — prevents accidental runtime mutation.
+    assert isinstance(_CLEANUP_EXCLUDE_PATTERNS, tuple)
+    assert len(_CLEANUP_EXCLUDE_PATTERNS) > 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #5083

## Summary
- Added \`_CLEANUP_EXCLUDE_PATTERNS\` tuple: \`*.sqlite\`, \`*.sqlite3\`, \`*.sqlite-journal\`, \`*.sqlite-wal\`, \`*.sqlite-shm\`, \`*.wal\`, \`*.aof\`, \`*.rdb\`, \`*chroma*\`, \`*redis*\`
- \`_is_excluded(path)\` helper matches filename OR any parent directory name via \`fnmatch\`
- Hooked check into \`_cleanup_files_older_than\` before mtime comparison; \`logger.debug\` on skip

## Tests
7 new test cases: sqlite/journal/wal/aof/rdb preservation, chromadb/redis parent-dir match, filename pattern match, negative guard for cache/exports/chunks_temp, immutability guard.

## Status
PASS — 17 passed, 2 skipped (skipped need real celery)