### PR TITLE
fix(models): DateTime(timezone=True) + Alembic migration for skills and process_run (#5538)

### DIFF
--- a/autobot-backend/migrations/versions/20260422_018_skills_process_run_timestamptz.py
+++ b/autobot-backend/migrations/versions/20260422_018_skills_process_run_timestamptz.py
@@ -1,0 +1,56 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Convert naive DateTime columns to TIMESTAMPTZ in skills and process_run tables.
+
+skills_packages.created_at, skill_repos.last_synced, skill_approvals.requested_at,
+skill_approvals.reviewed_at, skill_approvals.promoted_at, process_runs.started_at,
+process_runs.completed_at, agent_sessions.expires_at.
+
+Revision ID: 20260422_018
+Revises: 20260324_017
+Issue #5538 — DateTime(timezone=True) for skills and process_run models.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260422_018"
+down_revision: Union[str, None] = "20260324_017"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_COLUMNS = [
+    ("skill_packages", "created_at"),
+    ("skill_packages", "promoted_at"),
+    ("skill_repos", "last_synced"),
+    ("skill_approvals", "requested_at"),
+    ("skill_approvals", "reviewed_at"),
+    ("process_runs", "started_at"),
+    ("process_runs", "completed_at"),
+    ("agent_sessions", "expires_at"),
+]
+
+
+def upgrade() -> None:
+    """Convert naive TIMESTAMP columns to TIMESTAMPTZ. Issue #5538."""
+    for table, column in _COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.DateTime(timezone=True),
+            postgresql_using=f"{column} AT TIME ZONE 'UTC'",
+        )
+
+
+def downgrade() -> None:
+    """Revert TIMESTAMPTZ columns back to naive TIMESTAMP. Issue #5538."""
+    for table, column in _COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.DateTime(timezone=False),
+        )

--- a/autobot-backend/models/process_run.py
+++ b/autobot-backend/models/process_run.py
@@ -52,8 +52,8 @@ class ProcessRun(Base):
     log_excerpt = Column(Text, nullable=True)
     log_path = Column(String(1024), nullable=True)
     timeout_seconds = Column(Integer, nullable=False, default=300)
-    started_at = Column(DateTime, nullable=True)
-    completed_at = Column(DateTime, nullable=True)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
 
     decompositions = relationship(
         "TaskDecomposition",
@@ -113,7 +113,7 @@ class AgentSession(Base):
     task_id = Column(String(255), nullable=False, index=True)
     session_state = Column(JSONB, nullable=True)
     ttl_seconds = Column(Integer, nullable=False, default=3600)
-    expires_at = Column(DateTime, nullable=False, index=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False, index=True)
 
     def __repr__(self) -> str:
         return (

--- a/autobot-backend/skills/models.py
+++ b/autobot-backend/skills/models.py
@@ -58,8 +58,8 @@ class SkillPackage(SkillsBase):
     mcp_pid = Column(Integer, nullable=True)
     gap_reason = Column(Text, nullable=True)
     requested_by = Column(String, default="autobot-self")
-    created_at = Column(DateTime, default=lambda: now_utc())
-    promoted_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: now_utc())
+    promoted_at = Column(DateTime(timezone=True), nullable=True)
 
 
 class SkillRepo(SkillsBase):
@@ -72,7 +72,7 @@ class SkillRepo(SkillsBase):
     repo_type = Column(String, nullable=False)
     auto_sync = Column(Boolean, default=False)
     sync_interval = Column(Integer, default=60)
-    last_synced = Column(DateTime, nullable=True)
+    last_synced = Column(DateTime(timezone=True), nullable=True)
     skill_count = Column(Integer, default=0)
     status = Column(String, default="active")
     error_message = Column(Text, nullable=True)
@@ -85,11 +85,11 @@ class SkillApproval(SkillsBase):
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
     skill_id = Column(String, nullable=False, index=True)
     requested_by = Column(String, nullable=False)
-    requested_at = Column(DateTime, default=lambda: now_utc())
+    requested_at = Column(DateTime(timezone=True), default=lambda: now_utc())
     reason = Column(Text, nullable=False)
     status = Column(String, default="pending")
     reviewed_by = Column(String, nullable=True)
-    reviewed_at = Column(DateTime, nullable=True)
+    reviewed_at = Column(DateTime(timezone=True), nullable=True)
     notes = Column(Text, nullable=True)
     restrictions = Column(JSON, default=dict)
 


### PR DESCRIPTION
## Summary

- **5 columns** in `skills/models.py` (`skill_packages`, `skill_repos`, `skill_approvals`) changed `Column(DateTime,` → `Column(DateTime(timezone=True),`
- **3 columns** in `models/process_run.py` (`process_runs`, `agent_sessions`) changed likewise
- **New Alembic migration** `20260422_018_skills_process_run_timestamptz.py` applies `ALTER TABLE … TYPE TIMESTAMPTZ USING col AT TIME ZONE 'UTC'` for all 8 columns

**Root cause:** `skill_packages.created_at` and `skill_approvals.requested_at` already wrote `now_utc()` (timezone-aware datetimes), but `Column(DateTime)` silently stripped `tzinfo` on insert — causing naive UTC values in DB and potential `TypeError` on naive/aware arithmetic.

Closes #5538

## Test plan
- [ ] `python -m py_compile autobot-backend/skills/models.py autobot-backend/models/process_run.py` — no errors
- [ ] Alembic migration applies cleanly to dev DB without data loss
- [ ] Verify `skill_packages.created_at` and `skill_approvals.requested_at` now store TIMESTAMPTZ values post-insert

🤖 Generated with [Claude Code](https://claude.com/claude-code)