### PR TITLE
refactor(codebase-analytics): rename _DEFAULT_HARDCODE_SEVERITY → public (#5348)

### DIFF
--- a/autobot-backend/api/codebase_analytics/analyzers.py
+++ b/autobot-backend/api/codebase_analytics/analyzers.py
@@ -773,7 +773,7 @@ def _extract_class_info(node: ast.ClassDef) -> Dict:
 # Issue #5290: canonical severity by hardcode type when the detector
 # doesn't set one explicitly. Consumed by the per-line detectors and by
 # the endpoint-boundary normalizer in stats.py.
-_DEFAULT_HARDCODE_SEVERITY: Dict[str, str] = {
+DEFAULT_HARDCODE_SEVERITY: Dict[str, str] = {
     "ip": "high",
     "api_key": "high",
     "password": "high",
@@ -786,7 +786,7 @@ _DEFAULT_HARDCODE_SEVERITY: Dict[str, str] = {
 
 
 def _default_severity_for(hardcode_type: str) -> str:
-    return _DEFAULT_HARDCODE_SEVERITY.get(hardcode_type, "low")
+    return DEFAULT_HARDCODE_SEVERITY.get(hardcode_type, "low")
 
 
 def _check_hardcoded_ip(ip: str, line_num: int, line_content: str, file_path: str) -> Optional[Dict]:

--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -17,7 +17,7 @@ from fastapi.responses import JSONResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from utils.chromadb_client import get_all_paginated
 
-from ..analyzers import _DEFAULT_HARDCODE_SEVERITY
+from ..analyzers import DEFAULT_HARDCODE_SEVERITY
 from ..scanner import _tasks_sync_lock, indexing_tasks
 from ..storage import get_code_collection, get_redis_connection
 from .shared import (
@@ -341,7 +341,7 @@ def _normalize_hardcode_record(record: dict) -> dict:
         normalized["file"] = normalized["file_path"]
     normalized.setdefault("file", "")
     if not normalized.get("severity"):
-        normalized["severity"] = _DEFAULT_HARDCODE_SEVERITY.get(normalized.get("type", ""), "low")
+        normalized["severity"] = DEFAULT_HARDCODE_SEVERITY.get(normalized.get("type", ""), "low")
     return normalized
 
 


### PR DESCRIPTION
## Summary

#5312 introduced a cross-module import of a module-private name (leading-underscore convention). Rename to match every other import in the package.

\`stats.py:\`
\`\`\`diff
-from ..analyzers import _DEFAULT_HARDCODE_SEVERITY
+from ..analyzers import DEFAULT_HARDCODE_SEVERITY
\`\`\`

Module-local helper \`_default_severity_for\` stays private (only used inside \`analyzers.py\`).

Closes #5348.

## Verification

- \`py_compile\` + \`black\` clean.
- 4 references updated (1 import + 1 consumer in stats.py, 1 declaration + 1 helper body in analyzers.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)