### PR TITLE
refactor(analytics): migrate useIndexingJob + useDashboardLoaders fetches (#5257)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useDashboardLoaders.ts
+++ b/autobot-frontend/src/composables/analytics/useDashboardLoaders.ts
@@ -13,8 +13,7 @@
  */
 
 import { ref } from 'vue'
-import { fetchWithAuth } from '@/utils/fetchWithAuth'
-import appConfig from '@/config/AppConfig.js'
+import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { useBackgroundTask } from '@/composables/useBackgroundTask'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
@@ -66,6 +65,54 @@ export function useDashboardLoaders(deps: UseDashboardLoadersDeps) {
   const realTimeEnabled = ref(false)
   const refreshInterval = ref<ReturnType<typeof setInterval> | null>(null)
 
+  // --- Endpoints (#5257) ---------------------------------------------------
+  // All but `duplicatesEndpoint` are non-codebase (quality / debt /
+  // performance / monitoring / communication). Default scopeToSource: false
+  // applies. pickData returns the raw response so per-loader synthesis can
+  // access nested fields (health_score, breakdown, patterns_enabled, etc.).
+
+  type Raw = Record<string, unknown>
+
+  const commPatternsEndpoint = useFetchEndpoint<Raw, Raw>({
+    path: '/api/analytics/communication/patterns',
+    pickData: (r) => r,
+    label: 'Communication patterns',
+  })
+
+  const qualityHealthEndpoint = useFetchEndpoint<Raw, Raw>({
+    path: '/api/quality/health-score',
+    pickData: (r) => r,
+    label: 'Quality health score',
+  })
+
+  const duplicatesEndpoint = useFetchEndpoint<Raw, Raw>(
+    {
+      path: '/api/analytics/codebase/duplicates',
+      scopeToSource: true,
+      pickData: (r) => r,
+      label: 'Codebase duplicates',
+    },
+    { withSourceId: deps.withSourceId },
+  )
+
+  const debtSummaryEndpoint = useFetchEndpoint<Raw, Raw>({
+    path: '/api/debt/summary',
+    pickData: (r) => r,
+    label: 'Technical debt summary',
+  })
+
+  const performanceSummaryEndpoint = useFetchEndpoint<Raw, Raw>({
+    path: '/api/performance/summary',
+    pickData: (r) => r,
+    label: 'Performance summary',
+  })
+
+  const monitoringStatusEndpoint = useFetchEndpoint<Raw, Raw>({
+    path: '/api/monitoring/status',
+    pickData: (r) => r,
+    label: 'Monitoring status',
+  })
+
   const loadSystemOverview = async () => {
     try {
       const ok = await dashboardTask.start()
@@ -105,123 +152,114 @@ export function useDashboardLoaders(deps: UseDashboardLoadersDeps) {
   }
 
   const loadCommunicationPatterns = async () => {
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const response = await fetchWithAuth(`${backendUrl}/api/analytics/communication/patterns`)
-
-      if (!response.ok) {
-        throw new Error(`Status ${response.status}`)
-      }
-
-      const result = await response.json()
-
-      const wsActivity = result.websocket_activity || {}
-      const apiPatterns = result.api_patterns || []
-      const totalCalls = result.total_api_calls || 0
-      const uniqueEndpoints = result.unique_endpoints || 0
-
-      const wsConnections = Object.keys(wsActivity).length || 0
-
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      const apiFrequency = apiPatterns.length > 0
-        ? Math.round(apiPatterns.reduce(
-          (sum: number, p: any) => sum + (p.frequency || 0), 0,
-        ) / Math.max(apiPatterns.length, 1))
-        : totalCalls
-      /* eslint-enable @typescript-eslint/no-explicit-any */
-
-      const avgResponseTime = result.avg_response_time || 0
-      const estimatedDataRate = Math.round((totalCalls * avgResponseTime * 10) / 100) / 10
-
-      communicationPatterns.value = {
-        websocket_connections: wsConnections,
-        api_call_frequency: apiFrequency,
-        data_transfer_rate: estimatedDataRate,
-        unique_endpoints: uniqueEndpoints,
-      }
-    } catch (error: unknown) {
-      logger.error('loadCommunicationPatterns failed:', error)
+    await commPatternsEndpoint.load()
+    if (commPatternsEndpoint.error.value || !commPatternsEndpoint.data.value) {
       communicationPatterns.value = null
+      return
+    }
+    const result = commPatternsEndpoint.data.value as Record<string, unknown>
+
+    const wsActivity = (result.websocket_activity as Record<string, unknown>) || {}
+    const apiPatterns = (result.api_patterns as Array<Record<string, unknown>>) || []
+    const totalCalls = (result.total_api_calls as number) || 0
+    const uniqueEndpoints = (result.unique_endpoints as number) || 0
+
+    const wsConnections = Object.keys(wsActivity).length || 0
+
+    const apiFrequency = apiPatterns.length > 0
+      ? Math.round(apiPatterns.reduce(
+        (sum: number, p) => sum + ((p.frequency as number) || 0), 0,
+      ) / Math.max(apiPatterns.length, 1))
+      : totalCalls
+
+    const avgResponseTime = (result.avg_response_time as number) || 0
+    const estimatedDataRate = Math.round((totalCalls * avgResponseTime * 10) / 100) / 10
+
+    communicationPatterns.value = {
+      websocket_connections: wsConnections,
+      api_call_frequency: apiFrequency,
+      data_transfer_rate: estimatedDataRate,
+      unique_endpoints: uniqueEndpoints,
     }
   }
 
   const loadCodeQuality = async () => {
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
+    // Three parallel loads; each endpoint tolerates !ok silently by
+    // returning data.value = null. Downstream synthesis handles missing
+    // fields with `??` fallbacks.
+    await Promise.all([
+      qualityHealthEndpoint.load(),
+      duplicatesEndpoint.load(),
+      debtSummaryEndpoint.load(),
+    ])
+    const healthData = qualityHealthEndpoint.data.value as Record<string, unknown> | null
+    const duplicatesData = duplicatesEndpoint.data.value as Record<string, unknown> | null
+    const debtData = debtSummaryEndpoint.data.value as Record<string, unknown> | null
 
-      const healthResponse = await fetchWithAuth(`${backendUrl}/api/quality/health-score`)
-      const healthData = healthResponse.ok ? await healthResponse.json() : null
-
-      const duplicatesResponse = await fetchWithAuth(
-        deps.withSourceId(`${backendUrl}/api/analytics/codebase/duplicates`),
-      )
-      const duplicatesData = duplicatesResponse.ok ? await duplicatesResponse.json() : null
-
-      const debtResponse = await fetchWithAuth(`${backendUrl}/api/debt/summary`)
-      const debtData = debtResponse.ok ? await debtResponse.json() : null
-
-      if (healthData?.status === 'no_data' && debtData?.status === 'no_data') {
-        codeQuality.value = null
-        logger.debug('No code quality data - run indexing first')
-        return
-      }
-
-      const testCoverage = healthData?.breakdown?.testability || 50
-      const performanceScore = healthData?.breakdown?.performance || 0
-      const overallScore = healthData?.health_score || performanceScore
-
-      let duplicateCount = 0
-      if (duplicatesData?.status === 'success') {
-        duplicateCount = duplicatesData.total_duplicates || duplicatesData.count || 0
-      }
-
-      const technicalDebt = debtData?.total_debt_hours || debtData?.total_items || 0
-
-      codeQuality.value = {
-        overall_score: Math.round(overallScore),
-        test_coverage: Math.round(testCoverage),
-        code_duplicates: duplicateCount,
-        technical_debt: technicalDebt,
-      }
-    } catch (error: unknown) {
-      logger.error('loadCodeQuality failed:', error)
+    if (healthData?.status === 'no_data' && debtData?.status === 'no_data') {
       codeQuality.value = null
+      logger.debug('No code quality data - run indexing first')
+      return
+    }
+
+    const breakdown = (healthData?.breakdown as Record<string, number>) || {}
+    const testCoverage = breakdown.testability || 50
+    const performanceScore = breakdown.performance || 0
+    const overallScore = (healthData?.health_score as number) || performanceScore
+
+    let duplicateCount = 0
+    if (duplicatesData?.status === 'success') {
+      duplicateCount =
+        (duplicatesData.total_duplicates as number) ||
+        (duplicatesData.count as number) ||
+        0
+    }
+
+    const technicalDebt =
+      (debtData?.total_debt_hours as number) ||
+      (debtData?.total_items as number) ||
+      0
+
+    codeQuality.value = {
+      overall_score: Math.round(overallScore),
+      test_coverage: Math.round(testCoverage),
+      code_duplicates: duplicateCount,
+      technical_debt: technicalDebt,
     }
   }
 
   const loadPerformanceMetrics = async () => {
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
+    // qualityHealthEndpoint is shared with loadCodeQuality — re-loading is
+    // cheap and keeps the two paths decoupled (caller doesn't have to know
+    // what the other already fetched).
+    await Promise.all([
+      performanceSummaryEndpoint.load(),
+      monitoringStatusEndpoint.load(),
+      qualityHealthEndpoint.load(),
+    ])
+    const summaryData = performanceSummaryEndpoint.data.value as Record<string, unknown> | null
+    const monitoringData = monitoringStatusEndpoint.data.value as Record<string, unknown> | null
+    const qualityData = qualityHealthEndpoint.data.value as Record<string, unknown> | null
 
-      const summaryResponse = await fetchWithAuth(`${backendUrl}/api/performance/summary`)
-      const summaryData = summaryResponse.ok ? await summaryResponse.json() : null
+    if (summaryData?.status === 'no_data' && qualityData?.status === 'no_data') {
+      performanceMetrics.value = null
+      logger.debug('No performance metrics data - run indexing first')
+      return
+    }
 
-      const monitoringResponse = await fetchWithAuth(`${backendUrl}/api/monitoring/status`)
-      const monitoringData = monitoringResponse.ok ? await monitoringResponse.json() : null
+    const breakdown = (qualityData?.breakdown as Record<string, number>) || {}
+    const performanceScore = breakdown.performance || 0
+    const efficiencyScore =
+      (summaryData?.average_score as number) || performanceScore
+    const patternsEnabled = (summaryData?.patterns_enabled as number) || 0
 
-      const qualityResponse = await fetchWithAuth(`${backendUrl}/api/quality/health-score`)
-      const qualityData = qualityResponse.ok ? await qualityResponse.json() : null
-
-      if (summaryData?.status === 'no_data' && qualityData?.status === 'no_data') {
-        performanceMetrics.value = null
-        logger.debug('No performance metrics data - run indexing first')
-        return
-      }
-
-      const performanceScore = qualityData?.breakdown?.performance || 0
-      const efficiencyScore = summaryData?.average_score || performanceScore
-      const patternsEnabled = summaryData?.patterns_enabled || 0
-
-      performanceMetrics.value = {
-        efficiency_score: Math.round(efficiencyScore) || Math.round(performanceScore),
-        memory_usage: patternsEnabled > 0 ? patternsEnabled * 15 : 0,
-        cpu_usage: Math.round(100 - performanceScore),
-        load_time: monitoringData?.uptime_seconds
-          ? Math.round(monitoringData.uptime_seconds)
-          : 0,
-      }
-    } catch (error: unknown) {
-      logger.error('loadPerformanceMetrics failed:', error)
+    performanceMetrics.value = {
+      efficiency_score: Math.round(efficiencyScore) || Math.round(performanceScore),
+      memory_usage: patternsEnabled > 0 ? patternsEnabled * 15 : 0,
+      cpu_usage: Math.round(100 - performanceScore),
+      load_time: monitoringData?.uptime_seconds
+        ? Math.round(monitoringData.uptime_seconds as number)
+        : 0,
     }
   }
 

--- a/autobot-frontend/src/composables/analytics/useIndexingJob.ts
+++ b/autobot-frontend/src/composables/analytics/useIndexingJob.ts
@@ -15,6 +15,7 @@
 import { ref, type Ref } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
+import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useIndexingJob')
@@ -81,6 +82,65 @@ export function useIndexingJob(deps: UseIndexingJobDeps) {
   const jobPhases = ref<JobPhasesData | null>(null)
   const jobBatches = ref<JobBatchesData | null>(null)
   const jobStats = ref<JobStatsData | null>(null)
+
+  // --- Endpoints (#5257) ---------------------------------------------------
+  // Shared by pollJobStatus + checkCurrentIndexingJob (same URL, different
+  // response-handling). `/index/current` and `/index/cancel` are NOT
+  // source-scoped (backend has a single module-level current-task slot).
+
+  interface CurrentJobRaw {
+    has_active_job?: boolean
+    task_id?: string
+    status?: string
+    progress?: { step?: string; percent?: number }
+    error?: string
+  }
+
+  const currentJobEndpoint = useFetchEndpoint<CurrentJobRaw, CurrentJobRaw>({
+    path: '/api/analytics/codebase/index/current',
+    pickData: (r) => r, // caller reads endpoint.data.value directly
+    label: 'Current indexing job',
+  })
+
+  const problemsPollEndpoint = useFetchEndpoint<
+    { problems?: unknown[] },
+    unknown[]
+  >(
+    {
+      path: '/api/analytics/codebase/problems',
+      scopeToSource: true,
+      pickData: (r) => r.problems ?? [],
+      onSuccess: (list) => {
+        deps.problemsReport.value = list
+      },
+    },
+    { withSourceId: deps.withSourceId },
+  )
+
+  const statsPollEndpoint = useFetchEndpoint<
+    { stats?: Record<string, unknown> },
+    Record<string, unknown>
+  >(
+    {
+      path: '/api/analytics/codebase/stats',
+      scopeToSource: true,
+      pickData: (r) => r.stats ?? null,
+      onSuccess: (stats) => {
+        deps.codebaseStats.value = stats
+      },
+    },
+    { withSourceId: deps.withSourceId },
+  )
+
+  const cancelEndpoint = useFetchEndpoint<
+    { success?: boolean; message?: string },
+    { success: boolean; message?: string }
+  >({
+    path: '/api/analytics/codebase/index/cancel',
+    method: 'POST',
+    pickData: (r) => ({ success: r.success ?? false, message: r.message }),
+    label: 'Index cancel',
+  })
 
   // --- Polling ---
 
@@ -156,87 +216,61 @@ export function useIndexingJob(deps: UseIndexingJobDeps) {
   }
 
   const pollJobStatus = async () => {
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const response = await fetchWithAuth(
-        `${backendUrl}/api/analytics/codebase/index/current`,
-      )
-      if (!response.ok) return
+    await currentJobEndpoint.load()
+    if (currentJobEndpoint.error.value) {
+      logger.warn('Job polling error:', currentJobEndpoint.error.value)
+      return
+    }
+    const data = currentJobEndpoint.data.value
+    if (!data) return
 
-      const data = await response.json()
-      currentJobStatus.value = data.status
-
-      if (data.has_active_job) {
-        _updateActiveJobProgress(data)
-        await pollIntermediateResults()
-      } else {
-        await _handleJobFinished(data.status, data.error)
-      }
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      logger.warn('Job polling error:', errorMessage)
+    currentJobStatus.value = data.status ?? null
+    if (data.has_active_job) {
+      _updateActiveJobProgress(data as Record<string, unknown>)
+      await pollIntermediateResults()
+    } else {
+      await _handleJobFinished(data.status ?? '', data.error)
     }
   }
 
   const pollIntermediateResults = async () => {
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-
-      const problemsResponse = await fetchWithAuth(
-        deps.withSourceId(`${backendUrl}/api/analytics/codebase/problems`),
-      )
-      if (problemsResponse.ok) {
-        const problemsData = await problemsResponse.json()
-        deps.problemsReport.value = problemsData.problems || []
-      }
-
-      const statsResponse = await fetchWithAuth(
-        deps.withSourceId(`${backendUrl}/api/analytics/codebase/stats`),
-      )
-      if (statsResponse.ok) {
-        const statsData = await statsResponse.json()
-        if (statsData.stats) {
-          deps.codebaseStats.value = statsData.stats
-        }
-      }
-    } catch {
-      // Silent - don't interrupt polling
-    }
+    // Silent: both endpoints write to deps refs via onSuccess, and errors
+    // are logged internally by the composable.
+    await Promise.all([problemsPollEndpoint.load(), statsPollEndpoint.load()])
   }
 
   // --- Public API ---
 
   const checkCurrentIndexingJob = async () => {
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const response = await fetchWithAuth(
-        `${backendUrl}/api/analytics/codebase/index/current`,
+    await currentJobEndpoint.load()
+    if (currentJobEndpoint.error.value) {
+      logger.warn(
+        'Could not check for running job:',
+        currentJobEndpoint.error.value,
       )
-      if (response.ok) {
-        const data = await response.json()
-        if (data.has_active_job) {
-          currentJobId.value = data.task_id
-          currentJobStatus.value = data.status
-          deps.analyzing.value = true
-          deps.progressStatus.value =
-            data.progress?.step ||
-            deps.t('analytics.codebase.status.indexingInProgress')
-          deps.progressPercent.value = data.progress?.percent || 20
-          startJobPolling()
-          deps.notify(
-            deps.t('analytics.codebase.notify.indexingAlreadyRunning'),
-            'info',
-          )
-        } else if (data.task_id && data.status !== 'idle') {
-          deps.progressStatus.value = deps.t(
-            'analytics.codebase.status.lastJob',
-            { status: data.status },
-          )
-        }
-      }
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      logger.warn('Could not check for running job:', errorMessage)
+      return
+    }
+    const data = currentJobEndpoint.data.value
+    if (!data) return
+
+    if (data.has_active_job) {
+      currentJobId.value = data.task_id ?? null
+      currentJobStatus.value = data.status ?? null
+      deps.analyzing.value = true
+      deps.progressStatus.value =
+        data.progress?.step ||
+        deps.t('analytics.codebase.status.indexingInProgress')
+      deps.progressPercent.value = data.progress?.percent || 20
+      startJobPolling()
+      deps.notify(
+        deps.t('analytics.codebase.notify.indexingAlreadyRunning'),
+        'info',
+      )
+    } else if (data.task_id && data.status !== 'idle') {
+      deps.progressStatus.value = deps.t(
+        'analytics.codebase.status.lastJob',
+        { status: data.status },
+      )
     }
   }
 
@@ -246,46 +280,46 @@ export function useIndexingJob(deps: UseIndexingJobDeps) {
       return
     }
 
-    try {
-      const backendUrl = await appConfig.getServiceUrl('backend')
-      const response = await fetchWithAuth(
-        `${backendUrl}/api/analytics/codebase/index/cancel`,
-        { method: 'POST', headers: { 'Content-Type': 'application/json' } },
-      )
-
-      if (response.ok) {
-        const data = await response.json()
-        if (data.success) {
-          deps.analyzing.value = false
-          stopJobPolling()
-          currentJobId.value = null
-          deps.progressStatus.value = deps.t(
-            'analytics.codebase.status.indexingCancelledByUser',
-          )
-          deps.notify(
-            deps.t('analytics.codebase.notify.indexingJobCancelled'),
-            'success',
-          )
-        } else {
-          deps.notify(
-            data.message ||
-              deps.t('analytics.codebase.notify.couldNotCancel'),
-            'warning',
-          )
-        }
-      } else {
-        deps.notify(deps.t('analytics.codebase.notify.cancelFailed'), 'error')
-      }
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
+    await cancelEndpoint.load()
+    if (cancelEndpoint.error.value) {
       deps.notify(
-        deps.t('analytics.codebase.notify.cancelError', { error: errorMessage }),
+        deps.t('analytics.codebase.notify.cancelError', {
+          error: cancelEndpoint.error.value,
+        }),
         'error',
+      )
+      return
+    }
+
+    const data = cancelEndpoint.data.value
+    if (data?.success) {
+      deps.analyzing.value = false
+      stopJobPolling()
+      currentJobId.value = null
+      deps.progressStatus.value = deps.t(
+        'analytics.codebase.status.indexingCancelledByUser',
+      )
+      deps.notify(
+        deps.t('analytics.codebase.notify.indexingJobCancelled'),
+        'success',
+      )
+    } else {
+      deps.notify(
+        data?.message || deps.t('analytics.codebase.notify.couldNotCancel'),
+        'warning',
       )
     }
   }
 
-  /** Send an index request with retry on 502/503. */
+  /**
+   * Send an index request with retry on 502/503.
+   *
+   * #5257: intentionally NOT migrated to useFetchEndpoint. The composable
+   * has no retry hook today (adding one for a single consumer would be
+   * speculative surface area), and the 502/503 handling here is
+   * domain-specific (backend-warmup vs real error). Keeping this one
+   * hand-rolled; the other 4 fetchers in this file migrated cleanly.
+   */
   const _sendIndexRequest = async (
     endpoint: string,
     body: string,


### PR DESCRIPTION
## Summary

Closes the last actionable migrations from the #5257 cleanup filing. After this PR, the **only** hand-rolled \`fetchWithAuth\` calls remaining in \`composables/analytics/\` are:

1. \`_sendIndexRequest\` in \`useIndexingJob.ts\` \u2014 intentional, has custom 502/503 retry logic.
2. Three small files (\`useEnvironmentAnalysis\`, \`useBugPrediction\`, \`useAnalyticsDebug\`) formally marked SKIP per audit critical-mass rule.

Closes #5257.

## useIndexingJob.ts \u2014 5 of 6 migrations

| Function | Endpoint | Migration notes |
|---|---|---|
| \`pollJobStatus\` | GET \`/index/current\` | Shares \`currentJobEndpoint\` with checkCurrentIndexingJob |
| \`checkCurrentIndexingJob\` | GET \`/index/current\` | Same shared endpoint |
| \`pollIntermediateResults\` | GET \`/problems\` + \`/stats\` | Both \`scopeToSource: true\`; silent parallel load |
| \`cancelIndexingJob\` | POST \`/index/cancel\` | Not source-scoped (global backend slot) |

**Intentional SKIP:** \`_sendIndexRequest\` keeps its hand-rolled 502/503 retry loop. Adding a retry hook to \`useFetchEndpoint\` for a single consumer would be speculative surface area. Comment in code documents this.

## useDashboardLoaders.ts \u2014 7 of 7 migrations

All 7 fetchWithAuth call sites now route through \`useFetchEndpoint\`. Six module-scope endpoint instances:

| Endpoint | Path | scopeToSource |
|---|---|---|
| commPatternsEndpoint | \`/api/analytics/communication/patterns\` | false |
| qualityHealthEndpoint | \`/api/quality/health-score\` | false |
| duplicatesEndpoint | \`/api/analytics/codebase/duplicates\` | **true** |
| debtSummaryEndpoint | \`/api/debt/summary\` | false |
| performanceSummaryEndpoint | \`/api/performance/summary\` | false |
| monitoringStatusEndpoint | \`/api/monitoring/status\` | false |

\`qualityHealthEndpoint\` is shared by both \`loadCodeQuality\` and \`loadPerformanceMetrics\`. Re-loading is cheap; keeps callers decoupled.

\`loadCodeQuality\` and \`loadPerformanceMetrics\` now parallel-load via \`Promise.all\`, reading each endpoint's \`data.value\` after. Same observable behaviour, same no_data fallbacks, same synthesis. Error handling moved into the composable.

## Documented SKIPs

Per audit critical-mass rule (\u2265 8 GET fetchers for LOC-positive migration) AND per absence of #5111-class source-scoping risk:

- \`useEnvironmentAnalysis.ts\` \u2014 1 fetch
- \`useBugPrediction.ts\` \u2014 1 fetch (silent cached read)
- \`useAnalyticsDebug.ts\` \u2014 2 fetches (debug-only composable)

These stay hand-rolled. SKIP verdicts recorded in #5257 body so future developers don't re-open.

## Verification

- [x] \`npx vue-tsc --noEmit -p tsconfig.app.json\` \u2014 **167 baseline unchanged**; zero new errors on changed files.
- [x] \`npx vitest run\` (3 composable suites) \u2014 **31/31 green**.
- [x] \`grep fetchWithAuth useDashboardLoaders.ts\` \u2192 **0**.
- [x] \`grep fetchWithAuth useIndexingJob.ts\` \u2192 **1** (the intentional \`_sendIndexRequest\` retry helper).
- [ ] Manual: start an indexing job \u2014 polls progress, intermediate problems/stats update, cancel button works.
- [ ] Manual: open analytics dashboard \u2014 system overview, communication patterns, code quality, performance cards all render.

## Post-this-PR state

\`composables/analytics/\` fetchWithAuth inventory:

\`\`\`
useEnvironmentAnalysis       1 fetch  SKIP
useBugPrediction             1 fetch  SKIP
useAnalyticsDebug            2 fetches SKIP
useIndexingJob               1 fetch  intentional (_sendIndexRequest retry)
\u2014 all others: 0 \u2014
\`\`\`

Analytics-namespace platform uniformity: every fetch that *can* go through \`useFetchEndpoint\` now does. The 5 remaining hand-rolled sites are all explicitly documented as such.

## Related

- Correction to overclaim: comment on PR #5256
- Canonical composable: \`composables/api/useFetchEndpoint.ts\`
- Audit source: #5164 / #5154 (merged)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)