### PR TITLE
feat(visual): visual regression tests for Storybook stories (#5077)

### DIFF
--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -25,6 +25,8 @@
     "test:playwright:headed": "playwright test --headed",
     "test:playwright:ui": "playwright test --ui",
     "test:playwright:report": "playwright show-report",
+    "test:visual": "playwright test --config playwright.visual.config.ts",
+    "test:visual:update": "playwright test --config playwright.visual.config.ts --update-snapshots",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:all": "run-s test:unit test:integration test:playwright",
     "build-only": "vite build",

--- a/autobot-frontend/playwright.visual.config.ts
+++ b/autobot-frontend/playwright.visual.config.ts
@@ -1,0 +1,77 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Playwright config for visual regression tests.
+ *
+ * Separated from playwright.config.ts (which targets the live frontend
+ * at :5173) because visual tests target Storybook at :6006 and have
+ * different timing / parallelism needs.
+ *
+ * Usage:
+ *   npm run test:visual                          # diff against baselines
+ *   npm run test:visual -- --update-snapshots    # regenerate baselines
+ *
+ * Issue #5077.
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+const STORYBOOK_PORT = 6006;
+const STORYBOOK_URL = `http://localhost:${STORYBOOK_PORT}`;
+
+export default defineConfig({
+  testDir: './tests/visual',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? 'github' : [['html', { open: 'never' }]],
+
+  // Snapshot baselines live next to the tests, organized per OS to avoid
+  // cross-platform rendering noise. Engineers regenerate locally on the
+  // OS they develop on; CI runs Linux baselines.
+  snapshotPathTemplate: '{testDir}/__screenshots__/{testFilePath}/{arg}-{platform}{ext}',
+
+  // Pixel-diff tolerance — small enough to catch real layout drift, large
+  // enough to ignore subpixel font rendering jitter across machines.
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixels: 100,
+      threshold: 0.2,
+      animations: 'disabled',
+    },
+  },
+
+  use: {
+    baseURL: STORYBOOK_URL,
+    trace: 'on-first-retry',
+    // Disable animations globally so transitions don't cause flaky diffs.
+    contextOptions: {
+      reducedMotion: 'reduce',
+    },
+  },
+
+  // Auto-start Storybook for the test run if it's not already running.
+  // Engineers may want to start it manually (faster iteration) — set
+  // SKIP_STORYBOOK_START=1 to bypass.
+  webServer: process.env.SKIP_STORYBOOK_START
+    ? undefined
+    : {
+        command: 'npm run storybook -- --ci --quiet',
+        port: STORYBOOK_PORT,
+        reuseExistingServer: true,
+        timeout: 120_000,
+      },
+
+  projects: [
+    {
+      name: 'chromium-light',
+      use: { ...devices['Desktop Chrome'], colorScheme: 'light' },
+    },
+    {
+      name: 'chromium-dark',
+      use: { ...devices['Desktop Chrome'], colorScheme: 'dark' },
+    },
+  ],
+});

--- a/autobot-frontend/tests/visual/README.md
+++ b/autobot-frontend/tests/visual/README.md
@@ -1,0 +1,92 @@
+# Visual regression tests
+
+Pixel-diff every Storybook story against committed baseline PNGs. Catches
+the kind of drift that type-check + unit tests miss — design-token rounds,
+icon path typos, layout shifts, color regressions.
+
+This was the safety gap closed by #5077, originally surfaced because
+PRs #5036 / #5043 / #4805 each touched 30+ UI files with no way to verify
+the visual result.
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Run all visual tests (diff against baselines) | `npm run test:visual` |
+| Generate / regenerate baselines | `npm run test:visual -- --update-snapshots` |
+| Run with Storybook already started elsewhere | `SKIP_STORYBOOK_START=1 npm run test:visual` |
+| View HTML report after a failure | `npx playwright show-report` |
+
+## How it works
+
+1. `playwright.visual.config.ts` auto-starts Storybook on port 6006 (unless
+   `SKIP_STORYBOOK_START=1` is set — useful for fast iteration when you
+   already have `npm run storybook` running)
+2. `tests/visual/storybook-stories.spec.ts` fetches Storybook's
+   `/index.json` to enumerate every story
+3. For each story, navigate to its iframe URL, wait for the root element,
+   screenshot the component, diff against the baseline in
+   `__screenshots__/`
+4. Diffs above the threshold (`maxDiffPixels: 100`, `threshold: 0.2`) fail
+   the test. The HTML report shows the actual / expected / diff images
+   side-by-side.
+
+Baselines are stored per-OS (`-linux.png`, `-darwin.png`, `-win32.png`)
+because subpixel font rendering varies across platforms. CI runs Linux
+baselines.
+
+## Workflow
+
+### When adding a new component
+
+1. Write the component as usual
+2. Add a `*.stories.ts` file demonstrating the variants you care about
+3. Run `npm run test:visual -- --update-snapshots`
+4. Commit the new `__screenshots__/*.png` baselines alongside the component
+
+### When intentionally changing visuals
+
+1. Make the design change
+2. Run `npm run test:visual` — it'll fail with a diff
+3. Inspect the diff (HTML report) to confirm the change is what you wanted
+4. Run `npm run test:visual -- --update-snapshots` to accept
+5. Commit the updated baselines with the design change in the same PR
+
+### When unintentionally breaking visuals
+
+1. PR review fails CI on visual regression
+2. Inspect the HTML report to see exactly what shifted
+3. Either fix the regression (most common) or update baselines if the
+   change was intentional but missed step 2 above
+
+## Coverage today
+
+Coverage = whatever has a `*.stories.ts`. Currently:
+
+- `auth/LoginForm`
+- `base/{BaseAlert, BaseBadge, BaseButton, BaseCard, BaseInput, BaseTable}`
+- `ui/{EmptyState, LoadingSpinner}`
+
+**Gaps worth filling** (touched recently, no story → no visual coverage):
+
+- `ui/Icon.vue` (added in #4805 — the icon registry)
+- `ui/ThemeToggle.vue`, `ui/DarkModeToggle.vue`
+- `ui/BaseModal.vue`, `ui/CommandPermissionDialog.vue`, `ui/PreferencesPanel.vue`
+- `ui/HostSelector.vue`, `ui/HostSelectionDialog.vue`
+- `ui/ToastContainer.vue`
+
+Adding a story is mechanical (~10-15 lines per variant set). New stories
+get visual coverage automatically.
+
+## Why Playwright + Storybook (not Chromatic / Percy)
+
+- **No external service**: tests run anywhere, no SaaS dependency, no
+  per-month seat cost
+- **Tests live with code**: baselines are in the repo, reviewable in PRs
+- **Existing infra**: both Storybook and Playwright were already installed;
+  this PR just wired them together
+- **Trade-off**: no fancy UI for browsing diffs across PRs (Chromatic's
+  strength). Use the local HTML report instead.
+
+If we ever outgrow this and want PR-level diff browsing, swap to Chromatic
+later — the stories themselves don't need to change.

--- a/autobot-frontend/tests/visual/storybook-stories.spec.ts
+++ b/autobot-frontend/tests/visual/storybook-stories.spec.ts
@@ -1,0 +1,108 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Visual regression: every Storybook story → screenshot diff
+ *
+ * Discovers stories at runtime via Storybook's `/index.json` endpoint and
+ * iterates through them inside a single test. New stories get coverage
+ * automatically — no per-story test boilerplate needed.
+ *
+ * Why one test instead of one per story:
+ *   Playwright loads test files BEFORE its `webServer` config starts
+ *   Storybook. Top-level `await fetch()` against :6006 would fail at
+ *   collection time. A single test that fetches stories during the run
+ *   sidesteps this. Trade-off: lose per-story failure isolation; gain a
+ *   test file that loads cleanly even when Storybook isn't running yet.
+ *
+ * First-run behavior:
+ *   The first time this runs after stories are added, baselines don't
+ *   exist yet. Run with `--update-snapshots` to generate them, then
+ *   commit the `__screenshots__/` directory.
+ *
+ *   $ npm run test:visual:update
+ *   $ git add tests/visual/__screenshots__/
+ *   $ git commit -m "chore(visual): regenerate baselines for <reason>"
+ *
+ * Issue #5077.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+interface StoryEntry {
+  id: string;
+  title: string;
+  name: string;
+  type: 'story' | 'docs';
+  importPath: string;
+}
+
+interface StoryIndex {
+  v: number;
+  entries: Record<string, StoryEntry>;
+}
+
+async function fetchStoryIndex(page: Page): Promise<StoryEntry[]> {
+  const res = await page.request.get('/index.json');
+  if (!res.ok()) {
+    throw new Error(
+      `Storybook /index.json returned ${res.status()}. ` +
+        `Is storybook running on :6006?`,
+    );
+  }
+  const index = (await res.json()) as StoryIndex;
+  return Object.values(index.entries).filter((e) => e.type === 'story');
+}
+
+async function snapshotStory(
+  page: Page,
+  story: StoryEntry,
+): Promise<void> {
+  await page.goto(
+    `/iframe.html?id=${encodeURIComponent(story.id)}&viewMode=story`,
+    { waitUntil: 'networkidle' },
+  );
+
+  // Storybook renders into `#storybook-root` (modern) or `#root` (legacy).
+  const root = page.locator('#storybook-root, #root').first();
+  await root.waitFor({ state: 'visible', timeout: 10_000 });
+
+  // Give Vue's mounting + any async setup one tick to settle so the
+  // screenshot doesn't race ongoing renders.
+  await page.waitForTimeout(200);
+
+  // Snapshot the root element (not the whole viewport) so the diff focuses
+  // on the component, not on Storybook's iframe scrollbar / body padding.
+  await expect(root).toHaveScreenshot(`${story.id}.png`);
+}
+
+test('all Storybook stories match baseline screenshots', async ({ page }) => {
+  const stories = await fetchStoryIndex(page);
+  if (stories.length === 0) {
+    throw new Error(
+      'Storybook returned 0 stories — check that *.stories.ts files exist',
+    );
+  }
+
+  // Soft-collect failures so one broken story doesn't hide the others.
+  const failures: Array<{ story: string; error: Error }> = [];
+  for (const story of stories) {
+    try {
+      await snapshotStory(page, story);
+    } catch (err) {
+      failures.push({
+        story: `${story.title} / ${story.name}`,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    }
+  }
+
+  if (failures.length > 0) {
+    const summary = failures
+      .map((f) => `  - ${f.story}: ${f.error.message.split('\n')[0]}`)
+      .join('\n');
+    throw new Error(
+      `${failures.length}/${stories.length} stories failed visual diff:\n${summary}`,
+    );
+  }
+});


### PR DESCRIPTION
Closes #5077.

## Why

The session that produced this work touched 30+ UI files across PRs #5036 (spacing tokens), #5043 (Icon spinner removal), #4805 (Font Awesome → SVG migration) — none with any way to verify the visual result. \`vue-tsc\` and \`vitest\` can prove code compiles and behaves; they can't prove a button is still 44px tall, an icon is still centered, or a color is still legible.

This PR closes that safety gap with **Playwright + Storybook visual snapshots**.

## Layout

```
autobot-frontend/
├── playwright.visual.config.ts             # Auto-starts Storybook, light + dark
└── tests/visual/
    ├── README.md                           # Workflow + coverage gaps
    ├── storybook-stories.spec.ts           # Discovers stories at runtime
    └── __screenshots__/                    # (created by --update-snapshots)
```

Plus two `package.json` scripts:
- `npm run test:visual` — diff against baselines
- `npm run test:visual:update` — regenerate baselines

## How it works

1. Auto-starts Storybook on :6006 (skip with `SKIP_STORYBOOK_START=1` if already running)
2. Fetches `/index.json` to enumerate every story
3. For each story: navigate to its iframe URL → wait for root → screenshot → diff against baseline
4. Diffs above threshold (`maxDiffPixels: 100`, `threshold: 0.2`) fail the test
5. HTML report shows actual / expected / diff side-by-side

Per-OS baselines (`-linux.png`, `-darwin.png`, `-win32.png`) prevent cross-platform font rendering noise.

## Why one big test (not one per story)

Playwright loads test files **before** its `webServer` config starts Storybook. Top-level `await fetch(':6006/index.json')` would fail at collection time. A single test that fetches stories during the run sidesteps the chicken-and-egg. Trade-off: lose per-story failure isolation; gain a test file that loads cleanly even when Storybook isn't running. Soft-collected failures preserve which stories failed.

## Why Playwright + Storybook (not Chromatic / Percy)

- **No external service**: tests run anywhere, no SaaS dependency, no per-month cost
- **Tests live with code**: baselines are in the repo, reviewable in PRs
- **Existing infra**: both already installed; this PR just wired them together
- **Trade-off**: no cross-PR diff browser. Use the local HTML report. If we outgrow this, swap to Chromatic later — the stories themselves don't need to change.

## Verification

```
$ SKIP_STORYBOOK_START=1 npx playwright test --config playwright.visual.config.ts --list
Listing tests:
  [chromium-light] › storybook-stories.spec.ts › all Storybook stories match baseline screenshots
  [chromium-dark]  › storybook-stories.spec.ts › all Storybook stories match baseline screenshots
Total: 2 tests in 1 file

$ npx vue-tsc --noEmit -p tsconfig.app.json | grep playwright.visual    # silence = clean
```

## First-run note

This PR adds **infrastructure only — no baselines yet**. The first developer to run `npm run test:visual:update` generates baselines for the existing 10 stories (LoginForm, BaseAlert, BaseBadge, BaseButton, BaseCard, BaseInput, BaseTable, EmptyState, LoadingSpinner, Welcome).

## Coverage gaps to fill (follow-ups)

The session-relevant components without stories — listed in `tests/visual/README.md`:
- `ui/Icon.vue` (the registry from #4805)
- `ui/ThemeToggle.vue`, `ui/DarkModeToggle.vue`
- `ui/BaseModal.vue`, `ui/CommandPermissionDialog.vue`, `ui/PreferencesPanel.vue`
- `ui/HostSelector.vue`, `ui/HostSelectionDialog.vue`
- `ui/ToastContainer.vue`

Adding a story is mechanical; new stories get visual coverage automatically.

## Pairs with PR #5205

PR #5205 (pre-push hook) catches code-level regressions (type errors, test failures). This PR catches visual regressions. Together they close the verification gaps from this session's incident retrospectives.