### PR TITLE
fix(composables): guard useDebounce onUnmounted with onScopeDispose (#5318)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useDebounce.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useDebounce.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for useDebounce / useDebouncedFn / useDebounceWithLoading (#5318)
+ *
+ * Verifies cleanup works via onScopeDispose instead of onUnmounted, which
+ * previously emitted "onUnmounted is called when there is no active
+ * component instance" warnings when used outside component setup().
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { effectScope, ref, nextTick } from 'vue'
+import { useDebounce, useDebouncedFn, useDebounceWithLoading } from '../useDebounce'
+
+describe('useDebounce (scope-aware cleanup)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('does not warn outside component setup when using useDebouncedFn in effectScope', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scope = effectScope()
+    scope.run(() => {
+      const fn = vi.fn()
+      const { debouncedFn } = useDebouncedFn(fn, 100)
+      debouncedFn()
+    })
+    scope.stop()
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('no active component')
+    )
+    warn.mockRestore()
+  })
+
+  it('does not warn outside component setup when using useDebounce in effectScope', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scope = effectScope()
+    scope.run(() => {
+      const source = ref('a')
+      useDebounce(source, 100)
+    })
+    scope.stop()
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('no active component')
+    )
+    warn.mockRestore()
+  })
+
+  it('does not warn outside component setup when using useDebounceWithLoading in effectScope', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scope = effectScope()
+    scope.run(() => {
+      const source = ref('a')
+      useDebounceWithLoading(source, 100)
+    })
+    scope.stop()
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('no active component')
+    )
+    warn.mockRestore()
+  })
+
+  it('does not warn when called with no active scope at all', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const fn = vi.fn()
+    const { debouncedFn, cancel } = useDebouncedFn(fn, 100)
+    debouncedFn()
+    cancel()
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('no active component')
+    )
+    warn.mockRestore()
+  })
+
+  it('cancels pending timeout when scope is stopped', async () => {
+    const fn = vi.fn()
+    const scope = effectScope()
+    let debouncedFn: ((...args: unknown[]) => void) | undefined
+    scope.run(() => {
+      ;({ debouncedFn } = useDebouncedFn(fn, 100))
+    })
+    debouncedFn!('arg')
+    scope.stop()
+    vi.advanceTimersByTime(200)
+    await nextTick()
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('stops updating debounced ref after scope is stopped', async () => {
+    const source = ref('initial')
+    const scope = effectScope()
+    let debounced: ReturnType<typeof useDebounce<string>> | undefined
+    scope.run(() => {
+      debounced = useDebounce(source, 100)
+    })
+    source.value = 'updated'
+    scope.stop()
+    vi.advanceTimersByTime(200)
+    await nextTick()
+    // unwatch() fires on scope dispose, so debounced never receives the new value
+    expect(debounced!.value).toBe('initial')
+  })
+})

--- a/autobot-frontend/src/composables/useDebounce.ts
+++ b/autobot-frontend/src/composables/useDebounce.ts
@@ -10,7 +10,7 @@
  * - Better UX - waits for user to finish typing
  */
 
-import { ref, watch, onUnmounted, type Ref } from 'vue'
+import { ref, watch, onScopeDispose, getCurrentScope, type Ref } from 'vue'
 
 /**
  * Debounce a reactive value
@@ -52,13 +52,15 @@ export function useDebounce<T>(value: Ref<T>, delay: number = 300): Ref<T> {
     { immediate: false }
   )
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    if (timeoutId !== null) {
-      clearTimeout(timeoutId)
-    }
-    unwatch()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+      unwatch()
+    })
+  }
 
   return debouncedValue
 }
@@ -107,10 +109,12 @@ export function useDebouncedFn<T extends (...args: any[]) => any>(
     }, delay)
   }
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    cancel()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      cancel()
+    })
+  }
 
   return {
     debouncedFn,
@@ -170,13 +174,15 @@ export function useDebounceWithLoading<T>(
     { immediate: false }
   )
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    if (timeoutId !== null) {
-      clearTimeout(timeoutId)
-    }
-    unwatch()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+      unwatch()
+    })
+  }
 
   return {
     debouncedValue,


### PR DESCRIPTION
Closes #5318

## Summary
3 \`onUnmounted\` calls in \`useDebounce.ts\` were unguarded — producing Vue warnings (\"no active component instance\") in unit tests and preventing usage outside setup().

## Fix
Swapped \`onUnmounted\` import → \`onScopeDispose, getCurrentScope\`. Each cleanup now:
\`\`\`ts
if (getCurrentScope()) {
  onScopeDispose(() => { /* cleanup */ })
}
\`\`\`

## Tests
- 6 new tests in \`useDebounce.test.ts\` covering effectScope usage, cancellation, watch teardown on scope.stop()
- Full composables suite: 832/833 pass (1 unrelated pre-existing failure in useKnowledgeVectorization)
- Warning count for useDebounce: 3 → 0

## Follow-up discovery
\`useThumbnailWorker.ts\` and \`useTimeout.ts\` (\`useCancelableSleep\`) have the same pattern — 13 remaining onUnmounted warnings in the suite all trace to those files. Filing as separate issue.