### PR TITLE
fix(dialogs): immediate: true on 10 focus watches + extract useBodyScrollLock (closes #5421 #5422)

### DIFF
--- a/autobot-frontend/src/components/analytics/AddSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/AddSourceModal.vue
@@ -211,6 +211,7 @@ import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -254,8 +255,9 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'visible'))
+useBodyScrollLock(toRef(props, 'visible'))
 const { focusFirst } = useInitialFocus(dialogRef)
-watch(() => props.visible, (open) => { if (open) focusFirst() })
+watch(() => props.visible, (open) => { if (open) focusFirst() }, { immediate: true })
 
 // ---- Constants ------------------------------------------------------------
 

--- a/autobot-frontend/src/components/analytics/ShareSourceModal.vue
+++ b/autobot-frontend/src/components/analytics/ShareSourceModal.vue
@@ -130,6 +130,7 @@ import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -158,8 +159,9 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'visible'))
+useBodyScrollLock(toRef(props, 'visible'))
 const { focusFirst } = useInitialFocus(dialogRef)
-watch(() => props.visible, (open) => { if (open) focusFirst() })
+watch(() => props.visible, (open) => { if (open) focusFirst() }, { immediate: true })
 
 // ---- Constants ------------------------------------------------------------
 

--- a/autobot-frontend/src/components/analytics/SourceManager.vue
+++ b/autobot-frontend/src/components/analytics/SourceManager.vue
@@ -184,6 +184,7 @@ import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -221,8 +222,9 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'visible'))
+useBodyScrollLock(toRef(props, 'visible'))
 const { focusFirst } = useInitialFocus(dialogRef)
-watch(() => props.visible, (open) => { if (open) focusFirst() })
+watch(() => props.visible, (open) => { if (open) focusFirst() }, { immediate: true })
 
 // ---- State ----------------------------------------------------------------
 

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -275,6 +275,7 @@ import { useBackoffPoller } from '@/composables/useBackoffPoller'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import { useVoiceOutput } from '@/composables/useVoiceOutput'
 import { useVoiceConversation } from '@/composables/useVoiceConversation'
 import { useChatStore } from '@/stores/useChatStore'
@@ -378,8 +379,9 @@ const toolApprovalDialogRef = ref<HTMLElement | null>(null)
 const isToolApprovalOpen = computed(() => pendingToolApproval.value !== null)
 const { onKeydown: onToolApprovalKeydown } = useFocusTrap(toolApprovalDialogRef)
 useFocusRestore(isToolApprovalOpen)
+useBodyScrollLock(isToolApprovalOpen)
 const { focusFirst: focusToolApprovalFirst } = useInitialFocus(toolApprovalDialogRef)
-watch(isToolApprovalOpen, (open) => { if (open) focusToolApprovalFirst() })
+watch(isToolApprovalOpen, (open) => { if (open) focusToolApprovalFirst() }, { immediate: true })
 
 const onToolApproved = async (comment?: string): Promise<void> => {
   _stopCountdown()

--- a/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
+++ b/autobot-frontend/src/components/collaboration/InviteUserDialog.vue
@@ -16,6 +16,7 @@ import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import { useSessionCollaboration } from '@/composables/useSessionCollaboration'
 import { useChatStore } from '@/stores/useChatStore'
 import { useDebounce } from '@/composables/useDebounce'
@@ -43,8 +44,9 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'modelValue'))
+useBodyScrollLock(toRef(props, 'modelValue'))
 const { focusFirst } = useInitialFocus(dialogRef)
-watch(() => props.modelValue, (open) => { if (open) focusFirst() })
+watch(() => props.modelValue, (open) => { if (open) focusFirst() }, { immediate: true })
 
 // Types
 interface User {

--- a/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
+++ b/autobot-frontend/src/components/knowledge/graph/EntityDetail.vue
@@ -136,6 +136,7 @@ import {
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import { getEntityTypeColor as getTypeColor } from '../constants'
 import RelationshipViewer from './RelationshipViewer.vue'
 
@@ -151,6 +152,8 @@ defineEmits<{
 const panelRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(panelRef)
 useFocusRestore()
+// Mount-lifecycle = always-active. Component is v-if'd by parent on open/close.
+useBodyScrollLock(ref(true))
 const { focusFirst } = useInitialFocus(panelRef)
 
 const propertyEntries = computed(() => {

--- a/autobot-frontend/src/components/profile/ProfileModal.vue
+++ b/autobot-frontend/src/components/profile/ProfileModal.vue
@@ -229,6 +229,7 @@ import { usePreferences } from '@/composables/usePreferences'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 
 const props = defineProps<{
   isOpen: boolean
@@ -237,8 +238,9 @@ const props = defineProps<{
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'isOpen'))
+useBodyScrollLock(toRef(props, 'isOpen'))
 const { focusFirst } = useInitialFocus(dialogRef)
-watch(() => props.isOpen, (open) => { if (open) focusFirst() })
+watch(() => props.isOpen, (open) => { if (open) focusFirst() }, { immediate: true })
 
 const emit = defineEmits<{
   close: []

--- a/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
+++ b/autobot-frontend/src/components/secrets/ShareSecretDialog.vue
@@ -14,6 +14,7 @@ import { useBatchSelection } from '@/composables/useBatchSelection'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 
 const { t } = useI18n()
 const { sessionPresence, shareSecretWithSession } = useSessionCollaboration()
@@ -39,8 +40,9 @@ const sharing = ref(false)
 const dialogRef = ref<HTMLElement | null>(null)
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 useFocusRestore(toRef(props, 'modelValue'))
+useBodyScrollLock(toRef(props, 'modelValue'))
 const { focusFirst } = useInitialFocus(dialogRef)
-watch(() => props.modelValue, (open) => { if (open) focusFirst() })
+watch(() => props.modelValue, (open) => { if (open) focusFirst() }, { immediate: true })
 
 // Available participants (excluding self)
 const participants = computed(() => sessionPresence.value)

--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -3,7 +3,6 @@
     <Transition
       name="modal-fade"
       @after-enter="onAfterEnter"
-      @after-leave="onAfterLeave"
     >
       <div
         v-if="modelValue"
@@ -53,11 +52,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onUnmounted, useId, toRef } from 'vue'
+import { ref, computed, useId, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import Icon from './Icon.vue'
 
 /**
@@ -129,6 +129,7 @@ const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef)
 // onAfterEnter focuses the first focusable, so the saved reference is
 // the trigger element (correct).
 useFocusRestore(toRef(props, 'modelValue'))
+useBodyScrollLock(toRef(props, 'modelValue'))
 
 const { focusFirst } = useInitialFocus(dialogRef)
 
@@ -159,22 +160,8 @@ const handleOverlayClick = () => {
   }
 }
 
-// Focus trap implementation — focus restore handled by useFocusRestore above.
-const onAfterEnter = async () => {
-  await focusFirst()
-  // Lock body scroll
-  document.body.style.overflow = 'hidden'
-}
-
-const onAfterLeave = () => {
-  // Unlock body scroll (focus restore handled by useFocusRestore watcher)
-  document.body.style.overflow = ''
-}
-
-// Cleanup on unmount
-onUnmounted(() => {
-  document.body.style.overflow = ''
-})
+// Focus, restore, and scroll-lock all driven by composables above.
+const onAfterEnter = () => focusFirst()
 </script>
 
 <style scoped>

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -191,6 +191,7 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner.vue';
 import { useFocusTrap } from '@/composables/useFocusTrap';
 import { useFocusRestore } from '@/composables/useFocusRestore';
 import { useInitialFocus } from '@/composables/useInitialFocus';
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock';
 
 const logger = createLogger('HostSelectionDialog');
 const { t } = useI18n();
@@ -247,6 +248,7 @@ const hostListLabelId = `host-list-label-${_uid}`;
 const dialogRef = ref<HTMLElement | null>(null);
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef);
 useFocusRestore(toRef(props, 'show'));
+useBodyScrollLock(toRef(props, 'show'));
 const { focusFirst } = useInitialFocus(dialogRef);
 
 // State

--- a/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
+++ b/autobot-frontend/src/components/workflow/NotificationConfigModal.vue
@@ -136,6 +136,7 @@ import {
 import { useFocusTrap } from '@/composables/useFocusTrap';
 import { useFocusRestore } from '@/composables/useFocusRestore';
 import { useInitialFocus } from '@/composables/useInitialFocus';
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock';
 
 const props = defineProps<{
   visible: boolean;
@@ -150,8 +151,9 @@ const emit = defineEmits<{
 const dialogRef = ref<HTMLElement | null>(null);
 const { onKeydown: onFocusTrapKeydown } = useFocusTrap(dialogRef);
 useFocusRestore(toRef(props, 'visible'));
+useBodyScrollLock(toRef(props, 'visible'));
 const { focusFirst } = useInitialFocus(dialogRef);
-watch(() => props.visible, (open) => { if (open) focusFirst() });
+watch(() => props.visible, (open) => { if (open) focusFirst() }, { immediate: true });
 
 const { config, loading, saving, error, fetchConfig, saveConfig } = useNotificationConfig();
 

--- a/autobot-frontend/src/composables/__tests__/useBodyScrollLock.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useBodyScrollLock.test.ts
@@ -1,0 +1,154 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * Unit tests for useBodyScrollLock composable (#5422).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { defineComponent, h, ref, nextTick, type Ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useBodyScrollLock, __resetLockStateForTests } from '../useBodyScrollLock'
+
+function mountWithLock(initial: boolean): {
+  wrapper: ReturnType<typeof mount>
+  active: Ref<boolean>
+} {
+  const active = ref(initial)
+  const Test = defineComponent({
+    setup() {
+      useBodyScrollLock(active)
+      return () => h('div', 'inside')
+    }
+  })
+  const wrapper = mount(Test, { attachTo: document.body })
+  return { wrapper, active }
+}
+
+describe('useBodyScrollLock', () => {
+  beforeEach(() => {
+    __resetLockStateForTests()
+  })
+
+  it('locks body scroll when active becomes true', async () => {
+    expect(document.body.style.overflow).toBe('')
+    const { wrapper, active } = mountWithLock(false)
+    await nextTick()
+    expect(document.body.style.overflow).toBe('')
+
+    active.value = true
+    await nextTick()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    wrapper.unmount()
+  })
+
+  it('unlocks body scroll when active becomes false', async () => {
+    const { wrapper, active } = mountWithLock(true)
+    await nextTick()
+    expect(document.body.style.overflow).toBe('hidden')
+
+    active.value = false
+    await nextTick()
+    expect(document.body.style.overflow).toBe('')
+
+    wrapper.unmount()
+  })
+
+  it('locks immediately on mount when active starts true', async () => {
+    const { wrapper } = mountWithLock(true)
+    await nextTick()
+    expect(document.body.style.overflow).toBe('hidden')
+    wrapper.unmount()
+  })
+
+  it('does nothing when active stays false throughout lifecycle', async () => {
+    const { wrapper } = mountWithLock(false)
+    await nextTick()
+    expect(document.body.style.overflow).toBe('')
+    wrapper.unmount()
+    await nextTick()
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  describe('reference counting across stacked consumers', () => {
+    it('inner close does not release the lock while outer is still active', async () => {
+      const outer = mountWithLock(true)
+      await nextTick()
+      expect(document.body.style.overflow).toBe('hidden')
+
+      const inner = mountWithLock(true)
+      await nextTick()
+      expect(document.body.style.overflow).toBe('hidden')
+
+      // Close inner first
+      inner.active.value = false
+      await nextTick()
+      // Outer is still active — scroll must still be locked
+      expect(document.body.style.overflow).toBe('hidden')
+
+      // Close outer
+      outer.active.value = false
+      await nextTick()
+      expect(document.body.style.overflow).toBe('')
+
+      inner.wrapper.unmount()
+      outer.wrapper.unmount()
+    })
+
+    it('unmount while active releases the lock correctly', async () => {
+      const a = mountWithLock(true)
+      const b = mountWithLock(true)
+      await nextTick()
+      expect(document.body.style.overflow).toBe('hidden')
+
+      // Unmount b while still active — should decrement but not unlock (a still holds)
+      b.wrapper.unmount()
+      await nextTick()
+      expect(document.body.style.overflow).toBe('hidden')
+
+      // Unmount a — now the lock releases
+      a.wrapper.unmount()
+      await nextTick()
+      expect(document.body.style.overflow).toBe('')
+    })
+  })
+
+  describe('preserves pre-existing overflow value', () => {
+    it('restores body.style.overflow to its prior value on full unlock', async () => {
+      document.body.style.overflow = 'scroll'
+      const { wrapper, active } = mountWithLock(false)
+
+      active.value = true
+      await nextTick()
+      expect(document.body.style.overflow).toBe('hidden')
+
+      active.value = false
+      await nextTick()
+      // Should restore to 'scroll', not ''
+      expect(document.body.style.overflow).toBe('scroll')
+
+      wrapper.unmount()
+      document.body.style.overflow = ''
+    })
+  })
+
+  describe('rapid toggle', () => {
+    it('does not double-acquire when active is imperatively set true while already true', async () => {
+      const { wrapper, active } = mountWithLock(true)
+      await nextTick()
+
+      // Re-setting to true (same state) should be a no-op
+      active.value = true
+      await nextTick()
+
+      // Closing once should still fully unlock (not leave count at 1)
+      active.value = false
+      await nextTick()
+      expect(document.body.style.overflow).toBe('')
+
+      wrapper.unmount()
+    })
+  })
+})

--- a/autobot-frontend/src/composables/useBodyScrollLock.ts
+++ b/autobot-frontend/src/composables/useBodyScrollLock.ts
@@ -1,0 +1,95 @@
+/**
+ * AutoBot - AI-Powered Automation Platform
+ * Copyright (c) 2025 mrveiss
+ * Author: mrveiss
+ *
+ * useBodyScrollLock Composable (#5422)
+ *
+ * Fourth primitive in the dialog-a11y set (with useFocusTrap #5130,
+ * useFocusRestore #5356, useInitialFocus #5411). Locks `document.body`
+ * scroll while "active" is true, unlocks when it becomes false.
+ *
+ * Reference-counted across all consumers — when two modals are stacked,
+ * closing the inner leaves the lock active until the outer also closes.
+ * This is the bug the original BaseModal implementation couldn't prevent
+ * because it toggled overflow unconditionally.
+ *
+ * Implementation note: we preserve the pre-lock value of
+ * `document.body.style.overflow` (captured once, the first time the
+ * counter goes from 0 → 1). If some other subsystem has already set
+ * overflow (e.g. a Vue Router transition), we restore to that value on
+ * full unlock, not to ''.
+ */
+
+import { watch, onUnmounted, type Ref } from 'vue'
+
+/**
+ * Module-level reference count and saved-overflow value. Shared across
+ * all calls to `useBodyScrollLock` so stacked modals compose correctly.
+ */
+let lockCount = 0
+let savedOverflow = ''
+
+function acquire(): void {
+  if (lockCount === 0) {
+    savedOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+  }
+  lockCount++
+}
+
+function release(): void {
+  if (lockCount === 0) return
+  lockCount--
+  if (lockCount === 0) {
+    document.body.style.overflow = savedOverflow
+    savedOverflow = ''
+  }
+}
+
+/**
+ * @param activeWhen  Ref that is true while the consumer wants body
+ *                    scroll locked. Fires on every false→true /
+ *                    true→false transition plus initial evaluation so
+ *                    components mounted with activeWhen=true lock
+ *                    immediately.
+ */
+export function useBodyScrollLock(activeWhen: Ref<boolean>): void {
+  // Track whether this consumer currently holds the lock, so unmount-
+  // while-active correctly releases without double-releasing on the
+  // subsequent watch callback (which won't fire after unmount anyway).
+  let held = false
+
+  watch(
+    activeWhen,
+    (active, wasActive) => {
+      if (active && !wasActive) {
+        acquire()
+        held = true
+      } else if (!active && wasActive) {
+        release()
+        held = false
+      }
+    },
+    { immediate: true }
+  )
+
+  onUnmounted(() => {
+    if (held) {
+      release()
+      held = false
+    }
+  })
+}
+
+/**
+ * Test-only: reset the module-level state. Used by unit tests to ensure
+ * a clean counter between cases. Not exported from the public surface.
+ */
+export function __resetLockStateForTests(): void {
+  lockCount = 0
+  savedOverflow = ''
+  if (typeof document !== 'undefined') {
+    document.body.style.overflow = ''
+  }
+}

--- a/autobot-frontend/src/views/DocumentsView.vue
+++ b/autobot-frontend/src/views/DocumentsView.vue
@@ -149,6 +149,7 @@ import { createLogger } from '@/utils/debugUtils'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 
 const logger = createLogger('DocumentsView')
 
@@ -163,8 +164,9 @@ const deleteDialogRef = ref<HTMLElement | null>(null)
 const isDeleteDialogOpen = computed(() => deleteTarget.value !== null)
 const { onKeydown: onDeleteDialogKeydown } = useFocusTrap(deleteDialogRef)
 useFocusRestore(isDeleteDialogOpen)
+useBodyScrollLock(isDeleteDialogOpen)
 const { focusFirst: focusDeleteFirst } = useInitialFocus(deleteDialogRef)
-watch(isDeleteDialogOpen, (open) => { if (open) focusDeleteFirst() })
+watch(isDeleteDialogOpen, (open) => { if (open) focusDeleteFirst() }, { immediate: true })
 const errorMessage = ref<string | null>(null)
 
 // ---------------------------------------------------------------------------

--- a/autobot-frontend/src/views/PluginsView.vue
+++ b/autobot-frontend/src/views/PluginsView.vue
@@ -360,6 +360,7 @@ import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
+import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
 import { usePlugins, type PluginInfo, type PluginManifest } from '@/composables/usePlugins'
 
 const { t } = useI18n()
@@ -390,8 +391,9 @@ const detailDialogRef = ref<HTMLElement | null>(null)
 const isDetailOpen = computed(() => selectedPlugin.value !== null)
 const { onKeydown: onDetailKeydown } = useFocusTrap(detailDialogRef)
 useFocusRestore(isDetailOpen)
+useBodyScrollLock(isDetailOpen)
 const { focusFirst: focusDetailFirst } = useInitialFocus(detailDialogRef)
-watch(isDetailOpen, (open) => { if (open) focusDetailFirst() })
+watch(isDetailOpen, (open) => { if (open) focusDetailFirst() }, { immediate: true })
 const pluginConfig = ref<Record<string, unknown> | null>(null)
 const configLoading = ref(false)
 const editingConfig = ref(false)


### PR DESCRIPTION
## Summary

Closes **#5421** (bug, regression from PR #5417) and **#5422** (discovery — 4th dialog-a11y primitive) in one PR since they share the same dialog-a11y surface.

## #5421 — \`{ immediate: true }\` on 10 focus watches (BUG FIX)

PR #5417 wired \`useInitialFocus\` into 10 dialogs via:

\`\`\`ts
watch(() => props.visible, (open) => { if (open) focusFirst() })
\`\`\`

Without \`{ immediate: true }\`, Vue's \`watch\` only fires on **change**. Dialogs mounted with trigger already \`true\` (URL deep-link, server-pushed approval, persisted state) never fired \`focusFirst()\` — trap+restore worked but initial focus didn't land.

**Highest-impact case**: ChatInterface tool-approval dialog — approval could be server-pushed on page load, security-critical dialog, no initial focus.

Fix is one line per file: append \`, { immediate: true }\` to each watch. Fixed in: ProfileModal, NotificationConfigModal, InviteUserDialog, ShareSecretDialog, AddSourceModal, ShareSourceModal, SourceManager, ChatInterface, DocumentsView, PluginsView.

## #5422 — \`useBodyScrollLock\` composable

Fourth primitive in the dialog-a11y set (after \`useFocusTrap\` #5130, \`useFocusRestore\` #5356, \`useInitialFocus\` #5411). Previously only \`BaseModal\` locked body scroll, and it did so **without reference-counting** — stacked modals would unlock scroll on inner-close while outer still open.

### Reference-counted implementation

\`\`\`ts
let lockCount = 0
let savedOverflow = ''

function acquire() {
  if (lockCount === 0) savedOverflow = document.body.style.overflow
  if (lockCount === 0) document.body.style.overflow = 'hidden'
  lockCount++
}
function release() {
  if (--lockCount === 0) document.body.style.overflow = savedOverflow
}
\`\`\`

Key correctness properties:
- **Stacked modals**: inner close → count 2→1, scroll stays locked; outer close → count 1→0, scroll releases
- **Preserves pre-existing overflow**: if some other subsystem set \`overflow: 'scroll'\` before the modal opened, restore to that value (not \`''\`)
- **Unmount while active**: \`onUnmounted\` releases the lock even if the watch didn't fire a transition
- **Rapid same-state toggle**: \`watch\` guards on \`active && !wasActive\` prevent double-acquire

### Tests (8)

- Lock on active=true, unlock on active=false
- Initial-true locks immediately
- Inactive dialog doesn't affect scroll
- Inner close while outer active keeps lock (ref-count)
- Unmount while active releases the lock
- Preserves pre-existing overflow value (restores \`'scroll'\`, not \`''\`)
- No double-acquire on same-state imperative set

### Applied to all 13 role=\"dialog\" components

BaseModal refactored to \`useBodyScrollLock(toRef(props, 'modelValue'))\` — removes inline \`document.body.style.overflow\` mutations + \`onUnmounted\` cleanup (now owned by the composable). 12 other dialogs gain scroll-lock for UX consistency. EntityDetail (mount-lifecycle) uses \`ref(true)\` as always-active trigger.

## Behavioral grep audits

**#5421**:
\`\`\`bash
$ grep -rE "if \(open\) focus.*First\(\) \}\)\$" src --include="*.vue"
# Before: 10 hits. After: 0 hits.
\`\`\`

**#5422**:
\`\`\`bash
$ grep -rE "document\.body\.style\.overflow" src/components --include="*.vue"
# Before: 3 hits (all BaseModal inline). After: 0 hits (BaseModal uses composable).

$ grep -lrE 'role="dialog"' src --include="*.vue" | xargs grep -L useBodyScrollLock
# Before: 12 hits. After: 0 hits.
\`\`\`

## Verification

- \`npx vitest run useBodyScrollLock useInitialFocus useFocusTrap useFocusRestore BaseModal HostSelectionDialog\` → **44/44 pass** (8 new + 36 sibling)
- \`npx vue-tsc --noEmit -p tsconfig.app.json\` → 0 new type errors
- Diff: **+289 / -28** across 15 files (composable + 154-line test + 13 dialog call-sites)

## Test plan

- [ ] Manual: open any modal → page behind is not scrollable
- [ ] Manual: open a modal → open a nested modal from inside it → close inner → verify page still not scrollable (ref-count test)
- [ ] Manual: deep-link to a page with a modal already open → verify initial focus lands inside the dialog on first render (#5421 fix)
- [ ] Manual: tool approval pushed from server → verify focus lands on first button (security-critical case)

## Related

- #5130 / PR #5343 — \`useFocusTrap\` (primitive 1)
- #5356 / PR #5382 — \`useFocusRestore\` (primitive 2)
- #5411 / PR #5417 — \`useInitialFocus\` (primitive 3) — \`#5421\` is the regression from that PR
- **#5421 — fixed here**
- **#5422 — \`useBodyScrollLock\` (primitive 4), closed here**
- #5372 — codify Phase 0d methodology (filed; codifies the rule that would have caught #5421 via a contract test on initial mount state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)