### PR TITLE
docs(shared): document UTC-format selection rule in autobot_shared.time_utils (#5169 part A)

### DIFF
--- a/autobot_shared/time_utils.py
+++ b/autobot_shared/time_utils.py
@@ -1,19 +1,53 @@
-"""Shared time utility helpers."""
+"""Shared UTC timestamp helpers.
+
+This module exposes two helpers for producing the current UTC time as an
+ISO-8601 string. They differ in *output format*; the choice between them
+is dictated by what consumers can parse, not by author preference.
+
+Selection rule (#5106, #5152, #5169)
+------------------------------------
+
+``utc_timestamp()`` — **default for new code.**
+    Returns ``+00:00`` ISO-8601 with microseconds
+    (e.g. ``2026-04-18T19:34:50.123456+00:00``). Use this unless you are
+    reading or writing a stored format that explicitly expects ``Z``.
+
+``utc_timestamp_z()`` — **legacy compatibility only.**
+    Returns ``Z``-suffix ISO-8601 with second precision and no
+    microseconds (e.g. ``2026-04-18T19:34:50Z``). Use ONLY when reading
+    or writing existing on-disk records that already use this format
+    (currently: workflow-version records via
+    ``services/workflow_versioning.py``). **Do not use for new
+    producers** — pick ``utc_timestamp()`` instead so the codebase
+    converges on one canonical format.
+
+Long-term canonicalization (#5169 parts B + C) is deferred pending a
+parser audit; until then both formats coexist and the rule above tells
+new code which to pick.
+"""
 import time
 from datetime import datetime, timezone
 
 
 def utc_timestamp() -> str:
-    """Return the current time as an ISO-8601 UTC timestamp string."""
+    """Return current UTC time as ISO-8601 with ``+00:00`` offset.
+
+    Format: ``YYYY-MM-DDTHH:MM:SS.ffffff+00:00`` (microsecond precision).
+    Default helper for new code — see module docstring for selection rule.
+    """
     return datetime.now(timezone.utc).isoformat()
 
 
 def utc_timestamp_z() -> str:
-    """Return current UTC time as an ISO-8601 string with Z suffix.
+    """Return current UTC time as ISO-8601 with ``Z`` suffix.
 
-    Produces exactly 20 characters in the form ``YYYY-MM-DDTHH:MM:SSZ``
-    with no microseconds and no ``+00:00`` offset — matching the on-disk
-    format used by workflow_versioning records (#5152).
+    Format: ``YYYY-MM-DDTHH:MM:SSZ`` (exactly 20 chars, second precision,
+    no microseconds, no ``+00:00`` offset). Matches the on-disk format
+    used by workflow_versioning records.
+
+    Use ONLY for legacy compatibility — see module docstring for
+    selection rule. Picking this for new producers perpetuates format
+    drift (#5106, #5152, #5169).
     """
     t = time.gmtime()
     return (


### PR DESCRIPTION
## Summary

**Part A of #5169** (documentation only). Issue #5169 stays OPEN — Parts B (parser audit) and C (canonicalization ADR) are deferred to follow-up PRs. Uses \`Refs #5169\` (not \`Closes\`).

Updates [`autobot_shared/time_utils.py`](autobot_shared/time_utils.py) module docstring with a clear selection rule for the two coexisting UTC helpers introduced by PRs #5126 and #5163. Each function docstring now cross-references the module rule.

## The rule

> **`utc_timestamp()` — default for new code.** Returns `+00:00` ISO-8601 with microseconds. Use this unless you are reading or writing a stored format that explicitly expects `Z`.
>
> **`utc_timestamp_z()` — legacy compatibility only.** Returns `Z`-suffix ISO-8601 with second precision. Use ONLY for existing on-disk records that already use this format (currently: workflow-version records). Do not use for new producers.

## What this does NOT do

- Does NOT touch function bodies — output is byte-identical pre/post
- Does NOT do Part B (parser audit) — separate PR
- Does NOT do Part C (canonicalization decision) — needs Part B's data first
- Does NOT close #5169

## Verification

```
$ python3 -c \"from autobot_shared.time_utils import utc_timestamp, utc_timestamp_z; print(utc_timestamp(), '|', utc_timestamp_z())\"
2026-04-18T20:36:03.523477+00:00 | 2026-04-18T20:36:03Z
```

Both formats unchanged.

## Diff

1 file (`autobot_shared/time_utils.py`, +40 / -6 — all docstrings).

## Test plan

- [x] `py_compile` passes
- [x] Module imports cleanly
- [x] Both helpers produce expected formats
- [ ] `gh pr checks` passes