### PR TITLE
refactor(composables): POC migrate useConfigDuplicates from useAnalyticsFetch \u2192 useFetchEndpoint (#5208)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useConfigDuplicates.ts
+++ b/autobot-frontend/src/composables/analytics/useConfigDuplicates.ts
@@ -7,48 +7,45 @@
  *
  * Configuration duplicate detection analysis.
  * Extracted from useSpecializedAnalysis (Issue #2372).
+ * Migrated from useAnalyticsFetch to useFetchEndpoint (Issue #5208 POC).
  */
 
-import { useAnalyticsFetch } from '@/composables/useAnalyticsFetch'
+import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import type {
   UseCodeIntelAnalysisDeps,
   ConfigDuplicatesResult,
 } from './codeIntelTypes'
-import { getApiBase } from '@/config/ssot-config'
 
-export function useConfigDuplicates(
-  deps: UseCodeIntelAnalysisDeps,
-) {
-  const { sourceIdQuery } = deps
+interface ConfigDuplicatesRaw {
+  status: string
+  duplicates_found?: number
+  duplicates?: ConfigDuplicatesResult['duplicates']
+  report?: string
+}
 
-  const {
-    data: configDuplicatesAnalysis,
-    loading: loadingConfigDuplicates,
-    error: configDuplicatesError,
-    load: _loadConfigDuplicates,
-  } = useAnalyticsFetch<ConfigDuplicatesResult>(
-    `${getApiBase()}/analytics/codebase/config-duplicates`,
-    (r) => {
-      if (r.status === 'success') {
-        return {
-          duplicates_found: (r.duplicates_found as number) || 0,
-          duplicates:
-            (r.duplicates as ConfigDuplicatesResult['duplicates']) ||
-            [],
-          report: (r.report as string) || '',
-        }
-      }
-      return undefined
+export function useConfigDuplicates(deps: UseCodeIntelAnalysisDeps) {
+  const { withSourceId } = deps
+
+  const endpoint = useFetchEndpoint<ConfigDuplicatesRaw, ConfigDuplicatesResult>(
+    {
+      path: '/api/analytics/codebase/config-duplicates',
+      scopeToSource: true,
+      pickData: (r) =>
+        r.status === 'success'
+          ? {
+              duplicates_found: r.duplicates_found ?? 0,
+              duplicates: r.duplicates ?? [],
+              report: r.report ?? '',
+            }
+          : null,
     },
+    { withSourceId },
   )
 
-  const loadConfigDuplicates = () =>
-    _loadConfigDuplicates(sourceIdQuery.value)
-
   return {
-    configDuplicatesAnalysis,
-    loadingConfigDuplicates,
-    configDuplicatesError,
-    loadConfigDuplicates,
+    configDuplicatesAnalysis: endpoint.data,
+    loadingConfigDuplicates: endpoint.loading,
+    configDuplicatesError: endpoint.error,
+    loadConfigDuplicates: endpoint.load,
   }
 }


### PR DESCRIPTION
## Summary

**POC migration of the smallest `useAnalyticsFetch` consumer** (`useConfigDuplicates`, 54 LOC, 1 GET endpoint, no POST, no multi-error) to the canonical `useFetchEndpoint`.

This answers the decision point in #5208 empirically: the migration is mechanical, breaks no existing callers, and surfaces no capability gap that would block the rest. The remaining 4 consumers + the deletion of `composables/useAnalyticsFetch.ts` + its tests will follow in a second PR.

Progresses #5208 (POC step only; does NOT close the issue).

## Empirical findings (documented for the follow-up)

### 1. Option mapping is 1:1

| useAnalyticsFetch | useFetchEndpoint |
|---|---|
| `path` | `path` |
| `extract(json) \u2192 T \| undefined` | `pickData(raw) \u2192 TOut \| null` |
| `opts.method: 'GET' \| 'POST'` | `method: 'GET' \| 'POST' \| 'DELETE'` |
| `load(query, body)` | `load(queryExtras)` + `body: () => unknown` factory |

Source scoping (\u2205 in the old helper) is purely additive: pass `scopeToSource: true` + `{ withSourceId }` deps.

### 2. Return-type delta is cosmetic for the current 5 consumers

`useAnalyticsFetch.load` returns `T \| null`; `useFetchEndpoint.load` returns `void`. Grep confirms **none of the 5 consumers read the return value** \u2014 all use `data.value` / `loading.value` / `error.value` reactively. No caller update needed.

### 3. Error shape delta is cosmetic for template usage

`useAnalyticsFetch.error` is `ComputedRef<string \| null>` (multi-error array joined with `;`). `useFetchEndpoint.error` is `Ref<string>` (single). Templates that do `v-if="error"` still work: `''` is falsy. The one template binding in this POC (`:error="configDuplicatesError"`) type-checks without change.

### 4. `reset()` is not carried over

`useAnalyticsFetch` exposes `reset()`; `useFetchEndpoint` doesn't. **Grep confirms no existing consumer calls `reset()`** \u2014 so the omission is fine. If a future consumer needs it, a 5-line addition to `useFetchEndpoint` covers it; filing a follow-up issue now would be speculative.

## Decision for the follow-up

Per the audit and this POC:
- **Proceed with migrating the remaining 4 consumers** (`useCodeIntelScores.ts`, `useOwnershipAnalysis.ts`, `useApiEndpointAnalysis.ts`, `useSourceRegistry.ts`).
- **Delete `composables/useAnalyticsFetch.ts`** (127 LOC) + its tests after the migration lands.
- Expected LOC win: ~-150 after all 5 + helper deletion.

## LOC delta (this POC)

| File | Before | After |
|---|---|---|
| `composables/analytics/useConfigDuplicates.ts` | 54 | 51 (-3) |

Marginal per the audit's critical-mass rule \u2014 real win lands with the helper deletion in the follow-up.

## Test plan

- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` \u2014 **166 baseline unchanged**; zero new errors on the migrated file or on the template that consumes it (`CodebaseAnalytics.vue:218`).
- [x] Grep verification: no caller reads `loadConfigDuplicates()`'s return value (it's used as an event handler + scan-runner callback where return is ignored).
- [ ] Manual: Codebase Analytics panel \u2192 Config Duplicates section \u2014 refresh button triggers fetch, panel renders duplicates, error state renders on failure.

## Related

- Umbrella: #5208 (stays OPEN after this PR \u2014 POC only)
- Audit that recommended this: #5154 / PR #5164 (merged)
- Canonical composable: `composables/api/useFetchEndpoint.ts` (rehomed in #5168 / #5187)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)