### PR TITLE
refactor(codebase-analytics): consolidate _DEFAULT_HARDCODE_SEVERITY (#5312)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from utils.chromadb_client import get_all_paginated
 
+from ..analyzers import _DEFAULT_HARDCODE_SEVERITY
 from ..scanner import _tasks_sync_lock, indexing_tasks
 from ..storage import get_code_collection, get_redis_connection
 from .shared import (
@@ -325,34 +326,22 @@ def _fetch_hardcodes_from_memory(storage, hardcode_type: Optional[str]) -> list:
     return results
 
 
-# Issue #5290: default severity mapping for legacy records that were
-# stored in Redis before the producer shape was fixed. Must stay in sync
-# with ``_DEFAULT_HARDCODE_SEVERITY`` in analyzers.py.
-_LEGACY_SEVERITY_BY_TYPE = {
-    "ip": "high",
-    "api_key": "high",
-    "password": "high",
-    "secret": "high",
-    "port": "medium",
-    "url": "medium",
-    "api_path": "low",
-    "config": "low",
-}
-
-
 def _normalize_hardcode_record(record: dict) -> dict:
     """Normalize a hardcode record to the canonical shape (Issue #5290).
 
     Old records use ``file_path``; new producers emit ``file``. Similarly
     ``severity`` was absent on many AST/regex detections — fill from the
     type's default so the frontend ``HardcodedValue`` contract holds.
+
+    Issue #5312: default-severity map lives in ``analyzers.py`` as the
+    single source of truth, imported here instead of duplicated.
     """
     normalized = dict(record)
     if "file" not in normalized and "file_path" in normalized:
         normalized["file"] = normalized["file_path"]
     normalized.setdefault("file", "")
     if not normalized.get("severity"):
-        normalized["severity"] = _LEGACY_SEVERITY_BY_TYPE.get(normalized.get("type", ""), "low")
+        normalized["severity"] = _DEFAULT_HARDCODE_SEVERITY.get(normalized.get("type", ""), "low")
     return normalized
 
 


### PR DESCRIPTION
## Summary

#5290 introduced two copies of the severity-by-type map with an explicit \"must stay in sync\" comment — exactly the kind of coupling that rots silently. Replaces the duplicate with a direct import.

- Delete \`_LEGACY_SEVERITY_BY_TYPE\` from \`stats.py\`.
- Import \`_DEFAULT_HARDCODE_SEVERITY\` from \`..analyzers\`.
- Drop the \"must stay in sync\" comment — single source of truth now.

Closes #5312.

## Verification

- \`py_compile\` clean.
- \`black\` clean.
- Normalizer contract unchanged — isolated unit test for all 4 drift cases still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)