### PR TITLE
fix(redis): fix unawaited coroutine + migrate to AsyncRedisClientMixin in saved_reports and analytics_llm_patterns (#5704)

### DIFF
--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -30,7 +30,8 @@ from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 from redis.exceptions import RedisError
 
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from constants.model_constants import (
     EXPENSIVE_MODEL_MARKER_GPT4,
     EXPENSIVE_MODEL_MARKER_OPUS,
@@ -269,23 +270,16 @@ class DateRangeParams(BaseModel):
 # =============================================================================
 
 
-class LLMPatternAnalyzer:
+class LLMPatternAnalyzer(AsyncRedisClientMixin):
     """Engine for analyzing LLM usage patterns and identifying optimizations"""
+
+    _redis_database = RedisDatabase.MAIN
 
     def __init__(self):
         """Initialize LLM pattern analyzer with Redis storage keys."""
-        self._redis = None
         self._usage_key = "autobot:llm_patterns:usage"
         self._cache_key = "autobot:llm_patterns:cache"
         self._stats_key = "autobot:llm_patterns:stats"
-
-    async def _get_redis(self):
-        """Get Redis client lazily"""
-        if self._redis is None:
-            self._redis = get_redis_client(
-                async_client=True, database=RedisDatabase.MAIN
-            )
-        return self._redis
 
     def _hash_prompt(self, prompt: str) -> str:
         """Create a hash of the prompt for caching detection"""

--- a/autobot-backend/services/saved_reports_service.py
+++ b/autobot-backend/services/saved_reports_service.py
@@ -19,7 +19,8 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import now_utc, utc_timestamp
 
 logger = logging.getLogger(__name__)
@@ -29,19 +30,10 @@ _REPORT_KEY_PREFIX = "saved_report:"
 _REPORT_INDEX_KEY = "saved_reports:index"
 
 
-class SavedReportsService:
+class SavedReportsService(AsyncRedisClientMixin):
     """Redis-backed CRUD service for saved analytics reports."""
 
-    def __init__(self):
-        self._redis = None
-
-    async def _get_redis(self):
-        """Get async Redis client for the analytics database."""
-        if self._redis is None:
-            self._redis = get_redis_client(
-                async_client=True, database=RedisDatabase.ANALYTICS
-            )
-        return self._redis
+    _redis_database = RedisDatabase.ANALYTICS
 
     # ------------------------------------------------------------------
     # CRUD


### PR DESCRIPTION
## Summary
- `saved_reports_service.py`: `SavedReportsService._get_redis()` stored unawaited coroutine via `get_redis_client(async_client=True)` — AttributeError at runtime. Removed buggy method + `__init__`, migrated to `AsyncRedisClientMixin` with `_redis_database = RedisDatabase.ANALYTICS`.
- `analytics_llm_patterns.py`: `LLMPatternAnalyzer._get_redis()` same bug. Migrated to `AsyncRedisClientMixin` with `_redis_database = RedisDatabase.MAIN`.

## Test plan
- [ ] `python3 -m py_compile autobot-backend/services/saved_reports_service.py`
- [ ] `python3 -m py_compile autobot-backend/api/analytics_llm_patterns.py`
- [ ] Import check: `python3 -c "from services.saved_reports_service import SavedReportsService"`

Closes #5704

🤖 Generated with [Claude Code](https://claude.com/claude-code)