### PR TITLE
refactor(tests): consolidate FakeRedis implementations into tests/helpers/fake_redis.py (#5431)

### DIFF
--- a/autobot-backend/orchestration/error_handler_test.py
+++ b/autobot-backend/orchestration/error_handler_test.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from constants.status_enums import TaskStatus
+from tests.helpers.fake_redis import SyncHashFakeRedis
 
 from .error_handler import (
     CHECKPOINT_TTL,
@@ -94,32 +95,10 @@ class TestStepCheckpoint:
 # ---------------------------------------------------------------------------
 
 
-class _FakeRedis:
-    """In-memory Redis substitute for checkpoint tests."""
-
-    def __init__(self) -> None:
-        self._hashes: Dict[str, Dict[str, str]] = {}
-        # Record (key, ttl) pairs for every expire() call so tests can assert
-        # that the correct TTL was applied (#3231).
-        self.expire_calls: list = []
-
-    def hset(self, key: str, field: str, value: str) -> None:
-        self._hashes.setdefault(key, {})[field] = value
-
-    def expire(self, key: str, ttl: int) -> None:
-        self.expire_calls.append((key, ttl))
-
-    def hgetall(self, key: str) -> Dict[str, str]:
-        return dict(self._hashes.get(key, {}))
-
-    def delete(self, key: str) -> None:
-        self._hashes.pop(key, None)
-
-
 class TestWorkflowCheckpointManager:
     def _manager_with_fake_redis(self) -> WorkflowCheckpointManager:
         mgr = WorkflowCheckpointManager()
-        mgr._redis = _FakeRedis()
+        mgr._redis = SyncHashFakeRedis()
         return mgr
 
     def test_save_and_load(self) -> None:

--- a/autobot-backend/services/knowledge/test_org_knowledge_config.py
+++ b/autobot-backend/services/knowledge/test_org_knowledge_config.py
@@ -16,23 +16,7 @@ from services.knowledge.org_knowledge_config import (
     OrgKnowledgeConfig,
     OrgKnowledgeConfigService,
 )
-
-
-class _FakeRedis:
-    """Minimal async Redis stub backed by an in-process dict."""
-
-    def __init__(self) -> None:
-        self._store: dict[str, str] = {}
-
-    async def get(self, key: str):
-        return self._store.get(key)
-
-    async def set(self, key: str, value: str) -> bool:
-        self._store[key] = value
-        return True
-
-    async def delete(self, key: str) -> int:
-        return 1 if self._store.pop(key, None) is not None else 0
+from tests.helpers.fake_redis import AsyncSimpleFakeRedis
 
 
 def _ssot_stub():
@@ -51,7 +35,7 @@ def _ssot_stub():
 @pytest.mark.asyncio
 async def test_set_then_get_returns_persisted_config():
     """A config set via ``set()`` round-trips via ``get()``."""
-    svc = OrgKnowledgeConfigService(redis_client=_FakeRedis())
+    svc = OrgKnowledgeConfigService(redis_client=AsyncSimpleFakeRedis())
     cfg = OrgKnowledgeConfig(
         llm_provider="openai",
         llm_model="gpt-4o-mini",
@@ -70,7 +54,7 @@ async def test_set_then_get_returns_persisted_config():
 @pytest.mark.asyncio
 async def test_get_effective_returns_ssot_defaults_when_unset():
     """With no persisted config, ``get_effective()`` returns SSOT defaults."""
-    svc = OrgKnowledgeConfigService(redis_client=_FakeRedis())
+    svc = OrgKnowledgeConfigService(redis_client=AsyncSimpleFakeRedis())
     with patch(
         "autobot_shared.ssot_config.get_config",
         return_value=_ssot_stub(),
@@ -85,7 +69,7 @@ async def test_get_effective_returns_ssot_defaults_when_unset():
 @pytest.mark.asyncio
 async def test_get_effective_merges_partial_org_config_over_ssot():
     """Partial org config fills in SSOT defaults for unset fields only."""
-    redis = _FakeRedis()
+    redis = AsyncSimpleFakeRedis()
     svc = OrgKnowledgeConfigService(redis_client=redis)
     await svc.set(
         "org-partial",
@@ -105,7 +89,7 @@ async def test_get_effective_merges_partial_org_config_over_ssot():
 @pytest.mark.asyncio
 async def test_default_org_sentinel_used_when_org_id_none():
     """Calls with org_id=None use the __default__ sentinel key."""
-    redis = _FakeRedis()
+    redis = AsyncSimpleFakeRedis()
     svc = OrgKnowledgeConfigService(redis_client=redis)
     await svc.set(None, OrgKnowledgeConfig(llm_model="default-llm"))
     # Key must exist under the sentinel.
@@ -118,7 +102,7 @@ async def test_default_org_sentinel_used_when_org_id_none():
 @pytest.mark.asyncio
 async def test_delete_removes_persisted_config():
     """``delete()`` clears the key and subsequent ``get()`` returns None."""
-    redis = _FakeRedis()
+    redis = AsyncSimpleFakeRedis()
     svc = OrgKnowledgeConfigService(redis_client=redis)
     await svc.set("org-gone", OrgKnowledgeConfig(llm_model="m"))
     assert await svc.delete("org-gone") is True
@@ -128,7 +112,7 @@ async def test_delete_removes_persisted_config():
 @pytest.mark.asyncio
 async def test_corrupt_payload_returns_none_and_logs():
     """Non-JSON persisted payloads are ignored rather than raising."""
-    redis = _FakeRedis()
+    redis = AsyncSimpleFakeRedis()
     redis._store["org_llm_config:broken"] = "not-json"
     svc = OrgKnowledgeConfigService(redis_client=redis)
     assert await svc.get("broken") is None
@@ -137,7 +121,7 @@ async def test_corrupt_payload_returns_none_and_logs():
 @pytest.mark.asyncio
 async def test_set_persists_json_payload_shape():
     """Persisted blob is valid JSON with the known key set."""
-    redis = _FakeRedis()
+    redis = AsyncSimpleFakeRedis()
     svc = OrgKnowledgeConfigService(redis_client=redis)
     await svc.set(
         "org-1",

--- a/autobot-backend/services/knowledge/test_sync_queue.py
+++ b/autobot-backend/services/knowledge/test_sync_queue.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
 import pytest
@@ -25,138 +24,16 @@ from services.knowledge.sync_queue import (
     SyncReason,
     SyncStatus,
 )
-
-
-# ---------------------------------------------------------------------------
-# Minimal in-memory async Redis stub
-# ---------------------------------------------------------------------------
-
-
-class _Pipeline:
-    """Accumulates Redis commands and replays them on ``execute()``."""
-
-    def __init__(self, redis: "_FakeAsyncRedis") -> None:
-        self._redis = redis
-        self._ops: List[Tuple[str, tuple, dict]] = []
-
-    def __getattr__(self, name: str):
-        def _op(*args, **kwargs):
-            self._ops.append((name, args, kwargs))
-            return self
-
-        return _op
-
-    async def execute(self) -> List[Any]:
-        out: List[Any] = []
-        for name, args, kwargs in self._ops:
-            method = getattr(self._redis, name)
-            result = method(*args, **kwargs)
-            if asyncio.iscoroutine(result):
-                result = await result
-            out.append(result)
-        return out
-
-
-class _FakeAsyncRedis:
-    """Just enough async Redis surface for :class:`DocumentSyncQueue`."""
-
-    def __init__(self) -> None:
-        self.hashes: Dict[str, Dict[str, str]] = {}
-        self.zsets: Dict[str, Dict[str, float]] = {}
-        self.strings: Dict[str, str] = {}
-
-    def pipeline(self) -> _Pipeline:
-        return _Pipeline(self)
-
-    async def hset(self, key: str, mapping: Optional[dict] = None, **kwargs) -> int:
-        payload = mapping or kwargs
-        bucket = self.hashes.setdefault(key, {})
-        added = 0
-        for k, v in payload.items():
-            if k not in bucket:
-                added += 1
-            bucket[k] = str(v)
-        return added
-
-    async def hgetall(self, key: str) -> Dict[str, str]:
-        return dict(self.hashes.get(key, {}))
-
-    async def get(self, key: str) -> Optional[str]:
-        return self.strings.get(key)
-
-    async def set(self, key: str, value: str) -> bool:
-        self.strings[key] = str(value)
-        return True
-
-    async def delete(self, *keys: str) -> int:
-        removed = 0
-        for k in keys:
-            if k in self.hashes:
-                del self.hashes[k]
-                removed += 1
-            if k in self.zsets:
-                del self.zsets[k]
-                removed += 1
-            if k in self.strings:
-                del self.strings[k]
-                removed += 1
-        return removed
-
-    async def zadd(self, key: str, mapping: Dict[str, float]) -> int:
-        bucket = self.zsets.setdefault(key, {})
-        added = 0
-        for m, score in mapping.items():
-            if m not in bucket:
-                added += 1
-            bucket[m] = float(score)
-        return added
-
-    async def zrem(self, key: str, *members: str) -> int:
-        bucket = self.zsets.get(key, {})
-        removed = 0
-        for m in members:
-            if m in bucket:
-                del bucket[m]
-                removed += 1
-        return removed
-
-    async def zrange(self, key: str, start: int, stop: int) -> List[str]:
-        bucket = self.zsets.get(key, {})
-        ordered = sorted(bucket.items(), key=lambda kv: kv[1])
-        # Redis ZRANGE stop is inclusive; -1 means last element.
-        if stop == -1:
-            stop = len(ordered) - 1
-        return [k for k, _ in ordered[start : stop + 1]]
-
-    async def zrevrange(self, key: str, start: int, stop: int) -> List[str]:
-        bucket = self.zsets.get(key, {})
-        ordered = sorted(bucket.items(), key=lambda kv: kv[1], reverse=True)
-        if stop == -1:
-            stop = len(ordered) - 1
-        return [k for k, _ in ordered[start : stop + 1]]
-
-    async def zrangebyscore(
-        self, key: str, min: float, max: float, **kwargs
-    ) -> List[str]:
-        bucket = self.zsets.get(key, {})
-        lo = float("-inf") if min == "-inf" else float(min)
-        hi = float("inf") if max == "+inf" else float(max)
-        return sorted(
-            (m for m, s in bucket.items() if lo <= s <= hi),
-            key=lambda m: bucket[m],
-        )
-
-    async def zcard(self, key: str) -> int:
-        return len(self.zsets.get(key, {}))
+from tests.helpers.fake_redis import AsyncFullFakeRedis
 
 
 @pytest.fixture
-def fake_redis() -> _FakeAsyncRedis:
-    return _FakeAsyncRedis()
+def fake_redis() -> AsyncFullFakeRedis:
+    return AsyncFullFakeRedis()
 
 
 @pytest.fixture
-def queue(fake_redis: _FakeAsyncRedis) -> DocumentSyncQueue:
+def queue(fake_redis: AsyncFullFakeRedis) -> DocumentSyncQueue:
     """A :class:`DocumentSyncQueue` patched to return the in-memory fake."""
 
     async def _return_redis(database: str = "main"):
@@ -227,7 +104,7 @@ class TestPriorityOrdering:
 
     @pytest.mark.asyncio
     async def test_priority_beats_fifo_across_one_second_gap(
-        self, queue: DocumentSyncQueue, fake_redis: _FakeAsyncRedis
+        self, queue: DocumentSyncQueue, fake_redis: AsyncFullFakeRedis
     ) -> None:
         """Regression for #5078: FIFO component must not overflow priority bucket.
 
@@ -548,7 +425,7 @@ class TestWorkerLoop:
 class TestPrune:
     @pytest.mark.asyncio
     async def test_prune_done_removes_expired_entries(
-        self, queue: DocumentSyncQueue, fake_redis: _FakeAsyncRedis
+        self, queue: DocumentSyncQueue, fake_redis: AsyncFullFakeRedis
     ) -> None:
         entry = await queue.enqueue_sync("a.md", SyncReason.MANUAL)
         await queue.mark_processing(entry.id)

--- a/autobot-backend/tests/helpers/fake_redis.py
+++ b/autobot-backend/tests/helpers/fake_redis.py
@@ -1,0 +1,286 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Shared in-memory Redis fakes for unit tests.
+
+Classes
+-------
+Sync
+  SyncHashFakeRedis        — hset / hgetall / delete / expire
+
+Async
+  AsyncSimpleFakeRedis     — get / set / delete  (string keys; ``_store`` dict)
+  AsyncHashFakeRedis       — hset / hget / hgetall / hdel  (hash fields; ``_store`` dict)
+  AsyncFullFakeRedis       — hashes + sorted sets + strings + pipeline
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Sync
+# ---------------------------------------------------------------------------
+
+
+class SyncHashFakeRedis:
+    """Sync in-memory stub with hash + expire ops.
+
+    Used by tests that drive synchronous Redis callers (e.g.
+    WorkflowCheckpointManager in error_handler_test.py).
+    ``expire_calls`` records ``(key, ttl)`` pairs so tests can assert TTLs.
+    """
+
+    def __init__(self) -> None:
+        self._hashes: Dict[str, Dict[str, str]] = {}
+        self.expire_calls: list = []
+
+    def hset(self, key: str, field: str, value: str) -> None:
+        """Store *field* under *key*."""
+        self._hashes.setdefault(key, {})[field] = value
+
+    def expire(self, key: str, ttl: int) -> None:
+        """Record an expire() call (does not actually expire keys)."""
+        self.expire_calls.append((key, ttl))
+
+    def hgetall(self, key: str) -> Dict[str, str]:
+        """Return all fields for *key* as a plain dict."""
+        return dict(self._hashes.get(key, {}))
+
+    def delete(self, key: str) -> None:
+        """Remove *key* entirely."""
+        self._hashes.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Async — simple string ops
+# ---------------------------------------------------------------------------
+
+
+class AsyncSimpleFakeRedis:
+    """Async in-memory stub: get / set / delete on plain string keys.
+
+    ``_store`` is the backing dict; tests may inspect or seed it directly.
+    Suitable for services that use only the basic key-value Redis surface
+    (e.g. OrgKnowledgeConfigService tests).
+    """
+
+    def __init__(self) -> None:
+        self._store: Dict[str, str] = {}
+
+    async def get(self, key: str) -> Optional[str]:
+        """Return the value for *key*, or ``None``."""
+        return self._store.get(key)
+
+    async def set(self, key: str, value: str) -> bool:
+        """Store *value* under *key*."""
+        self._store[key] = value
+        return True
+
+    async def delete(self, key: str) -> int:
+        """Remove *key*; return 1 if it existed, else 0."""
+        return 1 if self._store.pop(key, None) is not None else 0
+
+
+# ---------------------------------------------------------------------------
+# Async — hash ops
+# ---------------------------------------------------------------------------
+
+
+class AsyncHashFakeRedis:
+    """Async in-memory stub that supports Redis hash-field operations.
+
+    ``_store`` is ``Dict[str, Dict[str, bytes]]`` — outer key is the hash
+    name, inner dict maps field names to byte values.  Tests may seed or
+    inspect ``_store`` directly for setup / assertion.
+
+    Suitable for tests that interact with Redis hashes (e.g. knowledge_boards).
+    """
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, bytes]] = {}
+
+    async def hset(self, name: str, key: str, value: str) -> int:
+        """Set *key* field in hash *name*; return 1 if new, 0 if updated."""
+        bucket = self._store.setdefault(name, {})
+        existed = key in bucket
+        bucket[key] = value.encode("utf-8") if isinstance(value, str) else value
+        return 0 if existed else 1
+
+    async def hget(self, name: str, key: str) -> Optional[bytes]:
+        """Return the bytes value for *key* in hash *name*, or ``None``."""
+        return self._store.get(name, {}).get(key)
+
+    async def hgetall(self, name: str) -> Dict[bytes, bytes]:
+        """Return all fields of hash *name* with bytes keys and values."""
+        raw = self._store.get(name, {})
+        return {
+            (k.encode("utf-8") if isinstance(k, str) else k): (
+                v if isinstance(v, bytes) else v.encode("utf-8")
+            )
+            for k, v in raw.items()
+        }
+
+    async def hdel(self, name: str, key: str) -> int:
+        """Delete *key* from hash *name*; return 1 if it existed, else 0."""
+        bucket = self._store.get(name, {})
+        if key in bucket:
+            del bucket[key]
+            return 1
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Async — full surface (hashes + sorted sets + strings + pipeline)
+# ---------------------------------------------------------------------------
+
+
+class _Pipeline:
+    """Accumulates Redis commands and replays them on ``execute()``.
+
+    Used internally by :class:`AsyncFullFakeRedis`.
+    """
+
+    def __init__(self, redis: "AsyncFullFakeRedis") -> None:
+        self._redis = redis
+        self._ops: List[Tuple[str, tuple, dict]] = []
+
+    def __getattr__(self, name: str):
+        def _op(*args, **kwargs):
+            self._ops.append((name, args, kwargs))
+            return self
+
+        return _op
+
+    async def execute(self) -> List[Any]:
+        """Replay all buffered commands and return their results."""
+        out: List[Any] = []
+        for name, args, kwargs in self._ops:
+            method = getattr(self._redis, name)
+            result = method(*args, **kwargs)
+            if asyncio.iscoroutine(result):
+                result = await result
+            out.append(result)
+        return out
+
+
+class AsyncFullFakeRedis:
+    """Async in-memory stub with hashes, sorted sets, strings, and pipeline.
+
+    Provides the full surface needed by complex queue/state-machine tests
+    (e.g. DocumentSyncQueue).  ``zsets`` is a public attribute so tests can
+    seed or inspect sorted-set contents directly.
+
+    Note: ``hset`` accepts both ``mapping=`` and keyword-arg forms to match
+    redis-py's flexible calling convention.
+    """
+
+    def __init__(self) -> None:
+        self._hashes: Dict[str, Dict[str, str]] = {}
+        self.zsets: Dict[str, Dict[str, float]] = {}
+        self._strings: Dict[str, str] = {}
+
+    # -- string ops --
+
+    async def get(self, key: str) -> Optional[str]:
+        """Return the string value for *key*, or ``None``."""
+        return self._strings.get(key)
+
+    async def set(self, key: str, value: str) -> bool:
+        """Store *value* under *key* in the string store."""
+        self._strings[key] = str(value)
+        return True
+
+    async def delete(self, *keys: str) -> int:
+        """Remove one or more keys from hashes, zsets, and strings."""
+        removed = 0
+        for k in keys:
+            for store in (self._hashes, self.zsets, self._strings):
+                if k in store:
+                    del store[k]
+                    removed += 1
+        return removed
+
+    # -- hash ops --
+
+    async def hset(
+        self,
+        key: str,
+        mapping: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> int:
+        """Set one or more hash fields; accepts ``mapping=`` or keyword args."""
+        payload = mapping or kwargs
+        bucket = self._hashes.setdefault(key, {})
+        added = 0
+        for k, v in payload.items():
+            if k not in bucket:
+                added += 1
+            bucket[k] = str(v)
+        return added
+
+    async def hgetall(self, key: str) -> Dict[str, str]:
+        """Return all fields of *key* as plain strings."""
+        return dict(self._hashes.get(key, {}))
+
+    # -- pipeline --
+
+    def pipeline(self) -> _Pipeline:
+        """Return a buffered pipeline that replays on ``execute()``."""
+        return _Pipeline(self)
+
+    # -- sorted set ops --
+
+    async def zadd(self, key: str, mapping: Dict[str, float]) -> int:
+        """Add members with scores; return number of new members added."""
+        bucket = self.zsets.setdefault(key, {})
+        added = 0
+        for m, score in mapping.items():
+            if m not in bucket:
+                added += 1
+            bucket[m] = float(score)
+        return added
+
+    async def zrem(self, key: str, *members: str) -> int:
+        """Remove *members* from sorted set *key*."""
+        bucket = self.zsets.get(key, {})
+        removed = 0
+        for m in members:
+            if m in bucket:
+                del bucket[m]
+                removed += 1
+        return removed
+
+    async def zrange(self, key: str, start: int, stop: int) -> List[str]:
+        """Return members in ascending score order; ``stop=-1`` means last."""
+        bucket = self.zsets.get(key, {})
+        ordered = sorted(bucket.items(), key=lambda kv: kv[1])
+        if stop == -1:
+            stop = len(ordered) - 1
+        return [k for k, _ in ordered[start : stop + 1]]
+
+    async def zrevrange(self, key: str, start: int, stop: int) -> List[str]:
+        """Return members in descending score order; ``stop=-1`` means last."""
+        bucket = self.zsets.get(key, {})
+        ordered = sorted(bucket.items(), key=lambda kv: kv[1], reverse=True)
+        if stop == -1:
+            stop = len(ordered) - 1
+        return [k for k, _ in ordered[start : stop + 1]]
+
+    async def zrangebyscore(
+        self, key: str, min: float, max: float, **kwargs: Any
+    ) -> List[str]:
+        """Return members whose score is between *min* and *max* (inclusive)."""
+        bucket = self.zsets.get(key, {})
+        lo = float("-inf") if min == "-inf" else float(min)
+        hi = float("inf") if max == "+inf" else float(max)
+        return sorted(
+            (m for m, s in bucket.items() if lo <= s <= hi),
+            key=lambda m: bucket[m],
+        )
+
+    async def zcard(self, key: str) -> int:
+        """Return the number of members in sorted set *key*."""
+        return len(self.zsets.get(key, {}))

--- a/autobot-backend/tests/test_knowledge_boards.py
+++ b/autobot-backend/tests/test_knowledge_boards.py
@@ -15,7 +15,6 @@ The knowledge-base singleton is monkey-patched on each request via
 """
 
 import json
-from typing import Optional
 from unittest.mock import AsyncMock
 
 import pytest
@@ -28,42 +27,7 @@ from api.knowledge_boards import (
     GLOBAL_BOARD_ID,
 )
 from api.knowledge_boards import router as boards_router
-
-# ---------------------------------------------------------------------------
-# Fake in-process Redis hash
-# ---------------------------------------------------------------------------
-
-
-class _FakeRedis:
-    """Minimal async Redis stub that emulates hset / hget / hgetall / hdel."""
-
-    def __init__(self):
-        self._store: dict[str, dict[str, bytes]] = {}
-
-    async def hset(self, name: str, key: str, value: str) -> int:
-        bucket = self._store.setdefault(name, {})
-        existed = key in bucket
-        bucket[key] = value.encode("utf-8") if isinstance(value, str) else value
-        return 0 if existed else 1
-
-    async def hget(self, name: str, key: str) -> Optional[bytes]:
-        return self._store.get(name, {}).get(key)
-
-    async def hgetall(self, name: str) -> dict[bytes, bytes]:
-        raw = self._store.get(name, {})
-        return {
-            (k.encode("utf-8") if isinstance(k, str) else k): (
-                v if isinstance(v, bytes) else v.encode("utf-8")
-            )
-            for k, v in raw.items()
-        }
-
-    async def hdel(self, name: str, key: str) -> int:
-        bucket = self._store.get(name, {})
-        if key in bucket:
-            del bucket[key]
-            return 1
-        return 0
+from tests.helpers.fake_redis import AsyncHashFakeRedis
 
 
 # ---------------------------------------------------------------------------
@@ -71,7 +35,7 @@ class _FakeRedis:
 # ---------------------------------------------------------------------------
 
 
-def _make_app(fake_redis: _FakeRedis) -> FastAPI:
+def _make_app(fake_redis: AsyncHashFakeRedis) -> FastAPI:
     """Build a minimal FastAPI app with the boards router wired up."""
 
     class _FakeKB:
@@ -99,7 +63,7 @@ def _make_app(fake_redis: _FakeRedis) -> FastAPI:
 # ---------------------------------------------------------------------------
 
 
-def _seed_board(fake_redis: _FakeRedis, board_id: str, name: str) -> dict:
+def _seed_board(fake_redis: AsyncHashFakeRedis, board_id: str, name: str) -> dict:
     """Synchronously seed a board entry into the fake Redis store."""
     entry = {"board_id": board_id, "name": name, "description": "", "created_at": "2026-01-01T00:00:00+00:00"}
     # Direct store manipulation (sync path for test setup)
@@ -116,7 +80,7 @@ class TestKnowledgeBoardsList:
     """GET /boards always returns at least the global sentinel."""
 
     def test_empty_store_returns_global_board(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         client = TestClient(_make_app(fake_redis))
         resp = client.get("/api/knowledge_base/boards")
         assert resp.status_code == 200
@@ -126,7 +90,7 @@ class TestKnowledgeBoardsList:
         assert GLOBAL_BOARD_ID in ids
 
     def test_seeded_boards_appear_in_list(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         _seed_board(fake_redis, "project-alpha", "Project Alpha")
         client = TestClient(_make_app(fake_redis))
         resp = client.get("/api/knowledge_base/boards")
@@ -138,7 +102,7 @@ class TestKnowledgeBoardsList:
         assert data["total"] == 2
 
     def test_total_count_includes_global(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         _seed_board(fake_redis, "board-a", "Board A")
         _seed_board(fake_redis, "board-b", "Board B")
         client = TestClient(_make_app(fake_redis))
@@ -150,7 +114,7 @@ class TestKnowledgeBoardsCreate:
     """POST /boards — creation, validation, and duplicate handling."""
 
     def test_create_board_returns_201(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         client = TestClient(_make_app(fake_redis))
         resp = client.post(
             "/api/knowledge_base/boards",
@@ -162,7 +126,7 @@ class TestKnowledgeBoardsCreate:
         assert data["created"] is True
 
     def test_create_board_without_id_autogenerates(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         client = TestClient(_make_app(fake_redis))
         resp = client.post(
             "/api/knowledge_base/boards",
@@ -174,7 +138,7 @@ class TestKnowledgeBoardsCreate:
         assert data["board_id"]  # non-empty
 
     def test_create_board_persists_in_redis(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         client = TestClient(_make_app(fake_redis))
         client.post(
             "/api/knowledge_base/boards",
@@ -186,7 +150,7 @@ class TestKnowledgeBoardsCreate:
         assert entry["name"] == "Persisted"
 
     def test_duplicate_board_id_returns_409(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         _seed_board(fake_redis, "existing-board", "Existing Board")
         client = TestClient(_make_app(fake_redis))
         resp = client.post(
@@ -197,7 +161,7 @@ class TestKnowledgeBoardsCreate:
 
     def test_reserved_global_board_id_returns_422(self):
         """__global__ is reserved; the validator should reject it."""
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         client = TestClient(_make_app(fake_redis))
         resp = client.post(
             "/api/knowledge_base/boards",
@@ -208,7 +172,7 @@ class TestKnowledgeBoardsCreate:
 
     def test_invalid_board_id_chars_returns_422(self):
         """Board IDs must match [a-z0-9_-]."""
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         client = TestClient(_make_app(fake_redis))
         resp = client.post(
             "/api/knowledge_base/boards",
@@ -217,7 +181,7 @@ class TestKnowledgeBoardsCreate:
         assert resp.status_code == 422
 
     def test_board_id_with_spaces_returns_422(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         client = TestClient(_make_app(fake_redis))
         resp = client.post(
             "/api/knowledge_base/boards",
@@ -230,7 +194,7 @@ class TestKnowledgeBoardsDelete:
     """DELETE /boards/{board_id} — removal and guard cases."""
 
     def test_delete_existing_board_returns_200(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         _seed_board(fake_redis, "to-delete", "To Delete")
         client = TestClient(_make_app(fake_redis))
         resp = client.delete("/api/knowledge_base/boards/to-delete")
@@ -240,7 +204,7 @@ class TestKnowledgeBoardsDelete:
         assert data["board_id"] == "to-delete"
 
     def test_delete_removes_board_from_redis(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         _seed_board(fake_redis, "gone-board", "Gone Board")
         client = TestClient(_make_app(fake_redis))
         client.delete("/api/knowledge_base/boards/gone-board")
@@ -248,14 +212,14 @@ class TestKnowledgeBoardsDelete:
         assert remaining is None
 
     def test_delete_unknown_board_returns_404(self):
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         client = TestClient(_make_app(fake_redis))
         resp = client.delete("/api/knowledge_base/boards/does-not-exist")
         assert resp.status_code == 404
 
     def test_delete_global_board_returns_400(self):
         """The __global__ sentinel must never be deletable."""
-        fake_redis = _FakeRedis()
+        fake_redis = AsyncHashFakeRedis()
         client = TestClient(_make_app(fake_redis))
         resp = client.delete(f"/api/knowledge_base/boards/{GLOBAL_BOARD_ID}")
         assert resp.status_code == 400


### PR DESCRIPTION
## Summary

- Creates `autobot-backend/tests/helpers/fake_redis.py` with 4 concrete variants:
  - `SyncHashFakeRedis` — sync hset/hgetall/delete/expire with TTL tracking
  - `AsyncSimpleFakeRedis` — async get/set/delete
  - `AsyncHashFakeRedis` — async hash ops (hset/hget/hgetall/hdel)
  - `AsyncFullFakeRedis` — async hashes + sorted sets + strings + pipeline
- Migrates 4 test files off inline `_FakeRedis`/`_FakeAsyncRedis` definitions:
  - `tests/test_knowledge_boards.py`
  - `orchestration/error_handler_test.py`
  - `services/knowledge/test_org_knowledge_config.py`
  - `services/knowledge/test_sync_queue.py`

3 pre-existing test failures unrelated to this PR (`test_checkpoint_ttl_is_30_days`, `test_refresh_ttl_*` — `WorkflowCheckpointManager` missing `refresh_ttl()`).

Closes #5431

## Test plan
- [ ] `py_compile` passes on all 5 modified/created files
- [ ] 69 tests pass (3 pre-existing failures excluded)
- [ ] No new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)