### PR TITLE
refactor(schemas): fix extra=allow on request models; complete inline model migration (#5536 #5537)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -29,7 +29,6 @@ from autobot_shared.time_utils import now_utc, parse_utc_iso
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from pydantic import BaseModel, Field
 from redis.exceptions import RedisError
 
 from auth_middleware import check_admin_permission
@@ -48,6 +47,8 @@ from knowledge.schemas.connectors import (
     ConnectorTestResponse,
     ConnectorTypesResponse,
     ConnectorUpdateResponse,
+    CreateConnectorRequest,
+    UpdateConnectorRequest,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,38 +58,7 @@ router = APIRouter(
     dependencies=[Depends(check_admin_permission)],
 )
 
-# ---------------------------------------------------------------------------
-# Pydantic request / response models
-# ---------------------------------------------------------------------------
-
 _SUPPORTED_TYPES = ["file_server", "web_crawler", "database"]
-
-
-class CreateConnectorRequest(BaseModel):
-    """Request body for POST /connectors."""
-
-    connector_type: str = Field(
-        ..., description="One of: file_server, web_crawler, database"
-    )
-    name: str = Field(..., min_length=1, max_length=128)
-    config: Dict[str, Any] = Field(default_factory=dict)
-    enabled: bool = True
-    verification_mode: str = "collaborative"
-    schedule_cron: Optional[str] = None
-    include_patterns: List[str] = Field(default_factory=list)
-    exclude_patterns: List[str] = Field(default_factory=list)
-
-
-class UpdateConnectorRequest(BaseModel):
-    """Request body for PUT /connectors/{id}."""
-
-    name: Optional[str] = Field(None, min_length=1, max_length=128)
-    config: Optional[Dict[str, Any]] = None
-    enabled: Optional[bool] = None
-    verification_mode: Optional[str] = None
-    schedule_cron: Optional[str] = None
-    include_patterns: Optional[List[str]] = None
-    exclude_patterns: Optional[List[str]] = None
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/api/knowledge_mcp.py
+++ b/autobot-backend/api/knowledge_mcp.py
@@ -17,10 +17,11 @@ import threading
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, Field
-
 from auth_middleware import get_current_user
 from knowledge.schemas.mcp import (
+    DocumentAddRequest,
+    KnowledgeSearchRequest,
+    KnowledgeStatsRequest,
     McpAddDocumentResponse,
     McpHealthResponse,
     McpKnowledgeStatsResponse,
@@ -96,46 +97,16 @@ def _get_chat_ollama():
         return None
 
 
-class MCPTool(BaseModel):
-    """Standard MCP tool definition"""
-
-    name: str
-    description: str
-    input_schema: Metadata
-
-
-class KnowledgeSearchRequest(BaseModel):
-    """Request model for knowledge base search"""
-
-    query: str = Field(..., description="Search query")
-    top_k: int = Field(5, description="Number of results to return")
-    filters: Optional[Metadata] = Field(None, description="Optional filters")
-
-
-class DocumentAddRequest(BaseModel):
-    """Request model for adding documents"""
-
-    content: str = Field(..., description="Document content")
-    metadata: Optional[Metadata] = Field(None, description="Document metadata")
-    source: Optional[str] = Field(None, description="Document source")
-
-
-class KnowledgeStatsRequest(BaseModel):
-    """Request model for knowledge base statistics"""
-
-    include_details: bool = Field(False, description="Include detailed statistics")
-
-
-def _create_search_tool() -> MCPTool:
+def _create_search_tool() -> McpToolsResponse:
     """
     Create MCP tool for knowledge base search.
 
     Issue #665: Extracted from _get_knowledge_search_tools to reduce function length.
 
     Returns:
-        MCPTool definition for search_knowledge_base operation
+        McpToolsResponse definition for search_knowledge_base operation
     """
-    return MCPTool(
+    return McpToolsResponse(
         name="search_knowledge_base",
         description="Search the AutoBot knowledge base using LlamaIndex and Redis vector store",
         input_schema={
@@ -158,16 +129,16 @@ def _create_search_tool() -> MCPTool:
     )
 
 
-def _create_add_document_tool() -> MCPTool:
+def _create_add_document_tool() -> McpToolsResponse:
     """
     Create MCP tool for adding documents to knowledge base.
 
     Issue #665: Extracted from _get_knowledge_search_tools to reduce function length.
 
     Returns:
-        MCPTool definition for add_to_knowledge_base operation
+        McpToolsResponse definition for add_to_knowledge_base operation
     """
-    return MCPTool(
+    return McpToolsResponse(
         name="add_to_knowledge_base",
         description=(
             "Add new information to the AutoBot knowledge base (stored in Redis"
@@ -195,16 +166,16 @@ def _create_add_document_tool() -> MCPTool:
     )
 
 
-def _create_vector_search_tool() -> MCPTool:
+def _create_vector_search_tool() -> McpToolsResponse:
     """
     Create MCP tool for vector similarity search.
 
     Issue #665: Extracted from _get_knowledge_search_tools to reduce function length.
 
     Returns:
-        MCPTool definition for vector_similarity_search operation
+        McpToolsResponse definition for vector_similarity_search operation
     """
-    return MCPTool(
+    return McpToolsResponse(
         name="vector_similarity_search",
         description="Perform vector similarity search in Redis using embeddings",
         input_schema={
@@ -230,16 +201,16 @@ def _create_vector_search_tool() -> MCPTool:
     )
 
 
-def _create_qa_chain_tool() -> MCPTool:
+def _create_qa_chain_tool() -> McpToolsResponse:
     """
     Create MCP tool for LangChain QA chain.
 
     Issue #665: Extracted from _get_knowledge_search_tools to reduce function length.
 
     Returns:
-        MCPTool definition for langchain_qa_chain operation
+        McpToolsResponse definition for langchain_qa_chain operation
     """
-    return MCPTool(
+    return McpToolsResponse(
         name="langchain_qa_chain",
         description="Use LangChain QA chain for comprehensive answers from knowledge base",
         input_schema={
@@ -260,7 +231,7 @@ def _create_qa_chain_tool() -> MCPTool:
     )
 
 
-def _get_knowledge_search_tools() -> List[MCPTool]:
+def _get_knowledge_search_tools() -> List[McpToolsResponse]:
     """
     Get MCP tools for knowledge base search and retrieval operations.
 
@@ -269,7 +240,7 @@ def _get_knowledge_search_tools() -> List[MCPTool]:
     Issue #665: Further refactored to reduce from 102 lines to below 20 lines.
 
     Returns:
-        List of MCPTool definitions for search/retrieval operations
+        List of McpToolsResponse definitions for search/retrieval operations
     """
     return [
         _create_search_tool(),
@@ -279,7 +250,7 @@ def _get_knowledge_search_tools() -> List[MCPTool]:
     ]
 
 
-def _get_knowledge_management_tools() -> List[MCPTool]:
+def _get_knowledge_management_tools() -> List[McpToolsResponse]:
     """
     Get MCP tools for knowledge base management and admin operations.
 
@@ -287,10 +258,10 @@ def _get_knowledge_management_tools() -> List[MCPTool]:
     and improve maintainability of tool definitions by category.
 
     Returns:
-        List of MCPTool definitions for management/admin operations
+        List of McpToolsResponse definitions for management/admin operations
     """
     return [
-        MCPTool(
+        McpToolsResponse(
             name="get_knowledge_stats",
             description="Get statistics about the AutoBot knowledge base and Redis vector store",
             input_schema={
@@ -304,7 +275,7 @@ def _get_knowledge_management_tools() -> List[MCPTool]:
                 },
             },
         ),
-        MCPTool(
+        McpToolsResponse(
             name="summarize_knowledge_topic",
             description="Get a summary of knowledge on a specific topic using LangChain",
             input_schema={
@@ -320,7 +291,7 @@ def _get_knowledge_management_tools() -> List[MCPTool]:
                 "required": ["topic"],
             },
         ),
-        MCPTool(
+        McpToolsResponse(
             name="redis_vector_operations",
             description="Direct Redis vector store operations (advanced)",
             input_schema={
@@ -351,7 +322,7 @@ def _get_knowledge_management_tools() -> List[MCPTool]:
 @router.get("/mcp/tools", response_model=List[McpToolsResponse])
 async def get_mcp_tools(
     current_user: dict = Depends(get_current_user),
-) -> List[MCPTool]:
+) -> List[McpToolsResponse]:
     """Get available MCP tools for knowledge base operations.
 
     Issue #744: Requires authenticated user.

--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -15,72 +15,31 @@ import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field
-
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from constants.threshold_constants import QueryDefaults
 from knowledge.schemas.rag import (
+    AdvancedSearchRequest,
     AdvancedSearchResponse,
     BenchmarkRunResponse,
     EntityHistoryResponse,
     LoopApproveResponse,
     LoopRejectResponse,
     LoopStatusResponse,
+    RAGConfigUpdate,
     RagConfigResponse,
     RagStatsResponse,
+    RerankRequest,
     RerankResultsResponse,
+    RunBenchmarkRequest,
     UpdateRagConfigResponse,
 )
 from knowledge_factory import get_or_create_knowledge_base
 from services.rag_config import get_rag_config, update_rag_config
 from services.rag_service import RAGService
-from type_defs.common import Metadata
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-# ===== PYDANTIC MODELS =====
-
-
-class AdvancedSearchRequest(BaseModel):
-    """Request model for advanced RAG search with reranking"""
-
-    query: str = Field(..., min_length=1, max_length=1000, description="Search query")
-    max_results: int = Field(
-        default=QueryDefaults.RAG_DEFAULT_RESULTS,
-        ge=1,
-        le=50,
-        description="Maximum results",
-    )
-    enable_reranking: bool = Field(
-        default=True, description="Enable cross-encoder reranking"
-    )
-    return_context: bool = Field(
-        default=False, description="Return optimized context for RAG"
-    )
-    timeout: float = Field(default=None, description="Optional timeout in seconds")
-
-
-class RerankRequest(BaseModel):
-    """Request model for reranking existing search results"""
-
-    query: str = Field(
-        ..., min_length=1, max_length=1000, description="Original search query"
-    )
-    results: List[Metadata] = Field(..., description="Search results to rerank")
-
-
-class RAGConfigUpdate(BaseModel):
-    """Request model for updating RAG configuration"""
-
-    hybrid_weight_semantic: float = Field(default=None, ge=0.0, le=1.0)
-    hybrid_weight_keyword: float = Field(default=None, ge=0.0, le=1.0)
-    enable_reranking: bool = Field(default=None)
-    diversity_threshold: float = Field(default=None, ge=0.0, le=1.0)
-    max_results_per_stage: int = Field(default=None, ge=1, le=100)
 
 
 # ===== DEPENDENCY INJECTION =====
@@ -476,24 +435,6 @@ async def get_rag_stats(
         "stats": stats,
         "service_available": True,
     }
-
-
-class RunBenchmarkRequest(BaseModel):
-    """Request body for POST /rag/benchmark/run.
-
-    Issue #5074: callers must declare which split they are benchmarking
-    against so held-out scores are auditable.
-    """
-
-    split: str = Field(
-        ...,
-        description=(
-            "Which portion of the dataset to run: 'dev' (tuning), 'test' "
-            "(held-out final score), or 'all' (combined — not a held-out score)."
-        ),
-        pattern="^(dev|test|all)$",
-    )
-    k: int = Field(default=5, ge=1, le=50, description="Top-k results per query.")
 
 
 @with_error_handling(

--- a/autobot-backend/knowledge/schemas/__init__.py
+++ b/autobot-backend/knowledge/schemas/__init__.py
@@ -91,18 +91,25 @@ from knowledge.schemas.population import (
     TaskStatusResponse,
 )
 from knowledge.schemas.rag import (
+    AdvancedSearchRequest,
     AdvancedSearchResponse,
     BenchmarkRunResponse,
     EntityHistoryResponse,
     LoopApproveResponse,
     LoopRejectResponse,
     LoopStatusResponse,
+    RAGConfigUpdate,
     RagConfigResponse,
     RagStatsResponse,
+    RerankRequest,
     RerankResultsResponse,
+    RunBenchmarkRequest,
     UpdateRagConfigResponse,
 )
 from knowledge.schemas.mcp import (
+    DocumentAddRequest,
+    KnowledgeSearchRequest,
+    KnowledgeStatsRequest,
     McpAddDocumentResponse,
     McpHealthResponse,
     McpKnowledgeStatsResponse,
@@ -140,6 +147,8 @@ from knowledge.schemas.connectors import (
     ConnectorTypeEntry,
     ConnectorTypesResponse,
     ConnectorUpdateResponse,
+    CreateConnectorRequest,
+    UpdateConnectorRequest,
 )
 from knowledge.schemas.vectorization import (
     BackgroundVectorizationResponse,
@@ -221,15 +230,19 @@ __all__ = [
     "DocsWatcherControlResponse",
     "DocsWatcherStatusResponse",
     # rag.py
+    "AdvancedSearchRequest",
     "AdvancedSearchResponse",
     "BenchmarkRunResponse",
     "EntityHistoryResponse",
     "LoopApproveResponse",
     "LoopRejectResponse",
     "LoopStatusResponse",
+    "RAGConfigUpdate",
     "RagConfigResponse",
     "RagStatsResponse",
+    "RerankRequest",
     "RerankResultsResponse",
+    "RunBenchmarkRequest",
     "UpdateRagConfigResponse",
     # search.py
     "EnhancedSearchResponse",
@@ -296,7 +309,12 @@ __all__ = [
     "ConnectorTypeEntry",
     "ConnectorTypesResponse",
     "ConnectorUpdateResponse",
+    "CreateConnectorRequest",
+    "UpdateConnectorRequest",
     # mcp.py
+    "DocumentAddRequest",
+    "KnowledgeSearchRequest",
+    "KnowledgeStatsRequest",
     "McpAddDocumentResponse",
     "McpHealthResponse",
     "McpKnowledgeStatsResponse",

--- a/autobot-backend/knowledge/schemas/connectors.py
+++ b/autobot-backend/knowledge/schemas/connectors.py
@@ -5,7 +5,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ConnectorTypeEntry(BaseModel):
@@ -158,3 +158,28 @@ class ConnectorHistoryResponse(BaseModel):
     connector_id: str
     history: List[ConnectorHistoryEntry]
     total: int
+
+
+class CreateConnectorRequest(BaseModel):
+    """Request body for POST /knowledge_base/connectors."""
+
+    connector_type: str = Field(..., description="One of: file_server, web_crawler, database")
+    name: str = Field(..., min_length=1, max_length=128)
+    config: Dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = True
+    verification_mode: str = "collaborative"
+    schedule_cron: Optional[str] = None
+    include_patterns: List[str] = Field(default_factory=list)
+    exclude_patterns: List[str] = Field(default_factory=list)
+
+
+class UpdateConnectorRequest(BaseModel):
+    """Request body for PUT /knowledge_base/connectors/{id}."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=128)
+    config: Optional[Dict[str, Any]] = None
+    enabled: Optional[bool] = None
+    verification_mode: Optional[str] = None
+    schedule_cron: Optional[str] = None
+    include_patterns: Optional[List[str]] = None
+    exclude_patterns: Optional[List[str]] = None

--- a/autobot-backend/knowledge/schemas/mcp.py
+++ b/autobot-backend/knowledge/schemas/mcp.py
@@ -154,3 +154,25 @@ class RagFeedbackResponse(BaseModel):
     stream_key: Optional[str] = None
     decision: Optional[str] = None
     reason: Optional[str] = None
+
+
+class KnowledgeSearchRequest(BaseModel):
+    """Request body for POST /mcp/search_knowledge_base."""
+
+    query: str = Field(..., description="Search query")
+    top_k: int = Field(5, description="Number of results to return")
+    filters: Optional[Dict[str, Any]] = Field(None, description="Optional filters")
+
+
+class DocumentAddRequest(BaseModel):
+    """Request body for POST /mcp/add_to_knowledge_base."""
+
+    content: str = Field(..., description="Document content")
+    metadata: Optional[Dict[str, Any]] = Field(None, description="Document metadata")
+    source: Optional[str] = Field(None, description="Document source")
+
+
+class KnowledgeStatsRequest(BaseModel):
+    """Request body for POST /mcp/get_knowledge_stats."""
+
+    include_details: bool = Field(False, description="Include detailed statistics")

--- a/autobot-backend/knowledge/schemas/rag.py
+++ b/autobot-backend/knowledge/schemas/rag.py
@@ -121,3 +121,41 @@ class EntityHistoryResponse(BaseModel):
     entity_id: str = ""
     versions: List[Dict[str, Any]] = Field(default_factory=list)
     count: int = 0
+
+
+class AdvancedSearchRequest(BaseModel):
+    """Request body for POST /rag/advanced_search."""
+
+    query: str = Field(..., min_length=1, max_length=1000, description="Search query")
+    max_results: int = Field(default=5, ge=1, le=50, description="Maximum results")
+    enable_reranking: bool = Field(default=True, description="Enable cross-encoder reranking")
+    return_context: bool = Field(default=False, description="Return optimized context for RAG")
+    timeout: Optional[float] = Field(default=None, description="Optional timeout in seconds")
+
+
+class RerankRequest(BaseModel):
+    """Request body for POST /rag/rerank."""
+
+    query: str = Field(..., min_length=1, max_length=1000, description="Original search query")
+    results: List[Dict[str, Any]] = Field(..., description="Search results to rerank")
+
+
+class RAGConfigUpdate(BaseModel):
+    """Request body for PUT /rag/config."""
+
+    hybrid_weight_semantic: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    hybrid_weight_keyword: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    enable_reranking: Optional[bool] = Field(default=None)
+    diversity_threshold: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    max_results_per_stage: Optional[int] = Field(default=None, ge=1, le=100)
+
+
+class RunBenchmarkRequest(BaseModel):
+    """Request body for POST /rag/benchmark/run (#5074)."""
+
+    split: str = Field(
+        ...,
+        description="Which portion to benchmark: 'dev', 'test', or 'all'.",
+        pattern="^(dev|test|all)$",
+    )
+    k: int = Field(default=5, ge=1, le=50, description="Top-k results per query.")

--- a/autobot-backend/knowledge/schemas/vectorization.py
+++ b/autobot-backend/knowledge/schemas/vectorization.py
@@ -175,8 +175,6 @@ class ReindexWithContextStatusResponse(BaseModel):
 class BatchVectorizeRequest(BaseModel):
     """Request model for POST /vectorize_documents (#2077)."""
 
-    model_config = ConfigDict(extra="allow")
-
     document_ids: List[str] = Field(
         ...,
         min_length=1,
@@ -198,8 +196,6 @@ class BatchVectorizeRequest(BaseModel):
 
 class ReindexWithContextRequest(BaseModel):
     """Request model for POST /reindex_with_context (#1513)."""
-
-    model_config = ConfigDict(extra="allow")
 
     collection_name: Optional[str] = Field(
         default=None,


### PR DESCRIPTION
Closes #5536
Closes #5537

## Changes

### Fix #5536 — Remove `ConfigDict(extra="allow")` from request schemas
- `BatchVectorizeRequest` and `ReindexWithContextRequest` in `knowledge/schemas/vectorization.py` had `extra="allow"` (wrong for request models — pydantic v2 default `extra="ignore"` is correct)
- Removed `model_config` lines; restores original behavior

### Fix #5537 — Complete inline request model migration
Migrated all remaining inline `BaseModel` subclasses from 3 KB API files to their matching schema modules:

| API file | Classes moved | Schema file |
|---|---|---|
| `api/knowledge_connectors.py` | `CreateConnectorRequest`, `UpdateConnectorRequest` | `knowledge/schemas/connectors.py` |
| `api/knowledge_rag.py` | `AdvancedSearchRequest`, `RerankRequest`, `RAGConfigUpdate`, `RunBenchmarkRequest` | `knowledge/schemas/rag.py` |
| `api/knowledge_mcp.py` | `MCPTool` → replaced by `McpToolsResponse` (identical shape, eliminates duplicate); `KnowledgeSearchRequest`, `DocumentAddRequest`, `KnowledgeStatsRequest` | `knowledge/schemas/mcp.py` |

All three API files had `from pydantic import BaseModel, Field` removed after migration. `Metadata` import retained in `knowledge_mcp.py` (still used on 4 route handler parameters).

## Verification

```
python3 -m py_compile knowledge/schemas/vectorization.py  # OK
python3 -m py_compile knowledge/schemas/connectors.py     # OK
python3 -m py_compile knowledge/schemas/rag.py            # OK
python3 -m py_compile knowledge/schemas/mcp.py            # OK
python3 -m py_compile knowledge/schemas/__init__.py       # OK
python3 -m py_compile api/knowledge_connectors.py         # OK
python3 -m py_compile api/knowledge_rag.py                # OK
python3 -m py_compile api/knowledge_mcp.py                # OK
```