### PR TITLE
fix(security): threat_detection naive/aware datetime mismatches (#5350)

### DIFF
--- a/autobot-backend/security/enterprise/threat_detection/__init__.py
+++ b/autobot-backend/security/enterprise/threat_detection/__init__.py
@@ -28,7 +28,7 @@ Usage:
         "action": "authentication",
         "outcome": "failure",
         "source_ip": "192.168.1.100",
-        "timestamp": "2025-01-01T12:00:00",
+        "timestamp": "2025-01-01T12:00:00+00:00",
     })
 
     if threat:

--- a/autobot-backend/security/enterprise/threat_detection/engine.py
+++ b/autobot-backend/security/enterprise/threat_detection/engine.py
@@ -650,14 +650,14 @@ class ThreatDetectionEngine:
             expired_sessions = []
 
             for session_id, session_data in self.user_sessions.items():
-                if session_data.get("last_activity", datetime.utcnow()) < cutoff_time:
+                if session_data.get("last_activity", now_utc()) < cutoff_time:
                     expired_sessions.append(session_id)
 
             for session_id in expired_sessions:
                 del self.user_sessions[session_id]
 
             # Reset daily statistics
-            if datetime.utcnow().hour == 0:  # Midnight
+            if now_utc().hour == 0:  # Midnight
                 self.stats["threats_by_category"] = defaultdict(int)
                 self.stats["threats_by_level"] = defaultdict(int)
 

--- a/autobot-backend/security/enterprise/threat_detection/models.py
+++ b/autobot-backend/security/enterprise/threat_detection/models.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
-from autobot_shared.time_utils import now_utc, utc_timestamp
+from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 
 from .types import FILE_OPERATION_ACTIONS, ThreatCategory, ThreatLevel
 
@@ -50,7 +50,7 @@ class SecurityEvent:
     def timestamp(self) -> datetime:
         """Get event timestamp as datetime object."""
         timestamp_str = self.raw_event.get("timestamp", utc_timestamp())
-        return datetime.fromisoformat(timestamp_str)
+        return parse_utc_iso(timestamp_str)
 
     @property
     def details(self) -> Dict:
@@ -144,7 +144,7 @@ class EventHistory:
         count = 0
 
         for event in reversed(self.events):
-            event_time = datetime.fromisoformat(
+            event_time = parse_utc_iso(
                 event.get("timestamp", utc_timestamp())
             )
             if event_time < cutoff_time:
@@ -169,7 +169,7 @@ class EventHistory:
         count = 0
 
         for event in reversed(self.events):
-            event_time = datetime.fromisoformat(
+            event_time = parse_utc_iso(
                 event.get("timestamp", utc_timestamp())
             )
             if event_time < cutoff_time:
@@ -189,7 +189,7 @@ class EventHistory:
         count = 0
 
         for event in reversed(self.events):
-            event_time = datetime.fromisoformat(
+            event_time = parse_utc_iso(
                 event.get("timestamp", utc_timestamp())
             )
             if event_time < cutoff_time:
@@ -207,7 +207,7 @@ class EventHistory:
         count = 0
 
         for event in reversed(self.events):
-            event_time = datetime.fromisoformat(
+            event_time = parse_utc_iso(
                 event.get("timestamp", utc_timestamp())
             )
             if event_time < cutoff_time:
@@ -245,7 +245,7 @@ class EventHistory:
             1
             for event in self.events
             if event.get("user_id") == user_id
-            and datetime.fromisoformat(
+            and parse_utc_iso(
                 event.get("timestamp", utc_timestamp())
             ).hour
             < 6
@@ -347,7 +347,7 @@ class UserProfile:
                 self.api_usage_patterns.get(event.resource, 0) + 1
             )
 
-        self.last_updated = datetime.utcnow()
+        self.last_updated = now_utc()
 
     def calculate_risk_score(self, event_history: EventHistory) -> float:
         """Calculate risk score based on recent behavior from event history"""
@@ -386,7 +386,7 @@ class UserProfile:
                 if self.risk_score > 0.7
                 else "medium" if self.risk_score > 0.4 else "low"
             ),
-            "profile_age_days": (datetime.utcnow() - self.last_updated).days,
+            "profile_age_days": (now_utc() - self.last_updated).days,
             "total_actions": sum(self.baseline_actions.values()),
             "unique_actions": len(self.baseline_actions),
             "typical_access_hours": sorted(self.typical_hours),

--- a/autobot_shared/time_utils.py
+++ b/autobot_shared/time_utils.py
@@ -77,6 +77,26 @@ def now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def parse_utc_iso(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp string and return a tz-aware UTC datetime.
+
+    Accepts three forms:
+    - ``+00:00`` offset (canonical, produced by :func:`utc_timestamp`)
+    - ``Z`` suffix (legacy, produced by :func:`utc_timestamp_z`)
+    - **Naive** (no offset/suffix) — assumed UTC and tagged as such
+
+    Use this in consumer code that compares parsed timestamps against
+    aware ``datetime`` values (e.g. ``cutoff = now_utc() - timedelta(...)``)
+    when the input string may originate from external sources or legacy
+    producers. Avoids the ``TypeError: can't compare offset-naive and
+    offset-aware datetimes`` class flagged in #5350.
+    """
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
 def utc_timestamp_z() -> str:
     """Return current UTC time as ISO-8601 with ``Z`` suffix. **DEPRECATED.**
 

--- a/autobot_shared/time_utils_test.py
+++ b/autobot_shared/time_utils_test.py
@@ -7,7 +7,12 @@ import time
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-from autobot_shared.time_utils import now_utc, utc_timestamp, utc_timestamp_z
+from autobot_shared.time_utils import (
+    now_utc,
+    parse_utc_iso,
+    utc_timestamp,
+    utc_timestamp_z,
+)
 
 
 _Z_FMT = "%Y-%m-%dT%H:%M:%SZ"
@@ -139,3 +144,44 @@ def test_now_utc_round_trip_via_utc_timestamp() -> None:
     parsed = datetime.fromisoformat(s)
     # Both should be in UTC (offset 0)
     assert dt.utcoffset() == parsed.utcoffset() == timedelta(0)
+
+
+# ---------------------------------------------------------------------------
+# parse_utc_iso() — defensive parser for #5350 cutoff/since consumers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_utc_iso_canonical_offset() -> None:
+    """+00:00 form (canonical) round-trips and stays aware."""
+    parsed = parse_utc_iso("2026-04-21T12:34:56.789012+00:00")
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() == timedelta(0)
+
+
+def test_parse_utc_iso_z_suffix() -> None:
+    """Z suffix (legacy) is accepted and becomes aware UTC."""
+    parsed = parse_utc_iso("2026-04-21T12:34:56Z")
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() == timedelta(0)
+
+
+def test_parse_utc_iso_naive_string_assumed_utc() -> None:
+    """Naive input (no offset/suffix) is tagged as UTC — prevents TypeError vs aware."""
+    parsed = parse_utc_iso("2026-04-21T12:34:56")
+    assert parsed.tzinfo is not None, "naive input must be promoted to aware"
+    assert parsed.utcoffset() == timedelta(0)
+
+
+def test_parse_utc_iso_comparable_with_now_utc() -> None:
+    """The whole point: parsed value compares cleanly against now_utc() — no TypeError."""
+    parsed = parse_utc_iso("2026-04-21T12:34:56")  # naive input
+    cutoff = now_utc()
+    # Must not raise TypeError: can't compare offset-naive and offset-aware datetimes
+    assert (parsed < cutoff) or (parsed >= cutoff)
+
+
+def test_parse_utc_iso_invalid_raises() -> None:
+    """Malformed input raises ValueError (caller handles)."""
+    import pytest
+    with pytest.raises(ValueError):
+        parse_utc_iso("not-a-date")

--- a/docs/developer/audits/datetime-cutoff-consumer-audit.md
+++ b/docs/developer/audits/datetime-cutoff-consumer-audit.md
@@ -1,0 +1,151 @@
+# Datetime Cutoff Consumer Audit (#5350)
+
+> Companion to [datetime-parsing-audit.md](datetime-parsing-audit.md) and [datetime-utcnow-non-isoformat-audit.md](datetime-utcnow-non-isoformat-audit.md).
+
+## Why this audit exists
+
+PR [#5342](https://github.com/mrveiss/AutoBot-AI/pull/5342) (#5211 Phase B3.2) migrated 12 sites from
+`cutoff = datetime.utcnow() - timedelta(...)` to `cutoff = now_utc() - timedelta(...)`.
+The migrated variables are now **tz-aware**; before they were **naive**.
+
+This shifts the bug class from *naive vs naive (silently wrong)* to
+*aware vs naive (loud `TypeError`)*. The loud failures are good — they
+expose latent bugs — but each one needs a proven-safe consumer trace
+before merging.
+
+[#5350](https://github.com/mrveiss/AutoBot-AI/issues/5350) tracked the per-site verification.
+This document is the verification record.
+
+## Verification table
+
+| # | File / line | Migrated var | Consumer | Status |
+|---|---|---|---|---|
+| 1 | `services/feedback_tracker.py:152` | `cutoff` (then `.timestamp()`) | `redis.zremrangebyscore` (numeric) | ✅ epoch float — aware-ness invisible |
+| 2 | `services/feedback_tracker.py:163` | `last_retrain` | DB query against `Column(DateTime(timezone=True))` | ✅ AWARE column |
+| 3 | `services/feedback_tracker.py:251` | `since` | DB query against same column | ✅ AWARE column |
+| 4 | `services/incremental_trainer.py:149` | `since` | DB query against same column | ✅ AWARE column |
+| 5 | `api/usage.py:248` | `cutoff` | `cutoff.strftime("%Y-%m-%dT")` then string-prefix compare | ✅ string boundary — tz invisible |
+| 6 | `api/knowledge_organization.py:386` | `cutoff_date` | `_delete_expired_facts()` parses stored ISO via `fromisoformat(s.replace("Z","+00:00"))` → aware | ✅ aware vs aware |
+| 7 | `services/agent_analytics.py:639` | `cutoff` | `fromisoformat(t["started_at"])` — `started_at` is produced by `utc_timestamp()` (line 248) → `+00:00` aware | ✅ aware vs aware |
+| 8 | `security/.../engine.py:649` | `cutoff_time` | `session_data.get("last_activity", datetime.utcnow())` ← **naive fallback** vs aware cutoff | 🔴 **fixed** — see Fix 1 |
+| 9 | `security/.../learner.py:233` | `cutoff` | `fromisoformat(last_seen_raw)` — `last_seen` written via `utc_timestamp()` (line 88) → aware | ✅ aware vs aware |
+| 10 | `security/.../models.py:143` | `cutoff_time` (count_recent_failures) | `fromisoformat(event["timestamp"])` — fallback aware, but public API (engine `analyze_event` docstring) accepts caller-provided string with no tz | ⚠️ **hardened** — see Fix 2 |
+| 11 | `security/.../models.py:168` | `cutoff_time` (count_recent_api_requests) | same | ⚠️ **hardened** — see Fix 2 |
+| 12 | `security/.../models.py:188` | `cutoff_time` (get_recent_action_frequency) | same | ⚠️ **hardened** — see Fix 2 |
+| 13 | `security/.../models.py:206` | `cutoff_time` (get_recent_endpoint_usage) | same | ⚠️ **hardened** — see Fix 2 |
+
+> Site count became 13 because issue #5350 listed `models.py:143,168,188,206` as one row. Each is a distinct comparison.
+
+## Fix 1 — `engine.py` (real bug)
+
+**File:** `autobot-backend/security/enterprise/threat_detection/engine.py`
+
+```diff
+-                if session_data.get("last_activity", datetime.utcnow()) < cutoff_time:
++                if session_data.get("last_activity", now_utc()) < cutoff_time:
+```
+
+Trigger: any session that lacks `last_activity` (any code path that
+inserts a session without that key, or any newly-created session whose
+first activity hasn't fired yet). On hit: `TypeError: can't compare
+offset-naive and offset-aware datetimes`. The `try/except` at line 668
+would swallow the error, drop the cleanup pass, and leave stale sessions
+indefinitely — a slow leak, not a crash.
+
+The same module also had:
+
+```diff
+-            if datetime.utcnow().hour == 0:  # Midnight
++            if now_utc().hour == 0:  # Midnight
+```
+
+Standalone `.hour` works on both naive and aware, so this is a consistency
+fix not a bug — but consistent helpers prevent future copy-paste bugs.
+
+## Fix 2 — `models.py` parsing hardening
+
+The public engine entry point (`engine.analyze_event(event: Dict)`) had a
+docstring example with naive `"timestamp": "2025-01-01T12:00:00"`. Five
+parser sites consume that field via `datetime.fromisoformat(...)`:
+
+- `SecurityEvent.timestamp` (property, line 53)
+- `EventHistory.count_recent_failures` (line 147)
+- `EventHistory.count_recent_api_requests` (line 172)
+- `EventHistory.get_recent_action_frequency` (line 192)
+- `EventHistory.get_recent_endpoint_usage` (line 210)
+
+If a caller followed the docstring and passed a naive string, the result
+parsed naive and then mis-compared against the aware `cutoff_time`.
+
+### Helper added — `parse_utc_iso(s)`
+
+`autobot_shared/time_utils.py`:
+
+```python
+def parse_utc_iso(value: str) -> datetime:
+    """Parse ISO-8601 timestamp; return tz-aware UTC datetime.
+
+    Accepts +00:00 offset, Z suffix, or naive (assumed UTC).
+    Use in consumer code that compares parsed timestamps against
+    aware values (e.g. cutoff = now_utc() - timedelta(...)).
+    """
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+```
+
+Five tests added to `time_utils_test.py` cover canonical, Z-suffix,
+naive, comparable-with-now_utc, and malformed input.
+
+### Sites migrated
+
+All 5 `datetime.fromisoformat(...)` sites in `models.py` switched to
+`parse_utc_iso(...)`. The docstring example in `__init__.py` was also
+updated to canonical `"2025-01-01T12:00:00+00:00"` so future copy-pasters
+follow the right pattern.
+
+## Fix 3 — `UserProfile.last_updated` (hidden bug)
+
+While auditing models.py, found:
+
+| Line | Code | tz |
+|---|---|---|
+| 285 | `last_updated: datetime = field(default_factory=now_utc)` | aware |
+| 350 | `self.last_updated = datetime.utcnow()` | naive |
+| 389 | `(datetime.utcnow() - self.last_updated).days` | naive arithmetic |
+
+Default factory produces aware. First call to `update_with_event()`
+overwrites with naive. Then `get_risk_assessment()` does
+`naive - <aware-or-naive>` — `TypeError` if `update_with_event` hasn't
+been called since instantiation but `get_risk_assessment` has.
+
+Fix: both line 350 and 389 migrated to `now_utc()`. The whole field is
+now consistently aware regardless of code path.
+
+## Out-of-scope (deferred)
+
+- `engine.py:621` parses `event["timestamp"]` only to read `.hour` for
+  ML feature extraction. Naive vs aware is invisible to `.hour`. Not
+  changed (would add a needless dependency on the new helper).
+- `engine.py` and module-wide migration of remaining `datetime` symbol
+  usage is out of scope; only the comparison-against-aware sites that
+  were proven unsafe were touched.
+
+## Impact summary
+
+- **1 latent bug fixed** (engine.py:649 — silent cleanup-pass failure)
+- **1 latent bug fixed** (models.py UserProfile mixed-aware-naive arithmetic)
+- **5 parser sites hardened** (models.py — robust against naive
+  caller-provided timestamps consistent with public API docstring)
+- **1 helper added** (`parse_utc_iso`) + 5 unit tests
+- **1 docstring corrected** (engine `__init__.py` — canonical example)
+- **9 of 13 sites proven safe** without code changes (DB columns + epoch +
+  string-prefix + producer-controlled internal fromisoformat)
+
+## Verification command
+
+```bash
+python3 -m pytest autobot_shared/time_utils_test.py -q
+# 17 passed (12 prior + 5 new)
+```


### PR DESCRIPTION
## Summary

Consumer audit ([#5350](https://github.com/mrveiss/AutoBot-AI/issues/5350)) of the 13 cutoff/since sites migrated by PR #5342 (#5211 Phase B3.2 `now_utc` migration) surfaced two latent bugs plus a public-API docstring trap in `security/enterprise/threat_detection/`.

## Bugs fixed

**1. `engine.py:649` — silent cleanup-pass leak**

```python
# before
if session_data.get("last_activity", datetime.utcnow()) < cutoff_time:
# after
if session_data.get("last_activity", now_utc()) < cutoff_time:
```

The naive fallback compared against the (post-#5342) aware `cutoff_time` raised `TypeError`, swallowed by the outer `try/except`, leaking stale sessions indefinitely.

Also `engine.py:660` (`datetime.utcnow().hour == 0` midnight check) migrated to `now_utc().hour` for consistency.

**2. `models.py` `UserProfile` — mixed-aware-naive arithmetic on the same field**

| Line | Code | tz |
|---|---|---|
| 285 | `last_updated: datetime = field(default_factory=now_utc)` | aware |
| 350 | `self.last_updated = datetime.utcnow()` ← reassigned naive | naive |
| 389 | `(datetime.utcnow() - self.last_updated).days` | mismatch on first `update_with_event()` |

Lines 350 + 389 migrated to `now_utc()`.

## Public-API hardening — `parse_utc_iso(s)`

The engine `analyze_event(event: Dict)` docstring showed naive `"timestamp": "2025-01-01T12:00:00"`. Five `datetime.fromisoformat(...)` consumers in `models.py` would parse that naive and mis-compare against aware cutoffs.

- Added `autobot_shared.time_utils.parse_utc_iso(s)` — accepts `+00:00`, `Z`, or naive (assumed UTC) and returns tz-aware datetime
- Migrated all 5 parser sites in `models.py` to `parse_utc_iso`
- Updated docstring example to canonical `"2025-01-01T12:00:00+00:00"`
- 5 unit tests added (17 total passing)

## Audit doc

[`docs/developer/audits/datetime-cutoff-consumer-audit.md`](https://github.com/mrveiss/AutoBot-AI/blob/issue-5350/docs/developer/audits/datetime-cutoff-consumer-audit.md) — per-site verification table, fix rationale, and the 9 sites proven safe without code changes (DB tz-aware columns + epoch + string-prefix + producer-controlled internal `fromisoformat`).

## Test plan

- [x] `python3 -m pytest autobot_shared/time_utils_test.py -q` → 17 passed (12 prior + 5 new)
- [x] `python3 -m py_compile` on all changed `.py` files
- [x] Manual call-graph trace for all 13 cutoff sites — documented in audit
- [x] No production caller of `engine.analyze_event` exists outside docstring/tests today, so the `models.py` hardening is defense-in-depth for future wiring (gap previously documented in #5138)

Closes #5350
🤖 Generated with [Claude Code](https://claude.com/claude-code)