### PR TITLE
fix(api): standardize connector endpoint response shape — fix silent error discard (#5210)

### DIFF
--- a/autobot-backend/api/knowledge_connectors.py
+++ b/autobot-backend/api/knowledge_connectors.py
@@ -508,7 +508,7 @@ async def _get_status_for_config(cfg: ConnectorConfig) -> Dict[str, Any]:
         return {
             "connector_id": cfg.connector_id,
             "is_healthy": False,
-            "error": "Status check failed",
+            "last_error": "Status check failed",
         }
 
 

--- a/autobot-backend/knowledge/schemas/connectors.py
+++ b/autobot-backend/knowledge/schemas/connectors.py
@@ -38,7 +38,6 @@ class ConnectorStatusDict(BaseModel):
     documents_indexed: Optional[int] = None
     last_error: Optional[str] = None
     scheduled: Optional[bool] = None
-    error: Optional[str] = None
 
 
 class ConnectorConfigDict(BaseModel):


### PR DESCRIPTION
## Summary
- All 9 connector endpoints already had `response_model=` with dedicated Pydantic schemas (prior #5317 work)
- Found and fixed the last real inconsistency: `_get_status_for_config` error branch returned `"error"` key but `ConnectorStatusCard.vue` and the `ConnectorStatus` TS interface both read `last_error`
- Silent bug: connector errors were discarded client-side — the status card showed no error message even when the backend caught a failure

## Changes
- `autobot-backend/api/knowledge_connectors.py` — changed `"error"` → `"last_error"` in exception handler
- `autobot-backend/knowledge/schemas/connectors.py` — removed redundant `error: Optional[str] = None` field from `ConnectorStatusDict` (accommodated the wrong key; now all return paths use `last_error`)

## Validation
- `python3 -m py_compile` passes on both files
- 7/7 connector health tests pass

Closes #5210

🤖 Generated with [Claude Code](https://claude.com/claude-code)