### PR TITLE
chore(redis): migrate 3 remaining get_redis_client(async_client=True) callers to get_async_redis_client() (#5661)

### DIFF
--- a/autobot-backend/integrations/slack_integration.py
+++ b/autobot-backend/integrations/slack_integration.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, List, Optional
 
 import aiohttp
 
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from integrations.base import IntegrationAction
 from integrations.communication_integration import SlackIntegration
 
@@ -581,7 +581,7 @@ class SlackNotificationIntegration(SlackIntegration):
             Never raises; logs error and returns False instead.
         """
         try:
-            client = await get_redis_client(async_client=True, database="main")
+            client = await get_async_redis_client(database="main")
             if client is None:
                 logger.warning(
                     "Redis client unavailable for saving channel mapping (project_id=%s)",
@@ -628,7 +628,7 @@ class SlackNotificationIntegration(SlackIntegration):
             Never raises; logs error and returns None instead.
         """
         try:
-            client = await get_redis_client(async_client=True, database="main")
+            client = await get_async_redis_client(database="main")
             if client is None:
                 logger.warning(
                     "Redis client unavailable for loading channel mapping (project_id=%s)",
@@ -683,7 +683,7 @@ class SlackNotificationIntegration(SlackIntegration):
             Never raises; logs error and returns False instead.
         """
         try:
-            client = await get_redis_client(async_client=True, database="main")
+            client = await get_async_redis_client(database="main")
             if client is None:
                 logger.warning(
                     "Redis client unavailable for storing approval thread (approval_id=%s)",
@@ -734,7 +734,7 @@ class SlackNotificationIntegration(SlackIntegration):
             Never raises; logs error and returns None instead.
         """
         try:
-            client = await get_redis_client(async_client=True, database="main")
+            client = await get_async_redis_client(database="main")
             if client is None:
                 logger.warning(
                     "Redis client unavailable for loading approval thread (approval_id=%s)",

--- a/autobot-backend/knowledge/memory_graph/hybrid_scorer.py
+++ b/autobot-backend/knowledge/memory_graph/hybrid_scorer.py
@@ -86,8 +86,8 @@ class HybridScorer:
     async def _get_redis(self):
         """Lazily obtain the async Redis client (cached on self._redis)."""
         if self._redis is None:
-            from autobot_shared.redis_client import get_redis_client
-            self._redis = await get_redis_client(async_client=True, database="knowledge")
+            from autobot_shared.redis_client import get_async_redis_client
+            self._redis = await get_async_redis_client(database="knowledge")
         return self._redis
 
     # ------------------------------------------------------------------

--- a/autobot-backend/services/topic_retrieval_cache.py
+++ b/autobot-backend/services/topic_retrieval_cache.py
@@ -329,7 +329,7 @@ class TopicRetrievalCache(AsyncInitializable):
             results = await self._collection.get(limit=excess, include=["metadatas"])
             if results and results.get("ids"):
                 ids_to_delete = results["ids"]
-                client = await get_redis_client(async_client=True, database=_REDIS_DATABASE)
+                client = await get_async_redis_client(database=_REDIS_DATABASE)
                 if client:
                     for meta in results.get("metadatas", []):
                         rkey = meta.get("redis_key", "")


### PR DESCRIPTION
## Summary

Migrates the 3 remaining production files that still used the legacy `await get_redis_client(async_client=True, ...)` pattern to the safe `await get_async_redis_client(...)` wrapper.

- `integrations/slack_integration.py` — 4 call sites + import updated
- `knowledge/memory_graph/hybrid_scorer.py` — 1 call site + import updated
- `services/topic_retrieval_cache.py` — 1 call site (import was already `get_async_redis_client`, only call updated)

`security_workflow_manager.py` and `user_behavior_analytics.py` are excluded — covered by the active-bug fix in #5659.

## Test plan
- [ ] `grep -rn "get_redis_client(async_client=True" autobot-backend/integrations/slack_integration.py autobot-backend/knowledge/memory_graph/hybrid_scorer.py autobot-backend/services/topic_retrieval_cache.py` returns empty
- [ ] `python -m py_compile` on each migrated file succeeds

Closes #5661