### PR TITLE
feat(backend): add response_model= to api/knowledge_population.py endpoints (#5317 batch 3b)

### DIFF
--- a/autobot-backend/api/knowledge_population.py
+++ b/autobot-backend/api/knowledge_population.py
@@ -28,6 +28,16 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from constants.threshold_constants import TimingConstants
+from knowledge.schemas.population import (
+    JobStatusResponse,
+    PopulateManPagesResponse,
+    PopulateSystemCommandsResponse,
+    RefreshSystemKnowledgeResponse,
+    ScanManPagesChangesResponse,
+    ScanManPagesResponse,
+    TaskQueuedResponse,
+    TaskStatusResponse,
+)
 from knowledge_factory import get_or_create_knowledge_base
 from utils.template_loader import knowledge_data_exists, load_knowledge_data
 
@@ -409,7 +419,7 @@ async def _store_autobot_config_info(kb_to_use) -> bool:
     operation="populate_system_commands",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/populate_system_commands")
+@router.post("/populate_system_commands", response_model=PopulateSystemCommandsResponse)
 async def populate_system_commands(request: dict, req: Request):
     """
     Populate knowledge base with common system commands and usage examples.
@@ -621,7 +631,7 @@ async def _populate_man_pages_background(kb_to_use):
     operation="populate_man_pages",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/populate_man_pages")
+@router.post("/populate_man_pages", response_model=PopulateManPagesResponse)
 async def populate_man_pages(
     request: dict, req: Request, background_tasks: BackgroundTasks
 ):
@@ -652,7 +662,7 @@ async def populate_man_pages(
     operation="refresh_system_knowledge",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/refresh_system_knowledge")
+@router.post("/refresh_system_knowledge", response_model=RefreshSystemKnowledgeResponse)
 async def refresh_system_knowledge(request: dict, req: Request):
     """
     Refresh ALL system knowledge (man pages + AutoBot docs) - BACKGROUND JOB
@@ -693,7 +703,7 @@ async def refresh_system_knowledge(request: dict, req: Request):
     operation="get_job_status",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/job_status/{task_id}")
+@router.get("/job_status/{task_id}", response_model=JobStatusResponse)
 async def get_job_status(task_id: str, req: Request):
     """
     Get status of a background knowledge base job.
@@ -1005,7 +1015,7 @@ async def _process_all_doc_files(
     operation="populate_autobot_docs",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/populate_autobot_docs")
+@router.post("/populate_autobot_docs", response_model=TaskQueuedResponse)
 async def populate_autobot_docs(background_tasks: BackgroundTasks, request: dict, req: Request):
     """
     Queue documentation indexing as background task (#4103).
@@ -1110,7 +1120,7 @@ async def _index_autobot_docs_background(task_id: str, force_reindex: bool):
         )
 
 
-@router.get("/populate_autobot_docs/status/{task_id}")
+@router.get("/populate_autobot_docs/status/{task_id}", response_model=TaskStatusResponse)
 async def get_populate_status(task_id: str):
     """
     Poll the status of a background documentation indexing task.
@@ -1219,7 +1229,7 @@ async def _index_code_background(task_id: str, root_dir: str, force: bool) -> No
     operation="index_code",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/index/code")
+@router.post("/index/code", response_model=TaskQueuedResponse)
 async def index_code(request: dict = None):
     """Index source files in *root_dir* via AST-based CodeIndexer (#4835).
 
@@ -1264,7 +1274,7 @@ async def index_code(request: dict = None):
     }
 
 
-@router.get("/index/code/status/{task_id}")
+@router.get("/index/code/status/{task_id}", response_model=TaskStatusResponse)
 async def get_index_code_status(task_id: str):
     """Poll the status of a background code indexing task (#4912).
 
@@ -1496,7 +1506,7 @@ def _parse_scan_request(request: dict | None) -> tuple[int | None, list | None, 
     operation="scan_man_pages",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/scan_man_pages")
+@router.post("/scan_man_pages", response_model=ScanManPagesResponse)
 async def scan_man_pages(
     request: dict,
     req: Request,
@@ -1563,7 +1573,7 @@ async def _store_parsed_man_pages(kb_to_use, parsed_content: list) -> int:
     operation="scan_man_pages_changes",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/scan_man_pages_changes")
+@router.post("/scan_man_pages_changes", response_model=ScanManPagesChangesResponse)
 async def scan_man_pages_changes(
     request: dict,
     req: Request,

--- a/autobot-backend/knowledge/schemas/__init__.py
+++ b/autobot-backend/knowledge/schemas/__init__.py
@@ -54,6 +54,16 @@ from knowledge.schemas.search import (
     SearchAnalyticsResponse,
     SimilaritySearchResponse,
 )
+from knowledge.schemas.population import (
+    JobStatusResponse,
+    PopulateManPagesResponse,
+    PopulateSystemCommandsResponse,
+    RefreshSystemKnowledgeResponse,
+    ScanManPagesChangesResponse,
+    ScanManPagesResponse,
+    TaskQueuedResponse,
+    TaskStatusResponse,
+)
 from knowledge.schemas.rag import (
     AdvancedSearchResponse,
     BenchmarkRunResponse,
@@ -131,6 +141,15 @@ __all__ = [
     "RecordClickResponse",
     "SearchAnalyticsResponse",
     "SimilaritySearchResponse",
+    # population.py
+    "JobStatusResponse",
+    "PopulateManPagesResponse",
+    "PopulateSystemCommandsResponse",
+    "RefreshSystemKnowledgeResponse",
+    "ScanManPagesChangesResponse",
+    "ScanManPagesResponse",
+    "TaskQueuedResponse",
+    "TaskStatusResponse",
     # operations.py
     "ImportStatisticsResponse",
     "ImportStatusResponse",

--- a/autobot-backend/knowledge/schemas/population.py
+++ b/autobot-backend/knowledge/schemas/population.py
@@ -1,0 +1,123 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Response schemas for knowledge population endpoints (Issue #5317 batch 3b)."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PopulateSystemCommandsResponse(BaseModel):
+    """Response for POST /populate_system_commands."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    message: str
+    items_added: int = 0
+    total_commands: Optional[int] = None
+
+
+class PopulateManPagesResponse(BaseModel):
+    """Response for POST /populate_man_pages."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    message: str
+    items_added: int = 0
+    background: Optional[bool] = None
+
+
+class RefreshSystemKnowledgeResponse(BaseModel):
+    """Response for POST /refresh_system_knowledge."""
+
+    model_config = ConfigDict(extra="allow")
+
+    task_id: str
+    status: str
+    message: str
+    poll_url: str
+
+
+class JobStatusResponse(BaseModel):
+    """Response for GET /job_status/{task_id}."""
+
+    model_config = ConfigDict(extra="allow")
+
+    task_id: str
+    status: str
+    message: Optional[str] = None
+    result: Optional[Any] = None
+    error: Optional[str] = None
+    meta: Optional[Dict[str, Any]] = None
+
+
+class TaskQueuedResponse(BaseModel):
+    """Response for endpoints that queue a background task and return immediately.
+
+    Used by POST /populate_autobot_docs and POST /index/code.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    task_id: str
+    message: str
+    status_url: str
+
+
+class TaskStatusResponse(BaseModel):
+    """Response for task status poll endpoints.
+
+    Used by GET /populate_autobot_docs/status/{task_id} and
+    GET /index/code/status/{task_id}.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    task_id: str
+    status: str
+    message: Optional[str] = None
+    progress_percent: Optional[float] = None
+    items_processed: Optional[int] = None
+    items_total: Optional[int] = None
+    error: Optional[str] = None
+    elapsed_seconds: Optional[float] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class ScanManPagesResponse(BaseModel):
+    """Response for POST /scan_man_pages.
+
+    When run_background=True the body is a lightweight acknowledgement;
+    when run synchronously it carries full counts.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    message: str
+    background: Optional[bool] = None
+    machine_id: Optional[str] = None
+    limit: Optional[int] = None
+    sections: Optional[Any] = None
+    items_added: Optional[int] = None
+    items_failed: Optional[int] = None
+    total_scanned: Optional[int] = None
+
+
+class ScanManPagesChangesResponse(BaseModel):
+    """Response for POST /scan_man_pages_changes."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    machine_id: str
+    scan_duration_seconds: float = 0.0
+    summary: Optional[Dict[str, Any]] = None
+    items_stored: int = 0
+    parsed_count: int = 0


### PR DESCRIPTION
Part of #5317 systematic `response_model=` sweep. Covers all 10 endpoints in `api/knowledge_population.py`.

## New file: `knowledge/schemas/population.py`

| Schema | Endpoint |
|--------|----------|
| `PopulateSystemCommandsResponse` | `POST /populate_system_commands` |
| `PopulateManPagesResponse` | `POST /populate_man_pages` |
| `RefreshSystemKnowledgeResponse` | `POST /refresh_system_knowledge` |
| `JobStatusResponse` | `GET /job_status/{task_id}` |
| `TaskQueuedResponse` | `POST /populate_autobot_docs`, `POST /index/code` |
| `TaskStatusResponse` | `GET /populate_autobot_docs/status/{task_id}`, `GET /index/code/status/{task_id}` |
| `ScanManPagesResponse` | `POST /scan_man_pages` |
| `ScanManPagesChangesResponse` | `POST /scan_man_pages_changes` |

All schemas use `ConfigDict(extra="allow")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)