### PR TITLE
fix(backend): adopt parse_utc_iso + now_utc() in 8 mixed files (#5419 P2 batch 4)

### DIFF
--- a/autobot-backend/api/analytics_agents.py
+++ b/autobot-backend/api/analytics_agents.py
@@ -300,11 +300,12 @@ def _check_agent_metrics(metrics) -> list:
             )
 
     if metrics.total_tasks > 0 and metrics.last_activity:
-        from datetime import datetime, timedelta
+        from datetime import timedelta
+        from autobot_shared.time_utils import now_utc, parse_utc_iso
 
         try:
-            last = datetime.fromisoformat(metrics.last_activity)
-            if datetime.utcnow() - last > timedelta(days=7):
+            last = parse_utc_iso(metrics.last_activity)
+            if now_utc() - last > timedelta(days=7):
                 recommendations.append(
                     {
                         "type": "low_activity",

--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -25,6 +25,7 @@ import json
 import logging
 import uuid
 from datetime import datetime
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -155,7 +156,7 @@ def _parse_dt(value: Optional[str]) -> Optional[datetime]:
     if not value:
         return None
     try:
-        return datetime.fromisoformat(value)
+        return parse_utc_iso(value)
     except (ValueError, TypeError):
         return None
 
@@ -234,7 +235,7 @@ async def _run_sync_background(connector_id: str, incremental: bool) -> None:
         sync_result = None
 
     if sync_result is not None:
-        cfg.last_sync_at = sync_result.completed_at or datetime.utcnow()
+        cfg.last_sync_at = sync_result.completed_at or now_utc()
         await _save_connector(cfg)
 
         history_entry = {

--- a/autobot-backend/knowledge/connectors/database.py
+++ b/autobot-backend/knowledge/connectors/database.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 from contextlib import asynccontextmanager
 from datetime import datetime
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 from typing import Any, Dict, List, Optional
 
 from knowledge.connectors.base import AbstractConnector
@@ -122,7 +123,7 @@ class DatabaseConnector(AbstractConnector):
                     ChangeInfo(
                         source_id=source_id,
                         change_type=change_type,
-                        timestamp=ts or datetime.utcnow(),
+                        timestamp=ts or now_utc(),
                         details={"id_column": self._id_column, "id_value": id_val},
                     )
                 )
@@ -171,7 +172,7 @@ class DatabaseConnector(AbstractConnector):
         row_dict = _row_to_dict(row)
         id_val = row_dict.get(self._id_column)
         source_id = _row_to_source_id(self.config.connector_id, id_val)
-        ts = _extract_timestamp(row_dict, self._timestamp_column) or datetime.utcnow()
+        ts = _extract_timestamp(row_dict, self._timestamp_column) or now_utc()
 
         return SourceInfo(
             source_id=source_id,
@@ -234,7 +235,7 @@ def _extract_timestamp(
         return val
     if isinstance(val, str):
         try:
-            return datetime.fromisoformat(val)
+            return parse_utc_iso(val)
         except ValueError:
             pass
     return None

--- a/autobot-backend/knowledge/connectors/notion.py
+++ b/autobot-backend/knowledge/connectors/notion.py
@@ -18,6 +18,7 @@ Config keys (under ``ConnectorConfig.config``):
 import hashlib
 import logging
 from datetime import datetime
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 from typing import Any, Dict, List, Optional
 
 import aiohttp
@@ -188,7 +189,7 @@ class NotionConnector(AbstractConnector):
             return ChangeInfo(
                 source_id=page_id,
                 change_type="added",
-                timestamp=datetime.utcnow(),
+                timestamp=now_utc(),
                 details={"last_edited_time": last_edited},
             )
 
@@ -199,7 +200,7 @@ class NotionConnector(AbstractConnector):
             return ChangeInfo(
                 source_id=page_id,
                 change_type=change_type,
-                timestamp=datetime.utcnow(),
+                timestamp=now_utc(),
                 details={"last_edited_time": last_edited},
             )
         return None
@@ -285,9 +286,9 @@ def _page_to_source_info(page: Dict[str, Any], database_id: str) -> SourceInfo:
     page_id = page.get("id", "")
     last_edited = page.get("last_edited_time", "")
     try:
-        last_modified = datetime.fromisoformat(last_edited.rstrip("Z"))
+        last_modified = parse_utc_iso(last_edited)
     except (ValueError, AttributeError):
-        last_modified = datetime.utcnow()
+        last_modified = now_utc()
 
     return SourceInfo(
         source_id=page_id,

--- a/autobot-backend/models/document_version.py
+++ b/autobot-backend/models/document_version.py
@@ -12,6 +12,7 @@ import asyncio
 import hashlib
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 from enum import Enum
 from typing import Optional
 
@@ -109,7 +110,7 @@ class DocumentVersion:
     @classmethod
     def from_dict(cls, data: Metadata) -> "DocumentVersion":
         """Create from dictionary"""
-        data["created_at"] = datetime.fromisoformat(data["created_at"])
+        data["created_at"] = parse_utc_iso(data["created_at"])
         data["change_type"] = ChangeType(data["change_type"])
         return cls(**data)
 
@@ -218,7 +219,7 @@ class DocumentChangeTracker:
             machine_id=machine_id,
             os_type=os_type,
             os_version=os_version,
-            created_at=datetime.utcnow(),
+            created_at=now_utc(),
             change_type=change_type,
             previous_hash=previous_hash,
             metadata=metadata or {},

--- a/autobot-backend/security/enterprise/compliance_manager.py
+++ b/autobot-backend/security/enterprise/compliance_manager.py
@@ -23,7 +23,7 @@ import aiofiles
 import yaml
 from cryptography.fernet import Fernet
 
-from autobot_shared.time_utils import utc_timestamp
+from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from constants.path_constants import PATH
 
 logger = logging.getLogger(__name__)
@@ -545,7 +545,7 @@ class ComplianceManager:
         pii_log_path = (
             self.audit_base_path
             / "pii_access"
-            / f"{datetime.utcnow().strftime('%Y-%m-%d')}.json"
+            / f"{now_utc().strftime('%Y-%m-%d')}.json"
         )
         # Issue #358 - avoid blocking
         await asyncio.to_thread(pii_log_path.parent.mkdir, exist_ok=True)
@@ -563,7 +563,7 @@ class ComplianceManager:
         """Store audit event with appropriate security measures"""
 
         # Determine storage path based on event type and date
-        date_str = datetime.fromisoformat(audit_event["timestamp"]).strftime("%Y-%m-%d")
+        date_str = parse_utc_iso(audit_event["timestamp"]).strftime("%Y-%m-%d")
         event_type = audit_event["event_type"]
 
         storage_path = self.audit_base_path / event_type / f"{date_str}.jsonl"
@@ -738,7 +738,7 @@ class ComplianceManager:
         violations_path = (
             self.audit_base_path
             / "violations"
-            / f"{datetime.utcnow().strftime('%Y-%m-%d')}.jsonl"
+            / f"{now_utc().strftime('%Y-%m-%d')}.jsonl"
         )
         # Issue #358 - avoid blocking
         await asyncio.to_thread(violations_path.parent.mkdir, exist_ok=True)

--- a/autobot-backend/services/feedback_tracker.py
+++ b/autobot-backend/services/feedback_tracker.py
@@ -12,7 +12,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 
-from autobot_shared.time_utils import now_utc, utc_timestamp
+from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from sqlalchemy import create_engine, func
 from sqlalchemy.orm import sessionmaker
 
@@ -66,7 +66,7 @@ class FeedbackTracker:
             try:
                 # Create feedback record
                 feedback = CompletionFeedback(
-                    timestamp=datetime.utcnow(),
+                    timestamp=now_utc(),
                     user_id=user_id,
                     context=context,
                     suggestion=suggestion,
@@ -125,7 +125,7 @@ class FeedbackTracker:
             pattern.acceptance_rate = pattern.times_accepted / pattern.times_suggested
 
         # Update last_seen timestamp
-        pattern.last_seen = datetime.utcnow()
+        pattern.last_seen = now_utc()
 
         logger.debug(
             f"Updated pattern {pattern_id}: "
@@ -158,7 +158,7 @@ class FeedbackTracker:
             # Get feedback count since last retrain
             last_retrain_str = self.redis_client.get(self.last_retrain_key)
             if last_retrain_str:
-                last_retrain = datetime.fromisoformat(last_retrain_str.decode())
+                last_retrain = parse_utc_iso(last_retrain_str.decode())
             else:
                 last_retrain = now_utc() - timedelta(days=30)
 

--- a/autobot-backend/services/gateway/types.py
+++ b/autobot-backend/services/gateway/types.py
@@ -14,7 +14,7 @@ from enum import Enum
 from typing import Any, Dict, List
 from uuid import uuid4
 
-from autobot_shared.time_utils import now_utc
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 
 class ChannelType(str, Enum):
@@ -110,9 +110,9 @@ class UnifiedMessage:
             content=data.get("content"),
             metadata=data.get("metadata", {}),
             created_at=(
-                datetime.fromisoformat(data["created_at"])
+                parse_utc_iso(data["created_at"])
                 if "created_at" in data
-                else datetime.utcnow()
+                else now_utc()
             ),
         )
 
@@ -148,7 +148,7 @@ class GatewaySession:
 
     def update_activity(self) -> None:
         """Update last activity timestamp."""
-        self.last_activity = datetime.utcnow()
+        self.last_activity = now_utc()
 
     def add_message(self, message_id: str) -> None:
         """Add message to history."""


### PR DESCRIPTION
Closes part of #5419

## Summary

- Migrates 8 files that each have both `fromisoformat()` parsers and `utcnow()` producers
- All sites verified as independent (no aware–naive subtraction risk) except `analytics_agents.py` where the fromisoformat+utcnow are paired in a `now_utc() - last > timedelta(days=7)` comparison — migrated together
- Drops `.rstrip("Z")` in `notion.py` since `parse_utc_iso` handles `Z` suffix natively

## Files changed (8)

- `api/analytics_agents.py` — **paired** migration: `parse_utc_iso(metrics.last_activity)` + `now_utc()` in same comparison
- `api/knowledge_connectors.py` — independent: parser utility + utcnow fallback
- `knowledge/connectors/database.py` — independent: parser + utcnow fallbacks
- `knowledge/connectors/notion.py` — independent: utcnow producers + fromisoformat parser (+ rstrip("Z") cleanup)
- `models/document_version.py` — independent: fromisoformat deserialize + utcnow constructor default
- `security/enterprise/compliance_manager.py` — independent: strftime-only sites (no comparison)
- `services/feedback_tracker.py` — independent: utcnow producers + fromisoformat parser
- `services/gateway/types.py` — independent: ternary fallback + last_activity producer

🤖 Generated with [Claude Code](https://claude.com/claude-code)