### PR TITLE
refactor(analytics): migrate 6 expansion sites from Record/Array to useExpansion (#5323)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
+++ b/autobot-frontend/src/components/analytics/CodeSmellsSection.vue
@@ -54,7 +54,7 @@
             @click="toggleCodeSmellType(String(smellType))"
           >
             <div class="header-info">
-              <i :class="expandedCodeSmellTypes[smellType] ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isSmellTypeExpanded(smellType) ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">{{ formatCodeSmellType(String(smellType)) }}</span>
               <span class="header-count">({{ group.smells.length.toLocaleString() }})</span>
             </div>
@@ -76,7 +76,7 @@
 
           <!-- Expanded smell items -->
           <transition name="accordion">
-            <div v-if="expandedCodeSmellTypes[smellType]" class="accordion-items">
+            <div v-if="isSmellTypeExpanded(smellType)" class="accordion-items">
               <div
                 v-for="(smell, idx) in group.smells.slice(0, 20)"
                 :key="idx"
@@ -124,8 +124,9 @@
  * Issue #184: Split oversized Vue components
  */
 
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { useGroupingMemo } from '@/composables/useComputedMemo'
+import { useExpansion } from '@/composables/useExpansion'
 import EmptyState from '@/components/ui/EmptyState.vue'
 
 interface CodeSmell {
@@ -152,7 +153,8 @@ const emit = defineEmits<{
   export: [format: 'md' | 'json']
 }>()
 
-const expandedCodeSmellTypes = ref<Record<string, boolean>>({})
+const smellTypeExpansion = useExpansion<string>()
+const isSmellTypeExpanded = smellTypeExpansion.isExpanded
 
 const severitySummary = computed(() => {
   const counts = { critical: 0, high: 0, medium: 0, low: 0 }
@@ -187,7 +189,7 @@ const smellsByType = useGroupingMemo(
 )
 
 const toggleCodeSmellType = (type: string) => {
-  expandedCodeSmellTypes.value[type] = !expandedCodeSmellTypes.value[type]
+  smellTypeExpansion.toggle(type)
 }
 
 const formatCodeSmellType = (type: string): string => {

--- a/autobot-frontend/src/components/analytics/DeclarationsSection.vue
+++ b/autobot-frontend/src/components/analytics/DeclarationsSection.vue
@@ -44,7 +44,7 @@
             @click="toggleDeclarationType(String(type))"
           >
             <div class="header-info">
-              <i :class="expandedDeclarationTypes[type] ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isExpandedType(type) ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">{{ formatDeclarationType(String(type)) }}</span>
               <span class="header-count">({{ typeData.declarations.length.toLocaleString() }})</span>
             </div>
@@ -55,7 +55,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expandedDeclarationTypes[type]" class="accordion-items">
+            <div v-if="isExpandedType(type)" class="accordion-items">
               <div
                 v-for="(declaration, index) in typeData.declarations.slice(0, 30)"
                 :key="index"
@@ -98,9 +98,10 @@
  * Issue #704: Migrated to design tokens
  */
 
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useGroupingMemo } from '@/composables/useComputedMemo'
+import { useExpansion } from '@/composables/useExpansion'
 import EmptyState from '@/components/ui/EmptyState.vue'
 
 const { t } = useI18n()
@@ -122,7 +123,8 @@ const emit = defineEmits<{
   export: [format: 'md' | 'json']
 }>()
 
-const expandedDeclarationTypes = ref<Record<string, boolean>>({})
+const typeExpansion = useExpansion<string>()
+const isExpandedType = typeExpansion.isExpanded
 
 // Issue #4036: Memoized type grouping with export counts
 const declarationsByType = useGroupingMemo(
@@ -143,7 +145,7 @@ const declarationsByType = useGroupingMemo(
 )
 
 const toggleDeclarationType = (type: string) => {
-  expandedDeclarationTypes.value[type] = !expandedDeclarationTypes.value[type]
+  typeExpansion.toggle(type)
 }
 
 const formatDeclarationType = (type: string): string => {

--- a/autobot-frontend/src/components/analytics/DuplicatesSection.vue
+++ b/autobot-frontend/src/components/analytics/DuplicatesSection.vue
@@ -52,7 +52,7 @@
             @click="toggleDuplicateGroup(String(similarity))"
           >
             <div class="header-info">
-              <i :class="expandedDuplicateGroups[similarity] ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isGroupExpanded(similarity) ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">{{ formatSimilarityGroup(String(similarity)) }}</span>
               <span class="header-count">({{ group.length }})</span>
             </div>
@@ -63,7 +63,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expandedDuplicateGroups[similarity]" class="accordion-items">
+            <div v-if="isGroupExpanded(similarity)" class="accordion-items">
               <div
                 v-for="(duplicate, index) in group.slice(0, 20)"
                 :key="index"
@@ -109,10 +109,11 @@
  * Issue #184: Split oversized Vue components
  */
 
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import { useAggregationMemo } from '@/composables/useComputedMemo'
+import { useExpansion } from '@/composables/useExpansion'
 
 const { t } = useI18n()
 
@@ -132,7 +133,8 @@ const emit = defineEmits<{
   export: [format: 'md' | 'json']
 }>()
 
-const expandedDuplicateGroups = ref<Record<string, boolean>>({})
+const groupExpansion = useExpansion<string>()
+const isGroupExpanded = groupExpansion.isExpanded
 
 const duplicatesBySimilarity = computed(() => {
   const groups: Record<string, Duplicate[]> = { high: [], medium: [], low: [] }
@@ -152,7 +154,7 @@ const totalDuplicateLines = useAggregationMemo(
 )
 
 const toggleDuplicateGroup = (similarity: string) => {
-  expandedDuplicateGroups.value[similarity] = !expandedDuplicateGroups.value[similarity]
+  groupExpansion.toggle(similarity)
 }
 
 const formatSimilarityGroup = (similarity: string): string => {

--- a/autobot-frontend/src/components/analytics/HardcodesSection.vue
+++ b/autobot-frontend/src/components/analytics/HardcodesSection.vue
@@ -52,7 +52,7 @@
             @click="toggleGroup(String(severity))"
           >
             <div class="header-info">
-              <i :class="expandedGroups[severity] ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isGroupExpanded(severity) ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">{{ formatSeverityGroup(String(severity)) }}</span>
               <span class="header-count">({{ group.length }})</span>
             </div>
@@ -61,7 +61,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expandedGroups[severity]" class="accordion-items">
+            <div v-if="isGroupExpanded(severity)" class="accordion-items">
               <div
                 v-for="(hc, index) in group.slice(0, 20)"
                 :key="index"
@@ -115,9 +115,10 @@
  * Issue #5277: wire previously-fetched hardcodeAnalysis data into the UI.
  */
 
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import { useExpansion } from '@/composables/useExpansion'
 import type { HardcodedValue } from '@/composables/analytics/analyticsTypes'
 
 const { t } = useI18n()
@@ -131,7 +132,8 @@ const emit = defineEmits<{
   export: [format: 'md' | 'json']
 }>()
 
-const expandedGroups = ref<Record<string, boolean>>({})
+const groupExpansion = useExpansion<string>()
+const isGroupExpanded = groupExpansion.isExpanded
 
 const hardcodesBySeverity = computed(() => {
   const groups: Record<string, HardcodedValue[]> = { high: [], medium: [], low: [] }
@@ -149,7 +151,7 @@ const uniqueTypeCount = computed(
 )
 
 const toggleGroup = (severity: string) => {
-  expandedGroups.value[severity] = !expandedGroups.value[severity]
+  groupExpansion.toggle(severity)
 }
 
 const formatSeverityGroup = (severity: string): string => {

--- a/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
+++ b/autobot-frontend/src/components/analytics/PrecommitHookDashboard.vue
@@ -173,9 +173,9 @@
               <span class="category-icon">{{ getCategoryIcon(category.id) }}</span>
               <span class="category-name">{{ category.name }}</span>
               <span class="category-count">{{ category.enabled }}/{{ category.total }}</span>
-              <span class="expand-icon">{{ expandedCategories.includes(category.id) ? '▼' : '▶' }}</span>
+              <span class="expand-icon">{{ isCategoryExpanded(category.id) ? '▼' : '▶' }}</span>
             </div>
-            <div v-if="expandedCategories.includes(category.id)" class="category-checks">
+            <div v-if="isCategoryExpanded(category.id)" class="category-checks">
               <div
                 v-for="check in getChecksForCategory(category.id)"
                 :key="check.id"
@@ -295,6 +295,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useToast } from '@/composables/useToast'
+import { useExpansion } from '@/composables/useExpansion'
 import api from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
@@ -377,7 +378,8 @@ const summary = ref<Summary>({
   total_checks: 0
 })
 const activeSeverity = ref('all')
-const expandedCategories = ref<string[]>(['security', 'debug'])
+const categoryExpansion = useExpansion<string>(['security', 'debug'])
+const isCategoryExpanded = categoryExpansion.isExpanded
 
 // Severity filters
 const severities = computed(() => [
@@ -461,12 +463,7 @@ function getChecksForCategory(category: string): Check[] {
 }
 
 function toggleCategory(category: string) {
-  const idx = expandedCategories.value.indexOf(category)
-  if (idx >= 0) {
-    expandedCategories.value.splice(idx, 1)
-  } else {
-    expandedCategories.value.push(category)
-  }
+  categoryExpansion.toggle(category)
 }
 
 function formatTime(timestamp: string): string {

--- a/autobot-frontend/src/components/analytics/ProblemsReportSection.vue
+++ b/autobot-frontend/src/components/analytics/ProblemsReportSection.vue
@@ -55,7 +55,7 @@
             @click="toggleProblemType(String(type))"
           >
             <div class="header-info">
-              <i :class="expandedProblemTypes[type] ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isTypeExpanded(type) ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">{{ formatProblemType(String(type)) }}</span>
               <span class="header-count">({{ typeData.problems.length.toLocaleString() }})</span>
             </div>
@@ -75,7 +75,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expandedProblemTypes[type]" class="accordion-items">
+            <div v-if="isTypeExpanded(type)" class="accordion-items">
               <div
                 v-for="(problem, index) in typeData.problems.slice(0, 20)"
                 :key="index"
@@ -121,8 +121,8 @@
  * Issue #184: Split oversized Vue components
  */
 
-import { ref } from 'vue'
 import { useGroupingMemo } from '@/composables/useComputedMemo'
+import { useExpansion } from '@/composables/useExpansion'
 import EmptyState from '@/components/ui/EmptyState.vue'
 
 interface Problem {
@@ -147,7 +147,8 @@ const emit = defineEmits<{
   export: [format: string]
 }>()
 
-const expandedProblemTypes = ref<Record<string, boolean>>({})
+const typeExpansion = useExpansion<string>()
+const isTypeExpanded = typeExpansion.isExpanded
 
 // Issue #4036: Memoized grouping - avoid recalculating on every render
 const problemsBySeverity = useGroupingMemo(
@@ -190,7 +191,7 @@ const problemsByType = useGroupingMemo(
 )
 
 const toggleProblemType = (type: string) => {
-  expandedProblemTypes.value[type] = !expandedProblemTypes.value[type]
+  typeExpansion.toggle(type)
 }
 
 const formatProblemType = (type: string): string => {


### PR DESCRIPTION
## Summary

Collapses the remaining `ref<Record<string, boolean>>({})` and `ref<string[]>([...])` expansion patterns in analytics/ onto the `useExpansion<Key>` primitive landed in PR #5308. #5306 explicitly listed these as out-of-scope follow-up.

## Sites migrated

| File | Before | After |
|---|---|---|
| `DeclarationsSection.vue` | `expandedDeclarationTypes: Record<string, boolean>` | `typeExpansion = useExpansion<string>()` |
| `DuplicatesSection.vue` | `expandedDuplicateGroups: Record<string, boolean>` | `groupExpansion = useExpansion<string>()` |
| `ProblemsReportSection.vue` | `expandedProblemTypes: Record<string, boolean>` | `typeExpansion = useExpansion<string>()` |
| `HardcodesSection.vue` | `expandedGroups: Record<string, boolean>` | `groupExpansion = useExpansion<string>()` |
| `CodeSmellsSection.vue` | `expandedCodeSmellTypes: Record<string, boolean>` | `smellTypeExpansion = useExpansion<string>()` |
| `PrecommitHookDashboard.vue` | `expandedCategories: string[]` (pre-seeded) | `categoryExpansion = useExpansion<string>(['security', 'debug'])` |

## Changes

- Template bindings switched from `expandedFoo[key]` → `isFooExpanded(key)` (or `.includes(key)` → `isFooExpanded(key)` for the `string[]` variant).
- Each component retains its original `toggleFoo(key)` helper for template stability; body delegates to `expansion.toggle(key)`.
- `PrecommitHookDashboard`'s manual `indexOf` / `splice` / `push` deleted in favor of the composable.
- Removed now-unused `ref` imports in 5 of 6 files.

## Acceptance (from #5323)

- ✅ All 6 sites use `useExpansion<string>()`
- ✅ Bespoke `ref<Record<string, boolean>>({})` and `ref<string[]>([...])` expansion state deleted
- ✅ `PrecommitHookDashboard` uses pre-seeded `useExpansion<string>(['security', 'debug'])`
- ✅ `grep -rnE 'expanded\w+\s*=\s*ref<Record<string,\s*boolean>' autobot-frontend/src/components/analytics` returns 0 hits

## Overlap with #5291

Partially overlaps — #5291 would extract an `AccordionSeveritySection` primitive covering 3 of these 6 (Hardcodes/Duplicates/Declarations). If #5291 ships after this, the extracted component uses `useExpansion` for free. If #5291 ships first, it can reuse this migration.

## Closes #5323

## Test plan

- [ ] Analytics dashboard loads
- [ ] Expand/collapse chevrons on each section work (DeclarationsSection, DuplicatesSection, ProblemsReportSection, HardcodesSection, CodeSmellsSection)
- [ ] PrecommitHookDashboard opens with `security` and `debug` expanded by default
- [ ] Toggling a category flips the expand icon + reveals children

🤖 Generated with [Claude Code](https://claude.com/claude-code)