### PR TITLE
fix(knowledge_vectorization): restore @with_error_handling on 2 endpoints (#5358)

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -2620,15 +2620,15 @@ class TestVectorizeExistingFactsEndpoint:
     """Test migrated POST /vectorize_facts endpoint"""
 
     def test_vectorize_existing_facts_has_decorator(self):
-        """Verify FastAPI route decorator is applied"""
+        """Verify @with_error_handling decorator is applied (restored in #5358)"""
         import inspect
 
         from api.knowledge_vectorization import vectorize_existing_facts
 
         source = inspect.getsource(vectorize_existing_facts)
-        # Issue #620 refactor removed @with_error_handling in favor of explicit
-        # HTTPException raises; only the @router.post decorator remains.
-        assert '@router.post("/vectorize_facts")' in source
+        assert "@with_error_handling" in source
+        assert "ErrorCategory.SERVER_ERROR" in source
+        assert 'error_code_prefix="KNOWLEDGE"' in source
 
     def test_vectorize_existing_facts_no_outer_try_catch(self):
         """Verify outer try-catch block was removed"""

--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -313,6 +313,11 @@ async def _perform_uncached_batch_check(
     return result
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="check_vectorization_status_batch",
+    error_code_prefix="KNOWLEDGE",
+)
 @router.post("/vectorization_status")
 async def check_vectorization_status_batch(
     request: dict, req: Request, _user: dict = Depends(get_current_user)
@@ -585,6 +590,11 @@ def _build_vectorization_response(
     }
 
 
+@with_error_handling(
+    category=ErrorCategory.SERVER_ERROR,
+    operation="vectorize_existing_facts",
+    error_code_prefix="KNOWLEDGE",
+)
 @router.post("/vectorize_facts")
 async def vectorize_existing_facts(
     req: Request,


### PR DESCRIPTION
Closes #5358

## Fix

Adds `@with_error_handling` to two endpoints that were missing it despite 5 sibling endpoints in the same file using the same decorator:

| Endpoint | Line | Before | After |
|---|---|---|---|
| `check_vectorization_status_batch` | 316 | none | `@with_error_handling(SERVER_ERROR, "check_vectorization_status_batch", "KNOWLEDGE")` |
| `vectorize_existing_facts` | 588 | none | `@with_error_handling(SERVER_ERROR, "vectorize_existing_facts", "KNOWLEDGE")` |

Sibling endpoints already using this decoration pattern: `vectorize_individual_fact` (L1044), `vectorize_documents` (L1140), and 3 more (L1199, L1262, L1319).

## Root cause

Issue #620's helper-extraction refactor dropped the decorator on these 2 endpoints while leaving the others intact. PR #5353 (#5336) then worked around the broken `test_vectorize_existing_facts_has_decorator` test by updating it to assert `@router.post` instead of `@with_error_handling` — treating a regression as an intentional removal.

## Also reverts PR #5353's test workaround

`test_vectorize_existing_facts_has_decorator` now asserts `@with_error_handling` + `ErrorCategory.SERVER_ERROR` + `error_code_prefix="KNOWLEDGE"` are present, matching its original intent. The test is back to a regression guard instead of a current-state snapshot.

## Verification

- TestVectorizeExistingFactsEndpoint: 5/5 pass (verified)
- Endpoints now emit structured errors with ErrorCategory tagging + KNOWLEDGE prefix, matching sibling consistency

## Diff

2 files, 14 insertions / 4 deletions.