### PR TITLE
fix(utils): background_task_manager aware-naive TypeError — silent timeout leak (#5419 P0)

### DIFF
--- a/autobot-backend/utils/background_task_manager.py
+++ b/autobot-backend/utils/background_task_manager.py
@@ -33,6 +33,7 @@ from fastapi import HTTPException
 
 from autobot_shared.redis_management.cache_wrapper import RedisCache
 from autobot_shared.ssot_config import config
+from autobot_shared.time_utils import parse_utc_iso
 from constants.ttl_constants import TTL_24_HOURS
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ class BackgroundTaskManager:
             started = task.get("started_at")
             if started:
                 try:
-                    elapsed = (now - datetime.fromisoformat(started)).total_seconds()
+                    elapsed = (now - parse_utc_iso(started)).total_seconds()
                     if elapsed < self._timeout:
                         continue  # Still within timeout — may be running on another worker
                 except (ValueError, TypeError):
@@ -180,7 +181,7 @@ class BackgroundTaskManager:
             stuck = True
             if started:
                 try:
-                    elapsed = (now - datetime.fromisoformat(started)).total_seconds()
+                    elapsed = (now - parse_utc_iso(started)).total_seconds()
                     stuck = elapsed > self._timeout
                 except (ValueError, TypeError):
                     pass
@@ -323,7 +324,7 @@ class BackgroundTaskManager:
             started = redis_task.get("started_at")
             if started:
                 try:
-                    elapsed = (datetime.now(tz=timezone.utc) - datetime.fromisoformat(started)).total_seconds()
+                    elapsed = (datetime.now(tz=timezone.utc) - parse_utc_iso(started)).total_seconds()
                     if elapsed > self._timeout:
                         redis_task["status"] = "failed"
                         redis_task["error"] = "Task timed out (auto-recovered)"

--- a/autobot-backend/utils/background_task_manager_test.py
+++ b/autobot-backend/utils/background_task_manager_test.py
@@ -1,0 +1,182 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Regression tests for background_task_manager.py datetime arithmetic (#5419 P0).
+
+Pre-fix, three sites did ``(now_aware - datetime.fromisoformat(started))`` where
+``started`` from Redis could be naive ISO. ``aware - naive`` raised TypeError,
+caught by ``except (ValueError, TypeError): pass`` — silently skipping timeout
+detection on every tick. Timed-out tasks never got marked failed; orphaned
+tasks never got cleaned up.
+
+After fix, ``parse_utc_iso(started)`` always returns aware UTC regardless of
+input format, so the subtraction works cleanly.
+
+These tests exercise the in-memory cleanup path (_cleanup_stuck) which is the
+simplest to reach without Redis mocking. The other two sites (_clear_orphaned,
+_load_from_redis-based get_task) share the same bug class and the same fix.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from utils.background_task_manager import BackgroundTaskManager
+
+
+@pytest.fixture
+def manager() -> BackgroundTaskManager:
+    return BackgroundTaskManager(redis_prefix="test_task:", task_timeout=60)
+
+
+def _add_running_task(
+    manager: BackgroundTaskManager, task_id: str, started_at: str
+) -> None:
+    """Seed manager._tasks with a running task carrying a string started_at."""
+    manager._tasks[task_id] = {
+        "status": "running",
+        "started_at": started_at,
+        "params": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_stuck — the pure in-memory path (no Redis)
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_stuck_with_aware_iso_started_marks_timed_out(
+    manager: BackgroundTaskManager,
+) -> None:
+    """Aware +00:00 ISO beyond timeout → task marked failed."""
+    past = (datetime.now(tz=timezone.utc) - timedelta(seconds=120)).isoformat()
+    _add_running_task(manager, "t1", past)
+
+    cleaned = manager._cleanup_stuck()
+    assert cleaned == 1
+    assert manager._tasks["t1"]["status"] == "failed"
+    assert manager._tasks["t1"]["reason"] == "timeout"
+
+
+def test_cleanup_stuck_with_z_suffix_started_marks_timed_out(
+    manager: BackgroundTaskManager,
+) -> None:
+    """Z-suffix ISO beyond timeout — parse_utc_iso handles Z natively."""
+    past = (
+        (datetime.now(tz=timezone.utc) - timedelta(seconds=120))
+        .replace(microsecond=0)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+    _add_running_task(manager, "t2", past)
+
+    cleaned = manager._cleanup_stuck()
+    assert cleaned == 1
+    assert manager._tasks["t2"]["status"] == "failed"
+
+
+def test_cleanup_stuck_with_naive_iso_started_no_typeerror(
+    manager: BackgroundTaskManager,
+) -> None:
+    """The #5419 regression guard: NAIVE ISO input must not TypeError.
+
+    Pre-fix: ``datetime.now(tz=utc) - datetime.fromisoformat(naive)`` raised
+    TypeError, silently caught by ``except (ValueError, TypeError): pass``,
+    leaving ``stuck = True`` (the default) — which meant the task WOULD be
+    marked failed, but for the wrong reason (skipped timeout check, not
+    elapsed-beyond-threshold). With the fix, the timeout check actually runs.
+    """
+    # Naive ISO — what pre-migration code paths wrote to Redis
+    past_naive = (datetime.now(timezone.utc) - timedelta(seconds=120)).replace(
+        tzinfo=None
+    ).isoformat()
+    _add_running_task(manager, "t3", past_naive)
+
+    # Must not raise
+    cleaned = manager._cleanup_stuck()
+    assert cleaned == 1
+    assert manager._tasks["t3"]["status"] == "failed"
+    assert manager._tasks["t3"]["reason"] == "timeout"
+
+
+def test_cleanup_stuck_within_timeout_keeps_running(
+    manager: BackgroundTaskManager,
+) -> None:
+    """Recent started_at (within timeout) leaves task running."""
+    recent = (datetime.now(tz=timezone.utc) - timedelta(seconds=10)).isoformat()
+    _add_running_task(manager, "t4", recent)
+
+    cleaned = manager._cleanup_stuck()
+    assert cleaned == 0
+    assert manager._tasks["t4"]["status"] == "running"
+
+
+def test_cleanup_stuck_within_timeout_with_naive_iso_keeps_running(
+    manager: BackgroundTaskManager,
+) -> None:
+    """The other half of the #5419 fix: naive-within-timeout should NOT be
+    marked failed. Pre-fix, TypeError in the try block silently left
+    ``stuck = True`` default, causing false-positive failure marking.
+    """
+    recent_naive = (
+        datetime.now(timezone.utc) - timedelta(seconds=10)
+    ).replace(tzinfo=None).isoformat()
+    _add_running_task(manager, "t5", recent_naive)
+
+    cleaned = manager._cleanup_stuck()
+    assert cleaned == 0, (
+        "task within timeout must not be marked failed — pre-fix, the "
+        "silently-caught TypeError caused false positives"
+    )
+    assert manager._tasks["t5"]["status"] == "running"
+
+
+def test_cleanup_stuck_malformed_started_still_marks_stuck(
+    manager: BackgroundTaskManager,
+) -> None:
+    """Existing contract: truly malformed started_at → stuck=True fallback.
+
+    parse_utc_iso raises ValueError on garbage input; the surrounding
+    ``except (ValueError, TypeError): pass`` leaves ``stuck = True`` default,
+    which is the safe choice (mark as failed rather than leave in-memory).
+    """
+    _add_running_task(manager, "t6", "not-a-timestamp")
+
+    cleaned = manager._cleanup_stuck()
+    assert cleaned == 1
+    assert manager._tasks["t6"]["status"] == "failed"
+
+
+def test_cleanup_stuck_missing_started_still_marks_stuck(
+    manager: BackgroundTaskManager,
+) -> None:
+    """No started_at → stuck=True default, task marked failed."""
+    manager._tasks["t7"] = {"status": "running", "params": {}}
+
+    cleaned = manager._cleanup_stuck()
+    assert cleaned == 1
+    assert manager._tasks["t7"]["status"] == "failed"
+
+
+def test_cleanup_stuck_non_running_tasks_untouched(
+    manager: BackgroundTaskManager,
+) -> None:
+    """Only ``status == 'running'`` tasks are considered."""
+    past_naive = (
+        datetime.now(timezone.utc) - timedelta(seconds=120)
+    ).replace(tzinfo=None).isoformat()
+    manager._tasks["t8"] = {
+        "status": "pending",
+        "started_at": past_naive,
+        "params": {},
+    }
+    manager._tasks["t9"] = {
+        "status": "completed",
+        "started_at": past_naive,
+        "params": {},
+    }
+
+    cleaned = manager._cleanup_stuck()
+    assert cleaned == 0
+    assert manager._tasks["t8"]["status"] == "pending"
+    assert manager._tasks["t9"]["status"] == "completed"


### PR DESCRIPTION
## Summary

Fixes the 3 P0 confirmed bugs from [#5419](https://github.com/mrveiss/AutoBot-AI/issues/5419) in \`autobot-backend/utils/background_task_manager.py\`. Same bug class as [#5350](https://github.com/mrveiss/AutoBot-AI/issues/5350) (engine.py:649): aware-minus-unguarded-fromisoformat silently caught by broad exception handler.

## The bug (3 sites)

\`\`\`python
# Lines 151, 184, 327 (pre-fix)
elapsed = (now - datetime.fromisoformat(started)).total_seconds()
\`\`\`

- \`now = datetime.now(tz=timezone.utc)\` is **aware**
- \`started\` from Redis **may be naive** (pre-migration writers wrote naive ISO strings)
- \`aware - naive\` → \`TypeError: can't subtract offset-naive and offset-aware datetimes\`
- Caught by surrounding \`except (ValueError, TypeError): pass\` → silent failure

### Production impact

| Site | Function | Silent failure mode |
|---|---|---|
| 151 | \`_clear_orphaned\` | Orphaned tasks never marked failed after backend restart — cleanup pass silently no-ops per tick |
| 184 | \`_cleanup_stuck\` | In-memory tasks with naive \`started_at\` get flagged \`stuck=True\` by default (TypeError skips elapsed check) — **false-positive failure marking** for tasks still within timeout |
| 327 | \`get_task\` auto-recovery | Timed-out tasks returned as still \`running\` until different path catches them |

## Fix

Import \`parse_utc_iso\`, replace all 3 \`fromisoformat\` calls. \`parse_utc_iso\` (added in PR #5377) accepts +00:00, Z, and naive inputs; always returns aware UTC. Net +1 import, zero LOC added in hot path.

## Tests

New \`autobot-backend/utils/background_task_manager_test.py\` — **8 regression tests** covering \`_cleanup_stuck\` with:

- Aware +00:00 ISO beyond timeout → marked failed ✓
- Z-suffix ISO beyond timeout → marked failed ✓ (parse_utc_iso handles Z)
- **Naive ISO beyond timeout → no TypeError, marked failed for the right reason** ✓
- **Naive ISO within timeout → NOT marked failed** (false-positive guard) ✓
- Recent aware ISO → stays running ✓
- Malformed timestamp → stuck=True fallback (existing contract) ✓
- Missing started_at → stuck=True fallback ✓
- Non-running tasks (pending/completed) → untouched ✓

## Verification

Pre-fix vs post-fix inline reproduction:
\`\`\`
Pre-fix:  (aware_now - fromisoformat(naive_iso)) → TypeError silently caught
Post-fix: (aware_now - parse_utc_iso(naive_iso)) → elapsed=120.0s, clean
\`\`\`

## Scope

**Partial closure of [#5419](https://github.com/mrveiss/AutoBot-AI/issues/5419)** — the 3 P0 \"confirmed bugs\" from the issue body only. P1 (checkpoint_manager, task_queue, memory/storage) and P2 (project_state_tracking, planner, events) remain open — 93 more unguarded \`fromisoformat\` sites across autobot-backend + autobot-slm-backend.

## Test plan

- [x] \`python3 -m pytest autobot-backend/utils/background_task_manager_test.py -q\` → 8 passed
- [x] \`python3 -m py_compile\` on both files → OK
- [x] Inline reproduction confirmed bug + fix behavior

Refs #5419
🤖 Generated with [Claude Code](https://claude.com/claude-code)