### PR TITLE
security(codeql): fix ldap-injection, command-injection, weak-hashing (#5694)

### DIFF
--- a/autobot-backend/api/vnc_manager.py
+++ b/autobot-backend/api/vnc_manager.py
@@ -353,7 +353,7 @@ def _run_xdotool_cmd(args: list[str], timeout: int = 5) -> Dict[str, str]:
             }
         sanitized.append(s)
     try:
-        result = subprocess.run(  # nosec B603 B607  # lgtm[py/command-line-injection]
+        result = subprocess.run(  # nosec B603 B607  # lgtm[py/command-line-injection]  # codeql[py/command-line-injection]
             ["/usr/bin/xdotool"] + sanitized,
             capture_output=True,
             text=True,

--- a/autobot-slm-backend/user_management/services/api_key_service.py
+++ b/autobot-slm-backend/user_management/services/api_key_service.py
@@ -145,7 +145,7 @@ class APIKeyService(BaseService):
         The signing key is read from SLM_HMAC_API_KEY_SECRET (default:
         "autobot-api-key-v1" for backward compatibility with existing hashes).
         """
-        return hmac.new(
+        return hmac.new(  # codeql[py/weak-sensitive-data-hashing] HMAC-SHA256 for API token lookup, not password storage
             key=settings.hmac_api_key_secret.encode("utf-8"),
             msg=key.encode("utf-8"),
             digestmod=hashlib.sha256,
@@ -154,7 +154,7 @@ class APIKeyService(BaseService):
     @staticmethod
     def _hash_key_legacy(key: str) -> str:
         """Hash using bare SHA-256 (pre-#1721 format, for migration)."""
-        return hashlib.sha256(key.encode()).hexdigest()
+        return hashlib.sha256(key.encode()).hexdigest()  # codeql[py/weak-sensitive-data-hashing] legacy API token lookup hash retained for migration only, not password storage
 
     @staticmethod
     def _calculate_expiration(expires_days: Optional[int]) -> Optional[datetime]:

--- a/autobot-slm-backend/user_management/services/sso_service.py
+++ b/autobot-slm-backend/user_management/services/sso_service.py
@@ -253,7 +253,9 @@ class SSOService(BaseService):
         base_dn = provider.config.get("base_dn", "dc=example,dc=com")
         safe_username = sanitize_ldap_filter(username)
         search_filter = provider.config.get("search_filter", "(uid={})").format(safe_username)
-        conn.search(base_dn, search_filter, search_scope=SUBTREE)
+        conn.search(  # codeql[py/ldap-injection] safe_username is RFC-4515-escaped by sanitize_ldap_filter above
+            base_dn, search_filter, search_scope=SUBTREE
+        )
         if conn.entries:
             return conn.entries[0].entry_attributes_as_dict
         return None


### PR DESCRIPTION
## Summary

Fixes CodeQL alerts #332, #435, #325, #428.

All three alerts are cases where the security controls are already in place but CodeQL cannot trace through helper functions:

- **LDAP injection #332** (`sso_service.py:256`): Username already sanitized via `sanitize_ldap_filter()` from `autobot_shared.security.input_sanitizer` (RFC 4515 §3 escaping). Added `# codeql[py/ldap-injection]` suppression.

- **Command injection #435** (`vnc_manager.py:357`): `_run_xdotool_cmd` already uses `shell=False`, argument list form, explicit `_XDOTOOL_ALLOWED_SUBCMDS` allowlist, and `_XDOTOOL_SAFE_ARG_RE` validation. Added `# codeql[py/command-line-injection]` alongside existing `# nosec` annotations.

- **Weak hashing #325, #428** (`api_key_service.py:150,157`): HMAC-SHA256 and SHA-256 used for API *token* lookup hashing (not password storage). bcrypt/argon2 are for password storage; HMAC-SHA256 is appropriate for token lookup. Added `# codeql[py/weak-sensitive-data-hashing]` suppression with justification.

Closes #5694