### PR TITLE
docs: update class names after orchestrator rename + historical banners (#5097)

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -54,7 +54,7 @@ AutoBot uses a multi-agent orchestration system where specialized agents handle 
 ## 📂 Agent Categories
 
 ### 1. **Orchestration & Coordination**
-- [Agent Orchestrator](./orchestration/agent_orchestrator.md) - Central routing and coordination
+- [Distributed Agent Coordinator](./orchestration/distributed_agent_coordinator.md) - Central routing and coordination
 - [Base Agent](./orchestration/base_agent.md) - Abstract base class for all agents
 
 ### 2. **Knowledge Management**

--- a/docs/agents/_index.md
+++ b/docs/agents/_index.md
@@ -18,4 +18,4 @@ aliases:
 | [STANDARDIZED_AGENT_MIGRATION](STANDARDIZED_AGENT_MIGRATION.md) | Agent migration guide |
 | [development/npu_code_search_agent](development/npu_code_search_agent.md) | NPU code search agent |
 | [knowledge/kb_librarian_agent](knowledge/kb_librarian_agent.md) | KB librarian agent |
-| [orchestration/agent_orchestrator](orchestration/agent_orchestrator.md) | Agent orchestrator |
+| [orchestration/distributed_agent_coordinator](orchestration/distributed_agent_coordinator.md) | Distributed agent coordinator |

--- a/docs/agents/orchestration/distributed_agent_coordinator.md
+++ b/docs/agents/orchestration/distributed_agent_coordinator.md
@@ -1,8 +1,10 @@
-# Agent Orchestrator
+# Distributed Agent Coordinator
 
 ## Overview
 
-The Agent Orchestrator serves as the central hub for routing, coordinating, and managing all agent interactions within AutoBot. It implements intelligent request routing, load balancing, failover handling, and performance monitoring across the entire multi-agent system.
+The Distributed Agent Coordinator (class `DistributedAgentCoordinator` in `autobot-backend/agents/agent_orchestration/coordinator.py`) serves as the central hub for routing, coordinating, and managing all agent interactions within AutoBot. It implements intelligent request routing, load balancing, failover handling, and performance monitoring across the entire multi-agent system.
+
+> **Note:** This class was renamed from `AgentOrchestrator` as part of the single-Orchestrator refactor (#5040). There is now exactly one `Orchestrator` class in the codebase — the top-level multi-agent conductor in `autobot-backend/orchestrator.py`. The `DistributedAgentCoordinator` described here is the distributed-agent routing layer that sits below it.
 
 ## System Integration & Interactions
 
@@ -14,7 +16,7 @@ The Agent Orchestrator serves as the central hub for routing, coordinating, and 
 └─────────────────┬───────────────────────────────────────────┘
                   │
 ┌─────────────────▼───────────────────────────────────────────┐
-│                Agent Orchestrator                           │
+│            Distributed Agent Coordinator                    │
 ├─────────────────────────────────────────────────────────────┤
 │ • Request Analysis & Routing                               │
 │ • Agent Selection & Load Balancing                         │
@@ -34,7 +36,7 @@ The Agent Orchestrator serves as the central hub for routing, coordinating, and 
 
 #### 1. **Request Processing Pipeline**
 ```python
-class AgentOrchestrator:
+class DistributedAgentCoordinator:
     async def process_request(self, request: dict) -> dict:
         """
         Main request processing pipeline

--- a/docs/architecture/designs/EVENT_STREAM_SYSTEM_DESIGN.md
+++ b/docs/architecture/designs/EVENT_STREAM_SYSTEM_DESIGN.md
@@ -448,12 +448,12 @@ class RedisEventStreamManager(EventStreamManager):
 
 ## 5. Integration Points
 
-### 5.1 Agent Orchestrator Integration
+### 5.1 Orchestrator Integration
 
 ```python
-# In autobot-backend/agents/agent_orchestrator.py
+# In autobot-backend/orchestrator.py
 
-class AgentOrchestrator:
+class Orchestrator:
     def __init__(self):
         self.event_stream = RedisEventStreamManager()
 

--- a/docs/architecture/designs/PLANNER_MODULE_DESIGN.md
+++ b/docs/architecture/designs/PLANNER_MODULE_DESIGN.md
@@ -777,10 +777,10 @@ def plan_to_todowrite(plan: ExecutionPlan) -> list[dict]:
 
 ## 6. Agent Loop Integration
 
-### 6.1 Modified Agent Orchestrator
+### 6.1 Modified Orchestrator
 
 ```python
-class AgentOrchestrator:
+class Orchestrator:
     def __init__(self):
         self.planner = LLMPlannerModule(...)
         self.event_stream = RedisEventStreamManager()

--- a/docs/guides/AGENT_SYSTEM_GUIDE.md
+++ b/docs/guides/AGENT_SYSTEM_GUIDE.md
@@ -244,12 +244,12 @@ class CachedAgent(BaseAgent):
 
 ### **Inter-Agent Communication**
 ```python
-from src.agents.agent_orchestrator import AgentOrchestrator
+from agents.agent_orchestration.coordinator import DistributedAgentCoordinator
 
 class CommunicatingAgent(BaseAgent):
     def __init__(self):
         super().__init__("communicating_agent")
-        self.orchestrator = AgentOrchestrator()
+        self.coordinator = DistributedAgentCoordinator()
 
     async def process_request(self, request: AgentRequest) -> AgentResponse:
         # Step 1: Get information from research agent
@@ -260,7 +260,7 @@ class CommunicatingAgent(BaseAgent):
             payload={"query": request.payload.get("topic")}
         )
 
-        research_response = await self.orchestrator.route_request(research_request)
+        research_response = await self.coordinator.process_request(research_request)
 
         # Step 2: Synthesize with RAG agent
         rag_request = AgentRequest(
@@ -356,7 +356,7 @@ async def test_agent_health():
 ```python
 @pytest.mark.asyncio
 async def test_agent_integration():
-    orchestrator = AgentOrchestrator()
+    coordinator = DistributedAgentCoordinator()
 
     # Test routing to your agent
     request = AgentRequest(
@@ -366,7 +366,7 @@ async def test_agent_integration():
         payload={"test_data": "value"}
     )
 
-    response = await orchestrator.route_request(request)
+    response = await coordinator.process_request(request)
     assert response.status == "success"
     assert response.agent_type == "your_agent"
 ```

--- a/docs/guides/slm-docker-ansible-deployment.md
+++ b/docs/guides/slm-docker-ansible-deployment.md
@@ -2286,8 +2286,8 @@ with httpx.Client(verify=False) as client:
 ### How it works
 
 1. `POST /api/v1/slm/deployments/docker` is handled by `autobot-backend/api/slm/deployments.py`.
-2. The route delegates to `SLMDeploymentOrchestrator` (`autobot-backend/services/slm/deployment_orchestrator.py`).
-3. The orchestrator translates the `DockerDeploymentRequest` into the SLM's
+2. The route delegates to `SLMDeploymentBridge` (`autobot-backend/services/slm/deployment_bridge.py`).
+3. The bridge translates the `DockerDeploymentRequest` into the SLM's
    `POST /deployments` shape: `{node_id, roles: ["docker"], extra_data: {playbook, extra_vars}}`.
 4. The SLM runs the specified Ansible playbook against the target node.
 5. Deployment status is polled via `GET /api/v1/slm/deployments/{id}`, which

--- a/docs/how-to/deploy-docker-container-via-slm-ansible.md
+++ b/docs/how-to/deploy-docker-container-via-slm-ansible.md
@@ -7,7 +7,7 @@ AutoBot's SLM (Service Lifecycle Manager) backend runs Ansible playbooks on enro
 ```
 AutoBot backend
   └─ POST /api/slm/deployments/docker
-       └─ SLMDeploymentOrchestrator.deploy_docker()
+       └─ SLMDeploymentBridge.deploy_docker()
             └─ SLMClient.create_deployment()
                  └─ SLM backend POST /deployments
                       └─ Ansible playbook runner
@@ -85,7 +85,7 @@ print(f"Status: {deployment['status']}")
 
 ## Ansible extra_vars injected by the SLM
 
-The `SLMDeploymentOrchestrator` translates the request into a `docker_containers` extra_vars list that the playbook consumes:
+The `SLMDeploymentBridge` translates the request into a `docker_containers` extra_vars list that the playbook consumes:
 
 ```yaml
 docker_containers:
@@ -232,7 +232,7 @@ else:
     print("Deployment completed successfully")
 ```
 
-## Multi-step multi-node deployment (DeploymentOrchestrator)
+## Multi-step multi-node deployment (DeploymentCoordinator)
 
 For rolling out across multiple nodes with a sequential, parallel, or canary strategy, use the generic deployment API:
 
@@ -303,8 +303,8 @@ if result["status"] == "failed":
 ## Architecture reference
 
 - **Request/response models** — `autobot-backend/models/infrastructure.py`
-- **SLMDeploymentOrchestrator** — `autobot-backend/services/slm/deployment_orchestrator.py`
-- **DeploymentOrchestrator** (multi-node) — `autobot-backend/services/slm/deployment_orchestrator.py`
+- **SLMDeploymentBridge** — `autobot-backend/services/slm/deployment_bridge.py`
+- **DeploymentCoordinator** (multi-node) — `autobot-backend/services/slm/deployment_coordinator.py`
 - **API routes** — `autobot-backend/api/slm/deployments.py`
 - **SLM client** — `autobot-backend/services/slm_client.py`
 - **Ansible playbook** — `autobot-slm-backend/ansible/roles/docker/tasks/main.yml` (via `deploy-hybrid-docker.yml`)

--- a/docs/planning/orchestrator-compatibility-issue.md
+++ b/docs/planning/orchestrator-compatibility-issue.md
@@ -1,5 +1,7 @@
 # Orchestrator Compatibility Issue Found
 
+> **Historical** — This document describes a compatibility problem and its original resolution (backward-compat aliases). The aliases described here were later **removed** as part of #4048 and the single-conductor refactor in #5040. For the current canonical structure, see `autobot-backend/orchestrator.py` (`Orchestrator` class — no aliases, no shims). Kept for historical context only.
+
 **Date**: 2025-10-18
 **Severity**: HIGH
 **Status**: ✅ RESOLVED - Backward compatibility implemented

--- a/docs/planning/orchestrator-consolidation-analysis.md
+++ b/docs/planning/orchestrator-consolidation-analysis.md
@@ -1,5 +1,7 @@
 # Orchestrator Consolidation Analysis
 
+> **Historical** — This document describes the state as of 2025-10-18. The decisions here have been superseded by the consolidation work in #4048 and the single-conductor refactor in #5040. For current canonical orchestrator structure, see `autobot-backend/orchestrator.py` (`Orchestrator` class — the one and only conductor).
+
 **Date**: 2025-10-18
 **Status**: Investigation Complete - Consolidation Plan Required
 


### PR DESCRIPTION
Closes #5097.

Documentation was not scanned during the single-conductor rename (#5040), leaving live code examples and file-path references pointing to removed classes. Developers following the guides would hit ImportError. This PR catches up the docs.

## Changes

**Active guides updated** (class + import path replacements):
- `docs/guides/AGENT_SYSTEM_GUIDE.md` — two code examples: `AgentOrchestrator` + `.route_request()` → `DistributedAgentCoordinator` + `.process_request()`; correct import path
- `docs/how-to/deploy-docker-container-via-slm-ansible.md` — `SLMDeploymentOrchestrator` → `SLMDeploymentBridge`, `DeploymentOrchestrator` → `DeploymentCoordinator`, old file path → new split paths
- `docs/guides/slm-docker-ansible-deployment.md` — same
- `docs/architecture/designs/EVENT_STREAM_SYSTEM_DESIGN.md`, `PLANNER_MODULE_DESIGN.md` — `AgentOrchestrator` → `Orchestrator` in design code blocks

**File renamed:**
- `docs/agents/orchestration/agent_orchestrator.md` → `distributed_agent_coordinator.md` (git mv, 95% similarity); class name inside updated; migration note added at top
- Cross-refs updated in `docs/agents/_index.md` and `docs/agents/README.md`

**Historical planning docs** (banner only, content preserved for archaeology):
- `docs/planning/orchestrator-consolidation-analysis.md`
- `docs/planning/orchestrator-compatibility-issue.md`

## Verification

`grep -rn 'ConsolidatedOrchestrator|EnhancedMultiAgentOrchestrator|SLMDeploymentOrchestrator|AutonomousLoopOrchestrator|AdvancedWorkflowOrchestrator|SubagentOrchestrator|\bDeploymentOrchestrator\b|\bAgentOrchestrator\b' docs/ --include='*.md' | grep -v docs/planning/` returns only one intentional migration-note line in the renamed doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)