### PR TITLE
fix(knowledge-connectors): align testConnector + syncConnector with backend response shapes (#5203 #5204)

### DIFF
--- a/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
+++ b/autobot-frontend/src/components/knowledge/connectors/ConnectorManager.vue
@@ -89,12 +89,12 @@ function openEdit(id: string) {
 async function handleSync(id: string) {
   try {
     const result = await knowledgeRepository.syncConnector(id)
+    // Sync runs as a background task; only the enqueue is acknowledged here.
+    // Actual counts arrive via getConnectorHistory(id) once the job finishes.
     logger.info(
-      'Sync completed for %s: added=%d updated=%d deleted=%d',
+      'Sync started for %s (incremental=%s)',
       id,
-      result.added,
-      result.updated,
-      result.deleted
+      result.incremental
     )
     // Refresh the connector to get updated status
     await refreshConnectorStatus(id)

--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -618,28 +618,44 @@ export class KnowledgeRepository extends ApiRepository {
   }
 
   /**
-   * Test a connector's connection
+   * Test a connector's connection.
+   *
+   * Backend returns `{connector_id, healthy}`; we translate the boolean
+   * into the `{success, message}` shape callers expect (#5203).
    */
   async testConnector(
     id: string
   ): Promise<{ success: boolean; message: string }> {
-    const response = await this.post(
+    const response = await this.post<{ connector_id: string; healthy: boolean }>(
       `${getApiBase()}/knowledge_base/connectors/${encodeURIComponent(id)}/test`
     )
-    return response.data as { success: boolean; message: string }
+    const healthy = response.data.healthy
+    return {
+      success: healthy,
+      message: healthy ? 'Connection healthy' : 'Connection failed',
+    }
   }
 
   /**
-   * Trigger a sync for a connector
+   * Trigger a sync for a connector.
+   *
+   * Sync runs as a background task on the backend; the response only
+   * acknowledges the enqueue (`{connector_id, status: 'sync_started',
+   * incremental}`). Actual counts arrive later via
+   * {@link getConnectorHistory} (#5204).
    */
   async syncConnector(
     id: string,
     incremental = true
-  ): Promise<SyncResult> {
-    const response = await this.post(
+  ): Promise<{ connector_id: string; status: string; incremental: boolean }> {
+    const response = await this.post<{
+      connector_id: string
+      status: string
+      incremental: boolean
+    }>(
       `${getApiBase()}/knowledge_base/connectors/${encodeURIComponent(id)}/sync?incremental=${incremental}`
     )
-    return response.data as SyncResult
+    return response.data
   }
 
   /**

--- a/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.connectors.test.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.connectors.test.ts
@@ -163,4 +163,75 @@ describe('KnowledgeRepository connector endpoints (#5200)', () => {
       )
     })
   })
+
+  describe('testConnector — translates {healthy} into {success, message} (#5203)', () => {
+    it('maps healthy=true to success=true with "Connection healthy" message', async () => {
+      postSpy.mockResolvedValue({
+        data: { connector_id: 'id-1', healthy: true }
+      })
+
+      const result = await repo.testConnector('id-1')
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Connection healthy'
+      })
+      expect(postSpy).toHaveBeenCalledWith(
+        '/api/knowledge_base/connectors/id-1/test'
+      )
+    })
+
+    it('maps healthy=false to success=false with "Connection failed" message', async () => {
+      postSpy.mockResolvedValue({
+        data: { connector_id: 'id-2', healthy: false }
+      })
+
+      const result = await repo.testConnector('id-2')
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Connection failed'
+      })
+    })
+  })
+
+  describe('syncConnector — returns backend enqueue shape (#5204)', () => {
+    it('returns the {connector_id, status, incremental} payload directly', async () => {
+      postSpy.mockResolvedValue({
+        data: {
+          connector_id: 'id-1',
+          status: 'sync_started',
+          incremental: true
+        }
+      })
+
+      const result = await repo.syncConnector('id-1')
+
+      expect(result).toEqual({
+        connector_id: 'id-1',
+        status: 'sync_started',
+        incremental: true
+      })
+      expect(postSpy).toHaveBeenCalledWith(
+        '/api/knowledge_base/connectors/id-1/sync?incremental=true'
+      )
+    })
+
+    it('forwards incremental=false to the backend', async () => {
+      postSpy.mockResolvedValue({
+        data: {
+          connector_id: 'id-2',
+          status: 'sync_started',
+          incremental: false
+        }
+      })
+
+      const result = await repo.syncConnector('id-2', false)
+
+      expect(result.incremental).toBe(false)
+      expect(postSpy).toHaveBeenCalledWith(
+        '/api/knowledge_base/connectors/id-2/sync?incremental=false'
+      )
+    })
+  })
 })


### PR DESCRIPTION
Closes #5203, #5204

## Summary
Two sister follow-ups to #5202 (#5200). Same pattern: declared TS type lied about actual backend response shape.

### #5203 — testConnector
Backend returns \`{connector_id, healthy}\`; repository declared \`{success, message}\`. Unwrap with helpful fallback message:
\`\`\`ts
return {
  success: healthy,
  message: healthy ? 'Connection healthy' : 'Connection failed'
}
\`\`\`

### #5204 — syncConnector
Backend returns \`{connector_id, status: \"sync_started\", incremental}\` (async ack). Repository declared \`SyncResult\` with \`.added/.updated/.deleted\` that never existed.

Chose Option A from issue body: narrow the declared return type to match backend. Async sync results come via \`getConnectorHistory()\`.

Updated \`ConnectorManager.handleSync\` to log \"Sync started for %s (incremental=%s)\" instead of misleading \"Sync completed ... added=NaN updated=NaN deleted=NaN\".

## Tests
4 new tests in \`KnowledgeRepository.connectors.test.ts\`:
- testConnector healthy true → \`{success: true, ...}\`
- testConnector healthy false → \`{success: false, ...}\`
- syncConnector default + incremental=false

## Test Status
PASS — 10/10 (6 existing + 4 new); 0 new TS errors