### PR TITLE
refactor(frontend): migrate 2 boolean-map expansions to useExpansion (#5522)

### DIFF
--- a/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseApiEndpointsPanel.vue
@@ -97,10 +97,10 @@
         <div v-if="analysis.orphaned?.length > 0" class="accordion-group">
           <div
             class="accordion-header warning"
-            @click="expanded.orphaned = !expanded.orphaned"
+            @click="toggle('orphaned')"
           >
             <div class="header-info">
-              <i :class="expanded.orphaned ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isExpanded('orphaned') ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">
                 {{ $t('analytics.codebase.apiCoverage.orphanedEndpoints') }}
               </span>
@@ -113,7 +113,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expanded.orphaned" class="accordion-items">
+            <div v-if="isExpanded('orphaned')" class="accordion-items">
               <div
                 v-for="(ep, index) in analysis.orphaned.slice(0, 30)"
                 :key="'orphan-' + index"
@@ -138,10 +138,10 @@
         <div v-if="analysis.missing?.length > 0" class="accordion-group">
           <div
             class="accordion-header critical"
-            @click="expanded.missing = !expanded.missing"
+            @click="toggle('missing')"
           >
             <div class="header-info">
-              <i :class="expanded.missing ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isExpanded('missing') ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">
                 {{ $t('analytics.codebase.apiCoverage.missingEndpoints') }}
               </span>
@@ -154,7 +154,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expanded.missing" class="accordion-items">
+            <div v-if="isExpanded('missing')" class="accordion-items">
               <div
                 v-for="(ep, index) in analysis.missing.slice(0, 30)"
                 :key="'missing-' + index"
@@ -180,10 +180,10 @@
         <div v-if="(analysis.used?.length ?? 0) > 0" class="accordion-group">
           <div
             class="accordion-header success"
-            @click="expanded.used = !expanded.used"
+            @click="toggle('used')"
           >
             <div class="header-info">
-              <i :class="expanded.used ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isExpanded('used') ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">
                 {{ $t('analytics.codebase.apiCoverage.usedEndpointsHeader') }}
               </span>
@@ -196,7 +196,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expanded.used" class="accordion-items">
+            <div v-if="isExpanded('used')" class="accordion-items">
               <div
                 v-for="(usage, index) in analysis.used?.slice(0, 30)"
                 :key="'used-' + index"
@@ -239,8 +239,8 @@
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import { useExpansion } from '@/composables/useExpansion'
 
 interface ApiEndpointInfo {
   path: string
@@ -283,7 +283,8 @@ const emit = defineEmits<{
   export: [format: 'md' | 'json']
 }>()
 
-const expanded = reactive({ orphaned: false, missing: false, used: false })
+type Section = 'orphaned' | 'missing' | 'used'
+const { isExpanded, toggle } = useExpansion<Section>()
 
 function getCoverageClass(percentage: number): string {
   if (!percentage || percentage < 50) return 'critical'

--- a/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
+++ b/autobot-frontend/src/components/analytics/panels/CodebaseCrossLanguagePanel.vue
@@ -100,10 +100,10 @@
         <div v-if="analysis.dto_mismatches?.length > 0" class="accordion-group">
           <div
             class="accordion-header critical"
-            @click="expanded.dtoMismatches = !expanded.dtoMismatches"
+            @click="toggle('dtoMismatches')"
           >
             <div class="header-info">
-              <i :class="expanded.dtoMismatches ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isExpanded('dtoMismatches') ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">
                 {{ $t('analytics.codebase.crossLanguage.dtoTypeMismatches') }}
               </span>
@@ -116,7 +116,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expanded.dtoMismatches" class="accordion-items">
+            <div v-if="isExpanded('dtoMismatches')" class="accordion-items">
               <div
                 v-for="(m, index) in analysis.dto_mismatches.slice(0, 20)"
                 :key="'dto-' + index"
@@ -144,10 +144,10 @@
         <div v-if="analysis.api_contract_mismatches?.length > 0" class="accordion-group">
           <div
             class="accordion-header warning"
-            @click="expanded.apiMismatches = !expanded.apiMismatches"
+            @click="toggle('apiMismatches')"
           >
             <div class="header-info">
-              <i :class="expanded.apiMismatches ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isExpanded('apiMismatches') ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">
                 {{ $t('analytics.codebase.crossLanguage.apiContractIssues') }}
               </span>
@@ -160,7 +160,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expanded.apiMismatches" class="accordion-items">
+            <div v-if="isExpanded('apiMismatches')" class="accordion-items">
               <div
                 v-for="(m, index) in analysis.api_contract_mismatches.slice(0, 20)"
                 :key="'api-' + index"
@@ -198,10 +198,10 @@
         <div v-if="analysis.validation_duplications?.length > 0" class="accordion-group">
           <div
             class="accordion-header info"
-            @click="expanded.validationDups = !expanded.validationDups"
+            @click="toggle('validationDups')"
           >
             <div class="header-info">
-              <i :class="expanded.validationDups ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
+              <i :class="isExpanded('validationDups') ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"></i>
               <span class="header-name">
                 {{ $t('analytics.codebase.crossLanguage.validationDuplications') }}
               </span>
@@ -214,7 +214,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expanded.validationDups" class="accordion-items">
+            <div v-if="isExpanded('validationDups')" class="accordion-items">
               <div
                 v-for="(v, index) in analysis.validation_duplications.slice(0, 15)"
                 :key="'val-' + index"
@@ -251,11 +251,11 @@
         <div v-if="analysis.pattern_matches?.length > 0" class="accordion-group">
           <div
             class="accordion-header success"
-            @click="expanded.semanticMatches = !expanded.semanticMatches"
+            @click="toggle('semanticMatches')"
           >
             <div class="header-info">
               <i
-                :class="expanded.semanticMatches ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"
+                :class="isExpanded('semanticMatches') ? 'fas fa-chevron-down' : 'fas fa-chevron-right'"
               ></i>
               <span class="header-name">
                 {{ $t('analytics.codebase.crossLanguage.semanticPatternMatches') }}
@@ -269,7 +269,7 @@
             </div>
           </div>
           <transition name="accordion">
-            <div v-if="expanded.semanticMatches" class="accordion-items">
+            <div v-if="isExpanded('semanticMatches')" class="accordion-items">
               <div
                 v-for="(m, index) in analysis.pattern_matches.slice(0, 15)"
                 :key="'match-' + index"
@@ -319,8 +319,8 @@
 </template>
 
 <script setup lang="ts">
-import { reactive } from 'vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import { useExpansion } from '@/composables/useExpansion'
 
 interface PatternLocation {
   file_path: string
@@ -394,12 +394,8 @@ const emit = defineEmits<{
   export: [format: 'md' | 'json']
 }>()
 
-const expanded = reactive({
-  dtoMismatches: false,
-  apiMismatches: false,
-  validationDups: false,
-  semanticMatches: false,
-})
+type Section = 'dtoMismatches' | 'apiMismatches' | 'validationDups' | 'semanticMatches'
+const { isExpanded, toggle } = useExpansion<Section>()
 
 function formatTimestamp(timestamp: string | undefined): string {
   if (!timestamp) return 'Unknown'


### PR DESCRIPTION
## Summary

Two analytics panel components using `reactive({})` boolean objects for multi-section expansion migrated to `useExpansion<Section>`:

- `CodebaseCrossLanguagePanel.vue` — `const expanded = reactive({...})`
- `CodebaseApiEndpointsPanel.vue` — `const expanded = reactive({ orphaned: false, missing: false, used: false })`

**Pattern applied:**
```ts
type Section = 'orphaned' | 'missing' | 'used'
const { isExpanded, toggle } = useExpansion<Section>()
```

Closes #5522

## Test plan
- [ ] Both components compile without TS errors (`vue-tsc --noEmit -p tsconfig.app.json`)
- [ ] All inline toggle assignments replaced with `toggle(key)`
- [ ] No regression in accordion behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)