### PR TITLE
refactor(composables): extend useFetchEndpoint with onResponse + reset; migrate last 2 hand-rolled fetchers (#5235)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeIntelScores.ts
@@ -9,14 +9,19 @@
  * and toggle logic. Extracted from useCodeIntelAnalysis (Issue #2260).
  * Migrated from useAnalyticsFetch to useFetchEndpoint (Issue #5208).
  *
- * /code-intelligence/* endpoints are NOT source-scoped (they take the raw
- * repo path directly), so every migrated endpoint keeps the default
- * `scopeToSource: false`.
+ * Most `/code-intelligence/*` endpoints take the raw repo path directly
+ * (no `source_id` needed), so they keep the default `scopeToSource: false`.
+ * The Redis health endpoint is the exception — the pre-migration code
+ * wrapped its URL with `withSourceId()`, so its migrated form passes
+ * `scopeToSource: true` to preserve parity.
+ *
+ * #5235 additionally routes the two remaining hand-rolled fetchers
+ * (`loadRedisHealth`, `loadCachedSecurityScore`) through `useFetchEndpoint`,
+ * using the new `onResponse` hook for 504 / `detail` error extraction.
+ * The file no longer imports `fetchWithAuth` or `appConfig`.
  */
 
 import { ref } from 'vue'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
 import { useTaskLoader } from '@/composables/useTaskLoader'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { createLogger } from '@/utils/debugUtils'
@@ -103,11 +108,55 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
         : null,
   })
 
-  // --- Redis health (hand-rolled — complex 504 timeout handling, not migrated) ---
+  // --- Redis health (#5235: migrated via useFetchEndpoint `onResponse`) ---
 
-  const redisHealth = ref<RedisHealthResult | null>(null)
-  const loadingRedisHealth = ref(false)
-  const redisHealthError = ref('')
+  interface RedisHealthRaw {
+    status: string
+    health_score?: number
+    redis_health_score?: number
+    grade?: string
+    status_message?: string
+    total_files?: number
+    total_issues?: number
+    total_optimizations?: number
+    files_with_issues?: number
+  }
+
+  const redisHealthEndpoint = useFetchEndpoint<RedisHealthRaw, RedisHealthResult>(
+    {
+      path: '/api/code-intelligence/redis/health-score',
+      scopeToSource: true,
+      label: 'Redis health endpoint',
+      pickData: (r) =>
+        r.status === 'success'
+          ? {
+              redis_health_score:
+                r.health_score ?? r.redis_health_score ?? 0,
+              grade: r.grade || 'N/A',
+              status_message: r.status_message || '',
+              total_files: r.total_files || 0,
+              total_issues: r.total_optimizations || r.total_issues || 0,
+              files_with_issues: r.files_with_issues || 0,
+            }
+          : null,
+      onNoData: () =>
+        logger.debug('No Redis health data - run indexing first'),
+      onResponse: async (response) => {
+        if (response.status === 504) {
+          return 'Analysis timed out -- codebase too large for real-time scan'
+        }
+        const detail = (await response.json().catch(() => null)) as
+          | { detail?: string }
+          | null
+        return detail?.detail
+      },
+    },
+    { withSourceId },
+  )
+
+  const redisHealth = redisHealthEndpoint.data
+  const loadingRedisHealth = redisHealthEndpoint.loading
+  const redisHealthError = redisHealthEndpoint.error
 
   // --- Detailed findings (POST with body factory) ---
 
@@ -168,56 +217,7 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
       )
       return
     }
-    loadingRedisHealth.value = true
-    redisHealthError.value = ''
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const url = withSourceId(
-        `${backendUrl}/api/code-intelligence/redis/health-score?path=${encodeURIComponent(rootPath.value)}`,
-      )
-      const response = await fetchWithAuth(url, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-      })
-      if (!response.ok) {
-        if (response.status === 504) {
-          throw new Error(
-            'Analysis timed out -- codebase too large for real-time scan',
-          )
-        }
-        const detail = await response.json().catch(() => null)
-        throw new Error(
-          detail?.detail ||
-            `Redis health endpoint returned ${response.status}`,
-        )
-      }
-      const data = await response.json()
-      if (data.status === 'success') {
-        redisHealth.value = {
-          redis_health_score:
-            data.health_score ?? data.redis_health_score ?? 0,
-          grade: data.grade || 'N/A',
-          status_message: data.status_message || '',
-          total_files: data.total_files || 0,
-          total_issues:
-            data.total_optimizations || data.total_issues || 0,
-          files_with_issues: data.files_with_issues || 0,
-        }
-      } else if (data.status === 'no_data') {
-        redisHealth.value = null
-        logger.debug('No Redis health data - run indexing first')
-      }
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      logger.error('Failed to load Redis health:', error)
-      redisHealthError.value = errorMessage
-    } finally {
-      loadingRedisHealth.value = false
-    }
+    await redisHealthEndpoint.load({ path: rootPath.value })
   }
 
   // --- Detailed findings loaders ---
@@ -269,30 +269,53 @@ export function useCodeIntelScores(deps: UseCodeIntelAnalysisDeps) {
     }
   }
 
-  // --- Cached security score loader (hand-rolled — out of scope) ---
+  // --- Cached security score loader (#5235: best-effort read; on failure
+  // the useTaskLoader-backed `securityScore` ref is left untouched) ---
 
-  const loadCachedSecurityScore = async () => {
-    const backendUrl = await appConfig.getServiceUrl('backend')
-    const resp = await fetchWithAuth(
-      `${backendUrl}/api/code-intelligence/security/score/cached`,
-    )
-    if (!resp.ok) return
-    const data = await resp.json()
-    if (data.status === 'success' && data.security_score !== undefined) {
-      securityScore.value = {
-        security_score: data.security_score ?? 0,
-        grade: data.grade ?? 'N/A',
-        risk_level: data.risk_level ?? 'unknown',
-        status_message: data.status_message ?? '',
-        total_findings: data.total_findings ?? 0,
-        critical_issues: data.critical_issues ?? 0,
-        high_issues: data.high_issues ?? 0,
-        files_analyzed: data.files_analyzed ?? 0,
-        severity_breakdown: data.severity_breakdown ?? {},
-        owasp_breakdown: data.owasp_breakdown ?? {},
-      }
-    }
+  interface CachedSecurityScoreRaw {
+    status: string
+    security_score?: number
+    grade?: string
+    risk_level?: string
+    status_message?: string
+    total_findings?: number
+    critical_issues?: number
+    high_issues?: number
+    files_analyzed?: number
+    severity_breakdown?: Record<string, number>
+    owasp_breakdown?: Record<string, number>
   }
+
+  const cachedSecurityScoreEndpoint = useFetchEndpoint<
+    CachedSecurityScoreRaw,
+    SecurityScoreResult
+  >({
+    path: '/api/code-intelligence/security/score/cached',
+    label: 'Cached security score',
+    pickData: (r) =>
+      r.status === 'success' && r.security_score !== undefined
+        ? {
+            security_score: r.security_score ?? 0,
+            grade: r.grade ?? 'N/A',
+            risk_level: r.risk_level ?? 'unknown',
+            status_message: r.status_message ?? '',
+            total_findings: r.total_findings ?? 0,
+            critical_issues: r.critical_issues ?? 0,
+            high_issues: r.high_issues ?? 0,
+            files_analyzed: r.files_analyzed ?? 0,
+            severity_breakdown: r.severity_breakdown ?? {},
+            owasp_breakdown: r.owasp_breakdown ?? {},
+          }
+        : null,
+    // Mutate the useTaskLoader-backed `securityScore` ref only on a
+    // successful cached read. On no_data / error / !ok, leave it alone
+    // so a prior live-scan result remains visible.
+    onSuccess: (picked) => {
+      securityScore.value = picked
+    },
+  })
+
+  const loadCachedSecurityScore = () => cachedSecurityScoreEndpoint.load()
 
   return {
     // Scores

--- a/autobot-frontend/src/composables/api/useFetchEndpoint.test.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.test.ts
@@ -254,4 +254,96 @@ describe('useFetchEndpoint (rehomed)', () => {
     expect(error.value).toBe('')
     expect(onNoData).toHaveBeenCalledTimes(1)
   })
+
+  // ───────── #5235: onResponse hook + reset() ─────────
+
+  it('onResponse return string overrides the default `${label} returned ${status}` error message', async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse({}, 504))
+    const { error, load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/slow',
+      label: 'Slow endpoint',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+      onResponse: (response) =>
+        response.status === 504
+          ? 'Analysis timed out -- codebase too large for real-time scan'
+          : undefined,
+    })
+    await load()
+    expect(error.value).toBe(
+      'Analysis timed out -- codebase too large for real-time scan',
+    )
+  })
+
+  it('onResponse async return (e.g. parses `{ detail }` JSON body) is awaited', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ detail: 'Backend rejected: rootPath not indexed' }, 400),
+    )
+    const { error, load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/analyze',
+      label: 'Analyze endpoint',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+      onResponse: async (response) => {
+        const body = (await response.json().catch(() => null)) as
+          | { detail?: string }
+          | null
+        return body?.detail
+      },
+    })
+    await load()
+    expect(error.value).toBe('Backend rejected: rootPath not indexed')
+  })
+
+  it('onResponse returning undefined falls through to the default error format', async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse({}, 500))
+    const { error, load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/boom',
+      label: 'Boom endpoint',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+      onResponse: () => undefined,
+    })
+    await load()
+    expect(error.value).toBe('Boom endpoint returned 500')
+  })
+
+  it('onResponse is NOT called on a successful (ok=true) response', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: true, value: 42 }),
+    )
+    const onResponse = vi.fn()
+    const { data, load } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/ok',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+      onResponse,
+    })
+    await load()
+    expect(data.value).toBe(42)
+    expect(onResponse).not.toHaveBeenCalled()
+  })
+
+  it('reset() clears data, loading, and error back to initial state', async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse({}, 500))
+    const { data, error, load, reset } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/boom',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+    })
+    await load()
+    expect(error.value).not.toBe('')
+    reset()
+    expect(error.value).toBe('')
+    expect(data.value).toBeNull()
+  })
+
+  it('reset() after a successful load clears data', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse({ ok: true, value: 99 }),
+    )
+    const { data, load, reset } = useFetchEndpoint<RawPayload, number>({
+      path: '/api/ok',
+      pickData: (raw) => (raw.ok ? (raw.value ?? null) : null),
+    })
+    await load()
+    expect(data.value).toBe(99)
+    reset()
+    expect(data.value).toBeNull()
+  })
 })

--- a/autobot-frontend/src/composables/api/useFetchEndpoint.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.ts
@@ -68,6 +68,23 @@ export interface UseFetchEndpointOptions<TRaw, TOut> {
    * resolved error message (same value that lands in `error.value`).
    */
   onError?: (message: string, err: unknown) => void
+  /**
+   * Hook fired with the raw Response **before** the default `!ok` throw.
+   * Return a string to override the default `${label} returned ${status}`
+   * error message (useful for status-specific copy like 504 -> "timeout"
+   * or for parsing a `{ detail }` JSON body). Return `undefined` / void
+   * to fall through to the default error handling.
+   *
+   * Only called when `response.ok === false`. Does NOT prevent the throw
+   * — the return value only shapes the error message that ends up in
+   * `error.value` and in `onError(message, err)`.
+   *
+   * Introduced in #5235 to unblock migration of fetchers with special-
+   * case error handling (504 timeout copy, `detail` field extraction).
+   */
+  onResponse?: (
+    response: Response,
+  ) => string | undefined | Promise<string | undefined>
   /** Human-readable label used only for log messages. */
   label?: string
 }
@@ -85,6 +102,11 @@ export interface UseFetchEndpointReturn<TOut> {
   loading: Ref<boolean>
   error: Ref<string>
   load: (queryExtras?: Record<string, string>) => Promise<void>
+  /**
+   * Clear `data`, `loading`, and `error` back to their initial state.
+   * Parity with the deleted `useAnalyticsFetch` (#5208/#5235).
+   */
+  reset: () => void
 }
 
 function appendQueryExtras(
@@ -152,7 +174,12 @@ export function useFetchEndpoint<TRaw, TOut>(
       }
       const response = await fetchWithAuth(url, init)
       if (!response.ok) {
-        throw new Error(`${label} returned ${response.status}`)
+        const overrideMsg = opts.onResponse
+          ? await opts.onResponse(response)
+          : undefined
+        throw new Error(
+          overrideMsg ?? `${label} returned ${response.status}`,
+        )
       }
       const raw = (await response.json()) as TRaw
       const picked = opts.pickData(raw)
@@ -174,5 +201,11 @@ export function useFetchEndpoint<TRaw, TOut>(
     }
   }
 
-  return { data, loading, error, load }
+  const reset = (): void => {
+    data.value = null
+    loading.value = false
+    error.value = ''
+  }
+
+  return { data, loading, error, load, reset }
 }

--- a/docs/developer/audits/composable-fetcher-boilerplate.md
+++ b/docs/developer/audits/composable-fetcher-boilerplate.md
@@ -243,16 +243,16 @@ migration notes.
 | Error type | `ComputedRef<string \| null>` (multi-error array) | `Ref<string>` (single error) |
 | Logger label | derived from `path` | explicit `opts.label` |
 
-**Active consumers of `useAnalyticsFetch` (5):**
-- `autobot-frontend/src/composables/analytics/useCodeIntelScores.ts` (L16, used 5x — security/performance/redis)
+**Active consumers of `useAnalyticsFetch` at audit time (4 confirmed; `useSourceRegistry.ts` had only a stale JSDoc reference, not an import):**
+- `autobot-frontend/src/composables/analytics/useCodeIntelScores.ts` (used 4x — performance score, security/performance/redis findings)
 - `autobot-frontend/src/composables/analytics/useOwnershipAnalysis.ts`
 - `autobot-frontend/src/composables/analytics/useConfigDuplicates.ts`
 - `autobot-frontend/src/composables/analytics/useApiEndpointAnalysis.ts`
-- `autobot-frontend/src/composables/analytics/useSourceRegistry.ts`
 
-**Status:** Both helpers live under `composables/` (one at root, one nested), both used inside `analytics/`. `useAnalyticsFetch` is NOT dead code; it has 5 consumers. The two abstractions have meaningfully different APIs (return-from-load vs side-effect-into-data, single vs multi-error, POST support vs GET-only) so a mechanical merge would break consumers.
+**Status (final, after #5223 + #5232 + #5235):**
+All 4 consumers migrated to `composables/api/useFetchEndpoint`. `useAnalyticsFetch.ts` + any test coverage deleted. `#5235` additionally migrated the two hand-rolled `fetchWithAuth` fetchers inside `useCodeIntelScores.ts` (`loadRedisHealth` + `loadCachedSecurityScore`) after adding `onResponse` (for 504 / `detail` error extraction) and `reset()` to `useFetchEndpoint`. The file no longer imports `fetchWithAuth` or `appConfig` at all.
 
-**Recommendation:** see Recommendations section below.
+**Resolution of Recommendation 2:** complete. `useFetchEndpoint` is the single canonical GET/POST/DELETE fetcher primitive. The broader four-helper sprawl (`useApi` / `useApiLoading` / `useUnifiedLoading` / …) remains scoped to #5108 for loading-state rationalisation; it was never in scope for this audit.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the two gaps #5208 explicitly left open:

- **`loadRedisHealth`** — needed 504-specific error copy (\"Analysis timed out\u2026\") and `detail` JSON-body extraction.
- **`loadCachedSecurityScore`** — needed best-effort silent-on-failure semantics while mutating a foreign useTaskLoader-backed ref on success.

Closes #5235.

## `useFetchEndpoint` API extensions

```ts
export interface UseFetchEndpointOptions<TRaw, TOut> {
  // \u2026existing options\u2026
  /** Fires with the raw Response before the `!ok` throw.
   *  Return a string to override the default error message;
   *  undefined falls through to `${label} returned ${status}`. */
  onResponse?: (response: Response) =>
    string | undefined | Promise<string | undefined>
}

export interface UseFetchEndpointReturn<TOut> {
  // \u2026existing\u2026
  /** Clear data, loading, error back to initial state. */
  reset: () => void
}
```

**6 new unit tests** cover: onResponse string override, onResponse async (detail body parse), onResponse undefined falls through, onResponse NOT called on successful responses, reset clears after error, reset clears after success. Suite total: **13 \u2192 19 passing**.

## `useCodeIntelScores` migrations

**`loadRedisHealth`** (was 62 LOC hand-rolled):

```ts
const redisHealthEndpoint = useFetchEndpoint<RedisHealthRaw, RedisHealthResult>({
  path: '/api/code-intelligence/redis/health-score',
  scopeToSource: true,
  pickData: (r) => r.status === 'success' ? { \u2026mapped fields\u2026 } : null,
  onNoData: () => logger.debug('No Redis health data \u2014 run indexing first'),
  onResponse: async (response) => {
    if (response.status === 504) return 'Analysis timed out \u2014 codebase too large for real-time scan'
    const detail = (await response.json().catch(() => null)) as { detail?: string } | null
    return detail?.detail
  },
}, { withSourceId })
```

Behaviour parity preserved: `scopeToSource: true` matches the pre-migration `withSourceId(url)` wrap; same 504 copy; same `detail` extraction; same early-skip for `/opt/autobot` and `/data/code-sources/*` paths.

**`loadCachedSecurityScore`** (was 22 LOC):

```ts
const cachedSecurityScoreEndpoint = useFetchEndpoint<CachedSecurityScoreRaw, SecurityScoreResult>({
  path: '/api/code-intelligence/security/score/cached',
  pickData: (r) => r.status === 'success' && r.security_score !== undefined ? { \u2026 } : null,
  onSuccess: (picked) => { securityScore.value = picked },
})
const loadCachedSecurityScore = () => cachedSecurityScoreEndpoint.load()
```

The `onSuccess` hook mutates the useTaskLoader-backed `securityScore` ref only on a successful cached read \u2014 preserving the original's silent-on-failure semantics (no_data / error / !ok leave a prior live-scan result visible).

**Net effect:** `useCodeIntelScores.ts` no longer imports `fetchWithAuth` or `appConfig`. All fetch logic goes through one composable.

## Audit doc cleanup

`docs/developer/audits/composable-fetcher-boilerplate.md` section 10 body updated:
- Stale \"5 consumers\" list corrected to 4 (`useSourceRegistry.ts` had only a JSDoc reference, not an import).
- Status rewritten to reflect the completed reconciliation post-#5208 + #5235.
- Recommendation 2 explicitly marked complete.

## LOC note

`useCodeIntelScores.ts` grew **+49 LOC**. Per the audit's critical-mass rule, migrations below 8 fetchers are LOC-negative: the `Raw` interfaces + endpoint config outweigh the hand-rolled try/catch savings for a 2-fetcher migration.

**Why ship anyway:** the real win is platform uniformity \u2014 the file no longer imports `fetchWithAuth` at all, and the new `onResponse` / `reset` hooks are now permanently available for any future fetcher that needs them. LOC is the wrong metric for this kind of consolidation.

## Test plan

- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` \u2014 167 baseline unchanged; zero new errors on changed files.
- [x] `npx vitest run` across `composables/api/` + `composables/charts/` \u2014 **31/31 green** (was 25, +6 new tests).
- [x] `grep 'fetchWithAuth' useCodeIntelScores.ts` \u2192 **0** (was 2).
- [ ] Manual: Redis Health Dashboard card \u2014 scan completes on first render for a normal path; 504 timeout surfaces the custom copy; \"detail\" from a 4xx backend error surfaces correctly.
- [ ] Manual: Cached Security Score \u2014 refresh shows cached data if present; does not blow away a live-scan result when cache read fails.

## Related

- Wave-2 umbrella: #5153
- Reconciliation that filed the gap: #5208 / PR #5232 (merged)
- Composable origin: #5112 / PR #5137 (merged) \u2192 rehomed #5168 / PR #5187 (merged)
- Audit source: #5164 / #5154 (merged)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)