### PR TITLE
fix(frontend): replace manual script-strip regex with sanitizeHtml utility (#5711)

### DIFF
--- a/autobot-frontend/src/components/chat/ChatMessages.vue
+++ b/autobot-frontend/src/components/chat/ChatMessages.vue
@@ -1292,17 +1292,11 @@ watch(() => store.currentMessages.length, (newLen, oldLen) => {
     const latestMessage = store.currentMessages[newLen - 1]
     if (latestMessage) {
       const sender = getSenderName(latestMessage.sender)
-      // #1721: Remove script tags first (complete multi-char sanitization), then strip remaining HTML
-      let preview = latestMessage.content.substring(0, 200) // over-read then trim after strip
-        .replace(/<script[\s\S]*?<\/script\s*>/gi, '') // codeql[js/incomplete-multi-character-sanitization]
-        .replace(/<script[^>]*>/gi, '') // codeql[js/incomplete-multi-character-sanitization]
+      // Use DOMPurify-backed sanitizeChatHtml to strip scripts/event-handlers, then
+      // remove any remaining HTML tags to obtain plain text for the aria-live region.
+      const preview = sanitizeChatHtml(latestMessage.content.substring(0, 200))
+        .replace(/<[^>]*>/g, '')  // strip remaining HTML tags → plain text
         .substring(0, 100)
-      let prev = ''
-      while (prev !== preview) {
-        prev = preview
-        preview = preview.replace(/<[^>]*?>/g, '')
-      }
-      preview = preview.replace(/</g, '&lt;')
       screenReaderStatus.value = `New message from ${sender}: ${preview}${preview.length < latestMessage.content.length ? '...' : ''}`
 
       setTimeout(() => {

--- a/autobot-frontend/src/components/terminal/TerminalOutput.vue
+++ b/autobot-frontend/src/components/terminal/TerminalOutput.vue
@@ -32,7 +32,7 @@
 
 <script setup lang="ts">
 import { ref, nextTick, watch } from 'vue'
-import { escapeHtml } from '@/utils/sanitize'
+import { escapeHtml, sanitizeHtml } from '@/utils/sanitize'
 
 interface OutputLine {
   content: string
@@ -76,18 +76,12 @@ watch(() => props.outputLines.length, (newLength) => {
     lastAnnouncedLength = newLength
     const latestLine = props.outputLines[newLength - 1]
     if (latestLine) {
-      // Strip HTML and ANSI codes for announcement
-      // #1721: Remove script tags first (complete multi-char sanitization), then strip remaining HTML
-      let cleanContent = latestLine.content
-        .replace(/\x1b\[[0-9;]*m/g, '')  // Remove ANSI codes
-        .replace(/<script[\s\S]*?<\/script\s*>/gi, '') // codeql[js/incomplete-multi-character-sanitization]
-        .replace(/<script[^>]*>/gi, '') // codeql[js/incomplete-multi-character-sanitization]
-      let prevContent = ''
-      while (prevContent !== cleanContent) {
-        prevContent = cleanContent
-        cleanContent = cleanContent.replace(/<[^>]*>/g, '')
-      }
-      cleanContent = cleanContent.substring(0, 150)  // Limit to 150 chars
+      // Strip ANSI codes first (not HTML — must happen before DOMPurify), then use
+      // DOMPurify-backed sanitizeHtml to remove scripts/event-handlers, then strip
+      // remaining tags to get plain text for the aria-live announcement.
+      const cleanContent = sanitizeHtml(latestLine.content.replace(/\x1b\[[0-9;]*m/g, ''))
+        .replace(/<[^>]*>/g, '')  // strip remaining HTML tags → plain text
+        .substring(0, 150)  // Limit to 150 chars
 
       const lineType = latestLine.type ? ` (${latestLine.type})` : ''
       screenReaderStatus.value = `New terminal output${lineType}: ${cleanContent}`


### PR DESCRIPTION
## Summary

Replaces the manual `/<script.../gi` regex added in #5697 with the project's existing DOMPurify-backed `sanitizeHtml()` utility in two accessibility code paths.

## Changes

**`ChatMessages.vue:~1295`** — screen-reader preview for aria-live announcements:
- Before: 2× manual script-regex + while-loop HTML stripper (8 lines)
- After: `sanitizeChatHtml(content).replace(/<[^>]*>/g, '').substring(0, 100)` (3 lines)
- `sanitizeChatHtml` was already imported at line 535

**`TerminalOutput.vue:~83`** — screen-reader announcement of terminal lines:
- Before: ANSI strip + 2× script-regex + while-loop (10 lines)
- After: ANSI strip → `sanitizeHtml()` → tag strip (4 lines)
- Added `sanitizeHtml` to existing `escapeHtml` import from `@/utils/sanitize`

DOMPurify handles all XSS vectors, not just `<script>` tags. `useVoiceConversation.ts` not changed — TTS path correctly uses plain-text regex.

Closes #5711