### PR TITLE
test(shared): add unit tests for autobot_shared.time_utils helpers (#5170)

### DIFF
--- a/autobot_shared/time_utils_test.py
+++ b/autobot_shared/time_utils_test.py
@@ -1,0 +1,86 @@
+"""Unit tests for autobot_shared.time_utils — see #5170.
+
+Both helpers ship as production code with implicit format invariants;
+these tests pin the invariants so future format changes fail loudly.
+"""
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from autobot_shared.time_utils import utc_timestamp, utc_timestamp_z
+
+
+_Z_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def test_utc_timestamp_format() -> None:
+    s = utc_timestamp()
+    assert s.endswith("+00:00")
+    assert "T" in s
+    parsed = datetime.fromisoformat(s)
+    assert parsed.tzinfo is not None
+
+
+def test_utc_timestamp_round_trip() -> None:
+    s = utc_timestamp()
+    parsed = datetime.fromisoformat(s)
+    assert parsed.isoformat() == s
+
+
+def test_utc_timestamp_is_utc_not_local() -> None:
+    """Regression guard: must use timezone.utc, not naive or local time.
+
+    If the implementation regresses to ``datetime.now()`` the result will
+    be tz-naive and ``fromisoformat`` will return a naive datetime — caught
+    by the tzinfo assertion. If it regresses to ``datetime.now(local_tz)``
+    the offset will be non-zero — caught by the offset assertion.
+    """
+    s = utc_timestamp()
+    parsed = datetime.fromisoformat(s)
+    assert parsed.tzinfo is not None, f"expected aware datetime, got naive: {s}"
+    assert parsed.utcoffset() == timedelta(0), (
+        f"expected UTC offset 0, got {parsed.utcoffset()} from {s}"
+    )
+    assert s.endswith("+00:00"), f"expected +00:00 suffix (UTC), got: {s}"
+
+
+def test_utc_timestamp_z_format() -> None:
+    s = utc_timestamp_z()
+    assert len(s) == 20, f"expected exactly 20 chars, got {len(s)}: {s!r}"
+    assert s.endswith("Z")
+    assert "T" in s
+    assert "+" not in s
+    datetime.strptime(s, _Z_FMT)
+
+
+def test_utc_timestamp_z_no_microseconds() -> None:
+    """The on-disk workflow_versioning format depends on no microseconds."""
+    s = utc_timestamp_z()
+    assert "." not in s, f"unexpected microseconds in: {s!r}"
+
+
+def test_utc_timestamp_z_round_trip() -> None:
+    s = utc_timestamp_z()
+    parsed = datetime.strptime(s, _Z_FMT)
+    assert parsed.strftime(_Z_FMT) == s
+
+
+def test_utc_timestamp_z_is_utc_not_local() -> None:
+    """Regression guard: must use time.gmtime, not time.localtime.
+
+    Mocks both with distinguishable struct_time values so the test fails
+    if the implementation switches to localtime, regardless of the host's
+    actual timezone (CI may run in UTC, where a naive comparison would
+    silently pass).
+    """
+    fake_utc = time.struct_time((2026, 4, 18, 12, 0, 0, 0, 0, 0))
+    fake_local = time.struct_time((2026, 4, 18, 14, 30, 45, 0, 0, 0))
+
+    with patch("autobot_shared.time_utils.time.gmtime", return_value=fake_utc), \
+            patch("autobot_shared.time_utils.time.localtime", return_value=fake_local):
+        result = utc_timestamp_z()
+
+    assert result == "2026-04-18T12:00:00Z", (
+        f"expected gmtime-derived string, got {result!r} — implementation may use localtime"
+    )
+    assert "14:30:45" not in result


### PR DESCRIPTION
## Summary

Closes #5170.

Adds [`autobot_shared/time_utils_test.py`](autobot_shared/time_utils_test.py) — 7 unit tests covering both `utc_timestamp()` and `utc_timestamp_z()`. Both helpers ship as production code with implicit format invariants and zero test coverage; this PR pins them.

Tests use the AutoBot co-located convention (`*_test.py` next to source per [pytest.ini](pytest.ini)).

## Tests added

| Test | What it pins |
|---|---|
| `test_utc_timestamp_format` | `+00:00` suffix, contains `T`, parses via `fromisoformat`, tz-aware |
| `test_utc_timestamp_round_trip` | parse + reformat is byte-identical |
| `test_utc_timestamp_is_utc_not_local` | tz regression guard — fails if `timezone.utc` is dropped, fails on any non-zero offset |
| `test_utc_timestamp_z_format` | exactly 20 chars, ends `Z`, contains `T`, no `+`, parses via strict `strptime` |
| `test_utc_timestamp_z_no_microseconds` | explicit guard — on-disk format depends on this |
| `test_utc_timestamp_z_round_trip` | strptime → strftime is byte-identical |
| `test_utc_timestamp_z_is_utc_not_local` | tz regression guard — mocks both `time.gmtime` and `time.localtime` with distinguishable values, asserts gmtime path. Works in CI even when host tz is UTC. |

## Verification

```
$ python3 -m pytest autobot_shared/time_utils_test.py -v
... 7 passed in 0.04s
```

## Why the tz-confusion guards matter

`utc_timestamp()` uses `datetime.now(timezone.utc)`; `utc_timestamp_z()` uses `time.gmtime()`. Both depend on \"correct UTC-getting primitive\" choice. A future \"simplification\" PR could silently swap to `datetime.now()` (local) or `time.localtime()` and consumers would silently get local-time strings labeled as UTC. The mock-based regression guards catch this without depending on host tz.

## Diff

1 new file (`autobot_shared/time_utils_test.py`, +86 LOC). No production code changed.

## Test plan

- [x] All 7 tests pass
- [x] `py_compile` passes
- [x] Co-located convention (`*_test.py`) matches sibling test files in `autobot_shared/`
- [ ] `gh pr checks` passes