### PR TITLE
a11y(ChatSidebar): remove duplicate chatHistory label from mobile header (#5456)

### DIFF
--- a/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
+++ b/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
@@ -238,12 +238,10 @@ describe('ChatInterface', () => {
 
       // i18n keys render as-is since test i18n has empty messages
       await waitFor(() => {
-        // #5366: ChatSidebar renders the label twice (mobile + desktop
-        // variants) — both present in jsdom because CSS media queries
-        // (`lg:hidden` / `hidden lg:flex`) don't apply. Use getAllByText
-        // so the assertion succeeds regardless of which variant the
-        // viewport reports.
-        expect(screen.getAllByText('chat.sidebar.chatHistory').length).toBeGreaterThan(0)
+        // #5456: ChatSidebar's mobile header no longer duplicates the
+        // chatHistory label (moved to h3-only), so getByText matches
+        // exactly once.
+        expect(screen.getByText('chat.sidebar.chatHistory')).toBeInTheDocument()
       })
       expect(screen.getByLabelText('chat.sidebar.createNew')).toBeInTheDocument()
       expect(screen.getByLabelText('chat.sidebar.resetChat')).toBeInTheDocument()
@@ -255,12 +253,10 @@ describe('ChatInterface', () => {
       renderComponent(ChatInterface, { pinia: true })
 
       await waitFor(() => {
-        // #5366: ChatSidebar renders the label twice (mobile + desktop
-        // variants) — both present in jsdom because CSS media queries
-        // (`lg:hidden` / `hidden lg:flex`) don't apply. Use getAllByText
-        // so the assertion succeeds regardless of which variant the
-        // viewport reports.
-        expect(screen.getAllByText('chat.sidebar.chatHistory').length).toBeGreaterThan(0)
+        // #5456: ChatSidebar's mobile header no longer duplicates the
+        // chatHistory label (moved to h3-only), so getByText matches
+        // exactly once.
+        expect(screen.getByText('chat.sidebar.chatHistory')).toBeInTheDocument()
       })
 
       // The collapse button aria-label depends on sidebarCollapsed state
@@ -533,12 +529,10 @@ describe('ChatInterface', () => {
 
       await waitFor(() => {
         // Should handle empty state - sidebar title still renders
-        // #5366: ChatSidebar renders the label twice (mobile + desktop
-        // variants) — both present in jsdom because CSS media queries
-        // (`lg:hidden` / `hidden lg:flex`) don't apply. Use getAllByText
-        // so the assertion succeeds regardless of which variant the
-        // viewport reports.
-        expect(screen.getAllByText('chat.sidebar.chatHistory').length).toBeGreaterThan(0)
+        // #5456: ChatSidebar's mobile header no longer duplicates the
+        // chatHistory label (moved to h3-only), so getByText matches
+        // exactly once.
+        expect(screen.getByText('chat.sidebar.chatHistory')).toBeInTheDocument()
       })
     })
   })

--- a/autobot-frontend/src/components/chat/ChatSidebar.vue
+++ b/autobot-frontend/src/components/chat/ChatSidebar.vue
@@ -13,9 +13,17 @@
       >
         <i :class="store.sidebarCollapsed ? 'fas fa-chevron-right' : 'fas fa-chevron-left'"></i>
       </BaseButton>
-      <!-- Mobile header: title + close button -->
-      <div class="lg:hidden flex items-center justify-between w-full px-3 py-2">
-        <span class="text-sm font-semibold text-autobot-text-primary">{{ $t('chat.sidebar.chatHistory') }}</span>
+      <!--
+        Mobile header: close button only.
+
+        #5456: previously also rendered a `<span>{{ chatHistory }}</span>`
+        title which duplicated the `<h3>` below on L36 — in the DOM at
+        all viewports (CSS media queries don't hide the subtree from
+        jsdom / a11y readers in every case). The `<h3>` serves as the
+        single accessible section heading; the mobile header keeps just
+        the close button, which already has an `aria-label`.
+      -->
+      <div class="lg:hidden flex items-center justify-end w-full px-3 py-2">
         <BaseButton
           variant="ghost"
           class="p-2 text-autobot-text-secondary"


### PR DESCRIPTION
## Summary

#5366 worked around the test-level symptom by switching \`getByText\` → \`getAllByText\`, but the component bug remained: \`ChatSidebar\` renders \"chat.sidebar.chatHistory\" twice — once in the mobile header span and once in the desktop \`<h3>\`. Screen readers announce the label twice.

**Fix:** remove the text from the mobile header. The \`<h3>\` inside the content section remains the single accessible section heading; the mobile header keeps just the close button (which already has its own \`aria-label\`).

Also restores \`getByText\` in \`ChatInterface.test.ts\` (3 assertions) — the duplicate that made \`getAllByText\` necessary is gone.

Closes #5456.

## Verification

- \`ChatInterface.test.ts\`: 23/23 pass with strict \`getByText\`.
- \`vue-tsc\` baseline unchanged (167 errors, 0 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)