### PR TITLE
fix(backend): adopt safe_http_detail() in 4 exception handlers to restore debug logging (#5712)

### DIFF
--- a/autobot-backend/api/chat.py
+++ b/autobot-backend/api/chat.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_utils import safe_http_detail
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 from constants.threshold_constants import CategoryDefaults, TimingConstants
 
@@ -1104,7 +1105,7 @@ async def _stream_chat_workflow_messages(
 
     except Exception as e:
         logger.error("[%s] Streaming error: %s", request_id, e, exc_info=True)
-        evt = {"type": "error", "content": "stream_error", "request_id": request_id}
+        evt = {"type": "error", "content": safe_http_detail(e, "stream_error"), "request_id": request_id}
         yield f"data: {json.dumps(evt)}\n\n"
 
 

--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -23,6 +23,7 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import JSONResponse
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_utils import safe_http_detail
 from constants.threshold_constants import AnalyticsConfig
 from utils.background_task_manager import BackgroundTaskManager
 from utils.chromadb_client import get_all_paginated
@@ -346,7 +347,9 @@ async def _handle_detection_failure(
     if fallback:
         return JSONResponse(fallback)
 
-    return JSONResponse(_build_detection_error_response())
+    resp = _build_detection_error_response()
+    resp["message"] = safe_http_detail(error, resp["message"])
+    return JSONResponse(resp)
 
 
 @router.get("/duplicates")

--- a/autobot-backend/api/process_management.py
+++ b/autobot-backend/api/process_management.py
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel, Field
 
 from auth_middleware import get_current_user
+from autobot_shared.error_utils import safe_http_detail
 from constants.threshold_constants import TimingConstants
 from services.process_adapter_service import ProcessAdapterService
 
@@ -222,4 +223,4 @@ def _read_log_file(log_path: str) -> str:
             return fh.read()
     except OSError as exc:
         logger.warning("Could not read log file %s: %s", log_path, exc)
-        return "Log file unavailable"
+        return safe_http_detail(exc, "Log file unavailable")

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -135,6 +135,7 @@ from api.terminal_models import (
 )
 from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
+from autobot_shared.error_utils import safe_http_detail
 from constants.error_constants import ERR_SESSION_NOT_FOUND
 from services.simple_pty import simple_pty_manager
 
@@ -1398,10 +1399,10 @@ async def admin_execute_command(body: AdminExecuteRequest) -> dict:
             }
     try:
         cmd_parts = shlex.split(body.command)
-    except ValueError:
+    except ValueError as exc:
         return {
             "stdout": "",
-            "stderr": "Invalid command syntax",
+            "stderr": safe_http_detail(exc, "Invalid command syntax"),
             "exit_code": 1,
         }
     try:


### PR DESCRIPTION
## Summary

The batch fix in #5692 replaced `str(exc)` with static strings, which is security-correct but silently swallows exceptions — no debug logging means zero diagnostic information when these endpoints fail in production.

`safe_http_detail(exc, fallback)` from `autobot_shared.error_utils` logs the full exception at DEBUG level and returns the safe fallback string. This restores observability without leaking to HTTP clients.

## Changes (4 files)

| File | Location | Fix |
|------|----------|-----|
| `api/chat.py:1107` | SSE stream error event `content` | `"stream_error"` → `safe_http_detail(e, "stream_error")` |
| `api/codebase_analytics/endpoints/duplicates.py` | `_handle_detection_failure` | response message → `safe_http_detail(error, resp["message"])` |
| `api/process_management.py:225` | `_read_log_file` OSError | `"Log file unavailable"` → `safe_http_detail(exc, "Log file unavailable")` |
| `api/terminal.py:1402` | ValueError handler | bare `except` → `except ValueError as exc:`, `safe_http_detail(exc, "Invalid command syntax")` |

`nodes.py` provisioning path skipped — the `if not result["success"]:` branch has no exception variable in scope; that fix is covered by #5713.

Closes #5712