### PR TITLE
refactor(knowledge): add KB.redis() public accessor; migrate 4 production call sites (#5184)

### DIFF
--- a/autobot-backend/api/knowledge_boards.py
+++ b/autobot-backend/api/knowledge_boards.py
@@ -90,7 +90,7 @@ async def _get_redis(req: Request):
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb is None or kb.aioredis_client is None:
         raise HTTPException(status_code=503, detail="Knowledge base not available")
-    return kb.aioredis_client
+    return kb.redis()
 
 
 @with_error_handling(

--- a/autobot-backend/background_vectorization.py
+++ b/autobot-backend/background_vectorization.py
@@ -87,7 +87,7 @@ class BackgroundVectorizer:
 
     async def _get_vectorization_status(self, kb, batch: list) -> list:
         """Get vectorization status for a batch (Issue #336 - extracted helper)."""
-        async with kb.aioredis_client.pipeline() as pipe:
+        async with kb.redis().pipeline() as pipe:
             for fact_key in batch:
                 await pipe.hget(fact_key, "vectorization_status")
             return await pipe.execute()
@@ -109,7 +109,7 @@ class BackgroundVectorizer:
         """Batch fetch fact data (Issue #336 - extracted helper)."""
         if not facts_to_process:
             return []
-        async with kb.aioredis_client.pipeline() as pipe:
+        async with kb.redis().pipeline() as pipe:
             for fact_key in facts_to_process:
                 await pipe.hgetall(fact_key)
             return await pipe.execute()
@@ -127,7 +127,7 @@ class BackgroundVectorizer:
     async def _mark_vectorization_complete(self, kb, fact_key: str) -> None:
         """Mark fact as vectorized (Issue #336 - extracted helper)."""
         try:
-            await kb.aioredis_client.hset(
+            await kb.redis().hset(
                 fact_key,
                 mapping={
                     "vectorization_status": "completed",

--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -533,6 +533,21 @@ class KnowledgeBaseCore:
                 "or get instance via get_knowledge_base() factory function."
             )
 
+    def redis(self) -> aioredis.Redis:
+        """Return the async Redis client configured for knowledge-base persistence.
+
+        Public accessor for cross-module callers so they don't have to reach
+        into the private ``aioredis_client`` attribute (#5184).
+
+        Raises:
+            RuntimeError: If called before ``initialize()`` completed.
+        """
+        if self.aioredis_client is None:
+            raise RuntimeError(
+                "KnowledgeBase.redis() called before initialize() completed"
+            )
+        return self.aioredis_client
+
     async def ping_redis(self) -> str:
         """Test Redis connection"""
         self.ensure_initialized()

--- a/autobot-backend/tests/test_knowledge_boards.py
+++ b/autobot-backend/tests/test_knowledge_boards.py
@@ -77,6 +77,9 @@ def _make_app(fake_redis: _FakeRedis) -> FastAPI:
     class _FakeKB:
         aioredis_client = fake_redis
 
+        def redis(self):
+            return self.aioredis_client
+
     async def _fake_get_kb(app, force_refresh=False):  # noqa: ANN001
         return _FakeKB()
 


### PR DESCRIPTION
Closes #5184

## Summary

Deferred from #5101. Adds a public `redis()` accessor method on `KnowledgeBase` so cross-module callers no longer have to reach into `kb.aioredis_client` directly.

### Method added

[`autobot-backend/knowledge/base.py:536`](autobot-backend/knowledge/base.py#L536) \u2014 `KnowledgeBaseCore.redis() -> aioredis.Redis`. Raises `RuntimeError` if called before `initialize()` completes.

### Production call sites migrated (4)

- `autobot-backend/api/knowledge_boards.py:88` \u2014 `_get_redis(req)`
- `autobot-backend/background_vectorization.py:90` \u2014 `kb.aioredis_client.pipeline()`
- `autobot-backend/background_vectorization.py:112` \u2014 same
- `autobot-backend/background_vectorization.py:130` \u2014 `kb.aioredis_client.hset(...)`

### Attribute preserved (not renamed)

`aioredis_client` is kept as a public attribute so existing test mocks (`knowledge_base_async_test.py`, `test_facts_dedup.py`, etc.) that use direct assignment still work. Follow-up can rename to `_aioredis_client` once all consumers are on `redis()`.

### Test-fixture update

`tests/test_knowledge_boards.py::_FakeKB` stub doesn't subclass `KnowledgeBase`, so it needed a 2-line `redis()` method to satisfy the new public API.

## Test plan

- [x] `tests/test_knowledge_boards.py` \u2014 14/14 pass
- [x] `api/knowledge_vectorization_test.py` \u2014 28/28 pass
- [x] `python -m py_compile` on all modified files

## Scope gap (discovery follow-up)

Grep revealed **~25 more cross-module call sites** in `api/knowledge*.py` files that also reach into `kb.aioredis_client` directly (knowledge.py, knowledge_audit.py, knowledge_vectorization.py, knowledge_organization.py, knowledge_collaboration.py). The original #5184 scope listed only 4 sites; the rest are out-of-scope here and will be filed as a follow-up discovery issue to migrate systematically before the attribute can be renamed.