### PR TITLE
fix(composables): systematic onUnmounted/onMounted guard audit across 25 composables (#5406)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/useFocusRestore.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useFocusRestore.test.ts
@@ -6,8 +6,8 @@
  * Unit tests for useFocusRestore composable (#5356).
  */
 
-import { describe, it, expect, beforeEach } from 'vitest'
-import { defineComponent, h, nextTick, ref, type Ref } from 'vue'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { defineComponent, effectScope, h, nextTick, ref, type Ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { useFocusRestore } from '../useFocusRestore'
 
@@ -239,5 +239,33 @@ describe('useFocusRestore', () => {
     // Should not throw — element.focus() on a detached node is silently
     // ignored by browsers (and jsdom matches that behavior).
     expect(() => wrapper.unmount()).not.toThrow()
+  })
+
+  // ========================================
+  // Scope-aware lifecycle (#5406)
+  // ========================================
+
+  describe('scope-aware lifecycle (#5406)', () => {
+    it('does not warn when used inside an effectScope (no component)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const scope = effectScope()
+      scope.run(() => {
+        useFocusRestore()
+      })
+      scope.stop()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
+
+    it('does not warn when called with no active scope at all', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      useFocusRestore()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
   })
 })

--- a/autobot-frontend/src/composables/__tests__/useKeyboard.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useKeyboard.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { defineComponent, ref, nextTick } from 'vue'
+import { defineComponent, effectScope, ref, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
 import {
   useKeyPress,
@@ -1072,5 +1072,50 @@ describe('useKeyboard - Integration Tests', () => {
 
     dispatchKey(document, 'keydown', 's', { ctrl: true })
     expect(saveCallback).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ========================================
+// Scope-aware lifecycle (#5406)
+// ========================================
+
+describe('useKeyboard — scope-aware lifecycle (#5406)', () => {
+  it('useKeyPress does not warn in effectScope', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scope = effectScope()
+    scope.run(() => {
+      useKeyPress('Escape', () => {})
+    })
+    scope.stop()
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('no active component')
+    )
+    warn.mockRestore()
+  })
+
+  it('useKeyboardShortcut does not warn in effectScope', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scope = effectScope()
+    scope.run(() => {
+      useKeyboardShortcut('ctrl+s', () => {})
+    })
+    scope.stop()
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('no active component')
+    )
+    warn.mockRestore()
+  })
+
+  it('useArrowKeys does not warn in effectScope', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scope = effectScope()
+    scope.run(() => {
+      useArrowKeys({ up: () => {}, down: () => {} })
+    })
+    scope.stop()
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('no active component')
+    )
+    warn.mockRestore()
   })
 })

--- a/autobot-frontend/src/composables/__tests__/useNavOverflow.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useNavOverflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { ref, nextTick, createApp, defineComponent } from 'vue'
+import { ref, nextTick, createApp, defineComponent, effectScope } from 'vue'
 import { useNavOverflow } from '../useNavOverflow'
 
 let observeCallback: ((entries: any[]) => void) | null = null
@@ -130,5 +130,26 @@ describe('useNavOverflow', () => {
     expect(result.visibleCount.value).toBe(3)
 
     app.unmount()
+  })
+
+  // ========================================
+  // Scope-aware lifecycle (#5406)
+  // ========================================
+
+  describe('scope-aware lifecycle (#5406)', () => {
+    it('does not warn when used inside an effectScope (no component)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const container = makeContainer(400, [100, 100])
+      const itemCount = ref(2)
+      const scope = effectScope()
+      scope.run(() => {
+        useNavOverflow(ref(container), itemCount)
+      })
+      scope.stop()
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('no active component')
+      )
+      warn.mockRestore()
+    })
   })
 })

--- a/autobot-frontend/src/composables/__tests__/useNetworkStatus.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useNetworkStatus.test.ts
@@ -76,3 +76,36 @@ describe('useNetworkStatus - browser events', () => {
     wrapper.unmount()
   })
 })
+
+// ========================================
+// Scope-aware lifecycle (#5406)
+// ========================================
+
+describe('useNetworkStatus — scope-aware lifecycle (#5406)', () => {
+  it('does not warn when used inside an effectScope (no component)', async () => {
+    const { useNetworkStatus } = await import('../useNetworkStatus')
+    const { effectScope } = await import('vue')
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scope = effectScope()
+    scope.run(() => {
+      useNetworkStatus()
+    })
+    scope.stop()
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('no active component')
+    )
+    warn.mockRestore()
+  })
+
+  it('does not warn when called with no active scope at all', async () => {
+    const { useNetworkStatus } = await import('../useNetworkStatus')
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    useNetworkStatus()
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('no active component')
+    )
+    warn.mockRestore()
+  })
+})

--- a/autobot-frontend/src/composables/useActivityTracking.ts
+++ b/autobot-frontend/src/composables/useActivityTracking.ts
@@ -7,7 +7,7 @@
  * Combines activity logging with WebSocket broadcasting for multi-user sessions.
  */
 
-import { computed, onMounted, onUnmounted, type ComputedRef, type Ref } from 'vue'
+import { computed, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope, type ComputedRef, type Ref } from 'vue'
 import {
   useSessionActivityLogger,
   type ActivityType,
@@ -299,24 +299,28 @@ export function useActivityTracking(): UseActivityTrackingReturn {
   // Auto-sync activities on interval
   let syncInterval: ReturnType<typeof setInterval> | null = null
 
-  onMounted(() => {
-    // Start periodic sync
-    syncInterval = setInterval(() => {
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      // Start periodic sync
+      syncInterval = setInterval(() => {
+        activityLogger.syncActivitiesToBackend()
+      }, 30000) // Every 30 seconds
+
+      logger.debug('[Issue #874] Activity tracking initialized')
+    })
+  }
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (syncInterval) {
+        clearInterval(syncInterval)
+        syncInterval = null
+      }
+
+      // Final sync before unmount
       activityLogger.syncActivitiesToBackend()
-    }, 30000) // Every 30 seconds
-
-    logger.debug('[Issue #874] Activity tracking initialized')
-  })
-
-  onUnmounted(() => {
-    if (syncInterval) {
-      clearInterval(syncInterval)
-      syncInterval = null
-    }
-
-    // Final sync before unmount
-    activityLogger.syncActivitiesToBackend()
-  })
+    })
+  }
 
   return {
     activities,

--- a/autobot-frontend/src/composables/useAuditApi.ts
+++ b/autobot-frontend/src/composables/useAuditApi.ts
@@ -7,7 +7,7 @@
  * Issue #578 - Audit Logging Dashboard GUI Integration
  */
 
-import { ref, computed, onUnmounted } from 'vue'
+import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
 import { useApiWithState } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
 import type {
@@ -577,10 +577,12 @@ export function useAuditState() {
     URL.revokeObjectURL(url)
   }
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    stopPolling()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopPolling()
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/useBackoffPoller.ts
+++ b/autobot-frontend/src/composables/useBackoffPoller.ts
@@ -12,7 +12,7 @@
  * - Respecting page visibility (pauses when tab is hidden)
  */
 
-import { ref, onUnmounted } from 'vue'
+import { ref, onScopeDispose, getCurrentScope } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useBackoffPoller')
@@ -162,7 +162,9 @@ export function useBackoffPoller(options: BackoffPollerOptions): BackoffPollerRe
     logger.debug('Poller stopped')
   }
 
-  onUnmounted(stop)
+  if (getCurrentScope()) {
+    onScopeDispose(stop)
+  }
 
   return { start, stop, isCircuitOpen, consecutiveFailures, currentInterval }
 }

--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -7,7 +7,7 @@
  * Issue #584 - Batch Processing Manager
  */
 
-import { ref, computed, onUnmounted } from 'vue'
+import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
 import { useApiWithState } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
 import type {
@@ -601,10 +601,12 @@ export function useBatchProcessingState() {
     return jobs.value.filter((job) => job.status === status)
   }
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    stopPolling()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopPolling()
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/useBrowserAutomation.ts
+++ b/autobot-frontend/src/composables/useBrowserAutomation.ts
@@ -7,7 +7,7 @@
  * Issue #900 - Browser Automation Dashboard
  */
 
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
@@ -304,18 +304,22 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   // ===== Lifecycle =====
 
-  onMounted(() => {
-    if (autoFetch) {
-      Promise.all([fetchWorkerStatus(), fetchSessions()])
-    }
-    if (pollInterval > 0) {
-      startPolling()
-    }
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      if (autoFetch) {
+        Promise.all([fetchWorkerStatus(), fetchSessions()])
+      }
+      if (pollInterval > 0) {
+        startPolling()
+      }
+    })
+  }
 
-  onUnmounted(() => {
-    stopPolling()
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopPolling()
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/useCodeIntelligence.ts
+++ b/autobot-frontend/src/composables/useCodeIntelligence.ts
@@ -7,7 +7,7 @@
  * Issue #899 - Code Intelligence Tools
  */
 
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, getCurrentInstance } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
@@ -354,15 +354,17 @@ export function useCodeIntelligence(options: UseCodeIntelligenceOptions = {}) {
 
   // ===== Lifecycle =====
 
-  onMounted(() => {
-    if (autoFetch) {
-      clearErrors()
-      Promise.all([
-        getSecurityScoreCached(),
-        getAnalysisHistory(),
-      ])
-    }
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      if (autoFetch) {
+        clearErrors()
+        Promise.all([
+          getSecurityScoreCached(),
+          getAnalysisHistory(),
+        ])
+      }
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/useDevSpeedup.ts
+++ b/autobot-frontend/src/composables/useDevSpeedup.ts
@@ -7,7 +7,7 @@
  * Issue #902 - Developer Speedup Tools
  */
 
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, getCurrentInstance } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
@@ -255,11 +255,13 @@ export function useDevSpeedup(options: UseDevSpeedupOptions = {}) {
 
   // ===== Lifecycle =====
 
-  onMounted(() => {
-    if (autoFetch) {
-      Promise.all([fetchTemplates(), fetchHistory()])
-    }
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      if (autoFetch) {
+        Promise.all([fetchTemplates(), fetchHistory()])
+      }
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/useDocumentChanges.ts
+++ b/autobot-frontend/src/composables/useDocumentChanges.ts
@@ -11,7 +11,7 @@
  * - Change history and statistics
  */
 
-import { ref, computed, onUnmounted } from 'vue'
+import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
@@ -336,10 +336,12 @@ export function useDocumentChanges() {
     }, null, 2)
   }
 
-  // Lifecycle
-  onUnmounted(() => {
-    stopAutoRefresh()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopAutoRefresh()
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/useFocusRestore.ts
+++ b/autobot-frontend/src/composables/useFocusRestore.ts
@@ -25,7 +25,7 @@
  *      but doesn't always behave like an HTMLElement; safer to skip)
  */
 
-import { onMounted, onUnmounted, watch, type Ref } from 'vue'
+import { onMounted, onScopeDispose, watch, getCurrentInstance, getCurrentScope, type Ref } from 'vue'
 
 /**
  * @param activeWhen  Optional Ref<boolean>. When provided, the composable
@@ -57,7 +57,11 @@ export function useFocusRestore(activeWhen?: Ref<boolean>): void {
       else if (!isActive && wasActive) restore()
     }, { immediate: true })
   } else {
-    onMounted(save)
-    onUnmounted(restore)
+    if (getCurrentInstance()) {
+      onMounted(save)
+    }
+    if (getCurrentScope()) {
+      onScopeDispose(restore)
+    }
   }
 }

--- a/autobot-frontend/src/composables/useKeyboard.ts
+++ b/autobot-frontend/src/composables/useKeyboard.ts
@@ -29,7 +29,7 @@
  * ```
  */
 
-import { onMounted, onUnmounted, type Ref } from 'vue'
+import { onMounted, onScopeDispose, getCurrentInstance, getCurrentScope, type Ref } from 'vue'
 import { resolveTarget } from './utils/target-resolver'
 
 // ========================================
@@ -153,16 +153,20 @@ export function useKeyPress(
   // Cache target to ensure cleanup works even if ref changes
   let cachedTarget: HTMLElement | Document | Window | null = null
 
-  onMounted(() => {
-    cachedTarget = resolveTarget(target)
-    cachedTarget.addEventListener(event, handleKeyPress)
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      cachedTarget = resolveTarget(target)
+      cachedTarget.addEventListener(event, handleKeyPress)
+    })
+  }
 
-  onUnmounted(() => {
-    if (cachedTarget) {
-      cachedTarget.removeEventListener(event, handleKeyPress)
-    }
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (cachedTarget) {
+        cachedTarget.removeEventListener(event, handleKeyPress)
+      }
+    })
+  }
 }
 
 // ========================================
@@ -398,16 +402,20 @@ export function useKeyboardShortcut(
   // Cache target to ensure cleanup works even if ref changes
   let cachedTarget: HTMLElement | Document | Window | null = null
 
-  onMounted(() => {
-    cachedTarget = resolveTarget(target)
-    cachedTarget.addEventListener(event, handleShortcut)
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      cachedTarget = resolveTarget(target)
+      cachedTarget.addEventListener(event, handleShortcut)
+    })
+  }
 
-  onUnmounted(() => {
-    if (cachedTarget) {
-      cachedTarget.removeEventListener(event, handleShortcut)
-    }
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (cachedTarget) {
+        cachedTarget.removeEventListener(event, handleShortcut)
+      }
+    })
+  }
 }
 
 // ========================================
@@ -555,16 +563,20 @@ export function useArrowKeys(
   // Cache target to ensure cleanup works even if ref changes
   let cachedTarget: HTMLElement | Document | Window | null = null
 
-  onMounted(() => {
-    cachedTarget = resolveTarget(target)
-    cachedTarget.addEventListener('keydown', handleArrowKey)
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      cachedTarget = resolveTarget(target)
+      cachedTarget.addEventListener('keydown', handleArrowKey)
+    })
+  }
 
-  onUnmounted(() => {
-    if (cachedTarget) {
-      cachedTarget.removeEventListener('keydown', handleArrowKey)
-    }
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (cachedTarget) {
+        cachedTarget.removeEventListener('keydown', handleArrowKey)
+      }
+    })
+  }
 }
 
 // ========================================
@@ -619,14 +631,18 @@ export function useCommandPaletteHotkey(
 
   let cachedTarget: HTMLElement | Document | Window | null = null
 
-  onMounted(() => {
-    cachedTarget = resolveTarget(target)
-    cachedTarget.addEventListener('keydown', handlePalette)
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      cachedTarget = resolveTarget(target)
+      cachedTarget.addEventListener('keydown', handlePalette)
+    })
+  }
 
-  onUnmounted(() => {
-    if (cachedTarget) {
-      cachedTarget.removeEventListener('keydown', handlePalette)
-    }
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (cachedTarget) {
+        cachedTarget.removeEventListener('keydown', handlePalette)
+      }
+    })
+  }
 }

--- a/autobot-frontend/src/composables/useNavOverflow.ts
+++ b/autobot-frontend/src/composables/useNavOverflow.ts
@@ -1,4 +1,4 @@
-import { ref, watch, onMounted, onUnmounted, nextTick, type Ref } from 'vue'
+import { ref, watch, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope, nextTick, type Ref } from 'vue'
 
 const MORE_BUTTON_WIDTH = 90
 const GAP = 16
@@ -44,13 +44,15 @@ export function useNavOverflow(
     visibleCount.value = Math.max(1, count)
   }
 
-  onMounted(async () => {
-    await nextTick()
-    measureNaturalWidths()
-    recalculate()
-    ro = new ResizeObserver(recalculate)
-    if (containerRef.value) ro.observe(containerRef.value)
-  })
+  if (getCurrentInstance()) {
+    onMounted(async () => {
+      await nextTick()
+      measureNaturalWidths()
+      recalculate()
+      ro = new ResizeObserver(recalculate)
+      if (containerRef.value) ro.observe(containerRef.value)
+    })
+  }
 
   watch(itemCount, async () => {
     await nextTick()
@@ -59,7 +61,9 @@ export function useNavOverflow(
     recalculate()
   })
 
-  onUnmounted(() => ro?.disconnect())
+  if (getCurrentScope()) {
+    onScopeDispose(() => ro?.disconnect())
+  }
 
   return { visibleCount }
 }

--- a/autobot-frontend/src/composables/useNetworkStatus.ts
+++ b/autobot-frontend/src/composables/useNetworkStatus.ts
@@ -16,7 +16,7 @@
  *   - 'prefers-network'  — works offline with degraded output (analytics sync)
  */
 
-import { ref, readonly, onMounted, onUnmounted } from 'vue'
+import { ref, readonly, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 
@@ -108,23 +108,29 @@ export function isFeatureAvailable(
 }
 
 export function useNetworkStatus() {
-  onMounted(() => {
-    _refCount++
-    if (_refCount === 1) {
-      window.addEventListener('online', _handleOnline)
-      window.addEventListener('offline', _handleOffline)
-      _startProbeLoop()
-    }
-  })
+  // Refcount must stay balanced: only register both hooks when we have a
+  // component instance (so onMounted runs), then tie cleanup to scope-dispose.
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      _refCount++
+      if (_refCount === 1) {
+        window.addEventListener('online', _handleOnline)
+        window.addEventListener('offline', _handleOffline)
+        _startProbeLoop()
+      }
+    })
 
-  onUnmounted(() => {
-    _refCount--
-    if (_refCount === 0) {
-      window.removeEventListener('online', _handleOnline)
-      window.removeEventListener('offline', _handleOffline)
-      _stopProbeLoop()
+    if (getCurrentScope()) {
+      onScopeDispose(() => {
+        _refCount--
+        if (_refCount === 0) {
+          window.removeEventListener('online', _handleOnline)
+          window.removeEventListener('offline', _handleOffline)
+          _stopProbeLoop()
+        }
+      })
     }
-  })
+  }
 
   return {
     isOnline: readonly(_isOnline),

--- a/autobot-frontend/src/composables/useOperationsApi.ts
+++ b/autobot-frontend/src/composables/useOperationsApi.ts
@@ -7,7 +7,7 @@
  * Issue #591 - Long-Running Operations Tracker
  */
 
-import { ref, computed, onUnmounted } from 'vue'
+import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
 import { useApiWithState } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
 import type {
@@ -332,10 +332,12 @@ export function useOperationsState() {
     return operations.value.filter((op) => op.status === status)
   }
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    stopPolling()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopPolling()
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/useOverseerAgent.ts
+++ b/autobot-frontend/src/composables/useOverseerAgent.ts
@@ -10,7 +10,7 @@
  * @copyright 2025 mrveiss
  */
 
-import { ref, computed, onUnmounted, type Ref } from 'vue'
+import { ref, computed, onScopeDispose, getCurrentScope, type Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 import { getBackendUrl, getApiBase } from '@/config/ssot-config'
 import { useWebSocket } from '@/composables/useWebSocket'
@@ -385,11 +385,13 @@ export function useOverseerAgent(options: UseOverseerAgentOptions) {
     connect()
   }
 
-  // useWebSocket registers onUnmounted cleanup automatically;
-  // we also reset isProcessing on unmount
-  onUnmounted(() => {
-    isProcessing.value = false
-  })
+  // useWebSocket registers scope-dispose cleanup automatically;
+  // we also reset isProcessing on unmount/scope disposal
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      isProcessing.value = false
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-frontend/src/composables/usePrometheusMetrics.ts
@@ -11,7 +11,7 @@
  * Resolved: Issue #76 - Replaced mockup data with real backend metrics
  */
 
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope } from 'vue'
 import type { Ref, ComputedRef } from 'vue'
 import { useApi } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
@@ -474,22 +474,26 @@ export function usePrometheusMetrics(
 
   // ===== Lifecycle =====
 
-  onMounted(() => {
-    if (autoFetch) {
-      fetchAll()
-    }
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      if (autoFetch) {
+        fetchAll()
+      }
 
-    if (enableWebSocket) {
-      connectWebSocket()
-    } else if (pollInterval > 0) {
-      startPolling()
-    }
-  })
+      if (enableWebSocket) {
+        connectWebSocket()
+      } else if (pollInterval > 0) {
+        startPolling()
+      }
+    })
+  }
 
-  onUnmounted(() => {
-    stopPolling()
-    // useWebSocket handles WebSocket cleanup via its own onUnmounted
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopPolling()
+      // useWebSocket handles WebSocket cleanup via its own scope-dispose hook
+    })
+  }
 
   return {
     // State
@@ -571,13 +575,17 @@ export function useSystemMetrics(pollInterval = 10000) {
     }
   }
 
-  onMounted(() => {
-    startPolling()
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      startPolling()
+    })
+  }
 
-  onUnmounted(() => {
-    stopPolling()
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopPolling()
+    })
+  }
 
   return {
     metrics,
@@ -642,13 +650,17 @@ export function useServiceHealth(pollInterval = 15000) {
     }
   }
 
-  onMounted(() => {
-    startPolling()
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      startPolling()
+    })
+  }
 
-  onUnmounted(() => {
-    stopPolling()
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopPolling()
+    })
+  }
 
   return {
     services,
@@ -733,13 +745,17 @@ export function useAlerts(pollInterval = 30000) {
     }
   }
 
-  onMounted(() => {
-    startPolling()
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      startPolling()
+    })
+  }
 
-  onUnmounted(() => {
-    stopPolling()
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      stopPolling()
+    })
+  }
 
   return {
     alerts,

--- a/autobot-frontend/src/composables/useServiceManagement.ts
+++ b/autobot-frontend/src/composables/useServiceManagement.ts
@@ -10,7 +10,7 @@
  * TypeScript migration of useServiceManagement.js (#819).
  */
 
-import { ref, onMounted, onUnmounted, type Ref } from 'vue'
+import { ref, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope, type Ref } from 'vue'
 import { NetworkConstants } from '@/constants/network'
 import redisServiceAPI, {
   type ServiceOperationResult,
@@ -294,13 +294,17 @@ export function useServiceManagement(
 
   // ---- Lifecycle hooks ----
 
-  onMounted(() => {
-    refreshStatus()
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      refreshStatus()
+    })
+  }
 
-  onUnmounted(() => {
-    unsubscribeFromUpdates()
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      unsubscribeFromUpdates()
+    })
+  }
 
   // ---- Public API ----
 

--- a/autobot-frontend/src/composables/useServiceMessages.ts
+++ b/autobot-frontend/src/composables/useServiceMessages.ts
@@ -7,7 +7,7 @@
  * Wraps /api/service-messages/* endpoints.
  */
 
-import { ref, onUnmounted } from 'vue'
+import { ref, onScopeDispose, getCurrentScope } from 'vue'
 import { useApiWithState } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
@@ -159,7 +159,9 @@ export function useServiceMessages() {
     isPolling.value = false
   }
 
-  onUnmounted(() => stopPolling())
+  if (getCurrentScope()) {
+    onScopeDispose(() => stopPolling())
+  }
 
   return {
     messages,

--- a/autobot-frontend/src/composables/useSessionCollaboration.ts
+++ b/autobot-frontend/src/composables/useSessionCollaboration.ts
@@ -22,7 +22,7 @@
  * ```
  */
 
-import { ref, computed, onMounted, onUnmounted, watch, type Ref, type ComputedRef } from 'vue'
+import { ref, computed, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope, watch, type Ref, type ComputedRef } from 'vue'
 import { useChatStore, type UserContext, type SessionActivity } from '@/stores/useChatStore'
 import { createLogger } from '@/utils/debugUtils'
 import globalWebSocketService from '@/services/GlobalWebSocketService'
@@ -533,39 +533,41 @@ export function useSessionCollaboration(): UseSessionCollaborationReturn {
   }
 
   // Subscribe to WebSocket messages on mount
-  onMounted(() => {
-    // Subscribe to collaboration messages
-    const unsubMessage = globalWebSocketService.subscribe('collaboration', handleCollaborationMessage as (data: unknown) => void)
-    unsubscribers.push(unsubMessage)
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      // Subscribe to collaboration messages
+      const unsubMessage = globalWebSocketService.subscribe('collaboration', handleCollaborationMessage as (data: unknown) => void)
+      unsubscribers.push(unsubMessage)
 
-    // Also subscribe to specific message types that might come separately
-    const messageTypes: CollaborationMessageType[] = [
-      'session_join',
-      'session_leave',
-      'presence_update',
-      'activity_broadcast',
-      'invitation_send',
-      'invitation_response',
-      'secret_shared',
-      'secret_revoked',
-      'cursor_move'
-    ]
+      // Also subscribe to specific message types that might come separately
+      const messageTypes: CollaborationMessageType[] = [
+        'session_join',
+        'session_leave',
+        'presence_update',
+        'activity_broadcast',
+        'invitation_send',
+        'invitation_response',
+        'secret_shared',
+        'secret_revoked',
+        'cursor_move'
+      ]
 
-    messageTypes.forEach(type => {
-      const unsub = globalWebSocketService.subscribe(type, (rawData: unknown) => {
-        const data = rawData as Record<string, unknown>
-        handleCollaborationMessage({
-          type,
-          sessionId: data.sessionId as string,
-          payload: data,
-          timestamp: data.timestamp as string || new Date().toISOString()
+      messageTypes.forEach(type => {
+        const unsub = globalWebSocketService.subscribe(type, (rawData: unknown) => {
+          const data = rawData as Record<string, unknown>
+          handleCollaborationMessage({
+            type,
+            sessionId: data.sessionId as string,
+            payload: data,
+            timestamp: data.timestamp as string || new Date().toISOString()
+          })
         })
+        unsubscribers.push(unsub)
       })
-      unsubscribers.push(unsub)
-    })
 
-    logger.debug('[Issue #608] Session collaboration initialized')
-  })
+      logger.debug('[Issue #608] Session collaboration initialized')
+    })
+  }
 
   // Watch for session changes
   watch(
@@ -581,12 +583,14 @@ export function useSessionCollaboration(): UseSessionCollaborationReturn {
     }
   )
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    leaveSession()
-    unsubscribers.forEach(unsub => unsub())
-    unsubscribers = []
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      leaveSession()
+      unsubscribers.forEach(unsub => unsub())
+      unsubscribers = []
+    })
+  }
 
   return {
     myPresence,

--- a/autobot-frontend/src/composables/useTerminalHistory.ts
+++ b/autobot-frontend/src/composables/useTerminalHistory.ts
@@ -35,7 +35,7 @@
  * ```
  */
 
-import { ref, onUnmounted, computed } from 'vue'
+import { ref, onScopeDispose, getCurrentScope, computed } from 'vue'
 import terminalService from '@/services/TerminalService'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -272,12 +272,14 @@ export function useTerminalHistory(sessionId: string) {
     logger.debug('[HISTORY] Received search results', { matchCount: searchMatches.value.length })
   }
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    history.value = []
-    historyIndex.value = -1
-    exitSearchMode()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      history.value = []
+      historyIndex.value = -1
+      exitSearchMode()
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/useTheme.ts
+++ b/autobot-frontend/src/composables/useTheme.ts
@@ -17,7 +17,7 @@
  *   setTheme('dark')  // or 'light', 'system'
  */
 
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, getCurrentInstance } from 'vue'
 
 /** Available theme options */
 export type Theme = 'dark' | 'light' | 'system'
@@ -183,9 +183,11 @@ export function useTheme() {
   }
 
   // Initialize on mount if in browser context
-  onMounted(() => {
-    initTheme()
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      initTheme()
+    })
+  }
 
   // Also initialize immediately if document exists (for SSR compatibility)
   if (typeof document !== 'undefined' && !isInitialized) {

--- a/autobot-frontend/src/composables/useThumbnailWorker.ts
+++ b/autobot-frontend/src/composables/useThumbnailWorker.ts
@@ -25,7 +25,7 @@
  * ```
  */
 
-import { ref, computed, onMounted, onScopeDispose, getCurrentScope } from 'vue'
+import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('useThumbnailWorker')

--- a/autobot-frontend/src/composables/useVirtualChatScroll.ts
+++ b/autobot-frontend/src/composables/useVirtualChatScroll.ts
@@ -12,7 +12,9 @@ import {
   watch,
   nextTick,
   onMounted,
-  onUnmounted,
+  onScopeDispose,
+  getCurrentInstance,
+  getCurrentScope,
   type Ref,
   type ComputedRef,
 } from 'vue'
@@ -97,21 +99,25 @@ export function useVirtualChatScroll(opts: UseVirtualChatScrollOptions) {
   }
 
   // --- Mount: locate external scroll container ---
-  onMounted(() => {
-    const el = messagesContainerRef.value?.closest(
-      '.overflow-y-auto',
-    ) as HTMLElement | null
-    scrollContainerRef.value = el
-    if (el) {
-      el.addEventListener('scroll', onScroll, { passive: true })
-    }
-    // Initial scroll to bottom
-    nextTick(scrollToBottom)
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      const el = messagesContainerRef.value?.closest(
+        '.overflow-y-auto',
+      ) as HTMLElement | null
+      scrollContainerRef.value = el
+      if (el) {
+        el.addEventListener('scroll', onScroll, { passive: true })
+      }
+      // Initial scroll to bottom
+      nextTick(scrollToBottom)
+    })
+  }
 
-  onUnmounted(() => {
-    scrollContainerRef.value?.removeEventListener('scroll', onScroll)
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      scrollContainerRef.value?.removeEventListener('scroll', onScroll)
+    })
+  }
 
   // --- Session change: reset stick-to-bottom ---
   watch(currentSessionId, () => {

--- a/autobot-frontend/src/composables/useVirtualList.ts
+++ b/autobot-frontend/src/composables/useVirtualList.ts
@@ -31,7 +31,7 @@
  * ```
  */
 
-import { ref, computed, onMounted, onUnmounted, watch, toValue, type MaybeRefOrGetter } from 'vue'
+import { ref, computed, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope, watch, toValue, type MaybeRefOrGetter } from 'vue'
 
 interface VirtualItem<T> {
   data: T
@@ -90,17 +90,21 @@ export function useVirtualList<T extends { id: string | number }>(
   }
 
   // Lifecycle
-  onMounted(() => {
-    if (containerRef.value) {
-      containerRef.value.addEventListener('scroll', handleScroll, { passive: true })
-    }
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      if (containerRef.value) {
+        containerRef.value.addEventListener('scroll', handleScroll, { passive: true })
+      }
+    })
+  }
 
-  onUnmounted(() => {
-    if (containerRef.value) {
-      containerRef.value.removeEventListener('scroll', handleScroll)
-    }
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (containerRef.value) {
+        containerRef.value.removeEventListener('scroll', handleScroll)
+      }
+    })
+  }
 
   // Re-attach listener if container ref changes
   watch(

--- a/autobot-frontend/src/composables/useVirtualScroll.ts
+++ b/autobot-frontend/src/composables/useVirtualScroll.ts
@@ -19,7 +19,7 @@
  * ```
  */
 
-import { ref, computed, watch, onMounted, onUnmounted, type Ref } from 'vue'
+import { ref, computed, watch, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope, type Ref } from 'vue'
 
 export interface UseVirtualScrollOptions<T = any> {
   /**
@@ -241,14 +241,18 @@ export function useVirtualScroll<T = any>(options: UseVirtualScrollOptions<T>) {
   }
 
   // Measure container size on mount and resize
-  onMounted(() => {
-    updateContainerSize()
-    window.addEventListener('resize', updateContainerSize)
-  })
+  if (getCurrentInstance()) {
+    onMounted(() => {
+      updateContainerSize()
+      window.addEventListener('resize', updateContainerSize)
+    })
+  }
 
-  onUnmounted(() => {
-    window.removeEventListener('resize', updateContainerSize)
-  })
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      window.removeEventListener('resize', updateContainerSize)
+    })
+  }
 
   // Watch for container ref changes
   watch(containerRef, () => {

--- a/autobot-frontend/src/composables/useWebSocket.ts
+++ b/autobot-frontend/src/composables/useWebSocket.ts
@@ -8,7 +8,7 @@
  * For the global singleton WebSocket, use useGlobalWebSocket instead.
  */
 
-import { ref, computed, onUnmounted, watch, unref, type Ref } from 'vue'
+import { ref, computed, onScopeDispose, getCurrentScope, watch, unref, type Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
 // Create scoped logger for useWebSocket
@@ -356,10 +356,12 @@ export function useWebSocket(
     connect()
   }
 
-  // Cleanup on unmount
-  onUnmounted(() => {
-    disconnect()
-  })
+  // Cleanup when effect scope disposes (component unmount or scope.stop())
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      disconnect()
+    })
+  }
 
   return {
     // State

--- a/autobot-frontend/src/composables/useWorkflowBuilder.ts
+++ b/autobot-frontend/src/composables/useWorkflowBuilder.ts
@@ -12,7 +12,7 @@
  * - /api/workflow-automation/* - Workflow automation management
  */
 
-import { ref, computed, reactive, onUnmounted, onMounted } from 'vue';
+import { ref, computed, reactive } from 'vue';
 import { getBackendUrl, getBackendWsUrl, getApiBase } from '@/config/ssot-config';
 import { createLogger } from '@/utils/debugUtils';
 import { getAuthToken } from '@/utils/fetchWithAuth';
@@ -1149,7 +1149,7 @@ export function useWorkflowBuilder() {
   // ==================================================================================
   // LIFECYCLE
   // ==================================================================================
-  // useWebSocket calls disconnect() in onUnmounted automatically
+  // useWebSocket calls disconnect() via onScopeDispose automatically
 
   // ==================================================================================
   // RETURN


### PR DESCRIPTION
Closes #5406

## Summary
Completes the sweep started by #5318/#5347. Fixed 25 composables with unguarded lifecycle hooks.

## Files fixed (25)
\`useActivityTracking\`, \`useAuditApi\`, \`useBackoffPoller\`, \`useBatchProcessing\`, \`useBrowserAutomation\`, \`useCodeIntelligence\`, \`useDevSpeedup\`, \`useDocumentChanges\`, \`useFocusRestore\`, \`useKeyboard\` (4 pairs), \`useNavOverflow\`, \`useNetworkStatus\`, \`useOperationsApi\`, \`useOverseerAgent\`, \`usePrometheusMetrics\` (4 pairs), \`useServiceManagement\`, \`useServiceMessages\`, \`useSessionCollaboration\`, \`useTerminalHistory\`, \`useTheme\`, \`useVirtualChatScroll\`, \`useVirtualList\`, \`useVirtualScroll\`, \`useWebSocket\`

## Pattern applied
- \`onUnmounted(fn)\` → \`if (getCurrentScope()) onScopeDispose(fn)\`
- \`onMounted(fn)\` → \`if (getCurrentInstance()) onMounted(fn)\`
- \`useNetworkStatus\` refcount-safe: both hooks gated by \`getCurrentInstance()\` (prevents \`_refCount--\` without matching \`++\`)

## Dead imports removed
- \`useWorkflowBuilder\` — unused \`onMounted\`/\`onUnmounted\`
- \`useThumbnailWorker\` — stale \`onMounted\` from #5399

## Already-guarded verified (skip list)
\`useLocalStorage\`, \`useErrorHandler\`, \`useToolApproval\`, \`useLiveEvents\`, \`useGlobalWebSocket\`, \`useReasoningTrace\` — all hooks properly guarded via existing \`getCurrentInstance()\` pattern.

## Warning count
Full composables suite: **13+ → 0** \`onUnmounted is called when there is no active component instance\`.

## Tests
8 new effectScope-aware tests across 4 spec files. 870/870 in full composables suite (zero new failures). 0 new TS errors.