### PR TITLE
security(codeql): fix py/incomplete-url-substring-sanitization in test files (#5696)

### DIFF
--- a/autobot-backend/services/autoresearch/auto_research_agent_test.py
+++ b/autobot-backend/services/autoresearch/auto_research_agent_test.py
@@ -115,7 +115,7 @@ class TestParseArxivAtom:
         results = _parse_arxiv_atom(ARXIV_ATOM_SAMPLE)
         assert results[0].source == "arxiv"
         assert "Attention" in results[0].title
-        assert "arxiv.org" in results[0].url
+        assert "arxiv.org" in results[0].url  # codeql[py/incomplete-url-substring-sanitization]
 
     def test_empty_xml_returns_empty_list(self):
         assert _parse_arxiv_atom("<feed></feed>") == []
@@ -137,7 +137,7 @@ class TestParseGitHubResults:
         r = results[0]
         assert r.source == "github"
         assert r.title == "karpathy/nanoGPT"
-        assert "github.com" in r.url
+        assert "github.com" in r.url  # codeql[py/incomplete-url-substring-sanitization]
 
     def test_empty_items_returns_empty_list(self):
         assert _parse_github_results({"items": []}) == []
@@ -416,9 +416,9 @@ def _mock_http_handler(request):
     """Return stub responses for arXiv and GitHub during tests."""
     import httpx
 
-    if "arxiv.org" in str(request.url):
+    if "arxiv.org" in str(request.url):  # codeql[py/incomplete-url-substring-sanitization]
         return httpx.Response(200, text=ARXIV_ATOM_SAMPLE)
-    if "api.github.com" in str(request.url):
+    if "api.github.com" in str(request.url):  # codeql[py/incomplete-url-substring-sanitization]
         return httpx.Response(200, json=GITHUB_JSON_SAMPLE)
     return httpx.Response(404)
 


### PR DESCRIPTION
## Summary

Fixes CodeQL alerts #431, #455, #456, #457, #458.

All 5 alerts are in test files where the URLs come from hardcoded fixtures and mock data — never from external user input.

- **#431** (`community_growth_test.py:183`) — Already uses `urlparse(url).hostname.endswith("reddit.com")`. No change needed.
- **#455, #456** (`auto_research_agent_test.py:118,140`) — URLs from inline `ARXIV_ATOM_SAMPLE` and `GITHUB_JSON_SAMPLE` module-level fixtures. Added `# codeql[py/incomplete-url-substring-sanitization]`.
- **#457, #458** (`auto_research_agent_test.py:419,421`) — Inside `_mock_http_handler`, `request.url` is an httpx URL object from hardcoded URLs in mock transport. Added suppression.

Closes #5696