### PR TITLE
refactor(api): migrate 21 cross-module kb.aioredis_client sites to kb.redis() (#5225 phase 1)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -360,7 +360,7 @@ async def _get_or_compute_category_counts(
     kb, cache_keys: dict, get_category_for_source, category_counts: dict
 ) -> None:
     """Get cached counts or compute from facts (Issue #398: extracted)."""
-    cached_values = await kb.aioredis_client.mget(list(cache_keys.values()))
+    cached_values = await kb.redis().mget(list(cache_keys.values()))
     if all(v is not None for v in cached_values):
         # Use cached values
         for i, cat_id in enumerate(cache_keys.keys()):
@@ -377,7 +377,7 @@ async def _get_or_compute_category_counts(
         logger.info("Category counts: %s", category_counts)
         # Cache for 1 hour
         for cat_id, cache_key in cache_keys.items():
-            await kb.aioredis_client.set(
+            await kb.redis().set(
                 cache_key, category_counts[cat_id], ex=CATEGORY_CACHE_TTL
             )
 

--- a/autobot-backend/api/knowledge_audit.py
+++ b/autobot-backend/api/knowledge_audit.py
@@ -131,7 +131,7 @@ async def get_fact_access_log(
 
     try:
         # Verify user is the owner
-        fact_data = await kb.aioredis_client.hget(f"fact:{fact_id}", "metadata")
+        fact_data = await kb.redis().hget(f"fact:{fact_id}", "metadata")
         if not fact_data:
             raise HTTPException(status_code=404, detail="Fact not found")
 

--- a/autobot-backend/api/knowledge_collaboration.py
+++ b/autobot-backend/api/knowledge_collaboration.py
@@ -317,12 +317,12 @@ async def get_knowledge_by_scope(
         # If scope filter provided, filter results
         if scope:
             fact_ids = await _filter_fact_ids_by_scope(
-                fact_ids, scope, kb.aioredis_client
+                fact_ids, scope, kb.redis()
             )
 
         # Fetch full fact data
         facts = await _fetch_facts_from_redis(
-            fact_ids, kb.aioredis_client, include_title_only=False
+            fact_ids, kb.redis(), include_title_only=False
         )
 
         return {"facts": facts, "count": len(facts), "total": len(fact_ids)}
@@ -372,7 +372,7 @@ async def get_organization_knowledge(
             offset=pagination.offset,
         )
         facts = await _fetch_facts_from_redis(
-            fact_ids, kb.aioredis_client, include_title_only=True
+            fact_ids, kb.redis(), include_title_only=True
         )
         return {"facts": facts, "count": len(facts)}
 
@@ -418,7 +418,7 @@ async def get_group_knowledge(
             group_id=group_id, limit=pagination.limit, offset=pagination.offset
         )
         facts = await _fetch_facts_from_redis(
-            fact_ids, kb.aioredis_client, include_title_only=True
+            fact_ids, kb.redis(), include_title_only=True
         )
         return {"facts": facts, "count": len(facts)}
 
@@ -461,7 +461,7 @@ async def share_knowledge(
     try:
         user_id, _, _ = extract_user_context_from_request(current_user)
         metadata = await _verify_fact_ownership(
-            fact_id, user_id, kb.aioredis_client, "share"
+            fact_id, user_id, kb.redis(), "share"
         )
 
         updated_metadata = await kb.ownership_manager.share_fact(
@@ -471,7 +471,7 @@ async def share_knowledge(
             fact_metadata=metadata,
         )
 
-        await kb.aioredis_client.hset(
+        await kb.redis().hset(
             f"fact:{fact_id}", "metadata", json.dumps(updated_metadata)
         )
 
@@ -528,14 +528,14 @@ async def unshare_knowledge(
     try:
         user_id, _, _ = extract_user_context_from_request(current_user)
         metadata = await _verify_fact_ownership(
-            fact_id, user_id, kb.aioredis_client, "unshare"
+            fact_id, user_id, kb.redis(), "unshare"
         )
 
         updated_metadata = await _unshare_fact_by_entity(
             fact_id, entity_id, entity_type, metadata, kb.ownership_manager
         )
 
-        await kb.aioredis_client.hset(
+        await kb.redis().hset(
             f"fact:{fact_id}", "metadata", json.dumps(updated_metadata)
         )
 
@@ -585,7 +585,7 @@ async def update_knowledge_permissions(
     try:
         # Fetch metadata and verify the caller is the owner
         user_id, user_org_id, _ = extract_user_context_from_request(current_user)
-        metadata = await _fetch_and_verify_owner(fact_id, user_id, kb.aioredis_client)
+        metadata = await _fetch_and_verify_owner(fact_id, user_id, kb.redis())
 
         # Apply visibility changes and org-level guard to metadata dict
         old_visibility = metadata.get("visibility")
@@ -601,7 +601,7 @@ async def update_knowledge_permissions(
             permissions_request=permissions_request,
             old_visibility=old_visibility,
             ownership_manager=kb.ownership_manager,
-            aioredis_client=kb.aioredis_client,
+            aioredis_client=kb.redis(),
         )
 
         return {
@@ -641,7 +641,7 @@ async def get_knowledge_access_info(
         raise HTTPException(status_code=503, detail="Knowledge base not available")
 
     try:
-        metadata = await _fetch_fact_metadata(fact_id, kb.aioredis_client)
+        metadata = await _fetch_fact_metadata(fact_id, kb.redis())
         user_id, user_org_id, user_group_ids = extract_user_context_from_request(
             current_user
         )

--- a/autobot-backend/api/knowledge_organization.py
+++ b/autobot-backend/api/knowledge_organization.py
@@ -99,7 +99,7 @@ async def get_organization_policy(
     try:
         # Get policy from Redis or use defaults
         policy_key = f"org:policy:{org_id}"
-        policy_data = await kb.aioredis_client.get(policy_key)
+        policy_data = await kb.redis().get(policy_key)
 
         if policy_data:
             import json
@@ -156,7 +156,7 @@ async def update_organization_policy(
         # Store policy in Redis
         policy_key = f"org:policy:{org_id}"
         policy_json = policy_request.policy.model_dump_json()
-        await kb.aioredis_client.set(policy_key, policy_json)
+        await kb.redis().set(policy_key, policy_json)
 
         logger.info("Updated organization policy for org %s", org_id)
 
@@ -185,7 +185,7 @@ async def _analyze_organization_facts(kb, fact_ids: list) -> dict:
     user_contributions = {}
 
     for fact_id in fact_ids:
-        fact_data = await kb.aioredis_client.hgetall(f"fact:{fact_id}")
+        fact_data = await kb.redis().hgetall(f"fact:{fact_id}")
         if not fact_data:
             continue
 
@@ -313,7 +313,7 @@ async def _delete_expired_facts(kb, fact_ids: list, cutoff_date) -> int:
 
     deleted_count = 0
     for fact_id in fact_ids:
-        fact_data = await kb.aioredis_client.hgetall(f"fact:{fact_id}")
+        fact_data = await kb.redis().hgetall(f"fact:{fact_id}")
         if not fact_data:
             continue
 
@@ -333,7 +333,7 @@ async def _delete_expired_facts(kb, fact_ids: list, cutoff_date) -> int:
             created_at = datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
             if created_at < cutoff_date:
                 await kb.ownership_manager.cleanup_ownership_indexes(fact_id, metadata)
-                await kb.aioredis_client.delete(f"fact:{fact_id}")
+                await kb.redis().delete(f"fact:{fact_id}")
                 deleted_count += 1
         except (ValueError, TypeError):
             # Skip if date parsing fails

--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -375,7 +375,7 @@ async def _fetch_batch_data(kb, batch: List[str], skip_existing: bool) -> tuple:
         Tuple of (all_fact_data, fact_ids, vector_exists_map)
     """
     # Batch fetch all fact data using pipeline - eliminates N+1 queries
-    async with kb.aioredis_client.pipeline() as pipe:
+    async with kb.redis().pipeline() as pipe:
         for fact_key in batch:
             await pipe.hgetall(fact_key)
         all_fact_data = await pipe.execute()
@@ -388,7 +388,7 @@ async def _fetch_batch_data(kb, batch: List[str], skip_existing: bool) -> tuple:
     # If skip_existing, also batch check vector existence
     vector_exists = {}
     if skip_existing:
-        async with kb.aioredis_client.pipeline() as pipe:
+        async with kb.redis().pipeline() as pipe:
             for fact_id in fact_ids:
                 await pipe.exists(f"llama_index/vector_{fact_id}")
             exists_results = await pipe.execute()


### PR DESCRIPTION
## Summary

**Phase 1 of #5225** — migrates 5 of 6 api/ files (21 sites) to use the \`kb.redis()\` public accessor introduced by [#5184 / PR #5218](https://github.com/mrveiss/AutoBot-AI/pull/5218).

## Files migrated (5 files, 21 sites)

| File | Sites |
|---|---|
| \`api/knowledge.py\` | 2 (lines 363, 380) |
| \`api/knowledge_audit.py\` | 1 |
| \`api/knowledge_collaboration.py\` | 11 (call sites only — local helper params unchanged) |
| \`api/knowledge_organization.py\` | 5 |
| \`api/knowledge_vectorization.py\` | 2 |

## Sites INTENTIONALLY NOT migrated (3 None-guards)

| Site | Why kept |
|---|---|
| \`api/knowledge.py:423\` | \`kb.aioredis_client is not None\` — defensive bool check |
| \`api/knowledge.py:434\` | \`if kb and kb.aioredis_client:\` — same |
| \`api/knowledge_boards.py:91\` | \`if kb.aioredis_client is None: raise; return kb.redis()\` — the canonical guard idiom from #5218 itself |

Migrating these would change semantics from "return False / skip" to "raise RuntimeError". Refactoring to try/except is a stylistic follow-up, not in scope.

## Scope correction vs #5225's original estimate

#5225's body claimed **159 sites** and proposed a 5-phase split (services/, api/, knowledge/, agents/, lint). Re-grepping confirmed:

- **159 LINE references** (raw grep count) but only **13 FILES total**
- **0 sites in services/**, agents/, connectors/, workflows/ — original phase plan was wrong
- **6 cross-module files in api/** ← this PR migrates 5 (1 file already had only None guards)
- **5 mixin files in knowledge/** (131 sites) — INTERNAL mixins of KnowledgeBase accessing their own \`self.aioredis_client\` attribute. **Not cross-module callers**, so the decoupling argument doesn't apply. Stylistic question deferred.
- **2 test files** — skip

This PR completes the genuine cross-module migration. The 131 internal mixin sites are a different scope question.

## Verification

- \`py_compile\` on all 5 migrated files: passes
- 0 cross-module \`kb.aioredis_client\` sites remain (only 3 intentional None guards)
- \`api/knowledge_boards.py\` unchanged — its \`is None\` check at L91 + \`kb.redis()\` at L93 is the canonical "guard then call" pattern from #5218

## What this PR does NOT do

- The 5 \`knowledge/\` mixin files (categories, collections, facts, relations, stats) — different concern per scope correction
- Refactor None guards into try/except — semantic change
- Make \`aioredis_client\` private — would break tests that mock via direct assignment (same constraint #5218 noted)
- Lint enforcement — defer to follow-up

## Diff

5 files, +21/-21 (pure substitution).

## Test plan

- [x] py_compile passes on all 5 modified files
- [x] All 21 cross-module call sites migrated
- [x] 3 None-guard sites verified intentionally untouched
- [x] knowledge_boards.py canonical guard pattern preserved
- [ ] \`gh pr checks\` passes