### PR TITLE
test(conftest): add mock_llm fixture to root conftest (#5432)

### DIFF
--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -13,7 +13,7 @@ import os
 import sys
 import types
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -286,6 +286,16 @@ def test_data_dir() -> Path:
 def temp_dir(tmp_path) -> Path:
     """Provide temporary directory for test files."""
     return tmp_path
+
+
+@pytest.fixture
+def mock_llm():
+    """Minimal LLM mock — tests attach .return_value / .side_effect as needed.
+
+    Extracted from 4+ inline duplicates (#5432). Tests that need richer
+    response-mock setup define their own local fixture which overrides this.
+    """
+    return AsyncMock()
 
 
 @pytest.fixture(autouse=True)

--- a/autobot-backend/services/autoresearch/scorers_test.py
+++ b/autobot-backend/services/autoresearch/scorers_test.py
@@ -98,11 +98,6 @@ class TestValBpbScorer:
 
 class TestLLMJudgeScorer:
     @pytest.fixture
-    def mock_llm(self):
-        llm = AsyncMock()
-        return llm
-
-    @pytest.fixture
     def scorer(self, mock_llm):
         return LLMJudgeScorer(
             llm_service=mock_llm,


### PR DESCRIPTION
Closes #5432

## Fix

4+ test files had inline `def mock_llm(): return AsyncMock()` fixtures. Moved the base to root `autobot-backend/conftest.py` (lines 291-298). Test-local overrides are kept only where additional setup is present.

## Files

- **Root conftest**: `mock_llm` fixture added
- **Inline removed (1)**: `services/autoresearch/scorers_test.py` (bare AsyncMock, no extra setup)
- **Inline kept (4, have setup)**:
  - `tests/test_autoresearch_m3.py` (sets `llm.chat.side_effect = [4 responses]`)
  - `services/autoresearch/prompt_optimizer_test.py` (`llm.chat.return_value` mutation)
  - `services/autoresearch/knowledge_synthesizer_test.py` (response mock)
  - `services/knowledge/test_contradiction_detector.py` (`llm.chat_completion = AsyncMock()`)

## Verification

- 71 tests pass across the 5 affected files, 0 failures
- Guardrail grep post-commit confirms: only fixtures with setup remain outside conftest

## Diff

Minimal: conftest.py + 1 file (removed duplicate).