### PR TITLE
refactor(composables): DocumentOverview.vue reactive(Set) → useExpansion (#5504)

### DIFF
--- a/autobot-frontend/src/components/knowledge/summaries/DocumentOverview.vue
+++ b/autobot-frontend/src/components/knowledge/summaries/DocumentOverview.vue
@@ -89,7 +89,7 @@
         >
           <div
             class="summary-card-header"
-            @click="toggleSection(section.id)"
+            @click="toggle(section.id)"
           >
             <span class="level-badge section">{{ $t('knowledge.summaries.overview.section') }}</span>
             <div class="section-topics-preview">
@@ -104,7 +104,7 @@
             <i
               :class="[
                 'fas',
-                expandedSections.has(section.id)
+                isExpanded(section.id)
                   ? 'fa-chevron-up'
                   : 'fa-chevron-down',
               ]"
@@ -112,7 +112,7 @@
             />
           </div>
 
-          <div v-if="expandedSections.has(section.id)">
+          <div v-if="isExpanded(section.id)">
             <p class="summary-content">{{ section.content }}</p>
 
             <button
@@ -140,11 +140,12 @@
 // Copyright (c) 2025 mrveiss
 // Author: mrveiss
 
-import { ref, reactive, onMounted, watch } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import {
   useKnowledgeGraph,
   type DocumentOverview,
 } from '@/composables/useKnowledgeGraph'
+import { useExpansion } from '@/composables/useExpansion'
 
 const props = defineProps<{
   documentId: string
@@ -156,19 +157,11 @@ defineEmits<{
 
 const { getOverview, loading, error } = useKnowledgeGraph()
 const overview = ref<DocumentOverview | null>(null)
-const expandedSections = reactive(new Set<string>())
-
-function toggleSection(sectionId: string): void {
-  if (expandedSections.has(sectionId)) {
-    expandedSections.delete(sectionId)
-  } else {
-    expandedSections.add(sectionId)
-  }
-}
+const { isExpanded, toggle, collapseAll } = useExpansion<string>()
 
 async function loadOverview(): Promise<void> {
   if (!props.documentId) return
-  expandedSections.clear()
+  collapseAll()
   overview.value = await getOverview(props.documentId)
 }
 


### PR DESCRIPTION
## Summary
- Replaces `reactive(new Set<string>())` + hand-rolled `toggleSection` / `.has` / `.clear` with `useExpansion<string>()`
- Removes `reactive` import (no longer needed)
- `collapseAll()` replaces `expandedSections.clear()` on document reload

## Behavioral grep audit
| Pattern | Before | After |
|---------|--------|-------|
| `reactive(new Set` | 1 | 0 |
| `useExpansion` in this file | 0 | 1 |

Closes #5504

🤖 Generated with [Claude Code](https://claude.com/claude-code)