### PR TITLE
refactor(tests): consolidate _FakeConnector into tests/helpers/fake_connector.py (#5558)

### DIFF
--- a/autobot-backend/api/knowledge_connectors_health_test.py
+++ b/autobot-backend/api/knowledge_connectors_health_test.py
@@ -23,18 +23,7 @@ from api.knowledge_connectors import _hydrate_all_instances, router
 from auth_middleware import check_admin_permission
 from knowledge.connectors.models import ConnectorConfig
 from knowledge.connectors.registry import ConnectorRegistry
-
-
-class _FakeConnector:
-    def __init__(self, config: ConnectorConfig, result=True):
-        self.config = config
-        self._result = result
-
-    async def test_connection(self):
-        if isinstance(self._result, Exception):
-            raise self._result
-        return self._result
-
+from tests.helpers.fake_connector import FakeConnector
 
 def _make_app() -> FastAPI:
     app = FastAPI()
@@ -42,7 +31,6 @@ def _make_app() -> FastAPI:
     app.dependency_overrides[check_admin_permission] = lambda: None
     app.include_router(router, prefix="/api")
     return app
-
 
 def _make_cfg(connector_id: str, connector_type: str, name: str) -> ConnectorConfig:
     return ConnectorConfig(
@@ -52,13 +40,11 @@ def _make_cfg(connector_id: str, connector_type: str, name: str) -> ConnectorCon
         config={},
     )
 
-
 @pytest.fixture(autouse=True)
 def _clear_registry():
     ConnectorRegistry._instances.clear()
     yield
     ConnectorRegistry._instances.clear()
-
 
 def test_health_endpoint_empty_registry():
     app = _make_app()
@@ -78,19 +64,18 @@ def test_health_endpoint_empty_registry():
     assert body["errors"] == {}
     assert "checked_at" in body
 
-
 def test_health_endpoint_aggregates_mixed_results():
     app = _make_app()
     client = TestClient(app)
 
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_cfg("a", "file_server", "docs-nfs"), result=True)
+        FakeConnector(_make_cfg("a", "file_server", "docs-nfs"), result=True)
     )
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_cfg("b", "web_crawler", "internal-wiki"), result=True)
+        FakeConnector(_make_cfg("b", "web_crawler", "internal-wiki"), result=True)
     )
     ConnectorRegistry.add_instance(
-        _FakeConnector(
+        FakeConnector(
             _make_cfg("c", "notion", "workspace-1"),
             result=RuntimeError("401 Unauthorized"),
         )
@@ -112,7 +97,6 @@ def test_health_endpoint_aggregates_mixed_results():
     assert "401 Unauthorized" in body["errors"]["notion:workspace-1"]
     assert "checked_at" in body
 
-
 def test_health_route_matched_before_connector_id_path():
     """Ensure FastAPI dispatches /health to the aggregate endpoint,
     not /{connector_id} (Issue #4420 route-ordering guard)."""
@@ -129,11 +113,9 @@ def test_health_route_matched_before_connector_id_path():
     assert resp.status_code == 200
     assert "healthy" in resp.json()
 
-
 # ---------------------------------------------------------------------------
 # Issue #5054 / #5055: hydration resiliency
 # ---------------------------------------------------------------------------
-
 
 @pytest.mark.asyncio
 async def test_hydration_returns_gracefully_when_redis_down():
@@ -146,7 +128,6 @@ async def test_hydration_returns_gracefully_when_redis_down():
         # to the in-memory registry.
         await _hydrate_all_instances()
 
-
 @pytest.mark.asyncio
 async def test_hydration_returns_gracefully_on_connection_error():
     """Issue #5054: OSError/ConnectionError from the Redis client must also
@@ -157,7 +138,6 @@ async def test_hydration_returns_gracefully_on_connection_error():
     ):
         await _hydrate_all_instances()
 
-
 def test_health_endpoint_works_when_redis_hydration_fails():
     """Issue #5054: /connectors/health must return 200 using the in-memory
     registry even when Redis is unreachable during hydration."""
@@ -165,7 +145,7 @@ def test_health_endpoint_works_when_redis_hydration_fails():
     client = TestClient(app)
 
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_cfg("in-mem", "file_server", "local-only"), result=True)
+        FakeConnector(_make_cfg("in-mem", "file_server", "local-only"), result=True)
     )
 
     with patch(
@@ -178,7 +158,6 @@ def test_health_endpoint_works_when_redis_hydration_fails():
     body = resp.json()
     assert "file_server:local-only" in body["healthy"]
     assert body["errors"] == {}
-
 
 @pytest.mark.asyncio
 async def test_hydration_skips_corrupted_record_and_continues():

--- a/autobot-backend/knowledge/connectors/registry_health_test.py
+++ b/autobot-backend/knowledge/connectors/registry_health_test.py
@@ -33,12 +33,11 @@ if _BACKEND_DIR not in sys.path:
 
 from knowledge.connectors.models import ConnectorConfig
 from knowledge.connectors.registry import ConnectorRegistry
-
+from tests.helpers.fake_connector import FakeConnector
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
 
 def _make_config(connector_id: str, connector_type: str, name: str) -> ConnectorConfig:
     return ConnectorConfig(
@@ -48,23 +47,6 @@ def _make_config(connector_id: str, connector_type: str, name: str) -> Connector
         config={},
     )
 
-
-class _FakeConnector:
-    """Minimal stand-in for an AbstractConnector instance (Issue #4420)."""
-
-    def __init__(self, config: ConnectorConfig, result=True, delay: float = 0.0):
-        self.config = config
-        self._result = result
-        self._delay = delay
-
-    async def test_connection(self):
-        if self._delay:
-            await asyncio.sleep(self._delay)
-        if isinstance(self._result, Exception):
-            raise self._result
-        return self._result
-
-
 @pytest.fixture(autouse=True)
 def _clear_registry():
     """Guarantee clean registry state between tests (Issue #4420)."""
@@ -72,11 +54,9 @@ def _clear_registry():
     yield
     ConnectorRegistry._instances.clear()
 
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-
 
 @pytest.mark.asyncio
 async def test_empty_registry_returns_empty_structure():
@@ -89,12 +69,11 @@ async def test_empty_registry_returns_empty_structure():
     parsed = datetime.fromisoformat(result["checked_at"])
     assert parsed.tzinfo is not None
 
-
 @pytest.mark.asyncio
 async def test_all_connectors_healthy():
     for i in range(3):
         cfg = _make_config(f"id-{i}", "file_server", f"src-{i}")
-        ConnectorRegistry.add_instance(_FakeConnector(cfg, result=True))
+        ConnectorRegistry.add_instance(FakeConnector(cfg, result=True))
 
     result = await ConnectorRegistry.health_check_all()
     assert sorted(result["healthy"]) == [
@@ -105,17 +84,16 @@ async def test_all_connectors_healthy():
     assert result["unavailable"] == []
     assert result["errors"] == {}
 
-
 @pytest.mark.asyncio
 async def test_mixed_healthy_and_unhealthy():
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_config("a", "file_server", "docs-nfs"), result=True)
+        FakeConnector(_make_config("a", "file_server", "docs-nfs"), result=True)
     )
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_config("b", "web_crawler", "internal-wiki"), result=True)
+        FakeConnector(_make_config("b", "web_crawler", "internal-wiki"), result=True)
     )
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_config("c", "notion", "workspace-1"), result=False)
+        FakeConnector(_make_config("c", "notion", "workspace-1"), result=False)
     )
 
     result = await ConnectorRegistry.health_check_all()
@@ -124,14 +102,13 @@ async def test_mixed_healthy_and_unhealthy():
     # False (not exception) → no error string
     assert result["errors"] == {}
 
-
 @pytest.mark.asyncio
 async def test_connector_exception_captured_in_errors():
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_config("a", "file_server", "good"), result=True)
+        FakeConnector(_make_config("a", "file_server", "good"), result=True)
     )
     ConnectorRegistry.add_instance(
-        _FakeConnector(
+        FakeConnector(
             _make_config("b", "notion", "workspace-1"),
             result=RuntimeError("401 Unauthorized"),
         )
@@ -143,25 +120,23 @@ async def test_connector_exception_captured_in_errors():
     assert "notion:workspace-1" in result["errors"]
     assert "401 Unauthorized" in result["errors"]["notion:workspace-1"]
 
-
 @pytest.mark.asyncio
 async def test_one_failure_does_not_block_others():
     """Verify asyncio.gather(return_exceptions=False) path: _check_one never raises."""
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_config("a", "t", "one"), result=ValueError("boom"))
+        FakeConnector(_make_config("a", "t", "one"), result=ValueError("boom"))
     )
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_config("b", "t", "two"), result=True)
+        FakeConnector(_make_config("b", "t", "two"), result=True)
     )
     ConnectorRegistry.add_instance(
-        _FakeConnector(_make_config("c", "t", "three"), result=True)
+        FakeConnector(_make_config("c", "t", "three"), result=True)
     )
 
     result = await ConnectorRegistry.health_check_all()
     assert sorted(result["healthy"]) == ["t:three", "t:two"]
     assert result["unavailable"] == ["t:one"]
     assert "boom" in result["errors"]["t:one"]
-
 
 @pytest.mark.asyncio
 async def test_checks_run_concurrently():
@@ -170,7 +145,7 @@ async def test_checks_run_concurrently():
     for i in range(5):
         cfg = _make_config(f"id-{i}", "slow", f"n-{i}")
         ConnectorRegistry.add_instance(
-            _FakeConnector(cfg, result=True, delay=delay)
+            FakeConnector(cfg, result=True, delay=delay)
         )
 
     start = time.monotonic()
@@ -182,21 +157,19 @@ async def test_checks_run_concurrently():
     # Allow generous overhead but still catch sequential execution.
     assert elapsed < 0.5, f"health_check_all took {elapsed:.3f}s — not concurrent"
 
-
 @pytest.mark.asyncio
 async def test_label_falls_back_to_connector_id_when_name_missing():
     cfg = _make_config("only-id", "file_server", "")
-    ConnectorRegistry.add_instance(_FakeConnector(cfg, result=True))
+    ConnectorRegistry.add_instance(FakeConnector(cfg, result=True))
 
     result = await ConnectorRegistry.health_check_all()
     assert result["healthy"] == ["file_server:only-id"]
-
 
 @pytest.mark.asyncio
 async def test_async_mock_connector():
     """Verify health check works against AsyncMock-style connectors too."""
     cfg = _make_config("am", "file_server", "mock")
-    instance = _FakeConnector(cfg, result=True)
+    instance = FakeConnector(cfg, result=True)
     instance.test_connection = AsyncMock(return_value=True)
     ConnectorRegistry.add_instance(instance)
 

--- a/autobot-backend/tests/helpers/fake_connector.py
+++ b/autobot-backend/tests/helpers/fake_connector.py
@@ -1,0 +1,31 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Shared fake AbstractConnector implementation for unit tests.
+
+Extracted from scattered _FakeConnector definitions per #5443/#5558.
+"""
+
+import asyncio
+
+from knowledge.connectors.base import ConnectorConfig
+
+
+class FakeConnector:
+    """Minimal stand-in for an AbstractConnector instance.
+
+    Supports optional delay for simulating slow connections and
+    Exception result for simulating failures.
+    """
+
+    def __init__(self, config: ConnectorConfig, result=True, delay: float = 0.0):
+        self.config = config
+        self._result = result
+        self._delay = delay
+
+    async def test_connection(self):
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result


### PR DESCRIPTION
## Summary

Creates `tests/helpers/fake_connector.py` with a single `FakeConnector(config, result, delay=0)` covering both prior variants, and migrates 2 test files:

- `knowledge/connectors/registry_health_test.py` — removes inline `_FakeConnector` (had delay support)
- `api/knowledge_connectors_health_test.py` — removes inline `_FakeConnector` (no delay, now defaults to 0)

Closes #5558

## Test plan
- [ ] `python -m pytest autobot-backend/knowledge/connectors/registry_health_test.py -v` passes
- [ ] `python -m pytest autobot-backend/api/knowledge_connectors_health_test.py -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)