### PR TITLE
feat(observability): wire 10+ KB degradation sites with differentiated reason labels (#5407)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -274,6 +274,14 @@ async def get_knowledge_stats(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized - emit ops-visible
+        # counter + warning so operators see the degradation.
+        logger.warning("get_knowledge_stats: KB uninitialized - returning offline stats")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="stats", reason="kb_uninit"
+        ).inc()
         return {
             "total_documents": 0,
             "total_chunks": 0,
@@ -341,6 +349,15 @@ async def get_knowledge_stats_basic(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning(
+            "get_knowledge_stats_basic: KB uninitialized - returning offline stats"
+        )
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="stats_basic", reason="kb_uninit"
+        ).inc()
         return KnowledgeStatsBasic(
             status="offline",
             total_facts=0,
@@ -445,15 +462,17 @@ async def get_main_categories(
         redis_client is not None,
     )
     if redis_client is None:
-        # Issue #5319: surface kb_connected=false as a log line + Prometheus
-        # counter so operators see the outage, not just the frontend banner.
+        # Issue #5319 / #5407: surface kb_connected=false as a log line +
+        # Prometheus counter so operators see the outage, not just the
+        # frontend banner.  reason="redis_down" - KB instance exists but
+        # its Redis connection is unreachable (infra page).
         logger.warning(
             "KB categories returning kb_connected=false - Redis unreachable"
         )
-        from knowledge.metrics import autobot_kb_redis_unreachable_total
+        from knowledge.metrics import autobot_kb_degradation_total
 
-        autobot_kb_redis_unreachable_total.labels(
-            endpoint="categories_main"
+        autobot_kb_degradation_total.labels(
+            endpoint="categories_main", reason="redis_down"
         ).inc()
 
     category_counts = {
@@ -498,6 +517,15 @@ async def get_knowledge_categories(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning(
+            "get_knowledge_categories: KB uninitialized - returning empty list"
+        )
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="categories", reason="kb_uninit"
+        ).inc()
         return KnowledgeCategoriesResponse(categories=[], total=0)
 
     # Get stats - await async method
@@ -664,6 +692,13 @@ async def add_text_to_knowledge(
     """
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized - emit counter before 500.
+        logger.warning("add_text_to_knowledge: KB uninitialized - raising 500")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="add_text", reason="kb_uninit"
+        ).inc()
         raise InternalError(
             "Knowledge base not initialized - please check logs for errors"
         )
@@ -916,6 +951,13 @@ async def add_facts_to_knowledge(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized - emit counter before 500.
+        logger.warning("add_facts_to_knowledge: KB uninitialized - raising 500")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="facts_add", reason="kb_uninit"
+        ).inc()
         raise InternalError(
             "Knowledge base not initialized - please check logs for errors"
         )
@@ -1003,6 +1045,13 @@ async def add_url_to_knowledge(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized - emit counter before 500.
+        logger.warning("add_url_to_knowledge: KB uninitialized - raising 500")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="url_add", reason="kb_uninit"
+        ).inc()
         raise InternalError("Knowledge base not initialized")
 
     try:
@@ -1180,6 +1229,13 @@ async def upload_file_to_knowledge(
 
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized - emit counter before 500.
+        logger.warning("upload_file_to_knowledge: KB uninitialized - raising 500")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="upload", reason="kb_uninit"
+        ).inc()
         raise InternalError("Knowledge base not initialized")
 
     form = await req.form()
@@ -1370,6 +1426,13 @@ async def ingest_audio_url(
     """
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized - emit counter before 500.
+        logger.warning("ingest_audio_url: KB uninitialized - raising 500")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="audio", reason="kb_uninit"
+        ).inc()
         raise InternalError("Knowledge base not initialized")
 
     logger.info(
@@ -1420,6 +1483,13 @@ async def upload_audio_file(
 
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized - emit counter before 500.
+        logger.warning("upload_audio_file: KB uninitialized - raising 500")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="audio_upload", reason="kb_uninit"
+        ).inc()
         raise InternalError("Knowledge base not initialized")
 
     form = await req.form()
@@ -1499,6 +1569,15 @@ async def get_knowledge_health(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning(
+            "get_knowledge_health: KB uninitialized - returning unhealthy status"
+        )
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="health", reason="kb_uninit"
+        ).inc()
         return {
             "status": "unhealthy",
             "initialized": False,
@@ -1580,6 +1659,13 @@ async def get_knowledge_entries(
     """
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning("get_knowledge_entries: KB uninitialized - returning empty list")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="entries", reason="kb_uninit"
+        ).inc()
         return _empty_entries_response(message="Knowledge base not initialized")
 
     logger.info("Getting knowledge entries: limit=%s, cursor=%s", limit, cursor)
@@ -1681,6 +1767,13 @@ async def get_detailed_stats(
     """
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning("get_detailed_stats: KB uninitialized - returning offline stats")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="detailed_stats", reason="kb_uninit"
+        ).inc()
         return DetailedKnowledgeStats(**_create_offline_stats_response())
 
     basic_stats = await kb.get_stats()
@@ -1774,6 +1867,15 @@ async def get_man_pages_summary(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning(
+            "get_man_pages_summary: KB uninitialized - returning error status"
+        )
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="man_pages_summary", reason="kb_uninit"
+        ).inc()
         return {
             "status": "error",
             "message": "Knowledge base not initialized",
@@ -1846,6 +1948,15 @@ async def initialize_machine_knowledge(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning(
+            "initialize_machine_knowledge: KB uninitialized - returning error status"
+        )
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="machine_knowledge_initialize", reason="kb_uninit"
+        ).inc()
         return {
             "status": "error",
             "message": "Knowledge base not initialized",
@@ -1889,6 +2000,15 @@ async def integrate_man_pages(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning(
+            "integrate_man_pages: KB uninitialized - returning error status"
+        )
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="man_pages_integrate", reason="kb_uninit"
+        ).inc()
         return {
             "status": "error",
             "message": "Knowledge base not initialized",
@@ -1925,6 +2045,13 @@ async def search_man_pages(
     kb_to_use = await get_or_create_knowledge_base(req.app, force_refresh=False)
 
     if kb_to_use is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning("search_man_pages: KB uninitialized - returning empty results")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="man_pages_search", reason="kb_uninit"
+        ).inc()
         return {"results": [], "total_results": 0, "query": query}
 
     logger.info("Searching man pages: '%s' (limit=%s)", query, limit)
@@ -1986,6 +2113,13 @@ async def clear_all_knowledge(
     """
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized.
+        logger.warning("clear_all_knowledge: KB uninitialized - returning error status")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="clear_all", reason="kb_uninit"
+        ).inc()
         return {
             "status": "error",
             "items_removed": 0,
@@ -2229,6 +2363,13 @@ async def get_facts_by_category(
     """
     kb = await get_or_create_knowledge_base(req.app)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning("get_facts_by_category: KB uninitialized - raising 503")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="facts_by_category", reason="kb_uninit"
+        ).inc()
         _raise_kb_unavailable()
 
     cached_result, cache_key = await _check_facts_cache(kb, category, limit)
@@ -2668,6 +2809,13 @@ async def browse_documentation(
     """
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning("browse_documentation: KB uninitialized - raising 503")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="docs_browse", reason="kb_uninit"
+        ).inc()
         raise HTTPException(status_code=503, detail="Knowledge base unavailable")
 
     # Get all indexed documents
@@ -2721,6 +2869,15 @@ async def get_documentation_categories(
     """
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning(
+            "get_documentation_categories: KB uninitialized - raising 503"
+        )
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="docs_categories", reason="kb_uninit"
+        ).inc()
         raise HTTPException(status_code=503, detail="Knowledge base unavailable")
 
     # Get all indexed documents
@@ -2782,6 +2939,13 @@ async def get_documentation_stats(
     """
     kb = await get_or_create_knowledge_base(req.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning("get_documentation_stats: KB uninitialized - raising 503")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="docs_stats", reason="kb_uninit"
+        ).inc()
         raise HTTPException(status_code=503, detail="Knowledge base unavailable")
 
     all_docs = await _get_indexed_docs_from_redis(kb)

--- a/autobot-backend/api/knowledge_audit.py
+++ b/autobot-backend/api/knowledge_audit.py
@@ -87,6 +87,13 @@ async def get_user_activity_log(
     """
     kb = await get_or_create_knowledge_base(request.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning("get_user_activity_log: KB uninitialized - raising 503")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="audit_user_activity", reason="kb_uninit"
+        ).inc()
         raise HTTPException(status_code=503, detail="Knowledge base not available")
 
     try:
@@ -127,6 +134,13 @@ async def get_fact_access_log(
     """
     kb = await get_or_create_knowledge_base(request.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning("get_fact_access_log: KB uninitialized - raising 503")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="audit_fact_access", reason="kb_uninit"
+        ).inc()
         raise HTTPException(status_code=503, detail="Knowledge base not available")
 
     try:
@@ -192,6 +206,15 @@ async def get_organization_audit_log(
 
     kb = await get_or_create_knowledge_base(request.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning(
+            "get_organization_audit_log: KB uninitialized - raising 503"
+        )
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="audit_organization", reason="kb_uninit"
+        ).inc()
         raise HTTPException(status_code=503, detail="Knowledge base not available")
 
     try:
@@ -237,6 +260,13 @@ async def get_permission_changes(
     """
     kb = await get_or_create_knowledge_base(request.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning("get_permission_changes: KB uninitialized - raising 503")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="audit_permission_changes", reason="kb_uninit"
+        ).inc()
         raise HTTPException(status_code=503, detail="Knowledge base not available")
 
     try:
@@ -295,6 +325,15 @@ async def generate_compliance_report(
 
     kb = await get_or_create_knowledge_base(request.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning(
+            "generate_compliance_report: KB uninitialized - raising 503"
+        )
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="audit_compliance_report", reason="kb_uninit"
+        ).inc()
         raise HTTPException(status_code=503, detail="Knowledge base not available")
 
     try:
@@ -348,6 +387,13 @@ async def get_compliance_summary(
 
     kb = await get_or_create_knowledge_base(request.app, force_refresh=False)
     if kb is None:
+        # Issue #5407: KB instance not initialized - emit counter before 503.
+        logger.warning("get_compliance_summary: KB uninitialized - raising 503")
+        from knowledge.metrics import autobot_kb_degradation_total
+
+        autobot_kb_degradation_total.labels(
+            endpoint="audit_compliance_summary", reason="kb_uninit"
+        ).inc()
         raise HTTPException(status_code=503, detail="Knowledge base not available")
 
     try:

--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -572,11 +572,12 @@ async def run_rag_benchmark(
     redis = await get_async_redis_client(database="analytics")
     if redis is None:
         logger.warning("run_rag_benchmark: Redis unavailable; benchmark events dropped")
-        # Issue #5319: emit ops-visible counter alongside the warning.
-        from knowledge.metrics import autobot_kb_redis_unreachable_total
+        # Issue #5319 / #5407: emit ops-visible counter alongside the
+        # warning.  reason="redis_down" - analytics Redis unreachable.
+        from knowledge.metrics import autobot_kb_degradation_total
 
-        autobot_kb_redis_unreachable_total.labels(
-            endpoint="rag_benchmark"
+        autobot_kb_degradation_total.labels(
+            endpoint="rag_benchmark", reason="redis_down"
         ).inc()
         return {
             "published": 0,

--- a/autobot-backend/api/knowledge_rag_feedback.py
+++ b/autobot-backend/api/knowledge_rag_feedback.py
@@ -96,11 +96,12 @@ async def record_rag_feedback(
                 "record_rag_feedback: Redis unavailable; annotation dropped for user %s",
                 uid,
             )
-            # Issue #5319: emit ops-visible counter alongside the warning.
-            from knowledge.metrics import autobot_kb_redis_unreachable_total
+            # Issue #5319 / #5407: emit ops-visible counter alongside the
+            # warning.  reason="redis_down" - analytics Redis unreachable.
+            from knowledge.metrics import autobot_kb_degradation_total
 
-            autobot_kb_redis_unreachable_total.labels(
-                endpoint="rag_feedback"
+            autobot_kb_degradation_total.labels(
+                endpoint="rag_feedback", reason="redis_down"
             ).inc()
             return {"status": "skipped", "reason": "redis_unavailable"}
 

--- a/autobot-backend/knowledge/metrics.py
+++ b/autobot-backend/knowledge/metrics.py
@@ -1,7 +1,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""KB-level Prometheus metrics with no-op fallback (#5319).
+"""KB-level Prometheus metrics with no-op fallback (#5319, #5407).
 
 This module exposes Prometheus counters for knowledge-base observability.
 It degrades to a no-op implementation when ``prometheus_client`` is not
@@ -9,11 +9,27 @@ installed (tests, minimal deployments), so importing is always safe.
 
 Current metrics:
 
-``autobot_kb_redis_unreachable_total{endpoint}``
-    Incremented whenever a KB endpoint serves a degraded response because
-    Redis is unreachable (i.e. ``kb_connected=false``).  Partners with a
-    ``logger.warning`` at the call site so operators can page on either
-    signal.
+``autobot_kb_degradation_total{endpoint, reason}``
+    Incremented whenever a KB endpoint serves a degraded response.  The
+    ``reason`` label distinguishes failure modes so operators can separate
+    'backend bug / cold start' from 'Redis outage':
+
+    - ``kb_uninit``          - KB instance not yet initialized (cold start
+                               or factory config problem).  Fix is a code /
+                               deployment change, not an infra page.
+    - ``redis_down``         - KB exists but Redis is unreachable
+                               (``kb_connected=false``).  Infra page.
+    - ``audit_log_missing``  - KB exists but its audit log subsystem is
+                               unavailable.
+
+Each call site also emits a ``logger.warning`` so operators can page on
+either signal.
+
+``autobot_kb_redis_unreachable_total{endpoint}`` is kept as a deprecated
+alias so existing dashboards and PR #5346 imports keep working; it
+auto-injects ``reason="redis_down"`` for callers that only pass
+``endpoint=``.  New call sites MUST import and use
+``autobot_kb_degradation_total`` directly with an explicit reason.
 
 Follows the pattern established by ``knowledge/query_sanitizer.py`` (#5064).
 """
@@ -38,13 +54,38 @@ class _NoopCounter:
 try:  # pragma: no cover - exercised in environments with the dep
     from prometheus_client import Counter as _PromCounter
 
-    autobot_kb_redis_unreachable_total = _PromCounter(
-        "autobot_kb_redis_unreachable_total",
-        "Count of KB requests served with Redis unreachable (kb_connected=false).",
-        ("endpoint",),
+    autobot_kb_degradation_total = _PromCounter(
+        "autobot_kb_degradation_total",
+        (
+            "Count of KB requests served with a degraded response, labelled "
+            "by endpoint and reason (kb_uninit | redis_down | "
+            "audit_log_missing)."
+        ),
+        ("endpoint", "reason"),
     )
 except Exception:  # pragma: no cover - defensive fallback
-    autobot_kb_redis_unreachable_total = _NoopCounter()
+    autobot_kb_degradation_total = _NoopCounter()
 
 
-__all__ = ["autobot_kb_redis_unreachable_total"]
+class _RedisUnreachableAlias:
+    """Deprecated alias for ``autobot_kb_redis_unreachable_total`` (#5319).
+
+    PR #5346 sites called ``.labels(endpoint="X").inc()`` with a single
+    label.  The new counter (#5407) requires a ``reason`` label; this
+    shim defaults it to ``redis_down`` so existing imports keep working
+    without a silent schema mismatch.
+    """
+
+    def labels(self, *args, **kwargs) -> object:
+        if "reason" not in kwargs:
+            kwargs["reason"] = "redis_down"
+        return autobot_kb_degradation_total.labels(*args, **kwargs)
+
+
+autobot_kb_redis_unreachable_total = _RedisUnreachableAlias()
+
+
+__all__ = [
+    "autobot_kb_degradation_total",
+    "autobot_kb_redis_unreachable_total",
+]

--- a/autobot-backend/knowledge/test_metrics.py
+++ b/autobot-backend/knowledge/test_metrics.py
@@ -1,11 +1,16 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2025 mrveiss
 # Author: mrveiss
-"""Tests for knowledge.metrics (#5319).
+"""Tests for knowledge.metrics (#5319, #5407).
 
 Verifies the Prometheus counter works in both environments:
 - With ``prometheus_client`` installed (real Counter)
 - Without ``prometheus_client`` (_NoopCounter fallback)
+
+#5407 extends the original counter to the multi-label
+``autobot_kb_degradation_total{endpoint, reason}`` with a backward
+compatible ``autobot_kb_redis_unreachable_total`` alias that injects
+``reason="redis_down"`` for one-label callers.
 """
 
 from __future__ import annotations
@@ -14,19 +19,61 @@ import importlib
 import sys
 
 
-def test_kb_redis_unreachable_counter_increments() -> None:
-    """Counter accepts labels().inc() calls without crashing.
+def test_kb_degradation_counter_with_all_reasons() -> None:
+    """New counter accepts every documented reason label without crashing.
 
     Works against both the real prometheus_client Counter and the
     _NoopCounter fallback - the fluent labels().inc() surface is the
     same for both.
     """
+    from knowledge.metrics import autobot_kb_degradation_total
+
+    # Every documented reason, across a spread of endpoint labels.
+    autobot_kb_degradation_total.labels(
+        endpoint="stats", reason="kb_uninit"
+    ).inc()
+    autobot_kb_degradation_total.labels(
+        endpoint="categories_main", reason="redis_down"
+    ).inc()
+    autobot_kb_degradation_total.labels(
+        endpoint="audit_user_activity", reason="audit_log_missing"
+    ).inc()
+    # inc(n) path.
+    autobot_kb_degradation_total.labels(
+        endpoint="rag_feedback", reason="redis_down"
+    ).inc(2)
+
+
+def test_kb_degradation_counter_distinguishes_reasons() -> None:
+    """Same endpoint with different reasons tracks as distinct series."""
+    from knowledge.metrics import autobot_kb_degradation_total
+
+    # Same endpoint, both reasons - must not raise and must be
+    # accepted as distinct label values.
+    autobot_kb_degradation_total.labels(
+        endpoint="stats", reason="kb_uninit"
+    ).inc()
+    autobot_kb_degradation_total.labels(
+        endpoint="stats", reason="redis_down"
+    ).inc()
+
+
+def test_deprecated_alias_injects_redis_down_reason() -> None:
+    """``autobot_kb_redis_unreachable_total`` auto-fills reason="redis_down".
+
+    PR #5346 sites call ``.labels(endpoint="X").inc()`` with a single
+    label.  The #5407 alias shim defaults the new ``reason`` label so
+    existing callers keep working.
+    """
     from knowledge.metrics import autobot_kb_redis_unreachable_total
 
-    autobot_kb_redis_unreachable_total.labels(endpoint="test").inc()
-    autobot_kb_redis_unreachable_total.labels(endpoint="test").inc(2)
-    # Distinct label values must not crash either.
+    # Single-label call must not raise; alias injects reason="redis_down".
     autobot_kb_redis_unreachable_total.labels(endpoint="categories_main").inc()
+    autobot_kb_redis_unreachable_total.labels(endpoint="rag_feedback").inc(2)
+    # Caller may also still pass reason explicitly; must not crash.
+    autobot_kb_redis_unreachable_total.labels(
+        endpoint="rag_benchmark", reason="redis_down"
+    ).inc()
 
 
 def test_kb_metrics_importable_without_prometheus() -> None:
@@ -34,7 +81,8 @@ def test_kb_metrics_importable_without_prometheus() -> None:
 
     Simulates absence by replacing the module entry with ``None`` so the
     ``from prometheus_client import Counter`` line raises, then reloads
-    ``knowledge.metrics`` and asserts the _NoopCounter surface still works.
+    ``knowledge.metrics`` and asserts the _NoopCounter surface still works
+    for both the new counter and the deprecated alias.
     """
     import knowledge.metrics as metrics_module
 
@@ -44,13 +92,21 @@ def test_kb_metrics_importable_without_prometheus() -> None:
         # Force the ImportError path on next reload.
         sys.modules["prometheus_client"] = None  # type: ignore[assignment]
         reloaded = importlib.reload(metrics_module)
-        # The exposed counter still accepts the fluent labels().inc() surface.
-        reloaded.autobot_kb_redis_unreachable_total.labels(endpoint="x").inc()
-        reloaded.autobot_kb_redis_unreachable_total.labels(endpoint="y").inc(3)
-        # And it is the _NoopCounter instance under the hood.
-        assert type(reloaded.autobot_kb_redis_unreachable_total).__name__ == (
+
+        # New counter: fluent labels().inc() surface still works.
+        reloaded.autobot_kb_degradation_total.labels(
+            endpoint="x", reason="kb_uninit"
+        ).inc()
+        reloaded.autobot_kb_degradation_total.labels(
+            endpoint="y", reason="redis_down"
+        ).inc(3)
+        # Under the hood it's the _NoopCounter.
+        assert type(reloaded.autobot_kb_degradation_total).__name__ == (
             "_NoopCounter"
         )
+
+        # Deprecated alias still works against _NoopCounter.
+        reloaded.autobot_kb_redis_unreachable_total.labels(endpoint="z").inc()
     finally:
         # Restore prometheus_client module and reload metrics to real state.
         if saved_prom is not None:


### PR DESCRIPTION
Closes #5407

## Summary
Extends #5346's single-endpoint metric to 30 sites with differentiated reason labels so operators can distinguish backend bugs (\`kb_uninit\`) from Redis outages (\`redis_down\`).

## Metric rename
\`autobot_kb_redis_unreachable_total{endpoint}\` → \`autobot_kb_degradation_total{endpoint, reason}\`

Old name kept as backward-compatible \`_RedisUnreachableAlias\` shim that auto-injects \`reason=\"redis_down\"\`.

## Sites wired (30 total)
- **reason=\"redis_down\" (3)**: categories_main, rag_feedback, rag_benchmark (preserved from #5346)
- **reason=\"kb_uninit\" (27)**:
  - \`api/knowledge.py\` (21): stats, stats_basic, categories, add_text, facts_add, url_add, upload, audio, audio_upload, health, entries, detailed_stats, man_pages_summary, machine_knowledge_initialize, man_pages_integrate, man_pages_search, clear_all, facts_by_category, docs_browse, docs_categories, docs_stats
  - \`api/knowledge_audit.py\` (6): audit_user_activity, audit_fact_access, audit_organization, audit_permission_changes, audit_compliance_report, audit_compliance_summary

## Skipped intentionally
\`knowledge_audit.py:62\` \`kb.audit_log is None\` is lazy-init (creates from \`kb.redis_client\`), not a degradation. \`audit_log_missing\` reason kept in vocabulary for future use.

## Tests
4/4 pass — coverage: all 3 reasons, same-endpoint-different-reason, alias backward-compat, NoopCounter fallback.