### PR TITLE
fix(tests): correct patch paths + fix _DIARY_FETCH_LIMIT NameError (#5624)

### DIFF
--- a/autobot-backend/memory/agent_diary.py
+++ b/autobot-backend/memory/agent_diary.py
@@ -113,7 +113,7 @@ class AgentDiaryService:
             # We fetch a generous window so that filtering by category+source
             # still yields enough entries even on large KBs.  The result is then
             # sorted and capped to last_n.
-            all_facts = await kb.get_all_facts(limit=_DIARY_FETCH_LIMIT)
+            all_facts = await kb.get_all_facts(limit=self._DIARY_FETCH_LIMIT)
             entries = [
                 f for f in all_facts
                 if (f.get("metadata") or {}).get("category") == self.CATEGORY

--- a/autobot-backend/tests/memory/test_working_memory.py
+++ b/autobot-backend/tests/memory/test_working_memory.py
@@ -48,7 +48,7 @@ def redis_mock():
 
 @pytest.mark.asyncio
 async def test_store_sets_key_with_default_ttl(service, redis_mock):
-    with patch("memory.working_memory.get_redis_client", new=AsyncMock(return_value=redis_mock)):
+    with patch("memory.working_memory.get_async_redis_client", new=AsyncMock(return_value=redis_mock)):
         await service.store(SESSION, KEY, VALUE)
         redis_mock.set.assert_awaited_once()
         call_args = redis_mock.set.call_args
@@ -59,7 +59,7 @@ async def test_store_sets_key_with_default_ttl(service, redis_mock):
 
 @pytest.mark.asyncio
 async def test_store_uses_custom_ttl(service, redis_mock):
-    with patch("memory.working_memory.get_redis_client", new=AsyncMock(return_value=redis_mock)):
+    with patch("memory.working_memory.get_async_redis_client", new=AsyncMock(return_value=redis_mock)):
         await service.store(SESSION, KEY, VALUE, ttl=120)
         assert redis_mock.set.call_args.kwargs["ex"] == 120
 
@@ -71,7 +71,7 @@ async def test_store_uses_custom_ttl(service, redis_mock):
 
 @pytest.mark.asyncio
 async def test_get_returns_deserialised_value(service, redis_mock):
-    with patch("memory.working_memory.get_redis_client", new=AsyncMock(return_value=redis_mock)):
+    with patch("memory.working_memory.get_async_redis_client", new=AsyncMock(return_value=redis_mock)):
         result = await service.get(SESSION, KEY)
         assert result == VALUE
 
@@ -80,7 +80,7 @@ async def test_get_returns_deserialised_value(service, redis_mock):
 async def test_get_returns_none_on_missing_key(service):
     missing_mock = _make_redis_mock(get_return=None)
     missing_mock.get = AsyncMock(return_value=None)
-    with patch("memory.working_memory.get_redis_client", new=AsyncMock(return_value=missing_mock)):
+    with patch("memory.working_memory.get_async_redis_client", new=AsyncMock(return_value=missing_mock)):
         result = await service.get(SESSION, "nonexistent")
         assert result is None
 
@@ -100,7 +100,7 @@ async def test_list_returns_key_suffixes(service):
 
     mock.scan_iter = _scan_iter
 
-    with patch("memory.working_memory.get_redis_client", new=AsyncMock(return_value=mock)):
+    with patch("memory.working_memory.get_async_redis_client", new=AsyncMock(return_value=mock)):
         keys = await service.list(SESSION)
         assert sorted(keys) == sorted([KEY, "other"])
 
@@ -115,7 +115,7 @@ async def test_list_returns_empty_when_no_keys(service):
 
     mock.scan_iter = _empty_scan
 
-    with patch("memory.working_memory.get_redis_client", new=AsyncMock(return_value=mock)):
+    with patch("memory.working_memory.get_async_redis_client", new=AsyncMock(return_value=mock)):
         keys = await service.list(SESSION)
         assert keys == []
 
@@ -135,7 +135,7 @@ async def test_clear_deletes_all_session_keys(service):
     mock.scan_iter = _scan_iter
     mock.delete = AsyncMock(return_value=1)
 
-    with patch("memory.working_memory.get_redis_client", new=AsyncMock(return_value=mock)):
+    with patch("memory.working_memory.get_async_redis_client", new=AsyncMock(return_value=mock)):
         deleted = await service.clear(SESSION)
         assert deleted == 1
         mock.delete.assert_awaited_once()
@@ -151,7 +151,7 @@ async def test_clear_returns_zero_when_no_keys(service):
 
     mock.scan_iter = _empty_scan
 
-    with patch("memory.working_memory.get_redis_client", new=AsyncMock(return_value=mock)):
+    with patch("memory.working_memory.get_async_redis_client", new=AsyncMock(return_value=mock)):
         deleted = await service.clear(SESSION)
         assert deleted == 0
         mock.delete.assert_not_awaited()


### PR DESCRIPTION
## Summary

- `tests/memory/test_working_memory.py`: changed 8 `@patch` targets from `memory.working_memory.get_redis_client` to `memory.working_memory.get_async_redis_client` — the module imports `get_async_redis_client` at module level, not `get_redis_client`
- `memory/agent_diary.py`: fixed bare `_DIARY_FETCH_LIMIT` reference → `self._DIARY_FETCH_LIMIT` — this was a `NameError` masked by the exception handler that caused read tests to silently return `[]`

## Test results

22 tests pass (8 in `test_working_memory.py`, 4 in `test_agent_diary.py`, 10 others in the suite).

## Note on root cause

The issue description said to patch `autobot_shared.redis_client.get_redis_client` — the actual fix required patching the name as imported into the module under test (`memory.working_memory.get_async_redis_client`), which is the correct Python mock.patch target for module-level imports.

Closes #5624