### PR TITLE
fix(redis): fix unawaited bug in analytics_infrastructure/detector; migrate 4 services to AsyncRedisClientMixin (#5708)

### DIFF
--- a/autobot-backend/code_intelligence/analytics_infrastructure.py
+++ b/autobot-backend/code_intelligence/analytics_infrastructure.py
@@ -28,6 +28,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from autobot_shared.redis_client import get_async_redis_client
+
 logger = logging.getLogger(__name__)
 
 # Issue #640 / #5231: NPU availability caching now lives inside the canonical
@@ -215,10 +217,8 @@ class AnalyticsInfrastructureMixin:
             async with self._infra_lock:
                 if self._redis_client is None:
                     try:
-                        from autobot_shared.redis_client import get_redis_client
-
-                        self._redis_client = get_redis_client(
-                            async_client=True, database=self._redis_database
+                        self._redis_client = await get_async_redis_client(
+                            database=self._redis_database
                         )
                         logger.info(
                             "Redis client initialized for '%s'", self._redis_database

--- a/autobot-backend/code_intelligence/cross_language_patterns/detector.py
+++ b/autobot-backend/code_intelligence/cross_language_patterns/detector.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from autobot_shared.redis_client import get_async_redis_client
 from .extractors import PythonPatternExtractor, TypeScriptPatternExtractor
 from .models import (
     APIContractMismatch,
@@ -166,11 +167,7 @@ class CrossLanguagePatternDetector:
         """Get Redis client for caching."""
         if self._redis_client is None and self.use_cache:
             try:
-                from autobot_shared.redis_client import get_redis_client
-
-                self._redis_client = get_redis_client(
-                    async_client=True, database="analytics"
-                )
+                self._redis_client = await get_async_redis_client(database="analytics")
                 logger.info("Redis client initialized for analytics")
             except Exception as e:
                 logger.warning("Redis not available for caching: %s", e)

--- a/autobot-backend/services/agent_analytics.py
+++ b/autobot-backend/services/agent_analytics.py
@@ -24,7 +24,8 @@ from enum import Enum
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from autobot_shared.singleton_factory import lazy_singleton
-from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
+from autobot_shared.redis_client import RedisDatabase
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from constants.ttl_constants import TTL_1_HOUR, TTL_30_DAYS
 
@@ -188,7 +189,7 @@ class AgentMetrics:
         ]
 
 
-class AgentAnalytics:
+class AgentAnalytics(AsyncRedisClientMixin):
     """
     Tracks and analyzes agent performance across the system.
 
@@ -200,20 +201,16 @@ class AgentAnalytics:
     - Historical trends
     """
 
+    _redis_database = RedisDatabase.ANALYTICS
+
     REDIS_KEY_PREFIX = "agent_analytics:"
     TASK_LIST_KEY = f"{REDIS_KEY_PREFIX}tasks"
     AGENT_METRICS_KEY = f"{REDIS_KEY_PREFIX}metrics"
     AGENT_HISTORY_KEY = f"{REDIS_KEY_PREFIX}history"
 
-    def __init__(self):
-        """Initialize agent analytics service with lazy Redis client."""
-        self._redis_client = None
-
     async def get_redis(self):
         """Get async Redis client"""
-        if self._redis_client is None:
-            self._redis_client = await get_async_redis_client(database=RedisDatabase.ANALYTICS)
-        return self._redis_client
+        return await self._get_redis()
 
     async def track_task_start(
         self,

--- a/autobot-backend/services/conflict_resolver.py
+++ b/autobot-backend/services/conflict_resolver.py
@@ -42,7 +42,7 @@ from api.knowledge_grounding_models import (
     ReviewTicketStatus,
     SourceType,
 )
-from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.ssot_config import config
 
 logger = logging.getLogger(__name__)
@@ -69,37 +69,16 @@ _DECAY_AGING = 0.6  # 30-90 days: 60% of base
 _DECAY_STALE = 0.4  # > 90 days: 40% of base (stale)
 
 
-class ConflictResolver:
+class ConflictResolver(AsyncRedisClientMixin):
     """Service for resolving conflicts between KB facts and agent claims.
 
     Compares confidence scores of competing information sources,
     applies age-based decay to older facts, and determines which
     source represents ground truth. Escalates uncertain cases to
     human review.
-
-    Attributes:
-        _redis_client: Async Redis client for persistence
     """
 
-    def __init__(self):
-        """Initialize ConflictResolver.
-
-        Sets up Redis connection for storing review tickets and
-        conflict history (lazy initialization on first use).
-        """
-        self._redis_client = None
-
-    async def _get_redis_client(self):
-        """Get or initialize Redis client (lazy loading).
-
-        Returns:
-            Redis async client connected to analytics database
-        """
-        if self._redis_client is None:
-            self._redis_client = await get_async_redis_client(
-                database=_REDIS_DATABASE
-            )
-        return self._redis_client
+    _redis_database = _REDIS_DATABASE
 
     def _calculate_age_decay(self, fact: KBFact) -> float:
         """Apply age decay to knowledge base fact.
@@ -357,7 +336,7 @@ class ConflictResolver:
         )
 
         try:
-            redis = await self._get_redis_client()
+            redis = await self._get_redis()
 
             # Store update record for audit trail
             update_record = {
@@ -433,7 +412,7 @@ class ConflictResolver:
         logger.debug(f"Created review ticket: {ticket.ticket_id} (priority={priority})")
 
         try:
-            redis = await self._get_redis_client()
+            redis = await self._get_redis()
 
             # Store ticket for human review team
             ticket_key = f"review_ticket:{ticket.ticket_id}"
@@ -502,7 +481,7 @@ class ConflictResolver:
         )
 
         try:
-            redis = await self._get_redis_client()
+            redis = await self._get_redis()
             ticket_key = f"review_ticket:{ticket_id}"
 
             # Retrieve ticket data
@@ -555,7 +534,7 @@ class ConflictResolver:
         )
 
         try:
-            redis = await self._get_redis_client()
+            redis = await self._get_redis()
             ticket_key = f"review_ticket:{ticket_id}"
 
             # Retrieve and update

--- a/autobot-backend/services/confounder_control_analyzer.py
+++ b/autobot-backend/services/confounder_control_analyzer.py
@@ -24,7 +24,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from autobot_shared.singleton_factory import lazy_singleton
-from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
+from autobot_shared.redis_client import RedisDatabase
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 
 logger = logging.getLogger(__name__)
 
@@ -97,8 +98,10 @@ class StratifiedComparison:
         }
 
 
-class ConfounderControlAnalyzer:
+class ConfounderControlAnalyzer(AsyncRedisClientMixin):
     """Analyzes agent performance with confounder control via stratification."""
+
+    _redis_database = RedisDatabase.ANALYTICS
 
     REDIS_KEY_PREFIX = "agent_analytics:"
     AGENT_HISTORY_KEY = f"{REDIS_KEY_PREFIX}history"
@@ -112,15 +115,9 @@ class ConfounderControlAnalyzer:
         "task_priority": {"low": 1, "medium": 2, "high": 3},
     }
 
-    def __init__(self):
-        """Initialize analyzer with lazy Redis client."""
-        self._redis_client = None
-
     async def get_redis(self):
         """Get async Redis client"""
-        if self._redis_client is None:
-            self._redis_client = await get_async_redis_client(database=RedisDatabase.ANALYTICS)
-        return self._redis_client
+        return await self._get_redis()
 
     async def compare_agents_stratified(
         self,

--- a/autobot-backend/services/llm_cost_tracker.py
+++ b/autobot-backend/services/llm_cost_tracker.py
@@ -22,7 +22,8 @@ from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from autobot_shared.redis_client import RedisDatabase, get_async_redis_client
+from autobot_shared.redis_client import RedisDatabase
+from autobot_shared.redis_mixin import AsyncRedisClientMixin
 from autobot_shared.time_utils import now_utc, utc_timestamp
 from constants.model_constants import (
     ANTHROPIC_CLAUDE_HAIKU4_5,
@@ -195,7 +196,7 @@ class BudgetAlert:
     enabled: bool = True
 
 
-class LLMCostTracker:
+class LLMCostTracker(AsyncRedisClientMixin):
     """
     Tracks LLM API usage costs across all providers.
 
@@ -206,6 +207,8 @@ class LLMCostTracker:
     - Budget alerting
     - Cost trend analysis
     """
+
+    _redis_database = RedisDatabase.ANALYTICS
 
     REDIS_KEY_PREFIX = "llm_cost:"
     USAGE_LIST_KEY = f"{REDIS_KEY_PREFIX}usage"
@@ -218,16 +221,13 @@ class LLMCostTracker:
     BUDGET_ALERTS_KEY = f"{REDIS_KEY_PREFIX}budget_alerts"
 
     def __init__(self):
-        """Initialize cost tracker with lazy Redis client and empty alerts."""
-        self._redis_client = None
+        """Initialize cost tracker with empty alerts."""
         self._budget_alerts: List[BudgetAlert] = []
         self._current_period_costs: Dict[str, float] = {}
 
     async def get_redis(self):
         """Get async Redis client"""
-        if self._redis_client is None:
-            self._redis_client = await get_async_redis_client(database=RedisDatabase.ANALYTICS)
-        return self._redis_client
+        return await self._get_redis()
 
     # Pattern-based pricing fallbacks for unknown models (#1961).
     # Ordered from most specific to least specific.

--- a/autobot-backend/utils/model_optimizer.py
+++ b/autobot-backend/utils/model_optimizer.py
@@ -24,7 +24,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from autobot_shared.http_client import get_http_client
-from autobot_shared.redis_client import get_redis_client
+from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
 from autobot_shared.ssot_config import config as ssot_config
 from config.manager import get_config_manager
@@ -166,8 +166,7 @@ class ModelOptimizer:
                 # Double-check after acquiring lock
                 if self._redis_client is None:
                     try:
-                        self._redis_client = await get_redis_client(
-                            async_client=True,
+                        self._redis_client = await get_async_redis_client(
                             database="analytics",
                         )
 


### PR DESCRIPTION
## Summary
- `code_intelligence/analytics_infrastructure.py`: `_get_redis_client()` called `get_redis_client(async_client=True, ...)` without `await` — stored coroutine. Fixed to `await get_async_redis_client(...)`.
- `code_intelligence/cross_language_patterns/detector.py`: same unawaited coroutine bug. Fixed.
- `utils/model_optimizer.py`: used old `get_redis_client(async_client=True)` API. Migrated to `get_async_redis_client`.
- `services/conflict_resolver.py`: migrated `ConflictResolver` to `AsyncRedisClientMixin`; renamed `_redis_client`→`_redis`, `_get_redis_client`→`_get_redis`, 4 call sites updated.
- `services/agent_analytics.py`, `services/confounder_control_analyzer.py`, `services/llm_cost_tracker.py`: migrated to `AsyncRedisClientMixin`; `get_redis()` kept as thin alias for backward compat.

## Test plan
- [ ] `python3 -m py_compile` on all 7 changed files

Closes #5708

🤖 Generated with [Claude Code](https://claude.com/claude-code)