### PR TITLE
refactor(analytics): DRY sources endpoint + parseResponse hook + audit doc (#5276)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
@@ -178,6 +178,7 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
+import { useSourcesListEndpoint } from '@/composables/analytics/useSourcesListEndpoint'
 import { createLogger } from '@/utils/debugUtils'
 import AddSourceModal from '@/components/analytics/AddSourceModal.vue'
 
@@ -202,7 +203,14 @@ interface SourceSummary {
 
 // ---- State ----------------------------------------------------------------
 
-const sources = ref<CodeSource[]>([])
+// #5276: `sources` + `loadSources` delegated to the shared
+// `useSourcesListEndpoint` composable (was duplicated with
+// `useSourceRegistry.ts`).
+const {
+  sources,
+  loadSources: _loadSourcesEndpoint,
+  error: sourcesEndpointError,
+} = useSourcesListEndpoint()
 const summaries = ref<Record<string, SourceSummary>>({})
 const loading = ref(false)
 const showAddModal = ref(false)
@@ -216,18 +224,6 @@ const POLL_INTERVAL_MS = 4000
 const POLL_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
 // ---- Endpoint composables (#5153 B) --------------------------------------
-
-const sourcesEndpoint = useFetchEndpoint<
-  { sources?: CodeSource[] },
-  CodeSource[]
->({
-  path: '/api/analytics/codebase/sources',
-  label: 'Sources list',
-  pickData: (r) => r.sources ?? [],
-  onSuccess: (list) => {
-    sources.value = list
-  },
-})
 
 const summariesEndpoint = useFetchEndpoint<
   { summaries?: Record<string, SourceSummary> },
@@ -246,7 +242,7 @@ const summariesEndpoint = useFetchEndpoint<
 async function loadSources() {
   loading.value = true
   try {
-    await sourcesEndpoint.load()
+    await _loadSourcesEndpoint()
     await loadSummaries()
   } finally {
     loading.value = false
@@ -376,13 +372,14 @@ async function _pollTick(): Promise<void> {
     _stopPolling()
     return
   }
-  // #5153 B: reuses `sourcesEndpoint` so the poll shares the single fetch
-  // path and error handling. sources.value is updated via the endpoint's
-  // onSuccess hook; we only need to react to the syncing state afterwards.
-  // Errors are already logged inside the composable — no extra try/catch.
-  await sourcesEndpoint.load()
-  if (sourcesEndpoint.error.value) {
-    logger.warn('Poll request failed:', sourcesEndpoint.error.value)
+  // #5276: reuses the shared `useSourcesListEndpoint` loader so the
+  // poll shares one fetch path and error handling. sources.value is
+  // updated via the endpoint's onSuccess hook; we only react to the
+  // syncing state afterwards. Errors are already logged inside the
+  // composable — no extra try/catch.
+  await _loadSourcesEndpoint()
+  if (sourcesEndpointError.value) {
+    logger.warn('Poll request failed:', sourcesEndpointError.value)
     return
   }
   if (!_hasSyncingSource()) {

--- a/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
+++ b/autobot-frontend/src/composables/analytics/useSourceRegistry.ts
@@ -14,6 +14,7 @@
 import { ref, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
+import { useSourcesListEndpoint } from '@/composables/analytics/useSourcesListEndpoint'
 import { createLogger } from '@/utils/debugUtils'
 import type { ToastType } from '@/composables/useToast'
 
@@ -39,8 +40,10 @@ export function useSourceRegistry(deps: UseSourceRegistryDeps) {
   const savedPath = localStorage.getItem(STORAGE_KEY_PATH)
   const rootPath = ref(savedPath || '/opt/autobot')
 
-  // Issue #1133: Source registry state
-  const sources = ref<CodeSource[]>([])
+  // Issue #1133: Source registry state. #5276: `sources` + `loadSources`
+  // delegated to the shared `useSourcesListEndpoint` composable (was
+  // duplicated across this file and `CodebaseAnalyticsLanding.vue`).
+  const { sources, loadSources } = useSourcesListEndpoint()
   const selectedSource = ref<CodeSource | null>(null)
   const showSourceManager = ref(false)
   const showAddSourceModal = ref(false)
@@ -72,25 +75,6 @@ export function useSourceRegistry(deps: UseSourceRegistryDeps) {
       return sid ? { source_id: sid } : {}
     },
   )
-
-  // Issue #1133: Source registry functions (#5153 B: routed through useFetchEndpoint)
-  const sourcesEndpoint = useFetchEndpoint<
-    { sources?: CodeSource[] },
-    CodeSource[]
-  >({
-    path: '/api/analytics/codebase/sources',
-    label: 'Sources list',
-    pickData: (r) => r.sources ?? [],
-    onSuccess: (list) => {
-      sources.value = list
-    },
-    // Silent on failure: the composable's internal logger.error already
-    // logs, and the template has no error UI for this read.
-  })
-
-  async function loadSources() {
-    await sourcesEndpoint.load()
-  }
 
   function handleSelectSource(source: CodeSource) {
     selectedSource.value = source

--- a/autobot-frontend/src/composables/analytics/useSourcesListEndpoint.ts
+++ b/autobot-frontend/src/composables/analytics/useSourcesListEndpoint.ts
@@ -1,0 +1,55 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+
+/**
+ * Composable: useSourcesListEndpoint (#5276)
+ *
+ * Shared `GET /api/analytics/codebase/sources` fetcher. Extracted from
+ * the identical definitions in `CodebaseAnalyticsLanding.vue` and
+ * `useSourceRegistry.ts` — same endpoint, same response shape, same
+ * `onSuccess` handler.
+ *
+ * Returns the reactive `sources` ref + the `useFetchEndpoint` handle
+ * so each caller can own loading/error presentation (Landing shows a
+ * page-level spinner; useSourceRegistry is silent on failure).
+ */
+
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
+import type { CodeSource } from '@/types/analytics'
+
+export interface UseSourcesListEndpointReturn {
+  sources: Ref<CodeSource[]>
+  loadSources: () => Promise<void>
+  loading: Ref<boolean>
+  error: Ref<string | null>
+}
+
+export function useSourcesListEndpoint(): UseSourcesListEndpointReturn {
+  const sources = ref<CodeSource[]>([])
+
+  const endpoint = useFetchEndpoint<
+    { sources?: CodeSource[] },
+    CodeSource[]
+  >({
+    path: '/api/analytics/codebase/sources',
+    label: 'Sources list',
+    pickData: (r) => r.sources ?? [],
+    onSuccess: (list) => {
+      sources.value = list
+    },
+  })
+
+  async function loadSources() {
+    await endpoint.load()
+  }
+
+  return {
+    sources,
+    loadSources,
+    loading: endpoint.loading,
+    error: endpoint.error,
+  }
+}

--- a/autobot-frontend/src/composables/api/__tests__/useFetchEndpoint.test.ts
+++ b/autobot-frontend/src/composables/api/__tests__/useFetchEndpoint.test.ts
@@ -1,0 +1,103 @@
+// AutoBot - AI-Powered Automation Platform
+// Copyright (c) 2025 mrveiss
+// Author: mrveiss
+/**
+ * useFetchEndpoint tests (#5276)
+ *
+ * Focused on the new `parseResponse` hook — verifies non-JSON payloads
+ * (text/markdown) route through the same loading/error/assign pipeline
+ * as JSON fetchers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useFetchEndpoint } from '../useFetchEndpoint'
+
+vi.mock('@/utils/fetchWithAuth', () => ({
+  fetchWithAuth: vi.fn(),
+}))
+
+vi.mock('@/config/AppConfig.js', () => ({
+  default: {
+    getServiceUrl: vi.fn(async () => 'http://backend'),
+  },
+}))
+
+import { fetchWithAuth } from '@/utils/fetchWithAuth'
+const mockFetch = fetchWithAuth as unknown as ReturnType<typeof vi.fn>
+
+const mkResponse = (body: string, opts: { ok?: boolean; status?: number } = {}) => ({
+  ok: opts.ok ?? true,
+  status: opts.status ?? 200,
+  json: async () => JSON.parse(body),
+  text: async () => body,
+})
+
+describe('useFetchEndpoint parseResponse hook (#5276)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('defaults to JSON parsing when parseResponse is omitted', async () => {
+    mockFetch.mockResolvedValue(mkResponse('{"value": 42}'))
+    const ep = useFetchEndpoint<{ value: number }, number>({
+      path: '/api/x',
+      pickData: (r) => r.value,
+    })
+    await ep.load()
+    expect(ep.data.value).toBe(42)
+    expect(ep.error.value).toBe('')
+  })
+
+  it('uses parseResponse when provided — text/markdown case', async () => {
+    const markdownBody = '# Header\n\nSome **markdown** content'
+    mockFetch.mockResolvedValue(mkResponse(markdownBody))
+    const ep = useFetchEndpoint<string, string>({
+      path: '/api/report',
+      parseResponse: async (r) => await r.text(),
+      pickData: (raw) => raw,
+    })
+    await ep.load()
+    expect(ep.data.value).toBe(markdownBody)
+    expect(ep.error.value).toBe('')
+  })
+
+  it('parseResponse result is passed to pickData', async () => {
+    mockFetch.mockResolvedValue(mkResponse('raw text'))
+    const pickData = vi.fn((raw: string) => raw.toUpperCase())
+    const ep = useFetchEndpoint<string, string>({
+      path: '/api/x',
+      parseResponse: async (r) => await r.text(),
+      pickData,
+    })
+    await ep.load()
+    expect(pickData).toHaveBeenCalledWith('raw text')
+    expect(ep.data.value).toBe('RAW TEXT')
+  })
+
+  it('parseResponse throw propagates through the normal error path', async () => {
+    mockFetch.mockResolvedValue(mkResponse('ok'))
+    const ep = useFetchEndpoint<string, string>({
+      path: '/api/x',
+      parseResponse: async () => {
+        throw new Error('parse kaboom')
+      },
+      pickData: (raw) => raw,
+    })
+    await ep.load()
+    expect(ep.error.value).toBe('parse kaboom')
+    expect(ep.data.value).toBe(null)
+  })
+
+  it('parseResponse is not invoked when response is not ok', async () => {
+    mockFetch.mockResolvedValue(mkResponse('err', { ok: false, status: 500 }))
+    const parser = vi.fn()
+    const ep = useFetchEndpoint<string, string>({
+      path: '/api/x',
+      parseResponse: parser,
+      pickData: (raw) => raw,
+    })
+    await ep.load()
+    expect(parser).not.toHaveBeenCalled()
+    expect(ep.error.value).toContain('500')
+  })
+})

--- a/autobot-frontend/src/composables/api/useFetchEndpoint.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.ts
@@ -85,6 +85,19 @@ export interface UseFetchEndpointOptions<TRaw, TOut> {
   onResponse?: (
     response: Response,
   ) => string | undefined | Promise<string | undefined>
+  /**
+   * Custom response parser. Defaults to `(r) => r.json()`. Override to
+   * handle non-JSON responses — e.g. `text/markdown` exports (see
+   * `useCodebaseExport.exportReport`), CSV exports, blobs, etc.
+   *
+   * The returned value is passed verbatim to `pickData(raw)`, so the
+   * `TRaw` type parameter should reflect whatever shape the custom
+   * parser yields.
+   *
+   * Introduced in #5276 so fetchers returning non-JSON can route
+   * through the same loading/error/assign plumbing as JSON fetchers.
+   */
+  parseResponse?: (response: Response) => Promise<TRaw>
   /** Human-readable label used only for log messages. */
   label?: string
 }
@@ -181,7 +194,9 @@ export function useFetchEndpoint<TRaw, TOut>(
           overrideMsg ?? `${label} returned ${response.status}`,
         )
       }
-      const raw = (await response.json()) as TRaw
+      const raw = opts.parseResponse
+        ? await opts.parseResponse(response)
+        : ((await response.json()) as TRaw)
       const picked = opts.pickData(raw)
       if (picked === null) {
         data.value = null

--- a/docs/developer/audits/composable-fetcher-boilerplate.md
+++ b/docs/developer/audits/composable-fetcher-boilerplate.md
@@ -1,5 +1,15 @@
 # Composable Fetcher Boilerplate Audit (Issue #5154)
 
+> **Final-state update (#5276, Apr 2026):** the analytics-namespace
+> migration is **complete**. See the "Final state of analytics namespace"
+> section at the bottom for the per-file outcome (migrated vs. SKIP, with
+> documented verdicts for each remaining hand-rolled fetcher).
+>
+> **New composable surface (#5276):** `useFetchEndpoint` gained an
+> optional `parseResponse` hook so non-JSON fetchers (e.g. `text/markdown`
+> exports) can route through the same loading/error/assign pipeline.
+> `exportReport` in `useCodebaseExport` is the first intended caller.
+
 > **Rehome update (#5168, #5174, Apr 2026):** the composable is now at
 > [`autobot-frontend/src/composables/api/useFetchEndpoint.ts`](../../../autobot-frontend/src/composables/api/useFetchEndpoint.ts)
 > with `deps` optional and `scopeToSource` defaulting to **false**.
@@ -416,3 +426,97 @@ All exported function names, signatures, and return types are unchanged. Verifie
 **LOC delta (`wc -l`):** 251 LOC -> 337 LOC = +86. The migration grew the file because the per-endpoint configuration ceremony for `useAnalyticsEndpoint` (12 lines x N endpoints + bridge `watch()` + path-parameterised factories + `noScope` shim) outweighed the per-fetcher boilerplate savings for a 6-fetcher file. See "POC migration measurement" above for the critical-mass analysis.
 
 **Why ship the POC anyway:** it answers the design questions in #5154 with empirical data. Specifically: (a) it proves the composable WORKS outside analytics, (b) it surfaces the two ergonomic gaps (`scopeToSource` default, `deps` mandatory) that must be fixed when rehoming, (c) it sets a critical-mass expectation for follow-up migrations. Reverting the POC would leave the design questions unanswered and the architectural team would re-derive these findings from first principles next time.
+
+---
+
+## Final state of analytics namespace (#5276, Apr 2026)
+
+Snapshot after the full migration wave (#5137 \u2192 #5168 \u2192 #5174 \u2192 #5187
+\u2192 #5206 \u2192 #5208 \u2192 #5232 \u2192 #5234 \u2192 #5235 \u2192 #5251 \u2192 #5253 \u2192 #5257
+\u2192 #5265 \u2192 #5266 \u2192 #5271). Records the per-file verdict so future
+readers don't have to re-derive why certain hand-rolled fetchers stayed.
+
+### Migrated to `useFetchEndpoint` (GET + POST + DELETE)
+
+| File | Fetchers | Migration PR |
+|---|---|---|
+| `composables/analytics/useAnalyticsDataFetchers.ts` | 14 GETs | #5137 (seed), #5187 (rehome-followup), #5208 |
+| `composables/analytics/useSourceRegistry.ts` | 2 (GET sources list, POST index) | #5251, #5276 (DRY `sources` via `useSourcesListEndpoint`) |
+| `composables/analytics/useCodeSmellAnalysis.ts` | 3 POSTs | #5157, #5187 |
+| `composables/analytics/useCodeIntelScores.ts` | 4 (GET + 3 POST analyze) | #5187, #5232, #5235 |
+| `composables/analytics/useCrossLanguageAnalysis.ts` | 2 GETs | #5253 \u2192 PR #5256 |
+| `composables/analytics/useApiEndpointAnalysis.ts` | 1 GET | #5208 |
+| `composables/analytics/useConfigDuplicates.ts` | 1 GET | #5208 |
+| `composables/analytics/useIndexingJob.ts` | 2 (GET status, DELETE cache) | #5257 \u2192 PR #5265 |
+| `composables/analytics/useDashboardLoaders.ts` | 1 GET | #5257 \u2192 PR #5265 |
+| `composables/analytics/useOwnershipAnalysis.ts` | 1 GET | #5232 |
+| `components/analytics/CodebaseAnalyticsLanding.vue` | 3 (GET sources, GET summaries, per-source sync POST) | #5251, #5276 (DRY `sources`) |
+
+### SKIP (hand-rolled, with recorded verdicts)
+
+| File | Fetcher(s) | Reason for SKIP |
+|---|---|---|
+| `composables/analytics/useEnvironmentAnalysis.ts` | 2 POSTs + 1 GET | Below critical mass + one endpoint uses `SSE` streaming that doesn't fit the `useFetchEndpoint` single-response shape. Migration would be LOC-negative. |
+| `composables/analytics/useBugPrediction.ts` | Composable facade built on `useCodeIntelligence`'s `ApiClient` wrapper | Already routed through a higher-level client; no direct `fetchWithAuth` calls. Out-of-scope for this audit. |
+| `composables/analytics/useAnalyticsDebug.ts` | Debug-only, single endpoint | Tool-only, not user-facing; migration would only add ceremony. |
+| `composables/analytics/useCodebaseExport.ts::exportReport` | GET that returns `text/markdown` | Required the `parseResponse` hook (#5276) before routing through `useFetchEndpoint`. **Now migratable \u2014 future cleanup.** |
+| `composables/analytics/useCodebaseExport.ts::_fetchEnvironmentExportData` | GET that returns JSON but passes through a try/catch fallback to `cachedData` if the network call fails | The fallback semantics don't map cleanly onto `useFetchEndpoint`'s error model (throws into `error.value`, doesn't return a default). Keep hand-rolled until a `fallbackData` option is added. |
+
+### Composable surface summary
+
+Post-migration, the analytics namespace exercises every major `useFetchEndpoint` capability:
+
+- `scopeToSource: true` + `withSourceId` wrap (the #5111 bug-prevention axis)
+- `method: 'POST'` + `body` factory (code-smells analyze, security/performance/redis analyze)
+- `method: 'DELETE'` + optional body (cache clear in `useIndexingJob`)
+- `onResponse` hook (#5235) for status-specific error copy (504 timeout, `{ detail }` body parsing)
+- `reset()` (#5235) for cache clearing
+- `parseResponse` hook (#5276) for non-JSON responses \u2014 pending migration of `exportReport`
+- `onSuccess` / `onNoData` / `onError` lifecycle hooks across all migrated fetchers
+
+---
+
+## Final state of analytics namespace (#5276, Apr 2026)
+
+Snapshot after the full migration wave (#5137 → #5168 → #5174 → #5187
+→ #5206 → #5208 → #5232 → #5234 → #5235 → #5251 → #5253 → #5257
+→ #5265 → #5266 → #5271). Records the per-file verdict so future
+readers don't have to re-derive why certain hand-rolled fetchers stayed.
+
+### Migrated to `useFetchEndpoint` (GET + POST + DELETE)
+
+| File | Fetchers | Migration PR |
+|---|---|---|
+| `composables/analytics/useAnalyticsDataFetchers.ts` | 14 GETs | #5137 (seed), #5187 (rehome-followup), #5208 |
+| `composables/analytics/useSourceRegistry.ts` | 2 (GET sources list, POST index) | #5251, #5276 (DRY `sources` via `useSourcesListEndpoint`) |
+| `composables/analytics/useCodeSmellAnalysis.ts` | 3 POSTs | #5157, #5187 |
+| `composables/analytics/useCodeIntelScores.ts` | 4 (GET + 3 POST analyze) | #5187, #5232, #5235 |
+| `composables/analytics/useCrossLanguageAnalysis.ts` | 2 GETs | #5253 → PR #5256 |
+| `composables/analytics/useApiEndpointAnalysis.ts` | 1 GET | #5208 |
+| `composables/analytics/useConfigDuplicates.ts` | 1 GET | #5208 |
+| `composables/analytics/useIndexingJob.ts` | 2 (GET status, DELETE cache) | #5257 → PR #5265 |
+| `composables/analytics/useDashboardLoaders.ts` | 1 GET | #5257 → PR #5265 |
+| `composables/analytics/useOwnershipAnalysis.ts` | 1 GET | #5232 |
+| `components/analytics/CodebaseAnalyticsLanding.vue` | 3 (GET sources, GET summaries, per-source sync POST) | #5251, #5276 (DRY `sources`) |
+
+### SKIP (hand-rolled, with recorded verdicts)
+
+| File | Fetcher(s) | Reason for SKIP |
+|---|---|---|
+| `composables/analytics/useEnvironmentAnalysis.ts` | 2 POSTs + 1 GET | Below critical mass + one endpoint uses SSE streaming that doesn't fit the `useFetchEndpoint` single-response shape. Migration would be LOC-negative. |
+| `composables/analytics/useBugPrediction.ts` | Facade built on `useCodeIntelligence`'s `ApiClient` wrapper | Already routed through a higher-level client; no direct `fetchWithAuth` calls. Out-of-scope for this audit. |
+| `composables/analytics/useAnalyticsDebug.ts` | Debug-only, single endpoint | Tool-only, not user-facing; migration would only add ceremony. |
+| `composables/analytics/useCodebaseExport.ts::exportReport` | GET that returns `text/markdown` | Required the `parseResponse` hook (#5276) before routing through `useFetchEndpoint`. **Now migratable — future cleanup.** |
+| `composables/analytics/useCodebaseExport.ts::_fetchEnvironmentExportData` | GET returning JSON with a try/catch fallback to `cachedData` | Fallback semantics don't map cleanly onto `useFetchEndpoint`'s error model (throws into `error.value`, doesn't return a default). Keep hand-rolled until a `fallbackData` option is added. |
+
+### Composable surface summary
+
+Post-migration, the analytics namespace exercises every major `useFetchEndpoint` capability:
+
+- `scopeToSource: true` + `withSourceId` wrap (the #5111 bug-prevention axis).
+- `method: 'POST'` + `body` factory (code-smells analyze, security/performance/redis analyze).
+- `method: 'DELETE'` + optional body (cache clear in `useIndexingJob`).
+- `onResponse` hook (#5235) for status-specific error copy (504 timeout, `{ detail }` body parsing).
+- `reset()` (#5235) for cache clearing.
+- `parseResponse` hook (#5276) for non-JSON responses — pending migration of `exportReport`.
+- `onSuccess` / `onNoData` / `onError` lifecycle hooks across all migrated fetchers.


### PR DESCRIPTION
## Summary

Three small cleanups that surfaced during the #5153 wave-2 migration, bundled per the #5276 plan.

### 1. loadSources duplication (DRY)

- New \`useSourcesListEndpoint\` composable owns the \`GET /api/analytics/codebase/sources\` endpoint + \`sources\` ref.
- \`useSourceRegistry\` delegates \`sources\` / \`loadSources\` to it (was: duplicated inline).
- \`CodebaseAnalyticsLanding.vue\` consumes it in place of its own inline duplicate. Polling keeps its local \`loading\` state; the shared composable owns the fetch.

### 2. \`parseResponse\` hook on \`useFetchEndpoint\`

- Optional \`parseResponse: (response) => Promise<TRaw>\` — defaults to \`r.json()\` (preserves every existing caller).
- Unblocks \`useCodebaseExport.exportReport\` migration (was hand-rolled because the endpoint returns \`text/markdown\`).
- **5 contract tests** in \`__tests__/useFetchEndpoint.test.ts\` covering JSON default, text/markdown override, pickData piping, parser-throw error path, and \`!ok\` short-circuit.

### 3. Audit doc final-state

- \`docs/developer/audits/composable-fetcher-boilerplate.md\` gained a \"Final state of analytics namespace\" section.
- Lists all 11 migrated files with PR lineage.
- Lists 5 remaining hand-rolled fetchers with documented SKIP verdicts.

Closes #5276.

## Verification

- \`vue-tsc --noEmit -p tsconfig.app.json\` → 167 errors (unchanged baseline; 0 new).
- All 5 \`useFetchEndpoint\` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)