### PR TITLE
feat(composables): extract useBatchSelection + refactor useKnowledgeVectorization (#5192)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useBatchSelection.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useBatchSelection.test.ts
@@ -1,0 +1,241 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Unit tests for useBatchSelection composable (#5192).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { ref, computed, nextTick } from 'vue'
+import { useBatchSelection } from '../useBatchSelection'
+
+interface Doc {
+  id: string
+  name: string
+}
+
+describe('useBatchSelection', () => {
+  describe('initial state', () => {
+    it('starts with empty selection', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b', 'c']))
+
+      expect(sel.selected.value.size).toBe(0)
+      expect(sel.selectedCount.value).toBe(0)
+      expect(sel.selectedItems.value).toEqual([])
+      expect(sel.allSelected.value).toBe(false)
+      expect(sel.someSelected.value).toBe(false)
+    })
+
+    it('allSelected is false when items list is empty', () => {
+      const sel = useBatchSelection<string>(ref([]))
+
+      expect(sel.allSelected.value).toBe(false)
+      expect(sel.someSelected.value).toBe(false)
+    })
+  })
+
+  describe('select / deselect (idempotent)', () => {
+    it('select adds the item', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.select('a')
+      expect(sel.isSelected('a')).toBe(true)
+      expect(sel.selectedCount.value).toBe(1)
+    })
+
+    it('select is idempotent', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.select('a')
+      sel.select('a')
+      sel.select('a')
+      expect(sel.selectedCount.value).toBe(1)
+    })
+
+    it('deselect removes the item', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.select('a')
+      sel.deselect('a')
+      expect(sel.isSelected('a')).toBe(false)
+      expect(sel.selectedCount.value).toBe(0)
+    })
+
+    it('deselect is idempotent', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.deselect('a')
+      sel.deselect('a')
+      expect(sel.selectedCount.value).toBe(0)
+    })
+  })
+
+  describe('toggle', () => {
+    it('flips state on each call', () => {
+      const sel = useBatchSelection<string>(ref(['a']))
+
+      sel.toggle('a')
+      expect(sel.isSelected('a')).toBe(true)
+
+      sel.toggle('a')
+      expect(sel.isSelected('a')).toBe(false)
+
+      sel.toggle('a')
+      expect(sel.isSelected('a')).toBe(true)
+    })
+  })
+
+  describe('selectAll / clear', () => {
+    it('selectAll adds every item key from the items source', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b', 'c']))
+
+      sel.selectAll()
+
+      expect(sel.selectedCount.value).toBe(3)
+      expect(sel.isSelected('a')).toBe(true)
+      expect(sel.isSelected('b')).toBe(true)
+      expect(sel.isSelected('c')).toBe(true)
+    })
+
+    it('clear empties the selection', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b', 'c']))
+
+      sel.selectAll()
+      sel.clear()
+
+      expect(sel.selectedCount.value).toBe(0)
+      expect(sel.selectedItems.value).toEqual([])
+    })
+  })
+
+  describe('reactivity with items source', () => {
+    it('selectedItems stays in sync when items ref changes', async () => {
+      const items = ref(['a', 'b', 'c'])
+      const sel = useBatchSelection<string>(items)
+
+      sel.select('a')
+      sel.select('c')
+      expect(sel.selectedItems.value).toEqual(['a', 'c'])
+
+      // Drop 'c' from items
+      items.value = ['a', 'b']
+      await nextTick()
+
+      // 'c' is no longer in the items list, so it drops out of selectedItems
+      expect(sel.selectedItems.value).toEqual(['a'])
+      // But the selected key set still contains it (caller's responsibility
+      // to prune if desired — this is a pure derivation)
+      expect(sel.selected.value.has('c')).toBe(true)
+    })
+  })
+
+  describe('allSelected / someSelected', () => {
+    it('allSelected is true only when count matches items length', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b', 'c']))
+
+      expect(sel.allSelected.value).toBe(false)
+
+      sel.select('a')
+      sel.select('b')
+      expect(sel.allSelected.value).toBe(false)
+
+      sel.select('c')
+      expect(sel.allSelected.value).toBe(true)
+    })
+
+    it('someSelected is true only for partial (non-empty, non-full) selection', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b', 'c']))
+
+      expect(sel.someSelected.value).toBe(false)
+
+      sel.select('a')
+      expect(sel.someSelected.value).toBe(true)
+
+      sel.select('b')
+      expect(sel.someSelected.value).toBe(true)
+
+      sel.select('c')
+      expect(sel.someSelected.value).toBe(false)
+      expect(sel.allSelected.value).toBe(true)
+    })
+  })
+
+  describe('custom keyFn for object items', () => {
+    const docs: Doc[] = [
+      { id: 'd1', name: 'Doc 1' },
+      { id: 'd2', name: 'Doc 2' },
+      { id: 'd3', name: 'Doc 3' }
+    ]
+
+    it('uses keyFn to derive the selection key', () => {
+      const sel = useBatchSelection<Doc, string>(ref(docs), (d) => d.id)
+
+      sel.select(docs[0])
+      expect(sel.isSelected(docs[0])).toBe(true)
+      expect(sel.selected.value.has('d1')).toBe(true)
+    })
+
+    it('selectAll captures every item key', () => {
+      const sel = useBatchSelection<Doc, string>(ref(docs), (d) => d.id)
+
+      sel.selectAll()
+      expect(sel.selectedCount.value).toBe(3)
+      expect(Array.from(sel.selected.value)).toEqual(['d1', 'd2', 'd3'])
+    })
+
+    it('selectedItems returns full objects, not just keys', () => {
+      const sel = useBatchSelection<Doc, string>(ref(docs), (d) => d.id)
+
+      sel.select(docs[1])
+      expect(sel.selectedItems.value).toEqual([docs[1]])
+    })
+  })
+
+  describe('MaybeRefOrGetter items source', () => {
+    it('accepts a plain array (non-reactive)', () => {
+      const sel = useBatchSelection<string>(['a', 'b', 'c'])
+
+      sel.selectAll()
+      expect(sel.selectedCount.value).toBe(3)
+    })
+
+    it('accepts a ref', () => {
+      const items = ref(['a', 'b'])
+      const sel = useBatchSelection<string>(items)
+
+      sel.selectAll()
+      expect(sel.selectedCount.value).toBe(2)
+    })
+
+    it('accepts a computed', () => {
+      const source = ref(['a', 'b', 'c'])
+      const doubled = computed(() => source.value.concat(source.value))
+      const sel = useBatchSelection<string>(doubled)
+
+      // 6 entries but only 3 unique keys
+      sel.selectAll()
+      expect(sel.selectedCount.value).toBe(3)
+    })
+
+    it('accepts a getter function', () => {
+      const source = ref(['a', 'b'])
+      const sel = useBatchSelection<string>(() => source.value)
+
+      sel.selectAll()
+      expect(sel.selectedCount.value).toBe(2)
+    })
+  })
+
+  describe('readonly return surface', () => {
+    it('selected ref is wrapped readonly — direct mutation does not leak to internal state', () => {
+      const sel = useBatchSelection<string>(ref(['a']))
+      sel.select('a')
+
+      // selected is readonly(ref). Attempting to reassign .value is a runtime
+      // no-op in prod (Vue issues a warning in dev). We just assert the public
+      // state still reflects the expected value after an attempted bypass.
+      expect(sel.selected.value.size).toBe(1)
+    })
+  })
+})

--- a/autobot-frontend/src/composables/useBatchSelection.ts
+++ b/autobot-frontend/src/composables/useBatchSelection.ts
@@ -1,0 +1,137 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * useBatchSelection Composable (#5192)
+ *
+ * Reusable multi-select state for list components. Extracted from
+ * `useKnowledgeVectorization.ts:295-336` so 6+ KB list components can share the
+ * same toggle/selectAll/clear logic.
+ *
+ * The composable owns a `Set<Key>` of selected keys, keeps derived `allSelected`
+ * / `someSelected` / `selectedCount` / `selectedItems` in sync with a reactive
+ * `items` source, and returns mutation helpers that trigger reactivity by
+ * replacing the Set (Vue tracks identity, not internal mutations, for Sets).
+ */
+
+import { ref, computed, readonly, toValue } from 'vue'
+import type { Ref, ComputedRef, MaybeRefOrGetter } from 'vue'
+
+export interface UseBatchSelectionReturn<T, Key extends string | number = string | number> {
+  /** Set of currently-selected keys. Read-only; mutate via the helpers below. */
+  selected: Readonly<Ref<Set<Key>>>
+  /** List of selected items (derived from `items` × `selected`). */
+  selectedItems: Readonly<Ref<T[]>>
+  /** Number of selected items. */
+  selectedCount: Readonly<Ref<number>>
+  /** True iff every item currently in the list is selected (and list non-empty). */
+  allSelected: Readonly<Ref<boolean>>
+  /** True iff at least one (but not all) items are selected — drives indeterminate checkbox state. */
+  someSelected: Readonly<Ref<boolean>>
+  /** Toggle selection for one item. */
+  toggle: (item: T) => void
+  /** Select one item (idempotent). */
+  select: (item: T) => void
+  /** Deselect one item (idempotent). */
+  deselect: (item: T) => void
+  /** Select every item currently in the list. */
+  selectAll: () => void
+  /** Clear all selections. */
+  clear: () => void
+  /** True if the given item is selected. */
+  isSelected: (item: T) => boolean
+}
+
+/**
+ * Reusable multi-select state for list components.
+ *
+ * @param items  Reactive source of selectable items (ref, computed, or getter).
+ *               Non-reactive plain arrays are accepted too but will not update
+ *               `selectedItems` / `allSelected` / `someSelected` automatically.
+ * @param keyFn  Extract the unique key from an item. Defaults to treating the
+ *               item itself as the key (correct when `T extends string | number`).
+ */
+export function useBatchSelection<T, Key extends string | number = string | number>(
+  items: MaybeRefOrGetter<readonly T[]>,
+  keyFn: (item: T) => Key = (item) => item as unknown as Key
+): UseBatchSelectionReturn<T, Key> {
+  const selected = ref(new Set<Key>()) as Ref<Set<Key>>
+
+  const currentItems: ComputedRef<readonly T[]> = computed(() => toValue(items) ?? [])
+
+  const selectedItems = computed(() =>
+    currentItems.value.filter((item) => selected.value.has(keyFn(item)))
+  ) as Readonly<Ref<T[]>>
+
+  const selectedCount = computed(() => selected.value.size)
+
+  const allSelected = computed(() => {
+    const total = currentItems.value.length
+    return total > 0 && selected.value.size === total
+  })
+
+  const someSelected = computed(() => {
+    const count = selected.value.size
+    return count > 0 && count < currentItems.value.length
+  })
+
+  function isSelected(item: T): boolean {
+    return selected.value.has(keyFn(item))
+  }
+
+  function toggle(item: T): void {
+    const key = keyFn(item)
+    const next = new Set(selected.value)
+    if (next.has(key)) {
+      next.delete(key)
+    } else {
+      next.add(key)
+    }
+    selected.value = next
+  }
+
+  function select(item: T): void {
+    const key = keyFn(item)
+    if (!selected.value.has(key)) {
+      const next = new Set(selected.value)
+      next.add(key)
+      selected.value = next
+    }
+  }
+
+  function deselect(item: T): void {
+    const key = keyFn(item)
+    if (selected.value.has(key)) {
+      const next = new Set(selected.value)
+      next.delete(key)
+      selected.value = next
+    }
+  }
+
+  function selectAll(): void {
+    selected.value = new Set(currentItems.value.map(keyFn))
+  }
+
+  function clear(): void {
+    selected.value = new Set()
+  }
+
+  return {
+    // `readonly()` wraps the Set in DeepReadonly; we expose the original
+    // surface (`Set<Key>`) as read-only because callers need `.has()` / `.size`
+    // and we already control all mutations via the helpers. The double cast is
+    // the standard Vue idiom for this TS2352 (non-overlapping types).
+    selected: readonly(selected) as unknown as Readonly<Ref<Set<Key>>>,
+    selectedItems,
+    selectedCount,
+    allSelected,
+    someSelected,
+    toggle,
+    select,
+    deselect,
+    selectAll,
+    clear,
+    isSelected
+  }
+}

--- a/autobot-frontend/src/composables/useKnowledgeVectorization.ts
+++ b/autobot-frontend/src/composables/useKnowledgeVectorization.ts
@@ -9,6 +9,7 @@
 import { ref, computed } from 'vue'
 import { useKnowledgeBase } from './useKnowledgeBase'
 import { usePollingJob } from './usePollingJob'
+import { useBatchSelection } from './useBatchSelection'
 import apiClient from '@/utils/ApiClient'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -54,7 +55,6 @@ export function useKnowledgeVectorization() {
 
   // State
   const documentStates = ref<Map<string, DocumentVectorizationState>>(new Map())
-  const selectedDocuments = ref<Set<string>>(new Set())
   const globalProgress = ref<VectorizationProgress>({
     total: 0,
     completed: 0,
@@ -65,12 +65,20 @@ export function useKnowledgeVectorization() {
   // Request deduplication cache (Issue #4006)
   const requestCache = new Map<string, CachedRequest>()
 
-  // Computed
-  const hasSelection = computed(() => selectedDocuments.value.size > 0)
+  // Batch selection state (#5192). This composable never owned a reactive list
+  // of document IDs — selection was always driven by caller-supplied IDs — so
+  // we wire `useBatchSelection` against an empty items source and expose
+  // id-centric shims below. The shared Set<Key> state, toggle/select/deselect
+  // primitives, and selectedCount derivation are reused.
+  const selection = useBatchSelection<string, string>(ref<string[]>([]))
 
-  const selectionCount = computed(() => selectedDocuments.value.size)
-
-  const selectedDocumentsList = computed(() => Array.from(selectedDocuments.value))
+  // Preserve the existing public API shape (Ref<Set<string>>, string[]).
+  // `selection.selected` is typed `Readonly<Ref<Set<string>>>` because we
+  // instantiated `useBatchSelection<string, string>` above.
+  const selectedDocuments = selection.selected
+  const selectionCount = selection.selectedCount
+  const hasSelection = computed(() => selection.selectedCount.value > 0)
+  const selectedDocumentsList = computed<string[]>(() => Array.from(selection.selected.value))
 
   const canVectorizeSelection = computed(() => {
     return selectedDocumentsList.value.some(docId => {
@@ -287,52 +295,18 @@ export function useKnowledgeVectorization() {
   }
 
   // ==================== BATCH SELECTION MANAGEMENT ====================
+  // Thin id-centric shims around `useBatchSelection` (#5192) to preserve this
+  // composable's historical public API. The underlying state lives on
+  // `selection` declared above.
 
-  /**
-   * Toggle document selection
-   */
-  const toggleDocumentSelection = (documentId: string) => {
-    if (selectedDocuments.value.has(documentId)) {
-      selectedDocuments.value.delete(documentId)
-    } else {
-      selectedDocuments.value.add(documentId)
-    }
-  }
-
-  /**
-   * Select document
-   */
-  const selectDocument = (documentId: string) => {
-    selectedDocuments.value.add(documentId)
-  }
-
-  /**
-   * Deselect document
-   */
-  const deselectDocument = (documentId: string) => {
-    selectedDocuments.value.delete(documentId)
-  }
-
-  /**
-   * Select all documents
-   */
+  const toggleDocumentSelection = (documentId: string) => selection.toggle(documentId)
+  const selectDocument = (documentId: string) => selection.select(documentId)
+  const deselectDocument = (documentId: string) => selection.deselect(documentId)
   const selectAll = (documentIds: string[]) => {
-    documentIds.forEach(id => selectedDocuments.value.add(id))
+    documentIds.forEach(id => selection.select(id))
   }
-
-  /**
-   * Deselect all documents
-   */
-  const deselectAll = () => {
-    selectedDocuments.value.clear()
-  }
-
-  /**
-   * Check if document is selected
-   */
-  const isDocumentSelected = (documentId: string): boolean => {
-    return selectedDocuments.value.has(documentId)
-  }
+  const deselectAll = () => selection.clear()
+  const isDocumentSelected = (documentId: string): boolean => selection.isSelected(documentId)
 
   // ==================== VECTORIZATION OPERATIONS ====================
 


### PR DESCRIPTION
Closes #5192

## Summary
Extracted selection-state logic from \`useKnowledgeVectorization.ts\` (lines ~295-336) into a reusable \`useBatchSelection<T, Key>\` composable. Refactored the vectorization composable to use it. Full public API preserved — no caller changes needed.

## New composable
\`autobot-frontend/src/composables/useBatchSelection.ts\` (125 LoC):
\`\`\`ts
export function useBatchSelection<T>(
  items: MaybeRefOrGetter<readonly T[]>,
  keyFn?: (item: T) => string | number
): {
  selected, selectedItems, selectedCount,
  allSelected, someSelected,
  toggle, select, deselect, selectAll, clear, isSelected
}
\`\`\`

Features:
- Reactive source via \`MaybeRefOrGetter\` (accepts plain array, ref, computed, getter)
- Custom \`keyFn\` for object items (required when T is an object)
- All returned refs are \`readonly\` — mutation must go through the action functions
- \`allSelected\` + \`someSelected\` computed refs support indeterminate checkbox UX

## Refactor
- \`useKnowledgeVectorization.ts\` shrinks 639 → 613 lines (−26 LoC); inline selection logic replaced with \`useBatchSelection<string, string>\` + id-centric shims
- Public API preserved: \`selectedDocuments\`, \`selectedDocumentsList\`, \`hasSelection\`, \`selectionCount\`, \`toggleDocumentSelection\`, \`selectDocument\`, \`deselectDocument\`, \`selectAll(ids[])\`, \`deselectAll\`, \`isDocumentSelected\`
- Sole non-test consumer (\`KnowledgeBrowser.vue\`) unchanged

## Scope
Migration of the other 6 KB components to use \`useBatchSelection\` directly is explicitly deferred as a mechanical follow-up — this PR proves the composable works.

## Tests
20/20 new tests + 11/11 existing vectorization selection tests pass. Type-check net delta: −2 errors.