### PR TITLE
refactor(backend): migrate Pattern A timing + cutoff sites in 10 files (#5211 phase B3.2)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -1198,7 +1198,7 @@ async def execute_enhanced_goal(
     enhanced_context = await _enhance_context_with_kb(payload, knowledge_base)
     coordination_mode = _determine_coordination_mode(payload, selected_agents)
 
-    execution_start = datetime.utcnow()
+    execution_start = time.monotonic()
 
     try:
         result = await ai_client.multi_agent_query(
@@ -1207,7 +1207,7 @@ async def execute_enhanced_goal(
             coordination_mode=coordination_mode,
         )
 
-        execution_time = (datetime.utcnow() - execution_start).total_seconds()
+        execution_time = time.monotonic() - execution_start
 
         return create_success_response(
             {

--- a/autobot-backend/api/knowledge_organization.py
+++ b/autobot-backend/api/knowledge_organization.py
@@ -361,7 +361,9 @@ async def cleanup_organization_knowledge(
     Raises:
         403: If user is not an organization admin
     """
-    from datetime import datetime, timedelta
+    from datetime import timedelta
+
+    from autobot_shared.time_utils import now_utc
 
     org_id = current_user.get("org_id")
     if not org_id:
@@ -383,7 +385,7 @@ async def cleanup_organization_knowledge(
             organization_id=org_id
         )
 
-        cutoff_date = datetime.utcnow() - timedelta(days=retention_days)
+        cutoff_date = now_utc() - timedelta(days=retention_days)
         deleted_count = await _delete_expired_facts(kb, fact_ids, cutoff_date)
 
         logger.info(

--- a/autobot-backend/api/usage.py
+++ b/autobot-backend/api/usage.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 from services.llm_cost_tracker import get_cost_tracker
 
 
@@ -245,7 +245,7 @@ async def export_usage_csv(
     Issue #1807: CSV export for billing/reporting.
     """
     tracker = get_cost_tracker()
-    cutoff = datetime.utcnow() - timedelta(days=days)
+    cutoff = now_utc() - timedelta(days=days)
 
     records = await tracker.get_recent_usage(limit=10000)
     filtered = [

--- a/autobot-backend/knowledge/connectors/scheduler.py
+++ b/autobot-backend/knowledge/connectors/scheduler.py
@@ -12,6 +12,7 @@ Parses simple interval expressions (e.g. "*/15" for every 15 minutes,
 import asyncio
 import logging
 import re
+import time
 from datetime import datetime
 from typing import Dict, Optional
 
@@ -182,7 +183,7 @@ class ConnectorScheduler:
             return
 
         logger.info("Scheduler triggering sync for connector %s", connector_id)
-        started_at = datetime.utcnow()
+        started_at = time.monotonic()
         try:
             result = await connector.sync(incremental=True)
             logger.info(
@@ -196,7 +197,7 @@ class ConnectorScheduler:
                 len(result.errors),
             )
         except Exception as exc:
-            elapsed = (datetime.utcnow() - started_at).total_seconds()
+            elapsed = time.monotonic() - started_at
             logger.error(
                 "Scheduled sync failed: connector=%s elapsed=%.1fs error=%s",
                 connector_id,

--- a/autobot-backend/security/enterprise/threat_detection/engine.py
+++ b/autobot-backend/security/enterprise/threat_detection/engine.py
@@ -25,7 +25,7 @@ from sklearn.cluster import DBSCAN
 from sklearn.ensemble import IsolationForest
 from sklearn.preprocessing import StandardScaler
 
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
 
@@ -646,7 +646,7 @@ class ThreatDetectionEngine:
         """Clean up old data and maintain performance"""
         try:
             # Clean up old user sessions
-            cutoff_time = datetime.utcnow() - timedelta(hours=24)
+            cutoff_time = now_utc() - timedelta(hours=24)
             expired_sessions = []
 
             for session_id, session_data in self.user_sessions.items():

--- a/autobot-backend/security/enterprise/threat_detection/learner.py
+++ b/autobot-backend/security/enterprise/threat_detection/learner.py
@@ -31,7 +31,7 @@ from datetime import datetime, timedelta
 from typing import Dict, Optional
 
 from autobot_shared.redis_client import get_redis_client
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +230,7 @@ class ThreatDetectionLearner:
         """
         pruned = 0
         flagged = 0
-        cutoff = datetime.utcnow() - timedelta(days=_INACTIVE_DAYS)
+        cutoff = now_utc() - timedelta(days=_INACTIVE_DAYS)
 
         try:
             pattern_keys = self._redis.keys(_OUTCOME_KEY_PREFIX + "*")

--- a/autobot-backend/security/enterprise/threat_detection/models.py
+++ b/autobot-backend/security/enterprise/threat_detection/models.py
@@ -140,7 +140,7 @@ class EventHistory:
         self, user_id: str, source_ip: str, window_minutes: int
     ) -> int:
         """Count recent authentication failures"""
-        cutoff_time = datetime.utcnow() - timedelta(minutes=window_minutes)
+        cutoff_time = now_utc() - timedelta(minutes=window_minutes)
         count = 0
 
         for event in reversed(self.events):
@@ -165,7 +165,7 @@ class EventHistory:
         self, user_id: str, source_ip: str, window_minutes: int
     ) -> int:
         """Count recent API requests"""
-        cutoff_time = datetime.utcnow() - timedelta(minutes=window_minutes)
+        cutoff_time = now_utc() - timedelta(minutes=window_minutes)
         count = 0
 
         for event in reversed(self.events):
@@ -185,7 +185,7 @@ class EventHistory:
         self, user_id: str, action: str, hours: int = 1
     ) -> int:
         """Count recent action frequency for a user"""
-        cutoff_time = datetime.utcnow() - timedelta(hours=hours)
+        cutoff_time = now_utc() - timedelta(hours=hours)
         count = 0
 
         for event in reversed(self.events):
@@ -203,7 +203,7 @@ class EventHistory:
         self, user_id: str, endpoint: str, hours: int = 24
     ) -> int:
         """Get recent endpoint usage count"""
-        cutoff_time = datetime.utcnow() - timedelta(hours=hours)
+        cutoff_time = now_utc() - timedelta(hours=hours)
         count = 0
 
         for event in reversed(self.events):

--- a/autobot-backend/services/agent_analytics.py
+++ b/autobot-backend/services/agent_analytics.py
@@ -24,7 +24,7 @@ from enum import Enum
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.ttl_constants import TTL_1_HOUR, TTL_30_DAYS
 
 logger = logging.getLogger(__name__)
@@ -636,7 +636,7 @@ class AgentAnalytics:
                 tasks = await self.get_agent_history(agent_id, limit=1000)
             else:
                 tasks = await self.get_recent_tasks(limit=5000)
-            cutoff = datetime.utcnow() - timedelta(days=days)
+            cutoff = now_utc() - timedelta(days=days)
             filtered_tasks = [
                 t for t in tasks if datetime.fromisoformat(t["started_at"]) > cutoff
             ]

--- a/autobot-backend/services/feedback_tracker.py
+++ b/autobot-backend/services/feedback_tracker.py
@@ -12,7 +12,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 from sqlalchemy import create_engine, func
 from sqlalchemy.orm import sessionmaker
 
@@ -149,7 +149,7 @@ class FeedbackTracker:
         self.redis_client.zadd(redis_key, {json.dumps(event_data): score})
 
         # Keep only last 30 days
-        cutoff = (datetime.utcnow() - timedelta(days=30)).timestamp()
+        cutoff = (now_utc() - timedelta(days=30)).timestamp()
         self.redis_client.zremrangebyscore(redis_key, 0, cutoff)
 
     def _check_retrain_threshold(self):
@@ -160,7 +160,7 @@ class FeedbackTracker:
             if last_retrain_str:
                 last_retrain = datetime.fromisoformat(last_retrain_str.decode())
             else:
-                last_retrain = datetime.utcnow() - timedelta(days=30)
+                last_retrain = now_utc() - timedelta(days=30)
 
             feedback_count = (
                 db.query(func.count(CompletionFeedback.id))
@@ -248,7 +248,7 @@ class FeedbackTracker:
         """
         with self.SessionLocal() as db:
             # Time window
-            since = datetime.utcnow() - timedelta(days=time_window_days)
+            since = now_utc() - timedelta(days=time_window_days)
 
             # Base query
             query = db.query(CompletionFeedback).filter(

--- a/autobot-backend/services/incremental_trainer.py
+++ b/autobot-backend/services/incremental_trainer.py
@@ -11,7 +11,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Optional
 
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, utc_timestamp
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -146,7 +146,7 @@ class IncrementalTrainer:
 
     def _fetch_recent_feedback(self, db, time_window_hours: int):
         """Helper for update_from_feedback. Ref: #1088."""
-        since = datetime.utcnow() - timedelta(hours=time_window_hours)
+        since = now_utc() - timedelta(hours=time_window_hours)
         return (
             db.query(CompletionFeedback)
             .filter(


### PR DESCRIPTION
## Summary

**#5211 Phase B3.2** — extends [B3 (PR #5321)](https://github.com/mrveiss/AutoBot-AI/pull/5321) from \`integrations/\` to remaining clean-classification subsystems (api/, services/, security/enterprise/threat_detection/, knowledge/connectors/).

**16 sites in 10 files** — split into 2 categories:

### Pure timing pairs → \`time.monotonic()\` (4 sites in 2 files)

| File | Sites |
|---|---|
| \`api/agent.py\` | 1201, 1210 (execution_start/time pair) |
| \`knowledge/connectors/scheduler.py\` | 185, 199 (started_at/elapsed pair) |

### Wall-clock subtraction → \`now_utc()\` (12 sites in 8 files)

| File | Sites |
|---|---|
| \`api/usage.py\` | cutoff (1) |
| \`api/knowledge_organization.py\` | cutoff_date (1) |
| \`services/agent_analytics.py\` | cutoff (1) |
| \`services/feedback_tracker.py\` | cutoff/since × 3 |
| \`services/incremental_trainer.py\` | since (1) |
| \`security/.../threat_detection/engine.py\` | cutoff_time (1) |
| \`security/.../threat_detection/learner.py\` | cutoff (1) |
| \`security/.../threat_detection/models.py\` | cutoff_time × 4 |

These produce an absolute aware datetime in the past for comparison with stored aware datetime fields. Required to use \`now_utc()\` (not \`time.monotonic()\`) for tz-aware semantics.

## What this PR does NOT do (deferred with rationale)

| Category | Files | Why deferred |
|---|---|---|
| Field-arithmetic (uptime/age/idle) | \`agent_loop/types.py:297\`, \`utils/task_queue.py:795\`, \`api/analytics_agents.py:307\`, \`security/.../sso_integration.py:967\`, \`security/.../security_policy_manager.py:781,1017\`, \`security/.../models.py:389\` | Need now_utc + verification that the RHS stored field is tz-aware. B4 makes storage aware; B5 follows. |
| Param-based timing | \`services/captcha_human_loop.py:186,289,365\` | \`start_time\` is a function PARAMETER typed \`datetime\`. Migrating requires changing the param type AND every caller. |
| Dual-purpose timestamps | \`api/agent.py:1266,1275\` | \`coordination_end\` serves both delta calc AND output; needs splitting into two vars. |
| Simple Pattern B field assigns | \`api/metrics.py\`, \`services/saved_reports_service.py\`, \`services/execution/base_backend.py\`, \`services/gateway/session_manager.py\` | Pattern B — gated on #5270 column-type audit recommendations |

## Cumulative #5211 progress

| Phase | Sites |
|---|---|
| B1 helper (now_utc) | — |
| B2 Pattern E (default_factory) | 23 |
| B3 timing (integrations) | 32 |
| #5305 SQLAlchemy column defaults | 6 |
| **B3.2 (this PR)** | **16** |
| **Total** | **~77 sites** |

## Verification

- \`py_compile\` passes on all 10 modified files
- 0 cutoff/since utcnow-timedelta sites remain in api/services/security/knowledge subsystems
- 4 timing sites correctly use \`time.monotonic\` (not \`now_utc\`)
- 12 wall-clock sites correctly use \`now_utc\` (not \`time.monotonic\`)

## Diff

10 files, +27/-24.