### PR TITLE
refactor(composables): SourceManager + CodebaseAnalyticsLanding → usePollingJob (#5508)

### DIFF
--- a/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
+++ b/autobot-frontend/src/components/analytics/CodebaseAnalyticsLanding.vue
@@ -174,11 +174,12 @@
  * Issue #1458
  */
 
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { useSourcesListEndpoint } from '@/composables/analytics/useSourcesListEndpoint'
+import { usePollingJob } from '@/composables/usePollingJob'
 import { createLogger } from '@/utils/debugUtils'
 import AddSourceModal from '@/components/analytics/AddSourceModal.vue'
 
@@ -217,11 +218,27 @@ const showAddModal = ref(false)
 const syncingId = ref<string | null>(null)
 const deletingId = ref<string | null>(null)
 
-// Polling state for syncing cards (#3092)
-const _pollTimer = ref<ReturnType<typeof setInterval> | null>(null)
-const _pollDeadline = ref<number>(0)
+// Polling for syncing cards (#3092): 4s interval, 5min timeout (75 attempts)
 const POLL_INTERVAL_MS = 4000
-const POLL_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+const POLL_MAX_ATTEMPTS = 75 // 5 minutes / 4s
+
+const _sourcePoller = usePollingJob<void>(
+  async (_taskId) => {
+    await _loadSourcesEndpoint()
+    if (sourcesEndpointError.value) {
+      logger.warn('Poll request failed:', sourcesEndpointError.value)
+    }
+  },
+  {
+    intervalMs: POLL_INTERVAL_MS,
+    maxAttempts: POLL_MAX_ATTEMPTS,
+    isComplete: () => !_hasSyncingSource(),
+    onDone: async () => {
+      await loadSummaries()
+      logger.info('All sources resolved — polling complete')
+    },
+  }
+)
 
 // ---- Endpoint composables (#5153 B) --------------------------------------
 
@@ -358,42 +375,9 @@ function _hasSyncingSource(): boolean {
   return sources.value.some((s) => s.status === 'syncing')
 }
 
-function _stopPolling(): void {
-  if (_pollTimer.value !== null) {
-    clearInterval(_pollTimer.value)
-    _pollTimer.value = null
-    logger.info('Status polling stopped')
-  }
-}
-
-async function _pollTick(): Promise<void> {
-  if (Date.now() > _pollDeadline.value) {
-    logger.warn('Status polling timed out after 5 minutes — stopping')
-    _stopPolling()
-    return
-  }
-  // #5276: reuses the shared `useSourcesListEndpoint` loader so the
-  // poll shares one fetch path and error handling. sources.value is
-  // updated via the endpoint's onSuccess hook; we only react to the
-  // syncing state afterwards. Errors are already logged inside the
-  // composable — no extra try/catch.
-  await _loadSourcesEndpoint()
-  if (sourcesEndpointError.value) {
-    logger.warn('Poll request failed:', sourcesEndpointError.value)
-    return
-  }
-  if (!_hasSyncingSource()) {
-    _stopPolling()
-    await loadSummaries()
-    logger.info('All sources resolved — polling complete')
-  }
-}
-
 function _startPolling(): void {
-  _stopPolling()
-  _pollDeadline.value = Date.now() + POLL_TIMEOUT_MS
-  _pollTimer.value = setInterval(_pollTick, POLL_INTERVAL_MS)
   logger.info('Status polling started (interval %dms, timeout 5min)', POLL_INTERVAL_MS)
+  _sourcePoller.start('')
 }
 
 // ---- Modal Handlers -------------------------------------------------------
@@ -415,10 +399,6 @@ onMounted(() => {
       _startPolling()
     }
   })
-})
-
-onUnmounted(() => {
-  _stopPolling()
 })
 </script>
 

--- a/autobot-frontend/src/components/analytics/SourceManager.vue
+++ b/autobot-frontend/src/components/analytics/SourceManager.vue
@@ -179,12 +179,13 @@
  * Issue #1133: Code Source Registry for codebase analytics.
  */
 
-import { ref, watch, onUnmounted, toRef } from 'vue'
+import { ref, watch, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
 import { useBodyScrollLock } from '@/composables/useBodyScrollLock'
+import { usePollingJob } from '@/composables/usePollingJob'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { createLogger } from '@/utils/debugUtils'
@@ -235,8 +236,39 @@ const syncingId = ref<string | null>(null)
 const deletingId = ref<string | null>(null)
 const queueLength = ref(0)
 const runningTask = ref<RunningTask | null>(null)
-let syncingRefreshInterval: ReturnType<typeof setInterval> | null = null
-let queuePollInterval: ReturnType<typeof setInterval> | null = null
+
+// Queue status polling (visible while panel is open, 5s interval)
+const queuePoller = usePollingJob<{ queue_length: number; running: RunningTask | null }>(
+  async (_taskId) => {
+    const backendUrl = await getBackendUrl()
+    const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/index/queue`)
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    return response.json()
+  },
+  {
+    intervalMs: 5000,
+    onDone: (data) => {
+      queueLength.value = data.queue_length ?? 0
+      runningTask.value = data.running ?? null
+    },
+  }
+)
+
+// Syncing-source refresh polling (3s interval, stops when no sources are syncing)
+const syncingPoller = usePollingJob<CodeSource[]>(
+  async (_taskId) => {
+    const backendUrl = await getBackendUrl()
+    const response = await fetchWithAuth(`${backendUrl}/api/analytics/codebase/sources`)
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    const data = await response.json()
+    return data.sources ?? []
+  },
+  {
+    intervalMs: 3000,
+    isComplete: (srcs) => !srcs.some((s) => s.status === 'syncing'),
+    onDone: (srcs) => { sources.value = srcs },
+  }
+)
 
 // ---- API helpers ----------------------------------------------------------
 
@@ -280,26 +312,26 @@ async function loadQueueStatus() {
   }
 }
 
+// Queue poller data watcher — keep refs in sync while polling is active
+watch(queuePoller.data, (data: { queue_length: number; running: RunningTask | null } | null) => {
+  if (data) {
+    queueLength.value = data.queue_length ?? 0
+    runningTask.value = data.running ?? null
+  }
+})
+
 // ---- Auto-refresh for syncing sources -------------------------------------
 
 function startSyncingRefreshIfNeeded() {
-  const hasSyncing = sources.value.some(s => s.status === 'syncing')
-  if (hasSyncing && !syncingRefreshInterval) {
-    syncingRefreshInterval = setInterval(async () => {
-      await loadSources()
-      if (!sources.value.some(s => s.status === 'syncing')) {
-        stopSyncingRefresh()
-      }
-    }, 3000)
+  if (sources.value.some((s: CodeSource) => s.status === 'syncing') && !syncingPoller.isPolling.value) {
+    syncingPoller.start('')
   }
 }
 
-function stopSyncingRefresh() {
-  if (syncingRefreshInterval) {
-    clearInterval(syncingRefreshInterval)
-    syncingRefreshInterval = null
-  }
-}
+// Syncing poller data watcher — keep sources in sync while polling is active
+watch(syncingPoller.data, (srcs: CodeSource[] | null) => {
+  if (srcs) sources.value = srcs
+})
 
 // ---- Source Actions -------------------------------------------------------
 
@@ -404,20 +436,12 @@ watch(() => props.visible, (visible) => {
   if (visible) {
     loadSources()
     loadQueueStatus()
-    queuePollInterval = setInterval(loadQueueStatus, 5000)
+    queuePoller.start('')
   } else {
-    if (queuePollInterval) {
-      clearInterval(queuePollInterval)
-      queuePollInterval = null
-    }
-    stopSyncingRefresh()
+    queuePoller.stop()
+    syncingPoller.stop()
   }
 }, { immediate: true })
-
-onUnmounted(() => {
-  if (queuePollInterval) clearInterval(queuePollInterval)
-  stopSyncingRefresh()
-})
 
 // Expose for parent to call after saving
 defineExpose({ loadSources })


### PR DESCRIPTION
## Summary

- **SourceManager.vue**: Replaced `setInterval(loadQueueStatus, 5000)` + `_syncingInterval` + manual `onUnmounted` cleanup with two `usePollingJob` instances (`queuePoller` + `syncingPoller`). Termination condition migrated to `isComplete` callback.
- **CodebaseAnalyticsLanding.vue**: Replaced hand-rolled `_startPolling` / `_stopPolling` / `_pollTick` + deadline timer with single `usePollingJob` instance (interval 4000ms, maxAttempts 75 ≈ 5-min timeout, `isComplete: () => !hasSyncingSource`, `onDone: loadSummaries`).
- Both components: removed manual `clearInterval` in `onUnmounted` — auto-cleanup handled by `onScopeDispose` inside `usePollingJob`.

## Behavioral grep audit

Before:
```bash
$ grep -rn "setInterval\|clearInterval\|_pollTimer\|_pollDeadline\|_pollTick" autobot-frontend/src/components/analytics/
# SourceManager.vue: setInterval + clearInterval + syncingRefreshInterval
# CodebaseAnalyticsLanding.vue: _pollTimer + _pollDeadline + _pollTick + _startPolling + _stopPolling
```

After:
```bash
$ grep -rn "setInterval\|clearInterval\|_pollTimer\|_pollDeadline\|_pollTick" autobot-frontend/src/components/analytics/
# 0 hits — all polling migrated to usePollingJob
```

## Acceptance Criteria
- ✅ Both components use `usePollingJob<T>`
- ✅ Deadline / termination logic migrated to `isComplete` / `maxAttempts`
- ✅ `onUnmounted` cleanup handled by composable (no manual clearInterval)
- ✅ `npx vue-tsc --noEmit -p tsconfig.app.json` — no new type errors

Closes #5508