### PR TITLE
feat(backend): add response_model= to api/knowledge_connectors.py endpoints (#5317 batch 4b)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -38,6 +38,17 @@ from constants.error_constants import ERR_CONNECTOR_NOT_FOUND
 from knowledge.connectors.models import ConnectorConfig
 from knowledge.connectors.registry import ConnectorRegistry
 from knowledge.connectors.scheduler import get_connector_scheduler
+from knowledge.schemas.connectors import (
+    ConnectorCreateResponse,
+    ConnectorDetailResponse,
+    ConnectorHistoryResponse,
+    ConnectorsHealthResponse,
+    ConnectorsListResponse,
+    ConnectorSyncResponse,
+    ConnectorTestResponse,
+    ConnectorTypesResponse,
+    ConnectorUpdateResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +271,7 @@ async def _run_sync_background(connector_id: str, incremental: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/knowledge_base/connector_types")
+@router.get("/knowledge_base/connector_types", response_model=ConnectorTypesResponse)
 async def list_connector_types():
     """Return all registered connector types with readiness tier (Issue #4421).
 
@@ -280,7 +291,7 @@ async def list_connector_types():
     return {"connector_types": types, "total": len(types)}
 
 
-@router.get("/knowledge_base/connectors")
+@router.get("/knowledge_base/connectors", response_model=ConnectorsListResponse)
 async def list_connectors():
     """Return all connectors with their current status."""
     try:
@@ -298,7 +309,7 @@ async def list_connectors():
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@router.post("/knowledge_base/connectors", status_code=201)
+@router.post("/knowledge_base/connectors", status_code=201, response_model=ConnectorCreateResponse)
 async def create_connector(request: CreateConnectorRequest):
     """Create a new connector, test the connection, and persist the config."""
     if request.connector_type not in _SUPPORTED_TYPES:
@@ -339,7 +350,7 @@ async def create_connector(request: CreateConnectorRequest):
     return {"connector_id": connector_id, "config": _cfg_to_dict(cfg)}
 
 
-@router.get("/knowledge_base/connectors/health")
+@router.get("/knowledge_base/connectors/health", response_model=ConnectorsHealthResponse)
 async def connectors_health():
     """Aggregate test_connection() across all live connectors (Issue #4420).
 
@@ -387,7 +398,7 @@ async def _hydrate_all_instances() -> None:
             logger.warning("Skipping corrupted connector %s: %s", cid, exc)
 
 
-@router.get("/knowledge_base/connectors/{connector_id}")
+@router.get("/knowledge_base/connectors/{connector_id}", response_model=ConnectorDetailResponse)
 async def get_connector(connector_id: str):
     """Return config and status for a single connector."""
     cfg = await _load_connector(connector_id)
@@ -397,7 +408,7 @@ async def get_connector(connector_id: str):
     return {"config": _cfg_to_dict(cfg), "status": status}
 
 
-@router.put("/knowledge_base/connectors/{connector_id}")
+@router.put("/knowledge_base/connectors/{connector_id}", response_model=ConnectorUpdateResponse)
 async def update_connector(connector_id: str, request: UpdateConnectorRequest):
     """Update mutable fields of an existing connector."""
     cfg = await _load_connector(connector_id)
@@ -430,7 +441,7 @@ async def delete_connector(connector_id: str):
     logger.info("Deleted connector %s", connector_id)
 
 
-@router.post("/knowledge_base/connectors/{connector_id}/test")
+@router.post("/knowledge_base/connectors/{connector_id}/test", response_model=ConnectorTestResponse)
 async def test_connector_connection(connector_id: str):
     """Run a connection test against the connector's target."""
     cfg = await _load_connector(connector_id)
@@ -445,7 +456,7 @@ async def test_connector_connection(connector_id: str):
     return {"connector_id": connector_id, "healthy": healthy}
 
 
-@router.post("/knowledge_base/connectors/{connector_id}/sync")
+@router.post("/knowledge_base/connectors/{connector_id}/sync", response_model=ConnectorSyncResponse)
 async def trigger_sync(
     connector_id: str,
     background_tasks: BackgroundTasks,
@@ -466,7 +477,7 @@ async def trigger_sync(
     }
 
 
-@router.get("/knowledge_base/connectors/{connector_id}/history")
+@router.get("/knowledge_base/connectors/{connector_id}/history", response_model=ConnectorHistoryResponse)
 async def get_sync_history(connector_id: str, limit: int = 20):
     """Return recent sync results for a connector."""
     cfg = await _load_connector(connector_id)

--- a/autobot-backend/knowledge/schemas/__init__.py
+++ b/autobot-backend/knowledge/schemas/__init__.py
@@ -112,6 +112,22 @@ from knowledge.schemas.stats import (
     KnowledgeMainCategoryEntry,
     KnowledgeStatsBasic,
 )
+from knowledge.schemas.connectors import (
+    ConnectorConfigDict,
+    ConnectorCreateResponse,
+    ConnectorDetailResponse,
+    ConnectorEntry,
+    ConnectorHistoryEntry,
+    ConnectorHistoryResponse,
+    ConnectorsHealthResponse,
+    ConnectorsListResponse,
+    ConnectorStatusDict,
+    ConnectorSyncResponse,
+    ConnectorTestResponse,
+    ConnectorTypeEntry,
+    ConnectorTypesResponse,
+    ConnectorUpdateResponse,
+)
 from knowledge.schemas.vectorization import (
     BackgroundVectorizationResponse,
     ClearFailedJobsResponse,
@@ -246,4 +262,19 @@ __all__ = [
     "VectorizeFactJobResponse",
     "VectorizeFactsResponse",
     "VectorizeJobStatusResponse",
+    # connectors.py
+    "ConnectorConfigDict",
+    "ConnectorCreateResponse",
+    "ConnectorDetailResponse",
+    "ConnectorEntry",
+    "ConnectorHistoryEntry",
+    "ConnectorHistoryResponse",
+    "ConnectorsHealthResponse",
+    "ConnectorsListResponse",
+    "ConnectorStatusDict",
+    "ConnectorSyncResponse",
+    "ConnectorTestResponse",
+    "ConnectorTypeEntry",
+    "ConnectorTypesResponse",
+    "ConnectorUpdateResponse",
 ]

--- a/autobot-backend/knowledge/schemas/connectors.py
+++ b/autobot-backend/knowledge/schemas/connectors.py
@@ -1,0 +1,160 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Response schemas for the knowledge connector endpoints (Issue #5317)."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ConnectorTypeEntry(BaseModel):
+    """Single entry in the connector_types list."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_type: str
+    tier: int
+
+
+class ConnectorTypesResponse(BaseModel):
+    """GET /knowledge_base/connector_types."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_types: List[ConnectorTypeEntry]
+    total: int
+
+
+class ConnectorStatusDict(BaseModel):
+    """Status sub-object returned inside connector list / detail responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_id: str
+    is_healthy: bool
+    last_sync_at: Optional[str] = None
+    last_sync_status: Optional[str] = None
+    documents_indexed: Optional[int] = None
+    last_error: Optional[str] = None
+    scheduled: Optional[bool] = None
+    error: Optional[str] = None
+
+
+class ConnectorConfigDict(BaseModel):
+    """Config sub-object returned inside connector list / detail responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_id: str
+    connector_type: str
+    name: str
+    config: Dict[str, Any]
+    enabled: bool
+    verification_mode: str
+    schedule_cron: Optional[str] = None
+    created_at: str
+    last_sync_at: Optional[str] = None
+    include_patterns: List[str]
+    exclude_patterns: List[str]
+    tier: int
+
+
+class ConnectorEntry(BaseModel):
+    """One element of the connectors list."""
+
+    model_config = ConfigDict(extra="allow")
+
+    config: ConnectorConfigDict
+    status: ConnectorStatusDict
+
+
+class ConnectorsListResponse(BaseModel):
+    """GET /knowledge_base/connectors."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connectors: List[ConnectorEntry]
+    total: int
+
+
+class ConnectorCreateResponse(BaseModel):
+    """POST /knowledge_base/connectors (201)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_id: str
+    config: ConnectorConfigDict
+
+
+class ConnectorsHealthResponse(BaseModel):
+    """GET /knowledge_base/connectors/health."""
+
+    model_config = ConfigDict(extra="allow")
+
+    healthy: List[str]
+    unavailable: List[str]
+    errors: Dict[str, str]
+    checked_at: str
+
+
+class ConnectorDetailResponse(BaseModel):
+    """GET /knowledge_base/connectors/{connector_id}."""
+
+    model_config = ConfigDict(extra="allow")
+
+    config: ConnectorConfigDict
+    status: ConnectorStatusDict
+
+
+class ConnectorUpdateResponse(BaseModel):
+    """PUT /knowledge_base/connectors/{connector_id}."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_id: str
+    config: ConnectorConfigDict
+
+
+class ConnectorTestResponse(BaseModel):
+    """POST /knowledge_base/connectors/{connector_id}/test."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_id: str
+    healthy: bool
+
+
+class ConnectorSyncResponse(BaseModel):
+    """POST /knowledge_base/connectors/{connector_id}/sync."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_id: str
+    status: str
+    incremental: bool
+
+
+class ConnectorHistoryEntry(BaseModel):
+    """Single history record stored per sync run."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_id: str
+    started_at: str
+    completed_at: Optional[str] = None
+    status: Optional[str] = None
+    added: Optional[int] = None
+    updated: Optional[int] = None
+    deleted: Optional[int] = None
+    errors: Optional[int] = None
+
+
+class ConnectorHistoryResponse(BaseModel):
+    """GET /knowledge_base/connectors/{connector_id}/history."""
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_id: str
+    history: List[ConnectorHistoryEntry]
+    total: int


### PR DESCRIPTION
Part of #5317. Covers 9 endpoints in `api/knowledge_connectors.py` (DELETE /connectors/{id} returns 204, no response_model needed). New file `knowledge/schemas/connectors.py` with 14 schemas.