### PR TITLE
refactor(utils): migrate task_queue get_task_queue() to lazy_singleton — missed in #5529 (#5578)

### DIFF
--- a/autobot-backend/utils/task_queue.py
+++ b/autobot-backend/utils/task_queue.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import parse_utc_iso
 
 try:
@@ -834,32 +835,15 @@ class TaskQueue:
         return cleaned_count
 
 
-# Global task queue instance (thread-safe)
-import threading
-
-_task_queue: Optional[TaskQueue] = None
-_task_queue_lock = threading.Lock()
-
-
-def get_task_queue() -> TaskQueue:
-    """Get the global task queue instance (thread-safe)."""
-    global _task_queue
-
-    if _task_queue is None:
-        with _task_queue_lock:
-            # Double-check after acquiring lock
-            if _task_queue is None:
-                _task_queue = TaskQueue()
-
-    return _task_queue
+get_task_queue = lazy_singleton(TaskQueue)
 
 
 def initialize_task_queue(**kwargs) -> TaskQueue:
-    """Initialize the global task queue."""
-    global _task_queue
+    """Initialize and return a fresh TaskQueue instance.
 
-    _task_queue = TaskQueue(**kwargs)
-    return _task_queue
+    Escape hatch: bypasses lazy_singleton cache for tests/forced reinit.
+    """
+    return TaskQueue(**kwargs)
 
 
 # Convenience decorators


### PR DESCRIPTION
## Summary

Migrates `utils/task_queue.py::get_task_queue()` to `lazy_singleton` — this file was listed in #5529's scope but was not included in PR #5571.

- Removes `_task_queue`, `_task_queue_lock`, and the 11-line double-checked locking body
- Replaces with `get_task_queue = lazy_singleton(TaskQueue)` (1 line)
- Removes `import threading` (was only used for `_task_queue_lock`)
- Keeps `initialize_task_queue(**kwargs)` as documented escape hatch (zero external callers — only used for forced reinit/tests)

**Pre-verified:** `initialize_task_queue` has zero external callers; `get_task_queue` called only from `initialization/lifespan.py`.

Closes #5578

## Test plan
- [ ] `py_compile utils/task_queue.py` passes
- [ ] `from utils.task_queue import get_task_queue` imports correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)