### PR TITLE
feat(tools): pre-push hook enforcing Phase 0c verification + Phase 6 duplicate check (#5142 #5143)

### DIFF
--- a/tools/git-hooks/README.md
+++ b/tools/git-hooks/README.md
@@ -1,0 +1,62 @@
+# tools/git-hooks
+
+Git hooks that enforce the `team-implement` skill's Phase 0c (verification
+mandate) and Phase 6 (pre-push duplicate check) automatically. Without these,
+the skill rules are advisory text — easy to skip when you're in a hurry.
+With them, git won't let you push something that fails the rules.
+
+This directory exists because of #5142 (verification mandate) and #5143
+(pre-push duplicate check), both filed after I personally caused two
+incidents this session that the rules were supposed to prevent:
+
+- **PR #5141 broke 3 tests.** I ran `vue-tsc` and called it verified.
+  `vitest run` would have caught the regression in 2 seconds.
+- **PR #5141 was a duplicate of merged PR #5128.** I didn't re-fetch
+  before pushing. Wasted ~30 minutes.
+
+## Setup (one-time per developer)
+
+```bash
+tools/git-hooks/install_hooks.sh
+```
+
+Symlinks each hook into `.git/hooks/`. Idempotent: safe to re-run. Existing
+hooks are backed up to `*.bak.<timestamp>` before being replaced.
+
+## What the pre-push hook does
+
+For each ref you're pushing, the hook walks the changed files and runs:
+
+| Check | When | What |
+|---|---|---|
+| **Phase 6 issue check** | branch matches `issue-NNNN` | warn if issue is CLOSED on GitHub OR if `origin/Dev_new_gui` already has a commit citing `#NNNN` |
+| **Phase 0c type check** | any `.ts` or `.vue` file changed | `vue-tsc --noEmit -p tsconfig.app.json` (90s timeout); only **errors in changed files** block — pre-existing project errors warn |
+| **Phase 0c test run** | any test file or composable changed | `vitest run <relevant test files>` (120s timeout); failures block |
+| **Phase 0c backend tests** | any `.py` file changed | `pytest <co-located *_test.py>` (120s timeout); failures block |
+
+Time-boxed: a slow check warns and skips rather than blocking forever. Real
+failures block the push with a clear "fix this" message.
+
+## Bypass
+
+```bash
+git push --no-verify
+```
+
+Use only when you actually have to (e.g. delivering a hotfix and CI will
+verify). Don't make a habit of it — every bypass is the path that produces
+PR #5141-class incidents.
+
+## Tested manually
+
+Verified on the issue-5142-hooks branch (this PR):
+- Phase 6: simulated a push to `issue-5128` (closed), correctly warned about
+  the closed issue and the existing `Dev_new_gui` commit citing it
+- Phase 0c: simulated a push with a test failure injected — correctly
+  blocked with a clear "vitest failures (#5142)" message
+- Idempotency: ran `install_hooks.sh` twice; second run was a no-op
+
+## Updating
+
+The hooks are symlinked, so edits to `tools/git-hooks/pre-push` in the repo
+are picked up on the next push — no resync needed.

--- a/tools/git-hooks/install_hooks.sh
+++ b/tools/git-hooks/install_hooks.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# install_hooks.sh — symlink each tools/git-hooks/<name> into .git/hooks/<name>
+# so they run on the next git operation.
+#
+# Idempotent: safe to re-run. Existing symlinks pointing at this repo are
+# refreshed; existing regular files are backed up to *.bak.<timestamp>.
+#
+# Issue #5142.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOKS_SRC="$REPO_ROOT/tools/git-hooks"
+
+# Use --git-common-dir so this works inside worktrees too. In a worktree,
+# `.git` is a file pointing at .git/worktrees/<name>/, but hooks live in
+# the main repo's .git/hooks/ shared across all worktrees.
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || echo "")"
+if [ -z "$GIT_COMMON_DIR" ]; then
+  echo "ERROR: not inside a git repository" >&2
+  exit 1
+fi
+
+# Resolve to absolute path (--git-common-dir may return a relative path)
+case "$GIT_COMMON_DIR" in
+  /*) HOOKS_DEST="$GIT_COMMON_DIR/hooks" ;;
+  *)  HOOKS_DEST="$(cd "$GIT_COMMON_DIR" && pwd)/hooks" ;;
+esac
+
+if [ ! -d "$HOOKS_SRC" ]; then
+  echo "ERROR: hook source directory missing: $HOOKS_SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$HOOKS_DEST"
+
+INSTALLED=0
+SKIPPED=0
+BACKED_UP=0
+
+for src_file in "$HOOKS_SRC"/*; do
+  [ -f "$src_file" ] || continue
+  base="$(basename "$src_file")"
+
+  # Skip non-hook files (README, install_hooks.sh itself)
+  case "$base" in
+    README*|install_hooks.sh|*.md)
+      continue
+      ;;
+  esac
+
+  hook_target="$HOOKS_DEST/$base"
+
+  if [ -L "$hook_target" ]; then
+    current="$(readlink "$hook_target")"
+    if [ "$current" = "$src_file" ]; then
+      echo "OK    $base (already symlinked to repo)"
+      SKIPPED=$((SKIPPED + 1))
+      continue
+    fi
+    rm "$hook_target"
+  elif [ -f "$hook_target" ]; then
+    backup="$hook_target.bak.$(date +%Y%m%d-%H%M%S)"
+    mv "$hook_target" "$backup"
+    echo "BACKUP $base -> $(basename "$backup")"
+    BACKED_UP=$((BACKED_UP + 1))
+  fi
+
+  ln -s "$src_file" "$hook_target"
+  chmod +x "$src_file"  # ensure executable for git
+  echo "LINK  $base -> $src_file"
+  INSTALLED=$((INSTALLED + 1))
+done
+
+echo ""
+echo "Installed: $INSTALLED  Refreshed: $SKIPPED  Backed up: $BACKED_UP"
+echo ""
+echo "Bypass an installed hook with: git push --no-verify (don't unless you must)"

--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# pre-push: enforce Phase 0c (verify before push) + Phase 6 (no duplicate
+# PR for already-merged issue) from the team-implement skill.
+#
+# Issues #5142 (verification mandate) and #5143 (pre-push duplicate check).
+#
+# Bypass with `git push --no-verify` if you absolutely must (don't).
+
+set -uo pipefail  # NOT -e: we want to capture exit codes and report
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Time-box each check. Frontend type-check on the whole project takes ~60s;
+# we'd rather warn than block forever.
+TYPE_CHECK_TIMEOUT=90
+TEST_TIMEOUT=120
+
+# Color helpers (no-op when not a tty)
+if [ -t 1 ]; then
+  RED='\033[0;31m'; YEL='\033[0;33m'; GRN='\033[0;32m'; BLU='\033[0;34m'; CLR='\033[0m'
+else
+  RED=''; YEL=''; GRN=''; BLU=''; CLR=''
+fi
+
+log()   { printf "${BLU}[pre-push]${CLR} %s\n" "$*" >&2; }
+warn()  { printf "${YEL}[pre-push WARN]${CLR} %s\n" "$*" >&2; }
+fail()  { printf "${RED}[pre-push FAIL]${CLR} %s\n" "$*" >&2; }
+ok()    { printf "${GRN}[pre-push OK]${CLR} %s\n" "$*" >&2; }
+
+EXIT_CODE=0
+
+# ---------------------------------------------------------------------------
+# Read git's stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>
+# Process each pushed ref. Skip deletes (sha = 0000...).
+# ---------------------------------------------------------------------------
+ZERO=0000000000000000000000000000000000000000
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ "$local_sha" = "$ZERO" ] && continue  # deletion
+  log "checking $local_ref → $remote_ref"
+
+  # ------------------------------------------------------------------------
+  # Phase 6 (#5143): pre-push duplicate check for issue branches
+  # ------------------------------------------------------------------------
+  branch_name="${local_ref#refs/heads/}"
+  if [[ "$branch_name" =~ ^issue-([0-9]+)(-.*)?$ ]]; then
+    issue_num="${BASH_REMATCH[1]}"
+
+    if command -v gh >/dev/null 2>&1; then
+      # Issue state lookup; tolerate gh failures (not signed in, offline, etc.)
+      issue_state=$(gh issue view "$issue_num" --json state --jq '.state' 2>/dev/null || echo "")
+      if [ "$issue_state" = "CLOSED" ]; then
+        warn "Issue #$issue_num is CLOSED on GitHub."
+        warn "  Verify your work isn't superseded before pushing."
+        warn "  $ gh issue view $issue_num --comments | head -50"
+      fi
+
+      # Has Dev_new_gui already merged a commit citing this issue?
+      git fetch origin Dev_new_gui --quiet 2>/dev/null || true
+      if git log origin/Dev_new_gui --oneline -50 2>/dev/null | grep -qE "#${issue_num}\\b"; then
+        warn "origin/Dev_new_gui already has a commit citing #$issue_num:"
+        git log origin/Dev_new_gui --oneline -50 2>/dev/null \
+          | grep -E "#${issue_num}\\b" \
+          | head -3 \
+          | sed 's/^/  /' >&2
+        warn "  If that commit covers your fix, your push will create a duplicate PR."
+      fi
+    else
+      warn "gh CLI not installed — skipping issue state check (#5143)"
+    fi
+  fi
+
+  # ------------------------------------------------------------------------
+  # Phase 0c (#5142): verification mandate (type-check + test-run)
+  # ------------------------------------------------------------------------
+  # Find files changed in the commits we're pushing. For first push of a
+  # branch, the remote sha is 0000...; in that case diff against the merge
+  # base with origin/Dev_new_gui.
+  if [ "$remote_sha" = "$ZERO" ]; then
+    base=$(git merge-base "$local_sha" origin/Dev_new_gui 2>/dev/null \
+        || git merge-base "$local_sha" main 2>/dev/null \
+        || echo "")
+    if [ -z "$base" ]; then
+      warn "Cannot determine merge base — skipping Phase 0c verification"
+      continue
+    fi
+    diff_range="${base}..${local_sha}"
+  else
+    diff_range="${remote_sha}..${local_sha}"
+  fi
+
+  changed=$(git diff --name-only "$diff_range" 2>/dev/null || echo "")
+  if [ -z "$changed" ]; then
+    log "no changed files in range — skipping Phase 0c"
+    continue
+  fi
+
+  # ----- Frontend (TypeScript / Vue) --------------------------------------
+  if echo "$changed" | grep -qE '\.(ts|vue)$'; then
+    log "frontend files changed — running vue-tsc (timeout ${TYPE_CHECK_TIMEOUT}s)"
+    if [ -d "$REPO_ROOT/autobot-frontend" ] \
+       && [ -d "$REPO_ROOT/autobot-frontend/node_modules" ]; then
+      tsc_output=$(
+        cd "$REPO_ROOT/autobot-frontend" \
+        && timeout "$TYPE_CHECK_TIMEOUT" npx vue-tsc --noEmit \
+             -p tsconfig.app.json 2>&1
+      ) || tsc_exit=$?
+      tsc_exit=${tsc_exit:-0}
+
+      if [ "$tsc_exit" = "124" ]; then
+        warn "vue-tsc timed out after ${TYPE_CHECK_TIMEOUT}s — skipping (run manually)"
+      elif [ "$tsc_exit" != "0" ]; then
+        # Distinguish errors in changed files (block) vs pre-existing (warn)
+        changed_ts_files=$(echo "$changed" | grep -E '\.(ts|vue)$' \
+          | sed 's|^autobot-frontend/||' || true)
+        if [ -n "$changed_ts_files" ]; then
+          # Show only errors that mention any of the changed files
+          relevant=$(echo "$tsc_output" \
+            | grep "error TS" \
+            | grep -F -f <(echo "$changed_ts_files") || true)
+          if [ -n "$relevant" ]; then
+            fail "vue-tsc errors in CHANGED files (#5142):"
+            echo "$relevant" | head -20 >&2
+            EXIT_CODE=1
+          else
+            ok "vue-tsc: no errors in changed files (other errors are pre-existing)"
+          fi
+        fi
+      else
+        ok "vue-tsc: 0 errors"
+      fi
+    else
+      warn "node_modules missing — skipping vue-tsc (run 'npm install')"
+    fi
+
+    # Targeted test runs for changed test files + sibling __tests__/
+    test_files=$(echo "$changed" \
+      | grep -E '\.test\.ts$' \
+      | head -10)
+    # Also test corresponding __tests__/ for any composable changes
+    composable_tests=$(echo "$changed" \
+      | grep -E 'composables/.*\.ts$' \
+      | grep -v '\.test\.' \
+      | sed -E 's|(composables)/(.+)\.ts$|\1/__tests__/\2.test.ts|' \
+      | xargs -I{} sh -c '[ -f "$REPO_ROOT/autobot-frontend/{}" ] && echo "{}"' \
+      2>/dev/null || true)
+    all_tests=$(printf "%s\n%s" "$test_files" "$composable_tests" \
+      | sort -u | grep -v '^$' || true)
+
+    if [ -n "$all_tests" ] \
+       && [ -d "$REPO_ROOT/autobot-frontend/node_modules" ]; then
+      log "running vitest on relevant tests (timeout ${TEST_TIMEOUT}s):"
+      echo "$all_tests" | sed 's/^/    /' >&2
+      vitest_output=$(
+        cd "$REPO_ROOT/autobot-frontend" \
+        && timeout "$TEST_TIMEOUT" npx vitest run $(echo "$all_tests") 2>&1
+      ) || vitest_exit=$?
+      vitest_exit=${vitest_exit:-0}
+
+      if [ "$vitest_exit" = "124" ]; then
+        warn "vitest timed out after ${TEST_TIMEOUT}s — skipping"
+      elif [ "$vitest_exit" != "0" ]; then
+        fail "vitest failures (#5142):"
+        echo "$vitest_output" | tail -25 >&2
+        EXIT_CODE=1
+      else
+        ok "vitest: all relevant tests pass"
+      fi
+    fi
+  fi
+
+  # ----- Backend (Python) -------------------------------------------------
+  py_changed=$(echo "$changed" | grep -E '\.py$' | grep -v '_test\.py$' || true)
+  py_tests=$(echo "$changed" | grep -E '_test\.py$' || true)
+  if [ -n "$py_changed" ] || [ -n "$py_tests" ]; then
+    # Co-located: foo.py is tested by foo_test.py in the same dir
+    sibling_tests=""
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      sibling="${f%.py}_test.py"
+      [ -f "$REPO_ROOT/$sibling" ] && sibling_tests+="$sibling"$'\n'
+    done <<< "$py_changed"
+    all_py_tests=$(printf "%s\n%s" "$py_tests" "$sibling_tests" \
+      | sort -u | grep -v '^$' || true)
+
+    if [ -n "$all_py_tests" ] && command -v pytest >/dev/null 2>&1; then
+      log "running pytest on:"
+      echo "$all_py_tests" | sed 's/^/    /' >&2
+      pytest_output=$(
+        timeout "$TEST_TIMEOUT" python3 -m pytest -xvs $all_py_tests 2>&1
+      ) || pytest_exit=$?
+      pytest_exit=${pytest_exit:-0}
+
+      if [ "$pytest_exit" = "124" ]; then
+        warn "pytest timed out after ${TEST_TIMEOUT}s — skipping"
+      elif [ "$pytest_exit" != "0" ]; then
+        fail "pytest failures (#5142):"
+        echo "$pytest_output" | tail -25 >&2
+        EXIT_CODE=1
+      else
+        ok "pytest: all relevant tests pass"
+      fi
+    fi
+  fi
+
+done
+
+if [ "$EXIT_CODE" != "0" ]; then
+  fail "Push BLOCKED. Fix the failures above or use 'git push --no-verify' to bypass."
+fi
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
Closes #5142 and #5143.

## Why

The team-implement skill's Phase 0c (verify before push) and Phase 6 (no duplicate PR) were advisory text I added during this session — easy to skip when in a hurry. I personally caused two incidents the rules were supposed to prevent:

- **PR #5141 broke 3 tests.** I ran `vue-tsc` and called it verified. `vitest run` would have caught the regression in 2 seconds.
- **PR #5141 was a duplicate of merged PR #5128.** I didn't re-fetch before pushing. Wasted ~30 minutes.

This PR turns those rules into git-enforced hooks.

## Layout

```
tools/git-hooks/
├── README.md            # Why + setup + bypass
├── pre-push             # The hook
└── install_hooks.sh     # Idempotent installer
```

Per-developer setup: `tools/git-hooks/install_hooks.sh` (one-time).

## What pre-push does (per pushed ref)

| Check | Trigger | Behavior |
|---|---|---|
| **Phase 6 issue check** | branch matches `issue-NNNN` | warn if issue is CLOSED on GitHub OR if `origin/Dev_new_gui` already has a commit citing `#NNNN` |
| **Phase 0c type check** | `.ts` or `.vue` files changed | `vue-tsc --noEmit` (90s timeout); only **errors in changed files** block — pre-existing project errors warn |
| **Phase 0c test run** | test files or composables changed | `vitest run <relevant tests>` (120s timeout); failures block |
| **Phase 0c backend tests** | `.py` files changed | `pytest <co-located *_test.py>` (120s timeout); failures block |

Time-boxed: a slow check warns and skips rather than blocking forever. Only **real** failures in **changed** code block.

## Verified

```
$ tools/git-hooks/install_hooks.sh
LINK  pre-push -> .../tools/git-hooks/pre-push
Installed: 1  Refreshed: 0  Backed up: 0

$ tools/git-hooks/install_hooks.sh   # idempotent
OK    pre-push (already symlinked to repo)
Installed: 0  Refreshed: 1  Backed up: 0

# Phase 6 with closed issue (correctly warns):
$ simulate push to issue-5093:
  WARN: Issue #5093 is CLOSED on GitHub.
  WARN: origin/Dev_new_gui has commit citing #5093:
    c392ec6de refactor(frontend): unify uploadKnowledgeFile (#5093) (#5116)
  WARN: If that commit covers your fix, your push will create a duplicate PR.

# Phase 6 with open issue (correctly silent):
$ simulate push to issue-5077: no warnings.
```

Self-test: this PR was pushed THROUGH the hook it installs. Hook ran, Phase 6 silent (issue #5142 open, no duplicate), Phase 0c skipped (only shell + markdown changed). Push succeeded.

## Worktree-aware

Uses `git rev-parse --git-common-dir` so hooks resolve to the main repo's `.git/hooks/` even when installed from a worktree. (My first iteration broke on this — the `install_hooks.sh` was checking for `.git/hooks` as a directory, but inside a worktree `.git` is a file.)

## Bypass

```bash
git push --no-verify
```

Don't make a habit of it — every bypass is the path that produces PR #5141-class incidents.

## Pairs with #5094

This PR depends on the `team-implement` skill being version-controlled (#5094) — without that, the hook enforces rules nobody can review.