### PR TITLE
refactor(frontend): make knowledge composables return reactive refs + managed fetch state (#5149)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useKnowledgeCategories.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeCategories.test.ts
@@ -236,4 +236,56 @@ describe('useKnowledgeCategories', () => {
       expect(getCategoryIcon('SeCuRiTy')).toBe('fas fa-shield-alt')
     })
   })
+
+  describe('reactive refs + refresh (#5149)', () => {
+    it('should populate categories + isLoading refs on refresh', async () => {
+      const mockResponse: CategoriesListResponse = {
+        categories: [{ name: 'security', count: 3, id: 's-1' }],
+        total: 1,
+      }
+      vi.mocked(apiClient.get).mockResolvedValue(mockResponse)
+
+      const { categories, isLoading, error, refresh } = useKnowledgeCategories()
+
+      expect(categories.value).toEqual([])
+      expect(isLoading.value).toBe(false)
+
+      const promise = refresh()
+      expect(isLoading.value).toBe(true)
+
+      const data = await promise
+      expect(data).toEqual(mockResponse.categories)
+      expect(categories.value).toEqual(mockResponse.categories)
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('should surface error via error ref when refresh fails', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({ notCategories: [] })
+
+      const { error, isLoading, refresh } = useKnowledgeCategories()
+
+      await expect(refresh()).rejects.toThrow('Invalid categories response format')
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBeInstanceOf(Error)
+    })
+
+    it('refreshCategorizedFacts populates categorizedFacts ref', async () => {
+      const mockCategorizedFacts: CategorizedFactsResponse = {
+        total_facts: 1,
+        categories: {
+          security: [
+            { key: '1', title: 'f1', content: 'c', category: 'security', type: 'general', metadata: {} },
+          ],
+        },
+      }
+      vi.mocked(apiClient.get).mockResolvedValue(mockCategorizedFacts)
+
+      const { categorizedFacts, refreshCategorizedFacts } = useKnowledgeCategories()
+      const data = await refreshCategorizedFacts()
+
+      expect(data).toEqual(mockCategorizedFacts)
+      expect(categorizedFacts.value).toEqual(mockCategorizedFacts)
+    })
+  })
 })

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeStats.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeStats.test.ts
@@ -79,4 +79,53 @@ describe('useKnowledgeStats', () => {
       expect(result).toBe(null)
     })
   })
+
+  describe('reactive refs + refresh (#5149)', () => {
+    it('should expose stats/isLoading/error refs and populate them on refresh', async () => {
+      const mockStats: KnowledgeStats = {
+        total_facts: 42,
+        total_documents: 10,
+      }
+      vi.mocked(apiClient.get).mockResolvedValue(mockStats)
+
+      const { stats, isLoading, error, refresh } = useKnowledgeStats()
+
+      expect(stats.value).toBe(null)
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+
+      const promise = refresh()
+      // isLoading flips true synchronously inside refresh
+      expect(isLoading.value).toBe(true)
+
+      const data = await promise
+      expect(data).toEqual(mockStats)
+      expect(stats.value).toEqual(mockStats)
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('should populate error ref and reset isLoading when refresh throws', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('boom'))
+
+      const { stats, isLoading, error, refresh } = useKnowledgeStats()
+
+      await expect(refresh()).rejects.toThrow('boom')
+      expect(stats.value).toBe(null)
+      expect(isLoading.value).toBe(false)
+      expect(error.value).toBeInstanceOf(Error)
+      expect(error.value?.message).toBe('boom')
+    })
+
+    it('refreshBasic should populate basicStats ref on success', async () => {
+      const mockStats: KnowledgeStats = { total_facts: 5, total_documents: 1 }
+      vi.mocked(apiClient.get).mockResolvedValue(mockStats)
+
+      const { basicStats, refreshBasic } = useKnowledgeStats()
+      const data = await refreshBasic()
+
+      expect(data).toEqual(mockStats)
+      expect(basicStats.value).toEqual(mockStats)
+    })
+  })
 })

--- a/autobot-frontend/src/composables/__tests__/useMachineKnowledge.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useMachineKnowledge.test.ts
@@ -132,4 +132,36 @@ describe('useMachineKnowledge', () => {
       expect(result.status).toBe('queued')
     })
   })
+
+  describe('reactive refs + refresh (#5149)', () => {
+    it('refreshProfiles populates profiles ref + isLoading cycle', async () => {
+      const mockProfiles: MachineProfile[] = [
+        { machine_id: 'host1', os_type: 'linux' },
+      ]
+      vi.mocked(apiClient.get).mockResolvedValue(mockProfiles)
+
+      const { profiles, isLoading, refreshProfiles } = useMachineKnowledge()
+      expect(profiles.value).toEqual([])
+      expect(isLoading.value).toBe(false)
+
+      const promise = refreshProfiles()
+      expect(isLoading.value).toBe(true)
+
+      const data = await promise
+      expect(data).toEqual(mockProfiles)
+      expect(profiles.value).toEqual(mockProfiles)
+      expect(isLoading.value).toBe(false)
+    })
+
+    it('refreshProfile populates profile ref', async () => {
+      const mockProfile: MachineProfile = { machine_id: 'host1', os_type: 'linux' }
+      vi.mocked(apiClient.get).mockResolvedValue(mockProfile)
+
+      const { profile, refreshProfile } = useMachineKnowledge()
+      const data = await refreshProfile('host1')
+
+      expect(data).toEqual(mockProfile)
+      expect(profile.value).toEqual(mockProfile)
+    })
+  })
 })

--- a/autobot-frontend/src/composables/__tests__/useManPages.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useManPages.test.ts
@@ -114,4 +114,35 @@ describe('useManPages', () => {
       expect(result).toEqual(mockResponse)
     })
   })
+
+  describe('reactive refs + refresh (#5149)', () => {
+    it('refresh populates summary ref + isLoading cycle', async () => {
+      const mockSummary: ManPagesSummary = { status: 'ready', processed: 150 }
+      vi.mocked(apiClient.get).mockResolvedValue(mockSummary)
+
+      const { summary, isLoading, refresh } = useManPages()
+      expect(summary.value).toBe(null)
+      expect(isLoading.value).toBe(false)
+
+      const promise = refresh()
+      expect(isLoading.value).toBe(true)
+
+      const data = await promise
+      expect(data).toEqual(mockSummary)
+      expect(summary.value).toEqual(mockSummary)
+      expect(isLoading.value).toBe(false)
+    })
+
+    it('refresh returns null + populates summary with null when bare fn swallows error', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('HTTP 500'))
+
+      const { summary, refresh, isLoading } = useManPages()
+      const data = await refresh()
+
+      // fetchManPagesSummary swallows errors and returns null
+      expect(data).toBe(null)
+      expect(summary.value).toBe(null)
+      expect(isLoading.value).toBe(false)
+    })
+  })
 })

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeCategories.ts
@@ -7,8 +7,14 @@
  * ApiClient already logs retries + final failure and never returns null.
  * Structural validation (Array.isArray / typeof) preserved — it is real
  * business logic, not error-hiding.
+ *
+ * Reactive refs layer (#5149): the composable now owns loading/error state
+ * for `refresh` (categories list) and `refreshCategorizedFacts`. The bare
+ * imperative functions remain exported at module scope for the
+ * `useKnowledgeBase` BC shim and non-reactive consumers.
  */
 
+import { ref, readonly, type Ref } from 'vue'
 import apiClient from '@/utils/ApiClient'
 import { formatCategoryName as formatCategoryHelper } from '@/utils/formatHelpers'
 import { createLogger } from '@/utils/debugUtils'
@@ -58,95 +64,167 @@ export function getCategoryIcon(category: string): string {
   return 'fas fa-folder'
 }
 
-export function useKnowledgeCategories() {
-  /**
-   * Fetch all categories with counts
-   * Returns list of categories with document counts for filtering.
-   */
-  const fetchCategories = async (): Promise<KnowledgeCategoryItem[]> => {
-    const data = await apiClient.get<CategoriesListResponse>(`${getApiBase()}/knowledge_base/categories`)
+// ==================== Bare imperative API ====================
 
-    // Structural validation — real business logic, not error hiding
-    if (!data || !Array.isArray(data.categories)) {
-      throw new Error('Invalid categories response format')
-    }
+/**
+ * Fetch all categories with counts.
+ * Returns list of categories with document counts for filtering.
+ */
+export const fetchCategories = async (): Promise<KnowledgeCategoryItem[]> => {
+  const data = await apiClient.get<CategoriesListResponse>(`${getApiBase()}/knowledge_base/categories`)
 
-    return data.categories
+  // Structural validation — real business logic, not error hiding
+  if (!data || !Array.isArray(data.categories)) {
+    throw new Error('Invalid categories response format')
   }
 
-  /**
-   * Fetch knowledge by category
-   */
-  const fetchCategory = (category: string): Promise<CategoryResponse> =>
-    apiClient.get<CategoryResponse>(`${getApiBase()}/knowledge_base/category/${category}`)
+  return data.categories
+}
 
-  /**
-   * Fetch facts grouped by category for browsing
-   * Uses GET /api/knowledge_base/facts/by_category endpoint.
-   * @param category - Optional category filter (null for all categories)
-   * @param limit - Maximum number of facts per category (default: 100)
-   */
-  const getCategorizedFacts = async (
+/**
+ * Fetch knowledge by category.
+ */
+export const fetchCategory = (category: string): Promise<CategoryResponse> =>
+  apiClient.get<CategoryResponse>(`${getApiBase()}/knowledge_base/category/${category}`)
+
+/**
+ * Fetch facts grouped by category for browsing.
+ * Uses GET /api/knowledge_base/facts/by_category endpoint.
+ * @param category - Optional category filter (null for all categories)
+ * @param limit - Maximum number of facts per category (default: 100)
+ */
+export const getCategorizedFacts = async (
+  category: string | null = null,
+  limit: number = 100
+): Promise<CategorizedFactsResponse> => {
+  const params = new URLSearchParams()
+  if (category) {
+    params.append('category', category)
+  }
+  params.append('limit', String(limit))
+
+  const url = `${getApiBase()}/knowledge_base/facts/by_category?${params.toString()}`
+  const data = await apiClient.get<CategorizedFactsResponse>(url)
+
+  // Structural validation
+  if (!data || typeof data.categories !== 'object') {
+    throw new Error('Invalid categorized facts response format')
+  }
+
+  logger.debug(
+    `Fetched categorized facts: ${data.total_facts} total facts across ${Object.keys(data.categories).length} categories`
+  )
+
+  return data
+}
+
+/**
+ * Build category filter options from categorized facts.
+ * Pure helper — does not fetch, no state needed.
+ */
+export const buildCategoryFilterOptions = (
+  categorizedFacts: CategorizedFactsResponse
+): CategoryFilterOption[] => {
+  const options: CategoryFilterOption[] = [
+    {
+      value: null,
+      label: 'All Categories',
+      icon: 'fas fa-th-large',
+      count: categorizedFacts.total_facts,
+    },
+  ]
+
+  for (const [categoryName, facts] of Object.entries(categorizedFacts.categories)) {
+    options.push({
+      value: categoryName,
+      label: formatCategoryHelper(categoryName),
+      icon: getCategoryIcon(categoryName),
+      count: facts.length,
+    })
+  }
+
+  // Sort by count (descending), keeping "All" at the top
+  options.sort((a, b) => {
+    if (a.value === null) return -1
+    if (b.value === null) return 1
+    return b.count - a.count
+  })
+
+  return options
+}
+
+// ==================== Reactive composable ====================
+
+export interface UseKnowledgeCategoriesReturn {
+  /** Latest categories list. */
+  categories: Readonly<Ref<KnowledgeCategoryItem[]>>
+  /** Latest categorized-facts result. */
+  categorizedFacts: Readonly<Ref<CategorizedFactsResponse | null>>
+  /** True while a refresh is in-flight. */
+  isLoading: Readonly<Ref<boolean>>
+  /** Last error raised by a refresh, cleared on the next call. */
+  error: Readonly<Ref<Error | null>>
+  /** Fetch the categories list, update `categories` + state refs. */
+  refresh: () => Promise<KnowledgeCategoryItem[]>
+  /** Fetch categorized facts, update `categorizedFacts` + state refs. */
+  refreshCategorizedFacts: (
+    category?: string | null,
+    limit?: number
+  ) => Promise<CategorizedFactsResponse>
+  // Imperative passthroughs — BC with pre-#5149 callers
+  fetchCategories: typeof fetchCategories
+  fetchCategory: typeof fetchCategory
+  getCategorizedFacts: typeof getCategorizedFacts
+  buildCategoryFilterOptions: typeof buildCategoryFilterOptions
+  getCategoryIcon: typeof getCategoryIcon
+}
+
+export function useKnowledgeCategories(): UseKnowledgeCategoriesReturn {
+  const categories = ref<KnowledgeCategoryItem[]>([])
+  const categorizedFacts = ref<CategorizedFactsResponse | null>(null)
+  const isLoading = ref(false)
+  const error = ref<Error | null>(null)
+
+  const refresh = async (): Promise<KnowledgeCategoryItem[]> => {
+    isLoading.value = true
+    error.value = null
+    try {
+      const data = await fetchCategories()
+      categories.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  const refreshCategorizedFacts = async (
     category: string | null = null,
     limit: number = 100
   ): Promise<CategorizedFactsResponse> => {
-    const params = new URLSearchParams()
-    if (category) {
-      params.append('category', category)
+    isLoading.value = true
+    error.value = null
+    try {
+      const data = await getCategorizedFacts(category, limit)
+      categorizedFacts.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      isLoading.value = false
     }
-    params.append('limit', String(limit))
-
-    const url = `${getApiBase()}/knowledge_base/facts/by_category?${params.toString()}`
-    const data = await apiClient.get<CategorizedFactsResponse>(url)
-
-    // Structural validation
-    if (!data || typeof data.categories !== 'object') {
-      throw new Error('Invalid categorized facts response format')
-    }
-
-    logger.debug(
-      `Fetched categorized facts: ${data.total_facts} total facts across ${Object.keys(data.categories).length} categories`
-    )
-
-    return data
-  }
-
-  /**
-   * Build category filter options from categorized facts
-   * Helper to create CategoryFilterOption[] for dropdowns/tabs.
-   */
-  const buildCategoryFilterOptions = (
-    categorizedFacts: CategorizedFactsResponse
-  ): CategoryFilterOption[] => {
-    const options: CategoryFilterOption[] = [
-      {
-        value: null,
-        label: 'All Categories',
-        icon: 'fas fa-th-large',
-        count: categorizedFacts.total_facts,
-      },
-    ]
-
-    for (const [categoryName, facts] of Object.entries(categorizedFacts.categories)) {
-      options.push({
-        value: categoryName,
-        label: formatCategoryHelper(categoryName),
-        icon: getCategoryIcon(categoryName),
-        count: facts.length,
-      })
-    }
-
-    // Sort by count (descending), keeping "All" at the top
-    options.sort((a, b) => {
-      if (a.value === null) return -1
-      if (b.value === null) return 1
-      return b.count - a.count
-    })
-
-    return options
   }
 
   return {
+    categories: readonly(categories) as Readonly<Ref<KnowledgeCategoryItem[]>>,
+    categorizedFacts: readonly(categorizedFacts) as Readonly<Ref<CategorizedFactsResponse | null>>,
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    refresh,
+    refreshCategorizedFacts,
     fetchCategories,
     fetchCategory,
     getCategorizedFacts,

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeStats.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeStats.ts
@@ -4,35 +4,99 @@
  * Fetches knowledge base statistics (full and basic).
  * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
  * ApiClient already logs retries + final failure and never returns null.
+ *
+ * Reactive refs layer (#5149): the composable now owns loading/error state
+ * via `ref`s and exposes a `refresh` action. The bare imperative functions
+ * are still exported at module scope so non-reactive consumers (and the
+ * `useKnowledgeBase` BC shim) keep working unchanged.
  */
 
+import { ref, readonly, type Ref } from 'vue'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import type { KnowledgeStats } from '@/types/knowledgeBase'
 
-export function useKnowledgeStats() {
-  /**
-   * Fetch knowledge base statistics
-   */
-  const fetchStats = (): Promise<KnowledgeStats> =>
-    apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats`)
+// ==================== Bare imperative API ====================
 
-  /**
-   * Fetch basic knowledge base statistics
-   * GET /api/knowledge_base/stats/basic
-   *
-   * Returns null on error to preserve previous caller expectations
-   * (UI treats missing basic stats as non-fatal).
-   */
-  const fetchBasicStats = async (): Promise<KnowledgeStats | null> => {
+/**
+ * Fetch knowledge base statistics.
+ */
+export const fetchStats = (): Promise<KnowledgeStats> =>
+  apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats`)
+
+/**
+ * Fetch basic knowledge base statistics.
+ * Returns null on error to preserve previous caller expectations
+ * (UI treats missing basic stats as non-fatal).
+ */
+export const fetchBasicStats = async (): Promise<KnowledgeStats | null> => {
+  try {
+    return await apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats/basic`)
+  } catch {
+    return null
+  }
+}
+
+// ==================== Reactive composable ====================
+
+export interface UseKnowledgeStatsReturn {
+  /** Latest full stats result, or null if never fetched / fetch failed. */
+  stats: Readonly<Ref<KnowledgeStats | null>>
+  /** Latest basic stats result, or null. */
+  basicStats: Readonly<Ref<KnowledgeStats | null>>
+  /** True while any fetch is in-flight. */
+  isLoading: Readonly<Ref<boolean>>
+  /** Last error raised by `refresh`/`refreshBasic`, cleared on the next call. */
+  error: Readonly<Ref<Error | null>>
+  /** Fetch full stats, update `stats` + state refs, return the payload. */
+  refresh: () => Promise<KnowledgeStats | null>
+  /** Fetch basic stats, update `basicStats` + state refs, return the payload. */
+  refreshBasic: () => Promise<KnowledgeStats | null>
+  // Imperative passthroughs — BC with pre-#5149 callers
+  fetchStats: typeof fetchStats
+  fetchBasicStats: typeof fetchBasicStats
+}
+
+export function useKnowledgeStats(): UseKnowledgeStatsReturn {
+  const stats = ref<KnowledgeStats | null>(null)
+  const basicStats = ref<KnowledgeStats | null>(null)
+  const isLoading = ref(false)
+  const error = ref<Error | null>(null)
+
+  const refresh = async (): Promise<KnowledgeStats | null> => {
+    isLoading.value = true
+    error.value = null
     try {
-      return await apiClient.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats/basic`)
-    } catch {
-      return null
+      const data = await fetchStats()
+      stats.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  const refreshBasic = async (): Promise<KnowledgeStats | null> => {
+    isLoading.value = true
+    error.value = null
+    try {
+      const data = await fetchBasicStats()
+      basicStats.value = data
+      return data
+    } finally {
+      isLoading.value = false
     }
   }
 
   return {
+    stats: readonly(stats) as Readonly<Ref<KnowledgeStats | null>>,
+    basicStats: readonly(basicStats) as Readonly<Ref<KnowledgeStats | null>>,
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    refresh,
+    refreshBasic,
     fetchStats,
     fetchBasicStats,
   }

--- a/autobot-frontend/src/composables/knowledge/useMachineKnowledge.ts
+++ b/autobot-frontend/src/composables/knowledge/useMachineKnowledge.ts
@@ -5,8 +5,13 @@
  * machine-specific knowledge entries, and refreshing system knowledge.
  * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
  * ApiClient already logs retries + final failure and never returns null.
+ *
+ * Reactive refs layer (#5149): the composable now owns loading/error state
+ * for `refreshProfiles`/`refreshProfile`. The bare imperative functions
+ * remain exported at module scope for the `useKnowledgeBase` BC shim.
  */
 
+import { ref, readonly, type Ref } from 'vue'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import type {
@@ -23,59 +28,118 @@ export interface MachineProfile {
   architecture?: string
 }
 
-export function useMachineKnowledge() {
-  /**
-   * Fetch all machine profiles.
-   * Issue #552: Fixed path — backend uses singular /api/knowledge_base/machine_profile.
-   * Returns [] on error so consumers can render an empty list without try/catch.
-   */
-  const fetchMachineProfiles = async (): Promise<MachineProfile[]> => {
+// ==================== Bare imperative API ====================
+
+/**
+ * Fetch all machine profiles.
+ * Issue #552: Fixed path — backend uses singular /api/knowledge_base/machine_profile.
+ * Returns [] on error so consumers can render an empty list without try/catch.
+ */
+export const fetchMachineProfiles = async (): Promise<MachineProfile[]> => {
+  try {
+    const data = await apiClient.get<MachineProfile[]>(`${getApiBase()}/knowledge_base/machine_profile`)
+    return Array.isArray(data) ? data : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Fetch machine profile for a specific machine.
+ * Returns null on error so consumers can gate UI on presence.
+ */
+export const fetchMachineProfile = async (machineId: string): Promise<MachineProfile | null> => {
+  try {
+    return await apiClient.get<MachineProfile>(
+      `${getApiBase()}/knowledge_base/machine_profile?machine_id=${encodeURIComponent(machineId)}`
+    )
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Initialize machine knowledge for a specific host.
+ * POST /api/knowledge_base/machine_knowledge/initialize
+ */
+export const initializeMachineKnowledge = (machineId: string): Promise<MachineKnowledgeResponse> =>
+  apiClient.post<MachineKnowledgeResponse>(
+    `${getApiBase()}/knowledge_base/machine_knowledge/initialize`,
+    { machine_id: machineId }
+  )
+
+/**
+ * Refresh system knowledge (rescan and update all system information).
+ * POST /api/knowledge_base/refresh_system_knowledge
+ *
+ * Returns immediately with task_id. Use useKnowledgeJobs().pollJobStatus
+ * to check completion.
+ */
+export const refreshSystemKnowledge = (): Promise<SystemKnowledgeResponse> =>
+  apiClient.post<SystemKnowledgeResponse>(
+    `${getApiBase()}/knowledge_base/refresh_system_knowledge`,
+    {}
+  )
+
+// ==================== Reactive composable ====================
+
+export interface UseMachineKnowledgeReturn {
+  /** Latest list of all machine profiles. */
+  profiles: Readonly<Ref<MachineProfile[]>>
+  /** Latest per-machine profile fetched via `refreshProfile`. */
+  profile: Readonly<Ref<MachineProfile | null>>
+  /** True while any refresh is in-flight. */
+  isLoading: Readonly<Ref<boolean>>
+  /** Last error raised; cleared on next call. */
+  error: Readonly<Ref<Error | null>>
+  /** Fetch all profiles, update `profiles`. */
+  refreshProfiles: () => Promise<MachineProfile[]>
+  /** Fetch one machine's profile, update `profile`. */
+  refreshProfile: (machineId: string) => Promise<MachineProfile | null>
+  // Imperative passthroughs — BC with pre-#5149 callers
+  fetchMachineProfiles: typeof fetchMachineProfiles
+  fetchMachineProfile: typeof fetchMachineProfile
+  initializeMachineKnowledge: typeof initializeMachineKnowledge
+  refreshSystemKnowledge: typeof refreshSystemKnowledge
+}
+
+export function useMachineKnowledge(): UseMachineKnowledgeReturn {
+  const profiles = ref<MachineProfile[]>([])
+  const profile = ref<MachineProfile | null>(null)
+  const isLoading = ref(false)
+  const error = ref<Error | null>(null)
+
+  const refreshProfiles = async (): Promise<MachineProfile[]> => {
+    isLoading.value = true
+    error.value = null
     try {
-      const data = await apiClient.get<MachineProfile[]>(`${getApiBase()}/knowledge_base/machine_profile`)
-      return Array.isArray(data) ? data : []
-    } catch {
-      return []
+      const data = await fetchMachineProfiles()
+      profiles.value = data
+      return data
+    } finally {
+      isLoading.value = false
     }
   }
 
-  /**
-   * Fetch machine profile for a specific machine.
-   * Returns null on error so consumers can gate UI on presence.
-   */
-  const fetchMachineProfile = async (machineId: string): Promise<MachineProfile | null> => {
+  const refreshProfile = async (machineId: string): Promise<MachineProfile | null> => {
+    isLoading.value = true
+    error.value = null
     try {
-      return await apiClient.get<MachineProfile>(
-        `${getApiBase()}/knowledge_base/machine_profile?machine_id=${encodeURIComponent(machineId)}`
-      )
-    } catch {
-      return null
+      const data = await fetchMachineProfile(machineId)
+      profile.value = data
+      return data
+    } finally {
+      isLoading.value = false
     }
   }
-
-  /**
-   * Initialize machine knowledge for a specific host.
-   * POST /api/knowledge_base/machine_knowledge/initialize
-   */
-  const initializeMachineKnowledge = (machineId: string): Promise<MachineKnowledgeResponse> =>
-    apiClient.post<MachineKnowledgeResponse>(
-      `${getApiBase()}/knowledge_base/machine_knowledge/initialize`,
-      { machine_id: machineId }
-    )
-
-  /**
-   * Refresh system knowledge (rescan and update all system information).
-   * POST /api/knowledge_base/refresh_system_knowledge
-   *
-   * Returns immediately with task_id. Use useKnowledgeJobs().pollJobStatus
-   * to check completion.
-   */
-  const refreshSystemKnowledge = (): Promise<SystemKnowledgeResponse> =>
-    apiClient.post<SystemKnowledgeResponse>(
-      `${getApiBase()}/knowledge_base/refresh_system_knowledge`,
-      {}
-    )
 
   return {
+    profiles: readonly(profiles) as Readonly<Ref<MachineProfile[]>>,
+    profile: readonly(profile) as Readonly<Ref<MachineProfile | null>>,
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    refreshProfiles,
+    refreshProfile,
     fetchMachineProfiles,
     fetchMachineProfile,
     initializeMachineKnowledge,

--- a/autobot-frontend/src/composables/knowledge/useManPages.ts
+++ b/autobot-frontend/src/composables/knowledge/useManPages.ts
@@ -6,8 +6,13 @@
  * pattern with man pages).
  * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
  * ApiClient already logs retries + final failure and never returns null.
+ *
+ * Reactive refs layer (#5149): the composable now owns loading/error state
+ * for `refresh` (summary fetch). The bare imperative functions remain
+ * exported at module scope for the `useKnowledgeBase` BC shim.
  */
 
+import { ref, readonly, type Ref } from 'vue'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import type {
@@ -27,61 +32,102 @@ export interface ManPagesSummary {
   available_commands?: string[]
 }
 
-export function useManPages() {
-  /**
-   * Fetch man pages summary.
-   * Returns null on error so consumers can treat missing summary as non-fatal.
-   */
-  const fetchManPagesSummary = async (): Promise<ManPagesSummary | null> => {
+// ==================== Bare imperative API ====================
+
+/**
+ * Fetch man pages summary.
+ * Returns null on error so consumers can treat missing summary as non-fatal.
+ */
+export const fetchManPagesSummary = async (): Promise<ManPagesSummary | null> => {
+  try {
+    return await apiClient.get<ManPagesSummary>(`${getApiBase()}/knowledge_base/man_pages/summary`)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Integrate man pages for a specific machine.
+ */
+export const integrateManPages = (machineId: string): Promise<IntegrationResponse> =>
+  apiClient.post<IntegrationResponse>(
+    `${getApiBase()}/knowledge_base/man_pages/integrate`,
+    { machine_id: machineId }
+  )
+
+/**
+ * Populate man pages for a specific machine.
+ * POST /api/knowledge_base/populate_man_pages
+ */
+export const populateManPages = (machineId: string): Promise<ManPagesPopulateResponse> =>
+  apiClient.post<ManPagesPopulateResponse>(
+    `${getApiBase()}/knowledge_base/populate_man_pages`,
+    { machine_id: machineId }
+  )
+
+/**
+ * Populate AutoBot documentation.
+ * POST /api/knowledge_base/populate_autobot_docs
+ */
+export const populateAutoBotDocs = (): Promise<AutoBotDocsResponse> =>
+  apiClient.post<AutoBotDocsResponse>(
+    `${getApiBase()}/knowledge_base/populate_autobot_docs`,
+    {}
+  )
+
+/**
+ * Search man pages (placeholder — current backend search returns man
+ * pages through the unified /search endpoint; callers should invoke
+ * useKnowledgeFacts().searchKnowledge with a man-page filter instead).
+ * Kept as a thin wrapper here for API discoverability.
+ */
+export const searchManPages = (query: string) =>
+  apiClient.post(`${getApiBase()}/knowledge_base/search`, {
+    query,
+    category: 'man_pages',
+  })
+
+// ==================== Reactive composable ====================
+
+export interface UseManPagesReturn {
+  /** Latest man-pages summary. */
+  summary: Readonly<Ref<ManPagesSummary | null>>
+  /** True while any refresh is in-flight. */
+  isLoading: Readonly<Ref<boolean>>
+  /** Last error; cleared on next call. */
+  error: Readonly<Ref<Error | null>>
+  /** Fetch summary, update `summary`. */
+  refresh: () => Promise<ManPagesSummary | null>
+  // Imperative passthroughs — BC with pre-#5149 callers
+  fetchManPagesSummary: typeof fetchManPagesSummary
+  integrateManPages: typeof integrateManPages
+  populateManPages: typeof populateManPages
+  populateAutoBotDocs: typeof populateAutoBotDocs
+  searchManPages: typeof searchManPages
+}
+
+export function useManPages(): UseManPagesReturn {
+  const summary = ref<ManPagesSummary | null>(null)
+  const isLoading = ref(false)
+  const error = ref<Error | null>(null)
+
+  const refresh = async (): Promise<ManPagesSummary | null> => {
+    isLoading.value = true
+    error.value = null
     try {
-      return await apiClient.get<ManPagesSummary>(`${getApiBase()}/knowledge_base/man_pages/summary`)
-    } catch {
-      return null
+      const data = await fetchManPagesSummary()
+      summary.value = data
+      return data
+    } finally {
+      isLoading.value = false
     }
   }
 
-  /**
-   * Integrate man pages for a specific machine.
-   */
-  const integrateManPages = (machineId: string): Promise<IntegrationResponse> =>
-    apiClient.post<IntegrationResponse>(
-      `${getApiBase()}/knowledge_base/man_pages/integrate`,
-      { machine_id: machineId }
-    )
-
-  /**
-   * Populate man pages for a specific machine.
-   * POST /api/knowledge_base/populate_man_pages
-   */
-  const populateManPages = (machineId: string): Promise<ManPagesPopulateResponse> =>
-    apiClient.post<ManPagesPopulateResponse>(
-      `${getApiBase()}/knowledge_base/populate_man_pages`,
-      { machine_id: machineId }
-    )
-
-  /**
-   * Populate AutoBot documentation.
-   * POST /api/knowledge_base/populate_autobot_docs
-   */
-  const populateAutoBotDocs = (): Promise<AutoBotDocsResponse> =>
-    apiClient.post<AutoBotDocsResponse>(
-      `${getApiBase()}/knowledge_base/populate_autobot_docs`,
-      {}
-    )
-
-  /**
-   * Search man pages (placeholder — current backend search returns man
-   * pages through the unified /search endpoint; callers should invoke
-   * useKnowledgeFacts().searchKnowledge with a man-page filter instead).
-   * Kept as a thin wrapper here for API discoverability.
-   */
-  const searchManPages = (query: string) =>
-    apiClient.post(`${getApiBase()}/knowledge_base/search`, {
-      query,
-      category: 'man_pages',
-    })
-
   return {
+    summary: readonly(summary) as Readonly<Ref<ManPagesSummary | null>>,
+    isLoading: readonly(isLoading),
+    error: readonly(error),
+    refresh,
     fetchManPagesSummary,
     integrateManPages,
     populateManPages,


### PR DESCRIPTION
Closes #5149

## Summary
4 composables refactored to return reactive refs + managed fetch actions while keeping the bare async functions as module-scope exports for backward compatibility:
- \`useKnowledgeStats\` — \`{ stats, isLoading, error, fetchStats, refresh }\` + bare \`fetchStats\`, \`fetchBasicStats\`
- \`useKnowledgeCategories\` — \`{ categories, isLoading, error, refresh, refreshCategorizedFacts }\` + bare fetch fns
- \`useMachineKnowledge\` — \`{ profiles, profile, isLoading, error, refreshProfiles, refreshProfile }\` + bare fns
- \`useManPages\` — \`{ summary, isLoading, error, refresh }\` + bare fns

All existing \`const { fetchStats } = useKnowledgeStats()\` destructures and the \`useKnowledgeBase\` BC shim continue to work unchanged.

Added 9 tests covering ref transitions during success/error cycles (isLoading true → false, error population on throw, refs populated on success).

## Test Status
PASS — 44/44 on refactored files + BC shim; vue-tsc net +0 new errors