### PR TITLE
feat(analytics): per-section loading spinners in Hardcodes/Duplicates/Declarations (#5368)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -174,18 +174,21 @@
       <!-- Duplicate Code Analysis (#1469, #184) -->
       <DuplicatesSection
         :duplicates="duplicateAnalysis"
+        :loading="loadingProgress.duplicates"
         @export="(fmt: string) => exportSection('duplicates', fmt as 'md' | 'json')"
       />
 
       <!-- Function Declarations (#1469, #184) -->
       <DeclarationsSection
         :declarations="declarationsForPanel"
+        :loading="loadingProgress.declarations"
         @export="(fmt: string) => exportSection('declarations', fmt as 'md' | 'json')"
       />
 
       <!-- Hardcoded Values (#5277: wire orphan data flow) -->
       <HardcodesSection
         :hardcodes="hardcodeAnalysis"
+        :loading="loadingProgress.hardcodes"
         @export="(fmt: string) => exportSection('hardcodes', fmt as 'md' | 'json')"
       />
 
@@ -543,6 +546,7 @@ const {
   duplicateAnalysis,
   declarationAnalysis,
   hardcodeAnalysis,
+  loadingProgress,
   chartData,
   chartDataLoading,
   chartDataError,

--- a/autobot-frontend/src/components/analytics/DeclarationsSection.vue
+++ b/autobot-frontend/src/components/analytics/DeclarationsSection.vue
@@ -14,7 +14,11 @@
         </button>
       </div>
     </h3>
-    <div v-if="declarations && declarations.length > 0" class="section-content">
+    <div v-if="loading" class="section-loading">
+      <i class="fas fa-spinner fa-spin"></i>
+      <span>{{ $t('analytics.codebase.actions.loading') }}</span>
+    </div>
+    <div v-else-if="declarations && declarations.length > 0" class="section-content">
       <!-- Type Summary Cards -->
       <div class="summary-cards">
         <div class="summary-card total">
@@ -77,7 +81,7 @@
       </div>
     </div>
     <EmptyState
-      v-else
+      v-else-if="!loading"
       icon="fas fa-code"
       :message="$t('analytics.declarations.emptyMessage')"
     />
@@ -116,6 +120,8 @@ interface Declaration {
 
 interface Props {
   declarations: Declaration[]
+  /** #5368: render a spinner during the scan instead of empty-state. */
+  loading?: boolean
 }
 
 const props = defineProps<Props>()
@@ -192,6 +198,23 @@ const getDeclarationTypeClass = (type: string): string => {
   background: var(--bg-active);
   border-radius: var(--radius-lg);
   padding: var(--spacing-4);
+}
+
+/* #5368: loading state shown during scan in progress */
+.section-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-6);
+  background: var(--bg-active);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.section-loading i {
+  color: var(--color-info);
 }
 
 .summary-cards {

--- a/autobot-frontend/src/components/analytics/DuplicatesSection.vue
+++ b/autobot-frontend/src/components/analytics/DuplicatesSection.vue
@@ -14,7 +14,11 @@
         </button>
       </div>
     </h3>
-    <div v-if="duplicates && duplicates.length > 0" class="section-content">
+    <div v-if="loading" class="section-loading">
+      <i class="fas fa-spinner fa-spin"></i>
+      <span>{{ $t('analytics.codebase.actions.loading') }}</span>
+    </div>
+    <div v-else-if="duplicates && duplicates.length > 0" class="section-content">
       <!-- Similarity Summary Cards -->
       <div class="summary-cards">
         <div class="summary-card total">
@@ -88,7 +92,7 @@
       </div>
     </div>
     <EmptyState
-      v-else
+      v-else-if="!loading"
       icon="fas fa-check-circle"
       :message="$t('analytics.duplicates.emptyMessage')"
       variant="success"
@@ -126,6 +130,8 @@ interface Duplicate {
 
 interface Props {
   duplicates: Duplicate[]
+  /** #5368: render a spinner during the scan instead of empty-state. */
+  loading?: boolean
 }
 
 const props = defineProps<Props>()
@@ -188,6 +194,23 @@ const formatSimilarityGroup = (similarity: string): string => {
   background: var(--bg-primary-alpha);
   border-radius: var(--radius-lg);
   padding: var(--spacing-4);
+}
+
+/* #5368: loading state shown during scan in progress */
+.section-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-6);
+  background: var(--bg-primary-alpha);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.section-loading i {
+  color: var(--color-info);
 }
 
 .summary-cards {

--- a/autobot-frontend/src/components/analytics/HardcodesSection.vue
+++ b/autobot-frontend/src/components/analytics/HardcodesSection.vue
@@ -14,7 +14,11 @@
         </button>
       </div>
     </h3>
-    <div v-if="hardcodes && hardcodes.length > 0" class="section-content">
+    <div v-if="loading" class="section-loading">
+      <i class="fas fa-spinner fa-spin"></i>
+      <span>{{ $t('analytics.codebase.actions.loading') }}</span>
+    </div>
+    <div v-else-if="hardcodes && hardcodes.length > 0" class="section-content">
       <!-- Summary Cards -->
       <div class="summary-cards">
         <div class="summary-card total">
@@ -96,7 +100,7 @@
       </div>
     </div>
     <EmptyState
-      v-else
+      v-else-if="!loading"
       icon="fas fa-check-circle"
       :message="$t('analytics.hardcodes.emptyMessage')"
       variant="success"
@@ -125,6 +129,11 @@ const { t } = useI18n()
 
 interface Props {
   hardcodes: HardcodedValue[]
+  /**
+   * #5368: when true, render a spinner in place of the empty-state
+   * message so users don't misread a running scan as "no results".
+   */
+  loading?: boolean
 }
 
 const props = defineProps<Props>()
@@ -184,6 +193,23 @@ const formatSeverityGroup = (severity: string): string => {
   background: var(--bg-primary-alpha);
   border-radius: var(--radius-lg);
   padding: var(--spacing-4);
+}
+
+/* #5368: loading state shown during scan in progress */
+.section-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-6);
+  background: var(--bg-primary-alpha);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.section-loading i {
+  color: var(--color-warning);
 }
 
 .summary-cards {


### PR DESCRIPTION
## Summary

The three analytics section components rendered the empty-state message while the fetcher was running — visually indistinguishable from a completed-zero-result scan.

- Add \`loading?: boolean\` prop to each of the 3 section components.
- When \`loading === true\`, render a spinner block instead of empty-state or data.
- \`CodebaseAnalytics.vue\` destructures \`loadingProgress\` (already exported from \`useAnalyticsDataFetchers\`) and passes \`.duplicates\` / \`.declarations\` / \`.hardcodes\` flags.

Closes #5368.

## Verification

- \`vue-tsc --noEmit -p tsconfig.app.json\` → 167 errors (unchanged baseline; 0 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)