### PR TITLE
refactor(utils): extract lazy_singleton primitive, migrate 3 chunker factories (#5423)

### DIFF
--- a/autobot-backend/utils/semantic_chunker.py
+++ b/autobot-backend/utils/semantic_chunker.py
@@ -14,12 +14,12 @@ Public API (preserved):
     - get_semantic_chunker()
 """
 
-import threading
 from typing import List
 
 import numpy as np
 
 from autobot_shared.logging_manager import get_llm_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import RetryConfig, TimingConstants
 from utils.semantic_chunker_base import SemanticChunk, SemanticChunkerBase
 
@@ -458,15 +458,4 @@ class AutoBotSemanticChunker(SemanticChunkerBase):
 # Public factory (preserves singleton semantics for all 15 CPU callers)
 # ----------------------------------------------------------------------
 
-_semantic_chunker_instance: "AutoBotSemanticChunker | None" = None
-_semantic_chunker_instance_lock = threading.Lock()
-
-
-def get_semantic_chunker() -> AutoBotSemanticChunker:
-    """Get the global semantic chunker instance (lazy, thread-safe)."""
-    global _semantic_chunker_instance
-    if _semantic_chunker_instance is None:
-        with _semantic_chunker_instance_lock:
-            if _semantic_chunker_instance is None:
-                _semantic_chunker_instance = AutoBotSemanticChunker()
-    return _semantic_chunker_instance
+get_semantic_chunker = lazy_singleton(AutoBotSemanticChunker)

--- a/autobot-backend/utils/semantic_chunker_gpu.py
+++ b/autobot-backend/utils/semantic_chunker_gpu.py
@@ -28,13 +28,13 @@ os.environ["CUDA_CACHE_DISABLE"] = "0"  # Enable CUDA kernel caching
 
 import asyncio
 import concurrent.futures
-import threading
 import time
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 
 from autobot_shared.logging_manager import get_llm_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import TimingConstants
 from utils.semantic_chunker_base import SemanticChunk, SemanticChunkerBase
 
@@ -314,18 +314,6 @@ class GPUSemanticChunker(SemanticChunkerBase):
 # Public factory (preserves singleton semantics for all 4 GPU callers)
 # ----------------------------------------------------------------------
 
-_gpu_chunker_instance: "GPUSemanticChunker | None" = None
-_gpu_chunker_instance_lock = threading.Lock()
-
-
-def get_gpu_semantic_chunker() -> GPUSemanticChunker:
-    """Get the global GPU semantic chunker instance (thread-safe)."""
-    global _gpu_chunker_instance
-    if _gpu_chunker_instance is None:
-        with _gpu_chunker_instance_lock:
-            if _gpu_chunker_instance is None:
-                _gpu_chunker_instance = GPUSemanticChunker(
-                    gpu_batch_size=500,
-                    enable_gpu_memory_pool=True,
-                )
-    return _gpu_chunker_instance
+get_gpu_semantic_chunker = lazy_singleton(
+    lambda: GPUSemanticChunker(gpu_batch_size=500, enable_gpu_memory_pool=True)
+)

--- a/autobot-backend/utils/semantic_chunker_gpu_optimized.py
+++ b/autobot-backend/utils/semantic_chunker_gpu_optimized.py
@@ -29,9 +29,9 @@ divergence from the canonical GPU chunker.
 
 from __future__ import annotations
 
-import threading
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.singleton_factory import lazy_singleton
 from utils.semantic_chunker_base import SemanticChunk
 from utils.semantic_chunker_gpu import GPUSemanticChunker
 
@@ -74,17 +74,4 @@ class OptimizedSemanticChunker(GPUSemanticChunker):
         return chunks
 
 
-_optimized_instance: Optional[OptimizedSemanticChunker] = None
-_optimized_lock = threading.Lock()
-
-
-def get_optimized_semantic_chunker(
-    *args: Any, **kwargs: Any
-) -> OptimizedSemanticChunker:
-    """Return the process-wide :class:`OptimizedSemanticChunker` singleton."""
-    global _optimized_instance
-    if _optimized_instance is None:
-        with _optimized_lock:
-            if _optimized_instance is None:
-                _optimized_instance = OptimizedSemanticChunker(*args, **kwargs)
-    return _optimized_instance
+get_optimized_semantic_chunker = lazy_singleton(OptimizedSemanticChunker)

--- a/autobot_shared/__init__.py
+++ b/autobot_shared/__init__.py
@@ -33,6 +33,8 @@ __all__ = [
     "get_enabled_features",
     "require_feature",
     "FeatureDisabledError",
+    # Singleton factory — issue #5423
+    "lazy_singleton",
 ]
 
 # Lazy import map — module attribute → (submodule, name)
@@ -53,6 +55,8 @@ _LAZY_IMPORTS = {
     "get_enabled_features": (".feature_flags", "get_enabled_features"),
     "require_feature": (".feature_flags", "require_feature"),
     "FeatureDisabledError": (".feature_flags", "FeatureDisabledError"),
+    # Singleton factory — issue #5423
+    "lazy_singleton": (".singleton_factory", "lazy_singleton"),
 }
 
 

--- a/autobot_shared/singleton_factory.py
+++ b/autobot_shared/singleton_factory.py
@@ -1,0 +1,33 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Thread-safe lazy singleton factory primitive.
+
+Issue #5423: extracted from the repeated double-checked locking pattern in
+``utils/semantic_chunker*.py``.  Third-occurrence rule triggered extraction.
+"""
+
+from threading import Lock
+from typing import Callable, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+def lazy_singleton(factory: Callable[..., T]) -> Callable[..., T]:
+    """Return a factory that creates and caches a thread-safe singleton.
+
+    Uses double-checked locking so the common (already-initialised) path
+    never acquires the lock.
+    """
+    instance: Optional[T] = None
+    lock = Lock()
+
+    def get(*args, **kwargs) -> T:
+        nonlocal instance
+        if instance is None:
+            with lock:
+                if instance is None:
+                    instance = factory(*args, **kwargs)
+        return instance
+
+    return get

--- a/docs/developer/PRIMITIVES.md
+++ b/docs/developer/PRIMITIVES.md
@@ -6,3 +6,4 @@ See #5060 for the extraction-first methodology.
 | Primitive | Module | Signature | Consumers | Issue |
 |-----------|--------|-----------|-----------|-------|
 | `bounded_gather` | `autobot-backend/orchestration/primitives/concurrency.py` | `bounded_gather(coros, max_parallel, *, return_exceptions=True)` | `Orchestrator._execute_agents_in_parallel`, `SubagentDispatcher.spawn_parallel_tasks` | #5059 |
+| `lazy_singleton` | `autobot_shared/singleton_factory.py` | `lazy_singleton(factory) -> Callable` | `utils/semantic_chunker.py`, `utils/semantic_chunker_gpu.py`, `utils/semantic_chunker_gpu_optimized.py` | #5423 |


### PR DESCRIPTION
## Summary

- Creates `autobot_shared/singleton_factory.py` with a `lazy_singleton` factory using double-checked locking
- Migrates 3 chunker singleton getters (`get_semantic_chunker`, `get_gpu_semantic_chunker`, `get_optimized_semantic_chunker`) to use the primitive
- Removes `threading.Lock()` boilerplate from all three modules
- Adds `lazy_singleton` entry to `docs/developer/PRIMITIVES.md`
- Exports `lazy_singleton` from `autobot_shared/__init__.py`

Note: ~15 additional `threading.Lock()` singleton patterns found across the backend — those are deferred to a follow-up batch migration issue.

Closes #5423

## Test plan
- [ ] `python -c "from autobot_shared.singleton_factory import lazy_singleton"` passes
- [ ] All three chunker modules pass `py_compile`
- [ ] `get_gpu_semantic_chunker` lambda correctly bakes in `gpu_batch_size=500, enable_gpu_memory_pool=True`
- [ ] PRIMITIVES.md entry present

🤖 Generated with [Claude Code](https://claude.com/claude-code)