### PR TITLE
refactor(tests): consolidate _FakeKB into tests/helpers/fake_kb.py (#5557)

### DIFF
--- a/autobot-backend/tests/helpers/fake_kb.py
+++ b/autobot-backend/tests/helpers/fake_kb.py
@@ -1,0 +1,45 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Shared fake KnowledgeBase implementations for unit tests.
+
+Extracted from scattered _FakeKB definitions per #5443/#5557.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from knowledge.facts.mixin import FactsMixin
+
+
+class MinimalFakeKB:
+    """Minimal KB stub exposing only the redis() accessor."""
+
+    def __init__(self, fake_redis=None):
+        self._aioredis_client = fake_redis if fake_redis is not None else AsyncMock()
+
+    def redis(self):
+        return self._aioredis_client
+
+
+class FactsFakeKB(MinimalFakeKB, FactsMixin):
+    """KB stub exposing FactsMixin interface for facts-layer unit tests."""
+
+    initialized = True
+    embedding_model_name = "test-embed"
+
+    def __init__(self, vector_store=None, fake_redis=None):
+        self.vector_store = vector_store
+        self.redis_client = MagicMock()
+        self._aioredis_client = fake_redis if fake_redis is not None else AsyncMock()
+
+    def ensure_initialized(self):
+        pass
+
+    async def _increment_stat(self, *_):
+        pass
+
+    def _schedule_bm25_refresh(self):
+        pass
+
+    async def _track_session_fact_relationship(self, *_):
+        pass

--- a/autobot-backend/tests/knowledge/test_facts_dedup.py
+++ b/autobot-backend/tests/knowledge/test_facts_dedup.py
@@ -14,6 +14,7 @@ sys.modules patching so the test suite can run without the full backend stack.
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
+from tests.helpers.fake_kb import FactsFakeKB
 
 import pytest
 
@@ -50,43 +51,9 @@ _svc_npu.get_npu_client = MagicMock()
 sys.modules.setdefault("services.npu_client", _svc_npu)
 
 import knowledge.facts as facts_module  # noqa: E402 — must follow sys.modules patches
-from knowledge.facts import FactsMixin  # noqa: E402
-
-# ---------------------------------------------------------------------------
-# Minimal concrete class that satisfies FactsMixin without a real KB stack
-# ---------------------------------------------------------------------------
 
 _THRESHOLD = 0.92
 
-
-class _FakeKB(FactsMixin):
-    """Minimal KB stub exposing only what FactsMixin needs for these tests."""
-
-    initialized = True
-    embedding_model_name = "test-embed"
-
-    def __init__(self, vector_store=None):
-        self.vector_store = vector_store
-        self.redis_client = MagicMock()
-        self._aioredis_client = AsyncMock()
-
-    def redis(self):
-        """Shim for the KB.redis() public accessor (#5225: attribute renamed
-        from the pre-existing public ``aioredis_client`` to private
-        ``_aioredis_client``)."""
-        return self._aioredis_client
-
-    def ensure_initialized(self):
-        pass
-
-    async def _increment_stat(self, *_):
-        pass
-
-    def _schedule_bm25_refresh(self):
-        pass
-
-    async def _track_session_fact_relationship(self, *_):
-        pass
 
 
 # ---------------------------------------------------------------------------
@@ -123,7 +90,7 @@ class TestFindDuplicate:
         chroma_collection.query = MagicMock(return_value=_chroma_result(distance=0.10, fact_id="dup-42"))
         vector_store = MagicMock()
         vector_store._collection = chroma_collection
-        kb = _FakeKB(vector_store=vector_store)
+        kb = FactsFakeKB(vector_store=vector_store)
 
         with (
             patch.object(
@@ -146,7 +113,7 @@ class TestFindDuplicate:
         chroma_collection.query = MagicMock(return_value=_chroma_result(distance=0.30, fact_id="not-dup"))
         vector_store = MagicMock()
         vector_store._collection = chroma_collection
-        kb = _FakeKB(vector_store=vector_store)
+        kb = FactsFakeKB(vector_store=vector_store)
 
         with (
             patch.object(
@@ -163,7 +130,7 @@ class TestFindDuplicate:
     @pytest.mark.asyncio
     async def test_no_vector_store_returns_none(self):
         """If vector_store is None the guard is skipped and returns None."""
-        kb = _FakeKB(vector_store=None)
+        kb = FactsFakeKB(vector_store=None)
         result = await kb._find_duplicate("some content", threshold=_THRESHOLD)
         assert result is None
 
@@ -174,7 +141,7 @@ class TestFindDuplicate:
         chroma_collection.query = MagicMock(side_effect=RuntimeError("chroma down"))
         vector_store = MagicMock()
         vector_store._collection = chroma_collection
-        kb = _FakeKB(vector_store=vector_store)
+        kb = FactsFakeKB(vector_store=vector_store)
 
         with (
             patch.object(
@@ -195,7 +162,7 @@ class TestFindDuplicate:
         chroma_collection.query = MagicMock(return_value=_empty_chroma_result())
         vector_store = MagicMock()
         vector_store._collection = chroma_collection
-        kb = _FakeKB(vector_store=vector_store)
+        kb = FactsFakeKB(vector_store=vector_store)
 
         with (
             patch.object(
@@ -228,7 +195,7 @@ class TestStoreFact:
         chroma_collection.query = MagicMock(return_value=_chroma_result(distance=chroma_distance, fact_id=fact_id))
         vector_store = MagicMock()
         vector_store._collection = chroma_collection
-        kb = _FakeKB(vector_store=vector_store)
+        kb = FactsFakeKB(vector_store=vector_store)
         kb.redis_client.get = MagicMock(return_value=None)
         kb.redis_client.exists = MagicMock(return_value=False)
         kb.redis_client.hset = MagicMock()
@@ -322,7 +289,7 @@ class TestStoreFact:
         chroma_collection.query = MagicMock(return_value=_empty_chroma_result())
         vector_store = MagicMock()
         vector_store._collection = chroma_collection
-        kb = _FakeKB(vector_store=vector_store)
+        kb = FactsFakeKB(vector_store=vector_store)
         kb.redis_client.get = MagicMock(return_value=None)
         kb.redis_client.hset = MagicMock()
         kb.redis_client.set = MagicMock()

--- a/autobot-backend/tests/test_knowledge_boards.py
+++ b/autobot-backend/tests/test_knowledge_boards.py
@@ -28,6 +28,7 @@ from api.knowledge_boards import (
 )
 from api.knowledge_boards import router as boards_router
 from tests.helpers.fake_redis import AsyncHashFakeRedis
+from tests.helpers.fake_kb import MinimalFakeKB
 
 
 # ---------------------------------------------------------------------------
@@ -38,14 +39,8 @@ from tests.helpers.fake_redis import AsyncHashFakeRedis
 def _make_app(fake_redis: AsyncHashFakeRedis) -> FastAPI:
     """Build a minimal FastAPI app with the boards router wired up."""
 
-    class _FakeKB:
-        _aioredis_client = fake_redis
-
-        def redis(self):
-            return self._aioredis_client
-
     async def _fake_get_kb(app, force_refresh=False):  # noqa: ANN001
-        return _FakeKB()
+        return MinimalFakeKB(fake_redis)
 
     app = FastAPI()
     # Patch module-level factory so _get_redis() resolves correctly


### PR DESCRIPTION
## Summary

Creates `tests/helpers/fake_kb.py` and migrates 2 inline `_FakeKB` classes:

- `MinimalFakeKB` — just the `redis()` accessor (used in `test_knowledge_boards.py`)
- `FactsFakeKB(MinimalFakeKB, FactsMixin)` — full FactsMixin interface (used in `test_facts_dedup.py`)

Both test files now import from `tests.helpers.fake_kb` instead of defining local classes.

Closes #5557

## Test plan
- [ ] `python -m pytest autobot-backend/tests/knowledge/test_facts_dedup.py -v` passes
- [ ] `python -m pytest autobot-backend/tests/test_knowledge_boards.py -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)