### PR TITLE
fix(security): SSH RejectPolicy — clearer error + known-hosts Ansible playbook + docs

### DIFF
--- a/autobot-backend/services/execution/ssh_backend.py
+++ b/autobot-backend/services/execution/ssh_backend.py
@@ -211,7 +211,15 @@ class SSHBackend(ExecutionBackend):
                 )
             except Exception as e:
                 self._client = None
-                raise RuntimeError(f"SSH connection failed: {e}")
+                err_msg = str(e)
+                if "not found in known_hosts" in err_msg or (
+                    "Server" in err_msg and "known_hosts" in err_msg
+                ):
+                    raise RuntimeError(
+                        f"SSH host key for '{self.hostname}' is not in known_hosts. "
+                        "Run: ssh-keyscan -H <host> >> ~/.ssh/known_hosts as the autobot service user."
+                    ) from e
+                raise RuntimeError(f"SSH connection failed: {e}") from e
 
         return self._client
 

--- a/autobot-slm-backend/ansible/playbooks/setup-ssh-known-hosts.yml
+++ b/autobot-slm-backend/ansible/playbooks/setup-ssh-known-hosts.yml
@@ -1,0 +1,64 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+#
+# Setup SSH Known Hosts for AutoBot Service User (Issue #5677)
+#
+# Populates ~/.ssh/known_hosts for the 'autobot' service user on the backend
+# host so that the SSH execution backend (RejectPolicy) can connect to fleet
+# nodes without a HostKey error.
+#
+# Run this playbook after enrolling new nodes or before first SSH execution.
+#
+# Prerequisites:
+#   - Inventory file with fleet nodes defined
+#   - SSH access to the backend host as a privileged user
+#
+# Usage:
+#   cd autobot-slm-backend/ansible
+#   ansible-playbook -i inventory/slm-nodes.yml playbooks/setup-ssh-known-hosts.yml
+---
+- name: Populate known_hosts for autobot SSH execution backend
+  hosts: "{{ backend_host | default('01-Backend') }}"
+  become: true
+
+  vars:
+    autobot_user: autobot
+    autobot_home: /opt/autobot
+    known_hosts_path: "{{ autobot_home }}/.ssh/known_hosts"
+
+  tasks:
+    - name: Ensure .ssh directory exists for autobot user
+      ansible.builtin.file:
+        path: "{{ autobot_home }}/.ssh"
+        state: directory
+        owner: "{{ autobot_user }}"
+        group: "{{ autobot_user }}"
+        mode: "0700"
+
+    - name: Ensure known_hosts file exists
+      ansible.builtin.file:
+        path: "{{ known_hosts_path }}"
+        state: touch
+        owner: "{{ autobot_user }}"
+        group: "{{ autobot_user }}"
+        mode: "0600"
+        modification_time: preserve
+        access_time: preserve
+
+    - name: Scan and add host keys for all fleet nodes
+      ansible.builtin.shell:
+        cmd: >
+          ssh-keyscan -H {{ hostvars[item]['ansible_host'] | default(item) }}
+          >> {{ known_hosts_path }}
+        creates: "{{ known_hosts_path }}"
+      loop: "{{ groups['all'] | difference([inventory_hostname]) }}"
+      when: hostvars[item]['ansible_host'] is defined or item != inventory_hostname
+      become_user: "{{ autobot_user }}"
+      changed_when: true
+
+    - name: Remove duplicate entries from known_hosts
+      ansible.builtin.shell:
+        cmd: "sort -u {{ known_hosts_path }} -o {{ known_hosts_path }}"
+      become_user: "{{ autobot_user }}"
+      changed_when: false

--- a/docs/developer/AUTOBOT_REFERENCE.md
+++ b/docs/developer/AUTOBOT_REFERENCE.md
@@ -202,6 +202,32 @@ mcp__memory__create_entities --entities '[{"name": "...", "entityType": "...", "
 
 ---
 
+## SSH Execution Backend
+
+AutoBot uses Paramiko with `RejectPolicy` — unknown host keys are **rejected**, not silently accepted.
+
+**Before first SSH execution to any node, populate known_hosts:**
+
+```bash
+# Run as the autobot service user on the backend host
+ssh-keyscan -H <node-ip-or-hostname> >> ~/.ssh/known_hosts
+```
+
+Or run the Ansible playbook (preferred for fleet-wide setup):
+
+```bash
+cd autobot-slm-backend/ansible
+ansible-playbook -i inventory/slm-nodes.yml playbooks/setup-ssh-known-hosts.yml
+```
+
+**Error message when host key is missing:**
+```
+RuntimeError: SSH host key for 'x.x.x.x' is not in known_hosts.
+Run: ssh-keyscan -H <host> >> ~/.ssh/known_hosts as the autobot service user.
+```
+
+---
+
 ## Documentation
 
 **Key docs:**


### PR DESCRIPTION
## Summary

Closes #5677

Three deliverables for the breaking change introduced in PR #5672 (AutoAddPolicy → RejectPolicy):

**1. `ssh_backend.py` — actionable error message**
Detects Paramiko's "not found in known_hosts" message and re-raises with a clear operator instruction:
```
SSH host key for 'x.x.x.x' is not in known_hosts.
Run: ssh-keyscan -H <host> >> ~/.ssh/known_hosts as the autobot service user.
```

**2. `setup-ssh-known-hosts.yml` (new Ansible playbook)**
Runs against the backend host, ensures `~/.ssh/known_hosts` exists with correct ownership/permissions (`0700`/`0600`), scans all inventory nodes with `ssh-keyscan -H`, and deduplicates the file. Override target with `--extra-vars backend_host=<host>`.

**3. `docs/developer/AUTOBOT_REFERENCE.md`**
New "SSH Execution Backend" section documenting the `RejectPolicy` behaviour, one-liner fix, Ansible playbook usage, and the exact error message operators will see.

## Test plan

- [ ] SSH to an unknown host produces the actionable error (not a raw SSHException)
- [ ] `ansible-playbook setup-ssh-known-hosts.yml --check` passes on a test inventory
- [ ] Docs section renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)