### PR TITLE
refactor(api): remove redundant .replace inside parse_utc_iso (#5473)

### DIFF
--- a/autobot-backend/api/analytics_evolution.py
+++ b/autobot-backend/api/analytics_evolution.py
@@ -270,9 +270,7 @@ async def store_quality_snapshot(snapshot: QualitySnapshot) -> bool:
     try:
         # Store snapshot with timestamp-based key
         key = f"{SNAPSHOT_PREFIX}{snapshot.timestamp}"
-        timestamp_score = parse_utc_iso(
-            snapshot.timestamp.replace("Z", "+00:00")
-        ).timestamp()
+        timestamp_score = parse_utc_iso(snapshot.timestamp).timestamp()
 
         # Issue #361: Execute sync Redis ops in thread pool
         def _store_snapshot():
@@ -301,9 +299,7 @@ async def store_pattern_snapshot(snapshot: PatternSnapshot) -> bool:
 
     try:
         key = f"{PATTERNS_PREFIX}{snapshot.pattern_type}:{snapshot.timestamp}"
-        timestamp_score = parse_utc_iso(
-            snapshot.timestamp.replace("Z", "+00:00")
-        ).timestamp()
+        timestamp_score = parse_utc_iso(snapshot.timestamp).timestamp()
         timeline_key = f"{PATTERNS_PREFIX}{snapshot.pattern_type}:timeline"
 
         # Issue #361: Execute sync Redis ops in thread pool


### PR DESCRIPTION
## Summary

Closes [#5473](https://github.com/mrveiss/AutoBot-AI/issues/5473). 2-site cleanup from PR #5468's bulk-sed approach.

\`analytics_evolution.py\` lines 273-275 and 304-306 wrapped \`parse_utc_iso\` around a manual \`.replace(\"Z\", \"+00:00\")\`. \`parse_utc_iso\` handles Z-suffix natively, so the outer replace is redundant.

\`\`\`diff
-        timestamp_score = parse_utc_iso(
-            snapshot.timestamp.replace(\"Z\", \"+00:00\")
-        ).timestamp()
+        timestamp_score = parse_utc_iso(snapshot.timestamp).timestamp()
\`\`\`

**Net: -4 LOC, zero behavior change.**

## Test plan

- [x] \`python3 -m py_compile\` → OK
- [x] \`git diff --stat\` → 2 insertions, 6 deletions
- [x] No functional change (parse_utc_iso byte-identical output for Z-suffix input)

Closes #5473
🤖 Generated with [Claude Code](https://claude.com/claude-code)