### PR TITLE
test(api): update stale source-inspection assertion for kb.redis() (#5338)

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -2681,7 +2681,7 @@ class TestVectorizeExistingFactsEndpoint:
 
         # Should have inner try-catch for fact processing
         assert "for fact_key in batch:" in source
-        assert "fact_data = await kb.aioredis_client.hgetall(fact_key)" in source
+        assert "fact_data = await kb.redis().hgetall(fact_key)" in source
         # Inner exception handling preserved
         assert "except Exception as e:" in source
         assert "failed_count += 1" in source


### PR DESCRIPTION
## Summary

Fixes a stale `inspect.getsource` assertion at [`api_endpoint_migrations_test.py:2684`](autobot-backend/api/api_endpoint_migrations_test.py#L2684) that has been silently broken since PR #5252 migrated `vectorize_existing_facts` from `kb.aioredis_client` to the public `kb.redis()` accessor.

Found during the post-PR-5330 audit (the new `no-kb-aioredis-access` lint should also now flag this line).

## Change

```diff
-assert "fact_data = await kb.aioredis_client.hgetall(fact_key)" in source
+assert "fact_data = await kb.redis().hgetall(fact_key)" in source
```

Matches [`knowledge_vectorization.py:378`](autobot-backend/api/knowledge_vectorization.py#L378) (the current production code).

## Closes #5338

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)