### PR TITLE
feat(composables): extract useFocusRestore + migrate 3 dialogs (#5356)

### DIFF
--- a/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
+++ b/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
@@ -127,7 +127,6 @@
 import {
   computed,
   onMounted,
-  onUnmounted,
   ref,
   nextTick,
 } from 'vue'
@@ -136,6 +135,7 @@ import {
   type Entity,
 } from '@/composables/useKnowledgeGraph'
 import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
 import { getEntityTypeColor as getTypeColor } from '../constants'
 import RelationshipViewer from './RelationshipViewer.vue'
 
@@ -150,13 +150,7 @@ defineEmits<{
 
 const panelRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(panelRef)
-let previouslyFocused: Element | null = null
-
-onUnmounted(() => {
-  if (previouslyFocused instanceof HTMLElement) {
-    previouslyFocused.focus()
-  }
-})
+useFocusRestore()
 
 const propertyEntries = computed(() => {
   return Object.entries(props.entity.properties || {})
@@ -169,7 +163,6 @@ function formatValue(value: unknown): string {
 }
 
 onMounted(async () => {
-  previouslyFocused = document.activeElement
   await nextTick()
   panelRef.value?.focus()
 })

--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -53,9 +53,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, onUnmounted, useId } from 'vue'
+import { ref, computed, nextTick, onUnmounted, useId, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFocusTrap, FOCUSABLE_SELECTOR } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
 import Icon from './Icon.vue'
 
 /**
@@ -121,7 +122,12 @@ const { t } = useI18n()
 // Refs
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
-let previousActiveElement: HTMLElement | null = null
+
+// Save activeElement on open, restore on close — driven by modelValue.
+// Note: this fires immediately on the prop change, before BaseModal's
+// onAfterEnter focuses the first focusable, so the saved reference is
+// the trigger element (correct).
+useFocusRestore(toRef(props, 'modelValue'))
 
 // Stable unique IDs for ARIA labeling (Vue 3.5+ useId)
 const _uid = useId()
@@ -150,11 +156,8 @@ const handleOverlayClick = () => {
   }
 }
 
-// Focus trap implementation
+// Focus trap implementation — focus restore handled by useFocusRestore above.
 const onAfterEnter = async () => {
-  // Store element that had focus before modal opened
-  previousActiveElement = document.activeElement as HTMLElement
-
   await nextTick()
 
   // Focus the dialog or first focusable element
@@ -173,12 +176,7 @@ const onAfterEnter = async () => {
 }
 
 const onAfterLeave = () => {
-  // Restore focus to element that opened modal
-  if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
-    previousActiveElement.focus()
-  }
-
-  // Unlock body scroll
+  // Unlock body scroll (focus restore handled by useFocusRestore watcher)
   document.body.style.overflow = ''
 }
 

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -181,7 +181,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, nextTick, onMounted, onUnmounted, watch, useId } from 'vue';
+import { ref, nextTick, onMounted, onUnmounted, watch, useId, toRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { secretsApiClient } from '@/utils/SecretsApiClient';
 import { getBackendUrl } from '@/config/ssot-config';
@@ -189,6 +189,7 @@ import { createLogger } from '@/utils/debugUtils';
 import Icon, { type IconName } from '@/components/ui/Icon.vue';
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
 import { useFocusTrap } from '@/composables/useFocusTrap';
+import { useFocusRestore } from '@/composables/useFocusRestore';
 
 const logger = createLogger('HostSelectionDialog');
 const { t } = useI18n();
@@ -244,7 +245,7 @@ const hostListLabelId = `host-list-label-${_uid}`;
 // Focus management
 const dialogRef = ref<HTMLElement | null>(null);
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef);
-let previousActiveElement: HTMLElement | null = null;
+useFocusRestore(toRef(props, 'show'));
 
 // State
 const showDialog = ref(false);
@@ -419,17 +420,13 @@ const handleEscape = (event: KeyboardEvent) => {
   }
 };
 
-// Watchers
+// Watchers — focus save/restore handled by useFocusRestore above.
 watch(() => props.show, async (newValue) => {
   showDialog.value = newValue;
   if (newValue) {
-    previousActiveElement = document.activeElement as HTMLElement;
     loadHosts();
     await nextTick();
     dialogRef.value?.focus();
-  } else {
-    previousActiveElement?.focus();
-    previousActiveElement = null;
   }
 }, { immediate: true });
 

--- a/autobot-frontend/src/composables/__tests__/useFocusRestore.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useFocusRestore.test.ts
@@ -1,0 +1,243 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Unit tests for useFocusRestore composable (#5356).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { defineComponent, h, nextTick, ref, type Ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useFocusRestore } from '../useFocusRestore'
+
+/** Mounts the composable and returns the wrapper for unmount control. */
+function mountWithRestore() {
+  const Test = defineComponent({
+    setup() {
+      useFocusRestore()
+      return () => h('div', { tabindex: -1 }, 'inside')
+    }
+  })
+  return mount(Test, { attachTo: document.body })
+}
+
+/** Mounts a trigger-based variant; returns wrapper + the trigger ref. */
+function mountWithTrigger(initial = false): { wrapper: ReturnType<typeof mount>; show: Ref<boolean> } {
+  const show = ref(initial)
+  const Test = defineComponent({
+    setup() {
+      useFocusRestore(show)
+      return () => h('div', { tabindex: -1 }, 'wrapper')
+    }
+  })
+  const wrapper = mount(Test, { attachTo: document.body })
+  return { wrapper, show }
+}
+
+describe('useFocusRestore', () => {
+  beforeEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild)
+  })
+
+  it('restores focus to the previously-focused HTMLElement on unmount', async () => {
+    const trigger = document.createElement('button')
+    trigger.textContent = 'open'
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    const wrapper = mountWithRestore()
+    await nextTick()
+    // Move focus elsewhere to simulate dialog grabbing focus
+    const inside = wrapper.find('div').element as HTMLElement
+    inside.focus()
+    expect(document.activeElement).toBe(inside)
+
+    wrapper.unmount()
+    await nextTick()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('does not restore when activeElement was document.body on mount', async () => {
+    // No previously-focused interactive element — body has implicit focus.
+    expect(document.activeElement).toBe(document.body)
+
+    const wrapper = mountWithRestore()
+    await nextTick()
+    // Whatever focus state ends up after mount, document.body is what
+    // we'd "restore" to — the composable should explicitly skip this.
+    const someoneElse = document.createElement('button')
+    document.body.appendChild(someoneElse)
+    someoneElse.focus()
+    expect(document.activeElement).toBe(someoneElse)
+
+    wrapper.unmount()
+    await nextTick()
+    // The composable's body-skip guard means previouslyFocused was never
+    // set on mount, so .focus() is never called on unmount. The element
+    // we focused after mount (someoneElse) remains the activeElement —
+    // proving we didn't yank focus back to body.
+    expect(document.activeElement).toBe(someoneElse)
+  })
+
+  it('does not throw when no element had focus before mount', async () => {
+    // Edge case: activeElement could be null in some headless environments.
+    // jsdom guarantees body is the fallback, but we guard against the null
+    // path anyway — assert no throw on mount/unmount.
+    expect(() => {
+      const wrapper = mountWithRestore()
+      wrapper.unmount()
+    }).not.toThrow()
+  })
+
+  it('handles non-HTMLElement activeElement gracefully', async () => {
+    // jsdom doesn't easily simulate an SVG with focus, so we verify the
+    // type guard by mounting with body as activeElement (which is an
+    // HTMLBodyElement IS HTMLElement, but the != body check excludes it).
+    // This test pairs with the body-skip case above.
+    const wrapper = mountWithRestore()
+    expect(() => wrapper.unmount()).not.toThrow()
+  })
+
+  it('clears the saved reference on unmount (no leak across mount/unmount cycles)', async () => {
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+
+    const w1 = mountWithRestore()
+    await nextTick()
+    w1.unmount()
+    await nextTick()
+
+    // Now remove trigger entirely — second mount/unmount should not try
+    // to focus the detached element from the first cycle.
+    document.body.removeChild(trigger)
+    const w2 = mountWithRestore()
+    await nextTick()
+    expect(() => w2.unmount()).not.toThrow()
+    // No assertion on activeElement — point is no exception was thrown
+    // by attempting to .focus() a stale reference.
+  })
+
+  describe('trigger-based mode (Ref<boolean>)', () => {
+    it('saves on false→true transition, restores on true→false', async () => {
+      const trigger = document.createElement('button')
+      document.body.appendChild(trigger)
+      trigger.focus()
+      expect(document.activeElement).toBe(trigger)
+
+      const { wrapper, show } = mountWithTrigger(false)
+      await nextTick()
+
+      // Open: save should fire
+      show.value = true
+      await nextTick()
+
+      // Move focus elsewhere to simulate dialog grabbing focus
+      const inside = wrapper.find('div').element as HTMLElement
+      inside.focus()
+      expect(document.activeElement).toBe(inside)
+
+      // Close: restore should fire
+      show.value = false
+      await nextTick()
+      expect(document.activeElement).toBe(trigger)
+
+      wrapper.unmount()
+    })
+
+    it('saves on initial mount when trigger is already true', async () => {
+      const trigger = document.createElement('button')
+      document.body.appendChild(trigger)
+      trigger.focus()
+
+      // Trigger starts true — save should fire on initial run
+      const { wrapper, show } = mountWithTrigger(true)
+      await nextTick()
+
+      const inside = wrapper.find('div').element as HTMLElement
+      inside.focus()
+
+      show.value = false
+      await nextTick()
+      expect(document.activeElement).toBe(trigger)
+
+      wrapper.unmount()
+    })
+
+    it('multiple open/close cycles each save/restore independently', async () => {
+      const triggerA = document.createElement('button')
+      const triggerB = document.createElement('button')
+      document.body.appendChild(triggerA)
+      document.body.appendChild(triggerB)
+
+      const { wrapper, show } = mountWithTrigger(false)
+      await nextTick()
+
+      // First open from triggerA
+      triggerA.focus()
+      show.value = true
+      await nextTick()
+      ;(wrapper.find('div').element as HTMLElement).focus()
+      show.value = false
+      await nextTick()
+      expect(document.activeElement).toBe(triggerA)
+
+      // Second open from triggerB
+      triggerB.focus()
+      show.value = true
+      await nextTick()
+      ;(wrapper.find('div').element as HTMLElement).focus()
+      show.value = false
+      await nextTick()
+      expect(document.activeElement).toBe(triggerB)
+
+      wrapper.unmount()
+    })
+
+    it('does nothing when trigger toggles within the same true/false state', async () => {
+      // Edge case: imperatively setting show=true when already true should
+      // not re-save. Watch handler's wasActive guard prevents this.
+      const trigger = document.createElement('button')
+      document.body.appendChild(trigger)
+      trigger.focus()
+
+      const { wrapper, show } = mountWithTrigger(true)
+      await nextTick()
+
+      const inside = wrapper.find('div').element as HTMLElement
+      inside.focus()
+
+      // Re-set to true (no-op for ref but sanity check)
+      show.value = true
+      await nextTick()
+
+      show.value = false
+      await nextTick()
+      // Restore should still go to the original trigger, not `inside`
+      expect(document.activeElement).toBe(trigger)
+
+      wrapper.unmount()
+    })
+  })
+
+  it('saves focus even when restored element is later detached from DOM', async () => {
+    // Real-world scenario: dialog opens, the trigger gets unmounted
+    // by reactive state changes, dialog closes — restoring focus to a
+    // detached element is a no-op in browsers (no error).
+    const trigger = document.createElement('button')
+    document.body.appendChild(trigger)
+    trigger.focus()
+
+    const wrapper = mountWithRestore()
+    await nextTick()
+
+    // Detach trigger before unmount
+    document.body.removeChild(trigger)
+
+    // Should not throw — element.focus() on a detached node is silently
+    // ignored by browsers (and jsdom matches that behavior).
+    expect(() => wrapper.unmount()).not.toThrow()
+  })
+})

--- a/autobot-frontend/src/composables/useFocusRestore.ts
+++ b/autobot-frontend/src/composables/useFocusRestore.ts
@@ -1,0 +1,63 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * useFocusRestore Composable (#5356)
+ *
+ * Saves the currently-focused HTMLElement when "active" begins, restores
+ * focus to it when "active" ends. Sister primitive to useFocusTrap (#5130) —
+ * together they cover the keyboard-modality side of dialog accessibility
+ * (trap inside, restore on close).
+ *
+ * Two modes:
+ *   1. Mount-based (no argument) — save on onMounted, restore on onUnmounted.
+ *      Fits dialogs that mount-on-show (parent gates with v-if).
+ *   2. Trigger-based (pass a Ref<boolean>) — save on false→true transition,
+ *      restore on true→false transition. Fits dialogs that stay mounted
+ *      and toggle a `show`/`modelValue` prop (BaseModal, HostSelectionDialog).
+ *
+ * The canonical guard covers three edge cases the prior bespoke
+ * implementations defended against separately:
+ *   1. activeElement is null (rare — happens when no focus history exists)
+ *   2. activeElement is document.body (no focused interactive element)
+ *   3. activeElement is not an HTMLElement (e.g. SVGElement.focus exists
+ *      but doesn't always behave like an HTMLElement; safer to skip)
+ */
+
+import { onMounted, onUnmounted, watch, type Ref } from 'vue'
+
+/**
+ * @param activeWhen  Optional Ref<boolean>. When provided, the composable
+ *                    saves focus on the false→true transition and restores
+ *                    it on the true→false transition. Omit for mount/unmount
+ *                    semantics.
+ */
+export function useFocusRestore(activeWhen?: Ref<boolean>): void {
+  let previouslyFocused: HTMLElement | null = null
+
+  function save(): void {
+    const active = document.activeElement
+    if (active instanceof HTMLElement && active !== document.body) {
+      previouslyFocused = active
+    }
+  }
+
+  function restore(): void {
+    previouslyFocused?.focus()
+    previouslyFocused = null
+  }
+
+  if (activeWhen) {
+    watch(activeWhen, (isActive, wasActive) => {
+      // `wasActive` is undefined on the first run; treat as falsy so that
+      // an initial `true` value also triggers a save (consistent with
+      // mount-based behavior when the dialog opens immediately).
+      if (isActive && !wasActive) save()
+      else if (!isActive && wasActive) restore()
+    }, { immediate: true })
+  } else {
+    onMounted(save)
+    onUnmounted(restore)
+  }
+}


### PR DESCRIPTION
## Summary

Closes #5356.

Sister primitive to [\`useFocusTrap\`](autobot-frontend/src/composables/useFocusTrap.ts) (#5130). Saves \`document.activeElement\` when "active" begins, restores it when "active" ends. Three dialog components ([\`BaseModal\`](autobot-frontend/src/components/ui/BaseModal.vue), [\`HostSelectionDialog\`](autobot-frontend/src/components/ui/HostSelectionDialog.vue), [\`EntityDetail\`](autobot-frontend/src/components/knowledge/graph/EntityDetail.vue)) each implemented this with a slightly different null/type guard:

| Component | Bespoke guard |
|---|---|
| BaseModal | \`typeof previousActiveElement.focus === 'function'\` |
| HostSelectionDialog | optional chaining + null reset |
| EntityDetail | \`instanceof HTMLElement\` |

The composable's canonical guard covers all three edge cases (null \`activeElement\`, \`document.body\`, non-HTMLElement) in one place.

## Two modes — supports both dialog lifecycle patterns

The 3 dialogs split between two patterns; a single composable shape doesn't fit both, so the composable is overloaded:

### Mount-based (no argument)
\`\`\`ts
useFocusRestore()
\`\`\`
Save on \`onMounted\`, restore on \`onUnmounted\`. Fits dialogs that mount-on-show (parent gates with \`v-if\`). **EntityDetail** uses this.

### Trigger-based (\`Ref<boolean>\`)
\`\`\`ts
useFocusRestore(toRef(props, 'modelValue'))
useFocusRestore(toRef(props, 'show'))
\`\`\`
Save on false→true transition, restore on true→false. Fits dialogs that stay mounted and toggle a \`show\` / \`modelValue\` prop. **BaseModal** and **HostSelectionDialog** use this.

## Behavioral grep audit

Before:
\`\`\`bash
$ grep -rn 'previousActiveElement\|previouslyFocused' autobot-frontend/src
# 12 hits across 3 files
\`\`\`

After:
\`\`\`bash
$ grep -rn 'previousActiveElement\|previouslyFocused' autobot-frontend/src
# 0 hits in the migrated files
\`\`\`

All three sites' bespoke save/restore plumbing fully extracted.

## Tests

[\`composables/__tests__/useFocusRestore.test.ts\`](autobot-frontend/src/composables/__tests__/useFocusRestore.test.ts) — 10 cases, all passing:

**Mount-based (6):**
- Restores focus to previously-focused HTMLElement on unmount
- Skips when activeElement was \`document.body\` on mount (no spurious refocus)
- No-throw when no element had focus before mount
- Handles non-HTMLElement activeElement gracefully
- Clears the saved reference on unmount (no leak across mount/unmount cycles)
- Detached-element no-throw on restore

**Trigger-based (4):**
- Saves on false→true transition, restores on true→false
- Saves on initial mount when trigger is already true
- Multiple open/close cycles each save/restore independently
- No double-save when imperatively setting same-state value

## Verification

- \`npx vitest run useFocusRestore.test.ts useFocusTrap.test.ts BaseModal.test.ts HostSelectionDialog.test.ts\` → **30/30 pass**.
- \`npx vue-tsc --noEmit -p tsconfig.app.json\` → 0 new type errors.
- Diff: -28 lines bespoke plumbing in 3 dialogs, +322 lines composable + tests.

## Test plan

- [ ] Manual: open BaseModal → focus an element on the page first → open the modal → close it → verify focus returns to the original element.
- [ ] Manual: open Host Selection dialog → same assertions.
- [ ] Manual: open Knowledge Graph entity detail panel → same assertions.
- [ ] Manual: rapid open/close cycles on a single dialog — focus restore should reset between cycles (no stale references).

## Related

- #5130 / PR #5343 — sister \`useFocusTrap\` extraction
- #5371 — 8 dialogs missing focus trap + escape; \`useFocusRestore\` is also needed there for full a11y kit
- #5060 — primitives umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)