### PR TITLE
refactor(composables): 4 single-key expand toggles → useExpansion<Key> (#5506)

### DIFF
--- a/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
+++ b/autobot-frontend/src/components/analytics/code-intelligence/FindingsTable.vue
@@ -54,11 +54,11 @@
           <template v-for="virtualItem in visibleItems" :key="virtualItem.index">
             <tr
               @click="toggleExpand(virtualItem.index)"
-              :class="{ expanded: expandedRow === virtualItem.index }"
+              :class="{ expanded: isRowExpanded(virtualItem.index) }"
               class="finding-row"
               role="button"
               tabindex="0"
-              :aria-expanded="expandedRow === virtualItem.index"
+              :aria-expanded="isRowExpanded(virtualItem.index)"
               :aria-label="`${virtualItem.data.severity} severity finding in ${virtualItem.data.file_path}, click to expand details`"
               @keydown.enter="toggleExpand(virtualItem.index)"
               @keydown.space.prevent="toggleExpand(virtualItem.index)"
@@ -76,7 +76,7 @@
               <td class="col-message">{{ truncateMessage(virtualItem.data.message) }}</td>
             </tr>
             <!-- Expanded detail card -->
-            <tr v-if="expandedRow === virtualItem.index" class="detail-row">
+            <tr v-if="isRowExpanded(virtualItem.index)" class="detail-row">
               <td colspan="4">
                 <div class="detail-card">
                   <div class="detail-section">
@@ -115,6 +115,7 @@ import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useVirtualList } from '@/composables/useVirtualList'
 import { useDebounce } from '@/composables/useDebounce'
+import { useExpansion } from '@/composables/useExpansion'
 import type { Severity } from '@/types/codeIntelligence'
 
 const { t } = useI18n()
@@ -142,7 +143,7 @@ const props = defineProps<{
 const severityLevels: Severity[] = ['critical', 'high', 'medium', 'low', 'info']
 const selectedSeverities = ref<Severity[]>([...severityLevels])
 const searchQuery = ref('')
-const expandedRow = ref<number | null>(null)
+const { isExpanded: isRowExpanded, expand: expandRow, collapseAll: collapseAllRows } = useExpansion<number>()
 
 // Debounce search query for performance (Issue #4035)
 // Reduces unnecessary filtering operations during rapid typing
@@ -198,7 +199,9 @@ function getRemediation(finding: Finding): string {
 }
 
 function toggleExpand(index: number): void {
-  expandedRow.value = expandedRow.value === index ? null : index
+  const wasExpanded = isRowExpanded(index)
+  collapseAllRows()
+  if (!wasExpanded) expandRow(index)
 }
 
 function copyPath(finding: Finding): void {

--- a/autobot-frontend/src/components/knowledge/summaries/SummarySearch.vue
+++ b/autobot-frontend/src/components/knowledge/summaries/SummarySearch.vue
@@ -67,7 +67,7 @@
         v-for="summary in summaries"
         :key="summary.id"
         class="result-card"
-        :class="{ expanded: expandedId === summary.id }"
+        :class="{ expanded: isExpanded(summary.id) }"
       >
         <div
           class="result-header"
@@ -84,7 +84,7 @@
           <i
             :class="[
               'fas',
-              expandedId === summary.id
+              isExpanded(summary.id)
                 ? 'fa-chevron-up'
                 : 'fa-chevron-down',
             ]"
@@ -94,7 +94,7 @@
 
         <!-- Preview -->
         <p class="result-preview">
-          {{ expandedId === summary.id
+          {{ isExpanded(summary.id)
             ? summary.content
             : truncate(summary.content, 200)
           }}
@@ -116,7 +116,7 @@
 
         <!-- Expanded Actions -->
         <div
-          v-if="expandedId === summary.id"
+          v-if="isExpanded(summary.id)"
           class="result-actions"
         >
           <button
@@ -147,6 +147,7 @@
 
 import { ref } from 'vue'
 import { useKnowledgeGraph } from '@/composables/useKnowledgeGraph'
+import { useExpansion } from '@/composables/useExpansion'
 
 defineEmits<{
   (e: 'drill-down', summaryId: string): void
@@ -161,7 +162,7 @@ const {
 
 const searchQuery = ref('')
 const levelFilter = ref('')
-const expandedId = ref<string | null>(null)
+const { isExpanded, expand, collapseAll } = useExpansion<string>()
 const hasSearched = ref(false)
 
 function truncate(text: string, maxLen: number): string {
@@ -170,13 +171,15 @@ function truncate(text: string, maxLen: number): string {
 }
 
 function toggleExpand(id: string): void {
-  expandedId.value = expandedId.value === id ? null : id
+  const wasExpanded = isExpanded(id)
+  collapseAll()
+  if (!wasExpanded) expand(id)
 }
 
 async function handleSearch(): Promise<void> {
   if (!searchQuery.value.trim()) return
   hasSearched.value = true
-  expandedId.value = null
+  collapseAll()
   await searchSummaries({
     query: searchQuery.value,
     level: (levelFilter.value as 'chunk' | 'section' | 'document' | '') || undefined,

--- a/autobot-frontend/src/components/knowledge/temporal/EventTimeline.vue
+++ b/autobot-frontend/src/components/knowledge/temporal/EventTimeline.vue
@@ -52,7 +52,7 @@
 
         <div
           class="timeline-card"
-          :class="{ expanded: expandedEvent === event.id }"
+          :class="{ expanded: isEventExpanded(event.id) }"
           @click="toggleExpand(event.id)"
         >
           <div class="card-header">
@@ -95,7 +95,7 @@
 
           <!-- Expanded Content -->
           <div
-            v-if="expandedEvent === event.id"
+            v-if="isEventExpanded(event.id)"
             class="expanded-content"
           >
             <div
@@ -128,6 +128,7 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { TemporalEvent } from '@/composables/useKnowledgeGraph'
+import { useExpansion } from '@/composables/useExpansion'
 import {
   getEventTypeColor as getEventColor,
   getEventTypeIcon as getEventIcon,
@@ -140,7 +141,7 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
-const expandedEvent = ref<string | null>(null)
+const { isExpanded: isEventExpanded, expand: expandEvent, collapseAll: collapseAllEvents } = useExpansion<string>()
 
 function formatTimestamp(event: TemporalEvent): string {
   if (event.timestamp) {
@@ -175,9 +176,9 @@ function shouldShowDateMarker(index: number): boolean {
 }
 
 function toggleExpand(eventId: string): void {
-  expandedEvent.value = expandedEvent.value === eventId
-    ? null
-    : eventId
+  const wasExpanded = isEventExpanded(eventId)
+  collapseAllEvents()
+  if (!wasExpanded) expandEvent(eventId)
 }
 </script>
 

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
@@ -43,7 +43,7 @@
         v-for="agent in agents"
         :key="agent.id"
         class="agent-card"
-        :class="[agent.status, { expanded: expandedAgent === agent.id }]"
+        :class="[agent.status, { expanded: isAgentExpanded(agent.id) }]"
         @click="toggleExpand(agent.id)"
       >
         <!-- Agent Avatar -->
@@ -92,7 +92,7 @@
 
         <!-- Expanded Details -->
         <Transition name="expand">
-          <div v-if="expandedAgent === agent.id" class="expanded-details">
+          <div v-if="isAgentExpanded(agent.id)" class="expanded-details">
             <div class="detail-section">
               <h5>{{ t('visualizations.agentActivity.recentTasks') }}</h5>
               <ul class="task-list">
@@ -185,6 +185,7 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { getCssVar } from '@/composables/useCssVars'
+import { useExpansion } from '@/composables/useExpansion'
 
 const { t } = useI18n()
 const logger = createLogger('AgentActivityVisualization')
@@ -242,7 +243,7 @@ const emit = defineEmits<{
 
 // State
 const viewMode = ref<'grid' | 'timeline'>('grid')
-const expandedAgent = ref<string | null>(null)
+const { isExpanded: isAgentExpanded, expand: expandAgent, collapseAll: collapseAllAgents } = useExpansion<string>()
 const agents = ref<Agent[]>([])
 const recentEvents = ref<ActivityEvent[]>([])
 
@@ -313,7 +314,9 @@ function getEventIcon(type: string): string {
 }
 
 function toggleExpand(agentId: string) {
-  expandedAgent.value = expandedAgent.value === agentId ? null : agentId
+  const wasExpanded = isAgentExpanded(agentId)
+  collapseAllAgents()
+  if (!wasExpanded) expandAgent(agentId)
 }
 
 function viewDetails(agent: Agent) {


### PR DESCRIPTION
## Summary
Migrates 4 components from `ref<string|null>(null)` / `ref<number|null>(null)` single-open accordion patterns to `useExpansion<Key>`:

| Component | Old pattern | Key type |
|-----------|-------------|----------|
| `AgentActivityVisualization.vue` | `expandedAgent: ref<string\|null>` | `string` |
| `EventTimeline.vue` | `expandedEvent: ref<string\|null>` | `string` |
| `SummarySearch.vue` | `expandedId: ref<string\|null>` | `string` |
| `FindingsTable.vue` | `expandedRow: ref<number\|null>` | `number` |

Single-open semantics preserved: each `toggleExpand` calls `collapseAll()` then `expand(id)` so only one item is open at a time (equivalent to the prior ternary assign-null pattern).

## Behavioral grep audit
| Pattern | Before | After |
|---------|--------|-------|
| `ref<string \| null>(null)` (expand) | 3 | 0 |
| `ref<number \| null>(null)` (expand) | 1 | 0 |
| `useExpansion` in these files | 0 | 4 |

Closes #5506

🤖 Generated with [Claude Code](https://claude.com/claude-code)