### PR TITLE
fix(codebase-analytics): scope getCodebaseStats + getProblemsReport by source_id (#5111)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
@@ -638,7 +638,9 @@ export function useAnalyticsDataFetchers(
   const getCodebaseStats = async () => {
     try {
       const backendUrl = await appConfig.getServiceUrl('backend')
-      const statsEndpoint = `${backendUrl}/api/analytics/codebase/stats`
+      const statsEndpoint = withSourceId(
+        `${backendUrl}/api/analytics/codebase/stats`,
+      )
       const response = await fetchWithAuth(statsEndpoint)
       if (!response.ok) {
         throw new Error(
@@ -669,7 +671,9 @@ export function useAnalyticsDataFetchers(
     )
     try {
       const backendUrl = await appConfig.getServiceUrl('backend')
-      const problemsEndpoint = `${backendUrl}/api/analytics/codebase/problems`
+      const problemsEndpoint = withSourceId(
+        `${backendUrl}/api/analytics/codebase/problems`,
+      )
       const response = await fetchWithAuth(problemsEndpoint)
       if (!response.ok) {
         throw new Error(


### PR DESCRIPTION
## Summary

- Wraps `/api/analytics/codebase/stats` and `/api/analytics/codebase/problems` in `withSourceId()` \u2014 they were the only two fetchers out of 14 in `useAnalyticsDataFetchers.ts` that dropped `?source_id=<id>`.
- Without the param, backend read the unscoped `codebase_stats` ChromaDB doc (empty after per-project indexing) and `/problems` fell back to `get_default_source_id()` \u2014 producing empty Stats / Problems / CodeSmells panels for the selected project.

Closes #5111.

## Root Cause

- `autobot-backend/api/codebase_analytics/endpoints/stats.py:223` \u2014 stats_doc_id is `codebase_stats_{source_id}` when `source_id` provided, else unscoped `codebase_stats`.
- `autobot-backend/api/codebase_analytics/endpoints/stats.py:591-600` \u2014 `/problems` silently defaults to the most-recent source when source_id missing.
- Frontend: `useAnalyticsDataFetchers.ts:638` + `:665` omitted the `withSourceId()` wrap (grep-verified vs. 12 working sites).

## Test plan

- [ ] `vue-tsc --noEmit -p tsconfig.app.json` passes for the changed file (pre-existing unrelated errors unchanged).
- [ ] Manual: visit `/analytics/codebase/{sourceId}` after indexing a source \u2014 Stats panel populates (files, lines, functions), Problems Report populates, CodeSmells populates.
- [ ] Manual: `curl ".../api/analytics/codebase/stats?source_id=<id>"` returns `status: success` with populated `stats`.
- [ ] No regression: CodebaseAnalyticsLanding still loads (hits `/sources`, unchanged).

## Follow-up

- #5112 tracks extracting `useAnalyticsEndpoint<T>` so `source_id` scoping becomes the default and this class of bug is prevented structurally.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)