### PR TITLE
refactor(redis): consolidate _decode helpers into autobot_shared.redis_utils (#5100)

### DIFF
--- a/autobot-backend/api/analytics_debt.py
+++ b/autobot-backend/api/analytics_debt.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, Field
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_utils import decode_redis_value as _decode_redis_value
 from constants.ttl_constants import TTL_30_DAYS
 
 logger = logging.getLogger(__name__)
@@ -494,13 +495,6 @@ def _store_debt_result(debt_result: Dict[str, Any]) -> None:
         debt_redis.set(f"{DEBT_PREFIX}latest", key)
     except Exception as e:
         logger.warning("Failed to store debt calculation: %s", e)
-
-
-def _decode_redis_value(value: Any) -> Optional[str]:
-    """Decode Redis value to string if bytes (Issue #315 - extracted helper)."""
-    if value is None:
-        return None
-    return value.decode("utf-8") if isinstance(value, bytes) else value
 
 
 def _get_latest_debt_data() -> Optional[Dict[str, Any]]:

--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -27,6 +27,7 @@ from api.analytics_shared import resolve_source_or_404 as _resolve_source_or_404
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_utils import decode_redis_value as _decode_redis_value
 from autobot_shared.security.path_validator import validate_path
 
 logger = logging.getLogger(__name__)
@@ -63,11 +64,6 @@ def _build_evolution_prefixes(source_id: Optional[str]) -> tuple[str, str, str]:
     else:
         ev = EVOLUTION_PREFIX
     return ev, f"{ev}snapshot:", f"{ev}patterns:"
-
-
-def _decode_redis_value(value) -> str:
-    """Decode Redis bytes value to string (Issue #315)."""
-    return value.decode("utf-8") if isinstance(value, bytes) else value
 
 
 def _get_snapshot_data(redis_client, keys: list) -> dict | None:

--- a/autobot-backend/api/redis_mcp/data_access.py
+++ b/autobot-backend/api/redis_mcp/data_access.py
@@ -12,6 +12,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_utils import decode_redis_value as _decode
 from constants.ttl_constants import TTL_24_HOURS
 from type_defs.common import Metadata
 
@@ -39,11 +40,6 @@ def _resolve_ttl(ttl: Optional[int], key: str) -> Optional[int]:
     if key.startswith(AGENT_MEMORY_PREFIX):
         return AGENT_MEMORY_TTL_SECONDS
     return None
-
-
-def _decode(value):
-    """Decode bytes to UTF-8 string, pass through other types."""
-    return value.decode("utf-8") if isinstance(value, bytes) else value
 
 
 async def _get_client(database: str = "main"):

--- a/autobot-backend/api/redis_mcp/ops_intelligence.py
+++ b/autobot-backend/api/redis_mcp/ops_intelligence.py
@@ -12,6 +12,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_utils import decode_redis_value as _decode
 from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
@@ -149,13 +150,6 @@ async def handle_redis_slowlog(count: int = 10, database: str = "main") -> Metad
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _decode(value: Any) -> Any:
-    """Decode bytes to str if needed."""
-    if isinstance(value, bytes):
-        return value.decode("utf-8")
-    return value
 
 
 def _stringify_info(info: dict) -> dict:

--- a/autobot_shared/redis_utils.py
+++ b/autobot_shared/redis_utils.py
@@ -1,0 +1,12 @@
+"""Shared Redis utility helpers."""
+from typing import Any, Optional
+
+
+def decode_redis_value(value: Any) -> Optional[str]:
+    """Decode a Redis value from bytes to str, passing through other types.
+
+    Returns None if input is None (null-safe).
+    """
+    if value is None:
+        return None
+    return value.decode("utf-8") if isinstance(value, bytes) else value


### PR DESCRIPTION
Closes #5100

## Summary

Four local `_decode` / `_decode_redis_value` helpers across the backend all converted `bytes \u2192 str` with minor syntactic variations. Consolidated into a single **null-safe** helper `decode_redis_value()` in new module `autobot_shared/redis_utils.py`.

Each call site keeps its original local name via an alias import to minimize churn (Option B from the issue):

```python
from autobot_shared.redis_utils import decode_redis_value as _decode
```

## Files touched

- NEW: `autobot_shared/redis_utils.py` (+12)
- `autobot-backend/api/redis_mcp/ops_intelligence.py` (delete local `_decode`, add alias)
- `autobot-backend/api/redis_mcp/data_access.py` (same)
- `autobot-backend/api/analytics_debt.py` (same)
- `autobot-backend/api/analytics_evolution.py` (same)

Total: 5 files, +16/-24.

## Test plan

- [x] `python -m py_compile` passes on all 5 files
- [x] `decode_redis_value(b'hi') == 'hi'`, `decode_redis_value(None) is None`, `decode_redis_value('x') == 'x'`
- [x] No remaining local `_decode*` defs in affected directories
- [ ] `gh pr checks` passes