### PR TITLE
fix(backend): migrate datetime.utcnow().isoformat() in tests + migration scripts (#5263)

### DIFF
--- a/autobot-backend/security/enterprise/threat_detection/test_learner.py
+++ b/autobot-backend/security/enterprise/threat_detection/test_learner.py
@@ -11,11 +11,12 @@ All Redis calls are patched so the suite runs without a live Redis instance.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from autobot_shared.time_utils import now_utc, utc_timestamp
 from security.enterprise.threat_detection.learner import (
     _EMA_ALPHA,
     _INACTIVE_DAYS,
@@ -245,7 +246,7 @@ class TestConsolidate:
         key = self._make_key("old_pattern")
         mock_redis.keys.return_value = [key]
 
-        old_ts = (datetime.utcnow() - timedelta(days=_INACTIVE_DAYS + 1)).isoformat()
+        old_ts = (now_utc() - timedelta(days=_INACTIVE_DAYS + 1)).isoformat()
         mock_redis.hmget.return_value = [b"5", b"0", old_ts.encode()]
 
         summary = learner.consolidate()
@@ -258,7 +259,7 @@ class TestConsolidate:
         key = self._make_key("recent_pattern")
         mock_redis.keys.return_value = [key]
 
-        recent_ts = datetime.utcnow().isoformat()
+        recent_ts = utc_timestamp()
         mock_redis.hmget.return_value = [b"10", b"0", recent_ts.encode()]
 
         summary = learner.consolidate()
@@ -270,7 +271,7 @@ class TestConsolidate:
         key = self._make_key("noisy_pattern")
         mock_redis.keys.return_value = [key]
 
-        recent_ts = datetime.utcnow().isoformat()
+        recent_ts = utc_timestamp()
         # 2 tp, 8 fp → precision 0.2, below _HIGH_FP_THRESHOLD
         mock_redis.hmget.return_value = [b"2", b"8", recent_ts.encode()]
 
@@ -283,7 +284,7 @@ class TestConsolidate:
         key = self._make_key("sparse_pattern")
         mock_redis.keys.return_value = [key]
 
-        recent_ts = datetime.utcnow().isoformat()
+        recent_ts = utc_timestamp()
         # Only 4 observations total — below _MIN_OBSERVATIONS
         mock_redis.hmget.return_value = [b"1", b"3", recent_ts.encode()]
 
@@ -295,8 +296,8 @@ class TestConsolidate:
         keys = [self._make_key("p1"), self._make_key("p2"), self._make_key("p3")]
         mock_redis.keys.return_value = keys
 
-        old_ts = (datetime.utcnow() - timedelta(days=_INACTIVE_DAYS + 5)).isoformat()
-        recent_ts = datetime.utcnow().isoformat()
+        old_ts = (now_utc() - timedelta(days=_INACTIVE_DAYS + 5)).isoformat()
+        recent_ts = utc_timestamp()
 
         # p1 → inactive (prune); p2 → high FP (flag); p3 → healthy
         mock_redis.hmget.side_effect = [

--- a/autobot-backend/security/threat_detection_refactor_test.py
+++ b/autobot-backend/security/threat_detection_refactor_test.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from autobot_shared.time_utils import now_utc, utc_timestamp
 from security.enterprise.threat_detection import (
     AnalysisContext,
     EventHistory,
@@ -32,7 +33,7 @@ def sample_event():
         "source_ip": "192.168.1.100",
         "action": "api_request",
         "resource": "/api/users",
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": utc_timestamp(),
         "outcome": "success",
         "details": {
             "command": "ls",
@@ -48,7 +49,7 @@ def sample_event():
 @pytest.fixture
 def sample_events_list():
     """Create a list of sample events"""
-    base_time = datetime.utcnow()
+    base_time = now_utc()
     events = []
 
     # Create variety of events
@@ -83,7 +84,7 @@ def sample_events_list():
 
     # Add off-hours activity
     for i in range(5):
-        early_morning = datetime.utcnow().replace(hour=3, minute=i)
+        early_morning = now_utc().replace(hour=3, minute=i)
         events.append(
             {
                 "user_id": "test_user",
@@ -132,7 +133,7 @@ class TestSecurityEvent:
             "user_id": "user1",
             "action": "authentication",
             "outcome": "failure",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
         }
         event = SecurityEvent(raw_event=auth_event)
 
@@ -144,7 +145,7 @@ class TestSecurityEvent:
         file_event = {
             "user_id": "user1",
             "action": "file_upload",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
         }
         event = SecurityEvent(raw_event=file_event)
 
@@ -165,7 +166,7 @@ class TestEventHistory:
                     "source_ip": "10.0.0.1",
                     "action": "authentication",
                     "outcome": "failure",
-                    "timestamp": (datetime.utcnow() - timedelta(minutes=i)).isoformat(),
+                    "timestamp": (now_utc() - timedelta(minutes=i)).isoformat(),
                 }
             )
 
@@ -202,7 +203,7 @@ class TestEventHistory:
             {
                 "user_id": "other_user",
                 "action": "login",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": utc_timestamp(),
             }
         ]
         events = deque(sample_events_list + other_user_events, maxlen=10000)
@@ -393,7 +394,7 @@ class TestThreatDetectionEngineBackwardCompatibility:
             "source_ip": "10.0.0.1",
             "action": "command",
             "resource": "/bin/bash",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_timestamp(),
             "outcome": "success",
             "details": {"command": "rm", "args": "-rf /"},
         }
@@ -416,7 +417,7 @@ class TestThreatDetectionEngineBackwardCompatibility:
                 "source_ip": "10.0.0.1",
                 "action": "authentication",
                 "resource": "login",
-                "timestamp": (datetime.utcnow() - timedelta(minutes=i)).isoformat(),
+                "timestamp": (now_utc() - timedelta(minutes=i)).isoformat(),
                 "outcome": "failure",
                 "details": {},
             }

--- a/autobot-backend/tests/api/test_analytics_stratified.py
+++ b/autobot-backend/tests/api/test_analytics_stratified.py
@@ -9,11 +9,11 @@ for fair agent performance comparison.
 """
 
 import json
-from datetime import datetime
 from unittest.mock import patch
 
 import pytest
 
+from autobot_shared.time_utils import utc_timestamp
 from services.confounder_control_analyzer import (
     ConfounderControlAnalyzer,
     StratifiedComparison,
@@ -45,8 +45,8 @@ def _create_task_record(
         "task_id": task_id,
         "task_name": f"task_{task_id}",
         "status": status,
-        "started_at": datetime.utcnow().isoformat(),
-        "completed_at": datetime.utcnow().isoformat(),
+        "started_at": utc_timestamp(),
+        "completed_at": utc_timestamp(),
         "duration_ms": duration_ms,
         "input_size": 100,
         "output_size": 200,

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/backfill_activity_user_ids.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/backfill_activity_user_ids.py
@@ -18,7 +18,6 @@ import asyncio
 import json
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -27,6 +26,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backe
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import utc_timestamp
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -149,7 +149,7 @@ class ActivityBackfiller:
 
                         # Update message
                         message["user_id"] = user_id
-                        message["backfilled_at"] = datetime.utcnow().isoformat()
+                        message["backfilled_at"] = utc_timestamp()
 
                         if self.dry_run:
                             logger.debug(f"[DRY RUN] Would update message in " f"{session_id} with user_id: {user_id}")
@@ -252,7 +252,7 @@ class ActivityBackfiller:
 
                     # Update activity
                     await self.redis_client.hset(activity_key, "user_id", session_owner)
-                    await self.redis_client.hset(activity_key, "backfilled_at", datetime.utcnow().isoformat())
+                    await self.redis_client.hset(activity_key, "backfilled_at", utc_timestamp())
                     updated_count += 1
 
                 except Exception as e:

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_secrets_ownership.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_secrets_ownership.py
@@ -19,7 +19,6 @@ import asyncio
 import json
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -28,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backe
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import utc_timestamp
 from encryption_service import encrypt_data, is_encryption_enabled
 
 # Configure logging
@@ -271,7 +271,7 @@ class SecretsMigrator:
             metadata = {}
 
         metadata["owner"] = owner_id
-        metadata["migrated_at"] = datetime.utcnow().isoformat()
+        metadata["migrated_at"] = utc_timestamp()
         await self.redis_client.hset(key, "metadata", json.dumps(metadata))
 
         # Register in user's secrets index

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_sessions_user_attribution.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/migrate_sessions_user_attribution.py
@@ -18,7 +18,6 @@ import asyncio
 import json
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -27,6 +26,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backe
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import utc_timestamp
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -172,11 +172,11 @@ class SessionMigrator:
 
             session_data["metadata"]["owner"] = owner_id
             session_data["metadata"]["user_id"] = owner_id
-            session_data["metadata"]["migrated_at"] = datetime.utcnow().isoformat()
+            session_data["metadata"]["migrated_at"] = utc_timestamp()
 
             if "created_at" not in session_data:
                 # Use lastModified if available, else now
-                created_at = session_data.get("lastModified", datetime.utcnow().isoformat())
+                created_at = session_data.get("lastModified", utc_timestamp())
                 session_data["created_at"] = created_at
 
             # Generate rollback SQL

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/validate_migration.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/validate_migration.py
@@ -20,7 +20,6 @@ import asyncio
 import json
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
@@ -29,6 +28,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backe
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import utc_timestamp
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -420,7 +420,7 @@ class MigrationValidator:
         report = []
         report.append("=" * 70)
         report.append("MIGRATION VALIDATION REPORT")
-        report.append(f"Generated: {datetime.utcnow().isoformat()}")
+        report.append(f"Generated: {utc_timestamp()}")
         report.append("=" * 70)
         report.append("")
 


### PR DESCRIPTION
## Summary

Scoped subset of [#5263](https://github.com/mrveiss/AutoBot-AI/issues/5263)'s 59-site audit. Migrates **17 sites in 7 files** where `autobot_shared` is unambiguously available — keeping the SLM agent + standalone shared scripts for a follow-up because they have separate deployment / embedded-import concerns.

## Files migrated

**`autobot-backend/` tests** (3 files, 11 sites)
- `tests/api/test_analytics_stratified.py` — 2 sites
- `security/threat_detection_refactor_test.py` — 5 explicit + 2 fixture sites (the fixture sites at lines 52/87 produce naive `datetime.utcnow()` consumed via `.isoformat()` into event-dict timestamps; same bug class)
- `security/enterprise/threat_detection/test_learner.py` — 4 explicit + 2 fixture sites (`(datetime.utcnow() - timedelta(...)).isoformat()` → `(now_utc() - ...).isoformat()`)

**`autobot-infrastructure/autobot-backend/scripts/migrations/`** (4 files, 6 sites)
- `migrate_secrets_ownership.py`
- `backfill_activity_user_ids.py` — 2 sites
- `migrate_sessions_user_attribution.py` — 2 sites
- `validate_migration.py`

## Skipped intentionally

`knowledge/knowledge_context_suggestions_test.py:61` — variable named `naive`; the test deliberately exercises the recency-score handler with a naive timestamp. Migrating would defeat the test purpose.

## Out of scope (follow-up)

- `autobot-slm-backend/` (production code + `ansible/roles/slm_agent/files/` synced copies)
- `autobot-slm-agent/` (standalone agent — runs on remote nodes potentially without `autobot_shared`)
- `autobot-infrastructure/shared/scripts/` (log forwarders, comprehensive_log_aggregator — has 4 `+ "Z"` mixed-format sites, same bug class as #5238)

These have standalone deployment / embedded-`autobot_shared` concerns. Each component needs per-component verification (lazy import vs top-level vs inline `datetime.now(timezone.utc)`). Filing as a follow-up so this PR stays focused and reviewable.

## Mechanical pattern

```diff
-from datetime import datetime
+from autobot_shared.time_utils import utc_timestamp

-"started_at": datetime.utcnow().isoformat()
+"started_at": utc_timestamp()

-"timestamp": (datetime.utcnow() - timedelta(minutes=i)).isoformat()
+"timestamp": (now_utc() - timedelta(minutes=i)).isoformat()
```

## Test plan

- [x] `python3 -m py_compile` on all 7 changed files
- [x] No remaining `datetime.utcnow().isoformat()` in changed scope (`grep -rn`)
- [x] Each modified migration script verified to retain its existing `from autobot_shared.redis_client import get_redis_client` (proves `autobot_shared` was already importable in that runtime context)
- [ ] CI runs the test suites — relies on test execution to catch any signature/format issues

Refs #5263
🤖 Generated with [Claude Code](https://claude.com/claude-code)