### PR TITLE
fix(ui): accessibility gap fixes from #4806 audit (#5592 #5593 #5594 #5595)

### DIFF
--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -43,12 +43,11 @@
               @keydown.space.prevent="column.sortable ? handleSort(column.key) : null"
             >
               {{ column.label }}
-              <i
+              <Icon
                 v-if="column.sortable"
-                class="fas"
-                :class="getSortIcon(column.key)"
-                aria-hidden="true"
-              ></i>
+                :name="getSortIcon(column.key)"
+                size="xs"
+              />
             </th>
             <th v-if="$slots.actions" scope="col" class="actions-column">{{ t('ui.dataTable.actions') }}</th>
           </tr>
@@ -117,7 +116,7 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import EmptyState from './EmptyState.vue'
 import LoadingSpinner from './LoadingSpinner.vue'
-import Icon from './Icon.vue'
+import Icon, { type IconName } from './Icon.vue'
 
 /**
  * Reusable Data Table Component
@@ -205,9 +204,9 @@ const handleSort = (key: string) => {
   emit('sort-change', key, sortDirection.value)
 }
 
-const getSortIcon = (key: string) => {
-  if (sortKey.value !== key) return 'fa-sort'
-  return sortDirection.value === 'asc' ? 'fa-sort-up' : 'fa-sort-down'
+const getSortIcon = (key: string): IconName => {
+  if (sortKey.value !== key) return 'sort'
+  return sortDirection.value === 'asc' ? 'chevron-up' : 'chevron-down'
 }
 
 // Pagination

--- a/autobot-frontend/src/components/ui/HostSelector.vue
+++ b/autobot-frontend/src/components/ui/HostSelector.vue
@@ -1,15 +1,12 @@
 <template>
   <div class="host-selector">
     <!-- Collapsed state - shows current selection -->
-    <div
+    <button
       v-if="!expanded"
+      type="button"
       class="host-selector-collapsed"
-      role="button"
-      tabindex="0"
       :aria-expanded="expanded"
       @click="toggleExpanded"
-      @keydown.enter="toggleExpanded"
-      @keydown.space.prevent="toggleExpanded"
     >
       <div class="selected-host" v-if="selectedHost">
         <Icon :name="getHostIcon(selectedHost)" size="sm" />
@@ -24,7 +21,7 @@
         <span>{{ t('ui.hostSelector.selectHost') }}</span>
       </div>
       <Icon name="chevron-down" size="sm" class="expand-icon" />
-    </div>
+    </button>
 
     <!-- Expanded state - shows host list -->
     <div v-else class="host-selector-expanded">
@@ -337,6 +334,11 @@ defineExpose({
   border-radius: var(--radius-lg);
   cursor: pointer;
   transition: all var(--duration-150);
+  appearance: none;
+  font-family: inherit;
+  font-size: inherit;
+  text-align: left;
+  width: 100%;
 }
 
 .host-selector-collapsed:hover {

--- a/autobot-frontend/src/components/ui/Icon.vue
+++ b/autobot-frontend/src/components/ui/Icon.vue
@@ -29,6 +29,7 @@ import { computed } from 'vue'
 const ICONS = {
   // Navigation
   'chevron-down': 'M19 9l-7 7-7-7',
+  sort: 'M8 9l4-4 4 4m-8 6l4 4 4-4',
   'chevron-up': 'M5 15l7-7 7 7',
   'chevron-left': 'M15 19l-7-7 7-7',
   'chevron-right': 'M9 5l7 7-7 7',

--- a/autobot-frontend/src/components/ui/LoadingSpinner.vue
+++ b/autobot-frontend/src/components/ui/LoadingSpinner.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="loading-spinner" :class="sizeClass" :style="customStyle" role="status" :aria-label="label || t('ui.loadingSpinner.loading')">
+  <div class="loading-spinner" :class="sizeClass" :style="customStyle" role="status">
+    <span class="sr-only">{{ label || t('ui.loadingSpinner.loading') }}</span>
     <div v-if="variant === 'dots'" class="loading-dots">
       <div class="dot"></div>
       <div class="dot"></div>
@@ -34,7 +35,7 @@
       </svg>
     </div>
 
-    <div v-if="label" class="loading-label" :class="labelClass">
+    <div v-if="label" class="loading-label" :class="labelClass" aria-hidden="true">
       {{ label }}
     </div>
   </div>
@@ -224,7 +225,19 @@ const customStyle = computed(() => ({
   }
 }
 
-/* Issue #704: Migrated to CSS design tokens */
+/* Visually hidden but readable by screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Label */
 .loading-label {
   font-size: var(--text-sm);

--- a/autobot-frontend/src/components/ui/UnifiedLoadingView.vue
+++ b/autobot-frontend/src/components/ui/UnifiedLoadingView.vue
@@ -24,7 +24,7 @@
     <div v-else-if="isLoading && !hasContent" class="loading-container" role="status" aria-live="polite" aria-atomic="true">
       <div class="loading-content">
         <div class="loading-spinner">
-          <div class="animate-spin rounded-full h-16 w-16 border-b-2 border-indigo-600"></div>
+          <LoadingSpinner size="xl" />
         </div>
         <p class="loading-message">{{ message || t('ui.unifiedLoading.loading') }}</p>
         <div v-if="hasTimedOut" class="timeout-warning">
@@ -55,6 +55,7 @@ import { useI18n } from 'vue-i18n'
 import { createLogger } from '@/utils/debugUtils'
 import { useUnifiedLoading } from '@/composables/useUnifiedLoading'
 import Icon from './Icon.vue'
+import LoadingSpinner from './LoadingSpinner.vue'
 
 const logger = createLogger('UnifiedLoadingView')
 const { t } = useI18n()


### PR DESCRIPTION
## Summary

Follow-up fixes discovered during #4806 accessibility implementation:

- **#5592** `LoadingSpinner`: Replace `aria-label` on `role="status"` root with inner `<span class="sr-only">` to prevent screen reader double-announcement; add `aria-hidden="true"` on visible label; add `.sr-only` CSS class
- **#5593** `UnifiedLoadingView`: Replace raw Tailwind `animate-spin` div with `<LoadingSpinner size="xl" />` for consistent accessible, themed spinner
- **#5594** `HostSelector`: Convert collapsed trigger from `role="button"` div to semantic `<button type="button">`; add CSS resets so button renders identically
- **#5595** `DataTable`: Replace `<i class="fas">` Font Awesome sort icons with `<Icon>` component; add `sort` (↕) icon to Icon.vue registry; update `getSortIcon` return type to `IconName`

## Test plan

- [ ] LoadingSpinner: screen reader announces label text once (not twice)
- [ ] UnifiedLoadingView: spinner uses design system spinner, not raw Tailwind
- [ ] HostSelector collapsed trigger: keyboard Space/Enter activates toggle natively via `<button>`
- [ ] DataTable sort icons render with Icon component (no Font Awesome dependency)

Closes #5592, #5593, #5594, #5595

🤖 Generated with [Claude Code](https://claude.com/claude-code)