### PR TITLE
refactor(utils): add lazy_optional_singleton + migrate secure_sandbox_executor (#5576)

### DIFF
--- a/autobot-backend/secure_sandbox_executor.py
+++ b/autobot-backend/secure_sandbox_executor.py
@@ -23,6 +23,7 @@ import docker
 from docker.errors import DockerException, ImageNotFound
 
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.singleton_factory import lazy_optional_singleton
 from autobot_shared.ssot_config import config as _ssot_config
 from constants.ttl_constants import TTL_1_HOUR
 
@@ -747,35 +748,26 @@ class SecureSandboxExecutor:
 # Global instance for easy access with lazy initialization
 # Lazy loading prevents startup blocking while ensuring security is available
 
-import threading
 
-_sandbox_lock = threading.Lock()
-_sandbox_instance = None
+def _create_secure_sandbox() -> Optional[SecureSandboxExecutor]:
+    """Factory for the global SecureSandboxExecutor singleton.
+
+    Returns None on Docker initialisation failure so callers can degrade
+    gracefully.  The None result is cached by lazy_optional_singleton so
+    construction is only attempted once (Issue #5576).
+    """
+    try:
+        logger.info("Initializing secure sandbox for command execution security")
+        instance = SecureSandboxExecutor()
+        logger.info("Secure sandbox initialized successfully")
+        return instance
+    except Exception as e:
+        logger.error("Failed to initialize secure sandbox: %s", e)
+        logger.warning("Command execution will proceed without sandboxing - SECURITY RISK")
+        return None
 
 
-def get_secure_sandbox() -> Optional[SecureSandboxExecutor]:
-    """Get or create the global secure sandbox instance with thread-safe lazy initialization"""
-    global _sandbox_instance
-
-    if _sandbox_instance is not None:
-        return _sandbox_instance
-
-    with _sandbox_lock:
-        if _sandbox_instance is None:
-            try:
-                logger.info(
-                    "Initializing secure sandbox for command execution security"
-                ),
-                _sandbox_instance = SecureSandboxExecutor()
-                logger.info("Secure sandbox initialized successfully")
-            except Exception as e:
-                logger.error("Failed to initialize secure sandbox: %s", e)
-                logger.warning(
-                    "Command execution will proceed without sandboxing - SECURITY RISK"
-                ),
-                _sandbox_instance = None
-
-        return _sandbox_instance
+get_secure_sandbox = lazy_optional_singleton(_create_secure_sandbox)
 
 
 # Maintain backward compatibility

--- a/autobot_shared/singleton_factory.py
+++ b/autobot_shared/singleton_factory.py
@@ -8,9 +8,34 @@ Issue #5423: extracted from the repeated double-checked locking pattern in
 """
 
 from threading import Lock
-from typing import Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 T = TypeVar("T")
+
+
+def lazy_optional_singleton(factory: Callable[[], Optional[T]]) -> Callable[[], Optional[T]]:
+    """Return a factory that creates and caches a thread-safe optional singleton.
+
+    Like ``lazy_singleton`` but supports ``None`` as a valid cached value.
+    Uses a sentinel ``_UNSET`` object to distinguish "not yet initialised"
+    from "initialised to None" (e.g. when construction fails gracefully).
+
+    Issue #5576: used for ``get_secure_sandbox()`` which returns None on
+    Docker initialisation failure.
+    """
+    _lock = Lock()
+    _UNSET: Any = object()
+    _instance: Any = _UNSET
+
+    def _get() -> Optional[T]:
+        nonlocal _instance
+        if _instance is _UNSET:
+            with _lock:
+                if _instance is _UNSET:
+                    _instance = factory()
+        return _instance  # type: ignore[return-value]
+
+    return _get
 
 
 def lazy_singleton(factory: Callable[..., T]) -> Callable[..., T]:


### PR DESCRIPTION
## Summary

- Added `lazy_optional_singleton()` to `autobot_shared/singleton_factory.py` — handles factories that may return `None` using a `_UNSET` sentinel (pattern matches `lazy_singleton`)
- Migrated `secure_sandbox_executor.py` `get_secure_sandbox()` from manual double-checked locking to `lazy_optional_singleton`
- `task_queue.py` required no change — `get_task_queue = lazy_singleton(TaskQueue)` was already in place; `initialize_task_queue` is a documented escape hatch that intentionally bypasses the cache

## Changed files

- `autobot_shared/singleton_factory.py` — `lazy_optional_singleton` added
- `autobot-backend/secure_sandbox_executor.py` — migrated to `lazy_optional_singleton`

## Test Plan

- [ ] `python -m py_compile autobot_shared/singleton_factory.py secure_sandbox_executor.py` passes
- [ ] `lazy_optional_singleton` caches `None` correctly on second call

Closes #5576

🤖 Generated with Claude Code