### PR TITLE
ci(lint): add datetime.utcnow().isoformat() regression-prevention hook (#5178 part C)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,24 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
 
+  # AutoBot custom: regression-prevention for #5178 datetime migration.
+  # Blocks datetime.utcnow().isoformat() (#5178), datetime.utcnow().isoformat()
+  # + "Z" mixed format (#5238), and bare time.strftime("%Y-%m-%dT...") (#5178
+  # bug-fix). Use autobot_shared.time_utils.utc_timestamp() instead.
+  # Only fires on staged Python files — does not block pre-existing
+  # violations until those files are touched. Broader DTZ003 enforcement
+  # gated on #5211 completion.
+  - repo: local
+    hooks:
+      - id: no-utcnow-isoformat
+        name: Block datetime.utcnow().isoformat() and friends (#5178 #5238)
+        entry: tools/lint/check_no_utcnow_isoformat.py
+        language: python
+        files: \.py$
+        # Stage matches the existing record-branch hook above.
+        stages: [pre-commit]
+        description: "Use autobot_shared.time_utils.utc_timestamp() instead of datetime.utcnow().isoformat()"
+
   # Python-specific checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/tools/lint/check_no_utcnow_isoformat.py
+++ b/tools/lint/check_no_utcnow_isoformat.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression-prevention check for the #5178 datetime migration.
+
+Blocks any new occurrence of three banned patterns that produce
+broken or inconsistent timestamp strings:
+
+  1. ``datetime.utcnow().isoformat()`` — produces tz-naive output;
+     the unguarded ``fromisoformat`` parsers in #5169's audit then
+     return naive datetimes that mis-compare against tz-aware values.
+  2. ``datetime.utcnow().isoformat() + "Z"`` — produces invalid
+     mixed-format ``2026-04-19T...Z`` (microseconds + Z mutually
+     exclusive) which raises ``ValueError`` from ``fromisoformat``
+     on Python 3.10.
+  3. ``time.strftime("%Y-%m-%dT%H:%M:%S")`` (no time arg) — silently
+     uses ``time.localtime()`` (LOCAL time, naive), then gets
+     mislabeled as UTC by callers.
+
+Use ``autobot_shared.time_utils.utc_timestamp()`` instead.
+
+This hook covers regression of the #5178 migration (PRs #5213,
+#5233, #5236, #5243). The broader DTZ003 enforcement (banning
+``datetime.utcnow()`` for non-isoformat purposes) is gated on #5211
+completion — adding it here would block on 248 pre-existing sites.
+
+Exit code:
+  0 — clean (no banned patterns found in scanned files)
+  1 — banned patterns found (PR/commit blocked)
+  2 — usage error
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+# Files allowed to contain banned patterns (very narrow allowlist)
+ALLOWLIST = {
+    # The hook itself contains the patterns as strings — exclude it
+    "tools/lint/check_no_utcnow_isoformat.py",
+    # The audit docs reference the patterns in code blocks
+    "docs/developer/audits/datetime-parsing-audit.md",
+    "docs/developer/audits/datetime-producer-audit.md",
+    # `utc_timestamp()` itself wraps `datetime.now(timezone.utc).isoformat()`
+    # — not the banned `utcnow().isoformat()` pattern, but the regex is
+    # defensive enough to flag it. Module is exempt by design.
+    "autobot_shared/time_utils.py",
+}
+
+# Patterns are intentionally precise — this hook only prevents regression
+# of the #5178 migration, not the broader datetime.utcnow() backlog
+# tracked by #5211.
+PATTERNS: List[Tuple[str, re.Pattern[str], str]] = [
+    (
+        "isoformat",
+        re.compile(r"datetime\.utcnow\(\)\.isoformat\("),
+        "Use `utc_timestamp()` from `autobot_shared.time_utils` instead. "
+        "`datetime.utcnow().isoformat()` produces tz-naive strings that "
+        "mis-compare against tz-aware datetimes (#5178).",
+    ),
+    (
+        "z-suffix-isoformat",
+        re.compile(r'datetime\.utcnow\(\)\.isoformat\(\)\s*\+\s*["\']Z["\']'),
+        "Use `utc_timestamp()` from `autobot_shared.time_utils` instead. "
+        "`datetime.utcnow().isoformat() + \"Z\"` produces invalid ISO-8601 "
+        "(microseconds + Z mutually exclusive) — fails `fromisoformat` on "
+        "Python 3.10 (#5238).",
+    ),
+    (
+        "naive-strftime-iso",
+        # time.strftime("%Y-%m-%dT...")  with no second positional arg
+        # → defaults to time.localtime() (LOCAL time, mislabeled UTC).
+        # Matches strftime calls with the ISO format and NO comma after
+        # the format string (no time tuple passed).
+        re.compile(r'time\.strftime\(\s*["\']%Y-%m-%dT[^"\']*["\']\s*\)'),
+        "Use `utc_timestamp()` from `autobot_shared.time_utils` instead. "
+        "`time.strftime(\"%Y-%m-%dT...\")` with no time argument defaults to "
+        "`time.localtime()` (LOCAL time, mislabeled as UTC) (#5178 audit).",
+    ),
+]
+
+
+def _is_allowlisted(rel_path: str) -> bool:
+    """Check if a file path is in the allowlist (POSIX-normalized)."""
+    posix = rel_path.replace("\\", "/")
+    return posix in ALLOWLIST
+
+
+def _scan(path: Path, repo_root: Path) -> List[Tuple[int, str, str]]:
+    """Return [(line_no, pattern_id, message)] of banned-pattern hits."""
+    try:
+        rel = str(path.resolve().relative_to(repo_root))
+    except ValueError:
+        # Path is outside the repo (e.g. /tmp test files) — scan as-is
+        rel = str(path)
+    if _is_allowlisted(rel):
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    hits: List[Tuple[int, str, str]] = []
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for pattern_id, regex, message in PATTERNS:
+            if regex.search(line):
+                hits.append((line_no, pattern_id, message))
+    return hits
+
+
+def _iter_target_files(args: List[str], repo_root: Path) -> Iterable[Path]:
+    """Yield target files: explicit argv if given, else staged .py files."""
+    if args:
+        for a in args:
+            p = Path(a)
+            if not p.is_absolute():
+                p = repo_root / p
+            if p.is_file() and p.suffix == ".py":
+                yield p
+        return
+    # Default: scan all repo .py files. Pre-commit will pass changed
+    # files via argv, so this branch only runs in manual / CI mode.
+    for p in repo_root.rglob("*.py"):
+        # Skip vendored / generated / external / vcs-ignored locations
+        parts = p.relative_to(repo_root).parts
+        if any(
+            part in {".venv", "venv", "node_modules", "__pycache__", ".git", "dist", "build"}
+            for part in parts
+        ):
+            continue
+        yield p
+
+
+def main(argv: List[str]) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    files = list(_iter_target_files(argv[1:], repo_root))
+    total_hits = 0
+    for path in files:
+        for line_no, pattern_id, message in _scan(path, repo_root):
+            try:
+                rel = path.resolve().relative_to(repo_root)
+            except ValueError:
+                rel = path
+            print(
+                f"[no-utcnow-isoformat] {rel}:{line_no}: {pattern_id} — {message}",
+                file=sys.stderr,
+            )
+            total_hits += 1
+    if total_hits:
+        print(
+            f"\n[no-utcnow-isoformat] {total_hits} banned pattern(s) found. "
+            f"Use `utc_timestamp()` from `autobot_shared.time_utils` instead.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

**Closes #5178** entirely (Parts A + B + C all shipped).

Adds [\`tools/lint/check_no_utcnow_isoformat.py\`](tools/lint/check_no_utcnow_isoformat.py) — a small Python regression-prevention hook that scans staged \`.py\` files for **3 banned patterns** that this session's #5178 + #5238 migrations eliminated:

| Pattern | Origin |
|---|---|
| \`datetime.utcnow().isoformat()\` | #5178 — produces tz-naive strings, mis-compares against tz-aware |
| \`datetime.utcnow().isoformat() + \"Z\"\` | #5238 — invalid mixed format, fails \`fromisoformat\` on Py 3.10 |
| \`time.strftime(\"%Y-%m-%dT...\")\` (no time arg) | #5178 audit outlier — silently uses \`time.localtime()\`, mislabeled UTC |

Wires into [\`.pre-commit-config.yaml\`](.pre-commit-config.yaml) as a local hook.

## Behavior

- **Pre-commit invocation**: only checks staged files. Pre-existing violations in unrelated files don't block commits until those files are touched.
- **Allowlist** (3 narrow entries): the hook script itself, the audit docs, and \`autobot_shared/time_utils.py\` (canonical helper).
- **Exit codes**: 0 = clean, 1 = banned pattern found.
- **Manual full-scan mode**: \`python3 tools/lint/check_no_utcnow_isoformat.py\` walks the whole repo.

## Why this scope, not full DTZ003

Ruff's [DTZ003](https://docs.astral.sh/ruff/rules/call-datetime-utcnow/) rule catches **all** \`datetime.utcnow()\` calls. Enabling DTZ003 globally would block on **248 pre-existing sites** tracked by [#5211](https://github.com/mrveiss/AutoBot-AI/issues/5211) (datetime field assignments + delta calculations — different bug class from #5178's string production).

Part C delivers **regression prevention for the shipped #5178 migration**. Broader DTZ003 enforcement is gated on #5211 completion.

## Discovery filed

[#5263](https://github.com/mrveiss/AutoBot-AI/issues/5263) — full-repo scan during script testing revealed **59 pre-existing violations OUTSIDE #5178's audit scope**:
- \`autobot-slm-backend/\` (8 files, 14 sites)
- \`autobot-slm-agent/\` (4 files)
- \`autobot-infrastructure/scripts/\` (7 files including 8 \`+ \"Z\"\` mixed-format sites)
- \`autobot-backend/tests/\` (4 files, 9 sites)

These don't block this PR — the pre-commit hook only fires on staged files. They become a #5263 Phase 4 follow-up.

## Verification

- YAML syntax: passes \`yaml.safe_load\`
- Allowlist works: \`autobot_shared/time_utils.py\` scan returns 0
- Pattern detection works: smoke test with deliberately-bad file detects all 3 patterns
- Path handling: /tmp files (outside repo) handled cleanly via try/except on \`relative_to()\`

## Cumulative #5178 progress (closed by this PR)

| Part | Deliverable | PR | Status |
|---|---|---|---|
| A | Selection-rule docstring in \`time_utils.py\` | #5176 | ✅ |
| B | Parser audit + canonicalization ADR | #5186 | ✅ |
| Part B Phase 1 | utils/agents/judges/websocket/models/planner/memory_graph (12 files, 25 sites) | #5213 | ✅ |
| Part B Phase 2 | knowledge/services (17 files, 30 sites) | #5233 | ✅ |
| Part B Phase 3 | api/security/enterprise (20 files, 58 sites) | #5236 | ✅ |
| Part B follow-up | 11 \`+ \"Z\"\` mixed-format sites (#5238) | #5243 | ✅ |
| **C** | **Regression-prevention hook** | **this PR** | **✅** |
| Total | **49 files, ~124 sites migrated; lint hook prevents regression** | | |

## Test plan

- [x] YAML validates
- [x] Hook detects all 3 patterns
- [x] Allowlist works
- [x] Path edge cases handled
- [x] Pre-existing violations identified + filed as #5263
- [ ] \`gh pr checks\` passes