### PR TITLE
fix(analytics): scope codebase export endpoints by source_id (#5266)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -783,6 +783,7 @@ const { exportReport, exportSection } = useCodebaseExport({
   progressStatus,
   fetchWithAuth: fetchWithAuth as typeof fetch,
   getBackendUrl: () => appConfig.getServiceUrl('backend'),
+  withSourceId,
   notify,
   t,
 })

--- a/autobot-frontend/src/composables/analytics/useCodebaseExport.ts
+++ b/autobot-frontend/src/composables/analytics/useCodebaseExport.ts
@@ -336,6 +336,14 @@ export function useCodebaseExport(deps: {
   progressStatus: Ref<string>
   fetchWithAuth: typeof fetch
   getBackendUrl: () => Promise<string>
+  /**
+   * URL wrapper that appends `?source_id=<id>` for per-project scoping.
+   * #5266: previously missing \u2014 both `/report` and `/env-analysis/export`
+   * are source-scoped at the backend but the frontend was dropping the
+   * scope, silently falling back to `get_default_source_id()` (same
+   * bug class as #5111).
+   */
+  withSourceId: (url: string) => string
   notify: (msg: string, type: 'info' | 'success' | 'warning' | 'error') => void
   t: (key: string, params?: Record<string, unknown>) => string
 }) {
@@ -350,7 +358,11 @@ export function useCodebaseExport(deps: {
 
     try {
       const backendUrl = await deps.getBackendUrl()
-      const url = `${backendUrl}/api/analytics/codebase/report?format=markdown&quick=${quick}`
+      // #5266: wrap with withSourceId so per-project exports hit the
+      // scoped doc instead of the backend's get_default_source_id() fallback.
+      const url = deps.withSourceId(
+        `${backendUrl}/api/analytics/codebase/report?format=markdown&quick=${quick}`,
+      )
       const response = await deps.fetchWithAuth(url, {
         method: 'GET',
         headers: { 'Accept': 'text/markdown' },
@@ -383,8 +395,11 @@ export function useCodebaseExport(deps: {
   ): Promise<unknown> => {
     try {
       const backendUrl = await deps.getBackendUrl()
+      // #5266: wrap with withSourceId \u2014 same rationale as exportReport.
       const response = await deps.fetchWithAuth(
-        `${backendUrl}/api/analytics/codebase/env-analysis/export`,
+        deps.withSourceId(
+          `${backendUrl}/api/analytics/codebase/env-analysis/export`,
+        ),
         { method: 'GET', headers: { 'Content-Type': 'application/json' } },
       )
       if (response.ok) {


### PR DESCRIPTION
## Summary

Same bug class as #5111: \`useCodebaseExport\` dropped \`source_id\` on two per-project endpoints, silently falling back to the backend's \`get_default_source_id()\` helper \u2014 so exports on a per-source analytics page would serve data from a different project.

Closes #5266.

## Bug confirmed

Backend accepts \`source_id\` on both endpoints:

- \`autobot-backend/api/codebase_analytics/endpoints/report.py:2082\` \u2014 \`source_id: Optional[str] = None\` with \`get_default_source_id()\` fallback at line 2106.
- \`autobot-backend/api/codebase_analytics/endpoints/environment.py:662\` \u2014 \`source_id: Optional[str] = Query(...)\`.

Frontend was fetching without \`?source_id=\u2026\`. Effect: when a user clicks Export Report / Export Environment on project A's analytics page, they get whatever project was most-recently indexed (via \`get_default_source_id()\`).

## Fix

Adds \`withSourceId: (url: string) => string\` to \`useCodebaseExport\`'s deps interface and wraps both URLs before fetching. The composable already had \`deps.fetchWithAuth\` + \`deps.getBackendUrl\` for testability; adding \`withSourceId\` follows the same injection pattern.

\`CodebaseAnalytics.vue\` passes \`withSourceId\` through (already destructured from \`useSourceRegistry\` at the top of the file).

## Why NOT migrated through useFetchEndpoint

\`GET /api/analytics/codebase/report?format=markdown\` returns \`text/markdown\`, not JSON. \`useFetchEndpoint\` does \`await response.json()\` which would reject on markdown content. A \`parseResponse\` hook is the cleanest unlock; filing as a separate follow-up only if someone else needs it.

This is the same principle as the \`_sendIndexRequest\` skip in PR #5265: when the canonical composable doesn't fit, don't force the migration \u2014 fix the underlying bug with a minimal diff and record the skip reasoning.

## Test plan

- [x] \`npx vue-tsc --noEmit -p tsconfig.app.json\` \u2014 167 baseline unchanged; zero new errors.
- [x] Grep verifies: \`withSourceId\` now wraps both fetch URLs.
- [ ] Manual: on a per-source analytics page (\`/analytics/codebase/{sourceId}\`), click Export Report \u2014 downloaded markdown should contain data for **that** source, not the default one.
- [ ] Manual: same check for Export Environment.

## Diff

- \`useCodebaseExport.ts\`: +17 / -2 (deps interface + 2 URL wraps + JSDoc)
- \`CodebaseAnalytics.vue\`: +1 / 0 (pass \`withSourceId\` to the composable)

## Related

- Bug-class origin: #5111 / PR #5113 (stats + problems fix, merged)
- Discovered during: PR #5265 post-merge audit
- Canonical composable: \`composables/api/useFetchEndpoint.ts\`

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)