### PR TITLE
test(knowledge): fix KnowledgeBase imports after _composed.py refactor (#5292)

### DIFF
--- a/autobot-backend/knowledge/knowledge_base.integration_test.py
+++ b/autobot-backend/knowledge/knowledge_base.integration_test.py
@@ -21,7 +21,7 @@ import time
 
 import pytest
 
-from knowledge_base import KnowledgeBase
+from knowledge import KnowledgeBase
 
 
 class TestKnowledgeBaseRedisIntegration:

--- a/autobot-backend/knowledge/knowledge_base_async_test.py
+++ b/autobot-backend/knowledge/knowledge_base_async_test.py
@@ -62,7 +62,7 @@ class TestInitRedisConnections:
     """Verify that _init_redis_connections properly awaits the async client."""
 
     def _make_kb(self):
-        from knowledge.base import KnowledgeBase
+        from knowledge import KnowledgeBase
 
         kb = KnowledgeBase.__new__(KnowledgeBase)
         kb.redis_client = None


### PR DESCRIPTION
Closes #5292

## Summary

Two test files failed at collection with \`ImportError: cannot import name 'KnowledgeBase' from 'knowledge.base'\`. The class was moved to \`knowledge._composed.py\` in a prior refactor, with \`knowledge/__init__.py\` re-exporting via PEP 562 lazy loading (\`__getattr__\`). The test files were never updated.

## Fix

Changed 2 imports from \`from knowledge.base import KnowledgeBase\` \u2192 \`from knowledge import KnowledgeBase\` (uses the stable public API, matches the convention used by production code via the \`knowledge_base.py\` shim).

## Files touched

- \`autobot-backend/knowledge/knowledge_base_async_test.py\` \u2014 1 import
- \`autobot-backend/knowledge/knowledge_base.integration_test.py\` \u2014 1 import

## Tests after

- \`knowledge_base_async_test.py\`: **5/5 pass** \u2014 restores #3962 regression coverage (TestInitRedisConnections)
- \`knowledge_base.integration_test.py\`: 27/27 collected cleanly; runtime mix of pass/skip/error depending on Redis availability (expected \u2014 integration tests need real Redis)

## Diff

2 files, +2/-2.