### PR TITLE
refactor(npu-worker): collapse config_bootstrap getters (#5436)

### DIFF
--- a/autobot-npu-worker/resources/windows-npu-worker/app/utils/config_bootstrap.py
+++ b/autobot-npu-worker/resources/windows-npu-worker/app/utils/config_bootstrap.py
@@ -184,6 +184,38 @@ async def fetch_bootstrap_config(
         return None
 
 
+# =============================================================================
+# Fallback defaults for bootstrap config sections
+# =============================================================================
+DEFAULT_REDIS_CONFIG: Dict[str, Any] = {}
+DEFAULT_BACKEND_CONFIG: Dict[str, Any] = {}
+DEFAULT_MODELS_CONFIG: Dict[str, Any] = {
+    "autoload_defaults": True,
+    "default_embedding": "nomic-embed-text",
+    "default_llm": "llama3.2:1b-instruct-q4_K_M",
+}
+
+
+def get_bootstrap_config_section(
+    section: str, default: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Return the named section from the cached bootstrap config, or default.
+
+    Args:
+        section: Top-level key to look up in the cached bootstrap config.
+        default: Fallback returned when bootstrap is unavailable or missing
+            the section. An empty dict is used if ``default`` is ``None``.
+
+    Returns:
+        The section dict from bootstrap config, or the provided default.
+    """
+    if _bootstrap_config and section in _bootstrap_config:
+        return _bootstrap_config[section]
+    if default is None:
+        return {}
+    return default
+
+
 def get_cached_config() -> Optional[Dict[str, Any]]:
     """Get the cached bootstrap configuration."""
     return _bootstrap_config
@@ -195,51 +227,22 @@ def get_worker_id() -> Optional[str]:
 
 
 def get_redis_config() -> Dict[str, Any]:
-    """
-    Get Redis configuration from bootstrap or fallback.
-
-    Returns:
-        Redis configuration dictionary
-    """
-    if _bootstrap_config and "redis" in _bootstrap_config:
-        return _bootstrap_config["redis"]
-
-    # Fallback - standalone mode (no Redis)
-    logger.warning("No bootstrap config available, Redis will not be configured")
-    return {}
+    """Get Redis configuration from bootstrap or fallback."""
+    if not _bootstrap_config or "redis" not in _bootstrap_config:
+        logger.warning("No bootstrap config available, Redis will not be configured")
+    return get_bootstrap_config_section("redis", DEFAULT_REDIS_CONFIG)
 
 
 def get_backend_config() -> Dict[str, Any]:
-    """
-    Get backend configuration from bootstrap or fallback.
+    """Get backend configuration from bootstrap or fallback.
 
     Note: No hardcoded IPs - backend config must come from YAML or bootstrap.
-
-    Returns:
-        Backend configuration dictionary (may be empty if not bootstrapped)
     """
-    if _bootstrap_config and "backend" in _bootstrap_config:
-        return _bootstrap_config["backend"]
-
-    # No hardcoded fallbacks - return empty dict for standalone mode
-    # Backend host/port must be in npu_worker.yaml config file
-    logger.warning("No bootstrap config available, using config from YAML file")
-    return {}
+    if not _bootstrap_config or "backend" not in _bootstrap_config:
+        logger.warning("No bootstrap config available, using config from YAML file")
+    return get_bootstrap_config_section("backend", DEFAULT_BACKEND_CONFIG)
 
 
 def get_models_config() -> Dict[str, Any]:
-    """
-    Get models configuration from bootstrap or fallback.
-
-    Returns:
-        Models configuration dictionary
-    """
-    if _bootstrap_config and "models" in _bootstrap_config:
-        return _bootstrap_config["models"]
-
-    # Fallback defaults
-    return {
-        "autoload_defaults": True,
-        "default_embedding": "nomic-embed-text",
-        "default_llm": "llama3.2:1b-instruct-q4_K_M",
-    }
+    """Get models configuration from bootstrap or fallback."""
+    return get_bootstrap_config_section("models", DEFAULT_MODELS_CONFIG)


### PR DESCRIPTION
Closes #5436

## Fix

`autobot-npu-worker/resources/windows-npu-worker/app/utils/config_bootstrap.py` had 3 section getters (`get_redis_config`, `get_backend_config`, `get_models_config`) each reimplementing the same lookup-with-default pattern. Extracted to `get_bootstrap_config_section(section, default)` helper.

## Changes

- NEW: `get_bootstrap_config_section()` helper at line 199
- NEW: 3 module-level default constants (`DEFAULT_REDIS_CONFIG`, `DEFAULT_BACKEND_CONFIG`, `DEFAULT_MODELS_CONFIG`)
- Section getters shrunk:
  - `get_redis_config`: 13 → 5 lines
  - `get_backend_config`: 16 → 7 lines
  - `get_models_config`: 16 → 3 lines
- `get_cached_config` / `get_worker_id` unchanged (they return globals, not config sections — don't fit the helper shape)
- All 5 public names preserved; `__init__.py` re-exports unchanged; callers don't need editing

## Verification

- `python -m py_compile` passes
- Known callers verified: `app/npu_worker.py:1602 get_worker_id()` + `app/npu_worker.py:1664 get_redis_config()` still valid
- Warning logs for missing sections preserved (fire exactly when the old code fired)

## Diff

59 lines → 62 lines net (helper + constants cost ~13 lines; getter bodies shed ~10 lines). The win is in DRY, not LOC.