### PR TITLE
security: safe_http_detail helper + fix all str(exc) leaks in HTTP responses

### DIFF
--- a/autobot-backend/a2a/task_executor.py
+++ b/autobot-backend/a2a/task_executor.py
@@ -159,16 +159,16 @@ async def execute_a2a_task(
         logger.error("A2A task %s failed: %s", task_id, exc)
         manager.add_artifact(
             task_id,
-            TaskArtifact(artifact_type="error", content=str(exc)),
+            TaskArtifact(artifact_type="error", content=type(exc).__name__),
         )
-        manager.update_state(task_id, TaskState.FAILED, message=str(exc))
+        manager.update_state(task_id, TaskState.FAILED, message=type(exc).__name__)
         manager.publish_event(
             task_id,
             {
                 "event": "state_change",
                 "state": "failed",
                 "terminal": True,
-                "message": str(exc),
+                "message": type(exc).__name__,
                 "task_id": task_id,
             },
         )

--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -637,7 +637,7 @@ async def signup(request: Request, signup_data: SignupRequest):
         from user_management.services.user_service import DuplicateUserError
 
         if isinstance(exc, DuplicateUserError):
-            raise HTTPException(status_code=409, detail=str(exc))
+            raise HTTPException(status_code=409, detail="Username already taken")
         logger.error("Signup error for %s: %s", signup_data.username, exc)
         raise HTTPException(status_code=500, detail="Registration failed. Please try again.")
 

--- a/autobot-backend/api/documents.py
+++ b/autobot-backend/api/documents.py
@@ -348,7 +348,7 @@ async def refine_document(
         )
     except Exception as exc:
         logger.error("Refinement LLM call failed for document %s: %s", doc_id, exc)
-        raise HTTPException(status_code=502, detail=f"LLM refinement failed: {exc}") from exc
+        raise HTTPException(status_code=502, detail="LLM refinement failed") from exc
 
     doc.content = refined_content
     doc.touch()

--- a/autobot-backend/api/knowledge_research_ws.py
+++ b/autobot-backend/api/knowledge_research_ws.py
@@ -99,7 +99,7 @@ async def _run_research(
         logger.error("Research WS error for query %r: %s", query, exc)
         await _send_event(
             websocket,
-            {"event": "research:error", "message": str(exc)},
+            {"event": "research:error", "message": "research_failed"},
         )
 
 

--- a/autobot-backend/api/skills.py
+++ b/autobot-backend/api/skills.py
@@ -228,7 +228,7 @@ async def get_skill_metrics(
         return data
     except Exception as e:
         logger.error("Failed to get metrics for %s: %s", name, e)
-        raise HTTPException(status_code=500, detail=f"Failed to retrieve metrics: {e}")
+        raise HTTPException(status_code=500, detail="Failed to retrieve metrics")
 
 
 @router.post("/{name}/feedback", summary="Submit skill feedback")
@@ -254,7 +254,7 @@ async def submit_skill_feedback(
         }
     except Exception as e:
         logger.error("Failed to log feedback: %s", e)
-        raise HTTPException(status_code=500, detail=f"Failed to log feedback: {e}")
+        raise HTTPException(status_code=500, detail="Failed to log feedback")
 
 
 @router.get("/{name}/suggestions", summary="Get skill refinement suggestions")

--- a/autobot-backend/api/triggers.py
+++ b/autobot-backend/api/triggers.py
@@ -123,7 +123,7 @@ async def create_trigger(
         trigger_id = await service.register_trigger(config)
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)  # user-facing validation error
         ) from exc
 
     webhook_url: Optional[str] = None

--- a/autobot-backend/integrations/github_integration.py
+++ b/autobot-backend/integrations/github_integration.py
@@ -365,14 +365,14 @@ class GitHubIntegration(BaseIntegration):
                 logger.warning("GitHub connection error for %s %s: %s", method, path, exc)
                 return {
                     "status_code": 0,
-                    "body": {"message": str(exc)},
+                    "body": {"message": "integration_error"},
                     "error": "connection_error",
                 }
             except aiohttp.ClientError as exc:
                 logger.warning("GitHub request error for %s %s: %s", method, path, exc)
                 return {
                     "status_code": 0,
-                    "body": {"message": str(exc)},
+                    "body": {"message": "integration_error"},
                     "error": "client_error",
                 }
 

--- a/autobot-infrastructure/shared/docker/ai-stack/ai_api_server.py
+++ b/autobot-infrastructure/shared/docker/ai-stack/ai_api_server.py
@@ -319,7 +319,7 @@ async def global_exception_handler(request: Request, exc: Exception):
     logger.error(f"Unhandled exception: {exc}")
     logger.error(traceback.format_exc())
 
-    return JSONResponse(status_code=500, content={"error": "Internal server error", "detail": str(exc)})
+    return JSONResponse(status_code=500, content={"error": "Internal server error"})
 
 
 if __name__ == "__main__":

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -407,7 +407,7 @@ async def get_file_drift(
     try:
         source_dir = get_default_source_dir(component)
     except ValueError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail="Failed to determine component path") from exc
     deployed_dir = get_default_deployed_dir(component)
 
     logger.info("drift check: comparing source=%s deployed=%s", source_dir, deployed_dir)

--- a/autobot_shared/__init__.py
+++ b/autobot_shared/__init__.py
@@ -35,6 +35,9 @@ __all__ = [
     "FeatureDisabledError",
     # Singleton factory — issue #5423
     "lazy_singleton",
+    # HTTP safety helpers — issue #5680
+    "safe_http_detail",
+    "user_facing_detail",
 ]
 
 # Lazy import map — module attribute → (submodule, name)
@@ -57,6 +60,9 @@ _LAZY_IMPORTS = {
     "FeatureDisabledError": (".feature_flags", "FeatureDisabledError"),
     # Singleton factory — issue #5423
     "lazy_singleton": (".singleton_factory", "lazy_singleton"),
+    # HTTP safety helpers — issue #5680
+    "safe_http_detail": (".error_utils", "safe_http_detail"),
+    "user_facing_detail": (".error_utils", "user_facing_detail"),
 }
 
 

--- a/autobot_shared/error_utils.py
+++ b/autobot_shared/error_utils.py
@@ -1,0 +1,30 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Safe HTTP detail helpers — prevent str(exc) leaking in API responses (#5680)."""
+
+from __future__ import annotations
+
+import logging
+
+_log = logging.getLogger(__name__)
+
+
+def safe_http_detail(exc: BaseException, fallback: str = "Internal server error") -> str:
+    """Return a client-safe error string that never leaks internal exception messages.
+
+    Always returns *fallback*. Logs the full exception at DEBUG level so the
+    information is available in server logs without being sent to clients.
+    """
+    _log.debug("safe_http_detail suppressed: %s: %s", type(exc).__name__, exc)
+    return fallback
+
+
+def user_facing_detail(exc: BaseException) -> str:
+    """Return str(exc) for user-input validation errors only.
+
+    Call this ONLY when the exception originates from explicit input validation
+    (Pydantic, ValueError raised by business logic with a user-readable message).
+    Never call for system/internal exceptions.
+    """
+    return str(exc)

--- a/autobot_shared/error_utils_test.py
+++ b/autobot_shared/error_utils_test.py
@@ -1,0 +1,19 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+import pytest
+from autobot_shared.error_utils import safe_http_detail, user_facing_detail
+
+
+def test_safe_http_detail_returns_fallback():
+    exc = ValueError("internal path /opt/autobot/secret")
+    assert safe_http_detail(exc) == "Internal server error"
+
+
+def test_safe_http_detail_custom_fallback():
+    exc = RuntimeError("oops")
+    assert safe_http_detail(exc, "LLM refinement failed") == "LLM refinement failed"
+
+
+def test_user_facing_detail_returns_str_exc():
+    exc = ValueError("Username already taken")
+    assert user_facing_detail(exc) == "Username already taken"


### PR DESCRIPTION
## Summary

Closes #5680 #5676 #5678 #5679

- New `autobot_shared/error_utils.py` — `safe_http_detail(exc, fallback)` always returns the fallback string and logs the full exception at DEBUG; `user_facing_detail(exc)` explicit pass-through for validation errors only
- Wired into `autobot_shared/__init__.py` lazy-import map
- 3 unit tests co-located in `autobot_shared/`
- **#5676** `skills.py:231,257` — removed `{e}` from two 500 detail strings
- **#5678** `documents.py:351` (502), `code_sync.py:410` (500), `auth.py:640` (409) — fixed; `triggers.py:126` (422 ValueError) — clarifying comment added, value preserved (intentional validation message)
- **#5679** `knowledge_research_ws.py:102` → `"research_failed"`, `ai_api_server.py:322` → drop `str(exc)`, `github_integration.py:368,375` → `"integration_error"`, `a2a/task_executor.py:162,164,171` → `type(exc).__name__`

## Test plan

- [ ] `python3 -m pytest autobot_shared/error_utils_test.py` passes
- [ ] Skill 500 endpoint returns generic message on failure
- [ ] RAG feedback WS error event contains `"research_failed"` (not exception string)
- [ ] A2A task failure message contains exception class name only

🤖 Generated with [Claude Code](https://claude.com/claude-code)