### PR TITLE
fix(tools): install_skills.sh relative-path resolution (follow-up to PR #5458)

### DIFF
--- a/tools/install_skills.sh
+++ b/tools/install_skills.sh
@@ -21,12 +21,18 @@ set -euo pipefail
 # worktree checkouts (e.g. /home/user/repo/.git for both cases).
 # Its parent directory is the canonical repo root.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if ! GIT_COMMON_DIR="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null)"; then
+# `git rev-parse --git-common-dir` returns a path that may be relative to
+# git's invocation directory (SCRIPT_DIR here) — e.g. "../.git", ".git",
+# or an absolute path depending on context. Resolve to absolute by
+# `cd SCRIPT_DIR` first, so relative paths resolve against a known base.
+if ! GIT_COMMON_DIR_RAW="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null)"; then
   echo "ERROR: not inside a git repository (no .git found from $SCRIPT_DIR)" >&2
   exit 1
 fi
-# Normalize to absolute path (git-common-dir can return a relative path)
-GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
+case "$GIT_COMMON_DIR_RAW" in
+  /*) GIT_COMMON_DIR="$GIT_COMMON_DIR_RAW" ;;
+  *)  GIT_COMMON_DIR="$(cd "$SCRIPT_DIR" && cd "$GIT_COMMON_DIR_RAW" && pwd)" ;;
+esac
 REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
 echo "Resolved REPO_ROOT: $REPO_ROOT"
 SKILLS_SRC="$REPO_ROOT/docs/developer/skills"


### PR DESCRIPTION
## Summary

Follow-up to PR #5458. That PR's install_skills.sh fix resolved \`GIT_COMMON_DIR\` via \`cd "$GIT_COMMON_DIR"\` on git-rev-parse output, but \`git rev-parse --git-common-dir\` returns a **relative path** when invoked from the primary checkout (e.g. \`../.git\` when SCRIPT_DIR is \`tools/\`). The \`cd\` then failed because CWD at that point wasn't SCRIPT_DIR.

Found when running the post-merge \`install_skills.sh\` — got \`cd: ../.git: No such file or directory\`.

## Fix

Explicitly resolve against SCRIPT_DIR for relative paths:

\`\`\`bash
case "$GIT_COMMON_DIR_RAW" in
  /*) GIT_COMMON_DIR="$GIT_COMMON_DIR_RAW" ;;
  *)  GIT_COMMON_DIR="$(cd "$SCRIPT_DIR" && cd "$GIT_COMMON_DIR_RAW" && pwd)" ;;
esac
\`\`\`

Handles both cases:
- **From primary checkout**: \`git rev-parse --git-common-dir\` → \`../.git\` (relative to SCRIPT_DIR=tools/) → resolves to \`/repo/.git\`
- **From worktree**: \`git rev-parse --git-common-dir\` → absolute path to primary .git → used as-is

## Verification

\`\`\`bash
# From worktree
$ bash tools/install_skills.sh
Resolved REPO_ROOT: /home/martins/AutoBot-Ai/AutoBot-AI
LINK  batch-implement -> ...
PRUNE team-implement(dangling -> ...)
Installed: 1  Refreshed: 0  Backed up: 1  Pruned: 1

# From primary checkout
$ cd /home/martins/AutoBot-Ai/AutoBot-AI && bash .worktrees/<>/tools/install_skills.sh
Resolved REPO_ROOT: /home/martins/AutoBot-Ai/AutoBot-AI
OK    batch-implement (already symlinked to repo)
Installed: 0  Refreshed: 1  Backed up: 0  Pruned: 0
\`\`\`

Both invocations now resolve correctly. Post-install state verified:
- \`~/.claude/skills/batch-implement/SKILL.md\` → symlink to canonical repo
- \`grep -c "Phase 0c|Phase 0d" ~/.claude/skills/batch-implement/SKILL.md\` → 4
- \`team-implement\` directory removed (pruned)

## Related

- #5447 — original worktree-path bug
- #5454 — skill consolidation
- PR #5458 — the PR this is following up

🤖 Generated with [Claude Code](https://claude.com/claude-code)