### PR TITLE
security(codeql): suppress py/clear-text-logging false positives in 8 locations (#5693)

### DIFF
--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -673,7 +673,7 @@ def audit_log(
     status = "SUCCESS" if success else "FAILED"
     # Redact secret_id to prevent sensitive data in logs
     safe_id = secret_id[:8] + "..." if secret_id and len(secret_id) > 8 else secret_id
-    logger.info(
+    logger.info(  # codeql[py/clear-text-logging-sensitive-data]
         "[Secrets Audit] %s | Operation: %s | " "SecretID: %s | Client: %s",
         status,
         operation,
@@ -912,7 +912,7 @@ async def get_secret(
                             "original_scope": secret.get("scope"),
                         },
                     )
-                    logger.debug(
+                    logger.debug(  # codeql[py/clear-text-logging-sensitive-data]
                         "[Issue #608] Created secret entity for %s... in session %s",
                         secret_id[:8],
                         chat_id,

--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -160,7 +160,7 @@ def start_vnc_server() -> Dict[str, str]:
     # Pre-check: VncAuth requires ~/.vnc/passwd to exist
     vnc_passwd = Path.home() / ".vnc" / "passwd"
     if not vnc_passwd.exists():
-        logger.error(
+        logger.error(  # codeql[py/clear-text-logging-sensitive-data]
             "VNC passwd file not found at %s; run vncpasswd before starting VNC server",
             vnc_passwd,
         )

--- a/autobot-backend/autobot_memory_graph/entities.py
+++ b/autobot-backend/autobot_memory_graph/entities.py
@@ -168,7 +168,7 @@ class EntityOperationsMixin:
             )
 
             await self._store_entity_in_redis(entity_id, entity)
-            logger.info(
+            logger.info(  # codeql[py/clear-text-logging-sensitive-data]
                 "Created entity: %s (%s) with ID %s",
                 name,
                 entity_type,

--- a/autobot-backend/autobot_memory_graph/relations.py
+++ b/autobot-backend/autobot_memory_graph/relations.py
@@ -185,7 +185,7 @@ class RelationOperationsMixin:
             )
             await self._store_outgoing_relation(from_entity_id, relation)
             await self._store_incoming_relation(to_entity_id, reverse_rel)
-            logger.debug(
+            logger.debug(  # codeql[py/clear-text-logging-sensitive-data]
                 "Created relation by ID: [%s] --[%s]--> [%s]",
                 from_entity_id[:8] if from_entity_id else "?",
                 relation_type,

--- a/autobot-backend/project_state_tracking/metrics.py
+++ b/autobot-backend/project_state_tracking/metrics.py
@@ -29,8 +29,7 @@ async def get_redis_metric(redis_client: Any, key: str, default: int = 0) -> int
         return int(value) if value else default
 
     except Exception:
-        # CodeQL: false positive — key is a Redis metric key name, not a secret
-        logger.debug(
+        logger.debug(  # codeql[py/clear-text-logging-sensitive-data]
             "Redis metric fetch failed for key: %s",
             key.split(":")[-1] if key else "unknown",
         )

--- a/autobot-backend/security/enterprise/security_policy_manager.py
+++ b/autobot-backend/security/enterprise/security_policy_manager.py
@@ -540,7 +540,9 @@ class SecurityPolicyManager:
         self._save_policy(policy)
         self._update_policy_statistics()
 
-        logger.info("Created new security policy: %s (%s)", name, policy_id)
+        logger.info(  # codeql[py/clear-text-logging-sensitive-data]
+            "Created new security policy: %s (%s)", name, policy_id
+        )
         return policy_id
 
     def update_policy(self, policy_id: str, updates: Dict, author: str) -> bool:


### PR DESCRIPTION
## Summary

Fixes CodeQL alerts #90, #436, #437, #438, #439, #440, #443, #446.

All 8 `py/clear-text-logging-sensitive-data` alerts are false positives — no actual secret values are logged. CodeQL flags these because variable names contain "secret", "password", or "password" but the logged values are:
- Truncated IDs (`secret_id[:8]+"..."`)
- Key names/type strings (not values)
- `pathlib.Path` objects (filesystem paths, not password content)
- Redis metric key name segments

All fixed with inline `# codeql[py/clear-text-logging-sensitive-data]` suppression comments.

Closes #5693