### PR TITLE
refactor(analytics): extract runTimed helper (#5153 D-2)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
@@ -26,6 +26,7 @@ import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import type { ToastType } from '@/composables/useToast'
 import { useAnalyticsEndpoint } from './useAnalyticsEndpoint'
+import { runTimed } from './useTimedNotify'
 import {
   CODE_SMELL_TYPES,
   type Problem,
@@ -386,6 +387,7 @@ export function useAnalyticsDataFetchers(deps: UseAnalyticsDataFetchersDeps) {
   /**
    * Shared wrapper for the three toast-emitting loaders. Preserves the
    * count + timing + (for hardcodes) types summary shown to the user.
+   * Timing + try/catch kernel lives in `runTimed` (#5153 D-2).
    */
   const notifyTimed = async (
     flag: 'declarations' | 'duplicates' | 'hardcodes',
@@ -398,28 +400,25 @@ export function useAnalyticsDataFetchers(deps: UseAnalyticsDataFetchersDeps) {
   ) => {
     loadingProgress[flag] = true
     progressStatus.value = t(statusKey)
-    const startTime = Date.now()
-    try {
-      const result = await runner()
-      const time = Date.now() - startTime
-      if (result === null) {
-        notify(t(failedKey, { error: 'request failed', time }), 'error')
-        return
-      }
-      notify(
-        t(foundKey, { count: result.count, time, ...result.extra }),
-        'success',
-      )
-    } catch (error: unknown) {
-      const time = Date.now() - startTime
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error(`${flag} failed:`, error)
-      notify(t(failedKey, { error: errorMessage, time }), 'error')
-    } finally {
-      loadingProgress[flag] = false
-      progressStatus.value = t('analytics.codebase.status.ready')
-    }
+    await runTimed(
+      runner,
+      (result, time) => {
+        if (result === null) {
+          notify(t(failedKey, { error: 'request failed', time }), 'error')
+          return
+        }
+        notify(
+          t(foundKey, { count: result.count, time, ...result.extra }),
+          'success',
+        )
+      },
+      (errorMessage, time, err) => {
+        logger.error(`${flag} failed:`, err)
+        notify(t(failedKey, { error: errorMessage, time }), 'error')
+      },
+    )
+    loadingProgress[flag] = false
+    progressStatus.value = t('analytics.codebase.status.ready')
   }
 
   const getDeclarationsData = () =>

--- a/autobot-frontend/src/composables/analytics/useTimedNotify.test.ts
+++ b/autobot-frontend/src/composables/analytics/useTimedNotify.test.ts
@@ -1,0 +1,113 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Unit tests for runTimed.
+ *
+ * Issue #5153 scope D-2.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { runTimed } from './useTimedNotify'
+
+describe('runTimed', () => {
+  it('calls onSuccess with the resolved value and elapsed ms; does not call onFail', async () => {
+    const onSuccess = vi.fn()
+    const onFail = vi.fn()
+    await runTimed(
+      async () => {
+        await new Promise((r) => setTimeout(r, 5))
+        return 'ok'
+      },
+      onSuccess,
+      onFail,
+    )
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    const [value, elapsed] = onSuccess.mock.calls[0]!
+    expect(value).toBe('ok')
+    expect(typeof elapsed).toBe('number')
+    expect(elapsed).toBeGreaterThanOrEqual(0)
+    expect(onFail).not.toHaveBeenCalled()
+  })
+
+  it('on thrown Error: passes Error.message string plus the original error and elapsed ms', async () => {
+    const onSuccess = vi.fn()
+    const onFail = vi.fn()
+    const boom = new Error('boom')
+    await runTimed(
+      async () => {
+        throw boom
+      },
+      onSuccess,
+      onFail,
+    )
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(onFail).toHaveBeenCalledTimes(1)
+    const [message, elapsed, originalErr] = onFail.mock.calls[0]!
+    expect(message).toBe('boom')
+    expect(typeof elapsed).toBe('number')
+    expect(originalErr).toBe(boom)
+  })
+
+  it('on thrown non-Error: stringifies the thrown value', async () => {
+    const onFail = vi.fn()
+    await runTimed(
+      async () => {
+        throw 'plain string failure' // eslint-disable-line @typescript-eslint/only-throw-error
+      },
+      vi.fn(),
+      onFail,
+    )
+    const [message] = onFail.mock.calls[0]!
+    expect(message).toBe('plain string failure')
+  })
+
+  it('loading ref: set to true before fn, false in success finally', async () => {
+    const loading = ref(false)
+    const seenDuring = ref<boolean | null>(null)
+    await runTimed(
+      async () => {
+        seenDuring.value = loading.value
+      },
+      vi.fn(),
+      vi.fn(),
+      { loadingRef: loading },
+    )
+    expect(seenDuring.value).toBe(true)
+    expect(loading.value).toBe(false)
+  })
+
+  it('loading ref: reset to false even when fn throws', async () => {
+    const loading = ref(false)
+    await runTimed(
+      async () => {
+        throw new Error('fail')
+      },
+      vi.fn(),
+      vi.fn(),
+      { loadingRef: loading },
+    )
+    expect(loading.value).toBe(false)
+  })
+
+  it('loading ref: reset to false even when onSuccess throws', async () => {
+    const loading = ref(false)
+    const onSuccessBomb = () => {
+      throw new Error('handler exploded')
+    }
+    await expect(
+      runTimed(async () => 'ok', onSuccessBomb, vi.fn(), {
+        loadingRef: loading,
+      }),
+    ).rejects.toThrow('handler exploded')
+    expect(loading.value).toBe(false)
+  })
+
+  it('works without a loading ref (options omitted)', async () => {
+    const onSuccess = vi.fn()
+    await runTimed(async () => 42, onSuccess, vi.fn())
+    expect(onSuccess).toHaveBeenCalledWith(42, expect.any(Number))
+  })
+})

--- a/autobot-frontend/src/composables/analytics/useTimedNotify.ts
+++ b/autobot-frontend/src/composables/analytics/useTimedNotify.ts
@@ -1,0 +1,60 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Helper: runTimed
+ *
+ * Times an async operation and fans the result out to success / failure
+ * handlers with the elapsed duration. Optionally toggles a loading ref
+ * around the operation.
+ *
+ * Extracts the shared kernel of the two `notifyTimed` helpers that were
+ * inlined in useAnalyticsDataFetchers (#5112) and useCodeSmellAnalysis
+ * (#5153 A-1 / PR #5157). Issue #5153 scope D-2.
+ *
+ * NB: this is a plain async function, not a composable. It holds no
+ * reactive state of its own; the loading ref (when provided) is owned
+ * by the caller.
+ */
+
+import type { Ref } from 'vue'
+
+export interface RunTimedOptions {
+  /**
+   * Optional loading ref. Set to `true` before `fn()` starts and `false`
+   * in `finally` — including when `onSuccess` or `onFail` throws.
+   */
+  loadingRef?: Ref<boolean>
+}
+
+/**
+ * @param fn        operation being timed
+ * @param onSuccess called on fulfilled `fn()` with (result, elapsedMs)
+ * @param onFail    called on rejected `fn()` with (errorMessage, elapsedMs, originalError)
+ * @param options   see {@link RunTimedOptions}
+ */
+export async function runTimed<T>(
+  fn: () => Promise<T>,
+  onSuccess: (result: T, elapsedMs: number) => void,
+  onFail: (errorMessage: string, elapsedMs: number, err: unknown) => void,
+  options?: RunTimedOptions,
+): Promise<void> {
+  const startTime = Date.now()
+  if (options?.loadingRef) options.loadingRef.value = true
+  try {
+    let result: T
+    try {
+      result = await fn()
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      onFail(message, Date.now() - startTime, err)
+      return
+    }
+    // Handler errors must propagate (they are not fn-failures); the outer
+    // finally still resets the loading ref either way.
+    onSuccess(result, Date.now() - startTime)
+  } finally {
+    if (options?.loadingRef) options.loadingRef.value = false
+  }
+}


### PR DESCRIPTION
## Summary

Second sub-PR of #5153 wave-2. Extracts the timing + try/catch kernel that was inlined in `useAnalyticsDataFetchers.ts` (from #5112) into a shared helper `composables/analytics/useTimedNotify.ts` with unit tests.

The same kernel is duplicated in `useCodeSmellAnalysis.ts` (PR #5157, still open). It will converge on this helper in a follow-up after #5157 merges.

Tracks #5153 (scope D-2).

## Design note \u2014 handler errors propagate

The outer catch in the original inlined version fired `onFail` for **any** throw inside the try block, including errors thrown by `onSuccess` itself \u2014 which is the wrong classification (a handler bug is not a fetch failure). The new `runTimed` uses a nested try/catch so:

- `fn()` rejections \u2192 `onFail(message, elapsed, err)`
- `onSuccess` throws \u2192 propagates to the caller
- In either case, the outer `finally` still resets the loading ref.

There is a unit test for each of those branches.

## Test plan

- [x] `npx vitest run src/composables/analytics/useTimedNotify.test.ts` \u2014 7/7 passing (success path, Error throw, non-Error throw, loading ref lifecycle across success / fn-throw / handler-throw, no loading ref).
- [x] `npx vitest run src/composables/analytics/useAnalyticsEndpoint.test.ts` \u2014 regression check, 8/8 passing on this base.
- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` \u2014 169 pre-existing baseline errors on unrelated files; zero new errors on `useTimedNotify.ts`, `useTimedNotify.test.ts`, `useAnalyticsDataFetchers.ts`.
- [ ] Manual: on `/analytics/codebase/{sourceId}`, run \"Analyze Declarations\" / \"Analyze Duplicates\" / \"Detect Hardcodes\" \u2014 each should still emit the same toast with count + (for hardcodes) types summary + response time, same as before.

## LOC note

`useAnalyticsDataFetchers.ts`: **693 -> 692** LOC. Essentially flat today because the domain-specific wrapper (loading-map flag + statusKey + toast-key schema) is still required. The payoff lands in the six remaining wave-2 sibling migrations (#5153 scope A) where each `.ts` file currently re-implements its own timing/catch kernel and can now reuse `runTimed`.

After #5157 merges, a follow-up will replace the local copy in `useCodeSmellAnalysis.ts` with this helper (\u224816 LOC savings there).

## Related

- Umbrella: #5153
- Wave-1 root: #5112 (introduced the first inlined copy)
- Wave-2 A-1: #5157 (introduced the second copy; cleanup deferred to follow-up)
- Wave-1 bug class: #5111

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)