### PR TITLE
feat(observability): add Prometheus counter + warning log on kb_connected=false (#5319)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -444,6 +444,17 @@ async def get_main_categories(
         kb is not None,
         redis_client is not None,
     )
+    if redis_client is None:
+        # Issue #5319: surface kb_connected=false as a log line + Prometheus
+        # counter so operators see the outage, not just the frontend banner.
+        logger.warning(
+            "KB categories returning kb_connected=false - Redis unreachable"
+        )
+        from knowledge.metrics import autobot_kb_redis_unreachable_total
+
+        autobot_kb_redis_unreachable_total.labels(
+            endpoint="categories_main"
+        ).inc()
 
     category_counts = {
         KnowledgeCategory.AUTOBOT_DOCUMENTATION: 0,

--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -572,6 +572,12 @@ async def run_rag_benchmark(
     redis = await get_async_redis_client(database="analytics")
     if redis is None:
         logger.warning("run_rag_benchmark: Redis unavailable; benchmark events dropped")
+        # Issue #5319: emit ops-visible counter alongside the warning.
+        from knowledge.metrics import autobot_kb_redis_unreachable_total
+
+        autobot_kb_redis_unreachable_total.labels(
+            endpoint="rag_benchmark"
+        ).inc()
         return {
             "published": 0,
             "total": len(report.results),

--- a/autobot-backend/api/knowledge_rag_feedback.py
+++ b/autobot-backend/api/knowledge_rag_feedback.py
@@ -96,6 +96,12 @@ async def record_rag_feedback(
                 "record_rag_feedback: Redis unavailable; annotation dropped for user %s",
                 uid,
             )
+            # Issue #5319: emit ops-visible counter alongside the warning.
+            from knowledge.metrics import autobot_kb_redis_unreachable_total
+
+            autobot_kb_redis_unreachable_total.labels(
+                endpoint="rag_feedback"
+            ).inc()
             return {"status": "skipped", "reason": "redis_unavailable"}
 
         await redis.xadd(stream_key, entry)

--- a/autobot-backend/knowledge/metrics.py
+++ b/autobot-backend/knowledge/metrics.py
@@ -1,0 +1,50 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""KB-level Prometheus metrics with no-op fallback (#5319).
+
+This module exposes Prometheus counters for knowledge-base observability.
+It degrades to a no-op implementation when ``prometheus_client`` is not
+installed (tests, minimal deployments), so importing is always safe.
+
+Current metrics:
+
+``autobot_kb_redis_unreachable_total{endpoint}``
+    Incremented whenever a KB endpoint serves a degraded response because
+    Redis is unreachable (i.e. ``kb_connected=false``).  Partners with a
+    ``logger.warning`` at the call site so operators can page on either
+    signal.
+
+Follows the pattern established by ``knowledge/query_sanitizer.py`` (#5064).
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class _NoopCounter:
+    """Fallback counter used when prometheus_client is unavailable."""
+
+    def labels(self, *_args, **_kwargs) -> "_NoopCounter":
+        return self
+
+    def inc(self, *_args, **_kwargs) -> None:
+        return None
+
+
+try:  # pragma: no cover - exercised in environments with the dep
+    from prometheus_client import Counter as _PromCounter
+
+    autobot_kb_redis_unreachable_total = _PromCounter(
+        "autobot_kb_redis_unreachable_total",
+        "Count of KB requests served with Redis unreachable (kb_connected=false).",
+        ("endpoint",),
+    )
+except Exception:  # pragma: no cover - defensive fallback
+    autobot_kb_redis_unreachable_total = _NoopCounter()
+
+
+__all__ = ["autobot_kb_redis_unreachable_total"]

--- a/autobot-backend/knowledge/test_metrics.py
+++ b/autobot-backend/knowledge/test_metrics.py
@@ -1,0 +1,61 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Tests for knowledge.metrics (#5319).
+
+Verifies the Prometheus counter works in both environments:
+- With ``prometheus_client`` installed (real Counter)
+- Without ``prometheus_client`` (_NoopCounter fallback)
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_kb_redis_unreachable_counter_increments() -> None:
+    """Counter accepts labels().inc() calls without crashing.
+
+    Works against both the real prometheus_client Counter and the
+    _NoopCounter fallback - the fluent labels().inc() surface is the
+    same for both.
+    """
+    from knowledge.metrics import autobot_kb_redis_unreachable_total
+
+    autobot_kb_redis_unreachable_total.labels(endpoint="test").inc()
+    autobot_kb_redis_unreachable_total.labels(endpoint="test").inc(2)
+    # Distinct label values must not crash either.
+    autobot_kb_redis_unreachable_total.labels(endpoint="categories_main").inc()
+
+
+def test_kb_metrics_importable_without_prometheus() -> None:
+    """Module still importable when prometheus_client is missing.
+
+    Simulates absence by replacing the module entry with ``None`` so the
+    ``from prometheus_client import Counter`` line raises, then reloads
+    ``knowledge.metrics`` and asserts the _NoopCounter surface still works.
+    """
+    import knowledge.metrics as metrics_module
+
+    saved_prom = sys.modules.get("prometheus_client")
+    saved_metrics = sys.modules.get("knowledge.metrics")
+    try:
+        # Force the ImportError path on next reload.
+        sys.modules["prometheus_client"] = None  # type: ignore[assignment]
+        reloaded = importlib.reload(metrics_module)
+        # The exposed counter still accepts the fluent labels().inc() surface.
+        reloaded.autobot_kb_redis_unreachable_total.labels(endpoint="x").inc()
+        reloaded.autobot_kb_redis_unreachable_total.labels(endpoint="y").inc(3)
+        # And it is the _NoopCounter instance under the hood.
+        assert type(reloaded.autobot_kb_redis_unreachable_total).__name__ == (
+            "_NoopCounter"
+        )
+    finally:
+        # Restore prometheus_client module and reload metrics to real state.
+        if saved_prom is not None:
+            sys.modules["prometheus_client"] = saved_prom
+        else:
+            sys.modules.pop("prometheus_client", None)
+        if saved_metrics is not None:
+            importlib.reload(saved_metrics)


### PR DESCRIPTION
Closes #5319

## Summary
Added observability for the KB-Redis-unreachable path that PR #5287 exposed to the UI. Operators now get a log + metric when Redis disconnects.

## New module
\`knowledge/metrics.py\` — patterns on \`knowledge/query_sanitizer.py\`:
- Counter \`autobot_kb_redis_unreachable_total{endpoint}\` exposed
- \`_NoopCounter\` fallback when \`prometheus_client\` isn't installed (tests-safe)

## Endpoints wired (3)
| Endpoint | Label |
|---|---|
| \`GET /api/knowledge_base/categories/main\` | \`endpoint=\"categories_main\"\` |
| \`POST /rag-feedback\` | \`endpoint=\"rag_feedback\"\` |
| \`run_rag_benchmark\` | \`endpoint=\"rag_benchmark\"\` |

All 3 now emit \`logger.warning(\"kb_connected=false...\")\` + increment the counter.

## Tests
2 new tests in \`knowledge/test_metrics.py\` cover both \`prometheus_client\` present and absent paths. Both pass.

## Deferred
Ops runbook update — no \`docs/ops/runbook*\` file exists in this worktree. Will file as separate doc task.