### PR TITLE
refactor(redis): route backend accessors through autobot_shared canonical (#5101)

### DIFF
--- a/autobot-backend/api/agent_terminal.py
+++ b/autobot-backend/api/agent_terminal.py
@@ -234,7 +234,7 @@ from pydantic import BaseModel, Field
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.error_constants import ERR_SESSION_NOT_FOUND
-from dependencies import get_redis_client
+from autobot_shared.redis_client import get_redis_client
 from services.agent_terminal import AgentSessionState, AgentTerminalService
 from services.command_approval_manager import AgentRole
 from services.command_execution_queue import get_command_queue

--- a/autobot-backend/api/codebase_analytics/chromadb_storage.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage.py
@@ -16,11 +16,12 @@ from typing import Dict, List, Optional
 
 from utils.file_categorization import FILE_CATEGORY_CODE
 
+from autobot_shared.redis_client import get_async_redis_client
+
 from .progress_tracker import FILE_HASH_REDIS_PREFIX
 from .storage import (
     get_code_collection_async,
     get_redis_connection,
-    get_redis_connection_async,
 )
 
 logger = logging.getLogger(__name__)
@@ -343,7 +344,7 @@ async def _clear_redis_codebase_cache(
     Issue #1710: When source_id is provided, only clear keys for that source.
     """
     try:
-        redis_client = await get_redis_connection_async()
+        redis_client = await get_async_redis_client(database="analytics")
         if redis_client:
             # Scope key pattern to source_id when provided (#1710)
             if source_id:

--- a/autobot-backend/api/codebase_analytics/progress_tracker.py
+++ b/autobot-backend/api/codebase_analytics/progress_tracker.py
@@ -15,9 +15,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from constants.ttl_constants import TTL_24_HOURS
+from autobot_shared.redis_client import get_async_redis_client
 
-from .storage import get_redis_connection_async
+from constants.ttl_constants import TTL_24_HOURS
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +140,7 @@ async def _file_needs_reindex(
 async def _save_task_to_redis(task_id: str, indexing_tasks: Dict) -> None:
     """Persist task state to Redis so all uvicorn workers can read it (#1179)."""
     try:
-        redis = await get_redis_connection_async()
+        redis = await get_async_redis_client(database="analytics")
         if redis:
             state = indexing_tasks.get(task_id)
             if state:
@@ -158,7 +158,7 @@ async def _save_task_to_redis(task_id: str, indexing_tasks: Dict) -> None:
 async def _load_task_from_redis(task_id: str) -> Optional[Dict]:
     """Load task state from Redis (#1179: cross-worker visibility)."""
     try:
-        redis = await get_redis_connection_async()
+        redis = await get_async_redis_client(database="analytics")
         if redis:
             data = await redis.get(f"{_TASK_REDIS_PREFIX}{task_id}")
             if data:
@@ -178,7 +178,7 @@ async def _load_task_from_redis(task_id: str) -> Optional[Dict]:
 async def _persist_queue_entry(entry: Dict) -> None:
     """Append a queue entry to Redis list (#1717)."""
     try:
-        redis = await get_redis_connection_async()
+        redis = await get_async_redis_client(database="analytics")
         if redis:
             await redis.rpush(_QUEUE_REDIS_KEY, json.dumps(entry, default=str))
     except Exception as e:
@@ -188,7 +188,7 @@ async def _persist_queue_entry(entry: Dict) -> None:
 async def _pop_queue_entry_redis() -> None:
     """Remove the front entry from the Redis queue (#1717)."""
     try:
-        redis = await get_redis_connection_async()
+        redis = await get_async_redis_client(database="analytics")
         if redis:
             await redis.lpop(_QUEUE_REDIS_KEY)
     except Exception as e:
@@ -198,7 +198,7 @@ async def _pop_queue_entry_redis() -> None:
 async def _remove_queue_entries_redis(source_id: str) -> None:
     """Remove all Redis queue entries matching *source_id* (#1717)."""
     try:
-        redis = await get_redis_connection_async()
+        redis = await get_async_redis_client(database="analytics")
         if not redis:
             return
         raw_items = await redis.lrange(_QUEUE_REDIS_KEY, 0, -1)
@@ -217,7 +217,7 @@ async def _remove_queue_entries_redis(source_id: str) -> None:
 async def _load_queue_from_redis() -> List[Dict]:
     """Load all queued entries from Redis (#1717: startup recovery)."""
     try:
-        redis = await get_redis_connection_async()
+        redis = await get_async_redis_client(database="analytics")
         if not redis:
             return []
         raw_items = await redis.lrange(_QUEUE_REDIS_KEY, 0, -1)

--- a/autobot-backend/api/codebase_analytics/source_storage.py
+++ b/autobot-backend/api/codebase_analytics/source_storage.py
@@ -12,6 +12,8 @@ Uses the analytics Redis database (DB 11) with keys:
 import logging
 from typing import List, Optional
 
+from autobot_shared.redis_client import get_async_redis_client
+
 from .source_models import CodeSource, SourceAccess
 
 logger = logging.getLogger(__name__)
@@ -20,20 +22,13 @@ _SOURCES_KEY_PREFIX = "code_source:"
 _SOURCES_INDEX_KEY = "code_sources:index"
 
 
-async def _get_redis():
-    """Return an async Redis client for the analytics database."""
-    from autobot_shared.redis_client import get_async_redis_client
-
-    return await get_async_redis_client(database="analytics")
-
-
 async def save_source(source: CodeSource) -> bool:
     """Persist a CodeSource to Redis.
 
     Stores JSON at code_source:{id} and adds the ID to the index set.
     Returns True on success, False if Redis is unavailable.
     """
-    redis = await _get_redis()
+    redis = await get_async_redis_client(database="analytics")
     if redis is None:
         logger.error("Redis unavailable; cannot save source %s", source.id)
         return False
@@ -49,7 +44,7 @@ update_source = save_source
 
 async def get_source(source_id: str) -> Optional[CodeSource]:
     """Retrieve a CodeSource by ID. Returns None if not found."""
-    redis = await _get_redis()
+    redis = await get_async_redis_client(database="analytics")
     if redis is None:
         return None
     key = f"{_SOURCES_KEY_PREFIX}{source_id}"
@@ -76,7 +71,7 @@ def _is_visible(source: CodeSource, owner_id: Optional[str]) -> bool:
 
 async def list_sources(owner_id: Optional[str] = None) -> List[CodeSource]:
     """Return all accessible code sources, optionally scoped to owner_id."""
-    redis = await _get_redis()
+    redis = await get_async_redis_client(database="analytics")
     if redis is None:
         return []
     raw_ids = await redis.smembers(_SOURCES_INDEX_KEY)
@@ -105,7 +100,7 @@ async def delete_source(source_id: str) -> bool:
     Removes the key and clears the source from the index set.
     Returns True on success, False if Redis is unavailable.
     """
-    redis = await _get_redis()
+    redis = await get_async_redis_client(database="analytics")
     if redis is None:
         return False
     key = f"{_SOURCES_KEY_PREFIX}{source_id}"

--- a/autobot-backend/api/codebase_analytics/storage.py
+++ b/autobot-backend/api/codebase_analytics/storage.py
@@ -27,7 +27,7 @@ async def get_redis_connection():
     Uses DB 11 (analytics) for codebase indexing and analysis.
 
     Returns a SYNC Redis client for use with asyncio.to_thread().
-    For async operations, use get_redis_connection_async() instead.
+    For async operations, call get_async_redis_client(database="analytics") directly.
     """
     # Use canonical Redis utility - returns sync client
     from autobot_shared.redis_client import get_redis_client
@@ -37,26 +37,6 @@ async def get_redis_connection():
         logger.warning(
             "Redis client initialization returned None, using in-memory storage"
         )
-        return None
-
-    return redis_client
-
-
-async def get_redis_connection_async():
-    """
-    Get async Redis connection for codebase analytics.
-
-    This follows CLAUDE.md "🔴 REDIS CLIENT USAGE" policy.
-    Uses DB 11 (analytics) for codebase indexing and analysis.
-
-    Returns an ASYNC Redis client for native async operations.
-    Use this when you want to avoid thread pool blocking.
-    """
-    from autobot_shared.redis_client import get_async_redis_client
-
-    redis_client = await get_async_redis_client(database="analytics")
-    if redis_client is None:
-        logger.warning("Async Redis client initialization returned None")
         return None
 
     return redis_client

--- a/autobot-backend/dependencies.py
+++ b/autobot-backend/dependencies.py
@@ -197,18 +197,6 @@ def get_cached_orchestrator(config: ConfigManager = Depends(get_config)):
     return dependency_cache.get_or_create("orchestrator", _create_orchestrator)
 
 
-def get_redis_client():
-    """
-    Dependency injection provider for Redis client (synchronous).
-
-    Returns:
-        Redis client instance (sync)
-    """
-    from autobot_shared.redis_client import get_redis_client as _get_redis_client
-
-    return _get_redis_client()
-
-
 async def get_async_redis_client(database: str = "main"):
     """
     Dependency injection provider for async Redis client.
@@ -233,7 +221,6 @@ KnowledgeBaseDep = Depends(get_knowledge_base)
 LLMInterfaceDep = Depends(get_llm_interface)
 OrchestratorDep = Depends(get_orchestrator)
 SecurityLayerDep = Depends(get_security_layer)
-RedisClientDep = Depends(get_redis_client)
 
 # Cached versions
 CachedKnowledgeBaseDep = Depends(get_cached_knowledge_base)

--- a/autobot-backend/dependency_container.py
+++ b/autobot-backend/dependency_container.py
@@ -368,11 +368,6 @@ container = AsyncServiceContainer()
 
 
 # Convenience functions for common services
-async def get_redis() -> async_redis.Redis:
-    """Get Redis manager"""
-    return await container.get_service("redis")
-
-
 async def get_config() -> ConfigManager:
     """Get config manager"""
     return await container.get_service("config")

--- a/autobot-backend/initialization/background_tasks.py
+++ b/autobot-backend/initialization/background_tasks.py
@@ -44,11 +44,14 @@ async def get_or_create_knowledge_base(app: FastAPI, force_refresh: bool = False
         return None
 
 
-async def _init_redis(update_status_fn, append_error_fn):
+async def _mark_redis_ready(update_status_fn, append_error_fn):
     """
-    Initialize Redis status using centralized client management.
+    Mark Redis as ready in the initialization status tracker.
 
-    Issue #281: Extracted helper for Redis initialization.
+    Issue #281: Extracted helper for Redis initialization status.
+    Issue #5101: Renamed from _init_redis — no Redis client is initialized here;
+    this function only flips the status flag. Components obtain Redis clients
+    directly via autobot_shared.redis_client.get_redis_client().
 
     Args:
         update_status_fn: Function to update initialization status
@@ -60,7 +63,7 @@ async def _init_redis(update_status_fn, append_error_fn):
         await update_status_fn("redis_pools", "ready")
         log_initialization_step(
             "Redis",
-            "Using centralized Redis client management (src.utils.redis_client)",
+            "Using centralized Redis client management (autobot_shared.redis_client)",
             90,
             True,
         )
@@ -270,7 +273,7 @@ async def enhanced_background_init(
 
         # Run all initialization tasks concurrently (Issue #281: uses helpers)
         tasks = [
-            _init_redis(update_status_fn, append_error_fn),
+            _mark_redis_ready(update_status_fn, append_error_fn),
             _init_knowledge_base(app, update_status_fn, append_error_fn, get_status_fn),
             _init_chat_workflow(app, update_status_fn, append_error_fn),
             _init_llm_sync(update_status_fn, append_error_fn),


### PR DESCRIPTION
Closes #5101

## Summary

Removed 4 thin wrappers that added no logic over canonical `autobot_shared.redis_client.{get_redis_client, get_async_redis_client}`.

### Deleted thin wrappers (callers migrated to canonical)

- `autobot-backend/dependencies.py` — `get_redis_client()` + unused `RedisClientDep` alias
- `autobot-backend/dependency_container.py` — `get_redis()` (0 external callers)
- `autobot-backend/api/codebase_analytics/source_storage.py` — `_get_redis()` (4 internal callers migrated to canonical with `database="analytics"`)
- `autobot-backend/api/codebase_analytics/storage.py` — `get_redis_connection_async()` (7 callers across 2 files migrated)

### Kept (with existing resilience)

- `autobot-backend/skills/manager.py` — `_get_redis()` — already had the try/except-None-on-error pattern; no simplification available.

### Renamed for clarity

- `autobot-backend/initialization/background_tasks.py` — `_init_redis` \u2192 `_mark_redis_ready` (it was a status-marker helper, not a client accessor).

### Deferred

- `autobot-backend/api/knowledge_boards.py` — `_get_redis(req)` reaches into `KB.aioredis_client` instance state. Migrating this requires KB to expose a public accessor method. Left for a separate architecture-review issue.
- `autobot-backend/api/codebase_analytics/storage.py` — `get_redis_connection()` (sync variant) already routes through canonical after #5099/PR #5124 fix. Kept as-is to avoid churning its 6 callers.

## Verification

- [x] `python -m py_compile` on all 8 modified files
- [x] Canonical imports resolve
- [x] Grep for removed names: 0 residual references
- [x] No test mocks broken \u2014 all `@patch("...get_redis_client")` sites target the canonical, not the removed wrappers

## Diff

8 files, +27 / -66 lines.