### PR TITLE
docs(shared): datetime parsing audit + canonicalization decision (#5169 parts B + C)

### DIFF
--- a/autobot_shared/time_utils.py
+++ b/autobot_shared/time_utils.py
@@ -1,29 +1,44 @@
 """Shared UTC timestamp helpers.
 
-This module exposes two helpers for producing the current UTC time as an
-ISO-8601 string. They differ in *output format*; the choice between them
-is dictated by what consumers can parse, not by author preference.
+Canonical format (#5169): **`+00:00` ISO-8601 produced by `utc_timestamp()`.**
 
-Selection rule (#5106, #5152, #5169)
-------------------------------------
+The parser audit at `docs/developer/audits/datetime-parsing-audit.md`
+established that 86% of internal `fromisoformat` callers (55 of 64
+files) are unguarded against `Z`-suffix input — they parse only the
+`+00:00` form. Python 3.10's `fromisoformat` raises `ValueError` on
+`Z`-suffix input. Aligning new producers with what the codebase
+already parses is the safe direction.
 
-``utc_timestamp()`` — **default for new code.**
+Selection rule
+--------------
+
+``utc_timestamp()`` — **default. Use for all new code.**
     Returns ``+00:00`` ISO-8601 with microseconds
-    (e.g. ``2026-04-18T19:34:50.123456+00:00``). Use this unless you are
-    reading or writing a stored format that explicitly expects ``Z``.
+    (e.g. ``2026-04-18T19:34:50.123456+00:00``).
+    Round-trips via ``datetime.fromisoformat`` on Python 3.10+.
 
-``utc_timestamp_z()`` — **legacy compatibility only.**
-    Returns ``Z``-suffix ISO-8601 with second precision and no
-    microseconds (e.g. ``2026-04-18T19:34:50Z``). Use ONLY when reading
-    or writing existing on-disk records that already use this format
-    (currently: workflow-version records via
-    ``services/workflow_versioning.py``). **Do not use for new
-    producers** — pick ``utc_timestamp()`` instead so the codebase
-    converges on one canonical format.
+``utc_timestamp_z()`` — **DEPRECATED — legacy compatibility only.**
+    Returns ``Z``-suffix ISO-8601 with second precision
+    (e.g. ``2026-04-18T19:34:50Z``). Retained ONLY because
+    ``services/workflow_versioning.py`` writes records in this format
+    historically. The audit confirmed zero internal parsers consume
+    those records, so a future migration of that producer is safe and
+    will allow this helper to be deleted.
+    **Do not call from new code.**
 
-Long-term canonicalization (#5169 parts B + C) is deferred pending a
-parser audit; until then both formats coexist and the rule above tells
-new code which to pick.
+Migration plan (#5169 part C)
+-----------------------------
+
+1. ✅ Selection rule documented (PR #5176)
+2. ✅ Audit + canonicalization decision (this PR)
+3. ⏳ Migrate 57 direct ``datetime.utcnow().isoformat()`` sites
+   to ``utc_timestamp()`` — tracked by #5178
+4. ⏳ Migrate ``workflow_versioning._utc_now`` → ``utc_timestamp``
+   (after step 3, requires either tolerant readers or one-time
+   data migration of stored Z records)
+5. ⏳ Delete ``utc_timestamp_z()`` (after step 4)
+6. ⏳ Python 3.11+ upgrade — drops the 9 ``.replace("Z", "+00:00")``
+   workaround sites since 3.11 ``fromisoformat`` accepts ``Z`` natively
 """
 import time
 from datetime import datetime, timezone
@@ -39,15 +54,18 @@ def utc_timestamp() -> str:
 
 
 def utc_timestamp_z() -> str:
-    """Return current UTC time as ISO-8601 with ``Z`` suffix.
+    """Return current UTC time as ISO-8601 with ``Z`` suffix. **DEPRECATED.**
 
     Format: ``YYYY-MM-DDTHH:MM:SSZ`` (exactly 20 chars, second precision,
     no microseconds, no ``+00:00`` offset). Matches the on-disk format
-    used by workflow_versioning records.
+    used by ``services/workflow_versioning.py`` records.
 
-    Use ONLY for legacy compatibility — see module docstring for
-    selection rule. Picking this for new producers perpetuates format
-    drift (#5106, #5152, #5169).
+    .. deprecated::
+        Use :func:`utc_timestamp` for all new code. This helper is
+        retained only for the single legacy producer above; see module
+        docstring for the migration plan that will delete it (#5169).
+        Calling this from new code violates the canonicalization
+        decision and will be flagged in review.
     """
     t = time.gmtime()
     return (

--- a/docs/developer/audits/datetime-parsing-audit.md
+++ b/docs/developer/audits/datetime-parsing-audit.md
@@ -1,0 +1,190 @@
+# Datetime Parsing Audit — `fromisoformat` and `strptime` Tolerance
+
+> **Status**: Part B + Part C of [#5169](https://github.com/mrveiss/AutoBot-AI/issues/5169). Closes the issue.
+> **Scope**: backend Python parsers of UTC-ISO-8601 strings. Frontend / TS parsers out of scope.
+> **Output**: parser landscape evidence + canonicalization decision.
+
+## TL;DR
+
+| Format | Producer | Python 3.10 `fromisoformat` | Internal consumer count |
+|---|---|---|---|
+| `2026-04-18T19:34:50.123456+00:00` | `utc_timestamp()` | ✅ accepts | 64 files |
+| `2026-04-18T19:34:50Z` | `utc_timestamp_z()` | ❌ **raises `ValueError`** | 0 files (write-only producer) |
+| `2026-04-18T19:34:50` (naive) | `datetime.utcnow().isoformat()` | ✅ accepts (returns naive) | tracked separately by [#5178](https://github.com/mrveiss/AutoBot-AI/issues/5178) |
+
+**Decision (Part C)**: canonicalize on `+00:00`. Mark `utc_timestamp_z()` deprecated. Plan a Python 3.11 upgrade so the 9 explicit Z-shim sites become redundant. No on-disk data migration required — the only Z-suffix producer (`workflow_versioning`) has zero internal parsers.
+
+---
+
+## Part B — Parser landscape
+
+### Method
+
+```bash
+grep -rn "fromisoformat" autobot-backend autobot_shared --include="*.py" | grep -v "_test.py\|__pycache__"
+grep -rn "strptime"      autobot-backend autobot_shared --include="*.py" | grep -v "_test.py\|__pycache__"
+```
+
+### Counts
+
+- **`fromisoformat` callers**: 64 files (119 call sites)
+- **Files with explicit `Z`-shim** (`replace("Z", "+00:00")` / `rstrip("Z")`): **9** (~14%)
+- **`strptime` callers**: 13 sites — none parse ISO-8601 with timezone suffix; all use SQLite TEXT (`%Y-%m-%d %H:%M:%S`), date-only (`%Y-%m-%d`), hour bucket, or PKI cert format. **Irrelevant to ISO-8601 canonicalization.**
+
+### Distribution by subsystem
+
+```
+api/         18 files   ← largest cluster (response normalization, analytics)
+knowledge/    9 files   ← KB metadata, connectors
+services/     8 files   ← agent_analytics, feedback_tracker, secrets
+security/     6 files
+utils/        4 files
+models/       4 files
+memory/       2 files
+code_intel/   2 files
+tests/        3 files
+```
+
+### Tolerance classification
+
+#### Class A — Z-shim guarded (handles both `Z` and `+00:00`)
+
+9 files. Pattern: `datetime.fromisoformat(s.replace("Z", "+00:00"))` or `.rstrip("Z")`.
+
+| File | Line | Source of input |
+|---|---|---|
+| [`utils/branch_metrics.py:104`](autobot-backend/utils/branch_metrics.py) | 104 | git CLI output |
+| [`chat_history/deduplication.py:29`](autobot-backend/chat_history/deduplication.py) | 29 | message timestamps |
+| [`knowledge/metadata.py:423`](autobot-backend/knowledge/metadata.py) | 423 | KB metadata field |
+| [`knowledge/connectors/notion.py:288`](autobot-backend/knowledge/connectors/notion.py) | 288 | Notion API response (Z-format) |
+| [`api/knowledge_organization.py:333`](autobot-backend/api/knowledge_organization.py) | 333 | KB record field |
+| [`api/analytics_evolution.py:980`](autobot-backend/api/analytics_evolution.py) | 980 | analytics record |
+| [`api/analytics_conversation.py:40,52,495`](autobot-backend/api/analytics_conversation.py) | 40, 52, 495 | conversation record |
+| [`api/chat.py:140`](autobot-backend/api/chat.py) | 140 | chat record |
+
+**These 9 files are safe under either format.** The shim is defensive: it was added because external APIs (Notion, git, Redis writes from older AutoBot versions) sometimes emit `Z`. Once we canonicalize on `+00:00` AND upgrade to Python 3.11+, the shim becomes redundant but harmless.
+
+#### Class B — unguarded (assumes `+00:00` or naive)
+
+55 files (86%). Pattern: `datetime.fromisoformat(s)` with no preprocessing.
+
+Spot-check sample:
+
+| File | Line | Field | Producer |
+|---|---|---|---|
+| [`project_state_tracking/database.py:260`](autobot-backend/project_state_tracking/database.py) | 260 | `row[0]` (SQLite TEXT) | internal write via `utc_timestamp()` or `datetime.utcnow().isoformat()` |
+| [`memory/storage/general_storage.py:223`](autobot-backend/memory/storage/general_storage.py) | 223 | `row["timestamp"]` | internal write |
+| [`memory/storage/task_storage.py:296,301,306`](autobot-backend/memory/storage/task_storage.py) | 296-306 | `created_at`, `started_at`, `completed_at` | internal write |
+| [`planner/types.py:105,110,285,290`](autobot-backend/planner/types.py) | 105-290 | task lifecycle fields | internal write |
+| [`events/types.py:157`](autobot-backend/events/types.py) | 157 | `data["timestamp"]` (event envelope) | internal write |
+
+**Risk profile**: each unguarded site would raise `ValueError` on Python 3.10 if fed a `Z`-suffix string. They work today because the producers feeding them never emit `Z` (they use `utc_timestamp()` → `+00:00`, or `datetime.utcnow().isoformat()` → naive).
+
+The 55 sites form an **invariant**: as long as no internal producer switches to `Z` form, no parser breaks. **`utc_timestamp_z()` violates this invariant**, but its output (`workflow_versioning` records) has zero internal parsers — so the violation is contained.
+
+#### Class C — strict-format `strptime` (irrelevant)
+
+All 13 sites parse non-ISO-8601 formats:
+
+```
+api/chat.py:141                      "%Y-%m-%d %H:%M:%S"      ← SQLite TEXT
+chat_history/deduplication.py:30     "%Y-%m-%d %H:%M:%S"      ← SQLite TEXT
+pki/generator.py:431                 "%b %d %H:%M:%S %Y %Z"   ← OpenSSL output
+knowledge/bulk.py:49,77              "%Y-%m-%d"               ← date-only
+knowledge/stats.py:796               "%Y-%m-%d"               ← date-only
+api/knowledge_models.py:399,1723     "%Y-%m-%d"               ← date-only
+api/analytics_log_patterns.py:171    "%Y-%m-%d %H:%M:%S"      ← log format
+api/analytics_log_patterns.py:403,4  "%Y-%m-%d %H:00"         ← hour bucket
+code_intelligence/log_pattern_miner.py:322,880  same as above
+```
+
+None of these would parse `utc_timestamp()` or `utc_timestamp_z()` output. They're orthogonal concerns and out of scope for the canonicalization decision.
+
+### Workflow_versioning record consumers
+
+Critical question: who parses the records produced by `_utc_now()` (now `utc_timestamp_z` after PR #5163)?
+
+```bash
+grep -rn "workflow_versioning\|WorkflowVersion\|workflow:version" autobot-backend --include="*.py" \
+  | grep -v "_test.py\|__pycache__\|services/workflow_versioning.py"
+# (zero hits)
+```
+
+**Zero internal consumers grep-found** outside of `workflow_versioning.py` itself. The records are written and either (a) returned verbatim to API clients (display-only) or (b) never re-read at all. Either way, the on-disk format choice has no parser dependency — we can change it whenever we want without breaking anything internal.
+
+### Python version constraint
+
+```
+$ python3 --version
+Python 3.10.12
+```
+
+`datetime.fromisoformat` does not accept `Z` suffix on Python 3.10:
+
+```
+>>> datetime.fromisoformat('2026-04-18T19:34:50Z')
+ValueError: Invalid isoformat string: '2026-04-18T19:34:50Z'
+
+>>> datetime.fromisoformat('2026-04-18T19:34:50+00:00')
+datetime.datetime(2026, 4, 18, 19, 34, 50, tzinfo=datetime.timezone.utc)
+```
+
+This was changed in Python 3.11 — `fromisoformat` accepts both forms natively from then on.
+
+---
+
+## Part C — Canonicalization decision (ADR)
+
+### Decision
+
+**Canonicalize the AutoBot codebase on `+00:00` ISO-8601 (the format produced by `utc_timestamp()`).**
+
+Rationale:
+1. **No on-disk migration risk.** The only `Z`-format producer (`workflow_versioning`) has zero internal parsers. We can deprecate `utc_timestamp_z()` without touching any record.
+2. **86% of parsers are already only-`+00:00`-compatible.** They work today because all our internal producers emit `+00:00` or naive. Choosing `+00:00` aligns the rule with what the codebase already does.
+3. **The Z-shim is a workaround, not a feature.** 9 files preprocess `Z`→`+00:00` defensively because external APIs (Notion, git, etc.) emit `Z`. After Python 3.11 upgrade, the shim is redundant. Designing internal producers around an external-API quirk is the wrong direction.
+4. **`+00:00` is what `datetime.now(timezone.utc).isoformat()` produces by default.** Picking the Python idiomatic form means new code is correct without thinking about format.
+
+### Implementation plan
+
+| Step | Status | Owner |
+|---|---|---|
+| 1. Document selection rule (Part A) | ✅ Done — PR #5176 | — |
+| 2. Mark `utc_timestamp_z()` as `@deprecated` in docstring | ✅ This PR | — |
+| 3. Migrate 57 direct `datetime.utcnow().isoformat()` sites to `utc_timestamp()` | Tracked by [#5178](https://github.com/mrveiss/AutoBot-AI/issues/5178) | — |
+| 4. Migrate `workflow_versioning._utc_now` consumer to `utc_timestamp()` | Future PR — only after step 3 | — |
+| 5. Delete `utc_timestamp_z()` from `time_utils.py` | After step 4 | — |
+| 6. Plan Python 3.11+ upgrade | Separate issue (#5169 follow-up) | — |
+| 7. Drop the 9 Z-shim workarounds (no longer needed after step 6) | Final cleanup | — |
+
+### What this PR does (closes #5169)
+
+- ✅ This audit document (Part B)
+- ✅ Decision recorded above (Part C)
+- ✅ `utc_timestamp_z()` marked `@deprecated` in [`autobot_shared/time_utils.py`](../../../autobot_shared/time_utils.py) docstring with migration pointer
+
+Steps 3–7 are tracked as separate issues (#5178 + future). #5169 itself is closed by this PR.
+
+### What this PR does NOT do
+
+- Does not migrate any of the 57 direct-usage sites — that's #5178
+- Does not delete `utc_timestamp_z()` — premature; it's still the canonical alias for `workflow_versioning`'s on-disk format until step 4
+- Does not bump Python to 3.11 — that's a separate scope
+- Does not touch the 9 Z-shim sites — they remain defensive against external APIs even after canonicalization
+
+---
+
+## Appendix — full grep output
+
+```
+$ grep -rln "fromisoformat" autobot-backend autobot_shared --include="*.py" | grep -v "_test.py\|__pycache__" | wc -l
+64
+
+$ grep -rln "fromisoformat.*replace.*Z\|fromisoformat.*rstrip.*Z" autobot-backend autobot_shared --include="*.py" | grep -v "_test.py\|__pycache__" | wc -l
+9
+
+$ grep -rn "strptime" autobot-backend autobot_shared --include="*.py" | grep -v "_test.py\|__pycache__" | wc -l
+13
+```
+
+Counts as of commit `b545e8326` (Dev_new_gui head at audit time).


### PR DESCRIPTION
## Summary

**Closes #5169** (Part A shipped in PR #5176; this PR ships Parts B + C).

Adds [`docs/developer/audits/datetime-parsing-audit.md`](docs/developer/audits/datetime-parsing-audit.md) with the parser landscape evidence (Part B) + canonicalization decision (Part C). Updates [`autobot_shared/time_utils.py`](autobot_shared/time_utils.py) docstring with the migration plan and marks `utc_timestamp_z()` as `.. deprecated::`.

## Part B — Parser audit findings

| Class | Count | Behavior on `Z`-suffix input (Py 3.10) |
|---|---|---|
| `fromisoformat` with explicit `.replace("Z", "+00:00")` shim | 9 files (14%) | ✅ accepts |
| `fromisoformat` unguarded | 55 files (86%) | ❌ `ValueError` |
| `strptime` with strict ISO-8601 + tz-suffix format | **0 files** | n/a |
| `strptime` with non-ISO formats (SQLite TEXT, date-only, etc.) | 13 sites | irrelevant |

**Critical**: workflow_versioning records (the only `Z`-format producer) have **zero internal parsers** found via grep. The on-disk format has no consumer dependency — we can deprecate `utc_timestamp_z()` without touching any record.

## Part C — Decision

**Canonicalize on `+00:00`.** Reasoning:
1. All 64 internal parsers handle `+00:00` (55 unguarded sites depend on it); only 9 also handle `Z`
2. `workflow_versioning` (only `Z` producer) is write-only/display-only — zero readers
3. Python idiomatic — `datetime.now(timezone.utc).isoformat()` produces `+00:00`
4. Python 3.11+ upgrade lets us drop all 9 Z-shims since 3.11 `fromisoformat` accepts `Z` natively

## What this PR does

- ✅ Part B audit document
- ✅ Part C decision recorded in audit + `time_utils.py` module docstring
- ✅ `utc_timestamp_z()` marked `.. deprecated::` (function body unchanged — output byte-identical)
- ✅ Migration roadmap documented (steps 3-7 tracked separately)

## What this PR does NOT do

- Does NOT migrate the 57 direct-usage sites — that's [#5178](https://github.com/mrveiss/AutoBot-AI/issues/5178)
- Does NOT migrate `workflow_versioning._utc_now` — premature; needs reader audit + (optional) one-time data migration
- Does NOT delete `utc_timestamp_z()` — required while the legacy producer still uses it
- Does NOT bump Python version — separate scope

## Verification

```
$ python3 -m pytest autobot_shared/time_utils_test.py -v
... 7 passed in 0.04s
$ python3 -c "from autobot_shared.time_utils import utc_timestamp, utc_timestamp_z; print(utc_timestamp(), '|', utc_timestamp_z())"
2026-04-19T17:04:53.711121+00:00 | 2026-04-19T17:04:53Z
```

Both helpers produce identical output to before; only the documentation and deprecation status changed.

## Test plan

- [x] All 7 unit tests pass
- [x] `py_compile` passes
- [x] Module imports cleanly
- [x] Both helpers produce expected formats
- [x] Audit grep counts cited match actual repo state at commit time
- [ ] `gh pr checks` passes