### PR TITLE
fix(knowledge): separate fetch-layer errors from Redis-down state (#5590)

### DIFF
--- a/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeBrowser.vue
@@ -5,6 +5,7 @@
       :categories="mainCategories"
       :population-states="populationStates"
       :kb-connected="kbConnected"
+      :kb-fetch-error="kbFetchError"
       @select="selectMainCategory"
       @populate="handlePopulate"
       @import="() => router.push('/knowledge/upload')"
@@ -275,6 +276,10 @@ const mainCategories = ref<any[]>([])
 // (kb_connected=false). Defaults to true so we don't flash the error
 // banner before the first fetch completes.
 const kbConnected = ref<boolean>(true)
+// Issue #5590: track fetch-layer errors (5xx, network) separately from
+// Redis-down (kb_connected=false). Prevents blaming Redis when the real
+// cause is an unrelated backend error.
+const kbFetchError = ref<boolean>(false)
 const categoryCounts = ref<Record<string, number>>({})
 const isVectorizing = ref(false)
 const showProgressModal = ref(false)
@@ -571,6 +576,7 @@ const selectMainCategory = (mainCatId: string) => {
 }
 
 const loadMainCategories = async () => {
+  kbFetchError.value = false
   try {
     const data = await apiClient.get<Record<string, any>>(`${getApiBase()}/knowledge_base/categories/main`)
 
@@ -583,9 +589,10 @@ const loadMainCategories = async () => {
     }
   } catch (err) {
     logger.error('Failed to load main categories:', err)
-    // Fetch itself failed — treat as broken KB so the UI shows the
-    // distinct error panel (#5201).
-    kbConnected.value = false
+    // Issue #5590: fetch failed (5xx, network error) — flag separately
+    // from kb_connected=false so the UI shows a generic message rather
+    // than blaming Redis for an unrelated backend error.
+    kbFetchError.value = true
     // Set default categories if API fails
     mainCategories.value = [
       {

--- a/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.vue
+++ b/autobot-frontend/src/components/knowledge/KnowledgeMainCategories.vue
@@ -1,8 +1,25 @@
 <template>
   <div class="main-categories-wrapper">
-    <!-- Issue #5201: broken-KB alert takes precedence over the empty-state hint -->
+    <!-- Issue #5590: fetch-layer error (5xx / network) — generic message, no Redis blame -->
     <div
-      v-if="!kbConnected"
+      v-if="kbFetchError"
+      class="kb-status-panel kb-status-panel--error"
+      role="alert"
+    >
+      <i class="fas fa-exclamation-triangle kb-status-panel__icon"></i>
+      <div class="kb-status-panel__body">
+        <h3 class="kb-status-panel__title">
+          {{ $t('knowledge.categoriesFetchError.title') }}
+        </h3>
+        <p class="kb-status-panel__text">
+          {{ $t('knowledge.categoriesFetchError.description') }}
+        </p>
+      </div>
+    </div>
+
+    <!-- Issue #5201: broken-KB alert — only when backend explicitly reports Redis down -->
+    <div
+      v-else-if="!kbConnected"
       class="kb-status-panel kb-status-panel--error"
       role="alert"
     >
@@ -122,6 +139,9 @@ interface Props {
   // Issue #5201: reflects backend Redis/KB reachability. Defaults to true
   // to preserve behavior with older backends that don't send the flag.
   kbConnected?: boolean
+  // Issue #5590: true when the fetch itself failed (5xx / network error),
+  // distinct from kbConnected=false which the backend sets for Redis outages.
+  kbFetchError?: boolean
 }
 
 interface Emits {
@@ -132,6 +152,7 @@ interface Emits {
 
 const props = withDefaults(defineProps<Props>(), {
   kbConnected: true,
+  kbFetchError: false,
 })
 defineEmits<Emits>()
 

--- a/autobot-frontend/src/components/knowledge/__tests__/KnowledgeMainCategories.spec.ts
+++ b/autobot-frontend/src/components/knowledge/__tests__/KnowledgeMainCategories.spec.ts
@@ -10,6 +10,11 @@
  *  - kb_connected == false → broken-KB error panel visible (takes precedence)
  *  - Any count > 0 → neither banner visible
  *  - Empty categories array (still loading) → no banner (prevents flash)
+ *
+ * Covers issue #5590:
+ *  - kbFetchError == true → fetch-error panel visible (top priority)
+ *  - kbFetchError overrides both !kbConnected and empty-state
+ *  - kbFetchError defaults to false when prop omitted
  */
 
 import { describe, it, expect } from 'vitest'
@@ -48,12 +53,14 @@ const SYSTEM_CATEGORIES = [
 function mountComponent(props: {
   categories?: typeof SYSTEM_CATEGORIES
   kbConnected?: boolean
+  kbFetchError?: boolean
 }) {
   return mount(KnowledgeMainCategories, {
     props: {
       categories: props.categories ?? SYSTEM_CATEGORIES,
       populationStates: {},
       kbConnected: props.kbConnected,
+      kbFetchError: props.kbFetchError,
     },
     global: {
       mocks: { $t: stubT },
@@ -125,5 +132,34 @@ describe('KnowledgeMainCategories — empty-KB vs broken-KB panels (#5201)', () 
     // No kbConnected prop → default true → empty-state shown (counts are 0)
     expect(wrapper.find('.kb-status-panel--info').exists()).toBe(true)
     expect(wrapper.find('.kb-status-panel--error').exists()).toBe(false)
+  })
+})
+
+describe('KnowledgeMainCategories — fetch-layer error panel (#5590)', () => {
+  it('shows fetch-error panel when kbFetchError is true', () => {
+    const wrapper = mountComponent({ kbFetchError: true, kbConnected: true })
+    expect(wrapper.find('.kb-status-panel--error').exists()).toBe(true)
+    expect(wrapper.text()).toContain('knowledge.categoriesFetchError.title')
+    expect(wrapper.text()).toContain('knowledge.categoriesFetchError.description')
+    expect(wrapper.find('.kb-status-panel--info').exists()).toBe(false)
+  })
+
+  it('fetch-error panel takes precedence over Redis-down panel', () => {
+    const wrapper = mountComponent({ kbFetchError: true, kbConnected: false })
+    // Both would show error, but fetch-error is first in v-if chain
+    expect(wrapper.text()).toContain('knowledge.categoriesFetchError.title')
+    expect(wrapper.text()).not.toContain('knowledge.categoriesError.title')
+  })
+
+  it('does not show fetch-error panel when kbFetchError is false', () => {
+    const wrapper = mountComponent({ kbFetchError: false, kbConnected: true })
+    expect(wrapper.text()).not.toContain('knowledge.categoriesFetchError.title')
+  })
+
+  it('defaults kbFetchError to false when prop omitted', () => {
+    const wrapper = mountComponent({ kbConnected: false })
+    // No kbFetchError prop → default false → Redis-down panel shown, not fetch-error
+    expect(wrapper.text()).toContain('knowledge.categoriesError.title')
+    expect(wrapper.text()).not.toContain('knowledge.categoriesFetchError.title')
   })
 })

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -2193,6 +2193,10 @@
       "description": "Each category shows 0 facts because nothing has been indexed yet.",
       "hint": "Click 'Populate' on any category card to seed it, or upload documents under User Knowledge."
     },
+    "categoriesFetchError": {
+      "title": "Failed to load knowledge base",
+      "description": "The server returned an error. Check the backend service logs."
+    },
     "categoriesError": {
       "title": "Knowledge base is unreachable",
       "description": "Redis connection failed. Check that the backend has Redis running."


### PR DESCRIPTION
## Summary

- Adds a new `kbFetchError` boolean prop to `KnowledgeMainCategories` — distinct from the existing `kbConnected` prop
- `kbFetchError=true` means the HTTP fetch itself failed (5xx / network error); `kbConnected=false` means the backend explicitly reported Redis is down
- Frontend now shows two different error messages instead of blaming Redis for every failure
- Adds `categoriesFetchError` i18n keys; the old `categoriesError` keys (Redis-down) are now displayed only in the correct scenario
- 4 new test cases covering `kbFetchError` prop behaviour and priority ordering

Closes #5590