### PR TITLE
refactor(llm): migrate rlm/benchmark.py _generate to call_ollama_generate (#5155)

### DIFF
--- a/autobot-backend/rlm/benchmark.py
+++ b/autobot-backend/rlm/benchmark.py
@@ -26,8 +26,6 @@ import time
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional
 
-import httpx
-
 from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
 from autobot_shared.ssot_config import config as _ssot_config
 from rlm.evaluator import ResponseQualityEvaluator
@@ -143,26 +141,17 @@ async def _generate(
 ) -> str:
     """Call Ollama generate and return the raw text."""
     from autobot_shared.ssot_config import get_config
+    from llm_providers.ollama_helpers import call_ollama_generate
 
     ssot = get_config()
-    url = f"{ssot.ollama_url}/api/generate"
-
-    async with httpx.AsyncClient(timeout=timeout_s) as client:
-        resp = await client.post(
-            url,
-            json={
-                "model": model,
-                "prompt": prompt,
-                "stream": False,
-                "options": {
-                    "temperature": temperature,
-                    "num_predict": max_tokens,
-                },
-            },
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        return data.get("response", "")
+    return await call_ollama_generate(
+        prompt=prompt,
+        model=model,
+        base_url=ssot.ollama_url,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        timeout_ms=int(timeout_s * 1000),
+    )
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #5155

## Summary
4th duplicate of the httpx \`/api/generate\` pattern (after #5102 consolidated the first 3) migrated to canonical \`call_ollama_generate()\` in \`llm_providers/ollama_helpers.py\`.

- \`_generate\` kept as thin wrapper so in-module callers (\`_run_single_pass\`, \`_run_rlm_pass\`) are unchanged
- \`timeout_s\` → \`timeout_ms\` conversion via \`int(timeout_s * 1000)\` matches helper signature
- Removed \`import httpx\` — \`grep httpx.AsyncClient autobot-backend/rlm/\` now returns 0

## Test Status
PASS — py_compile clean; no rlm/ test files exist (pre- and post-migration)