### PR TITLE
feat(knowledge): distinguish empty-KB vs broken-KB with clear CTA panels (#5201)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -465,6 +465,7 @@ async def get_main_categories(
     return KnowledgeMainCategoriesResponse(
         categories=main_categories,
         total=len(main_categories),
+        kb_connected=redis_client is not None,
     )
 
 

--- a/autobot-backend/knowledge/schemas/stats.py
+++ b/autobot-backend/knowledge/schemas/stats.py
@@ -156,9 +156,16 @@ class KnowledgeMainCategoryEntry(BaseModel):
 
 
 class KnowledgeMainCategoriesResponse(BaseModel):
-    """Shape of ``GET /api/knowledge_base/categories/main``."""
+    """Shape of ``GET /api/knowledge_base/categories/main``.
+
+    ``kb_connected`` (issue #5201) lets the UI distinguish an empty knowledge
+    base (counts == 0 because nothing has been indexed yet) from an
+    unreachable knowledge base (Redis unavailable) — both otherwise return
+    all-zero counts.
+    """
 
     model_config = ConfigDict(extra="allow")
 
     categories: List[KnowledgeMainCategoryEntry] = Field(default_factory=list)
     total: int = 0
+    kb_connected: bool = True

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -4,6 +4,7 @@
     <KnowledgeMainCategories
       :categories="mainCategories"
       :population-states="populationStates"
+      :kb-connected="kbConnected"
       @select="selectMainCategory"
       @populate="handlePopulate"
       @import="() => router.push('/knowledge/upload')"
@@ -270,6 +271,11 @@ const updateDebouncedSearch = useDebounce((value: string) => {
 const selectedCategory = ref<string | null>(null)
 const selectedMainCategory = ref<string | null>(null)
 const mainCategories = ref<any[]>([])
+// Issue #5201: track backend KB connectivity so the UI can distinguish
+// "empty KB" (all counts 0, kb_connected=true) from "broken KB"
+// (kb_connected=false). Defaults to true so we don't flash the error
+// banner before the first fetch completes.
+const kbConnected = ref<boolean>(true)
 const categoryCounts = ref<Record<string, number>>({})
 const isVectorizing = ref(false)
 const showProgressModal = ref(false)
@@ -571,9 +577,16 @@ const loadMainCategories = async () => {
 
     if (data && data.categories) {
       mainCategories.value = data.categories
+      // Issue #5201: surface backend connectivity flag. Treat missing
+      // field as "connected" (true) to stay compatible with older
+      // backends that predate the field.
+      kbConnected.value = data.kb_connected !== false
     }
   } catch (err) {
     logger.error('Failed to load main categories:', err)
+    // Fetch itself failed — treat as broken KB so the UI shows the
+    // distinct error panel (#5201).
+    kbConnected.value = false
     // Set default categories if API fails
     mainCategories.value = [
       {

--- a/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.vue
@@ -1,45 +1,84 @@
 <template>
-  <div class="main-categories">
+  <div class="main-categories-wrapper">
+    <!-- Issue #5201: broken-KB alert takes precedence over the empty-state hint -->
     <div
-      v-for="mainCat in categories"
-      :key="mainCat.id"
-      class="main-category-card"
-      :style="{ borderColor: mainCat.color }"
-      @click="$emit('select', mainCat.id)"
+      v-if="!kbConnected"
+      class="kb-status-panel kb-status-panel--error"
+      role="alert"
     >
-      <div class="category-icon" :style="{ backgroundColor: mainCat.color }">
-        <i :class="mainCat.icon"></i>
+      <i class="fas fa-exclamation-triangle kb-status-panel__icon"></i>
+      <div class="kb-status-panel__body">
+        <h3 class="kb-status-panel__title">
+          {{ $t('knowledge.categoriesError.title') }}
+        </h3>
+        <p class="kb-status-panel__text">
+          {{ $t('knowledge.categoriesError.description') }}
+        </p>
       </div>
-      <div class="category-info">
-        <h3>{{ mainCat.name }}</h3>
-        <p>{{ mainCat.description }}</p>
-        <div class="category-stats">
-          <span class="fact-count">{{ mainCat.count }} {{ $t('knowledge.browser.facts') }}</span>
-          <!-- Populate button for system categories -->
-          <BaseButton
-            v-if="mainCat.id !== 'user-knowledge'"
-            variant="primary"
-            size="sm"
-            :loading="populationStates[mainCat.id]?.isPopulating"
-            :disabled="populationStates[mainCat.id]?.isPopulating"
-            @click.stop="$emit('populate', mainCat.id)"
-            class="populate-btn"
-          >
-            <i v-if="!populationStates[mainCat.id]?.isPopulating" class="fas fa-sync"></i>
-            <span v-if="!populationStates[mainCat.id]?.isPopulating">{{ $t('knowledge.browser.populate') }}</span>
-            <span v-else>{{ populationStates[mainCat.id]?.progress || 0 }}%</span>
-          </BaseButton>
-          <!-- Import button for user knowledge -->
-          <BaseButton
-            v-if="mainCat.id === 'user-knowledge'"
-            variant="primary"
-            size="sm"
-            @click.stop="$emit('import')"
-            class="populate-btn"
-          >
-            <i class="fas fa-file-import"></i>
-            <span>{{ $t('knowledge.browser.import') }}</span>
-          </BaseButton>
+    </div>
+
+    <!-- Issue #5201: empty-KB hint — only when categories have loaded and every count is 0 -->
+    <div
+      v-else-if="showEmptyStateHint"
+      class="kb-status-panel kb-status-panel--info"
+      role="status"
+    >
+      <i class="fas fa-info-circle kb-status-panel__icon"></i>
+      <div class="kb-status-panel__body">
+        <h3 class="kb-status-panel__title">
+          {{ $t('knowledge.emptyState.title') }}
+        </h3>
+        <p class="kb-status-panel__text">
+          {{ $t('knowledge.emptyState.description') }}
+        </p>
+        <p class="kb-status-panel__text">
+          {{ $t('knowledge.emptyState.hint') }}
+        </p>
+      </div>
+    </div>
+
+    <div class="main-categories">
+      <div
+        v-for="mainCat in categories"
+        :key="mainCat.id"
+        class="main-category-card"
+        :style="{ borderColor: mainCat.color }"
+        @click="$emit('select', mainCat.id)"
+      >
+        <div class="category-icon" :style="{ backgroundColor: mainCat.color }">
+          <i :class="mainCat.icon"></i>
+        </div>
+        <div class="category-info">
+          <h3>{{ mainCat.name }}</h3>
+          <p>{{ mainCat.description }}</p>
+          <div class="category-stats">
+            <span class="fact-count">{{ mainCat.count }} {{ $t('knowledge.browser.facts') }}</span>
+            <!-- Populate button for system categories -->
+            <BaseButton
+              v-if="mainCat.id !== 'user-knowledge'"
+              variant="primary"
+              size="sm"
+              :loading="populationStates[mainCat.id]?.isPopulating"
+              :disabled="populationStates[mainCat.id]?.isPopulating"
+              @click.stop="$emit('populate', mainCat.id)"
+              class="populate-btn"
+            >
+              <i v-if="!populationStates[mainCat.id]?.isPopulating" class="fas fa-sync"></i>
+              <span v-if="!populationStates[mainCat.id]?.isPopulating">{{ $t('knowledge.browser.populate') }}</span>
+              <span v-else>{{ populationStates[mainCat.id]?.progress || 0 }}%</span>
+            </BaseButton>
+            <!-- Import button for user knowledge -->
+            <BaseButton
+              v-if="mainCat.id === 'user-knowledge'"
+              variant="primary"
+              size="sm"
+              @click.stop="$emit('import')"
+              class="populate-btn"
+            >
+              <i class="fas fa-file-import"></i>
+              <span>{{ $t('knowledge.browser.import') }}</span>
+            </BaseButton>
+          </div>
         </div>
       </div>
     </div>
@@ -57,8 +96,10 @@
  * Extracted from KnowledgeBrowser.vue for better maintainability.
  *
  * Issue #184: Split oversized Vue components
+ * Issue #5201: Distinguish empty-KB from broken-KB with clear CTA panels
  */
 
+import { computed } from 'vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 
 interface MainCategory {
@@ -78,6 +119,9 @@ interface PopulationState {
 interface Props {
   categories: MainCategory[]
   populationStates: Record<string, PopulationState>
+  // Issue #5201: reflects backend Redis/KB reachability. Defaults to true
+  // to preserve behavior with older backends that don't send the flag.
+  kbConnected?: boolean
 }
 
 interface Emits {
@@ -86,12 +130,29 @@ interface Emits {
   (e: 'import'): void
 }
 
-defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  kbConnected: true,
+})
 defineEmits<Emits>()
+
+// Show the empty-state hint only once categories have loaded AND every
+// visible card has a zero count. Rendering it before categories load
+// would flash a "you're empty" message during normal startup.
+const showEmptyStateHint = computed(
+  () =>
+    props.kbConnected &&
+    props.categories.length > 0 &&
+    props.categories.every((c) => (c.count ?? 0) === 0),
+)
 </script>
 
 <style scoped>
 /* Issue #704: Migrated to CSS design tokens */
+.main-categories-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
 .main-categories {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -176,6 +237,64 @@ defineEmits<Emits>()
   font-size: var(--text-xs);
 }
 
+/* Issue #5201: status panels for empty-KB / broken-KB states */
+.kb-status-panel {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  margin: var(--spacing-4) var(--spacing-6) var(--spacing-0);
+  padding: var(--spacing-4) var(--spacing-5);
+  border-radius: var(--radius-lg);
+  border: 1px solid transparent;
+}
+
+.kb-status-panel__icon {
+  font-size: var(--text-xl);
+  margin-top: var(--spacing-0-5);
+  flex-shrink: 0;
+}
+
+.kb-status-panel__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.kb-status-panel__title {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  margin: 0 0 var(--spacing-1) 0;
+}
+
+.kb-status-panel__text {
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  margin: 0 0 var(--spacing-1) 0;
+}
+
+.kb-status-panel__text:last-child {
+  margin-bottom: 0;
+}
+
+.kb-status-panel--info {
+  background: var(--color-primary-bg);
+  border-color: var(--color-primary-light);
+  color: var(--color-primary-dark);
+}
+
+.kb-status-panel--info .kb-status-panel__icon {
+  color: var(--color-primary);
+}
+
+.kb-status-panel--error {
+  background: var(--color-error-alpha-10);
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.kb-status-panel--error .kb-status-panel__icon {
+  color: var(--color-error);
+}
+
 @media (max-width: 640px) {
   .main-categories {
     grid-template-columns: 1fr;
@@ -189,6 +308,11 @@ defineEmits<Emits>()
 
   .category-stats {
     width: 100%;
+  }
+
+  .kb-status-panel {
+    margin: var(--spacing-3) var(--spacing-4) var(--spacing-0);
+    padding: var(--spacing-3);
   }
 }
 </style>

--- a/autobot-frontend/src/components/knowledge/__tests__/KnowledgeMainCategories.spec.ts
+++ b/autobot-frontend/src/components/knowledge/__tests__/KnowledgeMainCategories.spec.ts
@@ -1,0 +1,129 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Tests for KnowledgeMainCategories.vue — empty-KB vs broken-KB panels.
+ *
+ * Covers issue #5201:
+ *  - All counts == 0 AND kb_connected == true → empty-state banner visible
+ *  - kb_connected == false → broken-KB error panel visible (takes precedence)
+ *  - Any count > 0 → neither banner visible
+ *  - Empty categories array (still loading) → no banner (prevents flash)
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import KnowledgeMainCategories from '../KnowledgeMainCategories.vue'
+
+const stubT = (key: string) => key
+
+const SYSTEM_CATEGORIES = [
+  {
+    id: 'autobot-documentation',
+    name: 'AutoBot Documentation',
+    description: 'docs',
+    icon: 'fas fa-book',
+    color: '#3b82f6',
+    count: 0,
+  },
+  {
+    id: 'system-knowledge',
+    name: 'System Knowledge',
+    description: 'system',
+    icon: 'fas fa-server',
+    color: '#10b981',
+    count: 0,
+  },
+  {
+    id: 'user-knowledge',
+    name: 'User Knowledge',
+    description: 'user',
+    icon: 'fas fa-user-circle',
+    color: '#f59e0b',
+    count: 0,
+  },
+]
+
+function mountComponent(props: {
+  categories?: typeof SYSTEM_CATEGORIES
+  kbConnected?: boolean
+}) {
+  return mount(KnowledgeMainCategories, {
+    props: {
+      categories: props.categories ?? SYSTEM_CATEGORIES,
+      populationStates: {},
+      kbConnected: props.kbConnected,
+    },
+    global: {
+      mocks: { $t: stubT },
+      stubs: {
+        BaseButton: {
+          template: '<button><slot /></button>',
+          props: ['variant', 'size', 'loading', 'disabled'],
+        },
+      },
+    },
+  })
+}
+
+describe('KnowledgeMainCategories — empty-KB vs broken-KB panels (#5201)', () => {
+  it('shows empty-state hint when all counts are 0 and kb is connected', () => {
+    const wrapper = mountComponent({ kbConnected: true })
+    expect(wrapper.find('.kb-status-panel--info').exists()).toBe(true)
+    expect(wrapper.find('.kb-status-panel--error').exists()).toBe(false)
+    expect(wrapper.text()).toContain('knowledge.emptyState.title')
+    expect(wrapper.text()).toContain('knowledge.emptyState.hint')
+  })
+
+  it('shows broken-KB error panel when kb is disconnected (overrides empty-state)', () => {
+    const wrapper = mountComponent({ kbConnected: false })
+    expect(wrapper.find('.kb-status-panel--error').exists()).toBe(true)
+    expect(wrapper.find('.kb-status-panel--info').exists()).toBe(false)
+    expect(wrapper.text()).toContain('knowledge.categoriesError.title')
+    expect(wrapper.text()).toContain('knowledge.categoriesError.description')
+  })
+
+  it('shows neither banner when any category has count > 0', () => {
+    const populated = SYSTEM_CATEGORIES.map((c, i) =>
+      i === 0 ? { ...c, count: 5 } : c,
+    )
+    const wrapper = mountComponent({ categories: populated, kbConnected: true })
+    expect(wrapper.find('.kb-status-panel--info').exists()).toBe(false)
+    expect(wrapper.find('.kb-status-panel--error').exists()).toBe(false)
+  })
+
+  it('shows broken-KB panel even when counts would otherwise trigger empty-state', () => {
+    const wrapper = mountComponent({ kbConnected: false })
+    // Error panel present, info panel absent — error takes precedence
+    expect(wrapper.find('.kb-status-panel--error').exists()).toBe(true)
+    expect(wrapper.find('.kb-status-panel--info').exists()).toBe(false)
+  })
+
+  it('does not flash empty-state hint while categories are still loading', () => {
+    const wrapper = mountComponent({ categories: [], kbConnected: true })
+    expect(wrapper.find('.kb-status-panel--info').exists()).toBe(false)
+    expect(wrapper.find('.kb-status-panel--error').exists()).toBe(false)
+  })
+
+  it('defaults kbConnected to true when prop omitted', () => {
+    const wrapper = mount(KnowledgeMainCategories, {
+      props: {
+        categories: SYSTEM_CATEGORIES,
+        populationStates: {},
+      },
+      global: {
+        mocks: { $t: stubT },
+        stubs: {
+          BaseButton: {
+            template: '<button><slot /></button>',
+            props: ['variant', 'size', 'loading', 'disabled'],
+          },
+        },
+      },
+    })
+    // No kbConnected prop → default true → empty-state shown (counts are 0)
+    expect(wrapper.find('.kb-status-panel--info').exists()).toBe(true)
+    expect(wrapper.find('.kb-status-panel--error').exists()).toBe(false)
+  })
+})

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2168,6 +2168,15 @@
   },
   "knowledge": {
     "title": "Knowledge Base",
+    "emptyState": {
+      "title": "Your knowledge base is empty",
+      "description": "Each category shows 0 facts because nothing has been indexed yet.",
+      "hint": "Click 'Populate' on any category card to seed it, or upload documents under User Knowledge."
+    },
+    "categoriesError": {
+      "title": "Knowledge base is unreachable",
+      "description": "Redis connection failed. Check that the backend has Redis running."
+    },
     "search": {
       "aiSynthesis": "Ai synthesis",
       "allCategories": "All categories",


### PR DESCRIPTION
Closes #5201

## Summary
User reports \"/knowledge/categories shows no data\" was actually empty-KB + zero CTA. Now distinguishes three states:

1. **Any count > 0** → normal cards (no banner)
2. **All counts = 0 + \`kb_connected: true\`** → friendly empty-state banner with populate/upload hint
3. **\`kb_connected: false\`** → distinct error panel pointing at Redis

## Backend
\`GET /api/knowledge_base/categories/main\` now returns \`kb_connected: bool\` alongside \`categories\` + \`total\`. Pydantic model \`KnowledgeMainCategoriesResponse\` (from #5248) extended.

## Frontend
\`KnowledgeBrowser.vue\` reads \`data.kb_connected\`; treats missing as \`true\` (BC); fetch-error sets \`false\`. Passes as prop to \`KnowledgeMainCategories.vue\` which renders distinct info/error panels.

## i18n
\`knowledge.emptyState.{title,description,hint}\` + \`knowledge.categoriesError.{title,description}\` (en.json; non-en parity tracked under existing #5004).

## Tests
6/6 new in \`KnowledgeMainCategories.spec.ts\`: empty+connected shows info panel, disconnected shows error, any count>0 shows nothing, error-takes-precedence, no loading-flash, default kbConnected=true.

## Test Status
PASS — 6/6; type-check 167 (zero new errors)