### PR TITLE
test(frontend): fix 4 pre-existing baseline test failures (#5366)

### DIFF
--- a/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
+++ b/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
@@ -81,6 +81,10 @@ const mockController = {
   updateSessionTitle: vi.fn(),
   getSessionFacts: vi.fn().mockResolvedValue([]),
   preserveSessionFacts: vi.fn().mockResolvedValue({}),
+  // #5366 / Issue #4431: sync flow pushes local-only sessions before
+  // reconciling with backend. Must be mocked or `initializeChatInterface`
+  // throws `controller.pushLocalOnlySessions is not a function`.
+  pushLocalOnlySessions: vi.fn().mockResolvedValue(undefined),
   // Message handling
   sendMessage: vi.fn().mockResolvedValue(undefined),
   // Settings
@@ -234,7 +238,12 @@ describe('ChatInterface', () => {
 
       // i18n keys render as-is since test i18n has empty messages
       await waitFor(() => {
-        expect(screen.getByText('chat.sidebar.chatHistory')).toBeInTheDocument()
+        // #5366: ChatSidebar renders the label twice (mobile + desktop
+        // variants) — both present in jsdom because CSS media queries
+        // (`lg:hidden` / `hidden lg:flex`) don't apply. Use getAllByText
+        // so the assertion succeeds regardless of which variant the
+        // viewport reports.
+        expect(screen.getAllByText('chat.sidebar.chatHistory').length).toBeGreaterThan(0)
       })
       expect(screen.getByLabelText('chat.sidebar.createNew')).toBeInTheDocument()
       expect(screen.getByLabelText('chat.sidebar.resetChat')).toBeInTheDocument()
@@ -246,7 +255,12 @@ describe('ChatInterface', () => {
       renderComponent(ChatInterface, { pinia: true })
 
       await waitFor(() => {
-        expect(screen.getByText('chat.sidebar.chatHistory')).toBeInTheDocument()
+        // #5366: ChatSidebar renders the label twice (mobile + desktop
+        // variants) — both present in jsdom because CSS media queries
+        // (`lg:hidden` / `hidden lg:flex`) don't apply. Use getAllByText
+        // so the assertion succeeds regardless of which variant the
+        // viewport reports.
+        expect(screen.getAllByText('chat.sidebar.chatHistory').length).toBeGreaterThan(0)
       })
 
       // The collapse button aria-label depends on sidebarCollapsed state
@@ -519,7 +533,12 @@ describe('ChatInterface', () => {
 
       await waitFor(() => {
         // Should handle empty state - sidebar title still renders
-        expect(screen.getByText('chat.sidebar.chatHistory')).toBeInTheDocument()
+        // #5366: ChatSidebar renders the label twice (mobile + desktop
+        // variants) — both present in jsdom because CSS media queries
+        // (`lg:hidden` / `hidden lg:flex`) don't apply. Use getAllByText
+        // so the assertion succeeds regardless of which variant the
+        // viewport reports.
+        expect(screen.getAllByText('chat.sidebar.chatHistory').length).toBeGreaterThan(0)
       })
     })
   })

--- a/autobot-frontend/src/composables/useKnowledgeVectorization.ts
+++ b/autobot-frontend/src/composables/useKnowledgeVectorization.ts
@@ -303,7 +303,12 @@ export function useKnowledgeVectorization() {
   const selectDocument = (documentId: string) => selection.select(documentId)
   const deselectDocument = (documentId: string) => selection.deselect(documentId)
   const selectAll = (documentIds: string[]) => {
-    documentIds.forEach(id => selection.select(id))
+    // #5366: use `setSelected` for O(n) bulk assignment. The previous
+    // `forEach(id => selection.select(id))` was O(n²) — each `select`
+    // creates a new Set of growing size — blowing the 10s vitest
+    // timeout at 10k IDs. `setSelected` replaces the selection Set
+    // once in a single pass.
+    selection.setSelected(documentIds)
   }
   const deselectAll = () => selection.clear()
   const isDocumentSelected = (documentId: string): boolean => selection.isSelected(documentId)


### PR DESCRIPTION
## Summary

Three ChatInterface rendering tests + one useKnowledgeVectorization timeout were failing on clean \`Dev_new_gui\`. All fixed.

### ChatInterface (3 tests)

**Missing mock method:** \`ChatController.pushLocalOnlySessions\` (added in #4431) wasn't in the test mock. \`initializeChatInterface()\` hit \`controller.pushLocalOnlySessions is not a function\`, cascaded into the \`.catch\` on a downstream undefined, and prevented sidebar rendering. Mock now includes the method.

**Duplicate text assertion:** \`ChatSidebar\` renders \"chat.sidebar.chatHistory\" twice — mobile header (\`lg:hidden\`) and desktop header — both visible in jsdom (CSS media queries don't apply). \`getByText\` threw on multiple matches; switched the 3 assertions to \`getAllByText(...).length > 0\`.

### useKnowledgeVectorization (1 test)

\`selectAll(10_000 IDs)\` timed out at 23s. Root cause: \`forEach(id => selection.select(id))\` is O(n²) — each \`select\` creates a fresh Set and reassigns \`selected.value\`, so 10k IDs meant 10k Set copies of growing size. Switched to \`selection.setSelected(documentIds)\` (existing \`useBatchSelection\` method) which replaces the Set once in one O(n) pass. **1.3s** (was 23s).

Closes #5366.

## Verification

- \`ChatInterface.test.ts\`: 23/23 pass (was 20/23).
- \`useKnowledgeVectorization.test.ts\`: 41/41 pass (was 40/41 + 1 timeout).
- \`vue-tsc --noEmit -p tsconfig.app.json\` → 167 errors (unchanged baseline; 0 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)