### PR TITLE
fix(tests): add factory-exception retry test to lazy_singleton (#5631)

### DIFF
--- a/autobot_shared/singleton_factory_test.py
+++ b/autobot_shared/singleton_factory_test.py
@@ -61,6 +61,23 @@ class TestLazySingleton:
         assert get_b() is get_b()
         assert get_a() is not get_b()
 
+    def test_factory_exception_allows_retry(self):
+        calls = []
+        sentinel = object()
+
+        def factory():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("first call fails")
+            return sentinel
+
+        get = lazy_singleton(factory)
+        with pytest.raises(RuntimeError, match="first call fails"):
+            get()
+        result = get()
+        assert result is sentinel
+        assert len(calls) == 2
+
     def test_thread_safety(self):
         calls = []
         def factory():


### PR DESCRIPTION
## Summary

- Adds `test_factory_exception_retries_on_next_call` to `autobot_shared/singleton_factory_test.py`
- Verifies that when `factory()` raises on the first call, `instance` stays `None` and the next call retries correctly

## Behavioral contract verified

```python
get_instance = lazy_singleton(flaky_factory)
with pytest.raises(RuntimeError):
    get_instance()       # first call raises — instance stays None
result = get_instance()  # second call succeeds — factory called again
assert calls == 2
```

Prior to this test, all 8 existing tests covered caching, arg forwarding, arg-guard, independent closures, and thread safety — but not the retry-on-exception path.

## Test plan

- [ ] `pytest autobot_shared/singleton_factory_test.py -xvs` passes (9 tests)

Closes #5631