### PR TITLE
fix(database): swap 6 SQLAlchemy column defaults from datetime.utcnow to now_utc (#5305)

### DIFF
--- a/autobot-backend/models/activities.py
+++ b/autobot-backend/models/activities.py
@@ -20,6 +20,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
+from autobot_shared.time_utils import now_utc
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -92,7 +93,7 @@ class TerminalActivityModel(Base):
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        default=datetime.utcnow,
+        default=now_utc,
         index=True,
     )
 
@@ -169,7 +170,7 @@ class FileActivityModel(Base):
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        default=datetime.utcnow,
+        default=now_utc,
         index=True,
     )
 
@@ -248,7 +249,7 @@ class BrowserActivityModel(Base):
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        default=datetime.utcnow,
+        default=now_utc,
         index=True,
     )
 
@@ -328,7 +329,7 @@ class DesktopActivityModel(Base):
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        default=datetime.utcnow,
+        default=now_utc,
         index=True,
     )
 
@@ -414,7 +415,7 @@ class SecretUsageModel(Base):
     timestamp: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        default=datetime.utcnow,
+        default=now_utc,
         index=True,
     )
 

--- a/autobot-backend/user_management/models/team.py
+++ b/autobot-backend/user_management/models/team.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
+from autobot_shared.time_utils import now_utc
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -175,7 +176,7 @@ class TeamMembership(Base):
     # When the user joined the team
     joined_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
+        default=now_utc,
         nullable=False,
     )
 


### PR DESCRIPTION
## Summary

Closes #5305.

Removes the session-tz fragility flagged in PR #5281's [SQLAlchemy column audit](docs/developer/audits/sqlalchemy-datetime-column-audit.md). All 6 affected columns are on \`DateTime(timezone=True)\` — **no schema migration needed; pure default-callable swap.**

## Why this matters

\`default=datetime.utcnow\` (bare callable) returns a NAIVE datetime at insert time. Even on a \`DateTime(timezone=True)\` column, PostgreSQL INTERPRETS the naive value in the session timezone (typically UTC, but configurable via \`SET TIME ZONE\`). Behavior is correct only as long as the DB session timezone matches the implicit "this is UTC" assumption — fragile.

\`default=now_utc\` (added by #5211 Phase B1, PR #5289) returns a tz-AWARE datetime. SQLAlchemy stores it correctly, no session-tz dependency.

## Files migrated

| File | Columns | Default |
|---|---|---|
| [\`autobot-backend/models/activities.py\`](autobot-backend/models/activities.py) | 5 \`timestamp\` columns (TerminalActivity, FileActivity, BrowserActivity, DesktopActivity, SecretUsage) | swapped to \`now_utc\` |
| [\`autobot-backend/user_management/models/team.py\`](autobot-backend/user_management/models/team.py) | 1 \`joined_at\` column (TeamMembership) | swapped to \`now_utc\` |

Both files keep \`from datetime import datetime\` for the \`Mapped[datetime]\` type annotations.

## Verification

- \`py_compile\` passes on both files
- 0 \`default=datetime.utcnow\` sites remaining in either file
- \`DateTime(timezone=True)\` column type unchanged — no schema impact

## Diff

2 files, +8/-6.