### PR TITLE
fix(slm-backend): migrations_applied.applied_at TIMESTAMP → TIMESTAMPTZ (#5515)

### DIFF
--- a/autobot-slm-backend/migrations/runner.py
+++ b/autobot-slm-backend/migrations/runner.py
@@ -120,14 +120,32 @@ def get_connection(db_url: str = None) -> psycopg2.extensions.connection:
 
 
 def ensure_migrations_table(conn: psycopg2.extensions.connection) -> None:
-    """Create migrations tracking table if it doesn't exist (#786)."""
+    """Create migrations tracking table if it doesn't exist (#786, #5515)."""
     with conn.cursor() as cur:
         cur.execute("""
             CREATE TABLE IF NOT EXISTS migrations_applied (
                 id SERIAL PRIMARY KEY,
                 name VARCHAR(255) NOT NULL UNIQUE,
-                applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                applied_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
             )
+        """)
+        # Upgrade existing deployments that have the old TIMESTAMP column (#5515)
+        cur.execute("""
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'migrations_applied'
+                      AND column_name = 'applied_at'
+                      AND data_type = 'timestamp without time zone'
+                ) THEN
+                    ALTER TABLE migrations_applied
+                        ALTER COLUMN applied_at TYPE TIMESTAMPTZ
+                        USING applied_at AT TIME ZONE 'UTC';
+                END IF;
+            END
+            $$;
         """)
     conn.commit()
 


### PR DESCRIPTION
## Summary

- `migrations_applied.applied_at` was declared as `TIMESTAMP` (naive) but `mark_migration_applied()` writes `datetime.now(timezone.utc)` — tzinfo silently stripped on insert, same bug class as #5385
- Fix: change DDL column type to `TIMESTAMPTZ`
- Add an inline `DO $$` block inside `ensure_migrations_table` to `ALTER COLUMN ... TYPE TIMESTAMPTZ USING applied_at AT TIME ZONE 'UTC'` on existing deployments where the column is already `timestamp without time zone`

Closes #5515. Discovered during #5385.

## Test plan

- [ ] Fresh DB: `migrations_applied.applied_at` created as `TIMESTAMPTZ`
- [ ] Existing deployment: `DO $$` block detects old `timestamp without time zone` and upgrades column type
- [ ] Idempotent: re-running `ensure_migrations_table` on already-upgraded column is a no-op (DO block condition is false)
- [ ] `python3 -m py_compile migrations/runner.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)