### PR TITLE
fix(composables): guard onUnmounted with onScopeDispose in useThumbnailWorker + useTimeout (#5347)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useThumbnailWorker.spec.ts
+++ b/autobot-frontend/src/composables/__tests__/useThumbnailWorker.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { effectScope } from 'vue'
 import { useThumbnailWorker } from '../useThumbnailWorker'
 
 describe('useThumbnailWorker', () => {
@@ -171,5 +172,42 @@ describe('useThumbnailWorker', () => {
 
     clearCache()
     expect(getCacheStats().localStorageCacheSize).toBe(0)
+  })
+
+  // ========================================
+  // Scope-aware cleanup (#5347)
+  // ========================================
+
+  describe('scope-aware cleanup (#5347)', () => {
+    it('does not warn outside component setup when used in effectScope', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const scope = effectScope()
+      scope.run(() => {
+        useThumbnailWorker()
+      })
+      scope.stop()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
+
+    it('does not warn when called with no active scope at all', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { clearCache } = useThumbnailWorker()
+      clearCache()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
+
+    it('scope.stop() disposes cleanup without errors', () => {
+      const scope = effectScope()
+      scope.run(() => {
+        useThumbnailWorker()
+      })
+      expect(() => scope.stop()).not.toThrow()
+    })
   })
 })

--- a/autobot-frontend/src/composables/__tests__/useTimeout.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useTimeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent, effectScope, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import {
   useDebounce,
@@ -1104,6 +1104,107 @@ describe('useTimeout Composable', () => {
       await nextTick()
 
       expect(rejected).toBe(true)
+    })
+  })
+
+  // ========================================
+  // Scope-aware cleanup (#5347)
+  // ========================================
+
+  describe('scope-aware cleanup (#5347)', () => {
+    it('useDebounce does not warn in effectScope', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const scope = effectScope()
+      scope.run(() => {
+        useDebounce(() => {}, 100)
+      })
+      scope.stop()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
+
+    it('useThrottle does not warn in effectScope', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const scope = effectScope()
+      scope.run(() => {
+        useThrottle(() => {}, 100)
+      })
+      scope.stop()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
+
+    it('useTimeout does not warn in effectScope', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const scope = effectScope()
+      scope.run(() => {
+        useTimeout(() => {}, 100)
+      })
+      scope.stop()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
+
+    it('useInterval does not warn in effectScope', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const scope = effectScope()
+      scope.run(() => {
+        useInterval(() => {}, 100)
+      })
+      scope.stop()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
+
+    it('useCancelableSleep does not warn in effectScope', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const scope = effectScope()
+      scope.run(() => {
+        const sleep = useCancelableSleep(100)
+        // avoid unhandled rejection when scope.stop() cancels it
+        sleep.promise.catch(() => {})
+      })
+      scope.stop()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
+
+    it('useCancelableSleep does not warn when no active scope', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const sleep = useCancelableSleep(100)
+      sleep.promise.catch(() => {})
+      sleep.cancel()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
+
+    it('useCancelableSleep cleanup fires on scope.stop()', () => {
+      const scope = effectScope()
+      let sleep: ReturnType<typeof useCancelableSleep> | undefined
+      scope.run(() => {
+        sleep = useCancelableSleep(10000)
+      })
+      expect(sleep).toBeDefined()
+      let rejected = false
+      sleep!.promise.catch(() => {
+        rejected = true
+      })
+      scope.stop()
+      return Promise.resolve().then(() => {
+        expect(rejected).toBe(true)
+      })
     })
   })
 })

--- a/autobot-frontend/src/composables/useThumbnailWorker.ts
+++ b/autobot-frontend/src/composables/useThumbnailWorker.ts
@@ -25,7 +25,7 @@
  * ```
  */
 
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onScopeDispose, getCurrentScope } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useThumbnailWorker')
@@ -381,21 +381,23 @@ export function useThumbnailWorker() {
   }
 
   /**
-   * Cleanup on unmount
+   * Cleanup when effect scope disposes (component unmount or scope.stop())
    */
-  onUnmounted(() => {
-    // Revoke blob URLs to free memory
-    blobUrls.forEach(url => {
-      URL.revokeObjectURL(url)
-    })
-    blobUrls.clear()
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      // Revoke blob URLs to free memory
+      blobUrls.forEach(url => {
+        URL.revokeObjectURL(url)
+      })
+      blobUrls.clear()
 
-    // Terminate worker if no longer needed
-    if (workerInstance && pendingRequests.size === 0) {
-      workerInstance.terminate()
-      workerInstance = null
-    }
-  })
+      // Terminate worker if no longer needed
+      if (workerInstance && pendingRequests.size === 0) {
+        workerInstance.terminate()
+        workerInstance = null
+      }
+    })
+  }
 
   return {
     isSupported,

--- a/autobot-frontend/src/composables/useTimeout.ts
+++ b/autobot-frontend/src/composables/useTimeout.ts
@@ -37,7 +37,7 @@
  * ```
  */
 
-import { ref, onUnmounted, type Ref } from 'vue'
+import { ref, onScopeDispose, getCurrentScope, type Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
 // Create scoped logger for useTimeout
@@ -276,10 +276,12 @@ export function useDebounce<T extends (...args: any[]) => any>(
   debounced.cancel = cancel
   debounced.flush = flush
 
-  // Auto-cleanup on unmount
-  onUnmounted(() => {
-    cancel()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      cancel()
+    })
+  }
 
   return debounced
 }
@@ -395,10 +397,12 @@ export function useThrottle<T extends (...args: any[]) => any>(
 
   throttled.cancel = cancel
 
-  // Auto-cleanup on unmount
-  onUnmounted(() => {
-    cancel()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      cancel()
+    })
+  }
 
   return throttled
 }
@@ -489,10 +493,12 @@ export function useTimeout(
     start()
   }
 
-  // Auto-cleanup on unmount
-  onUnmounted(() => {
-    stop()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stop()
+    })
+  }
 
   return {
     start,
@@ -607,10 +613,12 @@ export function useInterval(
     start()
   }
 
-  // Auto-cleanup on unmount
-  onUnmounted(() => {
-    stop()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stop()
+    })
+  }
 
   return {
     start,
@@ -725,10 +733,12 @@ export function useCancelableSleep(ms: number): CancelableSleep {
     }
   }
 
-  // Auto-cleanup on unmount
-  onUnmounted(() => {
-    cancel()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      cancel()
+    })
+  }
 
   return {
     promise,


### PR DESCRIPTION
Closes #5347

## Summary
Sister to #5318 (PR #5345). Same \`onUnmounted\` → \`onScopeDispose\` + \`getCurrentScope\` guard pattern applied to the remaining 2 composables with unguarded lifecycle hooks.

## Files
- \`composables/useThumbnailWorker.ts\` — 1 hook converted
- \`composables/useTimeout.ts\` — 5 hooks converted (useDebounce, useThrottle, useTimeout, useInterval, useCancelableSleep)

## Warning count across full composables suite
**13 → 0** (10 from useThumbnailWorker + 3 from useCancelableSleep eliminated).

## Tests
10 new effectScope-aware tests (3 in useThumbnailWorker.spec.ts + 7 in useTimeout.test.ts). 883/884 pass in full composables suite (1 pre-existing unrelated timeout in useKnowledgeVectorization).