### PR TITLE
chore(frontend): delete useApiRequest (0 callers) (#5183)

### DIFF
--- a/autobot-frontend/src/utils/apiErrorHandler.ts
+++ b/autobot-frontend/src/utils/apiErrorHandler.ts
@@ -11,9 +11,7 @@
  * @module apiErrorHandler
  */
 
-import { ref, type Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
-import { useUnifiedLoading } from '@/composables/useUnifiedLoading'
 
 // Create scoped logger for apiErrorHandler
 const logger = createLogger('apiErrorHandler')
@@ -270,56 +268,6 @@ export async function handleApiCall<T>(
 
   // Should not reach here, but return error just in case
   return { success: false, error: lastError || parseError(new Error('Unknown error')) }
-}
-
-/**
- * Create a composable that wraps API calls with loading state
- *
- * Loading-state tracking is delegated to the canonical `useUnifiedLoading`
- * composable. The structured `ApiError` shape is preserved — callers of
- * `useApiRequest` see the same `{ loading, error, execute }` surface, with
- * `error` typed as `ApiError | null` (not a plain string).
- *
- * @param componentKey Optional key for scoping the shared loading state
- *                     registry; defaults to a unique per-instance key.
- * @returns API call wrapper with built-in loading state
- *
- * @example
- * ```typescript
- * const { loading, error, execute } = useApiRequest('UserList')
- *
- * const result = await execute(
- *   () => apiClient.get('/api/users'),
- *   { componentName: 'UserList' }
- * )
- * ```
- */
-export function useApiRequest<T = unknown>(componentKey?: string) {
-  const unified = useUnifiedLoading(componentKey)
-  const error: Ref<ApiError | null> = ref(null)
-
-  async function execute(
-    apiCall: () => Promise<T>,
-    options: ErrorHandlerOptions = {}
-  ): Promise<ApiResult<T>> {
-    error.value = null
-    unified.setLoading(true)
-
-    const result = await handleApiCall(apiCall, options)
-
-    if (!result.success && result.error) {
-      error.value = result.error
-    }
-
-    unified.setLoading(false)
-    return result
-  }
-
-  return {
-    loading: unified.isLoading,
-    error,
-    execute
-  }
 }
 
 // Export default options for customization


### PR DESCRIPTION
Closes #5183

## Summary

`useApiRequest<T>()` had 0 external callers after #5108's migration. Verified across main src tree + **24 open worktrees** \u2014 no in-flight consumers.

Deleted the function + its docstring + 3 imports that were exclusively used by it (`ref` and `Ref` from `vue`, `useUnifiedLoading`).

If a future need arises for structured-error + loading-state composition, `useUnifiedLoading` + an inline `execute()` wrapper does it in ~10 lines \u2014 no need for a dedicated composable with 0 users.

## Verification

- [x] Grep confirmed 0 callers in main tree
- [x] Grep confirmed 0 callers in 24 open worktrees
- [x] No test file references `useApiRequest`
- [x] No doc example references `useApiRequest`
- [x] `vue-tsc --noEmit`: 1955 errors (baseline 1956, -1 \u2014 an error inside the deleted function's `Ref<ApiError|null>` typing)
- [x] `oxlint`: 0 warnings/0 errors on modified file

## Diff

1 file, net -52 lines.