### PR TITLE
i18n(analytics): propagate hardcodes keys to 10 non-English locales (#5004 partial)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -1843,6 +1843,25 @@
         "low": "Low Similarity"
       }
     },
+    "hardcodes": {
+      "title": "قيم مشفرة ثابتة",
+      "values": "قيم",
+      "totalValues": "إجمالي القيم",
+      "highLabel": "مرتفع",
+      "mediumLabel": "متوسط",
+      "lowLabel": "منخفض",
+      "uniqueTypes": "أنواع فريدة",
+      "variable": "متغير",
+      "value": "قيمة",
+      "suggestedEnvVar": "متغير البيئة المقترح",
+      "showingOf": "عرض {shown} من {total}",
+      "emptyMessage": "لم يتم اكتشاف قيم مشفرة ثابتة",
+      "severityGroups": {
+        "high": "خطورة عالية",
+        "medium": "خطورة متوسطة",
+        "low": "خطورة منخفضة"
+      }
+    },
     "problems": {
       "title": "Problems Report",
       "total": "Total",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -1843,6 +1843,25 @@
         "low": "Niedrige Ähnlichkeit"
       }
     },
+    "hardcodes": {
+      "title": "Hartcodierte Werte",
+      "values": "Werte",
+      "totalValues": "Werte insgesamt",
+      "highLabel": "Hoch",
+      "mediumLabel": "Mittel",
+      "lowLabel": "Niedrig",
+      "uniqueTypes": "Eindeutige Typen",
+      "variable": "Variable",
+      "value": "Wert",
+      "suggestedEnvVar": "Vorgeschlagene Umgebungsvariable",
+      "showingOf": "Zeige {shown} von {total}",
+      "emptyMessage": "Keine hartcodierten Werte gefunden",
+      "severityGroups": {
+        "high": "Hohe Priorität",
+        "medium": "Mittlere Priorität",
+        "low": "Niedrige Priorität"
+      }
+    },
     "problems": {
       "title": "Probleme",
       "total": "Gesamt",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -1843,6 +1843,25 @@
         "low": "Baja similitud"
       }
     },
+    "hardcodes": {
+      "title": "Valores codificados",
+      "values": "valores",
+      "totalValues": "Valores totales",
+      "highLabel": "Alto",
+      "mediumLabel": "Medio",
+      "lowLabel": "Bajo",
+      "uniqueTypes": "Tipos únicos",
+      "variable": "Variable",
+      "value": "Valor",
+      "suggestedEnvVar": "Variable de entorno sugerida",
+      "showingOf": "Mostrando {shown} de {total}",
+      "emptyMessage": "No se detectaron valores codificados",
+      "severityGroups": {
+        "high": "Severidad alta",
+        "medium": "Severidad media",
+        "low": "Severidad baja"
+      }
+    },
     "problems": {
       "title": "Problemas",
       "total": "Total",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -1382,6 +1382,25 @@
         "low": "Low Similarity"
       }
     },
+    "hardcodes": {
+      "title": "مقادیر کدنویسی‌شده",
+      "values": "مقدار",
+      "totalValues": "تعداد کل مقادیر",
+      "highLabel": "بالا",
+      "mediumLabel": "متوسط",
+      "lowLabel": "پایین",
+      "uniqueTypes": "انواع یکتا",
+      "variable": "متغیر",
+      "value": "مقدار",
+      "suggestedEnvVar": "متغیر محیطی پیشنهادی",
+      "showingOf": "نمایش {shown} از {total}",
+      "emptyMessage": "هیچ مقدار کدنویسی‌شده‌ای یافت نشد",
+      "severityGroups": {
+        "high": "شدت بالا",
+        "medium": "شدت متوسط",
+        "low": "شدت پایین"
+      }
+    },
     "problems": {
       "title": "Problems Report",
       "total": "Total",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -1843,6 +1843,25 @@
         "low": "Faible similarité"
       }
     },
+    "hardcodes": {
+      "title": "Valeurs codées en dur",
+      "values": "valeurs",
+      "totalValues": "Valeurs totales",
+      "highLabel": "Élevé",
+      "mediumLabel": "Moyen",
+      "lowLabel": "Faible",
+      "uniqueTypes": "Types uniques",
+      "variable": "Variable",
+      "value": "Valeur",
+      "suggestedEnvVar": "Variable d'environnement suggérée",
+      "showingOf": "Affichage de {shown} sur {total}",
+      "emptyMessage": "Aucune valeur codée en dur détectée",
+      "severityGroups": {
+        "high": "Gravité élevée",
+        "medium": "Gravité moyenne",
+        "low": "Gravité faible"
+      }
+    },
     "problems": {
       "title": "Problèmes",
       "total": "Total",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -1382,6 +1382,25 @@
         "low": "Low Similarity"
       }
     },
+    "hardcodes": {
+      "title": "ערכים קשיחים",
+      "values": "ערכים",
+      "totalValues": "סך הערכים",
+      "highLabel": "גבוה",
+      "mediumLabel": "בינוני",
+      "lowLabel": "נמוך",
+      "uniqueTypes": "סוגים ייחודיים",
+      "variable": "משתנה",
+      "value": "ערך",
+      "suggestedEnvVar": "משתנה סביבה מוצע",
+      "showingOf": "מציג {shown} מתוך {total}",
+      "emptyMessage": "לא זוהו ערכים קשיחים",
+      "severityGroups": {
+        "high": "חומרה גבוהה",
+        "medium": "חומרה בינונית",
+        "low": "חומרה נמוכה"
+      }
+    },
     "problems": {
       "title": "Problems Report",
       "total": "Total",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -1843,6 +1843,25 @@
         "low": "Low Similarity"
       }
     },
+    "hardcodes": {
+      "title": "Kodētas vērtības",
+      "values": "vērtības",
+      "totalValues": "Vērtības kopā",
+      "highLabel": "Augsts",
+      "mediumLabel": "Vidējs",
+      "lowLabel": "Zems",
+      "uniqueTypes": "Unikāli tipi",
+      "variable": "Mainīgais",
+      "value": "Vērtība",
+      "suggestedEnvVar": "Ieteiktais vides mainīgais",
+      "showingOf": "Rādīts {shown} no {total}",
+      "emptyMessage": "Kodētas vērtības nav atrastas",
+      "severityGroups": {
+        "high": "Augsta nopietnība",
+        "medium": "Vidēja nopietnība",
+        "low": "Zema nopietnība"
+      }
+    },
     "problems": {
       "title": "Problems Report",
       "total": "Total",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -1843,6 +1843,25 @@
         "low": "Low Similarity"
       }
     },
+    "hardcodes": {
+      "title": "Wartości zakodowane",
+      "values": "wartości",
+      "totalValues": "Wartości razem",
+      "highLabel": "Wysoki",
+      "mediumLabel": "Średni",
+      "lowLabel": "Niski",
+      "uniqueTypes": "Unikalne typy",
+      "variable": "Zmienna",
+      "value": "Wartość",
+      "suggestedEnvVar": "Sugerowana zmienna środowiskowa",
+      "showingOf": "Wyświetlanie {shown} z {total}",
+      "emptyMessage": "Nie wykryto zakodowanych wartości",
+      "severityGroups": {
+        "high": "Wysoka istotność",
+        "medium": "Średnia istotność",
+        "low": "Niska istotność"
+      }
+    },
     "problems": {
       "title": "Problems Report",
       "total": "Total",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -1843,6 +1843,25 @@
         "low": "Low Similarity"
       }
     },
+    "hardcodes": {
+      "title": "Valores codificados",
+      "values": "valores",
+      "totalValues": "Total de valores",
+      "highLabel": "Alto",
+      "mediumLabel": "Médio",
+      "lowLabel": "Baixo",
+      "uniqueTypes": "Tipos únicos",
+      "variable": "Variável",
+      "value": "Valor",
+      "suggestedEnvVar": "Variável de ambiente sugerida",
+      "showingOf": "Mostrando {shown} de {total}",
+      "emptyMessage": "Nenhum valor codificado detectado",
+      "severityGroups": {
+        "high": "Gravidade alta",
+        "medium": "Gravidade média",
+        "low": "Gravidade baixa"
+      }
+    },
     "problems": {
       "title": "Problems Report",
       "total": "Total",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -1382,6 +1382,25 @@
         "low": "Low Similarity"
       }
     },
+    "hardcodes": {
+      "title": "ہارڈ کوڈڈ ویلیوز",
+      "values": "ویلیوز",
+      "totalValues": "کل ویلیوز",
+      "highLabel": "زیادہ",
+      "mediumLabel": "درمیانہ",
+      "lowLabel": "کم",
+      "uniqueTypes": "منفرد اقسام",
+      "variable": "ویریبل",
+      "value": "ویلیو",
+      "suggestedEnvVar": "تجویز کردہ ماحولیاتی ویریبل",
+      "showingOf": "{shown} میں سے {total} دکھا رہا ہے",
+      "emptyMessage": "کوئی ہارڈ کوڈڈ ویلیوز نہیں ملیں",
+      "severityGroups": {
+        "high": "اعلیٰ شدت",
+        "medium": "درمیانی شدت",
+        "low": "کم شدت"
+      }
+    },
     "problems": {
       "title": "Problems Report",
       "total": "Total",


### PR DESCRIPTION
## Summary

#5277 added 12 \`analytics.hardcodes.*\` keys to \`en.json\` only. This PR propagates them to the 10 locales tracked by the #5004 umbrella: de, es, fr, pt, ar, fa, he, lv, pl, ur.

Per locale: \`title\`, \`values\`, \`totalValues\`, \`highLabel\`, \`mediumLabel\`, \`lowLabel\`, \`uniqueTypes\`, \`variable\`, \`value\`, \`suggestedEnvVar\`, \`showingOf\`, \`emptyMessage\`, \`severityGroups.{high,medium,low}\` = 13 strings each.

Closes the **hardcodes portion** of #5004. Other key groups tracked by #5004 (nav, marketplace, about, DataTable UI, etc.) remain open.

## Verification

- \`vue-tsc --noEmit -p tsconfig.app.json\` → 167 errors (unchanged baseline).
- Python validation: all 10 locales have \`analytics.hardcodes\` with 13 translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)