### PR TITLE
fix(api): /v1/chat/completions streaming usage emission (#5019)

### DIFF
--- a/autobot-backend/api/openai_compat.py
+++ b/autobot-backend/api/openai_compat.py
@@ -46,6 +46,10 @@ class OAIMessage(BaseModel):
     name: Optional[str] = None
 
 
+class OAIStreamOptions(BaseModel):
+    include_usage: bool = False
+
+
 class ChatCompletionRequest(BaseModel):
     model: str = "autobot-default"
     messages: List[OAIMessage]
@@ -56,6 +60,7 @@ class ChatCompletionRequest(BaseModel):
     presence_penalty: float = 0.0
     stop: Optional[List[str]] = None
     stream: bool = False
+    stream_options: Optional[OAIStreamOptions] = None
     n: int = Field(default=1, ge=1)
     user: Optional[str] = None
 
@@ -103,6 +108,7 @@ class ChatCompletionChunk(BaseModel):
     created: int
     model: str
     choices: List[OAIStreamChoice]
+    usage: Optional[OAIUsage] = None
 
 
 class OAIModelCard(BaseModel):
@@ -161,14 +167,31 @@ def _make_completion_id() -> str:
     return f"chatcmpl-{uuid4().hex[:24]}"
 
 
+def _estimate_tokens(text: str) -> int:
+    """Approximate token count (OpenAI convention: 1 token ≈ 0.75 words).
+
+    Used for streaming usage when the provider does not return native token
+    counts per chunk. Slight overestimate so downstream budgeting is safe.
+    """
+    if not text:
+        return 0
+    import math
+
+    return math.ceil(len(text.split()) * 1.3)
+
+
 async def _stream_generator(
     provider,
     llm_request: LLMRequest,
     completion_id: str,
     model_name: str,
+    *,
+    include_usage: bool = False,
+    prompt_text: str = "",
 ) -> AsyncIterator[str]:
     """Yield SSE lines for a streaming completion."""
     created = int(time.time())
+    completion_text_parts: List[str] = []
 
     # Opening chunk — role delta
     role_chunk = ChatCompletionChunk(
@@ -188,6 +211,7 @@ async def _stream_generator(
     async for text_chunk in provider.stream_completion(llm_request):
         if not text_chunk:
             continue
+        completion_text_parts.append(text_chunk)
         chunk = ChatCompletionChunk(
             id=completion_id,
             created=created,
@@ -216,6 +240,24 @@ async def _stream_generator(
         ],
     )
     yield f"data: {final_chunk.model_dump_json()}\n\n"
+
+    # Usage chunk (OpenAI spec: emit only when stream_options.include_usage=true)
+    if include_usage:
+        prompt_tokens = _estimate_tokens(prompt_text)
+        completion_tokens = _estimate_tokens("".join(completion_text_parts))
+        usage_chunk = ChatCompletionChunk(
+            id=completion_id,
+            created=created,
+            model=model_name,
+            choices=[],
+            usage=OAIUsage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            ),
+        )
+        yield f"data: {usage_chunk.model_dump_json()}\n\n"
+
     yield "data: [DONE]\n\n"
 
 
@@ -248,8 +290,17 @@ async def chat_completions(
     resolved_model = body.model if body.model != "autobot-default" else provider.provider_name
 
     if body.stream:
+        include_usage = bool(body.stream_options and body.stream_options.include_usage)
+        prompt_text = "\n".join(m.content for m in body.messages)
         return StreamingResponse(
-            _stream_generator(provider, llm_request, completion_id, resolved_model),
+            _stream_generator(
+                provider,
+                llm_request,
+                completion_id,
+                resolved_model,
+                include_usage=include_usage,
+                prompt_text=prompt_text,
+            ),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",

--- a/autobot-backend/api/test_openai_compat.py
+++ b/autobot-backend/api/test_openai_compat.py
@@ -170,3 +170,84 @@ async def test_chat_completions_streaming_returns_sse_done():
         chunk = json.loads(raw_json)
         assert chunk["object"] == "chat.completion.chunk"
         assert "choices" in chunk
+
+
+def _stream_post(payload):
+    """Helper that issues the streaming POST and returns decoded SSE text."""
+    mock_registry = _make_mock_registry()
+
+    async def _run():
+        with patch(
+            "api.openai_compat.get_provider_registry", return_value=mock_registry
+        ), patch("api.openai_compat._get_user", return_value=_SYNTHETIC_USER):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                async with client.stream(
+                    "POST", "/v1/chat/completions", json=payload
+                ) as response:
+                    assert response.status_code == 200
+                    return (await response.aread()).decode("utf-8")
+
+    return _run
+
+
+def _parse_sse_chunks(text: str):
+    """Return the list of parsed JSON chunks (excluding [DONE])."""
+    return [
+        json.loads(line[len("data: "):])
+        for line in text.splitlines()
+        if line.startswith("data: ") and line.strip() != "data: [DONE]"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_streaming_emits_usage_when_include_usage_true():
+    """When stream_options.include_usage=true, the final chunk before [DONE] must carry usage (#5019)."""
+    text = await _stream_post(
+        {
+            "model": "autobot-model-1",
+            "messages": [{"role": "user", "content": "Hello world"}],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+    )()
+    assert "data: [DONE]" in text
+    chunks = _parse_sse_chunks(text)
+    usage_chunks = [c for c in chunks if c.get("usage") is not None]
+    assert len(usage_chunks) == 1, "Expected exactly one chunk with usage"
+    usage = usage_chunks[0]["usage"]
+    assert usage["prompt_tokens"] >= 1
+    assert usage["completion_tokens"] >= 1
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+    # Usage chunk must be the last chunk before [DONE]
+    assert chunks[-1] is usage_chunks[0]
+
+
+@pytest.mark.asyncio
+async def test_streaming_omits_usage_when_include_usage_false():
+    """stream_options.include_usage=false → no usage chunk (#5019)."""
+    text = await _stream_post(
+        {
+            "model": "autobot-model-1",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": True,
+            "stream_options": {"include_usage": False},
+        }
+    )()
+    chunks = _parse_sse_chunks(text)
+    assert all(c.get("usage") is None for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_streaming_omits_usage_when_stream_options_absent():
+    """stream_options absent entirely → backwards compat: no usage chunk (#5019)."""
+    text = await _stream_post(
+        {
+            "model": "autobot-model-1",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": True,
+        }
+    )()
+    chunks = _parse_sse_chunks(text)
+    assert all(c.get("usage") is None for c in chunks)


### PR DESCRIPTION
Closes #5019.

## Problem
Streaming path of `/v1/chat/completions` dropped `usage` entirely, violating OpenAI spec. Clients that rely on `stream_options.include_usage=true` (Cursor, Continue, LibreChat) saw no token counts in streaming mode.

## Fix
- Add `OAIStreamOptions` model + `stream_options` field on `ChatCompletionRequest`
- Add optional `usage` field on `ChatCompletionChunk`
- Accumulate chunk text during streaming; estimate token counts via `ceil(len(text.split()) * 1.3)` (OpenAI convention, slight overestimate for safe budgeting)
- Emit final usage-only chunk before `data: [DONE]` when `include_usage=true`
- Absent or `false` → no usage chunk (backwards compat)

## Tests
All 6 tests pass (3 new):
- `test_streaming_emits_usage_when_include_usage_true` — verifies usage chunk is present, last before [DONE], and sums correctly
- `test_streaming_omits_usage_when_include_usage_false` — no usage chunk
- `test_streaming_omits_usage_when_stream_options_absent` — backwards-compat default

## Out of scope (separate issues can be filed)
- Rate limiting on `/v1/chat/completions`
- Public `get_provider_by_name` accessor on `ProviderRegistry`
- Validation that every provider's `stream_completion` is an async iterator