### PR TITLE
feat(useFetchEndpoint): per-request context hook (#5457)

### DIFF
--- a/autobot-frontend/src/composables/api/__tests__/useFetchEndpoint.test.ts
+++ b/autobot-frontend/src/composables/api/__tests__/useFetchEndpoint.test.ts
@@ -142,7 +142,8 @@ describe('useFetchEndpoint fallbackData hook (#5389)', () => {
       onError,
     })
     await ep.load()
-    expect(onError).toHaveBeenCalledWith('boom', expect.any(Error))
+    // #5457: onError now receives context (undefined when not provided).
+    expect(onError).toHaveBeenCalledWith('boom', expect.any(Error), undefined)
     expect(ep.data.value).toBe('stale')
     expect(ep.error.value).toBe('')
   })
@@ -167,5 +168,97 @@ describe('useFetchEndpoint fallbackData hook (#5389)', () => {
     })
     await ep.load()
     expect(ep.data.value).toEqual({ items: ['live'] })
+  })
+})
+
+describe('useFetchEndpoint context hook (#5457)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('onSuccess receives the per-call context', async () => {
+    mockFetch.mockResolvedValue(mkResponse('{"value": 42}'))
+    const onSuccess = vi.fn()
+    const ep = useFetchEndpoint<{ value: number }, number, { quick: boolean }>({
+      path: '/api/x',
+      pickData: (r) => r.value,
+      onSuccess,
+    })
+    await ep.load(undefined, { quick: true })
+    expect(onSuccess).toHaveBeenCalledWith(42, { value: 42 }, { quick: true })
+  })
+
+  it('concurrent load() calls each receive their own context in onSuccess', async () => {
+    // Simulates the #5455 exportReport race: two concurrent load() calls
+    // with different context must each see their own context in onSuccess.
+    const successCalls: Array<{ quick: boolean; data: number }> = []
+    mockFetch.mockImplementation(async () =>
+      mkResponse(JSON.stringify({ value: successCalls.length + 1 })),
+    )
+    const ep = useFetchEndpoint<{ value: number }, number, { quick: boolean }>({
+      path: '/api/x',
+      pickData: (r) => r.value,
+      onSuccess: (data, _raw, ctx) => {
+        successCalls.push({ quick: ctx.quick, data })
+      },
+    })
+    await Promise.all([
+      ep.load(undefined, { quick: true }),
+      ep.load(undefined, { quick: false }),
+    ])
+    expect(successCalls).toHaveLength(2)
+    const quickCall = successCalls.find((c) => c.quick === true)
+    const fullCall = successCalls.find((c) => c.quick === false)
+    expect(quickCall).toBeDefined()
+    expect(fullCall).toBeDefined()
+  })
+
+  it('onError receives the context', async () => {
+    mockFetch.mockRejectedValue(new Error('boom'))
+    const onError = vi.fn()
+    const ep = useFetchEndpoint<string, string, string>({
+      path: '/api/x',
+      pickData: (r) => r,
+      onError,
+    })
+    await ep.load(undefined, 'request-42')
+    expect(onError).toHaveBeenCalledWith('boom', expect.any(Error), 'request-42')
+  })
+
+  it('onNoData receives the context', async () => {
+    mockFetch.mockResolvedValue(mkResponse('{"value": 42}'))
+    const onNoData = vi.fn()
+    const ep = useFetchEndpoint<{ value: number }, number, string>({
+      path: '/api/x',
+      pickData: () => null, // trigger no-data path
+      onNoData,
+    })
+    await ep.load(undefined, 'tag-xyz')
+    expect(onNoData).toHaveBeenCalledWith('tag-xyz')
+  })
+
+  it('onResponse receives the context for error-shape override', async () => {
+    mockFetch.mockResolvedValue(mkResponse('err', { ok: false, status: 504 }))
+    const onResponse = vi.fn().mockReturnValue('timeout')
+    const ep = useFetchEndpoint<string, string, { traceId: string }>({
+      path: '/api/x',
+      pickData: (r) => r,
+      onResponse,
+    })
+    await ep.load(undefined, { traceId: 't-9' })
+    expect(onResponse).toHaveBeenCalledWith(expect.anything(), { traceId: 't-9' })
+    expect(ep.error.value).toBe('timeout')
+  })
+
+  it('context is optional — existing callers without Ctx still work', async () => {
+    mockFetch.mockResolvedValue(mkResponse('{"value": 42}'))
+    const onSuccess = vi.fn()
+    const ep = useFetchEndpoint<{ value: number }, number>({
+      path: '/api/x',
+      pickData: (r) => r.value,
+      onSuccess,
+    })
+    await ep.load() // no context arg
+    expect(onSuccess).toHaveBeenCalledWith(42, { value: 42 }, undefined)
   })
 })

--- a/autobot-frontend/src/composables/api/useFetchEndpoint.ts
+++ b/autobot-frontend/src/composables/api/useFetchEndpoint.ts
@@ -34,7 +34,7 @@ const logger = createLogger('useFetchEndpoint')
 
 export type FetchEndpointMethod = 'GET' | 'POST' | 'DELETE'
 
-export interface UseFetchEndpointOptions<TRaw, TOut> {
+export interface UseFetchEndpointOptions<TRaw, TOut, Ctx = undefined> {
   /** API path appended to the resolved backend URL, e.g. '/api/analytics/codebase/stats'. */
   path: string
   /** HTTP method. Defaults to 'GET'. */
@@ -59,15 +59,23 @@ export interface UseFetchEndpointOptions<TRaw, TOut> {
    * Return `null` to indicate "no data" (leaves `data` as null without error).
    */
   pickData: (raw: TRaw) => TOut | null
-  /** Optional side-effect fired after `data` is assigned on success. */
-  onSuccess?: (data: TOut, raw: TRaw) => void
+  /**
+   * Optional side-effect fired after `data` is assigned on success.
+   *
+   * Issue #5457: receives the per-request `context` passed to `load()`.
+   * Lets callers thread request-scope state (filename hints, user-action
+   * tags, etc.) into the success handler without module-scope `let`
+   * workarounds — see the #5455 exportReport race this addresses.
+   */
+  onSuccess?: (data: TOut, raw: TRaw, context: Ctx) => void
   /** Optional side-effect fired when `pickData` returns null (no-data path). */
-  onNoData?: () => void
+  onNoData?: (context: Ctx) => void
   /**
    * Optional side-effect fired when fetch fails or throws. Receives the
-   * resolved error message (same value that lands in `error.value`).
+   * resolved error message (same value that lands in `error.value`) plus
+   * the per-request `context` (#5457).
    */
-  onError?: (message: string, err: unknown) => void
+  onError?: (message: string, err: unknown, context: Ctx) => void
   /**
    * Hook fired with the raw Response **before** the default `!ok` throw.
    * Return a string to override the default `${label} returned ${status}`
@@ -84,6 +92,7 @@ export interface UseFetchEndpointOptions<TRaw, TOut> {
    */
   onResponse?: (
     response: Response,
+    context: Ctx,
   ) => string | undefined | Promise<string | undefined>
   /**
    * Custom response parser. Defaults to `(r) => r.json()`. Override to
@@ -127,11 +136,20 @@ export interface UseFetchEndpointDeps {
   withSourceId?: (url: string) => string
 }
 
-export interface UseFetchEndpointReturn<TOut> {
+export interface UseFetchEndpointReturn<TOut, Ctx = undefined> {
   data: Ref<TOut | null>
   loading: Ref<boolean>
   error: Ref<string>
-  load: (queryExtras?: Record<string, string>) => Promise<void>
+  /**
+   * Trigger the fetch.
+   *
+   * @param queryExtras - Optional extra query-string params appended to the URL.
+   * @param context - Optional per-request context threaded into the
+   *   lifecycle callbacks (`onSuccess`/`onError`/`onNoData`/`onResponse`).
+   *   Introduced in #5457 to eliminate module-scope `let` workarounds for
+   *   request-specific state like filename hints.
+   */
+  load: (queryExtras?: Record<string, string>, context?: Ctx) => Promise<void>
   /**
    * Clear `data`, `loading`, and `error` back to their initial state.
    * Parity with the deleted `useAnalyticsFetch` (#5208/#5235).
@@ -157,10 +175,10 @@ function appendQueryExtras(
   return `${url}${sep}${qs}`
 }
 
-export function useFetchEndpoint<TRaw, TOut>(
-  opts: UseFetchEndpointOptions<TRaw, TOut>,
+export function useFetchEndpoint<TRaw, TOut, Ctx = undefined>(
+  opts: UseFetchEndpointOptions<TRaw, TOut, Ctx>,
   deps?: UseFetchEndpointDeps,
-): UseFetchEndpointReturn<TOut> {
+): UseFetchEndpointReturn<TOut, Ctx> {
   const data = ref<TOut | null>(null) as Ref<TOut | null>
   const loading = ref(false)
   const error = ref('')
@@ -181,7 +199,14 @@ export function useFetchEndpoint<TRaw, TOut>(
 
   const load = async (
     queryExtras?: Record<string, string>,
+    context?: Ctx,
   ): Promise<void> => {
+    // #5457: context is captured into the closure at load-time, so
+    // concurrent load() calls each see their own context in callbacks —
+    // no module-scope `let` workaround needed. The `as Ctx` cast is safe
+    // because when `Ctx = undefined` (the default) the optional parameter
+    // fills the slot correctly.
+    const ctx = context as Ctx
     loading.value = true
     error.value = ''
     try {
@@ -205,7 +230,7 @@ export function useFetchEndpoint<TRaw, TOut>(
       const response = await fetchWithAuth(url, init)
       if (!response.ok) {
         const overrideMsg = opts.onResponse
-          ? await opts.onResponse(response)
+          ? await opts.onResponse(response, ctx)
           : undefined
         throw new Error(
           overrideMsg ?? `${label} returned ${response.status}`,
@@ -217,15 +242,15 @@ export function useFetchEndpoint<TRaw, TOut>(
       const picked = opts.pickData(raw)
       if (picked === null) {
         data.value = null
-        opts.onNoData?.()
+        opts.onNoData?.(ctx)
         return
       }
       data.value = picked
-      opts.onSuccess?.(picked, raw)
+      opts.onSuccess?.(picked, raw, ctx)
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err)
       logger.error(`Failed to load ${label}:`, err)
-      opts.onError?.(message, err)
+      opts.onError?.(message, err, ctx)
       // #5389: when a fallback value is configured, return it as the
       // effective result instead of exposing the error. Callers opting
       // into this explicitly accept "success with stale/default data"


### PR DESCRIPTION
## Summary

Adds a 3rd generic \`Ctx\` (default \`undefined\`) to \`useFetchEndpoint\` that threads per-request context from \`load()\` into every lifecycle callback.

**Motivation:** #5388's \`exportReport\` migration used a module-scope \`let _currentReportType\` workaround because there was no way to pass the \`quick: boolean\` arg into \`onSuccess\`. That created the race condition tracked as #5455. This hook unblocks a clean fix.

## API changes (all backward-compatible)

\`\`\`ts
useFetchEndpoint<TRaw, TOut, Ctx = undefined>
load(queryExtras?, context?: Ctx)
onSuccess(data, raw, context: Ctx)
onError(message, err, context: Ctx)
onNoData(context: Ctx)
onResponse(response, context: Ctx)
\`\`\`

Context is captured at \`load()\` call time into the closure, so concurrent calls each see their own context in callbacks.

## Tests

**6 new contract tests** for the context hook + 1 existing \`fallbackData\` test updated for the new 3-arg \`onError\` signature. All 16 tests in the suite pass.

Closes #5457.

## Verification

- \`vue-tsc --noEmit -p tsconfig.app.json\` → 167 errors (unchanged baseline; 0 new).
- \`vitest useFetchEndpoint.test.ts\` → 16/16 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)