### PR TITLE
feat(backend): add response_model= to api/knowledge_rag.py endpoints (#5317 batch 3c)

### DIFF
--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -20,6 +20,18 @@ from pydantic import BaseModel, Field
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.threshold_constants import QueryDefaults
+from knowledge.schemas.rag import (
+    AdvancedSearchResponse,
+    BenchmarkRunResponse,
+    EntityHistoryResponse,
+    LoopApproveResponse,
+    LoopRejectResponse,
+    LoopStatusResponse,
+    RagConfigResponse,
+    RagStatsResponse,
+    RerankResultsResponse,
+    UpdateRagConfigResponse,
+)
 from knowledge_factory import get_or_create_knowledge_base
 from services.rag_config import get_rag_config, update_rag_config
 from services.rag_service import RAGService
@@ -154,7 +166,7 @@ def _build_search_metrics(metrics) -> dict:
     operation="advanced_rag_search",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/advanced_search")
+@router.post("/advanced_search", response_model=AdvancedSearchResponse)
 async def advanced_search(
     request: AdvancedSearchRequest,
     rag_service: RAGService = Depends(get_rag_service_dependency),
@@ -217,7 +229,7 @@ async def advanced_search(
     operation="rerank_results",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/rerank_results")
+@router.post("/rerank_results", response_model=RerankResultsResponse)
 async def rerank_results(
     request: RerankRequest,
     rag_service: RAGService = Depends(get_rag_service_dependency),
@@ -262,7 +274,7 @@ async def rerank_results(
     operation="get_rag_config",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/config/rag")
+@router.get("/config/rag", response_model=RagConfigResponse)
 async def get_rag_configuration(
     current_user: dict = Depends(get_current_user),
 ):
@@ -289,7 +301,7 @@ async def get_rag_configuration(
     operation="update_rag_config",
     error_code_prefix="KNOWLEDGE",
 )
-@router.put("/config/rag")
+@router.put("/config/rag", response_model=UpdateRagConfigResponse)
 async def update_rag_configuration(
     request: RAGConfigUpdate,
     current_user: dict = Depends(get_current_user),
@@ -335,7 +347,7 @@ async def update_rag_configuration(
     operation="get_loop_status",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/loop/status")
+@router.get("/loop/status", response_model=LoopStatusResponse)
 async def get_loop_status(
     current_user: dict = Depends(get_current_user),
 ):
@@ -377,7 +389,7 @@ async def get_loop_status(
     operation="approve_loop_variant",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/loop/approve")
+@router.post("/loop/approve", response_model=LoopApproveResponse)
 async def approve_loop_variant(
     current_user: dict = Depends(get_current_user),
 ):
@@ -411,7 +423,7 @@ async def approve_loop_variant(
     operation="reject_loop_variant",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/loop/reject")
+@router.post("/loop/reject", response_model=LoopRejectResponse)
 async def reject_loop_variant(
     current_user: dict = Depends(get_current_user),
 ):
@@ -442,7 +454,7 @@ async def reject_loop_variant(
     operation="get_rag_stats",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/stats/rag")
+@router.get("/stats/rag", response_model=RagStatsResponse)
 async def get_rag_stats(
     rag_service: RAGService = Depends(get_rag_service_dependency),
     current_user: dict = Depends(get_current_user),
@@ -489,7 +501,7 @@ class RunBenchmarkRequest(BaseModel):
     operation="run_rag_benchmark",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/benchmark/run")
+@router.post("/benchmark/run", response_model=BenchmarkRunResponse)
 async def run_rag_benchmark(
     request: RunBenchmarkRequest,
     admin_check: bool = Depends(check_admin_permission),
@@ -622,7 +634,7 @@ async def run_rag_benchmark(
     operation="get_entity_history",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/entity/{entity_id}/history")
+@router.get("/entity/{entity_id}/history", response_model=EntityHistoryResponse)
 async def get_entity_history(
     entity_id: str,
     current_user: dict = Depends(get_current_user),

--- a/autobot-backend/knowledge/schemas/__init__.py
+++ b/autobot-backend/knowledge/schemas/__init__.py
@@ -54,6 +54,18 @@ from knowledge.schemas.search import (
     SearchAnalyticsResponse,
     SimilaritySearchResponse,
 )
+from knowledge.schemas.rag import (
+    AdvancedSearchResponse,
+    BenchmarkRunResponse,
+    EntityHistoryResponse,
+    LoopApproveResponse,
+    LoopRejectResponse,
+    LoopStatusResponse,
+    RagConfigResponse,
+    RagStatsResponse,
+    RerankResultsResponse,
+    UpdateRagConfigResponse,
+)
 from knowledge.schemas.stats import (
     DetailedKnowledgeSizeMetrics,
     DetailedKnowledgeStats,
@@ -99,6 +111,17 @@ __all__ = [
     "DocsStatsResponse",
     "DocsWatcherControlResponse",
     "DocsWatcherStatusResponse",
+    # rag.py
+    "AdvancedSearchResponse",
+    "BenchmarkRunResponse",
+    "EntityHistoryResponse",
+    "LoopApproveResponse",
+    "LoopRejectResponse",
+    "LoopStatusResponse",
+    "RagConfigResponse",
+    "RagStatsResponse",
+    "RerankResultsResponse",
+    "UpdateRagConfigResponse",
     # search.py
     "EnhancedSearchResponse",
     "EnhancedSearchV2Response",

--- a/autobot-backend/knowledge/schemas/rag.py
+++ b/autobot-backend/knowledge/schemas/rag.py
@@ -1,0 +1,123 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Response schemas for RAG endpoints (Issue #5317 batch 3c)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AdvancedSearchResponse(BaseModel):
+    """Shape returned by POST /advanced_search.
+
+    Core keys: results, total_results, query, metrics, reranking_enabled.
+    Optional context/context_length when return_context=True.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    total_results: int = 0
+    query: str = ""
+    metrics: Dict[str, Any] = Field(default_factory=dict)
+    reranking_enabled: bool = True
+    context: Optional[str] = None
+    context_length: Optional[int] = None
+
+
+class RerankResultsResponse(BaseModel):
+    """Shape returned by POST /rerank_results."""
+
+    model_config = ConfigDict(extra="allow")
+
+    reranked_results: List[Any] = Field(default_factory=list)
+    original_count: int = 0
+    query: str = ""
+    reranking_applied: bool = True
+
+
+class RagConfigResponse(BaseModel):
+    """Shape returned by GET /config/rag and as the config sub-object in PUT responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    config: Dict[str, Any] = Field(default_factory=dict)
+    source: Optional[str] = None
+
+
+class UpdateRagConfigResponse(BaseModel):
+    """Shape returned by PUT /config/rag."""
+
+    model_config = ConfigDict(extra="allow")
+
+    message: str = ""
+    updated_fields: Optional[List[str]] = None
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LoopStatusResponse(BaseModel):
+    """Shape returned by GET /loop/status."""
+
+    model_config = ConfigDict(extra="allow")
+
+    loop_status: Dict[str, Any] = Field(default_factory=dict)
+    current_config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LoopApproveResponse(BaseModel):
+    """Shape returned by POST /loop/approve."""
+
+    model_config = ConfigDict(extra="allow")
+
+    message: str = ""
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LoopRejectResponse(BaseModel):
+    """Shape returned by POST /loop/reject."""
+
+    model_config = ConfigDict(extra="allow")
+
+    message: str = ""
+
+
+class RagStatsResponse(BaseModel):
+    """Shape returned by GET /stats/rag."""
+
+    model_config = ConfigDict(extra="allow")
+
+    stats: Dict[str, Any] = Field(default_factory=dict)
+    service_available: bool = True
+
+
+class BenchmarkRunResponse(BaseModel):
+    """Shape returned by POST /benchmark/run.
+
+    When Redis is unavailable, reason="redis_unavailable" and stream_key=None.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    published: int = 0
+    total: int = 0
+    stream_key: Optional[str] = None
+    split_used: Optional[str] = None
+    dev_size: Optional[int] = None
+    test_size: Optional[int] = None
+    tuned_on_dev: Optional[bool] = None
+    held_out_score: Optional[bool] = None
+    mean_precision_at_k: Optional[float] = None
+    reason: Optional[str] = None
+
+
+class EntityHistoryResponse(BaseModel):
+    """Shape returned by GET /entity/{entity_id}/history."""
+
+    model_config = ConfigDict(extra="allow")
+
+    entity_id: str = ""
+    versions: List[Dict[str, Any]] = Field(default_factory=list)
+    count: int = 0


### PR DESCRIPTION
Part of #5317 systematic `response_model=` sweep. Covers all 10 endpoints in `api/knowledge_rag.py`.

## New file: `knowledge/schemas/rag.py`

| Schema | Endpoint |
|--------|----------|
| `AdvancedSearchResponse` | `POST /advanced_search` |
| `RerankResultsResponse` | `POST /rerank_results` |
| `RagConfigResponse` | `GET /config/rag` |
| `UpdateRagConfigResponse` | `PUT /config/rag` |
| `LoopStatusResponse` | `GET /loop/status` |
| `LoopApproveResponse` | `POST /loop/approve` |
| `LoopRejectResponse` | `POST /loop/reject` |
| `RagStatsResponse` | `GET /stats/rag` |
| `BenchmarkRunResponse` | `POST /benchmark/run` |
| `EntityHistoryResponse` | `GET /entity/{entity_id}/history` |

All schemas use `ConfigDict(extra="allow")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)