### PR TITLE
fix(ui): real focus trap via keydown in BaseModal + HostSelectionDialog (#5016)

### DIFF
--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -20,6 +20,7 @@
           class="dialog"
           :class="[sizeClass, { 'dialog-scrollable': scrollable }]"
           @click.stop
+          @keydown="handleKeydown"
           tabindex="-1"
         >
           <!-- Header -->
@@ -52,7 +53,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, onUnmounted } from 'vue'
+import { ref, computed, nextTick, onUnmounted, useId } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from './Icon.vue'
 
@@ -64,7 +65,7 @@ import Icon from './Icon.vue'
  *
  * Accessibility Features:
  * - WCAG 2.1 Level AA compliant
- * - Focus trap (prevents focus from escaping modal)
+ * - Focus trap via Tab/Shift+Tab wrap (does not fight browser devtools or outside clicks)
  * - ESC key to close
  * - Focus restoration (returns focus to trigger element)
  * - Screen reader announcements (role="dialog", aria-modal="true")
@@ -120,8 +121,8 @@ const { t } = useI18n()
 const dialogRef = ref<HTMLElement | null>(null)
 let previousActiveElement: HTMLElement | null = null
 
-// Generate stable unique IDs for ARIA labeling (random only once, not per-render)
-const _uid = Math.random().toString(36).substr(2, 9)
+// Stable unique IDs for ARIA labeling (Vue 3.5+ useId)
+const _uid = useId()
 const titleId = computed(() => `modal-title-${_uid}`)
 const descriptionId = computed(() => `modal-desc-${_uid}`)
 
@@ -157,7 +158,7 @@ const onAfterEnter = async () => {
   // Focus the dialog or first focusable element
   if (dialogRef.value) {
     const firstFocusable = dialogRef.value.querySelector<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
     )
 
     if (firstFocusable) {
@@ -169,9 +170,6 @@ const onAfterEnter = async () => {
 
   // Lock body scroll
   document.body.style.overflow = 'hidden'
-
-  // Add focus trap
-  document.addEventListener('focusin', trapFocus)
 }
 
 const onAfterLeave = () => {
@@ -182,32 +180,37 @@ const onAfterLeave = () => {
 
   // Unlock body scroll
   document.body.style.overflow = ''
-
-  // Remove focus trap
-  document.removeEventListener('focusin', trapFocus)
 }
 
-const trapFocus = (event: FocusEvent) => {
-  if (!dialogRef.value) return
+/**
+ * Real focus trap via Tab/Shift+Tab wrap. Only intercepts when focus would
+ * leave the dialog — otherwise falls through to browser default, allowing
+ * natural navigation plus outside clicks (e.g. devtools) to remain usable.
+ */
+const handleKeydown = (event: KeyboardEvent) => {
+  if (event.key !== 'Tab' || !dialogRef.value) return
 
-  const focusableElements = dialogRef.value.querySelectorAll<HTMLElement>(
-    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  const focusable = dialogRef.value.querySelectorAll<HTMLElement>(
+    'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
   )
+  if (focusable.length === 0) return
 
-  if (focusableElements.length === 0) return
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const active = document.activeElement
 
-  const firstElement = focusableElements[0]
-
-  // If focus leaves dialog, trap it back to first element
-  if (!dialogRef.value.contains(event.target as Node)) {
-    firstElement.focus()
+  if (event.shiftKey && active === first) {
     event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault()
+    first.focus()
   }
+  // Otherwise allow default Tab behavior
 }
 
 // Cleanup on unmount
 onUnmounted(() => {
-  document.removeEventListener('focusin', trapFocus)
   document.body.style.overflow = ''
 })
 </script>

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -12,6 +12,7 @@
       :aria-labelledby="dialogTitleId"
       :aria-describedby="dialogDescId"
       tabindex="-1"
+      @keydown="handleDialogKeydown"
     >
       <div class="dialog-header">
         <div class="dialog-icon" aria-hidden="true">
@@ -180,7 +181,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue';
+import { ref, nextTick, onMounted, onUnmounted, watch, useId } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { secretsApiClient } from '@/utils/SecretsApiClient';
 import { getBackendUrl } from '@/config/ssot-config';
@@ -231,8 +232,8 @@ const emit = defineEmits<{
 // #1721: In-memory session host preference (avoids clear-text sessionStorage)
 let _sessionHostChoice: string | null = null;
 
-// Stable IDs for ARIA labeling
-const _uid = Math.random().toString(36).substr(2, 9);
+// Stable IDs for ARIA labeling (Vue 3.5+ useId)
+const _uid = useId();
 const dialogTitleId = `host-dialog-title-${_uid}`;
 const dialogDescId = `host-dialog-desc-${_uid}`;
 const hostListLabelId = `host-list-label-${_uid}`;
@@ -414,18 +415,31 @@ const handleEscape = (event: KeyboardEvent) => {
   }
 };
 
-// Focus trap helpers
-const trapFocus = (event: FocusEvent) => {
-  if (!dialogRef.value) return;
-  if (!dialogRef.value.contains(event.target as Node)) {
-    const focusable = dialogRef.value.querySelectorAll<HTMLElement>(
-      'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
-    );
-    if (focusable.length > 0) {
-      focusable[0].focus();
-      event.preventDefault();
-    }
+/**
+ * Real focus trap via Tab/Shift+Tab wrap. Only intercepts when focus would
+ * leave the dialog boundary — otherwise falls through to browser default,
+ * which keeps outside clicks (devtools, etc.) from being yanked back.
+ */
+const handleDialogKeydown = (event: KeyboardEvent) => {
+  if (event.key !== 'Tab' || !dialogRef.value) return;
+
+  const focusable = dialogRef.value.querySelectorAll<HTMLElement>(
+    'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+  );
+  if (focusable.length === 0) return;
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+
+  if (event.shiftKey && active === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
   }
+  // Otherwise allow default Tab behavior
 };
 
 // Watchers
@@ -434,11 +448,9 @@ watch(() => props.show, async (newValue) => {
   if (newValue) {
     previousActiveElement = document.activeElement as HTMLElement;
     loadHosts();
-    document.addEventListener('focusin', trapFocus);
     await nextTick();
     dialogRef.value?.focus();
   } else {
-    document.removeEventListener('focusin', trapFocus);
     previousActiveElement?.focus();
     previousActiveElement = null;
   }
@@ -451,7 +463,6 @@ onMounted(() => {
 
 onUnmounted(() => {
   document.removeEventListener('keydown', handleEscape);
-  document.removeEventListener('focusin', trapFocus);
 });
 </script>
 

--- a/autobot-frontend/src/components/ui/__tests__/BaseModal.test.ts
+++ b/autobot-frontend/src/components/ui/__tests__/BaseModal.test.ts
@@ -1,0 +1,141 @@
+/**
+ * BaseModal focus-trap tests (#5016)
+ *
+ * Covers the real Tab / Shift+Tab wrap behavior that replaces the old
+ * focusin snap-to-first-element pattern which broke keyboard wrap
+ * and bounced focus back on every outside click.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import BaseModal from '../BaseModal.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      ui: { modal: { closeDialog: 'Close dialog' } }
+    }
+  }
+})
+
+const mountModal = (slots?: Record<string, string>) =>
+  mount(BaseModal, {
+    props: { modelValue: true, title: 'Test' },
+    slots: {
+      default: '<button class="body-btn">Body</button>',
+      actions: '<button class="cancel">Cancel</button><button class="confirm">OK</button>',
+      ...(slots ?? {}),
+    },
+    global: {
+      plugins: [i18n],
+      stubs: { Teleport: true, Transition: false, Icon: true },
+    },
+    attachTo: document.body,
+  })
+
+const dispatchTab = (el: Element, shiftKey = false) => {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    bubbles: true,
+    cancelable: true,
+    shiftKey,
+  })
+  el.dispatchEvent(event)
+  return event
+}
+
+const getFocusables = (root: Element) =>
+  Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+    )
+  )
+
+describe('BaseModal focus trap (#5016)', () => {
+  beforeEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it('renders the dialog with a close button and slotted content', async () => {
+    const wrapper = mountModal()
+    await flushPromises()
+    const dialog = wrapper.find('[role="dialog"]')
+    expect(dialog.exists()).toBe(true)
+    expect(dialog.find('.close-btn').exists()).toBe(true)
+    expect(dialog.find('.body-btn').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('Shift+Tab on the first focusable wraps focus to the last', async () => {
+    const wrapper = mountModal()
+    await flushPromises()
+    const dialog = wrapper.find('[role="dialog"]').element as HTMLElement
+    const focusables = getFocusables(dialog)
+    expect(focusables.length).toBeGreaterThanOrEqual(2)
+
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    first.focus()
+    expect(document.activeElement).toBe(first)
+
+    const event = dispatchTab(dialog, true)
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(last)
+    wrapper.unmount()
+  })
+
+  it('Tab on the last focusable wraps focus to the first', async () => {
+    const wrapper = mountModal()
+    await flushPromises()
+    const dialog = wrapper.find('[role="dialog"]').element as HTMLElement
+    const focusables = getFocusables(dialog)
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    last.focus()
+    expect(document.activeElement).toBe(last)
+
+    const event = dispatchTab(dialog, false)
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(first)
+    wrapper.unmount()
+  })
+
+  it('Tab on a middle focusable uses browser default (no preventDefault)', async () => {
+    const wrapper = mountModal()
+    await flushPromises()
+    const dialog = wrapper.find('[role="dialog"]').element as HTMLElement
+    const focusables = getFocusables(dialog)
+    // A middle element must exist: close-btn, body-btn, cancel, confirm
+    expect(focusables.length).toBeGreaterThanOrEqual(3)
+    const middle = focusables[1]
+    middle.focus()
+
+    const forward = dispatchTab(dialog, false)
+    expect(forward.defaultPrevented).toBe(false)
+
+    const backward = dispatchTab(dialog, true)
+    expect(backward.defaultPrevented).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('does NOT bounce focus back when a focusable outside the dialog is clicked', async () => {
+    // Regression test for the focusin snap-back that PR #4980 introduced.
+    const outside = document.createElement('button')
+    outside.textContent = 'Outside'
+    outside.id = 'outside-btn'
+    document.body.appendChild(outside)
+
+    const wrapper = mountModal()
+    await flushPromises()
+
+    outside.focus()
+    // Give the browser a tick, then assert focus stayed on the outside button.
+    await flushPromises()
+    expect(document.activeElement).toBe(outside)
+    wrapper.unmount()
+    outside.remove()
+  })
+})

--- a/autobot-frontend/src/components/ui/__tests__/HostSelectionDialog.test.ts
+++ b/autobot-frontend/src/components/ui/__tests__/HostSelectionDialog.test.ts
@@ -1,0 +1,179 @@
+/**
+ * HostSelectionDialog focus-trap tests (#5016)
+ *
+ * Regression coverage for the Tab / Shift+Tab wrap that replaces the old
+ * focusin snap-to-first-element pattern which broke keyboard wrap and
+ * bounced focus back whenever a user clicked anything outside the dialog.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import HostSelectionDialog from '../HostSelectionDialog.vue'
+
+vi.mock('@/utils/SecretsApiClient', () => ({
+  secretsApiClient: {
+    getSecrets: vi.fn().mockResolvedValue({ secrets: [] }),
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getBackendUrl: () => 'http://localhost:8001',
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }),
+}))
+
+// Stub fetch to return one legacy host so the dialog has multiple focusables.
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      hosts: [
+        { id: 'h1', name: 'Host One', host: '10.0.0.1', ssh_port: 22, username: 'root' },
+        { id: 'h2', name: 'Host Two', host: '10.0.0.2', ssh_port: 22, username: 'root' },
+      ],
+    }),
+  }) as unknown as typeof fetch
+  document.body.replaceChildren()
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      ui: {
+        hostSelection: {
+          title: 'Host',
+          defaultPurpose: 'Choose',
+          close: 'Close',
+          commandToExecute: 'Run',
+          availableHosts: 'Hosts',
+          loadingHosts: 'Loading',
+          noHostsConfigured: 'None',
+          addHost: 'Add',
+          default: 'Default',
+          setAsDefault: 'Make default',
+          rememberChoice: 'Remember',
+          cancel: 'Cancel',
+          connecting: 'Connecting',
+          connectAndExecute: 'Connect',
+          securityNote: 'Secure',
+          pleaseSelectHost: 'Pick one',
+          hostNotFound: 'Missing',
+          failedToLoadHosts: 'Load failed',
+          failedToConnect: 'Connect failed',
+        },
+      },
+    },
+  },
+})
+
+const mountDialog = () =>
+  mount(HostSelectionDialog, {
+    props: { show: true, command: 'echo hi', purpose: 'test' },
+    global: { plugins: [i18n] },
+    attachTo: document.body,
+  })
+
+const dispatchTab = (el: Element, shiftKey = false) => {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Tab',
+    bubbles: true,
+    cancelable: true,
+    shiftKey,
+  })
+  el.dispatchEvent(event)
+  return event
+}
+
+const getFocusables = (root: Element) =>
+  Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+    )
+  )
+
+describe('HostSelectionDialog focus trap (#5016)', () => {
+  it('renders with loaded hosts producing multiple focusable controls', async () => {
+    const wrapper = mountDialog()
+    await flushPromises()
+    await flushPromises()
+    const dialog = wrapper.find('[role="dialog"]').element as HTMLElement
+    const focusables = getFocusables(dialog)
+    expect(focusables.length).toBeGreaterThanOrEqual(3)
+    wrapper.unmount()
+  })
+
+  it('Shift+Tab on the first focusable wraps to the last', async () => {
+    const wrapper = mountDialog()
+    await flushPromises()
+    await flushPromises()
+    const dialog = wrapper.find('[role="dialog"]').element as HTMLElement
+    const focusables = getFocusables(dialog)
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    first.focus()
+    expect(document.activeElement).toBe(first)
+
+    const event = dispatchTab(dialog, true)
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(last)
+    wrapper.unmount()
+  })
+
+  it('Tab on the last focusable wraps to the first', async () => {
+    const wrapper = mountDialog()
+    await flushPromises()
+    await flushPromises()
+    const dialog = wrapper.find('[role="dialog"]').element as HTMLElement
+    const focusables = getFocusables(dialog)
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    last.focus()
+    expect(document.activeElement).toBe(last)
+
+    const event = dispatchTab(dialog, false)
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(first)
+    wrapper.unmount()
+  })
+
+  it('Tab on a middle focusable does not preventDefault', async () => {
+    const wrapper = mountDialog()
+    await flushPromises()
+    await flushPromises()
+    const dialog = wrapper.find('[role="dialog"]').element as HTMLElement
+    const focusables = getFocusables(dialog)
+    expect(focusables.length).toBeGreaterThanOrEqual(3)
+    const middle = focusables[1]
+    middle.focus()
+
+    const forward = dispatchTab(dialog, false)
+    expect(forward.defaultPrevented).toBe(false)
+
+    const backward = dispatchTab(dialog, true)
+    expect(backward.defaultPrevented).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('does NOT bounce focus back when a button outside the dialog is focused', async () => {
+    // Regression: old focusin listener would yank focus back to focusable[0]
+    // any time an outside element gained focus.
+    const outside = document.createElement('button')
+    outside.textContent = 'Outside'
+    document.body.appendChild(outside)
+
+    const wrapper = mountDialog()
+    await flushPromises()
+    await flushPromises()
+
+    outside.focus()
+    await flushPromises()
+    expect(document.activeElement).toBe(outside)
+    wrapper.unmount()
+    outside.remove()
+  })
+})


### PR DESCRIPTION
Closes #5016.

## Problem
PR #4980's focus trap used a naive `focusin` snap-to-first listener that broke:
- Shift+Tab on the first focusable → bounces back to first (wrap to last never happens)
- Click outside dialog on any focusable element → bounces focus back, blocks devtools

## Fix
Replace with a Tab/Shift+Tab keydown handler on the dialog root that wraps focus only when Tab/Shift+Tab would exit the dialog. Outside focus changes (mouse, devtools) are untouched.

Also replaces deprecated `Math.random().toString(36).substr(...)` with Vue 3.5's `useId()` (package.json confirms `^3.5.31`).

## Files
- `autobot-frontend/src/components/ui/BaseModal.vue`
- `autobot-frontend/src/components/ui/HostSelectionDialog.vue`
- `__tests__/BaseModal.test.ts` + `__tests__/HostSelectionDialog.test.ts` — **10 new tests**

## Verification
- ✅ Tests pass
- ✅ `vue-tsc --noEmit -p tsconfig.app.json` zero errors in touched files
- ✅ ESLint 0 errors (pre-existing `any` warnings untouched)
- ✅ Third `focusin` consumer (EntityDetail.vue) already uses correct keydown pattern — left alone