### PR TITLE
fix(api): _is_session_in_range naive>=aware regression from PR #5414 (#5420)

### DIFF
--- a/autobot-backend/api/analytics_conversation.py
+++ b/autobot-backend/api/analytics_conversation.py
@@ -57,12 +57,20 @@ def _parse_session_timestamp(created: Any) -> Optional[datetime]:
 
 
 def _is_session_in_range(session: Dict[str, Any], cutoff: datetime) -> bool:
-    """Check if session is within the time range (Issue #315)."""
+    """Check if session is within the time range (Issue #315).
+
+    Both ``ts`` (from ``parse_utc_iso`` via ``_parse_session_timestamp``)
+    and ``cutoff`` (from ``datetime.now(tz=timezone.utc) - timedelta(...)``)
+    are tz-aware UTC. The previous ``ts.replace(tzinfo=None)`` workaround
+    is removed post-#5414 — when the parser switched to always-aware
+    output, stripping tzinfo started producing naive>=aware TypeErrors
+    (#5420).
+    """
     created = session.get("created_at") or session.get("timestamp")
     ts = _parse_session_timestamp(created)
     if ts is None:
         return True  # Include if can't parse date
-    return ts.replace(tzinfo=None) >= cutoff
+    return ts >= cutoff
 
 
 # ============================================================================

--- a/autobot-backend/api/analytics_conversation_test.py
+++ b/autobot-backend/api/analytics_conversation_test.py
@@ -1,0 +1,124 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression tests for analytics_conversation timestamp helpers (#5420).
+
+PR #5414 (#5398) migrated `_parse_session_timestamp` from
+`datetime.fromisoformat(s.replace("Z", "+00:00"))` to `parse_utc_iso(s)`,
+making the parsed value always tz-aware. The downstream consumer
+`_is_session_in_range` still stripped tzinfo with `.replace(tzinfo=None)`,
+which produced `naive >= aware` and TypeError'd unconditionally.
+
+This test pins the fix: both `ts` and `cutoff` are aware, comparison
+must work cleanly without TypeError.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from api.analytics_conversation import (
+    _is_session_in_range,
+    _parse_session_timestamp,
+    _parse_timestamp,
+)
+
+
+def test_parse_session_timestamp_returns_aware_for_offset_input() -> None:
+    """+00:00 input → aware datetime."""
+    parsed = _parse_session_timestamp("2026-04-20T12:00:00+00:00")
+    assert parsed is not None
+    assert parsed.tzinfo is not None
+
+
+def test_parse_session_timestamp_returns_aware_for_z_suffix() -> None:
+    """Z suffix input → aware datetime (parse_utc_iso handles this)."""
+    parsed = _parse_session_timestamp("2026-04-20T12:00:00Z")
+    assert parsed is not None
+    assert parsed.tzinfo is not None
+
+
+def test_parse_session_timestamp_returns_aware_for_naive_input() -> None:
+    """Naive input → aware datetime (parse_utc_iso assumes UTC)."""
+    parsed = _parse_session_timestamp("2026-04-20T12:00:00")
+    assert parsed is not None
+    assert parsed.tzinfo is not None, (
+        "parse_utc_iso must promote naive input to aware to keep "
+        "_is_session_in_range comparison consistent"
+    )
+
+
+def test_parse_session_timestamp_returns_passthrough_for_datetime_object() -> None:
+    """Datetime object input is returned unchanged (existing contract)."""
+    dt = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+    assert _parse_session_timestamp(dt) is dt
+
+
+def test_parse_session_timestamp_returns_none_for_falsy_input() -> None:
+    assert _parse_session_timestamp(None) is None
+    assert _parse_session_timestamp("") is None
+
+
+def test_parse_session_timestamp_returns_none_on_invalid_input() -> None:
+    """Malformed string returns None (existing contract)."""
+    assert _parse_session_timestamp("not-a-date") is None
+
+
+def test_is_session_in_range_aware_vs_aware_no_typeerror() -> None:
+    """The #5420 regression: aware ts vs aware cutoff must not TypeError.
+
+    Pre-#5414, `.replace(tzinfo=None)` worked because the parser sometimes
+    returned naive. Post-#5414, the parser is always aware, so stripping
+    tzinfo created `naive >= aware` TypeError on every call. The fix
+    removed `.replace(tzinfo=None)` since both sides are now aware.
+    """
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=24)
+    session_recent = {"created_at": datetime.now(tz=timezone.utc).isoformat()}
+    # Must not raise TypeError
+    assert _is_session_in_range(session_recent, cutoff) is True
+
+
+def test_is_session_in_range_old_session_excluded() -> None:
+    """Old session (before cutoff) returns False."""
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    old_iso = (datetime.now(tz=timezone.utc) - timedelta(days=2)).isoformat()
+    session = {"created_at": old_iso}
+    assert _is_session_in_range(session, cutoff) is False
+
+
+def test_is_session_in_range_naive_input_promoted_to_aware() -> None:
+    """Naive input string flows through parse_utc_iso → aware → comparable."""
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    # Naive ISO string (no tz suffix) — parse_utc_iso assumes UTC
+    naive_iso = (datetime.now(tz=timezone.utc) - timedelta(minutes=30)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+    session = {"created_at": naive_iso}
+    # Must not raise; ts (now aware UTC) is within last hour → True
+    assert _is_session_in_range(session, cutoff) is True
+
+
+def test_is_session_in_range_unparseable_timestamp_returns_true() -> None:
+    """Existing contract: include sessions with unparseable timestamps."""
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    session = {"created_at": "garbage"}
+    assert _is_session_in_range(session, cutoff) is True
+
+
+def test_is_session_in_range_uses_timestamp_fallback() -> None:
+    """If created_at is missing, fall back to timestamp field."""
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=24)
+    session = {"timestamp": datetime.now(tz=timezone.utc).isoformat()}
+    assert _is_session_in_range(session, cutoff) is True
+
+
+def test_parse_timestamp_returns_aware_for_offset_input() -> None:
+    """Sibling helper _parse_timestamp also produces aware via parse_utc_iso."""
+    parsed = _parse_timestamp("2026-04-20T12:00:00+00:00")
+    assert parsed is not None
+    assert parsed.tzinfo is not None
+
+
+def test_parse_timestamp_returns_passthrough_for_datetime_object() -> None:
+    """Datetime object input returned unchanged."""
+    dt = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+    assert _parse_timestamp(dt) is dt


### PR DESCRIPTION
## Summary

Fixes [#5420](https://github.com/mrveiss/issues/5420). A regression I introduced via PR [#5414](https://github.com/mrveiss/AutoBot-AI/pull/5414) (#5398) that I caught in Layer-N self-review.

## The bug

PR #5414 migrated \`_parse_session_timestamp\` from verbose \`datetime.fromisoformat(s.replace(\"Z\", \"+00:00\"))\` to \`parse_utc_iso(s)\`. Behavioral change: parsed value is **always tz-aware** (was: maybe naive, maybe aware depending on input format).

Downstream consumer \`_is_session_in_range\` at line 65 still stripped tzinfo:

\`\`\`python
return ts.replace(tzinfo=None) >= cutoff
\`\`\`

Pre-#5414 this worked because the parser sometimes returned naive — the strip handled the inconsistency. Post-#5414, \`ts\` is always aware, so stripping tzinfo produces naive, and \`naive >= aware\` raised \`TypeError\` **on every call**.

## Fix

Drop \`.replace(tzinfo=None)\`. Both \`ts\` (from \`parse_utc_iso\`) and \`cutoff\` (from \`datetime.now(tz=timezone.utc) - timedelta(...)\`) are aware UTC. Direct compare works:

\`\`\`diff
-    return ts.replace(tzinfo=None) >= cutoff
+    return ts >= cutoff
\`\`\`

Added docstring explaining the invariant + #5420 reference so future readers don't re-add the strip.

## Tests

New co-located test file \`autobot-backend/api/analytics_conversation_test.py\` — 13 tests covering:
- \`_parse_session_timestamp\` aware-ness for +00:00, Z suffix, naive, datetime passthrough, None/empty/malformed
- \`_is_session_in_range\` aware-vs-aware compare does NOT TypeError (the regression)
- Naive input promoted to aware via \`parse_utc_iso\`
- Old session excluded by cutoff
- Unparseable timestamp treated as include (existing contract)
- \`timestamp\` field fallback when \`created_at\` missing
- Sibling \`_parse_timestamp\` aware-ness sanity

All 13 pass.

## Reproduction + proof

Before this PR:
\`\`\`python
from datetime import datetime, timezone, timedelta
from autobot_shared.time_utils import parse_utc_iso
cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=24)
ts = parse_utc_iso(\"2026-04-20T12:00:00+00:00\")
ts.replace(tzinfo=None) >= cutoff
# TypeError: can't compare offset-naive and offset-aware datetimes
\`\`\`

After this PR:
\`\`\`python
from api.analytics_conversation import _is_session_in_range
_is_session_in_range({'created_at': '2026-04-20T12:00:00+00:00'}, cutoff)
# False (old session, cleanly excluded)
\`\`\`

## Test plan

- [x] \`python3 -m pytest autobot-backend/api/analytics_conversation_test.py -q\` → 13 passed
- [x] Direct reproduction shows TypeError no longer raised
- [x] \`python3 -m py_compile\` on both files

Closes #5420
🤖 Generated with [Claude Code](https://claude.com/claude-code)