### PR TITLE
a11y(dialogs): add focus trap + escape + restore to 8 modal dialogs (#5371)

### DIFF
--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -3,10 +3,14 @@
     <Transition name="modal-fade">
       <div v-if="visible" class="modal-overlay" @click.self="handleClose">
         <div
+          ref="dialogRef"
           class="modal-dialog"
           role="dialog"
           aria-modal="true"
           :aria-label="isEditMode ? $t('analytics.sources.editSource') : $t('analytics.sources.addCodeSource')"
+          tabindex="-1"
+          @keydown="onFocusTrapKeydown"
+          @keydown.escape="handleClose"
         >
           <!-- Header -->
           <div class="modal-header">
@@ -202,8 +206,10 @@
  * Issue #1133: Code Source Registry for codebase analytics.
  */
 
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -243,6 +249,10 @@ const emit = defineEmits<{
   (e: 'saved', source: CodeSource): void
   (e: 'close'): void
 }>()
+
+const dialogRef = ref<HTMLElement | null>(null)
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
+useFocusRestore(toRef(props, 'visible'))
 
 // ---- Constants ------------------------------------------------------------
 

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -3,10 +3,14 @@
     <Transition name="modal-fade">
       <div v-if="visible" class="modal-overlay" @click.self="$emit('close')">
         <div
+          ref="dialogRef"
           class="modal-dialog"
           role="dialog"
           aria-modal="true"
           :aria-label="$t('analytics.sources.shareSource')"
+          tabindex="-1"
+          @keydown="onFocusTrapKeydown"
+          @keydown.escape="$emit('close')"
         >
           <!-- Header -->
           <div class="modal-header">
@@ -121,8 +125,10 @@
  * Issue #1133: Code Source Registry for codebase analytics.
  */
 
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -147,6 +153,10 @@ const emit = defineEmits<{
   (e: 'saved', source: CodeSource): void
   (e: 'close'): void
 }>()
+
+const dialogRef = ref<HTMLElement | null>(null)
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
+useFocusRestore(toRef(props, 'visible'))
 
 // ---- Constants ------------------------------------------------------------
 

--- a/autobot-frontend/src/components/analytics/SourceManager.vue
+++ b/autobot-frontend/src/components/analytics/SourceManager.vue
@@ -1,7 +1,16 @@
 <template>
   <Teleport to="body">
     <div v-if="visible" class="source-manager-overlay" @click.self="$emit('close')">
-      <div class="source-manager-panel" role="dialog" aria-modal="true" :aria-label="$t('analytics.sources.registry')">
+      <div
+        ref="dialogRef"
+        class="source-manager-panel"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="$t('analytics.sources.registry')"
+        tabindex="-1"
+        @keydown="onFocusTrapKeydown"
+        @keydown.escape="$emit('close')"
+      >
         <!-- Panel Header -->
         <div class="panel-header">
           <div class="panel-title">
@@ -170,8 +179,10 @@
  * Issue #1133: Code Source Registry for codebase analytics.
  */
 
-import { ref, watch, onUnmounted } from 'vue'
+import { ref, watch, onUnmounted, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -205,6 +216,10 @@ const emit = defineEmits<{
   (e: 'share-source', source: CodeSource): void
   (e: 'close'): void
 }>()
+
+const dialogRef = ref<HTMLElement | null>(null)
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
+useFocusRestore(toRef(props, 'visible'))
 
 // ---- State ----------------------------------------------------------------
 

--- a/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
+++ b/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
@@ -11,8 +11,10 @@
  * Fetches real users from the /user-management/users API endpoint.
  */
 
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useSessionCollaboration } from '@/composables/useSessionCollaboration'
 import { useChatStore } from '@/stores/useChatStore'
 import { useDebounce } from '@/composables/useDebounce'
@@ -36,6 +38,10 @@ const emit = defineEmits<{
   'update:modelValue': [value: boolean]
   invited: [userId: string, username: string, role: string]
 }>()
+
+const dialogRef = ref<HTMLElement | null>(null)
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
+useFocusRestore(toRef(props, 'modelValue'))
 
 // Types
 interface User {
@@ -228,10 +234,14 @@ const roleOptions = computed(() => [
       <Transition name="modal-content">
         <div
           v-if="props.modelValue"
+          ref="dialogRef"
           class="bg-autobot-bg-secondary rounded-lg shadow-2xl w-full max-w-md border border-autobot-border"
           role="dialog"
           aria-labelledby="invite-dialog-title"
           aria-modal="true"
+          tabindex="-1"
+          @keydown="onFocusTrapKeydown"
+          @keydown.escape="closeDialog"
         >
           <!-- Header -->
           <div class="flex items-center justify-between px-6 py-4 border-b border-autobot-border">

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -4,7 +4,17 @@
 <!-- Author: mrveiss -->
 <template>
   <div v-if="isOpen" class="modal-overlay" @click="handleClose">
-    <div class="modal-content" @click.stop role="dialog" aria-modal="true" aria-labelledby="profile-title">
+    <div
+      ref="dialogRef"
+      class="modal-content"
+      @click.stop
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="profile-title"
+      tabindex="-1"
+      @keydown="onFocusTrapKeydown"
+      @keydown.escape="handleClose"
+    >
       <div class="modal-header">
         <h2 id="profile-title">{{ $t('profile.title') }}</h2>
         <button @click="handleClose" class="close-button" :aria-label="$t('profile.closeAria')">&times;</button>
@@ -209,17 +219,23 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/useUserStore'
 import PreferencesPanel from '@/components/ui/PreferencesPanel.vue'
 import VoiceSettingsPanel from '@/components/settings/VoiceSettingsPanel.vue'
 import LanguageSettingsPanel from '@/components/settings/LanguageSettingsPanel.vue'
 import { usePreferences } from '@/composables/usePreferences'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
 
-defineProps<{
+const props = defineProps<{
   isOpen: boolean
 }>()
+
+const dialogRef = ref<HTMLElement | null>(null)
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
+useFocusRestore(toRef(props, 'isOpen'))
 
 const emit = defineEmits<{
   close: []

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
@@ -1,7 +1,16 @@
 <template>
   <teleport to="body">
     <div v-if="visible" class="notif-overlay" @click.self="$emit('close')">
-      <div class="notif-modal" role="dialog" aria-modal="true" :aria-label="$t('workflow.notifications.title')">
+      <div
+        ref="dialogRef"
+        class="notif-modal"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="$t('workflow.notifications.title')"
+        tabindex="-1"
+        @keydown="onFocusTrapKeydown"
+        @keydown.escape="$emit('close')"
+      >
         <!-- Header -->
         <div class="notif-header">
           <h3><i class="fas fa-bell"></i> {{ $t('workflow.notifications.title') }}</h3>
@@ -116,7 +125,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, toRef } from 'vue';
 import {
   useNotificationConfig,
   NOTIFICATION_EVENTS,
@@ -124,6 +133,8 @@ import {
   type NotificationEvent,
   type NotificationChannel,
 } from '@/composables/useNotificationConfig';
+import { useFocusTrap } from '@/composables/useFocusTrap';
+import { useFocusRestore } from '@/composables/useFocusRestore';
 
 const props = defineProps<{
   visible: boolean;
@@ -134,6 +145,10 @@ const emit = defineEmits<{
   (e: 'close'): void;
   (e: 'saved'): void;
 }>();
+
+const dialogRef = ref<HTMLElement | null>(null);
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef);
+useFocusRestore(toRef(props, 'visible'));
 
 const { config, loading, saving, error, fetchConfig, saveConfig } = useNotificationConfig();
 

--- a/autobot-frontend/src/views/DocumentsView.vue
+++ b/autobot-frontend/src/views/DocumentsView.vue
@@ -102,10 +102,14 @@
     <!-- Delete confirmation dialog -->
     <div
       v-if="deleteTarget"
+      ref="deleteDialogRef"
       class="modal-overlay"
       role="dialog"
       aria-modal="true"
       :aria-label="`Confirm deletion of ${deleteTarget.title}`"
+      tabindex="-1"
+      @keydown="onDeleteDialogKeydown"
+      @keydown.escape="deleteTarget = null"
     >
       <div class="modal-card">
         <h3 class="modal-title">Delete document?</h3>
@@ -136,12 +140,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import BaseButton from '@/components/base/BaseButton.vue'
 import AIDocumentEditor from '@/components/documents/AIDocumentEditor.vue'
 import { useAIDocument, type AIDocument } from '@/composables/useAIDocument'
 import { createLogger } from '@/utils/debugUtils'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
 
 const logger = createLogger('DocumentsView')
 
@@ -151,6 +157,11 @@ const composable = useAIDocument()
 const selectedDocId = ref<string | null>(null)
 const currentOffset = ref(0)
 const deleteTarget = ref<{ id: string; title: string } | null>(null)
+
+const deleteDialogRef = ref<HTMLElement | null>(null)
+const isDeleteDialogOpen = computed(() => deleteTarget.value !== null)
+const { onKeydown: onDeleteDialogKeydown } = useFocusTrap(deleteDialogRef)
+useFocusRestore(isDeleteDialogOpen)
 const errorMessage = ref<string | null>(null)
 
 // ---------------------------------------------------------------------------

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -272,7 +272,16 @@
 
     <!-- Plugin Detail Modal -->
     <div v-if="selectedPlugin" class="modal-overlay" @click.self="closeDetail">
-      <div class="modal-panel" role="dialog" aria-modal="true" :aria-label="$t('views.plugins.pluginDetails')">
+      <div
+        ref="detailDialogRef"
+        class="modal-panel"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="$t('views.plugins.pluginDetails')"
+        tabindex="-1"
+        @keydown="onDetailKeydown"
+        @keydown.escape="closeDetail"
+      >
         <div class="modal-header">
           <h2 class="modal-title">{{ selectedPlugin.display_name }}</h2>
           <button class="modal-close" @click="closeDetail" :aria-label="$t('views.plugins.close')">
@@ -348,6 +357,8 @@
 // Issue #1359: i18n string extraction
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
 import { usePlugins, type PluginInfo, type PluginManifest } from '@/composables/usePlugins'
 
 const { t } = useI18n()
@@ -373,6 +384,11 @@ const actionLoading = ref<Record<string, boolean>>({})
 
 // Modal state
 const selectedPlugin = ref<PluginInfo | null>(null)
+
+const detailDialogRef = ref<HTMLElement | null>(null)
+const isDetailOpen = computed(() => selectedPlugin.value !== null)
+const { onKeydown: onDetailKeydown } = useFocusTrap(detailDialogRef)
+useFocusRestore(isDetailOpen)
 const pluginConfig = ref<Record<string, unknown> | null>(null)
 const configLoading = ref(false)
 const editingConfig = ref(false)


### PR DESCRIPTION
## Summary

Closes #5371.

Eight components declared themselves as modal dialogs (\`role=\"dialog\"\` + \`aria-modal=\"true\"\` + aria-label) but had **no focus trap and no Escape-to-close handler** — keyboard users could Tab right out of "modal" dialogs to the page beneath. WCAG 2.1.2 violation.

Each dialog now wires the full a11y kit (~6 lines per file):
- \`dialogRef\` + \`tabindex=\"-1\"\` on the dialog root
- \`useFocusTrap(dialogRef)\` → \`@keydown=\"onFocusTrapKeydown\"\` (Tab/Shift+Tab wrap)
- \`useFocusRestore(triggerRef)\` → save activeElement on open, restore on close
- \`@keydown.escape=\"<close-handler>\"\` → Escape dismisses

### Migrated dialogs

| File | Trigger source | Close handler |
|---|---|---|
| [\`views/DocumentsView.vue\`](autobot-frontend/src/views/DocumentsView.vue) | \`computed(() => deleteTarget !== null)\` | \`deleteTarget = null\` |
| [\`views/PluginsView.vue\`](autobot-frontend/src/views/PluginsView.vue) | \`computed(() => selectedPlugin !== null)\` | \`closeDetail\` |
| [\`collaboration/InviteUserDialog.vue\`](autobot-frontend/src/components/collaboration/InviteUserDialog.vue) | \`toRef(props, 'modelValue')\` | \`closeDialog\` |
| [\`profile/ProfileModal.vue\`](autobot-frontend/src/components/profile/ProfileModal.vue) | \`toRef(props, 'isOpen')\` | \`handleClose\` |
| [\`workflow/NotificationConfigModal.vue\`](autobot-frontend/src/components/workflow/NotificationConfigModal.vue) | \`toRef(props, 'visible')\` | \`$emit('close')\` |
| [\`analytics/AddSourceModal.vue\`](autobot-frontend/src/components/analytics/AddSourceModal.vue) | \`toRef(props, 'visible')\` | \`handleClose\` |
| [\`analytics/ShareSourceModal.vue\`](autobot-frontend/src/components/analytics/ShareSourceModal.vue) | \`toRef(props, 'visible')\` | \`$emit('close')\` |
| [\`analytics/SourceManager.vue\`](autobot-frontend/src/components/analytics/SourceManager.vue) | \`toRef(props, 'visible')\` | \`$emit('close')\` |

All 8 use trigger-based \`useFocusRestore\` since the components stay mounted and their dialog content is gated by \`v-if\`. Two views (DocumentsView, PluginsView) compute the trigger from a non-boolean state (\`!== null\`) since their dialog visibility is derived from a selected-item ref.

## Behavioral grep audit

Before:
\`\`\`bash
$ grep -lE 'role="dialog"' autobot-frontend/src --include="*.vue" -r | \\
    xargs grep -L 'useFocusTrap'
# 8 hits — DocumentsView, PluginsView, InviteUserDialog, ProfileModal,
# NotificationConfigModal, AddSourceModal, ShareSourceModal, SourceManager
\`\`\`

After:
\`\`\`bash
$ <same grep>
# 0 hits in the migrated files
\`\`\`

## Verification

- \`npx vue-tsc --noEmit -p tsconfig.app.json\` → 0 new type errors in changed files.
- \`npx vitest run useFocusTrap.test.ts useFocusRestore.test.ts BaseModal.test.ts HostSelectionDialog.test.ts\` → **30/30 pass** (composables + sister-dialog component tests unchanged).
- Per-file grep for \`useFocusTrap\` / \`useFocusRestore\` / \`keydown.escape\` → all 8 files have all 3.
- Diff: +115 / -12 (mostly composable wiring + dialog-root attribute additions).

## Dependency

This PR is **based on \`issue-5356\` (PR #5382)** because it consumes the \`useFocusRestore\` composable that PR introduces. Will rebase onto \`Dev_new_gui\` after #5382 merges. Once both are in, this becomes a clean diff against \`Dev_new_gui\`.

## Test plan

For each of the 8 dialogs: open it, focus an element on the page first, then:
- [ ] Tab through all controls — confirm wrap at end
- [ ] Shift+Tab at first control — confirm wrap to last
- [ ] Press Escape — confirm dialog closes
- [ ] After close — confirm focus returns to the element that opened the dialog

## Out of scope

\`useFocusTrap\` itself has a narrower correctness edge case (no aria-hidden / inert / visibility filter on \`FOCUSABLE_SELECTOR\`). Tracked separately as #5373. The 8 dialogs migrated here don't bite that edge case (their internals don't nest aria-hidden interactive subtrees), but it's a future improvement.

## Related

- #5130 / PR #5343 — \`useFocusTrap\` extraction (merged)
- #5356 / PR #5382 — \`useFocusRestore\` extraction (this PR depends on it)
- #5373 — \`useFocusTrap\` aria-hidden / inert / visibility filter enhancement
- #5060 — primitives umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)