### PR TITLE
refactor(typescript): delete parseApiResponse from useKnowledgeBase (#5033)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useKnowledgeBase.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeBase.test.ts
@@ -166,9 +166,7 @@ describe('useKnowledgeBase', () => {
         last_updated: '2025-04-12T10:00:00Z',
       }
 
-      const response = mockApiResponse(mockStats)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<KnowledgeStats>(mockStats)
+      vi.mocked(apiClient.get).mockResolvedValue(mockStats)
 
       const { fetchStats } = useKnowledgeBase()
       const result = await fetchStats()
@@ -183,16 +181,6 @@ describe('useKnowledgeBase', () => {
       const { fetchStats } = useKnowledgeBase()
 
       await expect(fetchStats()).rejects.toThrow('Failed to fetch stats')
-    })
-
-    it('should throw error when parseApiResponse fails', async () => {
-      const response = mockApiResponse<null>(null)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      vi.mocked(parseApiResponse).mockRejectedValue(new Error('Parse failed'))
-
-      const { fetchStats } = useKnowledgeBase()
-
-      await expect(fetchStats()).rejects.toThrow('Parse failed')
     })
   })
 
@@ -209,9 +197,7 @@ describe('useKnowledgeBase', () => {
         total: 2,
       }
 
-      const response = mockApiResponse(mockCategoriesResponse)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<CategoriesListResponse>(mockCategoriesResponse)
+      vi.mocked(apiClient.get).mockResolvedValue(mockCategoriesResponse)
 
       const { fetchCategories } = useKnowledgeBase()
       const result = await fetchCategories()
@@ -227,9 +213,7 @@ describe('useKnowledgeBase', () => {
       // shape-invalid.
       const invalidResponse: unknown = { notCategories: [] }
 
-      const response = mockApiResponse(invalidResponse)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<unknown>(invalidResponse)
+      vi.mocked(apiClient.get).mockResolvedValue(invalidResponse)
 
       const { fetchCategories } = useKnowledgeBase()
 
@@ -245,9 +229,7 @@ describe('useKnowledgeBase', () => {
         ],
       }
 
-      const response = mockApiResponse(mockCategory)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<CategoryResponse>(mockCategory)
+      vi.mocked(apiClient.get).mockResolvedValue(mockCategory)
 
       const { fetchCategory } = useKnowledgeBase()
       const result = await fetchCategory('security')
@@ -283,9 +265,7 @@ describe('useKnowledgeBase', () => {
         },
       }
 
-      const response = mockApiResponse(mockCategorizedFacts)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<CategorizedFactsResponse>(mockCategorizedFacts)
+      vi.mocked(apiClient.get).mockResolvedValue(mockCategorizedFacts)
 
       const { getCategorizedFacts } = useKnowledgeBase()
       const result = await getCategorizedFacts()
@@ -312,9 +292,7 @@ describe('useKnowledgeBase', () => {
         },
       }
 
-      const response = mockApiResponse(mockCategorizedFacts)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<CategorizedFactsResponse>(mockCategorizedFacts)
+      vi.mocked(apiClient.get).mockResolvedValue(mockCategorizedFacts)
 
       const { getCategorizedFacts } = useKnowledgeBase()
       await getCategorizedFacts('security', 100)
@@ -330,9 +308,7 @@ describe('useKnowledgeBase', () => {
       // shape is deliberately non-conforming.
       const invalidResponse: unknown = { total_facts: 0, noCategoriesField: {} }
 
-      const response = mockApiResponse(invalidResponse)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<unknown>(invalidResponse)
+      vi.mocked(apiClient.get).mockResolvedValue(invalidResponse)
 
       const { getCategorizedFacts } = useKnowledgeBase()
 
@@ -401,9 +377,7 @@ describe('useKnowledgeBase', () => {
         total_results: 1,
       }
 
-      const response = mockApiResponse(mockSearchResult)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<SearchResponse>(mockSearchResult)
+      vi.mocked(apiClient.post).mockResolvedValue(mockSearchResult)
 
       const { searchKnowledge } = useKnowledgeBase()
       const result = await searchKnowledge('test query')
@@ -431,9 +405,7 @@ describe('useKnowledgeBase', () => {
         total_results: 1,
       }
 
-      const response = mockApiResponse(mockResults)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<SearchResponse>(mockResults)
+      vi.mocked(apiClient.post).mockResolvedValue(mockResults)
 
       const { advancedSearch } = useKnowledgeBase()
       const result = await advancedSearch({
@@ -459,9 +431,7 @@ describe('useKnowledgeBase', () => {
     it('should support hybrid search mode', async () => {
       const mockResults: SearchResponse = { results: [], total_results: 0 }
 
-      const response = mockApiResponse(mockResults)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<SearchResponse>(mockResults)
+      vi.mocked(apiClient.post).mockResolvedValue(mockResults)
 
       const { advancedSearch } = useKnowledgeBase()
       await advancedSearch({
@@ -497,9 +467,7 @@ describe('useKnowledgeBase', () => {
         },
       }
 
-      const response = mockApiResponse(mockAddResponse)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<AddFactResponse>(mockAddResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockAddResponse)
 
       const { addFact } = useKnowledgeBase()
       const result = await addFact({
@@ -530,9 +498,7 @@ describe('useKnowledgeBase', () => {
         },
       }
 
-      const response = mockApiResponse(mockAddResponse)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<AddFactResponse>(mockAddResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockAddResponse)
 
       const { addFact } = useKnowledgeBase()
       const result = await addFact({
@@ -592,9 +558,7 @@ describe('useKnowledgeBase', () => {
         { machine_id: 'host2', os_type: 'linux', distro: 'CentOS' },
       ]
 
-      const response = mockApiResponse(mockProfiles)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<MachineProfile[]>(mockProfiles)
+      vi.mocked(apiClient.get).mockResolvedValue(mockProfiles)
 
       const { fetchMachineProfiles } = useKnowledgeBase()
       const result = await fetchMachineProfiles()
@@ -622,9 +586,7 @@ describe('useKnowledgeBase', () => {
         current_man_page_files: 1500,
       }
 
-      const response = mockApiResponse(mockSummary)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<ManPagesSummary>(mockSummary)
+      vi.mocked(apiClient.get).mockResolvedValue(mockSummary)
 
       const { fetchManPagesSummary } = useKnowledgeBase()
       const result = await fetchManPagesSummary()
@@ -657,9 +619,7 @@ describe('useKnowledgeBase', () => {
         total_processed: 50,
       }
 
-      const response = mockApiResponse(mockVectorizationResponse)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<VectorizationResponse>(mockVectorizationResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockVectorizationResponse)
 
       const { vectorizeFacts } = useKnowledgeBase()
       const result = await vectorizeFacts()
@@ -686,9 +646,7 @@ describe('useKnowledgeBase', () => {
         total_processed: 125,
       }
 
-      const response = mockApiResponse(mockResponse)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<VectorizationResponse>(mockResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
       const { vectorizeFacts } = useKnowledgeBase()
       await vectorizeFacts(100, 1.0, false)
@@ -713,9 +671,7 @@ describe('useKnowledgeBase', () => {
         vectorized_facts: 50,
       }
 
-      const response = mockApiResponse(mockStatus)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<VectorizationStatusResponse>(mockStatus)
+      vi.mocked(apiClient.get).mockResolvedValue(mockStatus)
 
       const { getVectorizationStatus } = useKnowledgeBase()
       const result = await getVectorizationStatus()
@@ -736,9 +692,7 @@ describe('useKnowledgeBase', () => {
         result: { processed: 100 },
       }
 
-      const response = mockApiResponse(mockJobStatus)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<JobStatus>(mockJobStatus)
+      vi.mocked(apiClient.get).mockResolvedValue(mockJobStatus)
 
       const { pollJobStatus } = useKnowledgeBase()
       const result = await pollJobStatus('task-123')
@@ -755,9 +709,7 @@ describe('useKnowledgeBase', () => {
       for (const status of statuses) {
         const mockJobStatus: JobStatus = { task_id: 'task-123', status }
 
-        const response = mockApiResponse(mockJobStatus)
-        vi.mocked(apiClient.get).mockResolvedValue(response)
-        mockParseApi<JobStatus>(mockJobStatus)
+        vi.mocked(apiClient.get).mockResolvedValue(mockJobStatus)
 
         const { pollJobStatus } = useKnowledgeBase()
         const result = await pollJobStatus('task-123')
@@ -776,9 +728,7 @@ describe('useKnowledgeBase', () => {
         facts_added: 50,
       }
 
-      const response = mockApiResponse(mockResponse)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<MachineKnowledgeResponse>(mockResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
       const { initializeMachineKnowledge } = useKnowledgeBase()
       const result = await initializeMachineKnowledge('host1')
@@ -799,9 +749,7 @@ describe('useKnowledgeBase', () => {
         total_machines: 3,
       }
 
-      const response = mockApiResponse(mockResponse)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<SystemKnowledgeResponse>(mockResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
       const { refreshSystemKnowledge } = useKnowledgeBase()
       const result = await refreshSystemKnowledge()
@@ -1011,9 +959,7 @@ describe('useKnowledgeBase', () => {
         man_pages_added: 150,
       }
 
-      const response = mockApiResponse(mockResponse)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<ManPagesPopulateResponse>(mockResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
       const { populateManPages } = useKnowledgeBase()
       const result = await populateManPages('host1')
@@ -1031,9 +977,7 @@ describe('useKnowledgeBase', () => {
         facts_added: 120,
       }
 
-      const response = mockApiResponse(mockResponse)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<AutoBotDocsResponse>(mockResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
       const { populateAutoBotDocs } = useKnowledgeBase()
       const result = await populateAutoBotDocs()
@@ -1050,9 +994,7 @@ describe('useKnowledgeBase', () => {
         distro: 'Ubuntu 20.04',
       }
 
-      const response = mockApiResponse(mockProfile)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<MachineProfile>(mockProfile)
+      vi.mocked(apiClient.get).mockResolvedValue(mockProfile)
 
       const { fetchMachineProfile } = useKnowledgeBase()
       const result = await fetchMachineProfile('host1')
@@ -1080,9 +1022,7 @@ describe('useKnowledgeBase', () => {
         total_documents: 3,
       }
 
-      const response = mockApiResponse(mockStats)
-      vi.mocked(apiClient.get).mockResolvedValue(response)
-      mockParseApi<KnowledgeStats>(mockStats)
+      vi.mocked(apiClient.get).mockResolvedValue(mockStats)
 
       const { fetchBasicStats } = useKnowledgeBase()
       const result = await fetchBasicStats()
@@ -1105,9 +1045,7 @@ describe('useKnowledgeBase', () => {
         machine_id: 'host1',
       }
 
-      const response = mockApiResponse(mockResponse)
-      vi.mocked(apiClient.post).mockResolvedValue(response)
-      mockParseApi<IntegrationResponse>(mockResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
 
       const { integrateManPages } = useKnowledgeBase()
       const result = await integrateManPages('host1')

--- a/autobot-frontend/src/composables/useKnowledgeBase.ts
+++ b/autobot-frontend/src/composables/useKnowledgeBase.ts
@@ -77,22 +77,20 @@ export interface ProgressMessage {
 
 export function useKnowledgeBase() {
   // ==================== API CALLS ====================
-  // NOTE: Now using shared parseApiResponse from @/utils/apiResponseHelpers
-  // Removed duplicate parseApiResponse implementation (was 40 lines)
 
   /**
    * Fetch knowledge base statistics
    */
   const fetchStats = async (): Promise<KnowledgeStats | null> => {
     try {
-      const response = await apiClient.get(`${getApiBase()}/knowledge_base/stats`)
+      const response = await apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats`)
 
       if (!response) {
         throw new Error('Failed to fetch stats: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
-      return data as KnowledgeStats
+      const data = response
+      return data
     } catch (error) {
       logger.error('Error fetching stats:', error)
       throw error
@@ -106,13 +104,13 @@ export function useKnowledgeBase() {
    */
   const fetchCategories = async (): Promise<KnowledgeCategoryItem[]> => {
     try {
-      const response = await apiClient.get(`${getApiBase()}/knowledge_base/categories`)
+      const response = await apiClient.get<CategoriesListResponse>(`${getApiBase()}/knowledge_base/categories`)
 
       if (!response) {
         throw new Error('Failed to fetch categories: No response from server')
       }
 
-      const data = (await parseApiResponse<Record<string, any>>(response as any)) as CategoriesListResponse
+      const data = response
 
       // Validate response structure
       if (!data || !Array.isArray(data.categories)) {
@@ -131,13 +129,13 @@ export function useKnowledgeBase() {
    */
   const fetchCategory = async (category: string): Promise<CategoryResponse> => {
     try {
-      const response = await apiClient.get(`${getApiBase()}/knowledge_base/category/${category}`)
+      const response = await apiClient.get<CategoryResponse>(`${getApiBase()}/knowledge_base/category/${category}`)
 
       if (!response) {
         throw new Error('Failed to fetch category: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('Error fetching category:', error)
@@ -164,13 +162,13 @@ export function useKnowledgeBase() {
       params.append('limit', String(limit))
 
       const url = `${getApiBase()}/knowledge_base/facts/by_category?${params.toString()}`
-      const response = (await apiClient.get(url)) as Record<string, unknown>
+      const response = await apiClient.get<CategorizedFactsResponse>(url)
 
       if (!response) {
         throw new Error('Failed to fetch categorized facts: No response from server')
       }
 
-      const data = (await parseApiResponse<Record<string, any>>(response as any)) as CategorizedFactsResponse
+      const data = response
 
       // Validate response structure
       if (!data || typeof data.categories !== 'object') {
@@ -230,13 +228,13 @@ export function useKnowledgeBase() {
   const searchKnowledge = async (query: string): Promise<SearchResponse> => {
     try {
       // Issue #552: Backend expects POST for search
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/search`, { query })
+      const response = await apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, { query })
 
       if (!response) {
         throw new Error('Search failed: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('Error searching knowledge:', error)
@@ -271,13 +269,13 @@ export function useKnowledgeBase() {
 
   const advancedSearch = async (options: AdvancedSearchOptions): Promise<SearchResponse> => {
     try {
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/search`, options)
+      const response = await apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, options)
 
       if (!response) {
         throw new Error('Advanced search failed: No response from server')
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('Error in advanced search:', error)
@@ -294,13 +292,13 @@ export function useKnowledgeBase() {
     metadata?: Record<string, unknown>
   }): Promise<AddFactResponse> => {
     try {
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/facts`, fact)
+      const response = await apiClient.post<AddFactResponse>(`${getApiBase()}/knowledge_base/facts`, fact)
 
       if (!response) {
         throw new Error('Failed to add fact: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('Error adding fact:', error)
@@ -341,13 +339,13 @@ export function useKnowledgeBase() {
   const fetchMachineProfiles = async (): Promise<MachineProfile[]> => {
     try {
       // Issue #552: Fixed path - backend uses singular /api/knowledge_base/machine_profile
-      const response = await apiClient.get(`${getApiBase()}/knowledge_base/machine_profile`)
+      const response = await apiClient.get<MachineProfile[]>(`${getApiBase()}/knowledge_base/machine_profile`)
 
       if (!response) {
         throw new Error('Failed to fetch machine profiles: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return Array.isArray(data) ? data : []
     } catch (error) {
       logger.error('Error fetching machine profiles:', error)
@@ -360,13 +358,13 @@ export function useKnowledgeBase() {
    */
   const fetchManPagesSummary = async (): Promise<ManPagesSummary | null> => {
     try {
-      const response = await apiClient.get(`${getApiBase()}/knowledge_base/man_pages/summary`)
+      const response = await apiClient.get<ManPagesSummary>(`${getApiBase()}/knowledge_base/man_pages/summary`)
 
       if (!response) {
         throw new Error('Failed to fetch man pages summary: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('Error fetching man pages summary:', error)
@@ -379,7 +377,7 @@ export function useKnowledgeBase() {
    */
   const integrateManPages = async (machineId: string): Promise<IntegrationResponse> => {
     try {
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/man_pages/integrate`, {
+      const response = await apiClient.post<IntegrationResponse>(`${getApiBase()}/knowledge_base/man_pages/integrate`, {
         machine_id: machineId
       })
 
@@ -387,7 +385,7 @@ export function useKnowledgeBase() {
         throw new Error('Integration failed: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('Error integrating man pages:', error)
@@ -401,13 +399,13 @@ export function useKnowledgeBase() {
   const getVectorizationStatus = async (): Promise<VectorizationStatusResponse> => {
     try {
       // Issue #552: Fixed path - backend uses /api/knowledge_base/vectorize_facts/status
-      const response = await apiClient.get(`${getApiBase()}/knowledge_base/vectorize_facts/status`)
+      const response = await apiClient.get<VectorizationStatusResponse>(`${getApiBase()}/knowledge_base/vectorize_facts/status`)
 
       if (!response) {
         throw new Error('Failed to get vectorization status: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('Error getting vectorization status:', error)
@@ -431,7 +429,7 @@ export function useKnowledgeBase() {
       // Get knowledge-specific timeout (300s for vectorization operations)
       const knowledgeTimeout = appConfig.getTimeout('knowledge')
 
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorize_facts`, {
+      const response = await apiClient.post<VectorizationResponse>(`${getApiBase()}/knowledge_base/vectorize_facts`, {
         batch_size: batchSize,
         batch_delay: batchDelay,
         skip_existing: skipExisting
@@ -444,7 +442,7 @@ export function useKnowledgeBase() {
       }
 
       // Parse successful response
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
 
       return data
     } catch (error) {
@@ -466,7 +464,7 @@ export function useKnowledgeBase() {
   const initializeMachineKnowledge = async (machineId: string): Promise<MachineKnowledgeResponse> => {
     try {
 
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/machine_knowledge/initialize`, {
+      const response = await apiClient.post<MachineKnowledgeResponse>(`${getApiBase()}/knowledge_base/machine_knowledge/initialize`, {
         machine_id: machineId
       })
 
@@ -476,7 +474,7 @@ export function useKnowledgeBase() {
         throw new Error('Machine knowledge initialization failed: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('[initializeMachineKnowledge] Error:', error)
@@ -493,7 +491,7 @@ export function useKnowledgeBase() {
   const refreshSystemKnowledge = async (): Promise<SystemKnowledgeResponse> => {
     try {
 
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/refresh_system_knowledge`, {})
+      const response = await apiClient.post<SystemKnowledgeResponse>(`${getApiBase()}/knowledge_base/refresh_system_knowledge`, {})
 
       logger.debug('[refreshSystemKnowledge] Response received')
 
@@ -501,7 +499,7 @@ export function useKnowledgeBase() {
         throw new Error('System knowledge refresh failed: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('[refreshSystemKnowledge] Error:', error)
@@ -517,7 +515,7 @@ export function useKnowledgeBase() {
    */
   const pollJobStatus = async (taskId: string): Promise<any> => {
     try {
-      const response = await apiClient.get(`${getApiBase()}/knowledge_base/job_status/${taskId}`)
+      const response = await apiClient.get<any>(`${getApiBase()}/knowledge_base/job_status/${taskId}`)
 
       logger.debug('[pollJobStatus] Response received', { taskId })
 
@@ -525,7 +523,7 @@ export function useKnowledgeBase() {
         throw new Error('Job status check failed: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('[pollJobStatus] Error:', error)
@@ -540,7 +538,7 @@ export function useKnowledgeBase() {
   const populateManPages = async (machineId: string): Promise<ManPagesPopulateResponse> => {
     try {
 
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/populate_man_pages`, {
+      const response = await apiClient.post<ManPagesPopulateResponse>(`${getApiBase()}/knowledge_base/populate_man_pages`, {
         machine_id: machineId
       })
 
@@ -550,7 +548,7 @@ export function useKnowledgeBase() {
         throw new Error('Man pages population failed: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('[populateManPages] Error:', error)
@@ -565,7 +563,7 @@ export function useKnowledgeBase() {
   const populateAutoBotDocs = async (): Promise<AutoBotDocsResponse> => {
     try {
 
-      const response = await apiClient.post(`${getApiBase()}/knowledge_base/populate_autobot_docs`, {})
+      const response = await apiClient.post<AutoBotDocsResponse>(`${getApiBase()}/knowledge_base/populate_autobot_docs`, {})
 
       logger.debug('[populateAutoBotDocs] Response received')
 
@@ -573,7 +571,7 @@ export function useKnowledgeBase() {
         throw new Error('AutoBot docs population failed: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
+      const data = response
       return data
     } catch (error) {
       logger.error('[populateAutoBotDocs] Error:', error)
@@ -588,7 +586,7 @@ export function useKnowledgeBase() {
   const fetchMachineProfile = async (machineId: string): Promise<MachineProfile | null> => {
     try {
 
-      const response = await apiClient.get(
+      const response = await apiClient.get<MachineProfile>(
         `${getApiBase()}/knowledge_base/machine_profile?machine_id=${encodeURIComponent(machineId)}`
       )
 
@@ -598,8 +596,8 @@ export function useKnowledgeBase() {
         throw new Error('Machine profile fetch failed: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
-      return data as MachineProfile
+      const data = response
+      return data
     } catch (error) {
       logger.error('[fetchMachineProfile] Error:', error)
       return null
@@ -613,7 +611,7 @@ export function useKnowledgeBase() {
   const fetchBasicStats = async (): Promise<KnowledgeStats | null> => {
     try {
 
-      const response = await apiClient.get(`${getApiBase()}/knowledge_base/stats/basic`)
+      const response = await apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats/basic`)
 
       logger.debug('[fetchBasicStats] Response received')
 
@@ -621,8 +619,8 @@ export function useKnowledgeBase() {
         throw new Error('Basic stats fetch failed: No response from server');
       }
 
-      const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
-      return data as KnowledgeStats
+      const data = response
+      return data
     } catch (error) {
       logger.error('[fetchBasicStats] Error:', error)
       return null
@@ -814,7 +812,5 @@ export function useKnowledgeBase() {
     getMessageIcon,
     formatTime,
     formatDateOnly: formatDateHelper, // Alias for backward compatibility
-    // Helper function
-    parseApiResponse
   }
 }


### PR DESCRIPTION
Continues #5033 (follows PR #5076 which migrated \`useKnowledgeVectorization.ts\`).

## Summary

Migrates 20 of the 21 \`parseApiResponse\` call sites in \`useKnowledgeBase.ts\` to use the typed \`apiClient\` directly. **One site remains** (line ~320 — \`uploadKnowledgeFile\`) because it uses \`fetchWithAuth\` which returns a raw \`Response\` object; \`parseApiResponse\` is legitimately needed there to handle the dual parsed-JSON / raw-Response contract.

## How types were inferred

Three-pass inference script (paths `/tmp/migrate_parseApiResponse_v2.py` + `/tmp/migrate_pass2.py`):

1. From outer cast on the \`parseApiResponse\` line (e.g. \`... as CategoriesListResponse\`)
2. From the return line (e.g. \`return data as KnowledgeStats\`)
3. Fallback: from the enclosing async function's \`Promise<T>\` annotation (stripping \`| null\` / \`| undefined\` unions)

## Pattern

\`\`\`typescript
// BEFORE
const response = await apiClient.get(url)
if (!response) { throw ... }
const data = ((await parseApiResponse<Record<string, any>>(response as any))) as any
return data as KnowledgeStats

// AFTER
const response = await apiClient.get<KnowledgeStats>(url)
if (!response) { throw ... }
const data = response
return data
\`\`\`

Also:
- Removed the composable's unnecessary re-export of \`parseApiResponse\` (no external consumers found via grep)
- Removed stale \`NOTE: Now using shared parseApiResponse\` comments
- \`parseApiResponse\` import kept (still needed for the legitimate \`fetchWithAuth\` call site)

**Stats:** -45 / +41 lines. 20 call sites migrated.

## Remaining #5033 work

- \`uploadKnowledgeFile\` in useKnowledgeBase.ts — intentionally kept (fetchWithAuth case)
- ~100 other call sites across \`components/knowledge/*\`, \`components/chat/*\`, etc. — to be migrated in future batches

After all non-fetchWithAuth call sites are migrated, evaluate whether \`parseApiResponse\` should be deleted entirely or kept narrowly for the raw-Response-handling case.

## Risk

Low. \`apiClient.get<T>()\`/\`.post<T>()\` have been returning parsed \`Promise<T>\` and throwing on error for many releases — confirmed in ApiClient.ts:337 (GET) and :379 (POST). The null checks I preserved are dead code but cheap, and keeping them limits PR blast radius.