### PR TITLE
refactor(ui): replace Font Awesome icon in EmptyState with Icon component (#5606)

### DIFF
--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -167,7 +167,7 @@ interface Props {
   itemsPerPage?: number
   /** Loading state */
   loading?: boolean
-  /** Empty state icon */
+  /** Empty state icon (IconName from Icon.vue registry) */
   emptyIcon?: string
   /** Empty state title */
   emptyTitle?: string
@@ -182,7 +182,7 @@ const props = withDefaults(defineProps<Props>(), {
   pagination: false,
   itemsPerPage: 10,
   loading: false,
-  emptyIcon: 'fas fa-inbox'
+  emptyIcon: 'inbox'
 })
 
 const emit = defineEmits<{

--- a/autobot-frontend/src/components/ui/EmptyState.vue
+++ b/autobot-frontend/src/components/ui/EmptyState.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="empty-state" :class="{ 'compact': compact }">
-    <i :class="iconClass" class="empty-icon"></i>
+    <Icon :name="icon" class="empty-icon" />
     <h4 v-if="title" class="empty-title">{{ title }}</h4>
     <p v-if="message" class="empty-message">{{ message }}</p>
     <slot name="actions"></slot>
@@ -8,31 +8,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-
-/**
- * Reusable Empty State Component
- *
- * Displays consistent empty states across the application.
- * Eliminates duplicate empty state implementations in 11+ components.
- *
- * Usage:
- * ```vue
- * <EmptyState
- *   icon="fas fa-inbox"
- *   title="No documents found"
- *   message="Start by adding your first document"
- * >
- *   <template #actions>
- *     <button @click="addDocument">Add Document</button>
- *   </template>
- * </EmptyState>
- * ```
- */
+import Icon, { type IconName } from './Icon.vue'
 
 interface Props {
-  /** Icon class (Font Awesome) */
-  icon?: string
+  /** Icon name from Icon.vue registry */
+  icon?: IconName
   /** Title text */
   title?: string
   /** Message text */
@@ -41,12 +21,10 @@ interface Props {
   compact?: boolean
 }
 
-const props = withDefaults(defineProps<Props>(), {
-  icon: 'fas fa-inbox',
+withDefaults(defineProps<Props>(), {
+  icon: 'inbox',
   compact: false
 })
-
-const iconClass = computed(() => props.icon)
 </script>
 
 <style scoped>
@@ -62,14 +40,16 @@ const iconClass = computed(() => props.icon)
 }
 
 .empty-icon {
-  font-size: var(--text-5xl);
+  width: var(--text-5xl);
+  height: var(--text-5xl);
   color: var(--text-tertiary);
   margin-bottom: var(--spacing-4);
   opacity: 0.5;
 }
 
 .empty-state.compact .empty-icon {
-  font-size: var(--text-3xl);
+  width: var(--text-3xl);
+  height: var(--text-3xl);
   margin-bottom: var(--spacing-3);
 }
 


### PR DESCRIPTION
## Summary
- Replaces `<i :class="iconClass" class="empty-icon">` (Font Awesome) with `<Icon :name="icon" class="empty-icon" />` (SVG Icon component)
- Changes `icon` prop type from `string` to `IconName` — now type-safe against the Icon registry
- Default changes from `'fas fa-inbox'` to `'inbox'` (matching Icon.vue registry key)
- CSS `.empty-icon` switches from `font-size` to `width/height` for SVG sizing
- DataTable's `emptyIcon` default updated from `'fas fa-inbox'` to `'inbox'`
- Removes `iconClass` computed property and `computed` import

## Behavioral grep audit
Before:
```
$ grep -n "fas fa-inbox" autobot-frontend/src/components/ui/EmptyState.vue DataTable.vue
EmptyState.vue: icon: 'fas fa-inbox',
DataTable.vue: emptyIcon: 'fas fa-inbox'
```
After:
```
$ grep -n "fas fa-inbox" autobot-frontend/src/components/ui/EmptyState.vue DataTable.vue
# 0 hits
```

Note: 9 callers of EmptyState still pass FA class strings (e.g. `icon="fas fa-cube"`) — filed as discovery #5607 for follow-up migration.

## Test plan
- [ ] Empty state in DataTable renders inbox icon (SVG)
- [ ] EmptyState compact mode sizing works (width/height)
- [ ] No visual regression on existing empty states

Closes #5606

🤖 Generated with [Claude Code](https://claude.com/claude-code)