### PR TITLE
refactor(vision): pass refreshInterval ref directly to usePollingJob (#5644)

### DIFF
--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
@@ -347,7 +347,7 @@ const { start: _startAutoRefresh, stop: _stopAutoRefresh } = usePollingJob(
     }
     return null;
   },
-  { intervalMs: refreshInterval.value, maxAttempts: Number.MAX_SAFE_INTEGER }
+  { intervalMs: refreshInterval, maxAttempts: Number.MAX_SAFE_INTEGER }
 );
 
 watch(autoRefresh, (enabled) => {
@@ -355,13 +355,6 @@ watch(autoRefresh, (enabled) => {
     _startAutoRefresh('');
   } else {
     _stopAutoRefresh();
-  }
-});
-
-watch(refreshInterval, (ms) => {
-  if (autoRefresh.value) {
-    _stopAutoRefresh();
-    _startAutoRefresh('');
   }
 });
 


### PR DESCRIPTION
## Summary

- Changed `intervalMs: refreshInterval.value` → `intervalMs: refreshInterval` in `ScreenCaptureViewer.vue`
- Removed the `watch(refreshInterval, (ms) => { ... })` block (6 lines) — interval changes are now handled automatically by `usePollingJob`'s reactive interval support (#5586/#5635)
- `watch(autoRefresh, ...)` left intact — it controls start/stop, unrelated to this change

## Test Plan
- [ ] Changing the interval select in ScreenCapture panel updates polling rate correctly on next cycle

Closes #5644

🤖 Generated with Claude Code