### PR TITLE
refactor(llm): extract shared call_ollama_generate helper (#5102)

### DIFF
--- a/autobot-backend/knowledge/search_components/agentic_search.py
+++ b/autobot-backend/knowledge/search_components/agentic_search.py
@@ -30,8 +30,6 @@ import threading
 from dataclasses import dataclass
 from typing import Any, List, Optional, Tuple
 
-import httpx
-
 from services.context_sufficiency import (
     SufficiencyVerdict,
     get_context_sufficiency_evaluator,
@@ -347,29 +345,22 @@ class AgenticSearchTool:
     async def _call_llm(self, prompt: str) -> str:
         """Send *prompt* to Ollama and return the raw response text.
 
-        Uses the same httpx transport pattern as rlm/evaluator.py.
+        Delegates to the shared ``call_ollama_generate`` transport
+        (Issue #5102).
         """
         from autobot_shared.ssot_config import get_config
 
-        ssot = get_config()
-        url = f"{ssot.ollama_url}/api/generate"
-        timeout = self.config.timeout_ms / 1000
+        from llm_providers.ollama_helpers import call_ollama_generate
 
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
-                url,
-                json={
-                    "model": self.config.model,
-                    "prompt": prompt,
-                    "stream": False,
-                    "options": {
-                        "temperature": self.config.temperature,
-                        "num_predict": self.config.max_rewrite_tokens,
-                    },
-                },
-            )
-            resp.raise_for_status()
-            return resp.json().get("response", "")
+        ssot = get_config()
+        return await call_ollama_generate(
+            prompt=prompt,
+            model=self.config.model,
+            base_url=ssot.ollama_url,
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_rewrite_tokens,
+            timeout_ms=self.config.timeout_ms,
+        )
 
     @staticmethod
     def _format_results(results: list) -> str:

--- a/autobot-backend/llm_providers/ollama_helpers.py
+++ b/autobot-backend/llm_providers/ollama_helpers.py
@@ -1,0 +1,59 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Shared narrow Ollama /api/generate transport.
+
+Used by modules that need a one-shot prompt completion without invoking
+the full OllamaProvider / LLMInterface stack (e.g. RAG refiner, query
+evaluator, agentic search query rewriter).
+
+Issue #5102: three near-identical ``_call_llm`` methods collapsed into
+this single helper.
+"""
+from __future__ import annotations
+
+import httpx
+
+
+async def call_ollama_generate(
+    prompt: str,
+    model: str,
+    base_url: str,
+    *,
+    temperature: float = 0.2,
+    max_tokens: int = 512,
+    timeout_ms: int = 30000,
+) -> str:
+    """POST /api/generate to Ollama and return the ``response`` field.
+
+    Args:
+        prompt:       Raw prompt text to send.
+        model:        Ollama model tag (e.g. ``llama3.2:latest``).
+        base_url:     Ollama server URL (no trailing slash required).
+        temperature:  Sampling temperature forwarded as ``options.temperature``.
+        max_tokens:   Token budget forwarded as ``options.num_predict``.
+        timeout_ms:   Per-request timeout in milliseconds.
+
+    Returns:
+        The string value of the ``response`` key, or an empty string when
+        the response body lacks that key.
+
+    Raises:
+        httpx.HTTPError: On transport failure or non-2xx HTTP status.
+            Callers are expected to catch and fall back as appropriate.
+    """
+    url = f"{base_url.rstrip('/')}/api/generate"
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+        "options": {
+            "temperature": temperature,
+            "num_predict": max_tokens,
+        },
+    }
+    timeout = httpx.Timeout(timeout_ms / 1000.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(url, json=payload)
+        resp.raise_for_status()
+        return resp.json().get("response", "")

--- a/autobot-backend/rlm/evaluator.py
+++ b/autobot-backend/rlm/evaluator.py
@@ -15,8 +15,6 @@ Issue #1373: Initial RLM prototype.
 import logging
 from typing import Optional
 
-import httpx
-
 from rlm.types import ReflectionResult, ReflectionVerdict, RLMConfig
 
 logger = logging.getLogger(__name__)
@@ -111,25 +109,17 @@ class ResponseQualityEvaluator:
         """Send *prompt* to Ollama and return the raw text response."""
         from autobot_shared.ssot_config import get_config
 
-        ssot = get_config()
-        url = f"{ssot.ollama_url}/api/generate"
-        timeout = self.config.timeout_ms / 1000
+        from llm_providers.ollama_helpers import call_ollama_generate
 
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
-                url,
-                json={
-                    "model": self.config.model,
-                    "prompt": prompt,
-                    "stream": False,
-                    "options": {
-                        "temperature": self.config.temperature,
-                        "num_predict": self.config.max_eval_tokens,
-                    },
-                },
-            )
-            resp.raise_for_status()
-            return resp.json().get("response", "")
+        ssot = get_config()
+        return await call_ollama_generate(
+            prompt=prompt,
+            model=self.config.model,
+            base_url=ssot.ollama_url,
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_eval_tokens,
+            timeout_ms=self.config.timeout_ms,
+        )
 
     # ------------------------------------------------------------------
     # Response parsing

--- a/autobot-backend/rlm/rag_refiner.py
+++ b/autobot-backend/rlm/rag_refiner.py
@@ -15,8 +15,6 @@ import logging
 from dataclasses import dataclass
 from typing import List, Optional
 
-import httpx
-
 from rlm.types import RLMConfig
 
 logger = logging.getLogger(__name__)
@@ -182,25 +180,17 @@ class AdaptiveRAGRefiner:
         """Send prompt to Ollama."""
         from autobot_shared.ssot_config import get_config
 
-        ssot = get_config()
-        url = f"{ssot.ollama_url}/api/generate"
-        timeout = self.config.timeout_ms / 1000
+        from llm_providers.ollama_helpers import call_ollama_generate
 
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
-                url,
-                json={
-                    "model": self.config.model,
-                    "prompt": prompt,
-                    "stream": False,
-                    "options": {
-                        "temperature": self.config.temperature,
-                        "num_predict": self.config.max_eval_tokens,
-                    },
-                },
-            )
-            resp.raise_for_status()
-            return resp.json().get("response", "")
+        ssot = get_config()
+        return await call_ollama_generate(
+            prompt=prompt,
+            model=self.config.model,
+            base_url=ssot.ollama_url,
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_eval_tokens,
+            timeout_ms=self.config.timeout_ms,
+        )
 
     @staticmethod
     def _parse(raw: str) -> RefinementResult:


### PR DESCRIPTION
Closes #5102

## Summary

Three near-identical `_call_llm` methods in `rlm/evaluator.py`, `rlm/rag_refiner.py`, and `knowledge/search_components/agentic_search.py` each reimplemented the same httpx POST to Ollama `/api/generate`. Extracted to a single narrow async helper `call_ollama_generate()` in `autobot-backend/llm_providers/ollama_helpers.py`.

Each module's `_call_llm` method is preserved as a thin wrapper so existing test mocks (patching `_call_llm` directly) continue to work. Only the 23-26 lines of httpx boilerplate collapsed.

## Files touched

- NEW: `autobot-backend/llm_providers/ollama_helpers.py`
- `autobot-backend/rlm/evaluator.py`
- `autobot-backend/rlm/rag_refiner.py`
- `autobot-backend/knowledge/search_components/agentic_search.py`

## Config-attribute mapping preserved

- `rlm/` uses `self.config.max_eval_tokens` \u2014 unchanged
- `agentic_search.py` uses `self.config.max_rewrite_tokens` \u2014 unchanged
- All three use `self.config.{model,temperature,timeout_ms}` and `ssot.ollama_url` \u2014 unchanged

## Test plan

- [x] `python -m py_compile` passes on all 4 files
- [x] `grep httpx.AsyncClient` in `rlm/` + `agentic_search.py` \u2014 0 matches in files migrated
- [x] `import httpx` removed from all 3 call-site files
- [ ] `gh pr checks` passes

## Discovery

While implementing, the agent found a **4th near-identical copy** of the same httpx `/api/generate` pattern at `rlm/benchmark.py:137 _generate` \u2014 not listed in the original issue scope. A follow-up discovery issue will be filed to migrate it to `call_ollama_generate` in a separate PR.