### PR TITLE
fix(backend): remaining datetime.utcnow() + time.gmtime() sites (#5199)

### DIFF
--- a/autobot-backend/services/conversation_export.py
+++ b/autobot-backend/services/conversation_export.py
@@ -14,6 +14,7 @@ Provides export and import operations for chat conversations:
 import json
 import logging
 import time
+from autobot_shared.time_utils import utc_timestamp
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -66,7 +67,7 @@ def _build_json_envelope(session_id: str, chat_data: Dict[str, Any]) -> Dict[str
     """Wrap raw session data in the versioned AutoBot JSON export envelope."""
     return {
         "format": AUTOBOT_EXPORT_FORMAT,
-        "exported_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "exported_at": utc_timestamp(),
         "session_id": session_id,
         "name": chat_data.get("name", ""),
         "created_time": chat_data.get("created_time", chat_data.get("createdTime", "")),
@@ -83,7 +84,7 @@ def _build_bulk_envelope(sessions: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Wrap multiple session envelopes in a bulk archive envelope."""
     return {
         "format": f"{AUTOBOT_EXPORT_FORMAT}-bulk",
-        "exported_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "exported_at": utc_timestamp(),
         "conversation_count": len(sessions),
         "conversations": sessions,
     }

--- a/autobot-backend/tests/test_execution_backends.py
+++ b/autobot-backend/tests/test_execution_backends.py
@@ -481,8 +481,8 @@ class TestExecutionResult:
             stdout="output",
             stderr="",
             return_code=0,
-            started_at=datetime.datetime.utcnow(),
-            completed_at=datetime.datetime.utcnow(),
+            started_at=datetime.datetime.now(datetime.timezone.utc),
+            completed_at=datetime.datetime.now(datetime.timezone.utc),
         )
 
         data = result.to_dict()


### PR DESCRIPTION
## Summary

Clears the last 4 deprecated datetime sites in autobot-backend:

- `services/conversation_export.py` (2): `time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())` → `utc_timestamp()` — consistent with canonical helper
- `tests/test_execution_backends.py` (2): `datetime.datetime.utcnow()` → `datetime.datetime.now(datetime.timezone.utc)` — test fixtures now aware UTC

After this PR: `grep -rn "datetime.utcnow()" autobot-backend/` returns 0 outside `__pycache__` and `time_utils.py`.

Closes #5199.

## Test plan
- [ ] Zero remaining `datetime.utcnow()` / `time.gmtime()` in autobot-backend (verified via grep)
- [ ] `python3 -m py_compile` passes on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)