### PR TITLE
fix(repository): unwrap SystemRepository health/info/metrics response shapes (#5212)

### DIFF
--- a/autobot-frontend/src/models/repositories/SystemRepository.ts
+++ b/autobot-frontend/src/models/repositories/SystemRepository.ts
@@ -1,34 +1,72 @@
 import { ApiRepository } from './ApiRepository'
-import type { AutoBotSettings, SystemMetrics, DiagnosticsReport } from '@/types/models'
+import type { AutoBotSettings, DiagnosticsReport } from '@/types/models'
 import { getApiBase } from '@/config/ssot-config'
 
+/**
+ * Backend `/api/system/health` response shape (#5212).
+ *
+ * Previously declared a fabricated `{version, uptime, services: {status, latency, message}}`
+ * envelope that the backend never returned. Rewritten to match the actual payload —
+ * `components` are string values (`"healthy"`, `"unhealthy"`, ...), not status objects.
+ */
 export interface HealthCheckResponse {
-  status: 'healthy' | 'unhealthy' | 'degraded' | 'warning' | 'error'
-  version: string
-  uptime: number
-  services: Record<string, {
-    status: 'up' | 'down' | 'degraded' | 'healthy' | 'unhealthy'
-    latency?: number
+  status: string
+  timestamp?: string
+  initialization?: {
+    status: string
     message?: string
-  }>
+  }
+  components?: Record<string, string>
 }
 
+/**
+ * Backend `/api/system/info` response shape (#5212).
+ *
+ * Previously declared a fabricated nested `{system, runtime, application}` envelope.
+ * Rewritten to match the actual flat payload returned by FastAPI.
+ */
 export interface SystemInfoResponse {
+  name: string
+  version: string
+  python_version: string
+  timestamp?: string
+  features?: Record<string, boolean>
+}
+
+/**
+ * Backend `/api/system/metrics` response shape (#5212).
+ *
+ * Replaces the flat `SystemMetrics` from `types/models.ts`, which described
+ * `cpu_usage/memory_usage/disk_usage/active_connections` fields the backend
+ * never produced. The real payload is nested under `system`/`python`/`cache`.
+ */
+export interface SystemMetricsResponse {
+  timestamp: string
   system: {
-    platform: string
-    architecture: string
-    cpu_count: number
-    memory_total: number
-    disk_space: number
+    cpu_percent: number
+    memory: {
+      total: number
+      available: number
+      percent: number
+      used: number
+      free: number
+    }
+    disk: {
+      total: number
+      used: number
+      free: number
+      percent: number
+    }
   }
-  runtime: {
-    python_version: string
-    pip_packages: Record<string, string>
-  }
-  application: {
+  python?: {
     version: string
-    environment: string
-    debug_mode: boolean
+    executable: string
+  }
+  cache?: {
+    status: string
+    total_keys: number
+    memory_usage: string
+    default_ttl: number
   }
 }
 
@@ -50,25 +88,64 @@ export interface CommandExecutionResponse {
 
 export class SystemRepository extends ApiRepository {
   // Health and status
+  // Issue #5212: Backend returns {status, timestamp, initialization, components}.
+  // Previously mis-typed as {version, uptime, services} — fields that never existed.
   async checkHealth(): Promise<HealthCheckResponse> {
-    const response = await this.get(`${getApiBase()}/system/health`)
-    return response.data as HealthCheckResponse
+    const response = await this.get<HealthCheckResponse>(`${getApiBase()}/system/health`)
+    const data = response.data
+    return {
+      status: data?.status ?? 'unknown',
+      timestamp: data?.timestamp,
+      initialization: data?.initialization,
+      components: data?.components ?? {}
+    }
   }
 
-  async getSystemStatus(): Promise<any> {
+  async getSystemStatus(): Promise<SystemInfoResponse> {
     // Issue #552: /api/system/status doesn't exist, use /api/system/info instead
-    const response = await this.get(`${getApiBase()}/system/info`)
-    return response.data as any
+    return this.getSystemInfo()
   }
 
+  // Issue #5212: Backend returns flat {name, version, python_version, timestamp, features}.
+  // Previously mis-typed as nested {system, runtime, application} — entirely fabricated.
   async getSystemInfo(): Promise<SystemInfoResponse> {
-    const response = await this.get(`${getApiBase()}/system/info`)
-    return response.data as SystemInfoResponse
+    const response = await this.get<SystemInfoResponse>(`${getApiBase()}/system/info`)
+    const data = response.data
+    return {
+      name: data?.name ?? 'unknown',
+      version: data?.version ?? 'unknown',
+      python_version: data?.python_version ?? 'unknown',
+      timestamp: data?.timestamp,
+      features: data?.features ?? {}
+    }
   }
 
-  async getSystemMetrics(): Promise<SystemMetrics> {
-    const response = await this.get(`${getApiBase()}/system/metrics`)
-    return response.data as SystemMetrics
+  // Issue #5212: Backend returns nested {timestamp, system: {cpu_percent, memory, disk}, python, cache}.
+  // Previously mis-typed as flat {cpu_usage, memory_usage, disk_usage, active_connections} — never returned.
+  async getSystemMetrics(): Promise<SystemMetricsResponse> {
+    const response = await this.get<SystemMetricsResponse>(`${getApiBase()}/system/metrics`)
+    const data = response.data
+    return {
+      timestamp: data?.timestamp ?? '',
+      system: {
+        cpu_percent: data?.system?.cpu_percent ?? 0,
+        memory: {
+          total: data?.system?.memory?.total ?? 0,
+          available: data?.system?.memory?.available ?? 0,
+          percent: data?.system?.memory?.percent ?? 0,
+          used: data?.system?.memory?.used ?? 0,
+          free: data?.system?.memory?.free ?? 0
+        },
+        disk: {
+          total: data?.system?.disk?.total ?? 0,
+          used: data?.system?.disk?.used ?? 0,
+          free: data?.system?.disk?.free ?? 0,
+          percent: data?.system?.disk?.percent ?? 0
+        }
+      },
+      python: data?.python,
+      cache: data?.cache
+    }
   }
 
   // Settings management

--- a/autobot-frontend/src/models/repositories/__tests__/SystemRepository.shape.test.ts
+++ b/autobot-frontend/src/models/repositories/__tests__/SystemRepository.shape.test.ts
@@ -6,6 +6,10 @@
  *
  * Backend endpoints return envelope-wrapped payloads that must be unpacked
  * into the flat shapes callers declare.
+ *
+ * Extended in #5212 to cover checkHealth / getSystemInfo / getSystemMetrics,
+ * whose declared types were fabricated (fields that never existed on the
+ * backend payload) before this fix.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -94,6 +98,218 @@ describe('SystemRepository shape handling (#5207 audit)', () => {
       const result = await repo.getLogs()
 
       expect(result).toEqual([])
+    })
+  })
+
+  // ==========================================================================
+  // #5212: checkHealth / getSystemInfo / getSystemMetrics
+  // ==========================================================================
+
+  describe('checkHealth — unwraps /api/system/health (#5212)', () => {
+    it('unwraps {status, timestamp, initialization, components} from backend', async () => {
+      const payload = {
+        status: 'healthy',
+        timestamp: '2026-04-20T09:20:06.896132+00:00',
+        initialization: { status: 'ready', message: 'All services initialized' },
+        components: {
+          backend: 'healthy',
+          config: 'healthy',
+          logging: 'healthy',
+          conversation_files_db: 'healthy'
+        }
+      }
+      getSpy.mockResolvedValue({ data: payload })
+
+      const result = await repo.checkHealth()
+
+      expect(result.status).toBe('healthy')
+      expect(result.timestamp).toBe(payload.timestamp)
+      expect(result.initialization).toEqual(payload.initialization)
+      expect(result.components).toEqual(payload.components)
+    })
+
+    it("defaults status to 'unknown' and components to {} on nullish payload", async () => {
+      getSpy.mockResolvedValue({ data: null })
+
+      const result = await repo.checkHealth()
+
+      expect(result.status).toBe('unknown')
+      expect(result.components).toEqual({})
+      expect(result.timestamp).toBeUndefined()
+      expect(result.initialization).toBeUndefined()
+    })
+
+    it('tolerates malformed payload (missing components)', async () => {
+      getSpy.mockResolvedValue({ data: { status: 'degraded' } })
+
+      const result = await repo.checkHealth()
+
+      expect(result.status).toBe('degraded')
+      expect(result.components).toEqual({})
+    })
+
+    it('hits the /system/health endpoint', async () => {
+      getSpy.mockResolvedValue({ data: { status: 'healthy' } })
+
+      await repo.checkHealth()
+
+      expect(getSpy).toHaveBeenCalledWith('/api/system/health')
+    })
+  })
+
+  describe('getSystemInfo — unwraps /api/system/info (#5212)', () => {
+    it('unwraps {name, version, python_version, timestamp, features} from backend', async () => {
+      const payload = {
+        name: 'AutoBot Backend',
+        version: '1.0.0',
+        python_version: '3.12.13',
+        timestamp: '2026-04-20T09:20:07.466719+00:00',
+        features: {
+          llm_integration: true,
+          knowledge_base: true,
+          chat_system: true,
+          caching: true,
+          websockets: true
+        }
+      }
+      getSpy.mockResolvedValue({ data: payload })
+
+      const result = await repo.getSystemInfo()
+
+      expect(result).toEqual(payload)
+    })
+
+    it("defaults string fields to 'unknown' and features to {} on nullish payload", async () => {
+      getSpy.mockResolvedValue({ data: null })
+
+      const result = await repo.getSystemInfo()
+
+      expect(result.name).toBe('unknown')
+      expect(result.version).toBe('unknown')
+      expect(result.python_version).toBe('unknown')
+      expect(result.features).toEqual({})
+    })
+
+    it('tolerates partial payload (missing features)', async () => {
+      getSpy.mockResolvedValue({
+        data: { name: 'AutoBot', version: '1.0.0', python_version: '3.12' }
+      })
+
+      const result = await repo.getSystemInfo()
+
+      expect(result.name).toBe('AutoBot')
+      expect(result.features).toEqual({})
+    })
+  })
+
+  describe('getSystemStatus — aliases getSystemInfo (#5212)', () => {
+    it('hits /system/info just like getSystemInfo', async () => {
+      getSpy.mockResolvedValue({
+        data: { name: 'AutoBot', version: '1.0.0', python_version: '3.12' }
+      })
+
+      const result = await repo.getSystemStatus()
+
+      expect(getSpy).toHaveBeenCalledWith('/api/system/info')
+      expect(result.name).toBe('AutoBot')
+    })
+  })
+
+  describe('getSystemMetrics — unwraps /api/system/metrics (#5212)', () => {
+    it('unwraps nested {timestamp, system: {cpu_percent, memory, disk}, python, cache} from backend', async () => {
+      const payload = {
+        timestamp: '2026-04-20T09:20:08.933609+00:00',
+        system: {
+          cpu_percent: 11.1,
+          memory: {
+            total: 63198334976,
+            available: 51172343808,
+            percent: 19.0,
+            used: 12025991168,
+            free: 49076850688
+          },
+          disk: {
+            total: 1081101176832,
+            used: 126288633856,
+            free: 899820187648,
+            percent: 11.681481489648299
+          }
+        },
+        python: {
+          version: '3.12.13',
+          executable: '/opt/autobot/autobot-backend/venv/bin/python3.12'
+        },
+        cache: {
+          status: 'enabled',
+          total_keys: 0,
+          memory_usage: '76.78M',
+          default_ttl: 300
+        }
+      }
+      getSpy.mockResolvedValue({ data: payload })
+
+      const result = await repo.getSystemMetrics()
+
+      expect(result.timestamp).toBe(payload.timestamp)
+      expect(result.system.cpu_percent).toBe(11.1)
+      expect(result.system.memory.percent).toBe(19.0)
+      expect(result.system.disk.percent).toBeCloseTo(11.68, 1)
+      expect(result.python).toEqual(payload.python)
+      expect(result.cache).toEqual(payload.cache)
+    })
+
+    it('defaults all nested numeric fields to 0 on nullish payload', async () => {
+      getSpy.mockResolvedValue({ data: null })
+
+      const result = await repo.getSystemMetrics()
+
+      expect(result.timestamp).toBe('')
+      expect(result.system.cpu_percent).toBe(0)
+      expect(result.system.memory.total).toBe(0)
+      expect(result.system.memory.available).toBe(0)
+      expect(result.system.memory.percent).toBe(0)
+      expect(result.system.memory.used).toBe(0)
+      expect(result.system.memory.free).toBe(0)
+      expect(result.system.disk.total).toBe(0)
+      expect(result.system.disk.used).toBe(0)
+      expect(result.system.disk.free).toBe(0)
+      expect(result.system.disk.percent).toBe(0)
+      expect(result.python).toBeUndefined()
+      expect(result.cache).toBeUndefined()
+    })
+
+    it('tolerates partial payload (missing python/cache)', async () => {
+      getSpy.mockResolvedValue({
+        data: {
+          timestamp: 't',
+          system: {
+            cpu_percent: 5,
+            memory: { total: 1, available: 1, percent: 1, used: 0, free: 1 },
+            disk: { total: 1, used: 0, free: 1, percent: 0 }
+          }
+        }
+      })
+
+      const result = await repo.getSystemMetrics()
+
+      expect(result.system.cpu_percent).toBe(5)
+      expect(result.python).toBeUndefined()
+      expect(result.cache).toBeUndefined()
+    })
+
+    it('tolerates partial nested objects (missing system.memory)', async () => {
+      getSpy.mockResolvedValue({
+        data: {
+          timestamp: 't',
+          system: { cpu_percent: 7 }
+        }
+      })
+
+      const result = await repo.getSystemMetrics()
+
+      expect(result.system.cpu_percent).toBe(7)
+      expect(result.system.memory.total).toBe(0)
+      expect(result.system.disk.total).toBe(0)
     })
   })
 })

--- a/autobot-frontend/src/types/models.ts
+++ b/autobot-frontend/src/types/models.ts
@@ -207,14 +207,17 @@ export interface KnowledgeCategory {
 // System Models
 // ============================================================================
 
-export interface SystemMetrics {
-  cpu_usage: number
-  memory_usage: number
-  disk_usage: number
-  uptime: number
-  active_connections: number
-  last_updated: string
-}
+/**
+ * Deprecated re-export alias for backwards compatibility (#5212).
+ *
+ * The previous flat shape (`cpu_usage`, `memory_usage`, `disk_usage`,
+ * `active_connections`, `last_updated`) described fields the backend never
+ * returned. The authoritative shape now lives in
+ * `@/models/repositories/SystemRepository` as `SystemMetricsResponse`.
+ *
+ * @deprecated Import `SystemMetricsResponse` from `@/models/repositories/SystemRepository` instead.
+ */
+export type { SystemMetricsResponse as SystemMetrics } from '@/models/repositories/SystemRepository'
 
 export interface LLMStatus {
   status: 'connected' | 'disconnected' | 'error'


### PR DESCRIPTION
Closes #5212

## Summary
Fourth #5200-class fix from the #5207 audit. Three SystemRepository methods had fabricated type declarations:

| Method | Was | Actual backend |
|---|---|---|
| \`checkHealth\` | \`{version, uptime, services: {status, latency, message}}\` | \`{status, timestamp, initialization, components: Record<string, string>}\` |
| \`getSystemInfo\` | nested \`{system, runtime, application}\` | flat \`{name, version, python_version, timestamp, features}\` |
| \`getSystemMetrics\` | flat \`SystemMetrics\` | nested \`{timestamp, system: {cpu_percent, memory, disk}, python, cache}\` |

All three now use typed \`get<Shape>()\` with defensive \`??\` defaults — no more raw \`as\` casts.

## Also
- \`getSystemStatus()\` now aliases \`getSystemInfo()\` (both hit the same endpoint)
- \`SystemMetrics\` in \`types/models.ts\` converted to deprecated alias of \`SystemMetricsResponse\` (never-delete rule)
- No production callers read the fabricated fields — zero behavior change, confirmed via grep

## Test Status
PASS — 18/18 tests (12 new for #5212 + 6 existing from #5207)