### PR TITLE
refactor(backend): migrate Phase 1 datetime.utcnow() producers to utc_timestamp() (#5178 part B phase 1)

### DIFF
--- a/autobot-backend/agents/man_page_knowledge_integrator.py
+++ b/autobot-backend/agents/man_page_knowledge_integrator.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
 import aiofiles
 import yaml
 
+from autobot_shared.time_utils import utc_timestamp
 from intelligence.os_detector import get_os_detector
 from utils.command_utils import execute_command
 
@@ -93,7 +94,7 @@ class ManPageParser:
             options=options,
             examples=examples,
             see_also=see_also,
-            last_updated=time.strftime("%Y-%m-%dT%H:%M:%S"),
+            last_updated=utc_timestamp(),
         )
 
     def _split_into_sections(self, content: str) -> Dict[str, str]:

--- a/autobot-backend/agents/task_pattern_learner.py
+++ b/autobot-backend/agents/task_pattern_learner.py
@@ -11,8 +11,9 @@ Persists learned patterns to Redis for orchestrator routing decisions.
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Any, Dict, List, Optional
+
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ class LearnedStrategy:
     sample_size: int
     confidence: float
     failure_patterns: List[str] = field(default_factory=list)
-    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    timestamp: str = field(default_factory=utc_timestamp)
 
 
 class TaskPatternLearner:

--- a/autobot-backend/agents/task_retry_strategy.py
+++ b/autobot-backend/agents/task_retry_strategy.py
@@ -11,8 +11,9 @@ using LLM to adapt strategy on retry.
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Any, List
+
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ class RetryApproach:
     tool_sequence: List[str] = field(default_factory=list)
     rationale: str = ""
     confidence: float = 0.5
-    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    timestamp: str = field(default_factory=utc_timestamp)
 
 
 class TaskRetryStrategy:

--- a/autobot-backend/autobot_memory_graph/secrets.py
+++ b/autobot-backend/autobot_memory_graph/secrets.py
@@ -13,8 +13,9 @@ Part of the modular autobot_memory_graph package (Issue #716).
 """
 
 import logging
-from datetime import datetime
 from typing import Any, Dict, List, Optional
+
+from autobot_shared.time_utils import utc_timestamp
 
 from .core import AutoBotMemoryGraphCore
 
@@ -122,7 +123,7 @@ class SecretManagementMixin:
                 "session_id": session_id,
                 "shared_with": shared_with or [],
                 "usage_count": 0,
-                "created_at": datetime.utcnow().isoformat(),
+                "created_at": utc_timestamp(),
             }
         )
         return secret_metadata
@@ -207,7 +208,7 @@ class SecretManagementMixin:
                 "user_id": user_id,
                 "activity_type": activity_type,
                 "activity_id": activity_id,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             }
 
             entity = await self.create_entity(

--- a/autobot-backend/autobot_memory_graph/user_session.py
+++ b/autobot-backend/autobot_memory_graph/user_session.py
@@ -15,8 +15,9 @@ Secret management is in secrets.py module.
 """
 
 import logging
-from datetime import datetime
 from typing import Any, Dict, List, Optional
+
+from autobot_shared.time_utils import utc_timestamp
 
 from .core import VALID_ACTIVITY_TYPES, AutoBotMemoryGraphCore
 
@@ -49,7 +50,7 @@ class UserSessionMixin:
                 "user_id": user_id,
                 "username": username,
                 "status": "active",
-                "created_at": datetime.utcnow().isoformat(),
+                "created_at": utc_timestamp(),
             }
         )
         return user_metadata
@@ -101,7 +102,7 @@ class UserSessionMixin:
                 "mode": "collaborative" if collaborators else "single_user",
                 "collaborators": collaborators or [],
                 "status": "active",
-                "created_at": datetime.utcnow().isoformat(),
+                "created_at": utc_timestamp(),
             }
         )
         return session_metadata
@@ -209,7 +210,7 @@ class UserSessionMixin:
                 "session_id": session_id,
                 "user_id": user_id,
                 "secrets_used": secrets_used or [],
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             }
         )
         return activity_metadata

--- a/autobot-backend/judges/task_outcome_judge.py
+++ b/autobot-backend/judges/task_outcome_judge.py
@@ -11,9 +11,9 @@ and efficiency. Stores outcomes in Redis for pattern learning.
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Any, Dict, List
 
+from autobot_shared.time_utils import utc_timestamp
 from judges import BaseLLMJudge, JudgmentDimension, JudgmentResult
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ class TaskOutcomeRecord:
     strategy_used: str
     score: float
     rationale: str
-    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    timestamp: str = field(default_factory=utc_timestamp)
 
 
 class TaskOutcomeJudge(BaseLLMJudge):

--- a/autobot-backend/models/session_collaboration.py
+++ b/autobot-backend/models/session_collaboration.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
+from autobot_shared.time_utils import utc_timestamp
 from sqlalchemy import ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
@@ -213,7 +214,7 @@ class SessionCollaboration(Base):
         invitation = {
             "user_id": str(user_id),
             "permission": permission.value,
-            "invited_at": datetime.utcnow().isoformat(),
+            "invited_at": utc_timestamp(),
         }
 
         if expires_at:

--- a/autobot-backend/planner/planner.py
+++ b/autobot-backend/planner/planner.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
 
+from autobot_shared.time_utils import utc_timestamp
 from constants.threshold_constants import (
     BatchConfig,
     LLMDefaults,
@@ -643,7 +644,7 @@ Output ONLY valid JSON in this format:
             {
                 "version": plan.version,
                 "reason": reason,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
                 "previous_steps": [s.to_dict() for s in plan.steps],
             }
         )

--- a/autobot-backend/utils/api_responses.py
+++ b/autobot-backend/utils/api_responses.py
@@ -70,9 +70,9 @@ return error_response(
 )
 """
 
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.time_utils import utc_timestamp
 from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
@@ -93,7 +93,7 @@ class StandardResponse(BaseModel):
     message: Optional[str] = Field(None, description="Human-readable message")
     data: Optional[Any] = Field(None, description="Response data payload")
     timestamp: str = Field(
-        default_factory=lambda: datetime.utcnow().isoformat(),
+        default_factory=utc_timestamp,
         description="Response timestamp (ISO 8601)",
     )
 
@@ -120,7 +120,7 @@ class ErrorResponse(BaseModel):
     error_code: Optional[str] = Field(None, description="Machine-readable error code")
     details: Optional[Dict[str, Any]] = Field(None, description="Additional error details")
     timestamp: str = Field(
-        default_factory=lambda: datetime.utcnow().isoformat(),
+        default_factory=utc_timestamp,
         description="Error timestamp (ISO 8601)",
     )
 
@@ -159,7 +159,7 @@ class PaginatedResponse(BaseModel):
         },
     )
     timestamp: str = Field(
-        default_factory=lambda: datetime.utcnow().isoformat(),
+        default_factory=utc_timestamp,
         description="Response timestamp",
     )
 
@@ -205,7 +205,7 @@ def success_response(
     """
     response_data = {
         "success": True,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
     }
 
     if message is not None:
@@ -275,7 +275,7 @@ def paginated_response(
         "success": True,
         "data": items,
         "pagination": _build_pagination_metadata(page, page_size, total),
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
     }
 
     if message:
@@ -331,7 +331,7 @@ def error_response(
     response_data = {
         "success": False,
         "error": message,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
     }
 
     if error_code:

--- a/autobot-backend/utils/chat_utils.py
+++ b/autobot-backend/utils/chat_utils.py
@@ -208,13 +208,13 @@ def create_success_response(
         >>> response.status_code
         200
     """
-    from datetime import datetime
+    from autobot_shared.time_utils import utc_timestamp
 
     response = {
         "success": True,
         "data": data,
         "message": message,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
     }
     if request_id:
         response["request_id"] = request_id

--- a/autobot-backend/utils/response_helpers.py
+++ b/autobot-backend/utils/response_helpers.py
@@ -14,9 +14,9 @@ Functions:
 """
 
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from autobot_shared.time_utils import utc_timestamp
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
@@ -46,7 +46,7 @@ def create_success_response(
         "success": True,
         "data": data,
         "message": message,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
     }
 
 
@@ -86,7 +86,7 @@ def create_error_response(
     error_content = {
         "code": error_code,
         "message": message,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
     }
 
     # Include request_id if provided

--- a/autobot-backend/websocket/presence.py
+++ b/autobot-backend/websocket/presence.py
@@ -12,9 +12,9 @@ import asyncio
 import json
 import logging
 from collections import defaultdict
-from datetime import datetime
 from typing import Dict, List, Set
 
+from autobot_shared.time_utils import utc_timestamp
 from fastapi import WebSocket, WebSocketDisconnect
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ class PresenceManager:
                 {
                     "type": "user_joined",
                     "user_id": user_id,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": utc_timestamp(),
                 },
                 exclude=websocket,
             )
@@ -99,7 +99,7 @@ class PresenceManager:
                             {
                                 "type": "user_left",
                                 "user_id": user_id,
-                                "timestamp": datetime.utcnow().isoformat(),
+                                "timestamp": utc_timestamp(),
                             },
                         )
 
@@ -222,7 +222,7 @@ async def _send_presence_sync(websocket: WebSocket, session_id: str) -> None:
         {
             "type": "presence_sync",
             "online_users": online_users,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
         }
     )
 
@@ -238,7 +238,7 @@ async def _handle_presence_message(
     Returns True to continue the loop, False to break out.
     """
     if message.get("type") == "ping":
-        await websocket.send_json({"type": "pong", "timestamp": datetime.utcnow().isoformat()})
+        await websocket.send_json({"type": "pong", "timestamp": utc_timestamp()})
         return True
     if message.get("type") == "broadcast":
         payload = message.get("payload", {})
@@ -248,7 +248,7 @@ async def _handle_presence_message(
                 "type": "user_message",
                 "user_id": user_id,
                 "payload": payload,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )
     return True


### PR DESCRIPTION
## Summary

**Phase 1 of #5178 part B**. Migrates 12 of 57 files (25 of 139 sites) from the [producer audit](docs/developer/audits/datetime-producer-audit.md) shipped in PR #5189. Phase 1 = low-blast-radius internal consumers; Phases 2 + 3 follow in separate PRs.

Also fixes the **1 real bug** identified in the audit at [\`agents/man_page_knowledge_integrator.py:96\`](autobot-backend/agents/man_page_knowledge_integrator.py#L96) — was using \`time.strftime(\"%Y-%m-%dT%H:%M:%S\")\` (no time arg → defaults to \`time.localtime()\`) and assigning to \`last_updated\` as if UTC.

## Pattern

Mechanical replacement, identical across all 25 sites:

\`\`\`python
# before
\"timestamp\": datetime.utcnow().isoformat(),
# after
from autobot_shared.time_utils import utc_timestamp
\"timestamp\": utc_timestamp(),
\`\`\`

For dataclass \`field(default_factory=...)\` sites, swap the lambda for the function reference: \`default_factory=utc_timestamp\` (lambdas no longer needed).

## Files migrated

| File | Sites | Notes |
|---|---|---|
| \`agents/man_page_knowledge_integrator.py\` | 1 | **🔴 real bug fix** (local-time strftime → UTC) |
| \`agents/task_pattern_learner.py\` | 1 | dataclass field |
| \`agents/task_retry_strategy.py\` | 1 | dataclass field |
| \`judges/task_outcome_judge.py\` | 1 | dataclass field |
| \`models/session_collaboration.py\` | 1 | datetime import retained (type hint at L194) |
| \`planner/planner.py\` | 1 | datetime import retained (9 other utcnow uses tracked in #5211) |
| \`websocket/presence.py\` | 5 | |
| \`utils/api_responses.py\` | 6 | |
| \`utils/chat_utils.py\` | 1 | inner-function import replaced |
| \`utils/response_helpers.py\` | 2 | |
| \`autobot_memory_graph/secrets.py\` | 2 | |
| \`autobot_memory_graph/user_session.py\` | 3 | |
| **Total** | **25** | **12 files** |

## Behavior change

Timestamp output gains \`+00:00\` suffix (was: tz-naive). The 55 unguarded \`fromisoformat\` parsers in [#5169's parser audit](docs/developer/audits/datetime-parsing-audit.md) now receive tz-aware datetimes back — eliminates the silent naive-vs-aware comparison bug class for these 25 sites.

## Verification

- \`python3 -m py_compile\` on all 12 files: passes
- All 25 isoformat sites verified migrated (zero remaining \`datetime.utcnow().isoformat()\` in any of the 12 files)
- Modules import cleanly
- **Pre-push hook ran colocated tests for all 5 affected test modules — all pass**

## What this PR does NOT do

- Phases 2 (services/, knowledge/, 19 files) and 3 (api/, security/enterprise/, 25 files) — separate PRs
- Outliers in \`conversation_export.py\` — defer per audit (Z-format export records)
- The 9 \`datetime.utcnow()\` field-assignments in \`planner.py\` — different bug class, tracked in [#5211](https://github.com/mrveiss/AutoBot-AI/issues/5211)
- Lint enforcement (Part C of #5178) — after Phases 2+3 land

## Discovery filed during implementation

[#5211](https://github.com/mrveiss/AutoBot-AI/issues/5211) — 206 additional \`datetime.utcnow()\` sites across the backend that are NOT \`.isoformat()\` (delta calculations + datetime-field assignments). Different bug class, different migration helper (\`time.monotonic()\` for deltas, \`datetime.now(timezone.utc)\` for fields). Filed to keep #5178's scope clean.

## Test plan

- [x] All 12 files \`py_compile\` clean
- [x] All 25 isoformat sites migrated
- [x] Modules import cleanly
- [x] Pre-push hook colocated tests pass for 5 affected test modules
- [x] \`datetime\` import retained where still needed (3 of 12 files)
- [x] \`time\` import retained in \`man_page_knowledge_integrator.py\` (still uses \`time.time()\` at L642)
- [ ] \`gh pr checks\` passes