### PR TITLE
fix(analytics): wire code-intel findings + delete 4 orphans + harden audit (#5365)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useApiEndpointAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useApiEndpointAnalysis.ts
@@ -11,7 +11,6 @@
  * single useFetchEndpoint instance (Issue #5208).
  */
 
-import { reactive } from 'vue'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { runTimed } from '@/composables/api/useTimedNotify'
 import type {
@@ -39,12 +38,6 @@ export function useApiEndpointAnalysis(deps: UseCodeIntelAnalysisDeps) {
     },
     { withSourceId },
   )
-
-  const expandedApiEndpointGroups = reactive({
-    orphaned: false,
-    missing: false,
-    used: false,
-  })
 
   // Silent cached load — callers read endpoint.data reactively.
   const loadApiEndpointAnalysis = () => endpoint.load()
@@ -96,7 +89,6 @@ export function useApiEndpointAnalysis(deps: UseCodeIntelAnalysisDeps) {
     apiEndpointAnalysis: endpoint.data,
     loadingApiEndpoints: endpoint.loading,
     apiEndpointsError: endpoint.error,
-    expandedApiEndpointGroups,
     loadApiEndpointAnalysis,
     getApiEndpointCoverage,
     getCoverageClass,

--- a/autobot-frontend/src/composables/analytics/useCodeIntelAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeIntelAnalysis.ts
@@ -22,6 +22,7 @@ import type {
   SecurityFinding,
   PerformanceFinding,
   RedisOptimizationFinding,
+  Severity,
 } from '@/types/codeIntelligence'
 
 import { useCodeIntelScores } from './useCodeIntelScores'
@@ -61,9 +62,8 @@ export function useCodeIntelAnalysis(
     getAnalysisHistory: codeIntelGetAnalysisHistory,
     batchAnalyze: codeIntelBatchAnalyze,
   } = useCodeIntelligence()
-  const codeIntelSecurityFindings = ref<SecurityFinding[]>([])
-  const codeIntelPerformanceFindings = ref<PerformanceFinding[]>([])
-  const codeIntelRedisFindings = ref<RedisOptimizationFinding[]>([])
+  // #5365: codeIntel{Security,Performance,Redis}Findings are declared
+  // as computed adapters further down, after `scores` is constructed.
   const codeIntelFindingsLoading = ref(false)
   const codeIntelFindingsFetched = ref({
     security: false,
@@ -136,8 +136,17 @@ export function useCodeIntelAnalysis(
     }
     codeIntelFindingsLoading.value = true
     try {
-      await codeIntelAnalyzeCode({ code: rootPath.value })
-      await codeIntelGetSuggestions(rootPath.value)
+      // #5365: fire the analyze endpoints so securityFindings,
+      // performanceFindings, and redisOptimizations (scores sub-composable)
+      // are populated. The adapter computeds below re-expose them under
+      // the legacy `codeIntel*Findings` names for the panel.
+      await Promise.all([
+        codeIntelAnalyzeCode({ code: rootPath.value }),
+        codeIntelGetSuggestions(rootPath.value),
+        scores.loadSecurityFindings(),
+        scores.loadPerformanceFindings(),
+        scores.loadRedisOptimizations(),
+      ])
       codeIntelFindingsFetched.value = {
         security: true,
         performance: true,
@@ -208,6 +217,54 @@ export function useCodeIntelAnalysis(
   const smells = useCodeSmellAnalysis(deps)
   const bugs = useBugPrediction(deps)
   const specialized = useSpecializedAnalysis(deps)
+
+  // #5365: Previously these three refs were declared as empty
+  // `ref<Type[]>([])` and never written — declared + returned + unwritten.
+  // CodebaseSecurityPanel therefore showed empty findings on every
+  // render regardless of scan results (same bug class as #5277).
+  //
+  // The live data is produced by `useCodeIntelScores` via POST to
+  // `/api/code-intelligence/{security,performance,redis}/analyze` into
+  // `securityFindings`, `performanceFindings`, `redisOptimizations` —
+  // but those use the `SecurityFindingDetail` shape (fields `line`,
+  // `description`, `recommendation`), while the panel prop types use
+  // the `SecurityFinding` shape (fields `line_number`, `message`,
+  // `remediation`). These computed adapters map between the two
+  // without changing the panel contract or consumer bindings.
+  const codeIntelSecurityFindings = computed<SecurityFinding[]>(() =>
+    (scores.securityFindings.value || []).map((f) => ({
+      severity: f.severity as Severity,
+      vulnerability_type: f.vulnerability_type,
+      file_path: f.file_path,
+      line_number: f.line ?? 0,
+      code_snippet: f.code_snippet ?? '',
+      message: f.description,
+      remediation: f.recommendation ?? '',
+      owasp_category: f.owasp_category ?? '',
+    })),
+  )
+  const codeIntelPerformanceFindings = computed<PerformanceFinding[]>(() =>
+    (scores.performanceFindings.value || []).map((f) => ({
+      issue_type: f.issue_type,
+      severity: f.severity as Severity,
+      file_path: f.file_path,
+      line_number: f.line ?? 0,
+      message: f.description,
+      recommendation: f.recommendation ?? '',
+      estimated_impact: '',
+    })),
+  )
+  const codeIntelRedisFindings = computed<RedisOptimizationFinding[]>(() =>
+    (scores.redisOptimizations.value || []).map((f) => ({
+      optimization_type: f.optimization_type,
+      severity: f.severity as Severity,
+      file_path: f.file_path,
+      line_number: f.line ?? 0,
+      message: f.description,
+      recommendation: f.recommendation ?? '',
+      category: f.category ?? '',
+    })),
+  )
 
   return {
     // Code Intelligence (facade-owned)

--- a/autobot-frontend/src/composables/analytics/useOwnershipAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useOwnershipAnalysis.ts
@@ -10,7 +10,6 @@
  * Migrated from useAnalyticsFetch to useFetchEndpoint (Issue #5208).
  */
 
-import { ref } from 'vue'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import type {
   UseCodeIntelAnalysisDeps,
@@ -78,10 +77,6 @@ export function useOwnershipAnalysis(deps: UseCodeIntelAnalysisDeps) {
     { withSourceId },
   )
 
-  const ownershipViewMode = ref<
-    'overview' | 'files' | 'contributors' | 'gaps'
-  >('overview')
-
   const loadOwnershipAnalysis = async () => {
     if (!rootPath.value) return
     await endpoint.load({ path: rootPath.value })
@@ -91,7 +86,6 @@ export function useOwnershipAnalysis(deps: UseCodeIntelAnalysisDeps) {
     ownershipAnalysis: endpoint.data,
     loadingOwnership: endpoint.loading,
     ownershipError: endpoint.error,
-    ownershipViewMode,
     loadOwnershipAnalysis,
   }
 }

--- a/autobot-frontend/src/composables/useBrowserAutomation.ts
+++ b/autobot-frontend/src/composables/useBrowserAutomation.ts
@@ -76,7 +76,6 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   const sessions = ref<BrowserSession[]>([])
   const currentSession = ref<BrowserSession | null>(null)
   const screenshots = ref<ScreenshotResult[]>([])
-  const scripts = ref<AutomationScript[]>([])
   const isLoading = ref(false)
   const error = ref<string | null>(null)
 
@@ -324,7 +323,6 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     sessions,
     currentSession,
     screenshots,
-    scripts,
     isLoading,
     error,
 

--- a/autobot-frontend/src/composables/useServiceDiscovery.ts
+++ b/autobot-frontend/src/composables/useServiceDiscovery.ts
@@ -35,7 +35,6 @@ export function useServiceDiscovery() {
   const userStore = useUserStore()
   const services = ref<Map<string, ServiceDiscoveryState>>(new Map())
   const isGlobalLoading = ref(false)
-  const globalError = ref<string | null>(null)
 
   /**
    * Get the auth token from user store.
@@ -139,7 +138,6 @@ export function useServiceDiscovery() {
     discoverUrl,
     getServiceState,
     isLoading,
-    globalError,
     clearAll,
     services,
   }

--- a/tools/lint/check_no_orphan_refs.py
+++ b/tools/lint/check_no_orphan_refs.py
@@ -131,11 +131,43 @@ def _is_used_in_file(source: str, name: str) -> bool:
     return len(matches) >= 3
 
 
-def _scan_file(path: Path) -> List[OrphanRef]:
+def _is_written_cross_file(search_root: Path, composable_path: Path, name: str) -> bool:
+    """Is the ref's ``.value`` written from any OTHER file in the tree?
+
+    Handles two legitimate patterns that look like orphans from a single
+    file's perspective:
+
+    1. Dependency injection: ``useComposableA({ exportingReport })`` and
+       composable B writes ``deps.exportingReport.value = ...`` (cross-file).
+    2. External template write: ``<input @input=\"foo.silenceThreshold.value = x\">``
+       inside a .vue consumer.
+
+    A cross-file grep for ``.NAME.value\\s*=`` is enough to catch both.
+    We exclude the composable's own file to avoid counting declaration-
+    local writes we'd already have caught via ``_is_used_in_file``.
+    """
+    pattern = rf"\.{re.escape(name)}\.value\s*="
+    compiled = re.compile(pattern)
+    for path in search_root.rglob("*"):
+        if path == composable_path:
+            continue
+        if path.suffix not in {".ts", ".vue"}:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if compiled.search(text):
+            return True
+    return False
+
+
+def _scan_file(path: Path, search_root: Path) -> List[OrphanRef]:
     """Return every orphan ref declared in ``path``.
 
     Orphan = declared + returned + never referenced outside the
-    declaration and return. Matches the #5340 bug shape exactly.
+    declaration and return, AND never written via dependency injection
+    or external template assignment. Matches the #5340 bug shape.
     """
     source = path.read_text(encoding="utf-8")
     orphans: List[OrphanRef] = []
@@ -145,6 +177,9 @@ def _scan_file(path: Path) -> List[OrphanRef]:
             # ref (fine) or dead code. Out of scope for this check.
             continue
         if _is_used_in_file(source, name):
+            continue
+        if _is_written_cross_file(search_root, path, name):
+            # DI or external .vue write — legitimate.
             continue
         orphans.append(OrphanRef(file=path, name=name, line=line))
     return orphans
@@ -163,12 +198,13 @@ def main(argv: List[str]) -> int:
         )
         return 2
 
+    src_root = root / "autobot-frontend" / "src"
     orphans: List[OrphanRef] = []
     for ts_file in composables_dir.rglob("*.ts"):
         # Skip test files and type-only files.
         if ts_file.name.endswith(".test.ts") or ts_file.name.endswith(".spec.ts"):
             continue
-        orphans.extend(_scan_file(ts_file))
+        orphans.extend(_scan_file(ts_file, src_root))
 
     if not orphans:
         return 0

--- a/tools/lint/check_no_orphan_refs_test.py
+++ b/tools/lint/check_no_orphan_refs_test.py
@@ -96,7 +96,7 @@ class TestDetectionContract:
     def test_5340_pattern_flagged(self, tmp_path: Path):
         composable = tmp_path / "useX.ts"
         composable.write_text("const refactoringSuggestions = ref([])\n" "return { refactoringSuggestions }\n")
-        orphans = _mod._scan_file(composable)
+        orphans = _mod._scan_file(composable, tmp_path)
         assert len(orphans) == 1
         assert orphans[0].name == "refactoringSuggestions"
 
@@ -105,7 +105,7 @@ class TestDetectionContract:
         composable.write_text(
             "const data = ref([])\n" "async function load() { data.value = await fetch() }\n" "return { data, load }\n"
         )
-        orphans = _mod._scan_file(composable)
+        orphans = _mod._scan_file(composable, tmp_path)
         assert orphans == []
 
     def test_v_model_target_not_flagged(self, tmp_path: Path):
@@ -118,14 +118,35 @@ class TestDetectionContract:
             "const filtered = computed(() => items.filter(i => i.cat === selectedCategory.value))\n"
             "return { selectedCategory, filtered }\n"
         )
-        orphans = _mod._scan_file(composable)
+        orphans = _mod._scan_file(composable, tmp_path)
         assert orphans == []
 
     def test_internal_ref_not_in_return_not_flagged(self, tmp_path: Path):
         composable = tmp_path / "useW.ts"
         composable.write_text("const internal = ref(0)\n" "function tick() { internal.value++ }\n" "return { tick }\n")
-        orphans = _mod._scan_file(composable)
+        orphans = _mod._scan_file(composable, tmp_path)
         # `internal` is not in the return — out of scope for this check.
+        assert orphans == []
+
+    def test_cross_file_di_write_not_flagged(self, tmp_path: Path):
+        # Dependency-injection pattern: one composable declares the ref,
+        # another writes to it via its deps argument. Script must not
+        # flag this as orphan.
+        composable = tmp_path / "useA.ts"
+        composable.write_text("const exporting = ref(false)\n" "return { exporting }\n")
+        consumer = tmp_path / "useB.ts"
+        consumer.write_text("function go(deps) { deps.exporting.value = true }\n")
+        orphans = _mod._scan_file(composable, tmp_path)
+        assert orphans == []
+
+    def test_cross_file_vue_template_write_not_flagged(self, tmp_path: Path):
+        # External .vue template write pattern: consumer component
+        # writes ``obj.silenceThreshold.value = x`` in an event handler.
+        composable = tmp_path / "useVoice.ts"
+        composable.write_text("const silenceThreshold = ref(1500)\n" "return { silenceThreshold }\n")
+        consumer = tmp_path / "Panel.vue"
+        consumer.write_text('<input @input="voice.silenceThreshold.value = Number($event.target.value)" />')
+        orphans = _mod._scan_file(composable, tmp_path)
         assert orphans == []
 
 


### PR DESCRIPTION
## Summary

**Primary fix — 3 #5277-class bugs** in \`useCodeIntelAnalysis.ts\`:

- \`codeIntelSecurityFindings\` / \`codeIntelPerformanceFindings\` / \`codeIntelRedisFindings\` were orphans declared as empty refs and never populated. \`CodebaseSecurityPanel\` received empty arrays on every render.
- Replaced orphan refs with **computed adapters** over \`scores.securityFindings\` / \`scores.performanceFindings\` / \`scores.redisOptimizations\` (live data produced by the scores sub-composable), mapping \`SecurityFindingDetail\` → \`SecurityFinding\` shape.
- Extended \`runCodeIntelligenceAnalysis\` to fire the 3 analyze endpoints (\`loadSecurityFindings\`, \`loadPerformanceFindings\`, \`loadRedisOptimizations\`) in parallel so panels populate on \"Run Analysis\" click.

**Deleted 4 true orphans** discovered by the audit script (#5349):

- \`useApiEndpointAnalysis.expandedApiEndpointGroups\` (reactive)
- \`useOwnershipAnalysis.ownershipViewMode\`
- \`useBrowserAutomation.scripts\`
- \`useServiceDiscovery.globalError\`

**Hardened \`tools/lint/check_no_orphan_refs.py\`** to eliminate 2 false positives:

- Added \`_is_written_cross_file\` check for DI-style writes (\`deps.exporting.value = ...\` in another file).
- Added \`_is_written_cross_file\` check for Vue template writes (\`voice.silenceThreshold.value = ...\`).
- Added 2 contract tests for both patterns.

## Verification

- \`vue-tsc --noEmit -p tsconfig.app.json\` → 167 errors (unchanged baseline; 0 new).
- \`python3 tools/lint/check_no_orphan_refs.py\` → exits **0** (was: 9 candidates on first run).
- All 13 audit-script contract tests pass.
- \`black\` clean.

Closes #5365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)