### PR TITLE
style(tokens): remove 3 unused --spacing-micro-* tokens (#5036)

### DIFF
--- a/autobot-frontend/src/assets/css/design-tokens.css
+++ b/autobot-frontend/src/assets/css/design-tokens.css
@@ -259,13 +259,12 @@
   --spacing-24: 6rem;
   --spacing-32: 8rem;
 
-  /* Sub-half-unit micro spacing — used in dense UI (badges, chips, voice controls) */
-  --spacing-micro-1: 0.1rem;   /* ~1.6px */
-  --spacing-micro-2: 0.15rem;  /* ~2.4px */
+  /* Sub-half-unit micro spacing — used in dense UI (badges, chips, voice controls).
+   * Unused (micro-1, micro-2, micro-6) removed in #5036 audit.
+   * Remaining values are rem-based, so they scale with user font size. */
   --spacing-micro-3: 0.2rem;   /* ~3.2px */
   --spacing-micro-4: 0.3rem;   /* ~4.8px */
   --spacing-micro-5: 0.4rem;   /* ~6.4px */
-  --spacing-micro-6: 0.45rem;  /* ~7.2px */
 
   /* Semantic accessibility tokens */
   --touch-target-min: 44px; /* WCAG 2.5.8 minimum touch target size */


### PR DESCRIPTION
Closes #5036.

## Audit completed across multiple PRs

The session-long #5036 audit started with PR #5009 adding 18 new spacing tokens unaudited. Subsequent work has cleaned them up:

| PR | What |
|---|---|
| #5042 | Renamed \`--spacing-44px\` → \`--touch-target-min\` (semantic WCAG name) |
| #5052 | Rounded 4 pixel tokens (\`--spacing-3px/15px/18px/30px\`) to nearest rem-scale token; deleted them; inlined \`--spacing-140px\` |
| **This PR** | Removed 3 unused micro tokens, completing the audit |

## What this PR changes

Removes the 3 micro tokens with **0 references**:

| Token | Value | References |
|---|---|---|
| \`--spacing-micro-1\` | 0.1rem | 0 |
| \`--spacing-micro-2\` | 0.15rem | 0 |
| \`--spacing-micro-6\` | 0.45rem | 0 |

The 3 micro tokens still in use are kept (rem-based, accessibility-safe):

| Token | Value | References |
|---|---|---|
| \`--spacing-micro-3\` | 0.2rem | 3 |
| \`--spacing-micro-4\` | 0.3rem | 2 |
| \`--spacing-micro-5\` | 0.4rem | 4 |

## Verification

```
$ for tok in micro-1 micro-2 micro-6; do
    grep -rn "var(--spacing-$tok)|--spacing-$tok\\b" autobot-frontend/src
  done
(no output — 0 references confirmed)
```

Negative tokens (`--spacing-neg-*`) all have 1+ references; kept. `--touch-target-min` has 1 use; kept (semantic accessibility token).

Net diff: −4 / +3 lines.