### PR TITLE
refactor(composables): delegate toggle/select to *ByKey primitives (#5331)

### DIFF
--- a/autobot-frontend/src/composables/useBatchSelection.ts
+++ b/autobot-frontend/src/composables/useBatchSelection.ts
@@ -88,24 +88,14 @@ export function useBatchSelection<T, Key extends string | number = string | numb
     return selected.value.has(keyFn(item))
   }
 
+  // Item-based methods delegate to their *ByKey primitives so mutation
+  // logic lives in exactly one place (#5331).
   function toggle(item: T): void {
-    const key = keyFn(item)
-    const next = new Set(selected.value)
-    if (next.has(key)) {
-      next.delete(key)
-    } else {
-      next.add(key)
-    }
-    selected.value = next
+    toggleByKey(keyFn(item))
   }
 
   function select(item: T): void {
-    const key = keyFn(item)
-    if (!selected.value.has(key)) {
-      const next = new Set(selected.value)
-      next.add(key)
-      selected.value = next
-    }
+    selectByKey(keyFn(item))
   }
 
   function deselect(item: T): void {


### PR DESCRIPTION
## Summary

Closes the internal-consistency gap surfaced in the #5329 post-merge audit: `deselect(item)` was already a 2-line delegator to `deselectByKey`, but `toggle(item)` and `select(item)` reimplemented the full Set-replacement logic from scratch.

## Changes

All three item-based methods now funnel through their `*ByKey` primitives:

\`\`\`ts
function toggle(item: T): void { toggleByKey(keyFn(item)) }
function select(item: T): void { selectByKey(keyFn(item)) }
function deselect(item: T): void { deselectByKey(keyFn(item)) }  // unchanged
\`\`\`

Net −12 lines, zero public API change. Existing tests cover both paths via delegation.

## Why

Single source of truth for mutation logic. If anyone adds reactivity tracing, emits change events, or enforces a `maxSelections` cap later, one edit instead of three.

## Closes #5331

🤖 Generated with [Claude Code](https://claude.com/claude-code)