### PR TITLE
feat(composables): extract useFocusTrap + migrate BaseModal + HostSelectionDialog (#5130)

### DIFF
--- a/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
+++ b/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
@@ -8,7 +8,12 @@
     @click.self="$emit('close')"
     @keydown.escape="$emit('close')"
   >
-    <div ref="panelRef" class="entity-detail" tabindex="-1">
+    <div
+      ref="panelRef"
+      class="entity-detail"
+      tabindex="-1"
+      @keydown="onFocusTrapKeydown"
+    >
       <!-- Header -->
       <div class="detail-header">
         <div class="header-left">
@@ -130,6 +135,7 @@ import {
   useKnowledgeGraph,
   type Entity,
 } from '@/composables/useKnowledgeGraph'
+import { useFocusTrap } from '@/composables/useFocusTrap'
 import { getEntityTypeColor as getTypeColor } from '../constants'
 import RelationshipViewer from './RelationshipViewer.vue'
 
@@ -143,27 +149,10 @@ defineEmits<{
 }>()
 
 const panelRef = ref<HTMLElement | null>(null)
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(panelRef)
 let previouslyFocused: Element | null = null
 
-function trapFocus(e: KeyboardEvent): void {
-  if (e.key !== 'Tab' || !panelRef.value) return
-  const focusable = panelRef.value.querySelectorAll<HTMLElement>(
-    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-  )
-  if (focusable.length === 0) return
-  const first = focusable[0]
-  const last = focusable[focusable.length - 1]
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault()
-    last.focus()
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault()
-    first.focus()
-  }
-}
-
 onUnmounted(() => {
-  document.removeEventListener('keydown', trapFocus)
   if (previouslyFocused instanceof HTMLElement) {
     previouslyFocused.focus()
   }
@@ -181,7 +170,6 @@ function formatValue(value: unknown): string {
 
 onMounted(async () => {
   previouslyFocused = document.activeElement
-  document.addEventListener('keydown', trapFocus)
   await nextTick()
   panelRef.value?.focus()
 })

--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -20,7 +20,7 @@
           class="dialog"
           :class="[sizeClass, { 'dialog-scrollable': scrollable }]"
           @click.stop
-          @keydown="handleKeydown"
+          @keydown="onFocusTrapKeydown"
           tabindex="-1"
         >
           <!-- Header -->
@@ -55,6 +55,7 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, onUnmounted, useId } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useFocusTrap, FOCUSABLE_SELECTOR } from '@/composables/useFocusTrap'
 import Icon from './Icon.vue'
 
 /**
@@ -119,6 +120,7 @@ const { t } = useI18n()
 
 // Refs
 const dialogRef = ref<HTMLElement | null>(null)
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 let previousActiveElement: HTMLElement | null = null
 
 // Stable unique IDs for ARIA labeling (Vue 3.5+ useId)
@@ -157,9 +159,7 @@ const onAfterEnter = async () => {
 
   // Focus the dialog or first focusable element
   if (dialogRef.value) {
-    const firstFocusable = dialogRef.value.querySelector<HTMLElement>(
-      'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
-    )
+    const firstFocusable = dialogRef.value.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
 
     if (firstFocusable) {
       firstFocusable.focus()
@@ -180,33 +180,6 @@ const onAfterLeave = () => {
 
   // Unlock body scroll
   document.body.style.overflow = ''
-}
-
-/**
- * Real focus trap via Tab/Shift+Tab wrap. Only intercepts when focus would
- * leave the dialog — otherwise falls through to browser default, allowing
- * natural navigation plus outside clicks (e.g. devtools) to remain usable.
- */
-const handleKeydown = (event: KeyboardEvent) => {
-  if (event.key !== 'Tab' || !dialogRef.value) return
-
-  const focusable = dialogRef.value.querySelectorAll<HTMLElement>(
-    'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
-  )
-  if (focusable.length === 0) return
-
-  const first = focusable[0]
-  const last = focusable[focusable.length - 1]
-  const active = document.activeElement
-
-  if (event.shiftKey && active === first) {
-    event.preventDefault()
-    last.focus()
-  } else if (!event.shiftKey && active === last) {
-    event.preventDefault()
-    first.focus()
-  }
-  // Otherwise allow default Tab behavior
 }
 
 // Cleanup on unmount

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -12,7 +12,7 @@
       :aria-labelledby="dialogTitleId"
       :aria-describedby="dialogDescId"
       tabindex="-1"
-      @keydown="handleDialogKeydown"
+      @keydown="onFocusTrapKeydown"
     >
       <div class="dialog-header">
         <div class="dialog-icon" aria-hidden="true">
@@ -188,6 +188,7 @@ import { getBackendUrl } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
 import Icon, { type IconName } from '@/components/ui/Icon.vue';
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
+import { useFocusTrap } from '@/composables/useFocusTrap';
 
 const logger = createLogger('HostSelectionDialog');
 const { t } = useI18n();
@@ -242,6 +243,7 @@ const hostListLabelId = `host-list-label-${_uid}`;
 
 // Focus management
 const dialogRef = ref<HTMLElement | null>(null);
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef);
 let previousActiveElement: HTMLElement | null = null;
 
 // State
@@ -415,33 +417,6 @@ const handleEscape = (event: KeyboardEvent) => {
   if (event.key === 'Escape' && showDialog.value && !isProcessing.value) {
     handleCancel();
   }
-};
-
-/**
- * Real focus trap via Tab/Shift+Tab wrap. Only intercepts when focus would
- * leave the dialog boundary — otherwise falls through to browser default,
- * which keeps outside clicks (devtools, etc.) from being yanked back.
- */
-const handleDialogKeydown = (event: KeyboardEvent) => {
-  if (event.key !== 'Tab' || !dialogRef.value) return;
-
-  const focusable = dialogRef.value.querySelectorAll<HTMLElement>(
-    'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
-  );
-  if (focusable.length === 0) return;
-
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
-  const active = document.activeElement;
-
-  if (event.shiftKey && active === first) {
-    event.preventDefault();
-    last.focus();
-  } else if (!event.shiftKey && active === last) {
-    event.preventDefault();
-    first.focus();
-  }
-  // Otherwise allow default Tab behavior
 };
 
 // Watchers

--- a/autobot-frontend/src/composables/__tests__/useFocusTrap.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useFocusTrap.test.ts
@@ -1,0 +1,193 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Unit tests for useFocusTrap composable (#5130).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { useFocusTrap, FOCUSABLE_SELECTOR } from '../useFocusTrap'
+
+/** Build a container with the given number of tabbable buttons. */
+function makeContainer(buttonCount: number): {
+  container: HTMLElement
+  buttons: HTMLButtonElement[]
+} {
+  const container = document.createElement('div')
+  const buttons: HTMLButtonElement[] = []
+  for (let i = 0; i < buttonCount; i++) {
+    const btn = document.createElement('button')
+    btn.textContent = `btn-${i}`
+    container.appendChild(btn)
+    buttons.push(btn)
+  }
+  document.body.appendChild(container)
+  return { container, buttons }
+}
+
+function tabEvent(shift = false): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    key: 'Tab',
+    shiftKey: shift,
+    cancelable: true,
+    bubbles: true
+  })
+}
+
+describe('useFocusTrap', () => {
+  beforeEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild)
+  })
+
+  it('exports a FOCUSABLE_SELECTOR matching the BaseModal/#5121 pattern', () => {
+    // Guard against drift — consumers rely on the module-level constant.
+    expect(FOCUSABLE_SELECTOR).toContain('button:not(:disabled)')
+    expect(FOCUSABLE_SELECTOR).toContain('[tabindex]:not([tabindex="-1"])')
+    expect(FOCUSABLE_SELECTOR).toContain('[href]')
+    expect(FOCUSABLE_SELECTOR).toContain('input:not(:disabled)')
+    expect(FOCUSABLE_SELECTOR).toContain('select:not(:disabled)')
+    expect(FOCUSABLE_SELECTOR).toContain('textarea:not(:disabled)')
+  })
+
+  describe('Tab wrap', () => {
+    it('wraps focus from last element to first when Tab pressed on last', () => {
+      const { container, buttons } = makeContainer(3)
+      const ref_ = ref<HTMLElement | null>(container)
+      const { onKeydown } = useFocusTrap(ref_)
+
+      buttons[2].focus()
+      expect(document.activeElement).toBe(buttons[2])
+
+      const ev = tabEvent(false)
+      const preventSpy = vi.spyOn(ev, 'preventDefault')
+      onKeydown(ev)
+
+      expect(preventSpy).toHaveBeenCalledOnce()
+      expect(document.activeElement).toBe(buttons[0])
+    })
+
+    it('lets Tab fall through when focus is in the middle', () => {
+      const { container, buttons } = makeContainer(3)
+      const ref_ = ref<HTMLElement | null>(container)
+      const { onKeydown } = useFocusTrap(ref_)
+
+      buttons[1].focus()
+      const ev = tabEvent(false)
+      const preventSpy = vi.spyOn(ev, 'preventDefault')
+      onKeydown(ev)
+
+      // Browser handles the Tab. We only assert we did NOT intercept.
+      expect(preventSpy).not.toHaveBeenCalled()
+      expect(document.activeElement).toBe(buttons[1])
+    })
+  })
+
+  describe('Shift+Tab wrap', () => {
+    it('wraps focus from first element to last when Shift+Tab pressed on first', () => {
+      const { container, buttons } = makeContainer(3)
+      const ref_ = ref<HTMLElement | null>(container)
+      const { onKeydown } = useFocusTrap(ref_)
+
+      buttons[0].focus()
+      expect(document.activeElement).toBe(buttons[0])
+
+      const ev = tabEvent(true)
+      const preventSpy = vi.spyOn(ev, 'preventDefault')
+      onKeydown(ev)
+
+      expect(preventSpy).toHaveBeenCalledOnce()
+      expect(document.activeElement).toBe(buttons[2])
+    })
+
+    it('lets Shift+Tab fall through when focus is in the middle', () => {
+      const { container, buttons } = makeContainer(3)
+      const ref_ = ref<HTMLElement | null>(container)
+      const { onKeydown } = useFocusTrap(ref_)
+
+      buttons[1].focus()
+      const ev = tabEvent(true)
+      const preventSpy = vi.spyOn(ev, 'preventDefault')
+      onKeydown(ev)
+
+      expect(preventSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('no-ops on empty container (no focusable descendants)', () => {
+      const container = document.createElement('div')
+      document.body.appendChild(container)
+      const ref_ = ref<HTMLElement | null>(container)
+      const { onKeydown } = useFocusTrap(ref_)
+
+      const ev = tabEvent(false)
+      const preventSpy = vi.spyOn(ev, 'preventDefault')
+      onKeydown(ev)
+
+      expect(preventSpy).not.toHaveBeenCalled()
+    })
+
+    it('no-ops when container ref is null', () => {
+      const ref_ = ref<HTMLElement | null>(null)
+      const { onKeydown } = useFocusTrap(ref_)
+
+      const ev = tabEvent(false)
+      const preventSpy = vi.spyOn(ev, 'preventDefault')
+      // Should not throw.
+      expect(() => onKeydown(ev)).not.toThrow()
+      expect(preventSpy).not.toHaveBeenCalled()
+    })
+
+    it('no-ops for non-Tab keys', () => {
+      const { container } = makeContainer(2)
+      const ref_ = ref<HTMLElement | null>(container)
+      const { onKeydown } = useFocusTrap(ref_)
+
+      const ev = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+      const preventSpy = vi.spyOn(ev, 'preventDefault')
+      onKeydown(ev)
+
+      expect(preventSpy).not.toHaveBeenCalled()
+    })
+
+    it('picks up new focusables added to the container after mount', () => {
+      // Regression guard: the handler re-runs querySelectorAll on every
+      // keypress, so dynamically-added buttons participate in the trap.
+      const { container, buttons } = makeContainer(2)
+      const ref_ = ref<HTMLElement | null>(container)
+      const { onKeydown } = useFocusTrap(ref_)
+
+      const added = document.createElement('button')
+      container.appendChild(added)
+
+      added.focus()
+      expect(document.activeElement).toBe(added)
+
+      const ev = tabEvent(false)
+      onKeydown(ev)
+      // New button was last in document order — Tab wraps to buttons[0].
+      expect(document.activeElement).toBe(buttons[0])
+    })
+
+    it('skips disabled buttons (FOCUSABLE_SELECTOR filter)', () => {
+      const container = document.createElement('div')
+      const a = document.createElement('button')
+      const b = document.createElement('button')
+      b.disabled = true
+      const c = document.createElement('button')
+      container.append(a, b, c)
+      document.body.appendChild(container)
+
+      const ref_ = ref<HTMLElement | null>(container)
+      const { onKeydown } = useFocusTrap(ref_)
+
+      c.focus()
+      const ev = tabEvent(false)
+      onKeydown(ev)
+      // b is disabled, so the "last" is c and the "first" is a.
+      expect(document.activeElement).toBe(a)
+    })
+  })
+})

--- a/autobot-frontend/src/composables/useFocusTrap.ts
+++ b/autobot-frontend/src/composables/useFocusTrap.ts
@@ -1,0 +1,78 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * useFocusTrap Composable (#5130)
+ *
+ * Tab / Shift+Tab focus trap that wraps focus inside a container. Extracted
+ * from the byte-for-byte identical handlers in BaseModal.vue and
+ * HostSelectionDialog.vue (introduced by #5121 / PR #5016).
+ *
+ * Only intercepts when focus would leave the container — middle-of-form
+ * Tabs fall through to browser default, so devtools / outside clicks stay
+ * usable during debugging.
+ *
+ * Consumer pattern:
+ *
+ *   const dialogRef = ref<HTMLElement | null>(null)
+ *   const { onKeydown } = useFocusTrap(dialogRef)
+ *
+ *   <template><div ref="dialogRef" @keydown="onKeydown">...</div></template>
+ */
+
+import type { Ref } from 'vue'
+
+/**
+ * CSS selector matching natively-focusable elements plus anything with an
+ * explicit non-negative tabindex. Kept as a module-level constant so all
+ * consumers agree on what "focusable" means — change in one place if
+ * `details` / `summary` / contenteditable ever need including.
+ */
+export const FOCUSABLE_SELECTOR =
+  'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), ' +
+  'textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+
+export interface UseFocusTrapReturn {
+  /**
+   * `keydown` handler to bind on the container. No-op for non-Tab keys and
+   * when the container ref is unset — safe to attach unconditionally.
+   */
+  onKeydown: (event: KeyboardEvent) => void
+}
+
+/**
+ * Focus trap composable.
+ *
+ * @param containerRef  Ref to the HTMLElement whose focusable descendants
+ *                      should be wrapped. When null, the handler no-ops —
+ *                      callers don't need a guard for the "before mounted"
+ *                      window.
+ */
+export function useFocusTrap(
+  containerRef: Ref<HTMLElement | null>
+): UseFocusTrapReturn {
+  function onKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Tab' || !containerRef.value) return
+
+    const focusables = containerRef.value.querySelectorAll<HTMLElement>(
+      FOCUSABLE_SELECTOR
+    )
+    if (focusables.length === 0) return
+
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    const active = document.activeElement
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault()
+      first.focus()
+    }
+    // Otherwise allow default Tab behavior.
+  }
+
+  return { onKeydown }
+}


### PR DESCRIPTION
## Summary

Closes #5130.

PR #5121 (#5016) fixed the focus trap in [`BaseModal.vue`](autobot-frontend/src/components/ui/BaseModal.vue) and [`HostSelectionDialog.vue`](autobot-frontend/src/components/ui/HostSelectionDialog.vue) by replacing the `focusin` snap-back with a proper Tab / Shift+Tab keydown wrap. The two implementations were byte-for-byte identical. Extracted to [`useFocusTrap(containerRef)`](autobot-frontend/src/composables/useFocusTrap.ts).

**Third site picked up via reflective audit:** [`knowledge/graph/EntityDetail.vue`](autobot-frontend/src/components/knowledge/graph/EntityDetail.vue) carried a slightly different bespoke trap — my initial #5130 grep missed it. Migrated in commit `1202fad71`; see "Latent bugs fixed" below.

## Behavioral grep audit

Before extracting, I grepped for the symbol names in the issue:

```bash
$ grep -rn 'handleKeydown\|handleDialogKeydown' autobot-frontend/src/components/ui/
# 2 hits, matches the issue's enumeration
```

Before declaring the PR complete, I re-grepped for the **behavior**, not the name:

```bash
$ grep -rnE "key\s*[=!]==\s*['\"]Tab|shiftKey\s*&&.*focus|focusable.*querySelectorAll" \
    autobot-frontend/src --include="*.vue" --include="*.ts"
# 3 hits (incl. EntityDetail.vue missed by symbol-only grep)
```

After migration:

```bash
$ grep 'handleKeydown\|handleDialogKeydown\|trapFocus' \
    autobot-frontend/src/components/ui/{BaseModal,HostSelectionDialog}.vue \
    autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
# 0 hits
```

All three behavior-grep hits are migrated in this PR. No follow-up sites remain.

## Composable

Exports two symbols:

- `useFocusTrap(containerRef)` — returns `{ onKeydown }` to bind on the container. No-op when container ref is null or the key isn't Tab.
- `FOCUSABLE_SELECTOR` — the CSS selector for focusable descendants. Also consumed by `BaseModal`'s initial-focus query in `onAfterEnter` so both lookups agree on what "focusable" means — one place to fix if e.g. `details` / `summary` / contenteditable ever need including.

## Latent bugs fixed in EntityDetail migration

The bespoke EntityDetail implementation diverged from the BaseModal/HostSelectionDialog version in two ways that the composable corrects:

1. **Looser FOCUSABLE_SELECTOR** — EntityDetail used \`'button, [href], input, select, textarea, [tabindex]:not([tabindex=\"-1\"])'\` without the \`:not(:disabled)\` filters. Tab could land on a disabled button inside the panel. The composable applies the strict filter everywhere.
2. **Global document-level listener** — EntityDetail bound via \`document.addEventListener('keydown', trapFocus)\` rather than template \`@keydown\`. The panel is \`position: fixed role=\"dialog\" aria-modal=\"true\"\` so it shouldn't matter in practice, but the global listener also intercepted Tab when focus had moved outside the panel (e.g. to devtools). Template \`@keydown\` on \`panelRef\` fires only when focus is inside — closer to semantic intent, no document-scope leak.

## Tests

[`composables/__tests__/useFocusTrap.test.ts`](autobot-frontend/src/composables/__tests__/useFocusTrap.test.ts) — 10 cases, all passing:

- Tab wrap (end → start) with \`preventDefault\` assertion
- Shift+Tab wrap (start → end)
- Middle-of-form Tab fallthrough (assert **not** intercepted)
- Middle-of-form Shift+Tab fallthrough
- Empty container no-op
- Null ref no-op (doesn't throw)
- Non-Tab key no-op
- Dynamic focusables picked up (querySelectorAll re-runs per event)
- Disabled buttons skipped
- \`FOCUSABLE_SELECTOR\` drift guard (contains each of the 6 selector segments)

## Verification

- \`npx vitest run src/composables/__tests__/useFocusTrap.test.ts src/components/ui/__tests__/BaseModal.test.ts src/components/ui/__tests__/HostSelectionDialog.test.ts\` → **20/20 pass**.
- Full suite has 4 pre-existing baseline failures unrelated to this PR (3 ChatInterface render tests + 1 useKnowledgeVectorization 10k-element timeout) — filed as #5366.
- \`npx vue-tsc --noEmit -p tsconfig.app.json\` → 0 new type errors in changed files.

## Follow-up discoveries

- **#5356** — \`useFocusRestore()\` composable. All three migrated dialogs also implement the same "save previousActiveElement on mount, restore on unmount" pattern, each with a different null/type guard. 3-site extraction threshold met under #5060.
- **#5366** — 4 pre-existing test-suite baseline failures surfaced during this PR's full-suite verification.

## Test plan

- [ ] Manual: open any modal (e.g. from Settings → Command Permission Dialog) → Tab through all controls, confirm wrap at end. Shift+Tab at first control → wrap to last.
- [ ] Manual: open a Host Selection dialog from secrets UI → same assertions.
- [ ] Manual: open a Knowledge Graph entity detail panel → confirm Tab wraps. Bonus: disable a button inside and confirm Tab skips it (regression check for the EntityDetail looser-selector fix).
- [ ] Manual: middle-of-form Tab should move to the next control (not stay stuck).

## Related

- #5016 → #5121 — the fix that exposed the duplication
- #5060 — primitives umbrella (parent methodology)
- #5192, #5306 — sibling Vue composables extracted from duplicated logic (\`useBatchSelection\`, \`useExpansion\`)
- #5356 — follow-up \`useFocusRestore\` discovery
- #5366 — pre-existing baseline test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)