### PR TITLE
fix(backend): add missing now_utc imports to 49 files (#5514 follow-up)

### DIFF
--- a/autobot-backend/a2a/task_manager.py
+++ b/autobot-backend/a2a/task_manager.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import config
+from autobot_shared.time_utils import now_utc
 
 from .tracing import TraceContext, TraceEvent, new_trace_id
 from .types import Task, TaskArtifact, TaskState, TaskStatus

--- a/autobot-backend/a2a/types.py
+++ b/autobot-backend/a2a/types.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
+from autobot_shared.time_utils import now_utc
 
 
 def _utcnow() -> str:

--- a/autobot-backend/agents/agent_orchestration/distributed_management.py
+++ b/autobot-backend/agents/agent_orchestration/distributed_management.py
@@ -19,6 +19,7 @@ from .types import CircuitState, DistributedAgentInfo
 
 if TYPE_CHECKING:
     from agents.base_agent import AgentHealth, BaseAgent
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/agents/agent_orchestration/distributed_management_test.py
+++ b/autobot-backend/agents/agent_orchestration/distributed_management_test.py
@@ -15,6 +15,7 @@ import pytest
 
 from .distributed_management import DistributedAgentManager
 from .types import CircuitState, DistributedAgentInfo
+from autobot_shared.time_utils import now_utc
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/autobot-backend/api/browser_mcp.py
+++ b/autobot-backend/api/browser_mcp.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, Field
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
+from autobot_shared.time_utils import now_utc
 from constants.network_constants import NetworkConstants
 from type_defs.common import JSONObject, Metadata
 

--- a/autobot-backend/api/codebase_analytics/codebase_stats_endpoint_test.py
+++ b/autobot-backend/api/codebase_analytics/codebase_stats_endpoint_test.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+from autobot_shared.time_utils import now_utc
 
 
 class TestIsTaskStale:

--- a/autobot-backend/api/database_mcp.py
+++ b/autobot-backend/api/database_mcp.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.time_utils import now_utc
 from type_defs.common import JSONObject, Metadata
 
 logger = logging.getLogger(__name__)

--- a/autobot-backend/api/git_mcp.py
+++ b/autobot-backend/api/git_mcp.py
@@ -39,6 +39,7 @@ from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.security.path_validator import validate_path
 from autobot_shared.ssot_config import PROJECT_ROOT
+from autobot_shared.time_utils import now_utc
 from constants.threshold_constants import QueryDefaults
 from type_defs.common import JSONObject, Metadata
 

--- a/autobot-backend/api/http_client_mcp.py
+++ b/autobot-backend/api/http_client_mcp.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, Field, field_validator
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.http_client import get_http_client
+from autobot_shared.time_utils import now_utc
 from constants.network_constants import NetworkConstants
 from type_defs.common import JSONObject, Metadata
 from utils.template_loader import load_mcp_tools, mcp_tools_exist

--- a/autobot-backend/api/llm.py
+++ b/autobot-backend/api/llm.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.ssot_config import config as ssot_config
+from autobot_shared.time_utils import now_utc
 from config.manager import get_config_manager
 
 # Import unified configuration system - NO HARDCODED VALUES

--- a/autobot-backend/api/skills_governance.py
+++ b/autobot-backend/api/skills_governance.py
@@ -25,6 +25,7 @@ from skills.models import (
 )
 from skills.promoter import SkillPromoter
 from skills.validator import SkillValidator
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 router = APIRouter()

--- a/autobot-backend/api/workflow_state.py
+++ b/autobot-backend/api/workflow_state.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, Field
 
 from autobot_shared.models.service_message import ServiceMessage
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.time_utils import now_utc
 from constants.ttl_constants import TTL_7_DAYS
 
 logger = logging.getLogger(__name__)

--- a/autobot-backend/knowledge/categories.py
+++ b/autobot-backend/knowledge/categories.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 if TYPE_CHECKING:
     import aioredis
     import redis
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/knowledge/collections.py
+++ b/autobot-backend/knowledge/collections.py
@@ -16,6 +16,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
+from autobot_shared.time_utils import now_utc
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:

--- a/autobot-backend/knowledge/connectors/registry.py
+++ b/autobot-backend/knowledge/connectors/registry.py
@@ -26,6 +26,7 @@ from types import MappingProxyType
 from typing import Any, Dict, List, Mapping, Optional, Type
 
 from knowledge.connectors.models import ConnectorConfig
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/knowledge/pipeline/cognifiers/context_generator.py
+++ b/autobot-backend/knowledge/pipeline/cognifiers/context_generator.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 
 from autobot_shared.redis_client import get_redis_client
 from autobot_shared.ssot_config import QUALITY_MODEL
+from autobot_shared.time_utils import now_utc
 from knowledge.pipeline.base import BaseCognifier, PipelineContext
 from knowledge.pipeline.registry import TaskRegistry
 from llm_interface_pkg import LLMInterface

--- a/autobot-backend/knowledge/pipeline/models/causal_edge.py
+++ b/autobot-backend/knowledge/pipeline/models/causal_edge.py
@@ -12,6 +12,7 @@ from typing import List, Literal, Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+from autobot_shared.time_utils import now_utc
 
 EffectType = Literal[
     "CAUSES",

--- a/autobot-backend/knowledge/pipeline/models/chunk.py
+++ b/autobot-backend/knowledge/pipeline/models/chunk.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+from autobot_shared.time_utils import now_utc
 
 
 def _utcnow() -> datetime:

--- a/autobot-backend/knowledge/pipeline/models/entity.py
+++ b/autobot-backend/knowledge/pipeline/models/entity.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+from autobot_shared.time_utils import now_utc
 
 EntityType = Literal[
     "PERSON",

--- a/autobot-backend/knowledge/pipeline/models/event.py
+++ b/autobot-backend/knowledge/pipeline/models/event.py
@@ -12,6 +12,7 @@ from typing import List, Literal, Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+from autobot_shared.time_utils import now_utc
 
 TemporalType = Literal["point", "range", "relative", "recurring"]
 EventType = Literal["action", "decision", "change", "milestone", "occurrence"]

--- a/autobot-backend/knowledge/pipeline/models/fact.py
+++ b/autobot-backend/knowledge/pipeline/models/fact.py
@@ -14,6 +14,7 @@ from typing import List, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+from autobot_shared.time_utils import now_utc
 
 FactType = Literal[
     "statement",      # Simple declarative fact (e.g., "X is Y")

--- a/autobot-backend/knowledge/pipeline/models/relationship.py
+++ b/autobot-backend/knowledge/pipeline/models/relationship.py
@@ -12,6 +12,7 @@ from typing import List, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+from autobot_shared.time_utils import now_utc
 
 RelationType = Literal[
     "CAUSES",

--- a/autobot-backend/knowledge/pipeline/models/summary.py
+++ b/autobot-backend/knowledge/pipeline/models/summary.py
@@ -12,6 +12,7 @@ from typing import List, Literal, Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+from autobot_shared.time_utils import now_utc
 
 SummaryLevel = Literal["chunk", "section", "document"]
 

--- a/autobot-backend/orchestration/causal_error_recovery.py
+++ b/autobot-backend/orchestration/causal_error_recovery.py
@@ -20,6 +20,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import now_utc
 from constants.ttl_constants import TTL_7_DAYS, TTL_30_DAYS
 from orchestration.causal_error_analyzer import CausalErrorAnalysis
 

--- a/autobot-backend/orchestration/error_handler.py
+++ b/autobot-backend/orchestration/error_handler.py
@@ -31,6 +31,7 @@ from enum import Enum
 from typing import Any, Dict, Optional
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import now_utc
 from constants.ttl_constants import TTL_7_DAYS
 from retry_mechanism import BackoffStrategy, RetryConfig, RetryMechanism
 

--- a/autobot-backend/services/agent_session_service.py
+++ b/autobot-backend/services/agent_session_service.py
@@ -18,6 +18,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from models.process_run import AgentSession
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/agents/subagent_manager.py
+++ b/autobot-backend/services/agents/subagent_manager.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+from autobot_shared.time_utils import now_utc
 
 from constants.ttl_constants import TTL_1_HOUR, TTL_30_DAYS
 

--- a/autobot-backend/services/approval_gate_service.py
+++ b/autobot-backend/services/approval_gate_service.py
@@ -12,6 +12,7 @@ notifications for pending approvals.
 import logging
 import uuid
 from datetime import datetime, timezone
+from autobot_shared.time_utils import now_utc
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import select

--- a/autobot-backend/services/failure_pattern_detector.py
+++ b/autobot-backend/services/failure_pattern_detector.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import now_utc
 from constants.ttl_constants import TTL_7_DAYS, TTL_30_DAYS
 
 logger = logging.getLogger(__name__)

--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from live_event_manager import publish_live_event
+from autobot_shared.time_utils import now_utc
 from models.heartbeat import (
     AgentRuntimeState,
     AgentWakeupRequest,

--- a/autobot-backend/services/knowledge/contradiction_detector.py
+++ b/autobot-backend/services/knowledge/contradiction_detector.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.time_utils import now_utc
 from llm_interface import LLMType, get_llm_interface
 
 logger = logging.getLogger(__name__)

--- a/autobot-backend/services/knowledge/synthesis_provenance.py
+++ b/autobot-backend/services/knowledge/synthesis_provenance.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/knowledge/task_status_manager.py
+++ b/autobot-backend/services/knowledge/task_status_manager.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/personality_service.py
+++ b/autobot-backend/services/personality_service.py
@@ -21,6 +21,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/process_adapter_service.py
+++ b/autobot-backend/services/process_adapter_service.py
@@ -37,6 +37,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from constants.threshold_constants import TimingConstants
 from models.process_run import ProcessRun, ProcessRunStatus
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/security_tool_parsers.py
+++ b/autobot-backend/services/security_tool_parsers.py
@@ -17,6 +17,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/security_workflow_manager.py
+++ b/autobot-backend/services/security_workflow_manager.py
@@ -26,6 +26,7 @@ from typing import Any, List, Optional
 from redis.exceptions import RedisError
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/skill_management/skill_feedback.py
+++ b/autobot-backend/services/skill_management/skill_feedback.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.time_utils import now_utc
 
 from .skill_metrics import SkillMetrics, REDIS_SKILL_METRICS_PREFIX
 

--- a/autobot-backend/services/skill_management/skill_metrics.py
+++ b/autobot-backend/services/skill_management/skill_metrics.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/services/test_notification_suppression.py
+++ b/autobot-backend/services/test_notification_suppression.py
@@ -2,6 +2,7 @@
 
 import unittest
 from datetime import datetime, timedelta, timezone
+from autobot_shared.time_utils import now_utc
 
 from notification_suppression import (
     NotificationFilter,

--- a/autobot-backend/services/trigger_service.py
+++ b/autobot-backend/services/trigger_service.py
@@ -40,6 +40,7 @@ from enum import Enum
 from typing import Any, Callable, Coroutine, Dict, List, Optional
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.time_utils import now_utc
 from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_90_DAYS
 

--- a/autobot-backend/skills/models.py
+++ b/autobot-backend/skills/models.py
@@ -9,6 +9,7 @@ from enum import Enum
 
 from sqlalchemy import JSON, Boolean, Column, DateTime, Integer, String, Text
 from sqlalchemy.orm import DeclarativeBase
+from autobot_shared.time_utils import now_utc
 
 
 class SkillsBase(DeclarativeBase):

--- a/autobot-backend/tests/memory_graph/test_invalidate_endpoints.py
+++ b/autobot-backend/tests/memory_graph/test_invalidate_endpoints.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from autobot_shared.time_utils import now_utc
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/autobot-backend/user_management/services/organization_service.py
+++ b/autobot-backend/user_management/services/organization_service.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from user_management.models import Organization, Team, User
 from user_management.models.audit import AuditAction, AuditLog, AuditResourceType
 from user_management.services.base_service import BaseService, TenantContext
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/user_management/services/team_service.py
+++ b/autobot-backend/user_management/services/team_service.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import selectinload
 from user_management.models import Team, TeamMembership
 from user_management.models.audit import AuditAction, AuditLog, AuditResourceType
 from user_management.services.base_service import BaseService, TenantContext
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/user_management/services/user_service.py
+++ b/autobot-backend/user_management/services/user_service.py
@@ -23,6 +23,7 @@ from user_management.models import Role, User, UserRole
 from user_management.models.audit import AuditAction, AuditLog, AuditResourceType
 from user_management.services.base_service import BaseService, TenantContext
 from user_management.services.session_service import SessionService
+from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
 

--- a/autobot-backend/user_management/services/user_service_test.py
+++ b/autobot-backend/user_management/services/user_service_test.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from autobot_shared.time_utils import now_utc
 
 from user_management.services.user_service import (
     InvalidCredentialsError,

--- a/autobot-backend/utils/background_task_manager_test.py
+++ b/autobot-backend/utils/background_task_manager_test.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from utils.background_task_manager import BackgroundTaskManager
+from autobot_shared.time_utils import now_utc
 
 
 @pytest.fixture

--- a/autobot-backend/utils/branch_metrics_test.py
+++ b/autobot-backend/utils/branch_metrics_test.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from autobot_shared.time_utils import now_utc
 
 from utils.branch_metrics import (
     BranchDivergence,


### PR DESCRIPTION
## Summary

Critical follow-up to PR #5533: the squash-merge only included the sed-replacement commit but omitted the import-additions commit. This left 49 files with `now_utc()` calls but no `from autobot_shared.time_utils import now_utc` import, causing `NameError` at runtime.

This PR adds the missing import line to all 49 affected files.

**Verified:** `a2a/task_manager.py` had `now_utc()` at line 53 with no import before this fix.

## Acceptance Criteria
- ✅ All 49 files have `from autobot_shared.time_utils import now_utc`
- ✅ `python -m py_compile` passes on sample files (a2a/task_manager.py, a2a/types.py confirmed)
- ✅ Zero remaining `now_utc()` calls without import in autobot-backend/

Refs #5514