### PR TITLE
refactor(frontend): unify uploadKnowledgeFile with apiClient pattern (#5093)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useKnowledgeBase.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeBase.test.ts
@@ -49,19 +49,6 @@ vi.mock('@/utils/ApiClient', () => ({
   },
 }))
 
-// Mock fetchWithAuth
-vi.mock('@/utils/fetchWithAuth', () => ({
-  fetchWithAuth: vi.fn(),
-}))
-
-// Mock parseApiResponse
-vi.mock('@/utils/apiResponseHelpers', () => ({
-  parseApiResponse: vi.fn((response) => {
-    if (!response) return null
-    return response.json ? response.json() : response
-  }),
-}))
-
 // Mock formatHelpers
 vi.mock('@/utils/formatHelpers', () => ({
   formatDate: (date: any) => new Date(date).toLocaleDateString(),
@@ -101,37 +88,10 @@ vi.mock('@/config/ssot-config', () => ({
 }))
 
 import apiClient from '@/utils/ApiClient'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
-import appConfig from '@/config/AppConfig.js'
 
 // ========================================
 // Helper Functions
 // ========================================
-
-function mockApiResponse<T>(data: T, ok = true) {
-  return {
-    ok,
-    status: ok ? 200 : 400,
-    statusText: ok ? 'OK' : 'Bad Request',
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
-    headers: new Map(),
-  } as unknown as Response
-}
-
-/**
- * Typed wrapper around parseApiResponse mock.
- *
- * `parseApiResponse` in production returns `Promise<any>`, so mocking it with
- * `vi.mocked(parseApiResponse).mockResolvedValue(x)` accepts any value and
- * silently hides test-fixture typos. This helper adds an explicit type
- * parameter so `mockParseApi<KnowledgeStats>(fixture)` fails type-check if
- * `fixture` is not assignable to `KnowledgeStats`.
- */
-function mockParseApi<T>(data: T): void {
-  vi.mocked(parseApiResponse).mockResolvedValue(data)
-}
 
 /**
  * Shape of the background job status response used by `pollJobStatus`.
@@ -525,22 +485,22 @@ describe('useKnowledgeBase', () => {
       const formData = new FormData()
       formData.append('file', new Blob(['test'], { type: 'application/pdf' }))
 
-      const response = mockApiResponse(mockUploadResponse)
-      vi.mocked(fetchWithAuth).mockResolvedValue(response)
-      mockParseApi<UploadResponse>(mockUploadResponse)
+      vi.mocked(apiClient.post).mockResolvedValue(mockUploadResponse)
 
       const { uploadKnowledgeFile } = useKnowledgeBase()
       const result = await uploadKnowledgeFile(formData)
 
       expect(result).toEqual(mockUploadResponse)
-      expect(fetchWithAuth).toHaveBeenCalled()
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/upload',
+        formData
+      )
     })
 
     it('should throw error on upload failure', async () => {
       const formData = new FormData()
 
-      const response = mockApiResponse<null>(null, false)
-      vi.mocked(fetchWithAuth).mockResolvedValue(response)
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('HTTP 400: Upload failed'))
 
       const { uploadKnowledgeFile } = useKnowledgeBase()
 

--- a/autobot-frontend/src/composables/useKnowledgeBase.ts
+++ b/autobot-frontend/src/composables/useKnowledgeBase.ts
@@ -6,8 +6,6 @@
  */
 
 import apiClient from '@/utils/ApiClient'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import {
   formatDate as formatDateHelper,
   formatFileSize as formatFileSizeHelper,
@@ -308,25 +306,18 @@ export function useKnowledgeBase() {
 
   /**
    * Upload knowledge base file
+   *
+   * Uses apiClient.post which handles FormData natively — rawRequest strips
+   * Content-Type so the browser sets multipart boundary automatically, and
+   * inherits the same auth/retry/error-handling as every other API call.
    */
   const uploadKnowledgeFile = async (formData: FormData): Promise<UploadResponse> => {
     try {
-      const url = await appConfig.getApiUrl(`${getApiBase()}/knowledge_base/upload`)
-
-      const response = await fetchWithAuth(url, {
-        method: 'POST',
-        body: formData
-      })
-
-      if (!response.ok) {
-        logger.error('File upload failed with status:', response.status)
-        const errorText = await response.text()
-        logger.error('Error response:', errorText)
-        throw new Error(`Upload failed: ${response.status} ${response.statusText}`)
-      }
-
-      const data = (await parseApiResponse<Record<string, any>>(response)) as any
-      return data
+      const data = await apiClient.post<Record<string, any>>(
+        `${getApiBase()}/knowledge_base/upload`,
+        formData
+      )
+      return data as UploadResponse
     } catch (error) {
       logger.error('Error uploading file:', error)
       throw error


### PR DESCRIPTION
Closes #5093

## Summary
- \`uploadKnowledgeFile\` migrated to \`apiClient.post<T>(url, formData)\` — ApiClient's \`rawRequest\` already strips \`Content-Type\` for FormData bodies (lines 282-288), so no new ApiClient method was needed
- Removed \`fetchWithAuth\`/\`parseApiResponse\` imports (now fully unused — last call site)
- Test file: dropped orphaned \`mockApiResponse\` helper, \`mockParseApi\` helper, \`parseApiResponse\` mock, \`fetchWithAuth\` mock, and \`appConfig\` mock

## Diff
15 insertions / 64 deletions (net −49 lines)

## Test Status
PASS — 62/62 useKnowledgeBase tests pass