### PR TITLE
fix(backend): replace 11 invalid mixed-format datetime.utcnow().isoformat() + "Z" sites with utc_timestamp() (#5238)

### DIFF
--- a/autobot-backend/api/analytics_reporting.py
+++ b/autobot-backend/api/analytics_reporting.py
@@ -13,7 +13,6 @@ Provides a single endpoint that aggregates all analytics data from:
 """
 
 import logging
-from datetime import datetime
 from typing import Any, Dict
 
 import aiohttp
@@ -22,6 +21,7 @@ from fastapi.responses import JSONResponse
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
+from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
 # Issue #3355: prefix moved to router registry (analytics_routers.py)
@@ -254,7 +254,7 @@ def _build_unified_report_response(
 
     return {
         "status": "success",
-        "generated_at": datetime.utcnow().isoformat() + "Z",
+        "generated_at": utc_timestamp(),
         "summary": {
             "health_score": health_score,
             "grade": get_grade(health_score),
@@ -356,7 +356,7 @@ async def get_quick_summary():
             "total_issues": total_issues,
             "high_priority": severity_totals.get("high", 0)
             + severity_totals.get("critical", 0),
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": utc_timestamp(),
         }
     )
 

--- a/autobot-backend/api/npu_workers.py
+++ b/autobot-backend/api/npu_workers.py
@@ -42,6 +42,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_management.types import DATABASE_MAPPING
 from autobot_shared.ssot_config import DEFAULT_EMBEDDING_MODEL, DEFAULT_LLM_MODEL
+from autobot_shared.time_utils import utc_timestamp
 from models.npu_models import (
     LoadBalancingConfig,
     NPUWorkerConfig,
@@ -836,7 +837,7 @@ async def repair_worker(
             "old_worker_id": worker_id,
             "new_worker_id": new_worker_id,
             "config": _generate_repair_bootstrap_config(),
-            "server_timestamp": datetime.utcnow().isoformat() + "Z",
+            "server_timestamp": utc_timestamp(),
             "message": "Worker unpaired. Use provided config for re-registration.",
         }
 
@@ -1053,7 +1054,7 @@ async def _execute_worker_pairing(
         "url": worker_url,
         "platform": health_info.platform,
         "device_info": device_info,
-        "paired_at": datetime.utcnow().isoformat() + "Z",
+        "paired_at": utc_timestamp(),
         "message": f"Successfully paired with worker at {worker_url}",
     }
 
@@ -1203,7 +1204,7 @@ async def worker_heartbeat(heartbeat: WorkerHeartbeat):
         return {
             "acknowledged": True,
             "worker_id": heartbeat.worker_id,
-            "server_timestamp": datetime.utcnow().isoformat() + "Z",
+            "server_timestamp": utc_timestamp(),
             "message": "Heartbeat received",
         }
 
@@ -1326,7 +1327,7 @@ def _build_bootstrap_response(
             "models": _build_worker_models_config(),
             "logging": _build_worker_logging_config(),
         },
-        "server_timestamp": datetime.utcnow().isoformat() + "Z",
+        "server_timestamp": utc_timestamp(),
         "message": "Bootstrap configuration provided",
     }
 

--- a/autobot-backend/api/phases.py
+++ b/autobot-backend/api/phases.py
@@ -15,9 +15,9 @@ is already in use throughout the backend.
 """
 
 import logging
-from datetime import datetime
 from typing import List
 
+from autobot_shared.time_utils import utc_timestamp
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
@@ -82,7 +82,7 @@ async def get_phases_status() -> PhasesStatusResponse:
             status="ok",
             service="phase_management",
             phases=phases,
-            timestamp=datetime.utcnow().isoformat() + "Z",
+            timestamp=utc_timestamp(),
         )
     except Exception as exc:
         logger.error("Error getting phases status: %s", exc)
@@ -102,7 +102,7 @@ async def run_phases_validation() -> ValidationRunResponse:
         return ValidationRunResponse(
             status="ok",
             message="Validation queued",
-            timestamp=datetime.utcnow().isoformat() + "Z",
+            timestamp=utc_timestamp(),
         )
     except Exception as exc:
         logger.error("Error queuing phase validation: %s", exc)

--- a/autobot-backend/api/project.py
+++ b/autobot-backend/api/project.py
@@ -14,9 +14,9 @@ URLs. This module exposes the correct /api/project/* paths.
 """
 
 import logging
-from datetime import datetime
 from typing import Dict, Optional
 
+from autobot_shared.time_utils import utc_timestamp
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
@@ -108,7 +108,7 @@ async def get_project_report() -> ProjectReportResponse:
             current_phase=raw.get("current_phase", "unknown"),
             total_phases=raw.get("total_phases", 0),
             completed_phases=raw.get("completed_phases", 0),
-            generated_at=datetime.utcnow().isoformat() + "Z",
+            generated_at=utc_timestamp(),
         )
     except Exception as exc:
         logger.error("Error generating project report: %s", exc)

--- a/autobot-backend/services/npu_worker_manager.py
+++ b/autobot-backend/services/npu_worker_manager.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional
 import aiofiles
 import yaml
 
+from autobot_shared.time_utils import utc_timestamp
 from constants.threshold_constants import TimingConstants
 from event_manager import event_manager
 from models.npu_models import (
@@ -389,7 +390,7 @@ class NPUWorkerManager(AsyncInitializable):
                 "data": {
                     "status": worker_details.status.status.value,
                     "current_load": worker_details.status.current_load,
-                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                    "timestamp": utc_timestamp(),
                 },
             }
 
@@ -581,7 +582,7 @@ class NPUWorkerManager(AsyncInitializable):
             {
                 "event": "worker.removed",
                 "worker_id": worker_id,
-                "data": {"timestamp": datetime.utcnow().isoformat() + "Z"},
+                "data": {"timestamp": utc_timestamp()},
             },
         )
 


### PR DESCRIPTION
## Summary

Closes #5238.

These 11 sites produced **invalid ISO-8601** like \`2026-04-19T17:04:53.123456Z\` — microseconds + Z suffix are mutually exclusive in ISO-8601, and Python 3.10's \`datetime.fromisoformat\` REJECTS this format with \`ValueError\`.

## Migration verified safe

Inspected all consumers before changing the wire format:

- **NPU worker** ([\`backend_telemetry.py:271-272\`](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/autobot-npu-worker/resources/windows-npu-worker/app/utils/backend_telemetry.py#L271)) only **logs** \`server_timestamp\` as \`%s\` — does not parse it.
- **Frontend** (\`BusinessIntelligenceView.vue:285\`) uses \`formatDate()\` helper — JS \`Date\` constructor tolerates both \`Z\` and \`+00:00\`.
- **api/rum.py:324** already uses canonical \`datetime.now(tz=timezone.utc).isoformat()\` (\`+00:00\`) for the same \`server_timestamp\` field name — this PR makes the rest of the backend consistent.

## Files migrated (5 files, 11 sites)

| File | Sites |
|---|---|
| \`api/phases.py\` | 2 |
| \`api/project.py\` | 1 |
| \`api/analytics_reporting.py\` | 2 |
| \`api/npu_workers.py\` | 4 |
| \`services/npu_worker_manager.py\` | 2 |

## Format change

| | Output |
|---|---|
| Before | \`2026-04-19T17:04:53.123456Z\`     ← invalid; rejected by \`fromisoformat\` on Py 3.10 |
| After | \`2026-04-19T17:04:53.123456+00:00\`  ← valid ISO-8601 |

## Out of scope

\`services/conversation_export.py\` (2 sites) uses \`time.strftime(\"%Y-%m-%dT%H:%M:%SZ\", time.gmtime())\` which produces **VALID Z second-precision** strings (different pattern, not the invalid \`+ \"Z\"\` mixed format). Deferred to #5169 step 4.

## Verification

- \`py_compile\` on all 5 files: passes
- 0 \`+ \"Z\"\` sites remaining in any of the 5
- \`utc_timestamp()\` runtime check: produces \`+00:00\` (no Z)

This completes the original #5178 audit's mechanical migration. The 2 \`conversation_export.py\` sites + 4 test sites are the only remaining isoformat-style sites in the codebase, both intentionally deferred.

## Test plan

- [x] py_compile passes
- [x] All 11 sites migrated, 0 remaining
- [x] Consumer audit (NPU worker, frontend, sibling rum.py) shows safe
- [ ] \`gh pr checks\` passes