### PR TITLE
refactor(frontend): split useKnowledgeBase into 7 domain composables + drop dead try/catch boilerplate (#5122 #5123)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useKnowledgeBase.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeBase.test.ts
@@ -1,47 +1,24 @@
 /**
- * useKnowledgeBase Composable Tests
+ * useKnowledgeBase BC Shim Smoke Tests
  *
- * Comprehensive unit tests for the knowledge base management composable.
- * Tests cover 30+ API methods and helper functions including:
- * - Knowledge base statistics and categories
- * - Search (basic and advanced)
- * - Fact management (add, upload, vectorize)
- * - Machine profiles and man pages
- * - Background job polling
- * - Icon/formatting helper functions
+ * The composable was split into 6 domain-focused composables under
+ * `../knowledge/*` (#5122). This file only verifies the backward-compat
+ * aggregator still exposes every function it did before the split, so
+ * unmigrated consumers keep working.
  *
- * @author mrveiss
- * @copyright 2025 mrveiss
+ * Per-function behavior is covered by the focused test files:
+ * - useKnowledgeStats.test.ts
+ * - useKnowledgeCategories.test.ts
+ * - useKnowledgeFacts.test.ts
+ * - useKnowledgeFiles.test.ts
+ * - useMachineKnowledge.test.ts
+ * - useManPages.test.ts
+ * - useKnowledgeJobs.test.ts
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import type {
-  KnowledgeStats,
-  CategoryResponse,
-  CategoriesListResponse,
-  SearchResponse,
-  AddFactResponse,
-  UploadResponse,
-  IntegrationResponse,
-  VectorizationStatusResponse,
-  VectorizationResponse,
-  MachineKnowledgeResponse,
-  SystemKnowledgeResponse,
-  ManPagesPopulateResponse,
-  AutoBotDocsResponse,
-  CategorizedFactsResponse,
-} from '@/types/knowledgeBase'
-import {
-  useKnowledgeBase,
-  type MachineProfile,
-  type ManPagesSummary,
-} from '../useKnowledgeBase'
+import { describe, it, expect, vi } from 'vitest'
+import { useKnowledgeBase } from '../useKnowledgeBase'
 
-// ========================================
-// Mock Setup
-// ========================================
-
-// Mock apiClient
 vi.mock('@/utils/ApiClient', () => ({
   default: {
     get: vi.fn(),
@@ -49,30 +26,23 @@ vi.mock('@/utils/ApiClient', () => ({
   },
 }))
 
-// Mock formatHelpers
 vi.mock('@/utils/formatHelpers', () => ({
-  formatDate: (date: any) => new Date(date).toLocaleDateString(),
+  formatDate: (date: unknown) => new Date(date as string).toLocaleDateString(),
   formatFileSize: (bytes: number) => `${(bytes / 1024).toFixed(2)} KB`,
   formatCategoryName: (name: string) => name.replace(/_/g, ' ').toUpperCase(),
 }))
 
-// Mock iconMappings
 vi.mock('@/utils/iconMappings', () => ({
-  getFileIcon: (name: string) => 'fas fa-file',
+  getFileIcon: () => 'fas fa-file',
 }))
 
-// Mock appConfig
 vi.mock('@/config/AppConfig.js', () => ({
   default: {
     getApiUrl: vi.fn((url) => Promise.resolve(`/api${url}`)),
-    getTimeout: vi.fn((type) => {
-      if (type === 'knowledge') return 300000
-      return 30000
-    }),
+    getTimeout: vi.fn(() => 300000),
   },
 }))
 
-// Mock logger
 vi.mock('@/utils/debugUtils', () => ({
   createLogger: () => ({
     debug: vi.fn(),
@@ -82,980 +52,72 @@ vi.mock('@/utils/debugUtils', () => ({
   }),
 }))
 
-// Mock ssot-config
 vi.mock('@/config/ssot-config', () => ({
   getApiBase: () => '/knowledge_base',
 }))
 
-import apiClient from '@/utils/ApiClient'
+describe('useKnowledgeBase (BC shim)', () => {
+  it('should export all API call methods from the aggregator', () => {
+    const composable = useKnowledgeBase()
 
-// ========================================
-// Helper Functions
-// ========================================
-
-/**
- * Shape of the background job status response used by `pollJobStatus`.
- * Production types this loosely as `any` (see useKnowledgeBase.ts), so we
- * declare a local interface to keep test fixtures type-checked.
- */
-interface JobStatus {
-  task_id: string
-  status: 'PENDING' | 'PROGRESS' | 'SUCCESS' | 'FAILURE'
-  result?: Record<string, unknown>
-  error?: string
-  progress?: number
-}
-
-// ========================================
-// Tests
-// ========================================
-
-describe('useKnowledgeBase', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+    // Stats
+    expect(typeof composable.fetchStats).toBe('function')
+    expect(typeof composable.fetchBasicStats).toBe('function')
+    // Categories
+    expect(typeof composable.fetchCategories).toBe('function')
+    expect(typeof composable.fetchCategory).toBe('function')
+    expect(typeof composable.getCategorizedFacts).toBe('function')
+    expect(typeof composable.buildCategoryFilterOptions).toBe('function')
+    // Facts / search
+    expect(typeof composable.searchKnowledge).toBe('function')
+    expect(typeof composable.advancedSearch).toBe('function')
+    expect(typeof composable.addFact).toBe('function')
+    // Files
+    expect(typeof composable.uploadKnowledgeFile).toBe('function')
+    // Machine
+    expect(typeof composable.fetchMachineProfiles).toBe('function')
+    expect(typeof composable.fetchMachineProfile).toBe('function')
+    expect(typeof composable.initializeMachineKnowledge).toBe('function')
+    expect(typeof composable.refreshSystemKnowledge).toBe('function')
+    // Man pages
+    expect(typeof composable.fetchManPagesSummary).toBe('function')
+    expect(typeof composable.integrateManPages).toBe('function')
+    expect(typeof composable.populateManPages).toBe('function')
+    expect(typeof composable.populateAutoBotDocs).toBe('function')
+    // Jobs / vectorization
+    expect(typeof composable.getVectorizationStatus).toBe('function')
+    expect(typeof composable.vectorizeFacts).toBe('function')
+    expect(typeof composable.pollJobStatus).toBe('function')
   })
 
-  // =========================================================================
-  // 1. Knowledge Statistics
-  // =========================================================================
-  describe('fetchStats', () => {
-    it('should fetch knowledge base statistics successfully', async () => {
-      const mockStats: KnowledgeStats = {
-        total_facts: 100,
-        total_documents: 50,
-        last_updated: '2025-04-12T10:00:00Z',
-      }
+  it('should export all helper/icon functions', () => {
+    const composable = useKnowledgeBase()
 
-      vi.mocked(apiClient.get).mockResolvedValue(mockStats)
-
-      const { fetchStats } = useKnowledgeBase()
-      const result = await fetchStats()
-
-      expect(result).toEqual(mockStats)
-      expect(apiClient.get).toHaveBeenCalledWith('/knowledge_base/knowledge_base/stats')
-    })
-
-    it('should throw error when stats fetch fails', async () => {
-      vi.mocked(apiClient.get).mockRejectedValue(new Error('HTTP 500: Server error'))
-
-      const { fetchStats } = useKnowledgeBase()
-
-      await expect(fetchStats()).rejects.toThrow('HTTP 500')
-    })
+    expect(typeof composable.getCategoryIcon).toBe('function')
+    expect(typeof composable.getTypeIcon).toBe('function')
+    expect(typeof composable.getFileIcon).toBe('function')
+    expect(typeof composable.getOSBadgeClass).toBe('function')
+    expect(typeof composable.getMessageIcon).toBe('function')
+    expect(typeof composable.formatTime).toBe('function')
   })
 
-  // =========================================================================
-  // 2. Categories
-  // =========================================================================
-  describe('fetchCategories', () => {
-    it('should fetch all categories with counts', async () => {
-      const mockCategoriesResponse: CategoriesListResponse = {
-        categories: [
-          { name: 'architecture', count: 10, id: 'arch-1' },
-          { name: 'security', count: 15, id: 'sec-1' },
-        ],
-        total: 2,
-      }
+  it('should export formatting functions from shared utilities', () => {
+    const composable = useKnowledgeBase()
 
-      vi.mocked(apiClient.get).mockResolvedValue(mockCategoriesResponse)
-
-      const { fetchCategories } = useKnowledgeBase()
-      const result = await fetchCategories()
-
-      expect(result).toEqual(mockCategoriesResponse.categories)
-      expect(apiClient.get).toHaveBeenCalledWith('/knowledge_base/knowledge_base/categories')
-    })
-
-    it('should throw error when response structure is invalid', async () => {
-      // Intentionally malformed: missing the required `categories` array so
-      // that the runtime validator in `fetchCategories` throws. Typed as
-      // `unknown` (not `CategoriesListResponse`) because it is deliberately
-      // shape-invalid.
-      const invalidResponse: unknown = { notCategories: [] }
-
-      vi.mocked(apiClient.get).mockResolvedValue(invalidResponse)
-
-      const { fetchCategories } = useKnowledgeBase()
-
-      await expect(fetchCategories()).rejects.toThrow('Invalid categories response format')
-    })
+    expect(typeof composable.formatDate).toBe('function')
+    expect(typeof composable.formatCategory).toBe('function')
+    expect(typeof composable.formatCategoryName).toBe('function')
+    expect(typeof composable.formatFileSize).toBe('function')
+    expect(typeof composable.formatDateOnly).toBe('function')
   })
 
-  describe('fetchCategory', () => {
-    it('should fetch facts for a specific category', async () => {
-      const mockCategory: CategoryResponse = {
-        facts: [
-          { id: '1', fact: 'Use strong passwords', category: 'security', created_at: '2025-04-12T10:00:00Z', updated_at: '2025-04-12T10:00:00Z' },
-        ],
-      }
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockCategory)
-
-      const { fetchCategory } = useKnowledgeBase()
-      const result = await fetchCategory('security')
-
-      expect(result).toEqual(mockCategory)
-      expect(apiClient.get).toHaveBeenCalledWith('/knowledge_base/knowledge_base/category/security')
-    })
-
-    it('should throw error for invalid category', async () => {
-      vi.mocked(apiClient.get).mockRejectedValue(new Error('HTTP 404: Category not found'))
-
-      const { fetchCategory } = useKnowledgeBase()
-
-      await expect(fetchCategory('nonexistent')).rejects.toThrow('HTTP 404')
-    })
-  })
-
-  // =========================================================================
-  // 3. Categorized Facts & Filtering
-  // =========================================================================
-  describe('getCategorizedFacts', () => {
-    it('should fetch categorized facts', async () => {
-      const mockCategorizedFacts: CategorizedFactsResponse = {
-        total_facts: 50,
-        categories: {
-          security: [
-            { key: '1', title: 'fact1', content: 'fact1 content', category: 'security', type: 'general', metadata: {} },
-            { key: '2', title: 'fact2', content: 'fact2 content', category: 'security', type: 'general', metadata: {} },
-          ],
-          architecture: [
-            { key: '3', title: 'fact3', content: 'fact3 content', category: 'architecture', type: 'general', metadata: {} },
-          ],
-        },
-      }
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockCategorizedFacts)
-
-      const { getCategorizedFacts } = useKnowledgeBase()
-      const result = await getCategorizedFacts()
-
-      expect(result).toEqual(mockCategorizedFacts)
-      expect(result.total_facts).toBe(50)
-      expect(Object.keys(result.categories).length).toBe(2)
-    })
-
-    it('should respect category filter parameter', async () => {
-      const mockCategorizedFacts: CategorizedFactsResponse = {
-        total_facts: 2,
-        categories: {
-          security: [
-            {
-              key: '1',
-              title: 'fact1',
-              content: 'fact1',
-              category: 'security',
-              type: 'general',
-              metadata: {},
-            },
-          ],
-        },
-      }
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockCategorizedFacts)
-
-      const { getCategorizedFacts } = useKnowledgeBase()
-      await getCategorizedFacts('security', 100)
-
-      expect(apiClient.get).toHaveBeenCalledWith(
-        expect.stringContaining('category=security')
-      )
-    })
-
-    it('should throw error for invalid response format', async () => {
-      // Intentionally malformed — `categories` is missing so the runtime
-      // validator rejects the response. Typed as `unknown` because the
-      // shape is deliberately non-conforming.
-      const invalidResponse: unknown = { total_facts: 0, noCategoriesField: {} }
-
-      vi.mocked(apiClient.get).mockResolvedValue(invalidResponse)
-
-      const { getCategorizedFacts } = useKnowledgeBase()
-
-      await expect(getCategorizedFacts()).rejects.toThrow('Invalid categorized facts response format')
-    })
-  })
-
-  describe('buildCategoryFilterOptions', () => {
-    it('should build filter options from categorized facts', () => {
-      const categorizedFacts: CategorizedFactsResponse = {
-        total_facts: 5,
-        categories: {
-          security: [
-            { key: '1', title: 'f1', content: 'fact1', category: 'security', type: 'general', metadata: {} },
-            { key: '2', title: 'f2', content: 'fact2', category: 'security', type: 'general', metadata: {} },
-          ],
-          architecture: [
-            { key: '3', title: 'f3', content: 'fact3', category: 'architecture', type: 'general', metadata: {} },
-          ],
-        },
-      }
-
-      const { buildCategoryFilterOptions } = useKnowledgeBase()
-      const options = buildCategoryFilterOptions(categorizedFacts)
-
-      expect(options.length).toBe(3)
-      expect(options[0].label).toBe('All Categories')
-      expect(options[0].value).toBe(null)
-      expect(options[0].count).toBe(5)
-    })
-
-    it('should sort options by count descending', () => {
-      const categorizedFacts: CategorizedFactsResponse = {
-        total_facts: 6,
-        categories: {
-          small: [
-            { key: '1', title: 'f1', content: 'fact1', category: 'small', type: 'general', metadata: {} },
-          ],
-          big: [
-            { key: '2', title: 'f2', content: 'fact2', category: 'big', type: 'general', metadata: {} },
-            { key: '3', title: 'f3', content: 'fact3', category: 'big', type: 'general', metadata: {} },
-            { key: '4', title: 'f4', content: 'fact4', category: 'big', type: 'general', metadata: {} },
-          ],
-        },
-      }
-
-      const { buildCategoryFilterOptions } = useKnowledgeBase()
-      const options = buildCategoryFilterOptions(categorizedFacts)
-
-      // First should be "All Categories"
-      expect(options[0].value).toBe(null)
-      // Rest should be sorted by count (big before small)
-      expect(options[1].count).toBeGreaterThanOrEqual(options[2].count)
-    })
-  })
-
-  // =========================================================================
-  // 4. Search Operations
-  // =========================================================================
-  describe('searchKnowledge', () => {
-    it('should perform basic keyword search', async () => {
-      const mockSearchResult: SearchResponse = {
-        results: [
-          { id: '1', fact: 'matching fact', similarity_score: 0.95 },
-        ],
-        total_results: 1,
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockSearchResult)
-
-      const { searchKnowledge } = useKnowledgeBase()
-      const result = await searchKnowledge('test query')
-
-      expect(result).toEqual(mockSearchResult)
-      expect(apiClient.post).toHaveBeenCalledWith(
-        '/knowledge_base/knowledge_base/search',
-        { query: 'test query' }
-      )
-    })
-
-    it('should throw error when search fails', async () => {
-      vi.mocked(apiClient.post).mockRejectedValue(new Error('HTTP 500: Search backend error'))
-
-      const { searchKnowledge } = useKnowledgeBase()
-
-      await expect(searchKnowledge('test')).rejects.toThrow('HTTP 500')
-    })
-  })
-
-  describe('advancedSearch', () => {
-    it('should perform advanced search with all options', async () => {
-      const mockResults: SearchResponse = {
-        results: [{ id: '1', fact: 'semantic match', similarity_score: 0.98 }],
-        total_results: 1,
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockResults)
-
-      const { advancedSearch } = useKnowledgeBase()
-      const result = await advancedSearch({
-        query: 'test',
-        mode: 'semantic',
-        enable_rag: true,
-        category: 'security',
-        top_k: 10,
-      })
-
-      expect(result).toEqual(mockResults)
-      expect(apiClient.post).toHaveBeenCalledWith(
-        '/knowledge_base/knowledge_base/search',
-        expect.objectContaining({
-          query: 'test',
-          mode: 'semantic',
-          enable_rag: true,
-          category: 'security',
-        })
-      )
-    })
-
-    it('should support hybrid search mode', async () => {
-      const mockResults: SearchResponse = { results: [], total_results: 0 }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockResults)
-
-      const { advancedSearch } = useKnowledgeBase()
-      await advancedSearch({
-        query: 'test',
-        mode: 'hybrid',
-        enable_reranking: true,
-      })
-
-      expect(apiClient.post).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          mode: 'hybrid',
-          enable_reranking: true,
-        })
-      )
-    })
-  })
-
-  // =========================================================================
-  // 5. Fact Management
-  // =========================================================================
-  describe('addFact', () => {
-    it('should add a new fact to knowledge base', async () => {
-      const mockAddResponse: AddFactResponse = {
-        success: true,
-        fact_id: 'fact-123',
-        fact: {
-          id: 'fact-123',
-          fact: 'New security fact',
-          category: 'security',
-          created_at: '2025-04-12T10:00:00Z',
-          updated_at: '2025-04-12T10:00:00Z',
-        },
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockAddResponse)
-
-      const { addFact } = useKnowledgeBase()
-      const result = await addFact({
-        content: 'New security fact',
-        category: 'security',
-      })
-
-      expect(result).toEqual(mockAddResponse)
-      expect(apiClient.post).toHaveBeenCalledWith(
-        '/knowledge_base/knowledge_base/facts',
-        expect.objectContaining({
-          content: 'New security fact',
-          category: 'security',
-        })
-      )
-    })
-
-    it('should add fact with metadata', async () => {
-      const mockAddResponse: AddFactResponse = {
-        success: true,
-        fact_id: 'fact-456',
-        fact: {
-          id: 'fact-456',
-          fact: 'Fact with metadata',
-          category: 'architecture',
-          created_at: '2025-04-12T10:00:00Z',
-          updated_at: '2025-04-12T10:00:00Z',
-        },
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockAddResponse)
-
-      const { addFact } = useKnowledgeBase()
-      const result = await addFact({
-        content: 'Fact with metadata',
-        category: 'architecture',
-        metadata: { source: 'manual', priority: 'high' },
-      })
-
-      expect(result.success).toBe(true)
-    })
-  })
-
-  // =========================================================================
-  // 6. File Upload
-  // =========================================================================
-  describe('uploadKnowledgeFile', () => {
-    it('should upload a knowledge file successfully', async () => {
-      const mockUploadResponse: UploadResponse = {
-        success: true,
-        file_path: '/uploads/test.pdf',
-        facts_added: 5,
-      }
-
-      const formData = new FormData()
-      formData.append('file', new Blob(['test'], { type: 'application/pdf' }))
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockUploadResponse)
-
-      const { uploadKnowledgeFile } = useKnowledgeBase()
-      const result = await uploadKnowledgeFile(formData)
-
-      expect(result).toEqual(mockUploadResponse)
-      expect(apiClient.post).toHaveBeenCalledWith(
-        '/knowledge_base/knowledge_base/upload',
-        formData
-      )
-    })
-
-    it('should throw error on upload failure', async () => {
-      const formData = new FormData()
-
-      vi.mocked(apiClient.post).mockRejectedValue(new Error('HTTP 400: Upload failed'))
-
-      const { uploadKnowledgeFile } = useKnowledgeBase()
-
-      await expect(uploadKnowledgeFile(formData)).rejects.toThrow('Upload failed')
-    })
-  })
-
-  // =========================================================================
-  // 7. Machine Profiles & Man Pages
-  // =========================================================================
-  describe('fetchMachineProfiles', () => {
-    it('should fetch all machine profiles', async () => {
-      const mockProfiles: MachineProfile[] = [
-        { machine_id: 'host1', os_type: 'linux', distro: 'Ubuntu' },
-        { machine_id: 'host2', os_type: 'linux', distro: 'CentOS' },
-      ]
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockProfiles)
-
-      const { fetchMachineProfiles } = useKnowledgeBase()
-      const result = await fetchMachineProfiles()
-
-      expect(result).toEqual(mockProfiles)
-      expect(Array.isArray(result)).toBe(true)
-    })
-
-    it('should return empty array on error', async () => {
-      vi.mocked(apiClient.get).mockResolvedValue(null)
-
-      const { fetchMachineProfiles } = useKnowledgeBase()
-      const result = await fetchMachineProfiles()
-
-      expect(result).toEqual([])
-    })
-  })
-
-  describe('fetchManPagesSummary', () => {
-    it('should fetch man pages summary', async () => {
-      const mockSummary: ManPagesSummary = {
-        status: 'ready',
-        successful: 150,
-        processed: 150,
-        current_man_page_files: 1500,
-      }
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockSummary)
-
-      const { fetchManPagesSummary } = useKnowledgeBase()
-      const result = await fetchManPagesSummary()
-
-      expect(result).toEqual(mockSummary)
-      expect(result?.status).toBe('ready')
-    })
-
-    it('should return null on error', async () => {
-      vi.mocked(apiClient.get).mockResolvedValue(null)
-
-      const { fetchManPagesSummary } = useKnowledgeBase()
-      const result = await fetchManPagesSummary()
-
-      expect(result).toBe(null)
-    })
-  })
-
-  // =========================================================================
-  // 8. Vectorization
-  // =========================================================================
-  describe('vectorizeFacts', () => {
-    it('should vectorize facts with default parameters', async () => {
-      const mockVectorizationResponse: VectorizationResponse = {
-        status: 'success',
-        message: 'Vectorization complete',
-        successful: 50,
-        skipped: 0,
-        failed: 0,
-        total_processed: 50,
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockVectorizationResponse)
-
-      const { vectorizeFacts } = useKnowledgeBase()
-      const result = await vectorizeFacts()
-
-      expect(result).toEqual(mockVectorizationResponse)
-      expect(apiClient.post).toHaveBeenCalledWith(
-        '/knowledge_base/knowledge_base/vectorize_facts',
-        {
-          batch_size: 50,
-          batch_delay: 0.5,
-          skip_existing: true,
-        },
-        { timeout: 300000 }
-      )
-    })
-
-    it('should vectorize with custom batch parameters', async () => {
-      const mockResponse: VectorizationResponse = {
-        status: 'success',
-        message: 'Vectorization complete',
-        successful: 100,
-        skipped: 25,
-        failed: 0,
-        total_processed: 125,
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
-
-      const { vectorizeFacts } = useKnowledgeBase()
-      await vectorizeFacts(100, 1.0, false)
-
-      expect(apiClient.post).toHaveBeenCalledWith(
-        expect.any(String),
-        {
-          batch_size: 100,
-          batch_delay: 1.0,
-          skip_existing: false,
-        },
-        expect.any(Object)
-      )
-    })
-  })
-
-  describe('getVectorizationStatus', () => {
-    it('should fetch vectorization status', async () => {
-      const mockStatus: VectorizationStatusResponse = {
-        status: 'in_progress',
-        total_facts: 200,
-        vectorized_facts: 50,
-      }
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockStatus)
-
-      const { getVectorizationStatus } = useKnowledgeBase()
-      const result = await getVectorizationStatus()
-
-      expect(result).toEqual(mockStatus)
-      expect(result.status).toBe('in_progress')
-    })
-  })
-
-  // =========================================================================
-  // 9. Background Job Operations
-  // =========================================================================
-  describe('pollJobStatus', () => {
-    it('should poll job status successfully', async () => {
-      const mockJobStatus: JobStatus = {
-        task_id: 'task-123',
-        status: 'SUCCESS',
-        result: { processed: 100 },
-      }
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockJobStatus)
-
-      const { pollJobStatus } = useKnowledgeBase()
-      const result = await pollJobStatus('task-123')
-
-      expect(result).toEqual(mockJobStatus)
-      expect(apiClient.get).toHaveBeenCalledWith(
-        '/knowledge_base/knowledge_base/job_status/task-123'
-      )
-    })
-
-    it('should handle various job statuses', async () => {
-      const statuses: JobStatus['status'][] = ['PENDING', 'PROGRESS', 'SUCCESS', 'FAILURE']
-
-      for (const status of statuses) {
-        const mockJobStatus: JobStatus = { task_id: 'task-123', status }
-
-        vi.mocked(apiClient.get).mockResolvedValue(mockJobStatus)
-
-        const { pollJobStatus } = useKnowledgeBase()
-        const result = await pollJobStatus('task-123')
-
-        expect(result.status).toBe(status)
-      }
-    })
-  })
-
-  describe('initializeMachineKnowledge', () => {
-    it('should initialize machine knowledge', async () => {
-      const mockResponse: MachineKnowledgeResponse = {
-        status: 'success',
-        message: 'Machine knowledge initialized',
-        machine_id: 'host1',
-        facts_added: 50,
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
-
-      const { initializeMachineKnowledge } = useKnowledgeBase()
-      const result = await initializeMachineKnowledge('host1')
-
-      expect(result).toEqual(mockResponse)
-      expect(apiClient.post).toHaveBeenCalledWith(
-        '/knowledge_base/knowledge_base/machine_knowledge/initialize',
-        { machine_id: 'host1' }
-      )
-    })
-  })
-
-  describe('refreshSystemKnowledge', () => {
-    it('should trigger system knowledge refresh and return task_id', async () => {
-      const mockResponse: SystemKnowledgeResponse = {
-        status: 'queued',
-        message: 'System knowledge refresh queued',
-        total_machines: 3,
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
-
-      const { refreshSystemKnowledge } = useKnowledgeBase()
-      const result = await refreshSystemKnowledge()
-
-      expect(result).toEqual(mockResponse)
-      expect(result.status).toBe('queued')
-    })
-  })
-
-  // =========================================================================
-  // 10. Icon & Formatting Helpers
-  // =========================================================================
-  describe('getCategoryIcon', () => {
-    it('should return correct icon for security category', () => {
-      const { getCategoryIcon } = useKnowledgeBase()
-      const icon = getCategoryIcon('security')
-
-      expect(icon).toBe('fas fa-shield-alt')
-    })
-
-    it('should return correct icon for architecture category', () => {
-      const { getCategoryIcon } = useKnowledgeBase()
-      const icon = getCategoryIcon('architecture')
-
-      expect(icon).toBe('fas fa-drafting-compass')
-    })
-
-    it('should return correct icon for devops category', () => {
-      const { getCategoryIcon } = useKnowledgeBase()
-      const icon = getCategoryIcon('devops')
-
-      expect(icon).toBe('fas fa-cogs')
-    })
-
-    it('should return default folder icon for unknown category', () => {
-      const { getCategoryIcon } = useKnowledgeBase()
-      const icon = getCategoryIcon('unknown')
-
-      expect(icon).toBe('fas fa-folder')
-    })
-
-    it('should handle case-insensitive matching', () => {
-      const { getCategoryIcon } = useKnowledgeBase()
-      const upper = getCategoryIcon('SECURITY')
-      const mixed = getCategoryIcon('SeCuRiTy')
-
-      expect(upper).toBe('fas fa-shield-alt')
-      expect(mixed).toBe('fas fa-shield-alt')
-    })
-  })
-
-  describe('getTypeIcon', () => {
-    it('should return PDF icon for PDF documents', () => {
-      const { getTypeIcon } = useKnowledgeBase()
-      const icon = getTypeIcon('pdf')
-
-      expect(icon).toBe('fas fa-file-pdf')
-    })
-
-    it('should return code icon for JSON types', () => {
-      const { getTypeIcon } = useKnowledgeBase()
-      const icon = getTypeIcon('json')
-
-      expect(icon).toBe('fas fa-file-code')
-    })
-
-    it('should return image icon for image types', () => {
-      const { getTypeIcon } = useKnowledgeBase()
-      expect(getTypeIcon('png')).toBe('fas fa-file-image')
-      expect(getTypeIcon('jpg')).toBe('fas fa-file-image')
-    })
-
-    it('should return default file icon for unknown type', () => {
-      const { getTypeIcon } = useKnowledgeBase()
-      const icon = getTypeIcon('unknown')
-
-      expect(icon).toBe('fas fa-file')
-    })
-  })
-
-  describe('getFileIcon', () => {
-    it('should return folder icon for directories', () => {
-      const { getFileIcon } = useKnowledgeBase()
-      const icon = getFileIcon('mydir', true)
-
-      expect(icon).toContain('fas fa-folder')
-    })
-
-    it('should return styled icon for file with color class', () => {
-      const { getFileIcon } = useKnowledgeBase()
-      const icon = getFileIcon('script.js', false)
-
-      expect(icon).toContain('text-')
-    })
-
-    it('should apply different colors for different file types', () => {
-      const { getFileIcon } = useKnowledgeBase()
-      const jsIcon = getFileIcon('app.js', false)
-      const pyIcon = getFileIcon('script.py', false)
-      const pdfIcon = getFileIcon('document.pdf', false)
-
-      // Different colors for different types
-      expect(jsIcon).not.toEqual(pyIcon)
-      expect(pyIcon).not.toEqual(pdfIcon)
-    })
-  })
-
-  describe('getOSBadgeClass', () => {
-    it('should return success class for Linux', () => {
-      const { getOSBadgeClass } = useKnowledgeBase()
-      const badgeClass = getOSBadgeClass('linux')
-
-      expect(badgeClass).toBe('badge-success')
-    })
-
-    it('should return info class for Windows', () => {
-      const { getOSBadgeClass } = useKnowledgeBase()
-      const badgeClass = getOSBadgeClass('windows')
-
-      expect(badgeClass).toBe('badge-info')
-    })
-
-    it('should return warning class for macOS', () => {
-      const { getOSBadgeClass } = useKnowledgeBase()
-      const badgeClass = getOSBadgeClass('macos')
-
-      expect(badgeClass).toBe('badge-warning')
-    })
-
-    it('should return secondary class for unknown OS', () => {
-      const { getOSBadgeClass } = useKnowledgeBase()
-      const badgeClass = getOSBadgeClass('unknown')
-
-      expect(badgeClass).toBe('badge-secondary')
-    })
-  })
-
-  describe('getMessageIcon', () => {
-    it('should return info icon for info type', () => {
-      const { getMessageIcon } = useKnowledgeBase()
-      const icon = getMessageIcon('info')
-
-      expect(icon).toContain('fas fa-info-circle')
-      expect(icon).toContain('text-blue-500')
-    })
-
-    it('should return success icon for success type', () => {
-      const { getMessageIcon } = useKnowledgeBase()
-      const icon = getMessageIcon('success')
-
-      expect(icon).toContain('fas fa-check-circle')
-      expect(icon).toContain('text-green-500')
-    })
-
-    it('should return warning icon for warning type', () => {
-      const { getMessageIcon } = useKnowledgeBase()
-      const icon = getMessageIcon('warning')
-
-      expect(icon).toContain('fas fa-exclamation-triangle')
-      expect(icon).toContain('text-yellow-500')
-    })
-
-    it('should return error icon for error type', () => {
-      const { getMessageIcon } = useKnowledgeBase()
-      const icon = getMessageIcon('error')
-
-      expect(icon).toContain('fas fa-times-circle')
-      expect(icon).toContain('text-red-500')
-    })
-
-    it('should default to info icon for unknown type', () => {
-      const { getMessageIcon } = useKnowledgeBase()
-      const icon = getMessageIcon('unknown')
-
-      expect(icon).toContain('fas fa-info-circle')
-    })
-  })
-
-  describe('formatTime', () => {
-    it('should format timestamp to locale time string', () => {
-      const { formatTime } = useKnowledgeBase()
-      const timestamp = '2025-04-12T10:30:45Z'
-      const formatted = formatTime(timestamp)
-
-      expect(typeof formatted).toBe('string')
-      expect(formatted).toMatch(/\d{1,2}:\d{2}:\d{2}/)
-    })
-
-    it('should handle Date objects', () => {
-      const { formatTime } = useKnowledgeBase()
-      const date = new Date('2025-04-12T10:30:45Z')
-      const formatted = formatTime(date)
-
-      expect(typeof formatted).toBe('string')
-    })
-  })
-
-  // =========================================================================
-  // 11. Additional Machine & Docs Operations
-  // =========================================================================
-  describe('populateManPages', () => {
-    it('should populate man pages for a machine', async () => {
-      const mockResponse: ManPagesPopulateResponse = {
-        status: 'success',
-        message: 'Man pages populated',
-        machine_id: 'host1',
-        man_pages_added: 150,
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
-
-      const { populateManPages } = useKnowledgeBase()
-      const result = await populateManPages('host1')
-
-      expect(result).toEqual(mockResponse)
-    })
-  })
-
-  describe('populateAutoBotDocs', () => {
-    it('should populate AutoBot documentation', async () => {
-      const mockResponse: AutoBotDocsResponse = {
-        status: 'success',
-        message: 'AutoBot docs populated',
-        documents_processed: 45,
-        facts_added: 120,
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
-
-      const { populateAutoBotDocs } = useKnowledgeBase()
-      const result = await populateAutoBotDocs()
-
-      expect(result).toEqual(mockResponse)
-    })
-  })
-
-  describe('fetchMachineProfile', () => {
-    it('should fetch profile for specific machine', async () => {
-      const mockProfile: MachineProfile = {
-        machine_id: 'host1',
-        os_type: 'linux',
-        distro: 'Ubuntu 20.04',
-      }
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockProfile)
-
-      const { fetchMachineProfile } = useKnowledgeBase()
-      const result = await fetchMachineProfile('host1')
-
-      expect(result).toEqual(mockProfile)
-      expect(apiClient.get).toHaveBeenCalledWith(
-        expect.stringContaining('machine_id=host1')
-      )
-    })
-
-    it('should return null on error', async () => {
-      vi.mocked(apiClient.get).mockResolvedValue(null)
-
-      const { fetchMachineProfile } = useKnowledgeBase()
-      const result = await fetchMachineProfile('host1')
-
-      expect(result).toBe(null)
-    })
-  })
-
-  describe('fetchBasicStats', () => {
-    it('should fetch basic statistics', async () => {
-      const mockStats: KnowledgeStats = {
-        total_facts: 75,
-        total_documents: 3,
-      }
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockStats)
-
-      const { fetchBasicStats } = useKnowledgeBase()
-      const result = await fetchBasicStats()
-
-      expect(result).toEqual(mockStats)
-      expect(apiClient.get).toHaveBeenCalledWith(
-        '/knowledge_base/knowledge_base/stats/basic'
-      )
-    })
-  })
-
-  // =========================================================================
-  // 12. Integration & Man Pages
-  // =========================================================================
-  describe('integrateManPages', () => {
-    it('should integrate man pages for a machine', async () => {
-      const mockResponse: IntegrationResponse = {
-        status: 'queued',
-        message: 'Man pages integration queued',
-        machine_id: 'host1',
-      }
-
-      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
-
-      const { integrateManPages } = useKnowledgeBase()
-      const result = await integrateManPages('host1')
-
-      expect(result).toEqual(mockResponse)
-      expect(apiClient.post).toHaveBeenCalledWith(
-        '/knowledge_base/knowledge_base/man_pages/integrate',
-        { machine_id: 'host1' }
-      )
-    })
-  })
-
-  // =========================================================================
-  // 13. Export Verification
-  // =========================================================================
-  describe('composable exports', () => {
-    it('should export all API call methods', () => {
-      const composable = useKnowledgeBase()
-
-      // API methods
-      expect(typeof composable.fetchStats).toBe('function')
-      expect(typeof composable.fetchCategories).toBe('function')
-      expect(typeof composable.fetchCategory).toBe('function')
-      expect(typeof composable.searchKnowledge).toBe('function')
-      expect(typeof composable.advancedSearch).toBe('function')
-      expect(typeof composable.addFact).toBe('function')
-      expect(typeof composable.uploadKnowledgeFile).toBe('function')
-      expect(typeof composable.vectorizeFacts).toBe('function')
-      expect(typeof composable.pollJobStatus).toBe('function')
-    })
-
-    it('should export all helper functions', () => {
-      const composable = useKnowledgeBase()
-
-      // Helper functions
-      expect(typeof composable.getCategoryIcon).toBe('function')
-      expect(typeof composable.getTypeIcon).toBe('function')
-      expect(typeof composable.getFileIcon).toBe('function')
-      expect(typeof composable.getOSBadgeClass).toBe('function')
-      expect(typeof composable.getMessageIcon).toBe('function')
-      expect(typeof composable.formatTime).toBe('function')
-    })
-
-    it('should export formatting functions from shared utilities', () => {
-      const composable = useKnowledgeBase()
-
-      // Formatting aliases
-      expect(typeof composable.formatDate).toBe('function')
-      expect(typeof composable.formatCategory).toBe('function')
-      expect(typeof composable.formatFileSize).toBe('function')
-    })
+  it('should keep behavior for key icon helpers', () => {
+    const { getCategoryIcon, getOSBadgeClass, getMessageIcon } = useKnowledgeBase()
+
+    expect(getCategoryIcon('security')).toBe('fas fa-shield-alt')
+    expect(getCategoryIcon('unknown')).toBe('fas fa-folder')
+    expect(getOSBadgeClass('linux')).toBe('badge-success')
+    expect(getOSBadgeClass('macos')).toBe('badge-warning')
+    expect(getMessageIcon('error')).toContain('fas fa-times-circle')
   })
 })

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeCategories.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeCategories.test.ts
@@ -1,0 +1,239 @@
+/**
+ * useKnowledgeCategories Composable Tests
+ *
+ * Split from useKnowledgeBase.test.ts (#5122).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type {
+  CategoryResponse,
+  CategoriesListResponse,
+  CategorizedFactsResponse,
+} from '@/types/knowledgeBase'
+import { useKnowledgeCategories } from '../knowledge/useKnowledgeCategories'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('@/utils/formatHelpers', () => ({
+  formatCategoryName: (name: string) => name.replace(/_/g, ' ').toUpperCase(),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  }),
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/knowledge_base',
+}))
+
+import apiClient from '@/utils/ApiClient'
+
+describe('useKnowledgeCategories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('fetchCategories', () => {
+    it('should fetch all categories with counts', async () => {
+      const mockCategoriesResponse: CategoriesListResponse = {
+        categories: [
+          { name: 'architecture', count: 10, id: 'arch-1' },
+          { name: 'security', count: 15, id: 'sec-1' },
+        ],
+        total: 2,
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockCategoriesResponse)
+
+      const { fetchCategories } = useKnowledgeCategories()
+      const result = await fetchCategories()
+
+      expect(result).toEqual(mockCategoriesResponse.categories)
+      expect(apiClient.get).toHaveBeenCalledWith('/knowledge_base/knowledge_base/categories')
+    })
+
+    it('should throw error when response structure is invalid', async () => {
+      const invalidResponse: unknown = { notCategories: [] }
+
+      vi.mocked(apiClient.get).mockResolvedValue(invalidResponse)
+
+      const { fetchCategories } = useKnowledgeCategories()
+
+      await expect(fetchCategories()).rejects.toThrow('Invalid categories response format')
+    })
+  })
+
+  describe('fetchCategory', () => {
+    it('should fetch facts for a specific category', async () => {
+      const mockCategory: CategoryResponse = {
+        facts: [
+          { id: '1', fact: 'Use strong passwords', category: 'security', created_at: '2025-04-12T10:00:00Z', updated_at: '2025-04-12T10:00:00Z' },
+        ],
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockCategory)
+
+      const { fetchCategory } = useKnowledgeCategories()
+      const result = await fetchCategory('security')
+
+      expect(result).toEqual(mockCategory)
+      expect(apiClient.get).toHaveBeenCalledWith('/knowledge_base/knowledge_base/category/security')
+    })
+
+    it('should throw error for invalid category', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('HTTP 404: Category not found'))
+
+      const { fetchCategory } = useKnowledgeCategories()
+
+      await expect(fetchCategory('nonexistent')).rejects.toThrow('HTTP 404')
+    })
+  })
+
+  describe('getCategorizedFacts', () => {
+    it('should fetch categorized facts', async () => {
+      const mockCategorizedFacts: CategorizedFactsResponse = {
+        total_facts: 50,
+        categories: {
+          security: [
+            { key: '1', title: 'fact1', content: 'fact1 content', category: 'security', type: 'general', metadata: {} },
+            { key: '2', title: 'fact2', content: 'fact2 content', category: 'security', type: 'general', metadata: {} },
+          ],
+          architecture: [
+            { key: '3', title: 'fact3', content: 'fact3 content', category: 'architecture', type: 'general', metadata: {} },
+          ],
+        },
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockCategorizedFacts)
+
+      const { getCategorizedFacts } = useKnowledgeCategories()
+      const result = await getCategorizedFacts()
+
+      expect(result).toEqual(mockCategorizedFacts)
+      expect(result.total_facts).toBe(50)
+      expect(Object.keys(result.categories).length).toBe(2)
+    })
+
+    it('should respect category filter parameter', async () => {
+      const mockCategorizedFacts: CategorizedFactsResponse = {
+        total_facts: 2,
+        categories: {
+          security: [
+            {
+              key: '1',
+              title: 'fact1',
+              content: 'fact1',
+              category: 'security',
+              type: 'general',
+              metadata: {},
+            },
+          ],
+        },
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockCategorizedFacts)
+
+      const { getCategorizedFacts } = useKnowledgeCategories()
+      await getCategorizedFacts('security', 100)
+
+      expect(apiClient.get).toHaveBeenCalledWith(
+        expect.stringContaining('category=security')
+      )
+    })
+
+    it('should throw error for invalid response format', async () => {
+      const invalidResponse: unknown = { total_facts: 0, noCategoriesField: {} }
+
+      vi.mocked(apiClient.get).mockResolvedValue(invalidResponse)
+
+      const { getCategorizedFacts } = useKnowledgeCategories()
+
+      await expect(getCategorizedFacts()).rejects.toThrow('Invalid categorized facts response format')
+    })
+  })
+
+  describe('buildCategoryFilterOptions', () => {
+    it('should build filter options from categorized facts', () => {
+      const categorizedFacts: CategorizedFactsResponse = {
+        total_facts: 5,
+        categories: {
+          security: [
+            { key: '1', title: 'f1', content: 'fact1', category: 'security', type: 'general', metadata: {} },
+            { key: '2', title: 'f2', content: 'fact2', category: 'security', type: 'general', metadata: {} },
+          ],
+          architecture: [
+            { key: '3', title: 'f3', content: 'fact3', category: 'architecture', type: 'general', metadata: {} },
+          ],
+        },
+      }
+
+      const { buildCategoryFilterOptions } = useKnowledgeCategories()
+      const options = buildCategoryFilterOptions(categorizedFacts)
+
+      expect(options.length).toBe(3)
+      expect(options[0].label).toBe('All Categories')
+      expect(options[0].value).toBe(null)
+      expect(options[0].count).toBe(5)
+    })
+
+    it('should sort options by count descending', () => {
+      const categorizedFacts: CategorizedFactsResponse = {
+        total_facts: 6,
+        categories: {
+          small: [
+            { key: '1', title: 'f1', content: 'fact1', category: 'small', type: 'general', metadata: {} },
+          ],
+          big: [
+            { key: '2', title: 'f2', content: 'fact2', category: 'big', type: 'general', metadata: {} },
+            { key: '3', title: 'f3', content: 'fact3', category: 'big', type: 'general', metadata: {} },
+            { key: '4', title: 'f4', content: 'fact4', category: 'big', type: 'general', metadata: {} },
+          ],
+        },
+      }
+
+      const { buildCategoryFilterOptions } = useKnowledgeCategories()
+      const options = buildCategoryFilterOptions(categorizedFacts)
+
+      expect(options[0].value).toBe(null)
+      expect(options[1].count).toBeGreaterThanOrEqual(options[2].count)
+    })
+  })
+
+  describe('getCategoryIcon', () => {
+    it('should return correct icon for security category', () => {
+      const { getCategoryIcon } = useKnowledgeCategories()
+      expect(getCategoryIcon('security')).toBe('fas fa-shield-alt')
+    })
+
+    it('should return correct icon for architecture category', () => {
+      const { getCategoryIcon } = useKnowledgeCategories()
+      expect(getCategoryIcon('architecture')).toBe('fas fa-drafting-compass')
+    })
+
+    it('should return correct icon for devops category', () => {
+      const { getCategoryIcon } = useKnowledgeCategories()
+      expect(getCategoryIcon('devops')).toBe('fas fa-cogs')
+    })
+
+    it('should return default folder icon for unknown category', () => {
+      const { getCategoryIcon } = useKnowledgeCategories()
+      expect(getCategoryIcon('unknown')).toBe('fas fa-folder')
+    })
+
+    it('should handle case-insensitive matching', () => {
+      const { getCategoryIcon } = useKnowledgeCategories()
+      expect(getCategoryIcon('SECURITY')).toBe('fas fa-shield-alt')
+      expect(getCategoryIcon('SeCuRiTy')).toBe('fas fa-shield-alt')
+    })
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeFacts.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeFacts.test.ts
@@ -1,0 +1,171 @@
+/**
+ * useKnowledgeFacts Composable Tests
+ *
+ * Split from useKnowledgeBase.test.ts (#5122).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type {
+  SearchResponse,
+  AddFactResponse,
+} from '@/types/knowledgeBase'
+import { useKnowledgeFacts } from '../knowledge/useKnowledgeFacts'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/knowledge_base',
+}))
+
+import apiClient from '@/utils/ApiClient'
+
+describe('useKnowledgeFacts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('searchKnowledge', () => {
+    it('should perform basic keyword search', async () => {
+      const mockSearchResult: SearchResponse = {
+        results: [
+          { id: '1', fact: 'matching fact', similarity_score: 0.95 },
+        ],
+        total_results: 1,
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockSearchResult)
+
+      const { searchKnowledge } = useKnowledgeFacts()
+      const result = await searchKnowledge('test query')
+
+      expect(result).toEqual(mockSearchResult)
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/search',
+        { query: 'test query' }
+      )
+    })
+
+    it('should throw error when search fails', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('HTTP 500: Search backend error'))
+
+      const { searchKnowledge } = useKnowledgeFacts()
+
+      await expect(searchKnowledge('test')).rejects.toThrow('HTTP 500')
+    })
+  })
+
+  describe('advancedSearch', () => {
+    it('should perform advanced search with all options', async () => {
+      const mockResults: SearchResponse = {
+        results: [{ id: '1', fact: 'semantic match', similarity_score: 0.98 }],
+        total_results: 1,
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockResults)
+
+      const { advancedSearch } = useKnowledgeFacts()
+      const result = await advancedSearch({
+        query: 'test',
+        mode: 'semantic',
+        enable_rag: true,
+        category: 'security',
+        top_k: 10,
+      })
+
+      expect(result).toEqual(mockResults)
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/search',
+        expect.objectContaining({
+          query: 'test',
+          mode: 'semantic',
+          enable_rag: true,
+          category: 'security',
+        })
+      )
+    })
+
+    it('should support hybrid search mode', async () => {
+      const mockResults: SearchResponse = { results: [], total_results: 0 }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockResults)
+
+      const { advancedSearch } = useKnowledgeFacts()
+      await advancedSearch({
+        query: 'test',
+        mode: 'hybrid',
+        enable_reranking: true,
+      })
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          mode: 'hybrid',
+          enable_reranking: true,
+        })
+      )
+    })
+  })
+
+  describe('addFact', () => {
+    it('should add a new fact to knowledge base', async () => {
+      const mockAddResponse: AddFactResponse = {
+        success: true,
+        fact_id: 'fact-123',
+        fact: {
+          id: 'fact-123',
+          fact: 'New security fact',
+          category: 'security',
+          created_at: '2025-04-12T10:00:00Z',
+          updated_at: '2025-04-12T10:00:00Z',
+        },
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockAddResponse)
+
+      const { addFact } = useKnowledgeFacts()
+      const result = await addFact({
+        content: 'New security fact',
+        category: 'security',
+      })
+
+      expect(result).toEqual(mockAddResponse)
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/facts',
+        expect.objectContaining({
+          content: 'New security fact',
+          category: 'security',
+        })
+      )
+    })
+
+    it('should add fact with metadata', async () => {
+      const mockAddResponse: AddFactResponse = {
+        success: true,
+        fact_id: 'fact-456',
+        fact: {
+          id: 'fact-456',
+          fact: 'Fact with metadata',
+          category: 'architecture',
+          created_at: '2025-04-12T10:00:00Z',
+          updated_at: '2025-04-12T10:00:00Z',
+        },
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockAddResponse)
+
+      const { addFact } = useKnowledgeFacts()
+      const result = await addFact({
+        content: 'Fact with metadata',
+        category: 'architecture',
+        metadata: { source: 'manual', priority: 'high' },
+      })
+
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeFiles.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeFiles.test.ts
@@ -1,0 +1,62 @@
+/**
+ * useKnowledgeFiles Composable Tests
+ *
+ * Split from useKnowledgeBase.test.ts (#5122).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { UploadResponse } from '@/types/knowledgeBase'
+import { useKnowledgeFiles } from '../knowledge/useKnowledgeFiles'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/knowledge_base',
+}))
+
+import apiClient from '@/utils/ApiClient'
+
+describe('useKnowledgeFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('uploadKnowledgeFile', () => {
+    it('should upload a knowledge file successfully', async () => {
+      const mockUploadResponse: UploadResponse = {
+        success: true,
+        file_path: '/uploads/test.pdf',
+        facts_added: 5,
+      }
+
+      const formData = new FormData()
+      formData.append('file', new Blob(['test'], { type: 'application/pdf' }))
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockUploadResponse)
+
+      const { uploadKnowledgeFile } = useKnowledgeFiles()
+      const result = await uploadKnowledgeFile(formData)
+
+      expect(result).toEqual(mockUploadResponse)
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/upload',
+        formData
+      )
+    })
+
+    it('should throw error on upload failure', async () => {
+      const formData = new FormData()
+
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('HTTP 400: Upload failed'))
+
+      const { uploadKnowledgeFile } = useKnowledgeFiles()
+
+      await expect(uploadKnowledgeFile(formData)).rejects.toThrow('Upload failed')
+    })
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeIcons.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeIcons.test.ts
@@ -1,0 +1,134 @@
+/**
+ * useKnowledgeIcons Composable Tests
+ *
+ * Split from useKnowledgeBase.test.ts (#5122).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { useKnowledgeIcons } from '../knowledge/useKnowledgeIcons'
+
+vi.mock('@/utils/iconMappings', () => ({
+  getFileIcon: () => 'fas fa-file',
+}))
+
+describe('useKnowledgeIcons', () => {
+  describe('getTypeIcon', () => {
+    it('should return PDF icon for PDF documents', () => {
+      const { getTypeIcon } = useKnowledgeIcons()
+      expect(getTypeIcon('pdf')).toBe('fas fa-file-pdf')
+    })
+
+    it('should return code icon for JSON types', () => {
+      const { getTypeIcon } = useKnowledgeIcons()
+      expect(getTypeIcon('json')).toBe('fas fa-file-code')
+    })
+
+    it('should return image icon for image types', () => {
+      const { getTypeIcon } = useKnowledgeIcons()
+      expect(getTypeIcon('png')).toBe('fas fa-file-image')
+      expect(getTypeIcon('jpg')).toBe('fas fa-file-image')
+    })
+
+    it('should return default file icon for unknown type', () => {
+      const { getTypeIcon } = useKnowledgeIcons()
+      expect(getTypeIcon('unknown')).toBe('fas fa-file')
+    })
+  })
+
+  describe('getFileIcon', () => {
+    it('should return folder icon for directories', () => {
+      const { getFileIcon } = useKnowledgeIcons()
+      const icon = getFileIcon('mydir', true)
+      expect(icon).toContain('fas fa-folder')
+    })
+
+    it('should return styled icon for file with color class', () => {
+      const { getFileIcon } = useKnowledgeIcons()
+      const icon = getFileIcon('script.js', false)
+      expect(icon).toContain('text-')
+    })
+
+    it('should apply different colors for different file types', () => {
+      const { getFileIcon } = useKnowledgeIcons()
+      const jsIcon = getFileIcon('app.js', false)
+      const pyIcon = getFileIcon('script.py', false)
+      const pdfIcon = getFileIcon('document.pdf', false)
+
+      expect(jsIcon).not.toEqual(pyIcon)
+      expect(pyIcon).not.toEqual(pdfIcon)
+    })
+  })
+
+  describe('getOSBadgeClass', () => {
+    it('should return success class for Linux', () => {
+      const { getOSBadgeClass } = useKnowledgeIcons()
+      expect(getOSBadgeClass('linux')).toBe('badge-success')
+    })
+
+    it('should return info class for Windows', () => {
+      const { getOSBadgeClass } = useKnowledgeIcons()
+      expect(getOSBadgeClass('windows')).toBe('badge-info')
+    })
+
+    it('should return warning class for macOS', () => {
+      const { getOSBadgeClass } = useKnowledgeIcons()
+      expect(getOSBadgeClass('macos')).toBe('badge-warning')
+    })
+
+    it('should return secondary class for unknown OS', () => {
+      const { getOSBadgeClass } = useKnowledgeIcons()
+      expect(getOSBadgeClass('unknown')).toBe('badge-secondary')
+    })
+  })
+
+  describe('getMessageIcon', () => {
+    it('should return info icon for info type', () => {
+      const { getMessageIcon } = useKnowledgeIcons()
+      const icon = getMessageIcon('info')
+      expect(icon).toContain('fas fa-info-circle')
+      expect(icon).toContain('text-blue-500')
+    })
+
+    it('should return success icon for success type', () => {
+      const { getMessageIcon } = useKnowledgeIcons()
+      const icon = getMessageIcon('success')
+      expect(icon).toContain('fas fa-check-circle')
+      expect(icon).toContain('text-green-500')
+    })
+
+    it('should return warning icon for warning type', () => {
+      const { getMessageIcon } = useKnowledgeIcons()
+      const icon = getMessageIcon('warning')
+      expect(icon).toContain('fas fa-exclamation-triangle')
+      expect(icon).toContain('text-yellow-500')
+    })
+
+    it('should return error icon for error type', () => {
+      const { getMessageIcon } = useKnowledgeIcons()
+      const icon = getMessageIcon('error')
+      expect(icon).toContain('fas fa-times-circle')
+      expect(icon).toContain('text-red-500')
+    })
+
+    it('should default to info icon for unknown type', () => {
+      const { getMessageIcon } = useKnowledgeIcons()
+      const icon = getMessageIcon('unknown')
+      expect(icon).toContain('fas fa-info-circle')
+    })
+  })
+
+  describe('formatTime', () => {
+    it('should format timestamp to locale time string', () => {
+      const { formatTime } = useKnowledgeIcons()
+      const formatted = formatTime('2025-04-12T10:30:45Z')
+      expect(typeof formatted).toBe('string')
+      expect(formatted).toMatch(/\d{1,2}:\d{2}:\d{2}/)
+    })
+
+    it('should handle Date objects', () => {
+      const { formatTime } = useKnowledgeIcons()
+      const formatted = formatTime(new Date('2025-04-12T10:30:45Z'))
+      expect(typeof formatted).toBe('string')
+    })
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeJobs.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeJobs.test.ts
@@ -1,0 +1,157 @@
+/**
+ * useKnowledgeJobs Composable Tests
+ *
+ * Split from useKnowledgeBase.test.ts (#5122).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type {
+  VectorizationStatusResponse,
+  VectorizationResponse,
+} from '@/types/knowledgeBase'
+import { useKnowledgeJobs } from '../knowledge/useKnowledgeJobs'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('@/config/AppConfig.js', () => ({
+  default: {
+    getApiUrl: vi.fn((url) => Promise.resolve(`/api${url}`)),
+    getTimeout: vi.fn((type) => {
+      if (type === 'knowledge') return 300000
+      return 30000
+    }),
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/knowledge_base',
+}))
+
+import apiClient from '@/utils/ApiClient'
+
+interface JobStatus {
+  task_id: string
+  status: 'PENDING' | 'PROGRESS' | 'SUCCESS' | 'FAILURE'
+  result?: Record<string, unknown>
+  error?: string
+  progress?: number
+}
+
+describe('useKnowledgeJobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('vectorizeFacts', () => {
+    it('should vectorize facts with default parameters', async () => {
+      const mockVectorizationResponse: VectorizationResponse = {
+        status: 'success',
+        message: 'Vectorization complete',
+        successful: 50,
+        skipped: 0,
+        failed: 0,
+        total_processed: 50,
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockVectorizationResponse)
+
+      const { vectorizeFacts } = useKnowledgeJobs()
+      const result = await vectorizeFacts()
+
+      expect(result).toEqual(mockVectorizationResponse)
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/vectorize_facts',
+        {
+          batch_size: 50,
+          batch_delay: 0.5,
+          skip_existing: true,
+        },
+        { timeout: 300000 }
+      )
+    })
+
+    it('should vectorize with custom batch parameters', async () => {
+      const mockResponse: VectorizationResponse = {
+        status: 'success',
+        message: 'Vectorization complete',
+        successful: 100,
+        skipped: 25,
+        failed: 0,
+        total_processed: 125,
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+      const { vectorizeFacts } = useKnowledgeJobs()
+      await vectorizeFacts(100, 1.0, false)
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          batch_size: 100,
+          batch_delay: 1.0,
+          skip_existing: false,
+        },
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('getVectorizationStatus', () => {
+    it('should fetch vectorization status', async () => {
+      const mockStatus: VectorizationStatusResponse = {
+        status: 'in_progress',
+        total_facts: 200,
+        vectorized_facts: 50,
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockStatus)
+
+      const { getVectorizationStatus } = useKnowledgeJobs()
+      const result = await getVectorizationStatus()
+
+      expect(result).toEqual(mockStatus)
+      expect(result.status).toBe('in_progress')
+    })
+  })
+
+  describe('pollJobStatus', () => {
+    it('should poll job status successfully', async () => {
+      const mockJobStatus: JobStatus = {
+        task_id: 'task-123',
+        status: 'SUCCESS',
+        result: { processed: 100 },
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockJobStatus)
+
+      const { pollJobStatus } = useKnowledgeJobs()
+      const result = await pollJobStatus('task-123')
+
+      expect(result).toEqual(mockJobStatus)
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/job_status/task-123'
+      )
+    })
+
+    it('should handle various job statuses', async () => {
+      const statuses: JobStatus['status'][] = ['PENDING', 'PROGRESS', 'SUCCESS', 'FAILURE']
+
+      for (const status of statuses) {
+        const mockJobStatus: JobStatus = { task_id: 'task-123', status }
+
+        vi.mocked(apiClient.get).mockResolvedValue(mockJobStatus)
+
+        const { pollJobStatus } = useKnowledgeJobs()
+        const result = (await pollJobStatus('task-123')) as JobStatus
+
+        expect(result.status).toBe(status)
+      }
+    })
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeStats.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeStats.test.ts
@@ -1,0 +1,82 @@
+/**
+ * useKnowledgeStats Composable Tests
+ *
+ * Split from useKnowledgeBase.test.ts (#5122).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { KnowledgeStats } from '@/types/knowledgeBase'
+import { useKnowledgeStats } from '../knowledge/useKnowledgeStats'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/knowledge_base',
+}))
+
+import apiClient from '@/utils/ApiClient'
+
+describe('useKnowledgeStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('fetchStats', () => {
+    it('should fetch knowledge base statistics successfully', async () => {
+      const mockStats: KnowledgeStats = {
+        total_facts: 100,
+        total_documents: 50,
+        last_updated: '2025-04-12T10:00:00Z',
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockStats)
+
+      const { fetchStats } = useKnowledgeStats()
+      const result = await fetchStats()
+
+      expect(result).toEqual(mockStats)
+      expect(apiClient.get).toHaveBeenCalledWith('/knowledge_base/knowledge_base/stats')
+    })
+
+    it('should throw error when stats fetch fails', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('HTTP 500: Server error'))
+
+      const { fetchStats } = useKnowledgeStats()
+
+      await expect(fetchStats()).rejects.toThrow('HTTP 500')
+    })
+  })
+
+  describe('fetchBasicStats', () => {
+    it('should fetch basic statistics', async () => {
+      const mockStats: KnowledgeStats = {
+        total_facts: 75,
+        total_documents: 3,
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockStats)
+
+      const { fetchBasicStats } = useKnowledgeStats()
+      const result = await fetchBasicStats()
+
+      expect(result).toEqual(mockStats)
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/stats/basic'
+      )
+    })
+
+    it('should return null when fetch fails', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('HTTP 500'))
+
+      const { fetchBasicStats } = useKnowledgeStats()
+      const result = await fetchBasicStats()
+
+      expect(result).toBe(null)
+    })
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useMachineKnowledge.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useMachineKnowledge.test.ts
@@ -1,0 +1,135 @@
+/**
+ * useMachineKnowledge Composable Tests
+ *
+ * Split from useKnowledgeBase.test.ts (#5122).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type {
+  MachineKnowledgeResponse,
+  SystemKnowledgeResponse,
+} from '@/types/knowledgeBase'
+import { useMachineKnowledge, type MachineProfile } from '../knowledge/useMachineKnowledge'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/knowledge_base',
+}))
+
+import apiClient from '@/utils/ApiClient'
+
+describe('useMachineKnowledge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('fetchMachineProfiles', () => {
+    it('should fetch all machine profiles', async () => {
+      const mockProfiles: MachineProfile[] = [
+        { machine_id: 'host1', os_type: 'linux', distro: 'Ubuntu' },
+        { machine_id: 'host2', os_type: 'linux', distro: 'CentOS' },
+      ]
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockProfiles)
+
+      const { fetchMachineProfiles } = useMachineKnowledge()
+      const result = await fetchMachineProfiles()
+
+      expect(result).toEqual(mockProfiles)
+      expect(Array.isArray(result)).toBe(true)
+    })
+
+    it('should return empty array when response is not an array', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue(null)
+
+      const { fetchMachineProfiles } = useMachineKnowledge()
+      const result = await fetchMachineProfiles()
+
+      expect(result).toEqual([])
+    })
+
+    it('should return empty array on error', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('HTTP 500'))
+
+      const { fetchMachineProfiles } = useMachineKnowledge()
+      const result = await fetchMachineProfiles()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('fetchMachineProfile', () => {
+    it('should fetch profile for specific machine', async () => {
+      const mockProfile: MachineProfile = {
+        machine_id: 'host1',
+        os_type: 'linux',
+        distro: 'Ubuntu 20.04',
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockProfile)
+
+      const { fetchMachineProfile } = useMachineKnowledge()
+      const result = await fetchMachineProfile('host1')
+
+      expect(result).toEqual(mockProfile)
+      expect(apiClient.get).toHaveBeenCalledWith(
+        expect.stringContaining('machine_id=host1')
+      )
+    })
+
+    it('should return null on error', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('HTTP 500'))
+
+      const { fetchMachineProfile } = useMachineKnowledge()
+      const result = await fetchMachineProfile('host1')
+
+      expect(result).toBe(null)
+    })
+  })
+
+  describe('initializeMachineKnowledge', () => {
+    it('should initialize machine knowledge', async () => {
+      const mockResponse: MachineKnowledgeResponse = {
+        status: 'success',
+        message: 'Machine knowledge initialized',
+        machine_id: 'host1',
+        facts_added: 50,
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+      const { initializeMachineKnowledge } = useMachineKnowledge()
+      const result = await initializeMachineKnowledge('host1')
+
+      expect(result).toEqual(mockResponse)
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/machine_knowledge/initialize',
+        { machine_id: 'host1' }
+      )
+    })
+  })
+
+  describe('refreshSystemKnowledge', () => {
+    it('should trigger system knowledge refresh and return task_id', async () => {
+      const mockResponse: SystemKnowledgeResponse = {
+        status: 'queued',
+        message: 'System knowledge refresh queued',
+        total_machines: 3,
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+      const { refreshSystemKnowledge } = useMachineKnowledge()
+      const result = await refreshSystemKnowledge()
+
+      expect(result).toEqual(mockResponse)
+      expect(result.status).toBe('queued')
+    })
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useManPages.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useManPages.test.ts
@@ -1,0 +1,117 @@
+/**
+ * useManPages Composable Tests
+ *
+ * Split from useKnowledgeBase.test.ts (#5122).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type {
+  IntegrationResponse,
+  ManPagesPopulateResponse,
+  AutoBotDocsResponse,
+} from '@/types/knowledgeBase'
+import { useManPages, type ManPagesSummary } from '../knowledge/useManPages'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/knowledge_base',
+}))
+
+import apiClient from '@/utils/ApiClient'
+
+describe('useManPages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('fetchManPagesSummary', () => {
+    it('should fetch man pages summary', async () => {
+      const mockSummary: ManPagesSummary = {
+        status: 'ready',
+        successful: 150,
+        processed: 150,
+        current_man_page_files: 1500,
+      }
+
+      vi.mocked(apiClient.get).mockResolvedValue(mockSummary)
+
+      const { fetchManPagesSummary } = useManPages()
+      const result = await fetchManPagesSummary()
+
+      expect(result).toEqual(mockSummary)
+      expect(result?.status).toBe('ready')
+    })
+
+    it('should return null on error', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('HTTP 500'))
+
+      const { fetchManPagesSummary } = useManPages()
+      const result = await fetchManPagesSummary()
+
+      expect(result).toBe(null)
+    })
+  })
+
+  describe('integrateManPages', () => {
+    it('should integrate man pages for a machine', async () => {
+      const mockResponse: IntegrationResponse = {
+        status: 'queued',
+        message: 'Man pages integration queued',
+        machine_id: 'host1',
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+      const { integrateManPages } = useManPages()
+      const result = await integrateManPages('host1')
+
+      expect(result).toEqual(mockResponse)
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/knowledge_base/knowledge_base/man_pages/integrate',
+        { machine_id: 'host1' }
+      )
+    })
+  })
+
+  describe('populateManPages', () => {
+    it('should populate man pages for a machine', async () => {
+      const mockResponse: ManPagesPopulateResponse = {
+        status: 'success',
+        message: 'Man pages populated',
+        machine_id: 'host1',
+        man_pages_added: 150,
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+      const { populateManPages } = useManPages()
+      const result = await populateManPages('host1')
+
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('populateAutoBotDocs', () => {
+    it('should populate AutoBot documentation', async () => {
+      const mockResponse: AutoBotDocsResponse = {
+        status: 'success',
+        message: 'AutoBot docs populated',
+        documents_processed: 45,
+        facts_added: 120,
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+      const { populateAutoBotDocs } = useManPages()
+      const result = await populateAutoBotDocs()
+
+      expect(result).toEqual(mockResponse)
+    })
+  })
+})

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
@@ -1,0 +1,156 @@
+/**
+ * useKnowledgeCategories Composable
+ *
+ * Knowledge base category listing, per-category browsing, categorized-fact
+ * retrieval, and UI filter-option building.
+ * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
+ * ApiClient already logs retries + final failure and never returns null.
+ * Structural validation (Array.isArray / typeof) preserved — it is real
+ * business logic, not error-hiding.
+ */
+
+import apiClient from '@/utils/ApiClient'
+import { formatCategoryName as formatCategoryHelper } from '@/utils/formatHelpers'
+import { createLogger } from '@/utils/debugUtils'
+import { getApiBase } from '@/config/ssot-config'
+import type {
+  CategoryResponse,
+  CategoriesListResponse,
+  KnowledgeCategoryItem,
+  CategorizedFactsResponse,
+  CategoryFilterOption,
+} from '@/types/knowledgeBase'
+
+const logger = createLogger('useKnowledgeCategories')
+
+/**
+ * Get icon for category (re-exported so consumers + category-option builder
+ * share the same mapping without depending on useKnowledgeBase.ts).
+ */
+export function getCategoryIcon(category: string): string {
+  const categoryLower = category.toLowerCase()
+
+  if (categoryLower.includes('architecture') || categoryLower.includes('design')) {
+    return 'fas fa-drafting-compass'
+  }
+  if (categoryLower.includes('implementation') || categoryLower.includes('code')) {
+    return 'fas fa-code'
+  }
+  if (categoryLower.includes('security')) {
+    return 'fas fa-shield-alt'
+  }
+  if (categoryLower.includes('operations') || categoryLower.includes('devops')) {
+    return 'fas fa-cogs'
+  }
+  if (categoryLower.includes('research') || categoryLower.includes('analysis')) {
+    return 'fas fa-flask'
+  }
+  if (categoryLower.includes('reports') || categoryLower.includes('documentation')) {
+    return 'fas fa-file-alt'
+  }
+  if (categoryLower.includes('archives') || categoryLower.includes('history')) {
+    return 'fas fa-archive'
+  }
+  if (categoryLower.includes('project') || categoryLower.includes('planning')) {
+    return 'fas fa-project-diagram'
+  }
+
+  return 'fas fa-folder'
+}
+
+export function useKnowledgeCategories() {
+  /**
+   * Fetch all categories with counts
+   * Returns list of categories with document counts for filtering.
+   */
+  const fetchCategories = async (): Promise<KnowledgeCategoryItem[]> => {
+    const data = await apiClient.get<CategoriesListResponse>(`${getApiBase()}/knowledge_base/categories`)
+
+    // Structural validation — real business logic, not error hiding
+    if (!data || !Array.isArray(data.categories)) {
+      throw new Error('Invalid categories response format')
+    }
+
+    return data.categories
+  }
+
+  /**
+   * Fetch knowledge by category
+   */
+  const fetchCategory = (category: string): Promise<CategoryResponse> =>
+    apiClient.get<CategoryResponse>(`${getApiBase()}/knowledge_base/category/${category}`)
+
+  /**
+   * Fetch facts grouped by category for browsing
+   * Uses GET /api/knowledge_base/facts/by_category endpoint.
+   * @param category - Optional category filter (null for all categories)
+   * @param limit - Maximum number of facts per category (default: 100)
+   */
+  const getCategorizedFacts = async (
+    category: string | null = null,
+    limit: number = 100
+  ): Promise<CategorizedFactsResponse> => {
+    const params = new URLSearchParams()
+    if (category) {
+      params.append('category', category)
+    }
+    params.append('limit', String(limit))
+
+    const url = `${getApiBase()}/knowledge_base/facts/by_category?${params.toString()}`
+    const data = await apiClient.get<CategorizedFactsResponse>(url)
+
+    // Structural validation
+    if (!data || typeof data.categories !== 'object') {
+      throw new Error('Invalid categorized facts response format')
+    }
+
+    logger.debug(
+      `Fetched categorized facts: ${data.total_facts} total facts across ${Object.keys(data.categories).length} categories`
+    )
+
+    return data
+  }
+
+  /**
+   * Build category filter options from categorized facts
+   * Helper to create CategoryFilterOption[] for dropdowns/tabs.
+   */
+  const buildCategoryFilterOptions = (
+    categorizedFacts: CategorizedFactsResponse
+  ): CategoryFilterOption[] => {
+    const options: CategoryFilterOption[] = [
+      {
+        value: null,
+        label: 'All Categories',
+        icon: 'fas fa-th-large',
+        count: categorizedFacts.total_facts,
+      },
+    ]
+
+    for (const [categoryName, facts] of Object.entries(categorizedFacts.categories)) {
+      options.push({
+        value: categoryName,
+        label: formatCategoryHelper(categoryName),
+        icon: getCategoryIcon(categoryName),
+        count: facts.length,
+      })
+    }
+
+    // Sort by count (descending), keeping "All" at the top
+    options.sort((a, b) => {
+      if (a.value === null) return -1
+      if (b.value === null) return 1
+      return b.count - a.count
+    })
+
+    return options
+  }
+
+  return {
+    fetchCategories,
+    fetchCategory,
+    getCategorizedFacts,
+    buildCategoryFilterOptions,
+    getCategoryIcon,
+  }
+}

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeFacts.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeFacts.ts
@@ -1,0 +1,70 @@
+/**
+ * useKnowledgeFacts Composable
+ *
+ * Search (basic + advanced) and direct-fact management for the knowledge base.
+ * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
+ * ApiClient already logs retries + final failure and never returns null.
+ */
+
+import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
+import type {
+  SearchResponse,
+  AddFactResponse,
+} from '@/types/knowledgeBase'
+
+/**
+ * Advanced search options (Issue #555).
+ *
+ * Uses the consolidated search endpoint with all available features:
+ * - mode: 'semantic' | 'keyword' | 'hybrid' | 'auto'
+ * - enable_rag: Enable RAG synthesis for responses
+ * - enable_reranking: Enable cross-encoder reranking
+ * - tags: Filter by tags
+ * - min_score: Minimum similarity threshold
+ * - category: Filter by category
+ */
+export interface AdvancedSearchOptions {
+  query: string
+  top_k?: number
+  mode?: 'semantic' | 'keyword' | 'hybrid' | 'auto'
+  enable_rag?: boolean
+  enable_reranking?: boolean
+  reformulate_query?: boolean
+  tags?: string[]
+  tags_match_any?: boolean
+  min_score?: number
+  category?: string
+  offset?: number
+}
+
+export function useKnowledgeFacts() {
+  /**
+   * Search knowledge base (basic)
+   * Issue #552: Backend expects POST for search
+   */
+  const searchKnowledge = (query: string): Promise<SearchResponse> =>
+    apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, { query })
+
+  /**
+   * Advanced search with full options (Issue #555)
+   */
+  const advancedSearch = (options: AdvancedSearchOptions): Promise<SearchResponse> =>
+    apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, options)
+
+  /**
+   * Add new fact to knowledge base
+   */
+  const addFact = (fact: {
+    content: string
+    category: string
+    metadata?: Record<string, unknown>
+  }): Promise<AddFactResponse> =>
+    apiClient.post<AddFactResponse>(`${getApiBase()}/knowledge_base/facts`, fact)
+
+  return {
+    searchKnowledge,
+    advancedSearch,
+    addFact,
+  }
+}

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeFiles.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeFiles.ts
@@ -1,0 +1,32 @@
+/**
+ * useKnowledgeFiles Composable
+ *
+ * Knowledge base file upload.
+ * Split from useKnowledgeBase (#5122). Dead try/catch wrapper removed (#5123):
+ * ApiClient already logs retries + final failure and never returns null.
+ *
+ * Preserves the apiClient FormData pattern from PR #5116 — rawRequest strips
+ * Content-Type so the browser sets the multipart boundary automatically, and
+ * inherits the same auth/retry/error-handling as every other API call.
+ */
+
+import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
+import type { UploadResponse } from '@/types/knowledgeBase'
+
+export function useKnowledgeFiles() {
+  /**
+   * Upload knowledge base file
+   */
+  const uploadKnowledgeFile = async (formData: FormData): Promise<UploadResponse> => {
+    const data = await apiClient.post<Record<string, unknown>>(
+      `${getApiBase()}/knowledge_base/upload`,
+      formData
+    )
+    return data as unknown as UploadResponse
+  }
+
+  return {
+    uploadKnowledgeFile,
+  }
+}

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeIcons.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeIcons.ts
@@ -1,0 +1,125 @@
+/**
+ * useKnowledgeIcons Composable
+ *
+ * UI helpers for knowledge base components: type/file/OS/message icons
+ * and a small time formatter. Split from useKnowledgeBase (#5122) so the
+ * domain composables stay API-focused.
+ */
+
+import { getFileIcon as getFileIconUtil } from '@/utils/iconMappings'
+import { getCategoryIcon } from './useKnowledgeCategories'
+
+export function useKnowledgeIcons() {
+  /**
+   * Get icon for document type.
+   */
+  const getTypeIcon = (type: string): string => {
+    const typeLower = type.toLowerCase()
+
+    if (typeLower.includes('pdf')) return 'fas fa-file-pdf'
+    if (typeLower.includes('word') || typeLower.includes('doc')) return 'fas fa-file-word'
+    if (typeLower.includes('excel') || typeLower.includes('xls')) return 'fas fa-file-excel'
+    if (typeLower.includes('image') || typeLower.includes('png') || typeLower.includes('jpg')) return 'fas fa-file-image'
+    if (typeLower.includes('video')) return 'fas fa-file-video'
+    if (typeLower.includes('audio')) return 'fas fa-file-audio'
+    if (typeLower.includes('json') || typeLower.includes('code')) return 'fas fa-file-code'
+    if (typeLower.includes('csv')) return 'fas fa-file-csv'
+    if (typeLower.includes('text') || typeLower.includes('txt')) return 'fas fa-file-alt'
+    if (typeLower.includes('markdown') || typeLower.includes('md')) return 'fas fa-file-alt'
+
+    return 'fas fa-file'
+  }
+
+  /**
+   * Get icon for file based on name and type.
+   * Icon mapping centralized in @/utils/iconMappings; colors added here
+   * for visual distinction in the knowledge base UI.
+   */
+  const getFileIcon = (name: string, isDir: boolean = false): string => {
+    if (isDir) {
+      return 'fas fa-folder'
+    }
+
+    const icon = getFileIconUtil(name, false)
+    const extension = name.split('.').pop()?.toLowerCase() || ''
+
+    const colorMap: Record<string, string> = {
+      // Code files — blue/green
+      js: 'text-blue-500',
+      ts: 'text-blue-500',
+      jsx: 'text-blue-500',
+      tsx: 'text-blue-500',
+      vue: 'text-blue-500',
+      py: 'text-green-500',
+      rb: 'text-green-500',
+      go: 'text-green-500',
+      java: 'text-green-500',
+      c: 'text-green-500',
+      cpp: 'text-green-500',
+      h: 'text-green-500',
+      // Data files — orange
+      json: 'text-orange-500',
+      yaml: 'text-orange-500',
+      yml: 'text-orange-500',
+      toml: 'text-orange-500',
+      // Documents — varied
+      md: 'text-gray-600',
+      txt: 'text-gray-600',
+      pdf: 'text-red-600',
+      doc: 'text-blue-600',
+      docx: 'text-blue-600',
+      xls: 'text-green-600',
+      xlsx: 'text-green-600',
+      csv: 'text-green-600',
+      // Images — purple
+      png: 'text-purple-500',
+      jpg: 'text-purple-500',
+      jpeg: 'text-purple-500',
+      gif: 'text-purple-500',
+      svg: 'text-purple-500',
+      webp: 'text-purple-500',
+      // Archives — yellow
+      zip: 'text-yellow-600',
+      tar: 'text-yellow-600',
+      gz: 'text-yellow-600',
+      rar: 'text-yellow-600',
+      '7z': 'text-yellow-600',
+    }
+
+    const color = colorMap[extension] || 'text-gray-600'
+    return `${icon} ${color}`
+  }
+
+  const getOSBadgeClass = (osType: string): string => {
+    switch (osType) {
+      case 'linux': return 'badge-success'
+      case 'windows': return 'badge-info'
+      case 'macos': return 'badge-warning'
+      default: return 'badge-secondary'
+    }
+  }
+
+  const getMessageIcon = (type: string): string => {
+    const icons: Record<string, string> = {
+      info: 'fas fa-info-circle text-blue-500',
+      success: 'fas fa-check-circle text-green-500',
+      warning: 'fas fa-exclamation-triangle text-yellow-500',
+      error: 'fas fa-times-circle text-red-500',
+    }
+    return icons[type] || icons.info
+  }
+
+  const formatTime = (timestamp: string | Date): string => {
+    const date = new Date(timestamp)
+    return date.toLocaleTimeString()
+  }
+
+  return {
+    getCategoryIcon,
+    getTypeIcon,
+    getFileIcon,
+    getOSBadgeClass,
+    getMessageIcon,
+    formatTime,
+  }
+}

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeJobs.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeJobs.ts
@@ -1,0 +1,68 @@
+/**
+ * useKnowledgeJobs Composable
+ *
+ * Vectorization API calls + background job polling. These are the
+ * low-level endpoints; `useKnowledgeVectorization` layers state + dedup
+ * caching on top of them.
+ * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
+ * ApiClient already logs retries + final failure and never returns null.
+ */
+
+import apiClient from '@/utils/ApiClient'
+import appConfig from '@/config/AppConfig.js'
+import { getApiBase } from '@/config/ssot-config'
+import type {
+  VectorizationStatusResponse,
+  VectorizationResponse,
+} from '@/types/knowledgeBase'
+
+export function useKnowledgeJobs() {
+  /**
+   * Get vectorization status.
+   * Issue #552: Fixed path — backend uses /api/knowledge_base/vectorize_facts/status.
+   */
+  const getVectorizationStatus = (): Promise<VectorizationStatusResponse> =>
+    apiClient.get<VectorizationStatusResponse>(
+      `${getApiBase()}/knowledge_base/vectorize_facts/status`
+    )
+
+  /**
+   * Generate vector embeddings for all existing facts using batched processing.
+   * @param batchSize - Number of facts to process per batch (default: 50)
+   * @param batchDelay - Delay in seconds between batches (default: 0.5)
+   * @param skipExisting - Skip facts that already have vectors (default: true)
+   */
+  const vectorizeFacts = (
+    batchSize: number = 50,
+    batchDelay: number = 0.5,
+    skipExisting: boolean = true
+  ): Promise<VectorizationResponse> => {
+    // Knowledge-specific timeout (300s for vectorization operations)
+    const knowledgeTimeout = appConfig.getTimeout('knowledge')
+
+    return apiClient.post<VectorizationResponse>(
+      `${getApiBase()}/knowledge_base/vectorize_facts`,
+      {
+        batch_size: batchSize,
+        batch_delay: batchDelay,
+        skip_existing: skipExisting,
+      },
+      { timeout: knowledgeTimeout }
+    )
+  }
+
+  /**
+   * Poll status of a background job (e.g., knowledge refresh, reindexing).
+   * GET /api/knowledge_base/job_status/{task_id}
+   *
+   * Returns current status: PENDING, PROGRESS, SUCCESS, or FAILURE.
+   */
+  const pollJobStatus = (taskId: string): Promise<unknown> =>
+    apiClient.get(`${getApiBase()}/knowledge_base/job_status/${taskId}`)
+
+  return {
+    getVectorizationStatus,
+    vectorizeFacts,
+    pollJobStatus,
+  }
+}

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeStats.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeStats.ts
@@ -1,0 +1,39 @@
+/**
+ * useKnowledgeStats Composable
+ *
+ * Fetches knowledge base statistics (full and basic).
+ * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
+ * ApiClient already logs retries + final failure and never returns null.
+ */
+
+import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
+import type { KnowledgeStats } from '@/types/knowledgeBase'
+
+export function useKnowledgeStats() {
+  /**
+   * Fetch knowledge base statistics
+   */
+  const fetchStats = (): Promise<KnowledgeStats> =>
+    apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats`)
+
+  /**
+   * Fetch basic knowledge base statistics
+   * GET /api/knowledge_base/stats/basic
+   *
+   * Returns null on error to preserve previous caller expectations
+   * (UI treats missing basic stats as non-fatal).
+   */
+  const fetchBasicStats = async (): Promise<KnowledgeStats | null> => {
+    try {
+      return await apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats/basic`)
+    } catch {
+      return null
+    }
+  }
+
+  return {
+    fetchStats,
+    fetchBasicStats,
+  }
+}

--- a/autobot-frontend/src/composables/knowledge/useMachineKnowledge.ts
+++ b/autobot-frontend/src/composables/knowledge/useMachineKnowledge.ts
@@ -1,0 +1,84 @@
+/**
+ * useMachineKnowledge Composable
+ *
+ * Per-machine knowledge operations: machine profile fetch, initializing
+ * machine-specific knowledge entries, and refreshing system knowledge.
+ * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
+ * ApiClient already logs retries + final failure and never returns null.
+ */
+
+import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
+import type {
+  MachineKnowledgeResponse,
+  SystemKnowledgeResponse,
+} from '@/types/knowledgeBase'
+
+export interface MachineProfile {
+  machine_id?: string
+  os_type?: string
+  distro?: string
+  package_manager?: string
+  available_tools?: string[]
+  architecture?: string
+}
+
+export function useMachineKnowledge() {
+  /**
+   * Fetch all machine profiles.
+   * Issue #552: Fixed path — backend uses singular /api/knowledge_base/machine_profile.
+   * Returns [] on error so consumers can render an empty list without try/catch.
+   */
+  const fetchMachineProfiles = async (): Promise<MachineProfile[]> => {
+    try {
+      const data = await apiClient.get<MachineProfile[]>(`${getApiBase()}/knowledge_base/machine_profile`)
+      return Array.isArray(data) ? data : []
+    } catch {
+      return []
+    }
+  }
+
+  /**
+   * Fetch machine profile for a specific machine.
+   * Returns null on error so consumers can gate UI on presence.
+   */
+  const fetchMachineProfile = async (machineId: string): Promise<MachineProfile | null> => {
+    try {
+      return await apiClient.get<MachineProfile>(
+        `${getApiBase()}/knowledge_base/machine_profile?machine_id=${encodeURIComponent(machineId)}`
+      )
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Initialize machine knowledge for a specific host.
+   * POST /api/knowledge_base/machine_knowledge/initialize
+   */
+  const initializeMachineKnowledge = (machineId: string): Promise<MachineKnowledgeResponse> =>
+    apiClient.post<MachineKnowledgeResponse>(
+      `${getApiBase()}/knowledge_base/machine_knowledge/initialize`,
+      { machine_id: machineId }
+    )
+
+  /**
+   * Refresh system knowledge (rescan and update all system information).
+   * POST /api/knowledge_base/refresh_system_knowledge
+   *
+   * Returns immediately with task_id. Use useKnowledgeJobs().pollJobStatus
+   * to check completion.
+   */
+  const refreshSystemKnowledge = (): Promise<SystemKnowledgeResponse> =>
+    apiClient.post<SystemKnowledgeResponse>(
+      `${getApiBase()}/knowledge_base/refresh_system_knowledge`,
+      {}
+    )
+
+  return {
+    fetchMachineProfiles,
+    fetchMachineProfile,
+    initializeMachineKnowledge,
+    refreshSystemKnowledge,
+  }
+}

--- a/autobot-frontend/src/composables/knowledge/useManPages.ts
+++ b/autobot-frontend/src/composables/knowledge/useManPages.ts
@@ -1,0 +1,91 @@
+/**
+ * useManPages Composable
+ *
+ * Man-page integration, population, summary fetch, and AutoBot-docs
+ * population (grouped here because it shares the same backend ingestion
+ * pattern with man pages).
+ * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
+ * ApiClient already logs retries + final failure and never returns null.
+ */
+
+import apiClient from '@/utils/ApiClient'
+import { getApiBase } from '@/config/ssot-config'
+import type {
+  IntegrationResponse,
+  ManPagesPopulateResponse,
+  AutoBotDocsResponse,
+} from '@/types/knowledgeBase'
+
+export interface ManPagesSummary {
+  status?: string
+  message?: string
+  successful?: number
+  processed?: number
+  current_man_page_files?: number
+  total_available_tools?: number
+  integration_date?: string
+  available_commands?: string[]
+}
+
+export function useManPages() {
+  /**
+   * Fetch man pages summary.
+   * Returns null on error so consumers can treat missing summary as non-fatal.
+   */
+  const fetchManPagesSummary = async (): Promise<ManPagesSummary | null> => {
+    try {
+      return await apiClient.get<ManPagesSummary>(`${getApiBase()}/knowledge_base/man_pages/summary`)
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Integrate man pages for a specific machine.
+   */
+  const integrateManPages = (machineId: string): Promise<IntegrationResponse> =>
+    apiClient.post<IntegrationResponse>(
+      `${getApiBase()}/knowledge_base/man_pages/integrate`,
+      { machine_id: machineId }
+    )
+
+  /**
+   * Populate man pages for a specific machine.
+   * POST /api/knowledge_base/populate_man_pages
+   */
+  const populateManPages = (machineId: string): Promise<ManPagesPopulateResponse> =>
+    apiClient.post<ManPagesPopulateResponse>(
+      `${getApiBase()}/knowledge_base/populate_man_pages`,
+      { machine_id: machineId }
+    )
+
+  /**
+   * Populate AutoBot documentation.
+   * POST /api/knowledge_base/populate_autobot_docs
+   */
+  const populateAutoBotDocs = (): Promise<AutoBotDocsResponse> =>
+    apiClient.post<AutoBotDocsResponse>(
+      `${getApiBase()}/knowledge_base/populate_autobot_docs`,
+      {}
+    )
+
+  /**
+   * Search man pages (placeholder — current backend search returns man
+   * pages through the unified /search endpoint; callers should invoke
+   * useKnowledgeFacts().searchKnowledge with a man-page filter instead).
+   * Kept as a thin wrapper here for API discoverability.
+   */
+  const searchManPages = (query: string) =>
+    apiClient.post(`${getApiBase()}/knowledge_base/search`, {
+      query,
+      category: 'man_pages',
+    })
+
+  return {
+    fetchManPagesSummary,
+    integrateManPages,
+    populateManPages,
+    populateAutoBotDocs,
+    searchManPages,
+  }
+}

--- a/autobot-frontend/src/composables/useKnowledgeBase.ts
+++ b/autobot-frontend/src/composables/useKnowledgeBase.ts
@@ -1,63 +1,51 @@
 /**
- * useKnowledgeBase Composable
+ * useKnowledgeBase Composable (backward-compat shim)
  *
- * Shared functions for knowledge base management across all knowledge manager components.
- * This composable eliminates duplicate code and provides a consistent API interface.
+ * The 807-line god-composable was split into domain-focused composables
+ * under `./knowledge/*` (#5122). This file re-exports everything from the
+ * new composables so existing consumers continue to work unchanged.
+ *
+ * Dead try/catch/log/rethrow wrappers around ApiClient calls were also
+ * removed during the split (#5123) — ApiClient already logs every retry
+ * and final failure, and it never returns null, so the wrappers only
+ * double-logged the same error.
+ *
+ * Migration path: consumers should import the focused composable directly
+ * (e.g. `import { useKnowledgeStats } from '@/composables/knowledge/useKnowledgeStats'`)
+ * and this aggregator can be deleted once no callers remain.
  */
 
-import apiClient from '@/utils/ApiClient'
 import {
   formatDate as formatDateHelper,
   formatFileSize as formatFileSizeHelper,
-  formatCategoryName as formatCategoryHelper
+  formatCategoryName as formatCategoryHelper,
 } from '@/utils/formatHelpers'
-import { getFileIcon as getFileIconUtil } from '@/utils/iconMappings'
-import appConfig from '@/config/AppConfig.js'
-import { createLogger } from '@/utils/debugUtils'
 
-const logger = createLogger('useKnowledgeBase')
-import type {
-  KnowledgeStats,
-  CategoryResponse,
-  CategoriesListResponse,
-  KnowledgeCategoryItem,
-  SearchResponse,
-  AddFactResponse,
-  UploadResponse,
-  IntegrationResponse,
-  VectorizationStatusResponse,
-  VectorizationResponse,
-  MachineKnowledgeResponse,
-  SystemKnowledgeResponse,
-  ManPagesPopulateResponse,
-  AutoBotDocsResponse,
-  CategorizedFactsResponse,
-  CategoryFilterOption
-} from '@/types/knowledgeBase'
-import { getApiBase } from '@/config/ssot-config'
+import { useKnowledgeStats } from './knowledge/useKnowledgeStats'
+import { useKnowledgeCategories } from './knowledge/useKnowledgeCategories'
+import { useKnowledgeFacts } from './knowledge/useKnowledgeFacts'
+import { useKnowledgeFiles } from './knowledge/useKnowledgeFiles'
+import { useMachineKnowledge } from './knowledge/useMachineKnowledge'
+import { useManPages } from './knowledge/useManPages'
+import { useKnowledgeJobs } from './knowledge/useKnowledgeJobs'
+import { useKnowledgeIcons } from './knowledge/useKnowledgeIcons'
 
-// KnowledgeStats imported from @/types/knowledgeBase (consolidated type definition)
+// ==================== Re-exports ====================
 
-export interface MachineProfile {
-  machine_id?: string
-  os_type?: string
-  distro?: string
-  package_manager?: string
-  available_tools?: string[]
-  architecture?: string
-}
+export { useKnowledgeStats } from './knowledge/useKnowledgeStats'
+export { useKnowledgeCategories } from './knowledge/useKnowledgeCategories'
+export { useKnowledgeFacts } from './knowledge/useKnowledgeFacts'
+export type { AdvancedSearchOptions } from './knowledge/useKnowledgeFacts'
+export { useKnowledgeFiles } from './knowledge/useKnowledgeFiles'
+export { useMachineKnowledge } from './knowledge/useMachineKnowledge'
+export type { MachineProfile } from './knowledge/useMachineKnowledge'
+export { useManPages } from './knowledge/useManPages'
+export type { ManPagesSummary } from './knowledge/useManPages'
+export { useKnowledgeJobs } from './knowledge/useKnowledgeJobs'
+export { useKnowledgeIcons } from './knowledge/useKnowledgeIcons'
 
-export interface ManPagesSummary {
-  status?: string
-  message?: string
-  successful?: number
-  processed?: number
-  current_man_page_files?: number
-  total_available_tools?: number
-  integration_date?: string
-  available_commands?: string[]
-}
-
+// Public state types that lived in this module — preserved for consumers
+// that still import them from `@/composables/useKnowledgeBase`.
 export interface ProgressState {
   currentTask: string
   taskDetail: string
@@ -73,621 +61,63 @@ export interface ProgressMessage {
   timestamp: number
 }
 
+/**
+ * @deprecated Use domain-specific composables from './knowledge/*' instead.
+ * This aggregator is kept for backward compatibility until all consumers
+ * migrate to importing only what they need.
+ */
 export function useKnowledgeBase() {
-  // ==================== API CALLS ====================
-
-  /**
-   * Fetch knowledge base statistics
-   */
-  const fetchStats = async (): Promise<KnowledgeStats> => {
-    try {
-      const data = await apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats`)
-      return data
-    } catch (error) {
-      logger.error('Error fetching stats:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Fetch all categories with counts
-   * Returns list of categories with document counts for filtering
-   * @throws Error if API request fails (consistent with other API functions)
-   */
-  const fetchCategories = async (): Promise<KnowledgeCategoryItem[]> => {
-    try {
-      const data = await apiClient.get<CategoriesListResponse>(`${getApiBase()}/knowledge_base/categories`)
-
-      // Validate response structure
-      if (!data || !Array.isArray(data.categories)) {
-        throw new Error('Invalid categories response format')
-      }
-
-      return data.categories
-    } catch (error) {
-      logger.error('Error fetching categories:', error)
-      throw error // Throw consistently with other API functions
-    }
-  }
-
-  /**
-   * Fetch knowledge by category
-   */
-  const fetchCategory = async (category: string): Promise<CategoryResponse> => {
-    try {
-      const data = await apiClient.get<CategoryResponse>(`${getApiBase()}/knowledge_base/category/${category}`)
-      return data
-    } catch (error) {
-      logger.error('Error fetching category:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Fetch facts grouped by category for browsing
-   * Uses GET /api/knowledge_base/facts/by_category endpoint
-   * @param category - Optional category filter (null for all categories)
-   * @param limit - Maximum number of facts per category (default: 100)
-   * @returns CategorizedFactsResponse with facts grouped by category
-   */
-  const getCategorizedFacts = async (
-    category: string | null = null,
-    limit: number = 100
-  ): Promise<CategorizedFactsResponse> => {
-    try {
-      const params = new URLSearchParams()
-      if (category) {
-        params.append('category', category)
-      }
-      params.append('limit', String(limit))
-
-      const url = `${getApiBase()}/knowledge_base/facts/by_category?${params.toString()}`
-      const data = await apiClient.get<CategorizedFactsResponse>(url)
-
-      // Validate response structure
-      if (!data || typeof data.categories !== 'object') {
-        throw new Error('Invalid categorized facts response format')
-      }
-
-      logger.debug(`Fetched categorized facts: ${data.total_facts} total facts across ${Object.keys(data.categories).length} categories`)
-
-      return data
-    } catch (error) {
-      logger.error('Error fetching categorized facts:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Build category filter options from categorized facts
-   * Helper method to create CategoryFilterOption[] for UI components
-   * @param categorizedFacts - Response from getCategorizedFacts
-   * @returns Array of CategoryFilterOption for use in dropdowns/tabs
-   */
-  const buildCategoryFilterOptions = (
-    categorizedFacts: CategorizedFactsResponse
-  ): CategoryFilterOption[] => {
-    const options: CategoryFilterOption[] = [
-      {
-        value: null,
-        label: 'All Categories',
-        icon: 'fas fa-th-large',
-        count: categorizedFacts.total_facts
-      }
-    ]
-
-    // Add each category as an option
-    for (const [categoryName, facts] of Object.entries(categorizedFacts.categories)) {
-      options.push({
-        value: categoryName,
-        label: formatCategoryHelper(categoryName),
-        icon: getCategoryIcon(categoryName),
-        count: facts.length
-      })
-    }
-
-    // Sort by count (descending), keeping "All" at the top
-    options.sort((a, b) => {
-      if (a.value === null) return -1
-      if (b.value === null) return 1
-      return b.count - a.count
-    })
-
-    return options
-  }
-
-  /**
-   * Search knowledge base (basic)
-   */
-  const searchKnowledge = async (query: string): Promise<SearchResponse> => {
-    try {
-      // Issue #552: Backend expects POST for search
-      const data = await apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, { query })
-      return data
-    } catch (error) {
-      logger.error('Error searching knowledge:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Advanced search with full options (Issue #555)
-   *
-   * Uses the consolidated search endpoint with all available features:
-   * - mode: 'semantic' | 'keyword' | 'hybrid' | 'auto'
-   * - enable_rag: Enable RAG synthesis for responses
-   * - enable_reranking: Enable cross-encoder reranking
-   * - tags: Filter by tags
-   * - min_score: Minimum similarity threshold
-   * - category: Filter by category
-   */
-  interface AdvancedSearchOptions {
-    query: string
-    top_k?: number
-    mode?: 'semantic' | 'keyword' | 'hybrid' | 'auto'
-    enable_rag?: boolean
-    enable_reranking?: boolean
-    reformulate_query?: boolean
-    tags?: string[]
-    tags_match_any?: boolean
-    min_score?: number
-    category?: string
-    offset?: number
-  }
-
-  const advancedSearch = async (options: AdvancedSearchOptions): Promise<SearchResponse> => {
-    try {
-      const data = await apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, options)
-      return data
-    } catch (error) {
-      logger.error('Error in advanced search:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Add new fact to knowledge base
-   */
-  const addFact = async (fact: {
-    content: string
-    category: string
-    metadata?: Record<string, unknown>
-  }): Promise<AddFactResponse> => {
-    try {
-      const data = await apiClient.post<AddFactResponse>(`${getApiBase()}/knowledge_base/facts`, fact)
-      return data
-    } catch (error) {
-      logger.error('Error adding fact:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Upload knowledge base file
-   *
-   * Uses apiClient.post which handles FormData natively — rawRequest strips
-   * Content-Type so the browser sets multipart boundary automatically, and
-   * inherits the same auth/retry/error-handling as every other API call.
-   */
-  const uploadKnowledgeFile = async (formData: FormData): Promise<UploadResponse> => {
-    try {
-      const data = await apiClient.post<Record<string, any>>(
-        `${getApiBase()}/knowledge_base/upload`,
-        formData
-      )
-      return data as UploadResponse
-    } catch (error) {
-      logger.error('Error uploading file:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Fetch machine profiles
-   */
-  const fetchMachineProfiles = async (): Promise<MachineProfile[]> => {
-    try {
-      // Issue #552: Fixed path - backend uses singular /api/knowledge_base/machine_profile
-      const data = await apiClient.get<MachineProfile[]>(`${getApiBase()}/knowledge_base/machine_profile`)
-      return Array.isArray(data) ? data : []
-    } catch (error) {
-      logger.error('Error fetching machine profiles:', error)
-      return []
-    }
-  }
-
-  /**
-   * Fetch man pages summary
-   */
-  const fetchManPagesSummary = async (): Promise<ManPagesSummary | null> => {
-    try {
-      const data = await apiClient.get<ManPagesSummary>(`${getApiBase()}/knowledge_base/man_pages/summary`)
-      return data
-    } catch (error) {
-      logger.error('Error fetching man pages summary:', error)
-      return null
-    }
-  }
-
-  /**
-   * Integrate man pages for a specific machine
-   */
-  const integrateManPages = async (machineId: string): Promise<IntegrationResponse> => {
-    try {
-      const data = await apiClient.post<IntegrationResponse>(`${getApiBase()}/knowledge_base/man_pages/integrate`, {
-        machine_id: machineId
-      })
-      return data
-    } catch (error) {
-      logger.error('Error integrating man pages:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Get vectorization status
-   */
-  const getVectorizationStatus = async (): Promise<VectorizationStatusResponse> => {
-    try {
-      // Issue #552: Fixed path - backend uses /api/knowledge_base/vectorize_facts/status
-      const data = await apiClient.get<VectorizationStatusResponse>(`${getApiBase()}/knowledge_base/vectorize_facts/status`)
-      return data
-    } catch (error) {
-      logger.error('Error getting vectorization status:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Generate vector embeddings for all existing facts using batched processing (legacy/manual)
-   * Enhanced with comprehensive error handling and response validation
-   * @param batchSize - Number of facts to process per batch (default: 50)
-   * @param batchDelay - Delay in seconds between batches (default: 0.5)
-   * @param skipExisting - Skip facts that already have vectors (default: true)
-   */
-  const vectorizeFacts = async (
-    batchSize: number = 50,
-    batchDelay: number = 0.5,
-    skipExisting: boolean = true
-  ): Promise<VectorizationResponse> => {
-    try {
-      // Get knowledge-specific timeout (300s for vectorization operations)
-      const knowledgeTimeout = appConfig.getTimeout('knowledge')
-
-      const data = await apiClient.post<VectorizationResponse>(`${getApiBase()}/knowledge_base/vectorize_facts`, {
-        batch_size: batchSize,
-        batch_delay: batchDelay,
-        skip_existing: skipExisting
-      }, { timeout: knowledgeTimeout })
-
-      logger.debug('[vectorizeFacts] Response received')
-
-      return data
-    } catch (error) {
-      logger.error('[vectorizeFacts] Error occurred:', error)
-
-      // Enhanced error with more context
-      if (error instanceof Error) {
-        throw error // Re-throw with original message
-      } else {
-        throw new Error(`Vectorization failed: ${String(error)}`)
-      }
-    }
-  }
-
-  /**
-   * Initialize machine knowledge for a specific host
-   * POST /api/knowledge_base/machine_knowledge/initialize
-   */
-  const initializeMachineKnowledge = async (machineId: string): Promise<MachineKnowledgeResponse> => {
-    try {
-      const data = await apiClient.post<MachineKnowledgeResponse>(`${getApiBase()}/knowledge_base/machine_knowledge/initialize`, {
-        machine_id: machineId
-      })
-
-      logger.debug('[initializeMachineKnowledge] Response received')
-
-      return data
-    } catch (error) {
-      logger.error('[initializeMachineKnowledge] Error:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Refresh system knowledge (rescan and update all system information) - ASYNC JOB
-   * POST /api/knowledge_base/refresh_system_knowledge
-   *
-   * Returns immediately with task_id. Use pollJobStatus to check completion.
-   */
-  const refreshSystemKnowledge = async (): Promise<SystemKnowledgeResponse> => {
-    try {
-      const data = await apiClient.post<SystemKnowledgeResponse>(`${getApiBase()}/knowledge_base/refresh_system_knowledge`, {})
-
-      logger.debug('[refreshSystemKnowledge] Response received')
-
-      return data
-    } catch (error) {
-      logger.error('[refreshSystemKnowledge] Error:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Poll status of a background job (e.g., knowledge refresh, reindexing)
-   * GET /api/knowledge_base/job_status/{task_id}
-   *
-   * Returns current status: PENDING, PROGRESS, SUCCESS, or FAILURE
-   */
-  const pollJobStatus = async (taskId: string): Promise<any> => {
-    try {
-      const data = await apiClient.get<any>(`${getApiBase()}/knowledge_base/job_status/${taskId}`)
-
-      logger.debug('[pollJobStatus] Response received', { taskId })
-
-      return data
-    } catch (error) {
-      logger.error('[pollJobStatus] Error:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Populate man pages for a specific machine
-   * POST /api/knowledge_base/populate_man_pages
-   */
-  const populateManPages = async (machineId: string): Promise<ManPagesPopulateResponse> => {
-    try {
-      const data = await apiClient.post<ManPagesPopulateResponse>(`${getApiBase()}/knowledge_base/populate_man_pages`, {
-        machine_id: machineId
-      })
-
-      logger.debug('[populateManPages] Response received')
-
-      return data
-    } catch (error) {
-      logger.error('[populateManPages] Error:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Populate AutoBot documentation
-   * POST /api/knowledge_base/populate_autobot_docs
-   */
-  const populateAutoBotDocs = async (): Promise<AutoBotDocsResponse> => {
-    try {
-      const data = await apiClient.post<AutoBotDocsResponse>(`${getApiBase()}/knowledge_base/populate_autobot_docs`, {})
-
-      logger.debug('[populateAutoBotDocs] Response received')
-
-      return data
-    } catch (error) {
-      logger.error('[populateAutoBotDocs] Error:', error)
-      throw error
-    }
-  }
-
-  /**
-   * Fetch machine profile for a specific machine
-   * GET /api/knowledge_base/machine_profile?machine_id=<id>
-   */
-  const fetchMachineProfile = async (machineId: string): Promise<MachineProfile | null> => {
-    try {
-      const data = await apiClient.get<MachineProfile>(
-        `${getApiBase()}/knowledge_base/machine_profile?machine_id=${encodeURIComponent(machineId)}`
-      )
-
-      logger.debug('[fetchMachineProfile] Response received')
-
-      return data
-    } catch (error) {
-      logger.error('[fetchMachineProfile] Error:', error)
-      return null
-    }
-  }
-
-  /**
-   * Fetch basic knowledge base statistics
-   * GET /api/knowledge_base/stats/basic
-   */
-  const fetchBasicStats = async (): Promise<KnowledgeStats | null> => {
-    try {
-      const data = await apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats/basic`)
-
-      logger.debug('[fetchBasicStats] Response received')
-
-      return data
-    } catch (error) {
-      logger.error('[fetchBasicStats] Error:', error)
-      return null
-    }
-  }
-
-  // ==================== FORMATTING FUNCTIONS ====================
-  // NOTE: Now using shared formatHelpers from @/utils/formatHelpers
-  // Removed duplicate formatDate, formatCategory implementations (was 23 lines)
-
-  /**
-   * Get icon for category
-   */
-  const getCategoryIcon = (category: string): string => {
-    const categoryLower = category.toLowerCase()
-
-    if (categoryLower.includes('architecture') || categoryLower.includes('design')) {
-      return 'fas fa-drafting-compass'
-    }
-    if (categoryLower.includes('implementation') || categoryLower.includes('code')) {
-      return 'fas fa-code'
-    }
-    if (categoryLower.includes('security')) {
-      return 'fas fa-shield-alt'
-    }
-    if (categoryLower.includes('operations') || categoryLower.includes('devops')) {
-      return 'fas fa-cogs'
-    }
-    if (categoryLower.includes('research') || categoryLower.includes('analysis')) {
-      return 'fas fa-flask'
-    }
-    if (categoryLower.includes('reports') || categoryLower.includes('documentation')) {
-      return 'fas fa-file-alt'
-    }
-    if (categoryLower.includes('archives') || categoryLower.includes('history')) {
-      return 'fas fa-archive'
-    }
-    if (categoryLower.includes('project') || categoryLower.includes('planning')) {
-      return 'fas fa-project-diagram'
-    }
-
-    return 'fas fa-folder'
-  }
-
-  /**
-   * Get icon for document type
-   */
-  const getTypeIcon = (type: string): string => {
-    const typeLower = type.toLowerCase()
-
-    if (typeLower.includes('pdf')) return 'fas fa-file-pdf'
-    if (typeLower.includes('word') || typeLower.includes('doc')) return 'fas fa-file-word'
-    if (typeLower.includes('excel') || typeLower.includes('xls')) return 'fas fa-file-excel'
-    if (typeLower.includes('image') || typeLower.includes('png') || typeLower.includes('jpg')) return 'fas fa-file-image'
-    if (typeLower.includes('video')) return 'fas fa-file-video'
-    if (typeLower.includes('audio')) return 'fas fa-file-audio'
-    if (typeLower.includes('json') || typeLower.includes('code')) return 'fas fa-file-code'
-    if (typeLower.includes('csv')) return 'fas fa-file-csv'
-    if (typeLower.includes('text') || typeLower.includes('txt')) return 'fas fa-file-alt'
-    if (typeLower.includes('markdown') || typeLower.includes('md')) return 'fas fa-file-alt'
-
-    return 'fas fa-file'
-  }
-
-  /**
-   * Get icon for file based on name and type
-   * Icon mapping centralized in @/utils/iconMappings
-   * Color classes added for visual distinction in knowledge base
-   */
-  const getFileIcon = (name: string, isDir: boolean = false): string => {
-    if (isDir) {
-      return 'fas fa-folder'
-    }
-
-    const icon = getFileIconUtil(name, false)
-    const extension = name.split('.').pop()?.toLowerCase() || ''
-
-    // Map extensions to color classes for visual distinction
-    const colorMap: Record<string, string> = {
-      // Code files - blue/green
-      'js': 'text-blue-500',
-      'ts': 'text-blue-500',
-      'jsx': 'text-blue-500',
-      'tsx': 'text-blue-500',
-      'vue': 'text-blue-500',
-      'py': 'text-green-500',
-      'rb': 'text-green-500',
-      'go': 'text-green-500',
-      'java': 'text-green-500',
-      'c': 'text-green-500',
-      'cpp': 'text-green-500',
-      'h': 'text-green-500',
-      // Data files - orange
-      'json': 'text-orange-500',
-      'yaml': 'text-orange-500',
-      'yml': 'text-orange-500',
-      'toml': 'text-orange-500',
-      // Documents - varied
-      'md': 'text-gray-600',
-      'txt': 'text-gray-600',
-      'pdf': 'text-red-600',
-      'doc': 'text-blue-600',
-      'docx': 'text-blue-600',
-      'xls': 'text-green-600',
-      'xlsx': 'text-green-600',
-      'csv': 'text-green-600',
-      // Images - purple
-      'png': 'text-purple-500',
-      'jpg': 'text-purple-500',
-      'jpeg': 'text-purple-500',
-      'gif': 'text-purple-500',
-      'svg': 'text-purple-500',
-      'webp': 'text-purple-500',
-      // Archives - yellow
-      'zip': 'text-yellow-600',
-      'tar': 'text-yellow-600',
-      'gz': 'text-yellow-600',
-      'rar': 'text-yellow-600',
-      '7z': 'text-yellow-600'
-    }
-
-    const color = colorMap[extension] || 'text-gray-600'
-    return `${icon} ${color}`
-  }
-
-  const getOSBadgeClass = (osType: string): string => {
-    switch (osType) {
-      case 'linux': return 'badge-success'
-      case 'windows': return 'badge-info'
-      case 'macos': return 'badge-warning'
-      default: return 'badge-secondary'
-    }
-  }
-
-  const getMessageIcon = (type: string): string => {
-    const icons: Record<string, string> = {
-      'info': 'fas fa-info-circle text-blue-500',
-      'success': 'fas fa-check-circle text-green-500',
-      'warning': 'fas fa-exclamation-triangle text-yellow-500',
-      'error': 'fas fa-times-circle text-red-500'
-    }
-    return icons[type] || icons.info
-  }
-
-  const formatTime = (timestamp: string | Date): string => {
-    const date = new Date(timestamp)
-    return date.toLocaleTimeString()
-  }
-
-  // NOTE: formatFileSize removed (was 7 lines) - now using formatFileSizeHelper from @/utils/formatHelpers
-
-  // ==================== EXPORTS ====================
+  const stats = useKnowledgeStats()
+  const categories = useKnowledgeCategories()
+  const facts = useKnowledgeFacts()
+  const files = useKnowledgeFiles()
+  const machine = useMachineKnowledge()
+  const manPages = useManPages()
+  const jobs = useKnowledgeJobs()
+  const icons = useKnowledgeIcons()
 
   return {
-    // API calls
-    fetchStats,
-    fetchCategories,
-    fetchCategory,
-    searchKnowledge,
-    advancedSearch,  // Issue #555: Consolidated search with all options
-    addFact,
-    uploadKnowledgeFile,
-    fetchMachineProfiles,
-    fetchManPagesSummary,
-    integrateManPages,
-    getVectorizationStatus,
-    vectorizeFacts,
-    // New API calls
-    initializeMachineKnowledge,
-    refreshSystemKnowledge,
-    pollJobStatus,  // NEW: Poll background job status
-    populateManPages,
-    populateAutoBotDocs,
-    fetchMachineProfile,
-    fetchBasicStats,
-    // Category filtering (Issue #161)
-    getCategorizedFacts,
-    buildCategoryFilterOptions,
+    // Stats
+    fetchStats: stats.fetchStats,
+    fetchBasicStats: stats.fetchBasicStats,
+    // Categories
+    fetchCategories: categories.fetchCategories,
+    fetchCategory: categories.fetchCategory,
+    getCategorizedFacts: categories.getCategorizedFacts,
+    buildCategoryFilterOptions: categories.buildCategoryFilterOptions,
+    // Facts / search
+    searchKnowledge: facts.searchKnowledge,
+    advancedSearch: facts.advancedSearch,
+    addFact: facts.addFact,
+    // Files
+    uploadKnowledgeFile: files.uploadKnowledgeFile,
+    // Machine
+    fetchMachineProfiles: machine.fetchMachineProfiles,
+    fetchMachineProfile: machine.fetchMachineProfile,
+    initializeMachineKnowledge: machine.initializeMachineKnowledge,
+    refreshSystemKnowledge: machine.refreshSystemKnowledge,
+    // Man pages
+    fetchManPagesSummary: manPages.fetchManPagesSummary,
+    integrateManPages: manPages.integrateManPages,
+    populateManPages: manPages.populateManPages,
+    populateAutoBotDocs: manPages.populateAutoBotDocs,
+    // Jobs / vectorization
+    getVectorizationStatus: jobs.getVectorizationStatus,
+    vectorizeFacts: jobs.vectorizeFacts,
+    pollJobStatus: jobs.pollJobStatus,
+    // Icons + formatting
+    getCategoryIcon: icons.getCategoryIcon,
+    getTypeIcon: icons.getTypeIcon,
+    getFileIcon: icons.getFileIcon,
+    getOSBadgeClass: icons.getOSBadgeClass,
+    getMessageIcon: icons.getMessageIcon,
+    formatTime: icons.formatTime,
     // Formatting helpers (using shared utilities)
     formatDate: formatDateHelper,
     formatCategory: formatCategoryHelper,
     formatCategoryName: formatCategoryHelper, // Alias for backward compatibility
     formatFileSize: formatFileSizeHelper,
-    // Icon helpers
-    getCategoryIcon,
-    getTypeIcon,
-    getFileIcon,
-    getOSBadgeClass,
-    getMessageIcon,
-    formatTime,
     formatDateOnly: formatDateHelper, // Alias for backward compatibility
   }
 }
+


### PR DESCRIPTION
Closes #5122, #5123

## Summary
Split the 807-line god-composable into focused domain composables; drop dead try/catch wrappers during the split (ApiClient already logs + throws).

### New composables under \`composables/knowledge/\`
- \`useKnowledgeStats\` — fetchStats, fetchBasicStats
- \`useKnowledgeCategories\` — fetchCategories, fetchCategory, getCategorizedFacts, buildCategoryFilterOptions
- \`useKnowledgeFacts\` — searchKnowledge, advancedSearch, addFact
- \`useKnowledgeFiles\` — uploadKnowledgeFile (preserves PR #5116 apiClient.post FormData pattern)
- \`useMachineKnowledge\` — fetchMachineProfile, initializeMachineKnowledge, refreshSystemKnowledge
- \`useManPages\` — fetchManPagesSummary, integrateManPages, populateManPages, searchManPages
- \`useKnowledgeJobs\` — pollJobStatus and related polling helpers
- \`useKnowledgeIcons\` — UI helper

### #5123 cleanup (during the split)
Removed 16 dead \`try/catch + logger.error + throw error\` wrappers + \`if (!response)\` null-guards. Kept structural validation (\`Array.isArray\`, \`typeof\`) and 4 functions with legitimate null-return business logic.

### Backward compatibility
\`useKnowledgeBase.ts\` kept as a 122-line thin BC shim re-exporting all functions — zero breakage for existing consumers. Deprecation docstring points to the domain composables.

### Test split
\`useKnowledgeBase.test.ts\` (1060 lines) split into 7 focused per-composable test files + slim 124-line BC smoke test. Net: 65 tests across 9 files.

## Diff
807 → 122 lines (85% reduction of main file); 8 new focused composables

## Test Status
PASS — 65/65; vue-tsc net +0 new errors