### PR TITLE
test(backend): migrate asyncio.run() test runners to @pytest.mark.asyncio (#5435)

### DIFF
--- a/autobot-backend/a2a/a2a_test.py
+++ b/autobot-backend/a2a/a2a_test.py
@@ -9,6 +9,7 @@ Issue #4502: TaskManager tests now mock Redis instead of the in-process dict.
 Uses no network connections and no external dependencies.
 """
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from a2a.agent_card import build_agent_card
@@ -569,74 +570,63 @@ class TestSelfEvaluator:
     scoring logic and EvalResult dataclass directly.
     """
 
-    def _run(self, coro):
-        import asyncio
-
-        return asyncio.run(coro)
-
-    def test_high_confidence_response_passes(self):
+    @pytest.mark.asyncio
+    async def test_high_confidence_response_passes(self):
         from a2a.self_evaluator import evaluate_task_output
 
-        result = self._run(
-            evaluate_task_output(
-                input_text="What is 2 + 2?",
-                response_text="The answer is 4. Addition of 2 and 2 yields 4.",
-                metadata={},
-                threshold=0.6,
-            )
+        result = await evaluate_task_output(
+            input_text="What is 2 + 2?",
+            response_text="The answer is 4. Addition of 2 and 2 yields 4.",
+            metadata={},
+            threshold=0.6,
         )
         assert result.passed is True
         assert result.confidence >= 0.6
         assert result.eval_reason == ""
 
-    def test_uncertain_response_fails(self):
+    @pytest.mark.asyncio
+    async def test_uncertain_response_fails(self):
         from a2a.self_evaluator import evaluate_task_output
 
         # Response with 4+ uncertainty phrases drives confidence below 0.6
-        result = self._run(
-            evaluate_task_output(
-                input_text="What is the capital of France?",
-                response_text=(
-                    "I don't know. I am not sure. I cannot answer this. "
-                    "Unable to provide information here. I have no data on this."
-                ),
-                metadata={},
-                threshold=0.6,
-            )
+        result = await evaluate_task_output(
+            input_text="What is the capital of France?",
+            response_text=(
+                "I don't know. I am not sure. I cannot answer this. "
+                "Unable to provide information here. I have no data on this."
+            ),
+            metadata={},
+            threshold=0.6,
         )
         assert result.passed is False
         assert result.confidence < 0.6
         assert result.eval_reason != ""
 
-    def test_empty_response_fails(self):
+    @pytest.mark.asyncio
+    async def test_empty_response_fails(self):
         from a2a.self_evaluator import evaluate_task_output
 
-        result = self._run(
-            evaluate_task_output(
-                input_text="Summarise this document.",
-                response_text="   ",
-                metadata={},
-                threshold=0.6,
-            )
+        result = await evaluate_task_output(
+            input_text="Summarise this document.",
+            response_text="   ",
+            metadata={},
+            threshold=0.6,
         )
         assert result.passed is False
         assert result.confidence == 0.0
 
-    def test_custom_threshold_respected(self):
+    @pytest.mark.asyncio
+    async def test_custom_threshold_respected(self):
         """A response that passes default threshold can fail a stricter one."""
         from a2a.self_evaluator import evaluate_task_output
 
         good_response = "Python is a high-level programming language used widely."
         # Should pass at default 0.6
-        result_default = self._run(
-            evaluate_task_output("Describe Python", good_response, {}, threshold=0.6)
-        )
+        result_default = await evaluate_task_output("Describe Python", good_response, {}, threshold=0.6)
         assert result_default.passed is True
 
         # Force failure with threshold above 1.0 (impossible to pass)
-        result_strict = self._run(
-            evaluate_task_output("Describe Python", good_response, {}, threshold=1.1)
-        )
+        result_strict = await evaluate_task_output("Describe Python", good_response, {}, threshold=1.1)
         assert result_strict.passed is False
 
     def test_confidence_is_bounded(self):
@@ -666,12 +656,8 @@ class TestExecuteA2aTaskEvalGate:
             mgr = TaskManager()
         return mgr
 
-    def _run(self, coro):
-        import asyncio
-
-        return asyncio.run(coro)
-
-    def test_pass_threshold_transitions_to_completed(self):
+    @pytest.mark.asyncio
+    async def test_pass_threshold_transitions_to_completed(self):
         """When eval passes, task must reach COMPLETED."""
         import sys
         from unittest.mock import AsyncMock, MagicMock, patch
@@ -701,12 +687,13 @@ class TestExecuteA2aTaskEvalGate:
             ),
             patch.dict(sys.modules, {"agents.agent_orchestration": mock_ao_module}),
         ):
-            self._run(execute_a2a_task(task.id, "Describe Python"))
+            await execute_a2a_task(task.id, "Describe Python")
 
         final = mgr.get_task(task.id)
         assert final.status.state == TaskState.COMPLETED
 
-    def test_fail_threshold_transitions_to_failed_with_eval_reason(self):
+    @pytest.mark.asyncio
+    async def test_fail_threshold_transitions_to_failed_with_eval_reason(self):
         """When eval fails, task must reach FAILED with eval_reason artifact."""
         import sys
         from unittest.mock import AsyncMock, MagicMock, patch
@@ -739,7 +726,7 @@ class TestExecuteA2aTaskEvalGate:
             ),
             patch.dict(sys.modules, {"agents.agent_orchestration": mock_ao_module}),
         ):
-            self._run(execute_a2a_task(task.id, "Explain quantum entanglement"))
+            await execute_a2a_task(task.id, "Explain quantum entanglement")
 
         final = mgr.get_task(task.id)
         assert final.status.state == TaskState.FAILED

--- a/autobot-backend/advanced_rag_optimizer_rerank_test.py
+++ b/autobot-backend/advanced_rag_optimizer_rerank_test.py
@@ -13,7 +13,6 @@ optimizer. These tests verify that:
 - The default (no argument) still produces the legacy 0.8/0.2 blend.
 """
 
-import asyncio
 import math
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -47,7 +46,7 @@ def _make_search_result(hybrid_score: float = 0.5, content: str = "test content"
 # ---------------------------------------------------------------------------
 
 
-class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
+class TestAdvancedRAGOptimizerRerankWeights(unittest.IsolatedAsyncioTestCase):
     """AdvancedRAGOptimizer rerank weights handling. Issue #2034."""
 
     def test_default_weights_are_legacy_split(self):
@@ -66,7 +65,7 @@ class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
         optimizer = AdvancedRAGOptimizer(rerank_weights=weights)
         self.assertIs(optimizer._rerank_weights, weights)
 
-    def test_apply_cross_encoder_scores_uses_stored_weights(self):
+    async def test_apply_cross_encoder_scores_uses_stored_weights(self):
         """_apply_cross_encoder_scores calls compute_blended_score with _rerank_weights."""
         from advanced_rag_optimizer import AdvancedRAGOptimizer
 
@@ -84,13 +83,11 @@ class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
         mock_ce = MagicMock()
         mock_ce.predict.return_value = [ce_score]
         optimizer._cross_encoder = mock_ce
-        asyncio.run(
-            optimizer._apply_cross_encoder_scores("query", [result])
-        )
+        await optimizer._apply_cross_encoder_scores("query", [result])
 
         self.assertAlmostEqual(result.rerank_score, expected, places=6)
 
-    def test_default_weights_produce_legacy_blend(self):
+    async def test_default_weights_produce_legacy_blend(self):
         """Without a custom weights arg the legacy 0.8 CE + 0.2 vector blend is used."""
         from advanced_rag_optimizer import AdvancedRAGOptimizer
 
@@ -104,13 +101,11 @@ class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
         mock_ce = MagicMock()
         mock_ce.predict.return_value = [ce_score]
         optimizer._cross_encoder = mock_ce
-        asyncio.run(
-            optimizer._apply_cross_encoder_scores("query", [result])
-        )
+        await optimizer._apply_cross_encoder_scores("query", [result])
 
         self.assertAlmostEqual(result.rerank_score, expected, places=6)
 
-    def test_edge_and_recency_weights_are_forwarded(self):
+    async def test_edge_and_recency_weights_are_forwarded(self):
         """Non-zero edge and recency weights are respected by compute_blended_score."""
         from advanced_rag_optimizer import AdvancedRAGOptimizer
 
@@ -126,17 +121,15 @@ class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
         mock_ce = MagicMock()
         mock_ce.predict.return_value = [ce_score]
         optimizer._cross_encoder = mock_ce
-        asyncio.run(
-            optimizer._apply_cross_encoder_scores("query", [result])
-        )
+        await optimizer._apply_cross_encoder_scores("query", [result])
 
         self.assertAlmostEqual(result.rerank_score, expected, places=6)
 
 
-class TestRAGServiceForwardsWeights(unittest.TestCase):
+class TestRAGServiceForwardsWeights(unittest.IsolatedAsyncioTestCase):
     """RAGService.initialize() must pass rerank_weights to AdvancedRAGOptimizer."""
 
-    def test_initialize_passes_rerank_weights_to_optimizer(self):
+    async def test_initialize_passes_rerank_weights_to_optimizer(self):
         """RAGService creates AdvancedRAGOptimizer with its config's rerank_weights."""
         from services.rag_config import RAGConfig
         from services.rag_service import RAGService
@@ -157,7 +150,7 @@ class TestRAGServiceForwardsWeights(unittest.TestCase):
             "services.rag_service.AdvancedRAGOptimizer",
             side_effect=lambda **kw: _capture_and_create(kw, captured_weights),
         ):
-            asyncio.run(service.initialize())
+            await service.initialize()
 
         if captured_weights:
             self.assertIs(captured_weights[0], custom_weights)

--- a/autobot-backend/agent_loop/test_loop_repetition.py
+++ b/autobot-backend/agent_loop/test_loop_repetition.py
@@ -11,11 +11,12 @@ Covers issues #3868, #3874, and #3877:
            prevents further iterations even if _should_iterate() does not detect the error.
 """
 
-import asyncio
 import hashlib
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from agent_loop.loop import AgentLoop
 from agent_loop.types import AgentLoopConfig, LoopState, TaskContext
@@ -141,7 +142,8 @@ def test_hash_dict_args_unchanged():
 # ---------------------------------------------------------------------------
 
 
-def test_halted_on_repetition_flag_set():
+@pytest.mark.asyncio
+async def test_halted_on_repetition_flag_set():
     """_execute_tools sets _halted_on_repetition when repetition is detected."""
     loop = _make_loop(max_identical=2)
     tool = _make_tool("bash", {"cmd": "ls"})
@@ -150,7 +152,7 @@ def test_halted_on_repetition_flag_set():
     h = AgentLoop._compute_tool_call_hash(tool)
     loop._current_context.tool_call_hashes[h] = 2  # already at threshold
 
-    result = asyncio.run(loop._execute_tools([tool]))
+    result = await loop._execute_tools([tool])
 
     assert loop._halted_on_repetition is True
     assert "bash" in result
@@ -174,7 +176,8 @@ def test_should_continue_true_before_halt():
     assert loop._should_continue() is True
 
 
-def test_loop_stops_after_repetition_halt():
+@pytest.mark.asyncio
+async def test_loop_stops_after_repetition_halt():
     """Integration: the main loop executes at most one extra iteration after halt fires.
 
     The pattern under test:
@@ -205,16 +208,13 @@ def test_loop_stops_after_repetition_halt():
         call_count += 1
         return [tool]
 
-    async def run():
-        loop._init_task_context("t-halt", "halt test", {})
-        loop._state = LoopState.RUNNING
-        # Patch _select_tools to always return the same tool
-        loop._select_tools = fake_select_tools  # type: ignore[method-assign]
-        # Patch _think_before_tools to no-op
-        loop._think_before_tools = AsyncMock()  # type: ignore[method-assign]
-        return await loop._execute_main_loop()
-
-    results = asyncio.run(run())
+    loop._init_task_context("t-halt", "halt test", {})
+    loop._state = LoopState.RUNNING
+    # Patch _select_tools to always return the same tool
+    loop._select_tools = fake_select_tools  # type: ignore[method-assign]
+    # Patch _think_before_tools to no-op
+    loop._think_before_tools = AsyncMock()  # type: ignore[method-assign]
+    results = await loop._execute_main_loop()
 
     # Halt fires on iteration 2; the loop breaks inside _execute_main_loop
     # because result.should_continue is False (error in tool_results) OR

--- a/autobot-backend/agent_loop/tests/test_first_turn_priming.py
+++ b/autobot-backend/agent_loop/tests/test_first_turn_priming.py
@@ -11,7 +11,7 @@ Covers issue #4563 / feature #4528:
   4. Empty note guard — empty string NOT appended.
 """
 
-import asyncio
+import pytest
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -42,11 +42,7 @@ def _make_loop(first_turn_priming_enabled: bool = True) -> AgentLoop:
     return loop
 
 
-def _run(coro: Any) -> Any:
-    return asyncio.run(coro)
-
-
-def _stub_iteration(loop: AgentLoop, events_context: dict[str, Any]) -> IterationResult:
+async def _stub_iteration(loop: AgentLoop, events_context: dict[str, Any]) -> IterationResult:
     """
     Stub _analyze_events to return *events_context*, stub _select_tools to return
     no tools (causes _execute_iteration_phases to return early after Phase 2).
@@ -56,7 +52,7 @@ def _stub_iteration(loop: AgentLoop, events_context: dict[str, Any]) -> Iteratio
     loop._select_tools = AsyncMock(return_value=[])  # type: ignore[method-assign]
 
     result = IterationResult(iteration_number=1)
-    return _run(loop._execute_iteration_phases(result))
+    return await loop._execute_iteration_phases(result)
 
 
 # ---------------------------------------------------------------------------
@@ -64,7 +60,8 @@ def _stub_iteration(loop: AgentLoop, events_context: dict[str, Any]) -> Iteratio
 # ---------------------------------------------------------------------------
 
 
-def test_first_turn_note_appended_to_task_description():
+@pytest.mark.asyncio
+async def test_first_turn_note_appended_to_task_description():
     """When enabled and first_turn_note is present, it is appended to task_description."""
     loop = _make_loop(first_turn_priming_enabled=True)
     captured: dict[str, Any] = {}
@@ -83,7 +80,7 @@ def test_first_turn_note_appended_to_task_description():
     loop._select_tools = fake_select_tools  # type: ignore[method-assign]
 
     result = IterationResult(iteration_number=1)
-    _run(loop._execute_iteration_phases(result))
+    await loop._execute_iteration_phases(result)
 
     assert "task_description" in captured
     td = captured["task_description"]
@@ -92,7 +89,8 @@ def test_first_turn_note_appended_to_task_description():
     assert td == "Do the thing\n\nNote: This is the first iteration — no tool results exist yet."
 
 
-def test_first_turn_note_used_when_task_description_absent():
+@pytest.mark.asyncio
+async def test_first_turn_note_used_when_task_description_absent():
     """When task_description is absent/empty, the note becomes the full task_description."""
     loop = _make_loop(first_turn_priming_enabled=True)
     captured: dict[str, Any] = {}
@@ -110,7 +108,7 @@ def test_first_turn_note_used_when_task_description_absent():
     loop._select_tools = fake_select_tools  # type: ignore[method-assign]
 
     result = IterationResult(iteration_number=1)
-    _run(loop._execute_iteration_phases(result))
+    await loop._execute_iteration_phases(result)
 
     assert captured.get("task_description") == "First-turn note only."
 
@@ -120,7 +118,8 @@ def test_first_turn_note_used_when_task_description_absent():
 # ---------------------------------------------------------------------------
 
 
-def test_first_turn_note_not_injected_when_disabled():
+@pytest.mark.asyncio
+async def test_first_turn_note_not_injected_when_disabled():
     """When first_turn_priming_enabled=False, note is NOT appended even if present."""
     loop = _make_loop(first_turn_priming_enabled=False)
     captured: dict[str, Any] = {}
@@ -139,7 +138,7 @@ def test_first_turn_note_not_injected_when_disabled():
     loop._select_tools = fake_select_tools  # type: ignore[method-assign]
 
     result = IterationResult(iteration_number=1)
-    _run(loop._execute_iteration_phases(result))
+    await loop._execute_iteration_phases(result)
 
     # task_description must remain unmodified
     assert captured.get("task_description") == "Do the thing"
@@ -152,7 +151,8 @@ def test_first_turn_note_not_injected_when_disabled():
 # ---------------------------------------------------------------------------
 
 
-def test_first_turn_note_absent_from_context_after_pop():
+@pytest.mark.asyncio
+async def test_first_turn_note_absent_from_context_after_pop():
     """first_turn_note is popped from events_context before _select_tools sees it."""
     loop = _make_loop(first_turn_priming_enabled=True)
     captured: dict[str, Any] = {}
@@ -171,13 +171,14 @@ def test_first_turn_note_absent_from_context_after_pop():
     loop._select_tools = fake_select_tools  # type: ignore[method-assign]
 
     result = IterationResult(iteration_number=1)
-    _run(loop._execute_iteration_phases(result))
+    await loop._execute_iteration_phases(result)
 
     # The key must have been popped — _select_tools must not receive it raw.
     assert "first_turn_note" not in captured
 
 
-def test_first_turn_note_not_present_on_second_iteration():
+@pytest.mark.asyncio
+async def test_first_turn_note_not_present_on_second_iteration():
     """_analyze_events does NOT set first_turn_note on iteration 2+.
 
     Simulates what happens when _iteration_count > 1: _analyze_events returns
@@ -201,7 +202,7 @@ def test_first_turn_note_not_present_on_second_iteration():
     loop._select_tools = fake_select_tools  # type: ignore[method-assign]
 
     result = IterationResult(iteration_number=1)
-    _run(loop._execute_iteration_phases(result))
+    await loop._execute_iteration_phases(result)
 
     assert captured.get("task_description") == "Still working"
     assert "first_turn_note" not in captured
@@ -212,7 +213,8 @@ def test_first_turn_note_not_present_on_second_iteration():
 # ---------------------------------------------------------------------------
 
 
-def test_empty_first_turn_note_not_appended():
+@pytest.mark.asyncio
+async def test_empty_first_turn_note_not_appended():
     """When first_turn_note is an empty string, task_description is NOT modified."""
     loop = _make_loop(first_turn_priming_enabled=True)
     captured: dict[str, Any] = {}
@@ -231,7 +233,7 @@ def test_empty_first_turn_note_not_appended():
     loop._select_tools = fake_select_tools  # type: ignore[method-assign]
 
     result = IterationResult(iteration_number=1)
-    _run(loop._execute_iteration_phases(result))
+    await loop._execute_iteration_phases(result)
 
     # task_description must remain unchanged when note is empty
     assert captured.get("task_description") == "Existing description"

--- a/autobot-backend/autobot_memory_graph/semantic_search_test.py
+++ b/autobot-backend/autobot_memory_graph/semantic_search_test.py
@@ -16,13 +16,14 @@ Covers:
 
 from __future__ import annotations
 
-import asyncio
 import math
 import sys
 import types
 from datetime import datetime, timezone
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Bootstrap stub modules so the package can be imported without the full
@@ -303,41 +304,37 @@ class TestProcessQuery:
 
         return proc
 
-    def test_process_query_empty_string_returns_empty(self) -> None:
+    @pytest.mark.asyncio
+    async def test_process_query_empty_string_returns_empty(self) -> None:
         redis_mock = MagicMock()
         proc = MemoryGraphQueryProcessor(redis_client=redis_mock)
-        result = asyncio.run(
-            proc.process_query("")
-        )
+        result = await proc.process_query("")
         assert result == []
 
-    def test_process_query_returns_search_results(self) -> None:
+    @pytest.mark.asyncio
+    async def test_process_query_returns_search_results(self) -> None:
         entities = [
             self._make_entity("Redis Bug Fix", "BUG"),
             self._make_entity("New Feature", "FEATURE"),
         ]
         proc = self._make_processor_with_candidates(entities)
-        results = asyncio.run(
-            proc.process_query("redis bug")
-        )
+        results = await proc.process_query("redis bug")
         assert isinstance(results, list)
         for r in results:
             assert isinstance(r, SearchResult)
 
-    def test_process_query_limit_respected(self) -> None:
+    @pytest.mark.asyncio
+    async def test_process_query_limit_respected(self) -> None:
         entities = [self._make_entity(f"Entity {i}", "TASK") for i in range(20)]
         proc = self._make_processor_with_candidates(entities)
-        results = asyncio.run(
-            proc.process_query("task", limit=3)
-        )
+        results = await proc.process_query("task", limit=3)
         assert len(results) <= 3
 
-    def test_search_result_has_required_fields(self) -> None:
+    @pytest.mark.asyncio
+    async def test_search_result_has_required_fields(self) -> None:
         entities = [self._make_entity("Test Bug", "BUG")]
         proc = self._make_processor_with_candidates(entities)
-        results = asyncio.run(
-            proc.process_query("test bug")
-        )
+        results = await proc.process_query("test bug")
         if results:
             r = results[0]
             assert hasattr(r, "entity")
@@ -366,22 +363,24 @@ class TestProcessQuery:
 
 
 class TestEnsureIndexes:
-    def test_ensure_indexes_calls_ft_create(self) -> None:
+    @pytest.mark.asyncio
+    async def test_ensure_indexes_calls_ft_create(self) -> None:
         redis_mock = AsyncMock()
         # First call to FT.INFO raises (index doesn't exist) → triggers FT.CREATE
         redis_mock.execute_command = AsyncMock(side_effect=Exception("not found"))
 
-        asyncio.run(ensure_indexes(redis_mock))
+        await ensure_indexes(redis_mock)
 
         # Should have been called for both FT.INFO and FT.CREATE per index
         assert redis_mock.execute_command.call_count >= 2
 
-    def test_ensure_indexes_skips_existing(self) -> None:
+    @pytest.mark.asyncio
+    async def test_ensure_indexes_skips_existing(self) -> None:
         redis_mock = AsyncMock()
         # FT.INFO succeeds → index exists → FT.CREATE should NOT be called
         redis_mock.execute_command = AsyncMock(return_value=["some", "info"])
 
-        asyncio.run(ensure_indexes(redis_mock))
+        await ensure_indexes(redis_mock)
 
         calls = [str(c) for c in redis_mock.execute_command.call_args_list]
         assert not any("FT.CREATE" in c for c in calls)

--- a/autobot-backend/chat_workflow/tool_loop_detection_test.py
+++ b/autobot-backend/chat_workflow/tool_loop_detection_test.py
@@ -20,12 +20,13 @@ module level before graph.py is loaded.  The test therefore runs with only
 Python stdlib and pytest installed.
 """
 
-import asyncio
 import importlib.util
 import sys
 import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Stub all missing runtime packages so graph.py can be imported in isolation.
@@ -350,30 +351,34 @@ class TestPrepareLlmResetsLoopState:
         base.update(overrides)
         return base
 
-    def test_loop_count_reset_to_zero(self):
+    @pytest.mark.asyncio
+    async def test_loop_count_reset_to_zero(self):
         """prepare_llm must return tool_loop_count=0 regardless of prior state."""
         state = self._make_state()
         config = self._make_config()
-        result = asyncio.run(prepare_llm(state, config))
+        result = await prepare_llm(state, config)
         assert result.get("tool_loop_count") == 0
 
-    def test_fingerprints_reset_to_empty(self):
+    @pytest.mark.asyncio
+    async def test_fingerprints_reset_to_empty(self):
         """prepare_llm must return tool_call_fingerprints=[] regardless of prior state."""
         state = self._make_state()
         config = self._make_config()
-        result = asyncio.run(prepare_llm(state, config))
+        result = await prepare_llm(state, config)
         assert result.get("tool_call_fingerprints") == []
 
-    def test_loop_warning_reset_to_empty(self):
+    @pytest.mark.asyncio
+    async def test_loop_warning_reset_to_empty(self):
         """prepare_llm must return tool_loop_warning='' regardless of prior state."""
         state = self._make_state()
         config = self._make_config()
-        result = asyncio.run(prepare_llm(state, config))
+        result = await prepare_llm(state, config)
         assert result.get("tool_loop_warning") == ""
 
-    def test_error_state_skips_reset(self):
+    @pytest.mark.asyncio
+    async def test_error_state_skips_reset(self):
         """prepare_llm returns {} when error is set — no KeyError on reset fields."""
         state = self._make_state(error="something failed")
         config = self._make_config()
-        result = asyncio.run(prepare_llm(state, config))
+        result = await prepare_llm(state, config)
         assert result == {}

--- a/autobot-backend/judges/task_outcome_judge_test.py
+++ b/autobot-backend/judges/task_outcome_judge_test.py
@@ -145,16 +145,14 @@ class TestTaskOutcomeJudge:
         # Should not raise
         await judge._persist_outcome("t", "g", "o", "s", result)
 
-    def test_prepare_judgment_prompt_contains_goal(self):
+    @pytest.mark.asyncio
+    async def test_prepare_judgment_prompt_contains_goal(self):
         judge = TaskOutcomeJudge()
-        import asyncio
 
-        prompt = asyncio.run(
-            judge._prepare_judgment_prompt(
-                subject={"goal": "my goal", "output": "my output"},
-                criteria=[],
-                context={"task_type": "test", "goal": "my goal", "strategy_used": "s"},
-            )
+        prompt = await judge._prepare_judgment_prompt(
+            subject={"goal": "my goal", "output": "my output"},
+            criteria=[],
+            context={"task_type": "test", "goal": "my goal", "strategy_used": "s"},
         )
         assert "my goal" in prompt
         assert "ACCURACY" in prompt

--- a/autobot-backend/knowledge/connectors/tier_test.py
+++ b/autobot-backend/knowledge/connectors/tier_test.py
@@ -142,12 +142,11 @@ class TestApiSerialization:
 class TestConnectorTypesEndpoint:
     """/knowledge_base/connector_types enumerates types with tier."""
 
-    def test_endpoint_returns_tier_per_type(self):
-        import asyncio
-
+    @pytest.mark.asyncio
+    async def test_endpoint_returns_tier_per_type(self):
         from api.knowledge_connectors import list_connector_types
 
-        response = asyncio.run(list_connector_types())
+        response = await list_connector_types()
         assert "connector_types" in response
         assert response["total"] == len(response["connector_types"])
 
@@ -161,12 +160,11 @@ class TestConnectorTypesEndpoint:
                 % (connector_type, expected, by_type.get(connector_type))
             )
 
-    def test_endpoint_sorted_by_tier_then_name(self):
-        import asyncio
-
+    @pytest.mark.asyncio
+    async def test_endpoint_sorted_by_tier_then_name(self):
         from api.knowledge_connectors import list_connector_types
 
-        response = asyncio.run(list_connector_types())
+        response = await list_connector_types()
         entries = response["connector_types"]
         keys = [(e["tier"], e["connector_type"]) for e in entries]
         assert keys == sorted(keys)

--- a/autobot-backend/knowledge/pipeline/cognifiers/cognifiers_test.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/cognifiers_test.py
@@ -7,7 +7,6 @@ Unit tests for cognifier _parse_llm_response and conversion logic.
 Issue #1075: Test coverage for knowledge pipeline cognifiers.
 """
 
-import asyncio
 import json
 import sys
 from datetime import datetime
@@ -571,7 +570,8 @@ def _make_context(n_chunks=2, doc_id="doc-1"):
 class TestContextGeneratorDisabled:
     """ContextGeneratorCognifier is a no-op when CONTEXT_ENABLED=false."""
 
-    def test_returns_context_unchanged(self):
+    @pytest.mark.asyncio
+    async def test_returns_context_unchanged(self):
         from knowledge.pipeline.cognifiers.context_generator import (
             ContextGeneratorCognifier,
         )
@@ -579,17 +579,18 @@ class TestContextGeneratorDisabled:
         cog = ContextGeneratorCognifier()
         ctx = _make_context()
         original_contents = [c.content for c in ctx.chunks]
-        result = asyncio.run(cog.process(ctx))
+        result = await cog.process(ctx)
         assert [c.content for c in result.chunks] == original_contents
 
-    def test_empty_chunks_returns_early(self):
+    @pytest.mark.asyncio
+    async def test_empty_chunks_returns_early(self):
         from knowledge.pipeline.cognifiers.context_generator import (
             ContextGeneratorCognifier,
         )
 
         cog = ContextGeneratorCognifier()
         ctx = _make_context(n_chunks=0)
-        result = asyncio.run(cog.process(ctx))
+        result = await cog.process(ctx)
         assert result.chunks == []
 
 
@@ -608,8 +609,9 @@ class TestContextGeneratorEnabled:
         resp.content = text
         return resp
 
+    @pytest.mark.asyncio
     @patch("knowledge.pipeline.cognifiers.context_generator.get_redis_client")
-    def test_enriches_chunks(self, mock_get_redis):
+    async def test_enriches_chunks(self, mock_get_redis):
         from knowledge.pipeline.cognifiers.context_generator import (
             ContextGeneratorCognifier,
         )
@@ -624,7 +626,7 @@ class TestContextGeneratorEnabled:
         )
 
         ctx = _make_context(n_chunks=2)
-        result = asyncio.run(cog.process(ctx))
+        result = await cog.process(ctx)
 
         for chunk in result.chunks:
             assert chunk.metadata["has_context"] is True
@@ -633,17 +635,16 @@ class TestContextGeneratorEnabled:
             assert "context_model" in chunk.metadata
             assert "context_generated_at" in chunk.metadata
 
+    @pytest.mark.asyncio
     @patch("knowledge.pipeline.cognifiers.context_generator.get_redis_client")
-    def test_cache_hit_skips_summary_llm_call(self, mock_get_redis):
-        import json
-
+    async def test_cache_hit_skips_summary_llm_call(self, mock_get_redis):
+        cached_payload = json.dumps(
+            {"summary": "cached summary", "model": "llama3.2:1b"}
+        )
         from knowledge.pipeline.cognifiers.context_generator import (
             ContextGeneratorCognifier,
         )
 
-        cached_payload = json.dumps(
-            {"summary": "cached summary", "model": "llama3.2:1b"}
-        )
         mock_get_redis.return_value = self._mock_redis(cached=cached_payload)
         cog = ContextGeneratorCognifier()
         cog.llm = MagicMock()
@@ -651,12 +652,13 @@ class TestContextGeneratorEnabled:
         cog.llm.chat_completion = AsyncMock(return_value=chunk_resp)
 
         ctx = _make_context(n_chunks=2)
-        asyncio.run(cog.process(ctx))
+        await cog.process(ctx)
 
         assert cog.llm.chat_completion.call_count == 2
 
+    @pytest.mark.asyncio
     @patch("knowledge.pipeline.cognifiers.context_generator.get_redis_client")
-    def test_llm_failure_sets_has_context_false(self, mock_get_redis):
+    async def test_llm_failure_sets_has_context_false(self, mock_get_redis):
         from knowledge.pipeline.cognifiers.context_generator import (
             ContextGeneratorCognifier,
         )
@@ -667,13 +669,14 @@ class TestContextGeneratorEnabled:
         cog.llm.chat_completion = AsyncMock(side_effect=RuntimeError("LLM down"))
 
         ctx = _make_context(n_chunks=1)
-        result = asyncio.run(cog.process(ctx))
+        result = await cog.process(ctx)
 
         assert result.chunks[0].metadata["has_context"] is False
         assert result.chunks[0].metadata["contextual_text"] == ""
 
+    @pytest.mark.asyncio
     @patch("knowledge.pipeline.cognifiers.context_generator.get_redis_client")
-    def test_enriched_content_format(self, mock_get_redis):
+    async def test_enriched_content_format(self, mock_get_redis):
         from knowledge.pipeline.cognifiers.context_generator import (
             ContextGeneratorCognifier,
         )
@@ -690,6 +693,6 @@ class TestContextGeneratorEnabled:
 
         ctx = _make_context(n_chunks=1)
         original = ctx.chunks[0].content
-        result = asyncio.run(cog.process(ctx))
+        result = await cog.process(ctx)
 
         assert result.chunks[0].content == f"ctx sentence\n\n{original}"

--- a/autobot-backend/media/audio/pipeline_test.py
+++ b/autobot-backend/media/audio/pipeline_test.py
@@ -101,17 +101,12 @@ class TestAudioPipelineResults:
 class TestAudioPipelineWhisper:
     """Tests for Whisper transcription path."""
 
-    def test_returns_unavailable_when_transformers_missing(self):
-        import asyncio
-
+    @pytest.mark.asyncio
+    async def test_returns_unavailable_when_transformers_missing(self):
         pipe = AudioPipeline()
-
-        async def _run():
-            media_input = _make_input(b"fake audio")
-            return await pipe._process_audio(media_input)
-
+        media_input = _make_input(b"fake audio")
         with patch("media.audio.pipeline._TRANSFORMERS_AVAILABLE", False):
-            result = asyncio.run(_run())
+            result = await pipe._process_audio(media_input)
         assert result["processing_status"] == "unavailable"
 
     def test_run_whisper_writes_temp_file_and_cleans_up(self):

--- a/autobot-backend/media/link/pipeline_test.py
+++ b/autobot-backend/media/link/pipeline_test.py
@@ -151,16 +151,11 @@ class TestLinkPipelineErrorHandling:
         assert result["processing_status"] == "error"
         assert result["error"] == "Connection refused"
 
-    def test_empty_url_returns_error(self):
+    @pytest.mark.asyncio
+    async def test_empty_url_returns_error(self):
         pipe = LinkPipeline()
-
-        async def _run():
-            media_input = _make_input("")
-            return await pipe._process_link(media_input)
-
-        import asyncio
-
-        result = asyncio.run(_run())
+        media_input = _make_input("")
+        result = await pipe._process_link(media_input)
         assert result["processing_status"] == "error"
 
 

--- a/autobot-backend/orchestration/error_handler_test.py
+++ b/autobot-backend/orchestration/error_handler_test.py
@@ -7,7 +7,6 @@ Tests for Step-level Error Handlers and Workflow Checkpoint Management
 Issue #2154.
 """
 
-import asyncio
 import json
 from typing import Any, Dict
 from unittest.mock import MagicMock
@@ -206,67 +205,57 @@ class TestWorkflowCheckpointManager:
 
 
 class TestStepErrorHandler:
-    def _run(self, coro: Any) -> Any:
-        return asyncio.run(coro)
-
     def _step(self, error_config: Dict[str, Any]) -> Dict[str, Any]:
         return {"id": "step_x", "action": "run", "error_config": error_config}
 
-    def test_abort_by_default(self) -> None:
+    @pytest.mark.asyncio
+    async def test_abort_by_default(self) -> None:
         handler = StepErrorHandler()
         step = {"id": "s1", "action": "run"}
-        outcome = self._run(
-            handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
-        )
+        outcome = await handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
         assert outcome["action"] == StepErrorAction.ABORT
 
-    def test_skip_action(self) -> None:
+    @pytest.mark.asyncio
+    async def test_skip_action(self) -> None:
         handler = StepErrorHandler()
         step = self._step({"action": "skip"})
-        outcome = self._run(
-            handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
-        )
+        outcome = await handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
         assert outcome["action"] == StepErrorAction.SKIP
 
-    def test_retry_below_max(self) -> None:
+    @pytest.mark.asyncio
+    async def test_retry_below_max(self) -> None:
         handler = StepErrorHandler()
         step = self._step({"action": "retry", "max_retries": 3, "base_delay": 0.0})
-        outcome = self._run(
-            handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
-        )
+        outcome = await handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
         assert outcome["action"] == StepErrorAction.RETRY
 
-    def test_retry_exhausted_becomes_abort(self) -> None:
+    @pytest.mark.asyncio
+    async def test_retry_exhausted_becomes_abort(self) -> None:
         handler = StepErrorHandler()
         step = self._step({"action": "retry", "max_retries": 3, "base_delay": 0.0})
-        outcome = self._run(
-            handler.handle_error(step, ValueError("oops"), 3, {"workflow_id": "wf"})
-        )
+        outcome = await handler.handle_error(step, ValueError("oops"), 3, {"workflow_id": "wf"})
         assert outcome["action"] == StepErrorAction.ABORT
 
-    def test_fallback_with_id(self) -> None:
+    @pytest.mark.asyncio
+    async def test_fallback_with_id(self) -> None:
         handler = StepErrorHandler()
         step = self._step({"action": "fallback", "fallback_step_id": "step_b"})
-        outcome = self._run(
-            handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
-        )
+        outcome = await handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
         assert outcome["action"] == StepErrorAction.FALLBACK
         assert outcome["fallback_id"] == "step_b"
 
-    def test_fallback_without_id_becomes_abort(self) -> None:
+    @pytest.mark.asyncio
+    async def test_fallback_without_id_becomes_abort(self) -> None:
         handler = StepErrorHandler()
         step = self._step({"action": "fallback"})
-        outcome = self._run(
-            handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
-        )
+        outcome = await handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
         assert outcome["action"] == StepErrorAction.ABORT
 
-    def test_pause_action(self) -> None:
+    @pytest.mark.asyncio
+    async def test_pause_action(self) -> None:
         handler = StepErrorHandler()
         step = self._step({"action": "pause"})
-        outcome = self._run(
-            handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
-        )
+        outcome = await handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
         assert outcome["action"] == StepErrorAction.PAUSE
 
     def test_exponential_backoff_grows(self) -> None:
@@ -291,14 +280,13 @@ class TestStepErrorHandler:
         assert handler._compute_delay(cfg, 2) == 4.0
         assert handler._compute_delay(cfg, 3) == 6.0
 
-    def test_invalid_error_config_falls_back_to_abort(self) -> None:
+    @pytest.mark.asyncio
+    async def test_invalid_error_config_falls_back_to_abort(self) -> None:
         handler = StepErrorHandler()
         step = {
             "id": "s1",
             "action": "run",
             "error_config": {"action": "invalid_action"},
         }
-        outcome = self._run(
-            handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
-        )
+        outcome = await handler.handle_error(step, ValueError("oops"), 1, {"workflow_id": "wf"})
         assert outcome["action"] == StepErrorAction.ABORT

--- a/autobot-backend/orchestration/execution_modes_test.py
+++ b/autobot-backend/orchestration/execution_modes_test.py
@@ -17,6 +17,8 @@ Covers:
 import asyncio
 import logging
 
+import pytest
+
 from .execution_modes import (
     DebugController,
     DryRunReport,
@@ -228,47 +230,39 @@ class TestDryRunReport:
 
 
 class TestDebugController:
-    def test_resume_signal(self) -> None:
-        async def _run() -> None:
-            ctrl = DebugController()
-            asyncio.get_running_loop().call_soon(
-                lambda: asyncio.ensure_future(ctrl.resume())
-            )
-            signal = await ctrl.wait_for_resume("step_1")
-            assert signal == DebugController.Signal.RESUME
+    @pytest.mark.asyncio
+    async def test_resume_signal(self) -> None:
+        ctrl = DebugController()
+        asyncio.get_running_loop().call_soon(
+            lambda: asyncio.ensure_future(ctrl.resume())
+        )
+        signal = await ctrl.wait_for_resume("step_1")
+        assert signal == DebugController.Signal.RESUME
 
-        asyncio.run(_run())
+    @pytest.mark.asyncio
+    async def test_skip_signal(self) -> None:
+        ctrl = DebugController()
+        asyncio.get_running_loop().call_soon(
+            lambda: asyncio.ensure_future(ctrl.skip())
+        )
+        signal = await ctrl.wait_for_resume("step_1")
+        assert signal == DebugController.Signal.SKIP
 
-    def test_skip_signal(self) -> None:
-        async def _run() -> None:
-            ctrl = DebugController()
-            asyncio.get_running_loop().call_soon(
-                lambda: asyncio.ensure_future(ctrl.skip())
-            )
-            signal = await ctrl.wait_for_resume("step_1")
-            assert signal == DebugController.Signal.SKIP
+    @pytest.mark.asyncio
+    async def test_retry_signal(self) -> None:
+        ctrl = DebugController()
+        asyncio.get_running_loop().call_soon(
+            lambda: asyncio.ensure_future(ctrl.retry())
+        )
+        signal = await ctrl.wait_for_resume("step_1")
+        assert signal == DebugController.Signal.RETRY
 
-        asyncio.run(_run())
-
-    def test_retry_signal(self) -> None:
-        async def _run() -> None:
-            ctrl = DebugController()
-            asyncio.get_running_loop().call_soon(
-                lambda: asyncio.ensure_future(ctrl.retry())
-            )
-            signal = await ctrl.wait_for_resume("step_1")
-            assert signal == DebugController.Signal.RETRY
-
-        asyncio.run(_run())
-
-    def test_stop_returns_resume_immediately(self) -> None:
-        async def _run() -> None:
-            ctrl = DebugController()
-            ctrl.stop()
-            signal = await ctrl.wait_for_resume("step_1")
-            assert signal == DebugController.Signal.RESUME
-
-        asyncio.run(_run())
+    @pytest.mark.asyncio
+    async def test_stop_returns_resume_immediately(self) -> None:
+        ctrl = DebugController()
+        ctrl.stop()
+        signal = await ctrl.wait_for_resume("step_1")
+        assert signal == DebugController.Signal.RESUME
 
     def test_is_active_starts_true(self) -> None:
         ctrl = DebugController()
@@ -286,17 +280,16 @@ class TestDebugController:
 
 
 class TestWorkflowExecutorDryRun:
-    def test_dry_run_returns_report_dict(self) -> None:
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_report_dict(self) -> None:
         executor = _make_executor()
         steps = _make_steps(2)
 
-        result = asyncio.run(
-            executor.execute_coordinated_workflow(
-                "wf_dr_1",
-                steps,
-                context={},
-                mode=ExecutionMode.DRY_RUN,
-            )
+        result = await executor.execute_coordinated_workflow(
+            "wf_dr_1",
+            steps,
+            context={},
+            mode=ExecutionMode.DRY_RUN,
         )
 
         assert result["mode"] == "dry_run"
@@ -306,7 +299,8 @@ class TestWorkflowExecutorDryRun:
         assert "issues" in result
         assert "warnings" in result
 
-    def test_dry_run_does_not_execute_steps(self) -> None:
+    @pytest.mark.asyncio
+    async def test_dry_run_does_not_execute_steps(self) -> None:
         """Verify that DRY_RUN never calls _execute_coordinated_step."""
         executor = _make_executor()
         steps = _make_steps(3)
@@ -320,18 +314,17 @@ class TestWorkflowExecutorDryRun:
 
         executor._execute_coordinated_step = _spy  # type: ignore[method-assign]
 
-        asyncio.run(
-            executor.execute_coordinated_workflow(
-                "wf_dr_spy",
-                steps,
-                context={},
-                mode=ExecutionMode.DRY_RUN,
-            )
+        await executor.execute_coordinated_workflow(
+            "wf_dr_spy",
+            steps,
+            context={},
+            mode=ExecutionMode.DRY_RUN,
         )
 
         assert executed == [], "DRY_RUN must not execute any step"
 
-    def test_dry_run_detects_broken_dependency(self) -> None:
+    @pytest.mark.asyncio
+    async def test_dry_run_detects_broken_dependency(self) -> None:
         executor = _make_executor()
         steps = [
             {
@@ -343,13 +336,11 @@ class TestWorkflowExecutorDryRun:
             },
         ]
 
-        result = asyncio.run(
-            executor.execute_coordinated_workflow(
-                "wf_dr_broken",
-                steps,
-                context={},
-                mode=ExecutionMode.DRY_RUN,
-            )
+        result = await executor.execute_coordinated_workflow(
+            "wf_dr_broken",
+            steps,
+            context={},
+            mode=ExecutionMode.DRY_RUN,
         )
 
         assert result["valid"] is False
@@ -362,35 +353,34 @@ class TestWorkflowExecutorDryRun:
 
 
 class TestWorkflowExecutorDebugMode:
-    def test_debug_mode_skip_marks_step_skipped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_debug_mode_skip_marks_step_skipped(self) -> None:
         """When the controller sends SKIP, the step dict should have status=skipped."""
         executor = _make_executor()
         steps = _make_steps(1)
         ctrl = DebugController()
 
         # Schedule an immediate skip signal so wait_for_resume unblocks right away.
-        async def _run():
-            task = asyncio.ensure_future(
-                executor.execute_coordinated_workflow(
-                    "wf_dbg_skip",
-                    steps,
-                    context={},
-                    mode=ExecutionMode.DEBUG,
-                    debug_controller=ctrl,
-                )
+        task = asyncio.ensure_future(
+            executor.execute_coordinated_workflow(
+                "wf_dbg_skip",
+                steps,
+                context={},
+                mode=ExecutionMode.DEBUG,
+                debug_controller=ctrl,
             )
-            # Let the executor reach wait_for_resume, then fire skip
-            await asyncio.sleep(0)
-            await ctrl.skip()
-            return await task
-
-        result = asyncio.run(_run())
+        )
+        # Let the executor reach wait_for_resume, then fire skip
+        await asyncio.sleep(0)
+        await ctrl.skip()
+        result = await task
 
         # Step was skipped, so it should appear in step_results
         step_id = steps[0]["id"]
         assert result["step_results"][step_id]["skipped"] is True
 
-    def test_debug_mode_without_controller_falls_back_to_normal(self, caplog) -> None:
+    @pytest.mark.asyncio
+    async def test_debug_mode_without_controller_falls_back_to_normal(self, caplog) -> None:
         """DEBUG without a controller logs a warning and falls back to NORMAL execution."""
         executor = _make_executor()
         steps = _make_steps(1)
@@ -398,30 +388,27 @@ class TestWorkflowExecutorDebugMode:
         with caplog.at_level(
             logging.WARNING, logger="autobot-backend.orchestration.workflow_executor"
         ):
-            asyncio.run(
-                executor.execute_coordinated_workflow(
-                    "wf_dbg_no_ctrl",
-                    steps,
-                    context={},
-                    mode=ExecutionMode.DEBUG,
-                    debug_controller=None,
-                )
+            await executor.execute_coordinated_workflow(
+                "wf_dbg_no_ctrl",
+                steps,
+                context={},
+                mode=ExecutionMode.DEBUG,
+                debug_controller=None,
             )
 
         assert any("debug_controller" in r.message.lower() for r in caplog.records)
 
-    def test_normal_mode_unchanged(self) -> None:
+    @pytest.mark.asyncio
+    async def test_normal_mode_unchanged(self) -> None:
         """NORMAL mode must still reach the step executor and produce an execution_context."""
         executor = _make_executor()
         steps = _make_steps(1)
 
-        result = asyncio.run(
-            executor.execute_coordinated_workflow(
-                "wf_normal",
-                steps,
-                context={},
-                mode=ExecutionMode.NORMAL,
-            )
+        result = await executor.execute_coordinated_workflow(
+            "wf_normal",
+            steps,
+            context={},
+            mode=ExecutionMode.NORMAL,
         )
 
         # NORMAL mode should have the standard execution_context keys
@@ -429,7 +416,8 @@ class TestWorkflowExecutorDebugMode:
         assert "step_results" in result
         assert "status" in result
 
-    def test_notification_config_injected_into_execution_context(self) -> None:
+    @pytest.mark.asyncio
+    async def test_notification_config_injected_into_execution_context(self) -> None:
         """Issue #3172: notification_config passed to execute_coordinated_workflow
         must appear in the returned execution_context so _resolve_notification_config
         can locate it and fire notifications.
@@ -438,18 +426,17 @@ class TestWorkflowExecutorDebugMode:
         steps = _make_steps(1)
         cfg = {"workflow_id": "wf_nc", "channels": {}}
 
-        result = asyncio.run(
-            executor.execute_coordinated_workflow(
-                "wf_nc",
-                steps,
-                context={},
-                notification_config=cfg,
-            )
+        result = await executor.execute_coordinated_workflow(
+            "wf_nc",
+            steps,
+            context={},
+            notification_config=cfg,
         )
 
         assert result.get("notification_config") is cfg
 
-    def test_notification_config_defaults_to_none(self) -> None:
+    @pytest.mark.asyncio
+    async def test_notification_config_defaults_to_none(self) -> None:
         """Issue #3172: when notification_config is not supplied the key is
         present in execution_context with value None so the resolver can safely
         call .get() without a KeyError.
@@ -457,18 +444,17 @@ class TestWorkflowExecutorDebugMode:
         executor = _make_executor()
         steps = _make_steps(1)
 
-        result = asyncio.run(
-            executor.execute_coordinated_workflow(
-                "wf_no_nc",
-                steps,
-                context={},
-            )
+        result = await executor.execute_coordinated_workflow(
+            "wf_no_nc",
+            steps,
+            context={},
         )
 
         assert "notification_config" in result
         assert result["notification_config"] is None
 
-    def test_dag_path_fires_send_workflow_notification(self) -> None:
+    @pytest.mark.asyncio
+    async def test_dag_path_fires_send_workflow_notification(self) -> None:
         """Issue #3172: DAG execution path must call _send_workflow_notification.
 
         Before the fix, execute_coordinated_workflow returned early from
@@ -505,14 +491,12 @@ class TestWorkflowExecutorDebugMode:
         with unittest.mock.patch.object(
             executor, "_send_workflow_notification", mock_notify
         ):
-            asyncio.run(
-                executor.execute_coordinated_workflow(
-                    "wf_dag_notif",
-                    steps,
-                    context={},
-                    edges=edges,
-                    notification_config=cfg,
-                )
+            await executor.execute_coordinated_workflow(
+                "wf_dag_notif",
+                steps,
+                context={},
+                edges=edges,
+                notification_config=cfg,
             )
 
         mock_notify.assert_called_once()

--- a/autobot-backend/orchestration/graph_runner_test.py
+++ b/autobot-backend/orchestration/graph_runner_test.py
@@ -18,7 +18,6 @@ Tests cover:
 - NodeRetryConfig delay calculations
 """
 
-import asyncio
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -203,22 +202,23 @@ class TestGraphRunnerLinear:
         builder.add_edge("b", END)
         return builder.compile()
 
-    def test_executes_all_nodes(self, simple_graph):
+    @pytest.mark.asyncio
+    async def test_executes_all_nodes(self, simple_graph):
         runner = GraphRunner(simple_graph, graph_id="test", enable_checkpoints=False)
-        state = asyncio.run(runner.run({}))
+        state = await runner.run({})
         assert state["a_done"] is True
         assert state["b_done"] is True
 
-    def test_state_accumulates(self, simple_graph):
+    @pytest.mark.asyncio
+    async def test_state_accumulates(self, simple_graph):
         runner = GraphRunner(simple_graph, graph_id="test", enable_checkpoints=False)
-        state = asyncio.run(
-            runner.run({"initial": 42})
-        )
+        state = await runner.run({"initial": 42})
         assert state["initial"] == 42
         assert state["a_done"] is True
         assert state["b_done"] is True
 
-    def test_configurable_forwarded(self):
+    @pytest.mark.asyncio
+    async def test_configurable_forwarded(self):
         received_config = {}
 
         async def node_a(state: dict, **kw: Any) -> dict:
@@ -237,7 +237,7 @@ class TestGraphRunnerLinear:
             enable_checkpoints=False,
             configurable={"manager": "mock_manager"},
         )
-        asyncio.run(runner.run({}))
+        await runner.run({})
         assert received_config["manager"] == "mock_manager"
 
 
@@ -271,19 +271,22 @@ class TestGraphRunnerConditional:
         builder.add_edge("false_branch", END)
         return builder.compile()
 
-    def test_routes_to_true_branch(self):
+    @pytest.mark.asyncio
+    async def test_routes_to_true_branch(self):
         graph = self._build_graph("true_branch")
         runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
-        state = asyncio.run(runner.run({}))
+        state = await runner.run({})
         assert state["branch"] == "true"
 
-    def test_routes_to_false_branch(self):
+    @pytest.mark.asyncio
+    async def test_routes_to_false_branch(self):
         graph = self._build_graph("false_branch")
         runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
-        state = asyncio.run(runner.run({}))
+        state = await runner.run({})
         assert state["branch"] == "false"
 
-    def test_async_router(self):
+    @pytest.mark.asyncio
+    async def test_async_router(self):
         builder: AutoBotGraph = AutoBotGraph()
 
         async def node_a(state: dict, **kw: Any) -> dict:
@@ -303,10 +306,11 @@ class TestGraphRunnerConditional:
         graph = builder.compile()
 
         runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
-        state = asyncio.run(runner.run({}))
+        state = await runner.run({})
         assert state["from_async"] is True
 
-    def test_router_returns_end(self):
+    @pytest.mark.asyncio
+    async def test_router_returns_end(self):
         builder: AutoBotGraph = AutoBotGraph()
 
         async def node_a(state: dict, **kw: Any) -> dict:
@@ -318,7 +322,7 @@ class TestGraphRunnerConditional:
         graph = builder.compile()
 
         runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
-        state = asyncio.run(runner.run({}))
+        state = await runner.run({})
         assert state["a"] == 1  # graph terminated cleanly at END
 
 
@@ -328,7 +332,8 @@ class TestGraphRunnerConditional:
 
 
 class TestGraphRunnerRetry:
-    def test_retry_on_transient_error(self):
+    @pytest.mark.asyncio
+    async def test_retry_on_transient_error(self):
         calls: List[int] = []
 
         async def flaky_node(state: dict, **kw: Any) -> dict:
@@ -348,11 +353,12 @@ class TestGraphRunnerRetry:
         graph = builder.compile()
 
         runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
-        state = asyncio.run(runner.run({}))
+        state = await runner.run({})
         assert state["result"] == "ok"
         assert len(calls) == 3
 
-    def test_exhausted_retries_propagate(self):
+    @pytest.mark.asyncio
+    async def test_exhausted_retries_propagate(self):
         async def always_fails(state: dict, **kw: Any) -> dict:
             raise RuntimeError("always fails")
 
@@ -368,9 +374,10 @@ class TestGraphRunnerRetry:
 
         runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
         with pytest.raises(RuntimeError, match="always fails"):
-            asyncio.run(runner.run({}))
+            await runner.run({})
 
-    def test_non_retryable_exception_not_retried(self):
+    @pytest.mark.asyncio
+    async def test_non_retryable_exception_not_retried(self):
         calls: List[int] = []
 
         async def specific_error(state: dict, **kw: Any) -> dict:
@@ -393,7 +400,7 @@ class TestGraphRunnerRetry:
 
         runner = GraphRunner(graph, graph_id="t", enable_checkpoints=False)
         with pytest.raises(ValueError):
-            asyncio.run(runner.run({}))
+            await runner.run({})
         assert len(calls) == 1  # No retry attempted
 
 
@@ -403,7 +410,8 @@ class TestGraphRunnerRetry:
 
 
 class TestStepEventEmitter:
-    def test_sink_receives_events(self):
+    @pytest.mark.asyncio
+    async def test_sink_receives_events(self):
         received: List[GraphStepEvent] = []
 
         async def sink(event: GraphStepEvent) -> None:
@@ -417,11 +425,12 @@ class TestStepEventEmitter:
             node_name="test",
             graph_id="g1",
         )
-        asyncio.run(emitter.emit(event))
+        await emitter.emit(event)
         assert len(received) == 1
         assert received[0].node_name == "test"
 
-    def test_failing_sink_suppressed(self):
+    @pytest.mark.asyncio
+    async def test_failing_sink_suppressed(self):
         async def bad_sink(event: GraphStepEvent) -> None:
             raise RuntimeError("sink failure")
 
@@ -434,9 +443,10 @@ class TestStepEventEmitter:
             graph_id="g",
         )
         # Must not raise.
-        asyncio.run(emitter.emit(event))
+        await emitter.emit(event)
 
-    def test_multiple_sinks(self):
+    @pytest.mark.asyncio
+    async def test_multiple_sinks(self):
         counter: List[int] = []
 
         async def sink_a(e: GraphStepEvent) -> None:
@@ -452,10 +462,11 @@ class TestStepEventEmitter:
         event = GraphStepEvent(
             event_type=StepEventType.NODE_START, node_name="n", graph_id="g"
         )
-        asyncio.run(emitter.emit(event))
+        await emitter.emit(event)
         assert sorted(counter) == [1, 2]
 
-    def test_events_emitted_during_execution(self):
+    @pytest.mark.asyncio
+    async def test_events_emitted_during_execution(self):
         emitted: List[StepEventType] = []
 
         async def sink(event: GraphStepEvent) -> None:
@@ -476,7 +487,7 @@ class TestStepEventEmitter:
         runner = GraphRunner(
             graph, graph_id="t", emitter=emitter, enable_checkpoints=False
         )
-        asyncio.run(runner.run({}))
+        await runner.run({})
 
         assert StepEventType.NODE_START in emitted
         assert StepEventType.NODE_END in emitted
@@ -533,23 +544,23 @@ class TestDAGGraphExecutor:
 
         return step_executor, executed
 
-    def test_linear_execution(self):
+    @pytest.mark.asyncio
+    async def test_linear_execution(self):
         from orchestration.dag_graph_adapter import DAGGraphExecutor
 
         dag = self._build_linear_dag(3)
         step_executor, executed = self._make_step_executor()
 
         executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
-        ctx = asyncio.run(
-            executor.execute(dag, "wf-linear")
-        )
+        ctx = await executor.execute(dag, "wf-linear")
 
         assert ctx.status == "completed"
         assert ctx.error is None
         # All nodes ran.
         assert "s0" in executed or "s0" in ctx.step_results
 
-    def test_empty_dag_returns_failed(self):
+    @pytest.mark.asyncio
+    async def test_empty_dag_returns_failed(self):
         from orchestration.dag_executor import WorkflowDAG
         from orchestration.dag_graph_adapter import DAGGraphExecutor
 
@@ -557,14 +568,13 @@ class TestDAGGraphExecutor:
         step_executor, _ = self._make_step_executor()
 
         executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
-        ctx = asyncio.run(
-            executor.execute(dag, "wf-empty")
-        )
+        ctx = await executor.execute(dag, "wf-empty")
 
         assert ctx.status == "failed"
         assert ctx.error is not None
 
-    def test_cycle_detection(self):
+    @pytest.mark.asyncio
+    async def test_cycle_detection(self):
         from orchestration.dag_executor import WorkflowDAG
         from orchestration.dag_graph_adapter import DAGGraphExecutor
 
@@ -580,30 +590,28 @@ class TestDAGGraphExecutor:
         step_executor, _ = self._make_step_executor()
 
         executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
-        ctx = asyncio.run(
-            executor.execute(dag, "wf-cycle")
-        )
+        ctx = await executor.execute(dag, "wf-cycle")
 
         assert ctx.status == "failed"
         assert "Cycle detected" in (ctx.error or "")
 
-    def test_condition_true_branch(self):
+    @pytest.mark.asyncio
+    async def test_condition_true_branch(self):
         from orchestration.dag_graph_adapter import DAGGraphExecutor
 
         dag = self._build_condition_dag(True)
         step_executor, executed = self._make_step_executor()
 
         executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
-        ctx = asyncio.run(
-            executor.execute(dag, "wf-cond-true")
-        )
+        ctx = await executor.execute(dag, "wf-cond-true")
 
         assert ctx.status == "completed"
         # true_branch should be in step_results; false_branch should be skipped.
         assert "true_branch" in ctx.skipped_nodes or "true_branch" in ctx.step_results
         assert "false_branch" in ctx.skipped_nodes or "false_branch" not in ctx.step_results
 
-    def test_step_results_populated(self):
+    @pytest.mark.asyncio
+    async def test_step_results_populated(self):
         from orchestration.dag_graph_adapter import DAGGraphExecutor
 
         dag = self._build_linear_dag(2)
@@ -615,9 +623,7 @@ class TestDAGGraphExecutor:
         )
 
         executor = DAGGraphExecutor(step_executor_callback=step_executor, enable_checkpoints=False)
-        ctx = asyncio.run(
-            executor.execute(dag, "wf-results")
-        )
+        ctx = await executor.execute(dag, "wf-results")
 
         assert ctx.status == "completed"
         assert ctx.step_results.get("s0", {}).get("output") == "hello"

--- a/autobot-backend/orchestration/workflow_memory_test.py
+++ b/autobot-backend/orchestration/workflow_memory_test.py
@@ -327,7 +327,8 @@ class TestWorkflowMemoryLazyRedis:
 class TestWorkflowMemoryAutoInjection:
     """Verify that _execute_coordinated_step injects shared_memory findings."""
 
-    def test_prior_findings_injected_into_context(self):
+    @pytest.mark.asyncio
+    async def test_prior_findings_injected_into_context(self):
         """When shared_memory has data, it appears in context['prior_agent_findings']."""
         from unittest.mock import AsyncMock, MagicMock
 
@@ -354,16 +355,13 @@ class TestWorkflowMemoryAutoInjection:
         )
         executor._create_agent_interaction = MagicMock(return_value=None)
 
-        import asyncio
-
         with pytest.raises(NotImplementedError):
-            asyncio.run(
-                executor._execute_coordinated_step(step, execution_context, context)
-            )
+            await executor._execute_coordinated_step(step, execution_context, context)
 
         assert context["prior_agent_findings"] == {"step1": "found data"}
 
-    def test_empty_memory_not_injected(self):
+    @pytest.mark.asyncio
+    async def test_empty_memory_not_injected(self):
         """When shared_memory is empty, no prior_agent_findings key is added."""
         from unittest.mock import AsyncMock, MagicMock
 
@@ -388,11 +386,7 @@ class TestWorkflowMemoryAutoInjection:
         )
         executor._create_agent_interaction = MagicMock(return_value=None)
 
-        import asyncio
-
         with pytest.raises(NotImplementedError):
-            asyncio.run(
-                executor._execute_coordinated_step(step, execution_context, context)
-            )
+            await executor._execute_coordinated_step(step, execution_context, context)
 
         assert "prior_agent_findings" not in context

--- a/autobot-backend/skills/builtin/skill_researcher_test.py
+++ b/autobot-backend/skills/builtin/skill_researcher_test.py
@@ -3,8 +3,9 @@
 # Author: mrveiss
 """Tests for SkillResearcherSkill (Issue #1182)."""
 
-import asyncio
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from skills.builtin.skill_researcher import (
     SkillResearcherSkill,
@@ -90,9 +91,10 @@ def test_parse_synthesis_returns_empty_on_malformed_json():
 # ---------------------------------------------------------------------------
 
 
-def test_execute_unknown_action_returns_error():
+@pytest.mark.asyncio
+async def test_execute_unknown_action_returns_error():
     skill = SkillResearcherSkill()
-    result = asyncio.run(skill.execute("nonexistent", {}))
+    result = await skill.execute("nonexistent", {})
     assert result["success"] is False
     assert "Unknown action" in result["error"]
 
@@ -102,17 +104,19 @@ def test_execute_unknown_action_returns_error():
 # ---------------------------------------------------------------------------
 
 
-def test_research_requires_capability():
+@pytest.mark.asyncio
+async def test_research_requires_capability():
     skill = SkillResearcherSkill()
-    result = asyncio.run(skill.execute("research_capability", {}))
+    result = await skill.execute("research_capability", {})
     assert result["success"] is False
     assert "capability" in result["error"].lower()
 
 
-def test_research_fails_gracefully_without_llm():
+@pytest.mark.asyncio
+async def test_research_fails_gracefully_without_llm():
     with patch("skills.builtin.skill_researcher.LLMInterface", None):
         skill = SkillResearcherSkill()
-        result = asyncio.run(skill.execute("research_capability", {"capability": "test"}))
+        result = await skill.execute("research_capability", {"capability": "test"})
     assert result["success"] is False
     assert "LLMInterface" in result["error"]
 
@@ -122,7 +126,8 @@ def test_research_fails_gracefully_without_llm():
 # ---------------------------------------------------------------------------
 
 
-def test_research_returns_structured_findings():
+@pytest.mark.asyncio
+async def test_research_returns_structured_findings():
     source_response = _mock_llm_response("Technical explanation of voice transcription.")
     synthesis_response = _mock_llm_response(
         '{"summary": "Converts speech to text", '
@@ -143,7 +148,7 @@ def test_research_returns_structured_findings():
     with patch("skills.builtin.skill_researcher.LLMInterface") as MockLLM:
         MockLLM.return_value.chat_completion = mock_chat
         skill = SkillResearcherSkill()
-        result = asyncio.run(skill.execute("research_capability", {"capability": "voice transcription"}))
+        result = await skill.execute("research_capability", {"capability": "voice transcription"})
 
     assert result["success"] is True
     assert result["capability"] == "voice transcription"
@@ -157,7 +162,8 @@ def test_research_returns_structured_findings():
 # ---------------------------------------------------------------------------
 
 
-def test_research_continues_when_some_queries_fail():
+@pytest.mark.asyncio
+async def test_research_continues_when_some_queries_fail():
     """One LLM failure does not abort the whole research pipeline."""
     call_count = 0
 
@@ -177,7 +183,7 @@ def test_research_continues_when_some_queries_fail():
     with patch("skills.builtin.skill_researcher.LLMInterface") as MockLLM:
         MockLLM.return_value.chat_completion = mock_chat
         skill = SkillResearcherSkill()
-        result = asyncio.run(skill.execute("research_capability", {"capability": "voice transcription"}))
+        result = await skill.execute("research_capability", {"capability": "voice transcription"})
 
     assert result["success"] is True
     assert result["sources_consulted"] == 2  # one query failed, two succeeded
@@ -188,7 +194,8 @@ def test_research_continues_when_some_queries_fail():
 # ---------------------------------------------------------------------------
 
 
-def test_research_returns_empty_findings_when_synthesis_fails():
+@pytest.mark.asyncio
+async def test_research_returns_empty_findings_when_synthesis_fails():
     """If synthesis LLM call fails, return empty findings (not an error)."""
 
     async def mock_chat(messages, llm_type="task"):
@@ -197,7 +204,7 @@ def test_research_returns_empty_findings_when_synthesis_fails():
     with patch("skills.builtin.skill_researcher.LLMInterface") as MockLLM:
         MockLLM.return_value.chat_completion = mock_chat
         skill = SkillResearcherSkill()
-        result = asyncio.run(skill.execute("research_capability", {"capability": "voice transcription"}))
+        result = await skill.execute("research_capability", {"capability": "voice transcription"})
 
     # sources_consulted == 0 means synthesis returns empty but success=True
     assert result["success"] is True

--- a/autobot-backend/skills/builtin/skill_router_test.py
+++ b/autobot-backend/skills/builtin/skill_router_test.py
@@ -3,8 +3,9 @@
 # Author: mrveiss
 """Tests for SkillRouterSkill (skill-router meta-skill)."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from skills.base_skill import SkillManifest
 from skills.builtin.skill_router import SkillRouterSkill, _score_skill, _tokenize
@@ -89,7 +90,8 @@ def test_score_skill_zero_for_no_match():
     assert score == 0.0
 
 
-def test_llm_rerank_parses_json_response():
+@pytest.mark.asyncio
+async def test_llm_rerank_parses_json_response():
     """_llm_rerank should parse skill name and reason from LLM JSON."""
     mock_response = MagicMock()
     mock_response.content = '{"skill": "document-analysis", "reason": "PDF task"}'
@@ -115,13 +117,14 @@ def test_llm_rerank_parses_json_response():
         instance.chat_completion = AsyncMock(return_value=mock_response)
 
         skill = SkillRouterSkill()
-        name, reason = asyncio.run(skill._llm_rerank("analyze this pdf", candidates))
+        name, reason = await skill._llm_rerank("analyze this pdf", candidates)
 
     assert name == "document-analysis"
     assert reason == "PDF task"
 
 
-def test_llm_rerank_handles_markdown_code_block():
+@pytest.mark.asyncio
+async def test_llm_rerank_handles_markdown_code_block():
     """_llm_rerank should extract JSON from ```json ... ``` blocks."""
     mock_response = MagicMock()
     mock_response.content = '```json\n{"skill": "code-review", "reason": "code task"}\n```'
@@ -136,13 +139,14 @@ def test_llm_rerank_handles_markdown_code_block():
         instance.chat_completion = AsyncMock(return_value=mock_response)
 
         skill = SkillRouterSkill()
-        name, reason = asyncio.run(skill._llm_rerank("review my code", candidates))
+        name, reason = await skill._llm_rerank("review my code", candidates)
 
     assert name == "code-review"
     assert reason == "code task"
 
 
-def test_find_skill_enables_best_match_via_llm():
+@pytest.mark.asyncio
+async def test_find_skill_enables_best_match_via_llm():
     """find_skill should enable the LLM-chosen winner and return it."""
     mock_llm_response = MagicMock()
     mock_llm_response.content = '{"skill": "document-analysis", "reason": "PDF task"}'
@@ -169,7 +173,7 @@ def test_find_skill_enables_best_match_via_llm():
 
         skill = SkillRouterSkill()
         skill.apply_config({"top_k": 5, "auto_enable": True})
-        result = asyncio.run(skill.execute("find_skill", {"task": "analyze this pdf document"}))
+        result = await skill.execute("find_skill", {"task": "analyze this pdf document"})
 
     assert result["success"] is True
     assert result["enabled_skill"] == "document-analysis"
@@ -179,7 +183,8 @@ def test_find_skill_enables_best_match_via_llm():
     mock_registry.enable_skill.assert_called_once_with("document-analysis")
 
 
-def test_find_skill_falls_back_to_keyword_on_llm_error():
+@pytest.mark.asyncio
+async def test_find_skill_falls_back_to_keyword_on_llm_error():
     """If LLM fails, use the top keyword-scored skill."""
     mock_registry = MagicMock()
     mock_registry.list_skills.return_value = [
@@ -202,14 +207,15 @@ def test_find_skill_falls_back_to_keyword_on_llm_error():
 
         skill = SkillRouterSkill()
         skill.apply_config({"top_k": 5, "auto_enable": True})
-        result = asyncio.run(skill.execute("find_skill", {"task": "analyze this pdf document"}))
+        result = await skill.execute("find_skill", {"task": "analyze this pdf document"})
 
     assert result["success"] is True
     assert result["enabled_skill"] == "document-analysis"
     assert result["method"] == "keyword_fallback"
 
 
-def test_find_skill_dry_run_does_not_enable():
+@pytest.mark.asyncio
+async def test_find_skill_dry_run_does_not_enable():
     """dry_run=True should return result without calling enable_skill."""
     mock_llm_response = MagicMock()
     mock_llm_response.content = '{"skill": "document-analysis", "reason": "test"}'
@@ -234,21 +240,23 @@ def test_find_skill_dry_run_does_not_enable():
 
         skill = SkillRouterSkill()
         skill.apply_config({"top_k": 5, "auto_enable": True})
-        result = asyncio.run(skill.execute("find_skill", {"task": "analyze pdf", "dry_run": True}))
+        result = await skill.execute("find_skill", {"task": "analyze pdf", "dry_run": True})
 
     assert result["success"] is True
     mock_registry.enable_skill.assert_not_called()
 
 
-def test_find_skill_requires_task_param():
+@pytest.mark.asyncio
+async def test_find_skill_requires_task_param():
     """find_skill with no task returns error."""
     skill = SkillRouterSkill()
-    result = asyncio.run(skill.execute("find_skill", {}))
+    result = await skill.execute("find_skill", {})
     assert result["success"] is False
     assert "task" in result["error"].lower()
 
 
-def test_find_skill_no_skills_registered():
+@pytest.mark.asyncio
+async def test_find_skill_no_skills_registered():
     """find_skill returns error when registry is empty and no build-skill available."""
     mock_registry = MagicMock()
     mock_registry.list_skills.return_value = []
@@ -256,13 +264,14 @@ def test_find_skill_no_skills_registered():
 
     with patch("skills.builtin.skill_router.get_skill_registry", return_value=mock_registry):
         skill = SkillRouterSkill()
-        result = asyncio.run(skill.execute("find_skill", {"task": "do something"}))
+        result = await skill.execute("find_skill", {"task": "do something"})
 
     assert result["success"] is False
     assert "no skills" in result["error"].lower()
 
 
-def test_find_skill_no_match_delegates_to_autonomous():
+@pytest.mark.asyncio
+async def test_find_skill_no_match_delegates_to_autonomous():
     """When no skill matches the task, delegate to autonomous-skill-development."""
     mock_build_skill = MagicMock()
     mock_build_skill.execute = AsyncMock(
@@ -288,7 +297,7 @@ def test_find_skill_no_match_delegates_to_autonomous():
     with patch("skills.builtin.skill_router.get_skill_registry", return_value=mock_registry):
         skill = SkillRouterSkill()
         skill.apply_config({"top_k": 5, "auto_enable": True})
-        result = asyncio.run(skill.execute("find_skill", {"task": "transcribe this audio file"}))
+        result = await skill.execute("find_skill", {"task": "transcribe this audio file"})
 
     assert result["success"] is True
     assert result["build_triggered"] is True
@@ -302,7 +311,8 @@ def test_find_skill_no_match_delegates_to_autonomous():
     )
 
 
-def test_find_skill_no_match_uses_research_context():
+@pytest.mark.asyncio
+async def test_find_skill_no_match_uses_research_context():
     """Research findings should enrich the capability passed to autonomous-skill-development."""
     mock_researcher = MagicMock()
     mock_researcher.execute = AsyncMock(
@@ -326,7 +336,7 @@ def test_find_skill_no_match_uses_research_context():
     with patch("skills.builtin.skill_router.get_skill_registry", return_value=mock_registry):
         skill = SkillRouterSkill()
         skill.apply_config({"top_k": 5, "auto_enable": True})
-        result = asyncio.run(skill.execute("find_skill", {"task": "voice transcription"}))
+        result = await skill.execute("find_skill", {"task": "voice transcription"})
 
     assert result["success"] is True
     assert result["research_performed"] is True
@@ -336,7 +346,8 @@ def test_find_skill_no_match_uses_research_context():
     assert call_args["context"].get("implementation_hints") == "Use faster-whisper for speed"
 
 
-def test_find_skill_no_match_dry_run_skips_build():
+@pytest.mark.asyncio
+async def test_find_skill_no_match_dry_run_skips_build():
     """dry_run=True with no matching skill returns info without triggering build."""
     mock_registry = MagicMock()
     mock_registry.list_skills.return_value = []
@@ -344,7 +355,7 @@ def test_find_skill_no_match_dry_run_skips_build():
     with patch("skills.builtin.skill_router.get_skill_registry", return_value=mock_registry):
         skill = SkillRouterSkill()
         skill.apply_config({"top_k": 5, "auto_enable": True})
-        result = asyncio.run(skill.execute("find_skill", {"task": "transcribe audio", "dry_run": True}))
+        result = await skill.execute("find_skill", {"task": "transcribe audio", "dry_run": True})
 
     assert result["success"] is True
     assert result["dry_run"] is True

--- a/autobot-backend/tests/agents/test_subagent_spawning.py
+++ b/autobot-backend/tests/agents/test_subagent_spawning.py
@@ -8,7 +8,6 @@ Tests autonomous subagent spawning, parallel execution, failure isolation,
 conflict resolution, and constraint validation.
 """
 
-import asyncio
 import pytest
 from unittest.mock import AsyncMock
 
@@ -114,32 +113,26 @@ class TestSubagentSpawner:
         # Validate constraints at spawner level
         assert len(tasks) <= 5  # MAX_SUBAGENTS_PER_PARENT
 
-    def test_spawn_exceeds_max_subagents(self, spawner):
+    @pytest.mark.asyncio
+    async def test_spawn_exceeds_max_subagents(self, spawner):
         """Test spawning exceeds max subagents constraint."""
         tasks = [
             {"goal": f"Task {i}", "context": {"index": i}} for i in range(6)
         ]
         # This should raise ValueError in spawn_subagents
-        async def test():
-            with pytest.raises(ValueError, match="Cannot spawn 6 subagents"):
-                await spawner.spawn_subagents("parent-1", tasks)
+        with pytest.raises(ValueError, match="Cannot spawn 6 subagents"):
+            await spawner.spawn_subagents("parent-1", tasks)
 
-        asyncio.run(test())
-
-    def test_spawn_exceeds_max_depth(self, spawner):
-
-
+    @pytest.mark.asyncio
+    async def test_spawn_exceeds_max_depth(self, spawner):
         """Test spawning at max depth constraint."""
         tasks = [{"goal": "Task", "context": {}}]
 
-        async def test():
-            # At depth 2 (max), should raise ValueError
-            with pytest.raises(ValueError, match="Cannot spawn subagents at depth"):
-                await spawner.spawn_subagents(
-                    "parent-1", tasks, parent_depth=2
-                )
-
-        asyncio.run(test())
+        # At depth 2 (max), should raise ValueError
+        with pytest.raises(ValueError, match="Cannot spawn subagents at depth"):
+            await spawner.spawn_subagents(
+                "parent-1", tasks, parent_depth=2
+            )
 
     @pytest.mark.asyncio
     async def test_spawn_without_waiting(self):

--- a/autobot-backend/tests/test_mmr_diversity.py
+++ b/autobot-backend/tests/test_mmr_diversity.py
@@ -16,7 +16,6 @@ Acceptance criteria tested:
 - RAGConfig mmr_lambda propagates to rerank_weights.
 """
 
-import asyncio
 import math
 import unittest
 from typing import Any, Dict, List
@@ -284,7 +283,7 @@ class TestRAGConfigMMRLambda(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
-class TestResultRerankerMMRIntegration(unittest.TestCase):
+class TestResultRerankerMMRIntegration(unittest.IsolatedAsyncioTestCase):
     """ResultReranker.rerank applies MMR when mmr_lambda > 0.
 
     These tests patch sentence_transformers in sys.modules so that the
@@ -311,9 +310,6 @@ class TestResultRerankerMMRIntegration(unittest.TestCase):
     def tearDown(self):
         self._st_patcher.stop()
 
-    def _run(self, coro):
-        return asyncio.run(coro)
-
     def _make_results(self) -> List[Dict[str, Any]]:
         emb_a = _unit([1.0, 0.0])
         emb_b = _unit([0.99, 0.14])  # near-duplicate of a
@@ -334,7 +330,7 @@ class TestResultRerankerMMRIntegration(unittest.TestCase):
         reranker._cross_encoder = mock_ce
         return reranker
 
-    def test_mmr_disabled_when_lambda_zero(self):
+    async def test_mmr_disabled_when_lambda_zero(self):
         """With mmr_lambda=0, apply_mmr_reorder is not called."""
         reranker = self._make_reranker_with_mock_ce([2.0, 1.8, 1.0])
         results = self._make_results()
@@ -345,10 +341,10 @@ class TestResultRerankerMMRIntegration(unittest.TestCase):
             "knowledge.search_components.reranking.apply_mmr_reorder",
             wraps=apply_mmr_reorder,
         ) as mock_mmr:
-            self._run(reranker.rerank("query", results, weights=weights))
+            await reranker.rerank("query", results, weights=weights)
             mock_mmr.assert_not_called()
 
-    def test_mmr_applied_when_lambda_positive(self):
+    async def test_mmr_applied_when_lambda_positive(self):
         """With mmr_lambda=0.5, apply_mmr_reorder is called after scoring."""
         reranker = self._make_reranker_with_mock_ce([2.0, 1.9, 0.5])
         results = self._make_results()
@@ -359,7 +355,7 @@ class TestResultRerankerMMRIntegration(unittest.TestCase):
             "knowledge.search_components.reranking.apply_mmr_reorder",
             wraps=apply_mmr_reorder,
         ) as mock_mmr:
-            final = self._run(reranker.rerank("query", results, weights=weights))
+            final = await reranker.rerank("query", results, weights=weights)
             mock_mmr.assert_called_once()
 
         # The diverse doc_c should appear before the near-duplicate doc_b
@@ -369,22 +365,22 @@ class TestResultRerankerMMRIntegration(unittest.TestCase):
         doc_c_pos = contents.index("doc_c")
         self.assertLess(doc_c_pos, doc_b_pos)
 
-    def test_mmr_does_not_drop_results(self):
+    async def test_mmr_does_not_drop_results(self):
         """MMR reorder must not drop any results."""
         reranker = self._make_reranker_with_mock_ce([2.0, 1.9, 0.5])
         results = self._make_results()
 
         weights = RerankWeights(mmr_lambda=0.5)
-        final = self._run(reranker.rerank("query", results, weights=weights))
+        final = await reranker.rerank("query", results, weights=weights)
         self.assertEqual(len(final), len(results))
 
-    def test_top_k_applied_after_mmr(self):
+    async def test_top_k_applied_after_mmr(self):
         """top_k slicing happens after the MMR reorder."""
         reranker = self._make_reranker_with_mock_ce([2.0, 1.9, 0.5])
         results = self._make_results()
 
         weights = RerankWeights(mmr_lambda=0.5)
-        final = self._run(reranker.rerank("query", results, top_k=2, weights=weights))
+        final = await reranker.rerank("query", results, top_k=2, weights=weights)
         self.assertEqual(len(final), 2)
 
 

--- a/autobot-backend/tests/test_rag_rerank_weights.py
+++ b/autobot-backend/tests/test_rag_rerank_weights.py
@@ -13,7 +13,6 @@ optimizer. These tests verify that:
 - The default (no argument) still produces the legacy 0.8/0.2 blend.
 """
 
-import asyncio
 import math
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -36,7 +35,7 @@ def _make_search_result(hybrid_score: float = 0.5, content: str = "test content"
     )
 
 
-class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
+class TestAdvancedRAGOptimizerRerankWeights(unittest.IsolatedAsyncioTestCase):
     """AdvancedRAGOptimizer rerank weights handling. Issue #2034."""
 
     def test_default_weights_are_legacy_split(self):
@@ -55,7 +54,7 @@ class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
         optimizer = AdvancedRAGOptimizer(rerank_weights=weights)
         self.assertIs(optimizer._rerank_weights, weights)
 
-    def test_apply_cross_encoder_scores_uses_stored_weights(self):
+    async def test_apply_cross_encoder_scores_uses_stored_weights(self):
         """_apply_cross_encoder_scores calls compute_blended_score with _rerank_weights."""
         from advanced_rag_optimizer import AdvancedRAGOptimizer
 
@@ -72,11 +71,11 @@ class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
         mock_ce = MagicMock()
         mock_ce.predict.return_value = [ce_score]
         optimizer._cross_encoder = mock_ce
-        asyncio.run(optimizer._apply_cross_encoder_scores("query", [result]))
+        await optimizer._apply_cross_encoder_scores("query", [result])
 
         self.assertAlmostEqual(result.rerank_score, expected, places=6)
 
-    def test_default_weights_produce_legacy_blend(self):
+    async def test_default_weights_produce_legacy_blend(self):
         """Without a custom weights arg the legacy 0.8 CE + 0.2 vector blend is used."""
         from advanced_rag_optimizer import AdvancedRAGOptimizer
 
@@ -90,11 +89,11 @@ class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
         mock_ce = MagicMock()
         mock_ce.predict.return_value = [ce_score]
         optimizer._cross_encoder = mock_ce
-        asyncio.run(optimizer._apply_cross_encoder_scores("query", [result]))
+        await optimizer._apply_cross_encoder_scores("query", [result])
 
         self.assertAlmostEqual(result.rerank_score, expected, places=6)
 
-    def test_edge_and_recency_weights_are_forwarded(self):
+    async def test_edge_and_recency_weights_are_forwarded(self):
         """Non-zero edge and recency weights are respected by compute_blended_score."""
         from advanced_rag_optimizer import AdvancedRAGOptimizer
 
@@ -110,15 +109,15 @@ class TestAdvancedRAGOptimizerRerankWeights(unittest.TestCase):
         mock_ce = MagicMock()
         mock_ce.predict.return_value = [ce_score]
         optimizer._cross_encoder = mock_ce
-        asyncio.run(optimizer._apply_cross_encoder_scores("query", [result]))
+        await optimizer._apply_cross_encoder_scores("query", [result])
 
         self.assertAlmostEqual(result.rerank_score, expected, places=6)
 
 
-class TestRAGServiceForwardsWeights(unittest.TestCase):
+class TestRAGServiceForwardsWeights(unittest.IsolatedAsyncioTestCase):
     """RAGService.initialize() must pass rerank_weights to AdvancedRAGOptimizer."""
 
-    def test_initialize_passes_rerank_weights_to_optimizer(self):
+    async def test_initialize_passes_rerank_weights_to_optimizer(self):
         """RAGService creates AdvancedRAGOptimizer with config's rerank_weights."""
         from services.rag_config import RAGConfig
         from services.rag_service import RAGService
@@ -135,7 +134,7 @@ class TestRAGServiceForwardsWeights(unittest.TestCase):
             "services.rag_service.AdvancedRAGOptimizer",
             side_effect=lambda **kw: _capture_and_create(kw, captured_weights),
         ):
-            asyncio.run(service.initialize())
+            await service.initialize()
 
         if captured_weights:
             self.assertIs(captured_weights[0], custom_weights)

--- a/autobot-backend/tests/test_session_adaptive_reranker.py
+++ b/autobot-backend/tests/test_session_adaptive_reranker.py
@@ -14,7 +14,6 @@ Verifies:
 - Learning-rate clamping keeps weights within [0.1, 0.9].
 """
 
-import asyncio
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -117,7 +116,7 @@ class TestSessionAdaptiveRerankerBasics(unittest.TestCase):
         self.assertIsNot(r1, r2)
 
 
-class TestRAGServiceSessionAdaptation(unittest.TestCase):
+class TestRAGServiceSessionAdaptation(unittest.IsolatedAsyncioTestCase):
     """RAGService session adaptive reranking integration."""
 
     def _make_search_result(
@@ -170,7 +169,7 @@ class TestRAGServiceSessionAdaptation(unittest.TestCase):
         sem, kw = service._session_reranker.get_weights("sess-y")
         self.assertAlmostEqual(sem, config.hybrid_weight_semantic)
 
-    def test_advanced_search_applies_adapted_weights(self):
+    async def test_advanced_search_applies_adapted_weights(self):
         """advanced_search() uses adapted weights from session reranker when feature enabled."""
         from advanced_rag_optimizer import AdvancedRAGOptimizer, RAGMetrics
         from services.rag_config import RAGConfig
@@ -214,9 +213,7 @@ class TestRAGServiceSessionAdaptation(unittest.TestCase):
                 new=AsyncMock(side_effect=lambda coro, timeout: coro),
             ),
         ):
-            asyncio.run(
-                service.advanced_search("test query", session_id="sess-z")
-            )
+            await service.advanced_search("test query", session_id="sess-z")
 
         # The applied weight should have been the adapted one (higher than default).
         if applied_sem_values:

--- a/autobot-backend/utils/error_metrics_test.py
+++ b/autobot-backend/utils/error_metrics_test.py
@@ -4,7 +4,6 @@ Tests for Error Metrics Collection System
 Validates error metrics collection, aggregation, and reporting functionality
 """
 
-import asyncio
 import time
 
 import pytest
@@ -106,9 +105,10 @@ class TestErrorMetrics:
         success = await collector.mark_resolved("nonexistent_trace")
         assert success is False
 
-    def test_get_recent_errors(self, collector):
+    @pytest.mark.asyncio
+    async def test_get_recent_errors(self, collector):
         """Test retrieving recent errors"""
-        asyncio.run(self._populate_errors(collector, count=15))
+        await self._populate_errors(collector, count=15)
 
         recent = collector.get_recent_errors(limit=10)
         assert len(recent) == 10
@@ -117,9 +117,10 @@ class TestErrorMetrics:
         timestamps = [m.timestamp for m in recent]
         assert timestamps == sorted(timestamps, reverse=True)
 
-    def test_component_filtering(self, collector):
+    @pytest.mark.asyncio
+    async def test_component_filtering(self, collector):
         """Test filtering errors by component"""
-        asyncio.run(self._populate_errors_multi_component(collector, component1="comp_a", component2="comp_b"))
+        await self._populate_errors_multi_component(collector, component1="comp_a", component2="comp_b")
 
         comp_a_stats = collector.get_stats(component="comp_a")
         comp_b_stats = collector.get_stats(component="comp_b")
@@ -127,9 +128,10 @@ class TestErrorMetrics:
         assert all(s.component == "comp_a" for s in comp_a_stats)
         assert all(s.component == "comp_b" for s in comp_b_stats)
 
-    def test_error_timeline(self, collector):
+    @pytest.mark.asyncio
+    async def test_error_timeline(self, collector):
         """Test error timeline generation"""
-        asyncio.run(self._populate_errors(collector, count=10))
+        await self._populate_errors(collector, count=10)
 
         timeline = collector.get_error_timeline(hours=24)
         assert isinstance(timeline, dict)
@@ -140,9 +142,10 @@ class TestErrorMetrics:
             assert isinstance(hour_key, str)
             assert isinstance(errors, list)
 
-    def test_category_breakdown(self, collector):
+    @pytest.mark.asyncio
+    async def test_category_breakdown(self, collector):
         """Test error breakdown by category"""
-        asyncio.run(self._populate_errors_multi_category(collector))
+        await self._populate_errors_multi_category(collector)
 
         breakdown = collector.get_category_breakdown()
 
@@ -150,9 +153,10 @@ class TestErrorMetrics:
         assert "validation" in breakdown
         assert all(isinstance(count, int) for count in breakdown.values())
 
-    def test_component_breakdown(self, collector):
+    @pytest.mark.asyncio
+    async def test_component_breakdown(self, collector):
         """Test error breakdown by component"""
-        asyncio.run(self._populate_errors_multi_component(collector))
+        await self._populate_errors_multi_component(collector)
 
         breakdown = collector.get_component_breakdown()
 
@@ -160,9 +164,10 @@ class TestErrorMetrics:
         assert "comp_b" in breakdown
         assert all(isinstance(count, int) for count in breakdown.values())
 
-    def test_top_errors(self, collector):
+    @pytest.mark.asyncio
+    async def test_top_errors(self, collector):
         """Test getting top N errors"""
-        asyncio.run(self._populate_errors_with_varying_counts(collector))
+        await self._populate_errors_with_varying_counts(collector)
 
         top_errors = collector.get_top_errors(limit=3)
 
@@ -171,9 +176,10 @@ class TestErrorMetrics:
         counts = [s.total_count for s in top_errors]
         assert counts == sorted(counts, reverse=True)
 
-    def test_summary(self, collector):
+    @pytest.mark.asyncio
+    async def test_summary(self, collector):
         """Test getting overall summary"""
-        asyncio.run(self._populate_errors(collector, count=20))
+        await self._populate_errors(collector, count=20)
 
         summary = collector.get_summary()
 
@@ -185,22 +191,20 @@ class TestErrorMetrics:
 
         assert summary["total_errors"] >= 20
 
-    def test_alert_threshold(self, collector):
+    @pytest.mark.asyncio
+    async def test_alert_threshold(self, collector):
         """Test setting and checking alert thresholds"""
         collector.set_alert_threshold("test_component", "TEST_001", threshold=5)
 
         # Record errors up to threshold
-        async def record_errors():
-            for i in range(10):
-                await collector.record_error(
-                    error_code="TEST_001",
-                    category=ErrorCategory.SERVER_ERROR,
-                    component="test_component",
-                    function="test_func",
-                    message=f"Test error {i}",
-                )
-
-        asyncio.run(record_errors())
+        for i in range(10):
+            await collector.record_error(
+                error_code="TEST_001",
+                category=ErrorCategory.SERVER_ERROR,
+                component="test_component",
+                function="test_func",
+                message=f"Test error {i}",
+            )
 
         stats = collector.get_stats(component="test_component")
         assert stats[0].total_count == 10


### PR DESCRIPTION
## Summary

Migrated 22 test files from `asyncio.run()` wrappers to native async test patterns:

- Plain pytest functions: added `@pytest.mark.asyncio`, converted to `async def`, replaced `asyncio.run(coro)` with `await coro`
- `unittest.TestCase` subclasses: changed to `unittest.IsolatedAsyncioTestCase`
- `_run(self, coro)` helpers: removed; callers converted to direct `await`
- Inline `async def wrapper() + asyncio.run(wrapper())`: collapsed to inline `await`

**Intentionally skipped:**
- `.e2e_test.py` integration runners with `asyncio.run(main())`
- `__main__` entry points
- `system_benchmarks.performance_test.py` — `asyncio.run()` is inside a sync measurement utility, restructuring would be out of scope

All 22 modified files pass `py_compile` syntax check.

Closes #5435

## Test plan
- [ ] All 22 modified files pass `py_compile`
- [ ] No remaining `asyncio.run(` in test files (except documented exceptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)