### PR TITLE
refactor(analytics): extract useAnalyticsEndpoint<T> to collapse 14 duplicated fetchers (#5112)

### DIFF
--- a/autobot-frontend/src/composables/analytics/analyticsTypes.ts
+++ b/autobot-frontend/src/composables/analytics/analyticsTypes.ts
@@ -1,0 +1,183 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Analytics type definitions — shared between useAnalyticsDataFetchers
+ * and its consumers (CodebaseAnalytics.vue). Extracted from the fetchers
+ * composable in #5112 to keep the fetchers file under 700 lines.
+ */
+
+export interface Problem {
+  severity: string
+  type: string
+  message: string
+  description?: string
+  file_path: string
+  line?: number
+  line_number?: number
+  category?: string
+  suggestion?: string
+}
+
+export interface DuplicateCode {
+  similarity: number
+  lines: number
+  file1: string
+  file2: string
+  start1?: number
+  start2?: number
+}
+
+export interface Declaration {
+  type: string
+  name: string
+  file_path: string
+  line?: number
+  line_number?: number
+  is_exported?: boolean
+}
+
+export interface HardcodedValue {
+  file: string
+  line: number
+  variable_name?: string
+  value: string
+  type: string
+  severity: string
+  suggested_env_var: string
+  context?: string
+  current_usage?: string
+}
+
+export interface RefactoringSuggestion {
+  type: string
+  severity: string
+  description: string
+  file_path: string
+  line?: number
+  suggestion: string
+}
+
+export interface ChartDataItem {
+  name: string
+  value: number
+  type?: string
+  [key: string]: unknown
+}
+
+export interface ChartDataSummary {
+  total_problems?: number
+  unique_problem_types?: number
+  files_with_problems?: number
+  race_condition_count?: number
+}
+
+export interface ChartData {
+  summary?: ChartDataSummary
+  problem_types?: ChartDataItem[]
+  severity_counts?: ChartDataItem[]
+  race_conditions?: ChartDataItem[]
+  top_files?: ChartDataItem[]
+  [key: string]: unknown
+}
+
+export interface DependencyNode {
+  id: string
+  name: string
+  type?: string
+}
+
+export interface DependencyEdge {
+  source: string
+  target: string
+  type?: string
+}
+
+export interface ModuleData {
+  name: string
+  path?: string
+  import_count: number
+  [key: string]: unknown
+}
+
+export interface ExternalDependency {
+  name: string
+  usage_count?: number
+  [key: string]: unknown
+}
+
+export type CircularDependency =
+  | string[]
+  | {
+      modules: string[]
+      cycle?: string[]
+      length?: number
+      severity?: string
+    }
+
+export interface DependencySummary {
+  total_modules?: number
+  total_import_relationships?: number
+  external_dependency_count?: number
+  circular_dependency_count?: number
+}
+
+export interface DependencyGraph {
+  nodes: DependencyNode[]
+  edges: DependencyEdge[]
+  summary?: DependencySummary
+  modules?: ModuleData[]
+  external_dependencies?: ExternalDependency[]
+  circular_dependencies?: CircularDependency[]
+  import_relationships?: DependencyEdge[]
+}
+
+export interface ImportTreeNode {
+  name: string
+  path: string
+  children?: ImportTreeNode[]
+  imports?: string[]
+}
+
+export interface UnifiedReportData {
+  categories: Record<string, Problem[]>
+  summary: {
+    total: number
+    by_severity: Record<string, number>
+    by_category: Record<string, number>
+  }
+  timestamp: string
+}
+
+export interface OrphanedFunction {
+  id: string
+  name: string
+  full_name: string
+  module: string
+  class: string | null
+  file: string
+  line: number
+  is_async: boolean
+}
+
+// Issue #609: Code smell types for filtering
+export const CODE_SMELL_TYPES = new Set([
+  'long_function',
+  'debug_code',
+  'race_condition',
+  'technical_debt_bug',
+  'technical_debt_todo',
+  'technical_debt_fixme',
+  'technical_debt_deprecated',
+  'performance_nested_loop_complexity',
+  'performance_quadratic_complexity',
+  'performance_n_plus_one_query',
+  'performance_blocking_io_in_async',
+  'performance_excessive_string_concat',
+  'performance_list_for_lookup',
+  'performance_repeated_computation',
+  'performance_repeated_file_open',
+  'performance_sequential_awaits',
+  'performance_unbatched_api_calls',
+])

--- a/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
@@ -9,197 +9,46 @@
  * call graph, codebase stats, problems, declarations, duplicates, hardcodes,
  * dependency/import-tree task loaders, and cached/full scan orchestration.
  *
- * Issues #2228, #2230: Extracted from CodebaseAnalytics.vue
+ * Issues #2228, #2230: Extracted from CodebaseAnalytics.vue.
+ * Issue #5112: the 14x GET-fetcher boilerplate now routes through
+ * `useAnalyticsEndpoint`, which defaults `scopeToSource: true` — making the
+ * #5111 class of bugs (forgetting `withSourceId`) structurally impossible
+ * for callers that don't explicitly opt out. Domain types live in
+ * `./analyticsTypes`.
  */
 
-import { ref, reactive, computed, type Ref, type ComputedRef } from 'vue'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { ref, reactive, computed, watch, type Ref, type ComputedRef } from 'vue'
 import appConfig from '@/config/AppConfig.js'
 import { useBackgroundTask } from '@/composables/useBackgroundTask'
 import { useTaskLoader } from '@/composables/useTaskLoader'
 import { useAnalyticsScanRunner } from '@/composables/useAnalyticsScanRunner'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import type { ToastType } from '@/composables/useToast'
+import { useAnalyticsEndpoint } from './useAnalyticsEndpoint'
+import {
+  CODE_SMELL_TYPES,
+  type Problem,
+  type DuplicateCode,
+  type Declaration,
+  type HardcodedValue,
+  type RefactoringSuggestion,
+  type ChartData,
+  type DependencyGraph,
+  type ImportTreeNode,
+  type UnifiedReportData,
+  type OrphanedFunction,
+} from './analyticsTypes'
+
+export * from './analyticsTypes'
 
 const logger = createLogger('useAnalyticsDataFetchers')
 
-// --- Type definitions ---
-
-export interface Problem {
-  severity: string
-  type: string
-  message: string
-  description?: string
-  file_path: string
-  line?: number
-  line_number?: number
-  category?: string
-  suggestion?: string
+interface CallGraphPayload {
+  call_graph: DependencyGraph
+  summary: Record<string, unknown> | null
+  orphaned_functions: OrphanedFunction[]
 }
-
-export interface DuplicateCode {
-  similarity: number
-  lines: number
-  file1: string
-  file2: string
-  start1?: number
-  start2?: number
-}
-
-export interface Declaration {
-  type: string
-  name: string
-  file_path: string
-  line?: number
-  line_number?: number
-  is_exported?: boolean
-}
-
-export interface HardcodedValue {
-  file: string
-  line: number
-  variable_name?: string
-  value: string
-  type: string
-  severity: string
-  suggested_env_var: string
-  context?: string
-  current_usage?: string
-}
-
-export interface RefactoringSuggestion {
-  type: string
-  severity: string
-  description: string
-  file_path: string
-  line?: number
-  suggestion: string
-}
-
-export interface ChartDataItem {
-  name: string
-  value: number
-  type?: string
-  [key: string]: unknown
-}
-
-export interface ChartDataSummary {
-  total_problems?: number
-  unique_problem_types?: number
-  files_with_problems?: number
-  race_condition_count?: number
-}
-
-export interface ChartData {
-  summary?: ChartDataSummary
-  problem_types?: ChartDataItem[]
-  severity_counts?: ChartDataItem[]
-  race_conditions?: ChartDataItem[]
-  top_files?: ChartDataItem[]
-  [key: string]: unknown
-}
-
-export interface DependencyNode {
-  id: string
-  name: string
-  type?: string
-}
-
-export interface DependencyEdge {
-  source: string
-  target: string
-  type?: string
-}
-
-export interface ModuleData {
-  name: string
-  path?: string
-  import_count: number
-  [key: string]: unknown
-}
-
-export interface ExternalDependency {
-  name: string
-  usage_count?: number
-  [key: string]: unknown
-}
-
-export type CircularDependency =
-  | string[]
-  | {
-      modules: string[]
-      cycle?: string[]
-      length?: number
-      severity?: string
-    }
-
-export interface DependencySummary {
-  total_modules?: number
-  total_import_relationships?: number
-  external_dependency_count?: number
-  circular_dependency_count?: number
-}
-
-export interface DependencyGraph {
-  nodes: DependencyNode[]
-  edges: DependencyEdge[]
-  summary?: DependencySummary
-  modules?: ModuleData[]
-  external_dependencies?: ExternalDependency[]
-  circular_dependencies?: CircularDependency[]
-  import_relationships?: DependencyEdge[]
-}
-
-export interface ImportTreeNode {
-  name: string
-  path: string
-  children?: ImportTreeNode[]
-  imports?: string[]
-}
-
-export interface UnifiedReportData {
-  categories: Record<string, Problem[]>
-  summary: {
-    total: number
-    by_severity: Record<string, number>
-    by_category: Record<string, number>
-  }
-  timestamp: string
-}
-
-interface OrphanedFunction {
-  id: string
-  name: string
-  full_name: string
-  module: string
-  class: string | null
-  file: string
-  line: number
-  is_async: boolean
-}
-
-// Issue #609: Code smell types for filtering
-const CODE_SMELL_TYPES = new Set([
-  'long_function',
-  'debug_code',
-  'race_condition',
-  'technical_debt_bug',
-  'technical_debt_todo',
-  'technical_debt_fixme',
-  'technical_debt_deprecated',
-  'performance_nested_loop_complexity',
-  'performance_quadratic_complexity',
-  'performance_n_plus_one_query',
-  'performance_blocking_io_in_async',
-  'performance_excessive_string_concat',
-  'performance_list_for_lookup',
-  'performance_repeated_computation',
-  'performance_repeated_file_open',
-  'performance_sequential_awaits',
-  'performance_unbatched_api_calls',
-])
-
-import type { ToastType } from '@/composables/useToast'
 
 export interface UseAnalyticsDataFetchersDeps {
   rootPath: Ref<string>
@@ -212,17 +61,8 @@ export interface UseAnalyticsDataFetchersDeps {
   notify: (msg: string, type?: ToastType) => void
 }
 
-export function useAnalyticsDataFetchers(
-  deps: UseAnalyticsDataFetchersDeps,
-) {
-  const {
-    rootPath,
-    sourceIdQuery,
-    withSourceId,
-    t,
-    showToast,
-    notify,
-  } = deps
+export function useAnalyticsDataFetchers(deps: UseAnalyticsDataFetchersDeps) {
+  const { rootPath, sourceIdQuery, withSourceId, t, showToast, notify } = deps
 
   // --- Task loaders (#1304/#1321) ---
 
@@ -233,12 +73,10 @@ export function useAnalyticsDataFetchers(
     load: _loadDependencyTask,
   } = useTaskLoader<DependencyGraph>(
     `${getApiBase()}/analytics/codebase/analytics/dependencies`,
-    (r) => {
-      if (r.status === 'success' && r.dependency_data) {
-        return r.dependency_data as unknown as DependencyGraph
-      }
-      return undefined
-    },
+    (r) =>
+      r.status === 'success' && r.dependency_data
+        ? (r.dependency_data as unknown as DependencyGraph)
+        : undefined,
   )
 
   const {
@@ -252,16 +90,13 @@ export function useAnalyticsDataFetchers(
       if (r.status === 'success' && r.import_tree) {
         return r.import_tree as unknown as ImportTreeNode[]
       }
-      return r.status === 'no_data'
-        ? ([] as ImportTreeNode[])
-        : undefined
+      return r.status === 'no_data' ? ([] as ImportTreeNode[]) : undefined
     },
   )
 
   const dupTask = useBackgroundTask(
     `${getApiBase()}/analytics/codebase/duplicates`,
   )
-
   const scanRunner = useAnalyticsScanRunner()
 
   // --- Reactive state ---
@@ -272,24 +107,11 @@ export function useAnalyticsDataFetchers(
   const declarationAnalysis = ref<Declaration[]>([])
   const hardcodeAnalysis = ref<HardcodedValue[]>([])
   const refactoringSuggestions = ref<RefactoringSuggestion[]>([])
-
-  const chartData = ref<ChartData | null>(null)
-  const chartDataLoading = ref(false)
-  const chartDataError = ref('')
-
   const unifiedReport = ref<UnifiedReportData | null>(null)
-  const unifiedReportLoading = ref(false)
-  const unifiedReportError = ref('')
   const selectedCategory = ref('all')
-
-  const callGraphData = ref<DependencyGraph>({
-    nodes: [],
-    edges: [],
-  })
+  const callGraphData = ref<DependencyGraph>({ nodes: [], edges: [] })
   const callGraphSummary = ref<Record<string, unknown> | null>(null)
   const callGraphOrphaned = ref<OrphanedFunction[]>([])
-  const callGraphLoading = ref(false)
-  const callGraphError = ref('')
 
   const loadingProgress = reactive({
     declarations: false,
@@ -301,20 +123,361 @@ export function useAnalyticsDataFetchers(
   const showAllProblems = ref(false)
   const showAllDeclarations = ref(false)
   const showAllDuplicates = ref(false)
-
   const progressPercent = ref(0)
   const progressStatus = ref('Ready')
 
+  // --- Generic endpoint-backed fetchers (#5112) ---
+
+  const chartEndpoint = useAnalyticsEndpoint<
+    { status: string; chart_data?: ChartData },
+    ChartData
+  >(
+    {
+      path: '/api/analytics/codebase/analytics/charts',
+      label: 'Chart data endpoint',
+      pickData: (raw) =>
+        raw.status === 'success' && raw.chart_data ? raw.chart_data : null,
+      onSuccess: (d) =>
+        logger.debug('Chart data loaded:', {
+          problemTypes: d.problem_types?.length || 0,
+          severities: d.severity_counts?.length || 0,
+          raceConditions: d.race_conditions?.length || 0,
+          topFiles: d.top_files?.length || 0,
+        }),
+      onNoData: () =>
+        logger.debug('No chart data available - run indexing first'),
+    },
+    { withSourceId },
+  )
+
+  const unifiedEndpoint = useAnalyticsEndpoint<
+    UnifiedReportData & { status: string },
+    UnifiedReportData
+  >(
+    {
+      path: '/api/unified/report',
+      scopeToSource: false, // global report — not source-scoped
+      label: 'Unified report endpoint',
+      pickData: (raw) => (raw.status === 'success' ? raw : null),
+      onSuccess: (d) =>
+        logger.debug('Unified report loaded:', {
+          categories: Object.keys(d.categories || {}).length,
+          summary: d.summary,
+        }),
+      onNoData: () =>
+        logger.debug('No unified report data - run indexing first'),
+    },
+    { withSourceId },
+  )
+  // Mirror to the historical `unifiedReport` ref shape consumers expect.
+  watch(unifiedEndpoint.data, (v) => { unifiedReport.value = v })
+
+  const callGraphEndpoint = useAnalyticsEndpoint<
+    {
+      status: string
+      call_graph?: DependencyGraph
+      summary?: Record<string, unknown>
+      orphaned_functions?: OrphanedFunction[]
+    },
+    CallGraphPayload
+  >(
+    {
+      path: '/api/analytics/codebase/analytics/call-graph',
+      label: 'Call graph endpoint',
+      pickData: (raw) =>
+        raw.status === 'success' && raw.call_graph
+          ? {
+              call_graph: raw.call_graph,
+              summary: raw.summary ?? null,
+              orphaned_functions: raw.orphaned_functions ?? [],
+            }
+          : null,
+      onSuccess: (p) => {
+        callGraphData.value = p.call_graph
+        callGraphSummary.value = p.summary
+        callGraphOrphaned.value = p.orphaned_functions
+      },
+      onNoData: () => {
+        callGraphData.value = { nodes: [], edges: [] }
+        callGraphSummary.value = null
+        callGraphOrphaned.value = []
+      },
+    },
+    { withSourceId },
+  )
+
+  // --- Silent loaders (populate array state, no toasts) ---
+
+  const declarationsSilent = useAnalyticsEndpoint<
+    { declarations?: Declaration[] },
+    Declaration[]
+  >(
+    {
+      path: '/api/analytics/codebase/declarations',
+      label: 'Declarations endpoint',
+      pickData: (raw) => raw.declarations ?? [],
+      onSuccess: (d) => { declarationAnalysis.value = d },
+    },
+    { withSourceId },
+  )
+
+  const hardcodesSilent = useAnalyticsEndpoint<
+    { hardcodes?: HardcodedValue[] },
+    HardcodedValue[]
+  >(
+    {
+      path: '/api/analytics/codebase/hardcodes',
+      label: 'Hardcodes endpoint',
+      pickData: (raw) => raw.hardcodes ?? [],
+      onSuccess: (d) => { hardcodeAnalysis.value = d },
+    },
+    { withSourceId },
+  )
+
+  const duplicatesSilent = useAnalyticsEndpoint<
+    { duplicates?: DuplicateCode[] },
+    DuplicateCode[]
+  >(
+    {
+      path: '/api/analytics/codebase/duplicates',
+      label: 'Duplicates endpoint',
+      pickData: (raw) => raw.duplicates ?? [],
+      onSuccess: (d) => { duplicateAnalysis.value = d },
+    },
+    { withSourceId },
+  )
+
+  const statsEndpoint = useAnalyticsEndpoint<
+    { status: string; stats?: Record<string, unknown> },
+    Record<string, unknown>
+  >(
+    {
+      path: '/api/analytics/codebase/stats',
+      label: 'Stats endpoint',
+      pickData: (raw) =>
+        raw.status === 'success' && raw.stats ? raw.stats : null,
+      onSuccess: (d) => { codebaseStats.value = d },
+      onNoData: () => {
+        codebaseStats.value = null
+        logger.debug('No codebase stats - run indexing first')
+      },
+    },
+    { withSourceId },
+  )
+
+  const problemsEndpoint = useAnalyticsEndpoint<
+    { status?: string; problems?: Problem[] },
+    Problem[]
+  >(
+    {
+      path: '/api/analytics/codebase/problems',
+      label: 'Problems endpoint',
+      pickData: (raw) => (raw.status === 'no_data' ? [] : raw.problems ?? []),
+      onSuccess: (d) => { problemsReport.value = d },
+    },
+    { withSourceId },
+  )
+
+  const cachedDuplicatesEndpoint = useAnalyticsEndpoint<
+    { status: string; duplicates?: DuplicateCode[] },
+    DuplicateCode[]
+  >(
+    {
+      path: '/api/analytics/codebase/duplicates/cached',
+      label: 'Cached duplicates endpoint',
+      pickData: (raw) =>
+        raw.status === 'success' && Array.isArray(raw.duplicates)
+          ? raw.duplicates
+          : null,
+      onSuccess: (d) => { duplicateAnalysis.value = d },
+    },
+    { withSourceId },
+  )
+
+  const cachedDependenciesEndpoint = useAnalyticsEndpoint<
+    { status: string; dependency_data?: unknown },
+    DependencyGraph
+  >(
+    {
+      path: '/api/analytics/codebase/analytics/dependencies/cached',
+      label: 'Cached dependencies endpoint',
+      pickData: (raw) =>
+        raw.status === 'success' && raw.dependency_data
+          ? (raw.dependency_data as DependencyGraph)
+          : null,
+      onSuccess: (d) => { dependencyData.value = d },
+    },
+    { withSourceId },
+  )
+
+  const cachedImportTreeEndpoint = useAnalyticsEndpoint<
+    { status: string; import_tree?: unknown },
+    ImportTreeNode[]
+  >(
+    {
+      path: '/api/analytics/codebase/analytics/import-tree/cached',
+      label: 'Cached import tree endpoint',
+      pickData: (raw) =>
+        raw.status === 'success' && raw.import_tree
+          ? (raw.import_tree as ImportTreeNode[])
+          : null,
+      onSuccess: (d) => { importTreeData.value = d },
+    },
+    { withSourceId },
+  )
+
+  // --- Loader wrappers: maintain legacy progress flags + status labels ---
+
+  const loadChartData = () => chartEndpoint.load()
+  const loadUnifiedReport = () => unifiedEndpoint.load()
+  const loadCallGraphData = () => callGraphEndpoint.load()
+  const getCodebaseStats = () => statsEndpoint.load()
+  const loadCachedDuplicates = () => cachedDuplicatesEndpoint.load()
+  const loadCachedDependencies = () => cachedDependenciesEndpoint.load()
+  const loadCachedImportTree = () => cachedImportTreeEndpoint.load()
+  const loadDependencyData = () => _loadDependencyTask()
+  const loadImportTreeData = () => _loadImportTreeTask()
+
+  const loadDeclarations = async () => {
+    loadingProgress.declarations = true
+    try {
+      await declarationsSilent.load()
+    } finally {
+      loadingProgress.declarations = false
+    }
+  }
+
+  const loadHardcodes = async () => {
+    loadingProgress.hardcodes = true
+    try {
+      await hardcodesSilent.load()
+    } finally {
+      loadingProgress.hardcodes = false
+    }
+  }
+
+  const loadDuplicates = async () => {
+    loadingProgress.duplicates = true
+    try {
+      const ok = await dupTask.start(undefined, sourceIdQuery.value)
+      if (ok && dupTask.result.value) {
+        const data = dupTask.result.value as Record<string, unknown>
+        duplicateAnalysis.value = Array.isArray(data.duplicates)
+          ? (data.duplicates as DuplicateCode[])
+          : []
+      }
+    } catch (error: unknown) {
+      logger.error('Failed to load duplicates:', error)
+    } finally {
+      loadingProgress.duplicates = false
+    }
+  }
+
+  const getProblemsReport = async () => {
+    loadingProgress.problems = true
+    progressStatus.value = t('analytics.codebase.status.analyzingProblems')
+    try {
+      await problemsEndpoint.load()
+    } finally {
+      loadingProgress.problems = false
+    }
+  }
+
+  /**
+   * Shared wrapper for the three toast-emitting loaders. Preserves the
+   * count + timing + (for hardcodes) types summary shown to the user.
+   */
+  const notifyTimed = async (
+    flag: 'declarations' | 'duplicates' | 'hardcodes',
+    statusKey: string,
+    runner: () => Promise<
+      { count: number; extra?: Record<string, unknown> } | null
+    >,
+    foundKey: string,
+    failedKey: string,
+  ) => {
+    loadingProgress[flag] = true
+    progressStatus.value = t(statusKey)
+    const startTime = Date.now()
+    try {
+      const result = await runner()
+      const time = Date.now() - startTime
+      if (result === null) {
+        notify(t(failedKey, { error: 'request failed', time }), 'error')
+        return
+      }
+      notify(
+        t(foundKey, { count: result.count, time, ...result.extra }),
+        'success',
+      )
+    } catch (error: unknown) {
+      const time = Date.now() - startTime
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
+      logger.error(`${flag} failed:`, error)
+      notify(t(failedKey, { error: errorMessage, time }), 'error')
+    } finally {
+      loadingProgress[flag] = false
+      progressStatus.value = t('analytics.codebase.status.ready')
+    }
+  }
+
+  const getDeclarationsData = () =>
+    notifyTimed(
+      'declarations',
+      'analytics.codebase.status.processingDeclarations',
+      async () => {
+        await declarationsSilent.load()
+        if (declarationsSilent.error.value) return null
+        return { count: declarationAnalysis.value.length }
+      },
+      'analytics.codebase.notify.declarationsFound',
+      'analytics.codebase.notify.declarationsFailed',
+    )
+
+  const getDuplicatesData = () =>
+    notifyTimed(
+      'duplicates',
+      'analytics.codebase.status.findingDuplicates',
+      async () => {
+        await duplicatesSilent.load()
+        if (duplicatesSilent.error.value) return null
+        return { count: duplicateAnalysis.value.length }
+      },
+      'analytics.codebase.notify.duplicatesFound',
+      'analytics.codebase.notify.duplicatesFailed',
+    )
+
+  const getHardcodesData = () =>
+    notifyTimed(
+      'hardcodes',
+      'analytics.codebase.status.detectingHardcodes',
+      async () => {
+        await hardcodesSilent.load()
+        if (hardcodesSilent.error.value) return null
+        const types =
+          hardcodeAnalysis.value.length > 0
+            ? [...new Set(hardcodeAnalysis.value.map((h) => h.type))].join(
+                ', ',
+              )
+            : 'none'
+        return { count: hardcodeAnalysis.value.length, extra: { types } }
+      },
+      'analytics.codebase.notify.hardcodesFound',
+      'analytics.codebase.notify.hardcodesFailed',
+    )
+
   // --- Computed ---
 
-  const hasAnyResults = computed(() => {
-    return !!(
-      codebaseStats.value ||
-      problemsReport.value.length > 0 ||
-      declarationAnalysis.value.length > 0 ||
-      duplicateAnalysis.value.length > 0
-    )
-  })
+  const hasAnyResults = computed(
+    () =>
+      !!(
+        codebaseStats.value ||
+        problemsReport.value.length > 0 ||
+        declarationAnalysis.value.length > 0 ||
+        duplicateAnalysis.value.length > 0
+      ),
+  )
 
   const availableCategories = computed(() => {
     if (!unifiedReport.value?.categories) return []
@@ -324,19 +487,17 @@ export function useAnalyticsDataFetchers(
       name: key
         .replace(/_/g, ' ')
         .replace(/\b\w/g, (c: string) => c.toUpperCase()),
-      count: Array.isArray(categories[key])
-        ? categories[key].length
-        : 0,
+      count: Array.isArray(categories[key]) ? categories[key].length : 0,
     }))
   })
 
-  const codeSmellsFromProblems = computed(() => {
-    if (!problemsReport.value || problemsReport.value.length === 0)
-      return []
-    return problemsReport.value.filter(
-      (p) => p.type && CODE_SMELL_TYPES.has(p.type),
-    )
-  })
+  const codeSmellsFromProblems = computed(() =>
+    !problemsReport.value || problemsReport.value.length === 0
+      ? []
+      : problemsReport.value.filter(
+          (p) => p.type && CODE_SMELL_TYPES.has(p.type),
+        ),
+  )
 
   const codeSmellsForPanel = computed(() =>
     codeSmellsFromProblems.value.map((p) => ({
@@ -359,151 +520,91 @@ export function useAnalyticsDataFetchers(
     })),
   )
 
-  // --- Data loaders ---
+  // --- Config load ---
 
-  const loadChartData = async () => {
-    chartDataLoading.value = true
-    chartDataError.value = ''
+  const loadProjectRoot = async () => {
+    const saved = localStorage.getItem('codebase-analytics-path')
+    if (saved) {
+      logger.debug('Using saved path from localStorage:', saved)
+      return
+    }
     try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const response = await fetchWithAuth(
-        withSourceId(
-          `${backendUrl}/api/analytics/codebase/analytics/charts`,
-        ),
-        {
-          method: 'GET',
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-        },
-      )
-      if (!response.ok) {
-        throw new Error(
-          `Chart data endpoint returned ${response.status}`,
-        )
-      }
-      const data = await response.json()
-      if (data.status === 'success' && data.chart_data) {
-        chartData.value = data.chart_data
-        logger.debug('Chart data loaded:', {
-          problemTypes:
-            data.chart_data.problem_types?.length || 0,
-          severities:
-            data.chart_data.severity_counts?.length || 0,
-          raceConditions:
-            data.chart_data.race_conditions?.length || 0,
-          topFiles: data.chart_data.top_files?.length || 0,
-        })
-      } else if (data.status === 'no_data') {
-        chartData.value = null
-        logger.debug(
-          'No chart data available - run indexing first',
-        )
+      const projectRoot = await appConfig.getProjectRoot()
+      if (projectRoot) {
+        rootPath.value = projectRoot
+      } else {
+        logger.warn('Project root not found in config, using default')
       }
     } catch (error: unknown) {
-      logger.error('Failed to load chart data:', error)
-      chartDataError.value =
-        error instanceof Error ? error.message : String(error)
-    } finally {
-      chartDataLoading.value = false
+      logger.error('Failed to load project root:', error)
+      progressStatus.value = t('analytics.codebase.status.enterProjectPath')
     }
   }
 
-  const loadUnifiedReport = async () => {
-    unifiedReportLoading.value = true
-    unifiedReportError.value = ''
+  // --- Scan orchestration ---
+
+  const buildScanList = (useFullScans: boolean) => [
+    { id: 'stats', label: t('analytics.codebase.scans.stats'), run: getCodebaseStats },
+    { id: 'problems', label: t('analytics.codebase.scans.problems'), run: getProblemsReport },
+    { id: 'declarations', label: t('analytics.codebase.scans.declarations'), run: loadDeclarations },
+    {
+      id: 'duplicates',
+      label: t('analytics.codebase.scans.duplicates'),
+      run: () => (useFullScans ? loadDuplicates() : loadCachedDuplicates()),
+    },
+    { id: 'hardcodes', label: t('analytics.codebase.scans.hardcodes'), run: loadHardcodes },
+    { id: 'charts', label: t('analytics.codebase.scans.charts'), run: loadChartData },
+    {
+      id: 'dependencies',
+      label: t('analytics.codebase.scans.dependencies'),
+      run: useFullScans
+        ? async () => { await loadDependencyData() }
+        : () => loadCachedDependencies(),
+    },
+    {
+      id: 'imports',
+      label: t('analytics.codebase.scans.imports'),
+      run: useFullScans
+        ? async () => { await loadImportTreeData() }
+        : () => loadCachedImportTree(),
+    },
+    { id: 'callgraph', label: t('analytics.codebase.scans.callGraph'), run: loadCallGraphData },
+  ]
+
+  const runScans = async (
+    useFullScans: boolean,
+    extraScans: Array<{ id: string; label: string; run: () => Promise<void> }>,
+    failLogPrefix: string,
+  ) => {
     try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const response = await fetchWithAuth(
-        `${backendUrl}/api/unified/report`,
-        {
-          method: 'GET',
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-        },
-      )
-      if (!response.ok) {
-        throw new Error(
-          `Unified report endpoint returned ${response.status}`,
+      await scanRunner.runAll([...buildScanList(useFullScans), ...extraScans])
+      if (scanRunner.failedCount.value > 0) {
+        progressStatus.value = t(
+          'analytics.codebase.status.loadPartialFailed',
+          { failed: scanRunner.failedCount.value, total: scanRunner.totalCount.value },
         )
-      }
-      const data = await response.json()
-      if (data.status === 'success') {
-        unifiedReport.value = data
-        logger.debug('Unified report loaded:', {
-          healthScore: data.summary?.health_score,
-          grade: data.summary?.grade,
-          totalIssues: data.summary?.total_issues,
-          categories: Object.keys(data.categories || {}).length,
-        })
-      } else if (data.status === 'no_data') {
-        unifiedReport.value = null
-        logger.debug(
-          'No unified report data - run indexing first',
-        )
+      } else {
+        progressStatus.value = t('analytics.codebase.status.loadComplete')
       }
     } catch (error: unknown) {
-      logger.error('Failed to load unified report:', error)
-      unifiedReportError.value =
+      const errorMessage =
         error instanceof Error ? error.message : String(error)
-    } finally {
-      unifiedReportLoading.value = false
+      logger.error(failLogPrefix, error)
+      progressStatus.value = t('analytics.codebase.status.loadFailed', {
+        error: errorMessage,
+      })
     }
   }
 
-  const loadCallGraphData = async () => {
-    callGraphLoading.value = true
-    callGraphError.value = ''
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const response = await fetchWithAuth(
-        withSourceId(
-          `${backendUrl}/api/analytics/codebase/analytics/call-graph`,
-        ),
-        {
-          method: 'GET',
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-        },
-      )
-      if (!response.ok) {
-        throw new Error(
-          `Call graph endpoint returned ${response.status}`,
-        )
-      }
-      const data = await response.json()
-      if (data.status === 'success' && data.call_graph) {
-        callGraphData.value = data.call_graph
-        callGraphSummary.value = data.summary
-        callGraphOrphaned.value =
-          data.orphaned_functions || []
-        logger.debug('Call graph loaded:', {
-          nodes: data.call_graph.nodes?.length || 0,
-          edges: data.call_graph.edges?.length || 0,
-          orphaned: data.orphaned_functions?.length || 0,
-          summary: data.summary,
-        })
-      } else if (data.status === 'no_data') {
-        callGraphData.value = { nodes: [], edges: [] }
-        callGraphSummary.value = null
-        callGraphOrphaned.value = []
-        logger.debug(
-          'No call graph data - run indexing first',
-        )
-      }
-    } catch (error: unknown) {
-      logger.error('Failed to load call graph:', error)
-      callGraphError.value =
-        error instanceof Error ? error.message : String(error)
-    } finally {
-      callGraphLoading.value = false
-    }
-  }
+  const loadCachedAnalyticsData = (
+    extraScans: Array<{ id: string; label: string; run: () => Promise<void> }>,
+  ) => runScans(false, extraScans, 'Failed to load cached analytics data:')
+
+  const runAllAnalysisScans = (
+    extraScans: Array<{ id: string; label: string; run: () => Promise<void> }>,
+  ) => runScans(true, extraScans, 'Failed to load codebase analytics data:')
+
+  // --- Navigation helpers ---
 
   const handleFileNavigate = (filePath: string) => {
     logger.debug('Navigate to file:', filePath)
@@ -523,565 +624,6 @@ export function useAnalyticsDataFetchers(
     )
   }
 
-  const loadDeclarations = async () => {
-    loadingProgress.declarations = true
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const declarationsEndpoint = withSourceId(
-        `${backendUrl}/api/analytics/codebase/declarations`,
-      )
-      const response = await fetchWithAuth(declarationsEndpoint, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      })
-      if (!response.ok) {
-        throw new Error(
-          `Declarations endpoint returned ${response.status}`,
-        )
-      }
-      const data = await response.json()
-      declarationAnalysis.value = data.declarations || []
-    } catch (error: unknown) {
-      logger.error('Failed to load declarations:', error)
-    } finally {
-      loadingProgress.declarations = false
-    }
-  }
-
-  const loadDuplicates = async () => {
-    loadingProgress.duplicates = true
-    try {
-      const ok = await dupTask.start(
-        undefined,
-        sourceIdQuery.value,
-      )
-      if (ok && dupTask.result.value) {
-        const data = dupTask.result.value as Record<
-          string,
-          unknown
-        >
-        duplicateAnalysis.value = Array.isArray(data.duplicates)
-          ? (data.duplicates as DuplicateCode[])
-          : []
-      }
-    } catch (error: unknown) {
-      logger.error('Failed to load duplicates:', error)
-    } finally {
-      loadingProgress.duplicates = false
-    }
-  }
-
-  const loadHardcodes = async () => {
-    loadingProgress.hardcodes = true
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const hardcodesEndpoint = withSourceId(
-        `${backendUrl}/api/analytics/codebase/hardcodes`,
-      )
-      const response = await fetchWithAuth(hardcodesEndpoint, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      })
-      if (!response.ok) {
-        throw new Error(
-          `Hardcodes endpoint returned ${response.status}`,
-        )
-      }
-      const data = await response.json()
-      hardcodeAnalysis.value = data.hardcodes || []
-    } catch (error: unknown) {
-      logger.error('Failed to load hardcodes:', error)
-    } finally {
-      loadingProgress.hardcodes = false
-    }
-  }
-
-  const loadDependencyData = () => _loadDependencyTask()
-  const loadImportTreeData = () => _loadImportTreeTask()
-
-  // --- Fetch project root from config ---
-
-  const loadProjectRoot = async () => {
-    const saved = localStorage.getItem('codebase-analytics-path')
-    if (saved) {
-      logger.debug(
-        'Using saved path from localStorage:',
-        saved,
-      )
-      return
-    }
-    try {
-      const projectRoot = await appConfig.getProjectRoot()
-      if (projectRoot) {
-        rootPath.value = projectRoot
-      } else {
-        logger.warn(
-          'Project root not found in config, using default',
-        )
-      }
-    } catch (error: unknown) {
-      logger.error('Failed to load project root:', error)
-      progressStatus.value = t(
-        'analytics.codebase.status.enterProjectPath',
-      )
-    }
-  }
-
-  // --- Debug button fetch functions ---
-
-  const getCodebaseStats = async () => {
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const statsEndpoint = withSourceId(
-        `${backendUrl}/api/analytics/codebase/stats`,
-      )
-      const response = await fetchWithAuth(statsEndpoint)
-      if (!response.ok) {
-        throw new Error(
-          `Stats endpoint returned ${response.status}`,
-        )
-      }
-      const data = await response.json()
-      if (data.status === 'success' && data.stats) {
-        codebaseStats.value = data.stats
-      } else if (
-        data.status === 'no_data' ||
-        data.status === 'indexing'
-      ) {
-        codebaseStats.value = null
-        logger.debug(
-          'No codebase stats - run indexing first',
-        )
-      }
-    } catch (error: unknown) {
-      logger.error('Failed to get stats:', error)
-    }
-  }
-
-  const getProblemsReport = async () => {
-    loadingProgress.problems = true
-    progressStatus.value = t(
-      'analytics.codebase.status.analyzingProblems',
-    )
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const problemsEndpoint = withSourceId(
-        `${backendUrl}/api/analytics/codebase/problems`,
-      )
-      const response = await fetchWithAuth(problemsEndpoint)
-      if (!response.ok) {
-        throw new Error(
-          `Problems endpoint returned ${response.status}`,
-        )
-      }
-      const data = await response.json()
-      if (data.status === 'no_data') {
-        problemsReport.value = []
-        logger.debug(
-          'No problems report - run indexing first',
-        )
-      } else {
-        problemsReport.value = data.problems || []
-      }
-    } catch (error: unknown) {
-      logger.error('Failed to get problems:', error)
-    } finally {
-      loadingProgress.problems = false
-    }
-  }
-
-  const getDeclarationsData = async () => {
-    const startTime = Date.now()
-    loadingProgress.declarations = true
-    progressStatus.value = t(
-      'analytics.codebase.status.processingDeclarations',
-    )
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const declarationsEndpoint = withSourceId(
-        `${backendUrl}/api/analytics/codebase/declarations`,
-      )
-      const response = await fetchWithAuth(declarationsEndpoint, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      })
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`Status ${response.status}: ${errorText}`)
-      }
-      const data = await response.json()
-      const responseTime = Date.now() - startTime
-      declarationAnalysis.value = data.declarations || []
-      notify(
-        t('analytics.codebase.notify.declarationsFound', {
-          count: declarationAnalysis.value.length,
-          time: responseTime,
-        }),
-        'success',
-      )
-    } catch (error: unknown) {
-      const responseTime = Date.now() - startTime
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error('Declarations failed:', error)
-      notify(
-        t('analytics.codebase.notify.declarationsFailed', {
-          error: errorMessage,
-          time: responseTime,
-        }),
-        'error',
-      )
-    } finally {
-      loadingProgress.declarations = false
-      progressStatus.value = t(
-        'analytics.codebase.status.ready',
-      )
-    }
-  }
-
-  const getDuplicatesData = async () => {
-    loadingProgress.duplicates = true
-    progressStatus.value = t(
-      'analytics.codebase.status.findingDuplicates',
-    )
-    const startTime = Date.now()
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const duplicatesEndpoint = withSourceId(
-        `${backendUrl}/api/analytics/codebase/duplicates`,
-      )
-      const response = await fetchWithAuth(duplicatesEndpoint, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      })
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`Status ${response.status}: ${errorText}`)
-      }
-      const data = await response.json()
-      const responseTime = Date.now() - startTime
-      duplicateAnalysis.value = data.duplicates || []
-      notify(
-        t('analytics.codebase.notify.duplicatesFound', {
-          count: duplicateAnalysis.value.length,
-          time: responseTime,
-        }),
-        'success',
-      )
-    } catch (error: unknown) {
-      const responseTime = Date.now() - startTime
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error('Duplicates failed:', error)
-      notify(
-        t('analytics.codebase.notify.duplicatesFailed', {
-          error: errorMessage,
-          time: responseTime,
-        }),
-        'error',
-      )
-    } finally {
-      loadingProgress.duplicates = false
-      progressStatus.value = t(
-        'analytics.codebase.status.ready',
-      )
-    }
-  }
-
-  const getHardcodesData = async () => {
-    loadingProgress.hardcodes = true
-    progressStatus.value = t(
-      'analytics.codebase.status.detectingHardcodes',
-    )
-    const startTime = Date.now()
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const hardcodesEndpoint = withSourceId(
-        `${backendUrl}/api/analytics/codebase/hardcodes`,
-      )
-      const response = await fetchWithAuth(hardcodesEndpoint, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      })
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`Status ${response.status}: ${errorText}`)
-      }
-      const data = await response.json()
-      const responseTime = Date.now() - startTime
-      hardcodeAnalysis.value = data.hardcodes || []
-      const hardcodeCount = hardcodeAnalysis.value.length
-      const hardcodeTypes =
-        hardcodeCount > 0
-          ? [
-              ...new Set(
-                hardcodeAnalysis.value.map((h) => h.type),
-              ),
-            ].join(', ')
-          : 'none'
-      notify(
-        t('analytics.codebase.notify.hardcodesFound', {
-          count: hardcodeCount,
-          types: hardcodeTypes,
-          time: responseTime,
-        }),
-        'success',
-      )
-    } catch (error: unknown) {
-      const responseTime = Date.now() - startTime
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error('Hardcodes failed:', error)
-      notify(
-        t('analytics.codebase.notify.hardcodesFailed', {
-          error: errorMessage,
-          time: responseTime,
-        }),
-        'error',
-      )
-    } finally {
-      loadingProgress.hardcodes = false
-      progressStatus.value = t(
-        'analytics.codebase.status.ready',
-      )
-    }
-  }
-
-  // --- Cached loaders (#1540) ---
-
-  const loadCachedDuplicates = async () => {
-    const backendUrl = await appConfig.getServiceUrl('backend')
-    const resp = await fetchWithAuth(
-      withSourceId(
-        `${backendUrl}/api/analytics/codebase/duplicates/cached`,
-      ),
-    )
-    if (!resp.ok) return
-    const data = await resp.json()
-    if (
-      data.status === 'success' &&
-      Array.isArray(data.duplicates)
-    ) {
-      duplicateAnalysis.value =
-        data.duplicates as DuplicateCode[]
-    }
-  }
-
-  const loadCachedDependencies = async () => {
-    const backendUrl = await appConfig.getServiceUrl('backend')
-    const resp = await fetchWithAuth(
-      withSourceId(
-        `${backendUrl}/api/analytics/codebase/analytics/dependencies/cached`,
-      ),
-    )
-    if (!resp.ok) return
-    const data = await resp.json()
-    if (data.status === 'success' && data.dependency_data) {
-      dependencyData.value =
-        data.dependency_data as unknown as DependencyGraph
-    }
-  }
-
-  const loadCachedImportTree = async () => {
-    const backendUrl = await appConfig.getServiceUrl('backend')
-    const resp = await fetchWithAuth(
-      withSourceId(
-        `${backendUrl}/api/analytics/codebase/analytics/import-tree/cached`,
-      ),
-    )
-    if (!resp.ok) return
-    const data = await resp.json()
-    if (data.status === 'success' && data.import_tree) {
-      importTreeData.value =
-        data.import_tree as unknown as ImportTreeNode[]
-    }
-  }
-
-  // --- Scan orchestration ---
-
-  const loadCachedAnalyticsData = async (
-    extraScans: Array<{
-      id: string
-      label: string
-      run: () => Promise<void>
-    }>,
-  ) => {
-    try {
-      await scanRunner.runAll([
-        {
-          id: 'stats',
-          label: t('analytics.codebase.scans.stats'),
-          run: () => getCodebaseStats(),
-        },
-        {
-          id: 'problems',
-          label: t('analytics.codebase.scans.problems'),
-          run: () => getProblemsReport(),
-        },
-        {
-          id: 'declarations',
-          label: t('analytics.codebase.scans.declarations'),
-          run: () => loadDeclarations(),
-        },
-        {
-          id: 'duplicates',
-          label: t('analytics.codebase.scans.duplicates'),
-          run: () => loadCachedDuplicates(),
-        },
-        {
-          id: 'hardcodes',
-          label: t('analytics.codebase.scans.hardcodes'),
-          run: () => loadHardcodes(),
-        },
-        {
-          id: 'charts',
-          label: t('analytics.codebase.scans.charts'),
-          run: () => loadChartData(),
-        },
-        {
-          id: 'dependencies',
-          label: t('analytics.codebase.scans.dependencies'),
-          run: () => loadCachedDependencies(),
-        },
-        {
-          id: 'imports',
-          label: t('analytics.codebase.scans.imports'),
-          run: () => loadCachedImportTree(),
-        },
-        {
-          id: 'callgraph',
-          label: t('analytics.codebase.scans.callGraph'),
-          run: () => loadCallGraphData(),
-        },
-        ...extraScans,
-      ])
-
-      if (scanRunner.failedCount.value > 0) {
-        progressStatus.value = t(
-          'analytics.codebase.status.loadPartialFailed',
-          {
-            failed: scanRunner.failedCount.value,
-            total: scanRunner.totalCount.value,
-          },
-        )
-      } else {
-        progressStatus.value = t(
-          'analytics.codebase.status.loadComplete',
-        )
-      }
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error(
-        'Failed to load cached analytics data:',
-        error,
-      )
-      progressStatus.value = t(
-        'analytics.codebase.status.loadFailed',
-        { error: errorMessage },
-      )
-    }
-  }
-
-  const runAllAnalysisScans = async (
-    extraScans: Array<{
-      id: string
-      label: string
-      run: () => Promise<void>
-    }>,
-  ) => {
-    try {
-      await scanRunner.runAll([
-        {
-          id: 'stats',
-          label: t('analytics.codebase.scans.stats'),
-          run: () => getCodebaseStats(),
-        },
-        {
-          id: 'problems',
-          label: t('analytics.codebase.scans.problems'),
-          run: () => getProblemsReport(),
-        },
-        {
-          id: 'declarations',
-          label: t('analytics.codebase.scans.declarations'),
-          run: () => loadDeclarations(),
-        },
-        {
-          id: 'duplicates',
-          label: t('analytics.codebase.scans.duplicates'),
-          run: () => loadDuplicates(),
-        },
-        {
-          id: 'hardcodes',
-          label: t('analytics.codebase.scans.hardcodes'),
-          run: () => loadHardcodes(),
-        },
-        {
-          id: 'charts',
-          label: t('analytics.codebase.scans.charts'),
-          run: () => loadChartData(),
-        },
-        {
-          id: 'dependencies',
-          label: t('analytics.codebase.scans.dependencies'),
-          run: async () => { await loadDependencyData() },
-        },
-        {
-          id: 'imports',
-          label: t('analytics.codebase.scans.imports'),
-          run: async () => { await loadImportTreeData() },
-        },
-        {
-          id: 'callgraph',
-          label: t('analytics.codebase.scans.callGraph'),
-          run: () => loadCallGraphData(),
-        },
-        ...extraScans,
-      ])
-
-      if (scanRunner.failedCount.value > 0) {
-        progressStatus.value = t(
-          'analytics.codebase.status.loadPartialFailed',
-          {
-            failed: scanRunner.failedCount.value,
-            total: scanRunner.totalCount.value,
-          },
-        )
-      } else {
-        progressStatus.value = t(
-          'analytics.codebase.status.loadComplete',
-        )
-      }
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error(
-        'Failed to load codebase analytics data:',
-        error,
-      )
-      progressStatus.value = t(
-        'analytics.codebase.status.loadFailed',
-        { error: errorMessage },
-      )
-    }
-  }
-
   return {
     // Task loaders
     dependencyData,
@@ -1099,18 +641,18 @@ export function useAnalyticsDataFetchers(
     declarationAnalysis,
     hardcodeAnalysis,
     refactoringSuggestions,
-    chartData,
-    chartDataLoading,
-    chartDataError,
+    chartData: chartEndpoint.data,
+    chartDataLoading: chartEndpoint.loading,
+    chartDataError: chartEndpoint.error,
     unifiedReport,
-    unifiedReportLoading,
-    unifiedReportError,
+    unifiedReportLoading: unifiedEndpoint.loading,
+    unifiedReportError: unifiedEndpoint.error,
     selectedCategory,
     callGraphData,
     callGraphSummary,
     callGraphOrphaned,
-    callGraphLoading,
-    callGraphError,
+    callGraphLoading: callGraphEndpoint.loading,
+    callGraphError: callGraphEndpoint.error,
     loadingProgress,
     showAllProblems,
     showAllDeclarations,

--- a/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.test.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.test.ts
@@ -1,0 +1,233 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Unit tests for useAnalyticsEndpoint.
+ *
+ * Issue #5112.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock fetchWithAuth (the composable calls it instead of raw fetch).
+vi.mock('@/utils/fetchWithAuth', () => ({
+  fetchWithAuth: vi.fn(),
+}))
+
+// Mock AppConfig.getServiceUrl so tests don't hit service discovery.
+vi.mock('@/config/AppConfig.js', () => ({
+  default: {
+    getServiceUrl: vi.fn(async () => 'http://backend.test'),
+  },
+}))
+
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { useAnalyticsEndpoint } from './useAnalyticsEndpoint'
+
+const mockedFetch = vi.mocked(fetchWithAuth)
+
+const withSourceId = vi.fn(
+  (u: string) => (u.includes('?') ? `${u}&source_id=s1` : `${u}?source_id=s1`),
+)
+
+interface RawStats {
+  status: 'success' | 'no_data'
+  stats?: { total: number }
+}
+
+interface Stats {
+  total: number
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('useAnalyticsEndpoint', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset()
+    withSourceId.mockClear()
+  })
+
+  it('loads data on success and cycles loading', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ status: 'success', stats: { total: 42 } }),
+    )
+
+    const onSuccess = vi.fn()
+    const { data, loading, error, load } = useAnalyticsEndpoint<
+      RawStats,
+      Stats
+    >(
+      {
+        path: '/api/analytics/codebase/stats',
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+        onSuccess,
+      },
+      { withSourceId },
+    )
+
+    expect(loading.value).toBe(false)
+    const p = load()
+    expect(loading.value).toBe(true)
+    await p
+
+    expect(loading.value).toBe(false)
+    expect(error.value).toBe('')
+    expect(data.value).toEqual({ total: 42 })
+    expect(onSuccess).toHaveBeenCalledWith(
+      { total: 42 },
+      { status: 'success', stats: { total: 42 } },
+    )
+  })
+
+  it('handles no_data (pickData returns null) without setting error', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ status: 'no_data' }),
+    )
+    const onNoData = vi.fn()
+    const { data, error, load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/analytics/codebase/stats',
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+        onNoData,
+      },
+      { withSourceId },
+    )
+
+    await load()
+
+    expect(data.value).toBeNull()
+    expect(error.value).toBe('')
+    expect(onNoData).toHaveBeenCalledTimes(1)
+  })
+
+  it('populates error on non-ok HTTP status and leaves data null', async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse({}, 500))
+    const onError = vi.fn()
+
+    const { data, error, load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/analytics/codebase/stats',
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+        onError,
+        label: 'Stats endpoint',
+      },
+      { withSourceId },
+    )
+
+    await load()
+
+    expect(data.value).toBeNull()
+    expect(error.value).toContain('Stats endpoint returned 500')
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  it('populates error on network/fetch rejection', async () => {
+    mockedFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    const { data, error, load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/analytics/codebase/stats',
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+      },
+      { withSourceId },
+    )
+
+    await load()
+
+    expect(data.value).toBeNull()
+    expect(error.value).toContain('Failed to fetch')
+  })
+
+  it('applies withSourceId by default (scopeToSource opt-out)', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ status: 'success', stats: { total: 1 } }),
+    )
+    const { load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/analytics/codebase/stats',
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+      },
+      { withSourceId },
+    )
+
+    await load()
+
+    expect(withSourceId).toHaveBeenCalledTimes(1)
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toContain('source_id=s1')
+  })
+
+  it('scopeToSource=false bypasses withSourceId', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ status: 'success', stats: { total: 1 } }),
+    )
+    const { load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/unified/report',
+        scopeToSource: false,
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+      },
+      { withSourceId },
+    )
+
+    await load()
+
+    expect(withSourceId).not.toHaveBeenCalled()
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toBe('http://backend.test/api/unified/report')
+  })
+
+  it('appends queryExtras to the URL', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ status: 'success', stats: { total: 1 } }),
+    )
+    const { load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/analytics/codebase/stats',
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+      },
+      { withSourceId },
+    )
+
+    await load({ problem_type: 'race_condition', limit: '50' })
+
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toContain('problem_type=race_condition')
+    expect(url).toContain('limit=50')
+    // still scoped
+    expect(url).toContain('source_id=s1')
+  })
+
+  it('skips empty queryExtras entries', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ status: 'success', stats: { total: 1 } }),
+    )
+    const { load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/analytics/codebase/stats',
+        scopeToSource: false,
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+      },
+      { withSourceId },
+    )
+
+    await load({ empty: '', also_empty: '' })
+
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toBe('http://backend.test/api/analytics/codebase/stats')
+  })
+})

--- a/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.ts
@@ -1,0 +1,144 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Composable: useAnalyticsEndpoint
+ *
+ * Generic GET-fetcher for analytics-style endpoints. Collapses the
+ * 14x near-identical boilerplate that lived in useAnalyticsDataFetchers:
+ *   loading flag → clear error → resolve backendUrl → withSourceId (opt-out)
+ *   → fetchWithAuth → !ok throw → json() → status branching → assign
+ *   → catch → finally.
+ *
+ * Key design: `scopeToSource` defaults to TRUE so forgetting to wire it
+ * (the #5111 class of bugs) is impossible without an explicit opt-out.
+ *
+ * Issue #5112.
+ */
+
+import { ref, type Ref } from 'vue'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import appConfig from '@/config/AppConfig.js'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useAnalyticsEndpoint')
+
+export interface UseAnalyticsEndpointOptions<TRaw, TOut> {
+  /** API path appended to the resolved backend URL, e.g. '/api/analytics/codebase/stats'. */
+  path: string
+  /**
+   * Whether to wrap the URL with `withSourceId()` before fetching.
+   * Defaults to TRUE — opt-out only. #5111 was caused by forgetting this,
+   * so the only way to skip source scoping is now an explicit `false`.
+   */
+  scopeToSource?: boolean
+  /**
+   * Reducer from raw JSON to the target data type.
+   * Return `null` to indicate "no data" (leaves `data` as null without error).
+   * Status-branching (success / no_data / indexing) lives here.
+   */
+  pickData: (raw: TRaw) => TOut | null
+  /** Optional side-effect fired after `data` is assigned on success. */
+  onSuccess?: (data: TOut, raw: TRaw) => void
+  /** Optional side-effect fired when `pickData` returns null (no-data path). */
+  onNoData?: () => void
+  /**
+   * Optional side-effect fired when fetch fails or throws. Receives the
+   * resolved error message (same value that lands in `error.value`).
+   */
+  onError?: (message: string, err: unknown) => void
+  /** Human-readable label used only for log messages. */
+  label?: string
+}
+
+export interface UseAnalyticsEndpointDeps {
+  withSourceId: (url: string) => string
+}
+
+export interface UseAnalyticsEndpointReturn<TOut> {
+  data: Ref<TOut | null>
+  loading: Ref<boolean>
+  error: Ref<string>
+  load: (queryExtras?: Record<string, string>) => Promise<void>
+}
+
+/**
+ * Appends a query-extras map to a URL, preserving any existing query string
+ * added by `withSourceId()`. Skips empty values.
+ */
+function appendQueryExtras(
+  url: string,
+  extras?: Record<string, string>,
+): string {
+  if (!extras) return url
+  const entries = Object.entries(extras).filter(
+    ([, v]) => v !== undefined && v !== null && v !== '',
+  )
+  if (entries.length === 0) return url
+  const sep = url.includes('?') ? '&' : '?'
+  const qs = entries
+    .map(
+      ([k, v]) =>
+        `${encodeURIComponent(k)}=${encodeURIComponent(v)}`,
+    )
+    .join('&')
+  return `${url}${sep}${qs}`
+}
+
+export function useAnalyticsEndpoint<TRaw, TOut>(
+  opts: UseAnalyticsEndpointOptions<TRaw, TOut>,
+  deps: UseAnalyticsEndpointDeps,
+): UseAnalyticsEndpointReturn<TOut> {
+  const data = ref<TOut | null>(null) as Ref<TOut | null>
+  const loading = ref(false)
+  const error = ref('')
+
+  const scopeToSource = opts.scopeToSource !== false
+  const label = opts.label ?? opts.path
+
+  const load = async (
+    queryExtras?: Record<string, string>,
+  ): Promise<void> => {
+    loading.value = true
+    error.value = ''
+    try {
+      const backendUrl = await appConfig.getServiceUrl('backend')
+      let url = `${backendUrl}${opts.path}`
+      if (scopeToSource) {
+        url = deps.withSourceId(url)
+      }
+      url = appendQueryExtras(url, queryExtras)
+
+      const response = await fetchWithAuth(url, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      })
+      if (!response.ok) {
+        throw new Error(`${label} returned ${response.status}`)
+      }
+      const raw = (await response.json()) as TRaw
+      const picked = opts.pickData(raw)
+      if (picked === null) {
+        data.value = null
+        opts.onNoData?.()
+        return
+      }
+      data.value = picked
+      opts.onSuccess?.(picked, raw)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`Failed to load ${label}:`, err)
+      error.value = message
+      data.value = null
+      opts.onError?.(message, err)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { data, loading, error, load }
+}


### PR DESCRIPTION
## Summary

- Introduces `autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.ts` \u2014 a 144-line generic composable that collapses the 25\u201335-line boilerplate repeated across 14 GET-fetchers in `useAnalyticsDataFetchers.ts`.
- `useAnalyticsDataFetchers.ts` shrinks from **1147 \u2192 693 lines** (-40%); 13 fetchers routed through the new composable.
- Adds `analyticsTypes.ts` (183 lines) \u2014 domain types extracted and re-exported from `useAnalyticsDataFetchers` so callers are unchanged.
- Adds `useAnalyticsEndpoint.test.ts` (233 lines, 8 passing tests): success / no_data / HTTP error / network error / scopeToSource default / scopeToSource=false / queryExtras.

Closes #5112.

## Key design point

`scopeToSource` defaults to **`true`** \u2014 every caller gets `withSourceId()` wrapping unless it explicitly opts out (only `loadUnifiedReport` does, because it hits `/api/unified/report`). This makes the bug class from #5111 (silently forgetting `withSourceId` on a source-scoped endpoint) **structurally impossible** for any new caller.

The 2-line #5111 fix landed via PR #5113 (commit a5eeec35b on Dev_new_gui). This PR was rebased onto that and preserves the fix through the new composable.

## Migration detail (13 fetchers)

| Fetcher | Endpoint | Instance |
|---|---|---|
| loadChartData | /api/analytics/codebase/analytics/charts | chartEndpoint |
| loadUnifiedReport | /api/unified/report | unifiedEndpoint *(scopeToSource: false)* |
| loadCallGraphData | /api/analytics/codebase/analytics/call-graph | callGraphEndpoint |
| getCodebaseStats | /api/analytics/codebase/stats | statsEndpoint |
| getProblemsReport | /api/analytics/codebase/problems | problemsEndpoint |
| loadDeclarations | /api/analytics/codebase/declarations | declarationsSilent |
| loadHardcodes | /api/analytics/codebase/hardcodes | hardcodesSilent |
| getDeclarationsData | /api/analytics/codebase/declarations | declarationsSilent + notifyTimed() |
| getDuplicatesData | /api/analytics/codebase/duplicates | duplicatesSilent + notifyTimed() |
| getHardcodesData | /api/analytics/codebase/hardcodes | hardcodesSilent + notifyTimed() |
| loadCachedDuplicates | /api/analytics/codebase/duplicates/cached | cachedDuplicatesEndpoint |
| loadCachedDependencies | .../analytics/dependencies/cached | cachedDependenciesEndpoint |
| loadCachedImportTree | .../analytics/import-tree/cached | cachedImportTreeEndpoint |

**Intentionally unchanged** (different pattern): `loadDuplicates` (uses `useBackgroundTask` polling), `loadDependencyData`/`loadImportTreeData` (use `useTaskLoader` polling).

## Test plan

- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` \u2014 zero new errors in the changed files (169 baseline unrelated errors unchanged).
- [x] `npx vitest run src/composables/analytics/useAnalyticsEndpoint.test.ts` \u2014 8/8 passing.
- [ ] Manual: visit `/analytics/codebase/{sourceId}` \u2014 all 14+ analytics panels populate as before.
- [ ] Manual: toast UX for `getDeclarationsData` / `getDuplicatesData` / `getHardcodesData` still shows count + response time on success and error on failure.

## Public API preserved

All exports from `useAnalyticsDataFetchers` are unchanged \u2014 `CodebaseAnalytics.vue` needs no edits. Call-site at `CodebaseAnalytics.vue:532-576` still destructures the same names.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)