### PR TITLE
refactor(composables): migrate useConversationFiles selection to useBatchSelection (#5322)

### DIFF
--- a/autobot-frontend/src/composables/useConversationFiles.ts
+++ b/autobot-frontend/src/composables/useConversationFiles.ts
@@ -7,6 +7,7 @@
 
 import { ref, computed } from 'vue'
 import { useApi } from './useApi'
+import { useBatchSelection } from './useBatchSelection'
 import { createLogger } from '@/utils/debugUtils'
 import { extractApiErrorMessage } from '@/utils/errorExtract'
 import { getApiBase } from '@/config/ssot-config'
@@ -69,13 +70,20 @@ export function useConversationFiles(sessionId: string) {
   const searchQuery = ref('')
   const sortField = ref<SortField>('date')
   const sortDirection = ref<SortDirection>('desc')
-  const selectedFileIds = ref<Set<string>>(new Set())
+  // Selection state is owned by the shared useBatchSelection primitive (#5322);
+  // `files` is passed as the reactive items source so `allSelected`/`selectedCount`
+  // stay in sync automatically when the file list changes.
+  const fileSelection = useBatchSelection<ConversationFile, string>(
+    files,
+    (f) => f.file_id,
+  )
+  const selectedFileIds = fileSelection.selected
+  const selectedCount = fileSelection.selectedCount
+  const allSelected = fileSelection.allSelected
 
   // Computed
   const hasFiles = computed(() => files.value.length > 0)
   const totalSizeFormatted = computed(() => formatFileSize(stats.value.total_size_bytes))
-  const selectedCount = computed(() => selectedFileIds.value.size)
-  const allSelected = computed(() => files.value.length > 0 && selectedFileIds.value.size === files.value.length)
 
   const sortedFiles = computed(() => {
     let result = [...files.value]
@@ -407,28 +415,32 @@ export function useConversationFiles(sessionId: string) {
   // Bulk & sort operations
 
   const toggleFileSelection = (fileId: string) => {
-    const next = new Set(selectedFileIds.value)
-    if (next.has(fileId)) { next.delete(fileId) } else { next.add(fileId) }
-    selectedFileIds.value = next
+    const file = files.value.find(f => f.file_id === fileId)
+    if (file) {
+      fileSelection.toggle(file)
+    } else {
+      // File already removed from the list — drop any stale selection entry.
+      fileSelection.deselectByKey(fileId)
+    }
   }
 
   const selectAllFiles = () => {
-    if (allSelected.value) {
-      selectedFileIds.value = new Set()
+    if (fileSelection.allSelected.value) {
+      fileSelection.clear()
     } else {
-      selectedFileIds.value = new Set(files.value.map(f => f.file_id))
+      fileSelection.selectAll()
     }
   }
 
   const deleteSelectedFiles = async (): Promise<boolean> => {
-    const ids = Array.from(selectedFileIds.value)
+    const ids = Array.from(fileSelection.selected.value)
     if (ids.length === 0) return false
     loading.value = true
     error.value = null
     for (const fid of ids) {
       try { await api.delete(`${API}/files/${fid}`) } catch { /* continue */ }
     }
-    selectedFileIds.value = new Set()
+    fileSelection.clear()
     await loadFiles()
     loading.value = false
     return true


### PR DESCRIPTION
## Summary

Collapses `useConversationFiles.ts`'s bespoke `ref<Set<string>>(new Set())` selection state onto the shared `useBatchSelection<T, Key>` primitive. Sixth site migrated; missed by the #5283 audit because its grep scope was `components/{base,chat,secrets}`, not `composables/`.

## Changes

- `selectedFileIds` now aliases `fileSelection.selected` (readonly `Ref<Set<string>>`)
- `selectedCount` / `allSelected` delegate to the composable (no manual re-computation)
- `toggleFileSelection(id)` looks up the item and calls `fileSelection.toggle(item)`, falling back to `fileSelection.deselectByKey(id)` for the edge case where the file was removed mid-selection
- `selectAllFiles()` delegates to `selectAll()` / `clear()`
- `deleteSelectedFiles()` uses `fileSelection.clear()` for post-delete reset

## Public surface

Unchanged. The only consumer that touches selection state (`ChatFilePanel.vue`) still destructures the same names with identical runtime shapes:
- `selectedFileIds.has(file.file_id)` — still works (read-only `.has()` on `Readonly<Set>`)
- `selectedCount` / `allSelected` — still `Readonly<Ref<number>>` / `Readonly<Ref<boolean>>`
- `toggleFileSelection(id)` / `selectAllFiles()` — same signatures

`ChatSidebar.vue` and `DeleteConversationDialog.vue` use `useConversationFiles` only for non-selection state (files/stats/loading); their own selection uses `useBatchSelection` directly and is unaffected.

## Closes #5322

## Test plan

- [ ] Type-check passes on touched files
- [ ] ChatFilePanel file-list checkbox toggles individual files
- [ ] Select-all / deselect-all button flips between all/none
- [ ] Bulk delete clears selection after completion
- [ ] Selection persists across search filter changes (reactive `items` source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)