### PR TITLE
refactor(knowledge): migrate 105 KB-mixin self.aioredis_client callers to self.redis() (Part of #5225, Phase 3)

### DIFF
--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -553,7 +553,7 @@ class KnowledgeBaseCore:
         self.ensure_initialized()
         try:
             if self.aioredis_client:
-                pong = await self.aioredis_client.ping()
+                pong = await self.redis().ping()
                 return "healthy" if pong else "unhealthy"
             else:
                 return "no_client"
@@ -586,7 +586,7 @@ class KnowledgeBaseCore:
 
         try:
             keys = []
-            async for key in self.aioredis_client.scan_iter(match=pattern):
+            async for key in self.redis().scan_iter(match=pattern):
                 if isinstance(key, bytes):
                     keys.append(key.decode("utf-8"))
                 else:
@@ -620,8 +620,8 @@ class KnowledgeBaseCore:
 
         try:
             # Look for model metadata in existing facts
-            async for key in self.aioredis_client.scan_iter(match="fact:*", count=10):
-                metadata_json = await self.aioredis_client.hget(key, "metadata")
+            async for key in self.redis().scan_iter(match="fact:*", count=10):
+                metadata_json = await self.redis().hget(key, "metadata")
                 model = _extract_embedding_model_from_metadata(metadata_json)
                 if model:
                     return model

--- a/autobot-backend/knowledge/categories.py
+++ b/autobot-backend/knowledge/categories.py
@@ -69,19 +69,19 @@ class CategoriesMixin:
         self, category_id: str, category_data: Dict[str, Any], parent_id: Optional[str]
     ) -> None:
         """Store category in Redis (Issue #398: extracted)."""
-        await self.aioredis_client.hset(
+        await self.redis().hset(
             f"category:{category_id}", mapping=category_data
         )
-        await self.aioredis_client.set(
+        await self.redis().set(
             f"category:path:{category_data['path']}", category_id
         )
 
         if parent_id:
-            await self.aioredis_client.sadd(
+            await self.redis().sadd(
                 f"category:children:{parent_id}", category_id
             )
         else:
-            await self.aioredis_client.sadd("category:root", category_id)
+            await self.redis().sadd("category:root", category_id)
 
     def _build_category_data(
         self,
@@ -142,7 +142,7 @@ class CategoriesMixin:
             if error:
                 return {"success": False, "message": error}
 
-            if await self.aioredis_client.get(f"category:path:{path}"):
+            if await self.redis().get(f"category:path:{path}"):
                 return {
                     "success": False,
                     "message": f"Category path already exists: {path}",
@@ -214,7 +214,7 @@ class CategoriesMixin:
 
         try:
             path = path.strip().lower()
-            category_id = await self.aioredis_client.get(f"category:path:{path}")
+            category_id = await self.redis().get(f"category:path:{path}")
 
             if not category_id:
                 return {"success": False, "message": f"Category path not found: {path}"}
@@ -250,7 +250,7 @@ class CategoriesMixin:
         else:
             new_path = new_name
 
-        if await self.aioredis_client.get(f"category:path:{new_path}"):
+        if await self.redis().get(f"category:path:{new_path}"):
             return f"Category path already exists: {new_path}"
 
         await self._update_category_path(category_id, old_path, new_path)
@@ -306,7 +306,7 @@ class CategoriesMixin:
 
             self._apply_metadata_updates(updates, description, icon, color)
 
-            await self.aioredis_client.hset(f"category:{category_id}", mapping=updates)
+            await self.redis().hset(f"category:{category_id}", mapping=updates)
             updated = await self._get_category_data(category_id)
             logger.info("Updated category '%s'", category_id)
 
@@ -326,7 +326,7 @@ class CategoriesMixin:
         """Reassign facts from categories being deleted (Issue #398: extracted)."""
         count = 0
         for cat_id in categories:
-            cat_facts = await self.aioredis_client.smembers(f"category:facts:{cat_id}")
+            cat_facts = await self.redis().smembers(f"category:facts:{cat_id}")
             for fact_id in cat_facts:
                 if isinstance(fact_id, bytes):
                     fact_id = fact_id.decode("utf-8")
@@ -346,15 +346,15 @@ class CategoriesMixin:
         path = cat_data.get("path", "")
         parent_id = cat_data.get("parent_id", "")
 
-        await self.aioredis_client.delete(f"category:path:{path}")
+        await self.redis().delete(f"category:path:{path}")
         if parent_id:
-            await self.aioredis_client.srem(f"category:children:{parent_id}", cat_id)
+            await self.redis().srem(f"category:children:{parent_id}", cat_id)
         else:
-            await self.aioredis_client.srem("category:root", cat_id)
+            await self.redis().srem("category:root", cat_id)
 
-        await self.aioredis_client.delete(f"category:children:{cat_id}")
-        await self.aioredis_client.delete(f"category:facts:{cat_id}")
-        await self.aioredis_client.delete(f"category:{cat_id}")
+        await self.redis().delete(f"category:children:{cat_id}")
+        await self.redis().delete(f"category:facts:{cat_id}")
+        await self.redis().delete(f"category:{cat_id}")
 
     async def _build_deletion_list(
         self, category_id: str, recursive: bool
@@ -369,7 +369,7 @@ class CategoriesMixin:
             Tuple of (categories_to_delete, error_response)
             error_response is None if successful
         """
-        children = await self.aioredis_client.smembers(
+        children = await self.redis().smembers(
             f"category:children:{category_id}"
         )
         if children and not recursive:
@@ -440,7 +440,7 @@ class CategoriesMixin:
         self, max_depth: int, include_fact_counts: bool
     ) -> Dict[str, Any]:
         """Build full tree from all roots (Issue #398: extracted)."""
-        root_ids = await self.aioredis_client.smembers("category:root")
+        root_ids = await self.redis().smembers("category:root")
         tree = []
         total = 0
 
@@ -507,7 +507,7 @@ class CategoriesMixin:
                         "message": f"Category not found: {category_id}",
                     }
 
-            child_ids = await self.aioredis_client.smembers(
+            child_ids = await self.redis().smembers(
                 f"category:children:{category_id}"
             )
             children = []
@@ -591,7 +591,7 @@ class CategoriesMixin:
         if not category:
             return None, f"Category not found: {category_id}"
 
-        fact_exists = await self.aioredis_client.exists(f"fact:{fact_id}")
+        fact_exists = await self.redis().exists(f"fact:{fact_id}")
         if not fact_exists:
             return None, f"Fact not found: {fact_id}"
 
@@ -603,7 +603,7 @@ class CategoriesMixin:
         """Remove fact from old category if reassigning (Issue #398: extracted)."""
         old_category = await self._get_fact_category_id(fact_id)
         if old_category and old_category != new_category_id:
-            await self.aioredis_client.srem(f"category:facts:{old_category}", fact_id)
+            await self.redis().srem(f"category:facts:{old_category}", fact_id)
             await self._decrement_category_count(old_category)
 
     async def assign_fact_to_category(
@@ -645,7 +645,7 @@ class CategoriesMixin:
         """Gather all fact IDs from multiple categories (Issue #398: extracted)."""
         all_ids: set = set()
         for cat_id in category_ids:
-            fact_ids = await self.aioredis_client.smembers(f"category:facts:{cat_id}")
+            fact_ids = await self.redis().smembers(f"category:facts:{cat_id}")
             for fid in fact_ids:
                 all_ids.add(fid.decode("utf-8") if isinstance(fid, bytes) else fid)
         return all_ids
@@ -654,7 +654,7 @@ class CategoriesMixin:
         """Load fact data for multiple fact IDs (Issue #398: extracted)."""
         facts = []
         for fid in fact_ids:
-            fact_data = await self.aioredis_client.hgetall(f"fact:{fid}")
+            fact_data = await self.redis().hgetall(f"fact:{fid}")
             if fact_data:
                 decoded = {
                     (k.decode("utf-8") if isinstance(k, bytes) else k): (
@@ -732,7 +732,7 @@ class CategoriesMixin:
             List of matching key strings
         """
         keys = []
-        async for key in self.aioredis_client.scan_iter(match=redis_pattern, count=100):
+        async for key in self.redis().scan_iter(match=redis_pattern, count=100):
             key = key.decode("utf-8") if isinstance(key, bytes) else key
             keys.append(key)
             if len(keys) >= max_keys:
@@ -751,7 +751,7 @@ class CategoriesMixin:
         Returns:
             List of decoded category data dicts
         """
-        pipe = self.aioredis_client.pipeline()
+        pipe = self.redis().pipeline()
         for cat_id in category_ids:
             pipe.hgetall(f"category:{cat_id}")
         results = await pipe.execute()
@@ -774,7 +774,7 @@ class CategoriesMixin:
         if not keys:
             return []
 
-        pipe = self.aioredis_client.pipeline()
+        pipe = self.redis().pipeline()
         for key in keys:
             pipe.get(key)
         category_ids = await pipe.execute()
@@ -841,7 +841,7 @@ class CategoriesMixin:
 
     async def _get_category_data(self, category_id: str) -> Optional[Dict[str, Any]]:
         """Get category data from Redis hash."""
-        data = await self.aioredis_client.hgetall(f"category:{category_id}")
+        data = await self.redis().hgetall(f"category:{category_id}")
         if not data:
             return None
 
@@ -902,7 +902,7 @@ class CategoriesMixin:
         Returns:
             List of child node dictionaries
         """
-        child_ids = await self.aioredis_client.smembers(
+        child_ids = await self.redis().smembers(
             f"category:children:{category_id}"
         )
         if not child_ids:
@@ -958,7 +958,7 @@ class CategoriesMixin:
 
     async def _get_all_descendants(self, category_id: str) -> List[str]:
         """Get all descendant category IDs recursively."""
-        child_ids = await self.aioredis_client.smembers(
+        child_ids = await self.redis().smembers(
             f"category:children:{category_id}"
         )
 
@@ -987,13 +987,13 @@ class CategoriesMixin:
     ) -> None:
         """Update category path and all descendant paths."""
         # Delete old path lookup
-        await self.aioredis_client.delete(f"category:path:{old_path}")
+        await self.redis().delete(f"category:path:{old_path}")
 
         # Set new path lookup
-        await self.aioredis_client.set(f"category:path:{new_path}", category_id)
+        await self.redis().set(f"category:path:{new_path}", category_id)
 
         # Update descendants
-        child_ids = await self.aioredis_client.smembers(
+        child_ids = await self.redis().smembers(
             f"category:children:{category_id}"
         )
 
@@ -1004,7 +1004,7 @@ class CategoriesMixin:
             if child_data:
                 child_old_path = child_data.get("path", "")
                 child_new_path = child_old_path.replace(old_path, new_path, 1)
-                await self.aioredis_client.hset(
+                await self.redis().hset(
                     f"category:{cid}", "path", child_new_path
                 )
                 await self._update_category_path(cid, child_old_path, child_new_path)
@@ -1012,28 +1012,28 @@ class CategoriesMixin:
     async def _assign_fact_to_category(self, fact_id: str, category_id: str) -> None:
         """Internal method to assign a fact to a category."""
         # Add to category's fact set
-        await self.aioredis_client.sadd(f"category:facts:{category_id}", fact_id)
+        await self.redis().sadd(f"category:facts:{category_id}", fact_id)
 
         # Update fact metadata
-        await self.aioredis_client.hset(f"fact:{fact_id}", "category_id", category_id)
+        await self.redis().hset(f"fact:{fact_id}", "category_id", category_id)
 
         # Increment category count
-        await self.aioredis_client.hincrby(f"category:{category_id}", "fact_count", 1)
+        await self.redis().hincrby(f"category:{category_id}", "fact_count", 1)
 
     async def _remove_fact_category(self, fact_id: str) -> None:
         """Remove category assignment from a fact."""
-        await self.aioredis_client.hdel(f"fact:{fact_id}", "category_id")
+        await self.redis().hdel(f"fact:{fact_id}", "category_id")
 
     async def _get_fact_category_id(self, fact_id: str) -> Optional[str]:
         """Get the category ID a fact is assigned to."""
-        category_id = await self.aioredis_client.hget(f"fact:{fact_id}", "category_id")
+        category_id = await self.redis().hget(f"fact:{fact_id}", "category_id")
         if category_id and isinstance(category_id, bytes):
             category_id = category_id.decode("utf-8")
         return category_id if category_id else None
 
     async def _decrement_category_count(self, category_id: str) -> None:
         """Decrement fact count for a category."""
-        current = await self.aioredis_client.hget(
+        current = await self.redis().hget(
             f"category:{category_id}", "fact_count"
         )
         if current:
@@ -1041,6 +1041,6 @@ class CategoriesMixin:
                 current.decode("utf-8") if isinstance(current, bytes) else current
             )
             if count > 0:
-                await self.aioredis_client.hset(
+                await self.redis().hset(
                     f"category:{category_id}", "fact_count", count - 1
                 )

--- a/autobot-backend/knowledge/collections.py
+++ b/autobot-backend/knowledge/collections.py
@@ -79,10 +79,10 @@ class CollectionsMixin:
         self, collection_id: str, collection_data: Dict[str, Any]
     ) -> None:
         """Store collection in Redis (Issue #398: extracted)."""
-        await self.aioredis_client.hset(
+        await self.redis().hset(
             f"collection:{collection_id}", mapping=collection_data
         )
-        await self.aioredis_client.sadd("collection:all", collection_id)
+        await self.redis().sadd("collection:all", collection_id)
 
     async def create_collection(
         self,
@@ -149,7 +149,7 @@ class CollectionsMixin:
 
     async def _fetch_all_collections(self) -> List[Dict[str, Any]]:
         """Fetch all collections from Redis (Issue #398: extracted)."""
-        collection_ids = await self.aioredis_client.smembers("collection:all")
+        collection_ids = await self.redis().smembers("collection:all")
         collections = []
         for cid in collection_ids:
             if isinstance(cid, bytes):
@@ -244,7 +244,7 @@ class CollectionsMixin:
             updates = self._build_collection_updates(
                 name, description, icon, color, metadata
             )
-            await self.aioredis_client.hset(
+            await self.redis().hset(
                 f"collection:{collection_id}", mapping=updates
             )
             updated = await self._get_collection_data(collection_id)
@@ -268,17 +268,17 @@ class CollectionsMixin:
         for fid in fact_ids:
             if isinstance(fid, bytes):
                 fid = fid.decode("utf-8")
-            await self.aioredis_client.srem(f"fact:collections:{fid}", collection_id)
+            await self.redis().srem(f"fact:collections:{fid}", collection_id)
             if delete_facts:
-                await self.aioredis_client.delete(f"fact:{fid}")
+                await self.redis().delete(f"fact:{fid}")
                 facts_deleted += 1
         return facts_deleted
 
     async def _delete_collection_records(self, collection_id: str) -> None:
         """Delete collection records from Redis (Issue #398: extracted)."""
-        await self.aioredis_client.delete(f"collection:{collection_id}")
-        await self.aioredis_client.delete(f"collection:facts:{collection_id}")
-        await self.aioredis_client.srem("collection:all", collection_id)
+        await self.redis().delete(f"collection:{collection_id}")
+        await self.redis().delete(f"collection:facts:{collection_id}")
+        await self.redis().srem("collection:all", collection_id)
 
     async def delete_collection(
         self, collection_id: str, delete_facts: bool = False
@@ -295,7 +295,7 @@ class CollectionsMixin:
                     "message": f"Collection not found: {collection_id}",
                 }
 
-            fact_ids = await self.aioredis_client.smembers(
+            fact_ids = await self.redis().smembers(
                 f"collection:facts:{collection_id}"
             )
             facts_count = len(fact_ids)
@@ -335,30 +335,30 @@ class CollectionsMixin:
         not_found = []
 
         for fid in fact_ids:
-            fact_exists = await self.aioredis_client.exists(f"fact:{fid}")
+            fact_exists = await self.redis().exists(f"fact:{fid}")
             if not fact_exists:
                 not_found.append(fid)
                 continue
 
-            is_member = await self.aioredis_client.sismember(
+            is_member = await self.redis().sismember(
                 f"collection:facts:{collection_id}", fid
             )
             if is_member:
                 already_in_collection += 1
                 continue
 
-            await self.aioredis_client.sadd(f"collection:facts:{collection_id}", fid)
-            await self.aioredis_client.sadd(f"fact:collections:{fid}", collection_id)
+            await self.redis().sadd(f"collection:facts:{collection_id}", fid)
+            await self.redis().sadd(f"fact:collections:{fid}", collection_id)
             added_count += 1
 
         return added_count, already_in_collection, not_found
 
     async def _update_collection_fact_count(self, collection_id: str) -> int:
         """Update and return collection fact count (Issue #398: extracted)."""
-        new_count = await self.aioredis_client.scard(
+        new_count = await self.redis().scard(
             f"collection:facts:{collection_id}"
         )
-        await self.aioredis_client.hset(
+        await self.redis().hset(
             f"collection:{collection_id}", "fact_count", new_count
         )
         return new_count
@@ -414,15 +414,15 @@ class CollectionsMixin:
         not_in_collection = 0
 
         for fid in fact_ids:
-            is_member = await self.aioredis_client.sismember(
+            is_member = await self.redis().sismember(
                 f"collection:facts:{collection_id}", fid
             )
             if not is_member:
                 not_in_collection += 1
                 continue
 
-            await self.aioredis_client.srem(f"collection:facts:{collection_id}", fid)
-            await self.aioredis_client.srem(f"fact:collections:{fid}", collection_id)
+            await self.redis().srem(f"collection:facts:{collection_id}", fid)
+            await self.redis().srem(f"fact:collections:{fid}", collection_id)
             removed_count += 1
 
         return removed_count, not_in_collection
@@ -472,7 +472,7 @@ class CollectionsMixin:
         self, fid: str, include_content: bool
     ) -> Optional[Dict[str, Any]]:
         """Fetch a single fact for collection display (Issue #398: extracted)."""
-        fact_data = await self.aioredis_client.hgetall(f"fact:{fid}")
+        fact_data = await self.redis().hgetall(f"fact:{fid}")
         if not fact_data:
             return None
         decoded = {
@@ -509,7 +509,7 @@ class CollectionsMixin:
                     "message": f"Collection not found: {collection_id}",
                 }
 
-            fact_ids = await self.aioredis_client.smembers(
+            fact_ids = await self.redis().smembers(
                 f"collection:facts:{collection_id}"
             )
             total_count = len(fact_ids)
@@ -561,12 +561,12 @@ class CollectionsMixin:
 
         try:
             # Verify fact exists
-            fact_exists = await self.aioredis_client.exists(f"fact:{fact_id}")
+            fact_exists = await self.redis().exists(f"fact:{fact_id}")
             if not fact_exists:
                 return {"success": False, "message": f"Fact not found: {fact_id}"}
 
             # Get collection IDs
-            collection_ids = await self.aioredis_client.smembers(
+            collection_ids = await self.redis().smembers(
                 f"fact:collections:{fact_id}"
             )
 
@@ -603,7 +603,7 @@ class CollectionsMixin:
         include_metadata: bool,
     ) -> Optional[Dict[str, Any]]:
         """Export a single fact with optional content/metadata (Issue #398: extracted)."""
-        fact_data = await self.aioredis_client.hgetall(f"fact:{fid}")
+        fact_data = await self.redis().hgetall(f"fact:{fid}")
         if not fact_data:
             return None
 
@@ -648,7 +648,7 @@ class CollectionsMixin:
                     "message": f"Collection not found: {collection_id}",
                 }
 
-            fact_ids = await self.aioredis_client.smembers(
+            fact_ids = await self.redis().smembers(
                 f"collection:facts:{collection_id}"
             )
 
@@ -687,7 +687,7 @@ class CollectionsMixin:
                 "message": f"Collection not found: {collection_id}",
             }
 
-        fact_count = await self.aioredis_client.scard(
+        fact_count = await self.redis().scard(
             f"collection:facts:{collection_id}"
         )
         return {
@@ -702,13 +702,13 @@ class CollectionsMixin:
         """Delete a fact and remove from all collections (Issue #398: extracted)."""
         if isinstance(fid, bytes):
             fid = fid.decode("utf-8")
-        collections = await self.aioredis_client.smembers(f"fact:collections:{fid}")
+        collections = await self.redis().smembers(f"fact:collections:{fid}")
         for cid in collections:
             if isinstance(cid, bytes):
                 cid = cid.decode("utf-8")
-            await self.aioredis_client.srem(f"collection:facts:{cid}", fid)
-        await self.aioredis_client.delete(f"fact:{fid}")
-        await self.aioredis_client.delete(f"fact:collections:{fid}")
+            await self.redis().srem(f"collection:facts:{cid}", fid)
+        await self.redis().delete(f"fact:{fid}")
+        await self.redis().delete(f"fact:collections:{fid}")
 
     async def bulk_delete_collection_facts(
         self, collection_id: str, confirm: bool = False
@@ -728,7 +728,7 @@ class CollectionsMixin:
                     "message": f"Collection not found: {collection_id}",
                 }
 
-            fact_ids = await self.aioredis_client.smembers(
+            fact_ids = await self.redis().smembers(
                 f"collection:facts:{collection_id}"
             )
             deleted_count = 0
@@ -736,7 +736,7 @@ class CollectionsMixin:
                 await self._delete_fact_completely(fid)
                 deleted_count += 1
 
-            await self.aioredis_client.hset(
+            await self.redis().hset(
                 f"collection:{collection_id}", "fact_count", 0
             )
             logger.info(
@@ -766,7 +766,7 @@ class CollectionsMixin:
         self, collection_id: str
     ) -> Optional[Dict[str, Any]]:
         """Get collection data from Redis hash."""
-        data = await self.aioredis_client.hgetall(f"collection:{collection_id}")
+        data = await self.redis().hgetall(f"collection:{collection_id}")
         if not data:
             return None
 

--- a/autobot-backend/knowledge/facts.py
+++ b/autobot-backend/knowledge/facts.py
@@ -863,7 +863,7 @@ class FactsMixin:
 
             # Batch fetch facts
             facts = []
-            pipeline = self.aioredis_client.pipeline()
+            pipeline = self.redis().pipeline()
             for key in fact_keys:
                 pipeline.hgetall(key)
             facts_data = await pipeline.execute()
@@ -1206,7 +1206,7 @@ class FactsMixin:
 
         try:
             # Use pipeline for batch fetch
-            pipeline = self.aioredis_client.pipeline()
+            pipeline = self.redis().pipeline()
             for fact_id in fact_ids:
                 pipeline.hgetall("fact:%s" % fact_id)
 

--- a/autobot-backend/knowledge/relations.py
+++ b/autobot-backend/knowledge/relations.py
@@ -63,11 +63,11 @@ class RelationsMixin:
 
     async def _fact_exists(self, fact_id: str) -> bool:
         """Check whether a fact key exists in Redis."""
-        return bool(await self.aioredis_client.exists(f"fact:{fact_id}"))
+        return bool(await self.redis().exists(f"fact:{fact_id}"))
 
     async def _get_fact_content(self, fact_id: str) -> Optional[dict]:
         """Return decoded fact hash or None."""
-        raw = await self.aioredis_client.hgetall(f"fact:{fact_id}")
+        raw = await self.redis().hgetall(f"fact:{fact_id}")
         if not raw:
             return None
         decoded = {}
@@ -130,7 +130,7 @@ class RelationsMixin:
         out_key = self._rel_out_key(source_fact_id)
         in_key = self._rel_in_key(target_fact_id)
 
-        pipe = self.aioredis_client.pipeline()
+        pipe = self.redis().pipeline()
         pipe.rpush(out_key, json.dumps(out_entry))
         pipe.rpush(in_key, json.dumps(in_entry))
         await pipe.execute()
@@ -155,7 +155,7 @@ class RelationsMixin:
         removed = 0
         # Filter outgoing
         out_key = self._rel_out_key(source_fact_id)
-        raw_out = await self.aioredis_client.lrange(out_key, 0, -1)
+        raw_out = await self.redis().lrange(out_key, 0, -1)
         if raw_out:
             kept = []
             for entry_bytes in raw_out:
@@ -166,13 +166,13 @@ class RelationsMixin:
                     removed += 1
                 else:
                     kept.append(entry_bytes)
-            await self.aioredis_client.delete(out_key)
+            await self.redis().delete(out_key)
             if kept:
-                await self.aioredis_client.rpush(out_key, *kept)
+                await self.redis().rpush(out_key, *kept)
 
         # Filter incoming
         in_key = self._rel_in_key(target_fact_id)
-        raw_in = await self.aioredis_client.lrange(in_key, 0, -1)
+        raw_in = await self.redis().lrange(in_key, 0, -1)
         if raw_in:
             kept = []
             for entry_bytes in raw_in:
@@ -183,9 +183,9 @@ class RelationsMixin:
                     pass  # drop
                 else:
                     kept.append(entry_bytes)
-            await self.aioredis_client.delete(in_key)
+            await self.redis().delete(in_key)
             if kept:
-                await self.aioredis_client.rpush(in_key, *kept)
+                await self.redis().rpush(in_key, *kept)
 
         if removed == 0:
             return {
@@ -207,7 +207,7 @@ class RelationsMixin:
         relations: List[Dict[str, Any]] = []
 
         if direction in ("outgoing", "both"):
-            raw = await self.aioredis_client.lrange(self._rel_out_key(fact_id), 0, -1)
+            raw = await self.redis().lrange(self._rel_out_key(fact_id), 0, -1)
             for entry_bytes in raw:
                 entry = json.loads(entry_bytes)
                 if relation_type and entry["type"] != relation_type:
@@ -224,7 +224,7 @@ class RelationsMixin:
                 relations.append(rel)
 
         if direction in ("incoming", "both"):
-            raw = await self.aioredis_client.lrange(self._rel_in_key(fact_id), 0, -1)
+            raw = await self.redis().lrange(self._rel_in_key(fact_id), 0, -1)
             for entry_bytes in raw:
                 entry = json.loads(entry_bytes)
                 if relation_type and entry["type"] != relation_type:
@@ -278,7 +278,7 @@ class RelationsMixin:
             if depth >= max_depth:
                 continue
 
-            raw = await self.aioredis_client.lrange(
+            raw = await self.redis().lrange(
                 self._rel_out_key(current_id), 0, -1
             )
             for entry_bytes in raw:
@@ -366,11 +366,11 @@ class RelationsMixin:
 
         cursor = b"0"
         while True:
-            cursor, keys = await self.aioredis_client.scan(
+            cursor, keys = await self.redis().scan(
                 cursor=cursor, match="kb:rel:out:*", count=200
             )
             for key in keys:
-                raw = await self.aioredis_client.lrange(key, 0, -1)
+                raw = await self.redis().lrange(key, 0, -1)
                 for entry_bytes in raw:
                     entry = json.loads(entry_bytes)
                     total += 1

--- a/autobot-backend/knowledge/stats.py
+++ b/autobot-backend/knowledge/stats.py
@@ -53,7 +53,7 @@ class StatsMixin:
         """Atomically increment a stats counter field."""
         if self.aioredis_client:
             try:
-                await self.aioredis_client.hincrby(self._stats_key, field, amount)
+                await self.redis().hincrby(self._stats_key, field, amount)
                 logger.debug("Incremented %s by %d", field, amount)
             except Exception as e:
                 logger.warning("Failed to increment stat %s: %s", field, e)
@@ -63,7 +63,7 @@ class StatsMixin:
         if self.aioredis_client:
             try:
                 # Use hincrby with negative value for atomic decrement
-                await self.aioredis_client.hincrby(self._stats_key, field, -amount)
+                await self.redis().hincrby(self._stats_key, field, -amount)
                 logger.debug("Decremented %s by %d", field, amount)
             except Exception as e:
                 logger.warning("Failed to decrement stat %s: %s", field, e)
@@ -72,7 +72,7 @@ class StatsMixin:
         """Get a single stats counter value (O(1))."""
         if self.aioredis_client:
             try:
-                value = await self.aioredis_client.hget(self._stats_key, field)
+                value = await self.redis().hget(self._stats_key, field)
                 if value is not None:
                     return int(value)
             except Exception as e:
@@ -91,7 +91,7 @@ class StatsMixin:
         """
         if self.aioredis_client:
             try:
-                stats = await self.aioredis_client.hgetall(self._stats_key)
+                stats = await self.redis().hgetall(self._stats_key)
                 result = {}
                 for k, v in stats.items():
                     key = k.decode() if isinstance(k, bytes) else k
@@ -114,7 +114,7 @@ class StatsMixin:
 
     async def _set_initial_counters(self, fact_count: int, vector_count: int) -> None:
         """Set initial counter values in Redis (Issue #398: extracted)."""
-        await self.aioredis_client.hset(
+        await self.redis().hset(
             self._stats_key,
             mapping={
                 "total_facts": fact_count,
@@ -134,7 +134,7 @@ class StatsMixin:
             return
 
         try:
-            exists = await self.aioredis_client.exists(self._stats_key)
+            exists = await self.redis().exists(self._stats_key)
             if exists:
                 logger.info("Stats counters already initialized")
                 return
@@ -142,7 +142,7 @@ class StatsMixin:
             logger.info("Initializing stats counters from existing data...")
 
             fact_count = 0
-            async for _ in self.aioredis_client.scan_iter(match="fact:*", count=1000):
+            async for _ in self.redis().scan_iter(match="fact:*", count=1000):
                 fact_count += 1
 
             vector_count = 0
@@ -160,7 +160,7 @@ class StatsMixin:
     async def _count_actual_facts(self) -> int:
         """Count actual facts via Redis scan (Issue #398: extracted)."""
         count = 0
-        async for _ in self.aioredis_client.scan_iter(match="fact:*", count=1000):
+        async for _ in self.redis().scan_iter(match="fact:*", count=1000):
             count += 1
         return count
 
@@ -178,7 +178,7 @@ class StatsMixin:
         self, actual_facts: int, actual_vectors: int
     ) -> None:
         """Correct stats counters to actual values (Issue #398: extracted)."""
-        await self.aioredis_client.hset(
+        await self.redis().hset(
             self._stats_key,
             mapping={
                 "total_facts": actual_facts,
@@ -259,7 +259,7 @@ class StatsMixin:
 
         categories = set()
         try:
-            async with self.aioredis_client.pipeline() as pipe:
+            async with self.redis().pipeline() as pipe:
                 for key in fact_keys_sample:
                     await pipe.hget(key, "metadata")
                 all_metadata = await pipe.execute()
@@ -337,7 +337,7 @@ class StatsMixin:
         """Sample fact keys for category extraction (Issue #315)."""
         fact_keys = []
         try:
-            async for key in self.aioredis_client.scan_iter(
+            async for key in self.redis().scan_iter(
                 match="fact:*", count=limit
             ):
                 fact_keys.append(key)
@@ -350,7 +350,7 @@ class StatsMixin:
     async def _get_redis_memory_size(self) -> int:
         """Get Redis memory usage (Issue #315)."""
         try:
-            info = await self.aioredis_client.info("memory")
+            info = await self.redis().info("memory")
             return info.get("used_memory", 0)
         except Exception as e:
             logger.debug("Could not get Redis memory info: %s", e)
@@ -474,7 +474,7 @@ class StatsMixin:
         timestamps = []
         for fact_key in fact_keys:
             try:
-                fact_data = await self.aioredis_client.hgetall(fact_key)
+                fact_data = await self.redis().hgetall(fact_key)
                 if fact_data and "timestamp" in fact_data:
                     timestamps.append(fact_data["timestamp"])
             except Exception:  # nosec B112


### PR DESCRIPTION
Part of #5225 (umbrella stays open for Phase 4+).

## Summary

Phase 3 of the `KB.redis()` migration: routes all internal KB-mixin method calls through the public accessor. 105 of 108 candidate sites migrated across 6 files; 3 sites in `knowledge/base.py` explicitly skipped because they live on the bootstrap/shutdown lifecycle path.

## Files touched

| File | Sites migrated |
|---|---|
| `knowledge/categories.py` | 39/39 |
| `knowledge/collections.py` | 33/33 |
| `knowledge/relations.py` | 14/14 |
| `knowledge/stats.py` | 13/13 |
| `knowledge/facts.py` | 2/2 |
| `knowledge/base.py` | 4/7 |

### base.py skips (3 sites)

- L349 `_init_redis_and_vector_store` \u2014 bootstrap: attribute is being assigned at L341 immediately above; `self.redis()` would raise because the accessor guards against pre-init
- L481 `_cleanup_on_failure` \u2014 shutdown: next line sets `self.aioredis_client = None`; direct access keeps lifecycle contract clear
- L639 `close()` \u2014 same shutdown reasoning as L481

## Option A preserved

Per the task brief: `if not self.aioredis_client:` null-guards were preserved verbatim (36 guards total, count unchanged). Only the hot-path method-call sites changed. This avoids changing the non-raising contract that `redis()` would have introduced.

## Verification

- [x] `python -m py_compile` passes on all 6 files
- [x] 188 tests pass (`tests/test_knowledge_boards.py`, `knowledge/knowledge_base_async_test.py`, `tests/knowledge/`, `api/knowledge_vectorization_test.py`)
- [x] 6 pre-existing failures verified unrelated (`llama_index.core` import missing, unrelated mock assertion) \u2014 reproduced on clean Dev_new_gui
- [x] Null-guard count invariant: 36 before = 36 after
- [x] Guardrail grep: only 10 remaining \u2014 7 in `knowledge_base.integration_test.py` (deferred to rename phase per umbrella) + 3 documented base.py skips
- [ ] `gh pr checks` passes

## Diff

Pure mechanical rename: +105 / -105.

## Part of umbrella

After this PR merges, the #5225 running total:

- PR #5252 (Phase 1, api/): 21 sites
- PR #5261 (catch-up): 5 sites
- PR #5262 (Phase 3 overlap but different area): unrelated cleanup
- This PR (Phase 3, knowledge/): 105 sites

Total migrated so far: **131 of ~159**. Remaining ~28 sites are in test fixtures (deferred to the final rename phase) and bootstrap paths (intentional skips here).