### PR TITLE
fix(analytics): Promise.allSettled in runCodeIntelligenceAnalysis (#5387)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useCodeIntelAnalysis.ts
+++ b/autobot-frontend/src/composables/analytics/useCodeIntelAnalysis.ts
@@ -138,9 +138,19 @@ export function useCodeIntelAnalysis(
     try {
       // #5365: fire the analyze endpoints so securityFindings,
       // performanceFindings, and redisOptimizations (scores sub-composable)
-      // are populated. The adapter computeds below re-expose them under
+      // are populated. The adapter computeds above re-expose them under
       // the legacy `codeIntel*Findings` names for the panel.
-      await Promise.all([
+      //
+      // #5387: use `Promise.allSettled` so one failing endpoint doesn't
+      // discard the other 4 successful results. `fetched` flags + toast
+      // reflect per-endpoint outcome (all-success / partial / all-fail).
+      const [
+        ,
+        ,
+        securityResult,
+        performanceResult,
+        redisResult,
+      ] = await Promise.allSettled([
         codeIntelAnalyzeCode({ code: rootPath.value }),
         codeIntelGetSuggestions(rootPath.value),
         scores.loadSecurityFindings(),
@@ -148,22 +158,43 @@ export function useCodeIntelAnalysis(
         scores.loadRedisOptimizations(),
       ])
       codeIntelFindingsFetched.value = {
-        security: true,
-        performance: true,
-        redis: true,
+        security: securityResult.status === 'fulfilled',
+        performance: performanceResult.status === 'fulfilled',
+        redis: redisResult.status === 'fulfilled',
       }
-      notify(
-        t('analytics.codebase.notify.codeIntelComplete', {
-          count: codeIntelTotalFindings.value,
-        }),
-        'success',
-      )
-    } catch (e) {
-      logger.error('Code Intelligence analysis failed:', e)
-      notify(
-        t('analytics.codebase.notify.codeIntelFailed'),
-        'error',
-      )
+      const findingFailures = [
+        securityResult,
+        performanceResult,
+        redisResult,
+      ].filter((r) => r.status === 'rejected')
+      if (findingFailures.length === 0) {
+        notify(
+          t('analytics.codebase.notify.codeIntelComplete', {
+            count: codeIntelTotalFindings.value,
+          }),
+          'success',
+        )
+      } else if (findingFailures.length < 3) {
+        // Partial success: surface a warning so the user knows which
+        // tabs have data. Successful arrays still render via the
+        // computed adapters (codeIntel*Findings above).
+        logger.warn(
+          'Code Intelligence analysis: partial failure',
+          findingFailures.map((r) => (r as PromiseRejectedResult).reason),
+        )
+        notify(
+          t('analytics.codebase.notify.codeIntelPartial', {
+            count: codeIntelTotalFindings.value,
+          }),
+          'warning',
+        )
+      } else {
+        logger.error(
+          'Code Intelligence analysis failed:',
+          findingFailures.map((r) => (r as PromiseRejectedResult).reason),
+        )
+        notify(t('analytics.codebase.notify.codeIntelFailed'), 'error')
+      }
     } finally {
       codeIntelFindingsLoading.value = false
     }

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -1085,6 +1085,7 @@
       },
       "notify": {
         "codeIntelComplete": "Code Intelligence analysis complete: {count} suggestions",
+        "codeIntelPartial": "Code Intelligence analysis partially complete: {count} suggestions (some scans failed — check console)",
         "codeIntelFailed": "Code Intelligence analysis failed",
         "fileScanComplete": "File scan complete: {count} result(s)",
         "fileScanNoIssues": "No issues found in file scan",


### PR DESCRIPTION
## Summary

#5365 introduced \`Promise.all\` across 5 parallel code-intel endpoints. When any endpoint rejected (e.g. Redis down), the catch fired and the 4 successful results were effectively discarded — \`fetched\` stayed false, success toast never fired, error toast reported total failure.

**Fix:** \`Promise.allSettled\` + per-endpoint outcome tracking:

- \`codeIntelFindingsFetched\` reflects per-endpoint status.
- Three outcome branches:
  - All 3 findings OK → success toast (existing).
  - 1–2 failed → warning toast (new \`codeIntelPartial\` i18n key).
  - All 3 failed → error toast (existing).
- Failures logged to console with reasons.

Closes #5387.

## Verification

- \`vue-tsc --noEmit -p tsconfig.app.json\` → 167 errors (unchanged baseline; 0 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)