### PR TITLE
feat(tools): add tools/codemods/ with proven Vue parseApiResponse codemod (#5150)

### DIFF
--- a/tools/codemods/README.md
+++ b/tools/codemods/README.md
@@ -1,0 +1,67 @@
+# tools/codemods
+
+One-shot code transformation scripts ("codemods") promoted from `/tmp` to
+this directory so they can be reviewed, tested, and reused.
+
+## When to add a codemod here
+
+You're doing a bulk edit across N+ files with the same mechanical shape —
+e.g. "replace every `parseApiResponse<T>(x)` wrapper with its inner
+`apiClient.get<T>(url)` call". The Edit tool requires unique `old_string`,
+which makes N-site rewrites per-Edit painful; a script is faster, and with
+tests it's safer.
+
+Put the script here (not `/tmp`) if **any** of these apply:
+
+- The same transform will run more than once (e.g. a migration happening in
+  batches across weeks)
+- The pattern is non-trivial (multi-line, nested, shared subtleties)
+- You want the diff to be reviewable as-code, not just as-output
+- Future sessions (yours or a teammate's) will need the same tool
+
+Discovered during session work — every session seems to need at least one
+bulk-edit script, and they've all been thrown away. See #5150 for the
+historical context.
+
+## Structure
+
+Each codemod is **two files** in this directory:
+
+- `<transform>.py` — the transform itself. Takes one-or-more file paths as
+  CLI args. Reads → transforms → writes in place. Prints a per-file count.
+  Exit 0 always.
+- `test_<transform>.py` — pytest tests with before/after fixture strings
+  embedded as triple-quoted multi-line constants. Asserts the transform
+  produces the exact expected output.
+
+## Running
+
+Transforms run directly as Python scripts (no install needed):
+
+```bash
+python3 tools/codemods/parse_api_response_vue_migration.py \
+  $(grep -rln "parseApiResponse" autobot-frontend/src/components --include='*.vue')
+```
+
+Tests run with pytest:
+
+```bash
+cd tools/codemods
+python3 -m pytest -xvs
+```
+
+## Future direction
+
+For AST-aware transforms (not just regex), prefer
+[ts-morph](https://ts-morph.com/) (TypeScript) or
+[libcst](https://libcst.readthedocs.io/) (Python). Regex is fine for the
+shallow migrations we've needed so far; add AST tooling when a regex
+misfires — #5150 argued for this after two iterations on `cleanup_5092.py`.
+
+## Reference codemods
+
+- `parse_api_response_vue_migration.py` — removes `parseApiResponse<T>(x)`
+  wrapper lines by typing the preceding `apiClient.METHOD(url)` call
+  directly. Used in PR #5177 to migrate 49 call sites across 17 Vue files.
+  Proven working on multi-line `apiClient.post(url, { ... })` bodies by
+  patching only the opener line.

--- a/tools/codemods/parse_api_response_vue_migration.py
+++ b/tools/codemods/parse_api_response_vue_migration.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Codemod: remove parseApiResponse<T>(x) wrappers in Vue components.
+
+Transforms the 2-line pattern:
+
+    const response = await apiClient.METHOD(url, ...)    # or ApiClient.METHOD(...)
+    const data = await parseApiResponse<T>(response)
+
+into a single typed call:
+
+    const data = await apiClient.METHOD<T>(url, ...)
+
+Also drops the `import { parseApiResponse } from '@/utils/apiResponseHelpers'`
+line once no parseApiResponse usage remains in the file.
+
+Key design: only the *opener* of the apiClient call is patched (add `<T>`
+and rename the binding) — args are left untouched. This makes multi-line
+calls like `apiClient.post(url, { a, b, c })` work without needing a
+multi-line paren matcher.
+
+Used in PR #5177 to migrate 49 call sites across 17 Vue files (#5033).
+
+Usage:
+    python3 tools/codemods/parse_api_response_vue_migration.py \\
+      $(grep -rln "parseApiResponse" autobot-frontend/src/components \\
+        --include='*.vue')
+"""
+import re
+import sys
+from pathlib import Path
+
+# Match the start of `const VAR = await (apiClient|ApiClient).METHOD(`.
+# Works for single-line AND multi-line call bodies because we only patch
+# the opener — the `(args)` span is left alone.
+RESPONSE_OPEN = re.compile(
+    r"^(\s*)const (\w+) = await "
+    r"(apiClient|ApiClient)\.(get|post|put|delete|patch)\("
+)
+
+# Match `const NEW_VAR = await parseApiResponse<TYPE>(PREV_VAR)` on one line.
+# TYPE captures everything up to the final `(` — handles nested generics
+# like `Record<string, any>` without needing brace counting.
+PARSE_LINE = re.compile(
+    r"^(\s*)const (\w+) = await parseApiResponse<([^(]+)>\((\w+)\)\s*$"
+)
+
+PARSE_IMPORT = re.compile(
+    r"^import \{ parseApiResponse \} from '@/utils/apiResponseHelpers'\s*\n",
+    flags=re.MULTILINE,
+)
+
+
+def transform(text: str) -> tuple[str, int]:
+    """Return (transformed_text, number_of_migrations_applied)."""
+    lines = text.splitlines(keepends=True)
+    out_lines = list(lines)
+    deletes: set[int] = set()
+    count = 0
+
+    for i, line in enumerate(out_lines):
+        if i in deletes:
+            continue
+        pm = PARSE_LINE.match(line.rstrip("\n"))
+        if not pm:
+            continue
+
+        new_var = pm.group(2)
+        type_arg = pm.group(3).strip()
+        prev_var = pm.group(4)
+
+        # Walk back up to ~15 lines to find the matching
+        # `const PREV_VAR = await ...METHOD(` opener.
+        match_idx: int | None = None
+        for j in range(i - 1, max(i - 15, -1), -1):
+            if j in deletes:
+                continue
+            rm = RESPONSE_OPEN.match(out_lines[j])
+            if rm and rm.group(2) == prev_var:
+                match_idx = j
+                break
+
+        if match_idx is None:
+            continue  # Pattern doesn't match cleanly; skip this site.
+
+        # Patch only the opener: rename the binding and type the method.
+        original = out_lines[match_idx]
+        patched = RESPONSE_OPEN.sub(
+            lambda m: (
+                f"{m.group(1)}const {new_var} = await "
+                f"{m.group(3)}.{m.group(4)}<{type_arg}>("
+            ),
+            original,
+            count=1,
+        )
+        out_lines[match_idx] = patched
+        deletes.add(i)
+        count += 1
+
+    new_lines = [
+        line for idx, line in enumerate(out_lines) if idx not in deletes
+    ]
+    text2 = "".join(new_lines)
+
+    # Drop `import { parseApiResponse }` if no uses remain.
+    if "parseApiResponse" not in text2.replace(
+        "import { parseApiResponse }", ""
+    ):
+        text2 = PARSE_IMPORT.sub("", text2)
+
+    return text2, count
+
+
+def main(paths: list[str]) -> None:
+    total = 0
+    for p in paths:
+        path = Path(p)
+        if not path.exists():
+            print(f"SKIP (missing): {p}", file=sys.stderr)
+            continue
+        text = path.read_text(encoding="utf-8")
+        new_text, n = transform(text)
+        if n > 0:
+            path.write_text(new_text, encoding="utf-8")
+            print(f"  {n:3d} migrated: {p}")
+            total += n
+    print(f"Total: {total}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/codemods/test_parse_api_response_vue_migration.py
+++ b/tools/codemods/test_parse_api_response_vue_migration.py
@@ -1,0 +1,216 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for parse_api_response_vue_migration.py codemod.
+
+Each test is a before/after string pair exercising one of the real patterns
+we migrated in PR #5177. If this codemod is ever rerun on a new batch of
+files, these tests catch regressions in the transform logic.
+"""
+import textwrap
+
+from parse_api_response_vue_migration import transform
+
+
+def _dedent(s: str) -> str:
+    return textwrap.dedent(s).lstrip("\n")
+
+
+def test_single_line_apiclient_get() -> None:
+    before = _dedent(
+        """
+        const response = await apiClient.get(`${url}/x`)
+        const data = await parseApiResponse<Record<string, any>>(response)
+        use(data)
+        """
+    )
+    expected = _dedent(
+        """
+        const data = await apiClient.get<Record<string, any>>(`${url}/x`)
+        use(data)
+        """
+    )
+    got, count = transform(before)
+    assert got == expected
+    assert count == 1
+
+
+def test_single_line_apiclient_post_with_body() -> None:
+    before = _dedent(
+        """
+        const response = await apiClient.post(`${url}/x`, { q: query })
+        const data = await parseApiResponse<Record<string, any>>(response)
+        use(data)
+        """
+    )
+    expected = _dedent(
+        """
+        const data = await apiClient.post<Record<string, any>>(`${url}/x`, { q: query })
+        use(data)
+        """
+    )
+    got, count = transform(before)
+    assert got == expected
+    assert count == 1
+
+
+def test_multiline_body_patches_opener_only() -> None:
+    # This was the tricky case in the 5033 Vue migration — my first script
+    # iteration missed these because its RESPONSE_LINE regex required the
+    # closing `)` on the same line.
+    before = _dedent(
+        """
+        const response = await apiClient.post(`${url}/extract`, {
+          conversation_id: conversationId.value.trim(),
+          messages
+        })
+
+        const parsedResponse = await parseApiResponse<Record<string, any>>(response)
+        use(parsedResponse)
+        """
+    )
+    expected = _dedent(
+        """
+        const parsedResponse = await apiClient.post<Record<string, any>>(`${url}/extract`, {
+          conversation_id: conversationId.value.trim(),
+          messages
+        })
+
+        use(parsedResponse)
+        """
+    )
+    got, count = transform(before)
+    assert got == expected
+    assert count == 1
+
+
+def test_uppercase_ApiClient_also_matched() -> None:
+    # Some Vue files use the `ApiClient` (PascalCase) singleton import.
+    before = _dedent(
+        """
+        const apiResponse = await ApiClient.post(`${url}/op`, {})
+        const response = await parseApiResponse<Record<string, any>>(apiResponse)
+        use(response)
+        """
+    )
+    expected = _dedent(
+        """
+        const response = await ApiClient.post<Record<string, any>>(`${url}/op`, {})
+        use(response)
+        """
+    )
+    got, count = transform(before)
+    assert got == expected
+    assert count == 1
+
+
+def test_drops_parseApiResponse_import_when_last_use_removed() -> None:
+    before = _dedent(
+        """
+        import apiClient from '@/utils/ApiClient'
+        import { parseApiResponse } from '@/utils/apiResponseHelpers'
+        import { useI18n } from 'vue-i18n'
+
+        async function run() {
+          const response = await apiClient.get(`${url}`)
+          const data = await parseApiResponse<Record<string, any>>(response)
+          return data
+        }
+        """
+    )
+    got, count = transform(before)
+    assert count == 1
+    assert "import { parseApiResponse }" not in got
+    # Other imports preserved
+    assert "import apiClient" in got
+    assert "import { useI18n }" in got
+
+
+def test_keeps_parseApiResponse_import_if_uses_remain() -> None:
+    # If the codemod can't migrate every site (pattern variant, etc.) the
+    # import must stay in place for the remaining uses.
+    before = _dedent(
+        """
+        import { parseApiResponse } from '@/utils/apiResponseHelpers'
+
+        async function a() {
+          const response = await apiClient.get(`${url}`)
+          const data = await parseApiResponse<Record<string, any>>(response)
+          return data
+        }
+
+        async function b() {
+          // Pattern the codemod doesn't handle (no matching opener)
+          const data = await parseApiResponse<SomeType>(externalResponse)
+          return data
+        }
+        """
+    )
+    got, count = transform(before)
+    assert count == 1
+    assert "import { parseApiResponse }" in got
+
+
+def test_multiple_sites_in_one_file() -> None:
+    # Real files often have many call sites. Each must be migrated once;
+    # count reflects total.
+    before = _dedent(
+        """
+        async function a() {
+          const response = await apiClient.get(`${url}/a`)
+          const data = await parseApiResponse<TypeA>(response)
+          return data
+        }
+
+        async function b() {
+          const response = await apiClient.post(`${url}/b`, {})
+          const data = await parseApiResponse<TypeB>(response)
+          return data
+        }
+        """
+    )
+    got, count = transform(before)
+    assert count == 2
+    assert "apiClient.get<TypeA>" in got
+    assert "apiClient.post<TypeB>" in got
+    assert "parseApiResponse" not in got
+
+
+def test_skips_parseApiResponse_without_matching_opener() -> None:
+    # If we can't find the `const X = await apiClient.METHOD(` opener, leave
+    # the site alone (rather than mangle). The import also stays.
+    before = _dedent(
+        """
+        import { parseApiResponse } from '@/utils/apiResponseHelpers'
+
+        async function weird() {
+          // Opener might be named differently, come from a different binding,
+          // or use fetchWithAuth. Codemod leaves this alone.
+          const raw = someOtherFetch()
+          const data = await parseApiResponse<SomeType>(raw)
+          return data
+        }
+        """
+    )
+    got, count = transform(before)
+    assert count == 0
+    assert "await parseApiResponse" in got
+
+
+def test_empty_file_is_unchanged() -> None:
+    before = ""
+    got, count = transform(before)
+    assert got == ""
+    assert count == 0
+
+
+def test_file_without_parseApiResponse_is_unchanged() -> None:
+    before = _dedent(
+        """
+        const x = await apiClient.get(`${url}`)
+        return x
+        """
+    )
+    got, count = transform(before)
+    assert got == before
+    assert count == 0


### PR DESCRIPTION
Closes #5150

## Summary

Promotes the codemod from `/tmp/migrate_vue_parseApiResponse.py` (proven in PR #5177 on **49 real call sites across 17 Vue files**) into a reviewable, tested, version-controlled location.

## Layout

```
tools/codemods/
├── README.md                                      ← When + how to add codemods
├── parse_api_response_vue_migration.py            ← The script
└── test_parse_api_response_vue_migration.py       ← 10 pytest cases
```

## Why this matters

This session alone produced **4 bulk-edit scripts** (parseApiResponse migration v1, v2, pass2, cleanup), all in `/tmp`, all discarded after one use. Each rewrite reintroduced the same regex bugs:
- First iteration of `cleanup_5092.py` corrupted file structure (bad `out.extend` logic)
- Second iteration stopped at inner `}` instead of `} catch` (over-eager scope detection)
- First Vue migration script missed multi-line bodies (single-line regex assumption)

With the script + tests in `tools/codemods/`, the next migration can either reuse this transform directly or fork it as a starting point. No more reinventing.

## Key design captured in tests

The tests document a non-obvious decision worth preserving: **patch only the opener, not the args span**. Test `test_multiline_body_patches_opener_only` exercises the case where `apiClient.post(url, { ... })` body spans multiple lines — the regex finds the opener `apiClient.METHOD(`, patches it to `apiClient.METHOD<TYPE>(`, and leaves the body alone. Avoids needing a multi-line paren matcher.

## Verification

```
$ cd tools/codemods && python3 -m pytest -xvs
============================== 10 passed in 0.03s ==============================
```

10/10 pass. Tests cover: single-line GET/POST, multi-line body, lowercase `apiClient` + uppercase `ApiClient`, import-removal logic (when last use gone vs. when sites remain), multiple sites in one file, opener-not-found skip, edge cases (empty file, no parseApiResponse).

## Future

The `README.md` sets the pattern for future codemods (one transform + one test file per migration). Adds a forward note about preferring `ts-morph` / `libcst` for AST-aware transforms once a regex misfires (already happened twice this session).