### PR TITLE
feat(benchmarks): enforce held-out dev/test split for RAG benchmarks (#5074)

### DIFF
--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -466,6 +466,24 @@ async def get_rag_stats(
     }
 
 
+class RunBenchmarkRequest(BaseModel):
+    """Request body for POST /rag/benchmark/run.
+
+    Issue #5074: callers must declare which split they are benchmarking
+    against so held-out scores are auditable.
+    """
+
+    split: str = Field(
+        ...,
+        description=(
+            "Which portion of the dataset to run: 'dev' (tuning), 'test' "
+            "(held-out final score), or 'all' (combined — not a held-out score)."
+        ),
+        pattern="^(dev|test|all)$",
+    )
+    k: int = Field(default=5, ge=1, le=50, description="Top-k results per query.")
+
+
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="run_rag_benchmark",
@@ -473,6 +491,7 @@ async def get_rag_stats(
 )
 @router.post("/benchmark/run")
 async def run_rag_benchmark(
+    request: RunBenchmarkRequest,
     admin_check: bool = Depends(check_admin_permission),
 ):
     """Run the RAG precision@k benchmark suite and publish results to RetrievalLearner.
@@ -486,10 +505,23 @@ async def run_rag_benchmark(
     Issue #5018: Admin-gated to prevent unauthenticated users from poisoning
     the ``__global__`` RetrievalLearner feedback stream.
 
+    Issue #5074: Requires an explicit ``split`` body param (``dev`` | ``test``
+    | ``all``).  Only ``split=test`` produces a ``held_out_score=true`` result.
+
+    **Body:**
+    - **split**: ``dev`` (tune) | ``test`` (held-out) | ``all`` (combined).
+    - **k**: top-k retrieval size (default 5).
+
     **Returns:**
     - **published**: Number of feedback events written to Redis.
     - **total**: Total benchmark queries run.
     - **stream_key**: Redis stream key where events were written.
+    - **split_used**: The split that was actually run.
+    - **dev_size**: Total dev-set queries in the dataset.
+    - **test_size**: Total test-set queries in the dataset.
+    - **tuned_on_dev**: Whether the harness has ever run a tune() pass.
+    - **held_out_score**: True iff split==test AND no dev leakage occurred.
+    - **mean_precision_at_k**: Mean precision@k across the run.
     """
     import asyncio
     from datetime import datetime, timezone
@@ -500,7 +532,10 @@ async def run_rag_benchmark(
     from knowledge.rag_benchmarks import (
         _BENCHMARK_USER,
         _TOPIC_DOCS,
+        BenchmarkHarness,
+        BenchmarkSplit,
         _deterministic_embed,
+        get_default_dataset,
         publish_feedback_events,
         run_benchmark_suite,
     )
@@ -519,9 +554,15 @@ async def run_rag_benchmark(
         metadatas=[{"topic": topic} for _, _, topic in _TOPIC_DOCS],
     )
 
-    # run_benchmark_suite is synchronous (ChromaDB EphemeralClient is sync).
+    split = BenchmarkSplit(request.split)
+    dataset = get_default_dataset()
+    harness = BenchmarkHarness(dataset=dataset)
+
+    def _runner(ds):
+        return run_benchmark_suite(collection, k=request.k, dataset=ds, split=split)
+
     loop = asyncio.get_running_loop()
-    results = await loop.run_in_executor(None, run_benchmark_suite, collection, 5)
+    report = await loop.run_in_executor(None, harness.run, _runner, split)
 
     try:
         client.delete_collection("benchmark_run")
@@ -533,24 +574,39 @@ async def run_rag_benchmark(
         logger.warning("run_rag_benchmark: Redis unavailable; benchmark events dropped")
         return {
             "published": 0,
-            "total": len(results),
+            "total": len(report.results),
             "stream_key": None,
             "reason": "redis_unavailable",
+            "split_used": report.split_used,
+            "dev_size": report.dev_size,
+            "test_size": report.test_size,
+            "tuned_on_dev": report.tuned_on_dev,
+            "held_out_score": report.held_out_score,
+            "mean_precision_at_k": report.mean_precision_at_k,
         }
 
     date_key = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
     stream_key = f"rag:feedback:{_BENCHMARK_USER}:{date_key}"
 
-    published = await publish_feedback_events(redis, results)
+    published = await publish_feedback_events(redis, report.results)
     logger.info(
-        "run_rag_benchmark: published %d/%d benchmark feedback events",
+        "run_rag_benchmark: split=%s published %d/%d feedback events "
+        "(held_out_score=%s)",
+        report.split_used,
         published,
-        len(results),
+        len(report.results),
+        report.held_out_score,
     )
     return {
         "published": published,
-        "total": len(results),
+        "total": len(report.results),
         "stream_key": stream_key,
+        "split_used": report.split_used,
+        "dev_size": report.dev_size,
+        "test_size": report.test_size,
+        "tuned_on_dev": report.tuned_on_dev,
+        "held_out_score": report.held_out_score,
+        "mean_precision_at_k": report.mean_precision_at_k,
     }
 
 

--- a/autobot-backend/knowledge/README.md
+++ b/autobot-backend/knowledge/README.md
@@ -1,0 +1,94 @@
+# Knowledge Base & RAG Benchmarks
+
+This directory owns the RAG (retrieval-augmented generation) stack and its
+benchmark harness.
+
+## Benchmark Discipline (Issue #5074)
+
+**Any metric published externally must be a `held_out_score`.** Tuning
+happens on `dev`; the final score comes from `test`, never the reverse.
+
+### Why this matters
+
+`knowledge/rag_benchmarks.py` and the `POST /rag/benchmark/run` endpoint
+let us run a precision@k benchmark over a dataset and report a score. If
+we tune hyperparameters on the same set that produces the headline number,
+we are silently teaching to the test — the number looks good in isolation
+but will not generalise to real user queries.
+
+To prevent this, the dataset is split into two disjoint groups:
+
+- **`dev_ids`** — used for hyperparameter search, reranker thresholds,
+  chunk-size experiments, prompt tweaks, etc.  Metrics derived from this
+  split are **not** suitable for external reporting.
+- **`test_ids`** — held out from all tuning activity.  A metric derived
+  from this split, with no dev leakage during the run, is a
+  `held_out_score` and is the only number that should appear in docs,
+  release blog posts, or dashboards shown to users.
+
+### The split is deterministic
+
+`BenchmarkDataset.from_ground_truth(...)` uses a SHA-256 hash of the
+query text modulo 100, with an 80/20 threshold.  The same query always
+lands in the same split; adding or removing queries doesn't reshuffle
+existing assignments.
+
+### API contract
+
+`POST /rag/benchmark/run` requires a body:
+
+```json
+{ "split": "dev" | "test" | "all", "k": 5 }
+```
+
+The response shape includes:
+
+- `split_used` — which split was actually run.
+- `dev_size`, `test_size` — total queries in each split.
+- `tuned_on_dev` — whether the harness has completed a tune() pass.
+- `held_out_score` — **True iff** `split_used == "test"` **and** no
+  dev-set access occurred during the run.  Any other combination is
+  `False`.
+- `mean_precision_at_k` — mean precision across results in this run.
+
+### Programmatic use
+
+```python
+from knowledge.rag_benchmarks import (
+    BenchmarkHarness,
+    BenchmarkSplit,
+    get_default_dataset,
+    run_benchmark_suite,
+)
+
+harness = BenchmarkHarness(dataset=get_default_dataset())
+
+# 1. Tune on dev — raises RuntimeError if you touch a test_id.
+tune_report = harness.tune(
+    lambda ds: run_benchmark_suite(collection, dataset=ds, split=BenchmarkSplit.DEV)
+)
+
+# 2. Final held-out score on test — raises RuntimeError if you touch a dev_id.
+test_report = harness.score(
+    lambda ds: run_benchmark_suite(collection, dataset=ds, split=BenchmarkSplit.TEST)
+)
+assert test_report.held_out_score is True
+```
+
+### Feedback events (Issue #4676 interaction)
+
+`publish_feedback_events()` tags every event written to
+`rag:feedback:__global__:<date>` with a `split_used` field.  The
+`RetrievalLearner` can therefore exclude `split_used == "test"` events
+from any training pass — the test split must never feed back into the
+system it is supposed to measure.
+
+### Rules of thumb
+
+- Do **not** iterate on the test split.  If you find yourself re-running
+  `split=test` to see whether a change helped, you are (by definition)
+  tuning on it.  Go back to `split=dev`.
+- If the dev and test means diverge strongly (e.g. dev goes up, test
+  goes down), that is overfitting — trust the test number.
+- When in doubt, report the test number with the `held_out_score=true`
+  flag alongside it.  No exceptions.

--- a/autobot-backend/knowledge/rag_benchmarks.py
+++ b/autobot-backend/knowledge/rag_benchmarks.py
@@ -6,17 +6,22 @@ including vector search, document retrieval, and context assembly.
 
 Issue #58 - Performance Benchmarking Suite
 Issue #4676 - Wire rag_benchmarks into RetrievalLearner feedback loop
+Issue #5074 - Enforce held-out dev/test split for benchmark runs
 Author: mrveiss
 """
 
+import enum
+import hashlib
 import json
 import logging
 import random
 import sys
 import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List
+from typing import Callable, Dict, List, Optional, Set
 
 import pytest
 
@@ -518,6 +523,191 @@ _GROUND_TRUTH = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Issue #5074 — Held-out dev/test split enforcement
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkSplit(str, enum.Enum):
+    """Which portion of the dataset a benchmark run touches.
+
+    - ``DEV``: tuning / hyperparameter search.  Results NOT suitable for
+      external reporting.
+    - ``TEST``: final held-out evaluation.  Results MAY be reported externally
+      provided no tuning touched the test IDs in this run.
+    - ``ALL``: combined DEV+TEST (for internal reporting only — ``held_out_score``
+      is always False here).
+    """
+
+    DEV = "dev"
+    TEST = "test"
+    ALL = "all"
+
+
+def _deterministic_dev_test_split(
+    query_ids: List[str], dev_fraction: float = 0.8
+) -> Dict[str, Set[str]]:
+    """Split *query_ids* into ``dev_ids`` and ``test_ids`` deterministically.
+
+    Uses SHA-256 of each query string modulo 100 as a sort key; a query ``q``
+    lands in DEV when ``int(sha256(q).hexdigest(), 16) % 100 < dev_fraction*100``.
+    This means:
+      - The same query always lands in the same split across runs (reproducible).
+      - Adding or removing queries doesn't reshuffle the existing assignments.
+
+    Args:
+        query_ids:    List of query identifiers (query text works as the ID).
+        dev_fraction: Fraction of queries routed to DEV.  Default 0.8 (80/20).
+
+    Returns:
+        ``{"dev_ids": set[str], "test_ids": set[str]}`` — disjoint and
+        covering ``query_ids``.
+    """
+    threshold = int(dev_fraction * 100)
+    dev_ids: Set[str] = set()
+    test_ids: Set[str] = set()
+    for qid in query_ids:
+        h = hashlib.sha256(qid.encode("utf-8")).hexdigest()
+        bucket = int(h, 16) % 100
+        if bucket < threshold:
+            dev_ids.add(qid)
+        else:
+            test_ids.add(qid)
+    # Guarantee both splits are non-empty for tiny datasets: if one side is
+    # empty, move the deterministically-smallest-hash query from the other.
+    if query_ids and (not dev_ids or not test_ids):
+        if not test_ids:
+            move = sorted(dev_ids, key=lambda q: hashlib.sha256(q.encode()).hexdigest())[-1]
+            dev_ids.remove(move)
+            test_ids.add(move)
+        elif not dev_ids:
+            move = sorted(test_ids, key=lambda q: hashlib.sha256(q.encode()).hexdigest())[0]
+            test_ids.remove(move)
+            dev_ids.add(move)
+    return {"dev_ids": dev_ids, "test_ids": test_ids}
+
+
+@dataclass
+class BenchmarkDataset:
+    """Explicit dev/test split for a benchmark dataset.
+
+    Issue #5074: formalizes train/dev/test hygiene so that a number
+    published externally can only come from the held-out TEST split.
+
+    Access to ground-truth IDs is tracked per-split so ``BenchmarkHarness``
+    can assert that ``tune()`` never touches ``test_ids`` and ``score()``
+    never touches ``dev_ids``.
+    """
+
+    ground_truth: Dict[str, Set[str]]
+    dev_ids: Set[str] = field(default_factory=set)
+    test_ids: Set[str] = field(default_factory=set)
+
+    # Access tracking — reset at the start of each tune/score call.
+    _accessed_dev: Set[str] = field(default_factory=set, init=False, repr=False)
+    _accessed_test: Set[str] = field(default_factory=set, init=False, repr=False)
+    _enforce_dev_only: bool = field(default=False, init=False, repr=False)
+    _enforce_test_only: bool = field(default=False, init=False, repr=False)
+
+    @classmethod
+    def from_ground_truth(
+        cls,
+        ground_truth: Dict[str, Set[str]],
+        dev_fraction: float = 0.8,
+    ) -> "BenchmarkDataset":
+        """Build a dataset with a deterministic hash-based dev/test split."""
+        split = _deterministic_dev_test_split(
+            sorted(ground_truth.keys()), dev_fraction=dev_fraction
+        )
+        return cls(
+            ground_truth=dict(ground_truth),
+            dev_ids=split["dev_ids"],
+            test_ids=split["test_ids"],
+        )
+
+    def iter_split(self, split: "BenchmarkSplit") -> List[str]:
+        """Return the list of query IDs for *split* (sorted for determinism)."""
+        if split == BenchmarkSplit.DEV:
+            return sorted(self.dev_ids)
+        if split == BenchmarkSplit.TEST:
+            return sorted(self.test_ids)
+        if split == BenchmarkSplit.ALL:
+            return sorted(self.dev_ids | self.test_ids)
+        raise ValueError(f"Unknown split: {split!r}")
+
+    def expected(self, query_id: str) -> Set[str]:
+        """Return expected doc IDs for *query_id*, tracking access per split.
+
+        Raises RuntimeError if enforcement is active and the caller crosses
+        the split boundary (e.g. tune() touching a test_id).
+        """
+        if query_id in self.dev_ids:
+            if self._enforce_test_only:
+                raise RuntimeError(
+                    f"score() accessed dev query_id={query_id!r}; "
+                    "test-only enforcement is active"
+                )
+            self._accessed_dev.add(query_id)
+        elif query_id in self.test_ids:
+            if self._enforce_dev_only:
+                raise RuntimeError(
+                    f"tune() accessed test query_id={query_id!r}; "
+                    "dev-only enforcement is active"
+                )
+            self._accessed_test.add(query_id)
+        else:
+            raise KeyError(
+                f"query_id {query_id!r} is not in any split of this dataset"
+            )
+        return set(self.ground_truth[query_id])
+
+    def reset_access(self) -> None:
+        """Clear per-run access tracking."""
+        self._accessed_dev.clear()
+        self._accessed_test.clear()
+
+    @contextmanager
+    def enforce_dev_only(self):
+        """Context manager: raise if caller accesses any test_id."""
+        prev = self._enforce_dev_only
+        self._enforce_dev_only = True
+        try:
+            yield self
+        finally:
+            self._enforce_dev_only = prev
+
+    @contextmanager
+    def enforce_test_only(self):
+        """Context manager: raise if caller accesses any dev_id."""
+        prev = self._enforce_test_only
+        self._enforce_test_only = True
+        try:
+            yield self
+        finally:
+            self._enforce_test_only = prev
+
+    @property
+    def dev_size(self) -> int:
+        return len(self.dev_ids)
+
+    @property
+    def test_size(self) -> int:
+        return len(self.test_ids)
+
+    @property
+    def accessed_dev(self) -> Set[str]:
+        return set(self._accessed_dev)
+
+    @property
+    def accessed_test(self) -> Set[str]:
+        return set(self._accessed_test)
+
+
+def get_default_dataset() -> BenchmarkDataset:
+    """Return the canonical BenchmarkDataset derived from ``_GROUND_TRUTH``."""
+    return BenchmarkDataset.from_ground_truth(_GROUND_TRUTH, dev_fraction=0.8)
+
+
 @pytest.mark.real_kb
 class TestRealKBBenchmarks:
     """
@@ -677,9 +867,18 @@ class BenchmarkResult:
                         expected set.  Range [0.0, 1.0].
         complexity:   QueryComplexity hint for the RetrievalLearner; defaults
                       to ``"moderate"`` for benchmark queries.
+        split_used:   Which split this query was drawn from
+                      (``"dev"`` | ``"test"`` | ``"all"``).  Issue #5074.
     """
 
-    __slots__ = ("query", "retrieved_ids", "ranked_ids", "precision_at_k", "complexity")
+    __slots__ = (
+        "query",
+        "retrieved_ids",
+        "ranked_ids",
+        "precision_at_k",
+        "complexity",
+        "split_used",
+    )
 
     def __init__(
         self,
@@ -688,35 +887,225 @@ class BenchmarkResult:
         ranked_ids: List[str],
         precision_at_k: float,
         complexity: str = "moderate",
+        split_used: str = BenchmarkSplit.ALL.value,
     ) -> None:
         self.query = query
         self.retrieved_ids = retrieved_ids
         self.ranked_ids = ranked_ids
         self.precision_at_k = precision_at_k
         self.complexity = complexity
+        self.split_used = split_used
 
 
-def run_benchmark_suite(chroma_collection, k: int = 5) -> List["BenchmarkResult"]:
+@dataclass
+class BenchmarkRunReport:
+    """Aggregate report returned by ``BenchmarkHarness.tune/score/run``.
+
+    Issue #5074: every run carries its split metadata so downstream consumers
+    (API response, feedback publisher, docs) can prove whether a reported
+    score was actually held out.
+
+    Attributes:
+        split_used:    Which split produced these results (``"dev"``/``"test"``/``"all"``).
+        dev_size:      Total number of dev queries in the dataset.
+        test_size:     Total number of test queries in the dataset.
+        tuned_on_dev:  True iff a tune() pass was completed on this dataset
+                       before this run (harness-level state).
+        held_out_score: True iff ``split_used == "test"`` **and** this run
+                        touched only ``test_ids`` (no dev-set leakage).
+                        Any other combination is False.
+        mean_precision_at_k: Mean precision@k across results in the run.
+        results:       The underlying BenchmarkResult list.
+    """
+
+    split_used: str
+    dev_size: int
+    test_size: int
+    tuned_on_dev: bool
+    held_out_score: bool
+    mean_precision_at_k: float
+    results: List["BenchmarkResult"]
+
+    def as_dict(self) -> dict:
+        return {
+            "split_used": self.split_used,
+            "dev_size": self.dev_size,
+            "test_size": self.test_size,
+            "tuned_on_dev": self.tuned_on_dev,
+            "held_out_score": self.held_out_score,
+            "mean_precision_at_k": self.mean_precision_at_k,
+            "num_results": len(self.results),
+        }
+
+
+class BenchmarkHarness:
+    """Enforces held-out dev/test discipline for RAG benchmarks.
+
+    Issue #5074.  Use ``harness.tune(fn)`` while searching hyperparameters
+    and ``harness.score(fn)`` for the final held-out number.  Any cross-split
+    access raises ``RuntimeError`` — the guard is runtime-checked, not advisory.
+
+    Example:
+        harness = BenchmarkHarness(dataset=get_default_dataset())
+
+        # Tune on dev only (score will be labelled held_out_score=False).
+        tune_report = harness.tune(lambda ds: run_benchmark_suite(
+            collection, dataset=ds, split=BenchmarkSplit.DEV,
+        ))
+
+        # Final held-out score on test only.
+        test_report = harness.score(lambda ds: run_benchmark_suite(
+            collection, dataset=ds, split=BenchmarkSplit.TEST,
+        ))
+        assert test_report.held_out_score is True
+    """
+
+    def __init__(self, dataset: BenchmarkDataset) -> None:
+        self.dataset = dataset
+        self._tuned_on_dev: bool = False
+
+    @property
+    def tuned_on_dev(self) -> bool:
+        return self._tuned_on_dev
+
+    def _build_report(
+        self,
+        split: BenchmarkSplit,
+        results: List["BenchmarkResult"],
+        touched_test: bool,
+    ) -> BenchmarkRunReport:
+        mean_p = (
+            sum(r.precision_at_k for r in results) / len(results)
+            if results
+            else 0.0
+        )
+        held_out = (split == BenchmarkSplit.TEST) and not touched_test_leakage(
+            self.dataset, split
+        )
+        return BenchmarkRunReport(
+            split_used=split.value,
+            dev_size=self.dataset.dev_size,
+            test_size=self.dataset.test_size,
+            tuned_on_dev=self._tuned_on_dev,
+            held_out_score=held_out,
+            mean_precision_at_k=mean_p,
+            results=results,
+        )
+
+    def tune(
+        self,
+        harness_fn: Callable[[BenchmarkDataset], List["BenchmarkResult"]],
+    ) -> BenchmarkRunReport:
+        """Run *harness_fn* under dev-only enforcement.
+
+        ``harness_fn`` receives the dataset and MUST only call
+        ``dataset.expected(qid)`` for qid in ``dataset.dev_ids``.  Any
+        access to a test_id raises RuntimeError.
+        """
+        self.dataset.reset_access()
+        with self.dataset.enforce_dev_only():
+            results = harness_fn(self.dataset)
+        self._tuned_on_dev = True
+        return self._build_report(
+            BenchmarkSplit.DEV, results, touched_test=False
+        )
+
+    def score(
+        self,
+        scorer_fn: Callable[[BenchmarkDataset], List["BenchmarkResult"]],
+    ) -> BenchmarkRunReport:
+        """Run *scorer_fn* under test-only enforcement.
+
+        ``scorer_fn`` receives the dataset and MUST only call
+        ``dataset.expected(qid)`` for qid in ``dataset.test_ids``.  Any
+        access to a dev_id raises RuntimeError.
+        """
+        self.dataset.reset_access()
+        with self.dataset.enforce_test_only():
+            results = scorer_fn(self.dataset)
+        return self._build_report(
+            BenchmarkSplit.TEST, results, touched_test=False
+        )
+
+    def run(
+        self,
+        runner_fn: Callable[[BenchmarkDataset], List["BenchmarkResult"]],
+        split: BenchmarkSplit = BenchmarkSplit.TEST,
+    ) -> BenchmarkRunReport:
+        """Generic entry point; dispatches to tune / score / combined run."""
+        if split == BenchmarkSplit.DEV:
+            return self.tune(runner_fn)
+        if split == BenchmarkSplit.TEST:
+            return self.score(runner_fn)
+        if split == BenchmarkSplit.ALL:
+            self.dataset.reset_access()
+            results = runner_fn(self.dataset)
+            mean_p = (
+                sum(r.precision_at_k for r in results) / len(results)
+                if results
+                else 0.0
+            )
+            return BenchmarkRunReport(
+                split_used=BenchmarkSplit.ALL.value,
+                dev_size=self.dataset.dev_size,
+                test_size=self.dataset.test_size,
+                tuned_on_dev=self._tuned_on_dev,
+                held_out_score=False,
+                mean_precision_at_k=mean_p,
+                results=results,
+            )
+        raise ValueError(f"Unknown split: {split!r}")
+
+
+def touched_test_leakage(dataset: BenchmarkDataset, split: BenchmarkSplit) -> bool:
+    """Return True if a run labelled *split* actually touched the wrong side.
+
+    This is the runtime check that turns ``held_out_score`` from a hope into
+    a fact: if TEST was the declared split but the run accessed dev_ids, the
+    score is leaky and ``held_out_score`` must be False.
+    """
+    if split == BenchmarkSplit.TEST:
+        return bool(dataset.accessed_dev)
+    if split == BenchmarkSplit.DEV:
+        return bool(dataset.accessed_test)
+    return False
+
+
+def run_benchmark_suite(
+    chroma_collection,
+    k: int = 5,
+    dataset: Optional[BenchmarkDataset] = None,
+    split: BenchmarkSplit = BenchmarkSplit.ALL,
+) -> List["BenchmarkResult"]:
     """Run the precision@k benchmark suite against *chroma_collection*.
 
     Issue #4676: Produces BenchmarkResult objects that can be passed to
     ``publish_feedback_events()`` so the scores feed into RetrievalLearner.
+    Issue #5074: Accepts an explicit *dataset* and *split* so the same suite
+    can serve both tuning (DEV) and held-out scoring (TEST).
 
     The function is synchronous because ChromaDB's EphemeralClient is
     synchronous.  Callers in async contexts should run it via
-    ``asyncio.get_event_loop().run_in_executor(None, run_benchmark_suite, ...)``.
+    ``loop.run_in_executor(None, run_benchmark_suite, ...)``.
 
     Args:
         chroma_collection: A ChromaDB collection pre-seeded with domain docs.
         k:                 Number of results to retrieve per query.
+        dataset:           Optional BenchmarkDataset.  If omitted, defaults to
+                           ``get_default_dataset()`` which has an 80/20 split.
+        split:             Which portion of the dataset to run against.
 
     Returns:
-        List of BenchmarkResult — one entry per ground-truth query.
+        List of BenchmarkResult — one entry per query in the requested split.
     """
+    if dataset is None:
+        dataset = get_default_dataset()
+
     results: List[BenchmarkResult] = []
     dim = 128  # must match _deterministic_embed default
 
-    for query, expected_ids in _GROUND_TRUTH.items():
+    for query in dataset.iter_split(split):
+        expected_ids = dataset.expected(query)
         query_vec = _deterministic_embed(query, dim)
         raw = chroma_collection.query(
             query_embeddings=[query_vec],
@@ -741,10 +1130,15 @@ def run_benchmark_suite(chroma_collection, k: int = 5) -> List["BenchmarkResult"
                 ranked_ids=ranked_ids,
                 precision_at_k=precision,
                 complexity="moderate",
+                split_used=split.value,
             )
         )
         logger.debug(
-            "benchmark_suite: query=%r p@%d=%.2f", query[:40], k, precision
+            "benchmark_suite: query=%r split=%s p@%d=%.2f",
+            query[:40],
+            split.value,
+            k,
+            precision,
         )
 
     return results
@@ -792,6 +1186,9 @@ async def publish_feedback_events(redis, results: List["BenchmarkResult"]) -> in
             "annotation": "benchmark",
             "precision_at_k": str(result.precision_at_k),
             "timestamp": str(time.time()),
+            # Issue #5074: tag each event with the split it came from so
+            # RetrievalLearner can exclude test-set feedback from training.
+            "split_used": getattr(result, "split_used", BenchmarkSplit.ALL.value),
         }
 
         try:

--- a/autobot-backend/knowledge/test_rag_benchmarks.py
+++ b/autobot-backend/knowledge/test_rag_benchmarks.py
@@ -1,0 +1,304 @@
+"""Tests for held-out dev/test split enforcement in rag_benchmarks.
+
+Issue #5074 — verifies:
+  * tune() allows dev access and blocks test access
+  * score() allows test access and blocks dev access
+  * hash-based split is deterministic across runs
+  * held_out_score is True only for split=TEST, False for DEV / ALL
+  * POST /rag/benchmark/run contract exposes all new fields
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge.rag_benchmarks import (
+    _GROUND_TRUTH,
+    BenchmarkDataset,
+    BenchmarkHarness,
+    BenchmarkResult,
+    BenchmarkSplit,
+    _deterministic_dev_test_split,
+    get_default_dataset,
+    publish_feedback_events,
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataset split correctness
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_split_is_reproducible():
+    """Same query list must always produce the same split."""
+    qs = list(_GROUND_TRUTH.keys())
+    a = _deterministic_dev_test_split(sorted(qs), dev_fraction=0.8)
+    b = _deterministic_dev_test_split(sorted(qs), dev_fraction=0.8)
+    assert a == b
+    # And across dataset instantiations
+    ds1 = BenchmarkDataset.from_ground_truth(_GROUND_TRUTH)
+    ds2 = BenchmarkDataset.from_ground_truth(_GROUND_TRUTH)
+    assert ds1.dev_ids == ds2.dev_ids
+    assert ds1.test_ids == ds2.test_ids
+
+
+def test_split_is_disjoint_and_covering():
+    ds = get_default_dataset()
+    assert ds.dev_ids.isdisjoint(ds.test_ids)
+    assert ds.dev_ids | ds.test_ids == set(_GROUND_TRUTH.keys())
+    # Sizes sum correctly
+    assert ds.dev_size + ds.test_size == len(_GROUND_TRUTH)
+
+
+def test_split_non_empty_for_small_dataset():
+    """Tiny datasets should still get at least one query in each split."""
+    tiny = {"only_query": {"doc_1"}}
+    ds = BenchmarkDataset.from_ground_truth(tiny, dev_fraction=0.8)
+    assert ds.dev_size + ds.test_size == 1
+    # Exactly one of the two must be non-empty (can't split 1 into two non-empty).
+    assert (ds.dev_size == 1) ^ (ds.test_size == 1)
+
+
+# ---------------------------------------------------------------------------
+# Enforcement: tune/score boundary
+# ---------------------------------------------------------------------------
+
+
+def _pick_ids(ds: BenchmarkDataset):
+    dev_qid = next(iter(ds.dev_ids))
+    test_qid = next(iter(ds.test_ids))
+    return dev_qid, test_qid
+
+
+def test_tune_allows_dev_access():
+    ds = get_default_dataset()
+    harness = BenchmarkHarness(dataset=ds)
+
+    def runner(dataset: BenchmarkDataset):
+        out = []
+        for qid in dataset.iter_split(BenchmarkSplit.DEV):
+            dataset.expected(qid)  # should not raise
+            out.append(
+                BenchmarkResult(qid, [], [], 1.0, split_used=BenchmarkSplit.DEV.value)
+            )
+        return out
+
+    report = harness.tune(runner)
+    assert report.split_used == BenchmarkSplit.DEV.value
+    assert report.held_out_score is False
+    assert report.tuned_on_dev is True
+    assert len(report.results) == ds.dev_size
+
+
+def test_tune_raises_on_test_access():
+    ds = get_default_dataset()
+    harness = BenchmarkHarness(dataset=ds)
+    _dev_qid, test_qid = _pick_ids(ds)
+
+    def leaky_runner(dataset: BenchmarkDataset):
+        dataset.expected(test_qid)  # boundary violation
+        return []
+
+    with pytest.raises(RuntimeError, match="tune\\(\\) accessed test"):
+        harness.tune(leaky_runner)
+
+
+def test_score_allows_test_access():
+    ds = get_default_dataset()
+    harness = BenchmarkHarness(dataset=ds)
+
+    def runner(dataset: BenchmarkDataset):
+        out = []
+        for qid in dataset.iter_split(BenchmarkSplit.TEST):
+            dataset.expected(qid)
+            out.append(
+                BenchmarkResult(qid, [], [], 1.0, split_used=BenchmarkSplit.TEST.value)
+            )
+        return out
+
+    report = harness.score(runner)
+    assert report.split_used == BenchmarkSplit.TEST.value
+    assert report.held_out_score is True
+    assert len(report.results) == ds.test_size
+
+
+def test_score_raises_on_dev_access():
+    ds = get_default_dataset()
+    harness = BenchmarkHarness(dataset=ds)
+    dev_qid, _test_qid = _pick_ids(ds)
+
+    def leaky_runner(dataset: BenchmarkDataset):
+        dataset.expected(dev_qid)  # boundary violation
+        return []
+
+    with pytest.raises(RuntimeError, match="score\\(\\) accessed dev"):
+        harness.score(leaky_runner)
+
+
+def test_expected_rejects_unknown_query():
+    ds = get_default_dataset()
+    with pytest.raises(KeyError):
+        ds.expected("not-a-known-query")
+
+
+# ---------------------------------------------------------------------------
+# held_out_score flag semantics
+# ---------------------------------------------------------------------------
+
+
+def test_run_dev_is_not_held_out():
+    ds = get_default_dataset()
+    harness = BenchmarkHarness(dataset=ds)
+
+    def runner(dataset: BenchmarkDataset):
+        return [
+            BenchmarkResult(q, [], [], 0.5, split_used=BenchmarkSplit.DEV.value)
+            for q in dataset.iter_split(BenchmarkSplit.DEV)
+        ]
+
+    report = harness.run(runner, split=BenchmarkSplit.DEV)
+    assert report.held_out_score is False
+    assert report.split_used == BenchmarkSplit.DEV.value
+
+
+def test_run_test_is_held_out():
+    ds = get_default_dataset()
+    harness = BenchmarkHarness(dataset=ds)
+
+    def runner(dataset: BenchmarkDataset):
+        return [
+            BenchmarkResult(q, [], [], 0.5, split_used=BenchmarkSplit.TEST.value)
+            for q in dataset.iter_split(BenchmarkSplit.TEST)
+        ]
+
+    report = harness.run(runner, split=BenchmarkSplit.TEST)
+    assert report.held_out_score is True
+    assert report.split_used == BenchmarkSplit.TEST.value
+
+
+def test_run_all_is_never_held_out():
+    ds = get_default_dataset()
+    harness = BenchmarkHarness(dataset=ds)
+
+    def runner(dataset: BenchmarkDataset):
+        return [
+            BenchmarkResult(q, [], [], 1.0, split_used=BenchmarkSplit.ALL.value)
+            for q in dataset.iter_split(BenchmarkSplit.ALL)
+        ]
+
+    report = harness.run(runner, split=BenchmarkSplit.ALL)
+    assert report.held_out_score is False
+    assert report.split_used == BenchmarkSplit.ALL.value
+
+
+# ---------------------------------------------------------------------------
+# Feedback publisher: split_used tag (Issue #5074 x #4676)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_feedback_events_tags_split():
+    """Emitted xadd entries must carry split_used so RetrievalLearner can
+    exclude test-set feedback from training."""
+    redis = AsyncMock()
+    redis.xadd = AsyncMock()
+    redis.expire = AsyncMock()
+
+    results = [
+        BenchmarkResult(
+            query="q1",
+            retrieved_ids=["a"],
+            ranked_ids=["a"],
+            precision_at_k=0.5,
+            split_used=BenchmarkSplit.TEST.value,
+        )
+    ]
+    published = await publish_feedback_events(redis, results)
+    assert published == 1
+    redis.xadd.assert_awaited_once()
+    call_args = redis.xadd.await_args
+    _stream_key, entry = call_args.args
+    assert entry["split_used"] == BenchmarkSplit.TEST.value
+
+
+# ---------------------------------------------------------------------------
+# Endpoint contract: new fields present in response
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_response_shape_has_new_fields():
+    """POST /rag/benchmark/run must return all Issue #5074 fields."""
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+
+    from api.knowledge_rag import router
+    from auth_middleware import check_admin_permission
+
+    app = FastAPI()
+    app.include_router(router, prefix="/rag")
+    app.dependency_overrides[check_admin_permission] = lambda: True
+
+    client = TestClient(app)
+
+    with patch(
+        "autobot_shared.redis_client.get_async_redis_client",
+        new=AsyncMock(return_value=None),
+    ):
+        resp = client.post("/rag/benchmark/run", json={"split": "test", "k": 5})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    for key in (
+        "published",
+        "total",
+        "split_used",
+        "dev_size",
+        "test_size",
+        "tuned_on_dev",
+        "held_out_score",
+        "mean_precision_at_k",
+    ):
+        assert key in body, f"missing field: {key}"
+    assert body["split_used"] == "test"
+    assert body["held_out_score"] is True
+
+
+def test_endpoint_rejects_invalid_split():
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+
+    from api.knowledge_rag import router
+    from auth_middleware import check_admin_permission
+
+    app = FastAPI()
+    app.include_router(router, prefix="/rag")
+    app.dependency_overrides[check_admin_permission] = lambda: True
+
+    client = TestClient(app)
+    resp = client.post("/rag/benchmark/run", json={"split": "holdout"})
+    assert resp.status_code == 422  # pydantic validation error
+
+
+def test_endpoint_dev_split_is_not_held_out():
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+
+    from api.knowledge_rag import router
+    from auth_middleware import check_admin_permission
+
+    app = FastAPI()
+    app.include_router(router, prefix="/rag")
+    app.dependency_overrides[check_admin_permission] = lambda: True
+
+    client = TestClient(app)
+    with patch(
+        "autobot_shared.redis_client.get_async_redis_client",
+        new=AsyncMock(return_value=None),
+    ):
+        resp = client.post("/rag/benchmark/run", json={"split": "dev"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["split_used"] == "dev"
+    assert body["held_out_score"] is False


### PR DESCRIPTION
Closes #5074

## Summary
Formalize train/dev/test hygiene for RAG benchmarks so tuning on the same set that produces the headline score is detected at runtime.

### Design
- **\`BenchmarkDataset\`** dataclass with \`dev_ids\` / \`test_ids\`
- **\`BenchmarkSplit\`** enum: DEV | TEST | ALL
- **Split strategy**: deterministic \`SHA-256(query) % 100 < 80\` → DEV, else TEST. Stable across runs; new queries don't reshuffle.
- **Runtime guard**: \`BenchmarkDataset.expected(id)\` raises \`RuntimeError\` if a tuner touches test_ids, or a scorer touches dev_ids
- **\`BenchmarkResult\`** fields: \`split_used\`, \`dev_size\`, \`test_size\`, \`tuned_on_dev\`, \`held_out_score\`
- **\`held_out_score\`** is True iff \`split == TEST\` AND no dev access during the run

### Endpoint contract change
\`POST /rag/benchmark/run\` now requires body \`{"split": "dev"|"test"|"all", "k": int}\`. Response includes all new fields alongside existing \`published\`/\`total\`/\`stream_key\`.

### Feedback loop integration (#4676 × #5074)
Every xadd entry in \`publish_feedback_events()\` now carries \`split_used\` so \`RetrievalLearner\` can exclude test-set events from training.

### Docs
New \`autobot-backend/knowledge/README.md\` explaining the discipline: "Any metric published externally must be a held_out_score. Tuning happens on dev; final score comes from test, never the reverse."

### Default dataset sizes
From existing 5-entry \`_GROUND_TRUTH\`: 4 dev (python_02/04, db_01/02, net_01/03, ml_04/05) + 1 test (ml_02/09).

## Test Status
PASS — 15/15 new + 8/8 pre-existing real_kb; 9 pre-existing errors in other benchmark tests unrelated (confirmed via stash test)