### PR TITLE
refactor(utils): migrate 40 module-level threading.Lock() singleton patterns to lazy_singleton phase 3 (#5619)

### DIFF
--- a/autobot-backend/services/user_behavior_analytics.py
+++ b/autobot-backend/services/user_behavior_analytics.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.ttl_constants import TTL_24_HOURS, TTL_30_DAYS, TTL_90_DAYS
 
@@ -514,19 +515,4 @@ class UserBehaviorAnalytics:
             return []
 
 
-# Singleton instance (thread-safe)
-import threading
-
-_behavior_analytics: Optional[UserBehaviorAnalytics] = None
-_behavior_analytics_lock = threading.Lock()
-
-
-def get_behavior_analytics() -> UserBehaviorAnalytics:
-    """Get the singleton UserBehaviorAnalytics instance (thread-safe)."""
-    global _behavior_analytics
-    if _behavior_analytics is None:
-        with _behavior_analytics_lock:
-            # Double-check after acquiring lock
-            if _behavior_analytics is None:
-                _behavior_analytics = UserBehaviorAnalytics()
-    return _behavior_analytics
+get_behavior_analytics = lazy_singleton(UserBehaviorAnalytics)

--- a/autobot-backend/services/workflow_automation/routes.py
+++ b/autobot-backend/services/workflow_automation/routes.py
@@ -9,7 +9,7 @@ FastAPI endpoints for workflow automation.
 
 import json
 import logging
-import threading
+from autobot_shared.singleton_factory import lazy_singleton
 from dataclasses import asdict
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
@@ -36,28 +36,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["workflow_automation"])
 
-# Global workflow manager instance (lazy initialization, thread-safe)
-# REUSABLE PATTERN: Lazy initialization avoids creating async resources at module import time
-_workflow_manager = None
-_workflow_manager_lock = threading.Lock()
-
-
-def get_workflow_manager() -> WorkflowAutomationManager:
-    """
-    Get or create the global workflow manager instance (thread-safe).
-
-    REUSABLE PATTERN: Lazy singleton initialization with double-checked locking
-    - Avoids creating async resources at module import time
-    - Ensures event loop exists before instantiation
-    - Thread-safe for FastAPI async context via double-checked locking
-    """
-    global _workflow_manager
-    if _workflow_manager is None:
-        with _workflow_manager_lock:
-            # Double-check after acquiring lock
-            if _workflow_manager is None:
-                _workflow_manager = WorkflowAutomationManager()
-    return _workflow_manager
+get_workflow_manager = lazy_singleton(WorkflowAutomationManager)
 
 
 @with_error_handling(

--- a/autobot-backend/services/workflow_secret_service.py
+++ b/autobot-backend/services/workflow_secret_service.py
@@ -13,7 +13,7 @@ Issue #2153 — Secret management for workflow credentials.
 
 import logging
 import re
-import threading
+from autobot_shared.singleton_factory import lazy_singleton
 from typing import Dict, FrozenSet, List, Optional
 
 from services.secrets_service import SecretsService, get_secrets_service
@@ -334,18 +334,4 @@ class WorkflowSecretService:
 # Thread-safe singleton
 # ---------------------------------------------------------------------------
 
-_service_instance: Optional[WorkflowSecretService] = None
-_service_lock = threading.Lock()
-
-
-def get_workflow_secret_service() -> WorkflowSecretService:
-    """Return (or lazily create) the WorkflowSecretService singleton.
-
-    Issue #2153.
-    """
-    global _service_instance
-    if _service_instance is None:
-        with _service_lock:
-            if _service_instance is None:
-                _service_instance = WorkflowSecretService()
-    return _service_instance
+get_workflow_secret_service = lazy_singleton(WorkflowSecretService)

--- a/autobot-backend/skills/mcp_process.py
+++ b/autobot-backend/skills/mcp_process.py
@@ -14,7 +14,7 @@ import logging
 import os
 import sys
 import tempfile
-import threading
+from autobot_shared.singleton_factory import lazy_singleton
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -203,15 +203,4 @@ class MCPProcessManager:
         return json.loads(line.decode())
 
 
-_manager: Optional[MCPProcessManager] = None
-_manager_lock = threading.Lock()
-
-
-def get_mcp_manager() -> MCPProcessManager:
-    """Get the singleton MCPProcessManager instance (thread-safe)."""
-    global _manager
-    if _manager is None:
-        with _manager_lock:
-            if _manager is None:
-                _manager = MCPProcessManager()
-    return _manager
+get_mcp_manager = lazy_singleton(MCPProcessManager)

--- a/autobot-backend/skills/registry.py
+++ b/autobot-backend/skills/registry.py
@@ -14,23 +14,11 @@ import pkgutil
 import threading
 from typing import Any, Dict, List, Optional, Set, Type
 
+from autobot_shared.singleton_factory import lazy_singleton
 from skills.base_skill import BaseSkill, SkillHealth, SkillManifest, SkillStatus
 from skills.dependency_resolver import check_missing_dependencies, resolve_dependencies
 
 logger = logging.getLogger(__name__)
-
-_registry_instance: Optional["SkillRegistry"] = None
-_registry_lock = threading.Lock()
-
-
-def get_skill_registry() -> "SkillRegistry":
-    """Get the singleton SkillRegistry instance."""
-    global _registry_instance
-    if _registry_instance is None:
-        with _registry_lock:
-            if _registry_instance is None:
-                _registry_instance = SkillRegistry()
-    return _registry_instance
 
 
 class SkillRegistry:
@@ -279,3 +267,6 @@ def _find_enabled_dependents(skills: Dict[str, BaseSkill], name: str) -> List[st
         if skill.enabled and name in skill.get_manifest().dependencies:
             dependents.append(skill_name)
     return dependents
+
+
+get_skill_registry = lazy_singleton(SkillRegistry)

--- a/autobot-backend/temporal_knowledge_manager.py
+++ b/autobot-backend/temporal_knowledge_manager.py
@@ -22,6 +22,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.logging_manager import get_llm_logger
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.threshold_constants import TimingConstants
 
 logger = get_llm_logger("temporal_knowledge_manager")
@@ -513,21 +514,4 @@ class TemporalKnowledgeManager:
         }
 
 
-# Global instance for system integration (thread-safe)
-import threading
-
-_temporal_manager_instance = None
-_temporal_manager_lock = threading.Lock()
-
-
-def get_temporal_manager() -> TemporalKnowledgeManager:
-    """Get the global temporal knowledge manager instance (thread-safe)."""
-    global _temporal_manager_instance
-
-    if _temporal_manager_instance is None:
-        with _temporal_manager_lock:
-            # Double-check after acquiring lock
-            if _temporal_manager_instance is None:
-                _temporal_manager_instance = TemporalKnowledgeManager()
-
-    return _temporal_manager_instance
+get_temporal_manager = lazy_singleton(TemporalKnowledgeManager)

--- a/autobot-backend/utils/error_boundaries/boundary_manager.py
+++ b/autobot-backend/utils/error_boundaries/boundary_manager.py
@@ -13,6 +13,8 @@ import json
 import logging
 import threading
 import time
+
+from autobot_shared.singleton_factory import lazy_singleton
 import traceback
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
@@ -459,22 +461,4 @@ class ErrorBoundaryManager:
             raise
 
 
-# Global error boundary manager instance (thread-safe)
-_error_boundary_manager: Optional[ErrorBoundaryManager] = None
-_error_boundary_manager_lock = threading.Lock()
-
-
-def get_error_boundary_manager() -> ErrorBoundaryManager:
-    """
-    Get global error boundary manager instance (thread-safe).
-
-    Returns:
-        Singleton ErrorBoundaryManager instance
-    """
-    global _error_boundary_manager
-    if _error_boundary_manager is None:
-        with _error_boundary_manager_lock:
-            # Double-check after acquiring lock
-            if _error_boundary_manager is None:
-                _error_boundary_manager = ErrorBoundaryManager()
-    return _error_boundary_manager
+get_error_boundary_manager = lazy_singleton(ErrorBoundaryManager)

--- a/autobot-backend/utils/model_optimizer.py
+++ b/autobot-backend/utils/model_optimizer.py
@@ -21,11 +21,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import threading
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.http_client import get_http_client
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
 from config.manager import get_config_manager
 
@@ -484,17 +484,4 @@ class ModelOptimizer:
         ]
 
 
-# Global optimizer instance (thread-safe)
-_model_optimizer: Optional[ModelOptimizer] = None
-_model_optimizer_lock = threading.Lock()
-
-
-def get_model_optimizer() -> ModelOptimizer:
-    """Get the global model optimizer instance (thread-safe)."""
-    global _model_optimizer
-    if _model_optimizer is None:
-        with _model_optimizer_lock:
-            # Double-check after acquiring lock
-            if _model_optimizer is None:
-                _model_optimizer = ModelOptimizer()
-    return _model_optimizer
+get_model_optimizer = lazy_singleton(ModelOptimizer)

--- a/autobot-backend/utils/payload_optimizer.py
+++ b/autobot-backend/utils/payload_optimizer.py
@@ -87,7 +87,6 @@ class PayloadOptimizer:
         self.chunk_size = chunk_size
         self.overlap_size = overlap_size
 
-        # Lock for thread-safe stats access
         import threading
 
         self._stats_lock = threading.Lock()
@@ -514,22 +513,9 @@ class PayloadOptimizer:
             self.chunking_count = 0
 
 
-# Global instance (thread-safe)
-import threading
+from autobot_shared.singleton_factory import lazy_singleton
 
-_global_optimizer: Optional[PayloadOptimizer] = None
-_global_optimizer_lock = threading.Lock()
-
-
-def get_payload_optimizer() -> PayloadOptimizer:
-    """Get the global payload optimizer instance (thread-safe)"""
-    global _global_optimizer
-    if _global_optimizer is None:
-        with _global_optimizer_lock:
-            # Double-check after acquiring lock
-            if _global_optimizer is None:
-                _global_optimizer = PayloadOptimizer()
-    return _global_optimizer
+get_payload_optimizer = lazy_singleton(PayloadOptimizer)
 
 
 def optimize_payload(payload: Any, context: str = "") -> OptimizationResult:

--- a/autobot-backend/utils/system_metrics.py
+++ b/autobot-backend/utils/system_metrics.py
@@ -16,6 +16,7 @@ import aiohttp
 import psutil
 
 from autobot_shared.http_client import get_http_client
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
 from config.manager import get_config_manager
 
@@ -567,19 +568,4 @@ class SystemMetricsCollector:
         self._is_collecting = False
 
 
-# Global metrics collector instance (thread-safe)
-import threading
-
-_metrics_collector = None
-_metrics_collector_lock = threading.Lock()
-
-
-def get_metrics_collector() -> SystemMetricsCollector:
-    """Get the global metrics collector instance (thread-safe)"""
-    global _metrics_collector
-    if _metrics_collector is None:
-        with _metrics_collector_lock:
-            # Double-check after acquiring lock
-            if _metrics_collector is None:
-                _metrics_collector = SystemMetricsCollector()
-    return _metrics_collector
+get_metrics_collector = lazy_singleton(SystemMetricsCollector)

--- a/autobot-backend/utils/system_validator.py
+++ b/autobot-backend/utils/system_validator.py
@@ -17,6 +17,7 @@ import aiohttp
 import psutil
 
 from autobot_shared.http_client import get_http_client
+from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
 from config.manager import get_config_manager
 from constants.network_constants import NetworkConstants
@@ -1410,19 +1411,4 @@ class SystemValidator:
         return recommendations
 
 
-# Global validator instance (thread-safe)
-import threading
-
-_system_validator = None
-_system_validator_lock = threading.Lock()
-
-
-def get_system_validator() -> SystemValidator:
-    """Get the global system validator instance (thread-safe)"""
-    global _system_validator
-    if _system_validator is None:
-        with _system_validator_lock:
-            # Double-check after acquiring lock
-            if _system_validator is None:
-                _system_validator = SystemValidator()
-    return _system_validator
+get_system_validator = lazy_singleton(SystemValidator)

--- a/autobot-backend/utils/terminal_input_handler.py
+++ b/autobot-backend/utils/terminal_input_handler.py
@@ -17,6 +17,7 @@ import threading
 from contextlib import contextmanager
 from typing import Dict, List, Optional
 
+from autobot_shared.singleton_factory import lazy_singleton
 from constants.network_constants import NetworkConstants
 from utils.service_registry import get_service_url
 
@@ -322,20 +323,7 @@ class TerminalInputHandler:
             self.default_responses.update(defaults)
 
 
-# Global instance (thread-safe)
-_terminal_input_handler = None
-_terminal_input_handler_lock = threading.Lock()
-
-
-def get_terminal_input_handler() -> TerminalInputHandler:
-    """Get or create global terminal input handler (thread-safe)."""
-    global _terminal_input_handler
-    if _terminal_input_handler is None:
-        with _terminal_input_handler_lock:
-            # Double-check after acquiring lock
-            if _terminal_input_handler is None:
-                _terminal_input_handler = TerminalInputHandler()
-    return _terminal_input_handler
+get_terminal_input_handler = lazy_singleton(TerminalInputHandler)
 
 
 def safe_input(prompt: str = "", timeout: float = None, default: str = "") -> str:


### PR DESCRIPTION
## Summary
- Migrates 12 remaining module-level double-checked-locking singletons to `lazy_singleton` primitive (phase 3 of #5579 series)
- 2 files excluded: `ollama_connection_pool.py` (lock used in 4 operations: get/configure/cleanup/reset — not a pure singleton); `skills/db.py` (non-trivial factory reads env var + has `close_skills_engine()` reset function)
- All 12 migrations confirmed pure no-arg singletons via phase 2 triage

## Files migrated (12)

| File | Factory |
|---|---|
| `services/user_behavior_analytics.py` | `UserBehaviorAnalytics` |
| `services/workflow_automation/routes.py` | `WorkflowAutomationManager` |
| `services/workflow_secret_service.py` | `WorkflowSecretService` |
| `skills/mcp_process.py` | `MCPProcessManager` |
| `skills/registry.py` | `SkillRegistry` (getter placed after class definition) |
| `temporal_knowledge_manager.py` | `TemporalKnowledgeManager` |
| `utils/error_boundaries/boundary_manager.py` | `ErrorBoundaryManager` |
| `utils/model_optimizer.py` | `ModelOptimizer` |
| `utils/payload_optimizer.py` | `PayloadOptimizer` |
| `utils/system_metrics.py` | `SystemMetricsCollector` |
| `utils/system_validator.py` | `SystemValidator` |
| `utils/terminal_input_handler.py` | `TerminalInputHandler` |

## Files excluded with reason

| File | Reason |
|---|---|
| `utils/ollama_connection_pool.py` | Lock used in 5 places: singleton getter + configure + cleanup (2×) — mutual exclusion, not singleton pattern |
| `skills/db.py` | Factory reads `AUTOBOT_BASE_DIR` env var + `close_skills_engine()` resets `_engine = None` — `lazy_singleton` has no reset path |

## Behavioral grep audit
Before:
```
$ grep -c "_.*_lock = threading.Lock()" autobot-backend/**/*.py (module-level)
# 12 more instances (these files)
```
After:
```
$ grep -rn "lazy_singleton" autobot-backend/ | grep -v test
# 12 new usages added; 12 boilerplate blocks (195 lines) removed
```

## Test plan
- [x] All 12 files pass `python3 -m py_compile` (verified)
- [ ] Backend starts without ImportError

Closes #5619

🤖 Generated with [Claude Code](https://claude.com/claude-code)