### PR TITLE
fix(tests): correct get_async_redis_client patch targets in 4 test files (#5655)

### DIFF
--- a/autobot-backend/services/approval_memory_test.py
+++ b/autobot-backend/services/approval_memory_test.py
@@ -246,7 +246,7 @@ class TestRememberApproval:
         mock_redis.get.return_value = None
 
         with patch(
-            "services.approval_memory.get_redis_client", return_value=mock_redis
+            "services.approval_memory.get_async_redis_client", return_value=mock_redis
         ):
             result = await manager.remember_approval(
                 project_path="/home/user/project",
@@ -280,7 +280,7 @@ class TestRememberApproval:
         mock_redis.get.return_value = json.dumps(existing)
 
         with patch(
-            "services.approval_memory.get_redis_client", return_value=mock_redis
+            "services.approval_memory.get_async_redis_client", return_value=mock_redis
         ):
             await manager.remember_approval(
                 project_path="/home/user/project",
@@ -296,7 +296,7 @@ class TestRememberApproval:
     @pytest.mark.asyncio
     async def test_redis_unavailable_returns_false(self, manager):
         """Returns False when Redis is unavailable."""
-        with patch("services.approval_memory.get_redis_client", return_value=None):
+        with patch("services.approval_memory.get_async_redis_client", return_value=None):
             result = await manager.remember_approval("/path", "ls", "user", "safe")
         assert result is False
 
@@ -342,7 +342,7 @@ class TestCheckRemembered:
         mock_redis.get.return_value = json.dumps(records)
 
         with patch(
-            "services.approval_memory.get_redis_client", return_value=mock_redis
+            "services.approval_memory.get_async_redis_client", return_value=mock_redis
         ):
             result = await manager.check_remembered(
                 project_path="/home/user/project",
@@ -367,7 +367,7 @@ class TestCheckRemembered:
         mock_redis.get.return_value = json.dumps(records)
 
         with patch(
-            "services.approval_memory.get_redis_client", return_value=mock_redis
+            "services.approval_memory.get_async_redis_client", return_value=mock_redis
         ):
             result = await manager.check_remembered(
                 project_path="/home/user/project",
@@ -392,7 +392,7 @@ class TestCheckRemembered:
         mock_redis.get.return_value = json.dumps(records)
 
         with patch(
-            "services.approval_memory.get_redis_client", return_value=mock_redis
+            "services.approval_memory.get_async_redis_client", return_value=mock_redis
         ):
             result = await manager.check_remembered(
                 project_path="/home/user/project",
@@ -409,7 +409,7 @@ class TestCheckRemembered:
         mock_redis.get.return_value = None
 
         with patch(
-            "services.approval_memory.get_redis_client", return_value=mock_redis
+            "services.approval_memory.get_async_redis_client", return_value=mock_redis
         ):
             result = await manager.check_remembered("/path", "ls", "user", "safe")
         assert result is False
@@ -429,7 +429,7 @@ class TestCheckRemembered:
         mock_redis.get.return_value = json.dumps(records)
 
         with patch(
-            "services.approval_memory.get_redis_client", return_value=mock_redis
+            "services.approval_memory.get_async_redis_client", return_value=mock_redis
         ):
             result = await manager.check_remembered(
                 project_path="/home/user/project",
@@ -454,7 +454,7 @@ class TestCheckRemembered:
         mock_redis.get.return_value = json.dumps(records)
 
         with patch(
-            "services.approval_memory.get_redis_client", return_value=mock_redis
+            "services.approval_memory.get_async_redis_client", return_value=mock_redis
         ):
             result = await manager.check_remembered(
                 project_path="/home/user/project",
@@ -472,7 +472,7 @@ class TestCheckRemembered:
         mock_redis.get.return_value = "not valid json{"
 
         with patch(
-            "services.approval_memory.get_redis_client", return_value=mock_redis
+            "services.approval_memory.get_async_redis_client", return_value=mock_redis
         ):
             result = await manager.check_remembered("/path", "ls", "user", "safe")
         assert result is False

--- a/autobot-backend/services/workflow_export_test.py
+++ b/autobot-backend/services/workflow_export_test.py
@@ -326,7 +326,7 @@ class TestShareWorkflow:
         sharing, manager = self._make_sharing()
         mock_redis = AsyncMock()
         with patch(
-            "services.workflow_sharing_service.get_redis_client",
+            "services.workflow_sharing_service.get_async_redis_client",
             return_value=mock_redis,
         ):
             share_id = await sharing.share_workflow(workflow_id="wf-test", owner_id="owner-1", public=True)
@@ -339,7 +339,7 @@ class TestShareWorkflow:
         sharing, _ = self._make_sharing()
         mock_redis = AsyncMock()
         with patch(
-            "services.workflow_sharing_service.get_redis_client",
+            "services.workflow_sharing_service.get_async_redis_client",
             return_value=mock_redis,
         ):
             share_id = await sharing.share_workflow(
@@ -360,7 +360,7 @@ class TestShareWorkflow:
     @pytest.mark.asyncio
     async def test_returns_none_when_redis_unavailable(self):
         sharing, _ = self._make_sharing()
-        with patch("services.workflow_sharing_service.get_redis_client", return_value=None):
+        with patch("services.workflow_sharing_service.get_async_redis_client", return_value=None):
             share_id = await sharing.share_workflow(workflow_id="wf-test", owner_id="owner-1", public=True)
         assert share_id is None
 
@@ -391,7 +391,7 @@ class TestUnshareWorkflow:
         mock_redis.get.return_value = record
 
         with patch(
-            "services.workflow_sharing_service.get_redis_client",
+            "services.workflow_sharing_service.get_async_redis_client",
             return_value=mock_redis,
         ):
             result = await sharing.unshare_workflow(share_id)
@@ -406,7 +406,7 @@ class TestUnshareWorkflow:
         mock_redis.get.return_value = None
 
         with patch(
-            "services.workflow_sharing_service.get_redis_client",
+            "services.workflow_sharing_service.get_async_redis_client",
             return_value=mock_redis,
         ):
             result = await sharing.unshare_workflow("nonexistent-share")
@@ -416,7 +416,7 @@ class TestUnshareWorkflow:
     @pytest.mark.asyncio
     async def test_returns_false_when_redis_unavailable(self):
         sharing = WorkflowSharingService(MagicMock())
-        with patch("services.workflow_sharing_service.get_redis_client", return_value=None):
+        with patch("services.workflow_sharing_service.get_async_redis_client", return_value=None):
             result = await sharing.unshare_workflow("any-share")
         assert result is False
 
@@ -457,7 +457,7 @@ class TestListShared:
         mock_redis.get = AsyncMock(return_value=record)
 
         with patch(
-            "services.workflow_sharing_service.get_redis_client",
+            "services.workflow_sharing_service.get_async_redis_client",
             return_value=mock_redis,
         ):
             shares = await sharing.list_shared(user_id="stranger")
@@ -477,7 +477,7 @@ class TestListShared:
         mock_redis.get = AsyncMock(return_value=record)
 
         with patch(
-            "services.workflow_sharing_service.get_redis_client",
+            "services.workflow_sharing_service.get_async_redis_client",
             return_value=mock_redis,
         ):
             shares = await sharing.list_shared(user_id="user-2")
@@ -495,7 +495,7 @@ class TestListShared:
         mock_redis.get = AsyncMock(return_value=record)
 
         with patch(
-            "services.workflow_sharing_service.get_redis_client",
+            "services.workflow_sharing_service.get_async_redis_client",
             return_value=mock_redis,
         ):
             shares = await sharing.list_shared(user_id="user-3")
@@ -505,7 +505,7 @@ class TestListShared:
     @pytest.mark.asyncio
     async def test_returns_empty_when_redis_unavailable(self):
         sharing = WorkflowSharingService(MagicMock())
-        with patch("services.workflow_sharing_service.get_redis_client", return_value=None):
+        with patch("services.workflow_sharing_service.get_async_redis_client", return_value=None):
             shares = await sharing.list_shared(user_id="anyone")
         assert shares == []
 
@@ -563,7 +563,7 @@ class TestCloneWorkflow:
         mock_redis.get = AsyncMock(return_value=record)
 
         with patch(
-            "services.workflow_sharing_service.get_redis_client",
+            "services.workflow_sharing_service.get_async_redis_client",
             return_value=mock_redis,
         ):
             new_id = await sharing.clone_workflow(share_id, new_owner_id="user-2")
@@ -577,7 +577,7 @@ class TestCloneWorkflow:
         mock_redis.get = AsyncMock(return_value=None)
 
         with patch(
-            "services.workflow_sharing_service.get_redis_client",
+            "services.workflow_sharing_service.get_async_redis_client",
             return_value=mock_redis,
         ):
             result = await sharing.clone_workflow("missing-share", new_owner_id="user-2")
@@ -587,7 +587,7 @@ class TestCloneWorkflow:
     @pytest.mark.asyncio
     async def test_returns_none_when_redis_unavailable(self):
         sharing = self._make_sharing_with_export({})
-        with patch("services.workflow_sharing_service.get_redis_client", return_value=None):
+        with patch("services.workflow_sharing_service.get_async_redis_client", return_value=None):
             result = await sharing.clone_workflow("any-share", new_owner_id="u")
         assert result is None
 

--- a/autobot-backend/services/workflow_versioning_test.py
+++ b/autobot-backend/services/workflow_versioning_test.py
@@ -69,7 +69,7 @@ class TestSaveVersion:
         mock_redis = _make_redis()
         mock_redis.zrevrange.return_value = []
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             version = await store.save_version("wf-1", _make_data())
 
         assert version == 1
@@ -80,7 +80,7 @@ class TestSaveVersion:
         mock_redis = _make_redis()
         mock_redis.zrevrange.return_value = ["3"]  # highest existing version
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             version = await store.save_version("wf-1", _make_data())
 
         assert version == 4
@@ -91,7 +91,7 @@ class TestSaveVersion:
         mock_redis = _make_redis()
         mock_redis.zrevrange.return_value = []
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             await store.save_version("wf-2", _make_data(), notes="initial save")
 
         mock_redis.set.assert_called_once()
@@ -110,7 +110,7 @@ class TestSaveVersion:
     @pytest.mark.asyncio
     async def test_returns_none_when_redis_unavailable(self):
         store = WorkflowVersionStore()
-        with patch("services.workflow_versioning.get_redis_client", return_value=None):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=None):
             result = await store.save_version("wf-x", _make_data())
 
         assert result is None
@@ -134,7 +134,7 @@ class TestSaveVersion:
         mock_redis.get.side_effect = fake_get
         mock_redis.zrevrange.return_value = []
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             version = await store.save_version("wf-rt", data, notes="rt")
             assert version == 1
 
@@ -173,7 +173,7 @@ class TestListVersions:
 
         mock_redis.get.side_effect = lambda key: _record(int(key.split(":")[-1]))
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             summaries = await store.list_versions("wf-order")
 
         assert [s["version"] for s in summaries] == [3, 2, 1]
@@ -184,7 +184,7 @@ class TestListVersions:
         mock_redis = _make_redis()
         mock_redis.zrevrange.return_value = []
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             summaries = await store.list_versions("wf-unknown")
 
         assert summaries == []
@@ -207,7 +207,7 @@ class TestListVersions:
         )
         mock_redis.get.side_effect = lambda key: None if ":2" in key else record_v1
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             summaries = await store.list_versions("wf-gap")
 
         assert len(summaries) == 1
@@ -216,7 +216,7 @@ class TestListVersions:
     @pytest.mark.asyncio
     async def test_returns_empty_when_redis_unavailable(self):
         store = WorkflowVersionStore()
-        with patch("services.workflow_versioning.get_redis_client", return_value=None):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=None):
             summaries = await store.list_versions("wf-x")
 
         assert summaries == []
@@ -238,7 +238,7 @@ class TestListVersions:
         )
         mock_redis.get.return_value = record
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             summaries = await store.list_versions("wf-sum")
 
         assert len(summaries) == 1
@@ -268,7 +268,7 @@ class TestGetVersion:
         mock_redis = _make_redis()
         mock_redis.get.return_value = record
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             wv = await store.get_version("wf-get", 5)
 
         assert wv is not None
@@ -283,7 +283,7 @@ class TestGetVersion:
         mock_redis = _make_redis()
         mock_redis.get.return_value = None
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             wv = await store.get_version("wf-miss", 99)
 
         assert wv is None
@@ -291,7 +291,7 @@ class TestGetVersion:
     @pytest.mark.asyncio
     async def test_returns_none_when_redis_unavailable(self):
         store = WorkflowVersionStore()
-        with patch("services.workflow_versioning.get_redis_client", return_value=None):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=None):
             wv = await store.get_version("wf-x", 1)
 
         assert wv is None
@@ -319,7 +319,7 @@ class TestRestoreVersion:
         mock_redis = _make_redis()
         mock_redis.get.return_value = record
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             restored = await store.restore_version("wf-restore", 2)
 
         assert restored == data
@@ -330,7 +330,7 @@ class TestRestoreVersion:
         mock_redis = _make_redis()
         mock_redis.get.return_value = None
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             restored = await store.restore_version("wf-restore", 99)
 
         assert restored is None
@@ -366,7 +366,7 @@ class TestDiffVersions:
         mock_redis = _make_redis()
         mock_redis.get.side_effect = lambda key: r1 if ":1" in key else r2
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             diff = await store.diff_versions("wf-diff", v1=1, v2=2)
 
         assert diff is not None
@@ -388,7 +388,7 @@ class TestDiffVersions:
         mock_redis = _make_redis()
         mock_redis.get.side_effect = lambda key: r1 if ":1" in key else r2
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             diff = await store.diff_versions("wf-diff", v1=1, v2=2)
 
         assert diff is not None
@@ -407,7 +407,7 @@ class TestDiffVersions:
         mock_redis = _make_redis()
         mock_redis.get.side_effect = lambda key: r1 if ":1" in key else r2
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             diff = await store.diff_versions("wf-diff", v1=1, v2=2)
 
         assert diff is not None
@@ -426,7 +426,7 @@ class TestDiffVersions:
         mock_redis = _make_redis()
         mock_redis.get.return_value = None
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             diff = await store.diff_versions("wf-diff", v1=1, v2=2)
 
         assert diff is None
@@ -440,7 +440,7 @@ class TestDiffVersions:
         mock_redis = _make_redis()
         mock_redis.get.side_effect = lambda key: r1 if ":1" in key else r2
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             diff = await store.diff_versions("wf-same", v1=1, v2=2)
 
         assert diff == {"added": [], "removed": [], "modified": []}
@@ -458,7 +458,7 @@ class TestDeleteVersion:
         mock_redis = _make_redis()
         mock_redis.delete.return_value = 1
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             result = await store.delete_version("wf-del", 3)
 
         assert result is True
@@ -471,7 +471,7 @@ class TestDeleteVersion:
         mock_redis = _make_redis()
         mock_redis.delete.return_value = 0  # key did not exist
 
-        with patch("services.workflow_versioning.get_redis_client", return_value=mock_redis):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=mock_redis):
             result = await store.delete_version("wf-del", 99)
 
         assert result is False
@@ -479,7 +479,7 @@ class TestDeleteVersion:
     @pytest.mark.asyncio
     async def test_returns_false_when_redis_unavailable(self):
         store = WorkflowVersionStore()
-        with patch("services.workflow_versioning.get_redis_client", return_value=None):
+        with patch("services.workflow_versioning.get_async_redis_client", return_value=None):
             result = await store.delete_version("wf-x", 1)
 
         assert result is False

--- a/autobot-backend/tests/utils/test_experiment_tracker.py
+++ b/autobot-backend/tests/utils/test_experiment_tracker.py
@@ -60,7 +60,7 @@ class TestExperimentTracker:
     def tracker(self):
         return ExperimentTracker()
 
-    @patch("utils.experiment_tracker.get_redis_client")
+    @patch("utils.experiment_tracker.get_async_redis_client")
     @pytest.mark.asyncio
     async def test_log_experiment(self, mock_redis_factory, tracker):
         mock_client = AsyncMock()
@@ -77,7 +77,7 @@ class TestExperimentTracker:
         assert record.name == "Test experiment"
         assert record.experiment_id.startswith("exp-")
 
-    @patch("utils.experiment_tracker.get_redis_client")
+    @patch("utils.experiment_tracker.get_async_redis_client")
     @pytest.mark.asyncio
     async def test_list_experiments(self, mock_redis_factory, tracker):
         mock_client = AsyncMock()
@@ -86,7 +86,7 @@ class TestExperimentTracker:
         results = await tracker.list_experiments()
         assert len(results) == 1
 
-    @patch("utils.experiment_tracker.get_redis_client")
+    @patch("utils.experiment_tracker.get_async_redis_client")
     @pytest.mark.asyncio
     async def test_list_by_area(self, mock_redis_factory, tracker):
         mock_client = AsyncMock()
@@ -99,7 +99,7 @@ class TestExperimentTracker:
         assert len(results) == 1
         assert results[0]["area"] == "inference"
 
-    @patch("utils.experiment_tracker.get_redis_client")
+    @patch("utils.experiment_tracker.get_async_redis_client")
     @pytest.mark.asyncio
     async def test_log_with_no_redis(self, mock_redis_factory, tracker):
         mock_redis_factory.side_effect = _async_return(None)


### PR DESCRIPTION
## Summary

Fixes 4 test files that patched `get_redis_client` but the production modules import `get_async_redis_client` — the patch silently did nothing and tests hit real Redis.

- `tests/utils/test_experiment_tracker.py` — 4 patches corrected
- `services/approval_memory_test.py` — 8 patches corrected (all `with patch(...)` blocks)
- `services/workflow_versioning_test.py` — 22 patches corrected
- `services/workflow_export_test.py` — 4 patches corrected

Each patch target changed from `<module>.get_redis_client` → `<module>.get_async_redis_client`.

## Test plan
- [ ] Run each test file in an environment without real Redis; all tests should pass (mocks are now effective)
- [ ] `grep -n "get_redis_client" autobot-backend/services/approval_memory_test.py autobot-backend/tests/utils/test_experiment_tracker.py` returns empty

Closes #5655