### PR TITLE
refactor(composables): migrate 10 composables from raw setInterval to usePollingJob (#5604)

### DIFF
--- a/autobot-frontend/src/composables/analytics/useIndexingJob.ts
+++ b/autobot-frontend/src/composables/analytics/useIndexingJob.ts
@@ -17,6 +17,7 @@ import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import appConfig from '@/config/AppConfig.js'
 import { useFetchEndpoint } from '@/composables/api/useFetchEndpoint'
 import { createLogger } from '@/utils/debugUtils'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const logger = createLogger('useIndexingJob')
 
@@ -78,7 +79,6 @@ export interface UseIndexingJobDeps {
 export function useIndexingJob(deps: UseIndexingJobDeps) {
   const currentJobId = ref<string | null>(null)
   const currentJobStatus = ref<string | null>(null)
-  const jobPollingInterval = ref<ReturnType<typeof setInterval> | null>(null)
   const jobPhases = ref<JobPhasesData | null>(null)
   const jobBatches = ref<JobBatchesData | null>(null)
   const jobStats = ref<JobStatsData | null>(null)
@@ -144,20 +144,13 @@ export function useIndexingJob(deps: UseIndexingJobDeps) {
 
   // --- Polling ---
 
-  const startJobPolling = () => {
-    if (jobPollingInterval.value) {
-      clearInterval(jobPollingInterval.value)
-    }
-    jobPollingInterval.value = setInterval(async () => {
-      await pollJobStatus()
-    }, 2000)
-  }
+  const { start: _startJobPoller, stop: stopJobPolling } = usePollingJob<void>(
+    async () => { await pollJobStatus() },
+    { intervalMs: 2000 }
+  )
 
-  const stopJobPolling = () => {
-    if (jobPollingInterval.value) {
-      clearInterval(jobPollingInterval.value)
-      jobPollingInterval.value = null
-    }
+  const startJobPolling = () => {
+    _startJobPoller('')
   }
 
   // --- Internal helpers ---

--- a/autobot-frontend/src/composables/useAuditApi.ts
+++ b/autobot-frontend/src/composables/useAuditApi.ts
@@ -7,9 +7,10 @@
  * Issue #578 - Audit Logging Dashboard GUI Integration
  */
 
-import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
+import { ref, computed } from 'vue'
 import { useApiWithState } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
+import { usePollingJob } from '@/composables/usePollingJob'
 import type {
   AuditEntry,
   AuditQueryParams,
@@ -204,7 +205,6 @@ export function useAuditState() {
   const pageSize = ref(100)
 
   // Polling state
-  let pollingInterval: ReturnType<typeof setInterval> | null = null
   const isPolling = ref(false)
   const pollingIntervalMs = ref(30000)
 
@@ -461,34 +461,36 @@ export function useAuditState() {
     selectedEntry.value = entry
   }
 
+  let _stopAuditPoller: (() => void) | null = null
+
   /**
    * Start polling for updates
    */
   function startPolling(intervalMs = 30000) {
-    if (pollingInterval) {
-      stopPolling()
-    }
+    if (_stopAuditPoller) _stopAuditPoller()
 
     pollingIntervalMs.value = intervalMs
     isPolling.value = true
-
-    pollingInterval = setInterval(async () => {
-      logger.debug('Polling for audit log updates...')
-      await loadLogs()
-      await loadStatistics()
-    }, intervalMs)
-
     logger.debug(`Started polling every ${intervalMs}ms`)
+
+    const poller = usePollingJob<void>(
+      async () => {
+        logger.debug('Polling for audit log updates...')
+        await loadLogs()
+        await loadStatistics()
+      },
+      { intervalMs }
+    )
+    _stopAuditPoller = poller.stop
+    poller.start('')
   }
 
   /**
    * Stop polling
    */
   function stopPolling() {
-    if (pollingInterval) {
-      clearInterval(pollingInterval)
-      pollingInterval = null
-    }
+    if (_stopAuditPoller) _stopAuditPoller()
+    _stopAuditPoller = null
     isPolling.value = false
     logger.debug('Stopped polling')
   }
@@ -577,12 +579,7 @@ export function useAuditState() {
     URL.revokeObjectURL(url)
   }
 
-  // Cleanup when effect scope disposes (component unmount or scope.stop())
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      stopPolling()
-    })
-  }
+  // usePollingJob handles cleanup via its own onScopeDispose hook.
 
   return {
     // State

--- a/autobot-frontend/src/composables/useAutoResearch.ts
+++ b/autobot-frontend/src/composables/useAutoResearch.ts
@@ -8,6 +8,7 @@ import { createLogger } from '@/utils/debugUtils'
 import { extractApiErrorMessage } from '@/utils/errorExtract'
 import { showSubtleErrorNotification } from '@/utils/cacheManagement'
 import { getApiBase } from '@/config/ssot-config'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const logger = createLogger('useAutoResearch')
 
@@ -104,8 +105,6 @@ export function useAutoResearch() {
   const pendingApprovals: Ref<ApprovalRequest[]> = ref([])
 
   const insights: Ref<ExperimentInsight[]> = ref([])
-
-  let pollTimer: ReturnType<typeof setInterval> | null = null
 
   // --- Experiments ---
 
@@ -241,23 +240,28 @@ export function useAutoResearch() {
 
   // --- Polling ---
 
+  let _stopAutoResearchPoller: (() => void) | null = null
+
   function startPolling(intervalMs: number = 10000): void {
-    stopPolling()
-    pollTimer = setInterval(async () => {
-      await Promise.all([
-        fetchExperiments(),
-        fetchStats(),
-        fetchOptimizerStatus(),
-        fetchPendingApprovals(),
-      ])
-    }, intervalMs)
+    if (_stopAutoResearchPoller) _stopAutoResearchPoller()
+    const poller = usePollingJob<void>(
+      async () => {
+        await Promise.all([
+          fetchExperiments(),
+          fetchStats(),
+          fetchOptimizerStatus(),
+          fetchPendingApprovals(),
+        ])
+      },
+      { intervalMs }
+    )
+    _stopAutoResearchPoller = poller.stop
+    poller.start('')
   }
 
   function stopPolling(): void {
-    if (pollTimer) {
-      clearInterval(pollTimer)
-      pollTimer = null
-    }
+    if (_stopAutoResearchPoller) _stopAutoResearchPoller()
+    _stopAutoResearchPoller = null
   }
 
   return {

--- a/autobot-frontend/src/composables/useBackgroundTask.ts
+++ b/autobot-frontend/src/composables/useBackgroundTask.ts
@@ -18,6 +18,7 @@ import appConfig from '@/config/AppConfig.js'
 import { getConfig } from '@/config/ssot-config'
 import { fetchWithAuth } from '@/utils/fetchWithAuth'
 import { createLogger } from '@/utils/debugUtils'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const logger = createLogger('useBackgroundTask')
 
@@ -185,78 +186,75 @@ export function useBackgroundTask(baseUrl: string, clearStuckUrl?: string) {
   /**
    * Poll GET /status/{id} every 2 s until completed or failed.
    * Resilient to transient network errors (up to MAX_CONSECUTIVE_ERRORS).
+   * Uses usePollingJob internally; returns a Promise for caller convenience.
    *
    * @returns 'completed', 'failed', or 'orphaned' to let callers decide on retry.
    */
   const poll = (id: string): Promise<'completed' | 'failed' | 'orphaned' | 'error'> => {
     let consecutiveErrors = 0
-    let intervalId: ReturnType<typeof setInterval> | null = null
+    let resolved = false
+
+    type PollResult = { done: boolean; outcome: 'completed' | 'failed' | 'orphaned' | 'error' | 'running' }
 
     return new Promise<'completed' | 'failed' | 'orphaned' | 'error'>((resolve) => {
-      const stop = () => {
-        if (intervalId !== null) {
-          clearInterval(intervalId)
-          intervalId = null
-        }
+      const settle = (outcome: 'completed' | 'failed' | 'orphaned' | 'error') => {
+        if (!resolved) { resolved = true; resolve(outcome) }
       }
 
-      const tick = async () => {
-        try {
-          const backendUrl = await getBackendUrl()
-          const resp = await fetchWithAuth(
-            `${backendUrl}${baseUrl}/status/${id}`,
-          )
-          if (!resp.ok) throw new Error(`Status ${resp.status}`)
+      const poller = usePollingJob<PollResult>(
+        async () => {
+          try {
+            const backendUrl = await getBackendUrl()
+            const resp = await fetchWithAuth(`${backendUrl}${baseUrl}/status/${id}`)
+            if (!resp.ok) throw new Error(`Status ${resp.status}`)
 
-          const data: TaskStatus = await resp.json()
-          taskStatus.value = data
-          progress.value = data.progress ?? 0
-          currentStep.value = data.current_step ?? null
-          consecutiveErrors = 0
+            const data: TaskStatus = await resp.json()
+            taskStatus.value = data
+            progress.value = data.progress ?? 0
+            currentStep.value = data.current_step ?? null
+            consecutiveErrors = 0
 
-          if (data.status === 'completed') {
-            result.value = data.result ?? null
-            progress.value = 100
-            running.value = false
-            stop()
-            resolve('completed')
-            return
-          }
-
-          if (data.status === 'failed') {
-            const orphaned = data.reason === 'orphaned'
-              || data.error?.includes('orphaned')
-            if (orphaned) {
-              wasInterrupted.value = true
-              error.value = 'Previous task was interrupted by a server restart.'
+            if (data.status === 'completed') {
+              result.value = data.result ?? null
+              progress.value = 100
               running.value = false
-              stop()
-              resolve('orphaned')
-            } else {
-              error.value = data.error || 'Task failed'
-              running.value = false
-              stop()
-              resolve('failed')
+              return { done: true, outcome: 'completed' }
             }
-            return
-          }
-        } catch (e: unknown) {
-          consecutiveErrors++
-          const msg = e instanceof Error ? e.message : String(e)
-          logger.warn(
-            `Poll error (${consecutiveErrors}/${MAX_CONSECUTIVE_ERRORS}): ${msg}`,
-          )
-          if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
-            error.value = `Lost connection after ${MAX_CONSECUTIVE_ERRORS} retries`
-            running.value = false
-            stop()
-            resolve('error')
-          }
-        }
-      }
 
-      tick()
-      intervalId = setInterval(tick, POLL_INTERVAL_MS)
+            if (data.status === 'failed') {
+              const orphaned = data.reason === 'orphaned' || data.error?.includes('orphaned')
+              if (orphaned) {
+                wasInterrupted.value = true
+                error.value = 'Previous task was interrupted by a server restart.'
+              } else {
+                error.value = data.error || 'Task failed'
+              }
+              running.value = false
+              return { done: true, outcome: orphaned ? 'orphaned' : 'failed' }
+            }
+
+            return { done: false, outcome: 'running' }
+          } catch (e: unknown) {
+            consecutiveErrors++
+            const msg = e instanceof Error ? e.message : String(e)
+            logger.warn(`Poll error (${consecutiveErrors}/${MAX_CONSECUTIVE_ERRORS}): ${msg}`)
+            if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+              error.value = `Lost connection after ${MAX_CONSECUTIVE_ERRORS} retries`
+              running.value = false
+              return { done: true, outcome: 'error' }
+            }
+            return { done: false, outcome: 'running' }
+          }
+        },
+        {
+          intervalMs: POLL_INTERVAL_MS,
+          maxAttempts: 600, // 20 minutes max — terminal status settles much earlier
+          isComplete: (r) => r.done,
+          onDone: (r) => settle(r.outcome as 'completed' | 'failed' | 'orphaned' | 'error'),
+        }
+      )
+
+      poller.start(id)
     })
   }
 

--- a/autobot-frontend/src/composables/useBatchProcessing.ts
+++ b/autobot-frontend/src/composables/useBatchProcessing.ts
@@ -7,9 +7,10 @@
  * Issue #584 - Batch Processing Manager
  */
 
-import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
+import { ref, computed } from 'vue'
 import { useApiWithState } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
+import { usePollingJob } from '@/composables/usePollingJob'
 import type {
   BatchJob,
   BatchTemplate,
@@ -315,7 +316,6 @@ export function useBatchProcessingState() {
   const schedulesLoading = ref(false)
 
   // Polling state
-  let pollingInterval: ReturnType<typeof setInterval> | null = null
   const isPolling = ref(false)
   const pollingIntervalMs = ref(5000)
 
@@ -557,39 +557,40 @@ export function useBatchProcessingState() {
     return result
   }
 
+  let _stopBatchPoller: (() => void) | null = null
+
   /**
    * Start polling for updates
    */
   function startPolling(intervalMs = 5000) {
-    if (pollingInterval) {
-      stopPolling()
-    }
+    if (_stopBatchPoller) _stopBatchPoller()
 
     pollingIntervalMs.value = intervalMs
     isPolling.value = true
-
-    pollingInterval = setInterval(async () => {
-      if (hasActiveJobs.value) {
-        logger.debug('Polling for batch job updates...')
-        await loadJobs()
-
-        if (selectedJob.value && !isTerminalStatus(selectedJob.value.status)) {
-          await refreshJob(selectedJob.value.job_id)
-        }
-      }
-    }, intervalMs)
-
     logger.debug(`Started polling every ${intervalMs}ms`)
+
+    const poller = usePollingJob<void>(
+      async () => {
+        if (hasActiveJobs.value) {
+          logger.debug('Polling for batch job updates...')
+          await loadJobs()
+          if (selectedJob.value && !isTerminalStatus(selectedJob.value.status)) {
+            await refreshJob(selectedJob.value.job_id)
+          }
+        }
+      },
+      { intervalMs }
+    )
+    _stopBatchPoller = poller.stop
+    poller.start('')
   }
 
   /**
    * Stop polling
    */
   function stopPolling() {
-    if (pollingInterval) {
-      clearInterval(pollingInterval)
-      pollingInterval = null
-    }
+    if (_stopBatchPoller) _stopBatchPoller()
+    _stopBatchPoller = null
     isPolling.value = false
     logger.debug('Stopped polling')
   }
@@ -601,12 +602,7 @@ export function useBatchProcessingState() {
     return jobs.value.filter((job) => job.status === status)
   }
 
-  // Cleanup when effect scope disposes (component unmount or scope.stop())
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      stopPolling()
-    })
-  }
+  // usePollingJob handles cleanup via its own onScopeDispose hook.
 
   return {
     // State

--- a/autobot-frontend/src/composables/useBrowserAutomation.ts
+++ b/autobot-frontend/src/composables/useBrowserAutomation.ts
@@ -7,10 +7,11 @@
  * Issue #900 - Browser Automation Dashboard
  */
 
-import { ref, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope } from 'vue'
+import { ref, onMounted, getCurrentInstance } from 'vue'
 import ApiClient from '@/utils/ApiClient'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const logger = createLogger('useBrowserAutomation')
 
@@ -78,8 +79,6 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
   const screenshots = ref<ScreenshotResult[]>([])
   const isLoading = ref(false)
   const error = ref<string | null>(null)
-
-  let pollingInterval: ReturnType<typeof setInterval> | null = null
 
   // ===== API Methods =====
 
@@ -285,22 +284,12 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
 
   // ===== Polling Methods =====
 
-  function startPolling(): void {
-    if (pollingInterval) return
-    logger.debug(`Starting polling with interval: ${pollInterval}ms`)
-    pollingInterval = setInterval(() => {
-      fetchWorkerStatus()
-      fetchSessions()
-    }, pollInterval)
-  }
-
-  function stopPolling(): void {
-    if (pollingInterval) {
-      clearInterval(pollingInterval)
-      pollingInterval = null
-      logger.debug('Polling stopped')
-    }
-  }
+  const { start: startPolling, stop: stopPolling } = usePollingJob<void>(
+    async () => {
+      await Promise.all([fetchWorkerStatus(), fetchSessions()])
+    },
+    { intervalMs: pollInterval }
+  )
 
   // ===== Lifecycle =====
 
@@ -310,14 +299,9 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
         Promise.all([fetchWorkerStatus(), fetchSessions()])
       }
       if (pollInterval > 0) {
-        startPolling()
+        logger.debug(`Starting polling with interval: ${pollInterval}ms`)
+        startPolling('')
       }
-    })
-  }
-
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      stopPolling()
     })
   }
 
@@ -343,7 +327,7 @@ export function useBrowserAutomation(options: UseBrowserAutomationOptions = {}) 
     executeScript,
     runAutomationScript,
     deleteSession,
-    startPolling,
+    startPolling: () => startPolling(''),
     stopPolling,
   }
 }

--- a/autobot-frontend/src/composables/useOperationsApi.ts
+++ b/autobot-frontend/src/composables/useOperationsApi.ts
@@ -7,9 +7,10 @@
  * Issue #591 - Long-Running Operations Tracker
  */
 
-import { ref, computed, onScopeDispose, getCurrentScope } from 'vue'
+import { ref, computed } from 'vue'
 import { useApiWithState } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
+import { usePollingJob } from '@/composables/usePollingJob'
 import type {
   Operation,
   OperationsListResponse,
@@ -160,7 +161,6 @@ export function useOperationsState() {
   })
 
   // Polling state
-  let pollingInterval: ReturnType<typeof setInterval> | null = null
   const isPolling = ref(false)
   const pollingIntervalMs = ref(5000)
 
@@ -287,40 +287,40 @@ export function useOperationsState() {
   }
 
   /**
-   * Start polling for updates
+   * Start polling for updates.
+   * usePollingJob is recreated on each call to support dynamic intervalMs.
    */
+  let _stopOperationsPoller: (() => void) | null = null
+
   function startPolling(intervalMs = 5000) {
-    if (pollingInterval) {
-      stopPolling()
-    }
+    if (_stopOperationsPoller) _stopOperationsPoller()
 
     pollingIntervalMs.value = intervalMs
     isPolling.value = true
-
-    pollingInterval = setInterval(async () => {
-      // Only poll if we have active operations
-      if (hasActiveOperations.value) {
-        logger.debug('Polling for operation updates...')
-        await loadOperations()
-
-        // Check if selected operation needs refresh
-        if (selectedOperation.value && !isTerminalStatus(selectedOperation.value.status)) {
-          await refreshOperation(selectedOperation.value.operation_id)
-        }
-      }
-    }, intervalMs)
-
     logger.debug(`Started polling every ${intervalMs}ms`)
+
+    const poller = usePollingJob<void>(
+      async () => {
+        if (hasActiveOperations.value) {
+          logger.debug('Polling for operation updates...')
+          await loadOperations()
+          if (selectedOperation.value && !isTerminalStatus(selectedOperation.value.status)) {
+            await refreshOperation(selectedOperation.value.operation_id)
+          }
+        }
+      },
+      { intervalMs }
+    )
+    _stopOperationsPoller = poller.stop
+    poller.start('')
   }
 
   /**
    * Stop polling
    */
   function stopPolling() {
-    if (pollingInterval) {
-      clearInterval(pollingInterval)
-      pollingInterval = null
-    }
+    if (_stopOperationsPoller) _stopOperationsPoller()
+    _stopOperationsPoller = null
     isPolling.value = false
     logger.debug('Stopped polling')
   }
@@ -332,12 +332,7 @@ export function useOperationsState() {
     return operations.value.filter((op) => op.status === status)
   }
 
-  // Cleanup when effect scope disposes (component unmount or scope.stop())
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      stopPolling()
-    })
-  }
+  // usePollingJob handles cleanup via its own onScopeDispose hook.
 
   return {
     // State

--- a/autobot-frontend/src/composables/usePatternAnalysis.ts
+++ b/autobot-frontend/src/composables/usePatternAnalysis.ts
@@ -9,6 +9,7 @@
  */
 
 import { ref, computed } from 'vue'
+import { usePollingJob } from '@/composables/usePollingJob'
 import { useExpansion } from '@/composables/useExpansion'
 import appConfig from '@/config/AppConfig.js'
 import { getConfig, getApiBase } from '@/config/ssot-config'
@@ -347,10 +348,10 @@ export function usePatternAnalysis() {
   }
 
   /**
-   * Poll for background task status using setInterval for resilience.
+   * Poll for background task status using usePollingJob for resilience.
    * Returns a Promise that resolves when the task completes or fails.
    * Transient fetch errors are retried — a single network glitch
-   * does not kill the polling loop.
+   * does not kill the polling loop (up to MAX_CONSECUTIVE_ERRORS).
    */
   const pollTaskStatus = (
     taskId: string,
@@ -358,126 +359,117 @@ export function usePatternAnalysis() {
     const POLL_INTERVAL_MS = 2000
     const MAX_CONSECUTIVE_ERRORS = 5
 
+    // Track consecutive errors inside the fetcher closure (resets on success)
     let consecutiveErrors = 0
-    let intervalId: ReturnType<typeof setInterval> | null = null
+    let resolved = false
 
     return new Promise<'completed' | 'failed' | 'orphaned' | 'error'>((resolve) => {
-      const stopPolling = () => {
-        if (intervalId !== null) {
-          clearInterval(intervalId)
-          intervalId = null
-        }
+      const settle = (result: 'completed' | 'failed' | 'orphaned' | 'error') => {
+        if (!resolved) { resolved = true; resolve(result) }
       }
 
-      const poll = async () => {
-        try {
-          const backendUrl = await getBackendUrl()
-          const response = await fetchWithAuth(
-            `${backendUrl}/api/analytics/codebase/patterns/status/${taskId}`
-          )
+      // The fetcher returns a sentinel object that isComplete can inspect
+      type PollResult = { done: boolean; outcome: 'completed' | 'failed' | 'orphaned' | 'error' | 'running' }
 
-          if (!response.ok) {
-            throw new Error(`Status check failed: ${response.statusText}`)
-          }
+      const poller = usePollingJob<PollResult>(
+        async () => {
+          try {
+            const backendUrl = await getBackendUrl()
+            const response = await fetchWithAuth(
+              `${backendUrl}/api/analytics/codebase/patterns/status/${taskId}`
+            )
+            if (!response.ok) {
+              throw new Error(`Status check failed: ${response.statusText}`)
+            }
+            const data: AnalysisTaskStatus = await response.json()
+            consecutiveErrors = 0 // Reset on successful fetch
+            taskStatus.value = data
 
-          const data = await response.json()
-          taskStatus.value = data
-          consecutiveErrors = 0 // Reset on success
-
-          // Apply partial results while analysis is running
-          if (data.partial_results && data.status === 'running') {
-            const pr = data.partial_results
-            if (pr.regex?.length) {
-              regexOpportunities.value = pr.regex
-            }
-            if (pr.complexity?.length) {
-              complexityHotspots.value = pr.complexity
-            }
-            if (pr.modularization?.length || pr.other_patterns?.length) {
-              refactoringSuggestions.value = [
-                ...(pr.modularization || []),
-                ...(pr.other_patterns || []),
-              ]
-            }
-            // Build incremental summary so UI can show results
-            const partialTotal =
-              (pr.regex?.length || 0) +
-              (pr.complexity?.length || 0) +
-              (pr.modularization?.length || 0) +
-              (pr.other_patterns?.length || 0)
-            if (partialTotal > 0) {
-              analysisReport.value = {
-                analysis_summary: {
-                  scan_path: '',
-                  timestamp: new Date().toISOString(),
-                  files_analyzed: pr.files_processed || 0,
-                  lines_analyzed: 0,
-                  duration_seconds: 0,
-                  total_patterns_found: partialTotal,
-                  potential_loc_reduction: 0,
-                  complexity_score: 'N/A',
-                },
-                pattern_counts: {},
-                severity_distribution: {},
-                duplicate_patterns: [],
-                regex_opportunities: pr.regex || [],
-                complexity_hotspots: pr.complexity || [],
-                modularization_suggestions: pr.modularization || [],
-                other_patterns: pr.other_patterns || [],
+            // Apply partial results while analysis is running
+            if (data.partial_results && data.status === 'running') {
+              const pr = data.partial_results
+              if (pr.regex?.length) regexOpportunities.value = pr.regex
+              if (pr.complexity?.length) complexityHotspots.value = pr.complexity
+              if (pr.modularization?.length || pr.other_patterns?.length) {
+                refactoringSuggestions.value = [
+                  ...(pr.modularization || []),
+                  ...(pr.other_patterns || []),
+                ]
+              }
+              const partialTotal =
+                (pr.regex?.length || 0) +
+                (pr.complexity?.length || 0) +
+                (pr.modularization?.length || 0) +
+                (pr.other_patterns?.length || 0)
+              if (partialTotal > 0) {
+                analysisReport.value = {
+                  analysis_summary: {
+                    scan_path: '',
+                    timestamp: new Date().toISOString(),
+                    files_analyzed: pr.files_processed || 0,
+                    lines_analyzed: 0,
+                    duration_seconds: 0,
+                    total_patterns_found: partialTotal,
+                    potential_loc_reduction: 0,
+                    complexity_score: 'N/A',
+                  },
+                  pattern_counts: {},
+                  severity_distribution: {},
+                  duplicate_patterns: [],
+                  regex_opportunities: pr.regex || [],
+                  complexity_hotspots: pr.complexity || [],
+                  modularization_suggestions: pr.modularization || [],
+                  other_patterns: pr.other_patterns || [],
+                }
               }
             }
-          }
 
-          if (data.status === 'completed' && data.result) {
-            analysisReport.value = data.result
-            duplicatePatterns.value = data.result.duplicate_patterns || []
-            regexOpportunities.value = data.result.regex_opportunities || []
-            complexityHotspots.value = data.result.complexity_hotspots || []
-            analyzing.value = false
-            stopPolling()
-            resolve('completed')
-            return
-          }
-
-          if (data.status === 'failed') {
-            const isOrphaned = data.reason === 'orphaned'
-              || data.error?.includes('orphaned')
-            if (isOrphaned) {
-              wasInterrupted.value = true
-              error.value = 'Previous analysis was interrupted by a server restart.'
+            if (data.status === 'completed' && data.result) {
+              analysisReport.value = data.result
+              duplicatePatterns.value = data.result.duplicate_patterns || []
+              regexOpportunities.value = data.result.regex_opportunities || []
+              complexityHotspots.value = data.result.complexity_hotspots || []
               analyzing.value = false
-              stopPolling()
-              resolve('orphaned')
-            } else {
-              error.value = data.error || 'Analysis failed'
-              analyzing.value = false
-              stopPolling()
-              resolve('failed')
+              return { done: true, outcome: 'completed' }
             }
-            return
-          }
 
-          // Still running — interval continues automatically
-        } catch (e: unknown) {
-          consecutiveErrors++
-          const msg = extractErrorMessage(e, 'Unknown poll error')
-          logger.warn(
-            `Task status poll error (${consecutiveErrors}/${MAX_CONSECUTIVE_ERRORS}): ${msg}`
-          )
+            if (data.status === 'failed') {
+              const isOrphaned = data.reason === 'orphaned' || data.error?.includes('orphaned')
+              if (isOrphaned) {
+                wasInterrupted.value = true
+                error.value = 'Previous analysis was interrupted by a server restart.'
+              } else {
+                error.value = data.error || 'Analysis failed'
+              }
+              analyzing.value = false
+              return { done: true, outcome: isOrphaned ? 'orphaned' : 'failed' }
+            }
 
-          if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
-            error.value = `Lost connection to backend after ${MAX_CONSECUTIVE_ERRORS} retries`
-            analyzing.value = false
-            stopPolling()
-            resolve('error')
+            return { done: false, outcome: 'running' }
+          } catch (e: unknown) {
+            consecutiveErrors++
+            const msg = extractErrorMessage(e, 'Unknown poll error')
+            logger.warn(
+              `Task status poll error (${consecutiveErrors}/${MAX_CONSECUTIVE_ERRORS}): ${msg}`
+            )
+            if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+              error.value = `Lost connection to backend after ${MAX_CONSECUTIVE_ERRORS} retries`
+              analyzing.value = false
+              return { done: true, outcome: 'error' }
+            }
+            // Transient error — keep polling
+            return { done: false, outcome: 'running' }
           }
-          // Otherwise interval continues — transient error, keep trying
+        },
+        {
+          intervalMs: POLL_INTERVAL_MS,
+          maxAttempts: 600, // 20 minutes max — terminal status settles much earlier
+          isComplete: (r) => r.done,
+          onDone: (r) => settle(r.outcome as 'completed' | 'failed' | 'orphaned' | 'error'),
         }
-      }
+      )
 
-      // Run first poll immediately, then on interval
-      poll()
-      intervalId = setInterval(poll, POLL_INTERVAL_MS)
+      poller.start(taskId)
     })
   }
 

--- a/autobot-frontend/src/composables/usePrometheusMetrics.ts
+++ b/autobot-frontend/src/composables/usePrometheusMetrics.ts
@@ -11,12 +11,13 @@
  * Resolved: Issue #76 - Replaced mockup data with real backend metrics
  */
 
-import { ref, computed, onMounted, onScopeDispose, getCurrentInstance, getCurrentScope } from 'vue'
+import { ref, computed, onMounted, getCurrentInstance } from 'vue'
 import type { Ref, ComputedRef } from 'vue'
 import { useApi } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
 import { useWebSocket } from '@/composables/useWebSocket'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 // Create scoped logger
 const logger = createLogger('usePrometheusMetrics')
@@ -252,9 +253,6 @@ export function usePrometheusMetrics(
   const lastUpdate = ref<Date | null>(null)
   const isConnected = ref(false)
 
-  // Polling state
-  let pollingInterval: ReturnType<typeof setInterval> | null = null
-
   // Build the monitoring WebSocket URL
   const _buildWsUrl = (): string => {
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
@@ -442,21 +440,14 @@ export function usePrometheusMetrics(
 
   // ===== Polling Methods =====
 
+  const { start: _startDashboardPoller, stop: stopPolling } = usePollingJob<void>(
+    async () => { await fetchAll() },
+    { intervalMs: pollInterval }
+  )
+
   function startPolling(): void {
-    if (pollingInterval) return // Already polling
-
     logger.debug(`Starting polling with interval: ${pollInterval}ms`)
-    pollingInterval = setInterval(() => {
-      fetchAll()
-    }, pollInterval)
-  }
-
-  function stopPolling(): void {
-    if (pollingInterval) {
-      clearInterval(pollingInterval)
-      pollingInterval = null
-      logger.debug('Polling stopped')
-    }
+    _startDashboardPoller('')
   }
 
   // ===== WebSocket Methods =====
@@ -488,12 +479,8 @@ export function usePrometheusMetrics(
     })
   }
 
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      stopPolling()
-      // useWebSocket handles WebSocket cleanup via its own scope-dispose hook
-    })
-  }
+  // usePollingJob handles polling cleanup via its own onScopeDispose hook.
+  // useWebSocket handles WebSocket cleanup via its own scope-dispose hook.
 
   return {
     // State
@@ -547,8 +534,6 @@ export function useSystemMetrics(pollInterval = 10000) {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
 
-  let interval: ReturnType<typeof setInterval> | null = null
-
   async function fetch() {
     isLoading.value = true
     try {
@@ -562,28 +547,14 @@ export function useSystemMetrics(pollInterval = 10000) {
     }
   }
 
-  function startPolling() {
-    if (interval) return
-    fetch()
-    interval = setInterval(fetch, pollInterval)
-  }
-
-  function stopPolling() {
-    if (interval) {
-      clearInterval(interval)
-      interval = null
-    }
-  }
+  const { start: startPolling, stop: stopPolling } = usePollingJob<void>(
+    async () => { await fetch() },
+    { intervalMs: pollInterval }
+  )
 
   if (getCurrentInstance()) {
     onMounted(() => {
-      startPolling()
-    })
-  }
-
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      stopPolling()
+      startPolling('')
     })
   }
 
@@ -592,7 +563,7 @@ export function useSystemMetrics(pollInterval = 10000) {
     isLoading,
     error,
     fetch,
-    startPolling,
+    startPolling: () => startPolling(''),
     stopPolling
   }
 }
@@ -608,8 +579,6 @@ export function useServiceHealth(pollInterval = 15000) {
   const summary = ref<Pick<ServicesSummary, 'total_services' | 'healthy_services' | 'degraded_services' | 'critical_services' | 'overall_status' | 'health_percentage'> | null>(null)
   const isLoading = ref(false)
   const error = ref<string | null>(null)
-
-  let interval: ReturnType<typeof setInterval> | null = null
 
   async function fetch() {
     isLoading.value = true
@@ -637,28 +606,14 @@ export function useServiceHealth(pollInterval = 15000) {
   const healthPercentage = computed(() => summary.value?.health_percentage ?? 0)
   const overallStatus = computed(() => summary.value?.overall_status ?? 'unknown')
 
-  function startPolling() {
-    if (interval) return
-    fetch()
-    interval = setInterval(fetch, pollInterval)
-  }
-
-  function stopPolling() {
-    if (interval) {
-      clearInterval(interval)
-      interval = null
-    }
-  }
+  const { start: startPolling, stop: stopPolling } = usePollingJob<void>(
+    async () => { await fetch() },
+    { intervalMs: pollInterval }
+  )
 
   if (getCurrentInstance()) {
     onMounted(() => {
-      startPolling()
-    })
-  }
-
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      stopPolling()
+      startPolling('')
     })
   }
 
@@ -672,7 +627,7 @@ export function useServiceHealth(pollInterval = 15000) {
     isLoading,
     error,
     fetch,
-    startPolling,
+    startPolling: () => startPolling(''),
     stopPolling
   }
 }
@@ -699,8 +654,6 @@ export function useAlerts(pollInterval = 30000) {
     alertmanager: 0,
     autobot_monitor: 0
   })
-
-  let interval: ReturnType<typeof setInterval> | null = null
 
   async function fetch() {
     isLoading.value = true
@@ -732,28 +685,14 @@ export function useAlerts(pollInterval = 30000) {
     alerts.value.filter((a: PerformanceAlert) => a.source === 'alertmanager')
   )
 
-  function startPolling() {
-    if (interval) return
-    fetch()
-    interval = setInterval(fetch, pollInterval)
-  }
-
-  function stopPolling() {
-    if (interval) {
-      clearInterval(interval)
-      interval = null
-    }
-  }
+  const { start: startPolling, stop: stopPolling } = usePollingJob<void>(
+    async () => { await fetch() },
+    { intervalMs: pollInterval }
+  )
 
   if (getCurrentInstance()) {
     onMounted(() => {
-      startPolling()
-    })
-  }
-
-  if (getCurrentScope()) {
-    onScopeDispose(() => {
-      stopPolling()
+      startPolling('')
     })
   }
 
@@ -772,7 +711,7 @@ export function useAlerts(pollInterval = 30000) {
     isLoading,
     error,
     fetch,
-    startPolling,
+    startPolling: () => startPolling(''),
     stopPolling
   }
 }

--- a/autobot-frontend/src/composables/useServiceMessages.ts
+++ b/autobot-frontend/src/composables/useServiceMessages.ts
@@ -7,10 +7,11 @@
  * Wraps /api/service-messages/* endpoints.
  */
 
-import { ref, onScopeDispose, getCurrentScope } from 'vue'
+import { ref } from 'vue'
 import { useApiWithState } from './useApi'
 import { createLogger } from '@/utils/debugUtils'
 import { getApiBase } from '@/config/ssot-config'
+import { usePollingJob } from '@/composables/usePollingJob'
 
 const logger = createLogger('useServiceMessages')
 
@@ -59,7 +60,6 @@ export function useServiceMessages() {
   const loading = ref(false)
   const error = ref<string | null>(null)
 
-  let pollingTimer: ReturnType<typeof setInterval> | null = null
   const isPolling = ref(false)
 
   async function fetchLatest(params?: {
@@ -144,23 +144,24 @@ export function useServiceMessages() {
     }
   }
 
+  let _stopServiceMessagesPoller: (() => void) | null = null
+
   function startPolling(intervalMs = 15000, params?: Parameters<typeof fetchLatest>[0]) {
-    stopPolling()
+    if (_stopServiceMessagesPoller) _stopServiceMessagesPoller()
     isPolling.value = true
-    pollingTimer = setInterval(() => fetchLatest(params), intervalMs)
     logger.debug(`Polling service messages every ${intervalMs}ms`)
+    const poller = usePollingJob<void>(
+      async () => { await fetchLatest(params) },
+      { intervalMs }
+    )
+    _stopServiceMessagesPoller = poller.stop
+    poller.start('')
   }
 
   function stopPolling() {
-    if (pollingTimer) {
-      clearInterval(pollingTimer)
-      pollingTimer = null
-    }
+    if (_stopServiceMessagesPoller) _stopServiceMessagesPoller()
+    _stopServiceMessagesPoller = null
     isPolling.value = false
-  }
-
-  if (getCurrentScope()) {
-    onScopeDispose(() => stopPolling())
   }
 
   return {


### PR DESCRIPTION
## Summary

Follows #5561 (7 component-level migrations). Migrates 10 composables that hand-rolled API polling with raw `setInterval` to `usePollingJob`, eliminating manual interval management and inconsistent cleanup.

**Files migrated:**
- `usePrometheusMetrics.ts` — 4 loops (main metrics, system metrics, service health, alerts)
- `useBrowserAutomation.ts` — automation session status polling
- `useOperationsApi.ts` — long-running operation status polling
- `useServiceMessages.ts` — service message fetch polling
- `usePatternAnalysis.ts` — background task status polling (Promise-based)
- `useBackgroundTask.ts` — background task tick polling (Promise-based)
- `useBatchProcessing.ts` — batch job status polling
- `analytics/useIndexingJob.ts` — indexing job status polling
- `useAuditApi.ts` — audit operation polling
- `useAutoResearch.ts` — research task polling

**Intentionally excluded:** `useWebSocket.ts` (heartbeat), `useNetworkStatus.ts` (probe), `useSessionCollaboration.ts` (presence push), `useActivityTracking.ts` (log flush), `useTimeout.ts` (primitive itself).

## Non-obvious decisions

**Dynamic-interval pollers** (`useOperationsApi`, `useBatchProcessing`, `useServiceMessages`): `startPolling(intervalMs)` accepts a runtime interval — `usePollingJob` is instantiated inside the start call (not at composable creation) to support dynamic intervals. Previous poller is stopped before starting a new one.

**Promise-based task pollers** (`usePatternAnalysis`, `useBackgroundTask`): Inner `setInterval` drove a returned Promise. Replaced with a sentinel `PollResult` type (`{ done: boolean; outcome: ... }`); `isComplete: (r) => r.done` + `onDone: (r) => settle(r.outcome)` drives Promise resolution. `maxAttempts: 600` (~20 min ceiling).

## Verification
- `npx vue-tsc --noEmit -p tsconfig.app.json` — no new type errors

Closes #5604