### PR TITLE
refactor(frontend): migrate 5 single-key expand toggles to useExpansion (#5521)

### DIFF
--- a/autobot-frontend/src/components/agents/HeartbeatPanel.vue
+++ b/autobot-frontend/src/components/agents/HeartbeatPanel.vue
@@ -125,9 +125,9 @@
               <td class="mono">
                 {{ run.cost_usd != null ? '$' + run.cost_usd.toFixed(4) : '—' }}
               </td>
-              <td class="chevron">{{ expandedRunId === run.id ? '▲' : '▼' }}</td>
+              <td class="chevron">{{ isRunExpanded(run.id) ? '▲' : '▼' }}</td>
             </tr>
-            <tr v-if="expandedRunId && expandedRun" class="events-row">
+            <tr v-if="expandedRun" class="events-row">
               <td colspan="7">
                 <div class="events-container">
                   <div v-if="expandedRun.error_message" class="error-message">
@@ -155,6 +155,7 @@ import { computed, onUnmounted, ref, watch } from 'vue'
 import { getBackendUrl } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { useLiveEvents } from '@/composables/useLiveEvents'
+import { useExpansion } from '@/composables/useExpansion'
 import type { LiveEvent } from '@/services/LiveEventService'
 
 const logger = createLogger('HeartbeatPanel')
@@ -221,8 +222,8 @@ const pendingWakeups = ref<WakeupRequest[]>([])
 const editEnabled = ref(false)
 const editInterval = ref(300)
 const editMaxDuration = ref(600)
-const expandedRunId = ref<string | null>(null)
-const expandedRun = computed(() => runs.value.find((r) => r.id === expandedRunId.value) ?? null)
+const { isExpanded: isRunExpanded, expand: expandRun, collapseAll: collapseAllRuns } = useExpansion<string>()
+const expandedRun = computed(() => runs.value.find((r) => isRunExpanded(r.id)) ?? null)
 
 // ── Live event subscription ───────────────────────────────────────────────────
 
@@ -365,7 +366,9 @@ async function queueWakeup(): Promise<void> {
 }
 
 function toggleEvents(runId: string): void {
-  expandedRunId.value = expandedRunId.value === runId ? null : runId
+  const wasExpanded = isRunExpanded(runId)
+  collapseAllRuns()
+  if (!wasExpanded) expandRun(runId)
 }
 
 function formatTime(iso: string | null): string {

--- a/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LLMPatternDashboard.vue
@@ -149,9 +149,9 @@
                   <span>{{ $t('analytics.llmPatterns.promptsAffected', { count: rec.affected_prompts }) }}</span>
                 </div>
                 <button class="expand-btn" @click="toggleSteps(rec.type)">
-                  {{ expandedRec === rec.type ? $t('analytics.llmPatterns.hideSteps') : $t('analytics.llmPatterns.showSteps') }}
+                  {{ isRecExpanded(rec.type) ? $t('analytics.llmPatterns.hideSteps') : $t('analytics.llmPatterns.showSteps') }}
                 </button>
-                <div v-if="expandedRec === rec.type" class="rec-steps">
+                <div v-if="isRecExpanded(rec.type)" class="rec-steps">
                   <ol>
                     <li v-for="(step, idx) in rec.implementation_steps" :key="idx">
                       {{ step }}
@@ -327,6 +327,7 @@ import { ref, computed, onMounted } from 'vue'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { useExpansion } from '@/composables/useExpansion'
 
 const logger = createLogger('LLMPatternDashboard')
 
@@ -408,7 +409,7 @@ const cacheOpportunities = ref<CacheOpportunity[]>([])
 const analyzePrompt = ref('')
 const analyzeModel = ref('')
 const analysisResult = ref<AnalysisResult | null>(null)
-const expandedRec = ref<string | null>(null)
+const { isExpanded: isRecExpanded, expand: expandRec, collapseAll: collapseAllRecs } = useExpansion<string>()
 
 // Chart configuration
 const chartWidth = 800
@@ -480,7 +481,9 @@ const getModelBarWidth = (model: ModelData): number => {
 }
 
 const toggleSteps = (type: string) => {
-  expandedRec.value = expandedRec.value === type ? null : type
+  const wasExpanded = isRecExpanded(type)
+  collapseAllRecs()
+  if (!wasExpanded) expandRec(type)
 }
 
 // API Calls

--- a/autobot-frontend/src/components/autoresearch/PromptOptimizerPanel.vue
+++ b/autobot-frontend/src/components/autoresearch/PromptOptimizerPanel.vue
@@ -4,6 +4,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import type { OptimizationSession, PromptVariant } from '@/composables/useAutoResearch'
+import { useExpansion } from '@/composables/useExpansion'
 
 defineProps<{
   session: OptimizationSession | null
@@ -20,7 +21,7 @@ const agentName = ref('autoresearch_hypothesis')
 const maxRounds = ref(3)
 const reviewScore = ref(5)
 const reviewComment = ref('')
-const reviewingVariantId = ref<string | null>(null)
+const { isExpanded: isReviewing, expand: startReview, collapseAll: closeAllReviews } = useExpansion<string>()
 
 function handleStart() {
   emit('start', agentName.value, maxRounds.value)
@@ -28,7 +29,7 @@ function handleStart() {
 
 function submitScore(variantId: string) {
   emit('scoreVariant', variantId, reviewScore.value, reviewComment.value)
-  reviewingVariantId.value = null
+  closeAllReviews()
   reviewScore.value = 5
   reviewComment.value = ''
 }
@@ -102,7 +103,7 @@ function submitScore(variantId: string) {
         </p>
 
         <!-- Human review form -->
-        <div v-if="reviewingVariantId === variant.id" class="mt-2 flex items-end gap-2">
+        <div v-if="isReviewing(variant.id)" class="mt-2 flex items-end gap-2">
           <input
             v-model.number="reviewScore"
             type="number"
@@ -125,7 +126,7 @@ function submitScore(variantId: string) {
         <button
           v-else
           class="mt-1 text-xs text-blue-600 hover:underline dark:text-blue-400"
-          @click="reviewingVariantId = variant.id"
+          @click="startReview(variant.id)"
         >
           Review
         </button>

--- a/autobot-frontend/src/components/collaboration/ParticipantList.vue
+++ b/autobot-frontend/src/components/collaboration/ParticipantList.vue
@@ -16,6 +16,7 @@ import { useI18n } from 'vue-i18n'
 import { useSessionCollaboration, type UserPresence } from '@/composables/useSessionCollaboration'
 import { useChatStore } from '@/stores/useChatStore'
 import { useVirtualList } from '@/composables/useVirtualList'
+import { useExpansion } from '@/composables/useExpansion'
 import { apiService, type ParticipantResponse } from '@/services/api'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -40,7 +41,7 @@ const emit = defineEmits<{
 }>()
 
 // Local state
-const showRoleMenu = ref<string | null>(null)
+const { isExpanded: isRoleMenuOpen, expand: openRoleMenu, collapseAll: closeAllRoleMenus } = useExpansion<string>()
 const removingUserId = ref<string | null>(null)
 const isLoadingParticipants = ref(false)
 const participantRoles = ref<Map<string, ParticipantResponse>>(new Map())
@@ -140,13 +141,15 @@ const getInitials = (username: string): string => {
 // Toggle role menu
 const toggleRoleMenu = (userId: string) => {
   if (!props.allowManagement || !isOwner.value) return
-  showRoleMenu.value = showRoleMenu.value === userId ? null : userId
+  const wasOpen = isRoleMenuOpen(userId)
+  closeAllRoleMenus()
+  if (!wasOpen) openRoleMenu(userId)
 }
 
 // Change participant role
 const changeRole = (userId: string, newRole: 'owner' | 'collaborator' | 'viewer') => {
   emit('changeRole', userId, newRole)
-  showRoleMenu.value = null
+  closeAllRoleMenus()
 }
 
 // Remove participant
@@ -327,7 +330,7 @@ watch(
 
               <!-- Role menu dropdown -->
               <div
-                v-if="showRoleMenu === virtualItem.data.userId"
+                v-if="isRoleMenuOpen(virtualItem.data.userId)"
                 class="mt-2 bg-autobot-bg-secondary border border-autobot-border rounded-lg shadow-lg overflow-hidden"
                 role="menu"
               >

--- a/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeUpload.vue
@@ -232,7 +232,7 @@
                 :key="fileItem.id"
                 class="file-item"
                 :class="{
-                  'expanded': expandedFileId === fileItem.id,
+                  'expanded': isFileExpanded(fileItem.id),
                   'uploading': fileItem.status === 'uploading',
                   'completed': fileItem.status === 'completed',
                   'failed': fileItem.status === 'failed'
@@ -265,11 +265,11 @@
                     <button
                       v-if="fileItem.previewAvailable"
                       class="preview-toggle-btn"
-                      :class="{ 'active': expandedFileId === fileItem.id }"
+                      :class="{ 'active': isFileExpanded(fileItem.id) }"
                       @click.stop="toggleFilePreview(fileItem.id)"
                       :title="$t('knowledge.upload.previewContentTitle')"
                     >
-                      <i :class="expandedFileId === fileItem.id ? 'fas fa-chevron-up' : 'fas fa-eye'"></i>
+                      <i :class="isFileExpanded(fileItem.id) ? 'fas fa-chevron-up' : 'fas fa-eye'"></i>
                     </button>
                     <button
                       class="remove-file-btn"
@@ -304,7 +304,7 @@
 
                 <!-- File Preview Panel -->
                 <Transition name="slide">
-                  <div v-if="expandedFileId === fileItem.id && fileItem.preview" class="file-preview">
+                  <div v-if="isFileExpanded(fileItem.id) && fileItem.preview" class="file-preview">
                     <div class="preview-header">
                       <span class="preview-label">{{ $t('knowledge.upload.contentPreview') }}</span>
                       <span class="preview-chars">
@@ -421,6 +421,7 @@ import { parseTags } from '@/utils/tagHelpers'
 import { resetFormFields } from '@/utils/formHelpers'
 import { useKnowledgeIcons } from '@/composables/knowledge/useKnowledgeIcons'
 import { useUploadProgress } from '@/composables/useUploadProgress'
+import { useExpansion } from '@/composables/useExpansion'
 import BaseAlert from '@/components/ui/BaseAlert.vue'
 import { createLogger } from '@/utils/debugUtils'
 
@@ -494,7 +495,7 @@ const isDragging = ref(false)
 const dragValid = ref(true)
 const dragCounter = ref(0)
 const selectedFiles = ref<FileItem[]>([])
-const expandedFileId = ref<string | null>(null)
+const { isExpanded: isFileExpanded, expand: expandFile, collapseAll: collapseAllFiles } = useExpansion<string>()
 const fileInput = ref<HTMLInputElement | null>(null)
 const successMessage = ref('')
 const errorMessage = ref('')
@@ -794,22 +795,24 @@ function readFileAsText(file: File): Promise<string> {
 
 function removeFile(index: number): void {
   const file = selectedFiles.value[index]
-  if (file && expandedFileId.value === file.id) {
-    expandedFileId.value = null
+  if (file && isFileExpanded(file.id)) {
+    collapseAllFiles()
   }
   selectedFiles.value.splice(index, 1)
 }
 
 function clearAllFiles(): void {
   selectedFiles.value = []
-  expandedFileId.value = null
+  collapseAllFiles()
   if (fileInput.value) {
     fileInput.value.value = ''
   }
 }
 
 function toggleFilePreview(fileId: string): void {
-  expandedFileId.value = expandedFileId.value === fileId ? null : fileId
+  const wasExpanded = isFileExpanded(fileId)
+  collapseAllFiles()
+  if (!wasExpanded) expandFile(fileId)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Five components using `ref<string | null>(null)` single-open accordion patterns migrated to `useExpansion<string>`:

- `KnowledgeUpload.vue` — `expandedFileId`
- `LLMPatternDashboard.vue` — `expandedRec`
- `HeartbeatPanel.vue` — `expandedRunId`
- `ParticipantList.vue` — `showRoleMenu`
- `PromptOptimizerPanel.vue` — `reviewingVariantId`

**Pattern applied** (single-open via `collapseAll()` + `expand(id)`):
```ts
const { isExpanded, expand, collapseAll } = useExpansion<string>()
function toggleExpand(id: string): void {
  const wasExpanded = isExpanded(id)
  collapseAll()
  if (!wasExpanded) expand(id)
}
```

Closes #5521

## Test plan
- [ ] All 5 components compile without TS errors (`vue-tsc --noEmit -p tsconfig.app.json`)
- [ ] Single-open accordion behaviour preserved in each component (expand one → others collapse)
- [ ] No regression in expand/collapse UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)