### PR TITLE
feat(composables): useInitialFocus + full-kit 2 missed dialogs (closes #5410 #5411)

### DIFF
--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -210,6 +210,7 @@ import { ref, computed, watch, onMounted, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -253,6 +254,8 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'visible'))
+const { focusFirst } = useInitialFocus(dialogRef)
+watch(() => props.visible, (open) => { if (open) focusFirst() })
 
 // ---- Constants ------------------------------------------------------------
 

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -129,6 +129,7 @@ import { ref, computed, watch, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -157,6 +158,8 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'visible'))
+const { focusFirst } = useInitialFocus(dialogRef)
+watch(() => props.visible, (open) => { if (open) focusFirst() })
 
 // ---- Constants ------------------------------------------------------------
 

--- a/autobot-frontend/src/components/analytics/SourceManager.vue
+++ b/autobot-frontend/src/components/analytics/SourceManager.vue
@@ -183,6 +183,7 @@ import { ref, watch, onUnmounted, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -220,6 +221,8 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'visible'))
+const { focusFirst } = useInitialFocus(dialogRef)
+watch(() => props.visible, (open) => { if (open) focusFirst() })
 
 // ---- State ----------------------------------------------------------------
 

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -185,7 +185,17 @@
 
       <!-- Agent-Loop Tool Approval Dialog (#4952) -->
       <!-- Shown when the agent loop publishes APPROVAL_REQUIRED for a sensitive tool -->
-      <div v-if="pendingToolApproval" class="tool-approval-overlay" role="dialog" aria-modal="true" :aria-label="$t('chat.interface.toolApprovalTitle')">
+      <div
+        v-if="pendingToolApproval"
+        ref="toolApprovalDialogRef"
+        class="tool-approval-overlay"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="$t('chat.interface.toolApprovalTitle')"
+        tabindex="-1"
+        @keydown="onToolApprovalKeydown"
+        @keydown.escape="onToolDenied()"
+      >
         <div class="tool-approval-dialog">
           <div class="tool-approval-header">
             <i class="fas fa-shield-exclamation" aria-hidden="true"></i>
@@ -262,6 +272,9 @@
 import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watch, provide } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useBackoffPoller } from '@/composables/useBackoffPoller'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useVoiceOutput } from '@/composables/useVoiceOutput'
 import { useVoiceConversation } from '@/composables/useVoiceConversation'
 import { useChatStore } from '@/stores/useChatStore'
@@ -358,6 +371,15 @@ watch(pendingToolApproval, (approval: PendingToolApproval | null) => {
     _stopCountdown()
   }
 }, { immediate: false })
+
+// Tool-approval dialog a11y kit (#5410). Escape denies (safer default
+// for a security prompt — avoids accidental approval via keyboard).
+const toolApprovalDialogRef = ref<HTMLElement | null>(null)
+const isToolApprovalOpen = computed(() => pendingToolApproval.value !== null)
+const { onKeydown: onToolApprovalKeydown } = useFocusTrap(toolApprovalDialogRef)
+useFocusRestore(isToolApprovalOpen)
+const { focusFirst: focusToolApprovalFirst } = useInitialFocus(toolApprovalDialogRef)
+watch(isToolApprovalOpen, (open) => { if (open) focusToolApprovalFirst() })
 
 const onToolApproved = async (comment?: string): Promise<void> => {
   _stopCountdown()

--- a/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
+++ b/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
@@ -11,10 +11,11 @@
  * Fetches real users from the /user-management/users API endpoint.
  */
 
-import { ref, computed, onMounted, toRef } from 'vue'
+import { ref, computed, onMounted, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useSessionCollaboration } from '@/composables/useSessionCollaboration'
 import { useChatStore } from '@/stores/useChatStore'
 import { useDebounce } from '@/composables/useDebounce'
@@ -42,6 +43,8 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'modelValue'))
+const { focusFirst } = useInitialFocus(dialogRef)
+watch(() => props.modelValue, (open) => { if (open) focusFirst() })
 
 // Types
 interface User {

--- a/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
+++ b/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
@@ -128,7 +128,6 @@ import {
   computed,
   onMounted,
   ref,
-  nextTick,
 } from 'vue'
 import {
   useKnowledgeGraph,
@@ -136,6 +135,7 @@ import {
 } from '@/composables/useKnowledgeGraph'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 import { getEntityTypeColor as getTypeColor } from '../constants'
 import RelationshipViewer from './RelationshipViewer.vue'
 
@@ -151,6 +151,7 @@ defineEmits<{
 const panelRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(panelRef)
 useFocusRestore()
+const { focusFirst } = useInitialFocus(panelRef)
 
 const propertyEntries = computed(() => {
   return Object.entries(props.entity.properties || {})
@@ -162,10 +163,7 @@ function formatValue(value: unknown): string {
   return String(value)
 }
 
-onMounted(async () => {
-  await nextTick()
-  panelRef.value?.focus()
-})
+onMounted(focusFirst)
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -228,6 +228,7 @@ import LanguageSettingsPanel from '@/components/settings/LanguageSettingsPanel.v
 import { usePreferences } from '@/composables/usePreferences'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 
 const props = defineProps<{
   isOpen: boolean
@@ -236,6 +237,8 @@ const props = defineProps<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'isOpen'))
+const { focusFirst } = useInitialFocus(dialogRef)
+watch(() => props.isOpen, (open) => { if (open) focusFirst() })
 
 const emit = defineEmits<{
   close: []

--- a/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
+++ b/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
@@ -7,10 +7,13 @@
  * Modal for sharing secrets with session participants.
  */
 
-import { ref, computed } from 'vue'
+import { ref, computed, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useSessionCollaboration } from '@/composables/useSessionCollaboration'
 import { useBatchSelection } from '@/composables/useBatchSelection'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 
 const { t } = useI18n()
 const { sessionPresence, shareSecretWithSession } = useSessionCollaboration()
@@ -32,6 +35,12 @@ const emit = defineEmits<{
 // Local state
 const expiresIn = ref<number>(24) // hours
 const sharing = ref(false)
+
+const dialogRef = ref<HTMLElement | null>(null)
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
+useFocusRestore(toRef(props, 'modelValue'))
+const { focusFirst } = useInitialFocus(dialogRef)
+watch(() => props.modelValue, (open) => { if (open) focusFirst() })
 
 // Available participants (excluding self)
 const participants = computed(() => sessionPresence.value)
@@ -82,9 +91,13 @@ const getInitials = (username: string): string => {
       <Transition name="modal-content">
         <div
           v-if="props.modelValue"
+          ref="dialogRef"
           class="bg-autobot-bg-card rounded-lg shadow-2xl w-full max-w-md border border-autobot-border"
           role="dialog"
           aria-modal="true"
+          tabindex="-1"
+          @keydown="onFocusTrapKeydown"
+          @keydown.escape="closeDialog"
         >
           <!-- Header -->
           <div class="flex items-center justify-between px-6 py-4 border-b border-autobot-border">

--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -53,10 +53,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, onUnmounted, useId, toRef } from 'vue'
+import { ref, computed, onUnmounted, useId, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useFocusTrap, FOCUSABLE_SELECTOR } from '@/composables/useFocusTrap'
+import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 import Icon from './Icon.vue'
 
 /**
@@ -129,6 +130,8 @@ const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 // the trigger element (correct).
 useFocusRestore(toRef(props, 'modelValue'))
 
+const { focusFirst } = useInitialFocus(dialogRef)
+
 // Stable unique IDs for ARIA labeling (Vue 3.5+ useId)
 const _uid = useId()
 const titleId = computed(() => `modal-title-${_uid}`)
@@ -158,19 +161,7 @@ const handleOverlayClick = () => {
 
 // Focus trap implementation — focus restore handled by useFocusRestore above.
 const onAfterEnter = async () => {
-  await nextTick()
-
-  // Focus the dialog or first focusable element
-  if (dialogRef.value) {
-    const firstFocusable = dialogRef.value.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
-
-    if (firstFocusable) {
-      firstFocusable.focus()
-    } else {
-      dialogRef.value.focus()
-    }
-  }
-
+  await focusFirst()
   // Lock body scroll
   document.body.style.overflow = 'hidden'
 }

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -181,7 +181,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, nextTick, onMounted, onUnmounted, watch, useId, toRef } from 'vue';
+import { ref, onMounted, onUnmounted, watch, useId, toRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { secretsApiClient } from '@/utils/SecretsApiClient';
 import { getBackendUrl } from '@/config/ssot-config';
@@ -190,6 +190,7 @@ import Icon, { type IconName } from '@/components/ui/Icon.vue';
 import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
 import { useFocusTrap } from '@/composables/useFocusTrap';
 import { useFocusRestore } from '@/composables/useFocusRestore';
+import { useInitialFocus } from '@/composables/useInitialFocus';
 
 const logger = createLogger('HostSelectionDialog');
 const { t } = useI18n();
@@ -246,6 +247,7 @@ const hostListLabelId = `host-list-label-${_uid}`;
 const dialogRef = ref<HTMLElement | null>(null);
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef);
 useFocusRestore(toRef(props, 'show'));
+const { focusFirst } = useInitialFocus(dialogRef);
 
 // State
 const showDialog = ref(false);
@@ -420,13 +422,13 @@ const handleEscape = (event: KeyboardEvent) => {
   }
 };
 
-// Watchers — focus save/restore handled by useFocusRestore above.
+// Watchers — focus save/restore handled by useFocusRestore above,
+// initial focus by useInitialFocus.
 watch(() => props.show, async (newValue) => {
   showDialog.value = newValue;
   if (newValue) {
     loadHosts();
-    await nextTick();
-    dialogRef.value?.focus();
+    await focusFirst();
   }
 }, { immediate: true });
 

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
@@ -135,6 +135,7 @@ import {
 } from '@/composables/useNotificationConfig';
 import { useFocusTrap } from '@/composables/useFocusTrap';
 import { useFocusRestore } from '@/composables/useFocusRestore';
+import { useInitialFocus } from '@/composables/useInitialFocus';
 
 const props = defineProps<{
   visible: boolean;
@@ -149,6 +150,8 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null);
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef);
 useFocusRestore(toRef(props, 'visible'));
+const { focusFirst } = useInitialFocus(dialogRef);
+watch(() => props.visible, (open) => { if (open) focusFirst() });
 
 const { config, loading, saving, error, fetchConfig, saveConfig } = useNotificationConfig();
 

--- a/autobot-frontend/src/composables/__tests__/useInitialFocus.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useInitialFocus.test.ts
@@ -1,0 +1,105 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Unit tests for useInitialFocus composable (#5411).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { useInitialFocus } from '../useInitialFocus'
+
+describe('useInitialFocus', () => {
+  beforeEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild)
+  })
+
+  it('focuses the first focusable descendant', async () => {
+    const container = document.createElement('div')
+    container.tabIndex = -1
+    const a = document.createElement('button')
+    a.textContent = 'a'
+    const b = document.createElement('button')
+    b.textContent = 'b'
+    container.append(a, b)
+    document.body.appendChild(container)
+
+    const containerRef = ref<HTMLElement | null>(container)
+    const { focusFirst } = useInitialFocus(containerRef)
+
+    await focusFirst()
+    expect(document.activeElement).toBe(a)
+  })
+
+  it('falls back to focusing the container when no focusable descendants exist', async () => {
+    const container = document.createElement('div')
+    container.tabIndex = -1
+    document.body.appendChild(container)
+
+    const containerRef = ref<HTMLElement | null>(container)
+    const { focusFirst } = useInitialFocus(containerRef)
+
+    await focusFirst()
+    expect(document.activeElement).toBe(container)
+  })
+
+  it('no-ops without throwing when containerRef is null', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const { focusFirst } = useInitialFocus(containerRef)
+
+    await expect(focusFirst()).resolves.toBeUndefined()
+  })
+
+  it('skips disabled buttons (FOCUSABLE_SELECTOR filter)', async () => {
+    const container = document.createElement('div')
+    container.tabIndex = -1
+    const a = document.createElement('button')
+    a.disabled = true
+    const b = document.createElement('button')
+    container.append(a, b)
+    document.body.appendChild(container)
+
+    const containerRef = ref<HTMLElement | null>(container)
+    const { focusFirst } = useInitialFocus(containerRef)
+
+    await focusFirst()
+    // a is disabled, so the first FOCUSABLE_SELECTOR match is b
+    expect(document.activeElement).toBe(b)
+  })
+
+  it('awaits nextTick before querying — picks up freshly-mounted children', async () => {
+    const container = document.createElement('div')
+    container.tabIndex = -1
+    document.body.appendChild(container)
+
+    const containerRef = ref<HTMLElement | null>(container)
+    const { focusFirst } = useInitialFocus(containerRef)
+
+    // Schedule the focus call before adding the child — simulates the
+    // consumer firing focusFirst() immediately after toggling a v-if'd
+    // child into the tree. The await nextTick() inside focusFirst means
+    // children added in the same microtask still get found.
+    const focusPromise = focusFirst()
+    const child = document.createElement('button')
+    container.appendChild(child)
+    await focusPromise
+
+    expect(document.activeElement).toBe(child)
+  })
+
+  it('returns a Promise — callers can await before asserting', async () => {
+    const container = document.createElement('div')
+    const btn = document.createElement('button')
+    container.appendChild(btn)
+    document.body.appendChild(container)
+
+    const containerRef = ref<HTMLElement | null>(container)
+    const { focusFirst } = useInitialFocus(containerRef)
+
+    const result = focusFirst()
+    expect(result).toBeInstanceOf(Promise)
+    await result
+    expect(document.activeElement).toBe(btn)
+  })
+})

--- a/autobot-frontend/src/composables/useInitialFocus.ts
+++ b/autobot-frontend/src/composables/useInitialFocus.ts
@@ -1,0 +1,53 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * useInitialFocus Composable (#5411)
+ *
+ * Third primitive in the dialog-a11y trio (with useFocusTrap #5130 and
+ * useFocusRestore #5356). Returns a `focusFirst()` helper the caller
+ * invokes from their open / mount / watch handler.
+ *
+ * Caller-controlled (not auto-fire on a trigger ref) because initial-focus
+ * timing varies — transition complete, mount, or after async data load —
+ * and the right moment is consumer-specific.
+ *
+ * Fallback order: first focusable descendant → the container itself
+ * (requires `tabindex="-1"`) → no-op.
+ */
+
+import { nextTick, type Ref } from 'vue'
+import { FOCUSABLE_SELECTOR } from './useFocusTrap'
+
+export interface UseInitialFocusReturn {
+  /**
+   * Move focus into the container. Awaits `nextTick()` so callers can fire
+   * this in a watch immediately after `show.value = true` without worrying
+   * about the v-if'd children not being mounted yet.
+   */
+  focusFirst: () => Promise<void>
+}
+
+/**
+ * @param containerRef  Ref to the dialog/panel element. Falls back to
+ *                      focusing the container itself if no focusable
+ *                      descendant is found, which requires the container
+ *                      to have `tabindex="-1"` to actually accept focus.
+ */
+export function useInitialFocus(
+  containerRef: Ref<HTMLElement | null>
+): UseInitialFocusReturn {
+  async function focusFirst(): Promise<void> {
+    await nextTick()
+    if (!containerRef.value) return
+    const first = containerRef.value.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
+    if (first) {
+      first.focus()
+    } else {
+      containerRef.value.focus()
+    }
+  }
+
+  return { focusFirst }
+}

--- a/autobot-frontend/src/views/DocumentsView.vue
+++ b/autobot-frontend/src/views/DocumentsView.vue
@@ -140,7 +140,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { RouterLink } from 'vue-router'
 import BaseButton from '@/components/base/BaseButton.vue'
 import AIDocumentEditor from '@/components/documents/AIDocumentEditor.vue'
@@ -148,6 +148,7 @@ import { useAIDocument, type AIDocument } from '@/composables/useAIDocument'
 import { createLogger } from '@/utils/debugUtils'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 
 const logger = createLogger('DocumentsView')
 
@@ -162,6 +163,8 @@ const deleteDialogRef = ref<HTMLElement | null>(null)
 const isDeleteDialogOpen = computed(() => deleteTarget.value !== null)
 const { onKeydown: onDeleteDialogKeydown } = useFocusTrap(deleteDialogRef)
 useFocusRestore(isDeleteDialogOpen)
+const { focusFirst: focusDeleteFirst } = useInitialFocus(deleteDialogRef)
+watch(isDeleteDialogOpen, (open) => { if (open) focusDeleteFirst() })
 const errorMessage = ref<string | null>(null)
 
 // ---------------------------------------------------------------------------

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -355,10 +355,11 @@
 <script setup lang="ts">
 // Issue #929 - Plugin Manager UI
 // Issue #1359: i18n string extraction
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
+import { useInitialFocus } from '@/composables/useInitialFocus'
 import { usePlugins, type PluginInfo, type PluginManifest } from '@/composables/usePlugins'
 
 const { t } = useI18n()
@@ -389,6 +390,8 @@ const detailDialogRef = ref<HTMLElement | null>(null)
 const isDetailOpen = computed(() => selectedPlugin.value !== null)
 const { onKeydown: onDetailKeydown } = useFocusTrap(detailDialogRef)
 useFocusRestore(isDetailOpen)
+const { focusFirst: focusDetailFirst } = useInitialFocus(detailDialogRef)
+watch(isDetailOpen, (open) => { if (open) focusDetailFirst() })
 const pluginConfig = ref<Record<string, unknown> | null>(null)
 const configLoading = ref(false)
 const editingConfig = ref(false)


### PR DESCRIPTION
## Summary

Closes **#5410** and **#5411** in a single PR — they share the same composable-extraction + dialog-migration surface.

Completes the dialog-a11y primitive trio: [\`useFocusTrap\`](autobot-frontend/src/composables/useFocusTrap.ts) (#5130), [\`useFocusRestore\`](autobot-frontend/src/composables/useFocusRestore.ts) (#5356), and now [\`useInitialFocus\`](autobot-frontend/src/composables/useInitialFocus.ts) (#5411). Simultaneously catches the 2 dialogs my #5371 grep undercounted (#5410).

## `useInitialFocus` (#5411)

Third and final primitive in the trio — caller-invoked \`focusFirst()\` that moves focus to the first focusable descendant, falling back to the container element. Caller-controlled (no auto-fire on a trigger ref) because initial-focus timing varies across consumers:

- **BaseModal** fires from \`onAfterEnter\` (transition complete)
- **EntityDetail** fires from \`onMounted\` (mount-on-show)
- **All other dialogs** fire from \`watch(show, ...)\` (prop toggle)

6 unit tests: first-focusable, container fallback, null no-op, disabled filter, nextTick timing, Promise return.

## Migrations (13 dialogs)

### 3 originally-trapped dialogs — simplified + correctness fix
| Dialog | Before | After |
|---|---|---|
| [\`BaseModal\`](autobot-frontend/src/components/ui/BaseModal.vue) | inline \`querySelector(FOCUSABLE_SELECTOR)\` | \`focusFirst()\` |
| [\`HostSelectionDialog\`](autobot-frontend/src/components/ui/HostSelectionDialog.vue) | \`dialogRef.value?.focus()\` — **wrong**: focused the container (non-interactive) instead of the first child | \`focusFirst()\` — correct |
| [\`EntityDetail\`](autobot-frontend/src/components/knowledge/graph/EntityDetail.vue) | \`panelRef.value?.focus()\` — same wrong pattern | \`focusFirst()\` |

### 8 dialogs from PR #5390 — add missing initial focus
All of these had trap+restore but **no initial-focus-on-open** — Tab wouldn't enter the dialog automatically. Now \`watch(show, (open) => { if (open) focusFirst() })\`.

- \`views/DocumentsView\`, \`views/PluginsView\`, \`collaboration/InviteUserDialog\`, \`profile/ProfileModal\`, \`workflow/NotificationConfigModal\`, \`analytics/AddSourceModal\`, \`analytics/ShareSourceModal\`, \`analytics/SourceManager\`

### 2 dialogs #5371 missed — full a11y kit (#5410)
| Dialog | Notes |
|---|---|
| [\`chat/ChatInterface\`](autobot-frontend/src/components/chat/ChatInterface.vue) **tool-approval** | Security-critical: approve/reject a sensitive tool with countdown timer. **Escape denies** (safer default than approve — avoids accidental approval via keyboard) |
| [\`secrets/ShareSecretDialog\`](autobot-frontend/src/components/secrets/ShareSecretDialog.vue) | I touched this file in PR #5288 for batch-selection migration but didn't notice missing focus management — classic "audit your scope, miss adjacent code" |

## Behavioral grep audit

**Before this PR** (post-#5390 state):
\`\`\`bash
$ grep -lrE 'role="dialog"' autobot-frontend/src --include="*.vue" | xargs grep -L useFocusTrap
src/components/chat/ChatInterface.vue
src/components/secrets/ShareSecretDialog.vue
# 2 hits — the #5410 dialogs
\`\`\`

**After this PR:**
\`\`\`bash
$ <same grep>
# 0 hits — every role="dialog" in the codebase now has the full a11y kit
\`\`\`

## Verification

- \`npx vitest run useInitialFocus useFocusTrap useFocusRestore BaseModal HostSelectionDialog\` → **36/36 pass** (6 new + 30 sister)
- \`npx vue-tsc --noEmit -p tsconfig.app.json\` → 0 new type errors (one pre-existing ChatInterface \`Record<string, unknown>[]\` → \`ChatSession[]\` baseline error shifts line number by my additions — same error already on Dev_new_gui)
- Diff: **+237 / -29** across 15 files (most additions are composable + 105-line test file)

## Test plan

For each of the 13 migrated dialogs: open, verify focus is **inside the dialog on the first focusable** (button, input, etc.) — not on the trigger, not on the container.

Specific attention for the security-critical tool-approval dialog:
- [ ] Open approval dialog → Tab/Shift+Tab wraps within dialog
- [ ] Press Escape → deny action fires (confirmed via notification), not approve
- [ ] Countdown timer expiry — focus behavior during auto-action

## Related

- #5130 / PR #5343 — \`useFocusTrap\` (primitive 1)
- #5356 / PR #5382 — \`useFocusRestore\` (primitive 2)
- **#5411 — \`useInitialFocus\` (primitive 3, closed by this PR)**
- **#5410 — 2 missed dialogs (closed by this PR)**
- #5371 / PR #5390 — 8-dialog sweep (where the initial-focus gap surfaced)
- #5372 — codify Phase 0d behavioral-grep methodology (the rule that would have caught #5410 upstream)
- #5373 — \`useFocusTrap\` visibility filter enhancement
- #5060 — primitives umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)