### PR TITLE
fix(backend): time_provider.py datetime.now() → now_utc() + infra session cleanup bug (#5513)

### DIFF
--- a/autobot-backend/context_aware_decision/time_provider.py
+++ b/autobot-backend/context_aware_decision/time_provider.py
@@ -14,6 +14,8 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Dict
 
+from autobot_shared.time_utils import now_utc
+
 
 class TimeProvider:
     """Utility class for time-related operations to reduce Feature Envy."""
@@ -35,25 +37,23 @@ class TimeProvider:
 
     @staticmethod
     def is_business_hours() -> bool:
-        """Check if current time is within business hours (9 AM - 5 PM, local server time)."""
-        current_hour = datetime.now().hour
-        return 9 <= current_hour <= 17
+        """Check if current time is within business hours (9 AM - 5 PM UTC)."""
+        return 9 <= now_utc().hour <= 17
 
     @staticmethod
     def is_weekend() -> bool:
-        """Check if current day is weekend (local server time)."""
-        return datetime.now().weekday() >= 5
+        """Check if current day is weekend (UTC)."""
+        return now_utc().weekday() >= 5
 
     @staticmethod
     def get_temporal_context_data() -> Dict[str, Any]:
         """Get comprehensive temporal context data."""
-        current_time_utc = datetime.now(tz=timezone.utc)
-        current_time_local = datetime.now()
+        current_time_utc = now_utc()
         return {
             "timestamp": time.time(),
             "datetime": current_time_utc.isoformat(),
-            "hour": current_time_local.hour,
-            "day_of_week": current_time_local.weekday(),
-            "is_business_hours": 9 <= current_time_local.hour <= 17,
-            "is_weekend": current_time_local.weekday() >= 5,
+            "hour": current_time_utc.hour,
+            "day_of_week": current_time_utc.weekday(),
+            "is_business_hours": 9 <= current_time_utc.hour <= 17,
+            "is_weekend": current_time_utc.weekday() >= 5,
         }

--- a/autobot-infrastructure/autobot-backend/scripts/migrations/cleanup_orphaned_sessions.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/cleanup_orphaned_sessions.py
@@ -158,8 +158,8 @@ class OrphanedSessionCleaner:
                 return None
 
             # Parse ISO format timestamp
-            timestamp = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
-            age = datetime.utcnow() - timestamp.replace(tzinfo=None)
+            timestamp = parse_utc_iso(timestamp_str)
+            age = now_utc() - timestamp
             return age.days
         except Exception as e:
             logger.debug(f"Could not determine session age: {e}")


### PR DESCRIPTION
## Summary

- **`context_aware_decision/time_provider.py`**: Replace 3 bare `datetime.now()` (local timezone) calls with `now_utc()`; eliminate redundant `current_time_local` variable; update docstrings from "local server time" → UTC
- **`autobot-infrastructure/cleanup_orphaned_sessions.py`**: Fix naive–aware TypeError bug — `datetime.utcnow() - timestamp.replace(tzinfo=None)` → `now_utc() - parse_utc_iso(timestamp_str)` (script already uses `autobot_shared`)

Closes #5513.

## Test plan

- [ ] `time_provider.is_business_hours()` and `is_weekend()` use UTC hours/weekday (consistent with AutoBot UTC-only deployment)
- [ ] `get_temporal_context_data()` returns UTC-based `hour` and `day_of_week` — no duplicate `datetime.now()` call
- [ ] `cleanup_orphaned_sessions.py` age calculation is now aware–aware subtraction (no TypeError when Redis timestamps include timezone info)
- [ ] `python3 -m py_compile` passes on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)