### PR TITLE
security(deps): bump uuid to 14.0.0 — fix buffer bounds check CVE (#5665)

### DIFF
--- a/autobot-frontend/package-lock.json
+++ b/autobot-frontend/package-lock.json
@@ -11813,7 +11813,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11985,13 +11985,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/verror": {

--- a/autobot-frontend/package.json
+++ b/autobot-frontend/package.json
@@ -69,7 +69,8 @@
     "vue3-apexcharts": "^1.11.1"
   },
   "overrides": {
-    "minimatch": ">=9.0.7"
+    "minimatch": ">=9.0.7",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@pinia/testing": "^1.0.3",

--- a/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package-lock.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package-lock.json
@@ -12,7 +12,7 @@
         "chrono-node": "^2.7.0",
         "natural": "^6.0.0",
         "redis": "^4.6.0",
-        "uuid": "^9.0.0",
+        "uuid": "^14.0.0",
         "zod": "^3.22.0"
       },
       "devDependencies": {
@@ -1606,6 +1606,19 @@
         "node": ">=0.4.10"
       }
     },
+    "node_modules/natural/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2246,16 +2259,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/package.json
@@ -14,7 +14,7 @@
     "chrono-node": "^2.7.0",
     "natural": "^6.0.0",
     "redis": "^4.6.0",
-    "uuid": "^9.0.0",
+    "uuid": "^14.0.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package-lock.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package-lock.json
@@ -17,7 +17,7 @@
         "chalk": "^5.3.0",
         "inquirer": "^12.5.0",
         "pino": "^9.6.0",
-        "uuid": "^11.1.0",
+        "uuid": "^14.0.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -4896,15 +4896,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package.json
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-task-manager-server/package.json
@@ -27,7 +27,7 @@
     "chalk": "^5.3.0",
     "inquirer": "^12.5.0",
     "pino": "^9.6.0",
-    "uuid": "^11.1.0",
+    "uuid": "^14.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Fixes Dependabot alerts #719, #720, #721 — `uuid` missing buffer bounds check in v3/v5/v6 when `buf` is provided (MODERATE).

| File | Before | After | Alert |
|---|---|---|---|
| `autobot-frontend/package.json` | 8.3.2 (transitive) | 14.0.0 (override) | #719 |
| `mcp-autobot-tracker/package.json` | `^9.0.0` → 9.0.1 | `^14.0.0` → 14.0.0 | #720 |
| `mcp-task-manager-server/package.json` | `^11.1.0` → 11.1.0 | `^14.0.0` → 14.0.0 | #721 |

All three `package-lock.json` files regenerated via `npm install --package-lock-only`.

The frontend fix uses `overrides.uuid` since uuid was a transitive dependency (not direct).

## Test plan
- [ ] CI passes
- [ ] Dependabot alerts #719/#720/#721 resolve after rescan

🤖 Generated with [Claude Code](https://claude.com/claude-code)