### PR TITLE
fix(llm-cache): unify get_llm_cache / get_llm_cache_async to one singleton (#5657)

### DIFF
--- a/autobot-backend/llm_interface_pkg/cache.py
+++ b/autobot-backend/llm_interface_pkg/cache.py
@@ -430,29 +430,13 @@ class LLMResponseCache:
         return {"l1_cleared": l1_count, "l2_cleared": l2_count}
 
 
-# Global cache instance with thread-safe initialization (Issue #662)
-_cache_init_lock = asyncio.Lock()
-
+# Global cache instance — both sync and async callers share the same singleton (#5657)
 get_llm_cache = lazy_singleton(LLMResponseCache)
 
 
 async def get_llm_cache_async() -> LLMResponseCache:
-    """
-    Get or create the global LLM response cache instance (async-safe).
-
-    Issue #551 Code Review: Thread-safe singleton with async lock
-    to prevent race conditions during initialization in async contexts.
-
-    Returns:
-        LLMResponseCache singleton instance
-    """
-    global _llm_response_cache
-    if _llm_response_cache is None:
-        async with _cache_init_lock:
-            # Double-check pattern for thread safety
-            if _llm_response_cache is None:
-                _llm_response_cache = LLMResponseCache()
-    return _llm_response_cache
+    """Async accessor for the LLM response cache — delegates to get_llm_cache()."""
+    return get_llm_cache()
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- `get_llm_cache_async` previously maintained its own `asyncio.Lock()` and double-checked pattern, creating a separate `LLMResponseCache` instance from `get_llm_cache()`
- Fix: `get_llm_cache_async` now delegates directly to `get_llm_cache()` — sync and async callers always share the same singleton
- Removes dead `_cache_init_lock` async lock variable

## Validation
- `python3 -m py_compile autobot-backend/llm_interface_pkg/cache.py` passes

Closes #5657

🤖 Generated with [Claude Code](https://claude.com/claude-code)