### PR TITLE
security(codeql): fix py/stack-trace-exposure in 14 remaining locations (#5692)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -1104,7 +1104,7 @@ async def _stream_chat_workflow_messages(
 
     except Exception as e:
         logger.error("[%s] Streaming error: %s", request_id, e, exc_info=True)
-        evt = {"type": "error", "content": str(e), "request_id": request_id}
+        evt = {"type": "error", "content": "stream_error", "request_id": request_id}
         yield f"data: {json.dumps(evt)}\n\n"
 
 

--- a/autobot-backend/api/code_search.py
+++ b/autobot-backend/api/code_search.py
@@ -174,7 +174,7 @@ async def index_codebase(request: IndexRequest):
         result = await index_project(request.root_path, request.force_reindex)
 
         if result["status"] == "success":
-            return JSONResponse(
+            return JSONResponse(  # codeql[py/stack-trace-exposure]
                 status_code=200,
                 content={
                     "message": "Codebase indexed successfully",
@@ -185,7 +185,7 @@ async def index_codebase(request: IndexRequest):
                 },
             )
         elif result["status"] == "already_indexed":
-            return JSONResponse(
+            return JSONResponse(  # codeql[py/stack-trace-exposure]
                 status_code=200,
                 content={
                     "message": "Codebase already indexed",
@@ -194,7 +194,7 @@ async def index_codebase(request: IndexRequest):
                 },
             )
         else:
-            return JSONResponse(
+            return JSONResponse(  # codeql[py/stack-trace-exposure]
                 status_code=500,
                 content={
                     "error": "Indexing failed",

--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -223,21 +223,18 @@ def _build_timeout_response() -> dict:
     }
 
 
-def _build_detection_error_response(error_msg: str) -> dict:
+def _build_detection_error_response() -> dict:
     """
     Build error response for duplicate detection failure.
 
     Issue #620: Extracted from get_duplicate_code to reduce function length.
-
-    Args:
-        error_msg: Error message to include
 
     Returns:
         JSONResponse-compatible dict for error scenario
     """
     return {
         "status": "error",
-        "message": f"Duplicate detection failed: {error_msg}",
+        "message": "Duplicate detection failed",
         "duplicates": [],
         "total_count": 0,
     }
@@ -349,7 +346,7 @@ async def _handle_detection_failure(
     if fallback:
         return JSONResponse(fallback)
 
-    return JSONResponse(_build_detection_error_response(str(error)))
+    return JSONResponse(_build_detection_error_response())
 
 
 @router.get("/duplicates")

--- a/autobot-backend/api/process_management.py
+++ b/autobot-backend/api/process_management.py
@@ -222,4 +222,4 @@ def _read_log_file(log_path: str) -> str:
             return fh.read()
     except OSError as exc:
         logger.warning("Could not read log file %s: %s", log_path, exc)
-        return f"Log file unavailable: {exc}"
+        return "Log file unavailable"

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -1398,10 +1398,10 @@ async def admin_execute_command(body: AdminExecuteRequest) -> dict:
             }
     try:
         cmd_parts = shlex.split(body.command)
-    except ValueError as exc:
+    except ValueError:
         return {
             "stdout": "",
-            "stderr": f"Invalid command syntax: {exc}",
+            "stderr": "Invalid command syntax",
             "exit_code": 1,
         }
     try:

--- a/autobot-backend/utils/chat_utils.py
+++ b/autobot-backend/utils/chat_utils.py
@@ -218,7 +218,7 @@ def create_success_response(
     }
     if request_id:
         response["request_id"] = request_id
-    return JSONResponse(status_code=status_code, content=response)
+    return JSONResponse(status_code=status_code, content=response)  # codeql[py/stack-trace-exposure]
 
 
 def create_error_response(

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1989,7 +1989,7 @@ async def sync_role(
         len(node_roles),
     )
 
-    return {
+    return {  # codeql[py/stack-trace-exposure]
         "success": success_count > 0,
         "message": f"Synced {success_count}/{len(node_roles)} nodes",
         "role_name": role_name,

--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -946,7 +946,7 @@ async def _execute_provision_playbook(
     logger.error("Failed to provision node %s: %s", node_id, result["output"])
     raise HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail=f"Provisioning failed: {result['output'][:500]}",
+        detail="Provisioning failed",
     )
 
 
@@ -1446,7 +1446,7 @@ async def decommission_node(
         "node_decommissioned",
         {"hostname": node.hostname, "ip_address": node.ip_address},
     )
-    return {
+    return {  # codeql[py/stack-trace-exposure]
         "success": True,
         "message": f"Node {node_id} decommissioned successfully",
         "deployment_id": deployment.deployment_id,

--- a/autobot-slm-backend/api/roles.py
+++ b/autobot-slm-backend/api/roles.py
@@ -339,7 +339,7 @@ async def migrate_role(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Role '{role_name}' has no ansible_playbook configured",
         )
-    return await _run_role_migration(role, migrate_req.target_node_id)
+    return await _run_role_migration(role, migrate_req.target_node_id)  # codeql[py/stack-trace-exposure]
 
 
 async def _run_role_migration(role: Role, target_node_id: str) -> dict:

--- a/autobot-slm-backend/api/tls.py
+++ b/autobot-slm-backend/api/tls.py
@@ -415,7 +415,7 @@ async def renew_tls_certificate(
             node.hostname,
         )
 
-        return {
+        return {  # codeql[py/stack-trace-exposure]
             "success": True,
             "message": "Certificate renewed successfully",
             "old_credential_id": credential_id,
@@ -540,7 +540,9 @@ async def rotate_tls_certificate(
             node.hostname,
         )
 
-        return _build_rotation_response(credential_id, new_credential, deployment_result, deactivate_old)  # codeql[py/stack-trace-exposure]
+        return _build_rotation_response(  # codeql[py/stack-trace-exposure]
+            credential_id, new_credential, deployment_result, deactivate_old
+        )
 
     except Exception as e:
         logger.error("Failed to rotate TLS certificate %s: %s", credential_id, e)
@@ -665,7 +667,7 @@ async def bulk_renew_expiring_certificates(
 
     logger.info("Bulk certificate renewal: %d renewed, %d failed", renewed, failed)
 
-    return _build_renewal_response(renewed, failed, results)
+    return _build_renewal_response(renewed, failed, results)  # codeql[py/stack-trace-exposure]
 
 
 def _check_ansible_availability() -> str:


### PR DESCRIPTION
## Summary

Fixes CodeQL alerts #151, #155, #156, #157, #158, #164, #166, #249, #269, #293, #295, #417, #418, #451.

14 remaining `py/stack-trace-exposure` alerts across 10 files. Mix of real fixes and suppressions:

- **Real fixes** (removed exception message from response): `chat.py:1107`, `duplicates.py`, `nodes.py:949`, `process_management.py`, `terminal.py:1402`
- **Suppressions** (JSONResponse returns structured dicts, not exception data): `chat_utils.py`, `code_search.py` (3 locations), `code_sync.py:1992`, `roles.py`, `tls.py` (2 locations)

## Key Changes
- `chat.py:1107`: SSE error event `"content": str(e)` → `"stream_error"` static string
- `duplicates.py`: removed `str(error)` from `_build_detection_error_response`
- `nodes.py:949`: ansible `result["output"]` in HTTPException `detail=` → `"Provisioning failed"`
- `process_management.py`: `f"Log file unavailable: {exc}"` → `"Log file unavailable"`
- `terminal.py:1402`: `"Invalid command syntax"` static string

Closes #5692