### PR TITLE
refactor(utils): add arg-guard to lazy_singleton — raise on mismatched non-first-call args (#5445)

### DIFF
--- a/autobot_shared/singleton_factory.py
+++ b/autobot_shared/singleton_factory.py
@@ -18,16 +18,30 @@ def lazy_singleton(factory: Callable[..., T]) -> Callable[..., T]:
 
     Uses double-checked locking so the common (already-initialised) path
     never acquires the lock.
+
+    Raises RuntimeError if called again with different args than the first
+    call, to prevent silent mis-configuration.
     """
     instance: Optional[T] = None
     lock = Lock()
+    _first_args: Optional[tuple] = None
+    _first_kwargs: Optional[dict] = None
 
     def get(*args, **kwargs) -> T:
-        nonlocal instance
+        nonlocal instance, _first_args, _first_kwargs
         if instance is None:
             with lock:
                 if instance is None:
                     instance = factory(*args, **kwargs)
+                    _first_args = args
+                    _first_kwargs = dict(kwargs)
+        elif args or kwargs:
+            if args != _first_args or kwargs != _first_kwargs:
+                raise RuntimeError(
+                    f"lazy_singleton: called with different args after first construction. "
+                    f"First: args={_first_args!r}, kwargs={_first_kwargs!r}. "
+                    f"Now: args={args!r}, kwargs={kwargs!r}."
+                )
         return instance
 
     return get


### PR DESCRIPTION
## Summary

Updates `autobot_shared/singleton_factory.py` to record the args/kwargs from the first construction call and raise `RuntimeError` if a subsequent call passes **different** args — implementing Option B (fail loudly).

**Before:** silent ignore on non-first-call args  
**After:** `RuntimeError: lazy_singleton: called with different args after first construction. First: args=..., kwargs=.... Now: args=..., kwargs=....`

**Callers verified:** All three chunker factory call sites (`get_semantic_chunker()`, `get_gpu_semantic_chunker()`, `get_optimized_semantic_chunker()`) pass zero arguments — guard will not fire in normal operation.

Closes #5445

## Test plan
- [ ] `py_compile autobot_shared/singleton_factory.py` passes
- [ ] `test_singleton_factory_caches` in `semantic_chunker_gpu_optimized_test.py` still passes (zero-arg calls)
- [ ] No production caller passes args to chunker factories

🤖 Generated with [Claude Code](https://claude.com/claude-code)