### PR TITLE
refactor(composables): rehome useAnalyticsEndpoint -> useFetchEndpoint with flipped defaults (#5153 C)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsEndpoint.ts
@@ -3,159 +3,55 @@
 // Author: mrveiss
 
 /**
- * Composable: useAnalyticsEndpoint
+ * Analytics-domain alias for `useFetchEndpoint` (#5153 scope C rehome).
  *
- * Generic GET-fetcher for analytics-style endpoints. Collapses the
- * 14x near-identical boilerplate that lived in useAnalyticsDataFetchers:
- *   loading flag → clear error → resolve backendUrl → withSourceId (opt-out)
- *   → fetchWithAuth → !ok throw → json() → status branching → assign
- *   → catch → finally.
+ * Preserves existing analytics semantics:
+ *   - `deps.withSourceId` is REQUIRED (not optional).
+ *   - `scopeToSource` defaults to **true** — forgetting to scope a
+ *     source-namespaced endpoint was the #5111 bug class and the whole
+ *     point of introducing the composable originally (#5112).
  *
- * Key design: `scopeToSource` defaults to TRUE so forgetting to wire it
- * (the #5111 class of bugs) is impossible without an explicit opt-out.
+ * Callers that want to opt out (e.g. `/api/unified/report`) pass
+ * `scopeToSource: false` explicitly — same spelling as before.
  *
- * Issue #5112.
+ * @deprecated New code should import `useFetchEndpoint` from
+ *   `@/composables/api/useFetchEndpoint` directly and pass
+ *   `scopeToSource: true` (plus the analytics `withSourceId`) when
+ *   source scoping is needed. This alias is kept for one release cycle
+ *   to avoid churning the 14+ existing analytics call-sites.
+ *
+ * Original issues: #5111 (bug class), #5112 (introduced),
+ * #5137 (merged), #5154 (audit), #5153 (wave-2 umbrella), #5164 (POC).
  */
 
-import { ref, type Ref } from 'vue'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
-import { createLogger } from '@/utils/debugUtils'
+import {
+  useFetchEndpoint,
+  type UseFetchEndpointOptions,
+  type UseFetchEndpointReturn,
+  type FetchEndpointMethod,
+} from '../api/useFetchEndpoint'
 
-const logger = createLogger('useAnalyticsEndpoint')
+export type AnalyticsEndpointMethod = FetchEndpointMethod
 
-export type AnalyticsEndpointMethod = 'GET' | 'POST'
-
-export interface UseAnalyticsEndpointOptions<TRaw, TOut> {
-  /** API path appended to the resolved backend URL, e.g. '/api/analytics/codebase/stats'. */
-  path: string
-  /**
-   * HTTP method. Defaults to 'GET'. Use 'POST' for action endpoints
-   * (e.g. `/api/code-intelligence/analyze`) that accept a JSON body.
-   */
-  method?: AnalyticsEndpointMethod
-  /**
-   * Factory returning the JSON body to send. Called at each `load()` so it
-   * can read fresh reactive state. Ignored when `method === 'GET'`.
-   */
-  body?: () => unknown
-  /**
-   * Whether to wrap the URL with `withSourceId()` before fetching.
-   * Defaults to TRUE — opt-out only. #5111 was caused by forgetting this,
-   * so the only way to skip source scoping is now an explicit `false`.
-   */
-  scopeToSource?: boolean
-  /**
-   * Reducer from raw JSON to the target data type.
-   * Return `null` to indicate "no data" (leaves `data` as null without error).
-   * Status-branching (success / no_data / indexing) lives here.
-   */
-  pickData: (raw: TRaw) => TOut | null
-  /** Optional side-effect fired after `data` is assigned on success. */
-  onSuccess?: (data: TOut, raw: TRaw) => void
-  /** Optional side-effect fired when `pickData` returns null (no-data path). */
-  onNoData?: () => void
-  /**
-   * Optional side-effect fired when fetch fails or throws. Receives the
-   * resolved error message (same value that lands in `error.value`).
-   */
-  onError?: (message: string, err: unknown) => void
-  /** Human-readable label used only for log messages. */
-  label?: string
-}
+export type UseAnalyticsEndpointOptions<TRaw, TOut> =
+  UseFetchEndpointOptions<TRaw, TOut>
 
 export interface UseAnalyticsEndpointDeps {
+  /** Required in the analytics alias (ensures #5111-class bugs are
+      prevented by construction). */
   withSourceId: (url: string) => string
 }
 
-export interface UseAnalyticsEndpointReturn<TOut> {
-  data: Ref<TOut | null>
-  loading: Ref<boolean>
-  error: Ref<string>
-  load: (queryExtras?: Record<string, string>) => Promise<void>
-}
-
-/**
- * Appends a query-extras map to a URL, preserving any existing query string
- * added by `withSourceId()`. Skips empty values.
- */
-function appendQueryExtras(
-  url: string,
-  extras?: Record<string, string>,
-): string {
-  if (!extras) return url
-  const entries = Object.entries(extras).filter(
-    ([, v]) => v !== undefined && v !== null && v !== '',
-  )
-  if (entries.length === 0) return url
-  const sep = url.includes('?') ? '&' : '?'
-  const qs = entries
-    .map(
-      ([k, v]) =>
-        `${encodeURIComponent(k)}=${encodeURIComponent(v)}`,
-    )
-    .join('&')
-  return `${url}${sep}${qs}`
-}
+export type UseAnalyticsEndpointReturn<TOut> = UseFetchEndpointReturn<TOut>
 
 export function useAnalyticsEndpoint<TRaw, TOut>(
-  opts: UseAnalyticsEndpointOptions<TRaw, TOut>,
+  opts: UseFetchEndpointOptions<TRaw, TOut>,
   deps: UseAnalyticsEndpointDeps,
-): UseAnalyticsEndpointReturn<TOut> {
-  const data = ref<TOut | null>(null) as Ref<TOut | null>
-  const loading = ref(false)
-  const error = ref('')
-
-  const scopeToSource = opts.scopeToSource !== false
-  const method: AnalyticsEndpointMethod = opts.method ?? 'GET'
-  const label = opts.label ?? opts.path
-
-  const load = async (
-    queryExtras?: Record<string, string>,
-  ): Promise<void> => {
-    loading.value = true
-    error.value = ''
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      let url = `${backendUrl}${opts.path}`
-      if (scopeToSource) {
-        url = deps.withSourceId(url)
-      }
-      url = appendQueryExtras(url, queryExtras)
-
-      const init: RequestInit = {
-        method,
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      }
-      if (method === 'POST' && opts.body) {
-        init.body = JSON.stringify(opts.body())
-      }
-      const response = await fetchWithAuth(url, init)
-      if (!response.ok) {
-        throw new Error(`${label} returned ${response.status}`)
-      }
-      const raw = (await response.json()) as TRaw
-      const picked = opts.pickData(raw)
-      if (picked === null) {
-        data.value = null
-        opts.onNoData?.()
-        return
-      }
-      data.value = picked
-      opts.onSuccess?.(picked, raw)
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err)
-      logger.error(`Failed to load ${label}:`, err)
-      error.value = message
-      data.value = null
-      opts.onError?.(message, err)
-    } finally {
-      loading.value = false
-    }
-  }
-
-  return { data, loading, error, load }
+): UseFetchEndpointReturn<TOut> {
+  // Default scopeToSource=true for analytics callers; opts.scopeToSource
+  // (including explicit false) overrides — `loadUnifiedReport` relies on this.
+  return useFetchEndpoint<TRaw, TOut>(
+    { scopeToSource: true, ...opts },
+    deps,
+  )
 }

--- a/autobot-frontend/src/composables/api/useFetchEndpoint.test.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.test.ts
@@ -1,0 +1,198 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Unit tests for the rehomed useFetchEndpoint.
+ *
+ * Focuses on the DIFFERENCES from the analytics-domain alias:
+ *   - `deps` is OPTIONAL
+ *   - `scopeToSource` defaults FALSE
+ *   - warns but doesn't throw when scopeToSource=true without withSourceId
+ *
+ * The analytics alias is covered by the pre-existing
+ * composables/analytics/useAnalyticsEndpoint.test.ts (which exercises the
+ * default-true scopeToSource path through the alias).
+ *
+ * Issue #5153 scope C.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/utils/fetchWithAuth', () => ({
+  fetchWithAuth: vi.fn(),
+}))
+
+vi.mock('@/config/AppConfig.js', () => ({
+  default: {
+    getServiceUrl: vi.fn(async () => 'http://backend.test'),
+  },
+}))
+
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import { useFetchEndpoint } from './useFetchEndpoint'
+
+const mockedFetch = vi.mocked(fetchWithAuth)
+
+interface RawPayload {
+  ok: boolean
+  value?: number
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('useFetchEndpoint (rehomed)', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset()
+  })
+
+  it('works with NO deps argument (deps is optional)', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: true, value: 42 }),
+    )
+    const { data, load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/templates/templates',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+    })
+    // no deps passed at all
+    await load()
+    expect(data.value).toBe(42)
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toBe('http://backend.test/api/templates/templates')
+  })
+
+  it('defaults scopeToSource to false (does NOT call withSourceId even when provided)', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: true, value: 1 }),
+    )
+    const withSourceId = vi.fn((u: string) => `${u}?source_id=s1`)
+    const { load } = useFetchEndpoint<RawPayload, number>(
+      {
+        path: '/api/whatever',
+        pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+      },
+      { withSourceId },
+    )
+    await load()
+    expect(withSourceId).not.toHaveBeenCalled()
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toBe('http://backend.test/api/whatever')
+  })
+
+  it('scopeToSource=true with deps.withSourceId wraps the URL', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: true, value: 1 }),
+    )
+    const withSourceId = vi.fn((u: string) => `${u}?source_id=s42`)
+    const { load } = useFetchEndpoint<RawPayload, number>(
+      {
+        path: '/api/analytics/codebase/stats',
+        scopeToSource: true,
+        pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+      },
+      { withSourceId },
+    )
+    await load()
+    expect(withSourceId).toHaveBeenCalledTimes(1)
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toBe('http://backend.test/api/analytics/codebase/stats?source_id=s42')
+  })
+
+  it('scopeToSource=true with NO deps falls back to identity and does not throw', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: true, value: 7 }),
+    )
+    const { data, error, load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/analytics/codebase/stats',
+      scopeToSource: true,
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+    })
+    await load()
+    expect(error.value).toBe('')
+    expect(data.value).toBe(7)
+    // URL unchanged — identity fallback
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toBe('http://backend.test/api/analytics/codebase/stats')
+  })
+
+  it('scopeToSource=true with deps={} (withSourceId omitted) falls back to identity', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: true, value: 1 }),
+    )
+    const { data, load } = useFetchEndpoint<RawPayload, number>(
+      {
+        path: '/api/x',
+        scopeToSource: true,
+        pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+      },
+      {}, // empty deps
+    )
+    await load()
+    expect(data.value).toBe(1)
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toBe('http://backend.test/api/x')
+  })
+
+  it('POST with body works without deps', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: true, value: 3 }),
+    )
+    const { load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/things/analyze',
+      method: 'POST',
+      body: () => ({ trigger: 'manual' }),
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+    })
+    await load()
+    const init = mockedFetch.mock.calls[0]?.[1] as RequestInit | undefined
+    expect(init?.method).toBe('POST')
+    expect(init?.body).toBe(JSON.stringify({ trigger: 'manual' }))
+  })
+
+  it('queryExtras still appended when scopeToSource=false', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: true, value: 1 }),
+    )
+    const { load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/search',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+    })
+    await load({ q: 'claude', limit: '5' })
+    const url = mockedFetch.mock.calls[0]?.[0] as string
+    expect(url).toContain('q=claude')
+    expect(url).toContain('limit=5')
+  })
+
+  it('error path populates error.value and clears data (unchanged from alias)', async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse({}, 500))
+    const { data, error, load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/boom',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+      label: 'Boom endpoint',
+    })
+    await load()
+    expect(data.value).toBeNull()
+    expect(error.value).toContain('Boom endpoint returned 500')
+  })
+
+  it('pickData null -> no-data path (onNoData fires, data stays null, no error)', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: false }),
+    )
+    const onNoData = vi.fn()
+    const { data, error, load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/x',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+      onNoData,
+    })
+    await load()
+    expect(data.value).toBeNull()
+    expect(error.value).toBe('')
+    expect(onNoData).toHaveBeenCalledTimes(1)
+  })
+})

--- a/autobot-frontend/src/composables/api/useFetchEndpoint.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.ts
@@ -1,0 +1,176 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Composable: useFetchEndpoint
+ *
+ * Generic single-call fetcher that collapses the loading / error /
+ * status-branch / assign boilerplate repeated across Vue composables.
+ *
+ * Originally shipped as `analytics/useAnalyticsEndpoint` (#5112). Rehomed
+ * here per the audit in #5154 so non-analytics callers (workflow templates,
+ * pattern analysis, landing pages) can use it without the source-scoping
+ * friction baked into the analytics default.
+ *
+ * Differences vs the analytics-domain alias:
+ *   - `deps` is OPTIONAL.           (analytics alias: required)
+ *   - `scopeToSource` defaults FALSE. (analytics alias: true, preserving #5111)
+ *   - `withSourceId` defaults to identity (no-op) when deps is omitted.
+ *
+ * Source-scoping stays explicit: `scopeToSource: true` + a `deps.withSourceId`
+ * injection point. The analytics alias flips the default back for its own
+ * callers so the #5111 bug class remains structurally prevented there.
+ *
+ * Issue #5153 scope C.
+ */
+
+import { ref, type Ref } from 'vue'
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+import appConfig from '@/config/AppConfig.js'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('useFetchEndpoint')
+
+export type FetchEndpointMethod = 'GET' | 'POST'
+
+export interface UseFetchEndpointOptions<TRaw, TOut> {
+  /** API path appended to the resolved backend URL, e.g. '/api/analytics/codebase/stats'. */
+  path: string
+  /** HTTP method. Defaults to 'GET'. */
+  method?: FetchEndpointMethod
+  /**
+   * Factory returning the JSON body to send. Called at each `load()` so it
+   * reads fresh reactive state. Ignored when `method === 'GET'`.
+   */
+  body?: () => unknown
+  /**
+   * When `true`, wraps the URL with `deps.withSourceId(...)` before fetching.
+   *
+   * Defaults to **false** at this (generic) layer. The analytics-domain
+   * alias flips the default to `true` because forgetting to scope is a
+   * known recurring bug class there (#5111).
+   */
+  scopeToSource?: boolean
+  /**
+   * Reducer from raw JSON to the target data type.
+   * Return `null` to indicate "no data" (leaves `data` as null without error).
+   */
+  pickData: (raw: TRaw) => TOut | null
+  /** Optional side-effect fired after `data` is assigned on success. */
+  onSuccess?: (data: TOut, raw: TRaw) => void
+  /** Optional side-effect fired when `pickData` returns null (no-data path). */
+  onNoData?: () => void
+  /**
+   * Optional side-effect fired when fetch fails or throws. Receives the
+   * resolved error message (same value that lands in `error.value`).
+   */
+  onError?: (message: string, err: unknown) => void
+  /** Human-readable label used only for log messages. */
+  label?: string
+}
+
+export interface UseFetchEndpointDeps {
+  /**
+   * Wraps the URL when `scopeToSource: true`. Optional — defaults to
+   * identity (no-op) so non-analytics callers don't need a shim.
+   */
+  withSourceId?: (url: string) => string
+}
+
+export interface UseFetchEndpointReturn<TOut> {
+  data: Ref<TOut | null>
+  loading: Ref<boolean>
+  error: Ref<string>
+  load: (queryExtras?: Record<string, string>) => Promise<void>
+}
+
+function appendQueryExtras(
+  url: string,
+  extras?: Record<string, string>,
+): string {
+  if (!extras) return url
+  const entries = Object.entries(extras).filter(
+    ([, v]) => v !== undefined && v !== null && v !== '',
+  )
+  if (entries.length === 0) return url
+  const sep = url.includes('?') ? '&' : '?'
+  const qs = entries
+    .map(
+      ([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`,
+    )
+    .join('&')
+  return `${url}${sep}${qs}`
+}
+
+export function useFetchEndpoint<TRaw, TOut>(
+  opts: UseFetchEndpointOptions<TRaw, TOut>,
+  deps?: UseFetchEndpointDeps,
+): UseFetchEndpointReturn<TOut> {
+  const data = ref<TOut | null>(null) as Ref<TOut | null>
+  const loading = ref(false)
+  const error = ref('')
+
+  const scopeToSource = opts.scopeToSource === true
+  const method: FetchEndpointMethod = opts.method ?? 'GET'
+  const label = opts.label ?? opts.path
+
+  if (scopeToSource && !deps?.withSourceId) {
+    // Caller opted in to source scoping but didn't wire the injector.
+    // Fall back to identity so we don't throw at mount time, but log loudly
+    // so the misconfiguration is visible.
+    logger.warn(
+      `scopeToSource=true but no deps.withSourceId provided for ${label}; falling back to identity (no scoping applied)`,
+    )
+  }
+  const withSourceId = deps?.withSourceId ?? ((u: string) => u)
+
+  const load = async (
+    queryExtras?: Record<string, string>,
+  ): Promise<void> => {
+    loading.value = true
+    error.value = ''
+    try {
+      const backendUrl = await appConfig.getServiceUrl('backend')
+      let url = `${backendUrl}${opts.path}`
+      if (scopeToSource) {
+        url = withSourceId(url)
+      }
+      url = appendQueryExtras(url, queryExtras)
+
+      const init: RequestInit = {
+        method,
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      }
+      if (method === 'POST' && opts.body) {
+        init.body = JSON.stringify(opts.body())
+      }
+      const response = await fetchWithAuth(url, init)
+      if (!response.ok) {
+        throw new Error(`${label} returned ${response.status}`)
+      }
+      const raw = (await response.json()) as TRaw
+      const picked = opts.pickData(raw)
+      if (picked === null) {
+        data.value = null
+        opts.onNoData?.()
+        return
+      }
+      data.value = picked
+      opts.onSuccess?.(picked, raw)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`Failed to load ${label}:`, err)
+      error.value = message
+      data.value = null
+      opts.onError?.(message, err)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { data, loading, error, load }
+}

--- a/autobot-frontend/src/composables/useWorkflowTemplates.ts
+++ b/autobot-frontend/src/composables/useWorkflowTemplates.ts
@@ -6,21 +6,23 @@
  * Workflow Templates API composable
  * Issue #778 - Workflow Templates Enhancement
  *
- * GET-fetchers route through `useAnalyticsEndpoint` per #5154 (POC migration).
- * The endpoint composable was introduced for analytics in #5137; this is the
- * proof point that it generalises outside the analytics domain. Workflow
- * templates are global (no source-id concept), so every endpoint opts out of
- * source scoping via `scopeToSource: false`.
+ * GET-fetchers route through `useFetchEndpoint` (POC migrated in #5154,
+ * rehomed from `analytics/useAnalyticsEndpoint` in #5153 scope C). The
+ * rehomed composable defaults `scopeToSource: false` and makes `deps`
+ * optional, so non-analytics callers like this one no longer need the
+ * `scopeToSource: false` + `noScope` shim per call site.
  *
  * POSTs (`createWorkflowFromTemplate`, `executeTemplate`) are intentionally
- * left untouched — `useAnalyticsEndpoint` is GET-only.
+ * left untouched — `useFetchEndpoint` also supports POST now (#5157) but
+ * these endpoints have non-standard response handling (direct `.json()`
+ * return) that doesn't fit `pickData`.
  */
 
 import { ref, computed, watch } from 'vue'
 import appConfig from '@/config/AppConfig.js'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
-import { useAnalyticsEndpoint } from '@/composables/analytics/useAnalyticsEndpoint'
+import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import type {
   WorkflowTemplateSummary,
   WorkflowTemplateDetail,
@@ -32,13 +34,6 @@ import type {
 } from '@/types/workflowTemplates'
 
 const logger = createLogger('useWorkflowTemplates')
-
-/**
- * No-op source-scoper required by `useAnalyticsEndpoint`'s deps contract.
- * Workflow templates are global; every call site sets `scopeToSource: false`
- * so this identity wrap never actually fires, but the deps shape is required.
- */
-const noScope = { withSourceId: (url: string) => url }
 
 export function useWorkflowTemplates() {
   const loading = ref(false)
@@ -58,66 +53,50 @@ export function useWorkflowTemplates() {
   // Endpoints that need a path parameter (`fetchTemplateDetail`,
   // `previewTemplate`) are constructed inside their wrapper function below.
 
-  const templatesEndpoint = useAnalyticsEndpoint<
+  const templatesEndpoint = useFetchEndpoint<
     { templates?: WorkflowTemplateSummary[] },
     WorkflowTemplateSummary[]
-  >(
-    {
-      path: '/api/templates/templates',
-      scopeToSource: false,
-      label: 'Templates list',
-      pickData: (raw) => raw.templates ?? [],
-      onSuccess: (d) => { templates.value = d },
-      onError: (msg) => { error.value = `Failed to fetch templates: ${msg}` },
-    },
-    noScope,
-  )
+  >({
+    path: '/api/templates/templates',
+    label: 'Templates list',
+    pickData: (raw) => raw.templates ?? [],
+    onSuccess: (d) => { templates.value = d },
+    onError: (msg) => { error.value = `Failed to fetch templates: ${msg}` },
+  })
 
-  const searchEndpoint = useAnalyticsEndpoint<
+  const searchEndpoint = useFetchEndpoint<
     { results?: WorkflowTemplateSummary[] },
     WorkflowTemplateSummary[]
-  >(
-    {
-      path: '/api/templates/templates/search',
-      scopeToSource: false,
-      label: 'Templates search',
-      pickData: (raw) => raw.results ?? [],
-      onError: (msg) => { error.value = `Failed to search templates: ${msg}` },
-    },
-    noScope,
-  )
+  >({
+    path: '/api/templates/templates/search',
+    label: 'Templates search',
+    pickData: (raw) => raw.results ?? [],
+    onError: (msg) => { error.value = `Failed to search templates: ${msg}` },
+  })
 
-  const categoriesEndpoint = useAnalyticsEndpoint<
+  const categoriesEndpoint = useFetchEndpoint<
     { categories?: TemplateCategoryInfo[] },
     TemplateCategoryInfo[]
-  >(
-    {
-      path: '/api/templates/templates/categories',
-      scopeToSource: false,
-      label: 'Templates categories',
-      pickData: (raw) => raw.categories ?? [],
-      onSuccess: (d) => { categories.value = d },
-      // Original `fetchCategories` logs but does NOT surface to error.value.
-      onError: () => { /* logger.error already fired inside endpoint */ },
-    },
-    noScope,
-  )
+  >({
+    path: '/api/templates/templates/categories',
+    label: 'Templates categories',
+    pickData: (raw) => raw.categories ?? [],
+    onSuccess: (d) => { categories.value = d },
+    // Original `fetchCategories` logs but does NOT surface to error.value.
+    onError: () => { /* logger.error already fired inside endpoint */ },
+  })
 
-  const statsEndpoint = useAnalyticsEndpoint<
+  const statsEndpoint = useFetchEndpoint<
     { statistics?: TemplateStatsResponse['statistics'] },
     TemplateStatsResponse['statistics']
-  >(
-    {
-      path: '/api/templates/templates/stats',
-      scopeToSource: false,
-      label: 'Templates stats',
-      pickData: (raw) => raw.statistics ?? null,
-      onSuccess: (d) => { stats.value = d },
-      // Original `fetchStats` logs but does NOT surface to error.value.
-      onError: () => { /* logger.error already fired inside endpoint */ },
-    },
-    noScope,
-  )
+  >({
+    path: '/api/templates/templates/stats',
+    label: 'Templates stats',
+    pickData: (raw) => raw.statistics ?? null,
+    onSuccess: (d) => { stats.value = d },
+    // Original `fetchStats` logs but does NOT surface to error.value.
+    onError: () => { /* logger.error already fired inside endpoint */ },
+  })
 
   // Bridge per-endpoint loading flags into the composable-level `loading` ref
   // so the public API (consumers reading `loading.value`) is preserved.
@@ -160,23 +139,19 @@ export function useWorkflowTemplates() {
     error.value = null
     ondemandLoading.value = true
     try {
-      const detailEndpoint = useAnalyticsEndpoint<
+      const detailEndpoint = useFetchEndpoint<
         { template?: WorkflowTemplateDetail },
         WorkflowTemplateDetail
-      >(
-        {
-          path: `/api/templates/templates/${templateId}`,
-          scopeToSource: false,
-          label: 'Template detail',
-          pickData: (raw) => raw.template ?? null,
-          onSuccess: (d) => { selectedTemplate.value = d },
-          // Original assigned `data.template` (possibly undefined) unconditionally.
-          // Preserve "clear on missing" behaviour via onNoData.
-          onNoData: () => { selectedTemplate.value = null },
-          onError: (msg) => { error.value = `Failed to fetch template: ${msg}` },
-        },
-        noScope,
-      )
+      >({
+        path: `/api/templates/templates/${templateId}`,
+        label: 'Template detail',
+        pickData: (raw) => raw.template ?? null,
+        onSuccess: (d) => { selectedTemplate.value = d },
+        // Original assigned `data.template` (possibly undefined) unconditionally.
+        // Preserve "clear on missing" behaviour via onNoData.
+        onNoData: () => { selectedTemplate.value = null },
+        onError: (msg) => { error.value = `Failed to fetch template: ${msg}` },
+      })
       await detailEndpoint.load()
       return detailEndpoint.data.value
     } finally {
@@ -211,20 +186,16 @@ export function useWorkflowTemplates() {
       if (variables && Object.keys(variables).length > 0) {
         query.variables = JSON.stringify(variables)
       }
-      const previewEndpoint = useAnalyticsEndpoint<
+      const previewEndpoint = useFetchEndpoint<
         TemplatePreviewResponse,
         TemplatePreviewResponse
-      >(
-        {
-          path: `/api/templates/templates/${templateId}/preview`,
-          scopeToSource: false,
-          label: 'Template preview',
-          pickData: (raw) => raw,
-          onSuccess: (d) => { preview.value = d },
-          onError: (msg) => { error.value = `Failed to preview template: ${msg}` },
-        },
-        noScope,
-      )
+      >({
+        path: `/api/templates/templates/${templateId}/preview`,
+        label: 'Template preview',
+        pickData: (raw) => raw,
+        onSuccess: (d) => { preview.value = d },
+        onError: (msg) => { error.value = `Failed to preview template: ${msg}` },
+      })
       await previewEndpoint.load(query)
       return previewEndpoint.data.value
     } finally {


### PR DESCRIPTION
## Summary

Third sub-PR of #5153 wave-2. Implements the audit-recommended rehome (#5154 Recommendation 1) and the two ergonomic fixes the POC migration surfaced (#5164):

- **Move** the generic GET/POST fetcher to `composables/api/useFetchEndpoint.ts`.
- **Make `deps` optional** — non-analytics callers no longer need a `noScope = { withSourceId: (u) => u }` shim.
- **Flip `scopeToSource` default to `false`** at the generic layer. Explicit `true` opts in; callers without a `withSourceId` injector fall back to identity with a logger.warn (no throw at mount).

The analytics-domain alias at `composables/analytics/useAnalyticsEndpoint.ts` survives as a **deprecated thin wrapper** that flips `scopeToSource: true` back by default \u2014 preserving #5111 bug prevention for the 14+ existing analytics call-sites and avoiding a code-churn storm.

Tracks #5153 scope C.

## Proof-point migration

`useWorkflowTemplates.ts` (the POC from PR #5164 / issue #5154) is migrated to `useFetchEndpoint` directly:

- **6 x `scopeToSource: false` dropped** (now the default).
- **`noScope` shim declaration + 6 usages dropped** (`deps` is now optional).
- File shrinks **337 -> 308 LOC** (-29), partially reversing the +86 LOC regression that #5164 honestly flagged as the ergonomic-friction cost.

The analytics alias shrinks **145 -> 57 LOC** (it is now a documentation-heavy 6-line wrapper).

## Test strategy

- **New `composables/api/useFetchEndpoint.test.ts`** covers the flipped defaults: no-deps call, default-false scoping, explicit-true opt-in with deps, identity fallback when scopeToSource=true but no `withSourceId`, POST + body, queryExtras, no-data and error paths.
- **Pre-existing `composables/analytics/useAnalyticsEndpoint.test.ts`** now exercises the alias unchanged. Its 8 passing tests remain green \u2014 regression coverage that analytics semantics (default-true scoping) still work end-to-end.
- Combined: **17/17 green**.
- `vue-tsc --noEmit -p tsconfig.app.json`: zero new errors on changed files, 169 baseline (unrelated) errors unchanged.

## Behavioural delta

- `useAnalyticsEndpoint` callers: **none**. The alias matches the old signature and defaults.
- `useFetchEndpoint` direct callers: see `useWorkflowTemplates.ts` \u2014 identical public API, identical network behaviour, 29 LOC less ceremony.
- New warning log when `scopeToSource: true` is set without a `withSourceId` injector. Falls back to identity so nothing breaks at runtime; the log makes the misconfiguration visible during dev.

## Rebase impact on currently-open sibling PRs

- **#5157** (`scope A-1`: POST + `useCodeSmellAnalysis`): imports `useAnalyticsEndpoint` \u2014 will rebase cleanly through the alias. No changes needed.
- **#5162** (`scope D-2`: `runTimed` extraction): touches `useAnalyticsDataFetchers.ts` only. No import changes. No conflict expected.
- **#5159** (cytoscape fix): unrelated. No conflict.

I can rebase either sibling PR on top of this one once it merges, or keep them stacked against Dev_new_gui directly \u2014 both paths produce the same final tree.

## Related

- Umbrella: #5153
- Audit that recommended this rehome: #5154 / PR #5164 (merged)
- Original composable: #5112 / PR #5137 (merged)
- Bug class the analytics alias preserves: #5111

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)