### PR TITLE
feat(composables): extract usePollingJob<T> + migrate KB job-status pollers (#5191)

### DIFF
--- a/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
+++ b/autobot-frontend/src/components/knowledge/SystemKnowledgeManager.vue
@@ -185,11 +185,12 @@
 </template>
 
 <script>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useKnowledgeBase } from '@/composables/useKnowledgeBase';
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore';  // NEW: Use shared store
 import { useAsyncOperation } from '@/composables/useAsyncOperation';
+import { usePollingJob } from '@/composables/usePollingJob';
 import appConfig from '@/config/AppConfig.js';
 import BaseButton from '@/components/base/BaseButton.vue';
 import BasePanel from '@/components/base/BasePanel.vue';
@@ -390,6 +391,68 @@ export default {
       }
     };
 
+    // Issue #5191: Managed job-status polling via usePollingJob
+    const refreshJob = usePollingJob(
+      (taskId) => pollJobStatusAPI(taskId),
+      {
+        intervalMs: 2000,
+        maxAttempts: 600, // up to 20 minutes at 2s intervals
+        isComplete: (r) => r?.status === 'SUCCESS' || r?.status === 'FAILURE',
+        onDone: async (statusResponse) => {
+          if (statusResponse.status === 'SUCCESS') {
+            progressPercent.value = 100;
+            progressMessage.value = 'Refresh complete!';
+
+            const result = statusResponse.result || {};
+            lastResult.value = {
+              status: 'success',
+              message: result.message || 'System knowledge refreshed successfully',
+              details: {
+                'Commands Indexed': result.commands_indexed || 0,
+                'Total Facts': result.total_facts || 0
+              }
+            };
+
+            commandsIndexed.value = result.commands_indexed || 0;
+            addLogEntry(`Indexed ${result.commands_indexed || 0} commands`, 'success');
+
+            await fetchStats();
+
+            setTimeout(() => {
+              progressMessage.value = '';
+              progressPercent.value = 0;
+              isRefreshing.value = false;
+            }, 3000);
+          } else {
+            // FAILURE
+            const errorMsg = statusResponse.error || 'Unknown error';
+            lastResult.value = {
+              status: 'error',
+              message: `System knowledge refresh failed: ${errorMsg}`
+            };
+            addLogEntry(`System knowledge refresh failed: ${errorMsg}`, 'error');
+            isRefreshing.value = false;
+            progressMessage.value = '';
+            progressPercent.value = 0;
+          }
+        }
+      }
+    );
+
+    // Mirror in-flight PENDING/PROGRESS updates into UI state
+    watch(refreshJob.data, (statusResponse) => {
+      if (!statusResponse) return;
+      logger.debug('Poll status:', statusResponse.status);
+      if (statusResponse.status === 'PENDING') {
+        progressMessage.value = 'Task queued, waiting to start...';
+        progressPercent.value = 5;
+      } else if (statusResponse.status === 'PROGRESS') {
+        const meta = statusResponse.meta || {};
+        progressMessage.value = meta.status || 'Processing...';
+        progressPercent.value = meta.current || 10;
+      }
+    });
+
     const refreshSystemKnowledge = async () => {
       if (isRefreshing.value) return;
 
@@ -401,8 +464,6 @@ export default {
       progressMessage.value = 'Starting background job...';
       progressPercent.value = 0;
       lastResult.value = null;
-
-      let pollInterval = null;
 
       try {
         addLogEntry('Starting comprehensive system knowledge refresh (background job)', 'info');
@@ -418,76 +479,10 @@ export default {
         progressMessage.value = 'Background job started. Polling for completion...';
         addLogEntry(`Background job started: ${taskId}`, 'info');
 
-        // Poll job status every 2 seconds
-        pollInterval = setInterval(async () => {
-          try {
-            const statusResponse = await pollJobStatusAPI(taskId);
-
-            logger.debug('Poll status:', statusResponse.status);
-
-            if (statusResponse.status === 'PENDING') {
-              progressMessage.value = 'Task queued, waiting to start...';
-              progressPercent.value = 5;
-
-            } else if (statusResponse.status === 'PROGRESS') {
-              // Update progress from backend
-              const meta = statusResponse.meta || {};
-              progressMessage.value = meta.status || 'Processing...';
-              progressPercent.value = meta.current || 10;
-
-            } else if (statusResponse.status === 'SUCCESS') {
-              // Job completed successfully
-              clearInterval(pollInterval);
-              progressPercent.value = 100;
-              progressMessage.value = 'Refresh complete!';
-
-              const result = statusResponse.result || {};
-              lastResult.value = {
-                status: 'success',
-                message: result.message || 'System knowledge refreshed successfully',
-                details: {
-                  'Commands Indexed': result.commands_indexed || 0,
-                  'Total Facts': result.total_facts || 0
-                }
-              };
-
-              commandsIndexed.value = result.commands_indexed || 0;
-              addLogEntry(`Indexed ${result.commands_indexed || 0} commands`, 'success');
-
-              // Refresh stats
-              await fetchStats();
-
-              // Clean up UI after 3 seconds
-              setTimeout(() => {
-                progressMessage.value = '';
-                progressPercent.value = 0;
-                isRefreshing.value = false;
-              }, 3000);
-
-            } else if (statusResponse.status === 'FAILURE') {
-              // Job failed
-              clearInterval(pollInterval);
-              const errorMsg = statusResponse.error || 'Unknown error';
-
-              lastResult.value = {
-                status: 'error',
-                message: `System knowledge refresh failed: ${errorMsg}`
-              };
-              addLogEntry(`System knowledge refresh failed: ${errorMsg}`, 'error');
-
-              isRefreshing.value = false;
-              progressMessage.value = '';
-              progressPercent.value = 0;
-            }
-
-          } catch (pollError) {
-            logger.error('Polling error:', pollError);
-            // Don't stop polling on transient errors - backend may be busy
-          }
-        }, 2000); // Poll every 2 seconds
+        refreshJob.start(taskId);
 
       } catch (error) {
-        if (pollInterval) clearInterval(pollInterval);
+        refreshJob.stop();
 
         let errorMessage = 'Failed to start system knowledge refresh';
         if (error instanceof Error) {

--- a/autobot-frontend/src/composables/__tests__/usePollingJob.test.ts
+++ b/autobot-frontend/src/composables/__tests__/usePollingJob.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for usePollingJob (#5191)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { effectScope, nextTick } from 'vue'
+
+import { usePollingJob } from '../usePollingJob'
+
+describe('usePollingJob', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('starts in idle state with null data/error', () => {
+    const fetcher = vi.fn().mockResolvedValue({ status: 'PENDING' })
+    const { isPolling, data, error, attempts } = usePollingJob(fetcher)
+
+    expect(isPolling.value).toBe(false)
+    expect(data.value).toBeNull()
+    expect(error.value).toBeNull()
+    expect(attempts.value).toBe(0)
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('fires fetcher immediately on start and again on each interval', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ status: 'PENDING' })
+    const { start, stop, isPolling, attempts } = usePollingJob(fetcher, {
+      intervalMs: 1000
+    })
+
+    start('task-1')
+    expect(isPolling.value).toBe(true)
+    // Immediate fire
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(fetcher).toHaveBeenCalledWith('task-1')
+
+    // Second tick after interval
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+
+    // Third tick
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+
+    expect(attempts.value).toBe(3)
+    stop()
+  })
+
+  it('stops polling and fires onDone when isComplete returns true', async () => {
+    const responses = [
+      { status: 'PENDING' },
+      { status: 'PROGRESS' },
+      { status: 'SUCCESS' }
+    ]
+    let i = 0
+    const fetcher = vi.fn().mockImplementation(() => Promise.resolve(responses[i++]))
+    const onDone = vi.fn()
+
+    const { start, isPolling, data } = usePollingJob(fetcher, {
+      intervalMs: 500,
+      isComplete: (r) => r.status === 'SUCCESS' || r.status === 'FAILURE',
+      onDone
+    })
+
+    start('task-success')
+
+    // First call (immediate)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(isPolling.value).toBe(true)
+
+    // Second tick
+    await vi.advanceTimersByTimeAsync(500)
+    expect(isPolling.value).toBe(true)
+
+    // Third tick — SUCCESS
+    await vi.advanceTimersByTimeAsync(500)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+    expect(isPolling.value).toBe(false)
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(onDone).toHaveBeenCalledWith({ status: 'SUCCESS' })
+    expect(data.value).toEqual({ status: 'SUCCESS' })
+  })
+
+  it('stores error but continues polling on transient fetcher errors', async () => {
+    const fetcher = vi.fn()
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockResolvedValueOnce({ status: 'PENDING' })
+      .mockResolvedValueOnce({ status: 'SUCCESS' })
+
+    const { start, isPolling, error } = usePollingJob(fetcher, {
+      intervalMs: 100,
+      isComplete: (r) => r.status === 'SUCCESS'
+    })
+
+    start('task-err')
+    // First call (immediate) → rejects
+    await vi.advanceTimersByTimeAsync(0)
+    expect(error.value).toBeInstanceOf(Error)
+    expect(error.value?.message).toBe('network blip')
+    expect(isPolling.value).toBe(true)
+
+    // Second tick → PENDING, still polling
+    await vi.advanceTimersByTimeAsync(100)
+    expect(isPolling.value).toBe(true)
+
+    // Third tick → SUCCESS, stop
+    await vi.advanceTimersByTimeAsync(100)
+    expect(isPolling.value).toBe(false)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops automatically when maxAttempts is reached', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ status: 'PENDING' })
+    const { start, isPolling, attempts } = usePollingJob(fetcher, {
+      intervalMs: 10,
+      maxAttempts: 3,
+      isComplete: () => false
+    })
+
+    start('task-max')
+    // Immediate + 2 interval ticks = 3 attempts
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(10)
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(attempts.value).toBe(3)
+    expect(isPolling.value).toBe(false)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+
+    // Verify no further calls after cap
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+  })
+
+  it('stop() halts polling and clears the interval', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ status: 'PENDING' })
+    const { start, stop, isPolling } = usePollingJob(fetcher, { intervalMs: 100 })
+
+    start('task-stop')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(isPolling.value).toBe(true)
+
+    stop()
+    expect(isPolling.value).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('auto-cleans up when owning effect scope is disposed', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ status: 'PENDING' })
+
+    const scope = effectScope()
+    let handle: ReturnType<typeof usePollingJob<unknown>>
+    scope.run(() => {
+      handle = usePollingJob(fetcher, { intervalMs: 50 })
+      handle.start('task-scope')
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    scope.stop()
+    expect(handle!.isPolling.value).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('last-caller-wins: restart with new taskId abandons in-flight old tick', async () => {
+    let resolveFirst: (v: { status: string; which: string }) => void = () => {}
+    const firstPromise = new Promise<{ status: string; which: string }>((r) => {
+      resolveFirst = r
+    })
+
+    const fetcher = vi.fn()
+      .mockImplementationOnce(() => firstPromise)
+      .mockResolvedValue({ status: 'PENDING', which: 'new' })
+
+    const { start, data, attempts } = usePollingJob(fetcher, {
+      intervalMs: 1000,
+      isComplete: (r: { status: string }) => r.status === 'SUCCESS'
+    })
+
+    start('task-old')
+    // First immediate call is pending (unresolved)
+    await nextTick()
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    // User restarts with a new task before old one resolves
+    start('task-new')
+    // attempts was reset to 0 on start(); the immediate poll tick then increments to 1
+    expect(attempts.value).toBe(1)
+
+    // Resolve the old promise — it should be abandoned (data stays null for old)
+    resolveFirst({ status: 'SUCCESS', which: 'old' })
+    await nextTick()
+    // New taskId's immediate poll fires
+    await vi.advanceTimersByTimeAsync(0)
+    await nextTick()
+
+    // data should reflect the NEW call, not the abandoned old one
+    expect(data.value).toEqual({ status: 'PENDING', which: 'new' })
+  })
+
+  it('onDone is not called if isComplete is not provided (polls until maxAttempts)', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ anything: true })
+    const onDone = vi.fn()
+    const { start, isPolling } = usePollingJob(fetcher, {
+      intervalMs: 10,
+      maxAttempts: 2,
+      onDone
+    })
+
+    start('task-nocomplete')
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(isPolling.value).toBe(false)
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  it('wraps non-Error rejections into Error instances', async () => {
+    const fetcher = vi.fn().mockRejectedValue('string rejection')
+    const { start, error } = usePollingJob(fetcher, {
+      intervalMs: 100,
+      maxAttempts: 1
+    })
+
+    start('task-strerr')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(error.value).toBeInstanceOf(Error)
+    expect(error.value?.message).toBe('string rejection')
+  })
+})

--- a/autobot-frontend/src/composables/useKnowledgeVectorization.ts
+++ b/autobot-frontend/src/composables/useKnowledgeVectorization.ts
@@ -8,6 +8,7 @@
 
 import { ref, computed } from 'vue'
 import { useKnowledgeBase } from './useKnowledgeBase'
+import { usePollingJob } from './usePollingJob'
 import apiClient from '@/utils/ApiClient'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -54,8 +55,6 @@ export function useKnowledgeVectorization() {
   // State
   const documentStates = ref<Map<string, DocumentVectorizationState>>(new Map())
   const selectedDocuments = ref<Set<string>>(new Set())
-  const isPolling = ref(false)
-  const pollInterval = ref<number | null>(null)
   const globalProgress = ref<VectorizationProgress>({
     total: 0,
     completed: 0,
@@ -528,26 +527,39 @@ export function useKnowledgeVectorization() {
 
   // ==================== STATUS POLLING ====================
 
+  // Issue #5191: Back status polling with usePollingJob for auto-cleanup + race protection.
+  type StatusResult = Awaited<ReturnType<typeof getVectorizationStatus>>
+
+  const applyStatusUpdate = (status: StatusResult | null) => {
+    if (!status) return
+    globalProgress.value = {
+      total: status.total_facts || 0,
+      completed: status.vectorized_facts || 0,
+      failed: 0,
+      inProgress: status.pending_vectorization || 0
+    }
+  }
+
+  const fetchStatus = async (): Promise<StatusResult | null> => {
+    const status = await getVectorizationStatus()
+    applyStatusUpdate(status ?? null)
+    return status ?? null
+  }
+
+  // Mirrors the polling job's lifecycle; allows callers to configure intervalMs on each start.
+  const isPolling = ref(false)
+  let statusJob: ReturnType<typeof usePollingJob<StatusResult | null>> | null = null
+
   /**
-   * Poll vectorization status from backend
+   * Poll vectorization status from backend (standalone — one-shot status fetch).
+   * Preserved for direct invocation by consumers that want a single status read.
+   * Does NOT start or drive the polling loop.
    */
   const pollStatus = async () => {
     try {
-      const status = await getVectorizationStatus()
-
-      if (status) {
-        // Update global progress using correct property names
-        globalProgress.value = {
-          total: status.total_facts || 0,
-          completed: status.vectorized_facts || 0,
-          failed: 0, // Not provided by backend, calculate from document states if needed
-          inProgress: status.pending_vectorization || 0
-        }
-
-        // Stop polling if complete
-        if (status.status === 'completed' || status.status === 'idle') {
-          stopPolling()
-        }
+      const status = await fetchStatus()
+      if (status && (status.status === 'completed' || status.status === 'idle')) {
+        stopPolling()
       }
     } catch (error) {
       logger.error('Failed to poll vectorization status:', error)
@@ -555,22 +567,33 @@ export function useKnowledgeVectorization() {
   }
 
   /**
-   * Start polling for status updates
+   * Start polling for status updates.
+   * No-op if already polling (idempotent, preserves legacy contract).
    */
   const startPolling = (intervalMs: number = 2000) => {
     if (isPolling.value) return
 
+    statusJob = usePollingJob<StatusResult | null>(fetchStatus, {
+      intervalMs,
+      maxAttempts: Number.MAX_SAFE_INTEGER, // lifecycle is caller-managed
+      isComplete: (status) =>
+        status?.status === 'completed' || status?.status === 'idle',
+      onDone: () => {
+        isPolling.value = false
+      }
+    })
+
     isPolling.value = true
-    pollInterval.value = window.setInterval(pollStatus, intervalMs)
+    statusJob.start('')
   }
 
   /**
    * Stop polling for status updates
    */
   const stopPolling = () => {
-    if (pollInterval.value) {
-      clearInterval(pollInterval.value)
-      pollInterval.value = null
+    if (statusJob) {
+      statusJob.stop()
+      statusJob = null
     }
     isPolling.value = false
   }

--- a/autobot-frontend/src/composables/usePollingJob.ts
+++ b/autobot-frontend/src/composables/usePollingJob.ts
@@ -1,0 +1,137 @@
+/**
+ * usePollingJob — managed setInterval wrapper for task-status polling.
+ *
+ * Extracted from KB components that each manually managed setInterval with
+ * inconsistent cleanup and error handling (#5191).
+ *
+ * Features:
+ * - Auto-cleanup via `onScopeDispose` — no component-unmount leaks
+ * - Last-caller-wins race protection: re-calling `start()` abandons in-flight fetches
+ * - `isComplete` callback decides terminal state; `onDone` fires once
+ * - Errors stored in `error` ref; polling continues on transient errors until `maxAttempts`
+ *
+ * @example
+ * ```ts
+ * const { start, stop, data, isPolling } = usePollingJob(
+ *   (taskId) => pollJobStatusAPI(taskId),
+ *   {
+ *     intervalMs: 2000,
+ *     isComplete: (r) => r.status === 'SUCCESS' || r.status === 'FAILURE',
+ *     onDone: (r) => { if (r.status === 'SUCCESS') refreshStats() }
+ *   }
+ * )
+ * start(taskId)
+ * ```
+ */
+
+import { ref, readonly, onScopeDispose, getCurrentScope } from 'vue'
+import type { Ref } from 'vue'
+import { createLogger } from '@/utils/debugUtils'
+
+const logger = createLogger('usePollingJob')
+
+export interface UsePollingJobOptions<T> {
+  /** Poll interval in milliseconds. Default: 2000. */
+  intervalMs?: number
+  /** Maximum attempts before auto-stopping. Default: 60. */
+  maxAttempts?: number
+  /** Callback fired once when `isComplete` returns true. */
+  onDone?: (data: T) => void
+  /** Return true to stop polling (terminal state reached). Default: never complete. */
+  isComplete?: (data: T) => boolean
+}
+
+export interface UsePollingJobReturn<T> {
+  isPolling: Readonly<Ref<boolean>>
+  data: Readonly<Ref<T | null>>
+  error: Readonly<Ref<Error | null>>
+  attempts: Readonly<Ref<number>>
+  /**
+   * Start polling for the given taskId. Any in-flight polling is stopped first.
+   * Pass an empty string when the fetcher doesn't need a task key.
+   */
+  start: (taskId: string) => void
+  /** Stop polling and clear the interval. Safe to call multiple times. */
+  stop: () => void
+}
+
+export function usePollingJob<T>(
+  fetcher: (taskId: string) => Promise<T>,
+  options: UsePollingJobOptions<T> = {}
+): UsePollingJobReturn<T> {
+  const {
+    intervalMs = 2000,
+    maxAttempts = 60,
+    onDone,
+    isComplete
+  } = options
+
+  const isPolling = ref(false)
+  const data = ref<T | null>(null) as Ref<T | null>
+  const error = ref<Error | null>(null)
+  const attempts = ref(0)
+
+  let timer: ReturnType<typeof setInterval> | null = null
+  let currentTaskId: string | null = null
+
+  function stop(): void {
+    if (timer !== null) {
+      clearInterval(timer)
+      timer = null
+    }
+    isPolling.value = false
+    currentTaskId = null
+  }
+
+  async function poll(taskId: string): Promise<void> {
+    // Race guard — if a newer start() replaced this taskId, abandon the tick
+    if (taskId !== currentTaskId) return
+
+    attempts.value += 1
+    try {
+      const result = await fetcher(taskId)
+      if (taskId !== currentTaskId) return
+      data.value = result
+      if (isComplete?.(result) ?? false) {
+        stop()
+        onDone?.(result)
+        return
+      }
+    } catch (err) {
+      if (taskId !== currentTaskId) return
+      error.value = err instanceof Error ? err : new Error(String(err))
+      logger.warn(`polling attempt ${attempts.value} failed: ${error.value.message}`)
+    }
+
+    if (attempts.value >= maxAttempts) {
+      logger.info(`polling reached maxAttempts (${maxAttempts}), stopping`)
+      stop()
+    }
+  }
+
+  function start(taskId: string): void {
+    stop()
+    currentTaskId = taskId
+    attempts.value = 0
+    error.value = null
+    data.value = null
+    isPolling.value = true
+    // Fire immediately so callers don't wait `intervalMs` before the first tick
+    void poll(taskId)
+    timer = setInterval(() => void poll(taskId), intervalMs)
+  }
+
+  // Auto-cleanup when owning scope (component / effectScope) disposes
+  if (getCurrentScope()) {
+    onScopeDispose(stop)
+  }
+
+  return {
+    isPolling: readonly(isPolling),
+    data: readonly(data) as Readonly<Ref<T | null>>,
+    error: readonly(error),
+    attempts: readonly(attempts),
+    start,
+    stop
+  }
+}


### PR DESCRIPTION
Closes #5191

## Summary
Extracted \`usePollingJob<T>\` composable to handle managed setInterval + auto-cleanup + last-caller-wins race protection. Migrated 2 real job-status polling sites; filed discovery for the 3 fake-progress sites that need a separate \`useFakeProgress\` extraction.

## New composable
\`autobot-frontend/src/composables/usePollingJob.ts\` (137 lines):
\`\`\`typescript
export function usePollingJob<T>(
  fetcher: (taskId: string) => Promise<T>,
  options: { intervalMs?, maxAttempts?, onDone?, isComplete? }
): { isPolling, data, error, attempts, start, stop }
\`\`\`

Features:
- \`onScopeDispose\` auto-cleanup
- last-caller-wins race guard (new \`start()\` abandons old polling)
- \`isComplete(result)\` stops polling on terminal state + invokes \`onDone\`
- \`maxAttempts\` stop-guard
- First tick fires immediately; subsequent ticks on interval

## Migrations
- \`SystemKnowledgeManager.vue\` \`refreshSystemKnowledge\` — manual \`setInterval\` replaced
- \`useKnowledgeVectorization.ts\` \`startPolling\`/\`stopPolling\` — legacy API preserved via shim

## Scope correction
Original issue listed 5 polling sites. Audit found 3 of them are fake-progress-bar simulators (count up while backend works), not real job pollers — different pattern. Filed [#5237](https://github.com/mrveiss/AutoBot-AI/issues/5237) for a separate \`useFakeProgress\` extraction.

## Tests
10/10 new tests + 6/6 existing vectorization polling tests pass. 4 pre-existing unrelated failures verified on Dev_new_gui baseline.