### PR TITLE
feat(composables): extract useFakeProgress + migrate KnowledgeAdvanced sites (#5237)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeAdvanced.vue
@@ -170,13 +170,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useKnowledgeStore } from '@/stores/useKnowledgeStore'
 import ApiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import BaseButton from '@/components/base/BaseButton.vue'
 import { createLogger } from '@/utils/debugUtils'
+import { useFakeProgress } from '@/composables/useFakeProgress'
 
 const logger = createLogger('KnowledgeAdvanced')
 const { t } = useI18n()
@@ -209,9 +210,37 @@ const statusMessages = ref<Array<{
   timestamp: number
 }>>([])
 
-// Progress tracking
-let progressInterval: number | null = null
+// Progress tracking — fake-progress counter drives itemsProcessed
+// (#5237: extracted from manual setInterval simulating backend progress)
+const fakeProgress = useFakeProgress({ intervalMs: 100, step: 1 })
 const startTime = ref(0)
+
+// Mirror fake-progress counter into itemsProcessed and derive percentage + ETA
+watch(fakeProgress.progress, (value) => {
+  const total = totalItems.value
+  itemsProcessed.value = value
+  if (total <= 0) {
+    progressPercentage.value = 0
+    estimatedTimeRemaining.value = ''
+    return
+  }
+  progressPercentage.value = Math.round((value / total) * 100)
+
+  const elapsed = Date.now() - startTime.value
+  if (value <= 0 || elapsed <= 0) {
+    estimatedTimeRemaining.value = ''
+    return
+  }
+  const rate = value / elapsed
+  const remaining = (total - value) / rate
+  if (remaining > 60000) {
+    estimatedTimeRemaining.value = `${Math.ceil(remaining / 60000)}m`
+  } else if (remaining > 1000) {
+    estimatedTimeRemaining.value = `${Math.ceil(remaining / 1000)}s`
+  } else {
+    estimatedTimeRemaining.value = '<1s'
+  }
+})
 
 // Computed
 const progressText = computed(() => {
@@ -270,41 +299,17 @@ const startProgress = (operation: string, total: number) => {
   itemsProcessed.value = 0
   progressPercentage.value = 0
   startTime.value = Date.now()
-
-  // Simulate progress updates (in real implementation, this would be driven by actual progress)
-  progressInterval = setInterval(() => {
-    if (itemsProcessed.value < totalItems.value) {
-      itemsProcessed.value++
-      progressPercentage.value = Math.round((itemsProcessed.value / totalItems.value) * 100)
-
-      // Calculate ETA
-      const elapsed = Date.now() - startTime.value
-      const rate = itemsProcessed.value / elapsed
-      const remaining = (totalItems.value - itemsProcessed.value) / rate
-
-      if (remaining > 60000) {
-        estimatedTimeRemaining.value = `${Math.ceil(remaining / 60000)}m`
-      } else if (remaining > 1000) {
-        estimatedTimeRemaining.value = `${Math.ceil(remaining / 1000)}s`
-      } else {
-        estimatedTimeRemaining.value = '<1s'
-      }
-    }
-  }, 100)
+  fakeProgress.start({ target: total })
 }
 
 const stopProgress = () => {
+  fakeProgress.reset()
   showProgress.value = false
   currentOperation.value = ''
   progressPercentage.value = 0
   itemsProcessed.value = 0
   totalItems.value = 0
   estimatedTimeRemaining.value = ''
-
-  if (progressInterval) {
-    clearInterval(progressInterval)
-    progressInterval = null
-  }
 }
 
 const populateSystemCommands = async () => {
@@ -473,13 +478,6 @@ const clearAllKnowledge = async () => {
     stopProgress()
   }
 }
-
-// Cleanup on unmount
-onUnmounted(() => {
-  if (progressInterval) {
-    clearInterval(progressInterval)
-  }
-})
 
 // Initial load
 onMounted(() => {

--- a/autobot-frontend/src/composables/__tests__/useFakeProgress.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useFakeProgress.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for useFakeProgress (#5237)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { effectScope } from 'vue'
+
+import { useFakeProgress } from '../useFakeProgress'
+
+describe('useFakeProgress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('starts in idle state with progress=0 and isRunning=false', () => {
+    const { progress, isRunning } = useFakeProgress()
+    expect(progress.value).toBe(0)
+    expect(isRunning.value).toBe(false)
+  })
+
+  it('start() sets isRunning=true and progress ticks up by step', () => {
+    const { start, progress, isRunning } = useFakeProgress({
+      target: 100,
+      intervalMs: 50,
+      step: 1
+    })
+
+    start()
+    expect(isRunning.value).toBe(true)
+    expect(progress.value).toBe(0)
+
+    vi.advanceTimersByTime(50)
+    expect(progress.value).toBe(1)
+
+    vi.advanceTimersByTime(50)
+    expect(progress.value).toBe(2)
+
+    vi.advanceTimersByTime(50 * 3)
+    expect(progress.value).toBe(5)
+  })
+
+  it('progress caps at cap and never exceeds it via ticking', () => {
+    const { start, progress } = useFakeProgress({
+      target: 10,
+      intervalMs: 10,
+      step: 1,
+      cap: 4
+    })
+
+    start()
+    // Advance enough ticks to exceed cap many times over
+    vi.advanceTimersByTime(10 * 50)
+    expect(progress.value).toBe(4)
+  })
+
+  it('cap defaults to target - 1', () => {
+    const { start, progress } = useFakeProgress({
+      target: 5,
+      intervalMs: 10,
+      step: 1
+    })
+
+    start()
+    vi.advanceTimersByTime(10 * 100)
+    expect(progress.value).toBe(4) // target - 1
+  })
+
+  it('finish() sets progress=target and isRunning=false', () => {
+    const { start, finish, progress, isRunning } = useFakeProgress({
+      target: 50,
+      intervalMs: 100
+    })
+
+    start()
+    vi.advanceTimersByTime(300) // progress around 3
+    expect(isRunning.value).toBe(true)
+
+    finish()
+    expect(progress.value).toBe(50)
+    expect(isRunning.value).toBe(false)
+
+    // No more ticking after finish
+    vi.advanceTimersByTime(1000)
+    expect(progress.value).toBe(50)
+  })
+
+  it('stop() halts at current value without completing', () => {
+    const { start, stop, progress, isRunning } = useFakeProgress({
+      target: 100,
+      intervalMs: 10,
+      step: 1
+    })
+
+    start()
+    vi.advanceTimersByTime(50) // progress=5
+    expect(progress.value).toBe(5)
+
+    stop()
+    expect(isRunning.value).toBe(false)
+    expect(progress.value).toBe(5) // held, not zeroed
+
+    vi.advanceTimersByTime(1000)
+    expect(progress.value).toBe(5)
+  })
+
+  it('reset() zeroes progress and halts', () => {
+    const { start, reset, progress, isRunning } = useFakeProgress({
+      target: 100,
+      intervalMs: 10,
+      step: 1
+    })
+
+    start()
+    vi.advanceTimersByTime(70)
+    expect(progress.value).toBe(7)
+
+    reset()
+    expect(progress.value).toBe(0)
+    expect(isRunning.value).toBe(false)
+
+    vi.advanceTimersByTime(1000)
+    expect(progress.value).toBe(0)
+  })
+
+  it('respects custom target, intervalMs, step, and cap', () => {
+    const { start, progress } = useFakeProgress({
+      target: 200,
+      intervalMs: 25,
+      step: 10,
+      cap: 150
+    })
+
+    start()
+    vi.advanceTimersByTime(25)
+    expect(progress.value).toBe(10)
+
+    vi.advanceTimersByTime(25 * 20)
+    expect(progress.value).toBe(150) // capped
+
+    vi.advanceTimersByTime(25 * 5)
+    expect(progress.value).toBe(150) // stays capped
+  })
+
+  it('start() after start() resets to 0 and restarts', () => {
+    const { start, progress } = useFakeProgress({
+      target: 100,
+      intervalMs: 10,
+      step: 1
+    })
+
+    start()
+    vi.advanceTimersByTime(50)
+    expect(progress.value).toBe(5)
+
+    // Restart mid-way
+    start()
+    expect(progress.value).toBe(0)
+
+    vi.advanceTimersByTime(20)
+    expect(progress.value).toBe(2)
+  })
+
+  it('Math.min guards step overshoot above cap', () => {
+    // step > (cap - progress) near the end should not overshoot
+    const { start, progress } = useFakeProgress({
+      target: 10,
+      intervalMs: 10,
+      step: 7,
+      cap: 10
+    })
+
+    start()
+    vi.advanceTimersByTime(10)
+    expect(progress.value).toBe(7)
+
+    vi.advanceTimersByTime(10)
+    expect(progress.value).toBe(10) // 7 + 7 capped to 10, not 14
+  })
+
+  it('auto-cleans up when owning effect scope is disposed', () => {
+    const scope = effectScope()
+    let handle: ReturnType<typeof useFakeProgress>
+    scope.run(() => {
+      handle = useFakeProgress({ target: 100, intervalMs: 10, step: 1 })
+      handle.start()
+    })
+
+    vi.advanceTimersByTime(30)
+    expect(handle!.progress.value).toBe(3)
+    expect(handle!.isRunning.value).toBe(true)
+
+    scope.stop()
+    expect(handle!.isRunning.value).toBe(false)
+
+    vi.advanceTimersByTime(1000)
+    // Progress frozen after scope disposal (no more ticks)
+    expect(handle!.progress.value).toBe(3)
+  })
+
+  it('can be called standalone outside a component scope without throwing', () => {
+    // getCurrentScope() returns undefined outside effectScope; should not register onScopeDispose
+    expect(() => {
+      const { start, stop } = useFakeProgress()
+      start()
+      stop()
+    }).not.toThrow()
+  })
+
+  it('start(overrides) applies per-run target/cap and finish() jumps to that target', () => {
+    const { start, finish, progress } = useFakeProgress({
+      target: 100,
+      intervalMs: 10,
+      step: 1
+    })
+
+    start({ target: 42 })
+    vi.advanceTimersByTime(10 * 100)
+    expect(progress.value).toBe(41) // override cap = 42 - 1
+
+    finish()
+    expect(progress.value).toBe(42)
+  })
+
+  it('start(overrides) accepts explicit cap alongside target', () => {
+    const { start, progress } = useFakeProgress({ intervalMs: 10, step: 1 })
+
+    start({ target: 50, cap: 10 })
+    vi.advanceTimersByTime(10 * 50)
+    expect(progress.value).toBe(10)
+  })
+
+  it('start() without overrides reverts to constructor defaults after a prior override run', () => {
+    const { start, finish, progress } = useFakeProgress({
+      target: 100,
+      intervalMs: 10,
+      step: 1
+    })
+
+    start({ target: 10 })
+    vi.advanceTimersByTime(10 * 50)
+    expect(progress.value).toBe(9)
+
+    // Restart with no overrides — should use target=100, cap=99
+    start()
+    vi.advanceTimersByTime(10 * 200)
+    expect(progress.value).toBe(99)
+
+    finish()
+    expect(progress.value).toBe(100)
+  })
+})

--- a/autobot-frontend/src/composables/useFakeProgress.ts
+++ b/autobot-frontend/src/composables/useFakeProgress.ts
@@ -1,0 +1,141 @@
+/**
+ * useFakeProgress — simulated progress counter for long-running operations
+ * where the backend provides no real progress signal.
+ *
+ * The counter increments by `step` every `intervalMs` until it reaches `cap`.
+ * It never advances past `cap` automatically — only a `finish()` call jumps
+ * the counter to `target`, signalling completion.
+ *
+ * Extracted from KnowledgeAdvanced.vue (#5237), where three populate actions
+ * and one clear action share the same fake-progress scaffold while backend
+ * work runs.
+ *
+ * @example
+ * ```ts
+ * const fake = useFakeProgress({ target: 150, intervalMs: 100 })
+ * fake.start()
+ * try {
+ *   await ApiClient.post('/populate', {})
+ *   fake.finish()
+ * } finally {
+ *   fake.stop()
+ * }
+ * ```
+ */
+
+import { ref, readonly, onScopeDispose, getCurrentScope } from 'vue'
+import type { Ref } from 'vue'
+
+export interface UseFakeProgressOptions {
+  /** Target value the counter completes at. Default 100. */
+  target?: number
+  /** Ms between ticks. Default 100. */
+  intervalMs?: number
+  /** Increment applied per tick. Default 1. */
+  step?: number
+  /** Ceiling the auto-ticker will not exceed. Only `finish()` reaches `target`. Default `target - 1`. */
+  cap?: number
+}
+
+export interface UseFakeProgressStartOverrides {
+  /** Override the constructor-level target for this run. */
+  target?: number
+  /** Override the constructor-level cap for this run. */
+  cap?: number
+  /** Override the constructor-level step for this run. */
+  step?: number
+  /** Override the constructor-level interval for this run. */
+  intervalMs?: number
+}
+
+export interface UseFakeProgressReturn {
+  /** Current progress counter. Starts at 0, caps at `cap`, jumps to `target` on finish(). */
+  progress: Readonly<Ref<number>>
+  /** True while the interval is active. */
+  isRunning: Readonly<Ref<boolean>>
+  /**
+   * Start ticking up toward `cap`. If already running, resets to 0 and restarts.
+   * Optional overrides replace constructor values for this run only; next call
+   * without overrides reverts to constructor defaults.
+   */
+  start: (overrides?: UseFakeProgressStartOverrides) => void
+  /** Jump to `target` (as configured for the current run) and stop ticking. */
+  finish: () => void
+  /** Halt at current value without completing. */
+  stop: () => void
+  /** Reset to 0 and halt. */
+  reset: () => void
+}
+
+export function useFakeProgress(
+  options: UseFakeProgressOptions = {}
+): UseFakeProgressReturn {
+  const defaultTarget = options.target ?? 100
+  const defaultIntervalMs = options.intervalMs ?? 100
+  const defaultStep = options.step ?? 1
+  const defaultCap = options.cap ?? defaultTarget - 1
+
+  // Active run configuration (re-assigned each start() so overrides apply)
+  let activeTarget = defaultTarget
+  let activeCap = defaultCap
+
+  const progress = ref(0)
+  const isRunning = ref(false)
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  function clearTimer(): void {
+    if (timer !== null) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+
+  function stop(): void {
+    clearTimer()
+    isRunning.value = false
+  }
+
+  function start(overrides: UseFakeProgressStartOverrides = {}): void {
+    clearTimer()
+    activeTarget = overrides.target ?? defaultTarget
+    activeCap = overrides.cap ?? (overrides.target !== undefined
+      ? overrides.target - 1
+      : defaultCap)
+    const runStep = overrides.step ?? defaultStep
+    const runInterval = overrides.intervalMs ?? defaultIntervalMs
+
+    progress.value = 0
+    isRunning.value = true
+    timer = setInterval(() => {
+      if (progress.value >= activeCap) return
+      progress.value = Math.min(progress.value + runStep, activeCap)
+    }, runInterval)
+  }
+
+  function finish(): void {
+    clearTimer()
+    progress.value = activeTarget
+    isRunning.value = false
+  }
+
+  function reset(): void {
+    clearTimer()
+    activeTarget = defaultTarget
+    activeCap = defaultCap
+    progress.value = 0
+    isRunning.value = false
+  }
+
+  if (getCurrentScope()) {
+    onScopeDispose(stop)
+  }
+
+  return {
+    progress: readonly(progress),
+    isRunning: readonly(isRunning),
+    start,
+    finish,
+    stop,
+    reset
+  }
+}


### PR DESCRIPTION
Closes #5237

## Summary
Extracted \`useFakeProgress\` composable for UI progress-bar simulators (incrementally tick toward cap, jump to target on real finish). Migrated 4 sites in KnowledgeAdvanced.vue.

## New composable
\`autobot-frontend/src/composables/useFakeProgress.ts\`:
\`\`\`ts
export function useFakeProgress(options?): {
  progress, isRunning, start(overrides?), finish(), stop(), reset()
}
\`\`\`

Features:
- Target/cap/step/intervalMs configurable at creation OR per-start
- \`onScopeDispose\` auto-cleanup
- Caps below target (never reaches 100% until \`finish()\` called)
- \`start(overrides)\` supports per-call target/step — useful when same component fakes progress for multiple operations

## Migrated sites (KnowledgeAdvanced.vue)
Issue mentioned 3 sites but audit found a single shared \`startProgress\`/\`stopProgress\` helper called from 4 places (populateSystemCommands target=150, populateManPages=50, populateAutoBotDocs=30, clearAllKnowledge=1). Shared helper replaced with single \`useFakeProgress\` instance + watcher that mirrors progress → itemsProcessed for ETA display.

## Test Status
PASS — 15/15 new tests; type-check baseline unchanged at 167