### PR TITLE
a11y(ui): fix ARIA roles, touch targets, and keyboard access (#4806)

### DIFF
--- a/autobot-frontend/src/components/ui/BaseModal.vue
+++ b/autobot-frontend/src/components/ui/BaseModal.vue
@@ -228,8 +228,8 @@ const onAfterEnter = () => focusFirst()
 }
 
 .close-btn {
-  width: 2.5rem;
-  height: 2.5rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   border: none;
   background: var(--bg-secondary);
   border-radius: var(--radius-md);

--- a/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
+++ b/autobot-frontend/src/components/ui/CommandPermissionDialog.vue
@@ -1,12 +1,12 @@
 <template>
   <div v-if="showDialog" class="command-overlay">
-    <div class="command-dialog">
+    <div class="command-dialog" role="dialog" aria-modal="true" aria-labelledby="cmd-permission-title">
       <div class="command-header">
-        <div class="command-icon">
+        <div class="command-icon" aria-hidden="true">
           <Icon name="terminal" size="md" />
         </div>
         <div class="command-title">
-          <h3>{{ t('ui.commandPermission.title') }}</h3>
+          <h3 id="cmd-permission-title">{{ t('ui.commandPermission.title') }}</h3>
           <p class="command-subtitle">{{ purpose || t('ui.commandPermission.defaultPurpose') }}</p>
         </div>
       </div>

--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -388,6 +388,7 @@ const formatCell = (value: any, column: Column) => {
 /* Issue #901: Technical Precision pagination buttons */
 .pagination-btn {
   padding: var(--spacing-2) var(--spacing-3);
+  min-height: 44px;
   border: 1px solid var(--border-default);
   background: var(--bg-card);
   border-radius: var(--radius-xs);

--- a/autobot-frontend/src/components/ui/HostSelectionDialog.vue
+++ b/autobot-frontend/src/components/ui/HostSelectionDialog.vue
@@ -752,8 +752,8 @@ onUnmounted(() => {
   background: transparent;
   border: 1px solid var(--border-secondary);
   color: var(--text-muted);
-  width: 32px;
-  height: 32px;
+  min-width: 44px;
+  min-height: 44px;
   border-radius: var(--radius-sm);
   cursor: pointer;
   display: flex;

--- a/autobot-frontend/src/components/ui/HostSelector.vue
+++ b/autobot-frontend/src/components/ui/HostSelector.vue
@@ -4,7 +4,12 @@
     <div
       v-if="!expanded"
       class="host-selector-collapsed"
+      role="button"
+      tabindex="0"
+      :aria-expanded="expanded"
       @click="toggleExpanded"
+      @keydown.enter="toggleExpanded"
+      @keydown.space.prevent="toggleExpanded"
     >
       <div class="selected-host" v-if="selectedHost">
         <Icon :name="getHostIcon(selectedHost)" size="sm" />
@@ -25,7 +30,7 @@
     <div v-else class="host-selector-expanded">
       <div class="selector-header">
         <h4>{{ t('ui.hostSelector.infrastructureHosts') }}</h4>
-        <button class="btn-close" @click="toggleExpanded">
+        <button class="btn-close" @click="toggleExpanded" :aria-label="t('ui.modal.closeDialog')">
           <Icon name="times" size="sm" />
         </button>
       </div>
@@ -99,7 +104,7 @@
       </div>
 
       <!-- Loading state -->
-      <div v-else class="loading-state">
+      <div v-else class="loading-state" role="status" aria-live="polite">
         <LoadingSpinner size="md" />
         <span>{{ t('ui.hostSelector.loadingHosts') }}</span>
       </div>
@@ -428,6 +433,11 @@ defineExpose({
   padding: var(--spacing-1);
   cursor: pointer;
   color: var(--text-muted);
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-close:hover {

--- a/autobot-frontend/src/components/ui/LoadingSpinner.vue
+++ b/autobot-frontend/src/components/ui/LoadingSpinner.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="loading-spinner" :class="sizeClass" :style="customStyle">
+  <div class="loading-spinner" :class="sizeClass" :style="customStyle" role="status" :aria-label="label || t('ui.loadingSpinner.loading')">
     <div v-if="variant === 'dots'" class="loading-dots">
       <div class="dot"></div>
       <div class="dot"></div>
@@ -42,6 +42,9 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 interface Props {
   variant?: 'circle' | 'dots' | 'pulse' | 'bars'

--- a/autobot-frontend/src/components/ui/UnifiedLoadingView.vue
+++ b/autobot-frontend/src/components/ui/UnifiedLoadingView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="unified-loading-view" :data-loading-key="loadingKey">
     <!-- Error State -->
-    <div v-if="error && !isLoading" class="error-container">
+    <div v-if="error && !isLoading" class="error-container" role="alert">
       <div class="error-content">
         <div class="error-icon">
           <Icon name="exclamation-triangle" size="xl" class="text-4xl" style="color: var(--color-error)" />
@@ -21,7 +21,7 @@
     </div>
 
     <!-- Loading State -->
-    <div v-else-if="isLoading && !hasContent" class="loading-container">
+    <div v-else-if="isLoading && !hasContent" class="loading-container" role="status" aria-live="polite" aria-atomic="true">
       <div class="loading-content">
         <div class="loading-spinner">
           <div class="animate-spin rounded-full h-16 w-16 border-b-2 border-indigo-600"></div>
@@ -41,7 +41,7 @@
       <slot />
 
       <!-- Subtle loading indicator when content exists -->
-      <div v-if="isLoading && hasContent" class="updating-indicator">
+      <div v-if="isLoading && hasContent" class="updating-indicator" role="status" aria-live="polite" aria-atomic="true">
         <div class="updating-pulse"></div>
         <span class="updating-text">{{ t('ui.unifiedLoading.updating') }}</span>
       </div>

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -5196,6 +5196,9 @@
     },
     "skeletonLoader": {
       "loadingContent": "Loading content"
+    },
+    "loadingSpinner": {
+      "loading": "Loading…"
     }
   },
   "base": {


### PR DESCRIPTION
## Summary

- **LoadingSpinner**: `role="status"` + `aria-label` — all animated spinners now announce themselves to screen readers
- **UnifiedLoadingView**: `role="alert"` on error state, `role="status" aria-live="polite"` on loading and updating-indicator containers
- **HostSelector**: `aria-label` on close button, keyboard-accessible collapsed trigger (`role="button"`, `tabindex`, Enter/Space handlers), 44px touch target on close button, `role="status"` on loading state
- **CommandPermissionDialog**: `role="dialog"` + `aria-modal="true"` + `aria-labelledby` pointing to the dialog h3; decorative terminal icon gets `aria-hidden`
- **BaseModal**: close button bumped from 40px → 44px minimum (WCAG 2.5.5)
- **HostSelectionDialog**: set-default-btn bumped from 32px → 44px minimum
- **DataTable**: pagination buttons get `min-height: 44px`
- **en.json**: `ui.loadingSpinner.loading` i18n key

Note: `Icon.vue` already has `aria-hidden="true"` hardcoded on its SVG — all Icon usages were already safe. No raw `<i class="fas ...">` remain in these components.

## Test plan
- [ ] Screen reader (VoiceOver/NVDA) announces spinner as "Loading…" on pages with LoadingSpinner
- [ ] Screen reader announces loading/error state changes in UnifiedLoadingView
- [ ] HostSelector close button reachable via Tab and activatable with Enter/Space
- [ ] CommandPermissionDialog announced as dialog by screen reader
- [ ] Close buttons/pagination/set-default meet 44px minimum tap area
- [ ] TypeScript: no new errors in changed files (`npx vue-tsc --noEmit`)

Closes #4806

🤖 Generated with [Claude Code](https://claude.com/claude-code)