### PR TITLE
fix(backend): P2 batch 1 — atomic_fact + database + entity_mapping + agent_analytics (#5419 P2 partial)

### DIFF
--- a/autobot-backend/models/atomic_fact.py
+++ b/autobot-backend/models/atomic_fact.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.time_utils import parse_utc_iso
+
 
 class FactType(Enum):
     """Classification of fact types based on their nature."""
@@ -242,14 +244,14 @@ class AtomicFact:
     def from_dict(cls, data: Dict[str, Any]) -> "AtomicFact":
         """Create an AtomicFact from a dictionary representation."""
         # Parse datetime fields
-        valid_from = datetime.fromisoformat(data["valid_from"])
+        valid_from = parse_utc_iso(data["valid_from"])
         valid_until = (
-            datetime.fromisoformat(data["valid_until"])
+            parse_utc_iso(data["valid_until"])
             if data.get("valid_until")
             else None
         )
         last_verified = (
-            datetime.fromisoformat(data["last_verified"])
+            parse_utc_iso(data["last_verified"])
             if data.get("last_verified")
             else None
         )

--- a/autobot-backend/models/entity_mapping.py
+++ b/autobot-backend/models/entity_mapping.py
@@ -12,6 +12,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
+from autobot_shared.time_utils import parse_utc_iso
+
 
 class EntityType(Enum):
     """Classification of entity types."""
@@ -217,8 +219,8 @@ class EntityMapping:
             child_entities=set(data.get("child_entities", [])),
             sources=set(data.get("sources", [])),
             contexts=data.get("contexts", []),
-            creation_timestamp=datetime.fromisoformat(data["creation_timestamp"]),
-            last_updated=datetime.fromisoformat(data["last_updated"]),
+            creation_timestamp=parse_utc_iso(data["creation_timestamp"]),
+            last_updated=parse_utc_iso(data["last_updated"]),
             created_by=data.get("created_by", "system"),
             mention_count=data.get("mention_count", 0),
             fact_count=data.get("fact_count", 0),

--- a/autobot-backend/project_state_tracking/database.py
+++ b/autobot-backend/project_state_tracking/database.py
@@ -17,6 +17,8 @@ import sqlite3
 from datetime import datetime
 from typing import List, Optional, Tuple
 
+from autobot_shared.time_utils import parse_utc_iso
+
 from .models import StateSnapshot
 from .types import TrackingMetric
 
@@ -257,7 +259,7 @@ def load_snapshots_from_db(db_path: str, limit: int = 100) -> List[StateSnapshot
 
         for row in cursor.fetchall():
             snapshot = StateSnapshot(
-                timestamp=datetime.fromisoformat(row[0]),
+                timestamp=parse_utc_iso(row[0]),
                 phase_states=json.loads(row[1]),
                 active_capabilities=set(json.loads(row[2])),
                 system_metrics={
@@ -285,6 +287,6 @@ def load_milestones_from_db(db_path: str, milestones: dict) -> None:
 
             milestones[name].achieved = bool(row[3])
             if row[4]:
-                milestones[name].achieved_at = datetime.fromisoformat(row[4])
+                milestones[name].achieved_at = parse_utc_iso(row[4])
             if row[5]:
                 milestones[name].evidence = json.loads(row[5])

--- a/autobot-backend/services/agent_analytics.py
+++ b/autobot-backend/services/agent_analytics.py
@@ -24,7 +24,7 @@ from enum import Enum
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
-from autobot_shared.time_utils import now_utc, utc_timestamp
+from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from constants.ttl_constants import TTL_1_HOUR, TTL_30_DAYS
 
 logger = logging.getLogger(__name__)
@@ -299,8 +299,8 @@ class AgentAnalytics:
             record = AgentTaskRecord.from_dict(json.loads(task_str))
 
             # Update completion info
-            completed_at = datetime.utcnow()
-            started_at = datetime.fromisoformat(record.started_at)
+            completed_at = now_utc()
+            started_at = parse_utc_iso(record.started_at)
             duration_ms = (completed_at - started_at).total_seconds() * 1000
 
             record.status = status.value
@@ -638,7 +638,7 @@ class AgentAnalytics:
                 tasks = await self.get_recent_tasks(limit=5000)
             cutoff = now_utc() - timedelta(days=days)
             filtered_tasks = [
-                t for t in tasks if datetime.fromisoformat(t["started_at"]) > cutoff
+                t for t in tasks if parse_utc_iso(t["started_at"]) > cutoff
             ]
             daily_stats = self._group_tasks_by_day(filtered_tasks)
             self._compute_daily_averages(daily_stats)


### PR DESCRIPTION
## Summary

10 sites in 4 files. Each file pre-audited for paired-pattern risk per the #5469 + #5475 lessons.

## Files

| File | Sites | Risk class | Notes |
|---|---|---|---|
| \`models/atomic_fact.py\` | 3 | Pure parser, no utcnow | SAFE |
| \`project_state_tracking/database.py\` | 2 | Pure parser, no utcnow | SAFE |
| \`models/entity_mapping.py\` | 2 | Pure parser, no utcnow | SAFE |
| \`services/agent_analytics.py\` | 2 + **paired utcnow** | Same-pattern as #5469 | **Coupled migration** |

## Coupled migration: agent_analytics.py

Lines 302-304 had the same paired pattern as #5469:

\`\`\`python
completed_at = datetime.utcnow()              # naive
started_at = datetime.fromisoformat(...)      # maybe naive
duration_ms = (completed_at - started_at)...  # mixed-tz risk
\`\`\`

Migrated all three together:
\`\`\`python
completed_at = now_utc()                      # aware
started_at = parse_utc_iso(record.started_at) # aware
# subtraction aware-aware, clean
\`\`\`

Also line 641 (cutoff compare with parsed value): the existing aware \`now_utc()\` cutoff at line 639 now compares against the migrated parser output — both aware, safe.

## Skipped from this batch

\`security/enterprise/sso_integration.py\` — 2 fromisoformat sites + **17** datetime.utcnow() sites. Defer for separate coordinated migration. Bulk-sed without per-site analysis would create #5469-class regression at any of those 17 sites.

## Test plan

- [x] \`python3 -m py_compile\` on all 4 files → OK
- [x] \`grep -rn datetime.fromisoformat\` in scope → 0 remaining
- [x] Pre-audit: \`grep -c datetime.utcnow\` per file before migrating

Refs #5419 P2 (10 of 50 sites migrated)
🤖 Generated with [Claude Code](https://claude.com/claude-code)