### PR TITLE
fix(slm-backend): adopt DateTime(timezone=True) columns + datetime.now(timezone.utc) (#5385)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/version.py
+++ b/autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/version.py
@@ -97,7 +97,7 @@ class AgentVersion:
             True if saved successfully
         """
         if built_at is None:
-            built_at = datetime.utcnow()
+            built_at = datetime.now(timezone.utc)
 
         version_info = {
             "commit": commit,

--- a/autobot-slm-backend/api/code_source.py
+++ b/autobot-slm-backend/api/code_source.py
@@ -452,7 +452,7 @@ async def _upsert_node_code_version(
         if cache_path:
             row.cache_path = cache_path
         if status == CodeStatus.UP_TO_DATE:
-            row.deployed_at = datetime.utcnow()
+            row.deployed_at = datetime.now(timezone.utc)
     else:
         db.add(
             NodeCodeVersion(
@@ -461,7 +461,7 @@ async def _upsert_node_code_version(
                 commit_hash=commit,
                 status=status.value,
                 cache_path=cache_path,
-                deployed_at=(datetime.utcnow() if status == CodeStatus.UP_TO_DATE else None),
+                deployed_at=(datetime.now(timezone.utc) if status == CodeStatus.UP_TO_DATE else None),
             )
         )
 
@@ -518,7 +518,7 @@ async def notify_new_commit(
 
     # Update source with new commit
     source.last_known_commit = notification.commit
-    source.last_notified_at = datetime.utcnow()
+    source.last_notified_at = datetime.now(timezone.utc)
 
     # Update source node's code_version and mark as up-to-date
     node_result = await db.execute(select(Node).where(Node.node_id == notification.node_id))

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -92,7 +92,7 @@ class FleetSyncJob:
     restart: bool
     nodes: Dict[str, NodeSyncState] = field(default_factory=dict)
     status: str = "pending"  # pending, running, completed, failed
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: Optional[datetime] = None
 
 
@@ -122,7 +122,7 @@ async def reconcile_stale_fleet_sync_jobs() -> int:
 
         for job in stale_jobs:
             job.status = "failed"
-            job.completed_at = datetime.utcnow()
+            job.completed_at = datetime.now(timezone.utc)
             job.failure_reason = "reconciled: server restarted while job was running"
             logger.warning(
                 "Reconciled stale fleet sync job %s " "(was 'running', marked 'failed')",
@@ -1014,7 +1014,7 @@ async def _sync_regular_nodes(executor, job: FleetSyncJob, regular_nodes: list) 
         tasks = []
         for node_state in batch:
             node_state.status = "syncing"
-            node_state.started_at = datetime.utcnow()
+            node_state.started_at = datetime.now(timezone.utc)
             await _update_node_state_db(
                 job.job_id,
                 node_state.node_id,
@@ -1038,7 +1038,7 @@ async def _sync_slm_self_node(executor, job: FleetSyncJob, slm_self_node: NodeSy
     the self-sync restart kills this process (#1707).
     """
     slm_self_node.status = "syncing"
-    slm_self_node.started_at = datetime.utcnow()
+    slm_self_node.started_at = datetime.now(timezone.utc)
     await _update_node_state_db(
         job.job_id,
         slm_self_node.node_id,
@@ -1060,14 +1060,14 @@ async def _sync_slm_self_node(executor, job: FleetSyncJob, slm_self_node: NodeSy
             job.job_id,
             slm_self_node.node_id,
             status="success",
-            completed_at=datetime.utcnow(),
+            completed_at=datetime.now(timezone.utc),
         )
-        await _update_job_status_db(job.job_id, status=pre_status, completed_at=datetime.utcnow())
+        await _update_job_status_db(job.job_id, status=pre_status, completed_at=datetime.now(timezone.utc))
         # Fire-and-forget — restart kills this process,
         # but all nodes are already done and persisted.
         await _sync_slm_from_code_source(slm_self_node.node_id)
         slm_self_node.status = "success"
-        slm_self_node.completed_at = datetime.utcnow()
+        slm_self_node.completed_at = datetime.now(timezone.utc)
     else:
         await _sync_single_node(executor, slm_self_node, restart=False, job_id=job.job_id)
 
@@ -1116,7 +1116,7 @@ async def _run_fleet_sync_job(job: FleetSyncJob) -> None:
         job.status = "failed"
         failure_reason = str(e)
 
-    job.completed_at = datetime.utcnow()
+    job.completed_at = datetime.now(timezone.utc)
     await _update_job_status_db(
         job.job_id,
         status=job.status,
@@ -1169,12 +1169,12 @@ async def _sync_single_node(
             node_state.status = "failed"
             node_state.message = f"Playbook failed: {result['output'][:500]}"
 
-        node_state.completed_at = datetime.utcnow()
+        node_state.completed_at = datetime.now(timezone.utc)
 
     except Exception as e:
         node_state.status = "failed"
         node_state.message = "Operation failed"
-        node_state.completed_at = datetime.utcnow()
+        node_state.completed_at = datetime.now(timezone.utc)
         logger.error("Node sync failed for %s: %s", node_state.node_id, e)
 
     # Persist node state to DB (#1707)
@@ -1558,7 +1558,7 @@ def _calculate_next_run(expression: str, base: datetime = None) -> datetime:
     """Calculate next run time from cron expression."""
     from croniter import croniter
 
-    base = base or datetime.utcnow()
+    base = base or datetime.now(timezone.utc)
     cron = croniter(expression, base)
     return cron.get_next(datetime)
 
@@ -1811,7 +1811,7 @@ async def run_schedule(
         _running_tasks[job.job_id] = task
 
     # Update schedule last_run
-    schedule.last_run = datetime.utcnow()
+    schedule.last_run = datetime.now(timezone.utc)
     schedule.next_run = _calculate_next_run(schedule.cron_expression)
     await db.commit()
 

--- a/autobot-slm-backend/api/config.py
+++ b/autobot-slm-backend/api/config.py
@@ -161,7 +161,7 @@ async def set_global_default(
     if config:
         config.config_value = request.value
         config.value_type = request.value_type
-        config.updated_at = datetime.utcnow()
+        config.updated_at = datetime.now(timezone.utc)
     else:
         config = NodeConfig(
             node_id=None,
@@ -324,7 +324,7 @@ async def set_node_config_key(
     if config:
         config.config_value = request.value
         config.value_type = request.value_type
-        config.updated_at = datetime.utcnow()
+        config.updated_at = datetime.now(timezone.utc)
     else:
         config = NodeConfig(
             node_id=node_id,

--- a/autobot-slm-backend/api/errors.py
+++ b/autobot-slm-backend/api/errors.py
@@ -221,7 +221,7 @@ async def _get_node_hostname_map(db: AsyncSession, node_ids: List[str]) -> Dict[
 
 async def _get_error_counts_by_period(db: AsyncSession) -> Dict[str, int]:
     """Get error counts for different time periods."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     cutoffs = {
         "24h": now - timedelta(hours=24),
         "7d": now - timedelta(days=7),
@@ -243,7 +243,7 @@ async def _get_error_counts_by_period(db: AsyncSession) -> Dict[str, int]:
 
 async def _calculate_error_trend(db: AsyncSession) -> str:
     """Calculate error trend based on recent vs previous period."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     recent_cutoff = now - timedelta(hours=12)
     prev_cutoff = now - timedelta(hours=24)
 
@@ -411,7 +411,7 @@ async def get_error_categories(
     hours: int = Query(24, ge=1, le=720),
 ) -> CategoriesResponse:
     """Get error categories breakdown."""
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
 
     result = await db.execute(
         select(NodeEvent.event_type, func.count(NodeEvent.id).label("count"))
@@ -445,7 +445,7 @@ async def get_error_components(
     hours: int = Query(24, ge=1, le=720),
 ) -> ComponentsResponse:
     """Get errors by component/node."""
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
 
     result = await db.execute(
         select(NodeEvent.node_id, func.count(NodeEvent.id).label("count"))
@@ -487,7 +487,7 @@ async def get_error_health(
     critical_threshold = await _get_setting_value(db, "error_alert_threshold_critical", 50)
 
     # Calculate current error rate (errors in last hour)
-    cutoff = datetime.utcnow() - timedelta(hours=1)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
     result = await db.execute(
         select(func.count(NodeEvent.id)).where(
             NodeEvent.created_at >= cutoff,
@@ -539,7 +539,7 @@ async def clear_errors(
     if severity:
         query = delete(NodeEvent).where(NodeEvent.severity == severity)
     if older_than_hours:
-        cutoff = datetime.utcnow() - timedelta(hours=older_than_hours)
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=older_than_hours)
         query = query.where(NodeEvent.created_at < cutoff)
 
     result = await db.execute(query)
@@ -626,7 +626,7 @@ async def get_metrics_summary(
     total, unresolved = await _get_metrics_total_and_unresolved(db)
 
     # Critical count (last 24h)
-    cutoff = datetime.utcnow() - timedelta(hours=24)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
     critical_result = await db.execute(
         select(func.count(NodeEvent.id)).where(
             NodeEvent.created_at >= cutoff,
@@ -685,7 +685,7 @@ async def get_error_timeline(
     interval: str = Query("hour", regex="^(hour|day)$"),
 ) -> TimelineResponse:
     """Get error timeline data."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     start = now - timedelta(hours=hours)
 
     result = await db.execute(
@@ -711,7 +711,7 @@ async def get_top_errors(
     limit: int = Query(10, ge=1, le=50),
 ) -> TopErrorsResponse:
     """Get most frequent errors."""
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
 
     # Get error counts by type and message
     result = await db.execute(
@@ -771,7 +771,7 @@ async def resolve_error(
     if not event:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Error not found")
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     username = user.get("username", "unknown")
 
     await db.execute(
@@ -840,7 +840,7 @@ async def cleanup_old_errors(
     if days is None:
         days = await _get_setting_value(db, "error_retention_days", 30)
 
-    cutoff = datetime.utcnow() - timedelta(days=days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
     result = await db.execute(
         delete(NodeEvent).where(

--- a/autobot-slm-backend/api/maintenance.py
+++ b/autobot-slm-backend/api/maintenance.py
@@ -115,7 +115,7 @@ async def get_active_windows(
     node_id: Optional[str] = Query(None),
 ) -> MaintenanceWindowListResponse:
     """Get currently active maintenance windows."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     query = select(MaintenanceWindow).where(
         and_(
@@ -185,7 +185,7 @@ async def create_maintenance_window(
             )
 
     # Determine initial status
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     if window_data.start_time <= now <= window_data.end_time:
         initial_status = "active"
     elif window_data.start_time > now:
@@ -329,7 +329,7 @@ async def activate_maintenance_window(
         )
 
     window.status = "active"
-    window.start_time = datetime.utcnow()
+    window.start_time = datetime.now(timezone.utc)
 
     if window.node_id:
         await _set_node_maintenance_status(db, window.node_id, True, window.window_id)
@@ -364,7 +364,7 @@ async def complete_maintenance_window(
         )
 
     window.status = "completed"
-    window.end_time = datetime.utcnow()
+    window.end_time = datetime.now(timezone.utc)
 
     if window.node_id:
         await _set_node_maintenance_status(db, window.node_id, False, window.window_id)
@@ -436,7 +436,7 @@ async def _set_node_maintenance_status(
 
 async def is_node_in_maintenance(db: AsyncSession, node_id: str) -> bool:
     """Check if a node is currently in a maintenance window."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     result = await db.execute(
         select(MaintenanceWindow)
@@ -459,7 +459,7 @@ async def is_node_in_maintenance(db: AsyncSession, node_id: str) -> bool:
 
 async def should_suppress_remediation(db: AsyncSession, node_id: str) -> bool:
     """Check if remediation should be suppressed for a node."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     result = await db.execute(
         select(MaintenanceWindow)

--- a/autobot-slm-backend/api/monitoring.py
+++ b/autobot-slm-backend/api/monitoring.py
@@ -73,7 +73,7 @@ class FleetMetricsResponse(BaseModel):
     running_services: int
     failed_services: int
     nodes: List[NodeMetrics]
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class AlertItem(BaseModel):
@@ -106,7 +106,7 @@ class SystemHealthResponse(BaseModel):
     health_score: float  # 0-100
     components: Dict[str, str]  # component -> status
     issues: List[str]
-    last_check: datetime = Field(default_factory=datetime.utcnow)
+    last_check: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class DashboardOverview(BaseModel):
@@ -460,7 +460,7 @@ async def get_alerts(
     hours: int = Query(24, ge=1, le=168),
 ) -> AlertsResponse:
     """Get alerts from node events within the specified time window."""
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
 
     query = select(NodeEvent).where(
         NodeEvent.created_at >= cutoff,
@@ -501,7 +501,7 @@ async def clear_alerts(
     hours: int = Query(24, ge=1, le=168),
 ) -> dict:
     """Delete all warning/error node events within the time window."""
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
     result = await db.execute(
         delete(NodeEvent).where(
             NodeEvent.created_at >= cutoff,
@@ -589,7 +589,7 @@ async def _check_deployment_health(
 
     Queries recent failed deployments and updates components/issues in place.
     """
-    recent_cutoff = datetime.utcnow() - timedelta(hours=1)
+    recent_cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
     deploy_result = await db.execute(
         select(Deployment).where(
             Deployment.created_at >= recent_cutoff,
@@ -611,7 +611,7 @@ async def _check_maintenance_health(
 
     Queries active maintenance windows and updates components/issues in place.
     """
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     maint_result = await db.execute(
         select(MaintenanceWindow).where(
             MaintenanceWindow.start_time <= now,
@@ -691,12 +691,12 @@ async def get_dashboard_overview(
     health_summary = await get_system_health(db, _)
 
     # Count recent deployments (last 24 hours)
-    cutoff = datetime.utcnow() - timedelta(hours=24)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
     deploy_result = await db.execute(select(func.count(Deployment.id)).where(Deployment.created_at >= cutoff))
     recent_deployments = deploy_result.scalar() or 0
 
     # Count active maintenance
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     maint_result = await db.execute(
         select(func.count(MaintenanceWindow.id)).where(
             MaintenanceWindow.start_time <= now,
@@ -754,7 +754,7 @@ async def get_logs(
     per_page: int = Query(50, ge=1, le=200),
 ) -> LogsResponse:
     """Query logs/events across the fleet."""
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
 
     # Build and apply filters to both queries
     base_query = select(NodeEvent).where(NodeEvent.created_at >= cutoff)
@@ -824,7 +824,7 @@ async def get_errors(
     - GET /api/errors/components - Errors by node
     - POST /api/errors/metrics/resolve/{event_id} - Mark errors resolved
     """
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
 
     result = await db.execute(
         select(NodeEvent)

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -1326,10 +1326,10 @@ async def _cleanup_decommissioned_node(
     await db.execute(delete(NodeCredential).where(NodeCredential.node_id == node.node_id))
     await db.execute(delete(NodeConfig).where(NodeConfig.node_id == node.node_id))
     node.status = NodeStatus.DECOMMISSIONED.value
-    node.updated_at = datetime.utcnow()
+    node.updated_at = datetime.now(timezone.utc)
 
     deployment.status = DeploymentStatus.COMPLETED.value
-    deployment.completed_at = datetime.utcnow()
+    deployment.completed_at = datetime.now(timezone.utc)
     deployment.playbook_output = ansible_result.get("output", "")
     await db.commit()
 
@@ -1342,7 +1342,7 @@ async def _fail_deployment(
 ) -> None:
     """Mark a deployment as failed and persist (#1369)."""
     deployment.status = DeploymentStatus.FAILED.value
-    deployment.completed_at = datetime.utcnow()
+    deployment.completed_at = datetime.now(timezone.utc)
     deployment.error = error_msg[:2000]
     if output:
         deployment.playbook_output = output
@@ -1467,7 +1467,7 @@ def _create_decommission_deployment(
         node_id=node_id,
         roles=[r["role_name"] for r in all_roles],
         status=DeploymentStatus.IN_PROGRESS.value,
-        started_at=datetime.utcnow(),
+        started_at=datetime.now(timezone.utc),
         triggered_by=current_user.get("username", "unknown"),
         extra_data={
             "action": "decommission",
@@ -1505,7 +1505,7 @@ async def reenroll_node(
     await db.execute(delete(NodeConfig).where(NodeConfig.node_id == node_id))
 
     node.status = NodeStatus.PENDING.value
-    node.updated_at = datetime.utcnow()
+    node.updated_at = datetime.now(timezone.utc)
 
     await _create_node_event(
         db,
@@ -2357,7 +2357,7 @@ async def get_node_certificate(
     # Calculate days until expiry
     days_until_expiry = None
     if cert.not_after:
-        delta = cert.not_after - datetime.utcnow()
+        delta = cert.not_after - datetime.now(timezone.utc)
         days_until_expiry = delta.days
 
     response = CertificateResponse.model_validate(cert)
@@ -2395,8 +2395,8 @@ async def renew_node_certificate(
             node_id=node_id,
             subject=f"CN={node.hostname}",
             issuer="CN=SLM-CA",
-            not_before=datetime.utcnow(),
-            not_after=datetime.utcnow().replace(year=datetime.utcnow().year + 1),
+            not_before=datetime.now(timezone.utc),
+            not_after=datetime.now(timezone.utc).replace(year=datetime.now(timezone.utc).year + 1),
             status="active",
         )
         db.add(new_cert)
@@ -2458,8 +2458,8 @@ async def deploy_node_certificate(
             node_id=node_id,
             subject=f"CN={node.hostname}",
             issuer="CN=SLM-CA",
-            not_before=datetime.utcnow(),
-            not_after=datetime.utcnow().replace(year=datetime.utcnow().year + 1),
+            not_before=datetime.now(timezone.utc),
+            not_after=datetime.now(timezone.utc).replace(year=datetime.now(timezone.utc).year + 1),
             status="active",
         )
         db.add(new_cert)
@@ -2554,7 +2554,7 @@ async def apply_node_updates(
     for update in updates:
         try:
             update.is_applied = True
-            update.applied_at = datetime.utcnow()
+            update.applied_at = datetime.now(timezone.utc)
             applied.append(update.update_id)
         except Exception as e:
             logger.error("Failed to apply update %s: %s", update.update_id, e)

--- a/autobot-slm-backend/api/npu.py
+++ b/autobot-slm-backend/api/npu.py
@@ -438,7 +438,7 @@ async def _build_node_metrics(node: Node, ip_address: str, port: int) -> NPUWork
                     memory_total_gb=caps.get("memory_gb", 0.0),
                     uptime_seconds=data.get("uptimeSeconds", 0),
                     error_count=data.get("errorCount", 0),
-                    timestamp=datetime.utcnow(),
+                    timestamp=datetime.now(timezone.utc),
                 )
     except Exception:
         logger.debug("Live metrics unavailable for %s, using stored data", node.node_id)
@@ -449,7 +449,7 @@ async def _build_node_metrics(node: Node, ip_address: str, port: int) -> NPUWork
         utilization=caps.get("utilization", 0.0),
         queue_depth=npu_data.get("queue_depth", 0),
         memory_total_gb=caps.get("memory_gb", 0.0),
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
     )
 
 

--- a/autobot-slm-backend/api/orchestration.py
+++ b/autobot-slm-backend/api/orchestration.py
@@ -778,7 +778,7 @@ async def _apply_fleet_action(
             svc.status = running_state
             svc.active_state = active_state
             svc.sub_state = sub_state
-            svc.last_checked = datetime.utcnow()
+            svc.last_checked = datetime.now(timezone.utc)
             await ws_manager.send_service_status(
                 node_id=svc.node_id,
                 service_name=service_name,

--- a/autobot-slm-backend/api/performance.py
+++ b/autobot-slm-backend/api/performance.py
@@ -309,7 +309,7 @@ def _alert_rule_to_model(rule: AlertRule) -> AlertRuleModel:
 
 async def _calculate_slo_compliance(db: AsyncSession, slo: SLODefinition) -> Optional[float]:
     """Calculate SLO compliance percentage. Helper for performance.py (Issue #752)."""
-    cutoff = datetime.utcnow() - timedelta(days=slo.window_days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=slo.window_days)
     query = select(PerformanceTrace).where(PerformanceTrace.created_at >= cutoff)
     if slo.node_id:
         query = query.where(PerformanceTrace.source_node_id == slo.node_id)
@@ -401,7 +401,7 @@ async def get_performance_overview(
     hours: int = Query(24, ge=1, le=168),
 ) -> PerformanceOverviewResponse:
     """Get performance overview with aggregated metrics."""
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
     result = await db.execute(select(PerformanceTrace).where(PerformanceTrace.created_at >= cutoff))
     traces = result.scalars().all()
 
@@ -410,7 +410,7 @@ async def get_performance_overview(
 
     durations = [t.duration_ms for t in traces]
     errors = sum(1 for t in traces if t.status == "error")
-    time_span_minutes = (datetime.utcnow() - cutoff).total_seconds() / 60
+    time_span_minutes = (datetime.now(timezone.utc) - cutoff).total_seconds() / 60
 
     active_slos = await _fetch_active_slos_count(db)
     top_slow_traces = await _fetch_top_slow_traces(db, cutoff, 10)
@@ -439,7 +439,7 @@ async def get_traces(
     per_page: int = Query(50, ge=1, le=200),
 ) -> TracesListResponse:
     """Get paginated list of traces with optional filters."""
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
     query = select(PerformanceTrace).where(PerformanceTrace.created_at >= cutoff)
 
     if status_filter:
@@ -659,7 +659,7 @@ async def get_node_metrics(
     hours: int = Query(24, ge=1, le=168),
 ) -> NodeMetricsResponse:
     """Get performance metrics for a specific node."""
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
     result = await db.execute(
         select(PerformanceTrace).where(
             PerformanceTrace.source_node_id == node_id,
@@ -684,7 +684,7 @@ async def get_node_metrics(
 
     durations = [t.duration_ms for t in traces]
     errors = sum(1 for t in traces if t.status == "error")
-    time_span_minutes = (datetime.utcnow() - cutoff).total_seconds() / 60
+    time_span_minutes = (datetime.now(timezone.utc) - cutoff).total_seconds() / 60
     hostname = await _get_node_hostname(db, node_id)
 
     return NodeMetricsResponse(
@@ -705,7 +705,7 @@ async def get_prometheus_metrics(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Response:
     """Export metrics in Prometheus text format."""
-    cutoff = datetime.utcnow() - timedelta(hours=1)
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
     traces_result = await db.execute(select(PerformanceTrace).where(PerformanceTrace.created_at >= cutoff))
     traces = traces_result.scalars().all()
 

--- a/autobot-slm-backend/api/security.py
+++ b/autobot-slm-backend/api/security.py
@@ -193,7 +193,7 @@ async def get_security_overview(
     _: Annotated[dict, Depends(get_current_user)],
 ) -> SecurityOverviewResponse:
     """Get security dashboard overview metrics."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     last_24h = now - timedelta(hours=24)
     last_30d = now - timedelta(days=30)
 
@@ -459,7 +459,7 @@ async def get_threat_summary(
     hours: int = Query(24, ge=1, le=720, description="Hours to look back"),
 ) -> ThreatSummary:
     """Get threat detection summary statistics."""
-    since = datetime.utcnow() - timedelta(hours=hours)
+    since = datetime.now(timezone.utc) - timedelta(hours=hours)
 
     severity_counts = await _get_threat_severity_counts(db, since)
     by_type, by_source_ip = await _get_threat_distribution(db, since)
@@ -564,7 +564,7 @@ async def acknowledge_security_event(
 
     event.is_acknowledged = True
     event.acknowledged_by = current_user.get("sub", "unknown")
-    event.acknowledged_at = datetime.utcnow()
+    event.acknowledged_at = datetime.now(timezone.utc)
 
     await db.commit()
     await db.refresh(event)
@@ -592,7 +592,7 @@ async def resolve_security_event(
 
     event.is_resolved = True
     event.resolved_by = current_user.get("sub", "unknown")
-    event.resolved_at = datetime.utcnow()
+    event.resolved_at = datetime.now(timezone.utc)
     event.resolution_notes = resolve_data.resolution_notes
 
     # Also mark as acknowledged if not already
@@ -848,7 +848,8 @@ def _parse_openssl_date(raw: Optional[str]) -> Optional[datetime]:
             continue
     # Last resort: try ISO-8601 for already-formatted inputs
     try:
-        return datetime.fromisoformat(raw)
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
     except ValueError:
         return None
 
@@ -857,7 +858,7 @@ def _days_until(dt: Optional[datetime]) -> Optional[int]:
     """Return days until datetime from now (negative = already expired)."""
     if dt is None:
         return None
-    return (dt - datetime.utcnow()).days
+    return (dt - datetime.now(timezone.utc)).days
 
 
 @router.get("/certificates", response_model=List[CertificateResponse])
@@ -879,7 +880,7 @@ async def list_certificates(
     certs = result.scalars().all()
 
     responses = []
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     for cert in certs:
         resp = CertificateResponse.model_validate(cert)
         resp.days_until_expiry = _days_until(cert.not_after)
@@ -899,7 +900,7 @@ async def list_expiring_certificates(
     days: int = Query(30, ge=1, le=365, description="Expiring within N days"),
 ) -> List[CertificateResponse]:
     """List certificates expiring within the given number of days."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     threshold = now + timedelta(days=days)
 
     result = await db.execute(
@@ -936,7 +937,7 @@ async def report_certificate(
     cert = existing.scalar_one_or_none()
 
     if cert is None:
-        cert = Certificate(cert_id=f"{report.node_id}-{int(datetime.utcnow().timestamp())}")
+        cert = Certificate(cert_id=f"{report.node_id}-{int(datetime.now(timezone.utc).timestamp())}")
         db.add(cert)
 
     cert.node_id = report.node_id

--- a/autobot-slm-backend/api/services.py
+++ b/autobot-slm-backend/api/services.py
@@ -391,7 +391,7 @@ async def scan_node_services(
             logger.warning("No service facts returned for %s", node.hostname)
             return _build_scan_failure_response(node_id, "No service data returned from Ansible")
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         discovered, created, updated = await _parse_ansible_service_facts(services_data, db, node_id, now)
 
         await db.commit()
@@ -505,7 +505,7 @@ async def start_service(
             service.status = ServiceStatus.RUNNING.value
             service.active_state = "active"
             service.sub_state = "running"
-            service.last_checked = datetime.utcnow()
+            service.last_checked = datetime.now(timezone.utc)
             await db.commit()
 
         # Broadcast status change via WebSocket
@@ -564,7 +564,7 @@ async def stop_service(
             service.status = ServiceStatus.STOPPED.value
             service.active_state = "inactive"
             service.sub_state = "dead"
-            service.last_checked = datetime.utcnow()
+            service.last_checked = datetime.now(timezone.utc)
             await db.commit()
 
         # Broadcast status change via WebSocket
@@ -635,7 +635,7 @@ async def _update_service_after_restart(db: AsyncSession, node_id: str, service_
         service.status = ServiceStatus.RUNNING.value
         service.active_state = "active"
         service.sub_state = "running"
-        service.last_checked = datetime.utcnow()
+        service.last_checked = datetime.now(timezone.utc)
         await db.commit()
 
 
@@ -898,7 +898,7 @@ async def _restart_single_service(
         svc.status = ServiceStatus.RUNNING.value
         svc.active_state = "active"
         svc.sub_state = "running"
-        svc.last_checked = datetime.utcnow()
+        svc.last_checked = datetime.now(timezone.utc)
 
         await ws_manager.send_service_status(
             node_id=node_id,
@@ -1248,7 +1248,7 @@ async def start_fleet_service(
             svc.status = ServiceStatus.RUNNING.value
             svc.active_state = "active"
             svc.sub_state = "running"
-            svc.last_checked = datetime.utcnow()
+            svc.last_checked = datetime.now(timezone.utc)
             # Broadcast status change for this node
             await ws_manager.send_service_status(
                 node_id=svc.node_id,
@@ -1306,7 +1306,7 @@ async def stop_fleet_service(
             svc.status = ServiceStatus.STOPPED.value
             svc.active_state = "inactive"
             svc.sub_state = "dead"
-            svc.last_checked = datetime.utcnow()
+            svc.last_checked = datetime.now(timezone.utc)
             # Broadcast status change for this node
             await ws_manager.send_service_status(
                 node_id=svc.node_id,
@@ -1364,7 +1364,7 @@ async def restart_fleet_service(
             svc.status = ServiceStatus.RUNNING.value
             svc.active_state = "active"
             svc.sub_state = "running"
-            svc.last_checked = datetime.utcnow()
+            svc.last_checked = datetime.now(timezone.utc)
             # Broadcast status change for this node
             await ws_manager.send_service_status(
                 node_id=svc.node_id,

--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -702,7 +702,7 @@ async def _create_wizard_deployments(
                         node_id=node.node_id,
                         roles=roles,
                         status=DeploymentStatus.IN_PROGRESS.value,
-                        started_at=datetime.utcnow(),
+                        started_at=datetime.now(timezone.utc),
                         triggered_by="setup-wizard",
                         extra_data={"source": "setup_wizard"},
                     )
@@ -746,7 +746,7 @@ async def _complete_wizard_deployments(
                     continue
                 node_succeeded = success and (reachable_nodes is None or node_id in reachable_nodes)
                 dep.status = DeploymentStatus.COMPLETED.value if node_succeeded else DeploymentStatus.FAILED.value
-                dep.completed_at = datetime.utcnow()
+                dep.completed_at = datetime.now(timezone.utc)
                 dep.playbook_output = output
                 if not node_succeeded:
                     dep.error = error or "Provisioning failed or node unreachable"

--- a/autobot-slm-backend/api/stateful.py
+++ b/autobot-slm-backend/api/stateful.py
@@ -513,7 +513,7 @@ async def _run_backup(backup_id: str, host: str, service_type: str) -> None:
             logger.error("Node %s not found for backup %s", backup.node_id, backup_id)
             backup.status = BackupStatus.FAILED.value
             backup.error = "Node not found"
-            backup.completed_at = datetime.utcnow()
+            backup.completed_at = datetime.now(timezone.utc)
             await db.commit()
             return
 
@@ -526,7 +526,7 @@ async def _run_backup(backup_id: str, host: str, service_type: str) -> None:
             # For unsupported service types, mark as failed
             backup.status = BackupStatus.FAILED.value
             backup.error = f"Unsupported service type: {service_type}"
-            backup.completed_at = datetime.utcnow()
+            backup.completed_at = datetime.now(timezone.utc)
             await db.commit()
             logger.warning("Backup %s failed: unsupported service type", backup_id)
 

--- a/autobot-slm-backend/api/tls.py
+++ b/autobot-slm-backend/api/tls.py
@@ -321,7 +321,7 @@ async def list_expiring_certificates(
 
             days_until = None
             if cred.tls_expires_at:
-                delta = cred.tls_expires_at - datetime.utcnow()
+                delta = cred.tls_expires_at - datetime.now(timezone.utc)
                 days_until = delta.days
 
             endpoints.append(

--- a/autobot-slm-backend/api/updates.py
+++ b/autobot-slm-backend/api/updates.py
@@ -124,7 +124,7 @@ async def _get_update_job_data(db: AsyncSession, job_id: str, node_id: str, upda
     if not node:
         job.status = UpdateJobStatus.FAILED.value
         job.error = "Node not found"
-        job.completed_at = datetime.utcnow()
+        job.completed_at = datetime.now(timezone.utc)
         await db.commit()
         return None
 
@@ -134,7 +134,7 @@ async def _get_update_job_data(db: AsyncSession, job_id: str, node_id: str, upda
     if not updates:
         job.status = UpdateJobStatus.FAILED.value
         job.error = "No valid updates found"
-        job.completed_at = datetime.utcnow()
+        job.completed_at = datetime.now(timezone.utc)
         await db.commit()
         return None
 
@@ -185,7 +185,7 @@ async def _handle_successful_update(
 
     for update in updates:
         update.is_applied = True
-        update.applied_at = datetime.utcnow()
+        update.applied_at = datetime.now(timezone.utc)
 
     await db.commit()
     await _broadcast_job_update(job.job_id, "completed", 100, f"Completed: {len(updates)} updates applied")
@@ -235,7 +235,7 @@ async def _run_update_job(job_id: str, node_id: str, update_ids: List[str]) -> N
         job, node, updates = job_data
 
         job.status = UpdateJobStatus.RUNNING.value
-        job.started_at = datetime.utcnow()
+        job.started_at = datetime.now(timezone.utc)
         job.total_steps = len(updates)
         await db.commit()
 
@@ -253,12 +253,12 @@ async def _run_update_job(job_id: str, node_id: str, update_ids: List[str]) -> N
             else:
                 await _handle_failed_update(db, job, node_id, result["output"])
 
-            job.completed_at = datetime.utcnow()
+            job.completed_at = datetime.now(timezone.utc)
             await db.commit()
 
         except asyncio.CancelledError:
             job.status = UpdateJobStatus.CANCELLED.value
-            job.completed_at = datetime.utcnow()
+            job.completed_at = datetime.now(timezone.utc)
             await db.commit()
             logger.info("Update job cancelled: %s", job_id)
             raise
@@ -267,7 +267,7 @@ async def _run_update_job(job_id: str, node_id: str, update_ids: List[str]) -> N
             logger.error("Update job failed: %s - %s", job_id, e)
             job.status = UpdateJobStatus.FAILED.value
             job.error = "Internal server error"
-            job.completed_at = datetime.utcnow()
+            job.completed_at = datetime.now(timezone.utc)
             await db.commit()
             await _broadcast_job_update(job_id, "failed", job.progress, "Update job failed")
 
@@ -936,14 +936,14 @@ async def _execute_upgrade_playbook(
             )
             .values(
                 is_applied=True,
-                applied_at=datetime.utcnow(),
+                applied_at=datetime.now(timezone.utc),
             )
         )
     else:
         j.status = UpdateJobStatus.FAILED.value
         j.error = r["output"][:500]
         j.output = r["output"]
-    j.completed_at = datetime.utcnow()
+    j.completed_at = datetime.now(timezone.utc)
     await sess.commit()
     await _broadcast_job_update(job_id, j.status, j.progress, j.current_step)
 
@@ -962,12 +962,12 @@ async def _run_upgrade_all(jid: str, nid: str) -> None:
         if not n:
             j.status = UpdateJobStatus.FAILED.value
             j.error = "Node not found"
-            j.completed_at = datetime.utcnow()
+            j.completed_at = datetime.now(timezone.utc)
             await sess.commit()
             return
 
         j.status = UpdateJobStatus.RUNNING.value
-        j.started_at = datetime.utcnow()
+        j.started_at = datetime.now(timezone.utc)
         j.current_step = "Running apt upgrade on node"
         await sess.commit()
         await _broadcast_job_update(jid, "running", 10, j.current_step)
@@ -978,7 +978,7 @@ async def _run_upgrade_all(jid: str, nid: str) -> None:
             logger.exception("Upgrade all failed: %s", jid)
             j.status = UpdateJobStatus.FAILED.value
             j.error = "Internal server error"
-            j.completed_at = datetime.utcnow()
+            j.completed_at = datetime.now(timezone.utc)
             await sess.commit()
 
 
@@ -1096,7 +1096,7 @@ async def cancel_job(
         del _running_jobs[job_id]
 
     job.status = UpdateJobStatus.CANCELLED.value
-    job.completed_at = datetime.utcnow()
+    job.completed_at = datetime.now(timezone.utc)
     await db.commit()
 
     logger.info("Update job cancelled: %s", job_id)

--- a/autobot-slm-backend/migrations/migrate_timestamps_to_timestamptz.py
+++ b/autobot-slm-backend/migrations/migrate_timestamps_to_timestamptz.py
@@ -1,0 +1,190 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""
+Migration: Convert all TIMESTAMP columns to TIMESTAMP WITH TIME ZONE
+
+Issue #5385 — slm-backend datetime.utcnow() → now_utc() migration gate.
+
+Converts every Column(DateTime) (naive TIMESTAMP) in models/database.py to
+TIMESTAMP WITH TIME ZONE, interpreting all existing stored values as UTC.
+This is correct because every write path used datetime.utcnow() (naive UTC).
+
+The USING clause converts each value to timestamptz:
+    ALTER COLUMN x TYPE TIMESTAMPTZ USING x AT TIME ZONE 'UTC'
+
+After this migration:
+- Column reads return timezone-aware UTC datetimes
+- now_utc() assignments are stored correctly
+- Python in-code comparisons (row.col - now_utc()) are aware-vs-aware
+"""
+
+import logging
+import sys
+
+from migrations.utils import get_connection, table_exists
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# All (table, column) pairs from models/database.py Column(DateTime) definitions
+TIMESTAMP_COLUMNS = [
+    ("nodes", "last_heartbeat"),
+    ("nodes", "created_at"),
+    ("nodes", "updated_at"),
+    ("deployments", "started_at"),
+    ("deployments", "completed_at"),
+    ("deployments", "created_at"),
+    ("deployments", "updated_at"),
+    ("backups", "started_at"),
+    ("backups", "completed_at"),
+    ("backups", "created_at"),
+    ("settings", "updated_at"),
+    ("node_events", "created_at"),
+    ("node_events", "resolved_at"),
+    ("certificates", "not_before"),
+    ("certificates", "not_after"),
+    ("certificates", "created_at"),
+    ("certificates", "updated_at"),
+    ("replications", "started_at"),
+    ("replications", "completed_at"),
+    ("replications", "created_at"),
+    ("replications", "updated_at"),
+    ("update_info", "applied_at"),
+    ("update_info", "created_at"),
+    ("update_jobs", "started_at"),
+    ("update_jobs", "completed_at"),
+    ("update_jobs", "created_at"),
+    ("update_jobs", "updated_at"),
+    ("fleet_sync_jobs", "created_at"),
+    ("fleet_sync_jobs", "completed_at"),
+    ("fleet_sync_node_states", "started_at"),
+    ("fleet_sync_node_states", "completed_at"),
+    ("services", "last_checked"),
+    ("services", "created_at"),
+    ("services", "updated_at"),
+    ("node_configs", "created_at"),
+    ("node_configs", "updated_at"),
+    ("service_conflicts", "created_at"),
+    ("agents", "created_at"),
+    ("agents", "updated_at"),
+    ("maintenance_windows", "start_time"),
+    ("maintenance_windows", "end_time"),
+    ("maintenance_windows", "created_at"),
+    ("maintenance_windows", "updated_at"),
+    ("blue_green_deployments", "monitoring_started_at"),
+    ("blue_green_deployments", "started_at"),
+    ("blue_green_deployments", "switched_at"),
+    ("blue_green_deployments", "completed_at"),
+    ("blue_green_deployments", "rollback_at"),
+    ("blue_green_deployments", "created_at"),
+    ("blue_green_deployments", "updated_at"),
+    ("system_secrets", "created_at"),
+    ("system_secrets", "updated_at"),
+    ("node_credentials", "tls_expires_at"),
+    ("node_credentials", "last_used"),
+    ("node_credentials", "created_at"),
+    ("node_credentials", "updated_at"),
+    ("audit_logs", "timestamp"),
+    ("audit_logs", "created_at"),
+    ("security_events", "timestamp"),
+    ("security_events", "acknowledged_at"),
+    ("security_events", "resolved_at"),
+    ("security_events", "created_at"),
+    ("security_events", "updated_at"),
+    ("security_policies", "last_evaluated"),
+    ("security_policies", "created_at"),
+    ("security_policies", "updated_at"),
+    ("update_schedules", "last_run"),
+    ("update_schedules", "next_run"),
+    ("update_schedules", "created_at"),
+    ("update_schedules", "updated_at"),
+    ("roles", "created_at"),
+    ("roles", "updated_at"),
+    ("node_roles", "last_synced_at"),
+    ("node_roles", "created_at"),
+    ("node_roles", "updated_at"),
+    ("node_code_versions", "deployed_at"),
+    ("node_code_versions", "updated_at"),
+    ("code_sources", "last_notified_at"),
+    ("code_sources", "created_at"),
+    ("code_sources", "updated_at"),
+    ("performance_traces", "created_at"),
+    ("trace_spans", "start_time"),
+    ("trace_spans", "end_time"),
+    ("slo_definitions", "created_at"),
+    ("slo_definitions", "updated_at"),
+    ("alert_rules", "last_triggered"),
+    ("alert_rules", "created_at"),
+    ("alert_rules", "updated_at"),
+    ("external_agents", "card_fetched_at"),
+    ("external_agents", "created_at"),
+    ("external_agents", "updated_at"),
+]
+
+
+def _is_already_timestamptz(cursor, table: str, column: str) -> bool:
+    """Return True if column is already TIMESTAMP WITH TIME ZONE."""
+    cursor.execute(
+        """
+        SELECT data_type
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = %s
+          AND column_name = %s
+        """,
+        (table, column),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return True  # column doesn't exist — skip
+    return row[0] == "timestamp with time zone"
+
+
+def migrate(db_url: str) -> None:
+    """Convert all TIMESTAMP columns to TIMESTAMPTZ (#5385)."""
+    logger.info("Running timestamps → timestamptz migration (#5385)")
+
+    conn = get_connection(db_url)
+    cursor = conn.cursor()
+
+    converted = 0
+    skipped = 0
+
+    for table, column in TIMESTAMP_COLUMNS:
+        if not table_exists(cursor, table):
+            logger.info("Table %s does not exist — skipping", table)
+            skipped += 1
+            continue
+
+        if _is_already_timestamptz(cursor, table, column):
+            logger.info("%s.%s already TIMESTAMPTZ — skipping", table, column)
+            skipped += 1
+            continue
+
+        sql = (
+            f"ALTER TABLE {table} "
+            f"ALTER COLUMN {column} TYPE TIMESTAMPTZ "
+            f"USING {column} AT TIME ZONE 'UTC'"
+        )
+        logger.info("Converting %s.%s → TIMESTAMPTZ", table, column)
+        cursor.execute(sql)
+        converted += 1
+
+    conn.commit()
+    conn.close()
+    logger.info(
+        "Migration complete: %d columns converted, %d skipped", converted, skipped
+    )
+
+
+def main():
+    """Entry point for running migration directly."""
+    from migrations.runner import get_db_url
+
+    db_url = sys.argv[1] if len(sys.argv) > 1 else get_db_url()
+    migrate(db_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/autobot-slm-backend/migrations/runner.py
+++ b/autobot-slm-backend/migrations/runner.py
@@ -20,7 +20,7 @@ Usage:
 import importlib
 import logging
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Tuple
 
 import psycopg2
@@ -60,6 +60,8 @@ MIGRATIONS = [
     "add_ansible_name_unique_constraint",
     # Issue #1980: add failure_reason column to fleet_sync_jobs
     "add_failure_reason_to_fleet_sync_jobs",
+    # Issue #5385: convert all TIMESTAMP columns to TIMESTAMPTZ (UTC-aware)
+    "migrate_timestamps_to_timestamptz",
 ]
 
 
@@ -142,7 +144,7 @@ def mark_migration_applied(conn: psycopg2.extensions.connection, name: str) -> N
     with conn.cursor() as cur:
         cur.execute(
             "INSERT INTO migrations_applied (name, applied_at) VALUES (%s, %s)",
-            (name, datetime.utcnow()),
+            (name, datetime.now(timezone.utc)),
         )
     conn.commit()
 

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -8,7 +8,7 @@ SQLAlchemy models for SLM state persistence.
 """
 
 import enum
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     JSON,
@@ -110,7 +110,7 @@ class Node(Base):
     cpu_percent = Column(Float, default=0.0)
     memory_percent = Column(Float, default=0.0)
     disk_percent = Column(Float, default=0.0)
-    last_heartbeat = Column(DateTime, nullable=True)
+    last_heartbeat = Column(DateTime(timezone=True), nullable=True)
 
     # Metadata
     agent_version = Column(String(20), nullable=True)
@@ -127,8 +127,8 @@ class Node(Base):
     role_versions = Column(JSON, default=dict)
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     @property
     def ansible_target(self) -> str:
@@ -148,8 +148,8 @@ class Deployment(Base):
     status = Column(String(20), default=DeploymentStatus.PENDING.value)
 
     # Execution details
-    started_at = Column(DateTime, nullable=True)
-    completed_at = Column(DateTime, nullable=True)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
     error = Column(Text, nullable=True)
     playbook_output = Column(Text, nullable=True)
 
@@ -158,8 +158,8 @@ class Deployment(Base):
     extra_data = Column(JSON, default=dict)
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class Backup(Base):
@@ -180,9 +180,9 @@ class Backup(Base):
     error = Column(Text, nullable=True)
 
     # Timestamps
-    started_at = Column(DateTime, nullable=True)
-    completed_at = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
 class Setting(Base):
@@ -195,7 +195,7 @@ class Setting(Base):
     value = Column(Text, nullable=True)
     value_type = Column(String(20), default="string")  # string, int, bool, json
     description = Column(String(255), nullable=True)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class EventType(str, enum.Enum):
@@ -264,11 +264,11 @@ class NodeEvent(Base):
     severity = Column(String(16), default=EventSeverity.INFO.value)
     message = Column(Text, nullable=False)
     details = Column(JSON, default=dict)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     # Error resolution tracking (Issue #563)
     resolved = Column(Boolean, default=False)
-    resolved_at = Column(DateTime, nullable=True)
+    resolved_at = Column(DateTime(timezone=True), nullable=True)
     resolved_by = Column(String(255), nullable=True)
 
 
@@ -283,12 +283,12 @@ class Certificate(Base):
     serial_number = Column(String(64), nullable=True)
     subject = Column(String(255), nullable=True)
     issuer = Column(String(255), nullable=True)
-    not_before = Column(DateTime, nullable=True)
-    not_after = Column(DateTime, nullable=True)
+    not_before = Column(DateTime(timezone=True), nullable=True)
+    not_after = Column(DateTime(timezone=True), nullable=True)
     fingerprint = Column(String(64), nullable=True)
     status = Column(String(20), default="pending")  # pending, active, expired, revoked
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class Replication(Base):
@@ -305,10 +305,10 @@ class Replication(Base):
     sync_position = Column(String(128), nullable=True)
     lag_bytes = Column(Integer, default=0)
     error = Column(Text, nullable=True)
-    started_at = Column(DateTime, nullable=True)
-    completed_at = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class UpdateInfo(Base):
@@ -325,8 +325,8 @@ class UpdateInfo(Base):
     severity = Column(String(16), default="low")  # low, medium, high, critical
     description = Column(Text, nullable=True)
     is_applied = Column(Boolean, default=False)
-    applied_at = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    applied_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
 class UpdateJobStatus(str, enum.Enum):
@@ -355,10 +355,10 @@ class UpdateJob(Base):
     completed_steps = Column(Integer, default=0)
     error = Column(Text, nullable=True)
     output = Column(Text, nullable=True)  # Command output/logs
-    started_at = Column(DateTime, nullable=True)
-    completed_at = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class FleetSyncJob(Base):
@@ -376,8 +376,8 @@ class FleetSyncJob(Base):
     completed_nodes = Column(Integer, default=0)
     failed_nodes = Column(Integer, default=0)
     failure_reason = Column(String(500), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    completed_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    completed_at = Column(DateTime(timezone=True), nullable=True)
 
 
 class FleetSyncNodeState(Base):
@@ -392,8 +392,8 @@ class FleetSyncNodeState(Base):
     ip_address = Column(String(45), nullable=True)
     status = Column(String(20), default="pending")
     message = Column(Text, nullable=True)
-    started_at = Column(DateTime, nullable=True)
-    completed_at = Column(DateTime, nullable=True)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
 
 
 class Service(Base):
@@ -412,7 +412,7 @@ class Service(Base):
     sub_state = Column(String(32), nullable=True)  # running, dead, exited
     main_pid = Column(Integer, nullable=True)
     memory_bytes = Column(BigInteger, nullable=True)
-    last_checked = Column(DateTime, nullable=True)
+    last_checked = Column(DateTime(timezone=True), nullable=True)
     extra_data = Column(JSON, default=dict)
 
     # Service Discovery Fields (Issue #760)
@@ -421,8 +421,8 @@ class Service(Base):
     endpoint_path = Column(String(256), nullable=True)  # e.g., "/api/health"
     is_discoverable = Column(Boolean, default=True)  # Include in discovery responses
 
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     # Composite unique constraint - one service record per node
     __table_args__ = (UniqueConstraint("node_id", "service_name", name="uq_node_service"),)
@@ -443,8 +443,8 @@ class NodeConfig(Base):
     config_value = Column(Text, nullable=True)
     value_type = Column(String(20), default="string")  # string, int, bool, json
 
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (UniqueConstraint("node_id", "config_key", name="uq_node_config"),)
 
@@ -464,7 +464,7 @@ class ServiceConflict(Base):
     reason = Column(Text, nullable=True)  # e.g., "Both bind to port 6379"
     conflict_type = Column(String(32), default="port")  # port, dependency, resource
 
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (UniqueConstraint("service_name_a", "service_name_b", name="uq_service_conflict"),)
 
@@ -496,8 +496,8 @@ class Agent(Base):
     is_default = Column(Boolean, default=False, index=True)
     is_active = Column(Boolean, default=True)
 
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class MaintenanceWindow(Base):
@@ -508,16 +508,16 @@ class MaintenanceWindow(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     window_id = Column(String(64), unique=True, nullable=False, index=True)
     node_id = Column(String(64), nullable=True, index=True)  # null = all nodes
-    start_time = Column(DateTime, nullable=False)
-    end_time = Column(DateTime, nullable=False)
+    start_time = Column(DateTime(timezone=True), nullable=False)
+    end_time = Column(DateTime(timezone=True), nullable=False)
     reason = Column(String(512), nullable=True)
     auto_drain = Column(Boolean, default=False)  # drain services before maintenance
     suppress_alerts = Column(Boolean, default=True)  # suppress alerts during window
     suppress_remediation = Column(Boolean, default=True)  # suppress auto-remediation
     status = Column(String(20), default="scheduled")  # scheduled, active, completed, cancelled
     created_by = Column(String(64), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class BlueGreenStatus(str, enum.Enum):
@@ -574,7 +574,7 @@ class BlueGreenDeployment(Base):
     post_deploy_monitor_duration = Column(Integer, default=1800)  # 30 min monitoring after switch
     health_failure_threshold = Column(Integer, default=3)  # Consecutive failures before rollback
     health_failures = Column(Integer, default=0)  # Current consecutive failure count
-    monitoring_started_at = Column(DateTime, nullable=True)  # When monitoring started
+    monitoring_started_at = Column(DateTime(timezone=True), nullable=True)  # When monitoring started
 
     # Status tracking
     status = Column(String(32), default=BlueGreenStatus.PENDING.value)
@@ -583,16 +583,16 @@ class BlueGreenDeployment(Base):
     error = Column(Text, nullable=True)
 
     # Timestamps
-    started_at = Column(DateTime, nullable=True)
-    switched_at = Column(DateTime, nullable=True)  # When traffic switched to green
-    completed_at = Column(DateTime, nullable=True)
-    rollback_at = Column(DateTime, nullable=True)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    switched_at = Column(DateTime(timezone=True), nullable=True)  # When traffic switched to green
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    rollback_at = Column(DateTime(timezone=True), nullable=True)
 
     # Metadata
     triggered_by = Column(String(64), nullable=True)
     extra_data = Column(JSON, default=dict)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class SecretCategory(str, enum.Enum):
@@ -617,8 +617,8 @@ class SystemSecret(Base):
     encrypted_value = Column(Text, nullable=False)
     category = Column(String(32), default=SecretCategory.SYSTEM.value)
     description = Column(String(255), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class CredentialType(str, enum.Enum):
@@ -660,16 +660,16 @@ class NodeCredential(Base):
     # TLS-specific fields (Issue #725: mTLS certificate storage)
     # Certs stored in encrypted_data as JSON: {"ca_cert", "server_cert", "server_key"}
     tls_common_name = Column(String(255), nullable=True)  # CN from certificate
-    tls_expires_at = Column(DateTime, nullable=True)  # Certificate expiration
+    tls_expires_at = Column(DateTime(timezone=True), nullable=True)  # Certificate expiration
     tls_fingerprint = Column(String(64), nullable=True)  # SHA256 fingerprint
 
     # State
     is_active = Column(Boolean, default=True)
-    last_used = Column(DateTime, nullable=True)
+    last_used = Column(DateTime(timezone=True), nullable=True)
 
     # Timestamps
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     # Composite unique constraint - one credential per node/type/name combo
     __table_args__ = (UniqueConstraint("node_id", "credential_type", "name", name="uq_node_cred_type_name"),)
@@ -737,7 +737,7 @@ class AuditLog(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     log_id = Column(String(64), unique=True, nullable=False, index=True)
-    timestamp = Column(DateTime, default=datetime.utcnow, index=True)
+    timestamp = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True)
 
     # Actor information
     user_id = Column(String(64), nullable=True, index=True)
@@ -765,7 +765,7 @@ class AuditLog(Base):
 
     # Metadata
     extra_data = Column(JSON, default=dict)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
 class SecurityEvent(Base):
@@ -775,7 +775,7 @@ class SecurityEvent(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     event_id = Column(String(64), unique=True, nullable=False, index=True)
-    timestamp = Column(DateTime, default=datetime.utcnow, index=True)
+    timestamp = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), index=True)
 
     # Event classification
     event_type = Column(String(64), nullable=False, index=True)
@@ -804,15 +804,15 @@ class SecurityEvent(Base):
     # Status
     is_acknowledged = Column(Boolean, default=False)
     acknowledged_by = Column(String(64), nullable=True)
-    acknowledged_at = Column(DateTime, nullable=True)
+    acknowledged_at = Column(DateTime(timezone=True), nullable=True)
     is_resolved = Column(Boolean, default=False)
     resolved_by = Column(String(64), nullable=True)
-    resolved_at = Column(DateTime, nullable=True)
+    resolved_at = Column(DateTime(timezone=True), nullable=True)
     resolution_notes = Column(Text, nullable=True)
 
     # Metadata
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class SecurityPolicy(Base):
@@ -842,7 +842,7 @@ class SecurityPolicy(Base):
     is_enforced = Column(Boolean, default=False)
 
     # Compliance tracking
-    last_evaluated = Column(DateTime, nullable=True)
+    last_evaluated = Column(DateTime(timezone=True), nullable=True)
     compliance_score = Column(Float, nullable=True)  # 0.0 - 100.0
     violations_count = Column(Integer, default=0)
 
@@ -853,8 +853,8 @@ class SecurityPolicy(Base):
     # Metadata
     created_by = Column(String(64), nullable=True)
     updated_by = Column(String(64), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 # =============================================================================
@@ -893,15 +893,15 @@ class UpdateSchedule(Base):
     restart_after_sync = Column(Boolean, default=True)
 
     # Execution tracking
-    last_run = Column(DateTime, nullable=True)
-    next_run = Column(DateTime, nullable=True)
+    last_run = Column(DateTime(timezone=True), nullable=True)
+    next_run = Column(DateTime(timezone=True), nullable=True)
     last_run_status = Column(String(20), nullable=True)  # success, failed, partial
     last_run_message = Column(Text, nullable=True)
 
     # Metadata
     created_by = Column(String(100), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 # =============================================================================
@@ -930,8 +930,8 @@ class Role(Base):
     required = Column(Boolean, default=False, nullable=False)
     degraded_without = Column(JSON, default=list)
     ansible_playbook = Column(String(200), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 class NodeRole(Base):
@@ -945,10 +945,10 @@ class NodeRole(Base):
     assignment_type = Column(String(20), default="auto")  # auto | manual
     status = Column(String(20), default=RoleStatus.NOT_INSTALLED.value)
     current_version = Column(String(64), nullable=True)
-    last_synced_at = Column(DateTime, nullable=True)
+    last_synced_at = Column(DateTime(timezone=True), nullable=True)
     last_error = Column(Text, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (UniqueConstraint("node_id", "role_name", name="uq_node_role"),)
 
@@ -967,9 +967,9 @@ class NodeCodeVersion(Base):
     role_name = Column(String(64), nullable=False, index=True)
     commit_hash = Column(String(64), nullable=True)
     status = Column(String(20), default=CodeStatus.UNKNOWN.value)
-    deployed_at = Column(DateTime, nullable=True)
+    deployed_at = Column(DateTime(timezone=True), nullable=True)
     cache_path = Column(String(512), nullable=True)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (UniqueConstraint("node_id", "role_name", name="uq_node_code_version"),)
 
@@ -985,9 +985,9 @@ class CodeSource(Base):
     repo_path = Column(String(255), nullable=False)
     branch = Column(String(100), default="main")
     last_known_commit = Column(String(64), nullable=True)
-    last_notified_at = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    last_notified_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
 
 # =============================================================================
@@ -1009,7 +1009,7 @@ class PerformanceTrace(Base):
     span_count = Column(Integer, default=1)
     error_message = Column(Text, nullable=True)
     metadata_json = Column(Text, nullable=True)
-    created_at = Column(DateTime, default=func.now())
+    created_at = Column(DateTime(timezone=True), default=func.now())
 
 
 class TraceSpan(Base):
@@ -1031,8 +1031,8 @@ class TraceSpan(Base):
     node_id = Column(String(100), nullable=True)
     status = Column(String(20), default="ok")
     duration_ms = Column(Float, nullable=False)
-    start_time = Column(DateTime, nullable=False)
-    end_time = Column(DateTime, nullable=False)
+    start_time = Column(DateTime(timezone=True), nullable=False)
+    end_time = Column(DateTime(timezone=True), nullable=False)
     attributes_json = Column(Text, nullable=True)
 
 
@@ -1052,8 +1052,8 @@ class SLODefinition(Base):
     window_days = Column(Integer, default=30)
     node_id = Column(String(100), nullable=True)
     enabled = Column(Boolean, default=True)
-    created_at = Column(DateTime, default=func.now())
-    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+    created_at = Column(DateTime(timezone=True), default=func.now())
+    updated_at = Column(DateTime(timezone=True), default=func.now(), onupdate=func.now())
 
 
 class AlertRule(Base):
@@ -1073,9 +1073,9 @@ class AlertRule(Base):
     node_id = Column(String(100), nullable=True)
     notification_channels = Column(Text, nullable=True)
     enabled = Column(Boolean, default=True)
-    last_triggered = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=func.now())
-    updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
+    last_triggered = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=func.now())
+    updated_at = Column(DateTime(timezone=True), default=func.now(), onupdate=func.now())
 
 
 class ExternalAgent(Base):
@@ -1092,7 +1092,7 @@ class ExternalAgent(Base):
 
     # A2A Agent Card cache
     card_data = Column(JSON, nullable=True)
-    card_fetched_at = Column(DateTime, nullable=True)
+    card_fetched_at = Column(DateTime(timezone=True), nullable=True)
     card_error = Column(Text, nullable=True)
 
     # Trust and connectivity
@@ -1101,5 +1101,5 @@ class ExternalAgent(Base):
     api_key = Column(Text, nullable=True)  # AES-GCM encrypted at rest
 
     created_by = Column(String(64), nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))

--- a/autobot-slm-backend/services/backup.py
+++ b/autobot-slm-backend/services/backup.py
@@ -40,7 +40,7 @@ class BackupService:
         backup = result.scalar_one_or_none()
         if backup:
             backup.status = BackupStatus.IN_PROGRESS.value
-            backup.started_at = datetime.utcnow()
+            backup.started_at = datetime.now(timezone.utc)
             await db.commit()
         return backup
 
@@ -292,10 +292,10 @@ class BackupService:
         max_wait: int = 120,
     ) -> bool:
         """Wait for BGSAVE to complete by monitoring LASTSAVE."""
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         initial_lastsave = None
 
-        while (datetime.utcnow() - start_time).seconds < max_wait:
+        while (datetime.now(timezone.utc) - start_time).seconds < max_wait:
             cmd = self._build_ssh_command(host, ssh_user, ssh_port, f"{redis_auth_prefix} redis-cli LASTSAVE")
             success, output = await self._run_command(cmd, timeout=10)
 
@@ -318,7 +318,7 @@ class BackupService:
         """Mark backup as failed and return error."""
         backup.status = BackupStatus.FAILED.value
         backup.error = error[:500]
-        backup.completed_at = datetime.utcnow()
+        backup.completed_at = datetime.now(timezone.utc)
         await db.commit()
         logger.error("Backup %s failed: %s", backup.backup_id, error)
         return False, error
@@ -464,7 +464,7 @@ class BackupService:
 
         Returns (success, backup_path, error_output).
         """
-        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
         backup_filename = f"{backup_id}_{timestamp}.rdb"
         backup_path = BACKUP_STORAGE_DIR / backup_filename
 
@@ -531,7 +531,7 @@ class BackupService:
                 "local_checksum": local_checksum,
             }
 
-        backup.completed_at = datetime.utcnow()
+        backup.completed_at = datetime.now(timezone.utc)
         await db.commit()
 
         logger.info(

--- a/autobot-slm-backend/services/blue_green.py
+++ b/autobot-slm-backend/services/blue_green.py
@@ -306,7 +306,7 @@ class BlueGreenService:
 
         deployment.status = BlueGreenStatus.FAILED.value
         deployment.error = "Cancelled by user"
-        deployment.completed_at = datetime.utcnow()
+        deployment.completed_at = datetime.now(timezone.utc)
         await db.commit()
 
         return True, "Deployment cancelled"
@@ -458,7 +458,7 @@ class BlueGreenService:
         deployment.status = BlueGreenStatus.COMPLETED.value
         deployment.progress_percent = 100
         deployment.current_step = "Deployment completed (monitoring stopped manually)"
-        deployment.completed_at = datetime.utcnow()
+        deployment.completed_at = datetime.now(timezone.utc)
         await db.commit()
 
         logger.info("Monitoring stopped for deployment: %s", bg_deployment_id)
@@ -652,7 +652,7 @@ class BlueGreenService:
         """Phase 1-2: Borrow roles and deploy to green node."""
         # Phase 1: Start borrowing
         deployment.status = BlueGreenStatus.BORROWING.value
-        deployment.started_at = datetime.utcnow()
+        deployment.started_at = datetime.now(timezone.utc)
         deployment.progress_percent = 10
         deployment.current_step = "Borrowing roles to green node"
         await db.commit()
@@ -711,7 +711,7 @@ class BlueGreenService:
         else:
             deployment.status = BlueGreenStatus.FAILED.value
             deployment.error = "Health verification failed"
-            deployment.completed_at = datetime.utcnow()
+            deployment.completed_at = datetime.now(timezone.utc)
             await db.commit()
 
     async def _phase_switch_traffic(
@@ -734,7 +734,7 @@ class BlueGreenService:
         green_node = await self._get_node(db, deployment.green_node_id)
         blue_node.roles = list(set(blue_node.roles or []) - set(deployment.blue_roles))
         green_node.roles = list(set(green_node.roles or []) | set(deployment.blue_roles))
-        deployment.switched_at = datetime.utcnow()
+        deployment.switched_at = datetime.now(timezone.utc)
         await db.commit()
 
     async def _phase_activate_and_monitor(
@@ -768,7 +768,7 @@ class BlueGreenService:
     ) -> None:
         """Start post-deployment health monitoring task."""
         deployment.status = BlueGreenStatus.MONITORING.value
-        deployment.monitoring_started_at = datetime.utcnow()
+        deployment.monitoring_started_at = datetime.now(timezone.utc)
         deployment.current_step = (
             f"Post-deployment monitoring ({deployment.post_deploy_monitor_duration}s, "
             f"threshold: {deployment.health_failure_threshold} failures)"
@@ -807,7 +807,7 @@ class BlueGreenService:
         deployment.status = BlueGreenStatus.COMPLETED.value
         deployment.progress_percent = 100
         deployment.current_step = "Deployment completed successfully"
-        deployment.completed_at = datetime.utcnow()
+        deployment.completed_at = datetime.now(timezone.utc)
         await db.commit()
 
         await self._broadcast_deployment_event(
@@ -834,7 +834,7 @@ class BlueGreenService:
             await self._execute_rollback(bg_deployment_id)
         else:
             deployment.status = BlueGreenStatus.FAILED.value
-            deployment.completed_at = datetime.utcnow()
+            deployment.completed_at = datetime.now(timezone.utc)
             await db.commit()
 
     # =========================================================================
@@ -861,7 +861,7 @@ class BlueGreenService:
                 logger.error("Rollback failed for %s: %s", bg_deployment_id, e)
                 deployment.status = BlueGreenStatus.FAILED.value
                 deployment.error = f"Rollback failed: {e}"
-                deployment.completed_at = datetime.utcnow()
+                deployment.completed_at = datetime.now(timezone.utc)
                 await db.commit()
 
     async def _rollback_restore_blue(self, db: AsyncSession, deployment: BlueGreenDeployment) -> None:
@@ -896,8 +896,8 @@ class BlueGreenService:
     ) -> None:
         """Complete the rollback process."""
         deployment.status = BlueGreenStatus.ROLLED_BACK.value
-        deployment.rollback_at = datetime.utcnow()
-        deployment.completed_at = datetime.utcnow()
+        deployment.rollback_at = datetime.now(timezone.utc)
+        deployment.completed_at = datetime.now(timezone.utc)
         deployment.current_step = "Rollback completed"
         await db.commit()
 
@@ -952,7 +952,7 @@ class BlueGreenService:
 
     def _get_monitoring_config(self, deployment: BlueGreenDeployment) -> dict:
         """Extract monitoring configuration from deployment."""
-        monitoring_start = deployment.monitoring_started_at or datetime.utcnow()
+        monitoring_start = deployment.monitoring_started_at or datetime.now(timezone.utc)
         return {
             "deadline": monitoring_start + timedelta(seconds=deployment.post_deploy_monitor_duration),
             "interval": deployment.health_check_interval,
@@ -970,7 +970,7 @@ class BlueGreenService:
     ) -> None:
         """Run the health monitoring loop."""
 
-        while datetime.utcnow() < config["deadline"]:
+        while datetime.now(timezone.utc) < config["deadline"]:
             # Check if deployment status changed externally
             should_continue = await self._check_monitoring_should_continue(bg_deployment_id)
             if not should_continue:
@@ -1118,7 +1118,7 @@ class BlueGreenService:
                 f"Deployment completed - monitoring passed "
                 f"({stats['successful_checks']}/{stats['total_checks']} health checks)"
             )
-            deployment.completed_at = datetime.utcnow()
+            deployment.completed_at = datetime.now(timezone.utc)
             await complete_db.commit()
 
         await self._broadcast_deployment_event(
@@ -1139,7 +1139,7 @@ class BlueGreenService:
             if deployment and deployment.status == BlueGreenStatus.MONITORING.value:
                 deployment.status = BlueGreenStatus.FAILED.value
                 deployment.error = f"Health monitoring error: {error}"
-                deployment.completed_at = datetime.utcnow()
+                deployment.completed_at = datetime.now(timezone.utc)
                 await error_db.commit()
 
     # =========================================================================
@@ -1259,10 +1259,10 @@ class BlueGreenService:
         """Verify node health after deployment."""
         from services.database import db_service
 
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
         deadline = start_time + timedelta(seconds=timeout)
 
-        while datetime.utcnow() < deadline:
+        while datetime.now(timezone.utc) < deadline:
             async with db_service.session() as db:
                 node = await self._get_node(db, node_id)
                 if not node:

--- a/autobot-slm-backend/services/deployment.py
+++ b/autobot-slm-backend/services/deployment.py
@@ -404,7 +404,7 @@ class DeploymentService:
             del self._running_deployments[deployment_id]
 
         deployment.status = DeploymentStatus.CANCELLED.value
-        deployment.completed_at = datetime.utcnow()
+        deployment.completed_at = datetime.now(timezone.utc)
         await db.commit()
         await db.refresh(deployment)
 
@@ -435,7 +435,7 @@ class DeploymentService:
 
         # Mark deployment as rolled back
         deployment.status = DeploymentStatus.ROLLED_BACK.value
-        deployment.completed_at = datetime.utcnow()
+        deployment.completed_at = datetime.now(timezone.utc)
 
         await db.commit()
         await db.refresh(deployment)
@@ -546,12 +546,12 @@ class DeploymentService:
             if not node:
                 deployment.status = DeploymentStatus.FAILED.value
                 deployment.error = "Node not found"
-                deployment.completed_at = datetime.utcnow()
+                deployment.completed_at = datetime.now(timezone.utc)
                 await db.commit()
                 return
 
             deployment.status = DeploymentStatus.IN_PROGRESS.value
-            deployment.started_at = datetime.utcnow()
+            deployment.started_at = datetime.now(timezone.utc)
             await db.commit()
 
             try:
@@ -569,7 +569,7 @@ class DeploymentService:
 
                 deployment.status = DeploymentStatus.COMPLETED.value
                 deployment.playbook_output = output
-                deployment.completed_at = datetime.utcnow()
+                deployment.completed_at = datetime.now(timezone.utc)
 
                 node.roles = list(set(node.roles or []) | set(deployment.roles))
                 await db.commit()
@@ -578,14 +578,14 @@ class DeploymentService:
 
             except asyncio.CancelledError:
                 deployment.status = DeploymentStatus.CANCELLED.value
-                deployment.completed_at = datetime.utcnow()
+                deployment.completed_at = datetime.now(timezone.utc)
                 await db.commit()
                 logger.info("Deployment cancelled: %s", deployment_id)
 
             except Exception as e:
                 deployment.status = DeploymentStatus.FAILED.value
                 deployment.error = str(e)
-                deployment.completed_at = datetime.utcnow()
+                deployment.completed_at = datetime.now(timezone.utc)
                 await db.commit()
                 logger.error("Deployment failed: %s - %s", deployment_id, e)
 

--- a/autobot-slm-backend/services/git_tracker.py
+++ b/autobot-slm-backend/services/git_tracker.py
@@ -138,7 +138,7 @@ class GitTracker:
         _, returncode = await self._run_git_command("fetch", self.remote)
 
         if returncode == 0:
-            self.last_fetch = datetime.utcnow()
+            self.last_fetch = datetime.now(timezone.utc)
             return True
         return False
 

--- a/autobot-slm-backend/services/reconciler.py
+++ b/autobot-slm-backend/services/reconciler.py
@@ -189,7 +189,7 @@ class ReconcilerService:
             if setting and setting.value:
                 self._heartbeat_timeout = int(setting.value)
 
-            cutoff = datetime.utcnow() - timedelta(seconds=self._heartbeat_timeout)
+            cutoff = datetime.now(timezone.utc) - timedelta(seconds=self._heartbeat_timeout)
 
             # Get nodes with stale or missing heartbeats
             result = await db.execute(
@@ -403,7 +403,7 @@ class ReconcilerService:
         Returns True if remediation was attempted, False if skipped.
         """
         node_id = node.node_id
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         # Check remediation limits (cooldown and max attempts)
         can_proceed, skip_reason, tracker = self._check_remediation_limits(node_id, now)
@@ -675,7 +675,7 @@ class ReconcilerService:
         Returns True if remediation was attempted, False if skipped.
         """
         key = (node.node_id, service.service_name)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         tracker = self._service_remediation_tracker.get(key, {"count": 0, "last_attempt": None})
 
@@ -771,7 +771,7 @@ class ReconcilerService:
             window_setting = rollback_window_setting.scalar_one_or_none()
             rollback_window = int(window_setting.value) if window_setting else DEFAULT_ROLLBACK_WINDOW
 
-            cutoff = datetime.utcnow() - timedelta(seconds=rollback_window)
+            cutoff = datetime.now(timezone.utc) - timedelta(seconds=rollback_window)
 
             # Find nodes that are degraded/error with recent completed deployments
             degraded_nodes = await db.execute(
@@ -1043,7 +1043,7 @@ class ReconcilerService:
         node.cpu_percent = cpu_percent
         node.memory_percent = memory_percent
         node.disk_percent = disk_percent
-        node.last_heartbeat = datetime.utcnow()
+        node.last_heartbeat = datetime.now(timezone.utc)
 
         if agent_version:
             node.agent_version = agent_version
@@ -1304,7 +1304,7 @@ class ReconcilerService:
         if not discovered_services:
             return
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         for svc_data in discovered_services:
             await self._upsert_service(db, node_id, svc_data, now)
@@ -1467,7 +1467,7 @@ class ReconcilerService:
 
             pem = Path(cert_path).read_bytes()
             cert = cryptography.x509.load_pem_x509_certificate(pem, default_backend())
-            delta = cert.not_valid_after_utc.replace(tzinfo=None) - datetime.utcnow()
+            delta = cert.not_valid_after_utc.replace(tzinfo=None) - datetime.now(timezone.utc)
             return max(0, delta.days)
         except Exception as exc:
             logger.debug("Could not read cert %s: %s", cert_path, exc)

--- a/autobot-slm-backend/services/replication.py
+++ b/autobot-slm-backend/services/replication.py
@@ -125,7 +125,7 @@ class ReplicationService:
             return None
 
         replication.status = ReplicationStatus.SYNCING.value
-        replication.started_at = datetime.utcnow()
+        replication.started_at = datetime.now(timezone.utc)
         await db.commit()
         return replication
 
@@ -311,7 +311,7 @@ class ReplicationService:
 
             # Update replication status
             replication.status = ReplicationStatus.STOPPED.value
-            replication.completed_at = datetime.utcnow()
+            replication.completed_at = datetime.now(timezone.utc)
             await db.commit()
 
             logger.info("Replica promoted: %s", replication_id)
@@ -337,7 +337,7 @@ class ReplicationService:
 
         # Update status
         replication.status = ReplicationStatus.STOPPED.value
-        replication.completed_at = datetime.utcnow()
+        replication.completed_at = datetime.now(timezone.utc)
         await db.commit()
 
         logger.info("Replication stopped: %s", replication_id)
@@ -646,9 +646,9 @@ class ReplicationService:
         timeout: int = 60,
     ) -> bool:
         """Wait for replica to sync with master."""
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
 
-        while (datetime.utcnow() - start_time).seconds < timeout:
+        while (datetime.now(timezone.utc) - start_time).seconds < timeout:
             repl_info = await self._get_replication_info(target_ip, ssh_user, ssh_port, redis_password)
 
             if repl_info.get("master_link_status") == "up":

--- a/autobot-slm-backend/services/schedule_executor.py
+++ b/autobot-slm-backend/services/schedule_executor.py
@@ -58,7 +58,7 @@ def calculate_next_run(expression: str, base: datetime = None) -> datetime:
     Returns:
         Next scheduled datetime
     """
-    base = base or datetime.utcnow()
+    base = base or datetime.now(timezone.utc)
     cron = croniter(expression, base)
     return cron.get_next(datetime)
 
@@ -281,7 +281,7 @@ async def check_and_execute_schedules() -> int:
     Returns:
         Number of schedules executed
     """
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     executed_count = 0
 
     try:

--- a/autobot-slm-backend/services/service_orchestrator.py
+++ b/autobot-slm-backend/services/service_orchestrator.py
@@ -678,13 +678,13 @@ class ServiceOrchestrator:
 
         if service:
             service.status = status
-            service.last_checked = datetime.utcnow()
+            service.last_checked = datetime.now(timezone.utc)
         else:
             service = Service(
                 node_id=node_id,
                 service_name=service_name,
                 status=status,
-                last_checked=datetime.utcnow(),
+                last_checked=datetime.now(timezone.utc),
             )
             db.add(service)
 

--- a/autobot-slm-backend/services/sync_orchestrator.py
+++ b/autobot-slm-backend/services/sync_orchestrator.py
@@ -238,7 +238,7 @@ class SyncOrchestrator:
 
             if node_role:
                 node_role.current_version = commit
-                node_role.last_synced_at = datetime.utcnow()
+                node_role.last_synced_at = datetime.now(timezone.utc)
                 node_role.status = RoleStatus.ACTIVE.value
             else:
                 node_role = NodeRole(
@@ -247,7 +247,7 @@ class SyncOrchestrator:
                     assignment_type="auto",
                     status=RoleStatus.ACTIVE.value,
                     current_version=commit,
-                    last_synced_at=datetime.utcnow(),
+                    last_synced_at=datetime.now(timezone.utc),
                 )
                 db.add(node_role)
 

--- a/autobot-slm-backend/services/tls_credentials.py
+++ b/autobot-slm-backend/services/tls_credentials.py
@@ -227,7 +227,7 @@ class TLSCredentialService:
             return None
 
         # Update last used timestamp
-        credential.last_used = datetime.utcnow()
+        credential.last_used = datetime.now(timezone.utc)
         await db.commit()
 
         # Decrypt and return
@@ -248,7 +248,7 @@ class TLSCredentialService:
         result = await db.execute(query)
         endpoints = []
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         for cred, node in result.all():
             days_until_expiry = None
             if cred.tls_expires_at:
@@ -273,7 +273,7 @@ class TLSCredentialService:
 
     async def get_expiring_certificates(self, db: AsyncSession, days: int = 30) -> List[NodeCredential]:
         """Get certificates expiring within the specified days."""
-        threshold = datetime.utcnow() + timedelta(days=days)
+        threshold = datetime.now(timezone.utc) + timedelta(days=days)
         result = await db.execute(
             select(NodeCredential).where(
                 NodeCredential.credential_type == CredentialType.TLS.value,
@@ -305,7 +305,7 @@ class TLSCredentialService:
         )
 
         # Build certificate with 1 year validity
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         cert_builder = x509.CertificateBuilder()
         cert_builder = cert_builder.subject_name(
             x509.Name(

--- a/autobot-slm-backend/services/vnc_credentials.py
+++ b/autobot-slm-backend/services/vnc_credentials.py
@@ -165,7 +165,7 @@ class VNCCredentialService:
         if data.extra_data is not None:
             credential.encrypted_data = encrypt_data(data.extra_data)
 
-        credential.updated_at = datetime.utcnow()
+        credential.updated_at = datetime.now(timezone.utc)
         await db.commit()
         await db.refresh(credential)
 
@@ -213,11 +213,11 @@ class VNCCredentialService:
         token_expires_at = None
         if generate_token:
             connection_token = self._generate_connection_token()
-            token_expires_at = datetime.utcnow() + timedelta(minutes=5)
+            token_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
             _connection_tokens[connection_token] = (credential_id, token_expires_at)
 
         # Update last_used timestamp
-        credential.last_used = datetime.utcnow()
+        credential.last_used = datetime.now(timezone.utc)
         await db.commit()
 
         return VNCConnectionInfo(
@@ -240,7 +240,7 @@ class VNCCredentialService:
         credential_id, expires_at = _connection_tokens.pop(token)
 
         # Check expiration
-        if datetime.utcnow() > expires_at:
+        if datetime.now(timezone.utc) > expires_at:
             logger.warning("Connection token expired for credential %s", credential_id)
             return None
 

--- a/autobot-slm-backend/slm/agent/version.py
+++ b/autobot-slm-backend/slm/agent/version.py
@@ -97,7 +97,7 @@ class AgentVersion:
             True if saved successfully
         """
         if built_at is None:
-            built_at = datetime.utcnow()
+            built_at = datetime.now(timezone.utc)
 
         version_info = {
             "commit": commit,

--- a/autobot-slm-backend/user_management/models/api_key.py
+++ b/autobot-slm-backend/user_management/models/api_key.py
@@ -152,7 +152,7 @@ class APIKey(Base, TimestampMixin):
         """Check if the key has expired."""
         if self.expires_at is None:
             return False
-        return datetime.utcnow() > self.expires_at
+        return datetime.now(timezone.utc) > self.expires_at
 
     @property
     def is_revoked(self) -> bool:
@@ -166,13 +166,13 @@ class APIKey(Base, TimestampMixin):
 
     def record_usage(self) -> None:
         """Record a usage of this API key."""
-        self.last_used_at = datetime.utcnow()
+        self.last_used_at = datetime.now(timezone.utc)
         self.usage_count += 1
 
     def revoke(self, revoked_by_user_id: Optional[uuid.UUID] = None) -> None:
         """Revoke the API key."""
         self.is_active = False
-        self.revoked_at = datetime.utcnow()
+        self.revoked_at = datetime.now(timezone.utc)
         self.revoked_by = revoked_by_user_id
 
     def has_scope(self, scope: str) -> bool:

--- a/autobot-slm-backend/user_management/models/mfa.py
+++ b/autobot-slm-backend/user_management/models/mfa.py
@@ -109,9 +109,9 @@ class UserMFA(Base, TimestampMixin):
 
     def record_verification(self) -> None:
         """Record a successful MFA verification."""
-        self.last_verified_at = datetime.utcnow()
+        self.last_verified_at = datetime.now(timezone.utc)
 
     def use_backup_code(self) -> None:
         """Record usage of a backup code."""
         self.backup_codes_remaining = max(0, self.backup_codes_remaining - 1)
-        self.last_verified_at = datetime.utcnow()
+        self.last_verified_at = datetime.now(timezone.utc)

--- a/autobot-slm-backend/user_management/models/organization.py
+++ b/autobot-slm-backend/user_management/models/organization.py
@@ -132,7 +132,7 @@ class Organization(Base, TimestampMixin):
 
     def soft_delete(self) -> None:
         """Soft delete the organization."""
-        self.deleted_at = datetime.utcnow()
+        self.deleted_at = datetime.now(timezone.utc)
         self.is_active = False
 
     def get_setting(self, key: str, default=None):

--- a/autobot-slm-backend/user_management/models/sso.py
+++ b/autobot-slm-backend/user_management/models/sso.py
@@ -235,4 +235,4 @@ class UserSSOLink(Base, TimestampMixin):
 
     def record_login(self) -> None:
         """Record a login via this SSO link."""
-        self.last_login_at = datetime.utcnow()
+        self.last_login_at = datetime.now(timezone.utc)

--- a/autobot-slm-backend/user_management/models/team.py
+++ b/autobot-slm-backend/user_management/models/team.py
@@ -114,7 +114,7 @@ class Team(Base, TenantMixin, TimestampMixin):
 
     def soft_delete(self) -> None:
         """Soft delete the team."""
-        self.deleted_at = datetime.utcnow()
+        self.deleted_at = datetime.now(timezone.utc)
 
     @property
     def member_count(self) -> int:
@@ -174,7 +174,7 @@ class TeamMembership(Base, TimestampMixin):
     # When the user joined the team
     joined_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=datetime.utcnow,
+        default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
 

--- a/autobot-slm-backend/user_management/services/api_key_service.py
+++ b/autobot-slm-backend/user_management/services/api_key_service.py
@@ -161,7 +161,7 @@ class APIKeyService(BaseService):
         """Calculate expiration datetime."""
         if expires_days is None:
             return None
-        return datetime.utcnow() + timedelta(days=expires_days)
+        return datetime.now(timezone.utc) + timedelta(days=expires_days)
 
     @staticmethod
     def _build_api_key(


### PR DESCRIPTION
## Summary

- **DB schema migration** (`migrate_timestamps_to_timestamptz`): converts all 93 `TIMESTAMP` columns across 32 slm-backend tables to `TIMESTAMPTZ` using `USING col AT TIME ZONE 'UTC'` — safe backfill of existing naive UTC values
- **ORM model** (`models/database.py`): all `Column(DateTime)` → `Column(DateTime(timezone=True))`; all `default=datetime.utcnow` / `onupdate=datetime.utcnow` callable refs → `lambda: datetime.now(timezone.utc)`
- **34 app files**: `datetime.utcnow()` → `datetime.now(timezone.utc)` throughout; callable `default_factory`/`default` forms fixed in `api/code_sync.py`, `api/monitoring.py`, `user_management/models/team.py`
- **`api/security.py`**: `datetime.fromisoformat()` → aware-normalizing parse
- **`migrations/runner.py`**: registered new migration + fixed missing `timezone` import

Closes #5385. Unblocked by #5270 (column audit already closed).

## Test plan

- [ ] Migration runs cleanly on fresh DB (all 93 columns converted, skips already-TIMESTAMPTZ)
- [ ] Migration is idempotent (re-running skips all columns)
- [ ] No `naive - aware` TypeErrors in `api/nodes.py` cert expiry arithmetic post-migration
- [ ] `python -m py_compile` passes on all modified files (verified locally)
- [ ] Zero remaining `datetime.utcnow()` in slm-backend app code (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)