### PR TITLE
fix(codebase-analytics): normalize HardcodedValue contract (#5290)

### DIFF
--- a/autobot-backend/api/codebase_analytics/analyzers.py
+++ b/autobot-backend/api/codebase_analytics/analyzers.py
@@ -75,9 +75,7 @@ _JS_API_PATH_RE = re.compile(r'[\'"`](/api/[^\'"` ]+)[\'"`]')
 # Issue #380: Module-level frozensets for file operation safety patterns
 _LOG_INDICATORS = frozenset({"log", "logs", ".log", "logging", "debug", "trace"})
 # nosec B108 - These are string patterns for detection, not actual temp directory usage
-_TEMP_INDICATORS = frozenset(
-    {"tmp", "temp", "tempfile", "temporary", "/tmp/"}
-)  # nosec B108
+_TEMP_INDICATORS = frozenset({"tmp", "temp", "tempfile", "temporary", "/tmp/"})  # nosec B108
 _SAFE_FILE_TYPES = frozenset(
     {
         ".pid",
@@ -185,9 +183,7 @@ def _is_mutable_constructor(value: ast.AST) -> bool:
     Returns:
         True if the value creates a mutable type
     """
-    if isinstance(
-        value, _COLLECTION_AST_TYPES
-    ):  # Issue #380: Use module-level constant
+    if isinstance(value, _COLLECTION_AST_TYPES):  # Issue #380: Use module-level constant
         return True
 
     if not isinstance(value, ast.Call):
@@ -211,9 +207,7 @@ def _is_mutable_constructor(value: ast.AST) -> bool:
     return func_name in mutable_constructors
 
 
-def _process_assign_node(
-    node: ast.Assign, global_vars: Dict[str, int], global_mutables: Set[str]
-) -> None:
+def _process_assign_node(node: ast.Assign, global_vars: Dict[str, int], global_mutables: Set[str]) -> None:
     """Process Assign node for global state extraction. (Issue #315 - extracted)"""
     for target in node.targets:
         if isinstance(target, ast.Name):
@@ -222,9 +216,7 @@ def _process_assign_node(
                 global_mutables.add(target.id)
 
 
-def _process_ann_assign_node(
-    node: ast.AnnAssign, global_vars: Dict[str, int], global_mutables: Set[str]
-) -> None:
+def _process_ann_assign_node(node: ast.AnnAssign, global_vars: Dict[str, int], global_mutables: Set[str]) -> None:
     """Process AnnAssign node for global state extraction. (Issue #315 - extracted)"""
     if not node.target or not isinstance(node.target, ast.Name):
         return
@@ -309,8 +301,7 @@ def _check_subscript_modification(
         return _create_race_condition_problem(
             lineno=stmt.lineno,
             description=(
-                f"Unprotected modification of global '{var_name}' "
-                f"in {async_prefix}function '{func_name}'"
+                f"Unprotected modification of global '{var_name}' " f"in {async_prefix}function '{func_name}'"
             ),
             suggestion=f"Use {lock_type} to protect concurrent access to '{var_name}'",
         )
@@ -369,8 +360,7 @@ def _check_mutating_method_call(
     return _create_race_condition_problem(
         lineno=stmt.lineno,
         description=(
-            f"Unprotected '{method_name}()' on global '{var_name}' "
-            f"in {async_prefix}function '{func_name}'"
+            f"Unprotected '{method_name}()' on global '{var_name}' " f"in {async_prefix}function '{func_name}'"
         ),
         suggestion=f"Use {lock_type} to protect concurrent modifications",
     )
@@ -525,9 +515,7 @@ def _is_safe_file_write_context(
     return False
 
 
-def _check_file_write_without_lock(
-    stmt: ast.With, file_path: str = "", func_name: str = ""
-) -> Optional[Dict]:
+def _check_file_write_without_lock(stmt: ast.With, file_path: str = "", func_name: str = "") -> Optional[Dict]:
     """
     Check for file writes without explicit locking.
 
@@ -572,10 +560,7 @@ def _check_file_write_without_lock(
         # This is a potentially risky file write - flag it
         return _create_race_condition_problem(
             lineno=stmt.lineno,
-            description=(
-                "File opened for writing without explicit locking - "
-                "concurrent writes may corrupt data"
-            ),
+            description=("File opened for writing without explicit locking - " "concurrent writes may corrupt data"),
             suggestion="Use file locking (fcntl.flock) or a separate lock for file access",
             severity="medium",
         )
@@ -785,7 +770,26 @@ def _extract_class_info(node: ast.ClassDef) -> Dict:
     }
 
 
-def _check_hardcoded_ip(ip: str, line_num: int, line_content: str) -> Optional[Dict]:
+# Issue #5290: canonical severity by hardcode type when the detector
+# doesn't set one explicitly. Consumed by the per-line detectors and by
+# the endpoint-boundary normalizer in stats.py.
+_DEFAULT_HARDCODE_SEVERITY: Dict[str, str] = {
+    "ip": "high",
+    "api_key": "high",
+    "password": "high",
+    "secret": "high",
+    "port": "medium",
+    "url": "medium",
+    "api_path": "low",
+    "config": "low",
+}
+
+
+def _default_severity_for(hardcode_type: str) -> str:
+    return _DEFAULT_HARDCODE_SEVERITY.get(hardcode_type, "low")
+
+
+def _check_hardcoded_ip(ip: str, line_num: int, line_content: str, file_path: str) -> Optional[Dict]:
     """Check if IP address is a known infrastructure IP."""
     # Issue #380: Use module-level constant for local IP prefixes
     if not ip.startswith(NetworkConstants.PRIVATE_IP_PREFIXES):
@@ -795,13 +799,13 @@ def _check_hardcoded_ip(ip: str, line_num: int, line_content: str) -> Optional[D
         "type": "ip",
         "value": ip,
         "line": line_num,
+        "file": file_path,
+        "severity": _default_severity_for("ip"),
         "context": line_content.strip(),
     }
 
 
-def _check_hardcoded_port(
-    port: str, line_num: int, line_content: str
-) -> Optional[Dict]:
+def _check_hardcoded_port(port: str, line_num: int, line_content: str, file_path: str) -> Optional[Dict]:
     """Check if port is a known infrastructure port."""
     known_ports = [
         str(NetworkConstants.BACKEND_PORT),
@@ -819,18 +823,24 @@ def _check_hardcoded_port(
         "type": "port",
         "value": port,
         "line": line_num,
+        "file": file_path,
+        "severity": _default_severity_for("port"),
         "context": line_content.strip(),
     }
 
 
-def _detect_hardcodes_in_line(line_num: int, line: str) -> List[Dict]:
-    """Detect hardcoded values in a single line of code."""
+def _detect_hardcodes_in_line(line_num: int, line: str, file_path: str) -> List[Dict]:
+    """Detect hardcoded values in a single line of code.
+
+    Issue #5290: every emitted record carries canonical ``file`` and
+    ``severity`` keys so the frontend `HardcodedValue` contract holds.
+    """
     hardcodes = []
 
     # Check for IP addresses
     ip_matches = _IP_ADDRESS_RE.findall(line)
     for ip in ip_matches:
-        result = _check_hardcoded_ip(ip, line_num, line)
+        result = _check_hardcoded_ip(ip, line_num, line, file_path)
         if result:
             hardcodes.append(result)
 
@@ -838,22 +848,27 @@ def _detect_hardcodes_in_line(line_num: int, line: str) -> List[Dict]:
     url_matches = _URL_IN_QUOTES_RE.findall(line)
     for url in url_matches:
         hardcodes.append(
-            {"type": "url", "value": url, "line": line_num, "context": line.strip()}
+            {
+                "type": "url",
+                "value": url,
+                "line": line_num,
+                "file": file_path,
+                "severity": _default_severity_for("url"),
+                "context": line.strip(),
+            }
         )
 
     # Check for ports
     port_matches = _PORT_NUMBER_RE.findall(line)
     for port in port_matches:
-        result = _check_hardcoded_port(port, line_num, line)
+        result = _check_hardcoded_port(port, line_num, line, file_path)
         if result:
             hardcodes.append(result)
 
     return hardcodes
 
 
-def _detect_technical_debt_in_line(
-    line_num: int, line: str, file_path: str
-) -> Tuple[List[Dict], List[Dict]]:
+def _detect_technical_debt_in_line(line_num: int, line: str, file_path: str) -> Tuple[List[Dict], List[Dict]]:
     """Detect technical debt markers in a line. Returns (debt_items, problem_items)."""
     debt_patterns = [
         # Require colon after keyword to avoid false positives (Issue #617)
@@ -1161,9 +1176,7 @@ def _count_js_vue_line_types(content: str) -> Dict[str, int]:
 
     for line in lines:
         stripped = line.strip()
-        line_type, in_multiline_comment = _classify_js_line(
-            stripped, in_multiline_comment
-        )
+        line_type, in_multiline_comment = _classify_js_line(stripped, in_multiline_comment)
         if line_type == "blank":
             blank_lines += 1
         elif line_type == "comment":
@@ -1188,14 +1201,19 @@ async def _merge_llm_results(
 ) -> None:
     """Merge LLM analysis results into existing hardcodes and technical debt lists."""
     try:
-        llm_results = await detect_hardcodes_and_debt_with_llm(
-            content, file_path, language="python"
-        )
+        llm_results = await detect_hardcodes_and_debt_with_llm(content, file_path, language="python")
 
         # Merge LLM hardcodes (avoid duplicates)
+        # Issue #5290: LLM prompt asks for {type, value, line, reason,
+        # severity} but not ``file`` — attach it here so records conform
+        # to the canonical shape without relying on the response-boundary
+        # normalizer.
         existing_values = {h.get("value") for h in hardcodes}
         for llm_hardcode in llm_results.get("hardcodes", []):
             if llm_hardcode.get("value") not in existing_values:
+                llm_hardcode.setdefault("file", file_path)
+                if not llm_hardcode.get("severity"):
+                    llm_hardcode["severity"] = _default_severity_for(llm_hardcode.get("type", ""))
                 hardcodes.append(llm_hardcode)
 
         # Add technical debt from LLM
@@ -1244,9 +1262,7 @@ def _analyze_ast_nodes(
     return functions, classes, imports, problems
 
 
-def _analyze_content_lines(
-    content: str, file_path: str
-) -> Tuple[List[Dict], List[Dict], List[Dict]]:
+def _analyze_content_lines(content: str, file_path: str) -> Tuple[List[Dict], List[Dict], List[Dict]]:
     """
     Analyze content line-by-line for hardcodes and technical debt.
 
@@ -1259,8 +1275,8 @@ def _analyze_content_lines(
 
     lines = content.split("\n")
     for i, line in enumerate(lines, 1):
-        # Detect hardcoded values
-        hardcodes.extend(_detect_hardcodes_in_line(i, line))
+        # Detect hardcoded values (Issue #5290: pass file_path into producers)
+        hardcodes.extend(_detect_hardcodes_in_line(i, line, file_path))
 
         # Detect technical debt
         debt_items, problem_items = _detect_technical_debt_in_line(i, line, file_path)
@@ -1310,9 +1326,7 @@ async def detect_hardcodes_and_debt_with_llm(
         return empty_result
 
 
-def _check_async_global_state_issue(
-    node: ast.AsyncFunctionDef, has_async_lock_import: bool
-) -> Optional[Dict]:
+def _check_async_global_state_issue(node: ast.AsyncFunctionDef, has_async_lock_import: bool) -> Optional[Dict]:
     """
     Check if async function uses global state without lock import.
 
@@ -1322,13 +1336,8 @@ def _check_async_global_state_issue(
     if uses_global and not has_async_lock_import:
         return _create_race_condition_problem(
             lineno=node.lineno,
-            description=(
-                f"Async function '{node.name}' uses global state "
-                f"but no asyncio.Lock imported"
-            ),
-            suggestion=(
-                "Consider using asyncio.Lock() to protect shared state in async context"
-            ),
+            description=(f"Async function '{node.name}' uses global state " f"but no asyncio.Lock imported"),
+            suggestion=("Consider using asyncio.Lock() to protect shared state in async context"),
             severity="medium",
         )
     return None
@@ -1350,11 +1359,7 @@ def _analyze_function_for_race_conditions(
     problems = []
 
     # Check for global state modifications
-    problems.extend(
-        _detect_global_state_modifications(
-            node, global_vars, global_mutables, lock_protected_vars
-        )
-    )
+    problems.extend(_detect_global_state_modifications(node, global_vars, global_mutables, lock_protected_vars))
 
     # Check for thread-unsafe singleton patterns
     problems.extend(_detect_singleton_patterns(node, global_vars))
@@ -1442,14 +1447,24 @@ def _extract_js_functions(line: str, line_num: int) -> List[Dict]:
     return functions
 
 
-def _extract_js_hardcodes(line: str, line_num: int) -> List[Dict]:
-    """Extract hardcoded values from a JS/Vue line (Issue #398: extracted)."""
+def _extract_js_hardcodes(line: str, line_num: int, file_path: str) -> List[Dict]:
+    """Extract hardcoded values from a JS/Vue line (Issue #398: extracted).
+
+    Issue #5290: emit canonical ``file`` and ``severity`` keys.
+    """
     hardcodes = []
     context = line.strip()
     # URLs
     for url in _URL_IN_QUOTES_RE.findall(line):
         hardcodes.append(
-            {"type": "url", "value": url, "line": line_num, "context": context}
+            {
+                "type": "url",
+                "value": url,
+                "line": line_num,
+                "file": file_path,
+                "severity": _default_severity_for("url"),
+                "context": context,
+            }
         )
     # API paths
     for api_path in _JS_API_PATH_RE.findall(line):
@@ -1458,6 +1473,8 @@ def _extract_js_hardcodes(line: str, line_num: int) -> List[Dict]:
                 "type": "api_path",
                 "value": api_path,
                 "line": line_num,
+                "file": file_path,
+                "severity": _default_severity_for("api_path"),
                 "context": context,
             }
         )
@@ -1465,7 +1482,14 @@ def _extract_js_hardcodes(line: str, line_num: int) -> List[Dict]:
     for ip in _IP_ADDRESS_RE.findall(line):
         if ip.startswith(NetworkConstants.PRIVATE_IP_PREFIXES):
             hardcodes.append(
-                {"type": "ip", "value": ip, "line": line_num, "context": context}
+                {
+                    "type": "ip",
+                    "value": ip,
+                    "line": line_num,
+                    "file": file_path,
+                    "severity": _default_severity_for("ip"),
+                    "context": context,
+                }
             )
     return hardcodes
 
@@ -1518,9 +1542,7 @@ def _create_parse_error_result(error_msg: str) -> Metadata:
     return result
 
 
-async def _run_analysis_phases(
-    file_path: str, content: str, tree: ast.AST, use_llm: bool
-) -> Metadata:
+async def _run_analysis_phases(file_path: str, content: str, tree: ast.AST, use_llm: bool) -> Metadata:
     """
     Execute all analysis phases on parsed Python content.
 
@@ -1530,9 +1552,7 @@ async def _run_analysis_phases(
     functions, classes, imports, problems = _analyze_ast_nodes(tree)
 
     # Phase 2: Line-by-line content analysis (hardcodes, technical debt)
-    hardcodes, technical_debt, line_problems = _analyze_content_lines(
-        content, file_path
-    )
+    hardcodes, technical_debt, line_problems = _analyze_content_lines(content, file_path)
     problems.extend(line_problems)
 
     # Phase 3: LLM semantic analysis (optional)
@@ -1548,9 +1568,7 @@ async def _run_analysis_phases(
 
     # Phase 5: Code intelligence analyzers
     # Issue #711: Run in thread pool to prevent event loop blocking.
-    code_intel_problems = await asyncio.to_thread(
-        _run_code_intelligence_analyzers, file_path
-    )
+    code_intel_problems = await asyncio.to_thread(_run_code_intelligence_analyzers, file_path)
     problems.extend(code_intel_problems)
 
     # Phase 6: Count line types (Issue #368)
@@ -1576,7 +1594,7 @@ def analyze_javascript_vue_file(file_path: str) -> Metadata:
         functions, hardcodes, problems = [], [], []
         for i, line in enumerate(content.splitlines(), 1):
             functions.extend(_extract_js_functions(line, i))
-            hardcodes.extend(_extract_js_hardcodes(line, i))
+            hardcodes.extend(_extract_js_hardcodes(line, i, file_path))
             if problem := _check_js_console_log(line, i):
                 problems.append(problem)
 

--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -325,6 +325,37 @@ def _fetch_hardcodes_from_memory(storage, hardcode_type: Optional[str]) -> list:
     return results
 
 
+# Issue #5290: default severity mapping for legacy records that were
+# stored in Redis before the producer shape was fixed. Must stay in sync
+# with ``_DEFAULT_HARDCODE_SEVERITY`` in analyzers.py.
+_LEGACY_SEVERITY_BY_TYPE = {
+    "ip": "high",
+    "api_key": "high",
+    "password": "high",
+    "secret": "high",
+    "port": "medium",
+    "url": "medium",
+    "api_path": "low",
+    "config": "low",
+}
+
+
+def _normalize_hardcode_record(record: dict) -> dict:
+    """Normalize a hardcode record to the canonical shape (Issue #5290).
+
+    Old records use ``file_path``; new producers emit ``file``. Similarly
+    ``severity`` was absent on many AST/regex detections — fill from the
+    type's default so the frontend ``HardcodedValue`` contract holds.
+    """
+    normalized = dict(record)
+    if "file" not in normalized and "file_path" in normalized:
+        normalized["file"] = normalized["file_path"]
+    normalized.setdefault("file", "")
+    if not normalized.get("severity"):
+        normalized["severity"] = _LEGACY_SEVERITY_BY_TYPE.get(normalized.get("type", ""), "low")
+    return normalized
+
+
 @router.get("/hardcodes")
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
@@ -340,6 +371,10 @@ async def get_hardcoded_values(
 
     Issue #620: Refactored to use helper functions.
     Issue #1710: source_id scopes to per-project data.
+    Issue #5290: response boundary normalizes legacy records so the
+    frontend receives canonical ``file`` + ``severity`` keys regardless
+    of whether the data was scanned before or after producers were
+    updated.
     """
     redis_client = await get_redis_connection()
 
@@ -365,17 +400,19 @@ async def get_hardcoded_values(
             }
         )
 
+    # Issue #5290: normalize before sorting/returning so legacy and new
+    # records share one shape on the wire.
+    all_hardcodes = [_normalize_hardcode_record(h) for h in all_hardcodes]
+
     # Sort by file and line number
-    all_hardcodes.sort(key=lambda x: (x.get("file_path", ""), x.get("line", 0)))
+    all_hardcodes.sort(key=lambda x: (x.get("file", ""), x.get("line", 0)))
 
     return JSONResponse(
         {
             "status": "success",
             "hardcodes": all_hardcodes,
             "total_count": len(all_hardcodes),
-            "hardcode_types": list(
-                set(h.get("type", "unknown") for h in all_hardcodes)
-            ),
+            "hardcode_types": list(set(h.get("type", "unknown") for h in all_hardcodes)),
             "storage_type": storage_type,
         }
     )
@@ -428,9 +465,7 @@ def _fetch_problems_from_chromadb(
         if problem_type:
             where_filter["problem_type"] = problem_type
 
-    results = get_all_paginated(
-        code_collection, where=where_filter, include=["metadatas"]
-    )
+    results = get_all_paginated(code_collection, where=where_filter, include=["metadatas"])
     problems = [_parse_problem_metadata(m) for m in results.get("metadatas", [])]
 
     # Issue #2724: Validate file paths against the indexed repository root.
@@ -438,9 +473,7 @@ def _fetch_problems_from_chromadb(
     return filter_problems_by_file_existence(problems, root)
 
 
-async def _fetch_problems_from_redis(
-    problem_type: Optional[str], source_id: Optional[str] = None
-) -> tuple:
+async def _fetch_problems_from_redis(problem_type: Optional[str], source_id: Optional[str] = None) -> tuple:
     """Fetch problems from Redis. Returns (problems, success).
 
     Issue #315: Extracted helper.
@@ -618,9 +651,7 @@ async def get_codebase_problems(
             )
             logger.info("Retrieved %s problems from ChromaDB", len(all_problems))
         except Exception as chroma_error:
-            logger.warning(
-                "ChromaDB query failed: %s, falling back to Redis", chroma_error
-            )
+            logger.warning("ChromaDB query failed: %s, falling back to Redis", chroma_error)
             code_collection = None
 
     # Issue #1759: Problems are stored to ChromaDB only (not Redis).

--- a/autobot-frontend/src/composables/analytics/analyticsTypes.ts
+++ b/autobot-frontend/src/composables/analytics/analyticsTypes.ts
@@ -38,14 +38,24 @@ export interface Declaration {
   is_exported?: boolean
 }
 
+/**
+ * Hardcoded value record (Issue #5290: contract aligned with backend).
+ *
+ * Canonical shape emitted by `/api/analytics/codebase/hardcodes`:
+ * - `file`, `line`, `value`, `type`, `severity` are always present
+ *   (backend response-boundary normalizer fills `file` + default
+ *   `severity` for legacy records without them).
+ * - `variable_name` / `suggested_env_var` are populated by the LLM path
+ *   only; AST/regex detections omit them.
+ */
 export interface HardcodedValue {
   file: string
   line: number
-  variable_name?: string
   value: string
   type: string
   severity: string
-  suggested_env_var: string
+  variable_name?: string
+  suggested_env_var?: string
   context?: string
   current_usage?: string
 }


### PR DESCRIPTION
## Summary

After #5277 wired the hardcoded-values panel, it surfaced a pre-existing backend↔frontend contract drift: producers emitted records with \`file_path\` (not \`file\`), and many records had no \`severity\` key — so the panel showed empty filenames and all non-classified values collapsed to the \"low\" bucket.

## Root-cause fix (producer side)

- \`_check_hardcoded_ip\`, \`_check_hardcoded_port\`, \`_detect_hardcodes_in_line\`, \`_extract_js_hardcodes\` now take \`file_path\` and emit canonical \`file\` + \`severity\` keys.
- \`_merge_llm_results\` backfills \`file\`/\`severity\` on LLM records.
- Central \`_DEFAULT_HARDCODE_SEVERITY\` map owns type→severity defaults: \`ip/api_key/password/secret → high\`, \`port/url → medium\`, \`api_path/config → low\`.

## Boundary safety net (response side)

- \`/hardcodes\` endpoint applies \`_normalize_hardcode_record\` to each record before sort/return.
- Legacy Redis data written before this fix (\`file_path\`, missing severity) is transparently upgraded without forcing a re-scan.
- Sort key changed to \`x.get(\"file\", \"\")\` (post-normalization).

## Frontend contract

- \`HardcodedValue\`: \`variable_name\`/\`suggested_env_var\` marked optional (LLM-only in practice); \`file\`/\`severity\` stay required (endpoint guarantees them).

Closes #5290.

## Verification

- Isolated unit tests for \`_normalize_hardcode_record\` cover 4 drift cases (legacy file_path → file, missing severity by type, explicit-severity preservation, unknown type fallback) → all pass.
- \`python3 -m py_compile\` clean on both modified modules.
- \`black\` clean.
- \`vue-tsc --noEmit -p tsconfig.app.json\` — 167 errors (unchanged baseline; 0 new).
- Existing \`test_get_hardcoded_values_*\` structural tests still pass (decorator + Simple Pattern + Redis/memory fallback checks unchanged).

## Test plan

- [ ] Run indexing on a source with mixed Python/JS/Vue
- [ ] Open hardcoded-values panel → filenames are non-empty
- [ ] Severity distribution shows IPs in high, URLs in medium, unclassified in low
- [ ] Export MD/JSON → records include \`file\` + \`severity\` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)