### PR TITLE
feat(composables): add selectByKey/toggleByKey to useBatchSelection + migrate 4 consumers (#5328)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -646,8 +646,7 @@ const cancelSelection = () => {
 }
 
 const toggleSelection = (sessionId: string) => {
-  const session = store.sessions.find(s => s.id === sessionId)
-  if (session) sessionSelection.toggle(session)
+  sessionSelection.toggleByKey(sessionId)
 }
 
 const deleteSelectedSessions = async () => {

--- a/autobot-frontend/src/components/chat/DeleteConversationDialog.vue
+++ b/autobot-frontend/src/components/chat/DeleteConversationDialog.vue
@@ -312,8 +312,7 @@ watch(() => props.kbFacts, (newFacts) => {
 }, { immediate: true })
 
 const toggleFactSelection = (factId: string) => {
-  const fact = props.kbFacts?.find(f => f.id === factId)
-  if (fact) factSelection.toggle(fact)
+  factSelection.toggleByKey(factId)
 }
 
 const selectAllFacts = () => factSelection.selectAll()

--- a/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeEntries.vue
@@ -610,13 +610,7 @@ const sortEntries = () => {
 }
 
 const toggleSelection = (id: string) => {
-  // Use deselectByKey/select since callers pass IDs, not items.
-  if (selection.selected.value.has(id)) {
-    selection.deselectByKey(id)
-  } else {
-    const item = paginatedEntries.value.find(e => e.id === id)
-    if (item) selection.select(item)
-  }
+  selection.toggleByKey(id)
 }
 
 const toggleSelectAll = () => {

--- a/autobot-frontend/src/composables/__tests__/useBatchSelection.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useBatchSelection.test.ts
@@ -263,6 +263,72 @@ describe('useBatchSelection', () => {
     })
   })
 
+  describe('selectByKey / toggleByKey', () => {
+    it('selectByKey adds the key without needing the item', () => {
+      const sel = useBatchSelection<Doc, string>(
+        ref([{ id: 'd1', name: 'Doc 1' }]),
+        (d) => d.id,
+      )
+
+      sel.selectByKey('d1')
+      expect(sel.selected.value.has('d1')).toBe(true)
+      expect(sel.selectedCount.value).toBe(1)
+    })
+
+    it('selectByKey is idempotent', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.selectByKey('a')
+      sel.selectByKey('a')
+      sel.selectByKey('a')
+      expect(sel.selectedCount.value).toBe(1)
+    })
+
+    it('selectByKey accepts keys not in the items source (cross-page)', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.selectByKey('z')
+      expect(sel.selected.value.has('z')).toBe(true)
+    })
+
+    it('toggleByKey flips state on each call', () => {
+      const sel = useBatchSelection<Doc, string>(
+        ref([{ id: 'd1', name: 'Doc 1' }]),
+        (d) => d.id,
+      )
+
+      sel.toggleByKey('d1')
+      expect(sel.isSelected({ id: 'd1', name: 'Doc 1' })).toBe(true)
+      sel.toggleByKey('d1')
+      expect(sel.selected.value.has('d1')).toBe(false)
+      sel.toggleByKey('d1')
+      expect(sel.selected.value.has('d1')).toBe(true)
+    })
+
+    it('toggleByKey works for keys not in the items source', () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+
+      sel.toggleByKey('ghost')
+      expect(sel.selected.value.has('ghost')).toBe(true)
+      sel.toggleByKey('ghost')
+      expect(sel.selected.value.has('ghost')).toBe(false)
+    })
+
+    it('reactivity fires on selectByKey / toggleByKey mutations', async () => {
+      const sel = useBatchSelection<string>(ref(['a', 'b']))
+      const countSnapshot = computed(() => sel.selectedCount.value)
+
+      expect(countSnapshot.value).toBe(0)
+      sel.selectByKey('a')
+      await nextTick()
+      expect(countSnapshot.value).toBe(1)
+
+      sel.toggleByKey('a')
+      await nextTick()
+      expect(countSnapshot.value).toBe(0)
+    })
+  })
+
   describe('setSelected', () => {
     it('replaces the entire selection with given keys', () => {
       const sel = useBatchSelection<string>(ref(['a', 'b', 'c']))

--- a/autobot-frontend/src/composables/useBatchSelection.ts
+++ b/autobot-frontend/src/composables/useBatchSelection.ts
@@ -33,10 +33,14 @@ export interface UseBatchSelectionReturn<T, Key extends string | number = string
   toggle: (item: T) => void
   /** Select one item (idempotent). */
   select: (item: T) => void
+  /** Select one item by key (idempotent). Use when only the ID is available. */
+  selectByKey: (key: Key) => void
   /** Deselect one item (idempotent). */
   deselect: (item: T) => void
   /** Deselect by key (when only the ID is available). */
   deselectByKey: (key: Key) => void
+  /** Toggle selection by key. Use when only the ID is available. */
+  toggleByKey: (key: Key) => void
   /** Select every item currently in the list. */
   selectAll: () => void
   /** Replace the entire selection with the given keys. */
@@ -121,6 +125,35 @@ export function useBatchSelection<T, Key extends string | number = string | numb
     }
   }
 
+  /**
+   * Select by key directly. Mirror of `deselectByKey` for the common case
+   * where consumers have an ID in hand (from a checkbox change event,
+   * a URL param, a cross-page selection, etc.) and shouldn't have to
+   * reach into the items list just to get an item reference. Idempotent.
+   */
+  function selectByKey(key: Key): void {
+    if (!selected.value.has(key)) {
+      const next = new Set(selected.value)
+      next.add(key)
+      selected.value = next
+    }
+  }
+
+  /**
+   * Toggle by key directly. Mirror of `toggle` for ID-only call sites —
+   * replaces the `items.find(i => keyFn(i) === id)` + `toggle(item)` shim
+   * with one O(1) call.
+   */
+  function toggleByKey(key: Key): void {
+    const next = new Set(selected.value)
+    if (next.has(key)) {
+      next.delete(key)
+    } else {
+      next.add(key)
+    }
+    selected.value = next
+  }
+
   function selectAll(): void {
     selected.value = new Set(currentItems.value.map(keyFn))
   }
@@ -151,8 +184,10 @@ export function useBatchSelection<T, Key extends string | number = string | numb
     someSelected,
     toggle,
     select,
+    selectByKey,
     deselect,
     deselectByKey,
+    toggleByKey,
     selectAll,
     setSelected,
     clear,

--- a/autobot-frontend/src/composables/useConversationFiles.ts
+++ b/autobot-frontend/src/composables/useConversationFiles.ts
@@ -415,13 +415,7 @@ export function useConversationFiles(sessionId: string) {
   // Bulk & sort operations
 
   const toggleFileSelection = (fileId: string) => {
-    const file = files.value.find(f => f.file_id === fileId)
-    if (file) {
-      fileSelection.toggle(file)
-    } else {
-      // File already removed from the list — drop any stale selection entry.
-      fileSelection.deselectByKey(fileId)
-    }
+    fileSelection.toggleByKey(fileId)
   }
 
   const selectAllFiles = () => {


### PR DESCRIPTION
## Summary

Closes the API-symmetry gap surfaced during PR #5326: `useBatchSelection` exposed `deselectByKey` but no `selectByKey` / `toggleByKey`, forcing ID-only consumers into O(n) `items.find(i => keyFn(i) === id)` shims. Four consumers were working around this in four different ways.

## API additions

```ts
selectByKey: (key: Key) => void   // mirror of deselectByKey
toggleByKey: (key: Key) => void   // flip state for a key directly
```

Implementation mirrors the existing `deselectByKey` — Set-identity replacement on mutation, idempotent.

## Consumer migrations

| File | Before | After |
|---|---|---|
| `useConversationFiles.ts:417-425` | 8-line find-or-deselect shim | `fileSelection.toggleByKey(fileId)` |
| `KnowledgeEntries.vue:612-620` | has explicit apology comment + find shim | `selection.toggleByKey(id)` |
| `DeleteConversationDialog.vue:314-317` | `kbFacts?.find(f => f.id === factId)` shim | `factSelection.toggleByKey(factId)` |
| `ChatSidebar.vue:648-651` | `store.sessions.find(s => s.id === sessionId)` shim | `sessionSelection.toggleByKey(sessionId)` |

Eliminates the "Use deselectByKey/select since callers pass IDs, not items" apology comment from `KnowledgeEntries`.

## Tests

Added a `selectByKey / toggleByKey` describe block covering:
- Idempotency (repeat calls don't duplicate / double-delete)
- Cross-page keys (keys not in `items` source accepted)
- Toggle flip state on each call
- Reactivity (mutations fire computed / watcher effects via `await nextTick()`)

## Acceptance (from #5328)

- ✅ `useBatchSelection` exports `selectByKey(key)` and `toggleByKey(key)`
- ✅ Unit tests covering idempotency, reactivity, and cross-page keys
- ✅ 4 consumers migrated (`useConversationFiles`, `KnowledgeEntries`, `DeleteConversationDialog`, `ChatSidebar`)
- ✅ Shim pattern grep returns 0 hits for selection-bound `find()` workarounds

## Closes #5328

## Test plan

- [ ] `npm run test:unit useBatchSelection` passes with new cases
- [ ] Knowledge entries checkbox selection still works (toggle + select-all-on-page)
- [ ] Chat sidebar multi-session delete flow selects / deselects correctly
- [ ] Delete-conversation dialog fact preservation toggles work
- [ ] Chat file panel bulk operations unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)