### PR TITLE
fix(knowledge): bulk.py + stats.py paired-parser migration to parse_utc_iso (#5475)

### DIFF
--- a/autobot-backend/knowledge/bulk.py
+++ b/autobot-backend/knowledge/bulk.py
@@ -18,6 +18,8 @@ from datetime import datetime, timezone
 from io import StringIO
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from autobot_shared.time_utils import parse_utc_iso
+
 if TYPE_CHECKING:
     import aioredis
     import redis
@@ -32,21 +34,23 @@ def _parse_date_bound(
     date_str: Optional[str], is_end_date: bool = False
 ) -> Optional[datetime]:
     """
-    Parse a date string to datetime.
+    Parse a date string to tz-aware UTC datetime.
 
     Issue #398: Extracted from _apply_date_filter.
+    Issue #5475: Returns aware UTC paired with `_parse_fact_timestamp` so
+    the comparisons in `_filter_facts_by_date_range` stay aware-vs-aware.
 
     Args:
         date_str: Date string in YYYY-MM-DD format
         is_end_date: If True, set time to end of day
 
     Returns:
-        Parsed datetime or None if invalid
+        Parsed tz-aware datetime (UTC) or None if invalid
     """
     if not date_str:
         return None
     try:
-        dt = datetime.strptime(date_str, "%Y-%m-%d")
+        dt = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
         if is_end_date:
             dt = dt.replace(hour=23, minute=59, second=59)
         return dt
@@ -71,10 +75,10 @@ def _parse_fact_timestamp(timestamp_str: Any) -> Optional[datetime]:
         return None
     try:
         if "T" in timestamp_str:
-            return datetime.fromisoformat(
-                timestamp_str.replace("Z", "+00:00").split("+")[0]
-            )
-        return datetime.strptime(timestamp_str, "%Y-%m-%d")
+            return parse_utc_iso(timestamp_str)
+        return datetime.strptime(timestamp_str, "%Y-%m-%d").replace(
+            tzinfo=timezone.utc
+        )
     except (ValueError, TypeError):
         return None
 

--- a/autobot-backend/knowledge/stats.py
+++ b/autobot-backend/knowledge/stats.py
@@ -14,6 +14,8 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from autobot_shared.time_utils import parse_utc_iso
+
 if TYPE_CHECKING:
     import aioredis
     import redis
@@ -789,14 +791,10 @@ class StatsMixin:
             return None
         try:
             if "T" in timestamp_str:
-                dt = datetime.fromisoformat(
-                    timestamp_str.replace("Z", "+00:00").split("+")[0]
-                )
-            else:
-                dt = datetime.strptime(timestamp_str, "%Y-%m-%d")
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt
+                return parse_utc_iso(timestamp_str)
+            return datetime.strptime(timestamp_str, "%Y-%m-%d").replace(
+                tzinfo=timezone.utc
+            )
         except (ValueError, TypeError):
             return None
 


### PR DESCRIPTION
## Summary

Closes [#5475](https://github.com/mrveiss/AutoBot-AI/issues/5475). Two sites that were missed by my earlier P2-tail \`grep -v 'replace.*Z'\` filter — they use a different idiom that produced naive datetimes.

## Files

**\`knowledge/stats.py\`** (1 site, line 792)
Already did strip-then-reattach-UTC at line 800 — functionally equivalent to \`parse_utc_iso\`. Replaced for clarity. Net -4 LOC.

**\`knowledge/bulk.py\`** (1 site, line 74)
**Paired with \`_parse_date_bound\` (line 31)** which also returned naive via \`strptime\`. Both feed into \`_filter_facts_by_date_range\` comparisons at lines 325-327. Migrating only one parser would create aware-vs-naive TypeError (same #5420-class bug). **Migrated both:**
- \`_parse_date_bound\`: \`strptime + .replace(tzinfo=timezone.utc)\`
- \`_parse_fact_timestamp\`: \`parse_utc_iso\` for ISO, \`strptime + tzinfo\` for date-only

Both sides now consistently aware UTC.

## Test plan

- [x] \`python3 -m py_compile\` on both files → OK
- [x] \`grep -n fromisoformat\` in both files → 0 remaining

## Lesson

When a file has paired naive parsers feeding the same comparison, migrating one without the other creates the #5420-class regression. **Trace BOTH sides before flipping aware-ness.**

Closes #5475
Refs #5419 P2-tail (2 of 52 sites)
🤖 Generated with [Claude Code](https://claude.com/claude-code)