### PR TITLE
refactor(knowledge): migrate /api/embeddings direct callers to services.npu_client canonical (#5182)

### DIFF
--- a/autobot-backend/autobot_memory_graph/semantic_search.py
+++ b/autobot-backend/autobot_memory_graph/semantic_search.py
@@ -381,33 +381,18 @@ class MemoryGraphQueryProcessor:
 
     async def _generate_embedding(self, text: str) -> List[float]:
         """
-        Generate a vector embedding via Ollama.
+        Generate a vector embedding via the canonical NPU/Ollama fallback helper.
 
         Returns an empty list if the embedding service is unavailable.
         """
         if not text:
             return []
-        try:
-            import aiohttp  # local import to avoid hard dependency at module level
+        from services.npu_client import generate_embedding_with_fallback
 
-            ollama_host = getattr(ssot_config, "ollama_host", "http://localhost:11434")
-            url = f"{ollama_host}/api/embeddings"
-            payload = {"model": self._embedding_model, "prompt": text}
-
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    url, json=payload, timeout=aiohttp.ClientTimeout(total=10)
-                ) as resp:
-                    if resp.status != 200:
-                        logger.warning(
-                            "Embedding service returned HTTP %d", resp.status
-                        )
-                        return []
-                    data = await resp.json()
-                    return data.get("embedding", [])
-        except Exception as exc:
-            logger.warning("Embedding generation failed: %s", exc)
-            return []
+        embedding = await generate_embedding_with_fallback(
+            text, model_name=self._embedding_model
+        )
+        return embedding or []
 
     # ------------------------------------------------------------------
     # Stage 4 — Redis candidate retrieval

--- a/autobot-backend/code_intelligence/analytics_infrastructure.py
+++ b/autobot-backend/code_intelligence/analytics_infrastructure.py
@@ -348,7 +348,7 @@ class AnalyticsInfrastructureMixin:
 
     async def _get_embedding_via_ollama(self, text: str) -> Optional[List[float]]:
         """
-        Generate embedding using Ollama (fallback method).
+        Generate embedding using the canonical NPU/Ollama fallback helper.
 
         Args:
             text: Text to embed
@@ -357,30 +357,15 @@ class AnalyticsInfrastructureMixin:
             Embedding vector or None if failed
         """
         try:
-            import aiohttp
+            from services.npu_client import generate_embedding_with_fallback
 
-            from autobot_shared.ssot_config import get_config
-
-            ssot = get_config()
-            url = f"{ssot.ollama_url}/api/embeddings"
-
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    url,
-                    json={"model": self._embedding_model, "prompt": text},
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        embedding = data.get("embedding")
-                        if embedding:
-                            logger.debug("Embedding generated via Ollama")
-                            return embedding
+            return await generate_embedding_with_fallback(
+                text, model_name=self._embedding_model
+            )
         except Exception as e:
-            logger.warning("Ollama embedding generation failed: %s", e)
+            logger.warning("Embedding generation failed: %s", e)
             self._metrics.add_error(f"Embedding generation failed: {e}")
-
-        return None
+            return None
 
     async def _get_embeddings_batch(
         self, texts: List[str], max_concurrent: int = 5

--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -195,7 +195,7 @@ class CrossLanguagePatternDetector:
 
     async def _get_embedding(self, text: str) -> Optional[List[float]]:
         """
-        Get embedding for text using LLM.
+        Get embedding for text using the canonical NPU/Ollama fallback helper.
 
         Uses caching to avoid redundant embedding generation.
         """
@@ -211,30 +211,17 @@ class CrossLanguagePatternDetector:
                 return cached
             self._cache_misses += 1
 
-        # Generate embedding using Ollama
         try:
-            import aiohttp
+            from services.npu_client import generate_embedding_with_fallback
 
-            from autobot_shared.ssot_config import get_config
-
-            ssot = get_config()
-            url = f"{ssot.ollama_url}/api/embeddings"
-
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    url,
-                    json={"model": self.embedding_model, "prompt": text},
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        embedding = data.get("embedding")
-                        if embedding:
-                            self._embeddings_generated += 1
-                            # Cache the embedding
-                            if cache:
-                                await cache.put(text, embedding)
-                            return embedding
+            embedding = await generate_embedding_with_fallback(
+                text, model_name=self.embedding_model
+            )
+            if embedding:
+                self._embeddings_generated += 1
+                if cache:
+                    await cache.put(text, embedding)
+                return embedding
         except Exception as e:
             logger.warning("Failed to generate embedding: %s", e)
 


### PR DESCRIPTION
Closes #5182

## Summary

Extends #5105 (facts.py) to the rest of the backend. 3 of 6 candidate sites migrated; 3 correctly skipped with documented rationale.

### Migrated (3)

| File | Function | Notes |
|---|---|---|
| [autobot_memory_graph/semantic_search.py:394](autobot-backend/autobot_memory_graph/semantic_search.py#L394) | `_generate_embedding` | Preserved `[]`-on-failure contract via `return result or []` |
| [code_intelligence/analytics_infrastructure.py:365](autobot-backend/code_intelligence/analytics_infrastructure.py#L365) | `_get_embedding_via_ollama` | Preserved outer try/except for `_metrics.add_error` side effect |
| [code_intelligence/cross_language_patterns/detector.py:221](autobot-backend/code_intelligence/cross_language_patterns/detector.py#L221) | `_get_embedding` | Preserved `_embeddings_generated` counter + cache wrapper |

### Skipped with rationale (3)

| File | Reason |
|---|---|
| [api/embeddings.py:81](autobot-backend/api/embeddings.py#L81) | Not a caller \u2014 f-string in a config-default dict; just exposes the endpoint URL |
| [api/system.py:92](autobot-backend/api/system.py#L92) | Not a caller \u2014 frontend-facing config URL in `_build_frontend_services_config` |
| [services/skill_management/skill_ranker.py:122](autobot-backend/services/skill_management/skill_ranker.py#L122) | **Different service** \u2014 hits `self.slm_host` (SLM, not Ollama) with OpenAI-compat payload (`{"input": text}` \u2192 `{"data": [...]}`). Routing through Ollama canonical would break the protocol. |

### Error-semantic preservation

Canonical `generate_embedding_with_fallback` returns `Optional[List[float]]` (None on failure). Original implementations variously returned `[]` on failure; each migrated site wraps appropriately (`result or []`) or keeps outer try/except for side effects (metrics / cache).

## Test plan

- [x] `python -m py_compile` on all 3 modified files
- [x] `grep /api/embeddings autobot-backend/ --include='*.py'` returns only: canonical, config defaults, endpoint definition, middleware auth rules, skill_ranker (SLM), embeddings.py (config), system.py (config)

## Discoveries (not in scope \u2014 will file follow-up)

- `analytics_infrastructure.py` has a parallel `_get_embedding_via_npu` path that duplicates the canonical's NPU-first logic \u2014 candidate for further consolidation
- Batch-embedding helpers in `analytics_infrastructure.py` and `detector.py` also bypass canonical (should use `generate_embeddings_batch_with_fallback`)

## Diff

3 files, aiohttp imports removed from 3 functions.