### PR TITLE
fix(autobot_shared): parse_utc_iso raises ValueError on non-str input (#5464)

### DIFF
--- a/autobot_shared/time_utils.py
+++ b/autobot_shared/time_utils.py
@@ -90,7 +90,17 @@ def parse_utc_iso(value: str) -> datetime:
     when the input string may originate from external sources or legacy
     producers. Avoids the ``TypeError: can't compare offset-naive and
     offset-aware datetimes`` class flagged in #5350.
+
+    Raises ``ValueError`` on non-string or malformed input — matches the
+    ``datetime.fromisoformat`` exception surface adopters expect (#5464).
+    Non-string inputs previously escaped as ``AttributeError`` from the
+    inner ``.replace()`` call, slipping past the common
+    ``except (ValueError, TypeError)`` adopter pattern.
     """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"parse_utc_iso: expected str, got {type(value).__name__}"
+        )
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)

--- a/autobot_shared/time_utils_test.py
+++ b/autobot_shared/time_utils_test.py
@@ -185,3 +185,42 @@ def test_parse_utc_iso_invalid_raises() -> None:
     import pytest
     with pytest.raises(ValueError):
         parse_utc_iso("not-a-date")
+
+
+def test_parse_utc_iso_non_string_raises_value_error() -> None:
+    """#5464: non-str input raises ValueError — NOT AttributeError.
+
+    Pre-#5464, ``parse_utc_iso(123)`` raised ``AttributeError`` from the
+    inner ``.replace()`` call, escaping the common
+    ``except (ValueError, TypeError)`` adopter pattern. The 13+ call sites
+    across PRs #5377, #5414, #5434, #5453, #5462 all kept the migration-
+    preserving exception handler expecting compatibility with
+    ``datetime.fromisoformat``'s ``TypeError``/``ValueError`` surface.
+
+    Post-#5464, the isinstance guard raises ``ValueError`` so adopters'
+    handlers catch it uniformly.
+    """
+    import pytest
+
+    for bad_input in (123, 12.5, {"a": 1}, [1, 2, 3], None):
+        with pytest.raises(ValueError, match="expected str"):
+            parse_utc_iso(bad_input)  # type: ignore[arg-type]
+
+
+def test_parse_utc_iso_non_string_does_not_raise_attribute_error() -> None:
+    """Explicit regression guard: the failure mode must NOT be AttributeError.
+
+    This is the exact escape path that prompted #5464 — if the isinstance
+    check is ever removed, this test fails with AttributeError leaking.
+    """
+    import pytest
+
+    try:
+        parse_utc_iso(123)  # type: ignore[arg-type]
+    except AttributeError:
+        pytest.fail(
+            "parse_utc_iso must not raise AttributeError on non-str input "
+            "(that's the #5464 bug — adopters' except clauses don't catch it)"
+        )
+    except ValueError:
+        pass  # expected


### PR DESCRIPTION
## Summary

Closes [#5464](https://github.com/mrveiss/AutoBot-AI/issues/5464). One-line contract tightening on \`parse_utc_iso\` — **retroactively hardens every adopter from this session**.

## The issue

\`parse_utc_iso(value: str)\` did \`value.replace(\"Z\", \"+00:00\")\` without a type guard. Non-string input raised **AttributeError** (from \`int.replace\` / \`dict.replace\` etc.) — escaping the common adopter pattern \`except (ValueError, TypeError): pass\` that 13+ call sites rely on.

Pre-migration callers used \`datetime.fromisoformat(value)\` which raises **TypeError** on non-str, caught by the adopter pattern. Post-migration, \`AttributeError\` silently escaped.

## Reproduction

\`\`\`python
>>> datetime.fromisoformat(123)
TypeError: fromisoformat: argument must be str     # caught by adopters

>>> parse_utc_iso(123)   # pre-#5464
AttributeError: 'int' object has no attribute 'replace'    # NOT caught
\`\`\`

## Adopter exposure (13+ sites across 6 session PRs)

| PR | File(s) | # sites |
|---|---|---|
| #5377 | \`security/enterprise/threat_detection/models.py\` | 5 |
| #5414 | \`branch_metrics.py\`, \`deduplication.py\`, \`metadata.py\`, \`knowledge_organization.py\`, \`analytics_evolution.py\`, \`analytics_conversation.py\`, \`chat.py\`, \`notification_suppression.py\`, \`advanced_apm_system.py\` | 11 |
| #5434 | \`rum.py\` | 1 |
| #5453 | \`analytics.py\` | 3 |
| #5462 | \`background_task_manager.py\` | 3 |

**Total: 23 sites.** Each kept \`except (ValueError, TypeError): pass\` expecting compatibility with \`fromisoformat\`'s exception surface.

## Fix

\`\`\`diff
 def parse_utc_iso(value: str) -> datetime:
     # ... docstring ...
+    if not isinstance(value, str):
+        raise ValueError(
+            f\"parse_utc_iso: expected str, got {type(value).__name__}\"
+        )
     parsed = datetime.fromisoformat(value.replace(\"Z\", \"+00:00\"))
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed
\`\`\`

One-line \`isinstance\` guard. No adopter code changes needed — \`ValueError\` is already in everyone's handler.

## Tests

Two new tests in \`autobot_shared/time_utils_test.py\`:

- \`test_parse_utc_iso_non_string_raises_value_error\` — covers \`int\` / \`float\` / \`dict\` / \`list\` / \`None\` inputs → all raise \`ValueError\` with \"expected str\" message
- \`test_parse_utc_iso_non_string_does_not_raise_attribute_error\` — explicit regression guard naming the bug class (fails if the isinstance check is ever removed)

## Verification

- [x] \`python3 -m pytest autobot_shared/time_utils_test.py -q\` → 19 passed (17 prior + 2 new)
- [x] Adopter sanity: \`analytics_conversation_test.py\` + \`background_task_manager_test.py\` → 38 passed total, zero regression
- [x] \`python3 -m py_compile\` on \`time_utils.py\` → OK

## Why this matters

This is the highest-leverage fix of the session — **one line retroactively strengthens every parse_utc_iso adopter** without touching any adoption site. Classic shared-helper payoff: centralize the safety guarantee where it belongs.

Closes #5464
🤖 Generated with [Claude Code](https://claude.com/claude-code)