### PR TITLE
test(lint): add unit tests for check_no_utcnow_isoformat.py (#5269)

### DIFF
--- a/tools/lint/check_no_utcnow_isoformat_test.py
+++ b/tools/lint/check_no_utcnow_isoformat_test.py
@@ -1,0 +1,293 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for tools/lint/check_no_utcnow_isoformat.py — see #5269.
+
+Covers detection, allowlisting, edge cases, and exit codes for the
+regression-prevention hook shipped in PR #5264 (#5178 Part C).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the script-under-test as a module. The script is intentionally
+# at tools/lint/ (not on a package path) — load it directly by file.
+_HOOK_PATH = Path(__file__).parent / "check_no_utcnow_isoformat.py"
+_spec = importlib.util.spec_from_file_location("_hook_under_test", _HOOK_PATH)
+assert _spec is not None and _spec.loader is not None
+hook = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hook)
+
+
+# ---------------------------------------------------------------------------
+# Detection — positive cases (each banned pattern produces a hit)
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_detects_utcnow_isoformat_after_from_import(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        "case.py",
+        "from datetime import datetime\nts = datetime.utcnow().isoformat()\n",
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 1
+
+
+def test_detects_utcnow_isoformat_after_module_import(tmp_path: Path) -> None:
+    # `import datetime; datetime.datetime.utcnow().isoformat()` — same regex
+    # because the inner `datetime.utcnow().isoformat(` substring matches.
+    f = _write(
+        tmp_path,
+        "case.py",
+        "import datetime\nts = datetime.datetime.utcnow().isoformat()\n",
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 1
+
+
+def test_detects_z_suffix_mixed_format(tmp_path: Path) -> None:
+    # The #5238 pattern: invalid microseconds + Z combined.
+    f = _write(
+        tmp_path,
+        "case.py",
+        'from datetime import datetime\nts = datetime.utcnow().isoformat() + "Z"\n',
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 1
+
+
+def test_detects_z_suffix_with_single_quotes(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        "case.py",
+        "from datetime import datetime\nts = datetime.utcnow().isoformat() + 'Z'\n",
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 1
+
+
+def test_detects_naive_strftime_iso(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        "case.py",
+        'import time\nts = time.strftime("%Y-%m-%dT%H:%M:%S")\n',
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 1
+
+
+def test_detects_naive_strftime_with_seconds_only(tmp_path: Path) -> None:
+    # time.strftime with a longer ISO format also fires
+    f = _write(
+        tmp_path,
+        "case.py",
+        'import time\nts = time.strftime("%Y-%m-%dT%H:%M:%SZ")\n',
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Detection — negative cases (these should NOT fire)
+# ---------------------------------------------------------------------------
+
+
+def test_clean_file_passes(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        "clean.py",
+        "from autobot_shared.time_utils import utc_timestamp\n"
+        "ts = utc_timestamp()\n",
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 0
+
+
+def test_canonical_aware_isoformat_not_flagged(tmp_path: Path) -> None:
+    # `datetime.now(timezone.utc).isoformat()` is the CORRECT pattern;
+    # the hook must not flag it.
+    f = _write(
+        tmp_path,
+        "ok.py",
+        "from datetime import datetime, timezone\n"
+        "ts = datetime.now(timezone.utc).isoformat()\n",
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 0
+
+
+def test_strftime_with_explicit_time_arg_not_flagged(tmp_path: Path) -> None:
+    # Passing an explicit time tuple (e.g. time.gmtime()) makes strftime
+    # safe — the hook only flags the no-arg form. The regex requires the
+    # closing paren immediately after the format-string literal, so a
+    # comma-separated second argument should pass.
+    f = _write(
+        tmp_path,
+        "ok.py",
+        'import time\nts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())\n',
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 0
+
+
+def test_non_iso_strftime_not_flagged(tmp_path: Path) -> None:
+    # Date-only / non-T-separated formats are out of scope for the
+    # #5178 regression hook (they don't produce the broken ISO-8601
+    # strings the hook protects against).
+    f = _write(
+        tmp_path,
+        "ok.py",
+        'import time\nts = time.strftime("%Y-%m-%d %H:%M:%S")\n',
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 0
+
+
+def test_bare_utcnow_without_isoformat_not_flagged(tmp_path: Path) -> None:
+    # Pattern A/B/C (#5211 territory) — the bare utcnow() call is NOT
+    # the responsibility of THIS hook; #5211's own enforcement (Ruff
+    # DTZ003) will cover it once enabled.
+    f = _write(
+        tmp_path,
+        "ok.py",
+        "from datetime import datetime\n"
+        "started_at = datetime.utcnow()\n"
+        "delta = (datetime.utcnow() - started_at).total_seconds()\n",
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_allowlisted_path_not_scanned(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Place a file at an allowlisted path inside tmp_path, point repo_root
+    # at tmp_path, and confirm scanning is skipped.
+    allowed = "autobot_shared/time_utils.py"
+    target = tmp_path / allowed
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "from datetime import datetime\nts = datetime.utcnow().isoformat()\n",
+        encoding="utf-8",
+    )
+    hits = hook._scan(target, tmp_path)
+    assert hits == [], "allowlisted file must not produce hits"
+
+
+def test_non_allowlisted_path_with_same_pattern_does_fire(tmp_path: Path) -> None:
+    # Sanity check the inverse — same pattern in non-allowlisted location
+    # DOES fire (proves the allowlist test isn't a no-op).
+    target = tmp_path / "autobot-backend" / "api" / "some_file.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "from datetime import datetime\nts = datetime.utcnow().isoformat()\n",
+        encoding="utf-8",
+    )
+    hits = hook._scan(target, tmp_path)
+    assert len(hits) == 1
+    assert hits[0][1] == "isoformat"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_path_outside_repo_root_handled(tmp_path: Path) -> None:
+    # The fix in PR #5264 made _scan() resilient to files outside repo_root
+    # via try/except on relative_to() — verify it still works.
+    f = _write(
+        tmp_path,
+        "outside.py",
+        "from datetime import datetime\nts = datetime.utcnow().isoformat()\n",
+    )
+    # Use a different "repo root" so the file is "outside" it
+    fake_root = tmp_path / "different_root"
+    fake_root.mkdir()
+    hits = hook._scan(f, fake_root)
+    assert len(hits) == 1
+
+
+def test_non_utf8_file_silently_skipped(tmp_path: Path) -> None:
+    # Files with bytes that don't decode as UTF-8 must not crash the scan.
+    f = tmp_path / "binary.py"
+    f.write_bytes(b"\xff\xfe\x00datetime.utcnow().isoformat()")
+    hits = hook._scan(f, tmp_path)
+    assert hits == []
+
+
+def test_missing_file_silently_skipped(tmp_path: Path) -> None:
+    # OSError on read should be swallowed (no exception, no hit).
+    nonexistent = tmp_path / "nope.py"
+    hits = hook._scan(nonexistent, tmp_path)
+    assert hits == []
+
+
+def test_multiple_patterns_one_line(tmp_path: Path) -> None:
+    # A line with both `utcnow().isoformat()` AND `+ "Z"` produces TWO hits
+    # (one per matching pattern) because the `+ "Z"` regex matches the
+    # whole expression and the bare `isoformat()` regex matches the prefix.
+    f = _write(
+        tmp_path,
+        "case.py",
+        'from datetime import datetime\nts = datetime.utcnow().isoformat() + "Z"\n',
+    )
+    hits = hook._scan(f, tmp_path)
+    pattern_ids = sorted(h[1] for h in hits)
+    assert pattern_ids == ["isoformat", "z-suffix-isoformat"]
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_exit_zero_when_clean(tmp_path: Path) -> None:
+    f = _write(tmp_path, "clean.py", "from autobot_shared.time_utils import utc_timestamp\n")
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 0
+
+
+def test_exit_one_when_violations_found(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        "bad.py",
+        "from datetime import datetime\nts = datetime.utcnow().isoformat()\n",
+    )
+    rc = hook.main(["check_no_utcnow_isoformat", str(f)])
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# argv handling
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_argv_overrides_full_scan(tmp_path: Path) -> None:
+    # When argv has paths, the scanner uses ONLY those paths — does not
+    # walk the whole repo. Confirms the pre-commit invocation pattern.
+    clean = _write(tmp_path, "clean.py", "ts = 'ok'\n")
+    rc = hook.main(["check_no_utcnow_isoformat", str(clean)])
+    assert rc == 0  # clean file → exit 0 even though repo has violations
+
+
+def test_non_python_argv_silently_skipped(tmp_path: Path) -> None:
+    # Pre-commit may pass non-.py files through; the scanner filters by
+    # `.py` suffix and silently skips others.
+    md = _write(tmp_path, "notes.md", "datetime.utcnow().isoformat() in markdown\n")
+    rc = hook.main(["check_no_utcnow_isoformat", str(md)])
+    assert rc == 0


### PR DESCRIPTION
## Summary

Closes #5269.

Adds [\`tools/lint/check_no_utcnow_isoformat_test.py\`](tools/lint/check_no_utcnow_isoformat_test.py) — **21 tests** covering the regression-prevention hook shipped in PR #5264 (#5178 Part C).

## Coverage

| Category | Tests | Notes |
|---|---|---|
| Detection (positive) | 6 | 3 banned patterns × import-style variants (from-import + module-import; both quote styles for Z-suffix) |
| Detection (negative) | 5 | canonical aware isoformat, strftime with explicit time arg, non-ISO strftime, bare utcnow() |
| Allowlist | 2 | allowlisted path skipped + non-allowlisted with same pattern fires (sanity inverse) |
| Edge cases | 4 | outside-repo path, non-UTF8, missing file, multiple patterns one line |
| Exit codes | 2 | 0 clean, 1 violations |
| argv handling | 2 | explicit paths override full-scan, non-.py silently skipped |

## Verification

\`\`\`
$ python3 -m pytest tools/lint/check_no_utcnow_isoformat_test.py -v
... 21 passed in 0.11s
\`\`\`

## Implementation

Tests load the script-under-test via \`importlib.util.spec_from_file_location\` since \`tools/lint/\` isn't on a package path. Calls \`hook.main()\` and \`hook._scan()\` directly for speed (no subprocess overhead).

## Diff

1 new file (\`tools/lint/check_no_utcnow_isoformat_test.py\`, 293 lines).

## Test plan

- [x] All 21 tests pass
- [x] Both positive + negative cases for each pattern
- [x] Allowlist mechanism + sanity inverse
- [x] Path edge cases (outside-repo, non-UTF8, missing)
- [x] Exit codes verified
- [ ] \`gh pr checks\` passes