### PR TITLE
feat(composables): extract useExpansion<Key> primitive + migrate 8 sites (#5306)

### DIFF
--- a/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue
@@ -318,6 +318,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useExpansion } from '@/composables/useExpansion'
 import { useI18n } from 'vue-i18n'
 import EmptyState from '@/components/ui/EmptyState.vue'
 
@@ -357,7 +358,8 @@ const emit = defineEmits<{
 const PAGE_SIZE = 50
 const activeFilter = ref<'all' | 'high' | 'medium' | 'low'>('all')
 const visibleCount = ref(PAGE_SIZE)
-const expandedFiles = ref<Set<string>>(new Set())
+const fileExpansion = useExpansion<string>()
+const expandedFiles = fileExpansion.expanded
 
 // Single pass over the file list to derive all three risk-bucket counts.
 // Replaces three separate .filter() traversals that each iterated the full
@@ -434,12 +436,7 @@ function setFilter(filter: 'high' | 'medium' | 'low'): void {
 }
 
 function toggleFileExpand(filePath: string): void {
-  if (expandedFiles.value.has(filePath)) {
-    expandedFiles.value.delete(filePath)
-  } else {
-    expandedFiles.value.add(filePath)
-  }
-  expandedFiles.value = new Set(expandedFiles.value)
+  fileExpansion.toggle(filePath)
 }
 
 function getSeverityForFactor(

--- a/autobot-frontend/src/components/audit/AuditTimeline.vue
+++ b/autobot-frontend/src/components/audit/AuditTimeline.vue
@@ -107,6 +107,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useExpansion } from '@/composables/useExpansion'
 import type { AuditEntry } from '@/types/audit'
 import { AUDIT_RESULT_CONFIG } from '@/types/audit'
 
@@ -128,7 +129,8 @@ const props = withDefaults(defineProps<Props>(), {
 
 defineEmits<Emits>()
 
-const expandedIds = ref<Set<string>>(new Set())
+const idExpansion = useExpansion<string>()
+const expandedIds = idExpansion.expanded
 
 const formatDateRange = computed(() => {
   if (props.entries.length === 0) return ''
@@ -175,11 +177,7 @@ function formatDetails(details: Record<string, unknown>): string {
 }
 
 function toggleDetails(id: string) {
-  if (expandedIds.value.has(id)) {
-    expandedIds.value.delete(id)
-  } else {
-    expandedIds.value.add(id)
-  }
+  idExpansion.toggle(id)
 }
 </script>
 

--- a/autobot-frontend/src/components/charts/FunctionCallGraph.vue
+++ b/autobot-frontend/src/components/charts/FunctionCallGraph.vue
@@ -348,6 +348,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { useExpansion } from '@/composables/useExpansion'
 import { useI18n } from 'vue-i18n'
 // Type imports only — runtime load handled by the shared composable (#5206).
 // The default namespace import below gives type-only access to helpers
@@ -443,7 +444,8 @@ const searchQuery = ref('')
 const filterModule = ref('')
 const resolvedFilter = ref<'all' | 'resolved' | 'unresolved'>('all')
 const viewMode = ref<'network' | 'list' | 'stats' | 'orphaned'>('network') // Default to network view
-const expandedFuncs = ref<Set<string>>(new Set())
+const funcExpansion = useExpansion<string>()
+const expandedFuncs = funcExpansion.expanded
 const selectedFunc = ref<string | null>(null)
 const zoomLevel = ref(1)
 const layoutMode = ref<'force' | 'grid'>('force')
@@ -1237,12 +1239,7 @@ function getNodeName(nodeId: string): string {
 }
 
 function toggleFunction(funcId: string) {
-  if (expandedFuncs.value.has(funcId)) {
-    expandedFuncs.value.delete(funcId)
-  } else {
-    expandedFuncs.value.add(funcId)
-  }
-  expandedFuncs.value = new Set(expandedFuncs.value)
+  funcExpansion.toggle(funcId)
   selectedFunc.value = funcId
   emit('select', funcId)
 }
@@ -1314,11 +1311,12 @@ watch(() => props.data, async (newData) => {
       const bCount = getOutgoingCalls(b.id).length + getIncomingCalls(b.id).length
       return bCount - aCount
     })
-    sorted.slice(0, 3).forEach(node => {
-      if (getOutgoingCalls(node.id).length || getIncomingCalls(node.id).length) {
-        expandedFuncs.value.add(node.id)
-      }
-    })
+    funcExpansion.expandAll(
+      sorted
+        .slice(0, 3)
+        .filter(node => getOutgoingCalls(node.id).length || getIncomingCalls(node.id).length)
+        .map(node => node.id)
+    )
   }
 }, { immediate: true })
 

--- a/autobot-frontend/src/components/charts/ImportTreeChart.vue
+++ b/autobot-frontend/src/components/charts/ImportTreeChart.vue
@@ -229,6 +229,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { useExpansion } from '@/composables/useExpansion'
 import { useI18n } from 'vue-i18n'
 import { getCssVar } from '@/composables/useCssVars'
 import { useDebounce } from '@/composables/useTimeout'
@@ -283,7 +284,8 @@ const emit = defineEmits<{
 
 // State
 const searchQuery = ref('')
-const expandedNodes = ref<Set<string>>(new Set())
+const nodeExpansion = useExpansion<string>()
+const expandedNodes = nodeExpansion.expanded
 const viewMode = ref<'network' | 'tree'>('network') // Default to network view
 const zoomLevel = ref(1)
 const layoutMode = ref<'force' | 'grid'>('force')
@@ -368,13 +370,7 @@ function normalizeImports(imports: ImportInfo[] | string[] | undefined): ImportI
 }
 
 function toggleNode(path: string) {
-  if (expandedNodes.value.has(path)) {
-    expandedNodes.value.delete(path)
-  } else {
-    expandedNodes.value.add(path)
-  }
-  // Force reactivity
-  expandedNodes.value = new Set(expandedNodes.value)
+  nodeExpansion.toggle(path)
 }
 
 function getFileName(path: string): string {

--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -508,6 +508,7 @@
 
 <script setup lang="ts">
 import { ref, computed, nextTick, watch, onMounted } from 'vue'
+import { useExpansion } from '@/composables/useExpansion'
 import { useI18n } from 'vue-i18n'
 import { useChatStore } from '@/stores/useChatStore'
 import { useChatController } from '@/models/controllers'
@@ -580,7 +581,8 @@ const typingStartTime = ref<number | null>(null)
 const estimatedResponseTime = ref<number | null>(null)
 
 // Issue #249: Citation display state
-const expandedCitations = ref<Set<string>>(new Set())
+const citationExpansion = useExpansion<string>()
+const expandedCitations = citationExpansion.expanded
 
 // Approval state
 const processingApproval = ref(false)
@@ -884,13 +886,7 @@ const hasCodeBlocks = (content: string): boolean => {
 
 // Issue #249: Citation helper functions
 const toggleCitations = (messageId: string) => {
-  if (expandedCitations.value.has(messageId)) {
-    expandedCitations.value.delete(messageId)
-  } else {
-    expandedCitations.value.add(messageId)
-  }
-  // Force reactivity update for Set
-  expandedCitations.value = new Set(expandedCitations.value)
+  citationExpansion.toggle(messageId)
 }
 
 const truncateCitation = (content: string, maxLength: number = 200): string => {

--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -187,6 +187,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { useExpansion } from '@/composables/useExpansion'
 import { useRouter } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
 import { getApiBase } from '@/config/ssot-config'
@@ -260,7 +261,8 @@ interface CategoryOption {
 
 // State
 const treeData = ref<TreeNode[]>([])
-const expandedNodes = ref<Set<string>>(new Set())
+const nodeExpansion = useExpansion<string>()
+const expandedNodes = nodeExpansion.expanded
 const selectedFile = ref<TreeNode | null>(null)
 const fileContent = ref('')
 const searchQuery = ref('')
@@ -463,7 +465,7 @@ const filteredTree = computed(() => {
 
         // Auto-expand matching folders
         if (node.type === 'folder' && (matches || children.length > 0)) {
-          expandedNodes.value.add(node.id)
+          nodeExpansion.expand(node.id)
         }
       }
 
@@ -762,11 +764,9 @@ const buildTreeFromEntries = (entries: any[]) => {
 }
 
 const toggleNode = (nodeId: string) => {
-  if (expandedNodes.value.has(nodeId)) {
-    expandedNodes.value.delete(nodeId)
-  } else {
-    expandedNodes.value.add(nodeId)
-
+  const wasExpanded = nodeExpansion.isExpanded(nodeId)
+  nodeExpansion.toggle(nodeId)
+  if (!wasExpanded) {
     // Load folder contents if not already loaded
     const node = findNode(treeData.value, nodeId)
     if (node && node.type === 'folder' && (!node.children || node.children.length === 0)) {
@@ -1045,7 +1045,7 @@ const restoreExpandedState = (nodes: TreeNode[], expandedPaths: Set<string>) => 
   }
 
   restorePaths(nodes)
-  expandedNodes.value = newExpandedIds
+  nodeExpansion.expandAll(newExpandedIds)
 }
 
 const clearSelection = () => {
@@ -1063,13 +1063,13 @@ const clearSearch = () => {
   searchQuery.value = ''
   debouncedSearchQuery.value = ''
   updateDebouncedSearch.cancel()
-  expandedNodes.value.clear()
+  nodeExpansion.collapseAll()
 }
 
 // Utility functions (now using composable)
 const getFileIcon = (node: TreeNode): string => {
   if (node.type === 'folder') {
-    return expandedNodes.value.has(node.id) ? 'fas fa-folder-open' : 'fas fa-folder'
+    return nodeExpansion.isExpanded(node.id) ? 'fas fa-folder-open' : 'fas fa-folder'
   }
 
   return getFileIconUtil(node.name, false)
@@ -1096,7 +1096,7 @@ watch(() => props.mode, () => {
   resetPagination()
   loadKnowledgeTree(loadKnowledgeTreeFn)
   clearSelection()
-  expandedNodes.value.clear()
+  nodeExpansion.collapseAll()
 })
 </script>
 

--- a/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue
@@ -16,6 +16,7 @@
  */
 
 import { ref, computed, onMounted, watch } from 'vue'
+import { useExpansion } from '@/composables/useExpansion'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 import apiClient from '@/utils/ApiClient'
@@ -68,7 +69,8 @@ const searchQuery = ref('')
 const categories = ref<DocCategory[]>([])
 const selectedCategory = ref<DocCategory | null>(null)
 const selectedDoc = ref<SystemDoc | null>(null)
-const expandedCategories = ref<Set<string>>(new Set())
+const categoryExpansion = useExpansion<string>()
+const expandedCategories = categoryExpansion.expanded
 
 // Export state
 const isExporting = ref(false)
@@ -183,15 +185,11 @@ function selectDoc(doc: SystemDoc): void {
 }
 
 function toggleCategory(categoryId: string): void {
-  if (expandedCategories.value.has(categoryId)) {
-    expandedCategories.value.delete(categoryId)
-  } else {
-    expandedCategories.value.add(categoryId)
-  }
+  categoryExpansion.toggle(categoryId)
 }
 
 function isCategoryExpanded(categoryId: string): boolean {
-  return expandedCategories.value.has(categoryId)
+  return categoryExpansion.isExpanded(categoryId)
 }
 
 async function copyToClipboard(): Promise<void> {

--- a/autobot-frontend/src/composables/__tests__/useExpansion.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useExpansion.test.ts
@@ -1,0 +1,155 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Unit tests for useExpansion composable (#5306).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { watchEffect, nextTick } from 'vue'
+import { useExpansion } from '../useExpansion'
+
+describe('useExpansion', () => {
+  describe('initial state', () => {
+    it('starts empty by default', () => {
+      const e = useExpansion()
+      expect(e.expanded.value.size).toBe(0)
+      expect(e.isExpanded('a')).toBe(false)
+    })
+
+    it('seeds from initialKeys iterable', () => {
+      const e = useExpansion(['a', 'b'])
+      expect(e.expanded.value.size).toBe(2)
+      expect(e.isExpanded('a')).toBe(true)
+      expect(e.isExpanded('b')).toBe(true)
+    })
+
+    it('accepts a Set as initialKeys', () => {
+      const e = useExpansion(new Set(['x']))
+      expect(e.isExpanded('x')).toBe(true)
+    })
+  })
+
+  describe('toggle', () => {
+    it('flips state on each call', () => {
+      const e = useExpansion()
+      e.toggle('a')
+      expect(e.isExpanded('a')).toBe(true)
+      e.toggle('a')
+      expect(e.isExpanded('a')).toBe(false)
+      e.toggle('a')
+      expect(e.isExpanded('a')).toBe(true)
+    })
+  })
+
+  describe('expand / collapse (idempotent)', () => {
+    it('expand adds the key', () => {
+      const e = useExpansion()
+      e.expand('a')
+      expect(e.isExpanded('a')).toBe(true)
+    })
+
+    it('expand is idempotent', () => {
+      const e = useExpansion()
+      e.expand('a')
+      e.expand('a')
+      e.expand('a')
+      expect(e.expanded.value.size).toBe(1)
+    })
+
+    it('collapse removes the key', () => {
+      const e = useExpansion(['a', 'b'])
+      e.collapse('a')
+      expect(e.isExpanded('a')).toBe(false)
+      expect(e.isExpanded('b')).toBe(true)
+    })
+
+    it('collapse is idempotent', () => {
+      const e = useExpansion()
+      e.collapse('a')
+      e.collapse('a')
+      expect(e.expanded.value.size).toBe(0)
+    })
+  })
+
+  describe('expandAll / collapseAll', () => {
+    it('expandAll replaces the set', () => {
+      const e = useExpansion(['a'])
+      e.expandAll(['x', 'y', 'z'])
+      expect(e.isExpanded('a')).toBe(false)
+      expect(e.isExpanded('x')).toBe(true)
+      expect(e.expanded.value.size).toBe(3)
+    })
+
+    it('collapseAll empties the set', () => {
+      const e = useExpansion(['a', 'b', 'c'])
+      e.collapseAll()
+      expect(e.expanded.value.size).toBe(0)
+    })
+
+    it('expandAll accepts an empty iterable to clear', () => {
+      const e = useExpansion(['a'])
+      e.expandAll([])
+      expect(e.expanded.value.size).toBe(0)
+    })
+  })
+
+  describe('reactivity', () => {
+    it('expanded is reactive — toggle triggers effects', async () => {
+      const e = useExpansion()
+      let lastHasA = false
+      let renders = 0
+      watchEffect(() => {
+        lastHasA = e.expanded.value.has('a')
+        renders++
+      })
+      await nextTick()
+      const initialRenders = renders
+
+      e.toggle('a')
+      await nextTick()
+      expect(lastHasA).toBe(true)
+      expect(renders).toBeGreaterThan(initialRenders)
+
+      e.toggle('a')
+      await nextTick()
+      expect(lastHasA).toBe(false)
+    })
+
+    it('isExpanded is reactive when used in effects', async () => {
+      const e = useExpansion()
+      let val = false
+      watchEffect(() => { val = e.isExpanded('k') })
+      await nextTick()
+      expect(val).toBe(false)
+      e.expand('k')
+      await nextTick()
+      expect(val).toBe(true)
+      e.collapse('k')
+      await nextTick()
+      expect(val).toBe(false)
+    })
+  })
+
+  describe('numeric keys', () => {
+    it('supports number keys via the Key generic', () => {
+      const e = useExpansion<number>([1, 2])
+      expect(e.isExpanded(1)).toBe(true)
+      e.toggle(3)
+      expect(e.isExpanded(3)).toBe(true)
+      e.collapse(1)
+      expect(e.isExpanded(1)).toBe(false)
+    })
+  })
+
+  describe('readonly return surface', () => {
+    it('expanded ref is wrapped readonly — direct .value reassignment does not leak', () => {
+      const e = useExpansion()
+      e.expand('a')
+      // expanded is readonly(ref). In dev, attempting to reassign .value is
+      // a runtime no-op + Vue warning. Public state stays intact.
+      expect(e.expanded.value.size).toBe(1)
+    })
+  })
+})

--- a/autobot-frontend/src/composables/analytics/useBugPrediction.ts
+++ b/autobot-frontend/src/composables/analytics/useBugPrediction.ts
@@ -10,6 +10,7 @@
  */
 
 import { ref, computed } from 'vue'
+import { useExpansion } from '@/composables/useExpansion'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { useBackgroundTask } from '@/composables/useBackgroundTask'
@@ -53,7 +54,8 @@ export function useBugPrediction(deps: UseCodeIntelAnalysisDeps) {
   const bugRiskFilter = ref<'all' | 'high' | 'medium' | 'low'>('all')
   const BUG_RISK_PAGE_SIZE = 50
   const bugRiskVisibleCount = ref(BUG_RISK_PAGE_SIZE)
-  const expandedBugRiskFiles = ref<Set<string>>(new Set())
+  const bugRiskExpansion = useExpansion<string>()
+  const expandedBugRiskFiles = bugRiskExpansion.expanded
 
   // --- Loaders ---
 
@@ -90,14 +92,7 @@ export function useBugPrediction(deps: UseCodeIntelAnalysisDeps) {
   }
 
   function toggleBugRiskFileExpand(filePath: string): void {
-    if (expandedBugRiskFiles.value.has(filePath)) {
-      expandedBugRiskFiles.value.delete(filePath)
-    } else {
-      expandedBugRiskFiles.value.add(filePath)
-    }
-    expandedBugRiskFiles.value = new Set(
-      expandedBugRiskFiles.value,
-    )
+    bugRiskExpansion.toggle(filePath)
   }
 
   function getFilteredBugRiskFiles(): BugPredictionFile[] {

--- a/autobot-frontend/src/composables/useExpansion.ts
+++ b/autobot-frontend/src/composables/useExpansion.ts
@@ -1,0 +1,102 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * useExpansion Composable (#5306)
+ *
+ * Reusable expansion state for tree / accordion / row-expand UIs. Sister
+ * primitive to `useBatchSelection<T, Key>` — same Set-keyed shape, different
+ * intent: expansion is about visibility / disclosure, selection is about
+ * action targeting. Kept separate so reader intent is preserved at the call
+ * site (`isExpanded(node)` reads differently from `isSelected(node)`).
+ *
+ * Owns a `Set<Key>` of expanded keys and exposes `isExpanded(key)` /
+ * `toggle(key)` / `expand(key)` / `collapse(key)` / `expandAll(keys)` /
+ * `collapseAll()`. Mutations replace the Set on every write — defensive but
+ * compatible with both `ref` and `shallowRef` consumers.
+ */
+
+import { ref, readonly } from 'vue'
+import type { Ref } from 'vue'
+
+export interface UseExpansionReturn<Key extends string | number = string> {
+  /** Set of currently-expanded keys. Read-only; mutate via the helpers below. */
+  expanded: Readonly<Ref<Set<Key>>>
+  /** True if the given key is expanded. */
+  isExpanded: (key: Key) => boolean
+  /** Toggle expansion for one key. */
+  toggle: (key: Key) => void
+  /** Expand one key (idempotent). */
+  expand: (key: Key) => void
+  /** Collapse one key (idempotent). */
+  collapse: (key: Key) => void
+  /** Replace the expansion set with the given keys. */
+  expandAll: (keys: Iterable<Key>) => void
+  /** Collapse everything. */
+  collapseAll: () => void
+}
+
+/**
+ * Reusable expansion state for tree / accordion / row-expand UIs.
+ *
+ * @param initialKeys  Optional iterable of keys to seed the expanded set
+ *                     (e.g. default-open categories in a settings dashboard).
+ */
+export function useExpansion<Key extends string | number = string>(
+  initialKeys?: Iterable<Key>
+): UseExpansionReturn<Key> {
+  const expanded = ref(new Set<Key>(initialKeys ?? [])) as Ref<Set<Key>>
+
+  function isExpanded(key: Key): boolean {
+    return expanded.value.has(key)
+  }
+
+  function toggle(key: Key): void {
+    const next = new Set(expanded.value)
+    if (next.has(key)) {
+      next.delete(key)
+    } else {
+      next.add(key)
+    }
+    expanded.value = next
+  }
+
+  function expand(key: Key): void {
+    if (!expanded.value.has(key)) {
+      const next = new Set(expanded.value)
+      next.add(key)
+      expanded.value = next
+    }
+  }
+
+  function collapse(key: Key): void {
+    if (expanded.value.has(key)) {
+      const next = new Set(expanded.value)
+      next.delete(key)
+      expanded.value = next
+    }
+  }
+
+  function expandAll(keys: Iterable<Key>): void {
+    expanded.value = new Set(keys)
+  }
+
+  function collapseAll(): void {
+    expanded.value = new Set()
+  }
+
+  return {
+    // `readonly()` wraps the Set in DeepReadonly; we expose the original
+    // surface (`Set<Key>`) as read-only because callers need `.has()` / `.size`
+    // and we already control all mutations via the helpers. The double cast is
+    // the standard Vue idiom for this TS2352 (non-overlapping types).
+    expanded: readonly(expanded) as unknown as Readonly<Ref<Set<Key>>>,
+    isExpanded,
+    toggle,
+    expand,
+    collapse,
+    expandAll,
+    collapseAll
+  }
+}


### PR DESCRIPTION
## Summary

Closes #5306.

Extracts a small sister primitive to [\`useBatchSelection\`](autobot-frontend/src/composables/useBatchSelection.ts) (#5192) for tree / accordion / row-expansion UIs that use a Set of expanded keys. The composable owns the Set and exposes \`isExpanded\` / \`toggle\` / \`expand\` / \`collapse\` / \`expandAll\` / \`collapseAll\`.

Both primitives have the same shape; they are kept separate so the call site reads cleanly — \`isExpanded(node)\` (visibility) and \`isSelected(node)\` (action target) carry different intent and shouldn't share an alias.

### Composable

[`autobot-frontend/src/composables/useExpansion.ts`](autobot-frontend/src/composables/useExpansion.ts) — 102 lines including JSDoc + the `readonly()` cast comment. Optional \`initialKeys\` constructor argument seeds the expanded set (matches the \`PrecommitHookDashboard\` precedent of pre-opening certain categories).

[`autobot-frontend/src/composables/__tests__/useExpansion.test.ts`](autobot-frontend/src/composables/__tests__/useExpansion.test.ts) — 15 cases:
- initial state (empty + seeded from iterable + seeded from Set)
- toggle / expand / collapse idempotency
- expandAll / collapseAll / expandAll with empty iterable
- reactivity through \`watchEffect\` (this is the assertion that defends against the Vue-2-cargo \`= new Set(...)\` fixup pattern)
- numeric Key generic
- readonly return surface

### Migrated sites (8)

Each had the identical 5-line \`if has → delete else add\` toggle. Three of them additionally had a defensive \`= new Set(...)\` reassignment after the mutation — that pattern is **unnecessary** in Vue 3 (verified empirically in PR #5288's reflective audit), so removing it is a small clarity win.

| File | Variable | Notes |
|---|---|---|
| [\`composables/analytics/useBugPrediction.ts\`](autobot-frontend/src/composables/analytics/useBugPrediction.ts) | \`expandedBugRiskFiles\` | Public API unchanged — the ref is still exported under the same name |
| [\`components/charts/ImportTreeChart.vue\`](autobot-frontend/src/components/charts/ImportTreeChart.vue) | \`expandedNodes\` | |
| [\`components/charts/FunctionCallGraph.vue\`](autobot-frontend/src/components/charts/FunctionCallGraph.vue) | \`expandedFuncs\` | Also collapses the auto-expand-top-3-on-data-load loop into a single \`expandAll()\` call |
| [\`components/audit/AuditTimeline.vue\`](autobot-frontend/src/components/audit/AuditTimeline.vue) | \`expandedIds\` | |
| [\`components/knowledge/KnowledgeSystemDocs.vue\`](autobot-frontend/src/components/knowledge/KnowledgeSystemDocs.vue) | \`expandedCategories\` | \`isCategoryExpanded\` now delegates to \`composable.isExpanded\` |
| [\`components/knowledge/KnowledgeBrowser.vue\`](autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue) | \`expandedNodes\` | Toggle has a load-on-expand side effect — captured via \`wasExpanded\` gate before \`toggle()\` |
| [\`components/analytics/panels/CodebaseBugPredictionPanel.vue\`](autobot-frontend/src/components/analytics/panels/CodebaseBugPredictionPanel.vue) | \`expandedFiles\` | |
| [\`components/chat/ChatMessages.vue\`](autobot-frontend/src/components/chat/ChatMessages.vue) | \`expandedCitations\` | |

## Verification

- \`npx vue-tsc --noEmit -p tsconfig.app.json\` → 0 new type errors in changed files. The one error that surfaces (\`ImportTreeChart\` line ~671 about \`'quality'\` not in \`BaseLayoutOptions\`) is pre-existing on \`Dev_new_gui\` baseline at the same call (verified by stashing the diff).
- \`npx vitest run src/composables/__tests__/useExpansion.test.ts src/composables/__tests__/useBatchSelection.test.ts\` → 42/42 pass (15 new + 27 sibling).
- Diff: +303 / -68 (most of the +303 is the new composable + 155 lines of tests; net component code shrank ~70 lines).

## Out of scope (related but different shape)

Already documented in #5306:
- 5 sites use \`ref<string | null>\` for **single-expansion** (one row open at a time). Trivial \`if (current === id) ... else ...\` — no composable warranted.
- 5 Analytics sites use \`Record<string, boolean>\` for the same intent. Should migrate to Set + \`useExpansion\` in a follow-up so all 13 sites land on the same primitive. Separate PR.

## Test plan

- [ ] Manual: open Knowledge Browser, expand/collapse folders, search to trigger auto-expand, clear search to verify collapseAll
- [ ] Manual: open Import Tree Chart, expand/collapse file nodes
- [ ] Manual: open Function Call Graph with data — top-3 functions should auto-expand on load
- [ ] Manual: open a chat session with citations — toggle citation panel
- [ ] Manual: open Audit Timeline → expand/collapse details rows
- [ ] Manual: open Codebase Analytics → Bug Prediction panel → expand/collapse file rows

## Related

- #5192 — \`useBatchSelection\` (sibling primitive)
- #5247 / PR #5278, #5283 / PR #5288 — \`useBatchSelection\` adoption work that surfaced this pattern
- #5060 — primitives umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)