### PR TITLE
refactor(llm): migrate agent_loop/think_tool to call_ollama_generate (#5181)

### DIFF
--- a/autobot-backend/agent_loop/think_tool.py
+++ b/autobot-backend/agent_loop/think_tool.py
@@ -350,29 +350,19 @@ class ThinkTool:
             # Use provided client
             return await self.llm_client.generate(prompt)
 
-        # Use Ollama directly
-        import httpx
-
+        # Use Ollama directly via the shared helper
         from autobot_shared.ssot_config import get_config
+        from llm_providers.ollama_helpers import call_ollama_generate
 
         ssot = get_config()
-        ollama_url = f"{ssot.ollama_url}/api/generate"
-
-        async with httpx.AsyncClient(timeout=self.config.timeout_ms / 1000) as client:
-            response = await client.post(
-                ollama_url,
-                json={
-                    "model": self.config.model,
-                    "prompt": prompt,
-                    "stream": False,
-                    "options": {
-                        "temperature": self.config.temperature,
-                        "num_predict": self.config.max_tokens,
-                    },
-                },
-            )
-            response.raise_for_status()
-            return response.json().get("response", "")
+        return await call_ollama_generate(
+            prompt=prompt,
+            model=self.config.model,
+            base_url=ssot.ollama_url,
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_tokens,
+            timeout_ms=self.config.timeout_ms,
+        )
 
     def _parse_response(
         self,


### PR DESCRIPTION
Closes #5181

## Summary

Fifth Ollama `/api/generate` duplicate \u2014 same pattern as #5102 (3 callers) and #5155 (4th). The `self.llm_client.generate(prompt)` preferred path is preserved; only the direct-httpx fallback branch delegates to the shared helper.

## Files touched

- `autobot-backend/agent_loop/think_tool.py` \u2014 `_get_llm_response` fallback branch migrated; inline `import httpx` removed (was the only httpx reference in the file).

## Config mapping

`ThinkToolConfig` dataclass attributes map 1:1 to `call_ollama_generate` kwargs:
- `model`, `temperature` (0.3), `max_tokens` (1000), `timeout_ms` (15000)

## Test plan

- [x] `python -m py_compile autobot-backend/agent_loop/think_tool.py` passes
- [x] `grep -n 'httpx.AsyncClient' autobot-backend/agent_loop/think_tool.py` returns 0 matches
- [x] `grep -n 'httpx' autobot-backend/agent_loop/think_tool.py` returns 0 matches (no residual import)

## Diff

1 file, 10 insertions / 20 deletions.