### PR TITLE
refactor(events): replace string literals with event_type constants (#5131)

### DIFF
--- a/autobot-backend/services/heartbeat_scheduler.py
+++ b/autobot-backend/services/heartbeat_scheduler.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from live_event_manager import publish_live_event
 from autobot_shared.time_utils import now_utc
 from models.heartbeat import (
+from events.event_types import HEARTBEAT_RUN_STARTED, HEARTBEAT_RUN_COMPLETED
     AgentRuntimeState,
     AgentWakeupRequest,
     HeartbeatRun,
@@ -194,7 +195,7 @@ class HeartbeatScheduler:
         logger.info("Heartbeat run %s started for agent %s", run_id, agent_id)
         await publish_live_event(
             f"agent:{agent_id}",
-            "heartbeat_run_started",
+            HEARTBEAT_RUN_STARTED,
             {"run_id": str(run_id), "agent_id": agent_id, "trigger": trigger.value},
         )
         return run_id, state_id, timeout
@@ -259,7 +260,7 @@ class HeartbeatScheduler:
             await session.commit()
         await publish_live_event(
             f"agent:{agent_id}",
-            "heartbeat_run_completed",
+            HEARTBEAT_RUN_COMPLETED,
             {
                 "run_id": str(run_id),
                 "agent_id": agent_id,

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -32,6 +32,7 @@ from services.rag_config import RAGConfig, get_rag_config
 from services.session_adaptive_reranker import get_session_adaptive_reranker
 from services.semantic_query_cache import get_semantic_query_cache
 from services.topic_retrieval_cache import CachedChunk, get_topic_retrieval_cache
+from events.event_types import RAG_RETRIEVAL
 from type_defs.common import Metadata
 
 logger = get_llm_logger("rag_service")
@@ -504,7 +505,7 @@ class RAGService:
     ) -> None:
         """Publish a rag_retrieval live event after each search. Issue #1516.
 
-        Fires publish_live_event("global", "rag_retrieval", ...) so that
+        Fires publish_live_event("global", RAG_RETRIEVAL, ...) so that
         Neural Mesh RAG (#1994) consumers can observe retrieval patterns in
         real time via the /ws/live WebSocket endpoint.
 
@@ -522,7 +523,7 @@ class RAGService:
             "timestamp": time.time(),
         }
         try:
-            await publish_live_event("global", "rag_retrieval", payload)
+            await publish_live_event("global", RAG_RETRIEVAL, payload)
         except Exception as exc:
             logger.debug("Live event publish failed (non-fatal): %s", exc)
 


### PR DESCRIPTION
## Summary
- Import `HEARTBEAT_RUN_STARTED`, `HEARTBEAT_RUN_COMPLETED` from `events.event_types` in `heartbeat_scheduler.py`
- Import `RAG_RETRIEVAL` from `events.event_types` in `rag_service.py`
- Replace all 3 string literals passed to `publish_live_event` with the typed constants

## Test plan
- [ ] Verify `heartbeat_scheduler.py` passes `HEARTBEAT_RUN_STARTED`/`HEARTBEAT_RUN_COMPLETED` to `publish_live_event`
- [ ] Verify `rag_service.py` passes `RAG_RETRIEVAL` to `publish_live_event`
- [ ] `python -m py_compile` passes on both files
- [ ] No remaining raw string literals for these event types

Closes #5131

🤖 Generated with [Claude Code](https://claude.ai/claude-code)