### PR TITLE
fix(backend): P1 state-recovery parse_utc_iso adoption (#5419 P1)

### DIFF
--- a/autobot-backend/memory/storage/general_storage.py
+++ b/autobot-backend/memory/storage/general_storage.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Union
 
 import aiosqlite
 
+from autobot_shared.time_utils import parse_utc_iso
+
 from ..enums import MemoryCategory
 from ..models import MemoryEntry
 
@@ -220,7 +222,7 @@ class GeneralStorage:
             content=row["content"],
             metadata=json.loads(row["metadata_json"]) if row["metadata_json"] else {},
             timestamp=(
-                datetime.fromisoformat(row["timestamp"])
+                parse_utc_iso(row["timestamp"])
                 if isinstance(row["timestamp"], str)
                 else row["timestamp"]
             ),

--- a/autobot-backend/memory/storage/task_storage.py
+++ b/autobot-backend/memory/storage/task_storage.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import aiosqlite
 
+from autobot_shared.time_utils import parse_utc_iso
+
 from ..enums import TaskPriority, TaskStatus
 from ..models import TaskExecutionRecord
 
@@ -293,17 +295,17 @@ class TaskStorage:
             status=TaskStatus(row["status"]),
             priority=TaskPriority(row["priority"]),
             created_at=(
-                datetime.fromisoformat(row["created_at"])
+                parse_utc_iso(row["created_at"])
                 if isinstance(row["created_at"], str)
                 else row["created_at"]
             ),
             started_at=(
-                datetime.fromisoformat(row["started_at"])
+                parse_utc_iso(row["started_at"])
                 if row["started_at"] and isinstance(row["started_at"], str)
                 else row["started_at"]
             ),
             completed_at=(
-                datetime.fromisoformat(row["completed_at"])
+                parse_utc_iso(row["completed_at"])
                 if row["completed_at"] and isinstance(row["completed_at"], str)
                 else row["completed_at"]
             ),

--- a/autobot-backend/utils/long_running_operations/checkpoint_manager.py
+++ b/autobot-backend/utils/long_running_operations/checkpoint_manager.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 import aiofiles
 import redis.asyncio as redis
 
+from autobot_shared.time_utils import parse_utc_iso
 from constants.path_constants import PATH
 from constants.ttl_constants import TTL_7_DAYS
 
@@ -182,7 +183,7 @@ class OperationCheckpointManager:
                         return OperationCheckpoint(
                             checkpoint_id=checkpoint_data["checkpoint_id"],
                             operation_id=checkpoint_data["operation_id"],
-                            checkpoint_time=datetime.fromisoformat(checkpoint_data["checkpoint_time"]),
+                            checkpoint_time=parse_utc_iso(checkpoint_data["checkpoint_time"]),
                             progress_percent=checkpoint_data["progress_percent"],
                             state_data=checkpoint_data["state_data"],
                             metadata=checkpoint_data.get("metadata", {}),
@@ -198,7 +199,7 @@ class OperationCheckpointManager:
                 return OperationCheckpoint(
                     checkpoint_id=checkpoint_data["checkpoint_id"],
                     operation_id=checkpoint_data["operation_id"],
-                    checkpoint_time=datetime.fromisoformat(checkpoint_data["checkpoint_time"]),
+                    checkpoint_time=parse_utc_iso(checkpoint_data["checkpoint_time"]),
                     progress_percent=checkpoint_data["progress_percent"],
                     state_data=checkpoint_data["state_data"],
                     metadata=checkpoint_data.get("metadata", {}),
@@ -221,7 +222,7 @@ class OperationCheckpointManager:
         return OperationCheckpoint(
             checkpoint_id=checkpoint_data["checkpoint_id"],
             operation_id=checkpoint_data["operation_id"],
-            checkpoint_time=datetime.fromisoformat(checkpoint_data["checkpoint_time"]),
+            checkpoint_time=parse_utc_iso(checkpoint_data["checkpoint_time"]),
             progress_percent=checkpoint_data["progress_percent"],
             state_data=checkpoint_data["state_data"],
             metadata=checkpoint_data.get("metadata", {}),

--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -19,6 +19,8 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
+from autobot_shared.time_utils import parse_utc_iso
+
 try:
     from redis.exceptions import RedisError
 
@@ -94,9 +96,9 @@ class TaskResult:
         if "status" in data:
             data["status"] = TaskStatus(data["status"])
         if "started_at" in data and data["started_at"]:
-            data["started_at"] = datetime.fromisoformat(data["started_at"])
+            data["started_at"] = parse_utc_iso(data["started_at"])
         if "completed_at" in data and data["completed_at"]:
-            data["completed_at"] = datetime.fromisoformat(data["completed_at"])
+            data["completed_at"] = parse_utc_iso(data["completed_at"])
         return cls(**data)
 
 
@@ -144,11 +146,11 @@ class Task:
         if "priority" in data:
             data["priority"] = TaskPriority(data["priority"])
         if "created_at" in data:
-            data["created_at"] = datetime.fromisoformat(data["created_at"])
+            data["created_at"] = parse_utc_iso(data["created_at"])
         if "scheduled_at" in data and data["scheduled_at"]:
-            data["scheduled_at"] = datetime.fromisoformat(data["scheduled_at"])
+            data["scheduled_at"] = parse_utc_iso(data["scheduled_at"])
         if "expires_at" in data and data["expires_at"]:
-            data["expires_at"] = datetime.fromisoformat(data["expires_at"])
+            data["expires_at"] = parse_utc_iso(data["expires_at"])
         return cls(**data)
 
 


### PR DESCRIPTION
## Summary

Migrates **12 \`datetime.fromisoformat\` sites** in state-recovery code paths to \`parse_utc_iso\`. Same bug class as [#5419 P0](https://github.com/mrveiss/AutoBot-AI/issues/5419) (merged in [#5462](https://github.com/mrveiss/AutoBot-AI/pull/5462)) — aware-vs-possibly-naive comparison silently caught by broad exception handlers.

## Files migrated (4 files, 12 sites)

| File | Sites | Purpose |
|---|---|---|
| \`utils/long_running_operations/checkpoint_manager.py\` | 3 (186, 202, 225) | \`checkpoint_time\` field parsing in \`load_checkpoint\` |
| \`utils/task_queue.py\` | 5 (99, 101, 149, 151, 153) | \`Task/TaskResult.from_dict\` deserialization |
| \`memory/storage/general_storage.py\` | 1 (225) | \`MemoryEntry\` row-to-entry conversion |
| \`memory/storage/task_storage.py\` | 3 (298, 303, 308) | \`TaskExecutionRecord\` row-to-record conversion |

## Why this matters

Each site reconstructs typed \`datetime\` from SQLite/Redis/JSON storage. If the value was written pre-migration as naive ISO (no tz suffix), \`fromisoformat\` returned naive. Downstream arithmetic/comparison with aware \`datetime.now(tz=utc)\` would \`TypeError\`.

\`parse_utc_iso\` always returns aware UTC regardless of input format. Bonus: Py 3.10's \`fromisoformat\` rejects Z-suffix input; \`parse_utc_iso\` handles it via \`.replace(\"Z\", \"+00:00\")\`. Migration quietly fixes any Z-suffix legacy data that pre-#5414 writers may have produced.

## Test plan

- [x] \`python3 -m py_compile\` on all 4 changed files → OK
- [x] \`grep -rn 'datetime\\.fromisoformat' --include='*.py'\` in scoped dirs → 0 remaining
- [x] #5464's \`isinstance\` guard (merged in #5465) protects all these adopters against non-str edge cases
- [ ] Runtime tests for checkpoint_manager / task_queue / storage deferred — code paths require SQLite/Redis fixtures that don't exist yet. Callers of these from_dict/row_to_* methods already have higher-level tests; the migration preserves behavior for all existing tz-aware inputs.

## Scope

**Partial closure of #5419 (P1 scope).** Remaining:

**P2 (~75 sites, lower urgency)**:
- \`project_state_tracking/database.py:260, 288\`
- \`planner/types.py:107, 112, 287, 292, 297\`
- \`events/types.py:159\`
- \`knowledge/temporal_search.py:119\`
- \`knowledge/connectors/notion.py:288\` (uses \`.rstrip(\"Z\")\` — DIFFERENT pattern)
- ~70 more type-conversion sites

Refs #5419
🤖 Generated with [Claude Code](https://claude.com/claude-code)