### PR TITLE
refactor(backend): migrate Phase 3 datetime.utcnow() producers to utc_timestamp() (#5178 part B phase 3)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from constants.threshold_constants import TimingConstants
 from dependencies import get_config, get_knowledge_base
 from monitoring.prometheus_metrics import get_metrics_manager
@@ -1218,7 +1219,7 @@ async def execute_enhanced_goal(
                 "result": result,
                 "enhanced_context_used": enhanced_context is not None,
                 "knowledge_base_integrated": payload.use_knowledge_base,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             }
         )
 
@@ -1503,7 +1504,7 @@ async def enhanced_agent_health():
             "ai_stack_available": health_status["status"] == "healthy",
             "multi_agent_coordination": health_status["status"] == "healthy",
             "enhanced_capabilities": health_status["status"] == "healthy",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
         }
 
     except Exception:
@@ -1513,5 +1514,5 @@ async def enhanced_agent_health():
             "multi_agent_coordination": False,
             "enhanced_capabilities": False,
             "error": "Internal server error",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
         }

--- a/autobot-backend/api/ai_stack_integration.py
+++ b/autobot-backend/api/ai_stack_integration.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from dependencies import get_knowledge_base
 from services.ai_stack_client import AIStackError, get_ai_stack_client
 from type_defs.common import Metadata
@@ -151,7 +152,7 @@ async def ai_stack_health_check(admin_check: bool = Depends(check_admin_permissi
                 "success": False,
                 "error": "AI Stack unavailable",
                 "details": "Internal server error",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )
 

--- a/autobot-backend/api/analytics_behavior.py
+++ b/autobot-backend/api/analytics_behavior.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from services.user_behavior_analytics import UserEvent, get_behavior_analytics
 
 logger = logging.getLogger(__name__)
@@ -222,7 +223,7 @@ async def get_feature_comparison(
     comparison.sort(key=lambda x: x["views"], reverse=True)
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "comparison": comparison,
         "total_features": len(comparison),
     }
@@ -423,7 +424,7 @@ async def get_behavior_summary(
     )
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "engagement": engagement.get("metrics", {}),
         "feature_popularity": engagement.get("feature_popularity", []),
         "most_popular_feature": engagement.get("most_popular_feature"),

--- a/autobot-backend/api/analytics_cost.py
+++ b/autobot-backend/api/analytics_cost.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from services.llm_cost_tracker import MODEL_PRICING, get_cost_tracker
 
 logger = logging.getLogger(__name__)
@@ -169,7 +170,7 @@ async def get_cost_by_model(
     )
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "models": [
             {
                 "model": model,
@@ -468,7 +469,7 @@ async def set_budget_alert(
         "period": alert.period,
         "notify_at_percent": alert.notify_at_percent,
         "enabled": alert.enabled,
-        "created_at": datetime.utcnow().isoformat(),
+        "created_at": utc_timestamp(),
     }
 
     import json
@@ -684,7 +685,7 @@ async def get_cost_by_agent_all(
         )
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "agents": result,
         "total_agents": len(result),
     }

--- a/autobot-backend/api/analytics_export.py
+++ b/autobot-backend/api/analytics_export.py
@@ -26,6 +26,7 @@ from fastapi.responses import PlainTextResponse, Response
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from services.agent_analytics import get_agent_analytics
 from services.llm_cost_tracker import get_cost_tracker
 
@@ -241,7 +242,7 @@ async def export_full_json(
 
     export_data = {
         "export_info": {
-            "generated_at": datetime.utcnow().isoformat(),
+            "generated_at": utc_timestamp(),
             "period_days": days,
             "start_date": start_date.isoformat(),
             "end_date": end_date.isoformat(),

--- a/autobot-backend/api/analytics_maintenance.py
+++ b/autobot-backend/api/analytics_maintenance.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from services.analytics_service import (
     MaintenancePriority,
     ResourceType,
@@ -123,7 +124,7 @@ async def get_maintenance_recommendations(
     recommendations = await service.get_predictive_maintenance()
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "total_recommendations": len(recommendations),
         "by_priority": {
             "critical": sum(
@@ -204,7 +205,7 @@ async def get_maintenance_summary(
     ]
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "summary": {
             "total_items": len(recommendations),
             "requires_immediate_action": len(critical_items),
@@ -266,7 +267,7 @@ async def get_resource_optimizations(
     )
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "total_recommendations": len(optimizations),
         "potential_savings": {
             "cost_usd": round(total_cost_savings, 2),
@@ -337,7 +338,7 @@ async def get_quick_wins(
     ]
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "total_quick_wins": len(quick_wins),
         "estimated_savings": sum(
             o.expected_savings.get("cost_usd", 0) for o in quick_wins
@@ -394,7 +395,7 @@ async def get_health_status(
     dashboard = await service.get_unified_dashboard(7)  # Last 7 days for health
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "health": dashboard["health"],
         "indicators": {
             "cost_trend": dashboard["cost"]["trend"],
@@ -547,7 +548,7 @@ async def get_insights(
     insights.sort(key=lambda x: priority_order.get(x["priority"], 4))
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "total_insights": len(insights),
         "insights": insights[:10],  # Top 10 insights
     }
@@ -578,7 +579,7 @@ async def get_trends_analysis(
     )
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "period_days": days,
         "cost_trends": {
             "direction": cost_trends.get("trend", "stable"),

--- a/autobot-backend/api/captcha.py
+++ b/autobot-backend/api/captcha.py
@@ -24,6 +24,7 @@ from fastapi import APIRouter, HTTPException, Path
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from autobot_shared.time_utils import utc_timestamp
 from services.captcha_human_loop import CaptchaResolutionStatus, get_captcha_human_loop
 
 router = APIRouter(prefix="/captcha", tags=["captcha"])
@@ -86,7 +87,7 @@ async def resolve_captcha(
                 "captcha_id": captcha_id,
                 "status": "solved",
                 "message": "CAPTCHA marked as solved. Research will continue.",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
             media_type="application/json; charset=utf-8",
         )
@@ -141,7 +142,7 @@ async def skip_captcha(
                 "captcha_id": captcha_id,
                 "status": "skipped",
                 "message": "CAPTCHA skipped. Source will be excluded from results.",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )
 
@@ -173,7 +174,7 @@ async def get_pending_captchas() -> JSONResponse:
                 "success": True,
                 "pending_captchas": pending,
                 "count": len(pending),
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )
 
@@ -204,7 +205,7 @@ async def captcha_health() -> JSONResponse:
                 "service": "captcha_human_loop",
                 "pending_captchas": pending_count,
                 "timeout_seconds": captcha_service.timeout_seconds,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )
 
@@ -216,6 +217,6 @@ async def captcha_health() -> JSONResponse:
                 "status": "unhealthy",
                 "service": "captcha_human_loop",
                 "error": "Internal server error",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from constants.threshold_constants import CategoryDefaults, TimingConstants
 
 # Import dependencies and utilities - Using available dependencies
@@ -475,7 +476,7 @@ async def _store_and_log_user_message(
         "id": user_message_id,
         "content": message.content,
         "role": message.role,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "metadata": message.metadata,
         "session_id": session_id,
     }
@@ -497,7 +498,7 @@ async def _store_and_log_user_message(
                 "message_id": user_message_id,
                 "author_id": author_id,
                 "role": message.role,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )
     except Exception:
@@ -649,7 +650,7 @@ async def _store_and_log_ai_response(
         "id": ai_message_id,
         "content": ai_response.get("content", ""),
         "role": "assistant",
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "metadata": ai_response.get("metadata", {}),
         "session_id": session_id,
     }
@@ -714,7 +715,7 @@ async def process_chat_message(
         "role": "assistant",
         "session_id": session_id,
         "message_id": ai_message_id,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "metadata": ai_response.get("metadata", {}),
     }
 
@@ -741,7 +742,7 @@ async def _generate_llm_stream(
                     "type": "chunk",
                     "content": chunk.get("content", ""),
                     "session_id": session_id,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": utc_timestamp(),
                 }
                 yield f"data: {json.dumps(chunk_data)}\n\n"
         else:
@@ -757,7 +758,7 @@ async def _generate_llm_stream(
         error_data = {
             "type": "error",
             "content": "Error generating response",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
         }
         yield f"data: {json.dumps(error_data)}\n\n"
 
@@ -985,7 +986,7 @@ async def chat_health_check(
 
     health_status = {
         "status": "healthy",
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "components": {
             "chat_history_manager": chat_history_status,
             "llm_service": llm_status,
@@ -1529,7 +1530,7 @@ async def _store_enhanced_user_message(
         "id": user_message_id,
         "content": message.content,
         "role": message.role,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "metadata": {
             **(message.metadata or {}),
             "ai_stack_enabled": message.use_ai_stack,
@@ -1714,7 +1715,7 @@ async def _store_enhanced_ai_response(
         "id": ai_message_id,
         "content": ai_response.get("content", ""),
         "role": "assistant",
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "metadata": ai_response.get("metadata", {}),
         "session_id": session_id,
     }
@@ -1786,7 +1787,7 @@ async def _execute_enhanced_chat_pipeline(
         "role": "assistant",
         "session_id": session_id,
         "message_id": ai_message_id,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "metadata": ai_response.get("metadata", {}),
         "knowledge_sources": knowledge_sources if message.include_sources else None,
     }
@@ -1861,7 +1862,7 @@ async def _stream_ai_stack_response(
                     "type": "chunk",
                     "content": chunk,
                     "session_id": session_id,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": utc_timestamp(),
                 }
             )
             await asyncio.sleep(TimingConstants.STREAMING_CHUNK_DELAY)
@@ -1881,7 +1882,7 @@ async def _stream_ai_stack_response(
             {
                 "type": "error",
                 "content": "Error generating enhanced response",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             }
         )
 
@@ -1897,7 +1898,7 @@ def _stream_enhanced_fallback_response(session_id: str):
             "type": "chunk",
             "content": fallback_msg,
             "session_id": session_id,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
         }
     )
 
@@ -1933,7 +1934,7 @@ async def _generate_enhanced_stream(
             {
                 "type": "error",
                 "content": "Error in enhanced streaming",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             }
         )
 
@@ -2066,7 +2067,7 @@ async def enhanced_chat_health_check(
     try:
         health_status = {
             "status": "healthy",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
             "components": {},
         }
 
@@ -2098,7 +2099,7 @@ async def enhanced_chat_health_check(
             content={
                 "status": "unhealthy",
                 "error": "Internal server error",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )
 

--- a/autobot-backend/api/entity_extraction.py
+++ b/autobot-backend/api/entity_extraction.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, Field, validator
 from agents.graph_entity_extractor import ExtractionResult, GraphEntityExtractor
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from type_defs.common import Metadata
 from utils.request_utils import generate_request_id
 
@@ -461,8 +462,6 @@ async def entity_extraction_health(
 
     Issue #744 (auth). Returns status of extractor/graph/agent components.
     """
-    from datetime import datetime
-
     try:
         # Check component health
         components = {
@@ -490,7 +489,7 @@ async def entity_extraction_health(
             content={
                 "status": overall_status,
                 "components": components,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
             media_type="application/json; charset=utf-8",
         )
@@ -502,7 +501,7 @@ async def entity_extraction_health(
             content={
                 "status": "unhealthy",
                 "components": {},
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
                 "error": "Internal server error",
             },
             media_type="application/json; charset=utf-8",

--- a/autobot-backend/api/graph_rag.py
+++ b/autobot-backend/api/graph_rag.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel, Field, validator
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from services.graph_rag_service import GraphRAGService
 from type_defs.common import Metadata
 from utils.request_utils import generate_request_id
@@ -281,8 +282,6 @@ async def graph_rag_health(
         }
         ```
     """
-    from datetime import datetime
-
     try:
         service_metrics = await service.get_metrics()
         components = _check_component_health(service)
@@ -294,7 +293,7 @@ async def graph_rag_health(
                 "status": overall_status,
                 "components": components,
                 "metrics": service_metrics,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
             media_type="application/json; charset=utf-8",
         )
@@ -306,7 +305,7 @@ async def graph_rag_health(
             content={
                 "status": "unhealthy",
                 "components": {},
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
                 "error": "Internal server error",
             },
             media_type="application/json; charset=utf-8",

--- a/autobot-backend/api/knowledge_ai_stack.py
+++ b/autobot-backend/api/knowledge_ai_stack.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from dependencies import get_knowledge_base
 from knowledge_factory import get_or_create_knowledge_base
 from services.ai_stack_client import AIStackError, get_ai_stack_client
@@ -440,7 +441,7 @@ async def _store_single_fact_with_semaphore(
                     "source": source,
                     "category": category,
                     "extraction_confidence": fact.get("confidence", 0.5),
-                    "extracted_at": datetime.utcnow().isoformat(),
+                    "extracted_at": utc_timestamp(),
                 },
             )
         except Exception as e:
@@ -710,7 +711,7 @@ async def get_enhanced_stats(
                 "local_knowledge_base": local_stats,
                 "ai_stack_insights": ai_stats,
                 "enhanced_capabilities": True,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             }
         )
 
@@ -740,7 +741,7 @@ async def enhanced_knowledge_health(
     try:
         health_status = {
             "status": "healthy",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
             "components": {},
         }
 
@@ -769,6 +770,6 @@ async def enhanced_knowledge_health(
             content={
                 "status": "unhealthy",
                 "error": "Internal server error",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )

--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -20,6 +20,7 @@ from redis.exceptions import RedisError
 
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from background_vectorization import get_background_vectorizer
 from exceptions import InternalError
 from knowledge.pipeline.base import PipelineContext
@@ -1691,7 +1692,7 @@ async def _reindex_with_context_task(
     _reindex_state["is_running"] = True
     _reindex_state["enriched_count"] = 0
     _reindex_state["total_count"] = 0
-    _reindex_state["started_at"] = datetime.utcnow().isoformat()
+    _reindex_state["started_at"] = utc_timestamp()
     _reindex_state["completed_at"] = None
     _reindex_state["error"] = None
     try:
@@ -1701,7 +1702,7 @@ async def _reindex_with_context_task(
         logger.exception("Reindex task failed")
     finally:
         _reindex_state["is_running"] = False
-        _reindex_state["completed_at"] = datetime.utcnow().isoformat()
+        _reindex_state["completed_at"] = utc_timestamp()
 
 
 async def _run_reindex(collection_name: str, batch_size: int) -> None:

--- a/autobot-backend/api/memory.py
+++ b/autobot-backend/api/memory.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, Field, validator
 from auth_middleware import check_admin_permission
 from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from type_defs.common import Metadata
 from utils.request_utils import generate_request_id
 
@@ -1541,7 +1542,7 @@ async def memory_health_check(
     try:
         health_status = {
             "status": "healthy",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
             "components": {
                 "memory_graph": (
                     "healthy" if memory_graph.initialized else "unavailable"
@@ -1573,7 +1574,7 @@ async def memory_health_check(
             content={
                 "status": "unhealthy",
                 "error": "Internal server error",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             },
         )
 

--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import utc_timestamp
 from services.llm_cost_tracker import get_cost_tracker
 
 
@@ -117,7 +118,7 @@ async def get_usage_by_user_all(
     users = await tracker.get_all_user_costs()
 
     return {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "users": users,
         "total_users": len(users),
     }

--- a/autobot-backend/security/enterprise/compliance_manager.py
+++ b/autobot-backend/security/enterprise/compliance_manager.py
@@ -23,6 +23,7 @@ import aiofiles
 import yaml
 from cryptography.fernet import Fernet
 
+from autobot_shared.time_utils import utc_timestamp
 from constants.path_constants import PATH
 
 logger = logging.getLogger(__name__)
@@ -292,7 +293,7 @@ class ComplianceManager:
         """
         return {
             "event_id": str(uuid4()),
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
             "event_type": event_type.value,
             "user_id": user_id,
             "action": action,
@@ -718,7 +719,7 @@ class ComplianceManager:
             # Log violation
             violation_event = {
                 "event_id": str(uuid4()),
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
                 "event_type": "compliance_violation",
                 "original_event_id": audit_event["event_id"],
                 "violation": violation,
@@ -804,7 +805,7 @@ class ComplianceManager:
         report = {
             "framework": framework.value,
             "period": {"start": start_date.isoformat(), "end": end_date.isoformat()},
-            "generated_at": datetime.utcnow().isoformat(),
+            "generated_at": utc_timestamp(),
             "statistics": await self._gather_compliance_statistics(
                 framework, start_date, end_date
             ),

--- a/autobot-backend/security/enterprise/security_policy_manager.py
+++ b/autobot-backend/security/enterprise/security_policy_manager.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 
 import yaml
 
+from autobot_shared.time_utils import utc_timestamp
 from constants.path_constants import PATH
 
 logger = logging.getLogger(__name__)
@@ -970,7 +971,7 @@ class SecurityPolicyManager:
 
         return {
             "framework": framework,
-            "generated_at": datetime.utcnow().isoformat(),
+            "generated_at": utc_timestamp(),
             "policy_coverage": policy_coverage,
             "violations_summary": self._calculate_violations_summary(),
             "compliance_score": compliance_score,
@@ -983,7 +984,7 @@ class SecurityPolicyManager:
         self.stats["active_policies"] = len(
             [p for p in self.policies.values() if p.status == PolicyStatus.ACTIVE]
         )
-        self.stats["last_policy_update"] = datetime.utcnow().isoformat()
+        self.stats["last_policy_update"] = utc_timestamp()
 
         # Calculate compliance score
         if self.stats["total_policies"] > 0:

--- a/autobot-backend/security/enterprise/sso_integration.py
+++ b/autobot-backend/security/enterprise/sso_integration.py
@@ -28,6 +28,8 @@ from cryptography.hazmat.primitives.serialization import (
     load_pem_public_key,
 )
 
+from autobot_shared.time_utils import utc_timestamp
+
 from autobot_shared.http_client import get_http_client
 from constants.path_constants import PATH
 
@@ -758,7 +760,7 @@ class SSOIntegrationFramework:
             # Update statistics
             self.stats["successful_authentications"] += 1
             self.stats["active_sessions"] = len(self.active_sessions)
-            self.stats["last_authentication"] = datetime.utcnow().isoformat()
+            self.stats["last_authentication"] = utc_timestamp()
 
             provider_name = provider.name
             self.stats["authentications_by_provider"][provider_name] = (

--- a/autobot-backend/security/enterprise/threat_detection/engine.py
+++ b/autobot-backend/security/enterprise/threat_detection/engine.py
@@ -25,6 +25,7 @@ from sklearn.cluster import DBSCAN
 from sklearn.ensemble import IsolationForest
 from sklearn.preprocessing import StandardScaler
 
+from autobot_shared.time_utils import utc_timestamp
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
 
@@ -618,7 +619,7 @@ class ThreatDetectionEngine:
                 len(event.get("action", "")),
                 len(event.get("resource", "")),
                 datetime.fromisoformat(
-                    event.get("timestamp", datetime.utcnow().isoformat())
+                    event.get("timestamp", utc_timestamp())
                 ).hour,
                 1 if event.get("outcome") == "success" else 0,
                 len(event.get("details", {})),

--- a/autobot-backend/security/enterprise/threat_detection/learner.py
+++ b/autobot-backend/security/enterprise/threat_detection/learner.py
@@ -31,6 +31,7 @@ from datetime import datetime, timedelta
 from typing import Dict, Optional
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +85,7 @@ class ThreatDetectionLearner:
         field = "tp" if is_true_positive else "fp"
         try:
             self._redis.hincrby(key, field, 1)
-            self._redis.hset(key, "last_seen", datetime.utcnow().isoformat())
+            self._redis.hset(key, "last_seen", utc_timestamp())
             logger.debug(
                 "Recorded outcome pattern=%s tp=%s", pattern_id, is_true_positive
             )

--- a/autobot-backend/security/enterprise/threat_detection/models.py
+++ b/autobot-backend/security/enterprise/threat_detection/models.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
+from autobot_shared.time_utils import utc_timestamp
+
 from .types import FILE_OPERATION_ACTIONS, ThreatCategory, ThreatLevel
 
 
@@ -47,7 +49,7 @@ class SecurityEvent:
     @property
     def timestamp(self) -> datetime:
         """Get event timestamp as datetime object."""
-        timestamp_str = self.raw_event.get("timestamp", datetime.utcnow().isoformat())
+        timestamp_str = self.raw_event.get("timestamp", utc_timestamp())
         return datetime.fromisoformat(timestamp_str)
 
     @property
@@ -143,7 +145,7 @@ class EventHistory:
 
         for event in reversed(self.events):
             event_time = datetime.fromisoformat(
-                event.get("timestamp", datetime.utcnow().isoformat())
+                event.get("timestamp", utc_timestamp())
             )
             if event_time < cutoff_time:
                 break
@@ -168,7 +170,7 @@ class EventHistory:
 
         for event in reversed(self.events):
             event_time = datetime.fromisoformat(
-                event.get("timestamp", datetime.utcnow().isoformat())
+                event.get("timestamp", utc_timestamp())
             )
             if event_time < cutoff_time:
                 break
@@ -188,7 +190,7 @@ class EventHistory:
 
         for event in reversed(self.events):
             event_time = datetime.fromisoformat(
-                event.get("timestamp", datetime.utcnow().isoformat())
+                event.get("timestamp", utc_timestamp())
             )
             if event_time < cutoff_time:
                 break
@@ -206,7 +208,7 @@ class EventHistory:
 
         for event in reversed(self.events):
             event_time = datetime.fromisoformat(
-                event.get("timestamp", datetime.utcnow().isoformat())
+                event.get("timestamp", utc_timestamp())
             )
             if event_time < cutoff_time:
                 break
@@ -244,7 +246,7 @@ class EventHistory:
             for event in self.events
             if event.get("user_id") == user_id
             and datetime.fromisoformat(
-                event.get("timestamp", datetime.utcnow().isoformat())
+                event.get("timestamp", utc_timestamp())
             ).hour
             < 6
         )


### PR DESCRIPTION
## Summary

**Phase 3 of #5178 part B**. Migrates **20 of 28** Phase 3 candidate files (~58 sites) — same mechanical pattern as Phases 1 & 2 (PRs #5213, #5233).

**8 files explicitly deferred**:
- 4 mixed-format \`+ "Z"\` files: \`analytics_reporting.py\` (2), \`npu_workers.py\` (4), \`phases.py\` (2), \`project.py\` (1)
- 1 audit outlier: \`services/conversation_export.py\` (2)
- 1 already-deferred from Phase 2: \`services/npu_worker_manager.py\` (2)
- 2 test files: \`tests/api/test_analytics_stratified.py\` (2), \`security/.../test_learner.py\` (4)

## Files migrated (20)

### api/ (14)
| File | Sites | Notes |
|---|---|---|
| \`agent.py\` | 3 | |
| \`ai_stack_integration.py\` | 1 | |
| \`analytics_behavior.py\` | 2 | |
| \`analytics_cost.py\` | 3 | |
| \`analytics_export.py\` | 1 | |
| \`analytics_maintenance.py\` | 7 | |
| \`captcha.py\` | 5 | |
| **\`chat.py\`** | **16** | **largest single file in entire #5178 audit** |
| \`entity_extraction.py\` | 2 | + dropped inner import |
| \`graph_rag.py\` | 2 | + dropped inner import |
| \`knowledge_ai_stack.py\` | 4 | |
| \`knowledge_vectorization.py\` | 2 | |
| \`memory.py\` | 2 | coexists with canonical \`datetime.now(timezone.utc)\` at L1685/L1746 — those untouched |
| \`usage.py\` | 1 | |

### security/enterprise/ (6)
| File | Sites |
|---|---|
| \`compliance_manager.py\` | 3 |
| \`security_policy_manager.py\` | 2 |
| \`sso_integration.py\` | 1 |
| \`threat_detection/engine.py\` | 1 |
| \`threat_detection/learner.py\` | 1 |
| \`threat_detection/models.py\` | 6 |

## Why defer the Z-suffix mixed-format files

These files use \`datetime.utcnow().isoformat() + \"Z\"\` which produces invalid mixed format like \`2026-04-19T17:04:53.123456Z\` (microseconds + Z is mutually exclusive in ISO-8601). Python 3.10's \`fromisoformat\` REJECTS this. Migrating to \`utc_timestamp()\` would change the format from invalid \`2026-...Z\` to valid \`2026-...+00:00\` — a fix not a regression, but external consumers may be parsing strict-Z. Tracked separately for careful migration alongside #5169's step 4 (workflow_versioning Z-format deprecation).

## Behavior change

Same as Phases 1 & 2: timestamps gain \`+00:00\` suffix (was: tz-naive). The 55 unguarded \`fromisoformat\` parsers in [#5169's parser audit](docs/developer/audits/datetime-parsing-audit.md) now receive tz-aware datetimes back — eliminates the silent naive-vs-aware comparison bug class for all 20 migrated files.

\`api/chat.py\` is the highest-traffic surface — carefully migrated all 16 sites (chat events, tool events, completion timestamps, async-loop status responses).

## Verification

- \`py_compile\` on all 20 files: passes
- 0 \`datetime.utcnow().isoformat()\` sites remaining in any of the 20
- Inner imports cleaned in entity_extraction.py & graph_rag.py
- api/memory.py canonical-form sites untouched

## Cumulative progress (Phases 1+2+3)

- Files migrated: **49** (12 + 17 + 20)
- Sites migrated: **~113**
- Sites still remaining: **~26** (~17 deferred Z-suffix + ~6 test files + a few leftovers from concurrent merges)

## What this PR does NOT do

- 8 deferred files (above)
- Lint enforcement (Part C of #5178)
- \`datetime.utcnow()\` field-assigns / delta calculations (#5211)

## Test plan

- [x] \`py_compile\` clean on all 20 files
- [x] All 58 isoformat sites migrated
- [x] Inner imports dropped from entity_extraction.py + graph_rag.py
- [x] memory.py canonical sites untouched
- [ ] \`gh pr checks\` passes