### PR TITLE
fix(typescript): drop misleading '| null' from fetchStats return type (#5103)

### DIFF
--- a/autobot-frontend/src/composables/useKnowledgeBase.ts
+++ b/autobot-frontend/src/composables/useKnowledgeBase.ts
@@ -81,7 +81,7 @@ export function useKnowledgeBase() {
   /**
    * Fetch knowledge base statistics
    */
-  const fetchStats = async (): Promise<KnowledgeStats | null> => {
+  const fetchStats = async (): Promise<KnowledgeStats> => {
     try {
       const response = await apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats`)
 


### PR DESCRIPTION
Fixes #5103

## Summary

\`fetchStats\` declared \`Promise<KnowledgeStats | null>\` but its catch block re-throws, so no execution path actually returns null. Tightening the signature to \`Promise<KnowledgeStats>\` makes it honest.

## Scope correction

The original #5103 issue claimed 4 functions had this problem. On closer inspection, **only \`fetchStats\` is affected**:

| Function | Catch block | Test contract | Signature was correct? |
|---|---|---|---|
| \`fetchStats\` | \`throw error\` | \`rejects.toThrow\` | ❌ — fixed by this PR |
| \`fetchManPagesSummary\` | \`return null\` | \`toBe(null)\` | ✅ |
| \`fetchMachineProfile\` | \`return null\` | \`toBe(null)\` | ✅ |
| \`fetchBasicStats\` | \`return null\` | (no null test) | ✅ |

The other 3 functions properly return null in their catch blocks — their \`| null\` signatures match runtime behavior. The migration script's \`| null\` stripping (per #5103) was over-eager about \`fetchStats\` only.

## Verification

- Audited all callers of \`useKnowledgeBase().fetchStats\`: only the test file consumes it. The test already uses \`rejects.toThrow\` for the failure case, so no caller relies on null return.
- \`vue-tsc --noEmit -p tsconfig.app.json\`: **0 errors in useKnowledgeBase.ts** before and after.

## Risk

Minimal. One-line type annotation tightening. Production callers (none) unaffected. Test (uses \`rejects.toThrow\`) unaffected.