### PR TITLE
fix(backend): split /api/health into distinct GET and HEAD operation_ids (#5222)

### DIFF
--- a/autobot-backend/initialization/endpoints.py
+++ b/autobot-backend/initialization/endpoints.py
@@ -120,11 +120,8 @@ def register_root_endpoints(app: FastAPI) -> None:
         app: FastAPI application instance
     """
 
-    @app.api_route("/api/health", methods=["GET", "HEAD"])
-    @with_error_handling(category=ErrorCategory.SYSTEM)
-    async def root_health_check(request: Request):
-        """Health endpoint with per-service breakdown and capabilities (supports GET and HEAD)."""
-        state = request.app.state
+    def _health_payload(state: Any) -> Dict[str, Any]:
+        """Build the /api/health response body (shared by GET and HEAD)."""
         services = _build_services_status(state)
         ai_stack_ready = services.get("ai_stack") == "connected"
         ai_agents_ready = services.get("ai_stack_agents") == "ready"
@@ -138,6 +135,18 @@ def register_root_endpoints(app: FastAPI) -> None:
             "capabilities": _build_capabilities(ai_stack_ready, ai_agents_ready),
             "circuit_breakers": _get_circuit_breaker_states(),
         }
+
+    @app.get("/api/health", operation_id="root_health_check_get")
+    @with_error_handling(category=ErrorCategory.SYSTEM)
+    async def root_health_check_get(request: Request):
+        """Health endpoint with per-service breakdown and capabilities."""
+        return _health_payload(request.app.state)
+
+    @app.head("/api/health", operation_id="root_health_check_head", include_in_schema=False)
+    @with_error_handling(category=ErrorCategory.SYSTEM)
+    async def root_health_check_head(request: Request):
+        """HEAD variant for liveness probes — FastAPI strips the body automatically."""
+        return _health_payload(request.app.state)
 
     @app.get("/api/health/ai-stack")
     @with_error_handling(category=ErrorCategory.SYSTEM)


### PR DESCRIPTION
Closes #5222

## Summary
\`/api/health\` was registered via \`@app.api_route(methods=[\"GET\",\"HEAD\"])\` which produced a single \`operation_id\` shared by both methods. OpenAPI schema then declared them as duplicate identifiers, causing TS2300 errors in the generated \`src/types/generated/api.ts\` from #5229.

## Fix
Split into two explicit decorators with distinct \`operation_id\`s:
\`\`\`python
@app.get(\"/api/health\", operation_id=\"root_health_check_get\")
async def health_get(...): return _health_payload(state)

@app.head(\"/api/health\", operation_id=\"root_health_check_head\", include_in_schema=False)
async def health_head(...): return _health_payload(state)
\`\`\`

\`include_in_schema=False\` on HEAD keeps the OpenAPI schema clean (liveness probes don't need schema exposure). Shared payload extracted to \`_health_payload(state)\` helper — zero logic duplication.

## Impact
Post-deploy regeneration of \`src/types/generated/api.ts\` will drop the 2 TS2300 errors, restoring \`verify:types\` CI to green.

## Test Status
PASS — py_compile OK on modified file