### PR TITLE
feat(backend): add response_model= to api/knowledge_vectorization.py endpoints (#5317 batch 4a)

### DIFF
--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -19,6 +19,20 @@ from pydantic import BaseModel, Field, field_validator
 from redis.exceptions import RedisError
 
 from auth_middleware import check_admin_permission, get_current_user
+from knowledge.schemas.vectorization import (
+    BackgroundVectorizationResponse,
+    ClearFailedJobsResponse,
+    DeleteJobResponse,
+    FailedJobsResponse,
+    ReindexWithContextStatusResponse,
+    RetryJobResponse,
+    VectorizationStatusPollResponse,
+    VectorizationStatusResponse,
+    VectorizeDocumentsResponse,
+    VectorizeFactJobResponse,
+    VectorizeFactsResponse,
+    VectorizeJobStatusResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.time_utils import utc_timestamp
 from background_vectorization import get_background_vectorizer
@@ -318,7 +332,7 @@ async def _perform_uncached_batch_check(
     operation="check_vectorization_status_batch",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/vectorization_status")
+@router.post("/vectorization_status", response_model=VectorizationStatusResponse)
 async def check_vectorization_status_batch(
     request: dict, req: Request, _user: dict = Depends(get_current_user)
 ):
@@ -595,7 +609,7 @@ def _build_vectorization_response(
     operation="vectorize_existing_facts",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/vectorize_facts")
+@router.post("/vectorize_facts", response_model=VectorizeFactsResponse)
 async def vectorize_existing_facts(
     req: Request,
     batch_size: int = 50,
@@ -1056,7 +1070,7 @@ async def _vectorize_fact_background(
     operation="vectorize_individual_fact",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/vectorize_fact/{fact_id}")
+@router.post("/vectorize_fact/{fact_id}", response_model=VectorizeFactJobResponse)
 async def vectorize_individual_fact(
     fact_id: str,
     req: Request,
@@ -1152,7 +1166,7 @@ async def _vectorize_single_document(kb, document_id: str) -> dict:
     operation="batch_vectorize_documents",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/vectorize_documents")
+@router.post("/vectorize_documents", response_model=VectorizeDocumentsResponse)
 async def batch_vectorize_documents(
     request: BatchVectorizeRequest,
     req: Request,
@@ -1211,7 +1225,7 @@ async def batch_vectorize_documents(
     operation="get_vectorization_job_status",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/vectorize_job/{job_id}")
+@router.get("/vectorize_job/{job_id}", response_model=VectorizeJobStatusResponse)
 async def get_vectorization_job_status(
     job_id: str, req: Request, _user: dict = Depends(get_current_user)
 ):
@@ -1274,7 +1288,7 @@ def _collect_failed_keys(keys: list, results: list) -> List[str]:
     operation="get_failed_vectorization_jobs",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/vectorize_jobs/failed")
+@router.get("/vectorize_jobs/failed", response_model=FailedJobsResponse)
 async def get_failed_vectorization_jobs(
     req: Request, _user: dict = Depends(get_current_user)
 ):
@@ -1331,7 +1345,7 @@ async def get_failed_vectorization_jobs(
     operation="retry_vectorization_job",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/vectorize_jobs/{job_id}/retry")
+@router.post("/vectorize_jobs/{job_id}/retry", response_model=RetryJobResponse)
 async def retry_vectorization_job(
     job_id: str,
     req: Request,
@@ -1383,7 +1397,7 @@ async def retry_vectorization_job(
     operation="delete_vectorization_job",
     error_code_prefix="KNOWLEDGE",
 )
-@router.delete("/vectorize_jobs/{job_id}")
+@router.delete("/vectorize_jobs/{job_id}", response_model=DeleteJobResponse)
 async def delete_vectorization_job(
     job_id: str, req: Request, _admin: bool = Depends(check_admin_permission)
 ):
@@ -1424,7 +1438,7 @@ async def delete_vectorization_job(
     operation="clear_failed_vectorization_jobs",
     error_code_prefix="KNOWLEDGE",
 )
-@router.delete("/vectorize_jobs/failed/clear")
+@router.delete("/vectorize_jobs/failed/clear", response_model=ClearFailedJobsResponse)
 async def clear_failed_vectorization_jobs(
     req: Request, _admin: bool = Depends(check_admin_permission)
 ):
@@ -1487,7 +1501,7 @@ async def clear_failed_vectorization_jobs(
     operation="start_background_vectorization",
     error_code_prefix="KNOWLEDGE",
 )
-@router.post("/vectorize_facts/background")
+@router.post("/vectorize_facts/background", response_model=BackgroundVectorizationResponse)
 async def start_background_vectorization(
     req: Request,
     background_tasks: BackgroundTasks,
@@ -1519,7 +1533,7 @@ async def start_background_vectorization(
     operation="get_vectorization_status",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/vectorize_facts/status")
+@router.get("/vectorize_facts/status", response_model=VectorizationStatusPollResponse)
 async def get_vectorization_status(
     req: Request, _user: dict = Depends(get_current_user)
 ):
@@ -1812,7 +1826,7 @@ async def reindex_with_context(
     operation="get_reindex_with_context_status",
     error_code_prefix="KNOWLEDGE",
 )
-@router.get("/reindex_with_context/status")
+@router.get("/reindex_with_context/status", response_model=ReindexWithContextStatusResponse)
 async def get_reindex_with_context_status(
     _user: dict = Depends(get_current_user),
 ) -> dict:

--- a/autobot-backend/knowledge/schemas/__init__.py
+++ b/autobot-backend/knowledge/schemas/__init__.py
@@ -112,6 +112,22 @@ from knowledge.schemas.stats import (
     KnowledgeMainCategoryEntry,
     KnowledgeStatsBasic,
 )
+from knowledge.schemas.vectorization import (
+    BackgroundVectorizationResponse,
+    ClearFailedJobsResponse,
+    DeleteJobResponse,
+    DocumentResult,
+    FailedJobsResponse,
+    ReindexWithContextStatusResponse,
+    RetryJobResponse,
+    VectorizationStatusPollResponse,
+    VectorizationStatusResponse,
+    VectorizationSummary,
+    VectorizeDocumentsResponse,
+    VectorizeFactJobResponse,
+    VectorizeFactsResponse,
+    VectorizeJobStatusResponse,
+)
 
 __all__ = [
     # maintenance.py
@@ -215,4 +231,19 @@ __all__ = [
     "ManPagesSummaryResponse",
     "OrgKnowledgeConfigResponse",
     "TestCategoriesResponse",
+    # vectorization.py
+    "BackgroundVectorizationResponse",
+    "ClearFailedJobsResponse",
+    "DeleteJobResponse",
+    "DocumentResult",
+    "FailedJobsResponse",
+    "ReindexWithContextStatusResponse",
+    "RetryJobResponse",
+    "VectorizationStatusPollResponse",
+    "VectorizationStatusResponse",
+    "VectorizationSummary",
+    "VectorizeDocumentsResponse",
+    "VectorizeFactJobResponse",
+    "VectorizeFactsResponse",
+    "VectorizeJobStatusResponse",
 ]

--- a/autobot-backend/knowledge/schemas/vectorization.py
+++ b/autobot-backend/knowledge/schemas/vectorization.py
@@ -1,0 +1,160 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Response schemas for the knowledge vectorization API endpoints (#5317)."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class VectorizationSummary(BaseModel):
+    """Summary statistics returned inside vectorization-status responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    total_checked: int
+    vectorized: int
+    not_vectorized: int
+    vectorization_percentage: float
+
+
+class VectorizationStatusResponse(BaseModel):
+    """Response for POST /vectorization_status."""
+
+    model_config = ConfigDict(extra="allow")
+
+    statuses: Dict[str, Any]
+    summary: VectorizationSummary
+    cached: bool
+    check_time_ms: float
+
+
+class VectorizeFactsResponse(BaseModel):
+    """Response for POST /vectorize_facts."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    message: str
+    processed: int
+    success: int
+    failed: int
+    skipped: int
+
+
+class VectorizeFactJobResponse(BaseModel):
+    """Response for POST /vectorize_fact/{fact_id}."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    message: str
+    job_id: str
+    fact_id: str
+    force: bool
+
+
+class DocumentResult(BaseModel):
+    """Per-document result entry in batch vectorization."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    status: str
+
+
+class VectorizeDocumentsResponse(BaseModel):
+    """Response for POST /vectorize_documents."""
+
+    model_config = ConfigDict(extra="allow")
+
+    results: List[DocumentResult]
+    total: int
+    succeeded: int
+
+
+class VectorizeJobStatusResponse(BaseModel):
+    """Response for GET /vectorize_job/{job_id}."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    job: Dict[str, Any]
+
+
+class FailedJobsResponse(BaseModel):
+    """Response for GET /vectorize_jobs/failed."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    failed_jobs: List[Dict[str, Any]]
+    total_failed: int
+
+
+class RetryJobResponse(BaseModel):
+    """Response for POST /vectorize_jobs/{job_id}/retry."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    message: str
+    new_job_id: str
+    fact_id: str
+    original_job_id: str
+
+
+class DeleteJobResponse(BaseModel):
+    """Response for DELETE /vectorize_jobs/{job_id}."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    message: str
+    job_id: str
+
+
+class ClearFailedJobsResponse(BaseModel):
+    """Response for DELETE /vectorize_jobs/failed/clear."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    message: str
+    deleted_count: int
+
+
+class BackgroundVectorizationResponse(BaseModel):
+    """Response for POST /vectorize_facts/background."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    message: str
+    last_run: Optional[str]
+    is_running: bool
+
+
+class VectorizationStatusPollResponse(BaseModel):
+    """Response for GET /vectorize_facts/status."""
+
+    model_config = ConfigDict(extra="allow")
+
+    is_running: bool
+    last_run: Optional[str]
+    check_interval: int
+    batch_size: int
+
+
+class ReindexWithContextStatusResponse(BaseModel):
+    """Response for GET /reindex_with_context/status (#1761)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    is_running: bool
+    enriched_count: int
+    total_count: int
+    started_at: Optional[str]
+    completed_at: Optional[str]
+    error: Optional[str]


### PR DESCRIPTION
Part of #5317. Covers 12 unwired endpoints in `api/knowledge_vectorization.py`. New file `knowledge/schemas/vectorization.py` with 13 schemas (all `ConfigDict(extra="allow")`).