### PR TITLE
refactor(knowledge): migrate 2 production callers onto BaseCollection ABC (#5194)

### DIFF
--- a/autobot-backend/services/knowledge/cognition_seeder.py
+++ b/autobot-backend/services/knowledge/cognition_seeder.py
@@ -19,11 +19,14 @@ import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import yaml
 
 from constants.path_constants import PATH
+
+if TYPE_CHECKING:
+    from knowledge.backends import BaseClient, BaseCollection
 
 logger = logging.getLogger(__name__)
 
@@ -143,24 +146,27 @@ class CognitionSeeder:
     """
 
     def __init__(self) -> None:
-        self._client = None
+        # Backend-agnostic handles (#5062, #5194). Resolved in
+        # ``_ensure_initialized()`` to a ``BaseClient``; the concrete
+        # production backend is ChromaDB today.
+        self._client: Optional["BaseClient"] = None
         self._embed_model = None
         self._initialized = False
         self._root_dir: Path = PATH.PROJECT_ROOT
 
     async def _ensure_initialized(self) -> bool:
-        """Lazy-initialize ChromaDB client and embedding model."""
+        """Lazy-initialize vector-store client and embedding model."""
         if self._initialized:
             return True
         try:
             from llama_index.embeddings.ollama import OllamaEmbedding
 
             from autobot_shared.ssot_config import get_ollama_url
-            from utils.chromadb_client import get_chromadb_client
+            from knowledge.backends import get_default_client
 
             chromadb_path = self._root_dir / "data" / "chromadb"
             self._client = await asyncio.to_thread(
-                get_chromadb_client, str(chromadb_path)
+                get_default_client, db_path=str(chromadb_path)
             )
             ollama_url = get_ollama_url()
             self._embed_model = OllamaEmbedding(

--- a/autobot-backend/services/knowledge/doc_searcher.py
+++ b/autobot-backend/services/knowledge/doc_searcher.py
@@ -10,11 +10,14 @@ Contains DocumentationSearcher for AutoBot documentation search integration.
 
 import re
 import threading
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_llm_logger
 from autobot_shared.ssot_config import get_ollama_url
 from constants.path_constants import PATH
+
+if TYPE_CHECKING:
+    from knowledge.backends import BaseClient, BaseCollection
 
 logger = get_llm_logger("doc_searcher")
 
@@ -51,11 +54,14 @@ class DocumentationSearcher:
         Initialize the documentation searcher.
 
         Args:
-            collection_name: ChromaDB collection name for documentation
+            collection_name: Vector-store collection name for documentation
         """
         self.collection_name = collection_name
-        self._client = None
-        self._collection = None
+        # Backend-agnostic handles (#5062, #5194). Resolved in ``initialize()``
+        # to a ``BaseClient`` / ``BaseCollection``; the concrete production
+        # backend is ChromaDB today.
+        self._client: Optional["BaseClient"] = None
+        self._collection: Optional["BaseCollection"] = None
         self._embed_model = None
         self._initialized = False
         self._doc_patterns = [
@@ -75,11 +81,11 @@ class DocumentationSearcher:
         try:
             from llama_index.embeddings.ollama import OllamaEmbedding
 
-            from utils.chromadb_client import get_chromadb_client
+            from knowledge.backends import get_default_client
 
-            # Initialize ChromaDB
+            # Initialize ChromaDB via pluggable backend seam (#5062, #5194).
             chromadb_path = PROJECT_ROOT / "data" / "chromadb"
-            self._client = get_chromadb_client(str(chromadb_path))
+            self._client = get_default_client(db_path=str(chromadb_path))
 
             # Get documentation collection (don't create if not exists)
             try:


### PR DESCRIPTION
Closes #5194 (partially — 2 of 10)

## Summary
First incremental migration onto the BaseCollection/BaseClient seam from #5129 (#5062). Proves the seam works under real callers; deferred 8 higher-risk callers to follow-up PRs.

## Migrated (2)
- \`services/knowledge/doc_searcher.py\` — read-only, 264 LOC
- \`services/knowledge/cognition_seeder.py\` — seed/status, 406 LOC, has tests

Both use: \`from knowledge.backends import get_default_client\` (replacing \`from utils.chromadb_client import get_chromadb_client\`). Type hints: \`chromadb.Collection\` → \`BaseCollection\` under \`TYPE_CHECKING\`. \`get_default_client(db_path=...)\` forwards to existing production path so HNSW/sqlite migrations still run. Thin seam swap — zero behavior change.

## Deferred (8)
With rationale in commit message:
- **Async-only (need async adapter)**: \`knowledge/pipeline/loaders/chromadb_loader.py\`, \`services/knowledge/doc_indexer.py\`
- **Direct \`chromadb.EphemeralClient\`**: \`services/knowledge/autonomous_loop.py\`
- **Write-heavy / larger blast radius**: \`code_intelligence/pattern_analysis/storage.py\`, \`api/codebase_analytics/storage.py\`
- **Needs audit for ChromaDB-specific features**: \`autobot_memory_graph/\`, \`utils/gpu_vector_search.py\`, \`knowledge/rag_benchmarks.py\`, \`npu_semantic_search.py\`, \`knowledge/index.py\`, \`api/knowledge_rag.py\`

## Test Status
PASS — 40 ABC contract tests + 13 cognition_seeder tests; 5 pre-existing failures on Dev_new_gui baseline (missing \`_apply_seed_priority_boost\`) verified unrelated.