### PR TITLE
fix(frontend): FunctionCallGraph 'cytoscape is not defined' - complete #3998 lazy-load refactor (#5158)

### DIFF
--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -103,8 +103,17 @@
         </div>
       </div>
 
-      <!-- Network view (Cytoscape) - DEFAULT -->
+      <!-- Network view (Cytoscape) - DEFAULT, lazy-loaded on demand (#5158) -->
       <div v-show="viewMode === 'network'" class="network-view">
+        <div v-if="cytoscapeLoading && !cy" class="cytoscape-loading">
+          <div class="loading-spinner"></div>
+          <span>{{ $t('charts.callGraph.loadingVisualization', 'Loading visualization library...') }}</span>
+        </div>
+        <div v-else-if="cytoscapeError" class="chart-error">
+          <span class="error-icon">!</span>
+          <span>{{ cytoscapeError }}</span>
+          <button @click="retryCytoscape" class="btn-link">{{ $t('charts.callGraph.retry', 'Retry') }}</button>
+        </div>
         <div ref="cytoscapeContainer" class="cytoscape-container"></div>
         <div class="network-controls">
           <button @click="zoomIn" :title="$t('charts.callGraph.controls.zoomIn')">
@@ -340,11 +349,9 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
-// Type imports only - actual implementation loaded dynamically
+// Type imports only - actual implementation loaded dynamically (#5158)
 import type cytoscape from 'cytoscape'
 import type { Core, NodeSingular } from 'cytoscape'
-// @ts-expect-error - cytoscape-fcose has no type declarations
-// import fcose from 'cytoscape-fcose' // Lazy-loaded on demand
 // Issue #711: Virtual scrolling for large orphaned function lists
 import { useVirtualScrollSimple } from '@/composables/useVirtualScroll'
 import { getCssVar } from '@/composables/useCssVars'
@@ -586,13 +593,44 @@ const filteredNodes = computed(() => {
 
 
 // ============================================================================
+// Cytoscape Lazy Loading (#5158 — completes the partial refactor from #3998)
+// ============================================================================
+
+async function loadCytoscapeLibrary() {
+  if (cytoscapeModule) return // Already loaded
+  try {
+    cytoscapeLoading.value = true
+    cytoscapeError.value = ''
+    const [cyModule, fcoseModuleImport] = await Promise.all([
+      import('cytoscape'),
+      // @ts-expect-error - cytoscape-fcose has no type declarations
+      import('cytoscape-fcose'),
+    ])
+    cytoscapeModule = cyModule.default
+    fcoseModule = fcoseModuleImport.default
+    if (cytoscapeModule) {
+      cytoscapeModule.use(fcoseModule)
+    }
+  } catch (err) {
+    cytoscapeError.value = `Failed to load visualization library: ${err instanceof Error ? err.message : 'Unknown error'}`
+    console.error('Cytoscape lazy-load error:', err)
+  } finally {
+    cytoscapeLoading.value = false
+  }
+}
+
+function retryCytoscape() {
+  loadCytoscapeLibrary()
+}
+
+// ============================================================================
 // Cytoscape Methods
 // ============================================================================
 
 function initCytoscape() {
-  if (!cytoscapeContainer.value) return
+  if (!cytoscapeModule || !cytoscapeContainer.value) return
 
-  cy = cytoscape({
+  cy = cytoscapeModule({
     container: cytoscapeContainer.value,
     style: getCytoscapeStyles(),
     elements: [],
@@ -894,9 +932,9 @@ function toggleFullscreen() {
 // ============================================================================
 
 function initClusterCytoscape() {
-  if (!clusterContainer.value) return
+  if (!cytoscapeModule || !clusterContainer.value) return
 
-  clusterCy = cytoscape({
+  clusterCy = cytoscapeModule({
     container: clusterContainer.value,
     style: getClusterCytoscapeStyles(),
     elements: [],
@@ -1261,6 +1299,8 @@ function truncateFunc(funcId: string): string {
 onMounted(async () => {
   await nextTick()
   if (cytoscapeContainer.value && props.data?.nodes?.length) {
+    await loadCytoscapeLibrary()
+    if (cytoscapeError.value) return
     initCytoscape()
     updateCytoscapeElements()
   }
@@ -1282,6 +1322,8 @@ watch(() => props.data, async (newData) => {
   if (newData?.nodes?.length) {
     await nextTick()
     if (!cy && cytoscapeContainer.value) {
+      await loadCytoscapeLibrary()
+      if (cytoscapeError.value) return
       initCytoscape()
     }
     updateCytoscapeElements()
@@ -1305,12 +1347,16 @@ watch(viewMode, async (newMode) => {
   if (newMode === 'network') {
     await nextTick()
     if (!cy && cytoscapeContainer.value) {
+      await loadCytoscapeLibrary()
+      if (cytoscapeError.value) return
       initCytoscape()
       updateCytoscapeElements()
     }
   } else if (newMode === 'stats') {
     await nextTick()
     if (!clusterCy && clusterContainer.value) {
+      await loadCytoscapeLibrary()
+      if (cytoscapeError.value) return
       initClusterCytoscape()
     }
     updateClusterElements()
@@ -1357,6 +1403,28 @@ watch(viewMode, async (newMode) => {
   min-height: 200px;
   color: var(--text-secondary);
   gap: var(--spacing-sm);
+}
+
+/* #5158: lazy-load states for the cytoscape library */
+.cytoscape-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-height: 200px;
+  gap: var(--spacing-2);
+  color: var(--text-secondary);
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: var(--text-sm);
+  padding: 0;
 }
 
 .loading-spinner {


### PR DESCRIPTION
## Summary

Fixes the runtime `ReferenceError: cytoscape is not defined` on the Function Call Graph panel (`/analytics/codebase/{sourceId}` \u2192 Network view).

Closes #5158.

## Root cause

PR #4082 (\"perf(frontend): lazy-load Cytoscape graph components\") completed the lazy-load in `ImportTreeChart.vue` but left `FunctionCallGraph.vue` **half-refactored**:

- Added type-only import (`import type cytoscape from 'cytoscape'`) \u2192 erased at build.
- Added the lazy-load state vars (`cytoscapeLoading`, `cytoscapeError`, `cytoscapeModule`, `fcoseModule`).
- **Never added the `loadCytoscapeLibrary()` function** \u2192 `cytoscape(\u2026)` calls at lines 595 and 899 hit an undefined identifier at runtime.

TypeScript didn't flag it because the type-only import exposes a callable namespace, so the build kept passing while production rendered broken.

## Fix

Completes the refactor by matching the working `ImportTreeChart.vue` pattern:

- `loadCytoscapeLibrary()` \u2014 dynamically imports `cytoscape` + `cytoscape-fcose`, stores `cytoscapeModule`, registers the fcose layout plugin.
- `retryCytoscape()` \u2014 exposed to the template retry button.
- `initCytoscape()` / `initClusterCytoscape()` \u2014 rewritten to call `cytoscapeModule(\u2026)` and early-return when the module isn't loaded.
- `onMounted`, `watch(props.data)`, `watch(viewMode)` \u2014 all `await loadCytoscapeLibrary()` and bail on error before calling init.
- Template \u2014 adds `cytoscape-loading` spinner and `chart-error` / retry UI in the network-view.
- Dropped stale `@ts-expect-error` that was guarding the commented-out eager import.

## Test plan

- [x] `vue-tsc --noEmit -p tsconfig.app.json` \u2014 zero errors on `FunctionCallGraph.vue`; baseline on unrelated files dropped from 169 \u2192 166 (stale `@ts-expect-error` cleanup).
- [ ] Manual: open `/analytics/codebase/{sourceId}` \u2192 Network view renders the graph (was throwing before).
- [ ] Manual: switch to Stats view \u2192 cluster graph renders.
- [ ] Manual: offline/404 the `cytoscape-*.js` chunk \u2192 loading spinner visible, then error + Retry button visible.
- [ ] Manual: bundle analyzer shows `cytoscape` + `cytoscape-fcose` still code-split (no regression on #3998's perf goal).

## Not covered here

- Kept `@ts-expect-error` on the dynamic `import('cytoscape-fcose')` call only (no types shipped with that package; same treatment as the sibling file).
- `KnowledgeGraph.vue` uses an **eager** static `import cytoscape` pattern and is intentionally left alone \u2014 it's not code-split, but it's not broken either, and changing its import strategy is out of scope for this bug.

## Related

- Origin of the partial refactor: #3998 / PR #4082
- Reference pattern: `ImportTreeChart.vue` (already lazy-loads correctly)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)