### PR TITLE
refactor(frontend): replace 7 raw setInterval loops with usePollingJob (#5561)

### DIFF
--- a/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
+++ b/autobot-frontend/src/components/analytics/LogPatternDashboard.vue
@@ -231,6 +231,7 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { getCssVar } from '@/composables/useCssVars'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const { t } = useI18n()
 
@@ -308,7 +309,10 @@ const patternFilters = computed(() => [
   { label: t('analytics.logPatterns.filterHighFreq'), value: 'high_freq' }
 ])
 
-let realtimeInterval: ReturnType<typeof setInterval> | null = null
+const { start: _startRealtime, stop: _stopRealtime } = usePollingJob(
+  async () => { await fetchRealtimeData(); return null },
+  { intervalMs: 30000, maxAttempts: Number.MAX_SAFE_INTEGER }
+)
 
 
 // Computed
@@ -413,15 +417,11 @@ const getTrendPoints = (trend: LogTrend): string => {
 onMounted(() => {
   fetchRealtimeData()
   runAnalysis()
-
-  // Refresh realtime data every 30 seconds
-  realtimeInterval = setInterval(fetchRealtimeData, 30000)
+  _startRealtime('')
 })
 
 onUnmounted(() => {
-  if (realtimeInterval) {
-    clearInterval(realtimeInterval)
-  }
+  _stopRealtime()
 })
 </script>
 

--- a/autobot-frontend/src/components/chat/ChatInterface.vue
+++ b/autobot-frontend/src/components/chat/ChatInterface.vue
@@ -272,6 +272,7 @@
 import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watch, provide } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useBackoffPoller } from '@/composables/useBackoffPoller'
+import { usePollingJob } from '@/composables/usePollingJob'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { useFocusRestore } from '@/composables/useFocusRestore'
 import { useInitialFocus } from '@/composables/useInitialFocus'
@@ -887,33 +888,25 @@ const checkConnection = async () => {
   }
 }
 
-// Interval refs for proper cleanup
-const heartbeatInterval = ref<number | null>(null)
-const autoSaveInterval = ref<number | null>(null)
+// Heartbeat: check connection every 60 s (reduced from 30 to minimise UI updates)
+const heartbeatPoller = usePollingJob(
+  async () => { await checkConnection(); return null },
+  { intervalMs: 60_000, maxAttempts: Number.MAX_SAFE_INTEGER }
+)
 
-const startHeartbeat = () => {
-  // Clear any existing interval first
-  if (heartbeatInterval.value) {
-    clearInterval(heartbeatInterval.value)
-  }
-  // Check connection every 60 seconds (reduced from 30 to minimize UI updates)
-  heartbeatInterval.value = setInterval(checkConnection, 60000) as unknown as number
-}
-
-// Auto-save functionality
-const enableAutoSave = () => {
-  // Clear any existing interval first
-  if (autoSaveInterval.value) {
-    clearInterval(autoSaveInterval.value)
-  }
-  // Auto-save current session every 2 minutes
-  autoSaveInterval.value = setInterval(() => {
+// Auto-save current session every 2 minutes
+const autoSavePoller = usePollingJob(
+  async () => {
     if (store.settings.autoSave && store.currentSessionId) {
-      controller.saveChatSession()
-        .catch((error: any) => logger.warn('Auto-save failed:', error))
+      await controller.saveChatSession().catch((error: any) => logger.warn('Auto-save failed:', error))
     }
-  }, 2 * 60 * 1000) as unknown as number
-}
+    return null
+  },
+  { intervalMs: 2 * 60 * 1000, maxAttempts: Number.MAX_SAFE_INTEGER }
+)
+
+const startHeartbeat = () => heartbeatPoller.start('')
+const enableAutoSave = () => autoSavePoller.start('')
 
 // Message polling with exponential backoff + circuit breaker (#1100)
 // Prevents 499 cascade: skips in-flight polls, backs off on failure, opens circuit
@@ -1071,15 +1064,8 @@ onUnmounted(() => {
   document.removeEventListener('keydown', handleKeyboardShortcuts)
 
   // Clean up intervals
-  if (heartbeatInterval.value) {
-    clearInterval(heartbeatInterval.value)
-    heartbeatInterval.value = null
-  }
-
-  if (autoSaveInterval.value) {
-    clearInterval(autoSaveInterval.value)
-    autoSaveInterval.value = null
-  }
+  heartbeatPoller.stop()
+  autoSavePoller.stop()
 
   _stopCountdown()
   messagePoller.stop()
@@ -1114,16 +1100,9 @@ onDeactivated(() => {
   // Pause message polling (will resume on onActivated)
   messagePoller.stop()
 
-  // Clean up intervals while cached
-  if (heartbeatInterval.value) {
-    clearInterval(heartbeatInterval.value)
-    heartbeatInterval.value = null
-  }
-
-  if (autoSaveInterval.value) {
-    clearInterval(autoSaveInterval.value)
-    autoSaveInterval.value = null
-  }
+  // Pause intervals while cached
+  heartbeatPoller.stop()
+  autoSavePoller.stop()
 
   // Clean up keyboard shortcuts while cached
   document.removeEventListener('keydown', handleKeyboardShortcuts)

--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
@@ -203,6 +203,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { createLogger } from '@/utils/debugUtils';
 import { useToast } from '@/composables/useToast';
+import { usePollingJob } from '@/composables/usePollingJob';
 import {
   visionMultimodalApiClient,
   type ScreenAnalysisResponse,
@@ -240,8 +241,6 @@ const confidenceThreshold = ref(50);
 // Auto-refresh
 const autoRefresh = ref(false);
 const refreshInterval = ref(10000);
-let refreshTimer: ReturnType<typeof setInterval> | null = null;
-
 // Computed
 const filteredElements = computed(() => {
   if (!analysisResult.value) return [];
@@ -341,38 +340,30 @@ const getElementIcon = (elementType: string): string => {
 };
 
 // Auto-refresh watcher
+const { start: _startAutoRefresh, stop: _stopAutoRefresh } = usePollingJob(
+  async () => {
+    if (!analyzing.value) {
+      await captureAndAnalyze();
+    }
+    return null;
+  },
+  { intervalMs: refreshInterval.value, maxAttempts: Number.MAX_SAFE_INTEGER }
+);
+
 watch(autoRefresh, (enabled) => {
   if (enabled) {
-    startAutoRefresh();
+    _startAutoRefresh('');
   } else {
-    stopAutoRefresh();
+    _stopAutoRefresh();
   }
 });
 
-watch(refreshInterval, () => {
+watch(refreshInterval, (ms) => {
   if (autoRefresh.value) {
-    stopAutoRefresh();
-    startAutoRefresh();
+    _stopAutoRefresh();
+    _startAutoRefresh('');
   }
 });
-
-const startAutoRefresh = () => {
-  if (refreshTimer) return;
-  refreshTimer = setInterval(() => {
-    if (!analyzing.value) {
-      captureAndAnalyze();
-    }
-  }, refreshInterval.value);
-  logger.debug('Auto-refresh started:', refreshInterval.value);
-};
-
-const stopAutoRefresh = () => {
-  if (refreshTimer) {
-    clearInterval(refreshTimer);
-    refreshTimer = null;
-    logger.debug('Auto-refresh stopped');
-  }
-};
 
 // Lifecycle
 onMounted(() => {
@@ -380,7 +371,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  stopAutoRefresh();
+  _stopAutoRefresh();
 });
 </script>
 

--- a/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
+++ b/autobot-frontend/src/components/visualizations/AgentActivityVisualization.vue
@@ -186,6 +186,7 @@ import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { getCssVar } from '@/composables/useCssVars'
 import { useExpansion } from '@/composables/useExpansion'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const { t } = useI18n()
 const logger = createLogger('AgentActivityVisualization')
@@ -505,22 +506,21 @@ function simulateActivity() {
 }
 
 // Lifecycle
-let refreshTimer: ReturnType<typeof setInterval> | null = null
+const { start: _startRefresh, stop: _stopRefresh } = usePollingJob(
+  async () => { simulateActivity(); return null },
+  { intervalMs: props.refreshInterval || 0, maxAttempts: Number.MAX_SAFE_INTEGER }
+)
 
 onMounted(async () => {
   await Promise.all([fetchAgents(), fetchEvents()])
 
   if (props.refreshInterval > 0) {
-    refreshTimer = setInterval(() => {
-      simulateActivity()
-    }, props.refreshInterval)
+    _startRefresh('')
   }
 })
 
 onUnmounted(() => {
-  if (refreshTimer) {
-    clearInterval(refreshTimer)
-  }
+  _stopRefresh()
 })
 
 // Expose

--- a/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
+++ b/autobot-frontend/src/components/visualizations/ResourceHeatmap.vue
@@ -78,7 +78,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import VueApexCharts from 'vue3-apexcharts'
 import type { ApexOptions } from 'apexcharts'
@@ -413,13 +413,16 @@ function updateData() {
 }
 
 // Lifecycle
-let refreshTimer: ReturnType<typeof setInterval> | null = null
+const { start: _startRefresh, stop: _stopRefresh } = usePollingJob(
+  async () => { await fetchData(); return null },
+  { intervalMs: props.refreshInterval || 0, maxAttempts: Number.MAX_SAFE_INTEGER }
+)
 
 onMounted(() => {
   fetchData()
 
   if (props.refreshInterval > 0) {
-    refreshTimer = setInterval(fetchData, props.refreshInterval)
+    _startRefresh('')
   }
 })
 
@@ -429,12 +432,8 @@ watch(() => props.machine, () => {
 })
 
 // Cleanup
-import { onUnmounted } from 'vue'
-import { getCssVar } from '@/composables/useCssVars'
 onUnmounted(() => {
-  if (refreshTimer) {
-    clearInterval(refreshTimer)
-  }
+  _stopRefresh()
 })
 
 // Expose methods

--- a/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
+++ b/autobot-frontend/src/components/visualizations/SystemArchitectureDiagram.vue
@@ -515,6 +515,7 @@ import apiClient from '@/utils/ApiClient'
 import { getConfig, getApiBase } from '@/config/ssot-config'
 import { createLogger } from '@/utils/debugUtils'
 import { getCssVar } from '@/composables/useCssVars'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const { t } = useI18n()
 
@@ -1201,13 +1202,16 @@ function resetView() {
 // Lifecycle
 // ============================================================================
 
-let refreshTimer: ReturnType<typeof setInterval> | null = null
+const { start: _startRefresh, stop: _stopRefresh } = usePollingJob(
+  async () => { await refreshArchitecture(); return null },
+  { intervalMs: props.refreshInterval || 0, maxAttempts: Number.MAX_SAFE_INTEGER }
+)
 
 onMounted(() => {
   refreshArchitecture()
 
   if (props.autoRefresh && props.refreshInterval > 0) {
-    refreshTimer = setInterval(refreshArchitecture, props.refreshInterval)
+    _startRefresh('')
   }
 })
 

--- a/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowProgressWidget.vue
@@ -81,6 +81,7 @@ import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import { apiService } from '@/services/api'
 import { getApiBase } from '@/config/ssot-config'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const { t } = useI18n()
 
@@ -98,7 +99,10 @@ const emit = defineEmits(['open-full-view', 'workflow-cancelled'])
 const activeWorkflow = ref(null)
 const workflowSteps = ref([])
 const expanded = ref(false)
-const refreshInterval = ref(null)
+const { start: _startRefresh, stop: _stopRefresh } = usePollingJob(
+  async () => { await loadWorkflowData(); return null },
+  { intervalMs: 3000, maxAttempts: Number.MAX_SAFE_INTEGER }
+)
 
 // Computed properties
 const progressPercentage = computed(() => {
@@ -164,17 +168,11 @@ const cancelWorkflow = async () => {
 // Lifecycle
 onMounted(() => {
   loadWorkflowData()
-
-  // Refresh every 3 seconds
-  refreshInterval.value = setInterval(() => {
-    loadWorkflowData()
-  }, 3000)
+  _startRefresh('')
 })
 
 onUnmounted(() => {
-  if (refreshInterval.value) {
-    clearInterval(refreshInterval.value)
-  }
+  _stopRefresh()
 })
 </script>
 


### PR DESCRIPTION
## Summary
- Migrate 7 components from manual `setInterval`/`clearInterval` to `usePollingJob`
- Files: `WorkflowProgressWidget`, `LogPatternDashboard`, `ScreenCaptureViewer`, `ResourceHeatmap`, `AgentActivityVisualization`, `SystemArchitectureDiagram`, `ChatInterface` (heartbeat + autoSave)
- All intervals now benefit from `onScopeDispose` auto-cleanup and last-caller-wins restart safety
- `ChatInterface` countdown timer (legitimate non-polling use) left as-is

## Test plan
- [ ] No raw `setInterval` calls remain in migrated components (except countdown)
- [ ] All 7 files import `usePollingJob`
- [ ] `ChatInterface` heartbeat and autoSave restart correctly on `onActivated`
- [ ] `ScreenCaptureViewer` auto-refresh restarts when `refreshInterval` prop changes
- [ ] `ResourceHeatmap` and `AgentActivityVisualization` only start polling when `props.refreshInterval > 0`

Closes #5561

🤖 Generated with [Claude Code](https://claude.ai/claude-code)