### PR TITLE
perf(frontend): lazy-load cytoscape in KnowledgeGraph.vue via useCytoscapeLibrary (#5234)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeGraph.vue
@@ -150,8 +150,17 @@
       </button>
     </div>
 
-    <!-- 2D Cytoscape Graph Container -->
+    <!-- 2D Cytoscape Graph Container (#5234: lazy-loaded on demand) -->
     <div v-else-if="viewMode === '2d'" class="graph-container">
+      <div v-if="cytoscapeLoading && !cy" class="cytoscape-loading">
+        <div class="loading-spinner"></div>
+        <span>{{ $t('knowledge.graph.loadingVisualization', 'Loading visualization library...') }}</span>
+      </div>
+      <div v-else-if="cytoscapeError" class="chart-error">
+        <span class="error-icon">!</span>
+        <span>{{ cytoscapeError }}</span>
+        <button @click="retryCytoscape" class="btn-link">{{ $t('knowledge.graph.retry', 'Retry') }}</button>
+      </div>
       <div ref="cytoscapeContainer" class="cytoscape-container"></div>
 
       <!-- Zoom Controls (2D only) -->
@@ -378,21 +387,19 @@
 // Author: mrveiss
 
 import { ref, shallowRef, computed, onMounted, onUnmounted, watch, nextTick, defineAsyncComponent } from 'vue'
-import cytoscape, { type Core, type NodeSingular } from 'cytoscape'
-// @ts-expect-error - cytoscape-fcose has no type declarations
-import fcose from 'cytoscape-fcose'
+// Type-only imports — runtime load handled by the shared composable (#5234).
+import type cytoscape from 'cytoscape'
+import type { Core, NodeSingular } from 'cytoscape'
+import { useCytoscapeLibrary } from '@/composables/charts/useCytoscapeLibrary'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
 import { useDebouncedFn } from '@/composables/useDebounce'
 import MemoryOrphanManager from '@/components/knowledge/MemoryOrphanManager.vue'
-const KnowledgeGraph3D = defineAsyncComponent(() => 
+const KnowledgeGraph3D = defineAsyncComponent(() =>
   import('@/components/knowledge/KnowledgeGraph3D.vue')
 )
-
-// Register fcose layout
-cytoscape.use(fcose)
 
 const logger = createLogger('KnowledgeGraph')
 
@@ -472,6 +479,24 @@ const newEntity = ref<NewEntity>({
 // Cytoscape instance - using shallowRef for non-reactive external library instance
 const cytoscapeContainer = ref<HTMLElement | null>(null)
 const cy = shallowRef<Core | null>(null)
+
+// Cytoscape lazy-load state is owned by the shared composable (#5234).
+// The `onReady` callback performs 2D init once the library is available.
+// Previously this file eagerly `import cytoscape + fcose` at module load,
+// adding the entire cytoscape bundle to whichever chunk this component
+// landed in. Now code-split like FunctionCallGraph/ImportTreeChart.
+const {
+  loading: cytoscapeLoading,
+  error: cytoscapeError,
+  cytoscapeModule,
+  ensureReady: ensureCytoscapeReady,
+  retry: retryCytoscape,
+} = useCytoscapeLibrary(() => {
+  if (viewMode.value === '2d' && !cy.value && cytoscapeContainer.value) {
+    initCytoscape()
+    updateCytoscapeElements()
+  }
+})
 
 // ============================================================================
 // Utilities
@@ -611,9 +636,9 @@ function formatDate(timestamp: number): string {
  * Sets up event handlers for node selection, hover effects, and zoom tracking
  */
 function initCytoscape(): void {
-  if (!cytoscapeContainer.value) return
+  if (!cytoscapeModule.value || !cytoscapeContainer.value) return
 
-  cy.value = cytoscape({
+  cy.value = cytoscapeModule.value({
     container: cytoscapeContainer.value,
     style: getCytoscapeStyles(),
     elements: [],
@@ -896,12 +921,15 @@ async function refreshGraph(): Promise<void> {
     // Wait for DOM to render the graph container (it's conditionally rendered)
     await nextTick()
 
-    // Initialize Cytoscape if not already done (2D mode only, container now exists)
+    // Initialize Cytoscape if not already done (2D mode only, container now exists).
+    // #5234: delegates to useCytoscapeLibrary so the library is lazy-loaded
+    // and the onReady callback runs init + updateCytoscapeElements. If the
+    // container isn't mounted yet (3D mode), ensureReady is a no-op init.
     if (viewMode.value === '2d' && !cy.value && cytoscapeContainer.value) {
-      initCytoscape()
+      await ensureCytoscapeReady()
+    } else {
+      updateCytoscapeElements()
     }
-
-    updateCytoscapeElements()
 
     // Emit refresh event with statistics
     emit('graph-refreshed', {
@@ -1168,11 +1196,14 @@ function toggleViewMode(): void {
     // Double nextTick: first tick commits the v-if DOM change; second tick guarantees
     // the container has non-zero dimensions before Cytoscape initialises (Issue #3400)
     nextTick(() => {
-      nextTick(() => {
+      nextTick(async () => {
         if (!cy.value && cytoscapeContainer.value) {
-          initCytoscape()
+          // #5234: ensureCytoscapeReady lazy-loads the library then fires
+          // the onReady callback which does init + updateCytoscapeElements.
+          await ensureCytoscapeReady()
+        } else {
+          updateCytoscapeElements()
         }
-        updateCytoscapeElements()
       })
     })
   }
@@ -1584,6 +1615,63 @@ watch(layoutMode, () => {
   right: 0;
   bottom: 0;
   min-height: 400px;
+}
+
+/* #5234: lazy-load states for the cytoscape library */
+.cytoscape-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  color: var(--text-secondary);
+  z-index: 2;
+}
+
+.chart-error {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  color: var(--text-secondary);
+  z-index: 2;
+}
+
+.loading-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border-default, var(--border-subtle));
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+.error-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: var(--color-error-bg, rgba(239, 68, 68, 0.12));
+  color: var(--color-error, #ef4444);
+  border-radius: 50%;
+  font-weight: bold;
+  font-size: var(--text-xl);
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: var(--text-sm);
+  padding: 0;
 }
 
 /* Zoom Controls */


### PR DESCRIPTION
## Summary

Converts the third (and last) cytoscape consumer to the shared `useCytoscapeLibrary` composable introduced by #5206 (PR #5220). Before this change, `KnowledgeGraph.vue` eager-imported `cytoscape` + `cytoscape-fcose` at module-load, forcing the full cytoscape bundle into whichever chunk this component landed in.

Closes #5234.

## Changes

- **Imports:** `import cytoscape from 'cytoscape'` \u2192 `import type cytoscape` (namespace kept for `cytoscape.EventObject` / `cytoscape.StylesheetStyle` / etc. type annotations used throughout the file).
- **Eager fcose register removed:** `import fcose from 'cytoscape-fcose'` + module-level `cytoscape.use(fcose)` deleted. The composable registers fcose inside its dynamic-import closure.
- **Runtime reference:** `cy.value = cytoscape({...})` \u2192 `cy.value = cytoscapeModule.value({...})` (ShallowRef from the composable).
- **Lifecycle:** two `initCytoscape()` call-sites (post-fetch refresh, viewMode `'2d'` toggle) now `await ensureCytoscapeReady()` so the library loads first and the `onReady` callback runs `initCytoscape() + updateCytoscapeElements()`. The double-nextTick from #3400 is preserved for the viewMode toggle path.
- **Template:** adds the same `.cytoscape-loading` spinner and `.chart-error` / Retry button UI that `FunctionCallGraph.vue` and `ImportTreeChart.vue` already have.
- **Scoped CSS:** adds matching rules (`.cytoscape-loading`, `.chart-error`, `.error-icon`, `.loading-spinner`, `.btn-link`) near the existing `.cytoscape-container` block. Reuses the existing `@keyframes spin`.

## Bundle impact

`cytoscape` + `cytoscape-fcose` are now code-split. Whichever chunk previously bundled them eagerly (knowledge-base route and anywhere else `KnowledgeGraph.vue` is reachable from) no longer ships them on first page load. Manual bundle-analyzer verification is flagged as a deferred test step below.

## Test plan

- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` \u2014 zero new errors on `KnowledgeGraph.vue`; pre-existing baseline in unrelated files unchanged.
- [x] `npx vitest run src/composables/charts/useCytoscapeLibrary.test.ts` \u2014 5/5 still green (no composable-side changes).
- [x] Grep: `grep 'import cytoscape'` \u2192 returns only type-only `import type cytoscape` and `import type { Core, NodeSingular }` (confirmed no runtime value import remains).
- [ ] Manual: open the Knowledge Graph panel in 2D mode \u2014 graph renders as before on first view; switching to 3D and back still initialises cleanly.
- [ ] Manual: DevTools Network tab \u2192 block `cytoscape-*.js` chunk \u2192 observe Retry UI \u2192 unblock \u2192 Retry renders the graph (same flow as FunctionCallGraph/ImportTreeChart post-#5206).
- [ ] Bundle-analyzer check: confirm `cytoscape` + `cytoscape-fcose` moved to their own chunks (should be automatic given the shared dynamic imports in `useCytoscapeLibrary.ts`).

## Behavioural deltas

- **Zero** on the happy path. Viewing the 2D graph works identically \u2014 the only difference is that the library now loads lazily on first view instead of eagerly at page load.
- The loading UI briefly flashes on first open (while the \~hundreds of KB cytoscape chunk fetches). Subsequent opens are instant because the composable's `load()` is idempotent (it early-returns if `cytoscapeModule.value` is set).
- Retry path works the same as the other two chart files (#5173 fix shared via the composable).

## Related

- Composable introduced in: #5206 / PR #5220 (merged)
- Pattern established by: #5158 / #5173 / #5190 (all merged)
- Completes the cytoscape migration trio: `FunctionCallGraph.vue`, `ImportTreeChart.vue`, `KnowledgeGraph.vue` all now share the same lazy-load primitive.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)