### PR TITLE
refactor(knowledge): migrate KnowledgeEntries + KnowledgeVerificationQueue to useBatchSelection (#5247)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -66,7 +66,7 @@
 
     <!-- Issue #747: Bulk Actions Toolbar -->
     <BulkActionsToolbar
-      :selected-count="selectedEntries.length"
+      :selected-count="selection.selectedCount.value"
       :total-count="filteredDocuments.length"
       :page-count="paginatedEntries.length"
       :all-page-selected="allSelected"
@@ -181,13 +181,13 @@
           <tr
             v-for="entry in displayedEntries"
             :key="entry.id"
-            :class="{ 'selected': selectedEntries.includes(entry.id) }"
+            :class="{ 'selected': selection.isSelected(entry) }"
           >
             <td class="checkbox-column">
               <input
                 type="checkbox"
-                :checked="selectedEntries.includes(entry.id)"
-                @change="toggleSelection(entry.id)"
+                :checked="selection.isSelected(entry)"
+                @change="selection.toggle(entry)"
               />
             </td>
             <td class="title-cell" @click="viewEntry(entry)">
@@ -451,6 +451,7 @@ import { formatDate, formatDateTime } from '@/utils/formatHelpers'
 import { getDocumentTypeIcon } from '@/utils/iconMappings'
 import { useDebounce } from '@/composables/useDebounce'
 import { useVirtualScroll } from '@/composables/useVirtualScroll'
+import { useBatchSelection } from '@/composables/useBatchSelection'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
@@ -479,8 +480,13 @@ const sortBy = ref('updatedAt')
 const currentPage = ref(1)
 const itemsPerPage = 20
 
-// Selection state
-const selectedEntries = ref<string[]>([])
+// Selection state — useBatchSelection's `items` source is the current page,
+// so `selection.selectAll` / `selection.allSelected` are page-level. Cross-page
+// "select all matching the filter" is handled below via setSelected(...).
+const selection = useBatchSelection<{ id: string }, string>(
+  () => paginatedEntries.value,
+  (item) => item.id
+)
 const allMatchingSelected = ref(false)
 
 // Bulk edit state (Issue #747)
@@ -571,15 +577,13 @@ const paginatedEntries = computed(() => {
   return filteredDocuments.value.slice(start, end)
 })
 
-const allSelected = computed(() =>
-  paginatedEntries.value.length > 0 &&
-  paginatedEntries.value.every(entry => selectedEntries.value.includes(entry.id))
-)
+// `selection.allSelected` covers this — derived from selection × current page.
+const allSelected = selection.allSelected
 
 // Issue #747: Bulk edit computed properties
 const selectedBulkEditEntries = computed<BulkEditEntry[]>(() => {
   return store.documents
-    .filter(doc => selectedEntries.value.includes(doc.id))
+    .filter(doc => selection.isSelected(doc))
     .map(doc => ({
       id: doc.id,
       title: doc.title || t('knowledge.entries.untitled'),
@@ -606,30 +610,22 @@ const sortEntries = () => {
 }
 
 const toggleSelection = (id: string) => {
-  const index = selectedEntries.value.indexOf(id)
-  if (index > -1) {
-    selectedEntries.value.splice(index, 1)
+  // Use deselectByKey/select since callers pass IDs, not items.
+  if (selection.selected.value.has(id)) {
+    selection.deselectByKey(id)
   } else {
-    selectedEntries.value.push(id)
+    const item = paginatedEntries.value.find(e => e.id === id)
+    if (item) selection.select(item)
   }
 }
 
 const toggleSelectAll = () => {
-  if (allSelected.value) {
+  if (selection.allSelected.value) {
     // Deselect all on current page
-    paginatedEntries.value.forEach(entry => {
-      const index = selectedEntries.value.indexOf(entry.id)
-      if (index > -1) {
-        selectedEntries.value.splice(index, 1)
-      }
-    })
+    paginatedEntries.value.forEach(entry => selection.deselectByKey(entry.id))
   } else {
     // Select all on current page
-    paginatedEntries.value.forEach(entry => {
-      if (!selectedEntries.value.includes(entry.id)) {
-        selectedEntries.value.push(entry.id)
-      }
-    })
+    selection.selectAll()
   }
 }
 
@@ -661,11 +657,11 @@ const deleteEntry = async (entry: KnowledgeDocument) => {
 }
 
 const deleteSelected = async () => {
-  if (!confirm(t('knowledge.entries.confirmDeleteSelected', { count: selectedEntries.value.length }))) return
+  if (!confirm(t('knowledge.entries.confirmDeleteSelected', { count: selection.selectedCount.value }))) return
 
   try {
-    await controller.bulkDeleteDocuments(selectedEntries.value)
-    selectedEntries.value = []
+    await controller.bulkDeleteDocuments([...selection.selected.value])
+    selection.clear()
   } catch (error) {
     logger.error('Failed to delete entries:', error)
   }
@@ -678,7 +674,7 @@ const exportSelected = async () => {
 // Issue #747: Enhanced export with multiple formats
 const handleExport = (format: ExportFormat) => {
   const entries = store.documents.filter(doc =>
-    selectedEntries.value.includes(doc.id)
+    selection.selected.value.has(doc.id)
   )
 
   let content: string
@@ -780,20 +776,16 @@ const downloadFile = (content: string, filename: string, mimeType: string) => {
 // Issue #747: Bulk actions toolbar handlers
 const selectAllPage = () => {
   allMatchingSelected.value = false
-  paginatedEntries.value.forEach(entry => {
-    if (!selectedEntries.value.includes(entry.id)) {
-      selectedEntries.value.push(entry.id)
-    }
-  })
+  selection.selectAll()
 }
 
 const selectAllMatching = () => {
   allMatchingSelected.value = true
-  selectedEntries.value = filteredDocuments.value.map(doc => doc.id)
+  selection.setSelected(filteredDocuments.value.map(doc => doc.id))
 }
 
 const clearSelection = () => {
-  selectedEntries.value = []
+  selection.clear()
   allMatchingSelected.value = false
 }
 
@@ -814,7 +806,7 @@ const openBulkRemoveTags = () => {
 
 const handleBulkEditConfirm = async (payload: { mode: BulkEditMode; value: string | string[] | { scope: string; groupIds: string[] } }) => {
   try {
-    const ids = selectedEntries.value
+    const ids = [...selection.selected.value]
 
     if (payload.mode === 'category') {
       await controller.bulkUpdateCategory(ids, payload.value as string)

--- a/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeVerificationQueue.vue
@@ -70,14 +70,14 @@
     </div>
 
     <!-- Bulk Actions -->
-    <div v-if="selectedIds.length > 0" class="bulk-toolbar">
+    <div v-if="selection.selectedCount.value > 0" class="bulk-toolbar">
       <span class="bulk-count">
-        {{ $t('knowledge.verification.selectedCount', { count: selectedIds.length }) }}
+        {{ $t('knowledge.verification.selectedCount', { count: selection.selectedCount.value }) }}
       </span>
       <BaseButton
         variant="ghost"
         size="sm"
-        @click="selectAllVisible"
+        @click="selection.selectAll"
       >
         {{ $t('knowledge.verification.selectAll') }}
       </BaseButton>
@@ -102,7 +102,7 @@
       <BaseButton
         variant="ghost"
         size="sm"
-        @click="clearSelection"
+        @click="selection.clear"
       >
         {{ $t('knowledge.verification.clearSelection') }}
       </BaseButton>
@@ -128,13 +128,13 @@
         v-for="source in store.pendingVerifications"
         :key="source.fact_id"
         class="source-card"
-        :class="{ selected: selectedIds.includes(source.fact_id) }"
+        :class="{ selected: selection.isSelected(source) }"
       >
         <div class="card-header">
           <input
             type="checkbox"
-            :checked="selectedIds.includes(source.fact_id)"
-            @change="toggleSelection(source.fact_id)"
+            :checked="selection.isSelected(source)"
+            @change="selection.toggle(source)"
             class="card-checkbox"
           />
           <div class="card-title-row">
@@ -245,6 +245,7 @@ import { useUserStore } from '@/stores/useUserStore'
 import { knowledgeRepository } from '@/models/repositories/KnowledgeRepository'
 import type { VerificationConfig } from '@/types/knowledgeBase'
 import { formatDate } from '@/utils/formatHelpers'
+import { useBatchSelection } from '@/composables/useBatchSelection'
 import BaseButton from '@/components/base/BaseButton.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import QualityScoreBadge from './QualityScoreBadge.vue'
@@ -261,7 +262,10 @@ const currentPage = ref(1)
 const pageSize = 20
 const todayApproved = ref(0)
 const todayRejected = ref(0)
-const selectedIds = ref<string[]>([])
+const selection = useBatchSelection<{ fact_id: string }, string>(
+  () => store.pendingVerifications,
+  (item) => item.fact_id
+)
 const actionLoadingId = ref<string | null>(null)
 const bulkProcessing = ref(false)
 const configLoading = ref(false)
@@ -310,7 +314,7 @@ async function approveSource(factId: string) {
     await knowledgeRepository.approveSource(factId, currentUser.value)
     store.removePendingSource(factId)
     todayApproved.value++
-    selectedIds.value = selectedIds.value.filter(id => id !== factId)
+    selection.deselectByKey(factId)
     logger.info('Source approved: %s', factId)
   } catch (error) {
     logger.error('Failed to approve source %s: %s', factId, error)
@@ -329,7 +333,7 @@ async function rejectSource(factId: string) {
     )
     store.removePendingSource(factId)
     todayRejected.value++
-    selectedIds.value = selectedIds.value.filter(id => id !== factId)
+    selection.deselectByKey(factId)
     logger.info('Source rejected: %s', factId)
   } catch (error) {
     logger.error('Failed to reject source %s: %s', factId, error)
@@ -359,10 +363,10 @@ async function setMode(mode: VerificationConfig['mode']) {
 
 // Bulk operations
 async function bulkApprove() {
-  if (selectedIds.value.length === 0) return
+  if (selection.selectedCount.value === 0) return
   bulkProcessing.value = true
   try {
-    const ids = [...selectedIds.value]
+    const ids = [...selection.selected.value]
     const results = await Promise.allSettled(
       ids.map(id =>
         knowledgeRepository.approveSource(id, currentUser.value)
@@ -376,7 +380,7 @@ async function bulkApprove() {
       }
     })
     todayApproved.value += approved
-    selectedIds.value = []
+    selection.clear()
     logger.info('Bulk approved %d sources', approved)
   } catch (error) {
     logger.error('Bulk approve failed: %s', error)
@@ -386,10 +390,10 @@ async function bulkApprove() {
 }
 
 async function bulkReject() {
-  if (selectedIds.value.length === 0) return
+  if (selection.selectedCount.value === 0) return
   bulkProcessing.value = true
   try {
-    const ids = [...selectedIds.value]
+    const ids = [...selection.selected.value]
     const results = await Promise.allSettled(
       ids.map(id =>
         knowledgeRepository.rejectSource(id, currentUser.value, false)
@@ -403,7 +407,7 @@ async function bulkReject() {
       }
     })
     todayRejected.value += rejected
-    selectedIds.value = []
+    selection.clear()
     logger.info('Bulk rejected %d sources', rejected)
   } catch (error) {
     logger.error('Bulk reject failed: %s', error)
@@ -412,28 +416,10 @@ async function bulkReject() {
   }
 }
 
-// Selection
-function toggleSelection(factId: string) {
-  const index = selectedIds.value.indexOf(factId)
-  if (index > -1) {
-    selectedIds.value.splice(index, 1)
-  } else {
-    selectedIds.value.push(factId)
-  }
-}
-
-function selectAllVisible() {
-  selectedIds.value = store.pendingVerifications.map(s => s.fact_id)
-}
-
-function clearSelection() {
-  selectedIds.value = []
-}
-
 // Pagination
 function goToPage(page: number) {
   currentPage.value = page
-  selectedIds.value = []
+  selection.clear()
   loadPendingVerifications()
 }
 

--- a/autobot-frontend/src/composables/__tests__/useBatchSelection.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useBatchSelection.test.ts
@@ -227,6 +227,80 @@ describe('useBatchSelection', () => {
     })
   })
 
+  describe('deselectByKey', () => {
+    it('removes selection when only the key is known', () => {
+      const docs: Doc[] = [
+        { id: 'd1', name: 'Doc 1' },
+        { id: 'd2', name: 'Doc 2' }
+      ]
+      const sel = useBatchSelection<Doc, string>(ref(docs), (d) => d.id)
+
+      sel.selectAll()
+      sel.deselectByKey('d1')
+
+      expect(sel.selected.value.has('d1')).toBe(false)
+      expect(sel.selected.value.has('d2')).toBe(true)
+    })
+
+    it('is idempotent for missing keys', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.deselectByKey('a')
+      sel.deselectByKey('a')
+      expect(sel.selectedCount.value).toBe(0)
+    })
+
+    it('works after the underlying item is removed from the items source', async () => {
+      const items = ref([{ id: 'd1' }, { id: 'd2' }])
+      const sel = useBatchSelection<{ id: string }, string>(items, (d) => d.id)
+
+      sel.select(items.value[0])
+      items.value = [{ id: 'd2' }]
+      await nextTick()
+
+      sel.deselectByKey('d1')
+      expect(sel.selected.value.has('d1')).toBe(false)
+    })
+  })
+
+  describe('setSelected', () => {
+    it('replaces the entire selection with given keys', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b', 'c']))
+
+      sel.select('a')
+      sel.setSelected(['b', 'c'])
+
+      expect(sel.isSelected('a')).toBe(false)
+      expect(sel.isSelected('b')).toBe(true)
+      expect(sel.isSelected('c')).toBe(true)
+      expect(sel.selectedCount.value).toBe(2)
+    })
+
+    it('accepts cross-page keys not in the items source', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.setSelected(['x', 'y', 'z'])
+
+      expect(sel.selectedCount.value).toBe(3)
+      expect(sel.selected.value.has('x')).toBe(true)
+    })
+
+    it('accepts an iterable (Set)', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.setSelected(new Set(['a', 'b']))
+      expect(sel.selectedCount.value).toBe(2)
+    })
+
+    it('clearing via empty iterable works', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.selectAll()
+      sel.setSelected([])
+      expect(sel.selectedCount.value).toBe(0)
+    })
+  })
+
   describe('readonly return surface', () => {
     it('selected ref is wrapped readonly — direct mutation does not leak to internal state', () => {
       const sel = useBatchSelection<string>(ref(['a']))

--- a/autobot-frontend/src/composables/useBatchSelection.ts
+++ b/autobot-frontend/src/composables/useBatchSelection.ts
@@ -35,8 +35,12 @@ export interface UseBatchSelectionReturn<T, Key extends string | number = string
   select: (item: T) => void
   /** Deselect one item (idempotent). */
   deselect: (item: T) => void
+  /** Deselect by key (when only the ID is available). */
+  deselectByKey: (key: Key) => void
   /** Select every item currently in the list. */
   selectAll: () => void
+  /** Replace the entire selection with the given keys. */
+  setSelected: (keys: Iterable<Key>) => void
   /** Clear all selections. */
   clear: () => void
   /** True if the given item is selected. */
@@ -101,7 +105,15 @@ export function useBatchSelection<T, Key extends string | number = string | numb
   }
 
   function deselect(item: T): void {
-    const key = keyFn(item)
+    deselectByKey(keyFn(item))
+  }
+
+  /**
+   * Deselect by key directly. Useful when consumers only have the ID
+   * (e.g. after an action processed an item by ID and the item object
+   * is no longer in the items list). Idempotent.
+   */
+  function deselectByKey(key: Key): void {
     if (selected.value.has(key)) {
       const next = new Set(selected.value)
       next.delete(key)
@@ -111,6 +123,16 @@ export function useBatchSelection<T, Key extends string | number = string | numb
 
   function selectAll(): void {
     selected.value = new Set(currentItems.value.map(keyFn))
+  }
+
+  /**
+   * Replace the entire selection with the given keys. Useful for
+   * "select all matching the current filter" patterns where the items
+   * to select aren't in the composable's `items` source (e.g. cross-page
+   * selection in a paginated list whose `items` is just the current page).
+   */
+  function setSelected(keys: Iterable<Key>): void {
+    selected.value = new Set(keys)
   }
 
   function clear(): void {
@@ -130,7 +152,9 @@ export function useBatchSelection<T, Key extends string | number = string | numb
     toggle,
     select,
     deselect,
+    deselectByKey,
     selectAll,
+    setSelected,
     clear,
     isSelected
   }


### PR DESCRIPTION
## Summary

Closes #5247.

`KnowledgeEntries.vue` and `KnowledgeVerificationQueue.vue` each maintained a parallel `selectedIds: ref<string[]>` plus ad-hoc toggle/selectAll/clear implementation. This PR migrates both to the existing [`useBatchSelection<T, Key>`](autobot-frontend/src/composables/useBatchSelection.ts) composable, which owns Set-based selection state and exposes derived `allSelected` / `someSelected` / `selectedCount` reactively (eliminating two duplicated derivations).

### Composable additions

Two helpers were added to support the consumers' real needs:

- **`deselectByKey(key)`** — remove selection when only the ID is in scope (e.g. after a delete action processes by ID and the item object is no longer in the items list). Used by `KnowledgeVerificationQueue` after individual approve/reject and by `KnowledgeEntries.toggleSelection`.
- **`setSelected(keys)`** — replace the entire selection with given keys. Used by `KnowledgeEntries.selectAllMatching` for the cross-page "select all matching the current filter" pattern, where the items aren't in the composable's `items` source (which is the current page only).

### Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json` → 0 new errors in changed files (pre-existing baseline unchanged).
- `npx vitest run src/composables/__tests__/useBatchSelection.test.ts` → 27/27 pass (20 original + 7 new for `deselectByKey` and `setSelected`).
- Diff: -75 lines, +151 lines (most of the +151 are the 7 new tests; the components themselves shrank ~30 lines net).

## Test plan

- [ ] Manual: open Knowledge Entries, select a few rows, batch-delete; verify selection clears and indeterminate header checkbox states correctly.
- [ ] Manual: select-all-page, then select-all-matching across pages; verify cross-page count and bulk action.
- [ ] Manual: open Knowledge Verification Queue, select multiple sources, batch-approve; verify only un-actioned ones remain selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)