### PR TITLE
refactor(knowledge): replace Dict[str, Any] with CategoryMeta TypedDict (#5591)

### DIFF
--- a/autobot-backend/knowledge_categories.py
+++ b/autobot-backend/knowledge_categories.py
@@ -11,7 +11,7 @@ Defines the 3 main categories for AutoBot's knowledge base:
 """
 
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Dict, List, TypedDict
 
 # Issue #380: Module-level tuples for source category detection
 _AUTOBOT_DOC_KEYWORDS = ("autobot", "docs/", "documentation")
@@ -33,8 +33,16 @@ class KnowledgeCategory(str, Enum):
     USER_KNOWLEDGE = "user-knowledge"
 
 
+class CategoryMeta(TypedDict):
+    name: str
+    description: str
+    icon: str
+    color: str
+    examples: List[str]
+
+
 # Category metadata for display and organization
-CATEGORY_METADATA: Dict[str, Dict[str, Any]] = {
+CATEGORY_METADATA: Dict[str, CategoryMeta] = {
     KnowledgeCategory.AUTOBOT_DOCUMENTATION: {
         "name": "AutoBot Documentation",
         "description": "AutoBot's initial knowledge - documentation and guides",


### PR DESCRIPTION
## Summary

- Adds `CategoryMeta(TypedDict)` to `knowledge_categories.py` with typed fields: `name`, `description`, `icon`, `color`, `examples: List[str]`
- Updates `CATEGORY_METADATA` annotation from `Dict[str, Dict[str, Any]]` to `Dict[str, CategoryMeta]`
- Replaces `Any` import with `TypedDict` (standard library, Python 3.8+)

## Why

The original `Dict[str, Dict[str, str]]` annotation caused a production 500 when `examples` was passed as a `str` where Pydantic expected `List[str]`. `Dict[str, Any]` fixed the runtime crash but left the type loose. `CategoryMeta` makes the mismatch a static type error instead.

## Test plan
- [ ] `python3 -c "from knowledge_categories import CATEGORY_METADATA"` — no import error
- [ ] Pydantic round-trip: `KnowledgeMainCategoryEntry(**{...meta, id=cat_id, count=0})` for each entry

Closes #5591