### PR TITLE
refactor(analytics): consolidate 4 duplicate HardcodedValue type defs (#5311)

### DIFF
--- a/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseEnvironmentPanel.vue
@@ -213,16 +213,8 @@
 
 <script setup lang="ts">
 import EmptyState from '@/components/ui/EmptyState.vue'
-
-interface HardcodedValue {
-  file: string
-  line: number
-  variable_name?: string
-  value: string
-  type: string
-  severity: string
-  suggested_env_var: string
-}
+// #5311: canonical HardcodedValue from analyticsTypes — was inline-duplicated here.
+import type { HardcodedValue } from '@/composables/analytics/analyticsTypes'
 
 interface EnvRecommendation {
   env_var_name: string

--- a/autobot-frontend/src/composables/analytics/codeIntelTypes.ts
+++ b/autobot-frontend/src/composables/analytics/codeIntelTypes.ts
@@ -10,6 +10,7 @@
 
 import type { Ref, ComputedRef } from 'vue'
 import type { ToastType } from '@/composables/useToast'
+import type { HardcodedValue } from '@/composables/analytics/analyticsTypes'
 
 // --- Dependencies interface ---
 
@@ -177,17 +178,8 @@ export interface EnvironmentAnalysisResult {
   recommendations_count: number
   categories: Record<string, number>
   analysis_time_seconds: number
-  hardcoded_values: Array<{
-    file: string
-    line: number
-    variable_name?: string
-    value: string
-    type: string
-    severity: string
-    suggested_env_var: string
-    context?: string
-    current_usage?: string
-  }>
+  // #5311: use canonical HardcodedValue from analyticsTypes.
+  hardcoded_values: HardcodedValue[]
   recommendations: EnvRecommendation[]
   is_truncated?: boolean
 }

--- a/autobot-frontend/src/composables/analytics/useCodebaseExport.ts
+++ b/autobot-frontend/src/composables/analytics/useCodebaseExport.ts
@@ -8,6 +8,7 @@
  */
 import type { Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
+import type { HardcodedValue } from '@/composables/analytics/analyticsTypes'
 
 const logger = createLogger('CodebaseExport')
 
@@ -48,17 +49,7 @@ interface EnvExportData {
   total_hardcoded_values?: number
   high_priority_count?: number
   categories?: Record<string, number>
-  hardcoded_values?: Array<{
-    type: string
-    severity: string
-    value: string
-    file?: string
-    line?: number
-    variable_name?: string
-    suggested_env_var?: string
-    context?: string
-    current_usage?: string
-  }>
+  hardcoded_values?: HardcodedValue[]
   recommendations?: Array<{
     priority?: string
     description?: string
@@ -147,15 +138,8 @@ function _generateDeclarationsMd(data: unknown): string {
 function _generateHardcodesMd(data: unknown): string {
   // #5277: dedicated markdown for the array form returned by
   // `/api/analytics/codebase/hardcodes` (distinct from env-analysis export).
-  const hcs = data as Array<{
-    file: string
-    line: number
-    variable_name?: string
-    value: string
-    type: string
-    severity: string
-    suggested_env_var?: string
-  }>
+  // #5311: use canonical `HardcodedValue` instead of inline shape.
+  const hcs = data as HardcodedValue[]
   let md = `## Hardcoded Values\n\n**Total Values Found:** ${hcs.length}\n\n`
   if (hcs.length === 0) return md
   const groups: Record<string, typeof hcs> = { high: [], medium: [], low: [] }


### PR DESCRIPTION
## Summary

Four inline copies of the \`HardcodedValue\` shape (one already drifted post-#5290) replaced with imports from the canonical \`analyticsTypes\`:

- \`CodebaseEnvironmentPanel.vue\` — was requiring \`suggested_env_var: string\` (drift)
- \`useCodebaseExport.ts\` — inline in \`EnvExportData.hardcoded_values\` + \`_generateHardcodesMd\`
- \`codeIntelTypes.ts\` — inline in \`EnvironmentAnalysisResult.hardcoded_values\`

Net -32 LOC; single source of truth.

Closes #5311.

## Verification

- \`vue-tsc --noEmit -p tsconfig.app.json\` → 167 errors (unchanged baseline; 0 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)