### PR TITLE
refactor(frontend): rationalize loading composables (#5108)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useErrorHandler.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useErrorHandler.test.ts
@@ -11,11 +11,10 @@
  * - useAsyncHandler - Edge Cases (9 tests)
  * - useErrorState - Basic (6 tests)
  * - useErrorState - Auto-Clear (6 tests)
- * - useLoadingState - Basic (6 tests)
  * - retryOperation - Utility (6 tests)
  * - Component Lifecycle (5 tests)
  *
- * Total Tests: 88 (100% passing)
+ * Total Tests: 82 (100% passing)
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -24,7 +23,6 @@ import { mount } from '@vue/test-utils'
 import {
   useAsyncHandler,
   useErrorState,
-  useLoadingState,
   retryOperation,
   useErrorBoundary
 } from '../useErrorHandler'
@@ -1707,141 +1705,6 @@ describe('useErrorHandler Composable', () => {
       await nextTick()
 
       expect(wrapper.vm.error).toBeNull()
-    })
-  })
-
-  // ========================================
-  // useLoadingState - Basic
-  // ========================================
-
-  describe('useLoadingState - Basic', () => {
-    it('should start loading manually', () => {
-      const TestComponent = defineComponent({
-        setup() {
-          const { loading, startLoading } = useLoadingState()
-          return { loading, startLoading }
-        },
-        template: '<div></div>'
-      })
-
-      const wrapper = mount(TestComponent)
-
-      expect(wrapper.vm.loading).toBe(false)
-
-      wrapper.vm.startLoading()
-
-      expect(wrapper.vm.loading).toBe(true)
-    })
-
-    it('should stop loading manually', () => {
-      const TestComponent = defineComponent({
-        setup() {
-          const { loading, startLoading, stopLoading } = useLoadingState()
-          return { loading, startLoading, stopLoading }
-        },
-        template: '<div></div>'
-      })
-
-      const wrapper = mount(TestComponent)
-
-      wrapper.vm.startLoading()
-      expect(wrapper.vm.loading).toBe(true)
-
-      wrapper.vm.stopLoading()
-      expect(wrapper.vm.loading).toBe(false)
-    })
-
-    it('should wrap operation with withLoading', async () => {
-      const TestComponent = defineComponent({
-        setup() {
-          const { loading, withLoading } = useLoadingState()
-          return { loading, withLoading }
-        },
-        template: '<div></div>'
-      })
-
-      const wrapper = mount(TestComponent)
-
-      const operation = async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100))
-        return 'done'
-      }
-
-      expect(wrapper.vm.loading).toBe(false)
-
-      const promise = wrapper.vm.withLoading(operation)
-      await nextTick()
-
-      expect(wrapper.vm.loading).toBe(true)
-
-      vi.advanceTimersByTime(100)
-      await promise
-
-      expect(wrapper.vm.loading).toBe(false)
-    })
-
-    it('should set loading true during operation', async () => {
-      const TestComponent = defineComponent({
-        setup() {
-          const { loading, withLoading } = useLoadingState()
-          return { loading, withLoading }
-        },
-        template: '<div></div>'
-      })
-
-      const wrapper = mount(TestComponent)
-
-      const promise = wrapper.vm.withLoading(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100))
-      })
-
-      await nextTick()
-      expect(wrapper.vm.loading).toBe(true)
-
-      vi.advanceTimersByTime(100)
-      await promise
-    })
-
-    it('should set loading false after operation', async () => {
-      const TestComponent = defineComponent({
-        setup() {
-          const { loading, withLoading } = useLoadingState()
-          return { loading, withLoading }
-        },
-        template: '<div></div>'
-      })
-
-      const wrapper = mount(TestComponent)
-
-      const promise = wrapper.vm.withLoading(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100))
-        return 'complete'
-      })
-
-      vi.advanceTimersByTime(100)
-      await promise
-
-      expect(wrapper.vm.loading).toBe(false)
-    })
-
-    it('should set loading false on operation error', async () => {
-      const TestComponent = defineComponent({
-        setup() {
-          const { loading, withLoading } = useLoadingState()
-          return { loading, withLoading }
-        },
-        template: '<div></div>'
-      })
-
-      const wrapper = mount(TestComponent)
-
-      const promise = wrapper.vm.withLoading(async () => {
-        throw new Error('Operation failed')
-      })
-
-      await expect(promise).rejects.toThrow('Operation failed')
-
-      expect(wrapper.vm.loading).toBe(false)
     })
   })
 

--- a/autobot-frontend/src/composables/useErrorHandler.examples.md
+++ b/autobot-frontend/src/composables/useErrorHandler.examples.md
@@ -535,9 +535,9 @@ const performOperation = async () => {
 
 **After** (8 lines):
 ```typescript
-import { useLoadingState } from '@/composables/useErrorHandler'
+import { useUnifiedLoading } from '@/composables/useUnifiedLoading'
 
-const { loading: isLoading, withLoading } = useLoadingState()
+const { isLoading, withLoading } = useUnifiedLoading('MyComponent')
 
 const performOperation = () => withLoading(async () => {
   await someAsyncOperation()

--- a/autobot-frontend/src/composables/useErrorHandler.ts
+++ b/autobot-frontend/src/composables/useErrorHandler.ts
@@ -325,38 +325,6 @@ export function useAsyncHandler<T = unknown>(
 }
 
 // ========================================
-// Loading State Helper
-// ========================================
-
-export function useLoadingState(initialState = false) {
-  const loading = ref(initialState)
-
-  const startLoading = () => {
-    loading.value = true
-  }
-
-  const stopLoading = () => {
-    loading.value = false
-  }
-
-  const withLoading = async <T>(operation: () => Promise<T>): Promise<T> => {
-    try {
-      loading.value = true
-      return await operation()
-    } finally {
-      loading.value = false
-    }
-  }
-
-  return {
-    loading,
-    startLoading,
-    stopLoading,
-    withLoading
-  }
-}
-
-// ========================================
 // Retry Utility
 // ========================================
 

--- a/autobot-frontend/src/utils/apiErrorHandler.ts
+++ b/autobot-frontend/src/utils/apiErrorHandler.ts
@@ -13,6 +13,7 @@
 
 import { ref, type Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
+import { useUnifiedLoading } from '@/composables/useUnifiedLoading'
 
 // Create scoped logger for apiErrorHandler
 const logger = createLogger('apiErrorHandler')
@@ -272,61 +273,20 @@ export async function handleApiCall<T>(
 }
 
 /**
- * Create a composable for API loading states
- *
- * @returns Loading state refs and helpers
- *
- * @example
- * ```typescript
- * const { loading, error, startLoading, stopLoading, setError, clearError } = useApiLoading()
- *
- * async function fetchData() {
- *   startLoading()
- *   try {
- *     const data = await apiClient.get('/api/data')
- *     // ... process data
- *   } catch (err) {
- *     setError(parseError(err))
- *   } finally {
- *     stopLoading()
- *   }
- * }
- * ```
- */
-export function useApiLoading() {
-  const loading: Ref<boolean> = ref(false)
-  const error: Ref<ApiError | null> = ref(null)
-
-  return {
-    loading,
-    error,
-    startLoading: () => {
-      loading.value = true
-      error.value = null
-    },
-    stopLoading: () => {
-      loading.value = false
-    },
-    setError: (err: ApiError) => {
-      error.value = err
-      loading.value = false
-    },
-    clearError: () => {
-      error.value = null
-    },
-    isLoading: () => loading.value,
-    hasError: () => error.value !== null
-  }
-}
-
-/**
  * Create a composable that wraps API calls with loading state
  *
+ * Loading-state tracking is delegated to the canonical `useUnifiedLoading`
+ * composable. The structured `ApiError` shape is preserved — callers of
+ * `useApiRequest` see the same `{ loading, error, execute }` surface, with
+ * `error` typed as `ApiError | null` (not a plain string).
+ *
+ * @param componentKey Optional key for scoping the shared loading state
+ *                     registry; defaults to a unique per-instance key.
  * @returns API call wrapper with built-in loading state
  *
  * @example
  * ```typescript
- * const { loading, error, execute } = useApiRequest()
+ * const { loading, error, execute } = useApiRequest('UserList')
  *
  * const result = await execute(
  *   () => apiClient.get('/api/users'),
@@ -334,28 +294,29 @@ export function useApiLoading() {
  * )
  * ```
  */
-export function useApiRequest<T = unknown>() {
-  const { loading, error, startLoading, stopLoading, setError, clearError } = useApiLoading()
+export function useApiRequest<T = unknown>(componentKey?: string) {
+  const unified = useUnifiedLoading(componentKey)
+  const error: Ref<ApiError | null> = ref(null)
 
   async function execute(
     apiCall: () => Promise<T>,
     options: ErrorHandlerOptions = {}
   ): Promise<ApiResult<T>> {
-    startLoading()
-    clearError()
+    error.value = null
+    unified.setLoading(true)
 
     const result = await handleApiCall(apiCall, options)
 
     if (!result.success && result.error) {
-      setError(result.error)
+      error.value = result.error
     }
 
-    stopLoading()
+    unified.setLoading(false)
     return result
   }
 
   return {
-    loading,
+    loading: unified.isLoading,
     error,
     execute
   }


### PR DESCRIPTION
Closes #5108

## Summary

`useApiLoading` was only used internally by `useApiRequest<T>()`. Migrated `useApiRequest` to use `useUnifiedLoading` for loading-state tracking, then deleted `useApiLoading`. `useLoadingState` had zero production callers (only tests + one doc example) and was also removed.

## Structured error path preserved

The critical non-trivial concern from the issue body is respected: `useApiRequest<T>()` still returns `{loading, error, execute}` with `error: Ref<ApiError | null>` (structured). The internal wiring swap does not affect the caller-facing shape.

## Caller impact

`useApiRequest` currently has **0 external callers** in the codebase (audit-time estimate of 2-4 was wrong). So even the signature-compatible change has no downstream impact.

## Files touched

- `src/utils/apiErrorHandler.ts` \u2014 `useApiLoading` deleted; `useApiRequest` migrated
- `src/composables/useErrorHandler.ts` \u2014 `useLoadingState` deleted
- `src/composables/useErrorHandler.test.ts` \u2014 corresponding test block removed
- `src/composables/useErrorHandler.examples.md` \u2014 example updated to `useUnifiedLoading`

## Verification

- [x] `vue-tsc --noEmit`: 0 new errors (baseline preserved)
- [x] `grep useApiLoading autobot-frontend/src/`: 0 matches
- [x] `useApiRequest` external signature unchanged
- [ ] `gh pr checks` passes

## Added bonus

`useApiRequest` now accepts optional `componentKey?: string` for scoping the unified loading registry. Backward-compatible (no existing callers to break).