### PR TITLE
fix(backend): adopt parse_utc_iso() at 11 fromisoformat sites (#5398)

### DIFF
--- a/autobot-backend/api/analytics_conversation.py
+++ b/autobot-backend/api/analytics_conversation.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import parse_utc_iso
 from constants.path_constants import PATH
 
 logger = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ def _parse_timestamp(ts_value: Any) -> Optional[datetime]:
         return None
     try:
         if isinstance(ts_value, str):
-            return datetime.fromisoformat(ts_value.replace("Z", "+00:00"))
+            return parse_utc_iso(ts_value)
         return ts_value
     except (ValueError, TypeError):
         return None
@@ -49,7 +50,7 @@ def _parse_session_timestamp(created: Any) -> Optional[datetime]:
         return None
     try:
         if isinstance(created, str):
-            return datetime.fromisoformat(created.replace("Z", "+00:00"))
+            return parse_utc_iso(created)
         return created
     except (ValueError, TypeError):
         return None
@@ -492,7 +493,7 @@ class ConversationAnalyzer:
         try:
             ts_str = messages[0]["timestamp"]
             if isinstance(ts_str, str):
-                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                ts = parse_utc_iso(ts_str)
                 hourly_dist[ts.strftime("%H:00")] += 1
         except (ValueError, TypeError, KeyError) as e:
             logger.debug("Failed to parse conversation timestamp: %s", e)

--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -29,6 +29,7 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.redis_utils import decode_redis_value as _decode_redis_value
 from autobot_shared.security.path_validator import validate_path
+from autobot_shared.time_utils import parse_utc_iso
 
 logger = logging.getLogger(__name__)
 router = APIRouter(
@@ -977,7 +978,7 @@ def _aggregate_by_granularity(
             continue
 
         try:
-            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            dt = parse_utc_iso(ts)
 
             if granularity == "weekly":
                 # Use ISO week

--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 from constants.threshold_constants import CategoryDefaults, TimingConstants
 
 # Import dependencies and utilities - Using available dependencies
@@ -138,7 +138,7 @@ def _parse_message_timestamp(msg_ts_str: str) -> Optional[datetime]:
         return None
     try:
         if "T" in msg_ts_str:
-            return datetime.fromisoformat(msg_ts_str.replace("Z", "+00:00"))
+            return parse_utc_iso(msg_ts_str)
         return datetime.strptime(msg_ts_str, "%Y-%m-%d %H:%M:%S")
     except (ValueError, TypeError):
         return None

--- a/autobot-backend/api/knowledge_organization.py
+++ b/autobot-backend/api/knowledge_organization.py
@@ -309,7 +309,8 @@ async def _delete_expired_facts(kb, fact_ids: list, cutoff_date) -> int:
     Helper for cleanup_organization_knowledge. Ref: #1088.
     """
     import json
-    from datetime import datetime
+
+    from autobot_shared.time_utils import parse_utc_iso
 
     deleted_count = 0
     for fact_id in fact_ids:
@@ -330,7 +331,7 @@ async def _delete_expired_facts(kb, fact_ids: list, cutoff_date) -> int:
             continue
 
         try:
-            created_at = datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
+            created_at = parse_utc_iso(created_at_str)
             if created_at < cutoff_date:
                 await kb.ownership_manager.cleanup_ownership_indexes(fact_id, metadata)
                 await kb.redis().delete(f"fact:{fact_id}")

--- a/autobot-backend/chat_history/deduplication.py
+++ b/autobot-backend/chat_history/deduplication.py
@@ -14,6 +14,8 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
+from autobot_shared.time_utils import parse_utc_iso
+
 logger = logging.getLogger(__name__)
 
 # Performance optimization: O(1) lookup for streaming message types (Issue #326)
@@ -26,7 +28,7 @@ def _parse_timestamp(msg_ts: str) -> Optional[datetime]:
         return None
     try:
         if "T" in msg_ts:
-            return datetime.fromisoformat(msg_ts.replace("Z", "+00:00"))
+            return parse_utc_iso(msg_ts)
         return datetime.strptime(msg_ts, "%Y-%m-%d %H:%M:%S")
     except (ValueError, TypeError):
         return None

--- a/autobot-backend/knowledge/metadata.py
+++ b/autobot-backend/knowledge/metadata.py
@@ -22,7 +22,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List
 
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 
 if TYPE_CHECKING:
     import aioredis
@@ -422,7 +422,7 @@ class MetadataMixin:
         elif field_type == "date":
             if isinstance(value, str):
                 try:
-                    datetime.fromisoformat(value.replace("Z", "+00:00"))
+                    parse_utc_iso(value)
                 except ValueError:
                     return f"Field '{field_name}' must be a valid ISO date"
             else:

--- a/autobot-backend/services/notification_suppression.py
+++ b/autobot-backend/services/notification_suppression.py
@@ -11,6 +11,8 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import List, Optional
 
+from autobot_shared.time_utils import parse_utc_iso
+
 logger = logging.getLogger(__name__)
 
 
@@ -131,7 +133,7 @@ class NotificationSuppressionManager:
 
         # Calculate age
         try:
-            updated = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+            updated = parse_utc_iso(updated_at)
             now = datetime.now(updated.tzinfo)
             age_days = (now - updated).days
         except (ValueError, TypeError):

--- a/autobot-backend/utils/branch_metrics.py
+++ b/autobot-backend/utils/branch_metrics.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
+from autobot_shared.time_utils import parse_utc_iso
+
 logger = logging.getLogger(__name__)
 
 
@@ -101,7 +103,7 @@ class BranchMetricsCollector:
 
         if code == 0 and timestamp_out:
             try:
-                return datetime.fromisoformat(timestamp_out.replace("Z", "+00:00"))
+                return parse_utc_iso(timestamp_out)
             except (ValueError, AttributeError):
                 logger.warning("Failed to parse activity time: %s", timestamp_out)
 

--- a/autobot-slm-backend/monitoring/advanced_apm_system.py
+++ b/autobot-slm-backend/monitoring/advanced_apm_system.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional
 import aiofiles
 
 from autobot_shared.network_constants import NetworkConstants
+from autobot_shared.time_utils import parse_utc_iso
 
 logger = logging.getLogger(__name__)
 
@@ -665,7 +666,7 @@ class AdvancedAPMSystem:
                 [
                     m
                     for m in api_metrics
-                    if (datetime.now(timezone.utc) - datetime.fromisoformat(m.timestamp.replace("Z", "+00:00"))).seconds
+                    if (datetime.now(timezone.utc) - parse_utc_iso(m.timestamp)).seconds
                     < 60
                 ]
             ),


### PR DESCRIPTION
## Summary

Closes [#5398](https://github.com/mrveiss/AutoBot-AI/issues/5398). PR [#5377](https://github.com/mrveiss/AutoBot-AI/pull/5377) (#5350) introduced \`autobot_shared.time_utils.parse_utc_iso()\` — a defensive parser accepting \`+00:00\`, \`Z\` suffix, or naive input and returning tz-aware UTC. This PR adopts the helper at the remaining **11 sites in 9 files** that used the verbose \`fromisoformat(s.replace(\"Z\", \"+00:00\"))\` pattern.

## Files migrated

**\`autobot-backend/\`** (8 files, 10 sites)
- \`utils/branch_metrics.py\`
- \`chat_history/deduplication.py\`
- \`knowledge/metadata.py\` (uses existing \`utc_timestamp\` import)
- \`api/knowledge_organization.py\` (lazy import, kept lazy)
- \`api/analytics_evolution.py\`
- \`api/analytics_conversation.py\` (3 sites)
- \`api/chat.py\` (uses existing \`utc_timestamp\` import)
- \`services/notification_suppression.py\`

**\`autobot-slm-backend/\`** (1 file, 1 site)
- \`monitoring/advanced_apm_system.py\` — confirmed top-level \`autobot_shared\` imports already present (\`network_constants\`), safe to add \`time_utils\`

## Behavior change

\`parse_utc_iso\` ALSO promotes naive input to aware (was: returned naive → mis-compared against aware values, the bug class fixed in #5350). Each migrated site now defensively handles all three input forms — naive, \`+00:00\`, \`Z\` — with tz-aware output.

## Out of scope (deferred)

- \`autobot-infrastructure/shared/scripts/logging/log_forwarder.py:138, 454\` — 2 more sites in a component without \`autobot_shared\` on path. Will migrate when the inline pattern from #5384 / lint hook from PR #5405 lands and we extend that to parse-side too.

## Test plan

- [x] \`grep -rn 'fromisoformat.*replace.*\"Z\".*\"+00:00\"' --include=\"*.py\" autobot-backend autobot-slm-backend\` → 0 sites remaining (excluding helper definition at \`autobot_shared/time_utils.py:94\`)
- [x] \`python3 -m py_compile\` on all 9 changed files
- [x] \`parse_utc_iso\` unit tests already pin canonical, Z, naive, comparable, malformed cases (5 tests added in PR #5377, currently 17 passing)

## Cross-reference

- Helper definition + 5 initial usage: PR #5377 (#5350)
- Audit doc: [\`docs/developer/audits/datetime-cutoff-consumer-audit.md\`](https://github.com/mrveiss/AutoBot-AI/blob/Dev_new_gui/docs/developer/audits/datetime-cutoff-consumer-audit.md)

Closes #5398
🤖 Generated with [Claude Code](https://claude.com/claude-code)