### PR TITLE
fix(redis): fix unawaited coroutine in 4 analytics services; migrate analytics_service to AsyncRedisClientMixin (#5707)

### DIFF
--- a/autobot-backend/services/agent_analytics.py
+++ b/autobot-backend/services/agent_analytics.py
@@ -24,7 +24,7 @@ from enum import Enum
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from autobot_shared.singleton_factory import lazy_singleton
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
 from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from constants.ttl_constants import TTL_1_HOUR, TTL_30_DAYS
 
@@ -212,9 +212,7 @@ class AgentAnalytics:
     async def get_redis(self):
         """Get async Redis client"""
         if self._redis_client is None:
-            self._redis_client = get_redis_client(
-                async_client=True, database=RedisDatabase.ANALYTICS
-            )
+            self._redis_client = await get_async_redis_client(database=RedisDatabase.ANALYTICS)
         return self._redis_client
 
     async def track_task_start(

--- a/autobot-backend/services/analytics_service.py
+++ b/autobot-backend/services/analytics_service.py
@@ -23,7 +23,8 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.model_constants import (
     EXPENSIVE_MODEL_MARKER_GPT4,
@@ -122,7 +123,7 @@ class ResourceOptimization:
         }
 
 
-class AnalyticsService:
+class AnalyticsService(AsyncRedisClientMixin):
     """
     Centralized analytics service providing a unified interface.
 
@@ -142,13 +143,13 @@ class AnalyticsService:
     REDIS_PREFIX = "analytics_service:"
     MAINTENANCE_KEY = f"{REDIS_PREFIX}maintenance"
     OPTIMIZATION_KEY = f"{REDIS_PREFIX}optimization"
+    _redis_database = RedisDatabase.ANALYTICS
 
     def __init__(self):
         """Initialize analytics service with lazy-loaded dependencies."""
         self._behavior: Optional[UserBehaviorAnalytics] = None
         self._agents: Optional[AgentAnalytics] = None
         self._cost: Optional[LLMCostTracker] = None
-        self._redis = None
 
     @property
     def behavior(self) -> UserBehaviorAnalytics:
@@ -170,14 +171,6 @@ class AnalyticsService:
         if self._cost is None:
             self._cost = get_cost_tracker()
         return self._cost
-
-    async def get_redis(self):
-        """Get Redis client for analytics database."""
-        if self._redis is None:
-            self._redis = get_redis_client(
-                async_client=True, database=RedisDatabase.ANALYTICS
-            )
-        return self._redis
 
     # =========================================================================
     # UNIFIED DASHBOARD
@@ -500,7 +493,7 @@ class AnalyticsService:
         recommendations = []
 
         try:
-            redis = await self.get_redis()
+            redis = await self._get_redis()
             info = await redis.info("memory")
 
             # Check Redis memory usage
@@ -716,7 +709,7 @@ class AnalyticsService:
         recommendations = []
 
         try:
-            redis = await self.get_redis()
+            redis = await self._get_redis()
             info = await redis.info()
 
             # Check hit rate

--- a/autobot-backend/services/confounder_control_analyzer.py
+++ b/autobot-backend/services/confounder_control_analyzer.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.singleton_factory import lazy_singleton
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -119,9 +119,7 @@ class ConfounderControlAnalyzer:
     async def get_redis(self):
         """Get async Redis client"""
         if self._redis_client is None:
-            self._redis_client = get_redis_client(
-                async_client=True, database=RedisDatabase.ANALYTICS
-            )
+            self._redis_client = await get_async_redis_client(database=RedisDatabase.ANALYTICS)
         return self._redis_client
 
     async def compare_agents_stratified(

--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -22,7 +22,7 @@ from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import RedisDatabase, get_redis_client
+from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.model_constants import (
     ANTHROPIC_CLAUDE_HAIKU4_5,
@@ -226,9 +226,7 @@ class LLMCostTracker:
     async def get_redis(self):
         """Get async Redis client"""
         if self._redis_client is None:
-            self._redis_client = get_redis_client(
-                async_client=True, database=RedisDatabase.ANALYTICS
-            )
+            self._redis_client = await get_async_redis_client(database=RedisDatabase.ANALYTICS)
         return self._redis_client
 
     # Pattern-based pricing fallbacks for unknown models (#1961).


### PR DESCRIPTION
## Summary
- `agent_analytics.py`, `confounder_control_analyzer.py`, `llm_cost_tracker.py`: stored unawaited coroutine from `get_redis_client(async_client=True)` — fixed to `await get_async_redis_client(...)`.
- `analytics_service.py`: same bug; additionally migrated to `AsyncRedisClientMixin` (renamed internal `get_redis` → `_get_redis`, updated 2 call sites).

## Test plan
- [ ] `python3 -m py_compile autobot-backend/services/agent_analytics.py`
- [ ] `python3 -m py_compile autobot-backend/services/analytics_service.py`
- [ ] `python3 -m py_compile autobot-backend/services/confounder_control_analyzer.py`
- [ ] `python3 -m py_compile autobot-backend/services/llm_cost_tracker.py`

Closes #5707

🤖 Generated with [Claude Code](https://claude.com/claude-code)