### PR TITLE
docs(architecture): add ARCHITECTURE_EXCEPTIONS.md for Windows NPU standalone redis_client (#5438)

### DIFF
--- a/autobot-npu-worker/resources/windows-npu-worker/app/utils/redis_client.py
+++ b/autobot-npu-worker/resources/windows-npu-worker/app/utils/redis_client.py
@@ -8,13 +8,12 @@ Standalone Redis Client for Windows NPU Worker
 This module provides Redis client initialization with connection pooling,
 retry logic, and health monitoring for the Windows NPU worker.
 
-STANDALONE DESIGN (Issue #1086): This module is deployed as part of the
-Windows NPU worker — a self-contained executable that runs on Windows hosts
-without access to the AutoBot monorepo. autobot_shared.redis_client cannot
-be imported here because autobot_shared is not packaged with the Windows
-deployment artifact. Direct redis.asyncio.Redis() instantiation is therefore
-intentional and required in this file only. All other backend code must use
-get_redis_client() from autobot_shared.redis_client.
+STANDALONE DESIGN (Issue #5438): This module is an intentional architectural
+exception documented in docs/developer/ARCHITECTURE_EXCEPTIONS.md. The Windows
+NPU worker is a self-contained PyInstaller executable that cannot import
+autobot_shared at runtime; direct redis.asyncio.Redis() instantiation is
+therefore required here. All other backend code must use get_redis_client()
+from autobot_shared.redis_client.
 
 Issue #725: Added mTLS support for secure Redis connections.
 

--- a/docs/developer/ARCHITECTURE_EXCEPTIONS.md
+++ b/docs/developer/ARCHITECTURE_EXCEPTIONS.md
@@ -1,0 +1,22 @@
+# Architecture Exceptions
+
+This document records intentional deviations from the standard AutoBot architecture.
+Each entry explains what diverges, which canonical module it mirrors, why the exception
+exists, and how to keep the two in sync.
+
+---
+
+## Windows NPU Worker — Standalone Redis Client
+
+**File:** `autobot-npu-worker/resources/windows-npu-worker/app/utils/redis_client.py`
+**Mirrors:** `autobot_shared/redis_client.py`
+**Issue:** #5438
+
+**Reason:** The Windows NPU worker is packaged as a self-contained executable via PyInstaller.
+It cannot import from `autobot_shared/` at runtime because the shared package is not bundled
+with the executable. The standalone redis_client.py replicates the subset of functionality
+needed by the worker.
+
+**Sync cadence:** When `autobot_shared/redis_client.py` changes (connection parameters,
+retry logic, health-check helpers), manually mirror those changes here. Reference this
+document to surface the obligation.


### PR DESCRIPTION
## Summary

- Creates `docs/developer/ARCHITECTURE_EXCEPTIONS.md` documenting the Windows NPU worker's standalone redis_client as an intentional architectural exception
- Updates `autobot-npu-worker/resources/windows-npu-worker/app/utils/redis_client.py` docstring to reference the new doc + #5438 instead of closed #1086

## Why

The Windows NPU worker is packaged as a PyInstaller self-contained executable and cannot import from `autobot_shared/`. The `redis_client.py` duplication is intentional. This doc makes that explicit and provides sync-cadence guidance for future maintainers.

Closes #5438

## Test plan
- [ ] `docs/developer/ARCHITECTURE_EXCEPTIONS.md` exists and has correct entry
- [ ] NPU worker redis_client.py docstring references `ARCHITECTURE_EXCEPTIONS.md` and `#5438`
- [ ] No functional code changed — documentation-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)