### PR TITLE
fix(backend): remove redundant safe_http_detail in duplicates.py (#5722)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/duplicates.py
@@ -23,7 +23,6 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
 from fastapi.responses import JSONResponse
 
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
-from autobot_shared.error_utils import safe_http_detail
 from constants.threshold_constants import AnalyticsConfig
 from utils.background_task_manager import BackgroundTaskManager
 from utils.chromadb_client import get_all_paginated
@@ -348,7 +347,6 @@ async def _handle_detection_failure(
         return JSONResponse(fallback)
 
     resp = _build_detection_error_response()
-    resp["message"] = safe_http_detail(error, resp["message"])
     return JSONResponse(resp)
 
 


### PR DESCRIPTION
## Summary
- Removes the `safe_http_detail(error, resp["message"])` call added in #5712
- `_build_detection_error_response()` already returns a safe static message; `safe_http_detail` is only needed when an exception would otherwise be silently swallowed
- `logger.error(..., exc_info=True)` already logs the full exception at ERROR level — no information is lost
- Removes the now-orphaned `from autobot_shared.error_utils import safe_http_detail` import

Closes #5722

🤖 Generated with [Claude Code](https://claude.com/claude-code)