### PR TITLE
feat(composables): usePollingJob accepts Ref<number> | number for intervalMs (#5586)

### DIFF
--- a/autobot-frontend/src/composables/__tests__/usePollingJob.test.ts
+++ b/autobot-frontend/src/composables/__tests__/usePollingJob.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { effectScope, nextTick } from 'vue'
+import { effectScope, nextTick, ref } from 'vue'
 
 import { usePollingJob } from '../usePollingJob'
 
@@ -240,5 +240,56 @@ describe('usePollingJob', () => {
 
     expect(error.value).toBeInstanceOf(Error)
     expect(error.value?.message).toBe('string rejection')
+  })
+
+  it('accepts Ref<number> for intervalMs and uses its value at start() time', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ status: 'PENDING' })
+    const intervalRef = ref(500)
+    const { start, stop, attempts } = usePollingJob(fetcher, {
+      intervalMs: intervalRef
+    })
+
+    start('task-ref-interval')
+    // Immediate fire
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    // Tick at captured interval (500ms)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+
+    expect(attempts.value).toBe(3)
+    stop()
+  })
+
+  it('picks up updated Ref<number> value when start() is called again', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ status: 'PENDING' })
+    const intervalRef = ref(1000)
+    const { start, stop } = usePollingJob(fetcher, {
+      intervalMs: intervalRef
+    })
+
+    // First polling session at 1000ms interval
+    start('task-ref-update')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    stop()
+
+    // Update ref and restart — new interval should be 200ms
+    intervalRef.value = 200
+    start('task-ref-update')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(200)
+    expect(fetcher).toHaveBeenCalledTimes(4)
+    // Old 1000ms interval should NOT fire at t=800ms
+    await vi.advanceTimersByTimeAsync(600)
+    expect(fetcher).toHaveBeenCalledTimes(7) // 3 more at 200ms: t=400, 600, 800
+    stop()
   })
 })

--- a/autobot-frontend/src/composables/usePollingJob.ts
+++ b/autobot-frontend/src/composables/usePollingJob.ts
@@ -24,15 +24,15 @@
  * ```
  */
 
-import { ref, readonly, onScopeDispose, getCurrentScope } from 'vue'
+import { ref, readonly, onScopeDispose, getCurrentScope, isRef } from 'vue'
 import type { Ref } from 'vue'
 import { createLogger } from '@/utils/debugUtils'
 
 const logger = createLogger('usePollingJob')
 
 export interface UsePollingJobOptions<T> {
-  /** Poll interval in milliseconds. Default: 2000. */
-  intervalMs?: number
+  /** Poll interval in milliseconds. Accepts a plain number or a `Ref<number>` for reactive intervals. Default: 2000. */
+  intervalMs?: number | Ref<number>
   /** Maximum attempts before auto-stopping. Default: 60. */
   maxAttempts?: number
   /** Callback fired once when `isComplete` returns true. */
@@ -60,7 +60,6 @@ export function usePollingJob<T>(
   options: UsePollingJobOptions<T> = {}
 ): UsePollingJobReturn<T> {
   const {
-    intervalMs = 2000,
     maxAttempts = 60,
     onDone,
     isComplete
@@ -118,7 +117,8 @@ export function usePollingJob<T>(
     isPolling.value = true
     // Fire immediately so callers don't wait `intervalMs` before the first tick
     void poll(taskId)
-    timer = setInterval(() => void poll(taskId), intervalMs)
+    const ms = isRef(options.intervalMs) ? options.intervalMs.value : (options.intervalMs ?? 2000)
+    timer = setInterval(() => void poll(taskId), ms)
   }
 
   // Auto-cleanup when owning scope (component / effectScope) disposes


### PR DESCRIPTION
## Summary

- `UsePollingJobOptions.intervalMs` now accepts `number | Ref<number>`
- `start()` reads `isRef(options.intervalMs) ? options.intervalMs.value : options.intervalMs` each time it is called — picks up updated ref value on restart
- Fully backwards-compatible: plain `number` works identically

## Changed files

- `src/composables/usePollingJob.ts` — type widened; `start()` reads ref at call time
- `src/composables/__tests__/usePollingJob.test.ts` — 2 new test cases (Ref<number> used at start time; updated ref picked up on restart)

## Test Plan

- [x] All 12 tests pass (10 original + 2 new)
- [ ] ScreenCaptureViewer dynamic refresh rate works correctly

Closes #5586

🤖 Generated with Claude Code