### PR TITLE
refactor(slm-backend): extract _extract_failure_summary to ansible_utils (#5564)

### DIFF
--- a/autobot-slm-backend/api/infrastructure.py
+++ b/autobot-slm-backend/api/infrastructure.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
 from services.auth import get_current_user
+from services.ansible_utils import _extract_failure_summary
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/infrastructure", tags=["infrastructure"])
@@ -646,7 +647,8 @@ async def _run_playbook(
             execution.output.append("[SUCCESS] Playbook completed successfully")
         else:
             execution.status = PlaybookStatus.FAILED
-            execution.error = f"Playbook failed with exit code {process.returncode}"
+            _summary = _extract_failure_summary("\n".join(execution.output))
+            execution.error = _summary or f"Playbook failed with exit code {process.returncode}"
             execution.output.append(f"[FAILED] Exit code: {process.returncode}")
 
     except Exception as e:

--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -11,7 +11,6 @@ node addition, enrollment, role assignment, and fleet provisioning.
 
 import asyncio
 import logging
-import re
 import tempfile
 import time
 import uuid
@@ -27,6 +26,7 @@ from pydantic import BaseModel
 
 from api.websocket import ws_manager
 from services.ansible_secrets import fetch_deploy_secrets
+from services.ansible_utils import _extract_failure_summary
 from services.auth import get_current_user
 from services.database import db_service
 from services.playbook_executor import get_playbook_executor
@@ -642,56 +642,6 @@ def _write_provision_log(line: str) -> None:
             f.write(line + "\n")
     except OSError:
         pass
-
-
-def _extract_failure_summary(output: str) -> str:
-    """Parse Ansible stdout and return a human-readable failure summary.
-
-    Extracts failed hosts, the task that failed, and the error message so
-    users see e.g. '172.16.168.26 failed at "Common | Update apt cache":
-    Failed to update apt cache: unknown reason' instead of 'exit code 2'.
-    """
-    lines = output.splitlines()
-    failures: list[str] = []
-    current_task = ""
-
-    i = 0
-    while i < len(lines):
-        line = lines[i].strip()
-
-        # Track the current task name
-        if line.startswith("TASK ["):
-            task_match = re.search(r"TASK \[(.+?)\]", line)
-            if task_match:
-                current_task = task_match.group(1).strip()
-
-        # Fatal failure or unreachable
-        if line.startswith("fatal:"):
-
-            host_match = re.search(r"fatal: \[([^\]]+)\]", line)
-            host = host_match.group(1) if host_match else "unknown host"
-            failure_type = "UNREACHABLE" if "UNREACHABLE" in line else "FAILED"
-
-            # Look ahead for msg: field in the next few lines
-            msg = ""
-            for j in range(i + 1, min(i + 10, len(lines))):
-                msg_match = re.search(r'"?msg"?\s*[:=]\s*["\']?(.+?)["\']?\s*$', lines[j].strip())
-                if msg_match:
-                    msg = msg_match.group(1).strip().strip("'\"")
-                    break
-
-            task_part = f' at "{current_task}"' if current_task else ""
-            msg_part = f": {msg}" if msg else ""
-            failures.append(f"{host} {failure_type.lower()}{task_part}{msg_part}")
-
-        i += 1
-
-    if not failures:
-        return ""
-
-    count = len(failures)
-    noun = "host" if count == 1 else "hosts"
-    return f"{count} {noun} failed — " + "; ".join(failures)
 
 
 def _handle_provision_result(result: dict) -> None:

--- a/autobot-slm-backend/api/tls.py
+++ b/autobot-slm-backend/api/tls.py
@@ -27,6 +27,7 @@ from models.schemas import (
     TLSEndpointsResponse,
 )
 from services.auth import get_current_user
+from services.ansible_utils import _extract_failure_summary
 from services.database import get_db
 from services.tls_credentials import get_tls_credential_service
 
@@ -773,7 +774,9 @@ def _build_enable_tls_response(success: bool, returncode: int, services: List[st
     Returns:
         Response dict with success, message, services, and results.
     """
-    message = "TLS enabled successfully" if success else f"TLS enablement failed with code {returncode}"
+    _stdout = (results.get("enable_tls") or {}).get("stdout", "")
+    _summary = _extract_failure_summary(_stdout)
+    message = "TLS enabled successfully" if success else (_summary or f"TLS enablement failed with code {returncode}")
 
     logger.info(
         "TLS enablement for %s: %s (code %d)",

--- a/autobot-slm-backend/services/ansible_utils.py
+++ b/autobot-slm-backend/services/ansible_utils.py
@@ -1,0 +1,52 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Ansible output parsing utilities for slm-backend endpoints."""
+
+import re
+
+
+def _extract_failure_summary(output: str) -> str:
+    """Parse Ansible stdout and return a human-readable failure summary.
+
+    Extracts failed hosts, the task that failed, and the error message so
+    users see e.g. '172.16.168.26 failed at "Common | Update apt cache":
+    Failed to update apt cache: unknown reason' instead of 'exit code 2'.
+    """
+    lines = output.splitlines()
+    failures: list[str] = []
+    current_task = ""
+
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+
+        if line.startswith("TASK ["):
+            task_match = re.search(r"TASK \[(.+?)\]", line)
+            if task_match:
+                current_task = task_match.group(1).strip()
+
+        if line.startswith("fatal:"):
+            host_match = re.search(r"fatal: \[([^\]]+)\]", line)
+            host = host_match.group(1) if host_match else "unknown host"
+            failure_type = "UNREACHABLE" if "UNREACHABLE" in line else "FAILED"
+
+            msg = ""
+            for j in range(i + 1, min(i + 10, len(lines))):
+                msg_match = re.search(r'"?msg"?\s*[:=]\s*["\']?(.+?)["\']?\s*$', lines[j].strip())
+                if msg_match:
+                    msg = msg_match.group(1).strip().strip('\'"')
+                    break
+
+            task_part = f' at "{current_task}"' if current_task else ""
+            msg_part = f": {msg}" if msg else ""
+            failures.append(f"{host} {failure_type.lower()}{task_part}{msg_part}")
+
+        i += 1
+
+    if not failures:
+        return ""
+
+    count = len(failures)
+    noun = "host" if count == 1 else "hosts"
+    return f"{count} {noun} failed \u2014 " + "; ".join(failures)


### PR DESCRIPTION
## Summary
- Extract `_extract_failure_summary` from `api/setup_wizard.py` into new `services/ansible_utils.py`
- Apply it in `api/infrastructure.py` to replace raw exit-code error message
- Apply it in `api/tls.py` to replace raw exit-code failure message
- Remove `import re` from `setup_wizard.py` (only used inside the moved function)

## Test plan
- [ ] `python -m py_compile` passes on all 4 modified files
- [ ] `infrastructure.py`: `execution.error` shows human-readable Ansible failure instead of "exit code N"
- [ ] `tls.py`: TLS failure message shows Ansible failure summary when available, falls back to exit code
- [ ] `setup_wizard.py` still calls `_extract_failure_summary` via re-import

Closes #5564

🤖 Generated with [Claude Code](https://claude.ai/claude-code)