### PR TITLE
fix(redis): remove dead _initialized state from RedisEventStreamManager (#5709)

### DIFF
--- a/autobot-backend/events/stream_manager.py
+++ b/autobot-backend/events/stream_manager.py
@@ -40,6 +40,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Callable, Optional
 
+from autobot_shared.redis_client import get_async_redis_client
 from events.types import AgentEvent, EventType, ObservationContent, TaskArtifact
 
 logger = logging.getLogger(__name__)
@@ -127,17 +128,13 @@ class RedisEventStreamManager(EventStreamManager):
         self.config = config or EventStreamConfig()
         self._redis: Any = None
         self._pubsub: Any = None
-        self._initialized = False
         self._listeners: dict[str, list[Callable]] = {}
 
     async def _get_redis(self) -> Any:
         """Get async Redis client with lazy initialization"""
         if self._redis is None:
             try:
-                from autobot_shared.redis_client import get_async_redis_client
-
                 self._redis = await get_async_redis_client(database="main")
-                self._initialized = True
                 logger.debug("Event stream Redis connection established")
             except Exception as e:
                 logger.error("Failed to connect to Redis for event stream: %s", e)
@@ -547,7 +544,6 @@ class RedisEventStreamManager(EventStreamManager):
             await self._redis.close()
             self._redis = None
 
-        self._initialized = False
         logger.debug("Event stream connections closed")
 
 


### PR DESCRIPTION
## Summary
`RedisEventStreamManager._initialized` was set in 3 places but never read anywhere — pure dead state. Removed all 3 assignments (`__init__`, `_get_redis`, `close`). Also moved the inline `from autobot_shared.redis_client import get_async_redis_client` to module level.

`AsyncRedisClientMixin` was NOT applied — the custom `_get_redis()` has a try/except with `logger.error` + re-raise that differs from the mixin's implementation; the custom method is intentional.

## Test plan
- [ ] `python3 -m py_compile autobot-backend/events/stream_manager.py`
- [ ] Confirm no `_initialized` in stream_manager.py

Closes #5709

🤖 Generated with [Claude Code](https://claude.com/claude-code)