### PR TITLE
chore(infra): delete dead commented import for non-existent SemanticChunker class (#5396)

### DIFF
--- a/autobot-infrastructure/shared/scripts/verify_knowledge_consistency.py
+++ b/autobot-infrastructure/shared/scripts/verify_knowledge_consistency.py
@@ -31,7 +31,6 @@ from utils.redis_client import get_redis_client
 
 # Initialize unified config
 config = ConfigManager()
-# from utils.semantic_chunker import SemanticChunker  # Skip if not available
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Closes #5396

## Fix

Commented import in `verify_knowledge_consistency.py:34` referenced `SemanticChunker` \u2014 a class name that never existed in `autobot-backend/utils/semantic_chunker.py` (actual class is `AutoBotSemanticChunker`). Dead line removed.

## Diff

1 file, -1.