### PR TITLE
refactor(base-table): adopt useBatchSelection for row selection (closes #5283)

### DIFF
--- a/autobot-frontend/src/components/base/BaseTable.vue
+++ b/autobot-frontend/src/components/base/BaseTable.vue
@@ -133,8 +133,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, useSlots } from 'vue'
+import { ref, computed, useSlots, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useBatchSelection } from '@/composables/useBatchSelection'
 
 interface TableColumn {
   key: string
@@ -182,7 +183,20 @@ const emit = defineEmits<{
 const slots = useSlots()
 const sortKey = ref<string>('')
 const sortOrder = ref<'asc' | 'desc'>('asc')
-const selectedRows = ref<Set<any>>(new Set())
+
+// Row selection backed by useBatchSelection. Items source is props.data;
+// the Key is whatever `row[props.rowKey]` yields (typically string/number).
+const rowSelection = useBatchSelection<any, any>(
+  () => props.data ?? [],
+  (row) => row[props.rowKey]
+)
+const selectedRows = rowSelection.selected
+const allSelected = rowSelection.allSelected
+
+// Emit selection-change whenever the selected keys mutate.
+watch(selectedRows, (set) => {
+  emit('selection-change', Array.from(set))
+}, { deep: false })
 
 const wrapperClasses = computed(() => [
   `table-${props.variant}`,
@@ -194,11 +208,6 @@ const totalColumns = computed(() => {
   if (props.selectable) count++
   if (slots.actions) count++
   return count
-})
-
-const allSelected = computed(() => {
-  if (!props.data || props.data.length === 0) return false
-  return props.data.every(row => selectedRows.value.has(row[props.rowKey]))
 })
 
 const handleSort = (key: string) => {
@@ -213,22 +222,20 @@ const handleSort = (key: string) => {
 
 const toggleSelectAll = () => {
   if (allSelected.value) {
-    selectedRows.value.clear()
+    rowSelection.clear()
   } else {
-    props.data.forEach(row => {
-      selectedRows.value.add(row[props.rowKey])
-    })
+    rowSelection.selectAll()
   }
-  emit('selection-change', Array.from(selectedRows.value))
 }
 
 const toggleRowSelection = (key: any) => {
-  if (selectedRows.value.has(key)) {
-    selectedRows.value.delete(key)
+  if (rowSelection.selected.value.has(key)) {
+    rowSelection.deselectByKey(key)
   } else {
-    selectedRows.value.add(key)
+    // Look up the row object to feed select(); row objects are the items source.
+    const row = props.data.find(r => r[props.rowKey] === key)
+    if (row) rowSelection.select(row)
   }
-  emit('selection-change', Array.from(selectedRows.value))
 }
 
 const handleRowClick = (row: any) => {


### PR DESCRIPTION
## Summary

Closes #5283 (the last component remaining after PR #5288 migrated the four leaf consumers).

[`BaseTable.vue`](autobot-frontend/src/components/base/BaseTable.vue) owned its own `ref(new Set<any>())` + `toggleSelectAll` / `toggleRowSelection` / `allSelected` logic. Now backed by `useBatchSelection<any, any>(() => props.data, row => row[props.rowKey])`.

### Public API unchanged

The `selection-change: [selectedKeys: any[]]` emit still fires with `Array.from(set)` on every mutation — but now driven by a single watcher on the composable's `selected` ref instead of being threaded through each toggle call site. That's a small correctness win: the previous code emitted only on the two specific mutation paths (`toggleSelectAll`, `toggleRowSelection`); a future code path that mutated selection by other means would have silently desynced consumers. The watcher closes that gap.

### Blast radius

Grep showed BaseTable has **no production consumers**:
- `views/ComponentShowcaseView.vue` — demo / showcase page
- `components/base/BaseTable.stories.ts` — Storybook stories

Both are doc/demo surfaces. The `selection-change` emit signature is preserved exactly, so neither needs changes.

## Verification

- `npx vue-tsc --noEmit -p tsconfig.app.json` → 0 new type errors. The 4 errors that show up in `BaseTable.stories.ts` (props `striped`/`hover`/`bordered` not in component) are **pre-existing on `Dev_new_gui` baseline** (verified by stashing the diff and re-running) — separate stories-file issue, not introduced here.
- `npx vitest run src/composables/__tests__/useBatchSelection.test.ts` → 27/27 pass.
- Diff: -16 / +23 lines (net +7, mostly the watcher and the row-lookup helper).

## Test plan

- [ ] Manual: open ComponentShowcaseView, exercise the BaseTable demo with `selectable=true` — toggle individual rows, click header checkbox to select all / clear all, verify the `selection-change` emit fires (visible via the showcase's count display).

## Related

- #5247 / PR #5278 — KB component migration
- #5283 / PR #5288 — first 4 of 5 components in this issue
- #5306 / PR #5308 — sister `useExpansion` composable
- #5192 — original `useBatchSelection` extraction
- #5060 — primitives umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)