### PR TITLE
refactor(shared): consolidate UTC-timestamp helpers into autobot_shared.time_utils (#5106)

### DIFF
--- a/autobot-backend/utils/command_utils.py
+++ b/autobot-backend/utils/command_utils.py
@@ -28,8 +28,9 @@ import asyncio
 import logging
 from asyncio import Queue as AsyncQueue
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Callable, Dict, List, Optional
+
+from autobot_shared.time_utils import utc_timestamp as get_timestamp
 
 # Issue #765: Use centralized strip_ansi_codes from encoding_utils
 from utils.encoding_utils import strip_ansi_codes
@@ -74,11 +75,6 @@ class StreamChunk:
     content: str
     chunk_type: str  # "stdout", "stderr"
     is_final: bool = False
-
-
-def get_timestamp() -> str:
-    """Get current timestamp in ISO format."""
-    return datetime.now(tz=timezone.utc).isoformat()
 
 
 async def execute_shell_command(command: str) -> Dict[str, Any]:

--- a/autobot-backend/utils/response_builder.py
+++ b/autobot-backend/utils/response_builder.py
@@ -37,19 +37,14 @@ Usage:
             return error_response("Internal server error", status_code=500)
 """
 
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
 from fastapi.responses import JSONResponse
 
+from autobot_shared.time_utils import utc_timestamp as get_timestamp
 from type_defs.common import Metadata
 
 T = TypeVar("T")
-
-
-def get_timestamp() -> str:
-    """Get current UTC timestamp in ISO format."""
-    return datetime.now(timezone.utc).isoformat()
 
 
 def success_response(

--- a/autobot_shared/time_utils.py
+++ b/autobot_shared/time_utils.py
@@ -1,0 +1,7 @@
+"""Shared time utility helpers."""
+from datetime import datetime, timezone
+
+
+def utc_timestamp() -> str:
+    """Return the current time as an ISO-8601 UTC timestamp string."""
+    return datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
Closes #5106

## Summary

Three local UTC-timestamp helpers existed across the backend. Added `utc_timestamp()` to new module `autobot_shared/time_utils.py` and migrated **two of three** local helpers via alias imports.

The third (`services/workflow_versioning.py::_utc_now`) is **intentionally not migrated** because its manual `time.gmtime()` formatting emits a trailing `Z` (e.g. `2026-04-17T18:00:00Z`) while `datetime.now(timezone.utc).isoformat()` returns `+00:00` suffix. Migrating would silently change stored workflow-version strings \u2014 treated as a user-visible format change requiring its own issue/decision.

## Files touched

- NEW: `autobot_shared/time_utils.py` (+7)
- `autobot-backend/utils/response_builder.py` \u2014 migrated (alias import, unused datetime/timezone imports removed)
- `autobot-backend/utils/command_utils.py` \u2014 migrated (same)
- `autobot-backend/services/workflow_versioning.py` \u2014 **NOT migrated** (see above)

Total: 3 files, +10/-12.

## Test plan

- [x] `python -m py_compile` passes on all modified files
- [x] Runtime check: `utc_timestamp()` returns an ISO-8601 string with `+00:00` suffix
- [ ] `gh pr checks` passes

## Follow-up

If a future issue decides to standardize on one format repo-wide (with or without `Z` suffix), `workflow_versioning._utc_now` can be migrated then.