### PR TITLE
fix(ui): convert HostSelector host-item divs to semantic buttons (#5587)

### DIFF
--- a/autobot-frontend/src/components/ui/HostSelector.vue
+++ b/autobot-frontend/src/components/ui/HostSelector.vue
@@ -59,9 +59,10 @@
 
       <!-- Host list -->
       <div class="host-list" v-if="!loading">
-        <div
+        <button
           v-for="host in filteredHosts"
           :key="host.id"
+          type="button"
           class="host-item"
           :class="{ selected: selectedHost?.id === host.id }"
           @click="selectHost(host)"
@@ -86,7 +87,7 @@
               {{ cap.toUpperCase() }}
             </span>
           </div>
-        </div>
+        </button>
 
         <!-- Empty state -->
         <div v-if="filteredHosts.length === 0" class="empty-state">
@@ -489,6 +490,14 @@ defineExpose({
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--duration-150);
+  appearance: none;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
 }
 
 .host-item:hover {


### PR DESCRIPTION
## Summary
- Converts `.host-item` `<div>` elements in HostSelector to native `<button type="button">` elements
- Adds CSS resets (`appearance: none; background: none; border: none; width: 100%; text-align: left; font-family: inherit; font-size: inherit; color: inherit`) so visual appearance is unchanged
- Native buttons get keyboard activation (Space/Enter), disabled state, and correct tab order for free — no ARIA role hacks needed

## Behavioral grep audit
Before:
```
$ grep -n "class=\"host-item\"" autobot-frontend/src/components/ui/HostSelector.vue
# <div class="host-item" ...> — non-interactive div
```
After:
```
$ grep -n "class=\"host-item\"" autobot-frontend/src/components/ui/HostSelector.vue
# <button type="button" class="host-item" ...> — semantic button
```

## Test plan
- [ ] Host items are keyboard-accessible (Tab to focus, Space/Enter to select)
- [ ] Visual appearance unchanged (CSS resets applied)
- [ ] Host selection still works on click

Closes #5587

🤖 Generated with [Claude Code](https://claude.com/claude-code)