### PR TITLE
fix(infra): remaining fromisoformat + missing parse_utc_iso/now_utc imports (#5513)

### DIFF
--- a/autobot-infrastructure/autobot-backend/scripts/migrations/cleanup_orphaned_sessions.py
+++ b/autobot-infrastructure/autobot-backend/scripts/migrations/cleanup_orphaned_sessions.py
@@ -19,7 +19,6 @@ import asyncio
 import json
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -28,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot-user-backe
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "autobot_shared"))
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")

--- a/autobot-infrastructure/shared/scripts/logging/log_forwarder.py
+++ b/autobot-infrastructure/shared/scripts/logging/log_forwarder.py
@@ -46,7 +46,11 @@ from typing import Any, Dict, List, Optional
 import requests
 
 # Add project root to path
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "autobot_shared"))
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from autobot_shared.time_utils import parse_utc_iso  # noqa: E402
 
 try:
     import docker
@@ -135,7 +139,7 @@ class LogEntry:
                     },
                     "values": [
                         [
-                            str(int(datetime.fromisoformat(self.timestamp.replace("Z", "+00:00")).timestamp() * 1e9)),
+                            str(int(parse_utc_iso(self.timestamp).timestamp() * 1e9)),
                             self.message,
                         ]
                     ],
@@ -451,7 +455,7 @@ class LokiDestination(LogDestination):
             # Create stream key from labels
             stream_key = (entry.source, entry.level)
             # Convert timestamp to nanoseconds
-            ts_ns = str(int(datetime.fromisoformat(entry.timestamp.replace("Z", "+00:00")).timestamp() * 1e9))
+            ts_ns = str(int(parse_utc_iso(entry.timestamp).timestamp() * 1e9))
             streams_dict[stream_key].append([ts_ns, entry.message])
 
         # Build Loki payload with all streams

--- a/autobot-infrastructure/shared/scripts/migrations/migrate_config_users.py
+++ b/autobot-infrastructure/shared/scripts/migrations/migrate_config_users.py
@@ -31,7 +31,11 @@ from pathlib import Path
 
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "autobot_shared"))
 sys.path.insert(0, str(project_root))
+
+from autobot_shared.time_utils import parse_utc_iso  # noqa: E402
 
 from config import ConfigManager
 from user_management.config import DeploymentMode, get_deployment_config
@@ -263,7 +267,7 @@ class ConfigUserMigrator:
         created_at = datetime.now(timezone.utc)
         if created_at_str:
             try:
-                created_at = datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
+                created_at = parse_utc_iso(created_at_str)
             except ValueError:
                 pass
 


### PR DESCRIPTION
## Summary

Follow-up to PR #5532 which missed 3 of 5 files for #5513.

**Missing from PR #5532:**
- `cleanup_orphaned_sessions.py`: `now_utc`/`parse_utc_iso` import was added in prior commit but `cleanup_orphaned_sessions.py` in the squash-merge still lacked one remaining import line
- `log_forwarder.py` (lines 138, 454): `fromisoformat(ts.replace("Z", "+00:00"))` → `parse_utc_iso(ts)` + added `sys.path`/import
- `migrate_config_users.py` (line 266): same pattern → `parse_utc_iso` + import

## Acceptance Criteria
- ✅ All 3 fromisoformat patterns removed
- ✅ `parse_utc_iso` imported via `sys.path` + `autobot_shared.time_utils`
- ✅ `python -m py_compile` passes on all affected files

Refs #5513