### PR TITLE
refactor(knowledge): split facts.py into ingestion/entries/query schema modules (#5486)

### DIFF
--- a/autobot-backend/knowledge/schemas/entries.py
+++ b/autobot-backend/knowledge/schemas/entries.py
@@ -1,0 +1,91 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Stored knowledge entry schemas.
+
+Covers response shapes for endpoints that retrieve existing knowledge
+base entries: ``GET /entries``, ``GET /facts/by_category``, and
+``GET /fact/{key}``.
+
+Split from ``facts.py`` per Issue #5486.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class KnowledgeEntry(BaseModel):
+    """Single row inside ``KnowledgeEntriesResponse.entries``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    key: str
+    title: str = "Untitled"
+    content: str = ""
+    category: str = ""
+    type: str = "unknown"
+    created_at: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class KnowledgeEntriesResponse(BaseModel):
+    """Shape of ``GET /api/knowledge_base/entries``.
+
+    Cursor-paginated list. ``next_cursor`` is a stringified integer;
+    ``has_more`` flips to False when the SCAN cursor wraps to 0.
+    Error branches populate ``error`` instead of raising.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    entries: List[KnowledgeEntry] = Field(default_factory=list)
+    next_cursor: str = "0"
+    count: int = 0
+    has_more: bool = False
+    # Degraded-path fields: populated on error / KB-uninit, absent on success.
+    message: Optional[str] = None
+    error: Optional[str] = None
+
+
+class FactByCategoryEntry(BaseModel):
+    """Single fact row nested under ``FactsByCategoryResponse.categories[cat]``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    key: str
+    title: str = "Untitled"
+    content: str = Field("", description="Truncated to 500 chars + ellipsis")
+    full_content: str = ""
+    category: str = ""
+    type: str = "unknown"
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class FactsByCategoryResponse(BaseModel):
+    """Shape of ``GET /api/knowledge_base/facts/by_category``.
+
+    Grouped facts keyed by category name. ``category_filter`` echoes the
+    optional ``?category=`` query param for client-side confirmation.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    categories: Dict[str, List[FactByCategoryEntry]] = Field(default_factory=dict)
+    total_facts: int = 0
+    category_filter: Optional[str] = None
+    # Error branch returns this + empty categories/total_facts.
+    error: Optional[str] = None
+
+
+class FactByKeyResponse(BaseModel):
+    """Shape of ``GET /api/knowledge_base/fact/{fact_key}``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    key: str
+    content: str = ""
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str = ""

--- a/autobot-backend/knowledge/schemas/facts.py
+++ b/autobot-backend/knowledge/schemas/facts.py
@@ -1,228 +1,36 @@
 # AutoBot - AI-Powered Automation Platform
 # Copyright (c) 2026 mrveiss
 # Author: mrveiss
-"""Response schemas for knowledge-base fact lifecycle endpoints.
+"""Backward-compat re-exports for knowledge-base fact schemas.
 
-Issue #5317 (follow-up to #5248): the fact ingestion / query / delete
-endpoints under ``/api/knowledge_base/*`` all returned plain dicts.
-FastAPI therefore could not emit them as OpenAPI component schemas, so
-the frontend keeps hand-writing ``KnowledgeFact`` / ``AddFactResponse``
-etc. in ``autobot-frontend/src/models/repositories/KnowledgeRepository.ts``.
+Classes have been split into focused sub-modules per Issue #5486:
 
-Declaring these as Pydantic ``BaseModel`` subclasses with
-``response_model=`` wires them into ``components.schemas`` in
-``/openapi.json`` so ``npm run gen:types`` picks them up.
+- :mod:`knowledge.schemas.ingestion` — add/upload/clear response shapes
+- :mod:`knowledge.schemas.entries`   — stored entry retrieval shapes
+- :mod:`knowledge.schemas.query`     — search/query response shapes
 
-Every model uses ``model_config = ConfigDict(extra="allow")`` because the
-backend dicts carry diagnostic keys (fact IDs, per-fact metadata shapes,
-error codes) that rotate between releases. Strict schemas would silently
-strip those and break existing UI renderers.
+Import directly from those modules in new code.  Existing callers that
+import from ``knowledge.schemas.facts`` continue to work unchanged.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
-
-from pydantic import BaseModel, ConfigDict, Field
-
-
-class AddTextResponse(BaseModel):
-    """Shape of ``POST /api/knowledge_base/add_text``.
-
-    Legacy text-ingestion endpoint (newer frontend uses /facts — see
-    :class:`AddFactResponse`). Returns the fact_id plus ownership
-    metadata echo for audit visibility.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    status: str = Field(..., description="'success' on insert")
-    message: str = ""
-    fact_id: Optional[str] = None
-    text_length: int = 0
-    title: str = ""
-    source: str = ""
-    access_level: Optional[str] = None
-    visibility: Optional[str] = None
-
-
-class AddFactResponse(BaseModel):
-    """Shape of ``POST /api/knowledge_base/facts`` (frontend-compatible).
-
-    Returns a truncated content echo (first 100 chars) — callers that
-    need the full content should re-fetch via ``GET /fact/{key}``.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    success: bool = True
-    document_id: Optional[str] = None
-    title: str = ""
-    content: str = Field("", description="Truncated to first 100 chars + ellipsis")
-    message: str = ""
-
-
-class AddUrlResponse(BaseModel):
-    """Shape of ``POST /api/knowledge_base/url``.
-
-    Same envelope as :class:`AddFactResponse`; the content field carries
-    the truncated fetched page text.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    success: bool = True
-    document_id: Optional[str] = None
-    title: str = ""
-    content: str = ""
-    message: str = ""
-
-
-class UploadFileResponse(BaseModel):
-    """Shape of ``POST /api/knowledge_base/upload``.
-
-    Adds ``word_count`` over the base upload envelope.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    success: bool = True
-    document_id: Optional[str] = None
-    title: str = ""
-    content: str = ""
-    word_count: int = 0
-    message: str = ""
-
-
-class AudioIngestResponse(BaseModel):
-    """Shape of ``POST /api/knowledge_base/audio`` and ``/audio/upload``.
-
-    Returned by the shared ``_ingest_audio_source`` helper after Whisper
-    transcription completes.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    success: bool = True
-    document_id: Optional[str] = None
-    title: str = ""
-    word_count: int = 0
-    message: str = ""
-
-
-class KnowledgeEntry(BaseModel):
-    """Single row inside ``KnowledgeEntriesResponse.entries``."""
-
-    model_config = ConfigDict(extra="allow")
-
-    key: str
-    title: str = "Untitled"
-    content: str = ""
-    category: str = ""
-    type: str = "unknown"
-    created_at: Optional[str] = None
-    metadata: Dict[str, Any] = Field(default_factory=dict)
-
-
-class KnowledgeEntriesResponse(BaseModel):
-    """Shape of ``GET /api/knowledge_base/entries``.
-
-    Cursor-paginated list. ``next_cursor`` is a stringified integer;
-    ``has_more`` flips to False when the SCAN cursor wraps to 0.
-    Error branches populate ``error`` instead of raising.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    entries: List[KnowledgeEntry] = Field(default_factory=list)
-    next_cursor: str = "0"
-    count: int = 0
-    has_more: bool = False
-    # Degraded-path fields: populated on error / KB-uninit, absent on success.
-    message: Optional[str] = None
-    error: Optional[str] = None
-
-
-class FactByCategoryEntry(BaseModel):
-    """Single fact row nested under ``FactsByCategoryResponse.categories[cat]``."""
-
-    model_config = ConfigDict(extra="allow")
-
-    key: str
-    title: str = "Untitled"
-    content: str = Field("", description="Truncated to 500 chars + ellipsis")
-    full_content: str = ""
-    category: str = ""
-    type: str = "unknown"
-    metadata: Dict[str, Any] = Field(default_factory=dict)
-
-
-class FactsByCategoryResponse(BaseModel):
-    """Shape of ``GET /api/knowledge_base/facts/by_category``.
-
-    Grouped facts keyed by category name. ``category_filter`` echoes the
-    optional ``?category=`` query param for client-side confirmation.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    categories: Dict[str, List[FactByCategoryEntry]] = Field(default_factory=dict)
-    total_facts: int = 0
-    category_filter: Optional[str] = None
-    # Error branch returns this + empty categories/total_facts.
-    error: Optional[str] = None
-
-
-class FactByKeyResponse(BaseModel):
-    """Shape of ``GET /api/knowledge_base/fact/{fact_key}``."""
-
-    model_config = ConfigDict(extra="allow")
-
-    key: str
-    content: str = ""
-    metadata: Dict[str, Any] = Field(default_factory=dict)
-    created_at: str = ""
-
-
-class ClearAllResponse(BaseModel):
-    """Shape of ``POST /api/knowledge_base/clear_all``.
-
-    DESTRUCTIVE operation. ``items_removed`` counts fact rows, not
-    vectors — vector store is cleared as part of ``kb.clear_all()``.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    status: str = Field(..., description="'success' | 'error'")
-    items_removed: int = 0
-    items_before: int = 0
-    message: str = ""
-
-
-class QueryKnowledgeResponse(BaseModel):
-    """Shape of legacy ``POST /api/knowledge_base/query``.
-
-    Proxies to :mod:`api.knowledge_search`. Fields mirror the shape returned
-    by ``_build_search_response`` in that module.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    status: str = "success"
-    synthesized_response: str = ""
-    results: List[Dict[str, Any]] = Field(default_factory=list)
-    total_results: int = 0
-    original_query: Optional[str] = None
-    reformulated_queries: List[str] = Field(default_factory=list)
-    rag_enhanced: bool = False
-
-
-class ManPageSearchResponse(BaseModel):
-    """Shape of ``GET /api/knowledge_base/man_pages/search``."""
-
-    model_config = ConfigDict(extra="allow")
-
-    results: List[Dict[str, Any]] = Field(default_factory=list)
-    total_results: int = 0
-    query: Optional[str] = None
-    limit: Optional[int] = None
+from knowledge.schemas.entries import (  # noqa: F401
+    FactByCategoryEntry,
+    FactByKeyResponse,
+    FactsByCategoryResponse,
+    KnowledgeEntriesResponse,
+    KnowledgeEntry,
+)
+from knowledge.schemas.ingestion import (  # noqa: F401
+    AddFactResponse,
+    AddTextResponse,
+    AddUrlResponse,
+    AudioIngestResponse,
+    ClearAllResponse,
+    UploadFileResponse,
+)
+from knowledge.schemas.query import (  # noqa: F401
+    ManPageSearchResponse,
+    QueryKnowledgeResponse,
+)

--- a/autobot-backend/knowledge/schemas/ingestion.py
+++ b/autobot-backend/knowledge/schemas/ingestion.py
@@ -1,0 +1,117 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Ingestion pipeline response schemas.
+
+Covers document/fact upload endpoints under ``/api/knowledge_base/*``:
+``/add_text``, ``/facts``, ``/url``, ``/upload``, ``/audio``, and
+``/clear_all``.  These are the response shapes returned after content is
+written into the knowledge base.
+
+Split from ``facts.py`` per Issue #5486.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AddTextResponse(BaseModel):
+    """Shape of ``POST /api/knowledge_base/add_text``.
+
+    Legacy text-ingestion endpoint (newer frontend uses /facts — see
+    :class:`AddFactResponse`). Returns the fact_id plus ownership
+    metadata echo for audit visibility.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = Field(..., description="'success' on insert")
+    message: str = ""
+    fact_id: Optional[str] = None
+    text_length: int = 0
+    title: str = ""
+    source: str = ""
+    access_level: Optional[str] = None
+    visibility: Optional[str] = None
+
+
+class AddFactResponse(BaseModel):
+    """Shape of ``POST /api/knowledge_base/facts`` (frontend-compatible).
+
+    Returns a truncated content echo (first 100 chars) — callers that
+    need the full content should re-fetch via ``GET /fact/{key}``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    document_id: Optional[str] = None
+    title: str = ""
+    content: str = Field("", description="Truncated to first 100 chars + ellipsis")
+    message: str = ""
+
+
+class AddUrlResponse(BaseModel):
+    """Shape of ``POST /api/knowledge_base/url``.
+
+    Same envelope as :class:`AddFactResponse`; the content field carries
+    the truncated fetched page text.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    document_id: Optional[str] = None
+    title: str = ""
+    content: str = ""
+    message: str = ""
+
+
+class UploadFileResponse(BaseModel):
+    """Shape of ``POST /api/knowledge_base/upload``.
+
+    Adds ``word_count`` over the base upload envelope.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    document_id: Optional[str] = None
+    title: str = ""
+    content: str = ""
+    word_count: int = 0
+    message: str = ""
+
+
+class AudioIngestResponse(BaseModel):
+    """Shape of ``POST /api/knowledge_base/audio`` and ``/audio/upload``.
+
+    Returned by the shared ``_ingest_audio_source`` helper after Whisper
+    transcription completes.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    success: bool = True
+    document_id: Optional[str] = None
+    title: str = ""
+    word_count: int = 0
+    message: str = ""
+
+
+class ClearAllResponse(BaseModel):
+    """Shape of ``POST /api/knowledge_base/clear_all``.
+
+    DESTRUCTIVE operation. ``items_removed`` counts fact rows, not
+    vectors — vector store is cleared as part of ``kb.clear_all()``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = Field(..., description="'success' | 'error'")
+    items_removed: int = 0
+    items_before: int = 0
+    message: str = ""

--- a/autobot-backend/knowledge/schemas/query.py
+++ b/autobot-backend/knowledge/schemas/query.py
@@ -1,0 +1,45 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2026 mrveiss
+# Author: mrveiss
+"""Query and search response schemas for the knowledge base.
+
+Covers ``POST /api/knowledge_base/query`` and
+``GET /api/knowledge_base/man_pages/search``.
+
+Split from ``facts.py`` per Issue #5486.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class QueryKnowledgeResponse(BaseModel):
+    """Shape of legacy ``POST /api/knowledge_base/query``.
+
+    Proxies to :mod:`api.knowledge_search`. Fields mirror the shape returned
+    by ``_build_search_response`` in that module.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str = "success"
+    synthesized_response: str = ""
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    total_results: int = 0
+    original_query: Optional[str] = None
+    reformulated_queries: List[str] = Field(default_factory=list)
+    rag_enhanced: bool = False
+
+
+class ManPageSearchResponse(BaseModel):
+    """Shape of ``GET /api/knowledge_base/man_pages/search``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    results: List[Dict[str, Any]] = Field(default_factory=list)
+    total_results: int = 0
+    query: Optional[str] = None
+    limit: Optional[int] = None


### PR DESCRIPTION
## Summary
- Splits monolithic `knowledge/schemas/facts.py` into three focused modules: `ingestion.py` (6 classes), `entries.py` (5 classes), `query.py` (2 classes)
- `facts.py` retained as a backward-compat re-export shim — all 13 names still importable from original path
- All existing callers (`api/knowledge.py`, `knowledge/schemas/__init__.py`) are unaffected

## Changes
- **New:** `autobot-backend/knowledge/schemas/ingestion.py` — AddTextResponse, AddFactResponse, AddUrlResponse, UploadFileResponse, AudioIngestResponse, ClearAllResponse
- **New:** `autobot-backend/knowledge/schemas/entries.py` — KnowledgeEntry, KnowledgeEntriesResponse, FactByCategoryEntry, FactsByCategoryResponse, FactByKeyResponse
- **New:** `autobot-backend/knowledge/schemas/query.py` — QueryKnowledgeResponse, ManPageSearchResponse
- **Modified:** `autobot-backend/knowledge/schemas/facts.py` — rewritten as re-export shim

## Validation
- `python3 -m py_compile` passes on all 4 files
- All 13 re-exported names resolve via `from knowledge.schemas.facts import ...`

Closes #5486

🤖 Generated with [Claude Code](https://claude.com/claude-code)