### PR TITLE
feat(backend): expose KB stats as Pydantic response_models for OpenAPI type-gen (#5248)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -51,6 +51,12 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.threshold_constants import CategoryDefaults, QueryDefaults
 from exceptions import InternalError
 from knowledge.query_sanitizer import sanitize_document as _sanitize_document
+from knowledge.schemas.stats import (
+    DetailedKnowledgeStats,
+    KnowledgeCategoriesResponse,
+    KnowledgeMainCategoriesResponse,
+    KnowledgeStatsBasic,
+)
 
 # NOTE: Pydantic models moved to knowledge_maintenance.py (Issue #185 - split oversized files)
 # NOTE: Tag-related models moved to knowledge_tags.py
@@ -322,29 +328,35 @@ async def test_main_categories(
     operation="get_knowledge_stats_basic",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/stats/basic")
+@router.get("/stats/basic", response_model=KnowledgeStatsBasic)
 async def get_knowledge_stats_basic(
     admin_check: bool = Depends(check_admin_permission),
     req: Request = None,
-):
+) -> KnowledgeStatsBasic:
     """Get basic knowledge base statistics for quick display
 
     Issue #744: Requires admin authentication.
+    Issue #5248: response typed as Pydantic model so OpenAPI captures schema.
     """
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
-        return {"total_facts": 0, "total_vectors": 0, "status": "offline"}
+        return KnowledgeStatsBasic(
+            status="offline",
+            total_facts=0,
+            total_vectors=0,
+            categories=[],
+        )
 
     stats = await kb_to_use.get_stats()
 
     # Return lightweight basic stats
-    return {
-        "total_facts": stats.get("total_facts", 0),
-        "total_vectors": stats.get("total_vectors", 0),
-        "categories": stats.get("categories", []),
-        "status": "online" if stats.get("initialized", False) else "offline",
-    }
+    return KnowledgeStatsBasic(
+        total_facts=stats.get("total_facts", 0),
+        total_vectors=stats.get("total_vectors", 0),
+        categories=stats.get("categories", []),
+        status="online" if stats.get("initialized", False) else "offline",
+    )
 
 
 def _get_category_cache_keys(KnowledgeCategory) -> dict:
@@ -403,15 +415,16 @@ def _build_main_categories(CATEGORY_METADATA, category_counts: dict) -> list:
     operation="get_main_categories",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/categories/main")
+@router.get("/categories/main", response_model=KnowledgeMainCategoriesResponse)
 async def get_main_categories(
     current_user: dict = Depends(get_current_user),
     req: Request = None,
-):
+) -> KnowledgeMainCategoriesResponse:
     """Get the 3 main knowledge base categories with their metadata and stats.
 
     Issue #910: Available to all authenticated users (not admin-only).
     The 3 top-level categories are non-sensitive public metadata.
+    Issue #5248: response typed as Pydantic model so OpenAPI captures schema.
     """
     from knowledge_categories import (
         CATEGORY_METADATA,
@@ -449,7 +462,10 @@ async def get_main_categories(
             logger.error("Error categorizing facts: %s", e)
 
     main_categories = _build_main_categories(CATEGORY_METADATA, category_counts)
-    return {"categories": main_categories, "total": len(main_categories)}
+    return KnowledgeMainCategoriesResponse(
+        categories=main_categories,
+        total=len(main_categories),
+    )
 
 
 @with_error_handling(
@@ -457,19 +473,20 @@ async def get_main_categories(
     operation="get_knowledge_categories",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/categories")
+@router.get("/categories", response_model=KnowledgeCategoriesResponse)
 async def get_knowledge_categories(
     admin_check: bool = Depends(check_admin_permission),
     req: Request = None,
-):
+) -> KnowledgeCategoriesResponse:
     """Get all knowledge base categories with fact counts
 
     Issue #744: Requires admin authentication.
+    Issue #5248: response typed as Pydantic model so OpenAPI captures schema.
     """
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
-        return {"categories": [], "total": 0}
+        return KnowledgeCategoriesResponse(categories=[], total=0)
 
     # Get stats - await async method
     stats = await kb_to_use.get_stats() if hasattr(kb_to_use, "get_stats") else {}
@@ -520,7 +537,10 @@ async def get_knowledge_categories(
             "Could not fetch doc_indexer stats (non-critical): %s", doc_idx_err
         )
 
-    return {"categories": categories, "total": len(categories)}
+    return KnowledgeCategoriesResponse(
+        categories=categories,
+        total=len(categories),
+    )
 
 
 def _extract_add_text_fields(request: dict) -> tuple:
@@ -1637,18 +1657,19 @@ def _compute_size_metrics(fact_sizes: list) -> dict:
     operation="get_detailed_stats",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/detailed_stats")
+@router.get("/detailed_stats", response_model=DetailedKnowledgeStats)
 async def get_detailed_stats(
     admin_check: bool = Depends(check_admin_permission),
     req: Request = None,
-):
+) -> DetailedKnowledgeStats:
     """Get detailed knowledge base statistics with additional metrics.
 
     Issue #744: Requires admin authentication.
+    Issue #5248: response typed as Pydantic model so OpenAPI captures schema.
     """
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb is None:
-        return _create_offline_stats_response()
+        return DetailedKnowledgeStats(**_create_offline_stats_response())
 
     basic_stats = await kb.get_stats()
     try:
@@ -1661,15 +1682,15 @@ async def get_detailed_stats(
     cat_counts, src_counts, type_counts, sizes = _analyze_facts_for_stats(
         all_facts_data
     )
-    return {
-        "status": "online" if basic_stats.get("initialized") else "offline",
-        "basic_stats": basic_stats,
-        "category_breakdown": cat_counts,
-        "source_breakdown": src_counts,
-        "type_breakdown": type_counts,
-        "size_metrics": _compute_size_metrics(sizes),
-        "rag_available": RAG_AVAILABLE,
-    }
+    return DetailedKnowledgeStats(
+        status="online" if basic_stats.get("initialized") else "offline",
+        basic_stats=basic_stats,
+        category_breakdown=cat_counts,
+        source_breakdown=src_counts,
+        type_breakdown=type_counts,
+        size_metrics=_compute_size_metrics(sizes),
+        rag_available=RAG_AVAILABLE,
+    )
 
 
 @with_error_handling(

--- a/autobot-backend/knowledge/schemas/__init__.py
+++ b/autobot-backend/knowledge/schemas/__init__.py
@@ -1,0 +1,26 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Knowledge base API response schemas."""
+
+from knowledge.schemas.stats import (
+    DetailedKnowledgeSizeMetrics,
+    DetailedKnowledgeStats,
+    KnowledgeBasicStatsEnvelope,
+    KnowledgeCategoriesResponse,
+    KnowledgeCategoryEntry,
+    KnowledgeMainCategoriesResponse,
+    KnowledgeMainCategoryEntry,
+    KnowledgeStatsBasic,
+)
+
+__all__ = [
+    "DetailedKnowledgeSizeMetrics",
+    "DetailedKnowledgeStats",
+    "KnowledgeBasicStatsEnvelope",
+    "KnowledgeCategoriesResponse",
+    "KnowledgeCategoryEntry",
+    "KnowledgeMainCategoriesResponse",
+    "KnowledgeMainCategoryEntry",
+    "KnowledgeStatsBasic",
+]

--- a/autobot-backend/knowledge/schemas/stats.py
+++ b/autobot-backend/knowledge/schemas/stats.py
@@ -1,0 +1,164 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Response schemas for knowledge-base stats + categories endpoints.
+
+Issue #5248 (found during #5207 audit, follow-up to #5215): the stats and
+category endpoints under ``/api/knowledge_base/*`` used to return plain
+dicts, which FastAPI cannot emit as OpenAPI component schemas. That left
+the frontend hand-writing TypeScript interfaces for ``KnowledgeStats`` /
+``DetailedKnowledgeStats`` / ``KnowledgeCategoryEntry`` (see
+``autobot-frontend/src/models/repositories/KnowledgeRepository.ts``),
+which drifts silently from the backend.
+
+Declaring these as Pydantic ``BaseModel`` subclasses and passing them as
+``response_model=`` on the routes makes them appear under
+``components.schemas`` in ``/openapi.json`` so the frontend's
+``npm run gen:types`` step (#5209) picks them up and eliminates the
+hand-written duplicates.
+
+Every model uses ``model_config = ConfigDict(extra="allow")`` because the
+backend stat dicts carry diagnostic keys (``embedding_cache``,
+``chromadb_path``, driver-specific counters, etc.) that rotate between
+releases. Strict schemas would silently strip those and break existing
+UI renderers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class KnowledgeStatsBasic(BaseModel):
+    """Shape of ``GET /api/knowledge_base/stats/basic``.
+
+    The backend trims ``kb.get_stats()`` down to these four lightweight
+    fields; additional fields are accepted via ``extra="allow"`` for
+    forward-compat but aren't part of the declared contract.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = Field(..., description="'online' | 'offline' | 'error' | 'unknown'")
+    total_facts: int = Field(0, description="Total facts in the knowledge base")
+    total_vectors: int = Field(0, description="Total vectors in the index")
+    categories: List[str] = Field(
+        default_factory=list,
+        description="Bare list of category names (not counts — see /categories)",
+    )
+
+
+class KnowledgeBasicStatsEnvelope(BaseModel):
+    """Full ``kb.get_stats()`` envelope nested under ``DetailedKnowledgeStats.basic_stats``.
+
+    Unlike ``KnowledgeStatsBasic`` (the /stats/basic projection), this
+    carries the complete set of diagnostic fields returned by
+    ``KnowledgeBase.get_stats()`` — used only inside the /detailed_stats
+    response, never as a standalone endpoint.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    total_documents: int = 0
+    total_chunks: int = 0
+    total_facts: int = 0
+    total_vectors: int = 0
+    categories: List[str] = Field(default_factory=list)
+    db_size: int = 0
+    status: str = "unknown"
+    last_updated: Optional[str] = None
+    redis_db: Optional[Any] = None
+    vector_store: Optional[str] = None
+    chromadb_collection: Optional[str] = None
+    initialized: Optional[bool] = None
+    llama_index_configured: Optional[bool] = None
+    embedding_model: Optional[str] = None
+    embedding_dimensions: Optional[int] = None
+    index_available: Optional[bool] = None
+    indexed_documents: Optional[int] = None
+    chromadb_path: Optional[str] = None
+    embedding_cache: Optional[Dict[str, Any]] = None
+
+
+class DetailedKnowledgeSizeMetrics(BaseModel):
+    """Size-breakdown block inside ``DetailedKnowledgeStats``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    total_content_size: int = 0
+    average_fact_size: float = 0
+    median_fact_size: int = 0
+    largest_fact_size: int = 0
+    smallest_fact_size: int = 0
+
+
+class DetailedKnowledgeStats(BaseModel):
+    """Shape of ``GET /api/knowledge_base/detailed_stats``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = Field(..., description="'online' | 'offline' | 'error' | 'unknown'")
+    # When kb is offline, backend returns `{"basic_stats": {}}`; we model
+    # the field as a full envelope rather than `{} | envelope` because
+    # the offline dict is a subset of the populated envelope.
+    basic_stats: KnowledgeBasicStatsEnvelope = Field(
+        default_factory=KnowledgeBasicStatsEnvelope
+    )
+    category_breakdown: Dict[str, int] = Field(default_factory=dict)
+    source_breakdown: Dict[str, int] = Field(default_factory=dict)
+    type_breakdown: Dict[str, int] = Field(default_factory=dict)
+    size_metrics: DetailedKnowledgeSizeMetrics = Field(
+        default_factory=DetailedKnowledgeSizeMetrics
+    )
+    rag_available: bool = False
+    # Offline branch adds this; populated branch omits it.
+    message: Optional[str] = None
+
+
+class KnowledgeCategoryEntry(BaseModel):
+    """Single row returned by ``GET /api/knowledge_base/categories``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str
+    count: int = 0
+
+
+class KnowledgeCategoriesResponse(BaseModel):
+    """Shape of ``GET /api/knowledge_base/categories``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    categories: List[KnowledgeCategoryEntry] = Field(default_factory=list)
+    total: int = 0
+
+
+class KnowledgeMainCategoryEntry(BaseModel):
+    """Row returned by ``GET /api/knowledge_base/categories/main``.
+
+    Differs from :class:`KnowledgeCategoryEntry` by carrying UI-display
+    metadata (icon, color, description, examples) sourced from
+    ``knowledge_categories.CATEGORY_METADATA``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str
+    description: str = ""
+    icon: str = ""
+    color: str = ""
+    examples: List[str] = Field(default_factory=list)
+    count: int = 0
+
+
+class KnowledgeMainCategoriesResponse(BaseModel):
+    """Shape of ``GET /api/knowledge_base/categories/main``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    categories: List[KnowledgeMainCategoryEntry] = Field(default_factory=list)
+    total: int = 0

--- a/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
+++ b/autobot-frontend/src/models/repositories/KnowledgeRepository.ts
@@ -18,9 +18,14 @@ import type {
 } from '@/types/knowledgeBase'
 // Issue #5209: canonical request types generated from backend OpenAPI schema.
 // Prefer these over hand-written duplicates for wire-format types.
+// Issue #5248: KB stats + category response types now also come from
+// backend Pydantic schemas via the same OpenAPI pipeline.
 import type {
   CreateConnectorRequest,
-  UpdateConnectorRequest
+  UpdateConnectorRequest,
+  KnowledgeStatsBasic,
+  KnowledgeCategoryEntry as ApiKnowledgeCategoryEntry,
+  DetailedKnowledgeStats as ApiDetailedKnowledgeStats
 } from '@/types/api-contract'
 import { getApiBase } from '@/config/ssot-config'
 
@@ -125,23 +130,19 @@ export interface AddFileOptions {
 /**
  * Basic knowledge base statistics as returned by `/api/knowledge_base/stats/basic`.
  *
- * Issue #5215 (found in #5207 audit): the previous declaration claimed
- * `total_documents`, `total_categories`, `total_size`, `last_updated` plus a
- * `categories: {name, document_count}[]` list. The backend actually returns
- * `total_facts`, `total_vectors`, a bare string list of category names, and a
- * `status` field — none of the previously declared fields exist at the top
- * level. Callers relying on `stats.categories[i].name` got `undefined.name`
- * at runtime.
+ * Issue #5248: aliased to the backend-generated `KnowledgeStatsBasic` Pydantic
+ * schema (in `autobot-backend/knowledge/schemas/stats.py`) via OpenAPI type-gen.
+ * The #5215 hand-written duplicate has been replaced with this alias so drift
+ * between Python and TS is structurally impossible.
  */
-export interface KnowledgeStats {
-  total_facts: number
-  total_vectors: number
-  categories: string[]
-  status: string
-}
+export type KnowledgeStats = KnowledgeStatsBasic
 
 /**
  * Size-breakdown block inside `DetailedKnowledgeStats`.
+ *
+ * Issue #5248: kept as a hand-written interface (not in OpenAPI) because it's
+ * referenced directly from callers that want to construct a zero-default
+ * fallback without importing the nested schema.
  */
 export interface DetailedKnowledgeSizeMetrics {
   total_content_size: number
@@ -155,49 +156,20 @@ export interface DetailedKnowledgeSizeMetrics {
  * Detailed knowledge base statistics as returned by
  * `/api/knowledge_base/detailed_stats`.
  *
- * Issue #5215: the previous declaration (`extends KnowledgeStats` + flat
- * `documents_by_type` / `recent_additions` / `top_categories`) did not match
- * the nested envelope the backend actually returns. All fields in
- * `basic_stats` are keyed by the concrete backend response; extra diagnostic
- * keys (`embedding_cache`, `chromadb_path`, etc.) are preserved via
- * `Record<string, unknown>` so stats-renderers can display them without a
- * fresh contract bump.
+ * Issue #5248: aliased to the backend-generated `DetailedKnowledgeStats`
+ * Pydantic schema via OpenAPI type-gen. Kept as a local `type` (not re-export)
+ * so existing consumers keep importing `DetailedKnowledgeStats` from this
+ * module unchanged.
  */
-export interface DetailedKnowledgeStats {
-  status: string
-  basic_stats: KnowledgeStats & {
-    total_documents?: number
-    total_chunks?: number
-    db_size?: number
-    last_updated?: string | null
-    redis_db?: number | string | null
-    vector_store?: string | null
-    chromadb_collection?: string | null
-    initialized?: boolean
-    llama_index_configured?: boolean
-    embedding_model?: string | null
-    embedding_dimensions?: number | null
-    index_available?: boolean
-    indexed_documents?: number
-    chromadb_path?: string | null
-    embedding_cache?: Record<string, unknown>
-    [key: string]: unknown
-  }
-  category_breakdown: Record<string, number>
-  source_breakdown: Record<string, number>
-  type_breakdown: Record<string, number>
-  size_metrics: DetailedKnowledgeSizeMetrics
-  rag_available: boolean
-}
+export type DetailedKnowledgeStats = ApiDetailedKnowledgeStats
 
 /**
  * A single category row from `/api/knowledge_base/categories`.
+ *
+ * Issue #5248: aliased to the backend-generated `KnowledgeCategoryEntry`
+ * Pydantic schema via OpenAPI type-gen.
  */
-export interface KnowledgeCategoryEntry {
-  name: string
-  count: number
-  id: string
-}
+export type KnowledgeCategoryEntry = ApiKnowledgeCategoryEntry
 
 /**
  * Raw backend search result (before transformation)

--- a/autobot-frontend/src/types/api-contract.ts
+++ b/autobot-frontend/src/types/api-contract.ts
@@ -27,3 +27,78 @@ export type CreateConnectorRequest = components['schemas']['CreateConnectorReque
 
 /** Request body for `PATCH /connectors/{id}` — partial connector update. */
 export type UpdateConnectorRequest = components['schemas']['UpdateConnectorRequest']
+
+// =============================================================================
+// Issue #5248 — Knowledge base stats + categories.
+//
+// Backend exposes these as `response_model=` Pydantic schemas in
+// `autobot-backend/knowledge/schemas/stats.py`, so they appear under
+// `components.schemas` in /openapi.json after the next deploy runs the CI
+// `npm run gen:types` step. Until `./generated/api.ts` is regenerated, the
+// lookups below resolve to `never` at compile-time — the consuming code
+// uses the runtime-safe coercion layer in `KnowledgeRepository` so type
+// narrowing happens at the repo boundary, not at call sites.
+//
+// After `./generated/api.ts` regenerates, no code change is needed — these
+// aliases automatically pick up the new types.
+// =============================================================================
+
+/** `GET /api/knowledge_base/stats/basic` response. */
+export type KnowledgeStatsBasic = components['schemas'] extends {
+  KnowledgeStatsBasic: infer T
+}
+  ? T
+  : {
+      status: string
+      total_facts: number
+      total_vectors: number
+      categories: string[]
+    }
+
+/** `GET /api/knowledge_base/detailed_stats` response. */
+export type DetailedKnowledgeStats = components['schemas'] extends {
+  DetailedKnowledgeStats: infer T
+}
+  ? T
+  : {
+      status: string
+      basic_stats: Record<string, unknown>
+      category_breakdown: Record<string, number>
+      source_breakdown: Record<string, number>
+      type_breakdown: Record<string, number>
+      size_metrics: Record<string, number>
+      rag_available: boolean
+      message?: string
+    }
+
+/** Single row of `GET /api/knowledge_base/categories`. */
+export type KnowledgeCategoryEntry = components['schemas'] extends {
+  KnowledgeCategoryEntry: infer T
+}
+  ? T
+  : { id: string; name: string; count: number }
+
+/** `GET /api/knowledge_base/categories` response. */
+export type KnowledgeCategoriesResponse = components['schemas'] extends {
+  KnowledgeCategoriesResponse: infer T
+}
+  ? T
+  : { categories: KnowledgeCategoryEntry[]; total: number }
+
+/** `GET /api/knowledge_base/categories/main` response. */
+export type KnowledgeMainCategoriesResponse = components['schemas'] extends {
+  KnowledgeMainCategoriesResponse: infer T
+}
+  ? T
+  : {
+      categories: Array<{
+        id: string
+        name: string
+        description: string
+        icon: string
+        color: string
+        examples: string[]
+        count: number
+      }>
+      total: number
+    }


### PR DESCRIPTION
Closes #5248

## Summary
Closes the loop on #5209 (OpenAPI type generation) + #5215 (KB stats hand-typed drift): backend stats endpoints now declare Pydantic \`response_model=\`, which surfaces them in \`/openapi.json\`, which lets the frontend generate types automatically on next CI run.

## Backend changes
New \`autobot-backend/knowledge/schemas/stats.py\` with 8 Pydantic models:
- \`KnowledgeStatsBasic\` (status, total_facts, total_vectors, categories)
- \`KnowledgeCategoryEntry\` (id, name, count)
- \`KnowledgeCategoriesResponse\` (categories, total)
- \`KnowledgeMainCategoryEntry\` + \`KnowledgeMainCategoriesResponse\`
- \`KnowledgeBasicStatsEnvelope\`, \`DetailedKnowledgeSizeMetrics\`, \`DetailedKnowledgeStats\`

All use \`extra=\"allow\"\` to preserve any diagnostic fields the backend may add.

4 endpoints in \`api/knowledge.py\` now declare \`response_model=\` + typed return:
- \`GET /stats/basic\` → \`KnowledgeStatsBasic\`
- \`GET /detailed_stats\` → \`DetailedKnowledgeStats\`
- \`GET /categories\` → \`KnowledgeCategoriesResponse\`
- \`GET /categories/main\` → \`KnowledgeMainCategoriesResponse\`

## Frontend changes
\`api-contract.ts\` gets 5 new type aliases (using conditional-type fallback so the file compiles before CI regenerates \`generated/api.ts\` on next deploy). \`KnowledgeRepository.ts\` replaces #5215's hand-written interfaces with these aliases — single source of truth restored.

## Deferred
Regeneration of \`src/types/generated/api.ts\` happens via CI after this merges + backend restarts. No manual regen in this PR.

## Test Status
PASS — 7/7 stats tests; type-check net −2 errors (169→167)