### PR TITLE
docs(methodology): codify Phase 0d Behavioral Grep rule (closes #5372)

### DIFF
--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -225,3 +225,35 @@ Create issue + DEFER (don't ask):
 When an issue is complete, wait for explicit user instruction before starting new work.
 
 > Violation: Noticing a broken error handler and not creating a GitHub issue because "it's not my task."
+
+---
+
+## Rule 7: Behavioral Grep for Extraction PRs (#5372)
+
+**Extraction PRs (pulling a duplicated pattern into a shared composable/utility + migrating N sites) MUST grep for the *behavior*, not just the *symbol*, and document before/after hit counts in the PR description.**
+
+**Why:** The issue body enumerates sites by symbol name at filing time. Symbol names drift (rename, different convention per consumer); behavior does not. Symbol-only greps underreport consistently — **~50% of extraction PRs this session shipped incomplete migrations** and required follow-up PRs.
+
+**Required PR section:**
+
+```markdown
+## Behavioral grep audit
+
+Before:
+\`\`\`bash
+$ grep -rnE "<behavior regex>" <tree>
+# N hits
+\`\`\`
+
+After:
+\`\`\`bash
+$ <same grep>
+# 0 hits (or explicit follow-up with #N filed)
+\`\`\`
+```
+
+**Rule of thumb:** Match the pattern body (e.g. `key === 'Tab'` and `shiftKey &&` for focus-trap code), cast wider than the issue's enumeration, and run **twice** — once loose, once tight — to catch the delta.
+
+Full Phase 0d specification and concrete examples: [`skills/team-implement.md` §Phase 0d](skills/team-implement.md).
+
+> Violation: Filing a follow-up issue #5410 for 2 dialogs that the original #5371 grep should have surfaced, because #5371 grepped for `handleKeydown` (symbol) instead of `key === 'Tab'` (behavior).

--- a/docs/developer/skills/team-implement.md
+++ b/docs/developer/skills/team-implement.md
@@ -159,6 +159,69 @@ If the issue is closed AND the merged commit supersedes your work: close your lo
 
 ---
 
+## Phase 0d: Behavioral Grep Audit (NEW — #5372, extraction PRs only)
+
+**Applies only to "extract a primitive / composable" issues** — PRs that pull a duplicated pattern from N sites into a shared utility + migrate those sites.
+
+**The problem this prevents:** The original issue body enumerates sites by grepping for a **symbol** (e.g. `handleKeydown`). Between filing and implementation, the set of sites that share the *behavior* (e.g. `key === 'Tab' && shiftKey && ...`) drifts from that enumeration:
+
+- **Over-counted** (some listed sites already migrated via sibling PRs)
+- **Under-counted** (other sites have the same behavior under a different symbol name, or were added to the codebase after the issue was filed)
+
+**This is not hypothetical.** Four instances this session:
+
+| Issue | Listed sites | Real sites | Gap type |
+|---|---|---|---|
+| #5247 | 5 | 2 | Over-count (3 already migrated) |
+| #5283 | 4 (explicit defer of BaseTable) | 5 | BaseTable was late-added |
+| #5371 | 8 | 10 (#5410 added 2) | Under-count — grep missed two different-symbol dialogs |
+| #5411 | 11 | 13 (#5410 doubled up) | Under-count — grep used symbol not behavior |
+
+Miss rate: **50% of extraction PRs this session shipped an incomplete migration.** Every miss required a follow-up PR.
+
+### The rule
+
+For extraction PRs, the PR description **must** include a **"Behavioral grep audit"** section with before / after hit counts:
+
+```markdown
+## Behavioral grep audit
+
+Before:
+\`\`\`bash
+$ grep -rnE "key\s*[=!]==\s*['\"]Tab|shiftKey\s*&&.*focus" autobot-frontend/src --include="*.vue"
+# 3 hits — BaseModal, HostSelectionDialog, EntityDetail
+\`\`\`
+
+After:
+\`\`\`bash
+$ <same grep>
+# 0 hits — all sites migrated to useFocusTrap
+\`\`\`
+```
+
+**Three rules for the regex:**
+1. **Match the behavior, not the symbol.** `handleKeydown` can be renamed; `key === 'Tab'` cannot.
+2. **Cast wider than the issue's enumeration.** If the issue listed 3 sites, grep for the pattern across *the whole relevant tree* to surface sites the filer missed.
+3. **The after-count must be 0** (or explicitly documented non-zero with a follow-up issue filed). Non-zero with no follow-up blocks merge.
+
+**When in doubt, grep two ways:**
+- A loose regex covering the pattern's core behavior
+- A tight regex for a unique fingerprint (e.g. a specific CSS selector string, an unusual attribute combination)
+
+If the two return different counts, investigate the delta — it's often the miss.
+
+### What to write in the PR
+
+A standard "Behavioral grep audit" block, as shown above, immediately after the "Summary" section. This is a merge gate — a missing audit section blocks review.
+
+**Concrete examples from merged PRs:**
+- [PR #5343](https://github.com/mrveiss/AutoBot-AI/pull/5343) — useFocusTrap extraction; amended post-merge to include the audit
+- [PR #5390](https://github.com/mrveiss/AutoBot-AI/pull/5390) — 8-dialog a11y sweep
+- [PR #5417](https://github.com/mrveiss/AutoBot-AI/pull/5417) — useInitialFocus + full kit for 2 missed dialogs
+- [PR #5433](https://github.com/mrveiss/AutoBot-AI/pull/5433) — useBodyScrollLock + immediate: true fix
+
+---
+
 ## Phase 1: Create Isolated Worktrees (idempotent)
 
 **For each issue in WORK_QUEUE:**


### PR DESCRIPTION
## Summary

Closes #5372.

Documents the rule that would have caught ~50% of this session's extraction-PR misses upstream. Two files updated:

1. **[`docs/developer/skills/team-implement.md`](docs/developer/skills/team-implement.md)** — new **Phase 0d: Behavioral Grep Audit** section between Phase 0c (Verification Mandate) and Phase 1 (Worktrees). Extraction PRs must grep for the *behavior* (pattern body), not just the *symbol* (handler name), and document before/after hit counts in the PR description. Non-zero after-count without a follow-up issue blocks merge.

2. **[`docs/developer/CLAUDE_RULES.md`](docs/developer/CLAUDE_RULES.md)** — new **Rule 7: Behavioral Grep for Extraction PRs** with a 1-paragraph summary + link to the full Phase 0d spec. Sits between Rule 6 and EOF so existing numbering is stable.

## Why this rule earns its place

Four extraction PRs this session shipped incomplete migrations:

| Issue | Listed sites | Real sites | Gap type |
|---|---|---|---|
| #5247 | 5 | 2 | Over-count (3 already migrated) |
| #5283 | 4 (BaseTable deferred) | 5 | BaseTable was late-added |
| #5371 | 8 | 10 (→ #5410) | Under-count — symbol-only grep missed two |
| #5411 | 11 | 13 (→ #5410) | Under-count — same failure mode |

**50% miss rate** on extraction PRs. Every miss required a follow-up PR and a reviewer re-audit. A behavioral grep run once, before \`gh pr create\`, would have caught each.

## Scope

**Narrow**: applies only to PRs that pull a duplicated pattern from N sites into a shared utility + migrate those sites. Normal bug fixes, feature work, refactors, etc. don't need a Behavioral Grep section.

**Existing PR description template unchanged for non-extraction PRs** — no extra friction on the 90%+ case.

## Test plan

No code changes. For the next extraction PR:
- [ ] Verify the author includes a "Behavioral grep audit" section
- [ ] Verify before-grep and after-grep are run, with hit counts shown
- [ ] If after-count > 0: verify a follow-up issue is filed and linked

Incident record kept in the concrete-examples table (links to PRs #5343, #5390, #5417, #5433) so future readers can see the pattern.

## Related

- #5142 / PR #5205 — Phase 0c Verification Mandate (sibling rule — type-check + test-run before push)
- #5247, #5283, #5371, #5411 — 4 extraction PRs this session that would have caught their own under-counts
- #5410 — the follow-up issue filed for missed dialogs, which would not have been needed if Phase 0d had fired on #5371
- #5060 — primitives umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)