### PR TITLE
refactor(frontend): complete reactive refs migration for useKnowledgeFacts/Files/Jobs (#5195)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useKnowledgeFacts.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeFacts.test.ts
@@ -168,4 +168,111 @@ describe('useKnowledgeFacts', () => {
       expect(result.success).toBe(true)
     })
   })
+
+  describe('reactive refs + managed actions (#5195)', () => {
+    it('should expose initial ref state as null/false/null', () => {
+      const { searchResults, lastAddedFact, isSearching, isAdding, error } =
+        useKnowledgeFacts()
+
+      expect(searchResults.value).toBe(null)
+      expect(lastAddedFact.value).toBe(null)
+      expect(isSearching.value).toBe(false)
+      expect(isAdding.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('search() should flip isSearching true while in-flight and populate searchResults on success', async () => {
+      const mockResults: SearchResponse = {
+        results: [{ id: '1', fact: 'hit', similarity_score: 0.9 }],
+        total_results: 1,
+      }
+      vi.mocked(apiClient.post).mockResolvedValue(mockResults)
+
+      const { searchResults, isSearching, error, search } = useKnowledgeFacts()
+
+      const promise = search('q')
+      expect(isSearching.value).toBe(true)
+
+      const data = await promise
+      expect(data).toEqual(mockResults)
+      expect(searchResults.value).toEqual(mockResults)
+      expect(isSearching.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('search() should populate error ref and reset isSearching when it throws', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('boom'))
+
+      const { searchResults, isSearching, error, search } = useKnowledgeFacts()
+
+      await expect(search('q')).rejects.toThrow('boom')
+      expect(searchResults.value).toBe(null)
+      expect(isSearching.value).toBe(false)
+      expect(error.value).toBeInstanceOf(Error)
+      expect(error.value?.message).toBe('boom')
+    })
+
+    it('runAdvancedSearch() should populate searchResults + state refs', async () => {
+      const mockResults: SearchResponse = { results: [], total_results: 0 }
+      vi.mocked(apiClient.post).mockResolvedValue(mockResults)
+
+      const { searchResults, isSearching, error, runAdvancedSearch } =
+        useKnowledgeFacts()
+
+      const data = await runAdvancedSearch({ query: 'q', mode: 'hybrid' })
+      expect(data).toEqual(mockResults)
+      expect(searchResults.value).toEqual(mockResults)
+      expect(isSearching.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('runAdvancedSearch() should wrap non-Error throw as Error instance', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue('string failure')
+
+      const { error, runAdvancedSearch } = useKnowledgeFacts()
+
+      await expect(runAdvancedSearch({ query: 'q' })).rejects.toBeDefined()
+      expect(error.value).toBeInstanceOf(Error)
+      expect(error.value?.message).toBe('string failure')
+    })
+
+    it('submitFact() should flip isAdding, populate lastAddedFact, clear error on success', async () => {
+      const mockAdd: AddFactResponse = {
+        success: true,
+        fact_id: 'f-1',
+        fact: {
+          id: 'f-1',
+          fact: 'x',
+          category: 'c',
+          created_at: 'now',
+          updated_at: 'now',
+        },
+      }
+      vi.mocked(apiClient.post).mockResolvedValue(mockAdd)
+
+      const { lastAddedFact, isAdding, error, submitFact } = useKnowledgeFacts()
+
+      const promise = submitFact({ content: 'x', category: 'c' })
+      expect(isAdding.value).toBe(true)
+
+      const data = await promise
+      expect(data).toEqual(mockAdd)
+      expect(lastAddedFact.value).toEqual(mockAdd)
+      expect(isAdding.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('submitFact() error should set error ref as Error instance, not raw string', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('add fail'))
+
+      const { error, isAdding, submitFact } = useKnowledgeFacts()
+
+      await expect(submitFact({ content: 'x', category: 'c' })).rejects.toThrow(
+        'add fail'
+      )
+      expect(isAdding.value).toBe(false)
+      expect(error.value).toBeInstanceOf(Error)
+      expect(typeof error.value).not.toBe('string')
+    })
+  })
 })

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeFiles.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeFiles.test.ts
@@ -59,4 +59,57 @@ describe('useKnowledgeFiles', () => {
       await expect(uploadKnowledgeFile(formData)).rejects.toThrow('Upload failed')
     })
   })
+
+  describe('reactive refs + managed upload (#5195)', () => {
+    it('should expose initial ref state as null/false/null', () => {
+      const { uploadResult, isUploading, error } = useKnowledgeFiles()
+
+      expect(uploadResult.value).toBe(null)
+      expect(isUploading.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('upload() should flip isUploading true while in-flight and populate uploadResult', async () => {
+      const mockResponse: UploadResponse = {
+        success: true,
+        file_path: '/uploads/x.pdf',
+        facts_added: 3,
+      }
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+      const { uploadResult, isUploading, error, upload } = useKnowledgeFiles()
+
+      const formData = new FormData()
+      const promise = upload(formData)
+      expect(isUploading.value).toBe(true)
+
+      const data = await promise
+      expect(data).toEqual(mockResponse)
+      expect(uploadResult.value).toEqual(mockResponse)
+      expect(isUploading.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('upload() should populate error ref and reset isUploading on failure', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('upload boom'))
+
+      const { uploadResult, isUploading, error, upload } = useKnowledgeFiles()
+
+      await expect(upload(new FormData())).rejects.toThrow('upload boom')
+      expect(uploadResult.value).toBe(null)
+      expect(isUploading.value).toBe(false)
+      expect(error.value).toBeInstanceOf(Error)
+      expect(error.value?.message).toBe('upload boom')
+    })
+
+    it('upload() error should wrap non-Error thrown value as Error instance', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue('raw string')
+
+      const { error, upload } = useKnowledgeFiles()
+
+      await expect(upload(new FormData())).rejects.toBeDefined()
+      expect(error.value).toBeInstanceOf(Error)
+      expect(error.value?.message).toBe('raw string')
+    })
+  })
 })

--- a/autobot-frontend/src/composables/__tests__/useKnowledgeJobs.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKnowledgeJobs.test.ts
@@ -154,4 +154,97 @@ describe('useKnowledgeJobs', () => {
       }
     })
   })
+
+  describe('reactive refs + managed actions (#5195)', () => {
+    it('should expose initial ref state as null/false/null', () => {
+      const {
+        vectorizationStatus,
+        vectorizationResult,
+        isLoadingStatus,
+        isVectorizing,
+        error,
+      } = useKnowledgeJobs()
+
+      expect(vectorizationStatus.value).toBe(null)
+      expect(vectorizationResult.value).toBe(null)
+      expect(isLoadingStatus.value).toBe(false)
+      expect(isVectorizing.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('refreshStatus() should flip isLoadingStatus and populate vectorizationStatus', async () => {
+      const mockStatus: VectorizationStatusResponse = {
+        status: 'idle',
+        total_facts: 10,
+        vectorized_facts: 10,
+      }
+      vi.mocked(apiClient.get).mockResolvedValue(mockStatus)
+
+      const { vectorizationStatus, isLoadingStatus, error, refreshStatus } =
+        useKnowledgeJobs()
+
+      const promise = refreshStatus()
+      expect(isLoadingStatus.value).toBe(true)
+
+      const data = await promise
+      expect(data).toEqual(mockStatus)
+      expect(vectorizationStatus.value).toEqual(mockStatus)
+      expect(isLoadingStatus.value).toBe(false)
+      expect(error.value).toBe(null)
+    })
+
+    it('refreshStatus() should populate error ref and reset isLoadingStatus on failure', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('status boom'))
+
+      const { vectorizationStatus, isLoadingStatus, error, refreshStatus } =
+        useKnowledgeJobs()
+
+      await expect(refreshStatus()).rejects.toThrow('status boom')
+      expect(vectorizationStatus.value).toBe(null)
+      expect(isLoadingStatus.value).toBe(false)
+      expect(error.value).toBeInstanceOf(Error)
+      expect(error.value?.message).toBe('status boom')
+    })
+
+    it('runVectorization() should flip isVectorizing, populate vectorizationResult on success', async () => {
+      const mockResponse: VectorizationResponse = {
+        status: 'success',
+        message: 'ok',
+        successful: 50,
+        skipped: 0,
+        failed: 0,
+        total_processed: 50,
+      }
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse)
+
+      const { vectorizationResult, isVectorizing, error, runVectorization } =
+        useKnowledgeJobs()
+
+      const promise = runVectorization(100, 1.0, false)
+      expect(isVectorizing.value).toBe(true)
+
+      const data = await promise
+      expect(data).toEqual(mockResponse)
+      expect(vectorizationResult.value).toEqual(mockResponse)
+      expect(isVectorizing.value).toBe(false)
+      expect(error.value).toBe(null)
+      // Verify params forwarded
+      expect(apiClient.post).toHaveBeenCalledWith(
+        expect.any(String),
+        { batch_size: 100, batch_delay: 1.0, skip_existing: false },
+        expect.any(Object)
+      )
+    })
+
+    it('runVectorization() error should set error ref as Error instance, not raw string', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue('vector failure')
+
+      const { error, isVectorizing, runVectorization } = useKnowledgeJobs()
+
+      await expect(runVectorization()).rejects.toBeDefined()
+      expect(isVectorizing.value).toBe(false)
+      expect(error.value).toBeInstanceOf(Error)
+      expect(error.value?.message).toBe('vector failure')
+    })
+  })
 })

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeFacts.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeFacts.ts
@@ -4,8 +4,15 @@
  * Search (basic + advanced) and direct-fact management for the knowledge base.
  * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
  * ApiClient already logs retries + final failure and never returns null.
+ *
+ * Reactive refs layer (#5195, follow-up to #5149): the composable now owns
+ * loading/error state via `ref`s and exposes managed `search`/`runAdvancedSearch`/
+ * `submitFact` actions. The bare imperative functions remain exported at module
+ * scope so non-reactive consumers (and the `useKnowledgeBase` BC shim) keep
+ * working unchanged.
  */
 
+import { ref, readonly, type Ref } from 'vue'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import type {
@@ -38,31 +45,121 @@ export interface AdvancedSearchOptions {
   offset?: number
 }
 
-export function useKnowledgeFacts() {
-  /**
-   * Search knowledge base (basic)
-   * Issue #552: Backend expects POST for search
-   */
-  const searchKnowledge = (query: string): Promise<SearchResponse> =>
-    apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, { query })
+export interface AddFactInput {
+  content: string
+  category: string
+  metadata?: Record<string, unknown>
+}
 
-  /**
-   * Advanced search with full options (Issue #555)
-   */
-  const advancedSearch = (options: AdvancedSearchOptions): Promise<SearchResponse> =>
-    apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, options)
+// ==================== Bare imperative API ====================
 
-  /**
-   * Add new fact to knowledge base
-   */
-  const addFact = (fact: {
-    content: string
-    category: string
-    metadata?: Record<string, unknown>
-  }): Promise<AddFactResponse> =>
-    apiClient.post<AddFactResponse>(`${getApiBase()}/knowledge_base/facts`, fact)
+/**
+ * Search knowledge base (basic).
+ * Issue #552: Backend expects POST for search.
+ */
+export const searchKnowledge = (query: string): Promise<SearchResponse> =>
+  apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, { query })
+
+/**
+ * Advanced search with full options (Issue #555).
+ */
+export const advancedSearch = (options: AdvancedSearchOptions): Promise<SearchResponse> =>
+  apiClient.post<SearchResponse>(`${getApiBase()}/knowledge_base/search`, options)
+
+/**
+ * Add new fact to knowledge base.
+ */
+export const addFact = (fact: AddFactInput): Promise<AddFactResponse> =>
+  apiClient.post<AddFactResponse>(`${getApiBase()}/knowledge_base/facts`, fact)
+
+// ==================== Reactive composable ====================
+
+export interface UseKnowledgeFactsReturn {
+  /** Latest search result (basic or advanced). */
+  searchResults: Readonly<Ref<SearchResponse | null>>
+  /** Latest add-fact response. */
+  lastAddedFact: Readonly<Ref<AddFactResponse | null>>
+  /** True while a search (basic or advanced) is in-flight. */
+  isSearching: Readonly<Ref<boolean>>
+  /** True while addFact is in-flight. */
+  isAdding: Readonly<Ref<boolean>>
+  /** Last error raised by a managed action; cleared on the next call. */
+  error: Readonly<Ref<Error | null>>
+  /** Run a basic search, update `searchResults` + state refs, return the payload. */
+  search: (query: string) => Promise<SearchResponse>
+  /** Run an advanced search, update `searchResults` + state refs. */
+  runAdvancedSearch: (options: AdvancedSearchOptions) => Promise<SearchResponse>
+  /** Add a fact, update `lastAddedFact` + state refs. */
+  submitFact: (fact: AddFactInput) => Promise<AddFactResponse>
+  // Imperative passthroughs — BC with pre-#5195 callers
+  searchKnowledge: typeof searchKnowledge
+  advancedSearch: typeof advancedSearch
+  addFact: typeof addFact
+}
+
+export function useKnowledgeFacts(): UseKnowledgeFactsReturn {
+  const searchResults = ref<SearchResponse | null>(null)
+  const lastAddedFact = ref<AddFactResponse | null>(null)
+  const isSearching = ref(false)
+  const isAdding = ref(false)
+  const error = ref<Error | null>(null)
+
+  const search = async (query: string): Promise<SearchResponse> => {
+    isSearching.value = true
+    error.value = null
+    try {
+      const data = await searchKnowledge(query)
+      searchResults.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      isSearching.value = false
+    }
+  }
+
+  const runAdvancedSearch = async (
+    options: AdvancedSearchOptions
+  ): Promise<SearchResponse> => {
+    isSearching.value = true
+    error.value = null
+    try {
+      const data = await advancedSearch(options)
+      searchResults.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      isSearching.value = false
+    }
+  }
+
+  const submitFact = async (fact: AddFactInput): Promise<AddFactResponse> => {
+    isAdding.value = true
+    error.value = null
+    try {
+      const data = await addFact(fact)
+      lastAddedFact.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      isAdding.value = false
+    }
+  }
 
   return {
+    searchResults: readonly(searchResults) as Readonly<Ref<SearchResponse | null>>,
+    lastAddedFact: readonly(lastAddedFact) as Readonly<Ref<AddFactResponse | null>>,
+    isSearching: readonly(isSearching),
+    isAdding: readonly(isAdding),
+    error: readonly(error),
+    search,
+    runAdvancedSearch,
+    submitFact,
     searchKnowledge,
     advancedSearch,
     addFact,

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeFiles.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeFiles.ts
@@ -8,25 +8,71 @@
  * Preserves the apiClient FormData pattern from PR #5116 — rawRequest strips
  * Content-Type so the browser sets the multipart boundary automatically, and
  * inherits the same auth/retry/error-handling as every other API call.
+ *
+ * Reactive refs layer (#5195, follow-up to #5149): the composable now owns
+ * loading/error state via `ref`s and exposes a managed `upload` action. The
+ * bare imperative function is still exported at module scope so non-reactive
+ * consumers (and the `useKnowledgeBase` BC shim) keep working unchanged.
  */
 
+import { ref, readonly, type Ref } from 'vue'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
 import type { UploadResponse } from '@/types/knowledgeBase'
 
-export function useKnowledgeFiles() {
-  /**
-   * Upload knowledge base file
-   */
-  const uploadKnowledgeFile = async (formData: FormData): Promise<UploadResponse> => {
-    const data = await apiClient.post<Record<string, unknown>>(
-      `${getApiBase()}/knowledge_base/upload`,
-      formData
-    )
-    return data as unknown as UploadResponse
+// ==================== Bare imperative API ====================
+
+/**
+ * Upload knowledge base file.
+ */
+export const uploadKnowledgeFile = async (formData: FormData): Promise<UploadResponse> => {
+  const data = await apiClient.post<Record<string, unknown>>(
+    `${getApiBase()}/knowledge_base/upload`,
+    formData
+  )
+  return data as unknown as UploadResponse
+}
+
+// ==================== Reactive composable ====================
+
+export interface UseKnowledgeFilesReturn {
+  /** Latest upload response, or null if never uploaded / upload failed. */
+  uploadResult: Readonly<Ref<UploadResponse | null>>
+  /** True while an upload is in-flight. */
+  isUploading: Readonly<Ref<boolean>>
+  /** Last error raised by `upload`; cleared on the next call. */
+  error: Readonly<Ref<Error | null>>
+  /** Upload a file, update `uploadResult` + state refs, return the payload. */
+  upload: (formData: FormData) => Promise<UploadResponse>
+  // Imperative passthroughs — BC with pre-#5195 callers
+  uploadKnowledgeFile: typeof uploadKnowledgeFile
+}
+
+export function useKnowledgeFiles(): UseKnowledgeFilesReturn {
+  const uploadResult = ref<UploadResponse | null>(null)
+  const isUploading = ref(false)
+  const error = ref<Error | null>(null)
+
+  const upload = async (formData: FormData): Promise<UploadResponse> => {
+    isUploading.value = true
+    error.value = null
+    try {
+      const data = await uploadKnowledgeFile(formData)
+      uploadResult.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      isUploading.value = false
+    }
   }
 
   return {
+    uploadResult: readonly(uploadResult) as Readonly<Ref<UploadResponse | null>>,
+    isUploading: readonly(isUploading),
+    error: readonly(error),
+    upload,
     uploadKnowledgeFile,
   }
 }

--- a/autobot-frontend/src/composables/knowledge/useKnowledgeJobs.ts
+++ b/autobot-frontend/src/composables/knowledge/useKnowledgeJobs.ts
@@ -3,11 +3,21 @@
  *
  * Vectorization API calls + background job polling. These are the
  * low-level endpoints; `useKnowledgeVectorization` layers state + dedup
- * caching on top of them.
+ * caching on top of them, and `usePollingJob` (#5191) provides generic
+ * managed interval polling on top of `pollJobStatus`.
+ *
  * Split from useKnowledgeBase (#5122). Dead try/catch wrappers removed (#5123):
  * ApiClient already logs retries + final failure and never returns null.
+ *
+ * Reactive refs layer (#5195, follow-up to #5149): the composable now owns
+ * loading/error state via `ref`s and exposes managed `refreshStatus` and
+ * `runVectorization` actions. The bare imperative functions remain exported at
+ * module scope so non-reactive consumers (and the `useKnowledgeBase` BC shim)
+ * keep working unchanged. `pollJobStatus` is a one-shot snapshot and is kept
+ * imperative — for managed polling, use `usePollingJob(pollJobStatus, ...)`.
  */
 
+import { ref, readonly, type Ref } from 'vue'
 import apiClient from '@/utils/ApiClient'
 import appConfig from '@/config/AppConfig.js'
 import { getApiBase } from '@/config/ssot-config'
@@ -16,51 +26,134 @@ import type {
   VectorizationResponse,
 } from '@/types/knowledgeBase'
 
-export function useKnowledgeJobs() {
-  /**
-   * Get vectorization status.
-   * Issue #552: Fixed path — backend uses /api/knowledge_base/vectorize_facts/status.
-   */
-  const getVectorizationStatus = (): Promise<VectorizationStatusResponse> =>
-    apiClient.get<VectorizationStatusResponse>(
-      `${getApiBase()}/knowledge_base/vectorize_facts/status`
-    )
+// ==================== Bare imperative API ====================
 
-  /**
-   * Generate vector embeddings for all existing facts using batched processing.
-   * @param batchSize - Number of facts to process per batch (default: 50)
-   * @param batchDelay - Delay in seconds between batches (default: 0.5)
-   * @param skipExisting - Skip facts that already have vectors (default: true)
-   */
-  const vectorizeFacts = (
+/**
+ * Get vectorization status.
+ * Issue #552: Fixed path — backend uses /api/knowledge_base/vectorize_facts/status.
+ */
+export const getVectorizationStatus = (): Promise<VectorizationStatusResponse> =>
+  apiClient.get<VectorizationStatusResponse>(
+    `${getApiBase()}/knowledge_base/vectorize_facts/status`
+  )
+
+/**
+ * Generate vector embeddings for all existing facts using batched processing.
+ * @param batchSize - Number of facts to process per batch (default: 50)
+ * @param batchDelay - Delay in seconds between batches (default: 0.5)
+ * @param skipExisting - Skip facts that already have vectors (default: true)
+ */
+export const vectorizeFacts = (
+  batchSize: number = 50,
+  batchDelay: number = 0.5,
+  skipExisting: boolean = true
+): Promise<VectorizationResponse> => {
+  // Knowledge-specific timeout (300s for vectorization operations)
+  const knowledgeTimeout = appConfig.getTimeout('knowledge')
+
+  return apiClient.post<VectorizationResponse>(
+    `${getApiBase()}/knowledge_base/vectorize_facts`,
+    {
+      batch_size: batchSize,
+      batch_delay: batchDelay,
+      skip_existing: skipExisting,
+    },
+    { timeout: knowledgeTimeout }
+  )
+}
+
+/**
+ * Poll status of a background job (e.g., knowledge refresh, reindexing).
+ * GET /api/knowledge_base/job_status/{task_id}
+ *
+ * Returns current status: PENDING, PROGRESS, SUCCESS, or FAILURE.
+ *
+ * One-shot snapshot. For managed interval polling, use `usePollingJob`
+ * (#5191) with this fetcher.
+ */
+export const pollJobStatus = (taskId: string): Promise<unknown> =>
+  apiClient.get(`${getApiBase()}/knowledge_base/job_status/${taskId}`)
+
+// ==================== Reactive composable ====================
+
+export interface UseKnowledgeJobsReturn {
+  /** Latest vectorization status snapshot, or null if never fetched. */
+  vectorizationStatus: Readonly<Ref<VectorizationStatusResponse | null>>
+  /** Latest vectorization run result, or null if never run. */
+  vectorizationResult: Readonly<Ref<VectorizationResponse | null>>
+  /** True while refreshStatus is in-flight. */
+  isLoadingStatus: Readonly<Ref<boolean>>
+  /** True while runVectorization is in-flight. */
+  isVectorizing: Readonly<Ref<boolean>>
+  /** Last error raised by a managed action; cleared on the next call. */
+  error: Readonly<Ref<Error | null>>
+  /** Fetch vectorization status, update `vectorizationStatus` + state refs. */
+  refreshStatus: () => Promise<VectorizationStatusResponse>
+  /** Run vectorization, update `vectorizationResult` + state refs. */
+  runVectorization: (
+    batchSize?: number,
+    batchDelay?: number,
+    skipExisting?: boolean
+  ) => Promise<VectorizationResponse>
+  // Imperative passthroughs — BC with pre-#5195 callers
+  getVectorizationStatus: typeof getVectorizationStatus
+  vectorizeFacts: typeof vectorizeFacts
+  pollJobStatus: typeof pollJobStatus
+}
+
+export function useKnowledgeJobs(): UseKnowledgeJobsReturn {
+  const vectorizationStatus = ref<VectorizationStatusResponse | null>(null)
+  const vectorizationResult = ref<VectorizationResponse | null>(null)
+  const isLoadingStatus = ref(false)
+  const isVectorizing = ref(false)
+  const error = ref<Error | null>(null)
+
+  const refreshStatus = async (): Promise<VectorizationStatusResponse> => {
+    isLoadingStatus.value = true
+    error.value = null
+    try {
+      const data = await getVectorizationStatus()
+      vectorizationStatus.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      isLoadingStatus.value = false
+    }
+  }
+
+  const runVectorization = async (
     batchSize: number = 50,
     batchDelay: number = 0.5,
     skipExisting: boolean = true
   ): Promise<VectorizationResponse> => {
-    // Knowledge-specific timeout (300s for vectorization operations)
-    const knowledgeTimeout = appConfig.getTimeout('knowledge')
-
-    return apiClient.post<VectorizationResponse>(
-      `${getApiBase()}/knowledge_base/vectorize_facts`,
-      {
-        batch_size: batchSize,
-        batch_delay: batchDelay,
-        skip_existing: skipExisting,
-      },
-      { timeout: knowledgeTimeout }
-    )
+    isVectorizing.value = true
+    error.value = null
+    try {
+      const data = await vectorizeFacts(batchSize, batchDelay, skipExisting)
+      vectorizationResult.value = data
+      return data
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err))
+      throw err
+    } finally {
+      isVectorizing.value = false
+    }
   }
 
-  /**
-   * Poll status of a background job (e.g., knowledge refresh, reindexing).
-   * GET /api/knowledge_base/job_status/{task_id}
-   *
-   * Returns current status: PENDING, PROGRESS, SUCCESS, or FAILURE.
-   */
-  const pollJobStatus = (taskId: string): Promise<unknown> =>
-    apiClient.get(`${getApiBase()}/knowledge_base/job_status/${taskId}`)
-
   return {
+    vectorizationStatus: readonly(vectorizationStatus) as Readonly<
+      Ref<VectorizationStatusResponse | null>
+    >,
+    vectorizationResult: readonly(vectorizationResult) as Readonly<
+      Ref<VectorizationResponse | null>
+    >,
+    isLoadingStatus: readonly(isLoadingStatus),
+    isVectorizing: readonly(isVectorizing),
+    error: readonly(error),
+    refreshStatus,
+    runVectorization,
     getVectorizationStatus,
     vectorizeFacts,
     pollJobStatus,


### PR DESCRIPTION
Closes #5195

## Summary
Completes #5167's reactive-refs migration for the 3 remaining KB composables. Same pattern — bare async functions at module scope (preserves BC), composable returns refs + managed actions.

## Migrated
- \`useKnowledgeFacts\` — searchResults, lastAddedFact, isSearching, isAdding, error + search/runAdvancedSearch/submitFact actions
- \`useKnowledgeFiles\` — uploadResult, isUploading, error + upload() action (FormData apiClient.post pattern from #5116 preserved)
- \`useKnowledgeJobs\` — vectorizationStatus, vectorizationResult, isLoadingStatus, isVectorizing, error + refreshStatus/runVectorization. \`pollJobStatus\` kept as one-shot snapshot; consumers wanting managed polling use \`usePollingJob\` (#5191) on top

## BC preserved
All 3 composables still return bare function references. \`useKnowledgeBase.ts\` shim unchanged; consumers like \`useKnowledgeVectorization\` destructuring \`vectorizeFacts\`/\`getVectorizationStatus\` unaffected.

## Tests
- useKnowledgeFacts: 13/13 (7 new)
- useKnowledgeFiles: 6/6 (4 new)
- useKnowledgeJobs: 10/10 (5 new)
- useKnowledgeBase.test.ts BC shim: 4/4
- useKnowledgeVectorization consumer: 41/41

Type-check 167 (baseline 169); zero new errors.