### PR TITLE
fix(ui): type DataTable emptyIcon prop as IconName (#5630)

### DIFF
--- a/autobot-frontend/src/components/ui/DataTable.vue
+++ b/autobot-frontend/src/components/ui/DataTable.vue
@@ -168,7 +168,7 @@ interface Props {
   /** Loading state */
   loading?: boolean
   /** Empty state icon (IconName from Icon.vue registry) */
-  emptyIcon?: string
+  emptyIcon?: IconName
   /** Empty state title */
   emptyTitle?: string
   /** Empty state message */


### PR DESCRIPTION
## Summary

- Changes `emptyIcon?: string` to `emptyIcon?: IconName` in `DataTable.vue` props interface
- No import change needed — `IconName` was already imported at line 119 from a prior PR (#5615)
- No call-site changes needed — grep confirmed `emptyIcon` is only referenced within `DataTable.vue` itself; no external template passes this prop

## Why

PR #5615 migrated `EmptyState.vue` to use `<Icon :name="icon" />` with `IconName` type. `DataTable.vue` passes `emptyIcon` down to `EmptyState` but its prop type remained `string`, meaning TypeScript would not catch callers passing FA class strings (e.g. `"fas fa-table"`) at the `DataTable` boundary.

## Test plan

- [ ] `npx vue-tsc --noEmit -p tsconfig.app.json` — no new errors introduced
- [ ] No external callers pass `emptyIcon` to `<DataTable>` (grep confirmed)

Closes #5630