### PR TITLE
refactor(redis): add AsyncRedisClientMixin and migrate 9 services to eliminate lazy-init boilerplate (#5671)

### DIFF
--- a/autobot-backend/agents/agent_orchestration/rl_router.py
+++ b/autobot-backend/agents/agent_orchestration/rl_router.py
@@ -23,6 +23,8 @@ import logging
 import time
 from typing import Dict, List, Tuple
 
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -76,7 +78,7 @@ _DOMAIN_KEYWORDS: Dict[str, List[str]] = {
 _LENGTH_BUCKETS = [(10, "short"), (30, "medium"), (60, "long")]
 
 
-class RLRouter:
+class RLRouter(AsyncRedisClientMixin):
     """
     Tabular Q-learning router for agent task routing.
 
@@ -91,8 +93,10 @@ class RLRouter:
     routing result so the caller can pass it back to :meth:`record_outcome`.
     """
 
+    _redis_database = "main"
+
     def __init__(self) -> None:
-        self._redis = None
+        pass
 
     # ------------------------------------------------------------------
     # Public API
@@ -321,18 +325,6 @@ class RLRouter:
                 await self._q_update(state_key, entry["action"], entry["reward"])
             except Exception as exc:
                 logger.debug("RL replay-update entry failed: %s", exc)
-
-    # ------------------------------------------------------------------
-    # Redis helper
-    # ------------------------------------------------------------------
-
-    async def _get_redis(self):
-        """Lazily initialize async Redis client (database='main')."""
-        if self._redis is None:
-            from autobot_shared.redis_client import get_async_redis_client
-
-            self._redis = await get_async_redis_client(database="main")
-        return self._redis
 
     # ------------------------------------------------------------------
     # Admin helpers (testing / monitoring)

--- a/autobot-backend/agents/task_pattern_learner.py
+++ b/autobot-backend/agents/task_pattern_learner.py
@@ -13,6 +13,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import utc_timestamp
 
 logger = logging.getLogger(__name__)
@@ -46,21 +47,14 @@ class LearnedStrategy:
     timestamp: str = field(default_factory=utc_timestamp)
 
 
-class TaskPatternLearner:
+class TaskPatternLearner(AsyncRedisClientMixin):
     """Analyzes task outcome history to extract optimal strategies per task type."""
+
+    _redis_database = "main"
 
     def __init__(self, llm_interface=None):
         """Initialize with optional LLM interface."""
         self._llm = llm_interface
-        self._redis = None
-
-    async def _get_redis(self):
-        """Lazily initialize Redis client."""
-        if self._redis is None:
-            from autobot_shared.redis_client import get_async_redis_client
-
-            self._redis = await get_async_redis_client(database="main")
-        return self._redis
 
     async def _get_llm(self):
         """Lazily initialize LLM interface."""

--- a/autobot-backend/knowledge/memory_graph/hybrid_scorer.py
+++ b/autobot-backend/knowledge/memory_graph/hybrid_scorer.py
@@ -25,6 +25,8 @@ import math
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -64,7 +66,7 @@ class SearchResult:
 # ---------------------------------------------------------------------------
 
 
-class HybridScorer:
+class HybridScorer(AsyncRedisClientMixin):
     """
     Combines cosine-similarity (semantic) and BM25 (keyword) scores.
 
@@ -75,20 +77,16 @@ class HybridScorer:
     entity embeddings from Redis asynchronously.
     """
 
+    _redis_database = "knowledge"
+
     def __init__(self, redis_client=None) -> None:
         """
         Args:
             redis_client: Optional async Redis client for embedding lookups.
                           When None a client is acquired lazily on first use.
         """
-        self._redis = redis_client
-
-    async def _get_redis(self):
-        """Lazily obtain the async Redis client (cached on self._redis)."""
-        if self._redis is None:
-            from autobot_shared.redis_client import get_async_redis_client
-            self._redis = await get_async_redis_client(database="knowledge")
-        return self._redis
+        if redis_client is not None:
+            self._redis = redis_client
 
     # ------------------------------------------------------------------
     # Public API

--- a/autobot-backend/memory/working_memory.py
+++ b/autobot-backend/memory/working_memory.py
@@ -15,7 +15,7 @@ import json
 import logging
 from typing import Any, List, Optional
 
-from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from constants.ttl_constants import TTL_WORKING_MEMORY_DEFAULT
 
 logger = logging.getLogger(__name__)
@@ -28,16 +28,10 @@ def _make_key(session_id: str, key: str) -> str:
     return _KEY_PREFIX.format(session_id=session_id, key=key)
 
 
-class WorkingMemoryService:
+class WorkingMemoryService(AsyncRedisClientMixin):
     """Session-scoped working memory backed by Redis with TTL support."""
 
-    def __init__(self) -> None:
-        self._redis = None
-
-    async def _get_redis(self):
-        if self._redis is None:
-            self._redis = await get_async_redis_client(database="knowledge")
-        return self._redis
+    _redis_database = "knowledge"
 
     async def store(
         self,

--- a/autobot-backend/services/autoresearch/osint_engine.py
+++ b/autobot-backend/services/autoresearch/osint_engine.py
@@ -30,6 +30,8 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -327,7 +329,7 @@ class NOAASource(OSINTSource):
 # ---------------------------------------------------------------------------
 
 
-class OSINTEngine:
+class OSINTEngine(AsyncRedisClientMixin):
     """Parallel OSINT intelligence sweep engine.
 
     Registers named sources, sweeps them concurrently with per-source timeout
@@ -345,12 +347,12 @@ class OSINTEngine:
 
     _REDIS_PREFIX = "osint"
     _RESULT_TTL = 3600  # 1 hour cache
+    _redis_database = "main"
 
     def __init__(self) -> None:
         self._sources: Dict[str, OSINTSource] = {}
         self._rules: List[CorrelationRule] = []
         self._last_sweep: Dict[str, float] = {}
-        self._redis = None
 
     # ------------------------------------------------------------------
     # Registration
@@ -477,14 +479,6 @@ class OSINTEngine:
     # ------------------------------------------------------------------
     # Redis caching
     # ------------------------------------------------------------------
-
-    async def _get_redis(self):
-        """Lazy-init async Redis client (main database)."""
-        if self._redis is None:
-            from autobot_shared.redis_client import get_async_redis_client
-
-            self._redis = await get_async_redis_client(database="main")
-        return self._redis
 
     async def _cache_results(self, results: List[SourceResult]) -> None:
         """Persist each SourceResult to Redis for RAG consumption."""

--- a/autobot-backend/services/autoresearch/prompt_optimizer.py
+++ b/autobot-backend/services/autoresearch/prompt_optimizer.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Coroutine, Dict, List, Optional
 
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from constants.ttl_constants import TTL_7_DAYS
 
 from .archive import Archive
@@ -141,7 +142,7 @@ class OptimizationSession:
 BenchmarkFn = Callable[[str], Coroutine[Any, Any, str]]
 
 
-class PromptOptimizer:
+class PromptOptimizer(AsyncRedisClientMixin):
     """Generic prompt optimizer with pluggable scorers.
 
     Drives a mutation -> benchmark -> score -> keep/discard loop.
@@ -151,6 +152,8 @@ class PromptOptimizer:
     (PromptOptTarget, BenchmarkFn) pair so ``start_optimization`` can look
     them up without hard-coding names in the route layer.
     """
+
+    _redis_database = "main"
 
     _MUTATION_SYSTEM_PROMPT = (
         "You are a prompt engineering expert. Generate {n} distinct variations "
@@ -172,7 +175,6 @@ class PromptOptimizer:
         self._config = config or AutoResearchConfig()
         self._cancel_event = asyncio.Event()
         self._current_session: Optional[OptimizationSession] = None
-        self._redis = None
         # Registry: agent_id -> (PromptOptTarget, BenchmarkFn)
         self._targets: Dict[str, tuple] = {}
 
@@ -489,13 +491,6 @@ class PromptOptimizer:
     @property
     def current_session(self) -> Optional[OptimizationSession]:
         return self._current_session
-
-    async def _get_redis(self):
-        if self._redis is None:
-            from autobot_shared.redis_client import get_async_redis_client
-
-            self._redis = await get_async_redis_client(database="main")
-        return self._redis
 
     async def _save_session(self, session: OptimizationSession) -> None:
         """Persist session to Redis."""

--- a/autobot-backend/services/autoresearch/scorers.py
+++ b/autobot-backend/services/autoresearch/scorers.py
@@ -19,6 +19,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
+
 if TYPE_CHECKING:
     from services.llm_service import LLMService
 
@@ -273,7 +275,7 @@ class LLMJudgeScorer(PromptScorer):
         return 0
 
 
-class HumanReviewScorer(PromptScorer):
+class HumanReviewScorer(AsyncRedisClientMixin, PromptScorer):
     """Queue a prompt variant for human review and wait for a score via BLPOP.
 
     Stores the variant in Redis; the API endpoint allows humans to
@@ -288,6 +290,7 @@ class HumanReviewScorer(PromptScorer):
     _PENDING_KEY = "autoresearch:prompt_review:pending:{session_id}:{variant_id}"
     _NOTIFY_KEY = HUMAN_REVIEW_NOTIFY_KEY
     _TTL_SECONDS = TTL_24_HOURS
+    _redis_database = "main"
 
     def __init__(
         self,
@@ -298,14 +301,6 @@ class HumanReviewScorer(PromptScorer):
         # internally — BLPOP blocks efficiently without periodic wakeups.
         self._poll_interval = poll_interval
         self._timeout = timeout
-        self._redis = None
-
-    async def _get_redis(self):
-        if self._redis is None:
-            from autobot_shared.redis_client import get_async_redis_client
-
-            self._redis = await get_async_redis_client(database="main")
-        return self._redis
 
     @property
     def name(self) -> str:

--- a/autobot-backend/services/terminal_history_service.py
+++ b/autobot-backend/services/terminal_history_service.py
@@ -9,13 +9,15 @@ import logging
 import time
 from typing import List
 
-from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 
 logger = logging.getLogger(__name__)
 
 
-class TerminalHistoryService:
+class TerminalHistoryService(AsyncRedisClientMixin):
     """Manages persistent command history in Redis."""
+
+    _redis_database = "main"
 
     def __init__(self, max_entries: int = 10000):
         """Initialize history service.
@@ -23,19 +25,7 @@ class TerminalHistoryService:
         Args:
             max_entries: Maximum commands to store per user
         """
-        self._redis = None
         self.max_entries = max_entries
-
-    async def _get_redis(self):
-        """Get async Redis client, initializing lazily on first use.
-
-        Issue #2956: get_async_client is a coroutine so it cannot be called
-        from __init__. Lazy initialization ensures the client is awaited
-        correctly in an async context.
-        """
-        if self._redis is None:
-            self._redis = await get_async_redis_client(database="main")
-        return self._redis
 
     async def add_command(self, user_id: str, command: str) -> None:
         """Add command to history with current timestamp.

--- a/autobot-backend/services/workflow_automation/state_machine.py
+++ b/autobot-backend/services/workflow_automation/state_machine.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field
 
 from autobot_shared.message_bus import get_message_bus
 from autobot_shared.models.service_message import ServiceMessage
-from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from constants.redis_constants import REDIS_KEY
 from constants.ttl_constants import TTL_24_HOURS
 
@@ -117,7 +117,7 @@ def _state_key(workflow_id: str) -> str:
 # ------------------------------------------------------------------
 
 
-class WorkflowStateMachine:
+class WorkflowStateMachine(AsyncRedisClientMixin):
     """Manages workflow state lifecycle with Redis persistence.
 
     Every transition is:
@@ -126,13 +126,7 @@ class WorkflowStateMachine:
        ``workflow_step`` message for audit trail (#1379).
     """
 
-    def __init__(self) -> None:
-        self._redis: Any = None
-
-    async def _get_redis(self) -> Any:
-        if self._redis is None:
-            self._redis = await get_async_redis_client(database="main")
-        return self._redis
+    _redis_database = "main"
 
     # -- Create --------------------------------------------------------
 

--- a/autobot_shared/__init__.py
+++ b/autobot_shared/__init__.py
@@ -38,6 +38,8 @@ __all__ = [
     # HTTP safety helpers — issue #5680
     "safe_http_detail",
     "user_facing_detail",
+    # Async Redis mixin — issue #5671
+    "AsyncRedisClientMixin",
 ]
 
 # Lazy import map — module attribute → (submodule, name)
@@ -63,6 +65,8 @@ _LAZY_IMPORTS = {
     # HTTP safety helpers — issue #5680
     "safe_http_detail": (".error_utils", "safe_http_detail"),
     "user_facing_detail": (".error_utils", "user_facing_detail"),
+    # Async Redis mixin — issue #5671
+    "AsyncRedisClientMixin": (".redis_mixin", "AsyncRedisClientMixin"),
 }
 
 

--- a/autobot_shared/redis_mixin.py
+++ b/autobot_shared/redis_mixin.py
@@ -1,0 +1,41 @@
+# AutoBot - AI-Powered Automation Platform
+# Copyright (c) 2025 mrveiss
+# Author: mrveiss
+"""Mixin providing lazy async Redis client initialization.
+
+Eliminates repeated boilerplate across ~43 async service classes:
+
+    async def _get_redis(self):
+        if self._redis is None:
+            self._redis = await get_async_redis_client(database=...)
+        return self._redis
+
+Usage::
+
+    from autobot_shared.redis_mixin import AsyncRedisClientMixin
+
+    class MyService(AsyncRedisClientMixin):
+        _redis_database = "analytics"  # override per class; default is "main"
+
+    # The mixin provides _get_redis(); no inline method needed.
+"""
+from typing import Any, Optional, Union
+
+from autobot_shared.redis_client import get_async_redis_client
+
+
+class AsyncRedisClientMixin:
+    """Provides lazy-initialized async Redis client via ``_get_redis()``.
+
+    Subclasses declare ``_redis_database`` as a class variable to select
+    the target database.  The client is created on first call and cached
+    for the lifetime of the instance.
+    """
+
+    _redis_database: Union[str, Any] = "main"
+    _redis: Optional[Any] = None
+
+    async def _get_redis(self) -> Optional[Any]:
+        if self._redis is None:
+            self._redis = await get_async_redis_client(database=self._redis_database)
+        return self._redis


### PR DESCRIPTION
## Summary

Introduces `autobot_shared.redis_mixin.AsyncRedisClientMixin` to eliminate the repeated lazy async Redis init pattern across production services, and migrates 9 of the cleanest callers.

## New primitive

**`autobot_shared/redis_mixin.py`** — `AsyncRedisClientMixin`:
```python
class AsyncRedisClientMixin:
    _redis_database: Union[str, Any] = "main"
    _redis: Optional[Any] = None

    async def _get_redis(self) -> Optional[Any]:
        if self._redis is None:
            self._redis = await get_async_redis_client(database=self._redis_database)
        return self._redis
```

## Migrated files (9)

| File | Class | Database |
|------|-------|----------|
| `agents/agent_orchestration/rl_router.py` | `RLRouter` | `"main"` |
| `agents/task_pattern_learner.py` | `TaskPatternLearner` | `"main"` |
| `knowledge/memory_graph/hybrid_scorer.py` | `HybridScorer` | `"knowledge"` |
| `memory/working_memory.py` | `WorkingMemoryService` | `"knowledge"` |
| `services/autoresearch/osint_engine.py` | `OSINTEngine` | `"main"` |
| `services/autoresearch/prompt_optimizer.py` | `PromptOptimizer` | `"main"` |
| `services/autoresearch/scorers.py` | `HumanReviewScorer` | `"main"` |
| `services/terminal_history_service.py` | `TerminalHistoryService` | `"main"` |
| `services/workflow_automation/state_machine.py` | `WorkflowStateMachine` | `"main"` |

## Intentionally excluded

- `events/stream_manager.py` — `_get_redis` has try/except with side-effects (logger, `_initialized` flag) — filed separately
- Complex double-checked-lock sites (`analytics_embedding_patterns`, `analytics_infrastructure`, `model_optimizer`) — filed separately
- Sites using non-standard attribute names (`_redis_client`, `_redis_sessions`) — separate follow-up
- Active bug sites (`saved_reports_service`, `analytics_llm_patterns`) — tracked in #5704

## Test plan
- [ ] `python3 -m py_compile autobot_shared/redis_mixin.py` passes
- [ ] `python3 -m py_compile` on each of the 9 migrated files passes
- [ ] `grep "_get_redis" autobot-backend/agents/task_pattern_learner.py` returns empty (method removed)
- [ ] Each migrated class still calls `await self._get_redis()` from its other methods — callers unchanged

Closes #5671