### PR TITLE
fix(backend): adopt parse_utc_iso across 24 pure-parser sites (#5419 P2 batch 2)

### DIFF
--- a/autobot-backend/agents/machine_aware_system_knowledge_manager.py
+++ b/autobot-backend/agents/machine_aware_system_knowledge_manager.py
@@ -14,6 +14,7 @@ import json
 import logging
 import shutil
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
@@ -77,7 +78,7 @@ class MachineProfile:
 
         last_updated_str = data.get("last_updated")
         if last_updated_str:
-            profile.last_updated = datetime.fromisoformat(last_updated_str)
+            profile.last_updated = parse_utc_iso(last_updated_str)
 
         return profile
 
@@ -739,7 +740,7 @@ class MachineAwareSystemKnowledgeManager(SystemKnowledgeManager):
         try:
             from datetime import datetime, timedelta, timezone
 
-            last_updated = datetime.fromisoformat(man_info.last_updated)
+            last_updated = parse_utc_iso(man_info.last_updated)
             if last_updated.tzinfo is None:
                 last_updated = last_updated.replace(tzinfo=timezone.utc)
             age_threshold = datetime.now(tz=timezone.utc) - timedelta(hours=max_age_hours)

--- a/autobot-backend/api/agent_config.py
+++ b/autobot-backend/api/agent_config.py
@@ -12,6 +12,8 @@ Each agent can have its own LLM model configuration and status monitoring.
 import logging
 import os
 from datetime import datetime, timezone
+
+from autobot_shared.time_utils import parse_utc_iso
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -858,12 +860,7 @@ async def get_agents_usage(
     window_tasks = []
     for task in history:
         try:
-            started = datetime.fromisoformat(task["started_at"])
-            # Normalise naive timestamps that predate the UTC migration
-            if started.tzinfo is None:
-                from datetime import timezone as _tz
-
-                started = started.replace(tzinfo=_tz.utc)
+            started = parse_utc_iso(task["started_at"])
             if started >= cutoff:
                 window_tasks.append(task)
         except (KeyError, ValueError):

--- a/autobot-backend/api/analytics_code_review.py
+++ b/autobot-backend/api/analytics_code_review.py
@@ -14,6 +14,7 @@ import logging
 import re
 import uuid
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
@@ -717,8 +718,8 @@ async def get_review_history(
             entry = json.loads(raw)
             if since:
                 try:
-                    entry_dt = datetime.fromisoformat(entry.get("analyzed_at", ""))
-                    since_dt = datetime.fromisoformat(since)
+                    entry_dt = parse_utc_iso(entry.get("analyzed_at", ""))
+                    since_dt = parse_utc_iso(since)
                     # Normalise both to UTC-aware for comparison
                     if entry_dt.tzinfo is None:
                         entry_dt = entry_dt.replace(tzinfo=timezone.utc)

--- a/autobot-backend/api/analytics_pattern_learning.py
+++ b/autobot-backend/api/analytics_pattern_learning.py
@@ -23,6 +23,7 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -399,7 +400,7 @@ class PatternLearningEngine:
             irrelevant_count=stats_data.get("irrelevant_count", 0),
             raw_score=stats_data.get("raw_score", 0.5),
             confidence_score=stats_data.get("confidence_score", 0.5),
-            last_updated=datetime.fromisoformat(
+            last_updated=parse_utc_iso(
                 stats_data.get("last_updated", datetime.now(tz=timezone.utc).isoformat())
             ),
             version=stats_data.get("version", 1),

--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import logging
 from datetime import datetime, timedelta, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
@@ -1191,7 +1192,7 @@ def _filter_trends_by_period(trends: list, cutoff: datetime) -> list:
     filtered = []
     for t in trends:
         try:
-            date = datetime.fromisoformat(t.get("date", ""))
+            date = parse_utc_iso(t.get("date", ""))
             if date >= cutoff:
                 filtered.append(t)
         except (ValueError, TypeError):

--- a/autobot-backend/api/audit.py
+++ b/autobot-backend/api/audit.py
@@ -18,6 +18,7 @@ Endpoints:
 
 import logging
 from datetime import datetime, timedelta, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -159,8 +160,8 @@ async def query_audit_logs(
     """
     try:
         audit_logger = await get_audit_logger()
-        start_dt = datetime.fromisoformat(start_time) if start_time else None
-        end_dt = datetime.fromisoformat(end_time) if end_time else None
+        start_dt = parse_utc_iso(start_time) if start_time else None
+        end_dt = parse_utc_iso(end_time) if end_time else None
 
         entries = await audit_logger.query(
             start_time=start_dt,

--- a/autobot-backend/api/codebase_analytics/endpoints/stats.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/stats.py
@@ -109,11 +109,9 @@ def _is_task_stale(task_info: dict) -> bool:
         return False
 
     try:
-        from datetime import datetime, timezone
+        from autobot_shared.time_utils import parse_utc_iso
 
-        start_time = datetime.fromisoformat(started_at)
-        if start_time.tzinfo is None:
-            start_time = start_time.replace(tzinfo=timezone.utc)
+        start_time = parse_utc_iso(started_at)
         elapsed = (datetime.now(tz=timezone.utc) - start_time).total_seconds()
         return elapsed > _STALE_TASK_TIMEOUT_SECONDS
     except (ValueError, TypeError):

--- a/autobot-backend/api/knowledge_graph_routes.py
+++ b/autobot-backend/api/knowledge_graph_routes.py
@@ -175,8 +175,8 @@ async def search_events(
         redis_client = await get_async_redis_client(database="knowledge")
         temporal_svc = TemporalSearchService(redis_client)
 
-        start = datetime.fromisoformat(start_date) if start_date else datetime.min
-        end = datetime.fromisoformat(end_date) if end_date else datetime.now(tz=timezone.utc)
+        start = parse_utc_iso(start_date) if start_date else datetime.min.replace(tzinfo=timezone.utc)
+        end = parse_utc_iso(end_date) if end_date else datetime.now(tz=timezone.utc)
         types_list = (
             [t.strip() for t in event_types.split(",")] if event_types else None
         )

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -24,6 +24,7 @@ import uuid
 from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from enum import Enum
 from time import time
 from typing import Dict, List, Optional
@@ -857,7 +858,7 @@ async def get_secrets_stats(
 
             # Count expired secrets
             if secret_data.get("expires_at"):
-                expires_at = datetime.fromisoformat(secret_data["expires_at"])
+                expires_at = parse_utc_iso(secret_data["expires_at"])
                 if expires_at < now:
                     stats["expired_count"] += 1
 

--- a/autobot-backend/api/vnc_mcp.py
+++ b/autobot-backend/api/vnc_mcp.py
@@ -10,6 +10,7 @@ Integrates with backend VNC proxy for browser and desktop observation
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from typing import List
 
 import aiohttp
@@ -331,7 +332,7 @@ async def observe_vnc_activity_mcp(request: VNCObservationRequest) -> Metadata:
         obs
         for obs in recent_activity
         if obs.get("timestamp")
-        and datetime.fromisoformat(obs["timestamp"]) > cutoff_time
+        and parse_utc_iso(obs["timestamp"]) > cutoff_time
     ]
 
     return {

--- a/autobot-backend/auth_middleware.py
+++ b/autobot-backend/auth_middleware.py
@@ -7,6 +7,7 @@ Provides JWT-based authentication, session management, and role-based access con
 """
 
 import datetime
+from autobot_shared.time_utils import parse_utc_iso
 import json
 import logging
 import os
@@ -361,7 +362,7 @@ class AuthenticationMiddleware:
         # Check session timeout for in-memory sessions
         last_activity = session.get("last_activity")
         if isinstance(last_activity, str):
-            last_activity = datetime.datetime.fromisoformat(last_activity)
+            last_activity = parse_utc_iso(last_activity)
             if last_activity.tzinfo is None:
                 last_activity = last_activity.replace(tzinfo=datetime.timezone.utc)
 

--- a/autobot-backend/code_intelligence/bug_predictor.py
+++ b/autobot-backend/code_intelligence/bug_predictor.py
@@ -32,6 +32,7 @@ import subprocess  # nosec B404 - required for git operations
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -850,7 +851,7 @@ class BugPredictor(_BaseClass):
         last_date = None
         if bugs:
             try:
-                last_date = datetime.fromisoformat(bugs[0].get("date", ""))
+                last_date = parse_utc_iso(bugs[0].get("date", ""))
             except Exception:
                 logger.debug("Suppressed exception in try block", exc_info=True)
 

--- a/autobot-backend/code_intelligence/conversation_analysis/analyzer.py
+++ b/autobot-backend/code_intelligence/conversation_analysis/analyzer.py
@@ -11,6 +11,7 @@ Contains the main ConversationFlowAnalyzer class that coordinates analysis.
 import logging
 from collections import Counter, defaultdict
 from datetime import datetime
+from autobot_shared.time_utils import parse_utc_iso
 from typing import Any, Dict, List, Optional, Tuple
 
 from .classifiers import IntentClassifier, ResponseClassifier
@@ -78,7 +79,7 @@ class ConversationFlowAnalyzer:
         """
         if timestamp and isinstance(timestamp, str):
             try:
-                return datetime.fromisoformat(timestamp)
+                return parse_utc_iso(timestamp)
             except ValueError:
                 return None
         return None

--- a/autobot-backend/events/types.py
+++ b/autobot-backend/events/types.py
@@ -25,7 +25,7 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Any, Optional
 
-from autobot_shared.time_utils import now_utc
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +156,7 @@ class AgentEvent:
             event_id=data["event_id"],
             event_type=EventType[data["event_type"]],
             timestamp=(
-                datetime.fromisoformat(data["timestamp"])
+                parse_utc_iso(data["timestamp"])
                 if isinstance(data["timestamp"], str)
                 else data["timestamp"]
             ),

--- a/autobot-backend/knowledge/search_quality.py
+++ b/autobot-backend/knowledge/search_quality.py
@@ -19,6 +19,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
@@ -348,7 +349,7 @@ class RelevanceScorer:
         created_at = None
         if "created_at" in metadata:
             try:
-                created_at = datetime.fromisoformat(metadata["created_at"])
+                created_at = parse_utc_iso(metadata["created_at"])
             except (ValueError, TypeError):
                 pass
 
@@ -519,7 +520,7 @@ class AdvancedFilter:
             return True  # Allow if no date info
 
         try:
-            created_at = datetime.fromisoformat(created_at_str)
+            created_at = parse_utc_iso(created_at_str)
         except (ValueError, TypeError):
             return True
 

--- a/autobot-backend/knowledge/suggestions.py
+++ b/autobot-backend/knowledge/suggestions.py
@@ -16,6 +16,7 @@ import logging
 import math
 from collections import defaultdict
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 if TYPE_CHECKING:
@@ -557,7 +558,7 @@ class SuggestionsMixin:
             return 0.5  # Unknown age: neutral score
 
         try:
-            ts = datetime.fromisoformat(timestamp_str)
+            ts = parse_utc_iso(timestamp_str)
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=timezone.utc)
             age_days = max(0.0, (datetime.now(tz=timezone.utc) - ts).total_seconds() / 86400.0)

--- a/autobot-backend/knowledge/temporal_search.py
+++ b/autobot-backend/knowledge/temporal_search.py
@@ -9,6 +9,7 @@ Issue #759: Knowledge Pipeline Foundation - Extract, Cognify, Load (ECL).
 
 import logging
 from datetime import datetime
+from autobot_shared.time_utils import parse_utc_iso
 from typing import List, Optional, Set
 from uuid import UUID
 
@@ -116,7 +117,7 @@ class TemporalSearchService:
                 if event and event.get("timestamp"):
                     events.append(event)
 
-            events.sort(key=lambda e: datetime.fromisoformat(e["timestamp"]))
+            events.sort(key=lambda e: parse_utc_iso(e["timestamp"]))
 
             logger.info(
                 "Retrieved %s events for %s",

--- a/autobot-backend/metrics/system_monitor.py
+++ b/autobot-backend/metrics/system_monitor.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from typing import Any, Dict, List
 
 import psutil
@@ -249,7 +250,7 @@ class SystemResourceMonitor:
 
         for data in reversed(self.resource_history):
             try:
-                data_time = datetime.fromisoformat(data["timestamp"]).timestamp()
+                data_time = parse_utc_iso(data["timestamp"]).timestamp()
                 if data_time >= cutoff_time:
                     recent_data.append(data)
                 else:

--- a/autobot-backend/models/completion_context.py
+++ b/autobot-backend/models/completion_context.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List, Optional, Set, Tuple
 
-from autobot_shared.time_utils import now_utc
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 
 @dataclass
@@ -120,7 +120,7 @@ class CompletionContext:
         """Deserialize from dictionary."""
         return cls(
             context_id=data["context_id"],
-            timestamp=datetime.fromisoformat(data["timestamp"]),
+            timestamp=parse_utc_iso(data["timestamp"]),
             file_path=data["file_context"]["file_path"],
             language=data["file_context"]["language"],
             imports=data["file_context"]["imports"],

--- a/autobot-backend/security/enterprise/threat_detection/engine.py
+++ b/autobot-backend/security/enterprise/threat_detection/engine.py
@@ -25,7 +25,7 @@ from sklearn.cluster import DBSCAN
 from sklearn.ensemble import IsolationForest
 from sklearn.preprocessing import StandardScaler
 
-from autobot_shared.time_utils import now_utc, utc_timestamp
+from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
 
@@ -618,7 +618,7 @@ class ThreatDetectionEngine:
             feature_vector = [
                 len(event.get("action", "")),
                 len(event.get("resource", "")),
-                datetime.fromisoformat(
+                parse_utc_iso(
                     event.get("timestamp", utc_timestamp())
                 ).hour,
                 1 if event.get("outcome") == "success" else 0,

--- a/autobot-backend/security/enterprise/threat_detection/learner.py
+++ b/autobot-backend/security/enterprise/threat_detection/learner.py
@@ -31,7 +31,7 @@ from datetime import datetime, timedelta
 from typing import Dict, Optional
 
 from autobot_shared.redis_client import get_redis_client
-from autobot_shared.time_utils import now_utc, utc_timestamp
+from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ class ThreatDetectionLearner:
         last_seen_raw = data[2]
         if last_seen_raw:
             try:
-                last_seen = datetime.fromisoformat(
+                last_seen = parse_utc_iso(
                     last_seen_raw.decode()
                     if isinstance(last_seen_raw, bytes)
                     else last_seen_raw

--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -35,6 +35,7 @@ import uuid
 from collections import deque
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from typing import Any, Deque, Dict, List, Optional
 
 from autobot_shared.redis_client import get_async_redis_client
@@ -317,7 +318,7 @@ class AutonomousLoopRunner:
                 data = json.loads(raw)
                 staged_at_str = data.pop("staged_at", None)
                 if staged_at_str:
-                    staged_at = datetime.fromisoformat(staged_at_str)
+                    staged_at = parse_utc_iso(staged_at_str)
                     if staged_at.tzinfo is None:
                         staged_at = staged_at.replace(tzinfo=timezone.utc)
                     if (datetime.now(timezone.utc) - staged_at).days > 7:

--- a/autobot-backend/services/knowledge/lineage_service.py
+++ b/autobot-backend/services/knowledge/lineage_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,7 @@ class SynthesisRun:
         """
         ran_at_raw = entry.get("ran_at", "")
         try:
-            ts = datetime.fromisoformat(ran_at_raw)
+            ts = parse_utc_iso(ran_at_raw)
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=timezone.utc)
         except (ValueError, TypeError):

--- a/autobot-backend/services/secrets_service.py
+++ b/autobot-backend/services/secrets_service.py
@@ -10,6 +10,7 @@ import json
 import logging
 import sqlite3
 from datetime import datetime, timezone
+from autobot_shared.time_utils import parse_utc_iso
 from pathlib import Path
 from typing import Dict, List, Optional
 from uuid import uuid4
@@ -197,7 +198,7 @@ class SecretsService:
         """Check if a secret has expired"""
         if not expires_at:
             return False
-        return datetime.fromisoformat(expires_at) < datetime.now(timezone.utc)
+        return parse_utc_iso(expires_at) < datetime.now(timezone.utc)
 
     def _update_access_tracking(
         self, cursor: sqlite3.Cursor, secret_id: str, accessed_by: Optional[str]


### PR DESCRIPTION
Closes part of #5419

## Summary

- Replaces `datetime.fromisoformat()` with `parse_utc_iso()` in 24 backend files
- All files pre-audited: zero paired `utcnow()` producers — safe parser-only upgrade
- Collapses two existing normalize-naive patterns (agent_config + stats endpoints) into single `parse_utc_iso()` call
- Fixes `datetime.min` fallback in knowledge_graph_routes → `datetime.min.replace(tzinfo=timezone.utc)` to keep aware comparison consistent

## Files changed (24)

`api/` (9): analytics_code_review, audit, analytics_quality, analytics_pattern_learning, agent_config, knowledge_graph_routes, codebase_analytics/endpoints/stats, secrets, vnc_mcp

`agents/` (1): machine_aware_system_knowledge_manager

`auth_middleware.py`, `events/types.py`, `models/completion_context.py`, `metrics/system_monitor.py`

`code_intelligence/` (2): bug_predictor, conversation_analysis/analyzer

`knowledge/` (3): search_quality, suggestions, temporal_search

`security/enterprise/threat_detection/` (2): engine, learner

`services/knowledge/` (2): autonomous_loop, lineage_service; `services/secrets_service.py`

## Regression safety

Pre-audit: `grep -c "datetime.utcnow()" $f` = 0 for every file in this batch. No aware–naive subtraction/comparison risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)