### PR TITLE
refactor(analytics): extend useAnalyticsEndpoint with POST+body, migrate useCodeSmellAnalysis (#5153)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.test.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.test.ts
@@ -211,6 +211,107 @@ describe('useAnalyticsEndpoint', () => {
     expect(url).toContain('source_id=s1')
   })
 
+  it('defaults to GET (no body sent) when method is omitted', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ status: 'success', stats: { total: 1 } }),
+    )
+    const { load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/analytics/codebase/stats',
+        scopeToSource: false,
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+      },
+      { withSourceId },
+    )
+
+    await load()
+
+    const init = mockedFetch.mock.calls[0]?.[1] as RequestInit | undefined
+    expect(init?.method).toBe('GET')
+    expect(init?.body).toBeUndefined()
+  })
+
+  it('sends POST with JSON body when method=POST', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ status: 'success', stats: { total: 7 } }),
+    )
+
+    const { load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/code-intelligence/analyze',
+        method: 'POST',
+        scopeToSource: false,
+        body: () => ({ path: '/opt/project', min_severity: 'low' }),
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+      },
+      { withSourceId },
+    )
+
+    await load()
+
+    const init = mockedFetch.mock.calls[0]?.[1] as RequestInit | undefined
+    expect(init?.method).toBe('POST')
+    expect(init?.body).toBe(
+      JSON.stringify({ path: '/opt/project', min_severity: 'low' }),
+    )
+    const headers = init?.headers as Record<string, string> | undefined
+    expect(headers?.['Content-Type']).toBe('application/json')
+  })
+
+  it('re-evaluates POST body factory on each load (reactive-friendly)', async () => {
+    // fresh Response per call — Response.json() consumes the body
+    mockedFetch.mockImplementation(async () =>
+      jsonResponse({ status: 'success', stats: { total: 1 } }),
+    )
+    let currentPath = '/a'
+    const { load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/code-intelligence/analyze',
+        method: 'POST',
+        scopeToSource: false,
+        body: () => ({ path: currentPath }),
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+      },
+      { withSourceId },
+    )
+
+    await load()
+    currentPath = '/b'
+    await load()
+
+    expect(mockedFetch.mock.calls[0]?.[1]).toMatchObject({
+      body: JSON.stringify({ path: '/a' }),
+    })
+    expect(mockedFetch.mock.calls[1]?.[1]).toMatchObject({
+      body: JSON.stringify({ path: '/b' }),
+    })
+  })
+
+  it('POST without body factory sends no body', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ status: 'success', stats: { total: 1 } }),
+    )
+    const { load } = useAnalyticsEndpoint<RawStats, Stats>(
+      {
+        path: '/api/analytics/codebase/cache',
+        method: 'POST',
+        scopeToSource: false,
+        pickData: (raw) =>
+          raw.status === 'success' && raw.stats ? raw.stats : null,
+      },
+      { withSourceId },
+    )
+
+    await load()
+
+    const init = mockedFetch.mock.calls[0]?.[1] as RequestInit | undefined
+    expect(init?.method).toBe('POST')
+    expect(init?.body).toBeUndefined()
+  })
+
   it('skips empty queryExtras entries', async () => {
     mockedFetch.mockResolvedValueOnce(
       jsonResponse({ status: 'success', stats: { total: 1 } }),

--- a/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.ts
@@ -24,9 +24,21 @@ import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useAnalyticsEndpoint')
 
+export type AnalyticsEndpointMethod = 'GET' | 'POST'
+
 export interface UseAnalyticsEndpointOptions<TRaw, TOut> {
   /** API path appended to the resolved backend URL, e.g. '/api/analytics/codebase/stats'. */
   path: string
+  /**
+   * HTTP method. Defaults to 'GET'. Use 'POST' for action endpoints
+   * (e.g. `/api/code-intelligence/analyze`) that accept a JSON body.
+   */
+  method?: AnalyticsEndpointMethod
+  /**
+   * Factory returning the JSON body to send. Called at each `load()` so it
+   * can read fresh reactive state. Ignored when `method === 'GET'`.
+   */
+  body?: () => unknown
   /**
    * Whether to wrap the URL with `withSourceId()` before fetching.
    * Defaults to TRUE — opt-out only. #5111 was caused by forgetting this,
@@ -95,6 +107,7 @@ export function useAnalyticsEndpoint<TRaw, TOut>(
   const error = ref('')
 
   const scopeToSource = opts.scopeToSource !== false
+  const method: AnalyticsEndpointMethod = opts.method ?? 'GET'
   const label = opts.label ?? opts.path
 
   const load = async (
@@ -110,13 +123,17 @@ export function useAnalyticsEndpoint<TRaw, TOut>(
       }
       url = appendQueryExtras(url, queryExtras)
 
-      const response = await fetchWithAuth(url, {
-        method: 'GET',
+      const init: RequestInit = {
+        method,
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
         },
-      })
+      }
+      if (method === 'POST' && opts.body) {
+        init.body = JSON.stringify(opts.body())
+      }
+      const response = await fetchWithAuth(url, init)
       if (!response.ok) {
         throw new Error(`${label} returned ${response.status}`)
       }

--- a/autobot-frontend/src/composables/analytics/useCodeSmellAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeSmellAnalysis.ts
@@ -7,22 +7,31 @@
  *
  * Code smell detection and health score calculation.
  * Extracted from useCodeIntelAnalysis (Issue #2260).
+ * Routed through useAnalyticsEndpoint<T> (Issue #5153 wave 2).
+ *
+ * The two backing endpoints live under `/api/code-intelligence/*` and are
+ * NOT source-scoped (they take the repo root path directly), so both
+ * endpoints opt out of source scoping via `scopeToSource: false`.
  */
 
 import { ref, computed } from 'vue'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
-import { createLogger } from '@/utils/debugUtils'
 import type {
   UseCodeIntelAnalysisDeps,
   CodeSmellsReportData,
   CodeHealthScoreData,
 } from './codeIntelTypes'
+import { useAnalyticsEndpoint } from './useAnalyticsEndpoint'
 
-const logger = createLogger('useCodeSmellAnalysis')
+interface AnalyzeResponse {
+  report?: CodeSmellsReportData
+}
+
+const LOCAL_PATH_MARKER = '/data/code-sources/'
 
 export function useCodeSmellAnalysis(deps: UseCodeIntelAnalysisDeps) {
   const { rootPath, t, notify } = deps
+  // Never source-scoped: /api/code-intelligence/* takes the raw repo path.
+  const withSourceId = (url: string) => url
 
   const codeSmellsReport = ref<CodeSmellsReportData | null>(null)
   const codeHealthScore = ref<CodeHealthScoreData | null>(null)
@@ -36,128 +45,168 @@ export function useCodeSmellAnalysis(deps: UseCodeIntelAnalysisDeps) {
       : t('analytics.codebase.progress.analyzingSmells')
   })
 
-  const runCodeSmellAnalysis = async () => {
+  // Times an async load, toggles the shared analyzing flag, and fans out
+  // to per-endpoint success / failure toasts with the elapsed duration.
+  const notifyTimed = async (
+    fn: () => Promise<void>,
+    onFinish: (responseTimeMs: number) => void,
+    onFail: (responseTimeMs: number, message: string) => void,
+  ): Promise<void> => {
     const startTime = Date.now()
+    analyzingCodeSmells.value = true
+    try {
+      await fn()
+      onFinish(Date.now() - startTime)
+    } catch (err: unknown) {
+      const responseTime = Date.now() - startTime
+      const message = err instanceof Error ? err.message : String(err)
+      onFail(responseTime, message)
+    } finally {
+      analyzingCodeSmells.value = false
+    }
+  }
+
+  const smellsEndpoint = useAnalyticsEndpoint<
+    AnalyzeResponse,
+    CodeSmellsReportData
+  >(
+    {
+      path: '/api/code-intelligence/analyze',
+      method: 'POST',
+      scopeToSource: false,
+      body: () => ({
+        path: rootPath.value,
+        exclude_dirs: [
+          'node_modules',
+          '.venv',
+          '__pycache__',
+          '.git',
+          'archives',
+        ],
+        min_severity: 'low',
+      }),
+      pickData: (raw) => raw.report ?? null,
+      onSuccess: (report) => {
+        codeSmellsReport.value = report
+      },
+      // Preserve original behavior: a no-report response clears stale state.
+      onNoData: () => {
+        codeSmellsReport.value = null
+      },
+      label: 'Code smell analysis',
+    },
+    { withSourceId },
+  )
+
+  const healthEndpoint = useAnalyticsEndpoint<
+    CodeHealthScoreData,
+    CodeHealthScoreData
+  >(
+    {
+      path: '/api/code-intelligence/health-score',
+      scopeToSource: false,
+      pickData: (raw) => raw,
+      onSuccess: (data) => {
+        codeHealthScore.value = data
+      },
+      onNoData: () => {
+        codeHealthScore.value = null
+      },
+      label: 'Health score',
+    },
+    { withSourceId },
+  )
+
+  const runCodeSmellAnalysis = async () => {
     codeSmellsAnalysisType.value = 'smells'
-    const analysisPath = rootPath.value
-    if (analysisPath.includes('/data/code-sources/')) {
+    if (rootPath.value.includes(LOCAL_PATH_MARKER)) {
       notify(
         t('analytics.codebase.notify.codeIntelLocalPathRequired'),
         'warning',
       )
       return
     }
-    analyzingCodeSmells.value = true
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const response = await fetchWithAuth(
-        `${backendUrl}/api/code-intelligence/analyze`,
-        {
-          method: 'POST',
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            path: analysisPath,
-            exclude_dirs: [
-              'node_modules',
-              '.venv',
-              '__pycache__',
-              '.git',
-              'archives',
-            ],
-            min_severity: 'low',
+    await notifyTimed(
+      async () => {
+        await smellsEndpoint.load()
+        if (smellsEndpoint.error.value) {
+          throw new Error(smellsEndpoint.error.value)
+        }
+      },
+      (responseTime) => {
+        // CodeSmellsReportData is index-signatured; narrow the fields we
+        // actually read from the /analyze backend contract.
+        const report = codeSmellsReport.value as
+          | ({ anti_patterns?: unknown[]; total_files?: number } & CodeSmellsReportData)
+          | null
+        const totalIssues = Array.isArray(report?.anti_patterns)
+          ? report.anti_patterns.length
+          : 0
+        const filesAnalyzed = report?.total_files ?? 0
+        notify(
+          t('analytics.codebase.notify.codeSmellsFound', {
+            count: totalIssues,
+            files: filesAnalyzed,
+            time: responseTime,
           }),
-        },
-      )
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`Status ${response.status}: ${errorText}`)
-      }
-      const data = await response.json()
-      const responseTime = Date.now() - startTime
-      codeSmellsReport.value = data.report
-      const totalIssues = data.report?.anti_patterns?.length || 0
-      const filesAnalyzed = data.report?.total_files || 0
-      notify(
-        t('analytics.codebase.notify.codeSmellsFound', {
-          count: totalIssues,
-          files: filesAnalyzed,
-          time: responseTime,
-        }),
-        totalIssues > 0 ? 'warning' : 'success',
-      )
-    } catch (error: unknown) {
-      const responseTime = Date.now() - startTime
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error('Code smell analysis failed:', error)
-      notify(
-        t('analytics.codebase.notify.codeSmellsFailed', {
-          error: errorMessage,
-          time: responseTime,
-        }),
-        'error',
-      )
-    } finally {
-      analyzingCodeSmells.value = false
-    }
+          totalIssues > 0 ? 'warning' : 'success',
+        )
+      },
+      (responseTime, message) => {
+        notify(
+          t('analytics.codebase.notify.codeSmellsFailed', {
+            error: message,
+            time: responseTime,
+          }),
+          'error',
+        )
+      },
+    )
   }
 
   const getCodeHealthScore = async () => {
-    const startTime = Date.now()
     codeSmellsAnalysisType.value = 'health'
-    const analysisPath = rootPath.value
-    if (analysisPath.includes('/data/code-sources/')) {
+    if (rootPath.value.includes(LOCAL_PATH_MARKER)) {
       notify(
         t('analytics.codebase.notify.healthScoreLocalPathRequired'),
         'warning',
       )
       return
     }
-    analyzingCodeSmells.value = true
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const healthEndpoint = `${backendUrl}/api/code-intelligence/health-score?path=${encodeURIComponent(analysisPath)}`
-      const response = await fetchWithAuth(healthEndpoint, {
-        method: 'GET',
-        headers: { Accept: 'application/json' },
-      })
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(`Status ${response.status}: ${errorText}`)
-      }
-      const data = await response.json()
-      const responseTime = Date.now() - startTime
-      codeHealthScore.value = data
-      const score = data.health_score || 0
-      const grade = data.grade || 'N/A'
-      const issues = data.total_issues || 0
-      notify(
-        t('analytics.codebase.notify.healthScoreResult', {
-          score,
-          grade,
-          issues,
-          time: responseTime,
-        }),
-        score >= 70 ? 'success' : 'warning',
-      )
-    } catch (error: unknown) {
-      const responseTime = Date.now() - startTime
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error('Health score failed:', error)
-      notify(
-        t('analytics.codebase.notify.healthScoreFailed', {
-          error: errorMessage,
-          time: responseTime,
-        }),
-        'error',
-      )
-    } finally {
-      analyzingCodeSmells.value = false
-    }
+    await notifyTimed(
+      async () => {
+        await healthEndpoint.load({ path: rootPath.value })
+        if (healthEndpoint.error.value) {
+          throw new Error(healthEndpoint.error.value)
+        }
+      },
+      (responseTime) => {
+        const h = codeHealthScore.value as
+          | (CodeHealthScoreData & { total_issues?: number })
+          | null
+        const score = h?.health_score ?? 0
+        const grade = h?.grade ?? 'N/A'
+        const issues = h?.total_issues ?? 0
+        notify(
+          t('analytics.codebase.notify.healthScoreResult', {
+            score,
+            grade,
+            issues,
+            time: responseTime,
+          }),
+          score >= 70 ? 'success' : 'warning',
+        )
+      },
+      (responseTime, message) => {
+        notify(
+          t('analytics.codebase.notify.healthScoreFailed', {
+            error: message,
+            time: responseTime,
+          }),
+          'error',
+        )
+      },
+    )
   }
 
   return {


### PR DESCRIPTION
## Summary

First sub-PR of the #5153 wave-2 migration. Two tightly coupled changes:

1. **Extends `useAnalyticsEndpoint<T>`** with `method: 'GET' | 'POST'` + `body: () => unknown` factory. Body factory runs at each `load()` so it sees fresh reactive state. POST without a body sends no body.
2. **Migrates `useCodeSmellAnalysis.ts`** \u2014 first sibling composable \u2014 through the extended composable. Both endpoints (`/api/code-intelligence/analyze` POST, `/api/code-intelligence/health-score` GET) opt out of source scoping via `scopeToSource: false` since `/api/code-intelligence/*` takes a raw repo path, not a `source_id`.

Tracks #5153 (scope A-1).

## Honest note on LOC

`useCodeSmellAnalysis.ts` grew slightly (174 \u2192 215 lines). The per-endpoint config overhead (`pickData` / `onSuccess` / `onNoData` / `label`) does not amortise across 2 fetchers. The payoff lands when:

- The pattern propagates to the 6 remaining sibling composables (`useBugPrediction`, `useCodeIntelScores`, `useCrossLanguageAnalysis`, `useApiEndpointAnalysis`, `useEnvironmentAnalysis`, `useCodeIntelAnalysis`) \u2014 each case eliminates \u224625 lines of boilerplate.
- The `notifyTimed()` helper is extracted per #5153 scope D-2, which shrinks this file by another \u224816 lines.

The direct wins here are **consistency** (one fetch path across the analytics surface) and **testability** (the composable is unit-tested; the old inline fetchers never were).

## Test plan

- [x] `npx vitest run src/composables/analytics/useAnalyticsEndpoint.test.ts` \u2014 12/12 passing (was 8/8 pre-change; 4 new POST tests).
- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` \u2014 zero new errors on changed files; 169 baseline errors on unrelated files unchanged.
- [ ] Manual: on `/analytics/codebase/{sourceId}`, click *Code Smells* \u2014 POST runs, panel populates, toast shows `<n>` findings across `<m>` files + response time.
- [ ] Manual: click *Health Score* \u2014 GET runs, panel populates, toast shows score + grade + issues + response time.
- [ ] Manual: empty `rootPath` (or `/data/code-sources/...` marker) \u2014 warning toast fires, no fetch.

## Behavioral delta from the hand-rolled version

- Log message changes from `Code smell analysis failed: ...` \u2192 `Failed to load Code smell analysis: ...` (from composable's `label`). Cosmetic.
- New: `onNoData` explicitly clears stale state when a successful response is missing `report` / score fields. Preserves the original overwrite-with-undefined behavior without stale carryover.
- No change to the path-check short-circuit, warning-toast copy, or the shared `analyzingCodeSmells` loading flag.

## Related

- Umbrella: #5153
- Parent composable: #5112 (wave-1, extracted `useAnalyticsEndpoint`)
- Root bug class this pattern prevents: #5111

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)