### PR TITLE
feat(composables): add useApiResource<T> reactive primitive (#5149)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useApiResource.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useApiResource.test.ts
@@ -1,0 +1,227 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+//
+// Tests for useApiResource (#5149)
+
+import { describe, it, expect, vi } from 'vitest'
+import { effectScope, nextTick } from 'vue'
+import { useApiResource } from '../useApiResource'
+
+/**
+ * Helper to create a deferred promise whose `resolve` / `reject` we can
+ * call from the test body. Lets us control fetch timing precisely.
+ */
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('useApiResource', () => {
+  it('initializes with data=null, error=null, isLoading=false', () => {
+    const { data, error, isLoading } = useApiResource(() =>
+      Promise.resolve(42)
+    )
+    expect(data.value).toBe(null)
+    expect(error.value).toBe(null)
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('refresh() sets isLoading=true while in flight, then data=result', async () => {
+    const d = deferred<number>()
+    const { data, isLoading, refresh } = useApiResource(() => d.promise)
+
+    const refreshPromise = refresh()
+    expect(isLoading.value).toBe(true)
+    expect(data.value).toBe(null)
+
+    d.resolve(42)
+    await refreshPromise
+
+    expect(isLoading.value).toBe(false)
+    expect(data.value).toBe(42)
+  })
+
+  it('refresh() captures rejection in error.value and clears isLoading', async () => {
+    const err = new Error('boom')
+    const { data, error, isLoading, refresh } = useApiResource(() =>
+      Promise.reject(err)
+    )
+
+    await refresh()
+
+    expect(error.value).toBe(err)
+    expect(data.value).toBe(null)
+    expect(isLoading.value).toBe(false)
+  })
+
+  it('wraps non-Error rejections (string, number, object) in Error', async () => {
+    const cases: unknown[] = ['string rejection', 42, { kind: 'obj' }]
+    for (const rejectValue of cases) {
+      const { error, refresh } = useApiResource(() =>
+        Promise.reject(rejectValue)
+      )
+      await refresh()
+      expect(error.value).toBeInstanceOf(Error)
+      expect(error.value?.message).toBe(String(rejectValue))
+    }
+  })
+
+  it('clears previous error on successful re-fetch', async () => {
+    let shouldFail = true
+    const { data, error, refresh } = useApiResource(() =>
+      shouldFail ? Promise.reject(new Error('boom')) : Promise.resolve(42)
+    )
+
+    await refresh()
+    expect(error.value?.message).toBe('boom')
+    expect(data.value).toBe(null)
+
+    shouldFail = false
+    await refresh()
+    expect(error.value).toBe(null)
+    expect(data.value).toBe(42)
+  })
+
+  it('keepPreviousData (default true): data remains visible during refresh', async () => {
+    let shouldReturn = 1
+    const d = deferred<number>()
+    const fetcher = vi.fn(() => {
+      if (shouldReturn === 1) return Promise.resolve(1)
+      return d.promise
+    })
+    const { data, isLoading, refresh } = useApiResource(fetcher)
+
+    await refresh()
+    expect(data.value).toBe(1)
+
+    shouldReturn = 2
+    const secondRefresh = refresh()
+    // Still loading, but data hasn't been cleared
+    expect(isLoading.value).toBe(true)
+    expect(data.value).toBe(1)
+
+    d.resolve(2)
+    await secondRefresh
+    expect(data.value).toBe(2)
+  })
+
+  it('keepPreviousData=false: data clears on every refresh', async () => {
+    let shouldReturn = 1
+    const d = deferred<number>()
+    const fetcher = () => {
+      if (shouldReturn === 1) return Promise.resolve(1)
+      return d.promise
+    }
+    const { data, refresh } = useApiResource(fetcher, {
+      keepPreviousData: false,
+    })
+
+    await refresh()
+    expect(data.value).toBe(1)
+
+    shouldReturn = 2
+    const p = refresh()
+    // data cleared immediately on refresh()
+    expect(data.value).toBe(null)
+
+    d.resolve(2)
+    await p
+    expect(data.value).toBe(2)
+  })
+
+  it('race: late-arriving first call does NOT overwrite later result', async () => {
+    const first = deferred<number>()
+    const second = deferred<number>()
+    let call = 0
+    const { data, refresh } = useApiResource(() => {
+      call += 1
+      return call === 1 ? first.promise : second.promise
+    })
+
+    const p1 = refresh()
+    const p2 = refresh()
+
+    // Second resolves first
+    second.resolve(2)
+    await p2
+    expect(data.value).toBe(2)
+
+    // First resolves LATER — should be discarded
+    first.resolve(1)
+    await p1
+    expect(data.value).toBe(2)
+  })
+
+  it('race: late-arriving first error does NOT overwrite later success', async () => {
+    const first = deferred<number>()
+    const second = deferred<number>()
+    let call = 0
+    const { data, error, refresh } = useApiResource(() => {
+      call += 1
+      return call === 1 ? first.promise : second.promise
+    })
+
+    const p1 = refresh()
+    const p2 = refresh()
+
+    second.resolve(42)
+    await p2
+    expect(data.value).toBe(42)
+    expect(error.value).toBe(null)
+
+    // First rejects late
+    first.reject(new Error('late failure'))
+    await p1
+    // Still success — late error was discarded
+    expect(data.value).toBe(42)
+    expect(error.value).toBe(null)
+  })
+
+  it('immediate: true triggers refresh() on creation', async () => {
+    const fetcher = vi.fn(() => Promise.resolve(42))
+    const { data } = useApiResource(fetcher, { immediate: true })
+
+    // Let the microtask flush
+    await nextTick()
+    await nextTick()
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(data.value).toBe(42)
+  })
+
+  it('immediate: false (default) does not auto-fetch', () => {
+    const fetcher = vi.fn(() => Promise.resolve(42))
+    useApiResource(fetcher)
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('onScopeDispose: in-flight fetches do not update disposed scope', async () => {
+    const d = deferred<number>()
+    const scope = effectScope()
+
+    let ref1!: ReturnType<typeof useApiResource<number>>
+    scope.run(() => {
+      ref1 = useApiResource(() => d.promise)
+    })
+
+    const p = ref1.refresh()
+    expect(ref1.isLoading.value).toBe(true)
+
+    // Simulate component unmount
+    scope.stop()
+
+    d.resolve(42)
+    await p
+
+    // Scope was disposed, so the refs were NOT updated — isLoading remains
+    // frozen at its last-observed state, data/error untouched.
+    expect(ref1.data.value).toBe(null)
+    expect(ref1.error.value).toBe(null)
+  })
+})

--- a/autobot-frontend/src/composables/useApiResource.ts
+++ b/autobot-frontend/src/composables/useApiResource.ts
@@ -1,0 +1,118 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Composable: useApiResource
+ *
+ * Generic wrapper around any async fetcher that exposes reactive `data`,
+ * `error`, `isLoading` refs plus a `refresh()` method. Designed to eliminate
+ * the imperative "loading ref + try/catch + assign" boilerplate that every
+ * fetch-style composable in `useKnowledgeBase.ts` (#5149) reimplements.
+ *
+ * Typical use with the typed ApiClient:
+ *
+ *   const stats = useApiResource<KnowledgeStats>(() =>
+ *     apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats`)
+ *   )
+ *   onMounted(stats.refresh)
+ *   // stats.data.value, stats.error.value, stats.isLoading.value are reactive
+ *
+ * Prior art in this repo: `composables/analytics/useAnalyticsEndpoint.ts`
+ * solves a narrower problem (fetchWithAuth + path + source-scoping). This
+ * composable is the generic form — any fetcher callback, no URL assumptions.
+ *
+ * Issue #5149.
+ */
+
+import { ref, getCurrentScope, onScopeDispose, type Ref } from 'vue'
+
+export interface UseApiResourceOptions {
+  /** Trigger `refresh()` immediately on composable creation. Default: false. */
+  immediate?: boolean
+  /**
+   * Keep the previous `data` value visible while the next `refresh()` is in
+   * flight. Default: true — matches what most UIs want (avoid flicker).
+   * Set to false to clear `data` before each refresh.
+   */
+  keepPreviousData?: boolean
+}
+
+export interface UseApiResourceReturn<T> {
+  /** The latest successful result, or `null` before the first success. */
+  data: Ref<T | null>
+  /** The last error from `refresh()`, cleared on successful refetch. */
+  error: Ref<Error | null>
+  /** True while a `refresh()` call is in flight. */
+  isLoading: Ref<boolean>
+  /** Invoke the fetcher. Resolves after state has been updated. */
+  refresh: () => Promise<void>
+}
+
+/**
+ * Wrap an async fetcher to get reactive loading/error/data refs.
+ *
+ * Race-condition handling: if `refresh()` is called again before the previous
+ * call resolves, the older call's result is discarded once it lands. The last
+ * caller wins. This prevents stale data from overwriting fresh data when a
+ * consumer fires refresh() multiple times in quick succession.
+ *
+ * Lifecycle: on `onScopeDispose` (component unmount / effect scope teardown),
+ * any pending fetches are effectively ignored — their resolutions no longer
+ * touch the refs. This prevents the classic "setState on unmounted component"
+ * warning and any memory leak from stale closures.
+ */
+export function useApiResource<T>(
+  fetcher: () => Promise<T>,
+  options: UseApiResourceOptions = {}
+): UseApiResourceReturn<T> {
+  const data = ref<T | null>(null) as Ref<T | null>
+  const error = ref<Error | null>(null)
+  const isLoading = ref(false)
+
+  const keepPreviousData = options.keepPreviousData !== false
+
+  // Monotonic ID for race-condition tracking. Incremented per refresh() call.
+  // When a fetch resolves, we ignore it unless its ID still matches the latest.
+  let latestCallId = 0
+  let disposed = false
+
+  const refresh = async (): Promise<void> => {
+    const callId = ++latestCallId
+    isLoading.value = true
+    error.value = null
+    if (!keepPreviousData) {
+      data.value = null
+    }
+
+    try {
+      const result = await fetcher()
+      if (disposed || callId !== latestCallId) return
+      data.value = result
+    } catch (e) {
+      if (disposed || callId !== latestCallId) return
+      error.value = e instanceof Error ? e : new Error(String(e))
+    } finally {
+      if (disposed || callId !== latestCallId) return
+      isLoading.value = false
+    }
+  }
+
+  // Only register the disposer if called inside an effect scope (e.g. a Vue
+  // component setup). Calling onScopeDispose outside a scope emits a warning
+  // and does nothing — guarding here keeps unit tests quiet and the callsite
+  // contract unchanged.
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      disposed = true
+    })
+  }
+
+  if (options.immediate) {
+    // Fire-and-forget — caller can still `await refresh()` later; we don't
+    // want `useApiResource` itself to be async.
+    refresh()
+  }
+
+  return { data, error, isLoading, refresh }
+}


### PR DESCRIPTION
First step toward #5149.

## What

Adds `autobot-frontend/src/composables/useApiResource.ts` — a generic wrapper around any async fetcher that exposes reactive `{ data, error, isLoading, refresh }` refs.

```typescript
const stats = useApiResource<KnowledgeStats>(() =>
  apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats`)
)
onMounted(stats.refresh)
// stats.data.value, stats.error.value, stats.isLoading.value are reactive
```

This eliminates the imperative `loading ref + try/catch + assign + finally` boilerplate that every fetch-style composable in `useKnowledgeBase.ts` reimplements (~14 functions, ~140 lines of duplicated try/catch — see #5123).

## Why this and not `useAnalyticsEndpoint`?

`composables/analytics/useAnalyticsEndpoint.ts` (#5112, merged) solves a **narrower** problem:
- Requires `path: string` + injected `withSourceId` dependency
- Uses `fetchWithAuth` + raw `Response` + `await response.json()`
- Analytics-specific source-scoping logic baked in

`useApiResource` is the **generic form** for non-analytics contexts (knowledge, chat, settings, workflows). It takes any fetcher callback — no URL or auth assumptions — and pairs naturally with the typed `apiClient.get<T>()` / `.post<T>()` pattern.

A future PR could refactor `useAnalyticsEndpoint` to use `useApiResource` underneath, but that's out of scope here.

## Design highlights

- **Race-condition handling**: monotonic call ID; older calls' resolutions are discarded. The last `refresh()` wins. Prevents the classic "stale data overwrites fresh data" bug.
- **Lifecycle**: `onScopeDispose` registered only if inside an effect scope (real component setup). Outside (unit tests), the disposer is silently skipped — no Vue warnings.
- **`keepPreviousData: true` by default**: avoids UI flicker. Set false to clear `data` before each refresh.
- **`immediate: false` by default**: explicit `refresh()` opt-in. Pass `{ immediate: true }` to fire on creation.

## Tests (12/12 pass)

Covers: initial state, load lifecycle, error wrapping (Error / string / number / object rejections), error clearing on success, `keepPreviousData` on/off, race conditions (late-arriving result, late-arriving error), `immediate` option, and `onScopeDispose` cleanup with `effectScope`.

## Verification

```
✓ src/composables/__tests__/useApiResource.test.ts (12 tests) 22ms
Tests  12 passed (12)

vue-tsc --noEmit -p tsconfig.app.json — 0 errors in new files
```

## What's next (out of scope for this PR)

- #5122: split `useKnowledgeBase` into 6-7 domain composables, each using `useApiResource`
- #5123: delete the redundant try/catch wrappers (replaced by `useApiResource`'s built-in handling)
- Rest of #5033: ~95 remaining `parseApiResponse` call sites

Each future migration is now a one-liner: `useApiResource(() => apiClient.get<T>(url))`.

## Process notes

Followed the new Phase 0c rules I added to the team-implement skill:
- Pre-push duplicate check: re-fetched, verified `useAnalyticsEndpoint` (just-merged related work) does not duplicate this primitive
- Type-check AND test-run before push