### PR TITLE
fix(rag-benchmarks): require ≥1 test_id access before labeling held_out_score (#5160)

### DIFF
--- a/autobot-backend/knowledge/rag_benchmarks.py
+++ b/autobot-backend/knowledge/rag_benchmarks.py
@@ -912,8 +912,10 @@ class BenchmarkRunReport:
         tuned_on_dev:  True iff a tune() pass was completed on this dataset
                        before this run (harness-level state).
         held_out_score: True iff ``split_used == "test"`` **and** this run
-                        touched only ``test_ids`` (no dev-set leakage).
-                        Any other combination is False.
+                        touched only ``test_ids`` (no dev-set leakage) **and**
+                        at least one ``test_id`` was actually accessed.
+                        Any other combination is False (Issue #5160: empty
+                        runs must not be labelled held-out).
         mean_precision_at_k: Mean precision@k across results in the run.
         results:       The underlying BenchmarkResult list.
     """
@@ -979,8 +981,10 @@ class BenchmarkHarness:
             if results
             else 0.0
         )
-        held_out = (split == BenchmarkSplit.TEST) and not touched_test_leakage(
-            self.dataset, split
+        held_out = (
+            split == BenchmarkSplit.TEST
+            and not touched_test_leakage(self.dataset, split)
+            and len(self.dataset.accessed_test) > 0
         )
         return BenchmarkRunReport(
             split_used=split.value,
@@ -1023,6 +1027,11 @@ class BenchmarkHarness:
         self.dataset.reset_access()
         with self.dataset.enforce_test_only():
             results = scorer_fn(self.dataset)
+        if not self.dataset.accessed_test:
+            raise RuntimeError(
+                "score() called but no test_ids were accessed — "
+                "harness returned zero results"
+            )
         return self._build_report(
             BenchmarkSplit.TEST, results, touched_test=False
         )

--- a/autobot-backend/knowledge/test_rag_benchmarks.py
+++ b/autobot-backend/knowledge/test_rag_benchmarks.py
@@ -168,10 +168,15 @@ def test_run_test_is_held_out():
     harness = BenchmarkHarness(dataset=ds)
 
     def runner(dataset: BenchmarkDataset):
-        return [
-            BenchmarkResult(q, [], [], 0.5, split_used=BenchmarkSplit.TEST.value)
-            for q in dataset.iter_split(BenchmarkSplit.TEST)
-        ]
+        out = []
+        for q in dataset.iter_split(BenchmarkSplit.TEST):
+            dataset.expected(q)  # Issue #5160: must access to mark held_out
+            out.append(
+                BenchmarkResult(
+                    q, [], [], 0.5, split_used=BenchmarkSplit.TEST.value
+                )
+            )
+        return out
 
     report = harness.run(runner, split=BenchmarkSplit.TEST)
     assert report.held_out_score is True
@@ -279,6 +284,44 @@ def test_endpoint_rejects_invalid_split():
     client = TestClient(app)
     resp = client.post("/rag/benchmark/run", json={"split": "holdout"})
     assert resp.status_code == 422  # pydantic validation error
+
+
+# ---------------------------------------------------------------------------
+# Issue #5160: empty-results guard on score()
+# ---------------------------------------------------------------------------
+
+
+def test_score_with_empty_results_raises():
+    """score() must raise when the scorer accesses zero test_ids.
+
+    Otherwise `held_out_score=True` would be falsely confident on an
+    empty run (harness silently succeeded with no evidence).
+    """
+    ds = get_default_dataset()
+    harness = BenchmarkHarness(dataset=ds)
+
+    def noop_runner(_dataset: BenchmarkDataset):
+        return []
+
+    with pytest.raises(RuntimeError, match="no test_ids were accessed"):
+        harness.score(noop_runner)
+
+
+def test_held_out_score_requires_test_access():
+    """run(split=TEST) with zero test accesses must surface as a RuntimeError.
+
+    Previously `held_out_score` could be True on a run that touched no
+    test_ids (no leakage, but also no evidence). The guard in score()
+    now refuses that outcome.
+    """
+    ds = get_default_dataset()
+    harness = BenchmarkHarness(dataset=ds)
+
+    def noop_runner(_dataset: BenchmarkDataset):
+        return []
+
+    with pytest.raises(RuntimeError, match="no test_ids were accessed"):
+        harness.run(noop_runner, split=BenchmarkSplit.TEST)
 
 
 def test_endpoint_dev_split_is_not_held_out():


### PR DESCRIPTION
Closes #5160

## Summary
- \`BenchmarkHarness.score()\` raises \`RuntimeError\` when \`scorer_fn\` returns with \`accessed_test\` still empty — prevents silent "empty run" false-positives
- \`_build_report.held_out\` now requires \`len(self.dataset.accessed_test) > 0\` in addition to existing \`split == TEST\` + no-leakage conditions
- Updated docstring on \`BenchmarkRunReport.held_out_score\` documenting the new requirement
- 2 new tests: \`test_score_with_empty_results_raises\`, \`test_held_out_score_requires_test_access\`

## Test Status
PASS — 17/17