### PR TITLE
fix(schemas): correct QueryKnowledgeResponse fields to match search response shape (#5487)

### DIFF
--- a/autobot-backend/knowledge/schemas/facts.py
+++ b/autobot-backend/knowledge/schemas/facts.py
@@ -202,16 +202,19 @@ class ClearAllResponse(BaseModel):
 class QueryKnowledgeResponse(BaseModel):
     """Shape of legacy ``POST /api/knowledge_base/query``.
 
-    Proxies to :mod:`api.knowledge_search`. The exact payload mirrors
-    whatever ``search_knowledge`` returns — declared with ``extra="allow"``
-    so search-side additions flow through.
+    Proxies to :mod:`api.knowledge_search`. Fields mirror the shape returned
+    by ``_build_search_response`` in that module.
     """
 
     model_config = ConfigDict(extra="allow")
 
+    status: str = "success"
+    synthesized_response: str = ""
     results: List[Dict[str, Any]] = Field(default_factory=list)
     total_results: int = 0
-    query: Optional[str] = None
+    original_query: Optional[str] = None
+    reformulated_queries: List[str] = Field(default_factory=list)
+    rag_enhanced: bool = False
 
 
 class ManPageSearchResponse(BaseModel):


### PR DESCRIPTION
Closes #5487

## Problem

`QueryKnowledgeResponse` in `knowledge/schemas/facts.py` had `query: Optional[str] = None` but the `/query` endpoint proxies to `search_knowledge` which returns `original_query` (not `query`). The old schema also missed `status`, `synthesized_response`, `reformulated_queries`, and `rag_enhanced` — all of which were passing through as untyped extras.

## Fix

Updated `QueryKnowledgeResponse` to match the actual `_build_search_response` return shape:

```python
# Before
results: List[...]
total_results: int
query: Optional[str]  # ← wrong field name, never populated

# After
status: str
synthesized_response: str
results: List[...]
total_results: int
original_query: Optional[str]  # ← correct
reformulated_queries: List[str]
rag_enhanced: bool
```

All fields still use `extra="allow"` so additional diagnostic keys pass through unchanged.

## Test plan
- [ ] `python3 -m py_compile autobot-backend/knowledge/schemas/facts.py` — passes
- [ ] After `npm run gen:types`, `QueryKnowledgeResponse` in `api.ts` has `original_query`, `synthesized_response`, `rag_enhanced`

🤖 Generated with [Claude Code](https://claude.com/claude-code)