### PR TITLE
fix(backend): captcha_human_loop param-based timing + agent.py dual-purpose split (#5351)

### DIFF
--- a/autobot-backend/api/agent.py
+++ b/autobot-backend/api/agent.py
@@ -1263,7 +1263,7 @@ async def coordinate_multi_agent_task(
             )
 
         # Execute coordinated task
-        coordination_start = datetime.utcnow()
+        coordination_start = time.monotonic()
 
         # Use AI Stack's multi-agent orchestration
         coordination_result = await ai_client.multi_agent_query(
@@ -1272,8 +1272,7 @@ async def coordinate_multi_agent_task(
             coordination_mode=payload.coordination_strategy,
         )
 
-        coordination_end = datetime.utcnow()
-        coordination_time = (coordination_end - coordination_start).total_seconds()
+        coordination_time = time.monotonic() - coordination_start
 
         return create_success_response(
             {
@@ -1286,7 +1285,7 @@ async def coordinate_multi_agent_task(
                     len(payload.dependencies) if payload.dependencies else 0
                 ),
                 "result": coordination_result,
-                "timestamp": coordination_end.isoformat(),
+                "timestamp": utc_timestamp(),
             }
         )
 

--- a/autobot-backend/services/captcha_human_loop.py
+++ b/autobot-backend/services/captcha_human_loop.py
@@ -39,9 +39,9 @@ import base64
 import logging
 import os
 import threading
+import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 
@@ -174,7 +174,7 @@ class CaptchaHumanLoop:
         self,
         captcha_id: str,
         url: str,
-        start_time: datetime,
+        start_time: float,
         solution: str,
         confidence: str,
     ) -> CaptchaResolutionResult:
@@ -183,7 +183,7 @@ class CaptchaHumanLoop:
 
         Issue #620.
         """
-        duration = (datetime.utcnow() - start_time).total_seconds()
+        duration = time.monotonic() - start_time
         return CaptchaResolutionResult(
             success=True,
             status=CaptchaResolutionStatus.AUTO_SOLVED,
@@ -202,7 +202,7 @@ class CaptchaHumanLoop:
         captcha_input_selector: Optional[str],
         captcha_id: str,
         url: str,
-        start_time: datetime,
+        start_time: float,
     ) -> Optional[CaptchaResolutionResult]:
         """
         Attempt automatic CAPTCHA solving.
@@ -267,7 +267,7 @@ class CaptchaHumanLoop:
         self,
         captcha_id: str,
         url: str,
-        start_time: datetime,
+        start_time: float,
         error_message: str,
     ) -> CaptchaResolutionResult:
         """Build error result for CAPTCHA intervention failures.
@@ -286,7 +286,7 @@ class CaptchaHumanLoop:
             status=CaptchaResolutionStatus.ERROR,
             captcha_id=captcha_id,
             url=url,
-            duration_seconds=(datetime.utcnow() - start_time).total_seconds(),
+            duration_seconds=time.monotonic() - start_time,
             error_message=error_message,
         )
 
@@ -343,7 +343,7 @@ class CaptchaHumanLoop:
         status: CaptchaResolutionStatus,
         captcha_id: str,
         url: str,
-        start_time: datetime,
+        start_time: float,
     ) -> CaptchaResolutionResult:
         """Build final CAPTCHA resolution result.
 
@@ -362,7 +362,7 @@ class CaptchaHumanLoop:
             status=status,
             captcha_id=captcha_id,
             url=url,
-            duration_seconds=(datetime.utcnow() - start_time).total_seconds(),
+            duration_seconds=time.monotonic() - start_time,
         )
 
     async def _try_auto_solve_flow(
@@ -372,7 +372,7 @@ class CaptchaHumanLoop:
         captcha_input_selector: Optional[str],
         captcha_id: str,
         url: str,
-        start_time: datetime,
+        start_time: float,
     ) -> tuple[Optional[CaptchaResolutionResult], str]:
         """Attempt auto-solve and return result with screenshot base64.
 
@@ -444,7 +444,7 @@ class CaptchaHumanLoop:
             CaptchaResolutionResult with success status and details.
         """
         captcha_id = str(uuid.uuid4())
-        start_time = datetime.utcnow()
+        start_time = time.monotonic()
         logger.info("Handling CAPTCHA at %s (type: %s)", url, captcha_type)
 
         try:


### PR DESCRIPTION
## Summary

Closes [#5351](https://github.com/mrveiss/AutoBot-AI/issues/5351). Two deferred categories from PR #5342 (#5211 Phase B3.2).

## captcha_human_loop.py — param-based timing → time.monotonic

- Lines 177, 205, 270, 346, 375: changed param annotation \`start_time: datetime\` → \`start_time: float\`
- Lines 186, 289, 365: migrated \`(datetime.utcnow() - start_time).total_seconds()\` → \`time.monotonic() - start_time\`
- Line 447: caller migrated \`start_time = datetime.utcnow()\` → \`start_time = time.monotonic()\`
- Removed \`from datetime import datetime\` (no longer needed)
- Added \`import time\`

## api/agent.py — dual-purpose timestamp split

\`coordination_start\`/\`coordination_end\` served both delta-calc and output-payload purposes. Split into:

\`\`\`python
# before
coordination_start = datetime.utcnow()
# ... work ...
coordination_end = datetime.utcnow()
coordination_time = (coordination_end - coordination_start).total_seconds()
return create_success_response({
    ...,
    \"timestamp\": coordination_end.isoformat(),
})

# after
coordination_start = time.monotonic()
# ... work ...
coordination_time = time.monotonic() - coordination_start
return create_success_response({
    ...,
    \"timestamp\": utc_timestamp(),  # wall-clock for output payload
})
\`\`\`

## Session context

This PR's commit was made early in the #5211 migration session (2026-04-20) but never pushed/merged — a session bookkeeping oversight discovered during session-final audit. The work itself is sound (already verified via \`py_compile\` at creation time and re-verified today).

## Test plan

- [x] \`python3 -m py_compile\` on both files → OK
- [x] Rebased onto latest Dev_new_gui cleanly

Closes #5351
🤖 Generated with [Claude Code](https://claude.com/claude-code)