### PR TITLE
refactor(base-table): collapse toggleRowSelection to toggleByKey (#5333)

### DIFF
--- a/autobot-frontend/src/components/base/BaseTable.vue
+++ b/autobot-frontend/src/components/base/BaseTable.vue
@@ -229,13 +229,7 @@ const toggleSelectAll = () => {
 }
 
 const toggleRowSelection = (key: any) => {
-  if (rowSelection.selected.value.has(key)) {
-    rowSelection.deselectByKey(key)
-  } else {
-    // Look up the row object to feed select(); row objects are the items source.
-    const row = props.data.find(r => r[props.rowKey] === key)
-    if (row) rowSelection.select(row)
-  }
+  rowSelection.toggleByKey(key)
 }
 
 const handleRowClick = (row: any) => {


### PR DESCRIPTION
## Summary

Collapses BaseTable's 8-line `find()` + `select`/`deselectByKey` shim into a single `rowSelection.toggleByKey(key)` call.

PR #5325 (BaseTable → useBatchSelection migration) was authored before PR #5329 (#5328) added `toggleByKey` to the composable. Both PRs merged within minutes of each other today, leaving BaseTable — the highest-leverage consumer of `useBatchSelection` — carrying the exact pattern #5328 was filed to eliminate.

## Change

```diff
 const toggleRowSelection = (key: any) => {
-  if (rowSelection.selected.value.has(key)) {
-    rowSelection.deselectByKey(key)
-  } else {
-    // Look up the row object to feed select(); row objects are the items source.
-    const row = props.data.find(r => r[props.rowKey] === key)
-    if (row) rowSelection.select(row)
-  }
+  rowSelection.toggleByKey(key)
 }
```

No behavior change — `toggleByKey` is semantically identical to the find/select/deselectByKey branches.

## Closes #5333

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)