### PR TITLE
fix(vision): restore watch(refreshInterval) to restart polling on interval change (#5660)

### DIFF
--- a/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
+++ b/autobot-frontend/src/components/vision/ScreenCaptureViewer.vue
@@ -358,6 +358,13 @@ watch(autoRefresh, (enabled) => {
   }
 });
 
+watch(refreshInterval, () => {
+  if (autoRefresh.value) {
+    _stopAutoRefresh();
+    _startAutoRefresh('');
+  }
+});
+
 // Lifecycle
 onMounted(() => {
   loadElementTypes();


### PR DESCRIPTION
## Summary

- Re-adds `watch(refreshInterval, ...)` to `ScreenCaptureViewer.vue`, removed in PR #5653
- Watches `refreshInterval` and restarts polling when the value changes while `autoRefresh` is active

## Why the watch was needed

`usePollingJob` reads `intervalMs` once at `start()` time (a plain number, not reactive). Passing a `Ref` via `toRef(props, 'refreshInterval')` does not cause the running `setInterval` to update — the ref's `.value` is captured at start and frozen in the closure.

The watch-restart pattern is the correct mechanism for mid-flight interval changes at the call-site level.

## Note on Ref<number> support in usePollingJob

The `Ref<number>` support added in #5635 is still useful for call sites where the interval is only read at `start()`. For `ScreenCaptureViewer`, the user can change the interval while polling is running, so the watch restart is still needed.

## Test plan

- [ ] `npx vue-tsc --noEmit -p tsconfig.app.json` — no new errors
- [ ] Manually: start autoRefresh, change interval dropdown — polling restarts at new rate

Closes #5660