### PR TITLE
refactor(frontend): migrate 6 setInterval polling loops to usePollingJob (#5535)

### DIFF
--- a/autobot-frontend/src/components/ChatInterface.ts
+++ b/autobot-frontend/src/components/ChatInterface.ts
@@ -1,5 +1,6 @@
 // ChatInterface TypeScript definitions and setup
 import { ref, computed, onUnmounted, nextTick } from 'vue'
+import { usePollingJob } from '@/composables/usePollingJob'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 
@@ -396,7 +397,6 @@ export function useChatInterface() {
   })
 
   // Message polling for real-time updates
-  let messagePollingInterval: number | null = null
   let _lastMessageCount = 0  // Tracks count for future deduplication optimization
 
   const loadChatMessages = async (chatId: string, silent: boolean = false): Promise<void> => {
@@ -447,29 +447,18 @@ export function useChatInterface() {
     }
   }
 
-  const startMessagePolling = (chatId: string) => {
-    // Clear any existing polling
-    stopMessagePolling()
-
-    // Poll every 2 seconds for new messages
-    messagePollingInterval = window.setInterval(async () => {
+  const { start: _startMessagePolling, stop: stopMessagePolling } = usePollingJob(
+    async (chatId: string) => {
       if (currentChatId.value === chatId) {
         await loadChatMessages(chatId, true) // silent=true to avoid error spam
-      } else {
-        // Chat switched, stop polling
-        stopMessagePolling()
       }
-    }, 2000)
+    },
+    { intervalMs: 2000, maxAttempts: Number.MAX_SAFE_INTEGER }
+  )
 
+  const startMessagePolling = (chatId: string) => {
     logger.debug(`Started message polling for chat ${chatId}`)
-  }
-
-  const stopMessagePolling = () => {
-    if (messagePollingInterval) {
-      clearInterval(messagePollingInterval)
-      messagePollingInterval = null
-      logger.debug('Stopped message polling')
-    }
+    _startMessagePolling(chatId)
   }
 
   const loadChatContext = async (chatId: string): Promise<void> => {

--- a/autobot-frontend/src/components/desktop/ConnectionSettingsPanel.vue
+++ b/autobot-frontend/src/components/desktop/ConnectionSettingsPanel.vue
@@ -82,9 +82,15 @@
 import { ref, onMounted, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useVncConnection } from '@/composables/useVncConnection'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const { t } = useI18n()
 const { loading, error, settings, metrics, loadSettings, updateSettings, loadMetrics, setQualityPreset } = useVncConnection()
+
+const { start: startMetricsPolling } = usePollingJob<void>(
+  async () => { await loadMetrics() },
+  { intervalMs: 10000, maxAttempts: Infinity }
+)
 
 const presets = computed(() => [
   { value: 'low' as const, label: t('desktop.connectionSettings.presetLow'), desc: t('desktop.connectionSettings.presetLowDesc') },
@@ -116,10 +122,7 @@ async function saveSettings() {
 
 onMounted(async () => {
   await loadSettings()
-  await loadMetrics()
-
-  // Auto-refresh metrics every 10 seconds
-  setInterval(loadMetrics, 10000)
+  startMetricsPolling('')  // fires loadMetrics immediately + every 10s; auto-cleans via onScopeDispose
 })
 </script>
 

--- a/autobot-frontend/src/components/desktop/DesktopContextPanel.vue
+++ b/autobot-frontend/src/components/desktop/DesktopContextPanel.vue
@@ -88,10 +88,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const { t } = useI18n()
 const logger = createLogger('DesktopContextPanel')
@@ -123,25 +124,28 @@ interface DesktopContext {
 const context = ref<DesktopContext | null>(null)
 const loading = ref(false)
 const error = ref<string | null>(null)
-let refreshInterval: number | null = null
 
-async function fetchContext() {
-  loading.value = true
-  error.value = null
+const { start: startContextPolling } = usePollingJob<DesktopContext | null>(
+  async () => {
+    loading.value = true
+    error.value = null
+    try {
+      const data = await ApiClient.get<DesktopContext>('/vnc/desktop/context')
+      context.value = data
+      return data
+    } catch (err: unknown) {
+      logger.error('Failed to fetch desktop context:', err)
+      error.value = t('desktop.contextPanel.error')
+      return null
+    } finally {
+      loading.value = false
+    }
+  },
+  { intervalMs: 5000, maxAttempts: Infinity }
+)
 
-  try {
-    const data = await ApiClient.get<DesktopContext>('/vnc/desktop/context')
-    context.value = data
-  } catch (err: any) {
-    logger.error('Failed to fetch desktop context:', err)
-    error.value = t('desktop.contextPanel.error')
-  } finally {
-    loading.value = false
-  }
-}
-
-function refresh() {
-  fetchContext()
+function refresh(): void {
+  startContextPolling('')
 }
 
 function formatTime(timestamp: string): string {
@@ -154,15 +158,7 @@ function formatTime(timestamp: string): string {
 }
 
 onMounted(() => {
-  fetchContext()
-  // Auto-refresh every 5 seconds
-  refreshInterval = window.setInterval(fetchContext, 5000)
-})
-
-onUnmounted(() => {
-  if (refreshInterval !== null) {
-    clearInterval(refreshInterval)
-  }
+  startContextPolling('')  // fires immediately + every 5s; auto-cleans via onScopeDispose
 })
 </script>
 

--- a/autobot-frontend/src/components/desktop/DesktopInterface.vue
+++ b/autobot-frontend/src/components/desktop/DesktopInterface.vue
@@ -178,6 +178,7 @@ import TouchFriendlyButton from '@/components/ui/TouchFriendlyButton.vue'
 import DesktopContextPanel from '@/components/desktop/DesktopContextPanel.vue'
 import { useAsyncOperation } from '@/composables/useAsyncOperation'
 import { useVncControls } from '@/composables/useVncControls'
+import { usePollingJob } from '@/composables/usePollingJob'
 import { createLogger } from '@/utils/debugUtils'
 
 const { t } = useI18n()
@@ -363,7 +364,10 @@ const handleDesktopTimeout = () => {
   error.value = t('desktop.interface.errorServiceTimeout')
 }
 
-let connectionCheckInterval
+const { start: startConnectionCheck } = usePollingJob(
+  async () => { await checkConnection() },
+  { intervalMs: 10000, maxAttempts: Infinity }
+)
 
 onMounted(async () => {
   // Load dynamic VNC URL first - wrapped in try-catch for safety
@@ -377,11 +381,8 @@ onMounted(async () => {
     error.value = t('desktop.interface.errorInitFailed')
   }
 
-  // Initial connection check
-  setTimeout(checkConnection, 2000)
-
-  // Check connection status periodically
-  connectionCheckInterval = setInterval(checkConnection, 10000)
+  // Initial connection check after 2s, then poll every 10s
+  setTimeout(() => startConnectionCheck(''), 2000)
 
   // Listen for fullscreen changes
   document.addEventListener('fullscreenchange', handleFullscreenChange)
@@ -449,10 +450,6 @@ function downloadScreenshot() {
 }
 
 onUnmounted(() => {
-  if (connectionCheckInterval) {
-    clearInterval(connectionCheckInterval)
-  }
-
   // Clean up event listener
   document.removeEventListener('fullscreenchange', handleFullscreenChange)
 })

--- a/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeResearchPanel.vue
@@ -21,6 +21,7 @@ import { createLogger } from '@/utils/debugUtils'
 import InteractiveScreenshot from '@/components/browser/InteractiveScreenshot.vue'
 import { useUserStore } from '@/stores/useUserStore'
 import { useWebSocket } from '@/composables/useWebSocket'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const logger = createLogger('KnowledgeResearchPanel')
 const userStore = useUserStore()
@@ -48,7 +49,6 @@ const screenshotLoading = ref(false)
 const viewportWidth = ref(1280)
 const viewportHeight = ref(720)
 
-let screenshotInterval: ReturnType<typeof setInterval> | null = null
 
 // Research WebSocket URL — set dynamically when research starts
 const researchWsUrl = ref('')
@@ -116,6 +116,27 @@ async function checkBrowserStatus(): Promise<void> {
   }
 }
 
+const { start: _startScreenshotPolling, stop: stopScreenshotPolling } = usePollingJob<void>(
+  async () => {
+    if (screenshotLoading.value) return
+    screenshotLoading.value = true
+    try {
+      const data = await ApiClient.post(`${getApiBase()}/playwright/worker-screenshot`, {}) as Record<string, unknown>
+      if (data.screenshot) {
+        screenshot.value = data.screenshot as string
+        browserConnected.value = true
+        if (data.viewportWidth) viewportWidth.value = data.viewportWidth as number
+        if (data.viewportHeight) viewportHeight.value = data.viewportHeight as number
+      }
+    } catch (e) {
+      logger.warn('Screenshot fetch failed:', e)
+    } finally {
+      screenshotLoading.value = false
+    }
+  },
+  { intervalMs: 3000, maxAttempts: Infinity }
+)
+
 async function fetchScreenshot(): Promise<void> {
   if (screenshotLoading.value) return
   screenshotLoading.value = true
@@ -135,16 +156,7 @@ async function fetchScreenshot(): Promise<void> {
 }
 
 function startScreenshotPolling(): void {
-  if (screenshotInterval) return
-  fetchScreenshot()
-  screenshotInterval = setInterval(fetchScreenshot, 3000)
-}
-
-function stopScreenshotPolling(): void {
-  if (screenshotInterval) {
-    clearInterval(screenshotInterval)
-    screenshotInterval = null
-  }
+  _startScreenshotPolling('')
 }
 
 // ── Source card helpers ────────────────────────────────────────────────────
@@ -341,7 +353,6 @@ onMounted(() => {
 
 onUnmounted(() => {
   closeWs()
-  stopScreenshotPolling()
 })
 </script>
 

--- a/autobot-frontend/src/components/terminal/SSHTerminal.vue
+++ b/autobot-frontend/src/components/terminal/SSHTerminal.vue
@@ -25,6 +25,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { createLogger } from '@/utils/debugUtils'
+import { usePollingJob } from '@/composables/usePollingJob'
 import { useWebSocket } from '@/composables/useWebSocket'
 
 const logger = createLogger('SSHTerminal')
@@ -253,22 +254,12 @@ const handleResize = () => {
 }
 
 // Heartbeat
-let heartbeatInterval: number | null = null
-
-const startHeartbeat = () => {
-  heartbeatInterval = window.setInterval(() => {
-    if (wsIsConnected.value) {
-      sendToServer({ type: 'ping' })
-    }
-  }, 30000)
-}
-
-const stopHeartbeat = () => {
-  if (heartbeatInterval) {
-    clearInterval(heartbeatInterval)
-    heartbeatInterval = null
-  }
-}
+const { start: startHeartbeat, stop: stopHeartbeat } = usePollingJob(
+  async (_: string) => {
+    if (wsIsConnected.value) sendToServer({ type: 'ping' })
+  },
+  { intervalMs: 30000, maxAttempts: Number.MAX_SAFE_INTEGER }
+)
 
 // Watch for host changes
 watch(() => props.hostId, (newHostId, oldHostId) => {


### PR DESCRIPTION
## Summary

Six components hand-rolling `setInterval` / `clearInterval` migrated to `usePollingJob`:

| Component | Interval | Purpose |
|---|---|---|
| `ConnectionSettingsPanel.vue` | 10 000 ms | `loadMetrics` — was leaking (no clearInterval) |
| `DesktopInterface.vue` | 10 000 ms | `checkConnection` — connection health |
| `DesktopContextPanel.vue` | 5 000 ms | `fetchContext` — context refresh |
| `KnowledgeResearchPanel.vue` | 3 000 ms | `fetchScreenshot` — live screenshot |
| `ChatInterface.ts` | 2 000 ms | message polling fallback |
| `SSHTerminal.vue` | 30 000 ms | WebSocket heartbeat keep-alive |

Key improvements:
- `ConnectionSettingsPanel`: was leaking (no clearInterval) — now auto-cleaned via `onScopeDispose`
- `ChatInterface.ts`: re-calling `start(chatId)` auto-cancels prior in-flight poll (replaces manual stop+start)
- All: `onScopeDispose` cleanup eliminates manual `clearInterval` boilerplate

Closes #5535

## Test plan
- [ ] All 6 components compile without TS errors (`vue-tsc --noEmit -p tsconfig.app.json`)
- [ ] Polling starts/stops as expected in each component
- [ ] No interval leaks on unmount (ConnectionSettingsPanel especially)
- [ ] SSHTerminal heartbeat fires every 30s while connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)