### PR TITLE
feat(utils): wire in semantic_chunker_gpu_optimized module (#5395 follow-up)

### DIFF
--- a/autobot-backend/utils/semantic_chunker_gpu_optimized.py
+++ b/autobot-backend/utils/semantic_chunker_gpu_optimized.py
@@ -1,0 +1,90 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+GPU-optimized semantic chunker with explicit optimization metadata.
+
+Wires in the module `utils.simple_optimization_test` expected to exist
+(originally referenced at import-time; the module was missing, so the
+test was blocked). Rather than redirecting the test to a different
+module (which hides the original design intent), this wires in a thin
+wrapper around the post-#5363 consolidated `GPUSemanticChunker`.
+
+The wrapper exposes:
+
+    * ``chunk_text_optimized(text, metadata=None)`` \u2014 explicit alias for
+      ``chunk_text`` that also adds an ``optimization_version`` field to
+      each chunk's metadata so smoke-tests can verify the optimized path
+      was taken.
+
+    * ``get_optimized_semantic_chunker()`` \u2014 singleton factory mirroring
+      the pattern used by :mod:`utils.semantic_chunker` and
+      :mod:`utils.semantic_chunker_gpu`.
+
+The underlying compute path is unchanged from :class:`GPUSemanticChunker`:
+FP16 mixed precision, TF32, cuDNN benchmark, GPU memory pool, kernel
+warmup. All performance features inherited through composition, no
+divergence from the canonical GPU chunker.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, List, Optional
+
+from utils.semantic_chunker_base import SemanticChunk
+from utils.semantic_chunker_gpu import GPUSemanticChunker
+
+__all__ = [
+    "OptimizedSemanticChunker",
+    "SemanticChunk",
+    "get_optimized_semantic_chunker",
+]
+
+# Bumped whenever the optimization-metadata contract changes so consumers
+# can gate behavior on a known baseline. Bump on material changes only.
+OPTIMIZATION_VERSION = "gpu-consolidated-1"
+
+
+class OptimizedSemanticChunker(GPUSemanticChunker):
+    """GPU semantic chunker with explicit ``optimization_version`` metadata.
+
+    Thin subclass that delegates the full pipeline to
+    :class:`GPUSemanticChunker` and augments each resulting chunk's
+    metadata with an ``optimization_version`` field so callers and
+    smoke-tests can assert the optimized path was used.
+    """
+
+    async def chunk_text_optimized(
+        self,
+        text: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> List[SemanticChunk]:
+        """Chunk ``text`` via the GPU-optimized pipeline.
+
+        Equivalent to :meth:`chunk_text` but each returned
+        :class:`SemanticChunk` carries ``metadata["optimization_version"]``
+        set to :data:`OPTIMIZATION_VERSION`.
+        """
+        chunks = await self.chunk_text(text, metadata=metadata)
+        for chunk in chunks:
+            if chunk.metadata is None:
+                chunk.metadata = {}
+            chunk.metadata["optimization_version"] = OPTIMIZATION_VERSION
+        return chunks
+
+
+_optimized_instance: Optional[OptimizedSemanticChunker] = None
+_optimized_lock = threading.Lock()
+
+
+def get_optimized_semantic_chunker(
+    *args: Any, **kwargs: Any
+) -> OptimizedSemanticChunker:
+    """Return the process-wide :class:`OptimizedSemanticChunker` singleton."""
+    global _optimized_instance
+    if _optimized_instance is None:
+        with _optimized_lock:
+            if _optimized_instance is None:
+                _optimized_instance = OptimizedSemanticChunker(*args, **kwargs)
+    return _optimized_instance

--- a/autobot-backend/utils/simple_optimization_test.py
+++ b/autobot-backend/utils/simple_optimization_test.py
@@ -18,9 +18,9 @@ async def test_direct_optimization():
     print("=" * 50)  # noqa: print
 
     try:
-        from utils.semantic_chunker_gpu import get_gpu_semantic_chunker
+        from utils.semantic_chunker_gpu_optimized import get_optimized_semantic_chunker
 
-        chunker = get_gpu_semantic_chunker()
+        chunker = get_optimized_semantic_chunker()
         print(f"✅ Optimized chunker imported: {type(chunker).__name__}")  # noqa: print
         print(f"📍 Module: {chunker.__class__.__module__}")  # noqa: print
 
@@ -38,7 +38,7 @@ async def test_direct_optimization():
         print(f"Text length: {len(test_text)} characters")  # noqa: print
 
         start_time = time.time()
-        chunks = await chunker.chunk_text(test_text)
+        chunks = await chunker.chunk_text_optimized(test_text)
         processing_time = time.time() - start_time
 
         print("\n📊 Results:")  # noqa: print
@@ -74,9 +74,9 @@ async def test_performance_stats():
     print("\n📊 Testing Performance Statistics...")  # noqa: print
 
     try:
-        from utils.semantic_chunker_gpu import get_gpu_semantic_chunker
+        from utils.semantic_chunker_gpu_optimized import get_optimized_semantic_chunker
 
-        chunker = get_gpu_semantic_chunker()
+        chunker = get_optimized_semantic_chunker()
 
         # Check if performance stats are available
         if hasattr(chunker, "get_performance_stats"):


### PR DESCRIPTION
Follow-up to closed #5395 / PR #5403.

## Why this PR exists

PR #5403 closed #5395 by **redirecting** `simple_optimization_test.py` to use `get_gpu_semantic_chunker()` instead of the missing `get_optimized_semantic_chunker()`. User feedback: that violated the repo's "never delete code, wire it in" rule \u2014 the test's original design intent (import an optimized variant, call `chunk_text_optimized()`, check `optimization_version` metadata) expresses a real design. It should be wired in, not routed around.

## Fix

- **NEW**: `autobot-backend/utils/semantic_chunker_gpu_optimized.py` with:
  - `OptimizedSemanticChunker(GPUSemanticChunker)` \u2014 thin subclass
  - `chunk_text_optimized()` method \u2014 calls `chunk_text()` and stamps `metadata['optimization_version'] = 'gpu-consolidated-1'` on each chunk
  - `get_optimized_semantic_chunker()` singleton factory (mirrors `get_gpu_semantic_chunker`)
  - `OPTIMIZATION_VERSION` constant for callers to gate on a known baseline
- **`simple_optimization_test.py`**: reverted PR #5403's workaround; uses the original import + `chunk_text_optimized()` call

## Post-#5363 context

All the performance features the original 'optimized' variant would have had (FP16, cuDNN benchmark, TF32, GPU memory pool, kernel warmup) are now on `GPUSemanticChunker` via `SemanticChunkerBase`. The optimized subclass is therefore a thin metadata wrapper \u2014 no divergent compute path to maintain.

## Verification

- `python -m py_compile` passes
- Runtime smoke: `OptimizedSemanticChunker` is subclass of `GPUSemanticChunker`, `chunk_text_optimized` exists and is callable, `OPTIMIZATION_VERSION` is a non-empty string

## Diff

2 files, +95/-5.

Closes #5395 properly (reopen then close via merge).