### PR TITLE
fix(agent_loop): APPROVAL_REQUIRED event casing + canonical event_type constants (#5014)

### DIFF
--- a/autobot-backend/agent_loop/loop.py
+++ b/autobot-backend/agent_loop/loop.py
@@ -37,6 +37,7 @@ from agent_loop.types import (
     ThinkCategory,
 )
 from events import EventStreamManager, EventType
+from events.event_types import APPROVAL_REQUIRED as EVT_APPROVAL_REQUIRED
 from events.types import create_approval_required_event, create_message_event
 from live_event_manager import publish_live_event
 from planner import PlannerModule
@@ -915,7 +916,7 @@ Duration: {self._current_context.get_duration_ms():.0f}ms
         # never reach the other without an explicit bridge call.
         await publish_live_event(
             "global",
-            "tool_approval_required",
+            EVT_APPROVAL_REQUIRED,
             {
                 "approval_id": approval_id,
                 "tool_name": tool_name,

--- a/autobot-backend/events/event_types.py
+++ b/autobot-backend/events/event_types.py
@@ -1,0 +1,20 @@
+"""Canonical event_type strings for LiveEventManager payloads.
+
+Frontend consumers filter on these values; backend publishers must import
+from here rather than using string literals, to prevent casing drift (#5014).
+
+Only event types that are *actually published today* via publish_live_event
+are listed here.  Speculative / future types must not be added until a
+real call-site exists.
+"""
+
+# Agent loop — approval bridge (loop.py → LiveEventManager → WebSocket)
+# Frontend: autobot-frontend/src/composables/useToolApproval.ts
+APPROVAL_REQUIRED = "APPROVAL_REQUIRED"
+
+# Heartbeat scheduler (services/heartbeat_scheduler.py)
+HEARTBEAT_RUN_STARTED = "heartbeat_run_started"
+HEARTBEAT_RUN_COMPLETED = "heartbeat_run_completed"
+
+# RAG service retrieval feedback (services/rag_service.py)
+RAG_RETRIEVAL = "rag_retrieval"


### PR DESCRIPTION
Closes #5014. Finishes #4959 (the bridge PR #4974 had a casing mismatch that silently dropped the approval dialog event).

## Problem
Backend published `"tool_approval_required"` (lowercase); frontend filter expects `"APPROVAL_REQUIRED"`. The event was silently dropped.

## Fix
1. Canonicalize to `APPROVAL_REQUIRED` in `agent_loop/loop.py:916`
2. New `autobot-backend/events/event_types.py` module with canonical string constants. Backend call-sites must import from here rather than using string literals — prevents the same casing drift from recurring.

## Constants included (only real, currently-published event types)
- `APPROVAL_REQUIRED` (consumed by frontend approval dialog)
- `HEARTBEAT_RUN_STARTED`, `HEARTBEAT_RUN_COMPLETED` (heartbeat_scheduler.py)
- `RAG_RETRIEVAL` (rag_service.py)

The loop.py fix uses the new constant; other callers can be migrated incrementally.

## Verification
`grep -rn 'tool_approval_required' autobot-backend/ --include='*.py'` returns zero hits.