### PR TITLE
fix(backend): task_queue/security_policy/planner producer-not-migrated regression (#5469)

### DIFF
--- a/autobot-backend/planner/types.py
+++ b/autobot-backend/planner/types.py
@@ -286,7 +286,7 @@ class ExecutionPlan:
             created_at=(
                 parse_utc_iso(data["created_at"])
                 if data.get("created_at")
-                else datetime.utcnow()
+                else now_utc()
             ),
             started_at=(
                 parse_utc_iso(data["started_at"])

--- a/autobot-backend/security/enterprise/security_policy_manager.py
+++ b/autobot-backend/security/enterprise/security_policy_manager.py
@@ -12,7 +12,7 @@ import json
 import logging
 import threading
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -525,8 +525,8 @@ class SecurityPolicyManager:
             enforcement_mode=enforcement_mode,
             rules=rules,
             metadata=metadata or {},
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(tz=timezone.utc),
+            updated_at=datetime.now(tz=timezone.utc),
             version="1.0",
             author=author,
             approval_required=self.config.get("policy_management", {}).get(
@@ -571,7 +571,7 @@ class SecurityPolicyManager:
                 setattr(policy, key, value)
 
         policy.version = new_version
-        policy.updated_at = datetime.utcnow()
+        policy.updated_at = datetime.now(tz=timezone.utc)
         policy.author = author
 
         # Reset approval if significant changes
@@ -597,10 +597,10 @@ class SecurityPolicyManager:
 
         policy.status = PolicyStatus.ACTIVE
         policy.approved_by = approver
-        policy.approved_at = datetime.utcnow()
+        policy.approved_at = datetime.now(tz=timezone.utc)
 
         if not policy.effective_date:
-            policy.effective_date = datetime.utcnow()
+            policy.effective_date = datetime.now(tz=timezone.utc)
 
         self._save_policy(policy)
         self._update_policy_statistics()
@@ -617,7 +617,7 @@ class SecurityPolicyManager:
 
         policy = self.policies[policy_id]
         policy.status = PolicyStatus.INACTIVE
-        policy.updated_at = datetime.utcnow()
+        policy.updated_at = datetime.now(tz=timezone.utc)
 
         self._save_policy(policy)
         self._update_policy_statistics()
@@ -637,7 +637,7 @@ class SecurityPolicyManager:
             action=context.get("action", ""),
             violation_type=check_result["violation_type"],
             severity=check_result["severity"],
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(tz=timezone.utc),
             details=check_result["details"],
         )
 
@@ -778,7 +778,7 @@ class SecurityPolicyManager:
             if rule["name"] == "idle_timeout_minutes":
                 last_activity = session_data.get("last_activity")
                 if last_activity:
-                    idle_time = (datetime.utcnow() - last_activity).total_seconds() / 60
+                    idle_time = (datetime.now(tz=timezone.utc) - last_activity).total_seconds() / 60
                     if idle_time > rule["value"]:
                         result["compliant"] = False
                         result["violation_type"] = "session_idle_timeout"
@@ -1014,7 +1014,7 @@ class SecurityPolicyManager:
                 [
                     v
                     for v in self.policy_violations
-                    if (datetime.utcnow() - v.timestamp).days <= 30
+                    if (datetime.now(tz=timezone.utc) - v.timestamp).days <= 30
                 ]
             ),
         }

--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -15,7 +15,7 @@ import time
 import traceback
 import uuid
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
@@ -124,7 +124,7 @@ class Task:
         if self.kwargs is None:
             self.kwargs = {}
         if self.created_at is None:
-            self.created_at = datetime.utcnow()
+            self.created_at = datetime.now(tz=timezone.utc)
         if self.metadata is None:
             self.metadata = {}
 
@@ -251,11 +251,11 @@ class TaskQueue:
         """
         scheduled_at = None
         if delay:
-            scheduled_at = datetime.utcnow() + timedelta(seconds=delay)
+            scheduled_at = datetime.now(tz=timezone.utc) + timedelta(seconds=delay)
 
         expires_at = None
         if expires_in:
-            expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+            expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
 
         return scheduled_at, expires_at
 
@@ -274,7 +274,7 @@ class TaskQueue:
         Issue #620.
         """
         try:
-            if scheduled_at and scheduled_at > datetime.utcnow():
+            if scheduled_at and scheduled_at > datetime.now(tz=timezone.utc):
                 score = scheduled_at.timestamp()
                 await self.redis.zadd(self.scheduled_key, {task_id: score})
             else:
@@ -369,7 +369,7 @@ class TaskQueue:
 
         self.is_running = True
         async with self._stats_lock:
-            self.stats["started_at"] = datetime.utcnow()
+            self.stats["started_at"] = datetime.now(tz=timezone.utc)
 
         # Start task workers
         for i in range(self.max_workers):
@@ -513,7 +513,7 @@ class TaskQueue:
         """
         result.status = TaskStatus.COMPLETED
         result.result = task_result
-        result.completed_at = datetime.utcnow()
+        result.completed_at = datetime.now(tz=timezone.utc)
         result.execution_time = time.time() - start_time
 
         async with self._stats_lock:
@@ -542,7 +542,7 @@ class TaskQueue:
         result.error = error
         if error_traceback:
             result.error_traceback = error_traceback
-        result.completed_at = datetime.utcnow()
+        result.completed_at = datetime.now(tz=timezone.utc)
         result.execution_time = time.time() - start_time
 
     def _check_task_expired(self, task: Task) -> bool:
@@ -557,7 +557,7 @@ class TaskQueue:
 
         Issue #620.
         """
-        return task.expires_at is not None and datetime.utcnow() > task.expires_at
+        return task.expires_at is not None and datetime.now(tz=timezone.utc) > task.expires_at
 
     async def _execute_task_with_timeout(self, task: Task, result: TaskResult, start_time: float) -> None:
         """
@@ -609,7 +609,7 @@ class TaskQueue:
 
         self.logger.info("Worker %s processing task %s: %s", worker_name, task_id, task.function_name)
 
-        result = TaskResult(task_id=task_id, status=TaskStatus.RUNNING, started_at=datetime.utcnow())
+        result = TaskResult(task_id=task_id, status=TaskStatus.RUNNING, started_at=datetime.now(tz=timezone.utc))
 
         try:
             await self._execute_task_with_timeout(task, result, start_time)
@@ -654,7 +654,7 @@ class TaskQueue:
         result.status = TaskStatus.RETRY
 
         retry_delay = task.retry_delay * (2**result.retry_count)
-        retry_time = datetime.utcnow() + timedelta(seconds=retry_delay)
+        retry_time = datetime.now(tz=timezone.utc) + timedelta(seconds=retry_delay)
 
         if task.metadata:
             task.metadata["retry_count"] = result.retry_count
@@ -746,7 +746,7 @@ class TaskQueue:
             result = TaskResult(
                 task_id=task_id,
                 status=TaskStatus.CANCELLED,
-                completed_at=datetime.utcnow(),
+                completed_at=datetime.now(tz=timezone.utc),
             )
 
             result_data = json.dumps(result.to_dict())
@@ -794,7 +794,7 @@ class TaskQueue:
         }
 
         if started_at:
-            uptime = datetime.utcnow() - started_at
+            uptime = datetime.now(tz=timezone.utc) - started_at
             stats["uptime_seconds"] = uptime.total_seconds()
 
         return stats


### PR DESCRIPTION
## Summary

🔴 **Regression I introduced via PRs [#5467](https://github.com/mrveiss/AutoBot-AI/pull/5467)/[#5468](https://github.com/mrveiss/AutoBot-AI/pull/5468)** — caught via Layer-N self-review before it reached users. Fixes [#5469](https://github.com/mrveiss/AutoBot-AI/issues/5469).

When migrating PARSERS to \`parse_utc_iso\` (always aware), I didn't migrate same-file PRODUCERS that still wrote naive \`datetime.utcnow()\` values. Post-migration, aware parsed values compared against naive producers → TypeError.

**Same bug class as #5420** (\`analytics_conversation._is_session_in_range\` regression from #5414).

## Reproduction

\`\`\`python
from datetime import datetime
from autobot_shared.time_utils import parse_utc_iso
scheduled = parse_utc_iso('2026-04-21T12:00:00')  # post-#5467: aware
now = datetime.utcnow()                            # line 277 RHS: naive
scheduled > now
# TypeError: can't compare offset-naive and offset-aware datetimes
\`\`\`

(Verified locally.)

## Files fixed (22 sites)

### \`autobot-backend/utils/task_queue.py\` (12 sites)

All \`datetime.utcnow()\` → \`datetime.now(tz=timezone.utc)\`. Mix points:
- Line 277: \`scheduled_at > datetime.utcnow()\` — aware > naive TypeError
- Line 560: \`datetime.utcnow() > task.expires_at\` — naive > aware TypeError
- Lines 254, 258: producers creating naive values that round-trip to aware parser

Added \`timezone\` import.

### \`autobot-backend/security/enterprise/security_policy_manager.py\` (9 sites)

\`SecurityPolicy\`/\`PolicyViolation\` objects created via \`datetime.utcnow()\` while round-trip-loaded via \`parse_utc_iso\`. Lines 781, 1017 did naive-aware subtraction that would crash. Added \`timezone\` import.

### \`autobot-backend/planner/types.py\` (1 site)

\`ExecutionPlan.from_dict\` \`datetime.utcnow()\` fallback when \`created_at\` missing → naive, while the \`parse_utc_iso\` branch → aware. Inconsistent type per instance. Switched to \`now_utc()\` (already imported).

## Pattern lesson

When migrating \`fromisoformat\` → \`parse_utc_iso\` in a file, ALSO grep the same file for \`datetime.utcnow()\`:

\`\`\`bash
git grep 'datetime\\.utcnow' <file>   # after any parse_utc_iso migration
\`\`\`

If any result exists, the same migration likely needs to extend to producers.

## Test plan

- [x] \`python3 -m py_compile\` on all 3 files → OK
- [x] Inline reproduction pre-fix: TypeError. Post-fix: clean aware-aware compare.
- [ ] Runtime tests for \`task_queue\` / \`security_policy_manager\` / \`planner\` deferred — same reasoning as #5467 (SQLite/Redis fixtures not available). The migration preserves behavior for all-aware inputs and fixes the aware-vs-naive class.

Closes #5469
🤖 Generated with [Claude Code](https://claude.com/claude-code)