### PR TITLE
fix(backend): add missing now_utc imports to 4 services/utils files (#5602)

### DIFF
--- a/autobot-backend/services/knowledge/autonomous_loop.py
+++ b/autobot-backend/services/knowledge/autonomous_loop.py
@@ -35,7 +35,7 @@ import uuid
 from collections import deque
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from autobot_shared.time_utils import parse_utc_iso
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 from typing import Any, Deque, Dict, List, Optional
 
 from autobot_shared.redis_client import get_async_redis_client

--- a/autobot-backend/services/knowledge/lineage_service.py
+++ b/autobot-backend/services/knowledge/lineage_service.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from autobot_shared.time_utils import parse_utc_iso
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)

--- a/autobot-backend/services/secrets_service.py
+++ b/autobot-backend/services/secrets_service.py
@@ -10,7 +10,7 @@ import json
 import logging
 import sqlite3
 from datetime import datetime, timezone
-from autobot_shared.time_utils import parse_utc_iso
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 from pathlib import Path
 from typing import Dict, List, Optional
 from uuid import uuid4

--- a/autobot-backend/utils/branch_metrics.py
+++ b/autobot-backend/utils/branch_metrics.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
-from autobot_shared.time_utils import parse_utc_iso
+from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Four backend files called `now_utc()` but only imported `parse_utc_iso` from `autobot_shared.time_utils`, causing a `NameError` at runtime when those code paths were reached.

- `utils/branch_metrics.py` (line 127)
- `services/secrets_service.py` (lines 201, 214, 256, 476, 512, 553, 646)
- `services/knowledge/autonomous_loop.py` (lines 324, 347, 372, 401, 438)
- `services/knowledge/lineage_service.py` (line 56)

**Fix:** Extended the existing `from autobot_shared.time_utils import parse_utc_iso` to `import now_utc, parse_utc_iso` on all 4 files.

**Verified:** `python3 -m py_compile` passes on all 4 files.

Closes #5602

🤖 Generated with [Claude Code](https://claude.com/claude-code)