### PR TITLE
fix(repository): unwrap KnowledgeRepository stats response shapes (#5215)

### DIFF
--- a/autobot-frontend/src/models/controllers/KnowledgeController.ts
+++ b/autobot-frontend/src/models/controllers/KnowledgeController.ts
@@ -369,18 +369,19 @@ export class KnowledgeController {
   // Category operations
   async loadCategories(): Promise<void> {
     try {
-      const stats = await knowledgeRepository.getKnowledgeStats()
+      // Issue #5215: switch to /api/knowledge_base/categories — the stats
+      // endpoint returns category names as a bare string list with no
+      // document_count, so populating cards from `stats.categories.map(cat =>
+      // cat.document_count)` was yielding undefined everywhere.
+      const categoryRows = await knowledgeRepository.getCategories()
 
-      // Update categories in store
-      const categories = stats.categories.map((cat: { name: string; document_count: number }) => ({
-        id: generateCategoryId(),
+      this.knowledgeStore.categories = categoryRows.map(cat => ({
+        id: cat.id ?? generateCategoryId(),
         name: cat.name,
         description: `Documents related to ${cat.name}`,
-        documentCount: cat.document_count,
+        documentCount: cat.count ?? 0,
         updatedAt: new Date()
       }))
-
-      this.knowledgeStore.categories = categories
 
     } catch (error: unknown) {
       logger.warn('Failed to load categories:', error)
@@ -415,13 +416,15 @@ export class KnowledgeController {
   // Statistics and maintenance
   async refreshStats(): Promise<void> {
     try {
-      const stats = await knowledgeRepository.getKnowledgeStats()
+      // Issue #5215: the stats/basic endpoint doesn't provide per-category
+      // counts, so refreshing category totals has to go through the dedicated
+      // /categories endpoint which actually returns {name, count, id} rows.
+      const categoryRows = await knowledgeRepository.getCategories()
 
-      // Update local categories with counts
-      stats.categories.forEach((catStat: { name: string; document_count: number }) => {
+      categoryRows.forEach(catStat => {
         const category = this.knowledgeStore.categories.find(c => c.name === catStat.name)
         if (category) {
-          category.documentCount = catStat.document_count
+          category.documentCount = catStat.count ?? 0
         }
       })
 

--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -123,30 +123,80 @@ export interface AddFileOptions {
 }
 
 /**
- * Basic knowledge base statistics
+ * Basic knowledge base statistics as returned by `/api/knowledge_base/stats/basic`.
+ *
+ * Issue #5215 (found in #5207 audit): the previous declaration claimed
+ * `total_documents`, `total_categories`, `total_size`, `last_updated` plus a
+ * `categories: {name, document_count}[]` list. The backend actually returns
+ * `total_facts`, `total_vectors`, a bare string list of category names, and a
+ * `status` field — none of the previously declared fields exist at the top
+ * level. Callers relying on `stats.categories[i].name` got `undefined.name`
+ * at runtime.
  */
 export interface KnowledgeStats {
-  total_documents: number
-  total_categories: number
-  total_size: number
-  last_updated: string
-  categories: Array<{
-    name: string
-    document_count: number
-  }>
+  total_facts: number
+  total_vectors: number
+  categories: string[]
+  status: string
 }
 
 /**
- * Detailed knowledge base statistics with additional metrics
+ * Size-breakdown block inside `DetailedKnowledgeStats`.
  */
-export interface DetailedKnowledgeStats extends KnowledgeStats {
-  documents_by_type: Record<string, number>
-  recent_additions: KnowledgeDocument[]
-  top_categories: Array<{
-    name: string
-    document_count: number
-    total_size: number
-  }>
+export interface DetailedKnowledgeSizeMetrics {
+  total_content_size: number
+  average_fact_size: number
+  median_fact_size: number
+  largest_fact_size: number
+  smallest_fact_size: number
+}
+
+/**
+ * Detailed knowledge base statistics as returned by
+ * `/api/knowledge_base/detailed_stats`.
+ *
+ * Issue #5215: the previous declaration (`extends KnowledgeStats` + flat
+ * `documents_by_type` / `recent_additions` / `top_categories`) did not match
+ * the nested envelope the backend actually returns. All fields in
+ * `basic_stats` are keyed by the concrete backend response; extra diagnostic
+ * keys (`embedding_cache`, `chromadb_path`, etc.) are preserved via
+ * `Record<string, unknown>` so stats-renderers can display them without a
+ * fresh contract bump.
+ */
+export interface DetailedKnowledgeStats {
+  status: string
+  basic_stats: KnowledgeStats & {
+    total_documents?: number
+    total_chunks?: number
+    db_size?: number
+    last_updated?: string | null
+    redis_db?: number | string | null
+    vector_store?: string | null
+    chromadb_collection?: string | null
+    initialized?: boolean
+    llama_index_configured?: boolean
+    embedding_model?: string | null
+    embedding_dimensions?: number | null
+    index_available?: boolean
+    indexed_documents?: number
+    chromadb_path?: string | null
+    embedding_cache?: Record<string, unknown>
+    [key: string]: unknown
+  }
+  category_breakdown: Record<string, number>
+  source_breakdown: Record<string, number>
+  type_breakdown: Record<string, number>
+  size_metrics: DetailedKnowledgeSizeMetrics
+  rag_available: boolean
+}
+
+/**
+ * A single category row from `/api/knowledge_base/categories`.
+ */
+export interface KnowledgeCategoryEntry {
+  name: string
+  count: number
+  id: string
 }
 
 /**
@@ -338,27 +388,75 @@ export class KnowledgeRepository extends ApiRepository {
   }
 
   /**
-   * Get basic knowledge base statistics
+   * Get basic knowledge base statistics from `/api/knowledge_base/stats/basic`.
+   *
+   * Issue #5215 (#5207 audit): the previous declaration was a lie — it
+   * promised `total_documents` / `total_categories` / `total_size` /
+   * `last_updated` and a structured `categories` list, none of which the
+   * backend returns. Nulls in the envelope collapse to a safe empty default
+   * rather than propagating `undefined` into render code.
    */
   async getKnowledgeStats(): Promise<KnowledgeStats> {
     const response = await this.get<KnowledgeStats>(`${getApiBase()}/knowledge_base/stats/basic`)
-    return response.data
+    const data = response?.data
+    return {
+      total_facts: data?.total_facts ?? 0,
+      total_vectors: data?.total_vectors ?? 0,
+      categories: Array.isArray(data?.categories) ? data.categories : [],
+      status: data?.status ?? 'unknown'
+    }
   }
 
   /**
-   * Get detailed knowledge base statistics
+   * Get detailed knowledge base statistics from
+   * `/api/knowledge_base/detailed_stats`.
+   *
+   * Issue #5215 (#5207 audit): the backend returns a nested envelope
+   * (`basic_stats`, `category_breakdown`, `source_breakdown`,
+   * `type_breakdown`, `size_metrics`, `rag_available`). The previous type
+   * claimed a flat shape with `documents_by_type` / `recent_additions` /
+   * `top_categories` that the backend never emits.
    */
   async getDetailedKnowledgeStats(): Promise<DetailedKnowledgeStats> {
     const response = await this.get<DetailedKnowledgeStats>(`${getApiBase()}/knowledge_base/detailed_stats`)
-    return response.data
+    const data = response?.data
+    return {
+      status: data?.status ?? 'unknown',
+      basic_stats: data?.basic_stats ?? {
+        total_facts: 0,
+        total_vectors: 0,
+        categories: [],
+        status: 'unknown'
+      },
+      category_breakdown: data?.category_breakdown ?? {},
+      source_breakdown: data?.source_breakdown ?? {},
+      type_breakdown: data?.type_breakdown ?? {},
+      size_metrics: data?.size_metrics ?? {
+        total_content_size: 0,
+        average_fact_size: 0,
+        median_fact_size: 0,
+        largest_fact_size: 0,
+        smallest_fact_size: 0
+      },
+      rag_available: data?.rag_available ?? false
+    }
   }
 
   /**
-   * Get all categories in knowledge base
+   * Get all categories in knowledge base from `/api/knowledge_base/categories`.
+   *
+   * Issue #5215: backend returns `{categories: KnowledgeCategoryEntry[], total}`;
+   * the previous declaration promised `string[]`. We unwrap the envelope so
+   * callers (e.g. `KnowledgeController.loadCategories`) receive real
+   * `{name, count, id}` rows instead of having to probe the unexpected shape.
    */
-  async getCategories(): Promise<string[]> {
-    const response = await this.get<string[]>(`${getApiBase()}/knowledge_base/categories`)
-    return response.data
+  async getCategories(): Promise<KnowledgeCategoryEntry[]> {
+    const response = await this.get<{
+      categories: KnowledgeCategoryEntry[]
+      total: number
+    }>(`${getApiBase()}/knowledge_base/categories`)
+    const list = response?.data?.categories
+    return Array.isArray(list) ? list : []
   }
 
   /**

--- a/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.stats.test.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/KnowledgeRepository.stats.test.ts
@@ -1,0 +1,184 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2026 mrveiss
+// Author: mrveiss
+/**
+ * Regression tests for #5215 (found during #5207 audit) —
+ * KnowledgeRepository stats + categories response-shape handling.
+ *
+ * Backend `/api/knowledge_base/stats/basic`, `/detailed_stats`, and
+ * `/categories` all return shapes that the previous declarations lied
+ * about. These tests lock in the real backend contracts so a future
+ * edit can't silently reintroduce the mismatch.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { KnowledgeRepository } from '../KnowledgeRepository'
+
+vi.mock('@/config/ssot-config', () => ({
+  getApiBase: () => '/api'
+}))
+
+describe('KnowledgeRepository stats endpoints (#5215)', () => {
+  let repo: KnowledgeRepository
+  let getSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    repo = new KnowledgeRepository()
+    getSpy = vi.fn()
+    // @ts-expect-error - override inherited method for unit test isolation
+    repo.get = getSpy
+  })
+
+  describe('getKnowledgeStats — /knowledge_base/stats/basic', () => {
+    it('returns the backend shape (total_facts/total_vectors/categories/status)', async () => {
+      getSpy.mockResolvedValue({
+        data: {
+          total_facts: 42,
+          total_vectors: 13,
+          categories: ['autobot_memory', 'docs'],
+          status: 'online'
+        }
+      })
+
+      const result = await repo.getKnowledgeStats()
+
+      expect(getSpy).toHaveBeenCalledWith('/api/knowledge_base/stats/basic')
+      expect(result).toEqual({
+        total_facts: 42,
+        total_vectors: 13,
+        categories: ['autobot_memory', 'docs'],
+        status: 'online'
+      })
+    })
+
+    it('coerces a missing envelope into a safe zeroed default', async () => {
+      getSpy.mockResolvedValue({ data: undefined })
+
+      const result = await repo.getKnowledgeStats()
+
+      expect(result).toEqual({
+        total_facts: 0,
+        total_vectors: 0,
+        categories: [],
+        status: 'unknown'
+      })
+    })
+
+    it('coerces a non-array categories field into an empty array', async () => {
+      // Older backend revs occasionally returned `{"cat": count}` map shape
+      getSpy.mockResolvedValue({
+        data: {
+          total_facts: 1,
+          total_vectors: 2,
+          categories: { autobot_memory: 1 } as unknown as string[],
+          status: 'online'
+        }
+      })
+
+      const result = await repo.getKnowledgeStats()
+
+      expect(result.categories).toEqual([])
+      expect(result.total_facts).toBe(1)
+    })
+  })
+
+  describe('getDetailedKnowledgeStats — /knowledge_base/detailed_stats', () => {
+    it('returns the nested envelope shape the backend actually emits', async () => {
+      getSpy.mockResolvedValue({
+        data: {
+          status: 'online',
+          basic_stats: {
+            total_documents: 0,
+            total_chunks: 0,
+            total_facts: 0,
+            total_vectors: 0,
+            categories: ['autobot_memory'],
+            db_size: 80519456,
+            status: 'online',
+            last_updated: '2026-04-20T06:08:51.983737+00:00',
+            vector_store: 'chromadb'
+          },
+          category_breakdown: { memory: 5 },
+          source_breakdown: { manual: 3 },
+          type_breakdown: { fact: 4 },
+          size_metrics: {
+            total_content_size: 1024,
+            average_fact_size: 128,
+            median_fact_size: 100,
+            largest_fact_size: 512,
+            smallest_fact_size: 8
+          },
+          rag_available: true
+        }
+      })
+
+      const result = await repo.getDetailedKnowledgeStats()
+
+      expect(getSpy).toHaveBeenCalledWith('/api/knowledge_base/detailed_stats')
+      expect(result.status).toBe('online')
+      expect(result.basic_stats.total_facts).toBe(0)
+      expect(result.basic_stats.categories).toEqual(['autobot_memory'])
+      expect(result.basic_stats.vector_store).toBe('chromadb')
+      expect(result.category_breakdown).toEqual({ memory: 5 })
+      expect(result.size_metrics.total_content_size).toBe(1024)
+      expect(result.rag_available).toBe(true)
+    })
+
+    it('coerces a missing envelope into a safe zeroed default', async () => {
+      getSpy.mockResolvedValue({ data: undefined })
+
+      const result = await repo.getDetailedKnowledgeStats()
+
+      expect(result.status).toBe('unknown')
+      expect(result.basic_stats).toEqual({
+        total_facts: 0,
+        total_vectors: 0,
+        categories: [],
+        status: 'unknown'
+      })
+      expect(result.category_breakdown).toEqual({})
+      expect(result.source_breakdown).toEqual({})
+      expect(result.type_breakdown).toEqual({})
+      expect(result.size_metrics).toEqual({
+        total_content_size: 0,
+        average_fact_size: 0,
+        median_fact_size: 0,
+        largest_fact_size: 0,
+        smallest_fact_size: 0
+      })
+      expect(result.rag_available).toBe(false)
+    })
+  })
+
+  describe('getCategories — /knowledge_base/categories', () => {
+    it('unwraps {categories, total} envelope into a bare KnowledgeCategoryEntry[]', async () => {
+      getSpy.mockResolvedValue({
+        data: {
+          categories: [
+            { name: 'autobot_memory', count: 0, id: 'autobot_memory' },
+            { name: 'autobot_docs', count: 5638, id: 'autobot_docs' }
+          ],
+          total: 2
+        }
+      })
+
+      const result = await repo.getCategories()
+
+      expect(getSpy).toHaveBeenCalledWith('/api/knowledge_base/categories')
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({ name: 'autobot_memory', count: 0, id: 'autobot_memory' })
+      expect(result[1].count).toBe(5638)
+    })
+
+    it('returns [] when the envelope is missing or malformed', async () => {
+      getSpy.mockResolvedValue({ data: undefined })
+      expect(await repo.getCategories()).toEqual([])
+
+      getSpy.mockResolvedValue({ data: {} })
+      expect(await repo.getCategories()).toEqual([])
+
+      getSpy.mockResolvedValue({ data: { categories: 'not-an-array' } })
+      expect(await repo.getCategories()).toEqual([])
+    })
+  })
+})

--- a/autobot-frontend/src/models/repositories/index.ts
+++ b/autobot-frontend/src/models/repositories/index.ts
@@ -52,7 +52,9 @@ export type {
   AddTextRequest,
   AddUrlRequest,
   KnowledgeStats,
-  DetailedKnowledgeStats
+  DetailedKnowledgeStats,
+  DetailedKnowledgeSizeMetrics,
+  KnowledgeCategoryEntry
 } from './KnowledgeRepository'
 
 export type {


### PR DESCRIPTION
Closes #5215

## Summary
Third #5200-class fix from the #5207 audit. Three stats endpoints had wrong declared shapes:

| Endpoint | Declared | Actual backend |
|---|---|---|
| \`GET /stats/basic\` | \`{total_documents, total_categories, total_size, categories: {name, document_count}[]}\` | \`{total_facts, total_vectors, categories: string[], status}\` |
| \`GET /detailed_stats\` | flat extension with fields that never existed | nested \`{status, basic_stats, category_breakdown, source_breakdown, type_breakdown, size_metrics, rag_available}\` |
| \`GET /categories\` | \`string[]\` | \`{categories: {name, count, id}[], total}\` |

## Fixes
- Rewrote \`KnowledgeStats\`, \`DetailedKnowledgeStats\` interfaces to match backend reality
- New types: \`KnowledgeCategoryEntry\`, \`DetailedKnowledgeSizeMetrics\`
- All three methods now unwrap with defensive safe-default fallbacks
- Live consumer bug: \`KnowledgeController.loadCategories/refreshStats\` read \`stats.categories[i].document_count\` which was always undefined because backend returns bare strings — now routes through \`getCategories()\` which returns real \`{name, count, id}\` rows

## Tests
7 new tests in \`KnowledgeRepository.stats.test.ts\` (34 total repo tests pass).

## Type-check
167 total errors; baseline was 169 (memory #5096). **Net delta: −2** (no new errors in changed files).