### PR TITLE
bug(knowledge/base): guard __del__ against unset self.initialized (#5357)

### DIFF
--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -656,7 +656,9 @@ class KnowledgeBaseCore:
     def __del__(self):
         """Destructor to ensure cleanup"""
         # Only log, don't perform async operations in __del__
-        if self.initialized:
+        # Use getattr so __new__'d instances (tests that skip __init__) don't
+        # raise AttributeError during GC (#5357).
+        if getattr(self, "initialized", False):
             logger.debug(
                 "KnowledgeBase instance deleted while still initialized - "
                 "consider calling await close() explicitly"


### PR DESCRIPTION
Closes #5357

## Fix

`KnowledgeBaseCore.__del__` now uses `getattr(self, "initialized", False)` instead of `self.initialized`. When unit tests create KB instances via `KnowledgeBase.__new__(KnowledgeBase)` (to exercise `_init_redis_connections` without the full `__init__`), `self.initialized` was never set, and the destructor raised `AttributeError` during GC — surfaced as Python warnings in test output.

## Verification

- `python -m py_compile` passes
- No behavior change for initialized instances (`getattr` returns the real value)
- No behavior change for GC paths (destructor silently no-ops when `initialized` is unset)

## Discovered during

PR #5352 (#5292) — fixing the KnowledgeBase import let `knowledge_base_async_test.py` actually run, surfacing this latent warning.

## Diff

1 file, 3 insertions / 1 deletion.