### PR TITLE
fix(slm): remove ansible output from reboot HTTP 500 detail (#5721)

### DIFF
--- a/autobot-slm-backend/api/nodes.py
+++ b/autobot-slm-backend/api/nodes.py
@@ -2049,7 +2049,7 @@ async def _execute_reboot_playbook(node_id: str, node) -> dict:
     logger.error("Failed to reboot node %s: %s", node_id, result["output"])
     raise HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail=f"Failed to reboot node: {result['output'][:500]}",
+        detail="Failed to reboot node",
     )
 
 


### PR DESCRIPTION
## Summary
- Removes `result['output'][:500]` from the reboot endpoint's HTTP 500 `detail=` string
- Output is already logged via `logger.error` above — leaking it in the response is a `py/stack-trace-exposure` violation
- Static message `"Failed to reboot node"` is sufficient for the client

Closes #5721

🤖 Generated with [Claude Code](https://claude.com/claude-code)