### PR TITLE
fix(lint): worktree exclusion + path-aware suggestions + test allowlist (#5393, #5394, #5397)

### DIFF
--- a/tools/lint/check_no_utcnow_isoformat.py
+++ b/tools/lint/check_no_utcnow_isoformat.py
@@ -41,6 +41,8 @@ from typing import Iterable, List, Tuple
 ALLOWLIST = {
     # The hook itself contains the patterns as strings — exclude it
     "tools/lint/check_no_utcnow_isoformat.py",
+    # The hook's test file uses the banned patterns as fixtures by design
+    "tools/lint/check_no_utcnow_isoformat_test.py",
     # The audit docs reference the patterns in code blocks
     "docs/developer/audits/datetime-parsing-audit.md",
     "docs/developer/audits/datetime-producer-audit.md",
@@ -48,7 +50,34 @@ ALLOWLIST = {
     # — not the banned `utcnow().isoformat()` pattern, but the regex is
     # defensive enough to flag it. Module is exempt by design.
     "autobot_shared/time_utils.py",
+    # Test deliberately exercises the recency-score handler against a naive
+    # timestamp (the test name is `test_naive_timestamp_handled`). Migrating
+    # the fixture would defeat the test purpose. See #5393.
+    "autobot-backend/knowledge/knowledge_context_suggestions_test.py",
 }
+
+# Path prefixes whose files cannot import `autobot_shared.time_utils` reliably
+# (standalone agent on remote nodes, ansible-synced agent code, infra log
+# forwarders). For violations in these paths, suggest the inline canonical
+# form instead of the helper. See PR #5384 (#5381) and #5397.
+INLINE_PATH_PREFIXES: Tuple[str, ...] = (
+    "autobot-slm-agent/",
+    "autobot-slm-backend/slm/agent/",
+    "autobot-slm-backend/ansible/roles/slm_agent/files/",
+    "autobot-infrastructure/shared/scripts/",
+)
+
+
+def _suggestion_for(rel_path: str) -> str:
+    """Return the canonical fix string appropriate for the file's deployment scope."""
+    posix = rel_path.replace("\\", "/")
+    if any(posix.startswith(p) for p in INLINE_PATH_PREFIXES):
+        return (
+            "`datetime.now(timezone.utc).isoformat()` (inline) — this component "
+            "lacks `autobot_shared` on path. See PR #5384."
+        )
+    return "`utc_timestamp()` from `autobot_shared.time_utils`."
+
 
 # Patterns are intentionally precise — this hook only prevents regression
 # of the #5178 migration, not the broader datetime.utcnow() backlog
@@ -57,14 +86,12 @@ PATTERNS: List[Tuple[str, re.Pattern[str], str]] = [
     (
         "isoformat",
         re.compile(r"datetime\.utcnow\(\)\.isoformat\("),
-        "Use `utc_timestamp()` from `autobot_shared.time_utils` instead. "
         "`datetime.utcnow().isoformat()` produces tz-naive strings that "
         "mis-compare against tz-aware datetimes (#5178).",
     ),
     (
         "z-suffix-isoformat",
         re.compile(r'datetime\.utcnow\(\)\.isoformat\(\)\s*\+\s*["\']Z["\']'),
-        "Use `utc_timestamp()` from `autobot_shared.time_utils` instead. "
         "`datetime.utcnow().isoformat() + \"Z\"` produces invalid ISO-8601 "
         "(microseconds + Z mutually exclusive) — fails `fromisoformat` on "
         "Python 3.10 (#5238).",
@@ -76,7 +103,6 @@ PATTERNS: List[Tuple[str, re.Pattern[str], str]] = [
         # Matches strftime calls with the ISO format and NO comma after
         # the format string (no time tuple passed).
         re.compile(r'time\.strftime\(\s*["\']%Y-%m-%dT[^"\']*["\']\s*\)'),
-        "Use `utc_timestamp()` from `autobot_shared.time_utils` instead. "
         "`time.strftime(\"%Y-%m-%dT...\")` with no time argument defaults to "
         "`time.localtime()` (LOCAL time, mislabeled as UTC) (#5178 audit).",
     ),
@@ -90,7 +116,12 @@ def _is_allowlisted(rel_path: str) -> bool:
 
 
 def _scan(path: Path, repo_root: Path) -> List[Tuple[int, str, str]]:
-    """Return [(line_no, pattern_id, message)] of banned-pattern hits."""
+    """Return [(line_no, pattern_id, message)] of banned-pattern hits.
+
+    Message includes the path-aware fix suggestion (utc_timestamp() vs inline
+    pattern) so the contributor sees the right replacement for the file's
+    deployment scope. See #5397.
+    """
     try:
         rel = str(path.resolve().relative_to(repo_root))
     except ValueError:
@@ -102,11 +133,12 @@ def _scan(path: Path, repo_root: Path) -> List[Tuple[int, str, str]]:
         text = path.read_text(encoding="utf-8")
     except (UnicodeDecodeError, OSError):
         return []
+    suggestion = _suggestion_for(rel)
     hits: List[Tuple[int, str, str]] = []
     for line_no, line in enumerate(text.splitlines(), start=1):
-        for pattern_id, regex, message in PATTERNS:
+        for pattern_id, regex, reason in PATTERNS:
             if regex.search(line):
-                hits.append((line_no, pattern_id, message))
+                hits.append((line_no, pattern_id, f"Use {suggestion} {reason}"))
     return hits
 
 
@@ -126,7 +158,17 @@ def _iter_target_files(args: List[str], repo_root: Path) -> Iterable[Path]:
         # Skip vendored / generated / external / vcs-ignored locations
         parts = p.relative_to(repo_root).parts
         if any(
-            part in {".venv", "venv", "node_modules", "__pycache__", ".git", "dist", "build"}
+            part
+            in {
+                ".venv",
+                "venv",
+                "node_modules",
+                "__pycache__",
+                ".git",
+                "dist",
+                "build",
+                ".worktrees",  # #5394: parallel-work git worktrees, not vendored code
+            }
             for part in parts
         ):
             continue
@@ -151,7 +193,7 @@ def main(argv: List[str]) -> int:
     if total_hits:
         print(
             f"\n[no-utcnow-isoformat] {total_hits} banned pattern(s) found. "
-            f"Use `utc_timestamp()` from `autobot_shared.time_utils` instead.",
+            f"See per-line fix suggestions above.",
             file=sys.stderr,
         )
         return 1

--- a/tools/lint/check_no_utcnow_isoformat_test.py
+++ b/tools/lint/check_no_utcnow_isoformat_test.py
@@ -291,3 +291,100 @@ def test_non_python_argv_silently_skipped(tmp_path: Path) -> None:
     md = _write(tmp_path, "notes.md", "datetime.utcnow().isoformat() in markdown\n")
     rc = hook.main(["check_no_utcnow_isoformat", str(md)])
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# .worktrees exclusion (#5394) — full-repo scan must skip parallel worktrees
+# ---------------------------------------------------------------------------
+
+
+def test_worktrees_directory_excluded_from_full_scan(tmp_path: Path) -> None:
+    # Simulate the repo layout: .worktrees/issue-XXXX/ contains a violation
+    # that would fire if scanned. Full-scan mode (no argv) must skip it.
+    worktree_file = tmp_path / ".worktrees" / "issue-9999" / "leaked.py"
+    worktree_file.parent.mkdir(parents=True)
+    worktree_file.write_text(
+        "from datetime import datetime\nts = datetime.utcnow().isoformat()\n",
+        encoding="utf-8",
+    )
+    files = list(hook._iter_target_files([], tmp_path))
+    assert worktree_file not in files, ".worktrees/ must be excluded from full scan"
+
+
+# ---------------------------------------------------------------------------
+# Path-aware suggestion (#5397) — message recommends inline form for
+# components that lack autobot_shared on path
+# ---------------------------------------------------------------------------
+
+
+def test_suggestion_uses_helper_for_default_path() -> None:
+    # autobot-backend/ files have autobot_shared on path → recommend helper
+    msg = hook._suggestion_for("autobot-backend/services/something.py")
+    assert "utc_timestamp()" in msg
+    assert "autobot_shared.time_utils" in msg
+
+
+def test_suggestion_uses_inline_for_slm_agent_standalone() -> None:
+    # Standalone agent runs on remote nodes possibly without autobot_shared
+    msg = hook._suggestion_for("autobot-slm-agent/agent.py")
+    assert "datetime.now(timezone.utc).isoformat()" in msg
+    assert "inline" in msg
+
+
+def test_suggestion_uses_inline_for_slm_backend_agent_subpackage() -> None:
+    # Same agent code lives under slm-backend/slm/agent/ — also remote-deployed
+    msg = hook._suggestion_for("autobot-slm-backend/slm/agent/health_collector.py")
+    assert "datetime.now(timezone.utc).isoformat()" in msg
+
+
+def test_suggestion_uses_inline_for_ansible_synced_copy() -> None:
+    # Ansible-synced mirror of the agent code — same constraints
+    msg = hook._suggestion_for(
+        "autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py"
+    )
+    assert "datetime.now(timezone.utc).isoformat()" in msg
+
+
+def test_suggestion_uses_inline_for_infra_shared_scripts() -> None:
+    # Log forwarders run as standalone scripts on infra nodes
+    msg = hook._suggestion_for(
+        "autobot-infrastructure/shared/scripts/seq_log_forwarder.py"
+    )
+    assert "datetime.now(timezone.utc).isoformat()" in msg
+
+
+def test_scan_emits_path_aware_suggestion_in_message(tmp_path: Path) -> None:
+    # End-to-end: a violation in an inline-path file produces a message
+    # recommending the inline form, not utc_timestamp().
+    target = tmp_path / "autobot-slm-agent" / "agent.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "from datetime import datetime\nts = datetime.utcnow().isoformat()\n",
+        encoding="utf-8",
+    )
+    hits = hook._scan(target, tmp_path)
+    assert len(hits) == 1
+    _, _, message = hits[0]
+    assert "datetime.now(timezone.utc).isoformat()" in message
+    assert "utc_timestamp()" not in message
+
+
+# ---------------------------------------------------------------------------
+# #5393 allowlist — knowledge_context_suggestions_test.py is exempt because
+# the test deliberately exercises naive-timestamp handling
+# ---------------------------------------------------------------------------
+
+
+def test_naive_timestamp_test_fixture_allowlisted(tmp_path: Path) -> None:
+    # The test at autobot-backend/knowledge/knowledge_context_suggestions_test.py
+    # has `naive = datetime.utcnow().isoformat()` by design. Allowlist exempts it.
+    target = tmp_path / "autobot-backend" / "knowledge" / "knowledge_context_suggestions_test.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "def test_naive_timestamp_handled(mixin):\n"
+        "    naive = datetime.utcnow().isoformat()\n"
+        "    assert mixin._compute_recency_score(naive) >= 0.0\n",
+        encoding="utf-8",
+    )
+    hits = hook._scan(target, tmp_path)
+    assert hits == [], "knowledge_context_suggestions_test.py must be allowlisted (#5393)"


### PR DESCRIPTION
## Summary

Three improvements to \`tools/lint/check_no_utcnow_isoformat.py\` surfaced by self-review of the merged PRs from this session ([#5377](https://github.com/mrveiss/AutoBot-AI/pull/5377), [#5380](https://github.com/mrveiss/AutoBot-AI/pull/5380), [#5384](https://github.com/mrveiss/AutoBot-AI/pull/5384)). All in one PR because they touch the same file.

## Changes

**[#5394](https://github.com/mrveiss/AutoBot-AI/issues/5394) — exclude \`.worktrees/\` from full-repo scan**

The hook walked \`repo_root.rglob('*.py')\` in CI mode but didn't skip \`.worktrees/\`. With 11 active parallel-work worktrees the scan reported **717 hits** where only **1 was real**. Added \`.worktrees\` to the exclude set alongside \`.venv\`, \`node_modules\`, etc.

**[#5397](https://github.com/mrveiss/AutoBot-AI/issues/5397) — path-aware fix suggestion**

The hardcoded \"Use \`utc_timestamp()\` from \`autobot_shared.time_utils\`\" message is wrong for 4 path prefixes that can't import \`autobot_shared\` (established by [PR #5384](https://github.com/mrveiss/AutoBot-AI/pull/5384)):
- \`autobot-slm-agent/\` (remote-node deployment)
- \`autobot-slm-backend/slm/agent/\` + \`ansible/roles/slm_agent/files/\` (synced mirror)
- \`autobot-infrastructure/shared/scripts/\` (standalone log forwarders)

Added \`_suggestion_for(rel_path)\` returning either the helper form or the inline \`datetime.now(timezone.utc).isoformat()\` form. \`PATTERNS\` now hold only the *reason* (what's broken); \`_scan()\` prepends the path-aware suggestion.

**[#5393](https://github.com/mrveiss/AutoBot-AI/issues/5393) — allowlist intentional naive test fixture**

\`autobot-backend/knowledge/knowledge_context_suggestions_test.py:61\` has \`naive = datetime.utcnow().isoformat()\` by design — the test name is \`test_naive_timestamp_handled\` and migrating defeats the test. Added to ALLOWLIST. Also added the hook's own test file to ALLOWLIST (it uses banned patterns as fixtures throughout — was previously emitting hits on every test fixture).

## Tests

8 new unit tests added (29 total passing):
- \`test_worktrees_directory_excluded_from_full_scan\`
- \`test_suggestion_uses_helper_for_default_path\`
- \`test_suggestion_uses_inline_for_slm_agent_standalone\`
- \`test_suggestion_uses_inline_for_slm_backend_agent_subpackage\`
- \`test_suggestion_uses_inline_for_ansible_synced_copy\`
- \`test_suggestion_uses_inline_for_infra_shared_scripts\`
- \`test_scan_emits_path_aware_suggestion_in_message\`
- \`test_naive_timestamp_test_fixture_allowlisted\`

## Verification

\`\`\`
$ python3 tools/lint/check_no_utcnow_isoformat.py
$ echo \$?
0
\`\`\`

Was 717 before this PR (716 worktree + test-fixture noise; 1 deliberately-naive test now allowlisted).

## Test plan

- [x] \`python3 -m pytest tools/lint/check_no_utcnow_isoformat_test.py -q\` → 29 passed
- [x] \`python3 tools/lint/check_no_utcnow_isoformat.py\` → exit 0, no output
- [x] \`python3 -m py_compile\` on changed files

Closes #5393
Closes #5394
Closes #5397
🤖 Generated with [Claude Code](https://claude.com/claude-code)