### PR TITLE
feat(backend): add response_model= to knowledge_mcp.py and knowledge_rag_feedback.py (#5317 batch 4c)

### DIFF
--- a/autobot-backend/api/knowledge_mcp.py
+++ b/autobot-backend/api/knowledge_mcp.py
@@ -20,6 +20,18 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
+from knowledge.schemas.mcp import (
+    McpAddDocumentResponse,
+    McpHealthResponse,
+    McpKnowledgeStatsResponse,
+    McpQaChainResponse,
+    McpRedisVectorOpsResponse,
+    McpSchemaResponse,
+    McpSearchResponse,
+    McpSummarizeTopicResponse,
+    McpToolsResponse,
+    McpVectorSimilarityResponse,
+)
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
 from constants.model_constants import ModelConstants
@@ -336,7 +348,7 @@ def _get_knowledge_management_tools() -> List[MCPTool]:
     operation="get_mcp_tools",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.get("/mcp/tools")
+@router.get("/mcp/tools", response_model=List[McpToolsResponse])
 async def get_mcp_tools(
     current_user: dict = Depends(get_current_user),
 ) -> List[MCPTool]:
@@ -356,7 +368,7 @@ async def get_mcp_tools(
     operation="mcp_search_knowledge_base",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.post("/mcp/search_knowledge_base")
+@router.post("/mcp/search_knowledge_base", response_model=McpSearchResponse)
 async def mcp_search_knowledge_base(
     request: KnowledgeSearchRequest,
     current_user: dict = Depends(get_current_user),
@@ -402,7 +414,7 @@ async def mcp_search_knowledge_base(
     operation="mcp_add_to_knowledge_base",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.post("/mcp/add_to_knowledge_base")
+@router.post("/mcp/add_to_knowledge_base", response_model=McpAddDocumentResponse)
 async def mcp_add_to_knowledge_base(
     request: DocumentAddRequest,
     current_user: dict = Depends(get_current_user),
@@ -437,7 +449,7 @@ async def mcp_add_to_knowledge_base(
     operation="mcp_get_knowledge_stats",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.post("/mcp/get_knowledge_stats")
+@router.post("/mcp/get_knowledge_stats", response_model=McpKnowledgeStatsResponse)
 async def mcp_get_knowledge_stats(
     request: KnowledgeStatsRequest,
     current_user: dict = Depends(get_current_user),
@@ -480,7 +492,7 @@ async def mcp_get_knowledge_stats(
     operation="mcp_summarize_knowledge_topic",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.post("/mcp/summarize_knowledge_topic")
+@router.post("/mcp/summarize_knowledge_topic", response_model=McpSummarizeTopicResponse)
 async def mcp_summarize_knowledge_topic(
     request: Metadata,
     current_user: dict = Depends(get_current_user),
@@ -544,7 +556,7 @@ async def mcp_summarize_knowledge_topic(
     operation="mcp_vector_similarity_search",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.post("/mcp/vector_similarity_search")
+@router.post("/mcp/vector_similarity_search", response_model=McpVectorSimilarityResponse)
 async def mcp_vector_similarity_search(
     request: Metadata,
     current_user: dict = Depends(get_current_user),
@@ -593,7 +605,7 @@ async def mcp_vector_similarity_search(
     operation="mcp_langchain_qa_chain",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.post("/mcp/langchain_qa_chain")
+@router.post("/mcp/langchain_qa_chain", response_model=McpQaChainResponse)
 async def mcp_langchain_qa_chain(
     request: Metadata,
     current_user: dict = Depends(get_current_user),
@@ -719,7 +731,7 @@ _VECTOR_OPERATIONS = {
     operation="mcp_redis_vector_operations",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.post("/mcp/redis_vector_operations")
+@router.post("/mcp/redis_vector_operations", response_model=McpRedisVectorOpsResponse)
 async def mcp_redis_vector_operations(
     request: Metadata,
     current_user: dict = Depends(get_current_user),
@@ -752,7 +764,7 @@ async def mcp_redis_vector_operations(
     operation="get_mcp_schema",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.get("/mcp/schema")
+@router.get("/mcp/schema", response_model=McpSchemaResponse)
 async def get_mcp_schema(
     current_user: dict = Depends(get_current_user),
 ):
@@ -781,7 +793,7 @@ async def get_mcp_schema(
     operation="mcp_health",
     error_code_prefix="KNOWLEDGE_MCP",
 )
-@router.get("/mcp/health")
+@router.get("/mcp/health", response_model=McpHealthResponse)
 async def mcp_health():
     """Check if MCP bridge is healthy"""
     try:

--- a/autobot-backend/api/knowledge_rag_feedback.py
+++ b/autobot-backend/api/knowledge_rag_feedback.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from auth_middleware import get_current_user
+from knowledge.schemas.mcp import RagFeedbackResponse
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.redis_client import get_async_redis_client
 from constants.ttl_constants import TTL_30_DAYS
@@ -45,7 +46,7 @@ class RagFeedbackRequest(BaseModel):
     user_id: Optional[str] = None
 
 
-@router.post("/rag-feedback")
+@router.post("/rag-feedback", response_model=RagFeedbackResponse)
 @with_error_handling(
     category=ErrorCategory.SERVER_ERROR,
     operation="record_rag_feedback",
@@ -54,7 +55,7 @@ class RagFeedbackRequest(BaseModel):
 async def record_rag_feedback(
     body: RagFeedbackRequest,
     current_user: dict = Depends(get_current_user),
-) -> dict:
+) -> RagFeedbackResponse:
     """Record a user's explicit accept/reject annotation for a retrieved source.
 
     Issue #3240: Writes to ``rag:feedback:{user_id}:{date}`` Redis stream so

--- a/autobot-backend/knowledge/schemas/__init__.py
+++ b/autobot-backend/knowledge/schemas/__init__.py
@@ -102,6 +102,19 @@ from knowledge.schemas.rag import (
     RerankResultsResponse,
     UpdateRagConfigResponse,
 )
+from knowledge.schemas.mcp import (
+    McpAddDocumentResponse,
+    McpHealthResponse,
+    McpKnowledgeStatsResponse,
+    McpQaChainResponse,
+    McpRedisVectorOpsResponse,
+    McpSchemaResponse,
+    McpSearchResponse,
+    McpSummarizeTopicResponse,
+    McpToolsResponse,
+    McpVectorSimilarityResponse,
+    RagFeedbackResponse,
+)
 from knowledge.schemas.stats import (
     DetailedKnowledgeSizeMetrics,
     DetailedKnowledgeStats,
@@ -277,4 +290,16 @@ __all__ = [
     "ConnectorTypeEntry",
     "ConnectorTypesResponse",
     "ConnectorUpdateResponse",
+    # mcp.py
+    "McpAddDocumentResponse",
+    "McpHealthResponse",
+    "McpKnowledgeStatsResponse",
+    "McpQaChainResponse",
+    "McpRedisVectorOpsResponse",
+    "McpSchemaResponse",
+    "McpSearchResponse",
+    "McpSummarizeTopicResponse",
+    "McpToolsResponse",
+    "McpVectorSimilarityResponse",
+    "RagFeedbackResponse",
 ]

--- a/autobot-backend/knowledge/schemas/mcp.py
+++ b/autobot-backend/knowledge/schemas/mcp.py
@@ -1,0 +1,156 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Response schemas for MCP bridge and RAG feedback endpoints (Issue #5317 batch 4c)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class McpToolsResponse(BaseModel):
+    """Shape returned by GET /mcp/tools — list of MCPTool definitions."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    description: str
+    input_schema: Dict[str, Any] = Field(default_factory=dict)
+
+
+class McpSearchResult(BaseModel):
+    """Single result entry from a knowledge base search."""
+
+    model_config = ConfigDict(extra="allow")
+
+    content: str = ""
+    score: float = 0.0
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    source: str = "unknown"
+
+
+class McpSearchResponse(BaseModel):
+    """Shape returned by POST /mcp/search_knowledge_base."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    query: str = ""
+    count: int = 0
+    error: Optional[str] = None
+
+
+class McpAddDocumentResponse(BaseModel):
+    """Shape returned by POST /mcp/add_to_knowledge_base."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    document_id: Optional[str] = None
+    message: Optional[str] = None
+    error: Optional[str] = None
+
+
+class McpKnowledgeStatsResponse(BaseModel):
+    """Shape returned by POST /mcp/get_knowledge_stats."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    stats: Dict[str, Any] = Field(default_factory=dict)
+    error: Optional[str] = None
+
+
+class McpSummarizeTopicResponse(BaseModel):
+    """Shape returned by POST /mcp/summarize_knowledge_topic."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    summary: str = ""
+    topic: Optional[str] = None
+    source_count: int = 0
+    error: Optional[str] = None
+
+
+class McpVectorSimilarityResponse(BaseModel):
+    """Shape returned by POST /mcp/vector_similarity_search."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    query: Optional[str] = None
+    threshold: Optional[float] = None
+    error: Optional[str] = None
+
+
+class McpQaChainResponse(BaseModel):
+    """Shape returned by POST /mcp/langchain_qa_chain."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    answer: str = ""
+    question: Optional[str] = None
+    sources: List[str] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
+class McpRedisVectorOpsResponse(BaseModel):
+    """Shape returned by POST /mcp/redis_vector_operations."""
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool
+    operation: Optional[str] = None
+    data: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+    error: Optional[str] = None
+
+
+class McpSchemaBackends(BaseModel):
+    """Backends sub-object in the MCP schema response."""
+
+    model_config = ConfigDict(extra="allow")
+
+    langchain: str = ""
+    llama_index: str = ""
+    redis: str = ""
+
+
+class McpSchemaResponse(BaseModel):
+    """Shape returned by GET /mcp/schema."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = ""
+    version: str = ""
+    description: str = ""
+    tools: List[Dict[str, Any]] = Field(default_factory=list)
+    backends: Dict[str, str] = Field(default_factory=dict)
+
+
+class McpHealthResponse(BaseModel):
+    """Shape returned by GET /mcp/health."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    knowledge_base_initialized: bool = False
+    vector_store_connected: bool = False
+    error: Optional[str] = None
+
+
+class RagFeedbackResponse(BaseModel):
+    """Shape returned by POST /rag-feedback."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    stream_key: Optional[str] = None
+    decision: Optional[str] = None
+    reason: Optional[str] = None


### PR DESCRIPTION
Part of #5317. Covers 10 endpoints in `api/knowledge_mcp.py` + 1 in `api/knowledge_rag_feedback.py`. New file `knowledge/schemas/mcp.py` with 11 schemas.