### PR TITLE
fix(code_intelligence): update redis_optimizer suggestion and test fixtures to canonical get_async_redis_client (#5670)

### DIFF
--- a/autobot-backend/code_intelligence/redis_optimizer.py
+++ b/autobot-backend/code_intelligence/redis_optimizer.py
@@ -858,7 +858,7 @@ class RedisOptimizer:
                         line_start=block_start,
                         line_end=block_start + block.count("\n"),
                         description="Potentially blocking Redis call in async function",
-                        suggestion="Use async Redis client: redis = await get_redis_client(async_client=True)",
+                        suggestion="Use async Redis client: redis = await get_async_redis_client(database='main')",
                         estimated_improvement="Non-blocking async I/O, better concurrency",
                         metrics={"blocking_calls": len(sync_calls)},
                     )

--- a/autobot-backend/code_intelligence/redis_optimizer_test.py
+++ b/autobot-backend/code_intelligence/redis_optimizer_test.py
@@ -200,10 +200,10 @@ class TestRedisOptimizer:
     def test_no_false_positives_for_good_code(self):
         """Test that good Redis patterns don't trigger warnings."""
         code = textwrap.dedent("""
-            from utils.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
             async def good_pipeline_usage():
-                redis = await get_redis_client(async_client=True)
+                redis = await get_async_redis_client(database='main')
                 async with redis.pipeline() as pipe:
                     pipe.set("key1", "value1")
                     pipe.set("key2", "value2")
@@ -217,7 +217,7 @@ class TestRedisOptimizer:
             optimizer = RedisOptimizer()
             results = optimizer.analyze_file(f.name)
 
-            # Should not detect connection issues (uses get_redis_client)
+            # Should not detect connection issues (uses get_async_redis_client)
             connection_results = [
                 r
                 for r in results
@@ -230,10 +230,10 @@ class TestRedisOptimizer:
         """Test directory-wide analysis."""
         # Create test files
         (tmp_path / "good.py").write_text(textwrap.dedent("""
-            from utils.redis_client import get_redis_client
+            from autobot_shared.redis_client import get_async_redis_client
 
             async def good_code():
-                redis = await get_redis_client(async_client=True)
+                redis = await get_async_redis_client(database='main')
                 return await redis.get("key")
         """))
 


### PR DESCRIPTION
## Summary

The `redis_optimizer` static analysis tool was giving stale advice after the `get_async_redis_client()` migration in #3962/#5659/#5661.

**`redis_optimizer.py:861`** (async blocking suggestion):
```python
# Before — stale, points to error-prone pattern
suggestion="Use async Redis client: redis = await get_redis_client(async_client=True)"
# After — canonical pattern
suggestion="Use async Redis client: redis = await get_async_redis_client(database='main')"
```

**`redis_optimizer_test.py:203/206` and `233/236`** (two test fixture code strings):
- Changed `from utils.redis_client import get_redis_client` → `from autobot_shared.redis_client import get_async_redis_client`
- Changed `await get_redis_client(async_client=True)` → `await get_async_redis_client(database='main')`

The sync suggestion at lines 826/834/835 (`get_redis_client()` without `async_client=True`) is unchanged — that path is still correct for sync callers.

## Test plan
- [ ] `python3 -m py_compile autobot-backend/code_intelligence/redis_optimizer.py` passes
- [ ] `python3 -m py_compile autobot-backend/code_intelligence/redis_optimizer_test.py` passes
- [ ] `grep "get_redis_client(async_client" autobot-backend/code_intelligence/redis_optimizer.py autobot-backend/code_intelligence/redis_optimizer_test.py` returns empty

Closes #5670