### PR TITLE
fix(redis): replace get_redis_client(async_client=True) with await get_async_redis_client() (#5659)

### DIFF
--- a/autobot-backend/services/security_workflow_manager.py
+++ b/autobot-backend/services/security_workflow_manager.py
@@ -25,7 +25,7 @@ from typing import Any, List, Optional
 
 from redis.exceptions import RedisError
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.time_utils import now_utc
 
 logger = logging.getLogger(__name__)
@@ -306,7 +306,7 @@ class SecurityWorkflowManager:
     async def _get_redis(self) -> Any:
         """Get Redis client for workflow database."""
         if self._redis_client is None:
-            self._redis_client = get_redis_client(async_client=True, database="workflows")
+            self._redis_client = await get_async_redis_client(database="workflows")
         return self._redis_client
 
     def _assessment_key(self, assessment_id: str) -> str:

--- a/autobot-backend/services/user_behavior_analytics.py
+++ b/autobot-backend/services/user_behavior_analytics.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Optional
 
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.ttl_constants import TTL_24_HOURS, TTL_30_DAYS, TTL_90_DAYS
@@ -105,7 +105,7 @@ class UserBehaviorAnalytics:
     async def get_redis(self):
         """Get Redis client for analytics database"""
         if self._redis is None:
-            self._redis = get_redis_client(async_client=True, database=RedisDatabase.ANALYTICS)
+            self._redis = await get_async_redis_client(database=RedisDatabase.ANALYTICS)
         return self._redis
 
     def _build_event_operations(self, redis, event: UserEvent) -> list:


### PR DESCRIPTION
## Summary

Fixes active bug where two services stored an unawaited coroutine as a Redis client — reproducing the exact issue that `get_async_redis_client()` was introduced to prevent (#3962).

- `services/security_workflow_manager.py:309` — `_get_redis()` now awaits `get_async_redis_client(database="workflows")`
- `services/user_behavior_analytics.py:108` — `get_redis()` now awaits `get_async_redis_client(database=RedisDatabase.ANALYTICS)`
- Import switched from `get_redis_client` to `get_async_redis_client` in both files

## Test plan
- [ ] `python -m py_compile autobot-backend/services/security_workflow_manager.py`
- [ ] `python -m py_compile autobot-backend/services/user_behavior_analytics.py`
- [ ] `grep -r "get_redis_client(async_client=True" autobot-backend/services/security_workflow_manager.py autobot-backend/services/user_behavior_analytics.py` returns empty

Closes #5659