### PR TITLE
feat(backend): add response_model= to api/knowledge_search.py endpoints (#5317 batch 2)

### DIFF
--- a/autobot-backend/api/knowledge_search.py
+++ b/autobot-backend/api/knowledge_search.py
@@ -23,6 +23,16 @@ from fastapi import APIRouter, HTTPException, Request
 
 from api.knowledge_models import ConsolidatedSearchRequest, EnhancedSearchRequest
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from knowledge.schemas import (
+    EnhancedSearchResponse,
+    EnhancedSearchV2Response,
+    ExpandQueryResponse,
+    KnowledgeSearchResponse,
+    RagSearchResponse,
+    RecordClickResponse,
+    SearchAnalyticsResponse,
+    SimilaritySearchResponse,
+)
 from knowledge.vector_search_engine import SearchResult as _EngineResult
 from knowledge.vector_search_engine import get_vector_search_engine
 from knowledge_factory import get_or_create_knowledge_base
@@ -558,7 +568,7 @@ async def _execute_basic_search_with_reranking(
     operation="consolidated_search",
     error_code_prefix="KB",
 )
-@router.post("/search")
+@router.post("/search", response_model=KnowledgeSearchResponse)
 async def consolidated_search(request: ConsolidatedSearchRequest, req: Request):
     """
     Consolidated knowledge base search endpoint (Issue #555).
@@ -762,7 +772,7 @@ def _enhanced_search_not_initialized_response() -> dict:
     operation="enhanced_search",
     error_code_prefix="KB",
 )
-@router.post("/enhanced_search", deprecated=True)
+@router.post("/enhanced_search", deprecated=True, response_model=EnhancedSearchResponse)
 async def enhanced_search(request: EnhancedSearchRequest, req: Request):
     """
     **[DEPRECATED]** Use POST /search with appropriate parameters instead.
@@ -832,7 +842,7 @@ async def enhanced_search(request: EnhancedSearchRequest, req: Request):
     operation="rag_enhanced_search",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/rag_search", deprecated=True)
+@router.post("/rag_search", deprecated=True, response_model=RagSearchResponse)
 async def rag_enhanced_search(request: dict, req: Request):
     """
     **[DEPRECATED]** Use POST /search with `enable_rag=true` instead.
@@ -895,7 +905,7 @@ async def rag_enhanced_search(request: dict, req: Request):
     operation="similarity_search",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/similarity_search", deprecated=True)
+@router.post("/similarity_search", deprecated=True, response_model=SimilaritySearchResponse)
 async def similarity_search(request: dict, req: Request):
     """
     **[DEPRECATED]** Use POST /search with `mode=semantic` instead (Issue #665: refactored).
@@ -1048,7 +1058,7 @@ async def _fallback_to_enhanced_search(kb_to_use, params: dict):
     operation="enhanced_search_v2",
     error_code_prefix="KB",
 )
-@router.post("/enhanced_search_v2", deprecated=True)
+@router.post("/enhanced_search_v2", deprecated=True, response_model=EnhancedSearchV2Response)
 async def enhanced_search_v2(request: dict, req: Request):
     """
     **[DEPRECATED]** Use POST /search with appropriate parameters instead.
@@ -1106,7 +1116,7 @@ async def enhanced_search_v2(request: dict, req: Request):
     operation="get_search_analytics",
     error_code_prefix="KB",
 )
-@router.get("/search_analytics")
+@router.get("/search_analytics", response_model=SearchAnalyticsResponse)
 async def get_search_analytics():
     """
     Get search analytics and performance metrics.
@@ -1144,7 +1154,7 @@ async def get_search_analytics():
     operation="record_search_click",
     error_code_prefix="KB",
 )
-@router.post("/record_click")
+@router.post("/record_click", response_model=RecordClickResponse)
 async def record_search_click(request: dict):
     """
     Record a search result click for analytics.
@@ -1183,7 +1193,7 @@ async def record_search_click(request: dict):
     operation="expand_query",
     error_code_prefix="KB",
 )
-@router.post("/expand_query")
+@router.post("/expand_query", response_model=ExpandQueryResponse)
 async def expand_query(request: dict):
     """
     Expand a query with synonyms and related terms.

--- a/autobot-backend/knowledge/schemas/__init__.py
+++ b/autobot-backend/knowledge/schemas/__init__.py
@@ -44,6 +44,16 @@ from knowledge.schemas.operations import (
     OrgKnowledgeConfigResponse,
     TestCategoriesResponse,
 )
+from knowledge.schemas.search import (
+    EnhancedSearchResponse,
+    EnhancedSearchV2Response,
+    ExpandQueryResponse,
+    KnowledgeSearchResponse,
+    RagSearchResponse,
+    RecordClickResponse,
+    SearchAnalyticsResponse,
+    SimilaritySearchResponse,
+)
 from knowledge.schemas.stats import (
     DetailedKnowledgeSizeMetrics,
     DetailedKnowledgeStats,
@@ -89,6 +99,15 @@ __all__ = [
     "DocsStatsResponse",
     "DocsWatcherControlResponse",
     "DocsWatcherStatusResponse",
+    # search.py
+    "EnhancedSearchResponse",
+    "EnhancedSearchV2Response",
+    "ExpandQueryResponse",
+    "KnowledgeSearchResponse",
+    "RagSearchResponse",
+    "RecordClickResponse",
+    "SearchAnalyticsResponse",
+    "SimilaritySearchResponse",
     # operations.py
     "ImportStatisticsResponse",
     "ImportStatusResponse",

--- a/autobot-backend/knowledge/schemas/search.py
+++ b/autobot-backend/knowledge/schemas/search.py
@@ -1,0 +1,134 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Response schemas for knowledge search endpoints (Issue #5317 batch 2)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class KnowledgeSearchResponse(BaseModel):
+    """Shape returned by POST /search (all three code paths).
+
+    The basic and enhanced paths use _build_search_response (keys: results,
+    total_results, query, mode, kb_implementation, rag_enhanced, reranking_applied).
+    The RAG path additionally includes status, synthesized_response, original_query,
+    reformulated_queries, confidence_score, etc.  extra="allow" admits all extra
+    fields so both code paths validate without wrapping returns.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    total_results: int = 0
+    query: Optional[str] = None
+    mode: Optional[str] = None
+    kb_implementation: Optional[str] = None
+    rag_enhanced: bool = False
+    reranking_applied: bool = False
+    status: Optional[str] = None
+    synthesized_response: Optional[str] = None
+    original_query: Optional[str] = None
+    reformulated_queries: List[str] = Field(default_factory=list)
+    message: Optional[str] = None
+
+
+class EnhancedSearchResponse(BaseModel):
+    """Shape returned by deprecated POST /enhanced_search.
+
+    Mirrors the kb.enhanced_search() contract: success, results, total_count,
+    query_processed, mode, tags_applied, min_score_applied, reranking_applied.
+    extra="allow" handles KB-specific additions.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    total_count: int = 0
+    query_processed: Optional[str] = None
+    mode: Optional[str] = None
+    tags_applied: Optional[List[str]] = None
+    min_score_applied: float = 0.0
+    reranking_applied: bool = False
+    message: Optional[str] = None
+
+
+class RagSearchResponse(BaseModel):
+    """Shape returned by deprecated POST /rag_search.
+
+    Shares the same RAG synthesis shape as the /search RAG path.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = "success"
+    synthesized_response: str = ""
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    total_results: int = 0
+    original_query: Optional[str] = None
+    reformulated_queries: List[str] = Field(default_factory=list)
+    rag_enhanced: bool = True
+    message: Optional[str] = None
+
+
+class SimilaritySearchResponse(BaseModel):
+    """Shape returned by deprecated POST /similarity_search."""
+
+    model_config = ConfigDict(extra="allow")
+
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    total_results: int = 0
+    query: str = ""
+    threshold: float = 0.7
+    kb_implementation: str = ""
+    rag_enhanced: bool = False
+    rag_analysis: Optional[Dict[str, Any]] = None
+
+
+class EnhancedSearchV2Response(BaseModel):
+    """Shape returned by deprecated POST /enhanced_search_v2.
+
+    Delegates to kb.enhanced_search_v2(); mirrors the enhanced_search shape.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    total_count: int = 0
+    message: Optional[str] = None
+
+
+class SearchAnalyticsResponse(BaseModel):
+    """Shape returned by GET /search_analytics."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    analytics: Dict[str, Any] = Field(default_factory=dict)
+    message: Optional[str] = None
+
+
+class RecordClickResponse(BaseModel):
+    """Shape returned by POST /record_click."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    message: str = ""
+
+
+class ExpandQueryResponse(BaseModel):
+    """Shape returned by POST /expand_query."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    original_query: str = ""
+    expanded_queries: List[str] = Field(default_factory=list)
+    expansion_count: int = 0
+    message: Optional[str] = None


### PR DESCRIPTION
Part of #5317 systematic `response_model=` sweep. Batch 1 covered all 33 endpoints in `api/knowledge.py` (#5480, #5483). This PR covers all 8 endpoints in `api/knowledge_search.py`.

## New schema file: `knowledge/schemas/search.py`

| Schema | Endpoint |
|--------|----------|
| `KnowledgeSearchResponse` | `POST /search` |
| `EnhancedSearchResponse` | `POST /enhanced_search` (deprecated) |
| `RagSearchResponse` | `POST /rag_search` (deprecated) |
| `SimilaritySearchResponse` | `POST /similarity_search` (deprecated) |
| `EnhancedSearchV2Response` | `POST /enhanced_search_v2` (deprecated) |
| `SearchAnalyticsResponse` | `GET /search_analytics` |
| `RecordClickResponse` | `POST /record_click` |
| `ExpandQueryResponse` | `POST /expand_query` |

All schemas use `ConfigDict(extra="allow")`. The four deprecated endpoints share the same `_build_search_response` shape as `/search` — each gets its own schema class so they appear as distinct components in `/openapi.json`.

## Test plan
- [ ] `python3 -m py_compile autobot-backend/api/knowledge_search.py` — passes
- [ ] `python3 -m py_compile autobot-backend/knowledge/schemas/search.py` — passes
- [ ] After `npm run gen:types`, all 8 schemas appear in `api.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)