### PR TITLE
fix(codebase-analytics): import get_redis_client instead of get_async_redis_client (#5099)

### DIFF
--- a/autobot-backend/api/codebase_analytics/storage.py
+++ b/autobot-backend/api/codebase_analytics/storage.py
@@ -30,7 +30,7 @@ async def get_redis_connection():
     For async operations, use get_redis_connection_async() instead.
     """
     # Use canonical Redis utility - returns sync client
-    from autobot_shared.redis_client import get_async_redis_client
+    from autobot_shared.redis_client import get_redis_client
 
     redis_client = get_redis_client(database="analytics", async_client=False)
     if redis_client is None:


### PR DESCRIPTION
Closes #5099

## Summary

[`api/codebase_analytics/storage.py:33`](autobot-backend/api/codebase_analytics/storage.py#L33) imported `get_async_redis_client` but line 35 called the undefined `get_redis_client`, raising `NameError` at runtime for 6 live callers.

Fix: single-line import swap — use the sync `get_redis_client` as the docstring already documents.

## Test plan

- [x] `python -m py_compile autobot-backend/api/codebase_analytics/storage.py` — passes
- [ ] Exercise one call site (e.g. endpoints/cache.py) in a running backend to confirm no NameError
- [ ] `gh pr checks` passes

## Diff size

1 file, +1/-1.