### PR TITLE
feat(useFetchEndpoint): fallbackData + migrate _fetchEnvironmentExportData (#5389)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalytics.vue
@@ -793,8 +793,6 @@ const { exportReport, exportSection } = useCodebaseExport({
   },
   exportingReport,
   progressStatus,
-  fetchWithAuth: fetchWithAuth as typeof fetch,
-  getBackendUrl: () => appConfig.getServiceUrl('backend'),
   withSourceId,
   notify,
   t,

--- a/autobot-frontend/src/composables/analytics/useCodebaseExport.ts
+++ b/autobot-frontend/src/composables/analytics/useCodebaseExport.ts
@@ -361,8 +361,6 @@ export function useCodebaseExport(deps: {
   sectionData: Record<SectionType, Ref<unknown>>
   exportingReport: Ref<boolean>
   progressStatus: Ref<string>
-  fetchWithAuth: typeof fetch
-  getBackendUrl: () => Promise<string>
   /**
    * URL wrapper that appends `?source_id=<id>` for per-project scoping.
    * #5266: previously missing \u2014 both `/report` and `/env-analysis/export`
@@ -444,36 +442,45 @@ export function useCodebaseExport(deps: {
 
   /**
    * Fetch environment export data with fallback to cached display data.
+   *
    * Issue #631: Uses dedicated export endpoint to avoid truncation.
+   * Issue #5389: routed through useFetchEndpoint's fallbackData hook.
+   * The composable's old strict error model required bespoke
+   * try/catch + notify branches. Now:
+   *   - onSuccess logs total_in_export / total_in_analysis.
+   *   - onError fires the "using cached data" warning toast.
+   *   - fallbackData returns the cached snapshot on failure, keeping
+   *     error.value empty so downstream export code proceeds with
+   *     the stale data rather than aborting.
    */
   const _fetchEnvironmentExportData = async (
     cachedData: unknown,
   ): Promise<unknown> => {
-    try {
-      const backendUrl = await deps.getBackendUrl()
-      // #5266: wrap with withSourceId \u2014 same rationale as exportReport.
-      const response = await deps.fetchWithAuth(
-        deps.withSourceId(
-          `${backendUrl}/api/analytics/codebase/env-analysis/export`,
-        ),
-        { method: 'GET', headers: { 'Content-Type': 'application/json' } },
-      )
-      if (response.ok) {
-        const data = await response.json()
-        logger.info('Environment export: fetched full data', {
-          total_in_export: (data as { total_in_export?: number }).total_in_export,
-          total_in_analysis: (data as { total_in_analysis?: number }).total_in_analysis,
-        })
-        return data
-      }
-      logger.warn('Environment export: endpoint failed, using display data')
-      deps.notify(deps.t('analytics.codebase.notify.usingCachedData'), 'warning')
-      return cachedData
-    } catch (err) {
-      logger.warn('Environment export: fetch failed, using display data', err)
-      deps.notify(deps.t('analytics.codebase.notify.exportEndpointUnavailable'), 'warning')
-      return cachedData
-    }
+    const endpoint = useFetchEndpoint<unknown, unknown>(
+      {
+        path: '/api/analytics/codebase/env-analysis/export',
+        scopeToSource: true,
+        pickData: (raw) => raw,
+        onSuccess: (data) => {
+          logger.info('Environment export: fetched full data', {
+            total_in_export: (data as { total_in_export?: number }).total_in_export,
+            total_in_analysis: (data as { total_in_analysis?: number }).total_in_analysis,
+          })
+        },
+        onError: (_msg, err) => {
+          logger.warn('Environment export: using display data', err)
+          deps.notify(
+            deps.t('analytics.codebase.notify.exportEndpointUnavailable'),
+            'warning',
+          )
+        },
+        fallbackData: cachedData,
+        label: 'Environment export',
+      },
+      { withSourceId: deps.withSourceId },
+    )
+    await endpoint.load()
+    return endpoint.data.value
   }
 
   /**

--- a/autobot-frontend/src/composables/api/__tests__/useFetchEndpoint.test.ts
+++ b/autobot-frontend/src/composables/api/__tests__/useFetchEndpoint.test.ts
@@ -101,3 +101,71 @@ describe('useFetchEndpoint parseResponse hook (#5276)', () => {
     expect(ep.error.value).toContain('500')
   })
 })
+
+describe('useFetchEndpoint fallbackData hook (#5389)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('on fetch failure, data.value is set to fallbackData and error stays empty', async () => {
+    mockFetch.mockResolvedValue(mkResponse('err', { ok: false, status: 500 }))
+    const ep = useFetchEndpoint<{ items: string[] }, { items: string[] }>({
+      path: '/api/x',
+      pickData: (r) => r,
+      fallbackData: { items: ['cached'] },
+    })
+    await ep.load()
+    expect(ep.data.value).toEqual({ items: ['cached'] })
+    expect(ep.error.value).toBe('')
+  })
+
+  it('fallbackData factory is called lazily', async () => {
+    mockFetch.mockRejectedValue(new Error('network'))
+    const factory = vi.fn(() => ({ items: ['fresh'] }))
+    const ep = useFetchEndpoint<{ items: string[] }, { items: string[] }>({
+      path: '/api/x',
+      pickData: (r) => r,
+      fallbackData: factory,
+    })
+    await ep.load()
+    expect(factory).toHaveBeenCalledOnce()
+    expect(ep.data.value).toEqual({ items: ['fresh'] })
+  })
+
+  it('onError still fires when fallbackData is provided', async () => {
+    mockFetch.mockRejectedValue(new Error('boom'))
+    const onError = vi.fn()
+    const ep = useFetchEndpoint<string, string>({
+      path: '/api/x',
+      pickData: (r) => r,
+      fallbackData: 'stale',
+      onError,
+    })
+    await ep.load()
+    expect(onError).toHaveBeenCalledWith('boom', expect.any(Error))
+    expect(ep.data.value).toBe('stale')
+    expect(ep.error.value).toBe('')
+  })
+
+  it('without fallbackData, errors behave as before (data=null, error set)', async () => {
+    mockFetch.mockRejectedValue(new Error('boom'))
+    const ep = useFetchEndpoint<string, string>({
+      path: '/api/x',
+      pickData: (r) => r,
+    })
+    await ep.load()
+    expect(ep.data.value).toBe(null)
+    expect(ep.error.value).toBe('boom')
+  })
+
+  it('successful fetch bypasses fallbackData entirely', async () => {
+    mockFetch.mockResolvedValue(mkResponse('{"items": ["live"]}'))
+    const ep = useFetchEndpoint<{ items: string[] }, { items: string[] }>({
+      path: '/api/x',
+      pickData: (r) => r,
+      fallbackData: { items: ['cached'] },
+    })
+    await ep.load()
+    expect(ep.data.value).toEqual({ items: ['live'] })
+  })
+})

--- a/autobot-frontend/src/composables/api/useFetchEndpoint.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.ts
@@ -98,6 +98,23 @@ export interface UseFetchEndpointOptions<TRaw, TOut> {
    * through the same loading/error/assign plumbing as JSON fetchers.
    */
   parseResponse?: (response: Response) => Promise<TRaw>
+  /**
+   * Graceful-degradation value returned when the fetch fails. When
+   * provided:
+   *   - On any failure (network error, `!ok`, parser throw, etc.)
+   *     `data.value` is set to `fallbackData` (or its factory result).
+   *   - `error.value` remains empty (no user-visible error).
+   *   - `onError` still fires so callers can log or surface a warning.
+   *
+   * Useful for export endpoints where a stale cached value is
+   * preferable to a user-visible error (see
+   * `useCodebaseExport._fetchEnvironmentExportData`).
+   *
+   * Default absence preserves the existing strict error behavior.
+   *
+   * Introduced in #5389.
+   */
+  fallbackData?: TOut | (() => TOut)
   /** Human-readable label used only for log messages. */
   label?: string
 }
@@ -208,9 +225,22 @@ export function useFetchEndpoint<TRaw, TOut>(
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err)
       logger.error(`Failed to load ${label}:`, err)
-      error.value = message
-      data.value = null
       opts.onError?.(message, err)
+      // #5389: when a fallback value is configured, return it as the
+      // effective result instead of exposing the error. Callers opting
+      // into this explicitly accept "success with stale/default data"
+      // over "user-visible error" semantics.
+      if (opts.fallbackData !== undefined) {
+        const fallback =
+          typeof opts.fallbackData === 'function'
+            ? (opts.fallbackData as () => TOut)()
+            : opts.fallbackData
+        data.value = fallback
+        error.value = ''
+      } else {
+        error.value = message
+        data.value = null
+      }
     } finally {
       loading.value = false
     }


### PR DESCRIPTION
## Summary

Closes the final gap in the composable-fetcher migration. \`_fetchEnvironmentExportData\` was the last hand-rolled fetcher in the analytics namespace — it couldn't use \`useFetchEndpoint\` because its graceful-degradation fallback (return cached data on failure) didn't fit the strict error model.

### New hook

\`\`\`ts
export interface UseFetchEndpointOptions<TRaw, TOut> {
  // \u2026existing options\u2026
  fallbackData?: TOut | (() => TOut)
}
\`\`\`

- On fetch failure: \`data.value = fallbackData\` (or factory result); \`error.value\` stays empty.
- \`onError\` still fires so callers can log or show a warning toast.
- Default absence preserves existing strict behavior.
- **5 contract tests** cover: success path unchanged, fallback on failure, factory call, onError-still-fires, no-fallback default.

### Migration

\`_fetchEnvironmentExportData\` rewritten as a \`useFetchEndpoint\` config:
- 25-line hand-rolled try/catch collapses to \`pickData\` + \`onSuccess\` + \`onError\` + \`fallbackData\`.
- \`deps.fetchWithAuth\` + \`deps.getBackendUrl\` dropped from the composable's interface (unused after both migrations); \`CodebaseAnalytics.vue\` stops passing them.

**After this PR, the analytics namespace is fully migrated to \`useFetchEndpoint\`.**

Closes #5389.

## Verification

- \`vue-tsc --noEmit -p tsconfig.app.json\` → 167 errors (unchanged baseline; 0 new).
- \`vitest\` — all 10 \`useFetchEndpoint\` tests pass (5 parseResponse from #5276 + 5 new fallbackData).

🤖 Generated with [Claude Code](https://claude.com/claude-code)