### PR TITLE
feat(rag): introduce BaseCollection + BaseClient ABCs for pluggable vector backends (#5062)

### DIFF
--- a/autobot-backend/knowledge/backends/__init__.py
+++ b/autobot-backend/knowledge/backends/__init__.py
@@ -1,0 +1,58 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Pluggable vector-store backends (Issue #5062).
+
+Public API:
+    * ``BaseCollection`` / ``BaseClient`` — ABCs every backend implements.
+    * ``ChromaDBCollection`` / ``ChromaDBClient`` — production adapter wrapping
+      the existing ChromaDB client from ``utils/chromadb_client.py``.
+    * ``InMemoryCollection`` / ``InMemoryClient`` — dependency-free adapter
+      used in unit tests.
+    * ``get_default_client`` — returns a ``BaseClient`` pointing at the current
+      environment's default backend (ChromaDB today).
+"""
+
+from __future__ import annotations
+
+from knowledge.backends.base import (
+    BaseClient,
+    BaseCollection,
+    Embedding,
+    Metadata,
+    Where,
+    WhereDocument,
+)
+from knowledge.backends.chromadb_adapter import ChromaDBClient, ChromaDBCollection
+from knowledge.backends.memory_adapter import InMemoryClient, InMemoryCollection
+
+
+def get_default_client(**kwargs) -> BaseClient:
+    """Return a ``BaseClient`` for the current default backend.
+
+    Today this always wraps ChromaDB via the existing ``utils.chromadb_client``
+    construction path, so all HNSW / sqlite migrations (#1390, #2735) still
+    run. Forwarded kwargs match ``utils.chromadb_client.get_chromadb_client``.
+    """
+    # Lazy import: utils/chromadb_client does heavy sqlite migration work
+    # on first call, and importing it eagerly from this package-init would
+    # slow down every `from knowledge.backends import ...` in tests.
+    from utils.chromadb_client import get_chromadb_client
+
+    return ChromaDBClient(get_chromadb_client(**kwargs))
+
+
+__all__ = [
+    "BaseCollection",
+    "BaseClient",
+    "ChromaDBClient",
+    "ChromaDBCollection",
+    "Embedding",
+    "InMemoryClient",
+    "InMemoryCollection",
+    "Metadata",
+    "Where",
+    "WhereDocument",
+    "get_default_client",
+]

--- a/autobot-backend/knowledge/backends/base.py
+++ b/autobot-backend/knowledge/backends/base.py
@@ -1,0 +1,198 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Abstract base classes for pluggable vector-store backends.
+
+Issue #5062: AutoBot's vector-store layer is currently coupled to ChromaDB via
+``utils/chromadb_client.py`` and direct ``chromadb`` imports in 10+ call sites.
+This module defines backend-agnostic ABCs so Qdrant / LanceDB / pgvector / an
+in-memory fake can all be swapped in behind a single interface.
+
+Scope of this module (per PR #5062):
+    * Define ``BaseCollection`` and ``BaseClient`` with ChromaDB-compatible
+      method signatures (kwargs-only, same return shapes) so existing callers
+      can migrate without rewriting their call sites.
+    * Production call-site migration is a follow-up.
+
+Return-shape contract (matches ChromaDB 1.x):
+    ``get(...)``  -> flat-list dict::
+        {"ids": [...], "documents": [...], "metadatas": [...],
+         "embeddings": [...] | None, ...}
+    ``query(...)`` -> nested-list dict (one inner list per query)::
+        {"ids": [[...]], "documents": [[...]], "metadatas": [[...]],
+         "distances": [[...]], "embeddings": [[...]] | None, ...}
+
+Any new adapter must honour this shape so existing callers keep working.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+# Type aliases kept loose on purpose: callers already use plain lists/dicts
+# against ChromaDB, so tightening these would break the migration seam.
+Embedding = Sequence[float]
+Metadata = Dict[str, Any]
+Where = Dict[str, Any]
+WhereDocument = Dict[str, Any]
+
+
+class BaseCollection(ABC):
+    """Backend-agnostic vector collection interface.
+
+    Method signatures mirror ``chromadb.Collection`` so call sites can switch
+    backends without touching keyword arguments. Implementations MUST preserve
+    these semantics:
+
+    * ``add`` inserts new items; on duplicate id the backend MAY warn but
+      MUST NOT raise (ChromaDB 1.x keeps the original; callers MUST use
+      ``upsert`` when they want replace semantics).
+    * ``upsert`` inserts or replaces by id with no warning.
+    * ``update`` modifies existing ids only; missing ids are a no-op or error
+      depending on backend — callers MUST NOT rely on one behaviour.
+    * ``get`` returns a flat-list dict (see module docstring).
+    * ``query`` returns a nested-list dict — one inner list per query vector.
+    * ``delete`` by ids OR by ``where`` filter; at least one must be provided.
+    * ``count`` returns the total number of stored items.
+    """
+
+    name: str
+
+    @abstractmethod
+    def add(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        """Insert new items. Duplicate ids are a no-op (original retained);
+        use ``upsert`` for replace semantics."""
+
+    @abstractmethod
+    def upsert(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        """Insert-or-replace items by id. No error on duplicate."""
+
+    @abstractmethod
+    def update(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        """Modify existing items by id. Missing ids are silently skipped."""
+
+    @abstractmethod
+    def get(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        """Fetch items by id / filter. Returns flat-list dict."""
+
+    @abstractmethod
+    def query(
+        self,
+        *,
+        query_embeddings: Optional[Sequence[Embedding]] = None,
+        query_texts: Optional[Sequence[str]] = None,
+        n_results: int = 10,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        """Vector search. Returns nested-list dict, one inner list per query.
+
+        At least one of ``query_embeddings`` / ``query_texts`` must be given.
+        Backends that do not support text-only queries MUST raise
+        ``NotImplementedError`` rather than silently returning empty.
+        """
+
+    @abstractmethod
+    def delete(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+    ) -> None:
+        """Delete items by id or filter. At least one filter required."""
+
+    @abstractmethod
+    def count(self) -> int:
+        """Return total number of stored items."""
+
+    @abstractmethod
+    def peek(self, limit: int = 10) -> Dict[str, Any]:
+        """Return up to ``limit`` items (any order). Flat-list dict."""
+
+
+class BaseClient(ABC):
+    """Backend-agnostic client / factory for collections.
+
+    Implementations back a persistent or in-memory store and MUST enforce
+    unique collection names per client instance.
+    """
+
+    @abstractmethod
+    def get_or_create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> BaseCollection:
+        """Return existing collection or create a new one."""
+
+    @abstractmethod
+    def get_collection(self, name: str) -> BaseCollection:
+        """Return existing collection. Raise ``ValueError`` if missing."""
+
+    @abstractmethod
+    def create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> BaseCollection:
+        """Create collection. Raise ``ValueError`` if name already exists."""
+
+    @abstractmethod
+    def list_collections(self) -> List[Union[str, BaseCollection]]:
+        """Return known collections. Adapters may return names or objects."""
+
+    @abstractmethod
+    def delete_collection(self, name: str) -> None:
+        """Delete a collection by name. Missing name MUST raise ``ValueError``."""
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Drop ALL collections. Destructive — guarded by backend config."""
+
+
+__all__ = [
+    "BaseCollection",
+    "BaseClient",
+    "Embedding",
+    "Metadata",
+    "Where",
+    "WhereDocument",
+]

--- a/autobot-backend/knowledge/backends/chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/chromadb_adapter.py
@@ -1,0 +1,232 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+ChromaDB adapter implementing the ``BaseCollection`` / ``BaseClient`` ABCs
+(Issue #5062).
+
+This module wraps ``chromadb.Client`` / ``chromadb.Collection`` instances —
+it does NOT reimplement any ChromaDB behaviour. The goal is a thin, explicit
+seam so callers can target the ABC while we keep the existing production
+client code (``utils/chromadb_client.py``) untouched.
+
+Usage::
+
+    from utils.chromadb_client import get_chromadb_client
+    from knowledge.backends.chromadb_adapter import ChromaDBClient
+
+    raw = get_chromadb_client()
+    backend = ChromaDBClient(raw)
+    col = backend.get_or_create_collection("knowledge_vectors")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Sequence
+
+from knowledge.backends.base import (
+    BaseClient,
+    BaseCollection,
+    Embedding,
+    Metadata,
+    Where,
+    WhereDocument,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ChromaDBCollection(BaseCollection):
+    """Thin wrapper around a ``chromadb.Collection`` instance.
+
+    Every method forwards its arguments verbatim to the underlying ChromaDB
+    collection — ChromaDB already supplies the flat-list / nested-list return
+    shapes documented in the ABC contract.
+    """
+
+    def __init__(self, raw: Any) -> None:
+        self._raw = raw
+        self.name = getattr(raw, "name", "")
+
+    def add(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        self._raw.add(
+            ids=list(ids),
+            documents=list(documents) if documents is not None else None,
+            metadatas=list(metadatas) if metadatas is not None else None,
+            embeddings=list(embeddings) if embeddings is not None else None,
+        )
+
+    def upsert(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        self._raw.upsert(
+            ids=list(ids),
+            documents=list(documents) if documents is not None else None,
+            metadatas=list(metadatas) if metadatas is not None else None,
+            embeddings=list(embeddings) if embeddings is not None else None,
+        )
+
+    def update(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        self._raw.update(
+            ids=list(ids),
+            documents=list(documents) if documents is not None else None,
+            metadatas=list(metadatas) if metadatas is not None else None,
+            embeddings=list(embeddings) if embeddings is not None else None,
+        )
+
+    def get(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> dict:
+        kwargs: dict = {}
+        if ids is not None:
+            kwargs["ids"] = list(ids)
+        if where is not None:
+            kwargs["where"] = where
+        if where_document is not None:
+            kwargs["where_document"] = where_document
+        if limit is not None:
+            kwargs["limit"] = limit
+        if offset is not None:
+            kwargs["offset"] = offset
+        if include is not None:
+            kwargs["include"] = list(include)
+        return self._raw.get(**kwargs)
+
+    def query(
+        self,
+        *,
+        query_embeddings: Optional[Sequence[Embedding]] = None,
+        query_texts: Optional[Sequence[str]] = None,
+        n_results: int = 10,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> dict:
+        kwargs: dict = {"n_results": n_results}
+        if query_embeddings is not None:
+            kwargs["query_embeddings"] = [list(e) for e in query_embeddings]
+        if query_texts is not None:
+            kwargs["query_texts"] = list(query_texts)
+        if where is not None:
+            kwargs["where"] = where
+        if where_document is not None:
+            kwargs["where_document"] = where_document
+        if include is not None:
+            kwargs["include"] = list(include)
+        return self._raw.query(**kwargs)
+
+    def delete(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+    ) -> None:
+        kwargs: dict = {}
+        if ids is not None:
+            kwargs["ids"] = list(ids)
+        if where is not None:
+            kwargs["where"] = where
+        if where_document is not None:
+            kwargs["where_document"] = where_document
+        if not kwargs:
+            raise ValueError("delete requires ids or where")
+        self._raw.delete(**kwargs)
+
+    def count(self) -> int:
+        return int(self._raw.count())
+
+    def peek(self, limit: int = 10) -> dict:
+        return self._raw.peek(limit=limit)
+
+
+class ChromaDBClient(BaseClient):
+    """Thin wrapper around a ``chromadb.Client`` / ``PersistentClient`` /
+    ``HttpClient`` instance.
+
+    The raw ChromaDB client is injected; this class does NOT construct one.
+    Keeping construction in ``utils/chromadb_client.py`` means the HNSW /
+    sqlite migration fixes (#1390, #2735) stay in a single place.
+    """
+
+    def __init__(self, raw: Any) -> None:
+        self._raw = raw
+
+    def get_or_create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> BaseCollection:
+        kwargs: dict = {"name": name}
+        if metadata is not None:
+            kwargs["metadata"] = metadata
+        if embedding_function is not None:
+            kwargs["embedding_function"] = embedding_function
+        return ChromaDBCollection(self._raw.get_or_create_collection(**kwargs))
+
+    def get_collection(self, name: str) -> BaseCollection:
+        try:
+            return ChromaDBCollection(self._raw.get_collection(name=name))
+        except Exception as exc:  # ChromaDB raises its own exception type
+            raise ValueError(f"no such collection: {name}") from exc
+
+    def create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> BaseCollection:
+        kwargs: dict = {"name": name}
+        if metadata is not None:
+            kwargs["metadata"] = metadata
+        if embedding_function is not None:
+            kwargs["embedding_function"] = embedding_function
+        try:
+            return ChromaDBCollection(self._raw.create_collection(**kwargs))
+        except Exception as exc:
+            raise ValueError(f"collection already exists: {name}") from exc
+
+    def list_collections(self) -> List[Any]:
+        return list(self._raw.list_collections())
+
+    def delete_collection(self, name: str) -> None:
+        try:
+            self._raw.delete_collection(name=name)
+        except Exception as exc:
+            raise ValueError(f"no such collection: {name}") from exc
+
+    def reset(self) -> None:
+        self._raw.reset()
+
+
+__all__ = ["ChromaDBCollection", "ChromaDBClient"]

--- a/autobot-backend/knowledge/backends/memory_adapter.py
+++ b/autobot-backend/knowledge/backends/memory_adapter.py
@@ -1,0 +1,329 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+In-memory vector-store backend for unit tests (Issue #5062).
+
+Provides a deterministic, dependency-free implementation of ``BaseCollection``
+and ``BaseClient`` for tests that would otherwise spin up a real ChromaDB
+instance. Not intended for production use.
+
+Semantics match the contract documented in ``knowledge.backends.base``:
+    * ``add`` is a no-op on duplicate ids (ChromaDB 1.x behaviour).
+    * ``upsert`` is idempotent.
+    * ``query`` uses brute-force cosine distance when embeddings are supplied.
+    * ``get`` returns flat-list dicts; ``query`` returns nested-list dicts.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Optional, Sequence
+
+from knowledge.backends.base import (
+    BaseClient,
+    BaseCollection,
+    Embedding,
+    Metadata,
+    Where,
+    WhereDocument,
+)
+
+
+def _cosine_distance(a: Sequence[float], b: Sequence[float]) -> float:
+    """Return 1 - cosine_similarity. Matches ChromaDB's default 'l2'-ish
+    ordering intent: lower is more similar. Zero-vectors get distance 1.0.
+    """
+    num = sum(x * y for x, y in zip(a, b))
+    da = math.sqrt(sum(x * x for x in a))
+    db = math.sqrt(sum(y * y for y in b))
+    if da == 0 or db == 0:
+        return 1.0
+    return 1.0 - (num / (da * db))
+
+
+def _match_where(meta: Optional[Metadata], where: Optional[Where]) -> bool:
+    """Minimal ``where`` filter: equality on top-level keys only.
+
+    Full ChromaDB where syntax (``$and``, ``$or``, ``$in`` ...) is out of
+    scope for the in-memory fake — tests that need it should use ChromaDB
+    directly or extend this helper.
+    """
+    if not where:
+        return True
+    if meta is None:
+        return False
+    for key, expected in where.items():
+        if meta.get(key) != expected:
+            return False
+    return True
+
+
+class InMemoryCollection(BaseCollection):
+    """Deterministic in-memory implementation of ``BaseCollection``."""
+
+    def __init__(self, name: str, metadata: Optional[Metadata] = None) -> None:
+        self.name = name
+        self.metadata = metadata or {}
+        # Parallel dicts keyed by id — keeps add/upsert/update O(1).
+        self._documents: Dict[str, Optional[str]] = {}
+        self._metadatas: Dict[str, Optional[Metadata]] = {}
+        self._embeddings: Dict[str, Optional[List[float]]] = {}
+
+    # ------------------------------------------------------------------ helpers
+
+    def _store(
+        self,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]],
+        metadatas: Optional[Sequence[Metadata]],
+        embeddings: Optional[Sequence[Embedding]],
+        *,
+        allow_overwrite: bool,
+    ) -> None:
+        if documents is not None and len(documents) != len(ids):
+            raise ValueError("documents length mismatch with ids")
+        if metadatas is not None and len(metadatas) != len(ids):
+            raise ValueError("metadatas length mismatch with ids")
+        if embeddings is not None and len(embeddings) != len(ids):
+            raise ValueError("embeddings length mismatch with ids")
+
+        for i, _id in enumerate(ids):
+            exists = _id in self._documents
+            # Match ChromaDB 1.x: add() on a duplicate id retains the
+            # original record. Only upsert / update may overwrite.
+            if exists and not allow_overwrite:
+                continue
+            if documents is not None:
+                self._documents[_id] = documents[i]
+            elif not exists:
+                self._documents[_id] = None
+            if metadatas is not None:
+                self._metadatas[_id] = dict(metadatas[i]) if metadatas[i] else None
+            elif not exists:
+                self._metadatas[_id] = None
+            if embeddings is not None:
+                self._embeddings[_id] = list(embeddings[i])
+            elif not exists:
+                self._embeddings[_id] = None
+
+    # -------------------------------------------------------------- write ops
+
+    def add(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        self._store(ids, documents, metadatas, embeddings, allow_overwrite=False)
+
+    def upsert(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        self._store(ids, documents, metadatas, embeddings, allow_overwrite=True)
+
+    def update(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        existing_ids = [_id for _id in ids if _id in self._documents]
+        if not existing_ids:
+            return
+        idx = [list(ids).index(_id) for _id in existing_ids]
+
+        def _pick(seq: Optional[Sequence[Any]]) -> Optional[List[Any]]:
+            return [seq[i] for i in idx] if seq is not None else None
+
+        self._store(
+            existing_ids,
+            _pick(documents),
+            _pick(metadatas),
+            _pick(embeddings),
+            allow_overwrite=True,
+        )
+
+    # ------------------------------------------------------------- read ops
+
+    def get(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        include = list(include) if include is not None else ["documents", "metadatas"]
+        candidate_ids: List[str] = list(ids) if ids is not None else list(self._documents.keys())
+        filtered = [
+            _id
+            for _id in candidate_ids
+            if _id in self._documents and _match_where(self._metadatas.get(_id), where)
+        ]
+        if offset:
+            filtered = filtered[offset:]
+        if limit is not None:
+            filtered = filtered[:limit]
+
+        result: Dict[str, Any] = {"ids": filtered}
+        if "documents" in include:
+            result["documents"] = [self._documents.get(_id) for _id in filtered]
+        if "metadatas" in include:
+            result["metadatas"] = [self._metadatas.get(_id) for _id in filtered]
+        if "embeddings" in include:
+            result["embeddings"] = [self._embeddings.get(_id) for _id in filtered]
+        return result
+
+    def query(
+        self,
+        *,
+        query_embeddings: Optional[Sequence[Embedding]] = None,
+        query_texts: Optional[Sequence[str]] = None,
+        n_results: int = 10,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        if query_embeddings is None and query_texts is None:
+            raise ValueError("either query_embeddings or query_texts is required")
+        if query_embeddings is None:
+            # The fake has no embedding function. Surface the limitation
+            # loudly so tests that need text queries don't get silent passes.
+            raise NotImplementedError(
+                "InMemoryCollection requires query_embeddings; text-only "
+                "queries need a real embedding backend"
+            )
+        include = list(include) if include is not None else ["documents", "metadatas", "distances"]
+
+        candidate_ids = [
+            _id
+            for _id in self._documents.keys()
+            if _match_where(self._metadatas.get(_id), where)
+        ]
+
+        out_ids: List[List[str]] = []
+        out_docs: List[List[Optional[str]]] = []
+        out_metas: List[List[Optional[Metadata]]] = []
+        out_dist: List[List[float]] = []
+        out_embs: List[List[Optional[List[float]]]] = []
+
+        for q_vec in query_embeddings:
+            scored = []
+            for _id in candidate_ids:
+                emb = self._embeddings.get(_id)
+                dist = _cosine_distance(q_vec, emb) if emb is not None else 1.0
+                scored.append((dist, _id))
+            scored.sort(key=lambda pair: pair[0])
+            top = scored[:n_results]
+            out_ids.append([_id for _, _id in top])
+            out_docs.append([self._documents.get(_id) for _, _id in top])
+            out_metas.append([self._metadatas.get(_id) for _, _id in top])
+            out_dist.append([dist for dist, _ in top])
+            out_embs.append([self._embeddings.get(_id) for _, _id in top])
+
+        result: Dict[str, Any] = {"ids": out_ids}
+        if "documents" in include:
+            result["documents"] = out_docs
+        if "metadatas" in include:
+            result["metadatas"] = out_metas
+        if "distances" in include:
+            result["distances"] = out_dist
+        if "embeddings" in include:
+            result["embeddings"] = out_embs
+        return result
+
+    def delete(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+    ) -> None:
+        if ids is None and where is None:
+            raise ValueError("delete requires ids or where")
+        target = list(ids) if ids is not None else list(self._documents.keys())
+        for _id in target:
+            if _id not in self._documents:
+                continue
+            if where and not _match_where(self._metadatas.get(_id), where):
+                continue
+            self._documents.pop(_id, None)
+            self._metadatas.pop(_id, None)
+            self._embeddings.pop(_id, None)
+
+    def count(self) -> int:
+        return len(self._documents)
+
+    def peek(self, limit: int = 10) -> Dict[str, Any]:
+        ids = list(self._documents.keys())[:limit]
+        return {
+            "ids": ids,
+            "documents": [self._documents[_id] for _id in ids],
+            "metadatas": [self._metadatas[_id] for _id in ids],
+            "embeddings": [self._embeddings[_id] for _id in ids],
+        }
+
+
+class InMemoryClient(BaseClient):
+    """Deterministic in-memory implementation of ``BaseClient``."""
+
+    def __init__(self) -> None:
+        self._collections: Dict[str, InMemoryCollection] = {}
+
+    def get_or_create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> BaseCollection:
+        col = self._collections.get(name)
+        if col is None:
+            col = InMemoryCollection(name=name, metadata=metadata)
+            self._collections[name] = col
+        return col
+
+    def get_collection(self, name: str) -> BaseCollection:
+        col = self._collections.get(name)
+        if col is None:
+            raise ValueError(f"no such collection: {name}")
+        return col
+
+    def create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> BaseCollection:
+        if name in self._collections:
+            raise ValueError(f"collection already exists: {name}")
+        col = InMemoryCollection(name=name, metadata=metadata)
+        self._collections[name] = col
+        return col
+
+    def list_collections(self) -> List[Any]:
+        return list(self._collections.values())
+
+    def delete_collection(self, name: str) -> None:
+        if name not in self._collections:
+            raise ValueError(f"no such collection: {name}")
+        del self._collections[name]
+
+    def reset(self) -> None:
+        self._collections.clear()
+
+
+__all__ = ["InMemoryCollection", "InMemoryClient"]

--- a/autobot-backend/knowledge/backends/test_base.py
+++ b/autobot-backend/knowledge/backends/test_base.py
@@ -1,0 +1,183 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Contract tests for ``BaseCollection`` / ``BaseClient`` (Issue #5062).
+
+Every test is parametrized over all adapters so a new backend (Qdrant,
+LanceDB, pgvector ...) only needs a fixture added to ``_BACKENDS`` below.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+
+from knowledge.backends import (
+    BaseClient,
+    BaseCollection,
+    ChromaDBClient,
+    InMemoryClient,
+)
+
+
+# --- fixture factories ------------------------------------------------------
+#
+# ChromaDB 1.x ``EphemeralClient()`` shares an in-memory database across
+# instances in the same process, so naively creating one per test leaks
+# state between parametrized cases. We use a per-test ``PersistentClient``
+# pointed at a fresh temp directory to get full isolation — still fast
+# (~20ms per instantiation), still avoids any network/HTTP dependency.
+
+def _memory_client(tmp_path) -> BaseClient:  # tmp_path unused, kept for uniform signature
+    return InMemoryClient()
+
+
+def _chromadb_client(tmp_path) -> BaseClient:
+    chromadb = pytest.importorskip("chromadb")
+    return ChromaDBClient(chromadb.PersistentClient(path=str(tmp_path)))
+
+
+# Adding a new adapter? Append ``(name, factory)`` here.
+_BACKENDS: list[tuple[str, Callable[..., BaseClient]]] = [
+    ("memory", _memory_client),
+    ("chromadb", _chromadb_client),
+]
+
+
+@pytest.fixture(params=_BACKENDS, ids=[name for name, _ in _BACKENDS])
+def client(request, tmp_path) -> BaseClient:
+    _name, factory = request.param
+    return factory(tmp_path)
+
+
+@pytest.fixture
+def collection(client: BaseClient) -> BaseCollection:
+    return client.get_or_create_collection("contract-test")
+
+
+# --- collection contract ----------------------------------------------------
+
+def test_add_then_count(collection: BaseCollection) -> None:
+    collection.add(
+        ids=["a", "b", "c"],
+        documents=["doc-a", "doc-b", "doc-c"],
+        metadatas=[{"n": 1}, {"n": 2}, {"n": 3}],
+        embeddings=[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
+    )
+    assert collection.count() == 3
+
+
+def test_add_duplicate_retains_original(collection: BaseCollection) -> None:
+    """ChromaDB 1.x contract: add() on a duplicate id is a no-op.
+    Callers that want replace semantics must use upsert()."""
+    collection.add(
+        ids=["dup"], documents=["first"], embeddings=[[1.0, 0.0]]
+    )
+    collection.add(
+        ids=["dup"], documents=["second"], embeddings=[[0.0, 1.0]]
+    )
+    assert collection.count() == 1
+    assert collection.get(ids=["dup"])["documents"] == ["first"]
+
+
+def test_get_by_ids_returns_flat_lists(collection: BaseCollection) -> None:
+    collection.add(
+        ids=["a", "b"],
+        documents=["doc-a", "doc-b"],
+        metadatas=[{"n": 1}, {"n": 2}],
+        embeddings=[[1.0, 0.0], [0.0, 1.0]],
+    )
+    got = collection.get(ids=["a"])
+    assert got["ids"] == ["a"]
+    assert got["documents"] == ["doc-a"]
+    # flat list, not nested
+    assert not isinstance(got["ids"][0], list)
+
+
+def test_query_returns_nested_lists_ordered_by_distance(
+    collection: BaseCollection,
+) -> None:
+    collection.add(
+        ids=["near", "far"],
+        documents=["near-doc", "far-doc"],
+        embeddings=[[1.0, 0.0], [0.0, 1.0]],
+    )
+    got = collection.query(
+        query_embeddings=[[1.0, 0.0]],
+        n_results=2,
+    )
+    # nested: one inner list per query vector
+    assert isinstance(got["ids"], list)
+    assert isinstance(got["ids"][0], list)
+    assert got["ids"][0][0] == "near"
+
+
+def test_delete_by_ids_reduces_count(collection: BaseCollection) -> None:
+    collection.add(
+        ids=["a", "b"], documents=["x", "y"], embeddings=[[1.0, 0.0], [0.0, 1.0]]
+    )
+    collection.delete(ids=["a"])
+    assert collection.count() == 1
+    assert collection.get(ids=["a"])["ids"] == []
+
+
+def test_upsert_replaces_existing(collection: BaseCollection) -> None:
+    collection.add(
+        ids=["a"], documents=["first"], embeddings=[[1.0, 0.0]]
+    )
+    collection.upsert(
+        ids=["a"], documents=["second"], embeddings=[[0.0, 1.0]]
+    )
+    assert collection.count() == 1
+    got = collection.get(ids=["a"])
+    assert got["documents"] == ["second"]
+
+
+def test_empty_query_returns_empty_inner_lists(
+    collection: BaseCollection,
+) -> None:
+    got = collection.query(query_embeddings=[[1.0, 0.0]], n_results=5)
+    assert got["ids"] == [[]]
+
+
+def test_peek_returns_flat_lists(collection: BaseCollection) -> None:
+    collection.add(
+        ids=["a", "b"], documents=["x", "y"], embeddings=[[1.0, 0.0], [0.0, 1.0]]
+    )
+    peek = collection.peek(limit=1)
+    assert len(peek["ids"]) == 1
+    assert not isinstance(peek["ids"][0], list)
+
+
+# --- client contract --------------------------------------------------------
+
+def test_get_or_create_is_idempotent(client: BaseClient) -> None:
+    a = client.get_or_create_collection("dup-collection")
+    b = client.get_or_create_collection("dup-collection")
+    a.add(ids=["x"], documents=["hello"], embeddings=[[1.0, 0.0]])
+    assert b.count() == 1
+
+
+def test_get_collection_missing_raises(client: BaseClient) -> None:
+    with pytest.raises(ValueError):
+        client.get_collection("does-not-exist")
+
+
+def test_create_collection_twice_raises(client: BaseClient) -> None:
+    client.create_collection("only-once")
+    with pytest.raises(ValueError):
+        client.create_collection("only-once")
+
+
+def test_delete_collection_missing_raises(client: BaseClient) -> None:
+    with pytest.raises(ValueError):
+        client.delete_collection("never-existed")
+
+
+def test_list_collections_reflects_state(client: BaseClient) -> None:
+    client.create_collection("alpha")
+    client.create_collection("beta")
+    cols = client.list_collections()
+    assert len(cols) >= 2

--- a/autobot-backend/utils/chromadb_client.py
+++ b/autobot-backend/utils/chromadb_client.py
@@ -52,6 +52,7 @@ __all__ = [
     "get_chromadb_client",
     "get_async_chromadb_client",
     "get_all_paginated",
+    "get_backend_client",
     "AsyncChromaClient",
     "AsyncChromaCollection",
     "wrap_collection_async",
@@ -414,3 +415,27 @@ def get_all_paginated(
             break
         offset += page_size
     return merged
+
+
+def get_backend_client(
+    db_path: str = "",
+    allow_reset: bool = False,
+    anonymized_telemetry: bool = False,
+) -> Any:
+    """Return a backend-agnostic ``BaseClient`` wrapping the ChromaDB client.
+
+    Issue #5062: opt-in seam for callers that want to target the
+    ``knowledge.backends.BaseClient`` ABC instead of ChromaDB directly.
+    Existing callers keep using ``get_chromadb_client`` unchanged.
+
+    Args match ``get_chromadb_client``; see that function for semantics.
+    """
+    # Lazy import to keep the backends package optional at import time.
+    from knowledge.backends.chromadb_adapter import ChromaDBClient
+
+    raw = get_chromadb_client(
+        db_path=db_path,
+        allow_reset=allow_reset,
+        anonymized_telemetry=anonymized_telemetry,
+    )
+    return ChromaDBClient(raw)


### PR DESCRIPTION
Closes #5062

## Scope
Define the seam only — **no production callers migrated** in this PR (follow-up work).

## What's added
- \`knowledge/backends/base.py\` — \`BaseCollection\` (add/upsert/update/query/get/delete/count/peek) + \`BaseClient\` (get_or_create_collection, list, delete, reset)
- \`knowledge/backends/chromadb_adapter.py\` — thin wrapper over existing \`chromadb.Client\`; same wire semantics as callers expect
- \`knowledge/backends/memory_adapter.py\` — \`InMemoryClient\`/\`InMemoryCollection\` with brute-force cosine, dict-backed; enables tests without real ChromaDB
- \`knowledge/backends/test_base.py\` — 13 parametrized contract tests run against BOTH adapters (26/26 pass); any future adapter (Qdrant/LanceDB/pgvector) just needs to pass these
- \`utils/chromadb_client.py\` — new opt-in \`get_backend_client()\` helper; existing API untouched so no callers break

## Key decisions
- ChromaDB 1.x \`add()\` on duplicate id is now a silent no-op (retains original); contract documented to match — callers must use \`upsert()\` to replace
- \`EphemeralClient()\` shares process-level state across tests → fixture uses \`PersistentClient(path=tmp_path)\` for real isolation
- \`get_default_client()\`/\`get_backend_client()\` lazy-import \`chromadb_client\` so \`knowledge.backends\` import is cheap
- In-memory adapter's text-only \`query()\` raises NotImplementedError (prevents silent empty-result false positives)

## Diff
+1025 lines (5 new files + 25-line opt-in helper in chromadb_client.py)

## Test Status
PASS — 26/26 contract tests (13 cases × 2 adapters)