### PR TITLE
refactor(analytics): remove orphaned refactoringSuggestions ref (#5340)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
+++ b/autobot-frontend/src/composables/analytics/useAnalyticsDataFetchers.ts
@@ -34,7 +34,6 @@ import {
   type DuplicateCode,
   type Declaration,
   type HardcodedValue,
-  type RefactoringSuggestion,
   type ChartData,
   type DependencyGraph,
   type ImportTreeNode,
@@ -108,7 +107,6 @@ export function useAnalyticsDataFetchers(deps: UseAnalyticsDataFetchersDeps) {
   const duplicateAnalysis = ref<DuplicateCode[]>([])
   const declarationAnalysis = ref<Declaration[]>([])
   const hardcodeAnalysis = ref<HardcodedValue[]>([])
-  const refactoringSuggestions = ref<RefactoringSuggestion[]>([])
   const unifiedReport = ref<UnifiedReportData | null>(null)
   const selectedCategory = ref('all')
   const callGraphData = ref<DependencyGraph>({ nodes: [], edges: [] })
@@ -650,7 +648,6 @@ export function useAnalyticsDataFetchers(deps: UseAnalyticsDataFetchersDeps) {
     duplicateAnalysis,
     declarationAnalysis,
     hardcodeAnalysis,
-    refactoringSuggestions,
     chartData: chartEndpoint.data,
     chartDataLoading: chartEndpoint.loading,
     chartDataError: chartEndpoint.error,


### PR DESCRIPTION
## Summary

\`refactoringSuggestions\` in \`useAnalyticsDataFetchers.ts\` was declared, exported, but never populated or consumed. Deleted 3 lines.

The real, working \`refactoringSuggestions\` lives in \`usePatternAnalysis.ts\` and drives \`PatternAnalysis.vue\` — that path is untouched.

Closes #5340.

## Verification

- \`vue-tsc\` — 167 errors (unchanged baseline; 0 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)