### PR TITLE
refactor(frontend): remove parseApiResponse wrapper in 17 knowledge Vue components (#5033)

### DIFF
--- a/autobot-frontend/src/components/knowledge/BackupManager.vue
+++ b/autobot-frontend/src/components/knowledge/BackupManager.vue
@@ -125,7 +125,6 @@ import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { formatFileSize, formatDateTime } from '@/utils/formatHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
@@ -194,8 +193,7 @@ const showStatus = (type: StatusMessage['type'], text: string) => {
 const loadBackups = async () => {
   try {
     isLoadingBackups.value = true
-    const response = await apiClient.get(`${getApiBase()}/knowledge-maintenance/backups`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/backups`)
 
     if (data.backups) {
       backups.value = data.backups
@@ -212,13 +210,12 @@ const createBackup = async () => {
   try {
     isCreatingBackup.value = true
 
-    const response = await apiClient.post(`${getApiBase()}/knowledge-maintenance/backup`, {
+    const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/backup`, {
       include_embeddings: backupOptions.value.includeEmbeddings,
       compression: backupOptions.value.compression,
       description: backupOptions.value.description || undefined
     })
 
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data.status === 'success') {
       showStatus('success', t('knowledge.backup.statusBackupCreated', { name: data.backup_name }))
@@ -246,12 +243,11 @@ const restoreBackup = async (backupName: string) => {
     isRestoring.value = true
 
     // First, dry run to validate
-    const dryRunResponse = await apiClient.post(`${getApiBase()}/knowledge-maintenance/restore`, {
+    const dryRunData = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/restore`, {
       backup_file: backupName,
       dry_run: true
     })
 
-    const dryRunData = await parseApiResponse<Record<string, any>>(dryRunResponse)
 
     if (dryRunData.status !== 'success') {
       throw new Error(dryRunData.message || t('knowledge.backup.errorValidation'))
@@ -265,13 +261,12 @@ const restoreBackup = async (backupName: string) => {
     if (!confirmRestore) return
 
     // Actual restore
-    const restoreResponse = await apiClient.post(`${getApiBase()}/knowledge-maintenance/restore`, {
+    const restoreData = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/restore`, {
       backup_file: backupName,
       dry_run: false,
       skip_duplicates: true
     })
 
-    const restoreData = await parseApiResponse<Record<string, any>>(restoreResponse)
 
     if (restoreData.status === 'success') {
       showStatus('success', t('knowledge.backup.statusRestored', { count: restoreData.restored }))
@@ -296,12 +291,11 @@ const deleteBackup = async (backupName: string) => {
   try {
     isDeletingBackup.value = true
 
-    const response = await apiClient.delete(`${getApiBase()}/knowledge-maintenance/backup`, {
+    const data = await apiClient.delete<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/backup`, {
       body: JSON.stringify({ backup_file: backupName }),
       headers: { 'Content-Type': 'application/json' }
     } as any)
 
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data.status === 'success') {
       showStatus('success', t('knowledge.backup.statusDeleted'))

--- a/autobot-frontend/src/components/knowledge/CleanupStatistics.vue
+++ b/autobot-frontend/src/components/knowledge/CleanupStatistics.vue
@@ -116,7 +116,6 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -197,14 +196,13 @@ const runDryScan = async () => {
     scanResult.value = null
     statusMessage.value = null
 
-    const response = await apiClient.post(`${getApiBase()}/knowledge-maintenance/cleanup`, {
+    const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/cleanup`, {
       remove_empty: options.value.removeEmpty,
       remove_orphaned_tags: options.value.removeOrphanedTags,
       fix_metadata: options.value.fixMetadata,
       dry_run: true
     })
 
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data.success !== false) {
       scanResult.value = {
@@ -242,14 +240,13 @@ const runCleanup = async () => {
   try {
     isCleaning.value = true
 
-    const response = await apiClient.post(`${getApiBase()}/knowledge-maintenance/cleanup`, {
+    const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/cleanup`, {
       remove_empty: options.value.removeEmpty,
       remove_orphaned_tags: options.value.removeOrphanedTags,
       fix_metadata: options.value.fixMetadata,
       dry_run: false
     })
 
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data.success !== false) {
       const total =

--- a/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
+++ b/autobot-frontend/src/components/knowledge/DeduplicationManager.vue
@@ -189,7 +189,6 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { formatDate } from '@/utils/formatHelpers'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
@@ -260,8 +259,7 @@ const scanForIssues = async () => {
   try {
     // Scan for duplicates (dry run)
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const dupResponse = await apiClient.post(`${getApiBase()}/knowledge-maintenance/deduplicate?dry_run=true`)
-    const dupData = await parseApiResponse<Record<string, any>>(dupResponse)
+    const dupData = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/deduplicate?dry_run=true`)
 
     if (dupData.status === 'success') {
       duplicateStats.value = dupData
@@ -271,8 +269,7 @@ const scanForIssues = async () => {
 
     // Scan for orphans
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const orphanResponse = await apiClient.get(`${getApiBase()}/knowledge-maintenance/orphans`)
-    const orphanData = await parseApiResponse<Record<string, any>>(orphanResponse)
+    const orphanData = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/orphans`)
 
     if (orphanData.status === 'success') {
       orphanStats.value = orphanData
@@ -300,8 +297,7 @@ const cleanupDuplicates = async () => {
 
   try {
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const response = await apiClient.post(`${getApiBase()}/knowledge-maintenance/deduplicate?dry_run=false`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/deduplicate?dry_run=false`)
 
     if (data.status === 'success') {
       logger.info(`Successfully removed ${data.deleted_count} duplicates`)
@@ -329,8 +325,7 @@ const cleanupOrphans = async () => {
 
   try {
     // Issue #552: Fixed path - backend uses /api/knowledge-maintenance/*
-    const response = await apiClient.delete(`${getApiBase()}/knowledge-maintenance/orphans?dry_run=false`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.delete<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/orphans?dry_run=false`)
 
     if (data.status === 'success') {
       logger.info(`Successfully removed ${data.deleted_count} orphans`)

--- a/autobot-frontend/src/components/knowledge/EntityExtractor.vue
+++ b/autobot-frontend/src/components/knowledge/EntityExtractor.vue
@@ -172,7 +172,6 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('EntityExtractor')
@@ -287,12 +286,11 @@ async function extractEntities(): Promise<void> {
     const messages = parseMessages(textInput.value)
     logger.info(`Extracting entities from ${messages.length} messages`)
 
-    const response = await apiClient.post(`${getApiBase()}/entities/extract`, {
+    const parsedResponse = await apiClient.post<Record<string, any>>(`${getApiBase()}/entities/extract`, {
       conversation_id: conversationId.value.trim(),
       messages
     })
 
-    const parsedResponse = await parseApiResponse<Record<string, any>>(response)
     const result = parsedResponse?.data || parsedResponse
 
     extractionResult.value = { ...result, timestamp: Date.now() }

--- a/autobot-frontend/src/components/knowledge/EntityGraphManager.vue
+++ b/autobot-frontend/src/components/knowledge/EntityGraphManager.vue
@@ -198,7 +198,6 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import EntityExtractor from './EntityExtractor.vue'
 import GraphRAGQuery from './GraphRAGQuery.vue'
@@ -295,8 +294,7 @@ async function refreshStats(): Promise<void> {
 
 async function fetchGraphStats(): Promise<void> {
   try {
-    const response = await apiClient.get(`${getApiBase()}/knowledge_base/unified/graph?max_facts=0`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/unified/graph?max_facts=0`)
     const graphData = data?.data || data
 
     if (graphData?.entities) {
@@ -317,8 +315,7 @@ async function fetchGraphStats(): Promise<void> {
 
 async function fetchExtractionHealth(): Promise<void> {
   try {
-    const response = await apiClient.get(`${getApiBase()}/entities/extract/health`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/entities/extract/health`)
     const healthData = data?.data || data
 
     extractionHealth.status = healthData?.status || 'unknown'
@@ -332,8 +329,7 @@ async function fetchExtractionHealth(): Promise<void> {
 
 async function fetchGraphRagHealth(): Promise<void> {
   try {
-    const response = await apiClient.get(`${getApiBase()}/graph-rag/health`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/graph-rag/health`)
     const healthData = data?.data || data
 
     graphRagHealth.status = healthData?.status || 'unknown'

--- a/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
+++ b/autobot-frontend/src/components/knowledge/FailedVectorizationsManager.vue
@@ -102,7 +102,6 @@ import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { formatDateTime } from '@/utils/formatHelpers'
 import { useAsyncOperation } from '@/composables/useAsyncOperation'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -130,8 +129,7 @@ const { execute: fetchFailedJobs, loading, error } = useAsyncOperation()
 
 // Fetch failed jobs
 const fetchFailedJobsFn = async () => {
-  const response = await apiClient.get(`${getApiBase()}/knowledge_base/vectorize_jobs/failed`)
-  const data = await parseApiResponse<Record<string, any>>(response)
+  const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/vectorize_jobs/failed`)
 
   if (data.status === 'success') {
     failedJobs.value = data.failed_jobs
@@ -150,8 +148,7 @@ const retryJob = async (jobId: string) => {
   retryingJobs.value.add(jobId)
 
   try {
-    const response = await apiClient.post(`${getApiBase()}/knowledge_base/vectorize_jobs/${jobId}/retry`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/vectorize_jobs/${jobId}/retry`)
 
     if (data.status === 'success') {
       // Remove from failed list
@@ -176,8 +173,7 @@ const deleteJob = async (jobId: string) => {
   }
 
   await fetchFailedJobs(async () => {
-    const response = await apiClient.delete(`${getApiBase()}/knowledge_base/vectorize_jobs/${jobId}`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.delete<Record<string, any>>(`${getApiBase()}/knowledge_base/vectorize_jobs/${jobId}`)
 
     if (data.status === 'success') {
       // Remove from list
@@ -195,8 +191,7 @@ const clearAllFailed = async () => {
   }
 
   await fetchFailedJobs(async () => {
-    const response = await apiClient.delete(`${getApiBase()}/knowledge_base/vectorize_jobs/failed/clear`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.delete<Record<string, any>>(`${getApiBase()}/knowledge_base/vectorize_jobs/failed/clear`)
 
     if (data.status === 'success') {
       failedJobs.value = []

--- a/autobot-frontend/src/components/knowledge/GraphRAGQuery.vue
+++ b/autobot-frontend/src/components/knowledge/GraphRAGQuery.vue
@@ -198,7 +198,6 @@ import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('GraphRAGQuery')
@@ -284,7 +283,7 @@ async function executeSearch(): Promise<void> {
   try {
     logger.info(`Executing Graph-RAG search: "${queryText.value.substring(0, 50)}..."`)
 
-    const response = await apiClient.post(`${getApiBase()}/graph-rag/search`, {
+    const parsedResponse = await apiClient.post<Record<string, any>>(`${getApiBase()}/graph-rag/search`, {
       query: queryText.value.trim(),
       start_entity: startEntity.value.trim() || null,
       max_depth: maxDepth.value,
@@ -292,7 +291,6 @@ async function executeSearch(): Promise<void> {
       enable_reranking: enableReranking.value
     })
 
-    const parsedResponse = await parseApiResponse<Record<string, any>>(response)
     searchResults.value = parsedResponse?.data || parsedResponse
 
     logger.info(`Search complete: ${searchResults.value?.results?.length || 0} results`)
@@ -308,8 +306,7 @@ async function checkHealth(): Promise<void> {
   isCheckingHealth.value = true
 
   try {
-    const response = await apiClient.get(`${getApiBase()}/graph-rag/health`)
-    const parsedResponse = await parseApiResponse<Record<string, any>>(response)
+    const parsedResponse = await apiClient.get<Record<string, any>>(`${getApiBase()}/graph-rag/health`)
     healthStatus.value = parsedResponse?.data || parsedResponse
     logger.info(`Health check: ${healthStatus.value?.status}`)
   } catch (error) {

--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -175,7 +175,6 @@ import { useI18n } from 'vue-i18n'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import ApiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -318,8 +317,7 @@ const populateSystemCommands = async () => {
     startProgress(t('knowledge.advanced.progressPopulatingSystemCommands'), 150)
     progressDetails.value = t('knowledge.advanced.progressAddingCommands')
 
-    const apiResponse = await ApiClient.post(`${getApiBase()}/knowledge_base/populate_system_commands`, {})
-    const response = await parseApiResponse<Record<string, any>>(apiResponse)
+    const response = await ApiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/populate_system_commands`, {})
 
     if (response.status === 'success') {
       populateStatus.value.systemCommands = 'success'
@@ -357,8 +355,7 @@ const populateManPages = async () => {
     startProgress(t('knowledge.advanced.progressPopulatingManPages'), 50)
     progressDetails.value = t('knowledge.advanced.progressAddingManPages')
 
-    const apiResponse = await ApiClient.post(`${getApiBase()}/knowledge_base/populate_man_pages`, {})
-    const response = await parseApiResponse<Record<string, any>>(apiResponse)
+    const response = await ApiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/populate_man_pages`, {})
 
     if (response.status === 'success') {
       populateStatus.value.manPages = 'success'
@@ -396,8 +393,7 @@ const populateAutoBotDocs = async () => {
     startProgress(t('knowledge.advanced.progressPopulatingAutobotDocs'), 30)
     progressDetails.value = t('knowledge.advanced.progressAddingAutobotDocs')
 
-    const apiResponse = await ApiClient.post(`${getApiBase()}/knowledge_base/populate_autobot_docs`, {})
-    const response = await parseApiResponse<Record<string, any>>(apiResponse)
+    const response = await ApiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/populate_autobot_docs`, {})
 
     if (response.status === 'success') {
       populateStatus.value.autobotDocs = 'success'
@@ -450,8 +446,7 @@ const clearAllKnowledge = async () => {
     startProgress(t('knowledge.advanced.progressClearingKB'), 1)
     progressDetails.value = t('knowledge.advanced.progressRemovingEntries')
 
-    const apiResponse = await ApiClient.post(`${getApiBase()}/knowledge_base/clear_all`, {})
-    const response = await parseApiResponse<Record<string, any>>(apiResponse)
+    const response = await ApiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/clear_all`, {})
 
     if (response.status === 'success') {
       addStatusMessage('success', t('knowledge.advanced.clearSuccess'),

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -193,7 +193,6 @@ import { createLogger } from '@/utils/debugUtils'
 
 // Create scoped logger for KnowledgeBrowser
 const logger = createLogger('KnowledgeBrowser')
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { useKnowledgeBase } from '@/composables/useKnowledgeBase'
 import { useKnowledgeVectorization } from '@/composables/useKnowledgeVectorization'
 import { useAsyncOperation } from '@/composables/useAsyncOperation'
@@ -307,8 +306,7 @@ const fetchEntries = async (cursor: string) => {
     limit: '100',
     cursor: cursor || '0'
   })
-  const response = await apiClient.get(`${getApiBase()}/knowledge_base/entries?${params}`)
-  const data = await parseApiResponse<Record<string, any>>(response)
+  const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/entries?${params}`)
 
   // Handle both cursor-based and offset-based formats
   if (data.next_cursor !== undefined) {
@@ -569,8 +567,7 @@ const selectMainCategory = (mainCatId: string) => {
 
 const loadMainCategories = async () => {
   try {
-    const response = await apiClient.get(`${getApiBase()}/knowledge_base/categories/main`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/categories/main`)
 
     if (data && data.categories) {
       mainCategories.value = data.categories
@@ -654,8 +651,7 @@ const refreshVectorizationStatus = async () => {
 // Load main knowledge tree with useAsyncOperation wrapper
 const loadKnowledgeTreeFn = async () => {
   // Load facts from knowledge base by category
-  const response = await apiClient.get(`${getApiBase()}/knowledge_base/facts/by_category`)
-  const data = await parseApiResponse<Record<string, any>>(response)
+  const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/facts/by_category`)
 
   if (data && data.categories) {
     // Build tree structure from categories
@@ -934,12 +930,11 @@ const handleImport = () => {
 const loadFolderContents = async (folder: TreeNode) => {
   try {
     // Load files for this category
-    const response = await apiClient.post(`${getApiBase()}/knowledge_base/search`, {
+    const data = await apiClient.post<Record<string, any>>(`${getApiBase()}/knowledge_base/search`, {
       query: '',
       category: folder.category,
       n_results: 100
     })
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data.results && Array.isArray(data.results)) {
       folder.children = data.results.map((item: any, idx: number) => ({
@@ -973,8 +968,7 @@ const loadFileContent = async (file: TreeNode) => {
 
       if (factKey) {
         // Fetch full fact data from backend
-        const apiResponse = await apiClient.get(`${getApiBase()}/knowledge_base/fact/${factKey}`)
-        const response = await parseApiResponse<Record<string, any>>(apiResponse)
+        const response = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/fact/${factKey}`)
 
         if (response && response.content) {
           fileContent.value = response.content

--- a/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeCategories.vue
@@ -170,7 +170,6 @@ import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { useKnowledgeBase } from '@/composables/useKnowledgeBase'
 import KnowledgeBrowser from './KnowledgeBrowser.vue'
 import DocumentChangeFeed from './DocumentChangeFeed.vue'
@@ -253,8 +252,7 @@ const viewCategoryDocuments = async (category: any) => {
   selectedCategoryPath.value = category.path
 
   try {
-    const response = await apiClient.get(`${getApiBase()}/knowledge_base/categories/${encodeURIComponent(category.path)}`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/categories/${encodeURIComponent(category.path)}`)
     categoryDocuments.value = data?.documents || []
     showCategoryDocuments.value = true
   } catch (error) {
@@ -286,19 +284,12 @@ const loadMainCategories = async () => {
   isLoadingCategories.value = true
   categoriesError.value = null
   try {
-    const response = await apiClient.get(`${getApiBase()}/knowledge_base/categories/main`)
-    if (response && typeof response === 'object' && 'status' in response) {
-      const status = (response as { status: number }).status
-      if (status === 401) {
-        categoriesError.value = t('knowledge.categories.authRequired')
-        return
-      }
-      if (status === 403) {
-        categoriesError.value = t('knowledge.categories.noPermission')
-        return
-      }
-    }
-    const data = await parseApiResponse<Record<string, any>>(response)
+    // apiClient.get<T> returns parsed JSON or throws on HTTP error — it
+    // never returns a Response-like object with a `status` field. The
+    // previous `if (response && 'status' in response)` guard was dead code
+    // left over from the parseApiResponse wrapper pattern (#5033); the 401 /
+    // 403 handling now lives in the catch below via the thrown error.
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/categories/main`)
     if (!data?.categories || !Array.isArray(data.categories)) {
       categoriesError.value = t('knowledge.categories.invalidResponse')
       return

--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -383,7 +383,6 @@ import cytoscape, { type Core, type NodeSingular } from 'cytoscape'
 import fcose from 'cytoscape-fcose'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
 import { useDebouncedFn } from '@/composables/useDebounce'
@@ -867,12 +866,10 @@ async function refreshGraph(): Promise<void> {
 
   try {
     // Fetch from unified knowledge graph endpoint (includes categories + facts)
-    const unifiedResponse = await apiClient.get(`${getApiBase()}/knowledge_base/unified/graph?max_facts=100&include_categories=true`)
-    const unifiedData = await parseApiResponse<Record<string, any>>(unifiedResponse)
+    const unifiedData = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/unified/graph?max_facts=100&include_categories=true`)
 
     // Also fetch memory entities for backward compatibility
-    const memoryResponse = await apiClient.get(`${getApiBase()}/memory/entities/all`)
-    const memoryData = await parseApiResponse<Record<string, any>>(memoryResponse)
+    const memoryData = await apiClient.get<Record<string, any>>(`${getApiBase()}/memory/entities/all`)
 
     // Merge entities from both sources
     const unifiedEntities = unifiedData?.data?.entities || []
@@ -932,8 +929,7 @@ async function fetchMemoryRelations(memoryEntities: Entity[]): Promise<void> {
 
   const relationResults = await Promise.allSettled(
     memoryEntities.map(async (entity) => {
-      const response = await apiClient.get(`${getApiBase()}/memory/entities/${entity.id}/relations`)
-      const parsedResponse = await parseApiResponse<Record<string, any>>(response)
+      const parsedResponse = await apiClient.get<Record<string, any>>(`${getApiBase()}/memory/entities/${entity.id}/relations`)
       return { entity, parsedResponse }
     })
   )
@@ -989,13 +985,12 @@ async function createEntity(): Promise<void> {
       .map(o => o.trim())
       .filter(o => o.length > 0)
 
-    const response = await apiClient.post(`${getApiBase()}/memory/entities`, {
+    const parsedResponse = await apiClient.post<Record<string, any>>(`${getApiBase()}/memory/entities`, {
       name: newEntity.value.name,
       entity_type: newEntity.value.type,
       observations
     })
 
-    const parsedResponse = await parseApiResponse<Record<string, any>>(response)
     const responseData = parsedResponse?.data || parsedResponse
 
     let createdEntity: Entity | null = null

--- a/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMaintenance.vue
@@ -197,7 +197,6 @@
 import { ref, onMounted } from 'vue'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { formatFileSize, formatTimeAgo } from '@/utils/formatHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import DeduplicationManager from '@/components/knowledge/DeduplicationManager.vue'
@@ -247,8 +246,7 @@ const loadHealthDashboard = async () => {
   isLoadingHealth.value = true
 
   try {
-    const response = await apiClient.get(`${getApiBase()}/knowledge-maintenance/health/dashboard`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge-maintenance/health/dashboard`)
 
     if (data) {
       healthDashboard.value = data

--- a/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgePromptEditor.vue
@@ -19,7 +19,6 @@ import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
@@ -148,8 +147,7 @@ async function loadPrompts(): Promise<void> {
   error.value = null
 
   try {
-    const response = await apiClient.get(`${getApiBase()}/prompts`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/prompts`)
 
     if (data?.prompts) {
       prompts.value = data.prompts
@@ -183,11 +181,10 @@ async function savePrompt(): Promise<void> {
   successMessage.value = null
 
   try {
-    const response = await apiClient.put(
+    const data = await apiClient.put<Record<string, any>>(
       `${getApiBase()}/prompts/${encodeURIComponent(selectedPrompt.value.id)}`,
       { content: editedContent.value }
     )
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data?.status === 'success') {
       // Update local state
@@ -222,10 +219,9 @@ async function loadHistory(): Promise<void> {
   showHistoryModal.value = true
 
   try {
-    const response = await apiClient.get(
+    const data = await apiClient.get<Record<string, any>>(
       `${getApiBase()}/prompts/${encodeURIComponent(selectedPrompt.value.id)}/history`
     )
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data?.versions) {
       promptHistory.value = data.versions
@@ -248,11 +244,10 @@ async function revertToVersion(version: PromptVersion): Promise<void> {
   isSaving.value = true
 
   try {
-    const response = await apiClient.post(
+    const data = await apiClient.post<Record<string, any>>(
       `${getApiBase()}/prompts/${encodeURIComponent(selectedPrompt.value.id)}/revert`,
       { version: version.version }
     )
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data?.status === 'success') {
       selectedPrompt.value.content = version.content

--- a/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeStats.vue
@@ -389,7 +389,6 @@ import DocumentChangeFeed from '@/components/knowledge/DocumentChangeFeed.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import {
   formatFileSize,
   formatTimeAgo,
@@ -786,8 +785,7 @@ const refreshVectorStats = async () => {
 
     // Fetch category fact counts (secondary API call - only when needed)
     try {
-      const factsResponse = await apiClient.get(`${getApiBase()}/knowledge_base/facts/by_category`)
-      const factsData = await parseApiResponse<Record<string, any>>(factsResponse)
+      const factsData = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/facts/by_category`)
 
       if (factsData && factsData.categories) {
         const counts: Record<string, number> = {}

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
@@ -20,7 +20,6 @@ import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import BaseButton from '@/components/base/BaseButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import { createLogger } from '@/utils/debugUtils'
@@ -106,8 +105,7 @@ async function loadDocCategories(): Promise<void> {
   error.value = null
 
   try {
-    const response = await apiClient.get(`${getApiBase()}/knowledge_base/system-docs/categories`)
-    const data = await parseApiResponse<Record<string, any>>(response)
+    const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/system-docs/categories`)
 
     if (data?.categories) {
       categories.value = data.categories
@@ -129,10 +127,9 @@ async function loadCategoryDocs(category: DocCategory): Promise<void> {
   error.value = null
 
   try {
-    const response = await apiClient.get(
+    const data = await apiClient.get<Record<string, any>>(
       `${getApiBase()}/knowledge_base/system-docs/category/${encodeURIComponent(category.path)}`
     )
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data?.docs) {
       category.docs = data.docs
@@ -155,10 +152,9 @@ async function loadDocContent(doc: SystemDoc): Promise<void> {
   error.value = null
 
   try {
-    const response = await apiClient.get(
+    const data = await apiClient.get<Record<string, any>>(
       `${getApiBase()}/knowledge_base/system-docs/${encodeURIComponent(doc.id)}`
     )
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data?.doc) {
       doc.content = data.doc.content

--- a/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
+++ b/autobot-frontend/src/components/knowledge/modals/CategoryEditModal.vue
@@ -18,7 +18,6 @@ import BaseModal from '@/components/ui/BaseModal.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { createLogger } from '@/utils/debugUtils'
 import { useI18n } from 'vue-i18n'
 
@@ -160,10 +159,9 @@ watch(() => props.category, (newCategory) => {
 async function loadFactCount(categoryId: string): Promise<void> {
   isLoadingFactCount.value = true
   try {
-    const response = await apiClient.get(
+    const data = await apiClient.get<Record<string, any>>(
       `${getApiBase()}/knowledge_base/categories/${encodeURIComponent(categoryId)}/facts?limit=1`
     )
-    const data = await parseApiResponse<Record<string, any>>(response)
     factCount.value = data?.total_count ?? 0
   } catch (err) {
     logger.error('Failed to load fact count:', err)
@@ -181,11 +179,10 @@ async function saveChanges(): Promise<void> {
   successMessage.value = null
 
   try {
-    const response = await apiClient.put(
+    const data = await apiClient.put<Record<string, any>>(
       `${getApiBase()}/knowledge_base/categories/${encodeURIComponent(props.category.id)}`,
       formData.value
     )
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data?.status === 'success') {
       successMessage.value = t('knowledge.modals.categoryEdit.updateSuccess')
@@ -213,10 +210,9 @@ async function deleteCategory(): Promise<void> {
   error.value = null
 
   try {
-    const response = await apiClient.delete(
+    const data = await apiClient.delete<Record<string, any>>(
       `${getApiBase()}/knowledge_base/categories/${encodeURIComponent(props.category.id)}`
     )
-    const data = await parseApiResponse<Record<string, any>>(response)
 
     if (data?.status === 'success') {
       emit('deleted', props.category.id)

--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
@@ -512,7 +512,6 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import apiClient from '@/utils/ApiClient'
-import { parseApiResponse } from '@/utils/apiResponseHelpers'
 import { getConfig, getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
@@ -704,8 +703,7 @@ async function refreshArchitecture() {
 
   try {
     // Issue #552: Fixed path - backend uses /api/monitoring/services/health
-    const healthResponse = await apiClient.get(`${getApiBase()}/monitoring/services/health`)
-    const healthData = await parseApiResponse<Record<string, any>>(healthResponse)
+    const healthData = await apiClient.get<Record<string, any>>(`${getApiBase()}/monitoring/services/health`)
 
     // Generate architecture based on known infrastructure
     generateArchitecture(healthData?.data?.services || healthData?.services || {})


### PR DESCRIPTION
Continues #5033 after PR #5145 split `useKnowledgeBase` into domain composables.

## Summary

49 `parseApiResponse` call sites across 17 Vue components migrated to typed `apiClient` directly.

**Pattern applied per call site:**

```typescript
// BEFORE (2 lines + import)
const response = await apiClient.post(url, { ... })
const data = await parseApiResponse<Record<string, any>>(response)

// AFTER (1 line)
const data = await apiClient.post<Record<string, any>>(url, { ... })
```

## Stats

- **17 files modified**
- **49 call sites migrated**
- **-126 / +54 lines** (−72 net)
- Each file dropped its `import { parseApiResponse }` once the last use was removed

## Additional cleanup

Removed a dead auth-status guard in `KnowledgeCategories.loadMainCategories`:

```typescript
// Unreachable — apiClient.get<T>() returns parsed JSON, never a Response
// object with .status. 401/403 handling lives in the catch branch.
if (response && 'status' in response) { /* dead */ }
```

## Verification

- **`vue-tsc --noEmit -p tsconfig.app.json`: 169 errors, SAME as baseline.** The 3 pre-existing errors in `DeduplicationManager`/`KnowledgeMaintenance` shifted up 2 lines (removed code) but their content is unchanged. Comm-diff confirms zero net new errors.
- **`vitest run src/components/`: 217/220 pass.** The 3 failures are pre-existing in `ChatInterface.test.ts` — I touched 0 chat files (verified with `git diff --name-only | grep -i chat` → empty).

## Remaining #5033 work (before we can delete parseApiResponse entirely)

- 2 Vue files with pattern variants my script couldn't automate (`useKnowledgeVectorization.test.ts`, helper spots) — manual next pass
- `src/utils/apiResponseHelpers.ts` itself (the function definition)
- Test imports / mocks in `useKnowledgeVectorization.test.ts`

Once those clear, `parseApiResponse` can be deleted entirely and #5033 closed.

## Process notes

Applied Phase 0c (verify type-check AND test-run, not just type-check) and Phase 6 pre-push duplicate check (re-fetched before push, no conflicts). Migration script at `/tmp/migrate_vue_parseApiResponse.py` — tracked in #5150 for eventual promotion to `tools/codemods/`.