### PR TITLE
fix(VisualBrowserPanel): URL normalization dead branch (#5139)

### DIFF
--- a/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
+++ b/autobot-frontend/src/components/chat/VisualBrowserPanel.vue
@@ -80,9 +80,17 @@ async function navigate(): Promise<void> {
   loading.value = true
   error.value = null
 
+  // #5139: if no scheme is present, normalize to a usable URL:
+  //   - `localhost` / `localhost:PORT` → `http://…` (HTTPS would fail for local dev)
+  //   - anything with a `.` → `https://…` (treat as domain)
+  //   - bare words → route through DuckDuckGo as a search query
+  // The prior branch excluded `localhost` at the outer condition AND then
+  // re-checked for it in the inner branch — dead code on both sides.
   let targetUrl = url.value.trim()
-  if (!targetUrl.includes('://') && !targetUrl.startsWith('localhost')) {
-    if (targetUrl.includes('.') || targetUrl.startsWith('localhost')) {
+  if (!targetUrl.includes('://')) {
+    if (targetUrl.startsWith('localhost')) {
+      targetUrl = `http://${targetUrl}`
+    } else if (targetUrl.includes('.')) {
       targetUrl = `https://${targetUrl}`
     } else {
       targetUrl = `https://duckduckgo.com/?q=${encodeURIComponent(targetUrl)}`


### PR DESCRIPTION
## Summary

\`VisualBrowserPanel.navigate()\` had a dead branch: the outer condition excluded \`targetUrl.startsWith('localhost')\` from entering normalization, then the inner condition re-checked for it — guaranteed false. \`localhost:3000\` / bare \`localhost\` passed through unchanged, so \`page.goto('localhost:3000')\` failed.

Restructured to a straightforward three-way dispatch inside one outer \`!includes('://')\` check:

- \`localhost\` / \`localhost:PORT\` → \`http://…\` (HTTPS breaks local dev)
- contains \`.\` → \`https://…\` (treat as domain)
- bare word → DuckDuckGo search

Closes #5139.

## Verification

- \`vue-tsc\` — zero new errors in changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)