### PR TITLE
test(knowledge): migrate 22 test-mock sites to KB.redis() pattern (#5282)

### DIFF
--- a/autobot-backend/api/knowledge_audit_test.py
+++ b/autobot-backend/api/knowledge_audit_test.py
@@ -44,10 +44,14 @@ def _make_audit_log():
 
 
 def _make_kb(audit_log=None):
-    """Return a mock knowledge base with an audit_log."""
+    """Return a mock knowledge base with an audit_log.
+
+    ``kb`` is a MagicMock so ``kb.redis()`` auto-creates a child mock; the RBAC
+    tests here do not exercise any Redis-backed code paths, so no explicit
+    redis() or aioredis_client setup is required.
+    """
     kb = MagicMock()
     kb.audit_log = audit_log or _make_audit_log()
-    kb.aioredis_client = MagicMock()
     return kb
 
 

--- a/autobot-backend/knowledge/knowledge_base.integration_test.py
+++ b/autobot-backend/knowledge/knowledge_base.integration_test.py
@@ -43,7 +43,7 @@ class TestKnowledgeBaseRedisIntegration:
         try:
             test_keys = await kb._scan_redis_keys_async("fact:test_*")
             if test_keys:
-                await kb.aioredis_client.delete(*test_keys)
+                await kb.redis().delete(*test_keys)
         except Exception:
             pass
 
@@ -55,7 +55,7 @@ class TestKnowledgeBaseRedisIntegration:
         assert kb.redis_manager is not None
 
         # Verify connection works with ping
-        result = await kb.aioredis_client.ping()
+        result = await kb.redis().ping()
         assert result is True
 
     @pytest.mark.asyncio
@@ -89,7 +89,7 @@ class TestKnowledgeBaseRedisIntegration:
 
         # Verify data was actually stored in Redis
         fact_key = f"fact:{fact_id}"
-        fact_data = await kb.aioredis_client.hgetall(fact_key)
+        fact_data = await kb.redis().hgetall(fact_key)
 
         assert fact_data is not None
         assert fact_data.get("content") == test_content
@@ -331,7 +331,7 @@ class TestKnowledgeBaseRedisIntegration:
         assert kb.aioredis_client is initial_client
 
         # Verify connection is still healthy
-        assert await kb.aioredis_client.ping() is True
+        assert await kb.redis().ping() is True
 
     @pytest.mark.asyncio
     async def test_error_recovery_invalid_data(self, kb):
@@ -368,7 +368,7 @@ class TestKnowledgeBaseRedisIntegration:
         assert len(results) == num_operations
 
         # Verify connection pool is still healthy
-        assert await kb.aioredis_client.ping() is True
+        assert await kb.redis().ping() is True
 
         print(  # noqa: print
             f"\n✓ {num_operations} operations completed without pool exhaustion in {duration:.2f}s"
@@ -453,7 +453,7 @@ class TestKnowledgeBaseAsyncRedisManagerIntegration:
             await kb.store_fact(f"Pool metrics test {i}", {"test": "pool"})
 
         # Verify connection pool is working (no errors)
-        assert await kb.aioredis_client.ping() is True
+        assert await kb.redis().ping() is True
 
     @pytest.mark.asyncio
     async def test_circuit_breaker_integration(self, kb):
@@ -485,7 +485,7 @@ class TestKnowledgeBasePerformanceIntegration:
         try:
             test_keys = await kb._scan_redis_keys_async("fact:perf_*")
             if test_keys:
-                await kb.aioredis_client.delete(*test_keys)
+                await kb.redis().delete(*test_keys)
         except Exception:
             pass
 

--- a/autobot-backend/tests/knowledge/test_facts_dedup.py
+++ b/autobot-backend/tests/knowledge/test_facts_dedup.py
@@ -70,6 +70,11 @@ class _FakeKB(FactsMixin):
         self.redis_client = MagicMock()
         self.aioredis_client = AsyncMock()
 
+    def redis(self):
+        """Shim for the KB.redis() public accessor so this fake survives the
+        pending ``aioredis_client`` -> ``_aioredis_client`` rename (#5225)."""
+        return self.aioredis_client
+
     def ensure_initialized(self):
         pass
 

--- a/autobot-backend/utils/stats_counter_parsing_test.py
+++ b/autobot-backend/utils/stats_counter_parsing_test.py
@@ -25,11 +25,21 @@ class TestStatsCounterParsing:
         """Create a minimal StatsMixin instance for testing."""
         from knowledge.stats import StatsMixin
 
-        # Create a simple class that inherits from StatsMixin for testing
+        # Create a simple class that inherits from StatsMixin for testing.
+        # ``aioredis_client`` stays as an attribute (read by the guard in
+        # ``_get_all_stats``) and ``redis()`` returns the same mock so that
+        # ``self.redis().hgetall(...)`` in production resolves to the same
+        # AsyncMock the tests configure below. This matches the shim pattern
+        # used by ``_FakeKB`` in ``tests/test_knowledge_boards.py`` and keeps
+        # the suite working across the pending ``aioredis_client`` ->
+        # ``_aioredis_client`` rename (#5225).
         class TestStats(StatsMixin):
             def __init__(self):
                 self.aioredis_client = AsyncMock()
                 self._stats_key = "kb:stats"  # Required by _get_all_stats()
+
+            def redis(self):
+                return self.aioredis_client
 
         instance = TestStats()
         return instance


### PR DESCRIPTION
Closes #5282

## Summary

Prerequisite to the final #5225 attribute rename. Migrates `aioredis_client` test-mock references so renaming the attribute won't regress any test.

## Per-file results

| File | Pattern | Sites | Tests after |
|---|---|---|---|
| `api/knowledge_audit_test.py` | A1 (drop unused mock line; \`kb\` is MagicMock that auto-creates `redis()`) | 1 | 9/9 pass |
| `tests/knowledge/test_facts_dedup.py` | A2 (kept attribute, added `redis()` shim to fake class) | 3 | 9/9 pass |
| `utils/stats_counter_parsing_test.py` | A2 (added `redis()` shim to TestStats fake) | 11 | 6/6 pass (**fixed 3 pre-existing fails from PR #5272**) |
| `knowledge/knowledge_base.integration_test.py` | C (method-call sites \u2192 `kb.redis().<method>`; init-state checks left) | 7 (issue body undercounted as 5) | Blocked by #5292 ImportError; edits verified by grep |
| `knowledge/knowledge_base_async_test.py` | INTENTIONALLY UNCHANGED \u2014 4 sites are init-state regression contracts (#3962) | 0 migrations | Blocked by #5292 ImportError |
| `tests/test_knowledge_boards.py` | B \u2014 already OK | 2 (no change) | n/a |
| `api/api_endpoint_migrations_test.py:2684` | D \u2014 pre-existing broken | 1 (untouched) | n/a |

**Total migrated: 22 of 27.** 5 retained legitimately (init-state contracts, docstrings).

## Bonus side-effect: 3 baseline test failures fixed

`stats_counter_parsing_test.py` had 3 failing tests before this PR:
```
'TestStats' object has no attribute 'redis'
```
PR #5272 migrated production `StatsMixin` methods to `self.redis().hgetall(...)` but didn't update the fake class's mock setup. Adding the `redis()` shim fixes them.

## Discoveries filed

- **#5292** \u2014 `knowledge_base_async_test.py` and `knowledge_base.integration_test.py` blocked by pre-existing `ImportError: cannot import name 'KnowledgeBase' from 'knowledge.base'`. KB class was moved to `knowledge._composed` in some prior refactor; these test files were never updated. Unrelated to this migration; documented but not fixed here.

## Verification

- [x] All testable files pass (38 tests across 4 files)
- [x] Guardrail grep: 0 surviving Pattern A/C method-call references on real KB objects
- [x] Init-state checks (`kb.aioredis_client is None`, `is not None`, `if not kb.aioredis_client`) preserved
- [x] Pattern B (`_FakeKB` with both attribute + `redis()`) untouched
- [x] Pattern D (pre-existing broken source-string assertion) untouched

## Path forward (after this PR merges)

The final phase of #5225 becomes a **mechanical 2-line change** in `knowledge/base.py`:
- Rename attribute `self.aioredis_client` \u2192 `self._aioredis_client`
- Update `redis()` accessor body to read `self._aioredis_client`

Plus a lint rule banning new direct-attribute access. I'll file/implement that as the next PR.