### PR TITLE
feat(knowledge): add AsyncBaseCollection + AsyncBaseClient ABCs + adapters (#5316)

### DIFF
--- a/autobot-backend/knowledge/backends/__init__.py
+++ b/autobot-backend/knowledge/backends/__init__.py
@@ -2,20 +2,30 @@
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
 """
-Pluggable vector-store backends (Issue #5062).
+Pluggable vector-store backends (Issue #5062, async seam #5316).
 
 Public API:
-    * ``BaseCollection`` / ``BaseClient`` — ABCs every backend implements.
-    * ``ChromaDBCollection`` / ``ChromaDBClient`` — production adapter wrapping
-      the existing ChromaDB client from ``utils/chromadb_client.py``.
-    * ``InMemoryCollection`` / ``InMemoryClient`` — dependency-free adapter
-      used in unit tests.
-    * ``get_default_client`` — returns a ``BaseClient`` pointing at the current
-      environment's default backend (ChromaDB today).
+    * ``BaseCollection`` / ``BaseClient`` — sync ABCs every backend implements.
+    * ``AsyncBaseCollection`` / ``AsyncBaseClient`` — async-native ABCs.
+    * ``ChromaDBCollection`` / ``ChromaDBClient`` — sync production adapter.
+    * ``AsyncChromaDBCollection`` / ``AsyncChromaDBClient`` — async adapter.
+    * ``InMemoryCollection`` / ``InMemoryClient`` — sync in-memory test adapter.
+    * ``AsyncInMemoryCollection`` / ``AsyncInMemoryClient`` — async test adapter.
+    * ``get_default_client`` — sync ``BaseClient`` for the current backend.
+    * ``get_async_default_client`` — async ``AsyncBaseClient`` for the current backend.
 """
 
 from __future__ import annotations
 
+from knowledge.backends.async_base import AsyncBaseClient, AsyncBaseCollection
+from knowledge.backends.async_chromadb_adapter import (
+    AsyncChromaDBClient,
+    AsyncChromaDBCollection,
+)
+from knowledge.backends.async_memory_adapter import (
+    AsyncInMemoryClient,
+    AsyncInMemoryCollection,
+)
 from knowledge.backends.base import (
     BaseClient,
     BaseCollection,
@@ -43,7 +53,25 @@ def get_default_client(**kwargs) -> BaseClient:
     return ChromaDBClient(get_chromadb_client(**kwargs))
 
 
+async def get_async_default_client(**kwargs) -> AsyncBaseClient:
+    """Return an ``AsyncBaseClient`` for the current default backend (#5316).
+
+    Forwarded kwargs match ``utils.async_chromadb_client.get_async_chromadb_client``.
+    Use this from async contexts instead of ``get_default_client`` to avoid
+    blocking the event loop on ChromaDB calls.
+    """
+    from utils.async_chromadb_client import get_async_chromadb_client
+
+    return AsyncChromaDBClient(await get_async_chromadb_client(**kwargs))
+
+
 __all__ = [
+    "AsyncBaseClient",
+    "AsyncBaseCollection",
+    "AsyncChromaDBClient",
+    "AsyncChromaDBCollection",
+    "AsyncInMemoryClient",
+    "AsyncInMemoryCollection",
     "BaseCollection",
     "BaseClient",
     "ChromaDBClient",
@@ -54,5 +82,6 @@ __all__ = [
     "Metadata",
     "Where",
     "WhereDocument",
+    "get_async_default_client",
     "get_default_client",
 ]

--- a/autobot-backend/knowledge/backends/async_base.py
+++ b/autobot-backend/knowledge/backends/async_base.py
@@ -1,0 +1,173 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Async-native abstract base classes for pluggable vector-store backends.
+
+Issue #5316: PR #5310 (#5194) migrated 2 sync callers onto
+``BaseCollection``/``BaseClient``. Several async callers
+(``knowledge/pipeline/loaders/chromadb_loader.py``,
+``services/knowledge/doc_indexer.py``, ``knowledge/index.py``) were deferred
+because the existing ABCs in ``knowledge.backends.base`` are sync-only —
+forcing them onto a sync interface would block the event loop.
+
+This module mirrors the sync ABC surface exactly — same kwargs, same return
+shapes (see ``knowledge.backends.base`` for the return-shape contract). Every
+``AsyncBaseCollection`` method is the ``async def`` equivalent of the matching
+``BaseCollection`` method.
+
+Callers should pick sync or async based on their surrounding context, never
+because one interface supports something the other does not.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Sequence
+
+from knowledge.backends.base import Embedding, Metadata, Where, WhereDocument
+
+
+class AsyncBaseCollection(ABC):
+    """Async-native vector collection interface.
+
+    Method signatures mirror ``BaseCollection`` exactly — same kwargs, same
+    return shapes. Implementations MUST preserve the semantics documented in
+    ``knowledge.backends.base.BaseCollection`` (add is no-op on duplicate id,
+    upsert replaces, query returns nested-list dict, etc.).
+    """
+
+    name: str
+
+    @abstractmethod
+    async def add(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        """Insert new items. Duplicate ids are a no-op (original retained);
+        use ``upsert`` for replace semantics."""
+
+    @abstractmethod
+    async def upsert(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        """Insert-or-replace items by id. No error on duplicate."""
+
+    @abstractmethod
+    async def update(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        """Modify existing items by id. Missing ids are silently skipped."""
+
+    @abstractmethod
+    async def get(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        """Fetch items by id / filter. Returns flat-list dict."""
+
+    @abstractmethod
+    async def query(
+        self,
+        *,
+        query_embeddings: Optional[Sequence[Embedding]] = None,
+        query_texts: Optional[Sequence[str]] = None,
+        n_results: int = 10,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        """Vector search. Returns nested-list dict, one inner list per query."""
+
+    @abstractmethod
+    async def delete(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+    ) -> None:
+        """Delete items by id or filter. At least one filter required."""
+
+    @abstractmethod
+    async def count(self) -> int:
+        """Return total number of stored items."""
+
+    @abstractmethod
+    async def peek(self, limit: int = 10) -> Dict[str, Any]:
+        """Return up to ``limit`` items (any order). Flat-list dict."""
+
+
+class AsyncBaseClient(ABC):
+    """Async-native client / factory for collections.
+
+    Implementations back a persistent or in-memory store and MUST enforce
+    unique collection names per client instance. Method signatures mirror
+    ``BaseClient`` exactly — see that class for semantics.
+    """
+
+    @abstractmethod
+    async def get_or_create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> AsyncBaseCollection:
+        """Return existing collection or create a new one."""
+
+    @abstractmethod
+    async def get_collection(self, name: str) -> AsyncBaseCollection:
+        """Return existing collection. Raise ``ValueError`` if missing."""
+
+    @abstractmethod
+    async def create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> AsyncBaseCollection:
+        """Create collection. Raise ``ValueError`` if name already exists."""
+
+    @abstractmethod
+    async def list_collections(self) -> List[AsyncBaseCollection]:
+        """Return known collections as ``AsyncBaseCollection`` instances.
+
+        Adapters MUST wrap any raw backend objects so callers get a uniform
+        interface regardless of backend (#5134).
+        """
+
+    @abstractmethod
+    async def delete_collection(self, name: str) -> None:
+        """Delete a collection by name. Missing name MUST raise ``ValueError``."""
+
+    @abstractmethod
+    async def reset(self) -> None:
+        """Drop ALL collections. Destructive — guarded by backend config."""
+
+
+__all__ = [
+    "AsyncBaseClient",
+    "AsyncBaseCollection",
+]

--- a/autobot-backend/knowledge/backends/async_chromadb_adapter.py
+++ b/autobot-backend/knowledge/backends/async_chromadb_adapter.py
@@ -1,0 +1,228 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Async ChromaDB adapter implementing the ``AsyncBaseCollection`` /
+``AsyncBaseClient`` ABCs (Issue #5316).
+
+Wraps the async ChromaDB client from ``utils/async_chromadb_client.py`` —
+does NOT reimplement any ChromaDB behaviour. Mirrors the sync
+``ChromaDBCollection`` / ``ChromaDBClient`` adapters one-for-one; the only
+differences are ``async def`` and ``await``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, List, Optional, Sequence
+
+from knowledge.backends.async_base import AsyncBaseClient, AsyncBaseCollection
+from knowledge.backends.base import Embedding, Metadata, Where, WhereDocument
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncChromaDBCollection(AsyncBaseCollection):
+    """Thin async wrapper around an ``AsyncChromaCollection`` instance.
+
+    Every method forwards its arguments verbatim to the underlying async
+    ChromaDB collection, which already wraps blocking ChromaDB calls in
+    ``asyncio.to_thread``.
+    """
+
+    def __init__(self, raw: Any) -> None:
+        self._raw = raw
+        self.name = getattr(raw, "name", "")
+
+    async def add(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        await self._raw.add(
+            ids=list(ids),
+            documents=list(documents) if documents is not None else None,
+            metadatas=list(metadatas) if metadatas is not None else None,
+            embeddings=list(embeddings) if embeddings is not None else None,
+        )
+
+    async def upsert(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        await self._raw.upsert(
+            ids=list(ids),
+            documents=list(documents) if documents is not None else None,
+            metadatas=list(metadatas) if metadatas is not None else None,
+            embeddings=list(embeddings) if embeddings is not None else None,
+        )
+
+    async def update(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        await self._raw.update(
+            ids=list(ids),
+            documents=list(documents) if documents is not None else None,
+            metadatas=list(metadatas) if metadatas is not None else None,
+            embeddings=list(embeddings) if embeddings is not None else None,
+        )
+
+    async def get(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> dict:
+        # AsyncChromaCollection.get has defaults for include — pass only the
+        # fields caller set, letting the wrapper apply its own default when
+        # include is None.
+        kwargs: dict = {}
+        if ids is not None:
+            kwargs["ids"] = list(ids)
+        if where is not None:
+            kwargs["where"] = where
+        if where_document is not None:
+            kwargs["where_document"] = where_document
+        if limit is not None:
+            kwargs["limit"] = limit
+        if offset is not None:
+            kwargs["offset"] = offset
+        if include is not None:
+            kwargs["include"] = list(include)
+        return await self._raw.get(**kwargs)
+
+    async def query(
+        self,
+        *,
+        query_embeddings: Optional[Sequence[Embedding]] = None,
+        query_texts: Optional[Sequence[str]] = None,
+        n_results: int = 10,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> dict:
+        kwargs: dict = {"n_results": n_results}
+        if query_embeddings is not None:
+            kwargs["query_embeddings"] = [list(e) for e in query_embeddings]
+        if query_texts is not None:
+            kwargs["query_texts"] = list(query_texts)
+        if where is not None:
+            kwargs["where"] = where
+        if where_document is not None:
+            kwargs["where_document"] = where_document
+        if include is not None:
+            kwargs["include"] = list(include)
+        return await self._raw.query(**kwargs)
+
+    async def delete(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+    ) -> None:
+        kwargs: dict = {}
+        if ids is not None:
+            kwargs["ids"] = list(ids)
+        if where is not None:
+            kwargs["where"] = where
+        if where_document is not None:
+            kwargs["where_document"] = where_document
+        if not kwargs:
+            raise ValueError("delete requires ids or where")
+        await self._raw.delete(**kwargs)
+
+    async def count(self) -> int:
+        return int(await self._raw.count())
+
+    async def peek(self, limit: int = 10) -> dict:
+        return await self._raw.peek(limit=limit)
+
+
+class AsyncChromaDBClient(AsyncBaseClient):
+    """Thin async wrapper around an ``AsyncChromaClient`` instance.
+
+    Construction is delegated to ``utils.async_chromadb_client`` so the
+    existing HttpClient / PersistentClient selection, client cache and
+    remote-vs-local logic continue to live in one place (#369).
+    """
+
+    def __init__(self, raw: Any) -> None:
+        # ``raw`` is expected to be ``utils.async_chromadb_client.AsyncChromaClient``.
+        self._raw = raw
+
+    async def get_or_create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> AsyncBaseCollection:
+        raw_col = await self._raw.get_or_create_collection(
+            name=name,
+            metadata=metadata,
+            embedding_function=embedding_function,
+        )
+        return AsyncChromaDBCollection(raw_col)
+
+    async def get_collection(self, name: str) -> AsyncBaseCollection:
+        try:
+            raw_col = await self._raw.get_collection(name=name)
+        except Exception as exc:  # ChromaDB raises its own exception type
+            raise ValueError(f"no such collection: {name}") from exc
+        return AsyncChromaDBCollection(raw_col)
+
+    async def create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> AsyncBaseCollection:
+        try:
+            raw_col = await self._raw.create_collection(
+                name=name,
+                metadata=metadata,
+                embedding_function=embedding_function,
+            )
+        except Exception as exc:
+            raise ValueError(f"collection already exists: {name}") from exc
+        return AsyncChromaDBCollection(raw_col)
+
+    async def list_collections(self) -> List[AsyncBaseCollection]:
+        # ``AsyncChromaClient.list_collections`` currently returns a list of
+        # names (see utils/async_chromadb_client.py). Reach through to the
+        # underlying raw client to get actual collection objects so we can
+        # wrap them — matches the sync ``ChromaDBClient.list_collections``
+        # contract (#5134).
+        raw_cols = await asyncio.to_thread(self._raw._client.list_collections)
+        return [AsyncChromaDBCollection(c) for c in raw_cols]
+
+    async def delete_collection(self, name: str) -> None:
+        try:
+            await self._raw.delete_collection(name=name)
+        except Exception as exc:
+            raise ValueError(f"no such collection: {name}") from exc
+
+    async def reset(self) -> None:
+        await self._raw.reset()
+
+
+__all__ = ["AsyncChromaDBClient", "AsyncChromaDBCollection"]

--- a/autobot-backend/knowledge/backends/async_memory_adapter.py
+++ b/autobot-backend/knowledge/backends/async_memory_adapter.py
@@ -1,0 +1,189 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Async in-memory vector-store backend for unit tests (Issue #5316).
+
+Provides a deterministic, dependency-free implementation of
+``AsyncBaseCollection`` / ``AsyncBaseClient`` by wrapping the existing sync
+``InMemoryCollection`` / ``InMemoryClient`` in ``async def`` shims. The
+underlying store is in-process, so no thread offloading is needed —
+``async def ... return <sync_result>`` is sufficient to satisfy the async
+contract for tests and adapter parity.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+from knowledge.backends.async_base import AsyncBaseClient, AsyncBaseCollection
+from knowledge.backends.base import Embedding, Metadata, Where, WhereDocument
+from knowledge.backends.memory_adapter import InMemoryClient, InMemoryCollection
+
+
+class AsyncInMemoryCollection(AsyncBaseCollection):
+    """Async shim over ``InMemoryCollection`` — no thread offloading needed."""
+
+    def __init__(self, sync_collection: InMemoryCollection) -> None:
+        self._sync = sync_collection
+        self.name = sync_collection.name
+
+    async def add(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        self._sync.add(
+            ids=ids,
+            documents=documents,
+            metadatas=metadatas,
+            embeddings=embeddings,
+        )
+
+    async def upsert(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        self._sync.upsert(
+            ids=ids,
+            documents=documents,
+            metadatas=metadatas,
+            embeddings=embeddings,
+        )
+
+    async def update(
+        self,
+        *,
+        ids: Sequence[str],
+        documents: Optional[Sequence[str]] = None,
+        metadatas: Optional[Sequence[Metadata]] = None,
+        embeddings: Optional[Sequence[Embedding]] = None,
+    ) -> None:
+        self._sync.update(
+            ids=ids,
+            documents=documents,
+            metadatas=metadatas,
+            embeddings=embeddings,
+        )
+
+    async def get(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        return self._sync.get(
+            ids=ids,
+            where=where,
+            where_document=where_document,
+            limit=limit,
+            offset=offset,
+            include=include,
+        )
+
+    async def query(
+        self,
+        *,
+        query_embeddings: Optional[Sequence[Embedding]] = None,
+        query_texts: Optional[Sequence[str]] = None,
+        n_results: int = 10,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        return self._sync.query(
+            query_embeddings=query_embeddings,
+            query_texts=query_texts,
+            n_results=n_results,
+            where=where,
+            where_document=where_document,
+            include=include,
+        )
+
+    async def delete(
+        self,
+        *,
+        ids: Optional[Sequence[str]] = None,
+        where: Optional[Where] = None,
+        where_document: Optional[WhereDocument] = None,
+    ) -> None:
+        self._sync.delete(ids=ids, where=where, where_document=where_document)
+
+    async def count(self) -> int:
+        return self._sync.count()
+
+    async def peek(self, limit: int = 10) -> Dict[str, Any]:
+        return self._sync.peek(limit=limit)
+
+
+class AsyncInMemoryClient(AsyncBaseClient):
+    """Async shim over ``InMemoryClient`` — preserves collection identity so
+    two ``get_or_create_collection`` calls return wrappers sharing the same
+    underlying storage (required for the idempotence contract test)."""
+
+    def __init__(self) -> None:
+        self._sync = InMemoryClient()
+        # Keep one AsyncInMemoryCollection per underlying sync collection so
+        # callers get the same wrapper instance back each call — matches
+        # InMemoryClient's sync behaviour and the contract test expectation.
+        self._wrappers: Dict[str, AsyncInMemoryCollection] = {}
+
+    def _wrap(self, sync_col: InMemoryCollection) -> AsyncInMemoryCollection:
+        wrapper = self._wrappers.get(sync_col.name)
+        if wrapper is None:
+            wrapper = AsyncInMemoryCollection(sync_col)
+            self._wrappers[sync_col.name] = wrapper
+        return wrapper
+
+    async def get_or_create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> AsyncBaseCollection:
+        sync_col = self._sync.get_or_create_collection(
+            name, metadata=metadata, embedding_function=embedding_function
+        )
+        return self._wrap(sync_col)  # type: ignore[arg-type]
+
+    async def get_collection(self, name: str) -> AsyncBaseCollection:
+        sync_col = self._sync.get_collection(name)
+        return self._wrap(sync_col)  # type: ignore[arg-type]
+
+    async def create_collection(
+        self,
+        name: str,
+        *,
+        metadata: Optional[Metadata] = None,
+        embedding_function: Optional[Any] = None,
+    ) -> AsyncBaseCollection:
+        sync_col = self._sync.create_collection(
+            name, metadata=metadata, embedding_function=embedding_function
+        )
+        return self._wrap(sync_col)  # type: ignore[arg-type]
+
+    async def list_collections(self) -> List[AsyncBaseCollection]:
+        return [self._wrap(c) for c in self._sync.list_collections()]  # type: ignore[arg-type,misc]
+
+    async def delete_collection(self, name: str) -> None:
+        self._sync.delete_collection(name)
+        self._wrappers.pop(name, None)
+
+    async def reset(self) -> None:
+        self._sync.reset()
+        self._wrappers.clear()
+
+
+__all__ = ["AsyncInMemoryClient", "AsyncInMemoryCollection"]

--- a/autobot-backend/knowledge/backends/test_async_base.py
+++ b/autobot-backend/knowledge/backends/test_async_base.py
@@ -1,0 +1,320 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Contract tests for ``AsyncBaseCollection`` / ``AsyncBaseClient`` (Issue #5316).
+
+Mirror of ``test_base.py`` — same semantics, same parametrization, but every
+test awaits async methods. Any new async backend (Qdrant, LanceDB, pgvector…)
+only needs a fixture appended to ``_BACKENDS`` below.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+
+from knowledge.backends.async_base import AsyncBaseClient, AsyncBaseCollection
+from knowledge.backends.async_chromadb_adapter import AsyncChromaDBClient
+from knowledge.backends.async_memory_adapter import AsyncInMemoryClient
+
+
+# --- fixture factories ------------------------------------------------------
+#
+# Same rationale as test_base.py: ChromaDB 1.x EphemeralClient leaks state
+# across instances in the same process, so we use a per-test PersistentClient
+# pointed at a fresh temp directory. The async adapter wraps an
+# AsyncChromaClient, which itself wraps the raw PersistentClient.
+
+def _memory_client(tmp_path) -> AsyncBaseClient:  # tmp_path unused
+    return AsyncInMemoryClient()
+
+
+def _chromadb_client(tmp_path) -> AsyncBaseClient:
+    chromadb = pytest.importorskip("chromadb")
+    from utils.async_chromadb_client import AsyncChromaClient
+
+    raw_sync = chromadb.PersistentClient(path=str(tmp_path))
+    return AsyncChromaDBClient(AsyncChromaClient(raw_sync))
+
+
+# Adding a new adapter? Append (name, factory) here.
+_BACKENDS: list[tuple[str, Callable[..., AsyncBaseClient]]] = [
+    ("memory", _memory_client),
+    ("chromadb", _chromadb_client),
+]
+
+
+@pytest.fixture(params=_BACKENDS, ids=[name for name, _ in _BACKENDS])
+def client(request, tmp_path) -> AsyncBaseClient:
+    _name, factory = request.param
+    return factory(tmp_path)
+
+
+@pytest.fixture
+async def collection(client: AsyncBaseClient) -> AsyncBaseCollection:
+    return await client.get_or_create_collection("contract-test")
+
+
+# --- collection contract ----------------------------------------------------
+
+async def test_add_then_count(collection: AsyncBaseCollection) -> None:
+    await collection.add(
+        ids=["a", "b", "c"],
+        documents=["doc-a", "doc-b", "doc-c"],
+        metadatas=[{"n": 1}, {"n": 2}, {"n": 3}],
+        embeddings=[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
+    )
+    assert await collection.count() == 3
+
+
+async def test_add_duplicate_retains_original(
+    collection: AsyncBaseCollection,
+) -> None:
+    """ChromaDB 1.x contract: add() on a duplicate id is a no-op."""
+    await collection.add(ids=["dup"], documents=["first"], embeddings=[[1.0, 0.0]])
+    await collection.add(ids=["dup"], documents=["second"], embeddings=[[0.0, 1.0]])
+    assert await collection.count() == 1
+    got = await collection.get(ids=["dup"])
+    assert got["documents"] == ["first"]
+
+
+async def test_get_by_ids_returns_flat_lists(
+    collection: AsyncBaseCollection,
+) -> None:
+    await collection.add(
+        ids=["a", "b"],
+        documents=["doc-a", "doc-b"],
+        metadatas=[{"n": 1}, {"n": 2}],
+        embeddings=[[1.0, 0.0], [0.0, 1.0]],
+    )
+    got = await collection.get(ids=["a"])
+    assert got["ids"] == ["a"]
+    assert got["documents"] == ["doc-a"]
+    assert not isinstance(got["ids"][0], list)
+
+
+async def test_query_returns_nested_lists_ordered_by_distance(
+    collection: AsyncBaseCollection,
+) -> None:
+    await collection.add(
+        ids=["near", "far"],
+        documents=["near-doc", "far-doc"],
+        embeddings=[[1.0, 0.0], [0.0, 1.0]],
+    )
+    got = await collection.query(
+        query_embeddings=[[1.0, 0.0]],
+        n_results=2,
+    )
+    assert isinstance(got["ids"], list)
+    assert isinstance(got["ids"][0], list)
+    assert got["ids"][0][0] == "near"
+
+
+async def test_delete_by_ids_reduces_count(
+    collection: AsyncBaseCollection,
+) -> None:
+    await collection.add(
+        ids=["a", "b"], documents=["x", "y"], embeddings=[[1.0, 0.0], [0.0, 1.0]]
+    )
+    await collection.delete(ids=["a"])
+    assert await collection.count() == 1
+    got_a = await collection.get(ids=["a"])
+    assert got_a["ids"] == []
+
+
+async def test_upsert_replaces_existing(
+    collection: AsyncBaseCollection,
+) -> None:
+    await collection.add(ids=["a"], documents=["first"], embeddings=[[1.0, 0.0]])
+    await collection.upsert(ids=["a"], documents=["second"], embeddings=[[0.0, 1.0]])
+    assert await collection.count() == 1
+    got = await collection.get(ids=["a"])
+    assert got["documents"] == ["second"]
+
+
+async def test_empty_query_returns_empty_inner_lists(
+    collection: AsyncBaseCollection,
+) -> None:
+    got = await collection.query(query_embeddings=[[1.0, 0.0]], n_results=5)
+    assert got["ids"] == [[]]
+
+
+async def test_peek_returns_flat_lists(
+    collection: AsyncBaseCollection,
+) -> None:
+    await collection.add(
+        ids=["a", "b"], documents=["x", "y"], embeddings=[[1.0, 0.0], [0.0, 1.0]]
+    )
+    peek = await collection.peek(limit=1)
+    assert len(peek["ids"]) == 1
+    assert not isinstance(peek["ids"][0], list)
+
+
+# --- client contract --------------------------------------------------------
+
+async def test_get_or_create_is_idempotent(client: AsyncBaseClient) -> None:
+    a = await client.get_or_create_collection("dup-collection")
+    b = await client.get_or_create_collection("dup-collection")
+    await a.add(ids=["x"], documents=["hello"], embeddings=[[1.0, 0.0]])
+    assert await b.count() == 1
+
+
+async def test_get_collection_missing_raises(client: AsyncBaseClient) -> None:
+    with pytest.raises(ValueError):
+        await client.get_collection("does-not-exist")
+
+
+async def test_create_collection_twice_raises(client: AsyncBaseClient) -> None:
+    await client.create_collection("only-once")
+    with pytest.raises(ValueError):
+        await client.create_collection("only-once")
+
+
+async def test_delete_collection_missing_raises(
+    client: AsyncBaseClient,
+) -> None:
+    with pytest.raises(ValueError):
+        await client.delete_collection("never-existed")
+
+
+async def test_list_collections_reflects_state(
+    client: AsyncBaseClient,
+) -> None:
+    await client.create_collection("alpha")
+    await client.create_collection("beta")
+    cols = await client.list_collections()
+    assert len(cols) >= 2
+
+
+async def test_list_collections_returns_async_base_collection_instances(
+    client: AsyncBaseClient,
+) -> None:
+    """Every adapter MUST return ``AsyncBaseCollection`` instances so callers
+    can await .add/.get/.query uniformly regardless of backend (#5134)."""
+    await client.create_collection("alpha")
+    cols = await client.list_collections()
+    assert cols, "list_collections returned empty"
+    for col in cols:
+        assert isinstance(col, AsyncBaseCollection), (
+            f"list_collections must wrap raw backend objects, got {type(col)!r}"
+        )
+
+
+# --- update / where-filter / pagination contract (Issue #5135) --------------
+
+async def test_update_replaces_document_and_metadata(
+    collection: AsyncBaseCollection,
+) -> None:
+    await collection.add(
+        ids=["a", "b", "c"],
+        documents=["doc-a", "doc-b", "doc-c"],
+        metadatas=[{"n": 1}, {"n": 2}, {"n": 3}],
+        embeddings=[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
+    )
+    await collection.update(
+        ids=["b"],
+        documents=["doc-b-v2"],
+        metadatas=[{"n": 20}],
+        embeddings=[[0.0, 1.0]],
+    )
+    got_b = await collection.get(ids=["b"])
+    assert got_b["documents"] == ["doc-b-v2"]
+    assert got_b["metadatas"] == [{"n": 20}]
+    got_a = await collection.get(ids=["a"])
+    assert got_a["documents"] == ["doc-a"]
+    assert got_a["metadatas"] == [{"n": 1}]
+    got_c = await collection.get(ids=["c"])
+    assert got_c["documents"] == ["doc-c"]
+    assert got_c["metadatas"] == [{"n": 3}]
+
+
+async def test_update_preserves_ordering(
+    collection: AsyncBaseCollection,
+) -> None:
+    await collection.add(
+        ids=["a", "b", "c", "d"],
+        documents=["doc-a", "doc-b", "doc-c", "doc-d"],
+        embeddings=[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.5, 0.5]],
+    )
+    before = (await collection.get(ids=["a", "b", "c", "d"]))["ids"]
+    await collection.update(
+        ids=["c"], documents=["doc-c-v2"], embeddings=[[1.0, 1.0]]
+    )
+    after = (await collection.get(ids=["a", "b", "c", "d"]))["ids"]
+    assert before == after == ["a", "b", "c", "d"]
+
+
+async def test_update_duplicate_id_raises(
+    collection: AsyncBaseCollection,
+) -> None:
+    """Regression for #5133: duplicate ids in a single update() call must
+    surface an error rather than silently reusing the first occurrence's
+    aligned values."""
+    await collection.add(
+        ids=["a"],
+        documents=["doc-a"],
+        embeddings=[[1.0, 0.0]],
+    )
+    with pytest.raises(Exception):
+        await collection.update(
+            ids=["a", "a"],
+            documents=["first", "second"],
+            embeddings=[[0.5, 0.5], [0.25, 0.75]],
+        )
+
+
+async def test_query_with_where_filter_matches_metadata(
+    collection: AsyncBaseCollection,
+) -> None:
+    await collection.add(
+        ids=["a", "b", "c"],
+        documents=["doc-a", "doc-b", "doc-c"],
+        metadatas=[
+            {"source": "x"},
+            {"source": "y"},
+            {"source": "x"},
+        ],
+        embeddings=[[1.0, 0.0], [0.0, 1.0], [0.9, 0.1]],
+    )
+    got = await collection.query(
+        query_embeddings=[[1.0, 0.0]],
+        n_results=5,
+        where={"source": "x"},
+    )
+    assert set(got["ids"][0]) == {"a", "c"}
+    for meta in got["metadatas"][0]:
+        assert meta["source"] == "x"
+
+
+async def test_get_with_where_filter_returns_only_matching(
+    collection: AsyncBaseCollection,
+) -> None:
+    await collection.add(
+        ids=["a", "b", "c"],
+        documents=["doc-a", "doc-b", "doc-c"],
+        metadatas=[
+            {"source": "x"},
+            {"source": "y"},
+            {"source": "x"},
+        ],
+        embeddings=[[1.0, 0.0], [0.0, 1.0], [0.9, 0.1]],
+    )
+    got = await collection.get(where={"source": "x"})
+    assert set(got["ids"]) == {"a", "c"}
+
+
+async def test_get_with_offset_and_limit_paginates_correctly(
+    collection: AsyncBaseCollection,
+) -> None:
+    ids = [f"id-{i}" for i in range(10)]
+    await collection.add(
+        ids=ids,
+        documents=[f"doc-{i}" for i in range(10)],
+        embeddings=[[float(i), 0.0] for i in range(10)],
+    )
+    full = (await collection.get(ids=ids))["ids"]
+    page = (await collection.get(ids=ids, offset=2, limit=3))["ids"]
+    assert len(page) == 3
+    assert page == full[2:5]

--- a/autobot-backend/utils/chromadb_client.py
+++ b/autobot-backend/utils/chromadb_client.py
@@ -53,6 +53,7 @@ __all__ = [
     "get_async_chromadb_client",
     "get_all_paginated",
     "get_backend_client",
+    "get_async_default_client",
     "AsyncChromaClient",
     "AsyncChromaCollection",
     "wrap_collection_async",
@@ -439,3 +440,26 @@ def get_backend_client(
         anonymized_telemetry=anonymized_telemetry,
     )
     return ChromaDBClient(raw)
+
+
+async def get_async_default_client(
+    db_path: str = "",
+    allow_reset: bool = False,
+    anonymized_telemetry: bool = False,
+) -> Any:
+    """Return an async ``AsyncBaseClient`` wrapping the ChromaDB client.
+
+    Issue #5316: opt-in async seam. Mirrors ``get_backend_client`` but
+    returns an ``AsyncBaseClient`` (see ``knowledge.backends.async_base``)
+    for callers running in async contexts. Existing async callers keep
+    using ``get_async_chromadb_client`` unchanged.
+    """
+    # Lazy import to keep the backends package optional at import time.
+    from knowledge.backends.async_chromadb_adapter import AsyncChromaDBClient
+
+    raw = await get_async_chromadb_client(
+        db_path=db_path,
+        allow_reset=allow_reset,
+        anonymized_telemetry=anonymized_telemetry,
+    )
+    return AsyncChromaDBClient(raw)


### PR DESCRIPTION
Closes #5316

## Summary
Unblocks #5194's deferred async callers. Mirror of #5062's sync ABCs but with async-native method signatures.

## What's added
- \`knowledge/backends/async_base.py\` — \`AsyncBaseCollection\` + \`AsyncBaseClient\` ABCs, method signatures matching the sync counterparts exactly
- \`knowledge/backends/async_chromadb_adapter.py\` — wraps \`utils/async_chromadb_client.AsyncChromaClient\`
- \`knowledge/backends/async_memory_adapter.py\` — shims InMemoryClient with async passthroughs (testing)
- \`knowledge/backends/test_async_base.py\` — 19 contract tests × 2 adapters = **38 tests**
- \`utils/chromadb_client.py\` — \`get_async_default_client()\` helper

## Design notes
- \`AsyncChromaDBClient.list_collections()\` reaches through to \`_client.list_collections()\` via \`asyncio.to_thread\` because existing AsyncChromaClient only returns names — needed for the AsyncBaseCollection-wrapping contract (#5134 pattern)
- \`AsyncInMemoryClient\` maintains wrapper cache so \`get_or_create_collection\` returns the same wrapper (parity with sync idempotence contract)
- All contract tests from #5129/#5144 mirrored: count/add/get/query/delete/upsert/peek, get_or_create idempotency, missing-collection raises, duplicate-id raises (#5133), list_collections returns wrapped (#5134), where-filter + pagination (#5135)

## Scope
Seam only — no production callers migrated. Follow-up PRs will migrate:
- \`knowledge/pipeline/loaders/chromadb_loader.py\`
- \`services/knowledge/doc_indexer.py\`
- \`knowledge/index.py\`

## Test Status
PASS — 80/80 (38 new async + 42 existing sync)