### PR TITLE
fix(lint+api): 3 Layer-N+1 gaps from PR #5424 review (#5418, #5426, #5427)

### DIFF
--- a/autobot-backend/api/analytics_conversation.py
+++ b/autobot-backend/api/analytics_conversation.py
@@ -44,30 +44,18 @@ def _parse_timestamp(ts_value: Any) -> Optional[datetime]:
         return None
 
 
-def _parse_session_timestamp(created: Any) -> Optional[datetime]:
-    """Parse session timestamp from various formats (Issue #315)."""
-    if not created:
-        return None
-    try:
-        if isinstance(created, str):
-            return parse_utc_iso(created)
-        return created
-    except (ValueError, TypeError):
-        return None
-
-
 def _is_session_in_range(session: Dict[str, Any], cutoff: datetime) -> bool:
     """Check if session is within the time range (Issue #315).
 
-    Both ``ts`` (from ``parse_utc_iso`` via ``_parse_session_timestamp``)
-    and ``cutoff`` (from ``datetime.now(tz=timezone.utc) - timedelta(...)``)
+    Both ``ts`` (from ``parse_utc_iso`` via ``_parse_timestamp``) and
+    ``cutoff`` (from ``datetime.now(tz=timezone.utc) - timedelta(...)``)
     are tz-aware UTC. The previous ``ts.replace(tzinfo=None)`` workaround
     is removed post-#5414 — when the parser switched to always-aware
     output, stripping tzinfo started producing naive>=aware TypeErrors
     (#5420).
     """
     created = session.get("created_at") or session.get("timestamp")
-    ts = _parse_session_timestamp(created)
+    ts = _parse_timestamp(created)
     if ts is None:
         return True  # Include if can't parse date
     return ts >= cutoff

--- a/autobot-backend/api/analytics_conversation_test.py
+++ b/autobot-backend/api/analytics_conversation_test.py
@@ -1,16 +1,16 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Regression tests for analytics_conversation timestamp helpers (#5420).
+"""Regression tests for analytics_conversation timestamp helpers (#5420, #5427).
 
-PR #5414 (#5398) migrated `_parse_session_timestamp` from
+PR #5414 (#5398) migrated the parser from
 `datetime.fromisoformat(s.replace("Z", "+00:00"))` to `parse_utc_iso(s)`,
 making the parsed value always tz-aware. The downstream consumer
 `_is_session_in_range` still stripped tzinfo with `.replace(tzinfo=None)`,
-which produced `naive >= aware` and TypeError'd unconditionally.
+producing `naive >= aware` TypeError unconditionally (#5420).
 
-This test pins the fix: both `ts` and `cutoff` are aware, comparison
-must work cleanly without TypeError.
+#5427 also deleted the duplicate `_parse_session_timestamp` wrapper —
+only `_parse_timestamp` remains. These tests exercise the unified helper.
 """
 from __future__ import annotations
 
@@ -18,28 +18,27 @@ from datetime import datetime, timedelta, timezone
 
 from api.analytics_conversation import (
     _is_session_in_range,
-    _parse_session_timestamp,
     _parse_timestamp,
 )
 
 
-def test_parse_session_timestamp_returns_aware_for_offset_input() -> None:
+def test_parse_timestamp_returns_aware_for_offset_input() -> None:
     """+00:00 input → aware datetime."""
-    parsed = _parse_session_timestamp("2026-04-20T12:00:00+00:00")
+    parsed = _parse_timestamp("2026-04-20T12:00:00+00:00")
     assert parsed is not None
     assert parsed.tzinfo is not None
 
 
-def test_parse_session_timestamp_returns_aware_for_z_suffix() -> None:
+def test_parse_timestamp_returns_aware_for_z_suffix() -> None:
     """Z suffix input → aware datetime (parse_utc_iso handles this)."""
-    parsed = _parse_session_timestamp("2026-04-20T12:00:00Z")
+    parsed = _parse_timestamp("2026-04-20T12:00:00Z")
     assert parsed is not None
     assert parsed.tzinfo is not None
 
 
-def test_parse_session_timestamp_returns_aware_for_naive_input() -> None:
+def test_parse_timestamp_returns_aware_for_naive_input() -> None:
     """Naive input → aware datetime (parse_utc_iso assumes UTC)."""
-    parsed = _parse_session_timestamp("2026-04-20T12:00:00")
+    parsed = _parse_timestamp("2026-04-20T12:00:00")
     assert parsed is not None
     assert parsed.tzinfo is not None, (
         "parse_utc_iso must promote naive input to aware to keep "
@@ -47,20 +46,20 @@ def test_parse_session_timestamp_returns_aware_for_naive_input() -> None:
     )
 
 
-def test_parse_session_timestamp_returns_passthrough_for_datetime_object() -> None:
+def test_parse_timestamp_returns_passthrough_for_datetime_object() -> None:
     """Datetime object input is returned unchanged (existing contract)."""
     dt = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
-    assert _parse_session_timestamp(dt) is dt
+    assert _parse_timestamp(dt) is dt
 
 
-def test_parse_session_timestamp_returns_none_for_falsy_input() -> None:
-    assert _parse_session_timestamp(None) is None
-    assert _parse_session_timestamp("") is None
+def test_parse_timestamp_returns_none_for_falsy_input() -> None:
+    assert _parse_timestamp(None) is None
+    assert _parse_timestamp("") is None
 
 
-def test_parse_session_timestamp_returns_none_on_invalid_input() -> None:
+def test_parse_timestamp_returns_none_on_invalid_input() -> None:
     """Malformed string returns None (existing contract)."""
-    assert _parse_session_timestamp("not-a-date") is None
+    assert _parse_timestamp("not-a-date") is None
 
 
 def test_is_session_in_range_aware_vs_aware_no_typeerror() -> None:
@@ -109,16 +108,3 @@ def test_is_session_in_range_uses_timestamp_fallback() -> None:
     cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=24)
     session = {"timestamp": datetime.now(tz=timezone.utc).isoformat()}
     assert _is_session_in_range(session, cutoff) is True
-
-
-def test_parse_timestamp_returns_aware_for_offset_input() -> None:
-    """Sibling helper _parse_timestamp also produces aware via parse_utc_iso."""
-    parsed = _parse_timestamp("2026-04-20T12:00:00+00:00")
-    assert parsed is not None
-    assert parsed.tzinfo is not None
-
-
-def test_parse_timestamp_returns_passthrough_for_datetime_object() -> None:
-    """Datetime object input returned unchanged."""
-    dt = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
-    assert _parse_timestamp(dt) is dt

--- a/autobot-backend/api/rum.py
+++ b/autobot-backend/api/rum.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import parse_utc_iso
 from monitoring.prometheus_metrics import get_metrics_manager
 from type_defs.common import Metadata
 
@@ -482,10 +483,8 @@ async def get_rum_status():
             today = datetime.now(tz=timezone.utc).date()
 
             for session_data in rum_sessions.values():
-                last_activity = datetime.fromisoformat(
-                    session_data["last_activity"].replace("Z", "+00:00")
-                )
-                if (datetime.now(tz=timezone.utc) - last_activity.replace(tzinfo=None)) < timedelta(
+                last_activity = parse_utc_iso(session_data["last_activity"])
+                if (datetime.now(tz=timezone.utc) - last_activity) < timedelta(
                     minutes=30
                 ):
                     active_sessions += 1

--- a/tools/lint/check_no_kb_aioredis_access.py
+++ b/tools/lint/check_no_kb_aioredis_access.py
@@ -160,7 +160,17 @@ def _iter_target_files(args: List[str], repo_root: Path) -> Iterable[Path]:
         # Skip vendored / generated / external / vcs-ignored locations
         parts = p.relative_to(repo_root).parts
         if any(
-            part in {".venv", "venv", "node_modules", "__pycache__", ".git", "dist", "build"}
+            part
+            in {
+                ".venv",
+                "venv",
+                "node_modules",
+                "__pycache__",
+                ".git",
+                "dist",
+                "build",
+                ".worktrees",  # #5418: parallel-work git worktrees, not vendored code
+            }
             for part in parts
         ):
             continue


### PR DESCRIPTION
## Summary

Three independent gaps surfaced by self-review of the regression fix in [PR #5424](https://github.com/mrveiss/AutoBot-AI/pull/5424) (#5420). Bundled in one PR because they're each small and all reactive to the same review session.

## [#5418](https://github.com/mrveiss/AutoBot-AI/issues/5418) — sibling lint hook \`.worktrees\` exclude

\`tools/lint/check_no_kb_aioredis_access.py\` had the identical \`_iter_target_files\` implementation as \`check_no_utcnow_isoformat.py\` (fixed in [PR #5405](https://github.com/mrveiss/AutoBot-AI/pull/5405) for #5394) but missed the \`.worktrees\` exclude. Same one-line fix.

## [#5426](https://github.com/mrveiss/AutoBot-AI/issues/5426) — rum.py aware-naive TypeError (🔴 same class as #5420)

\`autobot-backend/api/rum.py:488\` did:

\`\`\`python
(datetime.now(tz=timezone.utc) - last_activity.replace(tzinfo=None))
\`\`\`

which is \`aware - naive\` = \`TypeError\`. Wrapped in \`try/except Exception\` at \`get_rum_status()\`, so the endpoint silently returned the error-branch response whenever \`rum_sessions\` had any entries.

Fix: drop \`.replace(tzinfo=None)\`, both sides aware. Also adopted \`parse_utc_iso\` per #5398 to remove the verbose \`fromisoformat(s.replace(\"Z\",\"+00:00\"))\` pattern in the same hunk.

## [#5427](https://github.com/mrveiss/AutoBot-AI/issues/5427) — \`_parse_timestamp\` / \`_parse_session_timestamp\` dedup

\`autobot-backend/api/analytics_conversation.py\` had two helpers that were byte-identical after [PR #5414](https://github.com/mrveiss/AutoBot-AI/pull/5414) (only differed by parameter name). Deleted \`_parse_session_timestamp\`; redirected sole caller (\`_is_session_in_range:70\`) to \`_parse_timestamp\`. Net -10 lines, zero behavior change.

Test file updated — the parallel test set covered identical behavior twice, so consolidated (11 passing, down from 13).

## Test plan

- [x] \`python3 -m py_compile\` on all 4 changed files → OK
- [x] \`python3 tools/lint/check_no_kb_aioredis_access.py\` → exit 0 (was previously silently scanning \`.worktrees/\`)
- [x] \`python3 -m pytest autobot-backend/api/analytics_conversation_test.py -q\` → 11 passed
- [x] Inline reproduction of rum.py aware-aware subtract: no TypeError

Closes #5418
Closes #5426
Closes #5427
🤖 Generated with [Claude Code](https://claude.com/claude-code)