### PR TITLE
refactor(knowledge): migrate remaining production callers onto BaseCollection/BaseClient ABCs (#5194)

### DIFF
--- a/autobot-backend/api/codebase_analytics/chromadb_storage.py
+++ b/autobot-backend/api/codebase_analytics/chromadb_storage.py
@@ -465,7 +465,7 @@ async def _recreate_chromadb_collection(task_id: str, source_id: Optional[str] =
     Returns:
         The AsyncChromaCollection, or None on failure.
     """
-    from utils.chromadb_client import get_async_chromadb_client
+    from knowledge.backends import get_async_default_client
 
     chroma_path = str(Path(__file__).parent.parent.parent.parent / "data" / "chromadb")
     collection_name = "autobot_code"
@@ -474,7 +474,7 @@ async def _recreate_chromadb_collection(task_id: str, source_id: Optional[str] =
     }
 
     try:
-        async_client = await get_async_chromadb_client(
+        async_client = await get_async_default_client(
             db_path=chroma_path,
             allow_reset=False,
             anonymized_telemetry=False,

--- a/autobot-backend/api/codebase_analytics/storage.py
+++ b/autobot-backend/api/codebase_analytics/storage.py
@@ -11,7 +11,7 @@ import logging
 import re
 from pathlib import Path
 
-from utils.chromadb_client import get_async_chromadb_client, get_chromadb_client
+from knowledge.backends import get_async_default_client, get_default_client
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ def get_code_collection():
         chroma_path = _PROJECT_ROOT / "data" / "chromadb"
 
         # Create persistent client with telemetry disabled using shared utility
-        chroma_client = get_chromadb_client(
+        chroma_client = get_default_client(
             db_path=str(chroma_path), allow_reset=False, anonymized_telemetry=False
         )
 
@@ -91,7 +91,7 @@ async def get_code_collection_async():
         chroma_path = _PROJECT_ROOT / "data" / "chromadb"
 
         # Get async ChromaDB client
-        async_client = await get_async_chromadb_client(
+        async_client = await get_async_default_client(
             db_path=str(chroma_path), allow_reset=False, anonymized_telemetry=False
         )
 

--- a/autobot-backend/api/knowledge_graph_routes.py
+++ b/autobot-backend/api/knowledge_graph_routes.py
@@ -240,9 +240,9 @@ async def search_summaries(
     """Vector search on summary embeddings."""
     try:
         from knowledge.summary_search import SummarySearchService
-        from utils.async_chromadb_client import get_async_chromadb_client
+        from knowledge.backends import get_async_default_client
 
-        chromadb_client = await get_async_chromadb_client()
+        chromadb_client = await get_async_default_client()
         summary_svc = SummarySearchService(chromadb_client)
 
         summaries = await summary_svc.search_summaries(
@@ -263,9 +263,9 @@ async def get_document_overview(
     """Get document overview with hierarchical summaries."""
     try:
         from knowledge.summary_search import SummarySearchService
-        from utils.async_chromadb_client import get_async_chromadb_client
+        from knowledge.backends import get_async_default_client
 
-        chromadb_client = await get_async_chromadb_client()
+        chromadb_client = await get_async_default_client()
         summary_svc = SummarySearchService(chromadb_client)
 
         overview = await summary_svc.get_document_overview(UUID(document_id))
@@ -284,9 +284,9 @@ async def drill_down_summary(
     """Navigate from summary to children or source chunks."""
     try:
         from knowledge.summary_search import SummarySearchService
-        from utils.async_chromadb_client import get_async_chromadb_client
+        from knowledge.backends import get_async_default_client
 
-        chromadb_client = await get_async_chromadb_client()
+        chromadb_client = await get_async_default_client()
         summary_svc = SummarySearchService(chromadb_client)
 
         result = await summary_svc.drill_down(UUID(summary_id))

--- a/autobot-backend/api/knowledge_rag.py
+++ b/autobot-backend/api/knowledge_rag.py
@@ -597,10 +597,10 @@ async def get_entity_history(
     """
     from services.knowledge.lineage_service import LineageService
     from services.knowledge.synthesis_provenance import SynthesisProvenanceLog
-    from utils.chromadb_client import get_async_chromadb_client
+    from knowledge.backends import get_async_default_client
 
     async def _collection_factory(name: str):
-        client = await get_async_chromadb_client()
+        client = await get_async_default_client()
         return await client.get_or_create_collection(name=name)
 
     svc = LineageService(

--- a/autobot-backend/api/knowledge_vectorization.py
+++ b/autobot-backend/api/knowledge_vectorization.py
@@ -44,7 +44,7 @@ from knowledge.pipeline.cognifiers.context_generator import ContextGeneratorCogn
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge_factory import get_or_create_knowledge_base
 from type_defs.common import Metadata
-from utils.async_chromadb_client import get_async_chromadb_client
+from knowledge.backends import get_async_default_client
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -1686,7 +1686,7 @@ async def _reindex_with_context_task(
 async def _run_reindex(collection_name: str, batch_size: int) -> None:
     """Core reindex logic, separated for testability (#1513)."""
     cognifier = ContextGeneratorCognifier()
-    client = await get_async_chromadb_client()
+    client = await get_async_default_client()
 
     try:
         collection = await client.get_or_create_collection(name=collection_name)

--- a/autobot-backend/code_intelligence/analytics_infrastructure.py
+++ b/autobot-backend/code_intelligence/analytics_infrastructure.py
@@ -186,11 +186,9 @@ class AnalyticsInfrastructureMixin:
             async with self._infra_lock:
                 if self._chromadb_collection is None:
                     try:
-                        from utils.async_chromadb_client import (
-                            get_async_chromadb_client,
-                        )
+                        from knowledge.backends import get_async_default_client
 
-                        self._chromadb_client = await get_async_chromadb_client()
+                        self._chromadb_client = await get_async_default_client()
                         self._chromadb_collection = await self._chromadb_client.get_or_create_collection(
                             name=self._collection_name,
                             metadata={

--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -138,10 +138,10 @@ class CrossLanguagePatternDetector:
         """Get or create ChromaDB collection for patterns."""
         if self._chromadb_collection is None:
             try:
-                from utils.async_chromadb_client import get_async_chromadb_client
+                from knowledge.backends import get_async_default_client
 
                 chromadb_path = self.project_root / "data" / "chromadb"
-                self._chromadb_client = await get_async_chromadb_client(
+                self._chromadb_client = await get_async_default_client(
                     db_path=str(chromadb_path)
                 )
                 self._chromadb_collection = (

--- a/autobot-backend/code_intelligence/pattern_analysis/storage.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/storage.py
@@ -13,7 +13,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from utils.chromadb_client import get_async_chromadb_client, get_chromadb_client
+from knowledge.backends import get_async_default_client, get_default_client
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ def get_pattern_collection():
         chroma_path = _PROJECT_ROOT / "data" / "chromadb"
         chroma_path.mkdir(parents=True, exist_ok=True)
 
-        chroma_client = get_chromadb_client(
+        chroma_client = get_default_client(
             db_path=str(chroma_path), allow_reset=False, anonymized_telemetry=False
         )
 
@@ -77,7 +77,7 @@ async def get_pattern_collection_async():
         chroma_path = _PROJECT_ROOT / "data" / "chromadb"
         chroma_path.mkdir(parents=True, exist_ok=True)
 
-        async_client = await get_async_chromadb_client(
+        async_client = await get_async_default_client(
             db_path=str(chroma_path), allow_reset=False, anonymized_telemetry=False
         )
 

--- a/autobot-backend/knowledge/base.py
+++ b/autobot-backend/knowledge/base.py
@@ -26,8 +26,7 @@ from autobot_shared.error_boundaries import error_boundary, get_error_boundary_m
 from autobot_shared.redis_management.types import DATABASE_MAPPING
 from autobot_shared.ssot_config import config as ssot_config
 from config.manager import get_config_manager
-from utils.chromadb_client import get_chromadb_client as create_chromadb_client
-from utils.chromadb_client import wrap_collection_async
+from knowledge.backends import BaseCollection, get_default_client
 from utils.knowledge_base_timeouts import kb_timeouts
 
 if TYPE_CHECKING:
@@ -104,7 +103,7 @@ class KnowledgeBaseCore:
         self._aioredis_client: Optional[aioredis.Redis] = None
         self.vector_store: Optional[ChromaVectorStore] = None
         self.vector_index: Optional[VectorStoreIndex] = None
-        self._async_chroma_collection = None
+        self._async_chroma_collection: Optional["BaseCollection"] = None
         self.llama_index_configured = False
         self.embedding_model_name: Optional[str] = None
         self.embedding_dimensions: Optional[int] = None
@@ -373,21 +372,24 @@ class KnowledgeBaseCore:
             self.hnsw_m,
         )
 
-        chroma_collection = await asyncio.to_thread(
+        abc_collection = await asyncio.to_thread(
             chroma_client.get_or_create_collection,
             name=self.chromadb_collection,
             metadata=hnsw_metadata,
         )
 
-        self._async_chroma_collection = wrap_collection_async(chroma_collection)
-        self.vector_store = ChromaVectorStore(chroma_collection=chroma_collection)
+        self._async_chroma_collection = abc_collection
+        # LlamaIndex ChromaVectorStore requires the raw chromadb collection.
+        # ChromaDBCollection._raw holds the underlying chromadb object.
+        raw_collection = getattr(abc_collection, "_raw", abc_collection)
+        self.vector_store = ChromaVectorStore(chroma_collection=raw_collection)
 
         logger.info(
             "ChromaDB vector store initialized: collection='%s'",
             self.chromadb_collection,
         )
 
-        collection_count = await asyncio.to_thread(chroma_collection.count)
+        collection_count = await asyncio.to_thread(abc_collection.count)
         logger.info("ChromaDB collection contains %d vectors", collection_count)
 
     async def _init_vector_store(self):
@@ -396,7 +398,7 @@ class KnowledgeBaseCore:
             chroma_path = Path(self.chromadb_path)
             logger.info("Initializing ChromaDB at path: %s", chroma_path)
 
-            chroma_client = create_chromadb_client(
+            chroma_client = get_default_client(
                 db_path=str(chroma_path), allow_reset=False, anonymized_telemetry=False
             )
 

--- a/autobot-backend/knowledge/index.py
+++ b/autobot-backend/knowledge/index.py
@@ -176,7 +176,7 @@ class IndexMixin:
             return {"status": "error", "message": "Knowledge base not initialized"}
 
         try:
-            from utils.chromadb_client import get_chromadb_client as create_chromadb_client
+            from knowledge.backends import get_default_client as create_chromadb_client
 
             logger.info("Starting ChromaDB index rebuild with optimized HNSW params...")
             chroma_client = create_chromadb_client(
@@ -235,7 +235,7 @@ class IndexMixin:
             return {"status": "error", "message": "Knowledge base not initialized"}
 
         try:
-            from utils.chromadb_client import get_chromadb_client as create_chromadb_client
+            from knowledge.backends import get_default_client as create_chromadb_client
 
             chroma_path = Path(self.chromadb_path)
             chroma_client = create_chromadb_client(
@@ -247,8 +247,10 @@ class IndexMixin:
             )
             vector_count = await asyncio.to_thread(collection.count)
 
+            # ChromaDBCollection wraps the raw collection; access metadata via ._raw
+            raw_col = getattr(collection, "_raw", collection)
             return self._build_index_info_result(
-                chroma_path, vector_count, collection.metadata or {}
+                chroma_path, vector_count, getattr(raw_col, "metadata", None) or {}
             )
 
         except Exception as e:

--- a/autobot-backend/knowledge/pipeline/loaders/chromadb_loader.py
+++ b/autobot-backend/knowledge/pipeline/loaders/chromadb_loader.py
@@ -14,7 +14,7 @@ from knowledge.pipeline.base import BaseLoader, PipelineContext
 from knowledge.pipeline.models.chunk import ProcessedChunk
 from knowledge.pipeline.models.summary import Summary
 from knowledge.pipeline.registry import TaskRegistry
-from utils.async_chromadb_client import get_async_chromadb_client
+from knowledge.backends import get_async_default_client
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ class ChromaDBLoader(BaseLoader):
         Args:
             context: Pipeline context with processed data
         """
-        self.client = await get_async_chromadb_client()
+        self.client = await get_async_default_client()
 
         chunks: List[ProcessedChunk] = context.chunks
         if chunks:

--- a/autobot-backend/npu_semantic_search.py
+++ b/autobot-backend/npu_semantic_search.py
@@ -32,7 +32,7 @@ from constants.threshold_constants import TimingConstants
 from constants.ttl_constants import TTL_5_MINUTES
 from knowledge.embedding_cache import get_embedding_cache
 from knowledge_base import KnowledgeBase
-from utils.chromadb_client import get_chromadb_client
+from knowledge.backends import get_default_client
 
 # Issue #387: GPU-accelerated vector search
 from utils.gpu_vector_search import (
@@ -945,7 +945,7 @@ class NPUSemanticSearch:
 
         try:
             # Initialize ChromaDB client using shared utility function
-            self.chroma_client = get_chromadb_client(
+            self.chroma_client = get_default_client(
                 db_path=str(self.chroma_db_path),
                 allow_reset=True,
                 anonymized_telemetry=False,

--- a/autobot-backend/services/autoresearch/knowledge_synthesizer.py
+++ b/autobot-backend/services/autoresearch/knowledge_synthesizer.py
@@ -109,9 +109,9 @@ class KnowledgeSynthesizer(BaseSynthesizer):
     async def _get_collection(self):
         """Return the insights ChromaDB collection (lazy-init)."""
         if self._insights_collection is None:
-            from utils.chromadb_client import get_async_chromadb_client
+            from knowledge.backends import get_async_default_client
 
-            client = await get_async_chromadb_client()
+            client = await get_async_default_client()
             self._insights_collection = await client.get_or_create_collection(
                 name=self.INSIGHTS_COLLECTION,
                 metadata={"description": "Distilled AutoResearch experiment insights"},

--- a/autobot-backend/services/autoresearch/store.py
+++ b/autobot-backend/services/autoresearch/store.py
@@ -46,9 +46,9 @@ class ExperimentStore:
     async def _get_chromadb(self):
         """Lazy-init ChromaDB collection."""
         if self._chromadb_collection is None:
-            from utils.chromadb_client import get_async_chromadb_client
+            from knowledge.backends import get_async_default_client
 
-            client = await get_async_chromadb_client()
+            client = await get_async_default_client()
             self._chromadb_collection = await client.get_or_create_collection(
                 name=self.config.chromadb_collection,
                 metadata={"description": "AutoResearch experiment findings"},

--- a/autobot-backend/services/knowledge/analyzer_service.py
+++ b/autobot-backend/services/knowledge/analyzer_service.py
@@ -257,18 +257,18 @@ class AnalyzerService:
         target = name or self.COLLECTION_NAME
         if name is None:
             if self._collection is None:
-                from utils.chromadb_client import get_async_chromadb_client
+                from knowledge.backends import get_async_default_client
 
-                client = await get_async_chromadb_client()
+                client = await get_async_default_client()
                 self._collection = await client.get_or_create_collection(
                     name=target,
                     metadata={"description": "Analyzer-distilled lessons for context injection"},
                 )
             return self._collection
 
-        from utils.chromadb_client import get_async_chromadb_client
+        from knowledge.backends import get_async_default_client
 
-        client = await get_async_chromadb_client()
+        client = await get_async_default_client()
         return await client.get_or_create_collection(
             name=target,
             metadata={"description": "Analyzer-distilled lessons for context injection"},

--- a/autobot-backend/services/knowledge/doc_indexer.py
+++ b/autobot-backend/services/knowledge/doc_indexer.py
@@ -672,11 +672,11 @@ class DocIndexerService:
 
             from llama_index.embeddings.ollama import OllamaEmbedding
 
-            from utils.chromadb_client import get_chromadb_client
+            from knowledge.backends import get_default_client
 
             chromadb_path = self._root_dir / "data" / "chromadb"
             self._client = await asyncio.to_thread(
-                get_chromadb_client, str(chromadb_path)
+                get_default_client, str(chromadb_path)
             )
 
             self._collection = self._client.get_or_create_collection(

--- a/autobot-backend/services/knowledge/kb_synthesizer.py
+++ b/autobot-backend/services/knowledge/kb_synthesizer.py
@@ -85,9 +85,9 @@ class KBSynthesizer:
         name = collection_name or self.COLLECTION_NAME
         if collection_name is None:
             if self._collection is None:
-                from utils.chromadb_client import get_async_chromadb_client
+                from knowledge.backends import get_async_default_client
 
-                client = await get_async_chromadb_client()
+                client = await get_async_default_client()
                 self._collection = await client.get_or_create_collection(
                     name=name,
                     metadata={"description": "LLM-synthesized KB topic summaries"},
@@ -95,9 +95,9 @@ class KBSynthesizer:
             return self._collection
 
         if name not in self._named_collections:
-            from utils.chromadb_client import get_async_chromadb_client
+            from knowledge.backends import get_async_default_client
 
-            client = await get_async_chromadb_client()
+            client = await get_async_default_client()
             self._named_collections[name] = await client.get_or_create_collection(
                 name=name,
                 metadata={"description": "LLM-synthesized KB topic summaries"},

--- a/autobot-backend/services/rag_service.py
+++ b/autobot-backend/services/rag_service.py
@@ -861,7 +861,7 @@ class RAGService:
         Results from all collections are merged.  Per-collection errors are
         logged and swallowed so the main context path is never interrupted.
         """
-        from utils.chromadb_client import get_async_chromadb_client
+        from knowledge.backends import get_async_default_client
 
         # Collect all synthesis collection names: default + schema-defined targets.
         collection_names: List[str] = ["kb_synthesis"]
@@ -876,7 +876,7 @@ class RAGService:
 
         all_docs: List[str] = []
         try:
-            client = await get_async_chromadb_client()
+            client = await get_async_default_client()
         except Exception as exc:
             logger.debug("KB synthesis ChromaDB client unavailable (non-fatal): %s", exc)
             return ""
@@ -906,9 +906,9 @@ class RAGService:
         interrupted.
         """
         try:
-            from utils.chromadb_client import get_async_chromadb_client
+            from knowledge.backends import get_async_default_client
 
-            client = await get_async_chromadb_client()
+            client = await get_async_default_client()
             collection = await client.get_or_create_collection(name="autobot_lessons")
             results = await collection.query(query_texts=[query], n_results=2)
             if not (results and results.get("ids") and results["ids"][0]):

--- a/autobot-backend/services/security_memory_integration.py
+++ b/autobot-backend/services/security_memory_integration.py
@@ -108,9 +108,9 @@ class SecurityFindingsIndex:
         """Initialize ChromaDB collection."""
         if self._initialized:
             return
-        from utils.async_chromadb_client import get_async_chromadb_client
+        from knowledge.backends import get_async_default_client
 
-        client = await get_async_chromadb_client(db_path="data/chromadb")
+        client = await get_async_default_client(db_path="data/chromadb")
         self._collection = await client.get_or_create_collection(
             name=self.COLLECTION_NAME,
             metadata={"description": "Security assessment findings"},

--- a/autobot-backend/services/semantic_query_cache.py
+++ b/autobot-backend/services/semantic_query_cache.py
@@ -127,9 +127,9 @@ class SemanticQueryCache(AsyncInitializable):
 
     async def _get_or_create_collection(self):
         """Open or create the ChromaDB collection."""
-        from utils.async_chromadb_client import get_async_chromadb_client
+        from knowledge.backends import get_async_default_client
 
-        client = await get_async_chromadb_client()
+        client = await get_async_default_client()
         if client is None:
             logger.warning("ChromaDB async client unavailable")
             return None

--- a/autobot-backend/services/topic_retrieval_cache.py
+++ b/autobot-backend/services/topic_retrieval_cache.py
@@ -137,9 +137,9 @@ class TopicRetrievalCache(AsyncInitializable):
 
     async def _get_or_create_collection(self):
         """Open or create the ChromaDB collection."""
-        from utils.async_chromadb_client import get_async_chromadb_client
+        from knowledge.backends import get_async_default_client
 
-        client = await get_async_chromadb_client()
+        client = await get_async_default_client()
         if client is None:
             logger.warning("ChromaDB async client unavailable")
             return None


### PR DESCRIPTION
## Summary
- Migrates 21 production files from direct `chromadb.*` imports to `BaseCollection`/`BaseClient` ABCs via `knowledge.backends`
- Continues the work from the previous partial migration (2 callers) to complete the ABC seam

## Files migrated (21)
`knowledge/base.py`, `knowledge/index.py`, `knowledge/pipeline/loaders/chromadb_loader.py`, `api/codebase_analytics/storage.py`, `api/codebase_analytics/chromadb_storage.py`, `api/knowledge_graph_routes.py`, `api/knowledge_rag.py`, `api/knowledge_vectorization.py`, `code_intelligence/analytics_infrastructure.py`, `code_intelligence/cross_language_patterns/detector.py`, `code_intelligence/pattern_analysis/storage.py`, `npu_semantic_search.py`, `services/autoresearch/knowledge_synthesizer.py`, `services/autoresearch/store.py`, `services/knowledge/analyzer_service.py`, `services/knowledge/doc_indexer.py`, `services/knowledge/kb_synthesizer.py`, `services/rag_service.py`, `services/security_memory_integration.py`, `services/semantic_query_cache.py`, `services/topic_retrieval_cache.py`

## Files intentionally skipped
- `utils/chromadb_client.py`, `utils/async_chromadb_client.py` — ARE the wrapper layer, not callers
- `knowledge/backends/` — IS the adapter layer
- `utils/gpu_vector_search.py` — uses duck-typed injected client; no factory call
- `services/knowledge/autonomous_loop.py` + benchmark blocks — use `chromadb.EphemeralClient()` for eval, not production storage
- `autobot_memory_graph/` — no direct chromadb imports

## Validation
- `python3 -m py_compile` passes on all 21 migrated files

Closes #5194

🤖 Generated with [Claude Code](https://claude.com/claude-code)