### PR TITLE
fix(codebase-analytics): wire hardcoded-values panel (#5277)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -183,6 +183,12 @@
         @export="(fmt: string) => exportSection('declarations', fmt as 'md' | 'json')"
       />
 
+      <!-- Hardcoded Values (#5277: wire orphan data flow) -->
+      <HardcodesSection
+        :hardcodes="hardcodeAnalysis"
+        @export="(fmt: string) => exportSection('hardcodes', fmt as 'md' | 'json')"
+      />
+
       <!-- Issue #527: API Endpoint Checker Section (#1469: extracted to CodebaseApiEndpointsPanel) -->
       <CodebaseApiEndpointsPanel
         :analysis="apiEndpointAnalysis"
@@ -456,6 +462,7 @@ import CodebaseSecurityPanel from '@/components/analytics/CodebaseSecurityPanel.
 import CodeSmellsSection from '@/components/analytics/CodeSmellsSection.vue'
 import DuplicatesSection from '@/components/analytics/DuplicatesSection.vue'
 import DeclarationsSection from '@/components/analytics/DeclarationsSection.vue'
+import HardcodesSection from '@/components/analytics/HardcodesSection.vue'
 import SourceManager from '@/components/analytics/SourceManager.vue'
 import AddSourceModal from '@/components/analytics/AddSourceModal.vue'
 import ShareSourceModal from '@/components/analytics/ShareSourceModal.vue'
@@ -778,6 +785,7 @@ const { exportReport, exportSection } = useCodebaseExport({
     'environment': environmentAnalysis as Ref<unknown>,
     'statistics': codebaseStats as Ref<unknown>,
     'ownership': ownershipAnalysis as Ref<unknown>,
+    'hardcodes': hardcodeAnalysis as Ref<unknown>,
   },
   exportingReport,
   progressStatus,

--- a/autobot-frontend/src/components/analytics/HardcodesSection.vue
+++ b/autobot-frontend/src/components/analytics/HardcodesSection.vue
@@ -1,0 +1,391 @@
+<template>
+  <div class="hardcodes-section analytics-section">
+    <h3>
+      <i class="fas fa-bolt"></i> {{ $t('analytics.hardcodes.title') }}
+      <span v-if="hardcodes && hardcodes.length > 0" class="total-count">
+        ({{ hardcodes.length.toLocaleString() }} {{ $t('analytics.hardcodes.values') }})
+      </span>
+      <div v-if="hardcodes && hardcodes.length > 0" class="section-export-buttons">
+        <button @click="emit('export', 'md')" class="export-btn" :title="$t('analytics.codebase.actions.exportMarkdown')">
+          <i class="fas fa-file-alt"></i> MD
+        </button>
+        <button @click="emit('export', 'json')" class="export-btn" :title="$t('analytics.codebase.actions.exportJson')">
+          <i class="fas fa-file-code"></i> JSON
+        </button>
+      </div>
+    </h3>
+    <div v-if="hardcodes && hardcodes.length > 0" class="section-content">
+      <!-- Summary Cards -->
+      <div class="summary-cards">
+        <div class="summary-card total">
+          <div class="summary-value">{{ hardcodes.length.toLocaleString() }}</div>
+          <div class="summary-label">{{ $t('analytics.hardcodes.totalValues') }}</div>
+        </div>
+        <div class="summary-card high">
+          <div class="summary-value">{{ hardcodesBySeverity.high?.length || 0 }}</div>
+          <div class="summary-label">{{ $t('analytics.hardcodes.highLabel') }}</div>
+        </div>
+        <div class="summary-card medium">
+          <div class="summary-value">{{ hardcodesBySeverity.medium?.length || 0 }}</div>
+          <div class="summary-label">{{ $t('analytics.hardcodes.mediumLabel') }}</div>
+        </div>
+        <div class="summary-card low">
+          <div class="summary-value">{{ hardcodesBySeverity.low?.length || 0 }}</div>
+          <div class="summary-label">{{ $t('analytics.hardcodes.lowLabel') }}</div>
+        </div>
+        <div class="summary-card info">
+          <div class="summary-value">{{ uniqueTypeCount }}</div>
+          <div class="summary-label">{{ $t('analytics.hardcodes.uniqueTypes') }}</div>
+        </div>
+      </div>
+
+      <!-- Hardcoded Values by Severity Group -->
+      <div class="accordion-groups">
+        <div
+          v-for="(group, severity) in hardcodesBySeverity"
+          :key="severity"
+          v-show="group && group.length > 0"
+          class="accordion-group"
+        >
+          <div
+            class="accordion-header"
+            @click="toggleGroup(String(severity))"
+          >
+            <div class="header-info">
+              <i :class="expandedGroups[severity] ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <span class="header-name">{{ formatSeverityGroup(String(severity)) }}</span>
+              <span class="header-count">({{ group.length }})</span>
+            </div>
+            <div class="header-badges">
+              <span class="severity-badge" :class="severity">{{ severity }}</span>
+            </div>
+          </div>
+          <transition name="accordion">
+            <div v-if="expandedGroups[severity]" class="accordion-items">
+              <div
+                v-for="(hc, index) in group.slice(0, 20)"
+                :key="index"
+                class="list-item"
+                :class="`item-${severity}`"
+              >
+                <div class="item-header">
+                  <span class="item-type">{{ hc.type }}</span>
+                  <span class="item-location">{{ hc.file }}:{{ hc.line }}</span>
+                </div>
+                <div class="item-body">
+                  <div v-if="hc.variable_name" class="item-row">
+                    <span class="item-label">{{ $t('analytics.hardcodes.variable') }}:</span>
+                    <code class="item-code">{{ hc.variable_name }}</code>
+                  </div>
+                  <div class="item-row">
+                    <span class="item-label">{{ $t('analytics.hardcodes.value') }}:</span>
+                    <code class="item-code">{{ hc.value }}</code>
+                  </div>
+                  <div v-if="hc.suggested_env_var" class="item-row">
+                    <span class="item-label">{{ $t('analytics.hardcodes.suggestedEnvVar') }}:</span>
+                    <code class="item-code item-suggestion">{{ hc.suggested_env_var }}</code>
+                  </div>
+                </div>
+              </div>
+              <div v-if="group.length > 20" class="show-more">
+                <span class="muted">{{ $t('analytics.hardcodes.showingOf', { shown: 20, total: group.length.toLocaleString() }) }}</span>
+              </div>
+            </div>
+          </transition>
+        </div>
+      </div>
+    </div>
+    <EmptyState
+      v-else
+      icon="fas fa-check-circle"
+      :message="$t('analytics.hardcodes.emptyMessage')"
+      variant="success"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * Hardcodes Section Component
+ *
+ * Displays hardcoded-value detection results grouped by severity.
+ * Issue #5277: wire previously-fetched hardcodeAnalysis data into the UI.
+ */
+
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import EmptyState from '@/components/ui/EmptyState.vue'
+import type { HardcodedValue } from '@/composables/analytics/analyticsTypes'
+
+const { t } = useI18n()
+
+interface Props {
+  hardcodes: HardcodedValue[]
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  export: [format: 'md' | 'json']
+}>()
+
+const expandedGroups = ref<Record<string, boolean>>({})
+
+const hardcodesBySeverity = computed(() => {
+  const groups: Record<string, HardcodedValue[]> = { high: [], medium: [], low: [] }
+  props.hardcodes.forEach(h => {
+    const sev = (h.severity || '').toLowerCase()
+    if (sev === 'high' || sev === 'critical') groups.high.push(h)
+    else if (sev === 'medium') groups.medium.push(h)
+    else groups.low.push(h)
+  })
+  return groups
+})
+
+const uniqueTypeCount = computed(
+  () => new Set(props.hardcodes.map(h => h.type).filter(Boolean)).size,
+)
+
+const toggleGroup = (severity: string) => {
+  expandedGroups.value[severity] = !expandedGroups.value[severity]
+}
+
+const formatSeverityGroup = (severity: string): string => {
+  const key = `analytics.hardcodes.severityGroups.${severity}`
+  const translated = t(key)
+  return translated !== key ? translated : severity
+}
+</script>
+
+<style scoped>
+.hardcodes-section {
+  margin-bottom: var(--spacing-6);
+}
+
+.hardcodes-section h3 {
+  color: var(--color-warning);
+  margin-bottom: var(--spacing-4);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2-5);
+  flex-wrap: wrap;
+}
+
+.total-count {
+  font-size: 0.8em;
+  color: var(--text-muted);
+}
+
+.section-content {
+  background: var(--bg-primary-alpha);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-4);
+}
+
+.summary-cards {
+  display: flex;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-5);
+}
+
+.summary-card {
+  padding: var(--spacing-3) var(--spacing-5);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  min-width: 80px;
+}
+
+.summary-card.total { background: var(--bg-tertiary-alpha); }
+.summary-card.high { background: var(--color-error-bg); }
+.summary-card.medium { background: var(--color-warning-bg); }
+.summary-card.low { background: var(--color-success-bg); }
+.summary-card.info { background: var(--color-info-bg); }
+
+.summary-value {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  color: var(--text-on-primary);
+}
+
+.summary-label {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.accordion-groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.accordion-group {
+  background: var(--bg-tertiary-alpha);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.accordion-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-3) var(--spacing-4);
+  cursor: pointer;
+  transition: background var(--duration-200);
+}
+
+.accordion-header:hover {
+  background: var(--bg-hover);
+}
+
+.header-info {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2-5);
+}
+
+.header-name {
+  font-weight: var(--font-semibold);
+  color: var(--text-on-primary);
+}
+
+.header-count {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.severity-badge {
+  padding: var(--spacing-0-5) var(--spacing-2);
+  border-radius: var(--radius-default);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  text-transform: capitalize;
+}
+
+.severity-badge.high { background: var(--color-error-bg); color: var(--color-error); }
+.severity-badge.medium { background: var(--color-warning-bg); color: var(--color-warning); }
+.severity-badge.low { background: var(--color-success-bg); color: var(--color-success); }
+
+.accordion-items {
+  padding: 0 var(--spacing-4) var(--spacing-4);
+}
+
+.list-item {
+  background: var(--bg-primary-alpha);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-3);
+  margin-bottom: var(--spacing-2);
+  border-left: 3px solid var(--text-tertiary);
+}
+
+.list-item.item-high { border-left-color: var(--color-error); }
+.list-item.item-medium { border-left-color: var(--color-warning); }
+.list-item.item-low { border-left-color: var(--color-success); }
+
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-2);
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+.item-type {
+  padding: var(--spacing-0-5) var(--spacing-2);
+  border-radius: var(--radius-default);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  background: var(--bg-tertiary-alpha);
+  color: var(--text-secondary);
+  text-transform: capitalize;
+}
+
+.item-location {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+}
+
+.item-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+}
+
+.item-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacing-2);
+  font-size: var(--text-xs);
+}
+
+.item-label {
+  color: var(--text-muted);
+  min-width: 100px;
+  flex-shrink: 0;
+}
+
+.item-code {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  background: var(--bg-tertiary-alpha);
+  padding: var(--spacing-0-5) var(--spacing-1);
+  border-radius: var(--radius-default);
+  word-break: break-all;
+}
+
+.item-code.item-suggestion {
+  color: var(--color-success);
+  background: var(--color-success-bg);
+}
+
+.show-more {
+  text-align: center;
+  padding: var(--spacing-2);
+}
+
+.muted {
+  color: var(--text-disabled);
+  font-size: var(--text-xs);
+}
+
+.accordion-enter-active,
+.accordion-leave-active {
+  transition: all var(--duration-300) var(--ease-in-out);
+}
+
+.accordion-enter-from,
+.accordion-leave-to {
+  opacity: 0;
+  max-height: 0;
+}
+
+.section-export-buttons {
+  display: flex;
+  gap: var(--spacing-2);
+  margin-left: auto;
+}
+
+.export-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 0.8em;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  transition: all var(--duration-150) var(--ease-out);
+}
+
+.export-btn:hover {
+  background: var(--bg-card);
+  border-color: var(--color-warning-dark);
+  color: var(--text-primary);
+}
+</style>

--- a/autobot-frontend/src/composables/analytics/useCodebaseExport.ts
+++ b/autobot-frontend/src/composables/analytics/useCodebaseExport.ts
@@ -16,6 +16,7 @@ export type SectionType =
   | 'bug-prediction' | 'code-smells' | 'problems' | 'duplicates'
   | 'declarations' | 'api-endpoints' | 'cross-language' | 'config-duplicates'
   | 'code-intelligence' | 'environment' | 'statistics' | 'ownership'
+  | 'hardcodes'
 
 interface OwnershipExportData {
   summary: {
@@ -139,6 +140,46 @@ function _generateDeclarationsMd(data: unknown): string {
   if (decls.length > 0) {
     md += `| File | Name | Type | Line |\n|------|------|------|------|\n`
     decls.forEach(d => { md += `| ${d.file} | ${d.name} | ${d.type} | ${d.line} |\n` })
+  }
+  return md
+}
+
+function _generateHardcodesMd(data: unknown): string {
+  // #5277: dedicated markdown for the array form returned by
+  // `/api/analytics/codebase/hardcodes` (distinct from env-analysis export).
+  const hcs = data as Array<{
+    file: string
+    line: number
+    variable_name?: string
+    value: string
+    type: string
+    severity: string
+    suggested_env_var?: string
+  }>
+  let md = `## Hardcoded Values\n\n**Total Values Found:** ${hcs.length}\n\n`
+  if (hcs.length === 0) return md
+  const groups: Record<string, typeof hcs> = { high: [], medium: [], low: [] }
+  hcs.forEach(h => {
+    const sev = (h.severity || 'low').toLowerCase()
+    if (sev === 'high' || sev === 'critical') groups.high.push(h)
+    else if (sev === 'medium') groups.medium.push(h)
+    else groups.low.push(h)
+  })
+  const levels = [
+    { key: 'high', emoji: '🔴' },
+    { key: 'medium', emoji: '🟡' },
+    { key: 'low', emoji: '🟢' },
+  ]
+  for (const { key, emoji } of levels) {
+    if (groups[key].length === 0) continue
+    md += `### ${emoji} ${key.charAt(0).toUpperCase() + key.slice(1)} Severity (${groups[key].length})\n\n`
+    md += `| Type | File | Line | Variable | Value | Suggested Env Var |\n`
+    md += `|------|------|------|----------|-------|-------------------|\n`
+    groups[key].forEach(h => {
+      const val = String(h.value).substring(0, 50) + (String(h.value).length > 50 ? '...' : '')
+      md += `| ${h.type} | ${h.file} | ${h.line} | ${h.variable_name || '-'} | \`${val}\` | ${h.suggested_env_var ? '`' + h.suggested_env_var + '`' : '-'} |\n`
+    })
+    md += `\n`
   }
   return md
 }
@@ -296,6 +337,7 @@ const sectionGenerators: Record<SectionType, (data: unknown) => string> = {
   'environment': _generateEnvironmentMd,
   'code-intelligence': _generateCodeIntelligenceMd,
   'ownership': _generateOwnershipMd,
+  'hardcodes': _generateHardcodesMd,
 }
 
 /**
@@ -450,6 +492,7 @@ export function useCodebaseExport(deps: {
       'cross-language': 'cross-language', 'config-duplicates': 'config-duplicates',
       'code-intelligence': 'code-intelligence-scores', 'environment': 'environment-analysis',
       'statistics': 'codebase-statistics', 'ownership': 'ownership-analysis',
+      'hardcodes': 'hardcoded-values',
     }
     const baseName = nameMap[section] || section
     const ext = format === 'json' ? '.json' : '.md'

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -1879,6 +1879,25 @@
         "low": "Low Similarity"
       }
     },
+    "hardcodes": {
+      "title": "Hardcoded Values",
+      "values": "values",
+      "totalValues": "Total Values",
+      "highLabel": "High",
+      "mediumLabel": "Medium",
+      "lowLabel": "Low",
+      "uniqueTypes": "Unique Types",
+      "variable": "Variable",
+      "value": "Value",
+      "suggestedEnvVar": "Suggested Env Var",
+      "showingOf": "Showing {shown} of {total}",
+      "emptyMessage": "No hardcoded values detected",
+      "severityGroups": {
+        "high": "High Severity",
+        "medium": "Medium Severity",
+        "low": "Low Severity"
+      }
+    },
     "problems": {
       "title": "Problems Report",
       "total": "Total",


### PR DESCRIPTION
## Summary

- `/api/analytics/codebase/hardcodes` is fetched on Test Hardcodes clicks and during full scans, results populate `hardcodeAnalysis`, a success toast with count+types is fired — but the data had no template binding, so the panel never appeared.
- Adds `HardcodesSection.vue` (modeled on `DuplicatesSection.vue`) with severity groups (high/medium/low), summary cards, accordion items showing file:line + value + suggested env var, and MD/JSON export.
- Wires `<HardcodesSection>` into `CodebaseAnalytics.vue` after `<DeclarationsSection>`.
- Extends `useCodebaseExport`: new `'hardcodes'` SectionType, dedicated markdown generator, filename `hardcoded-values-*.md`.
- Registers `hardcodeAnalysis` in the sectionData map so MD/JSON export works.
- Adds `analytics.hardcodes.*` i18n keys (en locale).

Closes #5277.

## Verification

- `vue-tsc --noEmit -p tsconfig.app.json` → 167 errors (unchanged baseline; **0 new errors** in HardcodesSection, CodebaseAnalytics, or useCodebaseExport)
- Diff: +461 LOC across 4 files; only the new section component, template binding, export map, and i18n keys
- Pattern parity with `DuplicatesSection.vue` — same accordion/summary-card/export layout

## Test plan

- [ ] Navigate to `/analytics/codebase/{sourceId}`
- [ ] Click **Test Hardcodes** → panel renders with severity groups + values
- [ ] Run full scan → panel populates after scan completes
- [ ] Click MD/JSON export on the panel → file downloads with severity-grouped content
- [ ] Clear-cache / source switch → panel empties and re-renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)