### PR TITLE
fix(knowledge-connectors): unpack wrapped backend response shapes in KnowledgeRepository (#5200)

### DIFF
--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -534,30 +534,45 @@ export class KnowledgeRepository extends ApiRepository {
   // ==========================================================================
 
   /**
-   * List all connectors with their statuses
+   * List all connectors with their statuses.
+   *
+   * Backend returns `{connectors: [{config, status}, ...], total}` — an array
+   * of wrapped pairs. Here we unpack into two parallel structures so the
+   * store and components can key status lookups by `connector_id` (#5200).
    */
   async listConnectors(): Promise<{
     connectors: ConnectorConfig[]
     statuses: Record<string, ConnectorStatus>
   }> {
-    const response = await this.get(
-      `${getApiBase()}/knowledge_base/connectors`,
-      { skipCache: true }
-    )
-    return response.data as { connectors: ConnectorConfig[]; statuses: Record<string, ConnectorStatus> }
+    const response = await this.get<{
+      connectors: Array<{ config: ConnectorConfig; status: ConnectorStatus }>
+      total: number
+    }>(`${getApiBase()}/knowledge_base/connectors`, { skipCache: true })
+
+    const configs: ConnectorConfig[] = []
+    const statuses: Record<string, ConnectorStatus> = {}
+    for (const entry of response.data?.connectors ?? []) {
+      if (!entry?.config?.connector_id) continue
+      configs.push(entry.config)
+      statuses[entry.config.connector_id] = entry.status
+    }
+    return { connectors: configs, statuses }
   }
 
   /**
-   * Create a new connector
+   * Create a new connector.
+   *
+   * Backend returns `{connector_id, config}`; we extract `.config` so callers
+   * get a flat `ConnectorConfig` matching the declared return type (#5200).
    */
   async createConnector(
     config: Partial<ConnectorConfig>
   ): Promise<ConnectorConfig> {
-    const response = await this.post(
-      `${getApiBase()}/knowledge_base/connectors`,
-      config
-    )
-    return response.data as ConnectorConfig
+    const response = await this.post<{
+      connector_id: string
+      config: ConnectorConfig
+    }>(`${getApiBase()}/knowledge_base/connectors`, config)
+    return response.data.config
   }
 
   /**
@@ -574,17 +589,23 @@ export class KnowledgeRepository extends ApiRepository {
   }
 
   /**
-   * Update connector configuration
+   * Update connector configuration.
+   *
+   * Backend returns `{connector_id, config}`; we extract `.config` so callers
+   * get a flat `ConnectorConfig` matching the declared return type (#5200).
    */
   async updateConnector(
     id: string,
     updates: Partial<ConnectorConfig>
   ): Promise<ConnectorConfig> {
-    const response = await this.put(
+    const response = await this.put<{
+      connector_id: string
+      config: ConnectorConfig
+    }>(
       `${getApiBase()}/knowledge_base/connectors/${encodeURIComponent(id)}`,
       updates
     )
-    return response.data as ConnectorConfig
+    return response.data.config
   }
 
   /**

--- a/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.connectors.test.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.connectors.test.ts
@@ -1,0 +1,166 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2026 mrveiss
+// Author: mrveiss
+/**
+ * Regression tests for #5200 — KnowledgeRepository connector-endpoint
+ * response-shape handling.
+ *
+ * Backend returns wrapped pairs (`{config, status}` and `{connector_id, config}`)
+ * that must be unpacked into the flat shapes callers declare.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { KnowledgeRepository } from '../KnowledgeRepository'
+import type { ConnectorConfig, ConnectorStatus } from '@/types/connectors'
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api'
+}))
+
+function mkConfig(id: string, name = 'demo'): ConnectorConfig {
+  return {
+    connector_id: id,
+    name,
+    connector_type: 'file_server',
+    enabled: true,
+    target: '/data/test',
+    verification_mode: 'none',
+    schedule_cron: null,
+    include_patterns: [],
+    exclude_patterns: [],
+    tier: 0,
+    created_at: '2026-04-18T00:00:00Z',
+    updated_at: '2026-04-18T00:00:00Z'
+  } as unknown as ConnectorConfig
+}
+
+function mkStatus(connector_id: string): ConnectorStatus {
+  return {
+    connector_id,
+    is_healthy: true,
+    last_sync_at: null,
+    last_sync_status: 'never',
+    documents_count: 0
+  } as unknown as ConnectorStatus
+}
+
+describe('KnowledgeRepository connector endpoints (#5200)', () => {
+  let repo: KnowledgeRepository
+  let getSpy: ReturnType<typeof vi.fn>
+  let postSpy: ReturnType<typeof vi.fn>
+  let putSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    repo = new KnowledgeRepository()
+    getSpy = vi.fn()
+    postSpy = vi.fn()
+    putSpy = vi.fn()
+    // @ts-expect-error - override inherited methods for unit test isolation
+    repo.get = getSpy
+    // @ts-expect-error
+    repo.post = postSpy
+    // @ts-expect-error
+    repo.put = putSpy
+  })
+
+  describe('listConnectors — unpacks {config, status} pairs', () => {
+    it('splits backend-wrapped pairs into flat configs + statuses map', async () => {
+      const cfg1 = mkConfig('id-1', 'first')
+      const cfg2 = mkConfig('id-2', 'second')
+      const st1 = mkStatus('id-1')
+      const st2 = mkStatus('id-2')
+      getSpy.mockResolvedValue({
+        data: {
+          connectors: [
+            { config: cfg1, status: st1 },
+            { config: cfg2, status: st2 }
+          ],
+          total: 2
+        }
+      })
+
+      const result = await repo.listConnectors()
+
+      expect(result.connectors).toHaveLength(2)
+      expect(result.connectors[0]).toEqual(cfg1)
+      expect(result.connectors[1]).toEqual(cfg2)
+      expect(result.statuses).toEqual({ 'id-1': st1, 'id-2': st2 })
+    })
+
+    it('returns empty structures on empty backend response', async () => {
+      getSpy.mockResolvedValue({ data: { connectors: [], total: 0 } })
+
+      const result = await repo.listConnectors()
+
+      expect(result.connectors).toEqual([])
+      expect(result.statuses).toEqual({})
+    })
+
+    it('skips entries with missing config.connector_id', async () => {
+      const cfg = mkConfig('id-1')
+      const st = mkStatus('id-1')
+      getSpy.mockResolvedValue({
+        data: {
+          connectors: [
+            { config: cfg, status: st },
+            // Malformed entry — no connector_id
+            { config: {} as unknown as ConnectorConfig, status: st },
+            // Missing status
+            null as unknown as { config: ConnectorConfig; status: ConnectorStatus }
+          ],
+          total: 3
+        }
+      })
+
+      const result = await repo.listConnectors()
+
+      expect(result.connectors).toHaveLength(1)
+      expect(result.connectors[0].connector_id).toBe('id-1')
+      expect(result.statuses).toEqual({ 'id-1': st })
+    })
+
+    it('handles nullish data payload gracefully', async () => {
+      getSpy.mockResolvedValue({ data: null })
+
+      const result = await repo.listConnectors()
+
+      expect(result.connectors).toEqual([])
+      expect(result.statuses).toEqual({})
+    })
+  })
+
+  describe('createConnector — extracts wrapped config', () => {
+    it('unwraps {connector_id, config} response into flat ConnectorConfig', async () => {
+      const cfg = mkConfig('new-id', 'created')
+      postSpy.mockResolvedValue({
+        data: { connector_id: 'new-id', config: cfg }
+      })
+
+      const result = await repo.createConnector({ name: 'created' })
+
+      expect(result).toEqual(cfg)
+      expect(postSpy).toHaveBeenCalledWith('/api/knowledge_base/connectors', {
+        name: 'created'
+      })
+    })
+  })
+
+  describe('updateConnector — extracts wrapped config', () => {
+    it('unwraps {connector_id, config} response into flat ConnectorConfig', async () => {
+      const cfg = mkConfig('existing-id', 'updated')
+      putSpy.mockResolvedValue({
+        data: { connector_id: 'existing-id', config: cfg }
+      })
+
+      const result = await repo.updateConnector('existing-id', {
+        name: 'updated'
+      })
+
+      expect(result).toEqual(cfg)
+      expect(putSpy).toHaveBeenCalledWith(
+        '/api/knowledge_base/connectors/existing-id',
+        { name: 'updated' }
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes #5200

## Problem (user-reported)

\"Connectors does not work\" on the GUI. Visiting \`/knowledge/connectors\` rendered empty or broken cards because \`KnowledgeRepository.listConnectors()\` lied about the backend shape.

**Backend returns:**
\`\`\`json
GET /api/knowledge_base/connectors
{
  \"connectors\": [
    { \"config\": {...ConnectorConfig...}, \"status\": {...ConnectorStatus...} }
  ],
  \"total\": N
}
\`\`\`

**Repository declared (and cast):**
\`\`\`ts
{ connectors: ConnectorConfig[], statuses: Record<id, ConnectorStatus> }
\`\`\`

The cast was silent — \`store.connectors\` ended up holding wrapper objects, \`v-for=\"cfg in store.connectors\"\` read \`cfg.connector_id\` (undefined — it lives at \`cfg.config.connector_id\`), and \`getStatus(undefined)\` returned empty status. Cards rendered broken or not at all.

Same pattern broke \`createConnector\` and \`updateConnector\` — backend returns \`{connector_id, config}\`, repository declared \`ConnectorConfig\` directly. Create/Edit buttons would hand back an object missing every ConnectorConfig field.

## Fix

Unpack the wrapped shapes in the repository:

- \`listConnectors\` now splits the backend's \`[{config, status}]\` array into two parallel structures, keying statuses by \`connector_id\`
- \`createConnector\` / \`updateConnector\` extract \`.config\` from the \`{connector_id, config}\` response
- \`getConnector\` was already correct (backend and declared type both \`{config, status}\`) — untouched
- Added defensive handling for malformed entries (missing \`connector_id\`, null entries) and nullish \`data\` payload

## Tests

6 new regression tests in \`KnowledgeRepository.connectors.test.ts\`:
- listConnectors: unpacks pairs, empty response, skips malformed entries, handles null data
- createConnector: extracts wrapped config
- updateConnector: extracts wrapped config

**All 6 pass.** 0 new TypeScript errors (166 pre-existing baseline unchanged).

## Verification

\`\`\`bash
$ curl -sS http://127.0.0.1:8001/api/knowledge_base/connectors
{\"connectors\":[],\"total\":0}

# After fix + user creates a connector:
# - POST returns {connector_id, config} — repository extracts .config
# - GET returns wrapped pairs — repository unpacks
# - Store receives flat ConnectorConfig[] and Record<id, status>
# - ConnectorStatusCard v-for/props get the right shapes — renders correctly
\`\`\`

## Follow-ups (separate issues to file)

- \`testConnector\` — backend returns \`{connector_id, healthy}\` but repository declares \`{success, message}\`
- \`syncConnector\` — backend returns \`{connector_id, status: \"sync_started\"}\` but consumer (ConnectorManager.handleSync) reads \`result.added/updated/deleted\` — those fields don't exist on the response, are async via /history endpoint

These are cosmetic log-message issues (not user-visible breakage) so scoped out of this PR.