### PR TITLE
feat(shared): add now_utc() helper + migrate 23 dataclass default_factory sites (#5211 phases B1+B2)

### DIFF
--- a/autobot-backend/agent_loop/types.py
+++ b/autobot-backend/agent_loop/types.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Any, Optional
 
+from autobot_shared.time_utils import now_utc
 from constants.threshold_constants import BatchConfig, RetryConfig
 
 # =============================================================================
@@ -85,7 +86,7 @@ class ThinkResult:
     confidence: float  # 0.0 to 1.0
     alternatives_considered: list[str] = field(default_factory=list)
     risks_identified: list[str] = field(default_factory=list)
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=now_utc)
     task_id: Optional[str] = None
 
     def to_dict(self) -> dict:
@@ -121,7 +122,7 @@ class IterationResult:
     think_results: list[ThinkResult] = field(default_factory=list)
     should_continue: bool = True
     error: Optional[str] = None
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=now_utc)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for logging/events."""
@@ -226,7 +227,7 @@ class AgentMessage:
     content: str
     options: Optional[list[str]] = None  # For ASK messages
     metadata: dict = field(default_factory=dict)
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=now_utc)
     task_id: Optional[str] = None
     requires_response: bool = False
 
@@ -258,7 +259,7 @@ class TaskContext:
 
     task_id: str
     description: str
-    started_at: datetime = field(default_factory=datetime.utcnow)
+    started_at: datetime = field(default_factory=now_utc)
     iteration_count: int = 0
     tools_executed: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)

--- a/autobot-backend/events/types.py
+++ b/autobot-backend/events/types.py
@@ -25,6 +25,8 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Any, Optional
 
+from autobot_shared.time_utils import now_utc
+
 logger = logging.getLogger(__name__)
 
 
@@ -107,7 +109,7 @@ class AgentEvent:
     event_type: EventType = EventType.MESSAGE
 
     # Timing
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=now_utc)
 
     # Content
     content: dict = field(default_factory=dict)

--- a/autobot-backend/integrations/base.py
+++ b/autobot-backend/integrations/base.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.time_utils import now_utc
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ class IntegrationHealth(BaseModel):
     status: IntegrationStatus
     latency_ms: Optional[float] = None
     message: Optional[str] = None
-    last_checked: datetime = Field(default_factory=datetime.utcnow)
+    last_checked: datetime = Field(default_factory=now_utc)
     details: Dict[str, Any] = Field(default_factory=dict)
 
 

--- a/autobot-backend/knowledge/activity_types.py
+++ b/autobot-backend/knowledge/activity_types.py
@@ -18,6 +18,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Optional
 
+from autobot_shared.time_utils import now_utc
 from pydantic import BaseModel, Field
 
 
@@ -53,7 +54,7 @@ class TerminalActivity(BaseModel):
         default_factory=dict,
         description="Additional metadata (shell type, env vars, etc.)",
     )
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=now_utc)
 
     class Config:
         json_schema_extra = {
@@ -100,7 +101,7 @@ class FileActivity(BaseModel):
         default_factory=dict,
         description="Additional metadata (permissions, owner, etc.)",
     )
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=now_utc)
 
     class Config:
         json_schema_extra = {
@@ -151,7 +152,7 @@ class BrowserActivity(BaseModel):
         default_factory=dict,
         description="Additional metadata (status code, cookies, etc.)",
     )
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=now_utc)
 
     class Config:
         json_schema_extra = {
@@ -199,7 +200,7 @@ class DesktopActivity(BaseModel):
         default_factory=dict,
         description="Additional metadata (app name, OCR results, etc.)",
     )
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=now_utc)
 
     class Config:
         json_schema_extra = {
@@ -252,7 +253,7 @@ class SecretUsage(BaseModel):
         default_factory=dict,
         description="Additional metadata (IP, user agent, etc.)",
     )
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=now_utc)
 
     class Config:
         json_schema_extra = {

--- a/autobot-backend/knowledge/connectors/models.py
+++ b/autobot-backend/knowledge/connectors/models.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.time_utils import now_utc
+
 
 @dataclass
 class SourceInfo:
@@ -64,7 +66,7 @@ class ConnectorConfig:
     enabled: bool = True
     verification_mode: str = "collaborative"  # "autonomous" or "collaborative"
     schedule_cron: Optional[str] = None  # cron-like expression; None = manual only
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=now_utc)
     last_sync_at: Optional[datetime] = None
     include_patterns: List[str] = field(default_factory=list)
     exclude_patterns: List[str] = field(default_factory=list)

--- a/autobot-backend/models/completion_context.py
+++ b/autobot-backend/models/completion_context.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List, Optional, Set, Tuple
 
+from autobot_shared.time_utils import now_utc
+
 
 @dataclass
 class CompletionContext:
@@ -23,7 +25,7 @@ class CompletionContext:
 
     # Metadata
     context_id: str
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=now_utc)
 
     # File-level context
     file_path: str = ""

--- a/autobot-backend/models/npu_models.py
+++ b/autobot-backend/models/npu_models.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 
+from autobot_shared.time_utils import now_utc
 from pydantic import BaseModel, Field, validator
 
 from constants.network_constants import NetworkConstants
@@ -159,7 +160,7 @@ class NPUWorkerMetrics(BaseModel):
         default=None, description="Timestamp of last error"
     )
     metrics_timestamp: datetime = Field(
-        default_factory=datetime.utcnow, description="Metrics collection timestamp"
+        default_factory=now_utc, description="Metrics collection timestamp"
     )
 
     class Config:

--- a/autobot-backend/planner/types.py
+++ b/autobot-backend/planner/types.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
+from autobot_shared.time_utils import now_utc
+
 
 class StepStatus(Enum):
     """Status of a plan step"""
@@ -145,7 +147,7 @@ class ExecutionPlan:
     current_step_number: int = 0
 
     # Timing
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=now_utc)
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
 

--- a/autobot-backend/rlm/types.py
+++ b/autobot-backend/rlm/types.py
@@ -17,6 +17,7 @@ from enum import Enum, auto
 from typing import Any, Dict
 
 from autobot_shared.ssot_config import DEFAULT_LLM_MODEL
+from autobot_shared.time_utils import now_utc
 
 
 class ReflectionVerdict(Enum):
@@ -44,7 +45,7 @@ class ReflectionResult:
     critique: str = ""
     refinement_hint: str = ""
     iteration: int = 1
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=now_utc)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize for event stream / logging."""

--- a/autobot-backend/security/enterprise/threat_detection/models.py
+++ b/autobot-backend/security/enterprise/threat_detection/models.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 
 from .types import FILE_OPERATION_ACTIONS, ThreatCategory, ThreatLevel
 
@@ -282,7 +282,7 @@ class UserProfile:
     file_access_patterns: Dict[str, int] = field(default_factory=dict)
     api_usage_patterns: Dict[str, float] = field(default_factory=dict)
     risk_score: float = 0.5
-    last_updated: datetime = field(default_factory=datetime.utcnow)
+    last_updated: datetime = field(default_factory=now_utc)
 
     def is_anomalous_time(self, hour: int) -> bool:
         """Check if access hour is anomalous for this user"""

--- a/autobot-backend/services/analytics_service.py
+++ b/autobot-backend/services/analytics_service.py
@@ -24,7 +24,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.model_constants import (
     EXPENSIVE_MODEL_MARKER_GPT4,
     EXPENSIVE_MODEL_MARKER_OPUS,
@@ -72,7 +72,7 @@ class MaintenanceRecommendation:
     confidence: float  # 0.0 to 1.0
     recommended_action: str
     estimated_impact: str
-    detected_at: datetime = field(default_factory=datetime.utcnow)
+    detected_at: datetime = field(default_factory=now_utc)
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/autobot-backend/services/gateway/types.py
+++ b/autobot-backend/services/gateway/types.py
@@ -14,6 +14,8 @@ from enum import Enum
 from typing import Any, Dict, List
 from uuid import uuid4
 
+from autobot_shared.time_utils import now_utc
+
 
 class ChannelType(str, Enum):
     """Communication channel types."""
@@ -83,7 +85,7 @@ class UnifiedMessage:
     message_type: MessageType = MessageType.USER_TEXT
     content: Any = None
     metadata: Dict[str, Any] = field(default_factory=dict)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=now_utc)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert message to dictionary."""
@@ -140,8 +142,8 @@ class GatewaySession:
     context: Dict[str, Any] = field(default_factory=dict)
     message_history: List[str] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    last_activity: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=now_utc)
+    last_activity: datetime = field(default_factory=now_utc)
     rate_limit_tokens: int = 100  # Default rate limit
 
     def update_activity(self) -> None:

--- a/autobot-backend/services/user_behavior_analytics.py
+++ b/autobot-backend/services/user_behavior_analytics.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.ttl_constants import TTL_24_HOURS, TTL_30_DAYS, TTL_90_DAYS
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ class UserEvent:
     feature: str  # chat, knowledge, tools, monitoring, etc.
     user_id: Optional[str] = None
     session_id: Optional[str] = None
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=now_utc)
     duration_ms: Optional[int] = None
     metadata: dict = field(default_factory=dict)
 

--- a/autobot-backend/skills/base_skill.py
+++ b/autobot-backend/skills/base_skill.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.time_utils import now_utc
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ class SkillHealth(BaseModel):
     status: SkillStatus
     version: str = ""
     message: Optional[str] = None
-    last_checked: datetime = Field(default_factory=datetime.utcnow)
+    last_checked: datetime = Field(default_factory=now_utc)
     config_valid: bool = True
     dependencies_met: bool = True
     details: Dict[str, Any] = Field(default_factory=dict)

--- a/autobot_shared/time_utils.py
+++ b/autobot_shared/time_utils.py
@@ -53,6 +53,30 @@ def utc_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def now_utc() -> datetime:
+    """Return current UTC time as a tz-aware ``datetime``.
+
+    Companion to :func:`utc_timestamp` for callers that need the
+    ``datetime`` object itself (e.g. dataclass / Pydantic
+    ``default_factory=``, ORM column ``default=``, arithmetic with
+    ``timedelta``) rather than the ISO-8601 string.
+
+    Equivalent to ``datetime.now(timezone.utc)`` but importable as a
+    module-level callable so dataclass / Pydantic field defaults can
+    pass it directly without a lambda::
+
+        timestamp: datetime = field(default_factory=now_utc)
+        # vs
+        timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    Replaces ``datetime.utcnow`` (which Python 3.12 deprecates and
+    which returns a tz-NAIVE datetime that mis-compares against
+    tz-aware values) — see #5211 audit at
+    ``docs/developer/audits/datetime-utcnow-non-isoformat-audit.md``.
+    """
+    return datetime.now(timezone.utc)
+
+
 def utc_timestamp_z() -> str:
     """Return current UTC time as ISO-8601 with ``Z`` suffix. **DEPRECATED.**
 

--- a/autobot_shared/time_utils_test.py
+++ b/autobot_shared/time_utils_test.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-from autobot_shared.time_utils import utc_timestamp, utc_timestamp_z
+from autobot_shared.time_utils import now_utc, utc_timestamp, utc_timestamp_z
 
 
 _Z_FMT = "%Y-%m-%dT%H:%M:%SZ"
@@ -84,3 +84,58 @@ def test_utc_timestamp_z_is_utc_not_local() -> None:
         f"expected gmtime-derived string, got {result!r} — implementation may use localtime"
     )
     assert "14:30:45" not in result
+
+
+# ---------------------------------------------------------------------------
+# now_utc() — tz-aware datetime helper for #5211 Pattern E migration
+# ---------------------------------------------------------------------------
+
+
+def test_now_utc_returns_aware_datetime() -> None:
+    dt = now_utc()
+    assert isinstance(dt, datetime)
+    assert dt.tzinfo is not None, f"now_utc() must return tz-aware datetime, got naive: {dt}"
+
+
+def test_now_utc_offset_is_zero() -> None:
+    """Offset must be exactly UTC, not local timezone."""
+    dt = now_utc()
+    assert dt.utcoffset() == timedelta(0), (
+        f"expected UTC offset 0, got {dt.utcoffset()} — implementation may use local tz"
+    )
+
+
+def test_now_utc_close_to_real_now() -> None:
+    """Returned datetime should be within a small window of actual current UTC."""
+    dt = now_utc()
+    real_now = datetime.now(timezone.utc)
+    delta = abs((real_now - dt).total_seconds())
+    assert delta < 2.0, f"now_utc() returned {dt} but actual now is {real_now}, delta={delta}s"
+
+
+def test_now_utc_usable_as_default_factory() -> None:
+    """Smoke test: the helper works as a dataclass field default_factory.
+
+    This is the primary use case (Pattern E migration). If now_utc were
+    something other than a callable returning a datetime, this would
+    explode at class definition or instance construction time.
+    """
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class _Sample:
+        timestamp: datetime = field(default_factory=now_utc)
+
+    instance = _Sample()
+    assert isinstance(instance.timestamp, datetime)
+    assert instance.timestamp.tzinfo is not None
+    assert instance.timestamp.utcoffset() == timedelta(0)
+
+
+def test_now_utc_round_trip_via_utc_timestamp() -> None:
+    """now_utc() + utc_timestamp() agree on tz-awareness — same canonical UTC."""
+    dt = now_utc()
+    s = utc_timestamp()
+    parsed = datetime.fromisoformat(s)
+    # Both should be in UTC (offset 0)
+    assert dt.utcoffset() == parsed.utcoffset() == timedelta(0)


### PR DESCRIPTION
## Summary

**Phases B1 + B2 of #5211** — bundled because B2 has zero consumers other than the helper B1 introduces.

### B1 — extract \`now_utc()\` helper

Adds [\`now_utc()\`](autobot_shared/time_utils.py) — companion to \`utc_timestamp()\` that returns a tz-aware \`datetime\` (vs ISO string). Importable as a module-level callable so dataclass / Pydantic field defaults can pass it directly without lambda wrapping:

\`\`\`python
# before
timestamp: datetime = field(default_factory=datetime.utcnow)
# after
timestamp: datetime = field(default_factory=now_utc)
\`\`\`

Same canonical UTC as \`utc_timestamp()\` (\`datetime.now(timezone.utc)\`).

5 new tests added to \`time_utils_test.py\`:
- returns aware datetime
- offset is exactly UTC (zero)
- close to real now (timing sanity)
- usable as dataclass field default_factory (the primary use case)
- round-trip agreement with \`utc_timestamp()\`

**12/12 tests pass.**

### B2 — migrate Pattern E sites

Migrates **23 sites across 14 files** from \`default_factory=datetime.utcnow\` to \`default_factory=now_utc\`.

| File | Sites | Library |
|---|---|---|
| \`agent_loop/types.py\` | 4 | dataclass |
| \`events/types.py\` | 1 | dataclass |
| \`integrations/base.py\` | 1 | Pydantic |
| \`knowledge/activity_types.py\` | 5 | Pydantic |
| \`knowledge/connectors/models.py\` | 1 | dataclass |
| \`models/completion_context.py\` | 1 | dataclass |
| \`models/npu_models.py\` | 1 | Pydantic |
| \`planner/types.py\` | 1 | dataclass |
| \`rlm/types.py\` | 1 | dataclass |
| \`security/enterprise/threat_detection/models.py\` | 1 | dataclass |
| \`services/analytics_service.py\` | 1 | dataclass |
| \`services/gateway/types.py\` | 3 | dataclass |
| \`services/user_behavior_analytics.py\` | 1 | dataclass |
| \`skills/base_skill.py\` | 1 | Pydantic |
| **Total** | **23** | |

## Behavior change

Each migrated dataclass / Pydantic instance now stores a tz-AWARE datetime in its default-initialized timestamp/created_at/etc. fields (vs naive before). Consumers that compare these fields with other tz-aware datetimes no longer hit \`TypeError: can't compare offset-naive and offset-aware datetimes\`.

## What this PR does NOT do

- Phase B3 (~55 timing sites → \`time.monotonic\`) — separate PR
- Phase B4 (~117 Pattern B/C field/kwarg sites) — gated on the SQLAlchemy column-type audit shipped in PR #5281 (#5270)
- Phase B5 (~20 Pattern D predicates) — must follow B4
- Phase B6 (Ruff DTZ003 globally) — final step

## Verification

- \`py_compile\` on all 15 modified files: passes
- \`pytest autobot_shared/time_utils_test.py\` → **12/12 passed in 0.06s**
- 0 \`default_factory=datetime.utcnow\` sites remaining in scope (autobot-backend + autobot_shared, excluding tests + workflow_versioning)

## Diff

16 files changed, +122/-27.

## Test plan

- [x] Helper added with full docstring + cross-references
- [x] 5 new helper tests pass (positive + offset + timing + dataclass usage + cross-helper consistency)
- [x] 7 existing tests still pass
- [x] All 14 migration sites verified (0 remaining default_factory=datetime.utcnow)
- [x] py_compile passes on all 15 files
- [ ] \`gh pr checks\` passes