### PR TITLE
fix(config): correct Ports.browser default from 3000 to 9001 (#5620)

### DIFF
--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -129,7 +129,7 @@ class PortConfig(BaseSettings):
     redis: int = Field(default=6379, alias="AUTOBOT_REDIS_PORT")
     ollama: int = Field(default=11434, alias="AUTOBOT_OLLAMA_PORT")
     vnc: int = Field(default=6080, alias="AUTOBOT_VNC_PORT")
-    browser: int = Field(default=9001, alias="AUTOBOT_BROWSER_SERVICE_PORT")  # Issue #4662: 9001; 3000 is Grafana
+    browser: int = Field(default=9001, alias="AUTOBOT_BROWSER_SERVICE_PORT")  # Issue #4052: 9001; 3000 is Grafana
     aistack: int = Field(default=8080, alias="AUTOBOT_AI_STACK_PORT")
     chromadb: int = Field(
         default=8100, alias="AUTOBOT_CHROMADB_PORT"

--- a/autobot_shared/ssot_config.py
+++ b/autobot_shared/ssot_config.py
@@ -129,7 +129,7 @@ class PortConfig(BaseSettings):
     redis: int = Field(default=6379, alias="AUTOBOT_REDIS_PORT")
     ollama: int = Field(default=11434, alias="AUTOBOT_OLLAMA_PORT")
     vnc: int = Field(default=6080, alias="AUTOBOT_VNC_PORT")
-    browser: int = Field(default=3000, alias="AUTOBOT_BROWSER_SERVICE_PORT")
+    browser: int = Field(default=9001, alias="AUTOBOT_BROWSER_SERVICE_PORT")  # Issue #4662: 9001; 3000 is Grafana
     aistack: int = Field(default=8080, alias="AUTOBOT_AI_STACK_PORT")
     chromadb: int = Field(
         default=8100, alias="AUTOBOT_CHROMADB_PORT"


### PR DESCRIPTION
## Summary

- Changed `Ports.browser` default in `autobot_shared/ssot_config.py` from `3000` to `9001`
- Port 3000 is Grafana. Port 9001 is the canonical browser worker port established in #4662
- The Ansible role defaults were corrected in `b036ddfd0` but the Python-level fallback was missed — any deployment without `AUTOBOT_BROWSER_SERVICE_PORT` set in the env file would silently point the health check at Grafana, returning HTTP 404

## Gap 2 (already fixed — no code change needed)

The issue also noted that Ansible only wrote to `/etc/autobot/autobot-backend.env` while the systemd service reads `/opt/autobot/autobot-backend/.env`. This was already resolved by PR #2925 (issue #2824): `roles/backend/tasks/main.yml:485` already renders `backend.env.j2` to `{{ backend_code_dir }}/.env` in addition to the `/etc/autobot/` path. Both files are kept in sync on every provision run.

## Test Plan

- [x] `python3 -c "from autobot_shared.ssot_config import config; print(config.port.browser)"` → `9001`
- [x] No `AUTOBOT_BROWSER_SERVICE_PORT` env var set (pure default) → correctly resolves to `9001`

Closes #5620

🤖 Generated with Claude Code