### PR TITLE
test(knowledge_audit): fix 3 tests that bypass FastAPI injection (#5254)

### DIFF
--- a/autobot-backend/api/knowledge_audit_test.py
+++ b/autobot-backend/api/knowledge_audit_test.py
@@ -59,6 +59,8 @@ def _make_kb(audit_log=None):
 @pytest.mark.asyncio
 async def test_org_audit_log_admin_allowed():
     """Admin role can access org audit log."""
+    from autobot_shared.models.pagination import PaginationParams
+
     from api.knowledge_audit import get_organization_audit_log
 
     user = {"user_id": "u1", "org_id": "org1", "role": "admin"}
@@ -69,7 +71,9 @@ async def test_org_audit_log_admin_allowed():
         new=AsyncMock(return_value=kb),
     ):
         result = await get_organization_audit_log(
-            request=_make_request(kb), current_user=user
+            request=_make_request(kb),
+            current_user=user,
+            pagination=PaginationParams(limit=50, offset=0),
         )
 
     assert result["organization_id"] == "org1"
@@ -79,6 +83,8 @@ async def test_org_audit_log_admin_allowed():
 @pytest.mark.asyncio
 async def test_org_audit_log_org_admin_allowed():
     """org_admin role can access org audit log."""
+    from autobot_shared.models.pagination import PaginationParams
+
     from api.knowledge_audit import get_organization_audit_log
 
     user = {"user_id": "u2", "org_id": "org1", "role": "org_admin"}
@@ -89,7 +95,9 @@ async def test_org_audit_log_org_admin_allowed():
         new=AsyncMock(return_value=kb),
     ):
         result = await get_organization_audit_log(
-            request=_make_request(kb), current_user=user
+            request=_make_request(kb),
+            current_user=user,
+            pagination=PaginationParams(limit=50, offset=0),
         )
 
     assert result["organization_id"] == "org1"
@@ -215,7 +223,7 @@ async def test_compliance_summary_org_admin_allowed():
         new=AsyncMock(return_value=kb),
     ):
         result = await get_compliance_summary(
-            request=_make_request(kb), current_user=user
+            request=_make_request(kb), current_user=user, days=30
         )
 
     assert "summary_period_days" in result


### PR DESCRIPTION
Closes #5254

## Summary

Three tests in `autobot-backend/api/knowledge_audit_test.py` failed because they invoked FastAPI endpoint coroutines directly, so `Depends(...)` and `Query(...)` defaults arrived as sentinels instead of resolved values:

```
TypeError: unsupported type for timedelta days component: Query
AttributeError: 'Depends' object has no attribute 'limit'
```

## Fix: Option 2 (explicit values)

Chose to pass explicit values over the TestClient approach because **every other passing test in this file uses the direct-call pattern** — no `TestClient` import, no `client` fixture, `_make_request` builds a `MagicMock`. Switching to `TestClient` would make these 3 tests inconsistent with the other 6 and would require mocking `auth_middleware.get_current_user`, app state, and knowledge-base lookup at the app layer. Minimal surface-area fix matches the file's conventions.

### Fix details

- `test_org_audit_log_admin_allowed` \u2014 added `pagination=PaginationParams(limit=50, offset=0)` kwarg
- `test_org_audit_log_org_admin_allowed` \u2014 same
- `test_compliance_summary_org_admin_allowed` \u2014 added `days=30` kwarg
- Added `from autobot_shared.models.pagination import PaginationParams` at top of file

## Test plan

- [x] Before: 3 failing tests reproduced
- [x] After: 9/9 file tests pass
- [x] No regression in other tests in the file
- [ ] `gh pr checks` passes